### PR TITLE
fix(coding-agent): resolve kernel venv python on Windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Added Windows setup documentation covering npm 12 install quirks and the `PRIME_AGENT_KERNEL_PYTHON` kernel-bootstrap workaround.
+- Fixed the IPython kernel bootstrap failing on Windows by resolving the venv interpreter at `Scripts\python.exe` instead of the POSIX `bin/python` path.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -1,12 +1,114 @@
 # Windows Setup
 
+Prime Agent runs natively on Windows from a bash shell. It was primarily developed and tested on macOS and Linux, so expect rough edges; the modern [Windows Terminal](https://github.com/microsoft/terminal) is recommended for the TUI (24-bit color and VT input are only exercised there).
+
 Prime Agent requires a bash shell on Windows. Checked locations (in order):
 
 1. Custom path from `~/.prime/agent/settings.json`
 2. Git Bash (`C:\Program Files\Git\bin\bash.exe`)
 3. `bash.exe` on PATH (Cygwin, MSYS2, WSL)
 
-For most users, [Git for Windows](https://git-scm.com/download/win) is sufficient.
+For most users, [Git for Windows](https://git-scm.com/download/win) is sufficient. Use the **Git Bash** profile in Windows Terminal.
+
+## Prerequisites
+
+- [Git for Windows](https://git-scm.com/download/win) (provides Git Bash)
+- Node.js 22.8.0 or newer and npm
+- [uv](https://docs.astral.sh/uv/) (only if Prime Agent bootstraps the IPython kernel itself; it can also download uv automatically)
+
+## Installation
+
+From a Git Bash prompt, run the official installer:
+
+```bash
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
+```
+
+Then start Prime Agent in the project directory you want it to work on:
+
+```bash
+cd /path/to/project
+prime-agent
+```
+
+### npm 12 and the installer
+
+npm 12 (2026) changed two behaviors that affect Prime Agent's release tarball:
+
+- **Remote dependencies are refused by default** (`EALLOWREMOTE`): the `prime-agent` tarball depends on sibling packages served from the release CDN. Enable them first:
+
+  ```bash
+  npm config set allow-remote all
+  ```
+
+  This setting also lives in the user `~/.npmrc`, so it applies to `prime-agent update` self-updates as well.
+
+- **Global installs may fail with `EPERM`** if npm's global prefix resolves to a system directory such as `C:\Program Files\npm`, which is not writable without an elevated shell. npm ignores `prefix` set in `.npmrc`; use the environment variable instead:
+
+  ```bash
+  export NPM_CONFIG_PREFIX="$APPDATA/npm"
+  curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
+  ```
+
+  Make sure `%APPDATA%\npm` is on your PATH (or add it via System Settings → Environment Variables), then open a new terminal.
+
+## Running from a Source Checkout
+
+```bash
+git clone https://github.com/PrimeIntellect-ai/prime-agent
+cd prime-agent
+npm ci
+./prime-agent.sh
+```
+
+The source runner preserves the directory from which it is invoked, so you can call `/path/to/prime-agent/prime-agent.sh` from another project. `./prime-agent.sh --dist` runs the bundled build instead of tsx.
+
+### npm 12 blocks some install scripts
+
+npm 12 gates lifecycle scripts behind its `allow-scripts` policy, so `npm ci` may warn that install scripts for packages such as `esbuild`, `zeromq`, `koffi`, or `canvas` were blocked. This is harmless for Prime Agent:
+
+- `esbuild`, `zeromq`, and `koffi` ship prebuilt binaries and work without their install scripts.
+- `canvas` is a transitive dependency that the source does not import.
+
+If you need a native module that was blocked, allow and rebuild it explicitly:
+
+```bash
+npm install-scripts approve <pkg>
+npm rebuild <pkg>
+```
+
+## IPython Kernel Runtime
+
+The agent's only built-in tool is `ipython`, backed by a managed Python kernel venv at `~/.prime/agent/kernel-venv/`. On first use Prime Agent bootstraps it with uv (Python 3.11 + `ipykernel` + `prime-agent-runtime` + default packages), resolving the venv interpreter at `kernel-venv/Scripts/python.exe` on Windows and `kernel-venv/bin/python` elsewhere.
+
+Older releases resolved the interpreter only at the POSIX path, so automatic bootstrap failed on Windows. On those versions, or to reuse an existing Python instead of the managed venv, set `PRIME_AGENT_KERNEL_PYTHON` to a Python that already has `ipykernel`, `prime-agent-runtime`, and the default packages; Prime Agent validates and uses it without bootstrapping.
+
+Prepare such a Python once (or repair the managed venv):
+
+```bash
+# Create the venv and install the runtime into it
+uv venv ~/.prime/agent/kernel-venv --python 3.11 --seed
+
+# The bundled runtime lives next to the install; adapt the path for source checkouts
+uv pip install --python "$HOME/.prime/agent/kernel-venv/Scripts/python.exe" \
+  ipykernel \
+  "$APPDATA/npm/node_modules/prime-agent/dist/prime-agent-runtime" \
+  dill requests httpx pyyaml tomli python-dotenv pandas numpy scipy beautifulsoup4 lxml pydantic tyro
+
+# Make every Prime Agent process use it
+setx PRIME_AGENT_KERNEL_PYTHON "%USERPROFILE%\.prime\agent\kernel-venv\Scripts\python.exe"
+```
+
+Restart your terminals after `setx`. Existing Python environments with `ipykernel` and `prime-agent-runtime` installed also work, as documented under `PRIME_AGENT_KERNEL_PYTHON` in [skills.md](skills.md).
+
+## Known Limitations
+
+- **Use Windows Terminal**: the TUI targets modern terminals; legacy `conhost` windows will render poorly.
+- **Flashing console windows**: some child processes spawn a visible console window that briefly steals focus while they run.
+- **Resume failing with `EPERM`**: a crashed session worker can leave stale locks under `~/.prime/agent/session-leases/`; delete that directory and retry.
+- **`fsync` noise in logs**: Windows cannot fsync directories, which logs `EPERM` errors; they are harmless.
+- **No background suspend**: `app.suspend` (Ctrl+Z) is unavailable on native Windows because Windows terminals lack job control. It works under WSL.
+- **Image paste**: use `Alt+V` (not Ctrl+V) to paste images into the TUI.
 
 ## Custom Shell Path
 

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -342,6 +342,12 @@ export function getKernelVenvDir(): string {
 	return path.join(os.homedir(), ".prime", "agent", "kernel-venv");
 }
 
+// Python venvs place the interpreter at Scripts/python.exe on Windows and at
+// bin/python on POSIX; the platform layout is baked in by the venv tool.
+export function kernelVenvPythonPath(venv: string): string {
+	return process.platform === "win32" ? path.join(venv, "Scripts", "python.exe") : path.join(venv, "bin", "python");
+}
+
 function getXdgKernelVenvDir(): string {
 	const dataHome = process.env.XDG_DATA_HOME
 		? path.resolve(expandHome(process.env.XDG_DATA_HOME))
@@ -725,7 +731,7 @@ async function bootstrapVenv(
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv(options);
-	const python = path.join(venv, "bin", "python");
+	const python = kernelVenvPythonPath(venv);
 	const sourceDir = await resolveRuntimeSourceDir();
 	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
 	const runtimeIdentity = await resolveRuntimeIdentity();
@@ -886,7 +892,7 @@ async function ensureKernelPythonUncached(
 	}
 
 	const venv = await resolveWritableKernelVenvDir();
-	const python = path.join(venv, "bin", "python");
+	const python = kernelVenvPythonPath(venv);
 	const runtimeIdentity = await resolveRuntimeIdentity();
 	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -22,6 +22,7 @@ import {
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import type { LoadExtensionsResult } from "../src/core/extensions/index.js";
+import { kernelVenvPythonPath } from "../src/core/kernel/bootstrap.js";
 import { type HostRequestHandlers, KernelManager } from "../src/core/kernel/index.js";
 import { convertToLlm } from "../src/core/messages.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
@@ -2138,7 +2139,8 @@ describe("AgentSession rlm recursion", () => {
 
 	it("lets a stale kernel depth cap defer to the live host gate", () => {
 		const python =
-			process.env.PRIME_AGENT_KERNEL_PYTHON ?? join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python");
+			process.env.PRIME_AGENT_KERNEL_PYTHON ??
+			kernelVenvPythonPath(join(homedir(), ".prime", "agent", "kernel-venv"));
 		const runtime = join(process.cwd(), "..", "..", "prime-agent-runtime", "src");
 		const probe = spawnSync(
 			python,

--- a/packages/coding-agent/test/ipython-bootstrap.test.ts
+++ b/packages/coding-agent/test/ipython-bootstrap.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
+import { kernelVenvPythonPath } from "../src/core/kernel/bootstrap.js";
 import { KernelManager } from "../src/core/kernel/index.js";
 import { buildRlmBootstrapCode } from "../src/core/tools/ipython.js";
 
@@ -44,7 +45,7 @@ describe("IPython RLM bootstrap", () => {
 function resolveKernelPython(): string | null {
 	const candidates = [
 		process.env.PRIME_AGENT_KERNEL_PYTHON,
-		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+		kernelVenvPythonPath(join(homedir(), ".prime", "agent", "kernel-venv")),
 	].filter((p): p is string => Boolean(p));
 	for (const python of candidates) {
 		if (!existsSync(python)) continue;

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -9,6 +9,7 @@ import {
 	ensureKernelPython,
 	getKernelVenvDir,
 	type KernelPythonSkill,
+	kernelVenvPythonPath,
 	resolveRuntimeIdentity,
 } from "../src/core/kernel/bootstrap.js";
 
@@ -172,6 +173,12 @@ describe("kernel bootstrap", () => {
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
 		expect(getKernelVenvDir()).toBe(venv);
+	});
+
+	it("resolves the venv interpreter for the current platform", () => {
+		const venv = join(tempDir, "kernel-venv");
+		const expected = process.platform === "win32" ? join(venv, "Scripts", "python.exe") : join(venv, "bin", "python");
+		expect(kernelVenvPythonPath(venv)).toBe(expected);
 	});
 
 	it("bootstraps a missing venv with uv, ipykernel, prime-agent-runtime, and default extra packages", async () => {

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -3,13 +3,14 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { kernelVenvPythonPath } from "../src/core/kernel/bootstrap.js";
 import { KernelManager } from "../src/core/kernel/index.js";
 
 /** Find a python that can launch an ipykernel and has dill, or null to skip. */
 function resolveKernelPython(): string | null {
 	const candidates = [
 		process.env.PRIME_AGENT_KERNEL_PYTHON,
-		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+		kernelVenvPythonPath(join(homedir(), ".prime", "agent", "kernel-venv")),
 	].filter((p): p is string => Boolean(p));
 	for (const python of candidates) {
 		if (!existsSync(python)) continue;


### PR DESCRIPTION
## Summary

Fixes the IPython kernel bootstrap failing on Windows. `bootstrap.ts` resolved the kernel venv interpreter at `bin/python` (POSIX layout), but Windows venvs place it at `Scripts\python.exe`, so `uv pip install --python ...\bin\python ...` failed with exit code 2 and the kernel never bootstrapped.

Verified on Windows 11: `ensureKernelPython()` now bootstraps a fresh venv end-to-end and returns `...\kernel-venv\Scripts\python.exe`, and the full `npm run check` (biome, tsgo, installer render, browser smoke) passes.

## Changes

- `src/core/kernel/bootstrap.ts`: added `kernelVenvPythonPath(venv)` switching on `process.platform`, used in `bootstrapVenv` and `ensureKernelPythonUncached`.
- `test/kernel-bootstrap.test.ts`: added a platform-conditional unit test for the venv python path.
- `test/kernel-state-roundtrip.test.ts`, `test/ipython-bootstrap.test.ts`, `test/agent-session-recursion.test.ts`: derive the default venv python candidate from the helper instead of hardcoding `bin/python`.
- `docs/windows.md`: documented the fix and kept the `PRIME_AGENT_KERNEL_PYTHON` workaround for older releases.
- `CHANGELOG.md`: added an Unreleased entry.

## Notes

- `kernel-bootstrap.test.ts` fakes `uv` with a POSIX shell shim and runs on the ubuntu CI; the new path test runs on every platform.
- The real-kernel suites (`kernel-state-roundtrip`, `ipython-bootstrap`) fail on Windows for pre-existing environmental reasons unrelated to this change: `EPERM` while removing a directory the kernel still holds as its CWD, and 8.3 short-name vs long-name `realpath` mismatches.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix kernel venv Python path resolution on Windows in `bootstrap.ts`
> The venv interpreter was hardcoded to `bin/python` (POSIX), causing failures on Windows. Introduces `kernelVenvPythonPath()` in [`bootstrap.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/972/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) that returns `Scripts/python.exe` on `win32` and `bin/python` elsewhere. All call sites in `bootstrapVenv` and `ensureKernelPythonUncached`, plus test helpers, are updated to use this utility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c69bf2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->