### PR TITLE
Remove the interactive-theme dependency from headless HTML export

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed headless HTML export requiring interactive theme initialization and silently hiding custom renderer failures ([#936](https://github.com/PrimeIntellect-ai/prime-agent/issues/936)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/examples/extensions/tic-tac-toe.ts
+++ b/packages/coding-agent/examples/extensions/tic-tac-toe.ts
@@ -18,7 +18,12 @@
  */
 
 import { StringEnum } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionContext, Theme, ToolExecutionMode } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	ToolExecutionMode,
+	ToolRenderTheme,
+} from "@earendil-works/pi-coding-agent";
 import { type Component, matchesKey, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
@@ -514,9 +519,9 @@ class BannerMessageComponent implements Component {
 	private readonly title: string;
 	private readonly details: BoardDetails | undefined;
 	private readonly expanded: boolean;
-	private readonly theme: Theme;
+	private readonly theme: ToolRenderTheme;
 
-	constructor(title: string, details: BoardDetails | undefined, expanded: boolean, theme: Theme) {
+	constructor(title: string, details: BoardDetails | undefined, expanded: boolean, theme: ToolRenderTheme) {
 		this.title = title;
 		this.details = details;
 		this.expanded = expanded;
@@ -548,9 +553,9 @@ class BannerMessageComponent implements Component {
 class GameOverMessageComponent implements Component {
 	private readonly status: GameStatus;
 	private readonly details: BoardDetails | undefined;
-	private readonly theme: Theme;
+	private readonly theme: ToolRenderTheme;
 
-	constructor(status: GameStatus, details: BoardDetails | undefined, theme: Theme) {
+	constructor(status: GameStatus, details: BoardDetails | undefined, theme: ToolRenderTheme) {
 		this.status = status;
 		this.details = details;
 		this.theme = theme;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -48,7 +48,6 @@ import {
 	resetApiProviders,
 	supportsFastMode,
 } from "@earendil-works/pi-ai";
-import { theme } from "../modes/interactive/theme/theme.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
 import { sleep } from "../utils/sleep.js";
 import {
@@ -125,6 +124,7 @@ import type { AgentCronJob, AgentRlmHeartbeatController, AgentRlmHeartbeatStatus
 import { normalizeHeartbeatDeliveryMode } from "./cron-jobs.js";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.js";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.js";
+import { createHtmlExportTheme } from "./export-html/theme.js";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.js";
 import {
 	type ContextUsage,
@@ -11073,17 +11073,22 @@ export class AgentSession {
 	 */
 	async exportToHtml(outputPath?: string): Promise<string> {
 		const themeName = this.settingsManager.getTheme();
+		const exportTheme = createHtmlExportTheme({
+			themeName,
+			resources: this._resourceLoader.getThemes().themes,
+		});
 
 		// Create tool renderer if we have an extension runner (for custom tool HTML rendering)
 		const toolRenderer: ToolHtmlRenderer = createToolHtmlRenderer({
 			getToolDefinition: (name) => this.getToolDefinition(name),
-			theme,
+			theme: exportTheme.toolTheme,
 			cwd: this.sessionManager.getCwd(),
 		});
 
 		return await exportSessionToHtml(this.sessionManager, this.state, {
 			outputPath,
 			themeName,
+			theme: exportTheme,
 			toolRenderer,
 		});
 	}

--- a/packages/coding-agent/src/core/export-html/index.ts
+++ b/packages/coding-agent/src/core/export-html/index.ts
@@ -2,10 +2,10 @@ import type { AgentState } from "@earendil-works/pi-agent-core";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { basename, join } from "path";
 import { APP_NAME, getExportTemplateDir } from "../../config.js";
-import { getResolvedThemeColors, getThemeExportColors } from "../../modes/interactive/theme/theme.js";
 import type { ToolDefinition } from "../extensions/types.js";
 import type { SessionEntry } from "../session-manager.js";
 import { SessionManager } from "../session-manager.js";
+import { createHtmlExportTheme, type HtmlExportTheme } from "./theme.js";
 
 /**
  * Interface for rendering custom tools to HTML.
@@ -34,6 +34,8 @@ interface RenderedToolHtml {
 export interface ExportOptions {
 	outputPath?: string;
 	themeName?: string;
+	/** Pre-resolved theme service for settings-aware SDK/headless export. */
+	theme?: HtmlExportTheme;
 	/** Optional tool renderer for custom tools */
 	toolRenderer?: ToolHtmlRenderer;
 }
@@ -107,15 +109,15 @@ function deriveExportColors(baseColor: string): { pageBg: string; cardBg: string
 /**
  * Generate CSS custom property declarations from theme colors.
  */
-function generateThemeVars(themeName?: string): string {
-	const colors = getResolvedThemeColors(themeName);
+function generateThemeVars(theme: HtmlExportTheme): string {
+	const colors = theme.colors;
 	const lines: string[] = [];
 	for (const [key, value] of Object.entries(colors)) {
 		lines.push(`--${key}: ${value};`);
 	}
 
 	// Use explicit theme export colors if available, otherwise derive from userMessageBg
-	const themeExport = getThemeExportColors(themeName);
+	const themeExport = theme.exportColors;
 	const userMessageBg = colors.userMessageBg || "#343541";
 	const derivedColors = deriveExportColors(userMessageBg);
 
@@ -139,7 +141,7 @@ interface SessionData {
 /**
  * Core HTML generation logic shared by both export functions.
  */
-function generateHtml(sessionData: SessionData, themeName?: string): string {
+function generateHtml(sessionData: SessionData, theme: HtmlExportTheme): string {
 	const templateDir = getExportTemplateDir();
 	const template = readFileSync(join(templateDir, "template.html"), "utf-8");
 	const templateCss = readFileSync(join(templateDir, "template.css"), "utf-8");
@@ -147,9 +149,9 @@ function generateHtml(sessionData: SessionData, themeName?: string): string {
 	const markedJs = readFileSync(join(templateDir, "vendor", "marked.min.js"), "utf-8");
 	const hljsJs = readFileSync(join(templateDir, "vendor", "highlight.min.js"), "utf-8");
 
-	const themeVars = generateThemeVars(themeName);
-	const colors = getResolvedThemeColors(themeName);
-	const themeExport = getThemeExportColors(themeName);
+	const themeVars = generateThemeVars(theme);
+	const colors = theme.colors;
+	const themeExport = theme.exportColors;
 	const derivedExportColors = deriveExportColors(colors.userMessageBg || "#343541");
 	const bodyBg = themeExport.pageBg ?? derivedExportColors.pageBg;
 	const containerBg = themeExport.cardBg ?? derivedExportColors.cardBg;
@@ -238,6 +240,7 @@ export async function exportSessionToHtml(
 	options?: ExportOptions | string,
 ): Promise<string> {
 	const opts: ExportOptions = typeof options === "string" ? { outputPath: options } : options || {};
+	const exportTheme = opts.theme ?? createHtmlExportTheme({ themeName: opts.themeName });
 
 	const sessionFile = sm.getSessionFile();
 	if (!sessionFile) {
@@ -268,7 +271,7 @@ export async function exportSessionToHtml(
 		renderedTools,
 	};
 
-	const html = generateHtml(sessionData, opts.themeName);
+	const html = generateHtml(sessionData, exportTheme);
 
 	let outputPath = opts.outputPath;
 	if (!outputPath) {
@@ -286,6 +289,7 @@ export async function exportSessionToHtml(
  */
 export async function exportFromFile(inputPath: string, options?: ExportOptions | string): Promise<string> {
 	const opts: ExportOptions = typeof options === "string" ? { outputPath: options } : options || {};
+	const exportTheme = opts.theme ?? createHtmlExportTheme({ themeName: opts.themeName });
 
 	if (!existsSync(inputPath)) {
 		throw new Error(`File not found: ${inputPath}`);
@@ -301,7 +305,7 @@ export async function exportFromFile(inputPath: string, options?: ExportOptions 
 		tools: undefined,
 	};
 
-	const html = generateHtml(sessionData, opts.themeName);
+	const html = generateHtml(sessionData, exportTheme);
 
 	let outputPath = opts.outputPath;
 	if (!outputPath) {

--- a/packages/coding-agent/src/core/export-html/theme.ts
+++ b/packages/coding-agent/src/core/export-html/theme.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { getTerminalBackgroundKind } from "@earendil-works/pi-tui";
 import { getCustomThemesDir, getThemesDir } from "../../config.js";
 import type { SourceInfo } from "../source-info.js";
 import type { ThemeBg, ThemeColor, ToolRenderTheme } from "../theme-types.js";
@@ -30,7 +31,12 @@ export interface HtmlExportTheme {
 
 export interface HtmlExportThemeOptions {
 	themeName?: string;
-	resources?: ReadonlyArray<{ name?: string; sourcePath?: string }>;
+	resources?: ReadonlyArray<{ name?: string; sourcePath?: string; sourceInfo?: SourceInfo }>;
+}
+
+interface ResolvedThemeSource {
+	sourcePath: string;
+	sourceInfo?: SourceInfo;
 }
 
 const BUILTIN_THEME_NAMES = new Set(["prime", "dark", "light"]);
@@ -95,20 +101,20 @@ function readThemeDocument(themePath: string): ThemeDocument {
 	return { name: parsed.name, vars, colors, export: exportColors };
 }
 
-function resolveThemePath(name: string, resources: HtmlExportThemeOptions["resources"]): string {
+function resolveThemeSource(name: string, resources: HtmlExportThemeOptions["resources"]): ResolvedThemeSource {
 	const resource = resources?.find((candidate) => candidate.name === name);
 	if (resource) {
 		if (!resource.sourcePath) {
 			throw new Error(`Theme "${name}" has no source path for HTML export`);
 		}
-		return resource.sourcePath;
+		return { sourcePath: resource.sourcePath, sourceInfo: resource.sourceInfo };
 	}
 	if (BUILTIN_THEME_NAMES.has(name)) {
-		return join(getThemesDir(), `${name}.json`);
+		return { sourcePath: join(getThemesDir(), `${name}.json`) };
 	}
 	const customPath = join(getCustomThemesDir(), `${name}.json`);
 	if (existsSync(customPath)) {
-		return customPath;
+		return { sourcePath: customPath };
 	}
 	throw new Error(`Theme not found: ${name}`);
 }
@@ -172,7 +178,7 @@ function toAnsi(value: ColorValue, background: boolean): string {
 	if (typeof value === "number") {
 		return `\x1b[${background ? 48 : 38};5;${value}m`;
 	}
-	if (value === "") return "";
+	if (value === "") return `\x1b[${background ? 49 : 39}m`;
 	const match = value.match(/^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i);
 	if (!match) {
 		throw new Error(`Invalid theme color: ${value}`);
@@ -189,9 +195,10 @@ class HeadlessToolTheme implements ToolRenderTheme {
 	private readonly foregrounds: Map<ThemeColor, string>;
 	private readonly backgrounds: Map<ThemeBg, string>;
 
-	constructor(name: string, sourcePath: string, colors: Record<string, ColorValue>) {
+	constructor(name: string, sourcePath: string, colors: Record<string, ColorValue>, sourceInfo?: SourceInfo) {
 		this.name = name;
 		this.sourcePath = sourcePath;
+		this.sourceInfo = sourceInfo;
 		this.foregrounds = new Map();
 		this.backgrounds = new Map();
 		for (const [colorName, value] of Object.entries(colors)) {
@@ -283,8 +290,8 @@ class HeadlessToolTheme implements ToolRenderTheme {
 }
 
 export function createHtmlExportTheme(options: HtmlExportThemeOptions = {}): HtmlExportTheme {
-	const name = options.themeName ?? "prime";
-	const sourcePath = resolveThemePath(name, options.resources);
+	const name = options.themeName ?? (getTerminalBackgroundKind() === "light" ? "light" : "prime");
+	const { sourcePath, sourceInfo } = resolveThemeSource(name, options.resources);
 	const document = readThemeDocument(sourcePath);
 	const vars = document.vars ?? {};
 	const resolvedColors = Object.fromEntries(
@@ -294,12 +301,15 @@ export function createHtmlExportTheme(options: HtmlExportThemeOptions = {}): Htm
 	const cssColors = Object.fromEntries(
 		Object.entries(resolvedColors).map(([colorName, value]) => [colorName, toCssColor(value, defaultText)]),
 	);
-	const resolveExportColor = (value: ColorValue | undefined): string | undefined =>
-		value === undefined ? undefined : toCssColor(resolveColor(value, vars), defaultText);
+	const resolveExportColor = (value: ColorValue | undefined): string | undefined => {
+		if (value === undefined) return undefined;
+		const resolved = resolveColor(value, vars);
+		return resolved === "" ? undefined : toCssColor(resolved, defaultText);
+	};
 
 	return {
 		name,
-		toolTheme: new HeadlessToolTheme(name, sourcePath, resolvedColors),
+		toolTheme: new HeadlessToolTheme(name, sourcePath, resolvedColors, sourceInfo),
 		colors: cssColors,
 		exportColors: {
 			pageBg: resolveExportColor(document.export?.pageBg),

--- a/packages/coding-agent/src/core/export-html/theme.ts
+++ b/packages/coding-agent/src/core/export-html/theme.ts
@@ -1,0 +1,310 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getCustomThemesDir, getThemesDir } from "../../config.js";
+import type { SourceInfo } from "../source-info.js";
+import type { ThemeBg, ThemeColor, ToolRenderTheme } from "../theme-types.js";
+
+type ColorValue = string | number;
+
+interface ThemeDocument {
+	name: string;
+	vars?: Record<string, ColorValue>;
+	colors: Record<string, ColorValue>;
+	export?: {
+		pageBg?: ColorValue;
+		cardBg?: ColorValue;
+		infoBg?: ColorValue;
+	};
+}
+
+export interface HtmlExportTheme {
+	name: string;
+	toolTheme: ToolRenderTheme;
+	colors: Record<string, string>;
+	exportColors: {
+		pageBg?: string;
+		cardBg?: string;
+		infoBg?: string;
+	};
+}
+
+export interface HtmlExportThemeOptions {
+	themeName?: string;
+	resources?: ReadonlyArray<{ name?: string; sourcePath?: string }>;
+}
+
+const BUILTIN_THEME_NAMES = new Set(["prime", "dark", "light"]);
+const BACKGROUND_COLOR_NAMES = new Set<ThemeBg>([
+	"selectedBg",
+	"userMessageBg",
+	"customMessageBg",
+	"toolPendingBg",
+	"toolSuccessBg",
+	"toolErrorBg",
+	"toolDiffAddedBg",
+	"toolDiffRemovedBg",
+	"toolPanelBg",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isColorValue(value: unknown): value is ColorValue {
+	return typeof value === "string" || (typeof value === "number" && Number.isInteger(value));
+}
+
+function readThemeDocument(themePath: string): ThemeDocument {
+	const parsed: unknown = JSON.parse(readFileSync(themePath, "utf-8"));
+	if (!isRecord(parsed) || typeof parsed.name !== "string" || !isRecord(parsed.colors)) {
+		throw new Error(`Invalid theme "${themePath}": expected a name and colors object`);
+	}
+	const colors: Record<string, ColorValue> = {};
+	for (const [name, value] of Object.entries(parsed.colors)) {
+		if (!isColorValue(value)) {
+			throw new Error(`Invalid theme color "${name}" in ${themePath}`);
+		}
+		colors[name] = value;
+	}
+	const vars: Record<string, ColorValue> = {};
+	if (parsed.vars !== undefined) {
+		if (!isRecord(parsed.vars)) {
+			throw new Error(`Invalid theme vars in ${themePath}`);
+		}
+		for (const [name, value] of Object.entries(parsed.vars)) {
+			if (!isColorValue(value)) {
+				throw new Error(`Invalid theme variable "${name}" in ${themePath}`);
+			}
+			vars[name] = value;
+		}
+	}
+	let exportColors: ThemeDocument["export"];
+	if (parsed.export !== undefined) {
+		if (!isRecord(parsed.export)) {
+			throw new Error(`Invalid theme export colors in ${themePath}`);
+		}
+		exportColors = {};
+		for (const name of ["pageBg", "cardBg", "infoBg"] as const) {
+			const value = parsed.export[name];
+			if (value !== undefined && !isColorValue(value)) {
+				throw new Error(`Invalid theme export color "${name}" in ${themePath}`);
+			}
+			exportColors[name] = value;
+		}
+	}
+	return { name: parsed.name, vars, colors, export: exportColors };
+}
+
+function resolveThemePath(name: string, resources: HtmlExportThemeOptions["resources"]): string {
+	const resource = resources?.find((candidate) => candidate.name === name);
+	if (resource) {
+		if (!resource.sourcePath) {
+			throw new Error(`Theme "${name}" has no source path for HTML export`);
+		}
+		return resource.sourcePath;
+	}
+	if (BUILTIN_THEME_NAMES.has(name)) {
+		return join(getThemesDir(), `${name}.json`);
+	}
+	const customPath = join(getCustomThemesDir(), `${name}.json`);
+	if (existsSync(customPath)) {
+		return customPath;
+	}
+	throw new Error(`Theme not found: ${name}`);
+}
+
+function resolveColor(value: ColorValue, vars: Record<string, ColorValue>, visited = new Set<string>()): ColorValue {
+	if (typeof value === "number" || value === "" || value.startsWith("#")) {
+		return value;
+	}
+	if (visited.has(value)) {
+		throw new Error(`Circular theme variable reference: ${value}`);
+	}
+	const next = vars[value];
+	if (next === undefined) {
+		throw new Error(`Theme variable not found: ${value}`);
+	}
+	visited.add(value);
+	return resolveColor(next, vars, visited);
+}
+
+function ansi256ToHex(index: number): string {
+	if (index < 0 || index > 255) {
+		throw new Error(`Invalid ANSI color index: ${index}`);
+	}
+	const basic = [
+		"#000000",
+		"#800000",
+		"#008000",
+		"#808000",
+		"#000080",
+		"#800080",
+		"#008080",
+		"#c0c0c0",
+		"#808080",
+		"#ff0000",
+		"#00ff00",
+		"#ffff00",
+		"#0000ff",
+		"#ff00ff",
+		"#00ffff",
+		"#ffffff",
+	];
+	if (index < basic.length) return basic[index];
+	if (index >= 232) {
+		const value = (8 + (index - 232) * 10).toString(16).padStart(2, "0");
+		return `#${value}${value}${value}`;
+	}
+	const cube = [0, 95, 135, 175, 215, 255];
+	const offset = index - 16;
+	const red = cube[Math.floor(offset / 36)];
+	const green = cube[Math.floor((offset % 36) / 6)];
+	const blue = cube[offset % 6];
+	return `#${red.toString(16).padStart(2, "0")}${green.toString(16).padStart(2, "0")}${blue.toString(16).padStart(2, "0")}`;
+}
+
+function toCssColor(value: ColorValue, defaultText: string): string {
+	if (typeof value === "number") return ansi256ToHex(value);
+	return value === "" ? defaultText : value;
+}
+
+function toAnsi(value: ColorValue, background: boolean): string {
+	if (typeof value === "number") {
+		return `\x1b[${background ? 48 : 38};5;${value}m`;
+	}
+	if (value === "") return "";
+	const match = value.match(/^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i);
+	if (!match) {
+		throw new Error(`Invalid theme color: ${value}`);
+	}
+	const channels = match.slice(1).map((channel) => Number.parseInt(channel, 16));
+	return `\x1b[${background ? 48 : 38};2;${channels.join(";")}m`;
+}
+
+class HeadlessToolTheme implements ToolRenderTheme {
+	readonly colorMode = "truecolor" as const;
+	readonly name: string;
+	readonly sourcePath: string;
+	sourceInfo?: SourceInfo;
+	private readonly foregrounds: Map<ThemeColor, string>;
+	private readonly backgrounds: Map<ThemeBg, string>;
+
+	constructor(name: string, sourcePath: string, colors: Record<string, ColorValue>) {
+		this.name = name;
+		this.sourcePath = sourcePath;
+		this.foregrounds = new Map();
+		this.backgrounds = new Map();
+		for (const [colorName, value] of Object.entries(colors)) {
+			if (BACKGROUND_COLOR_NAMES.has(colorName as ThemeBg)) {
+				this.backgrounds.set(colorName as ThemeBg, toAnsi(value, true));
+			} else {
+				this.foregrounds.set(colorName as ThemeColor, toAnsi(value, false));
+			}
+		}
+	}
+
+	fg(color: ThemeColor, text: string): string {
+		const ansi = this.foregrounds.get(color);
+		if (ansi === undefined) throw new Error(`Unknown theme color: ${color}`);
+		return `${ansi}${text}\x1b[39m`;
+	}
+
+	bg(color: ThemeBg, text: string): string {
+		const ansi = this.backgrounds.get(color);
+		if (ansi === undefined) throw new Error(`Unknown theme background color: ${color}`);
+		return `${ansi}${text}\x1b[49m`;
+	}
+
+	getEditorBackgroundColor(): (text: string) => string {
+		return (text) => this.bg("userMessageBg", text);
+	}
+
+	getUserMessageBackgroundColor(): (text: string) => string {
+		return (text) => this.bg("userMessageBg", text);
+	}
+
+	getPopupBackgroundColor(): (text: string) => string {
+		return (text) => this.bg("toolPanelBg", text);
+	}
+
+	getSelectionBackgroundColor(): (text: string) => string {
+		return (text) => this.bg("selectedBg", text);
+	}
+
+	getAdaptiveAccentColor(): (text: string) => string {
+		return (text) => this.bold(this.fg("accent", text));
+	}
+
+	bold(text: string): string {
+		return `\x1b[1m${text}\x1b[22m`;
+	}
+
+	italic(text: string): string {
+		return `\x1b[3m${text}\x1b[23m`;
+	}
+
+	underline(text: string): string {
+		return `\x1b[4m${text}\x1b[24m`;
+	}
+
+	inverse(text: string): string {
+		return `\x1b[7m${text}\x1b[27m`;
+	}
+
+	strikethrough(text: string): string {
+		return `\x1b[9m${text}\x1b[29m`;
+	}
+
+	getFgAnsi(color: ThemeColor): string {
+		const ansi = this.foregrounds.get(color);
+		if (ansi === undefined) throw new Error(`Unknown theme color: ${color}`);
+		return ansi;
+	}
+
+	getBgAnsi(color: ThemeBg): string {
+		const ansi = this.backgrounds.get(color);
+		if (ansi === undefined) throw new Error(`Unknown theme background color: ${color}`);
+		return ansi;
+	}
+
+	getColorMode(): "truecolor" {
+		return this.colorMode;
+	}
+
+	getThinkingBorderColor(level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max") {
+		const color =
+			level === "max" ? "thinkingXhigh" : (`thinking${level[0].toUpperCase()}${level.slice(1)}` as ThemeColor);
+		return (text: string) => this.fg(color, text);
+	}
+
+	getBashModeBorderColor(): (text: string) => string {
+		return (text) => this.fg("bashMode", text);
+	}
+}
+
+export function createHtmlExportTheme(options: HtmlExportThemeOptions = {}): HtmlExportTheme {
+	const name = options.themeName ?? "prime";
+	const sourcePath = resolveThemePath(name, options.resources);
+	const document = readThemeDocument(sourcePath);
+	const vars = document.vars ?? {};
+	const resolvedColors = Object.fromEntries(
+		Object.entries(document.colors).map(([colorName, value]) => [colorName, resolveColor(value, vars)]),
+	);
+	const defaultText = name === "light" ? "#000000" : "#e5e5e7";
+	const cssColors = Object.fromEntries(
+		Object.entries(resolvedColors).map(([colorName, value]) => [colorName, toCssColor(value, defaultText)]),
+	);
+	const resolveExportColor = (value: ColorValue | undefined): string | undefined =>
+		value === undefined ? undefined : toCssColor(resolveColor(value, vars), defaultText);
+
+	return {
+		name,
+		toolTheme: new HeadlessToolTheme(name, sourcePath, resolvedColors),
+		colors: cssColors,
+		exportColors: {
+			pageBg: resolveExportColor(document.export?.pageBg),
+			cardBg: resolveExportColor(document.export?.cardBg),
+			infoBg: resolveExportColor(document.export?.infoBg),
+		},
+	};
+}

--- a/packages/coding-agent/src/core/export-html/tool-renderer.ts
+++ b/packages/coding-agent/src/core/export-html/tool-renderer.ts
@@ -7,19 +7,28 @@
 
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import type { Component } from "@earendil-works/pi-tui";
-import type { Theme } from "../../modes/interactive/theme/theme.js";
 import type { ToolDefinition, ToolRenderContext } from "../extensions/types.js";
+import type { ToolRenderTheme } from "../theme-types.js";
 import { ansiLinesToHtml } from "./ansi-to-html.js";
+
+export interface ToolHtmlRenderError {
+	phase: "call" | "result";
+	toolCallId: string;
+	toolName: string;
+	error: Error;
+}
 
 export interface ToolHtmlRendererDeps {
 	/** Function to look up tool definition by name */
 	getToolDefinition: (name: string) => ToolDefinition | undefined;
 	/** Theme for styling */
-	theme: Theme;
+	theme: ToolRenderTheme;
 	/** Working directory for render context */
 	cwd: string;
 	/** Terminal width for rendering (default: 100) */
 	width?: number;
+	/** Reports custom renderer failures before falling back to structured HTML. */
+	onRenderError?: (error: ToolHtmlRenderError) => void;
 }
 
 export interface ToolHtmlRenderer {
@@ -56,7 +65,32 @@ function trimRenderedResultLines(lines: string[]): string[] {
 }
 
 export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRenderer {
-	const { getToolDefinition, theme, cwd, width = 100 } = deps;
+	const {
+		getToolDefinition,
+		theme,
+		cwd,
+		width = 100,
+		onRenderError = ({ phase, toolCallId, toolName, error }) => {
+			console.warn(
+				`HTML export ${phase} renderer failed for ${toolName} (${toolCallId}); using structured fallback: ${error.message}`,
+			);
+		},
+	} = deps;
+
+	const reportRenderError = (
+		phase: ToolHtmlRenderError["phase"],
+		toolCallId: string,
+		toolName: string,
+		error: unknown,
+	): void => {
+		const normalized = error instanceof Error ? error : new Error(String(error));
+		try {
+			onRenderError({ phase, toolCallId, toolName, error: normalized });
+		} catch (reportError) {
+			const message = reportError instanceof Error ? reportError.message : String(reportError);
+			console.warn(`HTML export renderer error reporting failed: ${message}`);
+		}
+	};
 
 	const renderedCallComponents = new Map<string, Component>();
 	const renderedResultComponents = new Map<string, Component>();
@@ -107,13 +141,14 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 
 				const component = toolDef.renderCall(
 					args,
-					theme,
+					theme as unknown as Parameters<NonNullable<ToolDefinition["renderCall"]>>[1],
 					createRenderContext(toolCallId, renderedCallComponents.get(toolCallId), false, true, false),
 				);
 				renderedCallComponents.set(toolCallId, component);
 				const lines = component.render(width);
 				return ansiLinesToHtml(lines);
-			} catch {
+			} catch (error) {
+				reportRenderError("call", toolCallId, toolName, error);
 				// On error, return undefined so HTML export can fall back to structured result rendering
 				return undefined;
 			}
@@ -144,7 +179,7 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 				const collapsedComponent = toolDef.renderResult(
 					agentToolResult,
 					{ expanded: false, isPartial: false },
-					theme,
+					theme as unknown as Parameters<NonNullable<ToolDefinition["renderResult"]>>[2],
 					createRenderContext(toolCallId, renderedResultComponents.get(toolCallId), false, false, isError),
 				);
 				renderedResultComponents.set(toolCallId, collapsedComponent);
@@ -154,7 +189,7 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 				const expandedComponent = toolDef.renderResult(
 					agentToolResult,
 					{ expanded: true, isPartial: false },
-					theme,
+					theme as unknown as Parameters<NonNullable<ToolDefinition["renderResult"]>>[2],
 					createRenderContext(toolCallId, renderedResultComponents.get(toolCallId), true, false, isError),
 				);
 				renderedResultComponents.set(toolCallId, expandedComponent);
@@ -164,7 +199,8 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 					...(collapsed && collapsed !== expanded ? { collapsed } : {}),
 					expanded,
 				};
-			} catch {
+			} catch (error) {
+				reportRenderError("result", toolCallId, toolName, error);
 				// On error, return undefined so HTML export can fall back to structured result rendering
 				return undefined;
 			}

--- a/packages/coding-agent/src/core/export-html/tool-renderer.ts
+++ b/packages/coding-agent/src/core/export-html/tool-renderer.ts
@@ -141,7 +141,7 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 
 				const component = toolDef.renderCall(
 					args,
-					theme as unknown as Parameters<NonNullable<ToolDefinition["renderCall"]>>[1],
+					theme,
 					createRenderContext(toolCallId, renderedCallComponents.get(toolCallId), false, true, false),
 				);
 				renderedCallComponents.set(toolCallId, component);
@@ -179,7 +179,7 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 				const collapsedComponent = toolDef.renderResult(
 					agentToolResult,
 					{ expanded: false, isPartial: false },
-					theme as unknown as Parameters<NonNullable<ToolDefinition["renderResult"]>>[2],
+					theme,
 					createRenderContext(toolCallId, renderedResultComponents.get(toolCallId), false, false, isError),
 				);
 				renderedResultComponents.set(toolCallId, collapsedComponent);
@@ -189,7 +189,7 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 				const expandedComponent = toolDef.renderResult(
 					agentToolResult,
 					{ expanded: true, isPartial: false },
-					theme as unknown as Parameters<NonNullable<ToolDefinition["renderResult"]>>[2],
+					theme,
 					createRenderContext(toolCallId, renderedResultComponents.get(toolCallId), true, false, isError),
 				);
 				renderedResultComponents.set(toolCallId, expandedComponent);

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -59,6 +59,7 @@ import type {
 import type { SlashCommandInfo } from "../slash-commands.js";
 import type { SourceInfo } from "../source-info.js";
 import type { BuildSystemPromptOptions } from "../system-prompt.js";
+import type { ToolRenderTheme } from "../theme-types.js";
 import type { BashOperations } from "../tools/bash.js";
 import type { EditToolDetails } from "../tools/edit.js";
 import type {
@@ -419,6 +420,23 @@ export interface ToolRenderContext<TState = any, TArgs = any> {
 
 export type ReplayBuiltInToolName = "bash" | "edit";
 
+type ToolCallRenderer<TParams extends TSchema, TState> = {
+	bivarianceHack(
+		args: Static<TParams>,
+		theme: ToolRenderTheme,
+		context: ToolRenderContext<TState, Static<TParams>>,
+	): Component;
+}["bivarianceHack"];
+
+type ToolResultRenderer<TParams extends TSchema, TDetails, TState> = {
+	bivarianceHack(
+		result: AgentToolResult<TDetails>,
+		options: ToolRenderResultOptions,
+		theme: ToolRenderTheme,
+		context: ToolRenderContext<TState, Static<TParams>>,
+	): Component;
+}["bivarianceHack"];
+
 /**
  * Tool definition for registerTool().
  */
@@ -462,15 +480,10 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	): Promise<AgentToolResult<TDetails>>;
 
 	/** Custom rendering for tool call display */
-	renderCall?: (args: Static<TParams>, theme: Theme, context: ToolRenderContext<TState, Static<TParams>>) => Component;
+	renderCall?: ToolCallRenderer<TParams, TState>;
 
 	/** Custom rendering for tool result display */
-	renderResult?: (
-		result: AgentToolResult<TDetails>,
-		options: ToolRenderResultOptions,
-		theme: Theme,
-		context: ToolRenderContext<TState, Static<TParams>>,
-	) => Component;
+	renderResult?: ToolResultRenderer<TParams, TDetails, TState>;
 }
 
 type AnyToolDefinition = ToolDefinition<any, any, any>;

--- a/packages/coding-agent/src/core/theme-types.ts
+++ b/packages/coding-agent/src/core/theme-types.ts
@@ -1,0 +1,89 @@
+import type { SourceInfo } from "./source-info.js";
+
+export type ThemeColor =
+	| "accent"
+	| "border"
+	| "borderAccent"
+	| "borderMuted"
+	| "success"
+	| "error"
+	| "warning"
+	| "muted"
+	| "dim"
+	| "text"
+	| "thinkingText"
+	| "userMessageText"
+	| "customMessageText"
+	| "customMessageLabel"
+	| "toolTitle"
+	| "toolOutput"
+	| "mdHeading"
+	| "mdLink"
+	| "mdLinkUrl"
+	| "mdCode"
+	| "mdCodeBlock"
+	| "mdCodeBlockBorder"
+	| "mdQuote"
+	| "mdQuoteBorder"
+	| "mdHr"
+	| "mdListBullet"
+	| "toolDiffAdded"
+	| "toolDiffRemoved"
+	| "toolDiffText"
+	| "toolDiffContext"
+	| "syntaxComment"
+	| "syntaxKeyword"
+	| "syntaxFunction"
+	| "syntaxVariable"
+	| "syntaxString"
+	| "syntaxNumber"
+	| "syntaxType"
+	| "syntaxOperator"
+	| "syntaxPunctuation"
+	| "thinkingOff"
+	| "thinkingMinimal"
+	| "thinkingLow"
+	| "thinkingMedium"
+	| "thinkingHigh"
+	| "thinkingXhigh"
+	| "bashMode";
+
+export type ThemeBg =
+	| "selectedBg"
+	| "userMessageBg"
+	| "customMessageBg"
+	| "toolPendingBg"
+	| "toolSuccessBg"
+	| "toolErrorBg"
+	| "toolDiffAddedBg"
+	| "toolDiffRemovedBg"
+	| "toolPanelBg";
+
+export type ThemeColorMode = "truecolor" | "256color";
+
+/** Theme contract available to custom tool renderers in interactive and headless modes. */
+export interface ToolRenderTheme {
+	readonly name?: string;
+	readonly sourcePath?: string;
+	sourceInfo?: SourceInfo;
+	readonly colorMode: ThemeColorMode;
+	fg(color: ThemeColor, text: string): string;
+	bg(color: ThemeBg, text: string): string;
+	getEditorBackgroundColor(): ((text: string) => string) | undefined;
+	getUserMessageBackgroundColor(): (text: string) => string;
+	getPopupBackgroundColor(): (text: string) => string;
+	getSelectionBackgroundColor(): (text: string) => string;
+	getAdaptiveAccentColor(): (text: string) => string;
+	bold(text: string): string;
+	italic(text: string): string;
+	underline(text: string): string;
+	inverse(text: string): string;
+	strikethrough(text: string): string;
+	getFgAnsi(color: ThemeColor): string;
+	getBgAnsi(color: ThemeBg): string;
+	getColorMode(): ThemeColorMode;
+	getThinkingBorderColor(
+		level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
+	): (text: string) => string;
+	getBashModeBorderColor(): (text: string) => string;
+}

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -6,6 +6,7 @@ import { type Static, Type } from "typebox";
 import { renderDiff } from "../../modes/interactive/components/diff.js";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import type { ToolDefinition } from "../extensions/types.js";
+import type { ToolRenderTheme } from "../theme-types.js";
 import {
 	applyEditsToNormalizedContent,
 	computeEditsDiff,
@@ -191,10 +192,7 @@ function getRenderablePreviewInput(args: RenderableEditArgs | undefined): { path
 	return null;
 }
 
-function formatEditCall(
-	args: RenderableEditArgs | undefined,
-	theme: typeof import("../../modes/interactive/theme/theme.js").theme,
-): string {
+function formatEditCall(args: RenderableEditArgs | undefined, theme: ToolRenderTheme): string {
 	const invalidArg = invalidArgText(theme);
 	const rawPath = str(args?.file_path ?? args?.path);
 	const path = rawPath !== null ? shortenPath(rawPath) : null;
@@ -206,7 +204,7 @@ function formatEditResult(
 	args: RenderableEditArgs | undefined,
 	preview: EditPreview | undefined,
 	result: EditToolResultLike,
-	theme: typeof import("../../modes/interactive/theme/theme.js").theme,
+	theme: ToolRenderTheme,
 	isError: boolean,
 ): string | undefined {
 	const rawPath = str(args?.file_path ?? args?.path);
@@ -234,7 +232,7 @@ function formatEditResult(
 function getEditHeaderBg(
 	preview: EditPreview | undefined,
 	settledError: boolean | undefined,
-	theme: typeof import("../../modes/interactive/theme/theme.js").theme,
+	theme: ToolRenderTheme,
 ): (text: string) => string {
 	if (preview) {
 		if ("error" in preview) {
@@ -251,7 +249,7 @@ function getEditHeaderBg(
 function buildEditCallComponent(
 	component: EditCallRenderComponent,
 	args: RenderableEditArgs | undefined,
-	theme: typeof import("../../modes/interactive/theme/theme.js").theme,
+	theme: ToolRenderTheme,
 	expanded: boolean,
 	showExpandHint: boolean,
 ): EditCallRenderComponent {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -389,6 +389,7 @@ export {
 	initTheme,
 	Theme,
 	type ThemeColor,
+	type ToolRenderTheme,
 } from "./modes/interactive/theme/theme.js";
 // Clipboard utilities
 export { copyToClipboard } from "./utils/clipboard.js";

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -2,12 +2,13 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { type Component, Container, Image, Text, type TUI } from "@earendil-works/pi-tui";
 import type { ToolDefinition, ToolRenderContext, ToolRenderResultOptions } from "../../../core/extensions/types.js";
 import type { KernelSentAgentMessage } from "../../../core/kernel/index.js";
+import type { ToolRenderTheme } from "../../../core/theme-types.js";
 import { createBashToolDefinition } from "../../../core/tools/bash.js";
 import { createEditToolDefinition } from "../../../core/tools/edit.js";
 import { createAllToolDefinitions } from "../../../core/tools/index.js";
 import { getTextOutput as getRenderedTextOutput } from "../../../core/tools/render-utils.js";
 import type { AgentConnectionToolDefinition } from "../../agent-connection/index.js";
-import { type Theme, theme } from "../theme/theme.js";
+import { theme } from "../theme/theme.js";
 import { getWorkingPulseFrame, workingIconFrame } from "../theme/working-icon.js";
 import { FileChangeSummaryComponent, getToolFileChanges } from "./edit-summary.js";
 import { getIpythonCodeFromArgs, IPythonCellComponent } from "./ipython-cell.js";
@@ -21,11 +22,11 @@ export interface ToolExecutionOptions {
 
 export interface ToolExecutionRendererDefinition {
 	renderShell?: "default" | "self";
-	renderCall?: (args: any, theme: Theme, context: ToolRenderContext<any, any>) => Component;
+	renderCall?: (args: any, theme: ToolRenderTheme, context: ToolRenderContext<any, any>) => Component;
 	renderResult?: (
 		result: AgentToolResult<any>,
 		options: ToolRenderResultOptions,
-		theme: Theme,
+		theme: ToolRenderTheme,
 		context: ToolRenderContext<any, any>,
 	) => Component;
 }

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -18,7 +18,10 @@ import { type Static, type TProperties, Type } from "typebox";
 import type { Validator } from "typebox/compile";
 import { getCustomThemesDir, getThemesDir } from "../../../config.js";
 import type { SourceInfo } from "../../../core/source-info.js";
+import type { ThemeBg, ThemeColor, ThemeColorMode, ToolRenderTheme } from "../../../core/theme-types.js";
 import { closeWatcher, watchWithErrorHandler } from "../../../utils/fs-watch.js";
+
+export type { ThemeBg, ThemeColor, ToolRenderTheme } from "../../../core/theme-types.js";
 
 // ============================================================================
 // Types & Schema
@@ -124,66 +127,7 @@ export function preloadThemeValidator(): Promise<void> {
 	return themeValidatorPromise;
 }
 
-export type ThemeColor =
-	| "accent"
-	| "border"
-	| "borderAccent"
-	| "borderMuted"
-	| "success"
-	| "error"
-	| "warning"
-	| "muted"
-	| "dim"
-	| "text"
-	| "thinkingText"
-	| "userMessageText"
-	| "customMessageText"
-	| "customMessageLabel"
-	| "toolTitle"
-	| "toolOutput"
-	| "mdHeading"
-	| "mdLink"
-	| "mdLinkUrl"
-	| "mdCode"
-	| "mdCodeBlock"
-	| "mdCodeBlockBorder"
-	| "mdQuote"
-	| "mdQuoteBorder"
-	| "mdHr"
-	| "mdListBullet"
-	| "toolDiffAdded"
-	| "toolDiffRemoved"
-	| "toolDiffText"
-	| "toolDiffContext"
-	| "syntaxComment"
-	| "syntaxKeyword"
-	| "syntaxFunction"
-	| "syntaxVariable"
-	| "syntaxString"
-	| "syntaxNumber"
-	| "syntaxType"
-	| "syntaxOperator"
-	| "syntaxPunctuation"
-	| "thinkingOff"
-	| "thinkingMinimal"
-	| "thinkingLow"
-	| "thinkingMedium"
-	| "thinkingHigh"
-	| "thinkingXhigh"
-	| "bashMode";
-
-export type ThemeBg =
-	| "selectedBg"
-	| "userMessageBg"
-	| "customMessageBg"
-	| "toolPendingBg"
-	| "toolSuccessBg"
-	| "toolErrorBg"
-	| "toolDiffAddedBg"
-	| "toolDiffRemovedBg"
-	| "toolPanelBg";
-
-type ColorMode = "truecolor" | "256color";
+type ColorMode = ThemeColorMode;
 
 const ADAPTIVE_LIGHT_BG_ACCENT: Rgb = { r: 0, g: 95, b: 135 };
 const SURFACE_MIN_LUMINANCE_DELTA = 12;
@@ -365,7 +309,7 @@ function resolveThemeColors<T extends Record<string, ColorValue>>(
 // Theme Class
 // ============================================================================
 
-export class Theme {
+export class Theme implements ToolRenderTheme {
 	readonly name?: string;
 	readonly sourcePath?: string;
 	sourceInfo?: SourceInfo;

--- a/packages/coding-agent/test/export-html-whitespace.test.ts
+++ b/packages/coding-agent/test/export-html-whitespace.test.ts
@@ -2,9 +2,9 @@ import type { Component } from "@earendil-works/pi-tui";
 import { readFileSync } from "fs";
 import { describe, expect, it } from "vitest";
 import { ansiLinesToHtml } from "../src/core/export-html/ansi-to-html.js";
+import { createHtmlExportTheme } from "../src/core/export-html/theme.js";
 import { createToolHtmlRenderer } from "../src/core/export-html/tool-renderer.js";
 import type { ToolDefinition } from "../src/core/extensions/types.js";
-import type { Theme } from "../src/modes/interactive/theme/theme.js";
 
 describe("export HTML tool output whitespace", () => {
 	it("preserves whitespace for plain-text tool output lines without preserving template whitespace", () => {
@@ -31,7 +31,7 @@ describe("export HTML tool output whitespace", () => {
 		} as unknown as ToolDefinition;
 		const renderer = createToolHtmlRenderer({
 			getToolDefinition: () => tool,
-			theme: {} as Theme,
+			theme: createHtmlExportTheme().toolTheme,
 			cwd: "/tmp",
 		});
 

--- a/packages/coding-agent/test/suite/regressions/936-headless-html-theme.test.ts
+++ b/packages/coding-agent/test/suite/regressions/936-headless-html-theme.test.ts
@@ -1,10 +1,14 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
-import { Text } from "@earendil-works/pi-tui";
+import { clearDefaultTerminalColors, setDefaultTerminalColors, Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionFactory } from "../../../src/core/extensions/types.js";
+import { createHtmlExportTheme } from "../../../src/core/export-html/theme.js";
+import { createToolHtmlRenderer } from "../../../src/core/export-html/tool-renderer.js";
+import { defineTool, type ExtensionFactory } from "../../../src/core/extensions/types.js";
+import { createSyntheticSourceInfo } from "../../../src/core/source-info.js";
 import { createHarness, type Harness } from "../harness.js";
 
 const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme");
@@ -56,6 +60,7 @@ describe("regression #936: headless HTML export theme composition", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		clearDefaultTerminalColors();
 		while (harnesses.length > 0) harnesses.pop()?.cleanup();
 		delete (globalThis as Record<symbol, unknown>)[THEME_KEY];
 	});
@@ -100,5 +105,50 @@ describe("regression #936: headless HTML export theme composition", () => {
 		expect(warn).toHaveBeenCalledWith(expect.stringContaining("custom result renderer failed"));
 		expect(sessionData.renderedTools).toBeUndefined();
 		expect(sessionData.entries.length).toBeGreaterThan(0);
+	});
+
+	it.each([
+		{ background: { r: 245, g: 245, b: 245 }, expectedTheme: "light" },
+		{ background: { r: 10, g: 10, b: 10 }, expectedTheme: "prime" },
+	])("resolves an unset theme for the current terminal background", ({ background, expectedTheme }) => {
+		delete (globalThis as Record<symbol, unknown>)[THEME_KEY];
+		setDefaultTerminalColors({ foreground: { r: 128, g: 128, b: 128 }, background });
+
+		const exportTheme = createHtmlExportTheme();
+
+		expect(exportTheme.name).toBe(expectedTheme);
+		expect((globalThis as Record<symbol, unknown>)[THEME_KEY]).toBeUndefined();
+	});
+
+	it("retains loaded theme source metadata for custom renderers", () => {
+		const sourcePath = fileURLToPath(new URL("../../../src/modes/interactive/theme/prime.json", import.meta.url));
+		const sourceInfo = createSyntheticSourceInfo(sourcePath, {
+			source: "theme-package",
+			scope: "project",
+			origin: "package",
+		});
+		const exportTheme = createHtmlExportTheme({
+			themeName: "prime",
+			resources: [{ name: "prime", sourcePath, sourceInfo }],
+		});
+		const parameters = Type.Object({ value: Type.String() });
+		const definition = defineTool({
+			name: "source_info_theme_tool",
+			label: "Source info theme tool",
+			description: "Displays theme source metadata",
+			parameters,
+			execute: async () => ({ content: [{ type: "text", text: "done" }], details: {} }),
+			renderCall: (_args, theme) => new Text(`source:${theme.sourceInfo?.source ?? "missing"}`, 0, 0),
+		});
+		const renderer = createToolHtmlRenderer({
+			getToolDefinition: (name) => (name === definition.name ? definition : undefined),
+			theme: exportTheme.toolTheme,
+			cwd: process.cwd(),
+		});
+
+		expect(exportTheme.toolTheme.sourceInfo).toEqual(sourceInfo);
+		expect(renderer.renderCall("source-info-call", definition.name, { value: "example" })).toContain(
+			"source:theme-package",
+		);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/936-headless-html-theme.test.ts
+++ b/packages/coding-agent/test/suite/regressions/936-headless-html-theme.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionFactory } from "../../../src/core/extensions/types.js";
+import { createHarness, type Harness } from "../harness.js";
+
+const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme");
+
+interface ExportedSessionData {
+	entries: unknown[];
+	renderedTools?: Record<
+		string,
+		{
+			callHtml?: string;
+			resultHtmlCollapsed?: string;
+			resultHtmlExpanded?: string;
+		}
+	>;
+}
+
+function decodeSessionData(html: string): ExportedSessionData {
+	const match = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/);
+	if (!match) throw new Error("Expected embedded session data");
+	return JSON.parse(Buffer.from(match[1], "base64").toString("utf-8")) as ExportedSessionData;
+}
+
+function themedTool(options: { failRendering?: boolean } = {}): ExtensionFactory {
+	return (pi) => {
+		pi.registerTool({
+			name: "headless_theme_tool",
+			label: "Headless theme tool",
+			description: "Exercises custom HTML export rendering",
+			parameters: Type.Object({ value: Type.String() }),
+			execute: async (_toolCallId, params) => ({
+				content: [{ type: "text", text: `result:${params.value}` }],
+				details: { value: params.value },
+			}),
+			renderCall: (args, theme) => {
+				if (options.failRendering) throw new Error("custom call renderer failed");
+				return new Text(theme.fg("accent", `headless-call:${args.value}`), 0, 0);
+			},
+			renderResult: (result, _options, theme) => {
+				if (options.failRendering) throw new Error("custom result renderer failed");
+				const text = result.content.find((part) => part.type === "text")?.text ?? "missing";
+				return new Text(theme.fg("success", `headless-result:${text}`), 0, 0);
+			},
+		});
+	};
+}
+
+describe("regression #936: headless HTML export theme composition", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+		delete (globalThis as Record<symbol, unknown>)[THEME_KEY];
+	});
+
+	async function runToolAndExport(extensionFactory: ExtensionFactory): Promise<ExportedSessionData> {
+		delete (globalThis as Record<symbol, unknown>)[THEME_KEY];
+		const harness = await createHarness({
+			persistSession: true,
+			settings: { theme: "prime" },
+			extensionFactories: [extensionFactory],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("headless_theme_tool", { value: "example" }), {
+				stopReason: "toolUse",
+			}),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("render the custom tool");
+
+		expect((globalThis as Record<symbol, unknown>)[THEME_KEY]).toBeUndefined();
+		const outputPath = join(harness.tempDir, "session.html");
+		await harness.session.exportToHtml(outputPath);
+		expect((globalThis as Record<symbol, unknown>)[THEME_KEY]).toBeUndefined();
+		return decodeSessionData(readFileSync(outputPath, "utf-8"));
+	}
+
+	it("renders custom tool output without initializing the interactive theme", async () => {
+		const sessionData = await runToolAndExport(themedTool());
+		const rendered = Object.values(sessionData.renderedTools ?? {})[0];
+
+		expect(rendered?.callHtml).toContain("headless-call:example");
+		expect(rendered?.resultHtmlExpanded).toContain("headless-result:result:example");
+	});
+
+	it("reports renderer failures and intentionally keeps structured fallback data", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const sessionData = await runToolAndExport(themedTool({ failRendering: true }));
+
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("custom call renderer failed"));
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("custom result renderer failed"));
+		expect(sessionData.renderedTools).toBeUndefined();
+		expect(sessionData.entries.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/coding-agent/test/theme-export.test.ts
+++ b/packages/coding-agent/test/theme-export.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../src/config.js";
-import { getThemeExportColors } from "../src/modes/interactive/theme/theme.js";
+import { createHtmlExportTheme } from "../src/core/export-html/theme.js";
+import {
+	getResolvedThemeColors,
+	getThemeExportColors,
+	loadThemeFromPath,
+} from "../src/modes/interactive/theme/theme.js";
 
 type ThemeFile = {
 	name: string;
@@ -62,11 +67,13 @@ describe("getThemeExportColors", () => {
 
 		writeFileSync(join(agentDir, "themes", "custom-export-vars.json"), JSON.stringify(customTheme, null, 2));
 
-		expect(getThemeExportColors("custom-export-vars")).toEqual({
+		const expected = {
 			pageBg: "#112233",
 			cardBg: "#223344",
 			infoBg: "#445566",
-		});
+		};
+		expect(getThemeExportColors("custom-export-vars")).toEqual(expected);
+		expect(createHtmlExportTheme({ themeName: "custom-export-vars" }).exportColors).toEqual(expected);
 	});
 
 	it("resolves recursive vars and converts 256-color export values to hex", () => {
@@ -92,10 +99,55 @@ describe("getThemeExportColors", () => {
 
 		writeFileSync(join(agentDir, "themes", "custom-export-recursive.json"), JSON.stringify(customTheme, null, 2));
 
-		expect(getThemeExportColors("custom-export-recursive")).toEqual({
+		const expected = {
 			pageBg: "#abcdef",
 			cardBg: "#005f87",
 			infoBg: undefined,
-		});
+		};
+		expect(getThemeExportColors("custom-export-recursive")).toEqual(expected);
+		expect(createHtmlExportTheme({ themeName: "custom-export-recursive" }).exportColors).toEqual(expected);
+	});
+
+	it("keeps headless parsing and empty-token rendering aligned with interactive themes", () => {
+		const darkTheme = JSON.parse(
+			readFileSync(new URL("../src/modes/interactive/theme/dark.json", import.meta.url), "utf-8"),
+		) as ThemeFile;
+		const themeName = "custom-parser-parity";
+		const themePath = join(agentDir, "themes", `${themeName}.json`);
+		const customTheme: ThemeFile = {
+			...darkTheme,
+			name: themeName,
+			vars: {
+				...(darkTheme.vars ?? {}),
+				accentValue: "#123456",
+				accentAlias: "accentValue",
+				ansiOutput: 24,
+			},
+			colors: {
+				...darkTheme.colors,
+				accent: "accentAlias",
+				text: "",
+				userMessageBg: "",
+				toolOutput: "ansiOutput",
+			},
+			export: {
+				pageBg: "accentAlias",
+				cardBg: 24,
+				infoBg: "",
+			},
+		};
+		writeFileSync(themePath, JSON.stringify(customTheme, null, 2));
+
+		const headless = createHtmlExportTheme({ themeName });
+		const interactive = loadThemeFromPath(themePath, "truecolor");
+
+		expect(headless.colors).toEqual(getResolvedThemeColors(themeName));
+		expect(headless.exportColors).toEqual(getThemeExportColors(themeName));
+		expect(headless.exportColors.infoBg).toBeUndefined();
+		expect(headless.toolTheme.fg("text", "sample")).toBe("\x1b[39msample\x1b[39m");
+		expect(headless.toolTheme.fg("text", "sample")).toBe(interactive.fg("text", "sample"));
+		expect(headless.toolTheme.bg("userMessageBg", "sample")).toBe("\x1b[49msample\x1b[49m");
+		expect(headless.toolTheme.bg("userMessageBg", "sample")).toBe(interactive.bg("userMessageBg", "sample"));
+		expect(headless.toolTheme.fg("toolOutput", "sample")).toBe(interactive.fg("toolOutput", "sample"));
 	});
 });


### PR DESCRIPTION
## Summary

- resolve a deterministic HTML-export theme from session settings and loaded theme resources
- retain automatic light/prime selection from the current terminal background when no theme is configured
- remove runtime imports of the interactive theme module from `AgentSession` and HTML export
- preserve interactive empty-color resets, export-color fallbacks, and loaded theme source metadata
- report custom tool renderer failures before intentionally falling back to structured transcript rendering
- add SDK/headless regression coverage with the faux provider

## Root cause

HTML export reused interactive theme helpers, which required interactive initialization for custom tool rendering. The first headless resolver also treated an unset theme and empty color tokens differently from the interactive implementation.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/936-headless-html-theme.test.ts test/export-html-whitespace.test.ts test/theme-export.test.ts`
- `npm run check`

## Compatibility

- No daemon command, event, response-shape, protocol version, or schema revision changes.
- Existing `themeName` HTML export options remain supported; settings-aware sessions inject the resolved export theme.
- An unset theme still follows the current terminal background: light terminals use `light`; dark or unknown terminals use `prime`.
- Custom tool renderer callbacks now receive the shared `ToolRenderTheme` interface. It preserves the public styling surface of `Theme`, which implements it, and keeps explicitly `Theme`-annotated callbacks assignable.

Fixes #936


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove interactive theme dependency from headless HTML export
> - Introduces a new headless theme service ([theme.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/970/files#diff-13d72133860f29a3fb6a633a4d69ba512119ee942821b6b3cd0b756937acba2e)) that resolves theme colors and provides a `ToolRenderTheme` for HTML export without initializing the interactive theme subsystem.
> - `AgentSession.exportToHtml` now creates a headless `HtmlExportTheme` via `createHtmlExportTheme` and passes it into both the tool renderer and the export pipeline instead of using the interactive theme singleton.
> - Adds a `ToolRenderTheme` interface ([theme-types.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/970/files#diff-e6c5fdb62651765d9fceaca59a6304b4091136d880267b366d950ac6cf056305)) as a shared contract between interactive and headless renderers, replacing direct `Theme` references in tool render signatures.
> - Custom tool renderer failures during HTML export are now caught, reported via `console.warn`, and fall back to structured output instead of failing silently.
> - Behavioral Change: headless callers no longer trigger interactive theme initialization; default theme selection falls back to `light` or `prime` based on terminal background.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 869f1cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->