### PR TITLE
Keep exported transcripts network-isolated

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed exported transcripts loading model-provided remote images without an explicit viewer action ([#937](https://github.com/PrimeIntellect-ai/prime-agent/issues/937)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/export-html/template.css
+++ b/packages/coding-agent/src/core/export-html/template.css
@@ -881,9 +881,15 @@
     }
 
     .remote-image-link {
+      padding: 0;
+      border: 0;
       color: var(--mdLink);
+      background: transparent;
+      font: inherit;
       font-weight: 600;
+      text-decoration: underline;
       white-space: nowrap;
+      cursor: pointer;
     }
 
     /* Markdown content */

--- a/packages/coding-agent/src/core/export-html/template.css
+++ b/packages/coding-agent/src/core/export-html/template.css
@@ -863,6 +863,29 @@
       margin: var(--line-height) 0;
     }
 
+    .blocked-image {
+      display: inline-flex;
+      align-items: baseline;
+      flex-wrap: wrap;
+      gap: 6px;
+      max-width: 100%;
+      padding: 2px 6px;
+      border: 1px solid var(--dim);
+      border-radius: 3px;
+      color: var(--muted);
+      background: var(--container-bg);
+    }
+
+    .blocked-image-label {
+      overflow-wrap: anywhere;
+    }
+
+    .remote-image-link {
+      color: var(--mdLink);
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
     /* Markdown content */
     .markdown-content h1,
     .markdown-content h2,

--- a/packages/coding-agent/src/core/export-html/template.html
+++ b/packages/coding-agent/src/core/export-html/template.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="x-dns-prefetch-control" content="off">
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none'; font-src 'none'; media-src 'none'; object-src 'none'; frame-src 'none'; worker-src 'none'; manifest-src 'none'; base-uri 'none'; form-action 'none'">
   <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/packages/coding-agent/src/core/export-html/template.html
+++ b/packages/coding-agent/src/core/export-html/template.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none'; font-src 'none'; media-src 'none'; object-src 'none'; frame-src 'none'; worker-src 'none'; manifest-src 'none'; base-uri 'none'; form-action 'none'">
+  <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Session Export</title>
   <style>

--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -676,7 +676,7 @@
         const alt = escapeHtml(token.text || 'image');
         let out = `<span class="blocked-image" role="group"><span class="blocked-image-label">${remoteHref ? 'Remote image blocked' : 'Image blocked'}: ${alt}</span>`;
         if (remoteHref) {
-          out += ' <a class="remote-image-link" href="' + escapeHtml(remoteHref) + '" target="_blank" rel="noopener noreferrer nofollow" referrerpolicy="no-referrer">Open remote image</a>';
+          out += ' <button type="button" class="remote-image-link" data-remote-url="' + escapeHtml(remoteHref) + '">Open remote image</button>';
         }
         out += '</span>';
         return out;
@@ -1581,6 +1581,14 @@
             const entryId = btn.dataset.entryId;
             const shareUrl = buildShareUrl(entryId);
             copyToClipboard(shareUrl, btn);
+          });
+        });
+
+        // Remote URLs stay out of fetchable attributes until this explicit action.
+        messagesEl.querySelectorAll('.remote-image-link').forEach(button => {
+          button.addEventListener('click', () => {
+            const remoteHref = getRemoteImageHref(button.dataset.remoteUrl);
+            if (remoteHref) window.open(remoteHref, '_blank', 'noopener,noreferrer');
           });
         });
 

--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -620,6 +620,78 @@
         return div.innerHTML;
       }
 
+      const SAFE_DATA_IMAGE_URL = /^data:image\/(?:avif|gif|jpeg|png|webp);base64,[a-z0-9+/]*={0,2}$/i;
+      const SAFE_NAVIGATION_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+
+      function getSafeNavigation(href) {
+        const value = typeof href === 'string' ? href.trim() : '';
+        if (!value || /[\u0000-\u001f\u007f]/.test(value)) return null;
+        if (value.startsWith('#')) return { href: value, external: false };
+
+        if (value.startsWith('//')) {
+          try {
+            return { href: new URL(`https:${value}`).href, external: true };
+          } catch {
+            return null;
+          }
+        }
+
+        try {
+          const url = new URL(value, document.baseURI);
+          const hasExplicitProtocol = /^[a-z][a-z0-9+.-]*:/i.test(value);
+          if (hasExplicitProtocol && !SAFE_NAVIGATION_PROTOCOLS.has(url.protocol)) return null;
+          if (!hasExplicitProtocol && !['file:', 'http:', 'https:'].includes(url.protocol)) return null;
+          return {
+            href: value,
+            external: url.protocol === 'http:' || url.protocol === 'https:'
+          };
+        } catch {
+          return null;
+        }
+      }
+
+      function getEmbeddedImageHref(href) {
+        const value = typeof href === 'string' ? href.trim() : '';
+        if (SAFE_DATA_IMAGE_URL.test(value)) return value;
+        if (!value.toLowerCase().startsWith('blob:')) return null;
+        try {
+          return new URL(value).protocol === 'blob:' ? value : null;
+        } catch {
+          return null;
+        }
+      }
+
+      function getRemoteImageHref(href) {
+        const value = typeof href === 'string' ? href.trim() : '';
+        if (!value || /[\u0000-\u001f\u007f]/.test(value)) return null;
+        try {
+          const url = value.startsWith('//') ? new URL(`https:${value}`) : new URL(value, document.baseURI);
+          return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null;
+        } catch {
+          return null;
+        }
+      }
+
+      function renderBlockedImage(token, remoteHref) {
+        const alt = escapeHtml(token.text || 'image');
+        let out = `<span class="blocked-image" role="group"><span class="blocked-image-label">${remoteHref ? 'Remote image blocked' : 'Image blocked'}: ${alt}</span>`;
+        if (remoteHref) {
+          out += ' <a class="remote-image-link" href="' + escapeHtml(remoteHref) + '" target="_blank" rel="noopener noreferrer nofollow" referrerpolicy="no-referrer">Open remote image</a>';
+        }
+        out += '</span>';
+        return out;
+      }
+
+      function renderEmbeddedSessionImage(image, className) {
+        const mimeType = typeof image.mimeType === 'string' ? image.mimeType.toLowerCase() : '';
+        const data = typeof image.data === 'string' ? image.data : '';
+        if (!['image/avif', 'image/gif', 'image/jpeg', 'image/png', 'image/webp'].includes(mimeType) || !data) {
+          return '<span class="blocked-image"><span class="blocked-image-label">Unsupported embedded image blocked</span></span>';
+        }
+        const href = `data:${mimeType};base64,${data}`;
+        return `<img src="${escapeHtml(href)}" class="${className}" alt="Embedded session image" referrerpolicy="no-referrer" loading="lazy" decoding="async" />`;
+      }
+
       /**
        * Truncate string to maxLen chars, append "..." if truncated.
        */
@@ -918,7 +990,7 @@
           const images = getResultImages();
           if (images.length === 0) return '';
           return '<div class="tool-images">' +
-            images.map(img => `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${escapeHtml(img.data || '')}" class="tool-image" />`).join('') +
+            images.map(img => renderEmbeddedSessionImage(img, 'tool-image')).join('') +
             '</div>';
         };
 
@@ -1201,7 +1273,7 @@
                 if (images.length > 0) {
                   html += '<div class="message-images">';
                   for (const img of images) {
-                    html += `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${escapeHtml(img.data || '')}" class="message-image" />`;
+                    html += renderEmbeddedSessionImage(img, 'message-image');
                   }
                   html += '</div>';
                 }
@@ -1223,7 +1295,7 @@
               if (images.length > 0) {
                 html += '<div class="message-images">';
                 for (const img of images) {
-                  html += `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${escapeHtml(img.data || '')}" class="message-image" />`;
+                  html += renderEmbeddedSessionImage(img, 'message-image');
                 }
                 html += '</div>';
               }
@@ -1566,24 +1638,26 @@
         renderer: {
           // Sanitize link URLs to prevent javascript:/vbscript:/data: XSS
           link(token) {
-            const href = (token.href || '').trim();
-            if (/^\s*(javascript|vbscript|data):/i.test(href)) {
+            const navigation = getSafeNavigation(token.href);
+            if (!navigation) {
               return this.parser.parseInline(token.tokens);
             }
-            let out = '<a href="' + escapeHtml(href) + '"';
+            let out = '<a href="' + escapeHtml(navigation.href) + '"';
             if (token.title) {
               out += ' title="' + escapeHtml(token.title) + '"';
+            }
+            if (navigation.external) {
+              out += ' target="_blank" rel="noopener noreferrer nofollow" referrerpolicy="no-referrer"';
             }
             out += '>' + this.parser.parseInline(token.tokens) + '</a>';
             return out;
           },
-          // Sanitize image src URLs
+          // Keep the export network-isolated. Embedded raster data and existing
+          // blob URLs are safe to render; remote resources require a user click.
           image(token) {
-            const href = (token.href || '').trim();
-            if (/^\s*(javascript|vbscript|data):/i.test(href)) {
-              return escapeHtml(token.text || '');
-            }
-            let out = '<img src="' + escapeHtml(href) + '" alt="' + escapeHtml(token.text || '') + '"';
+            const embeddedHref = getEmbeddedImageHref(token.href);
+            if (!embeddedHref) return renderBlockedImage(token, getRemoteImageHref(token.href));
+            let out = '<img src="' + escapeHtml(embeddedHref) + '" alt="' + escapeHtml(token.text || '') + '" referrerpolicy="no-referrer" loading="lazy" decoding="async"';
             if (token.title) {
               out += ' title="' + escapeHtml(token.title) + '"';
             }

--- a/packages/coding-agent/test/export-html-xss.test.ts
+++ b/packages/coding-agent/test/export-html-xss.test.ts
@@ -21,6 +21,13 @@ describe("export HTML markdown link sanitization", () => {
 		expect(templateJs).toMatch(/escapeHtml\(remoteHref\)/);
 	});
 
+	it("defers remote image navigation until an explicit button activation", () => {
+		expect(templateJs).toContain('class="remote-image-link" data-remote-url="');
+		expect(templateJs).not.toContain('class="remote-image-link" href="');
+		expect(templateJs).toMatch(/getRemoteImageHref\(button\.dataset\.remoteUrl\)/);
+		expect(templateJs).toContain("window.open(remoteHref, '_blank', 'noopener,noreferrer')");
+	});
+
 	it("allowlists embedded session image MIME types", () => {
 		expect(templateJs).not.toMatch(/\$\{img\.mimeType\}/);
 		expect(templateJs).toMatch(/\['image\/avif', 'image\/gif', 'image\/jpeg', 'image\/png', 'image\/webp'\]/);

--- a/packages/coding-agent/test/export-html-xss.test.ts
+++ b/packages/coding-agent/test/export-html-xss.test.ts
@@ -5,31 +5,35 @@ describe("export HTML markdown link sanitization", () => {
 	const templateJs = readFileSync(new URL("../src/core/export-html/template.js", import.meta.url), "utf-8");
 
 	it("overrides the marked link renderer to block javascript: protocol", () => {
-		// The custom link renderer must check for dangerous protocols
 		expect(templateJs).toMatch(/link\s*\(\s*token\s*\)/);
-		expect(templateJs).toMatch(/javascript/i);
-		expect(templateJs).toMatch(/vbscript/i);
+		expect(templateJs).toMatch(/getSafeNavigation\(token\.href\)/);
+		expect(templateJs).toMatch(/SAFE_NAVIGATION_PROTOCOLS/);
 	});
 
-	it("overrides the marked image renderer to block javascript: protocol", () => {
+	it("overrides the marked image renderer to isolate remote resources", () => {
 		expect(templateJs).toMatch(/image\s*\(\s*token\s*\)/);
+		expect(templateJs).toMatch(/getEmbeddedImageHref\(token\.href\)/);
+		expect(templateJs).toMatch(/renderBlockedImage\(token, getRemoteImageHref\(token\.href\)\)/);
 	});
 
 	it("escapes href attributes in the custom link renderer", () => {
-		// The link renderer must escape href values to prevent attribute breakout
-		expect(templateJs).toMatch(/escapeHtml\(href\)/);
+		expect(templateJs).toMatch(/escapeHtml\(navigation\.href\)/);
+		expect(templateJs).toMatch(/escapeHtml\(remoteHref\)/);
 	});
 
-	it("escapes image mimeType attributes", () => {
-		// Image mimeType must be escaped to prevent attribute breakout
+	it("allowlists embedded session image MIME types", () => {
 		expect(templateJs).not.toMatch(/\$\{img\.mimeType\}/);
-		expect(templateJs).toMatch(/escapeHtml\(img\.mimeType/);
+		expect(templateJs).toMatch(/\['image\/avif', 'image\/gif', 'image\/jpeg', 'image\/png', 'image\/webp'\]/);
 	});
 
 	it("escapes image data attributes", () => {
-		// Image data is embedded in src attributes and must not allow attribute breakout.
 		expect(templateJs).not.toMatch(/;base64,\$\{img\.data\}"/);
-		expect(templateJs).toMatch(/;base64,\$\{escapeHtml\(img\.data \|\| (?:''|"")\)\}"/);
+		expect(templateJs).toMatch(/escapeHtml\(href\)/);
+	});
+
+	it("adds no-referrer isolation to external links and embedded images", () => {
+		expect(templateJs).toContain('rel="noopener noreferrer nofollow" referrerpolicy="no-referrer"');
+		expect(templateJs).toContain('referrerpolicy="no-referrer" loading="lazy" decoding="async"');
 	});
 
 	it("escapes entry IDs before inserting them into attributes", () => {

--- a/packages/coding-agent/test/suite/regressions/937-network-isolated-exports.test.ts
+++ b/packages/coding-agent/test/suite/regressions/937-network-isolated-exports.test.ts
@@ -60,6 +60,7 @@ function dumpDom(chromePath: string, url: string, userDataDir: string): Promise<
 				"--host-resolver-rules=MAP network-isolation.test 127.0.0.1,EXCLUDE localhost",
 				"--no-proxy-server",
 				`--user-data-dir=${userDataDir}`,
+				"--timeout=5000",
 				"--dump-dom",
 				url,
 			],
@@ -81,7 +82,7 @@ function dumpDom(chromePath: string, url: string, userDataDir: string): Promise<
 				`Timed out waiting for the export browser smoke test (stdout: ${Buffer.concat(stdout).length} bytes): ${Buffer.concat(stderr).toString("utf8")}`,
 			);
 			stopBrowser("SIGKILL");
-		}, 20_000);
+		}, 30_000);
 
 		child.stdout.on("data", (chunk: Buffer) => {
 			stdout.push(chunk);
@@ -232,6 +233,6 @@ describe("#937 network-isolated transcript exports", () => {
 			await dumpDom(chromePath, redirectUrl, join(harness.tempDir, "chrome-explicit-navigation"));
 			expect(remoteRequests.filter((path) => path !== "/favicon.ico")).toEqual(["/redirect.png", "/final.png"]);
 		},
-		30_000,
+		60_000,
 	);
 });

--- a/packages/coding-agent/test/suite/regressions/937-network-isolated-exports.test.ts
+++ b/packages/coding-agent/test/suite/regressions/937-network-isolated-exports.test.ts
@@ -51,13 +51,14 @@ function dumpDom(chromePath: string, url: string, userDataDir: string): Promise<
 			[
 				"--headless=new",
 				"--disable-gpu",
-				"--disable-background-networking",
 				"--disable-component-update",
 				"--disable-default-apps",
 				"--disable-dev-shm-usage",
 				"--disable-sync",
 				"--metrics-recording-only",
 				"--no-first-run",
+				"--host-resolver-rules=MAP network-isolation.test 127.0.0.1,EXCLUDE localhost",
+				"--no-proxy-server",
 				`--user-data-dir=${userDataDir}`,
 				"--dump-dom",
 				url,
@@ -137,6 +138,9 @@ describe("#937 network-isolated transcript exports", () => {
 			"utf8",
 		);
 		expect(templateHtml).toContain("default-src 'none'");
+		expect(templateHtml).toContain('<meta http-equiv="x-dns-prefetch-control" content="off">');
+		expect(templateHtml.indexOf('http-equiv="x-dns-prefetch-control"')).toBeLessThan(templateHtml.indexOf("<style>"));
+		expect(templateHtml).not.toMatch(/rel=["']dns-prefetch["']/i);
 		expect(templateHtml).toContain("img-src data: blob:");
 		expect(templateHtml).toContain("connect-src 'none'");
 		expect(templateHtml).toContain("media-src 'none'");
@@ -171,11 +175,11 @@ describe("#937 network-isolated transcript exports", () => {
 			servers.push(remoteServer);
 			const remotePort = await listen(remoteServer);
 
-			const httpUrl = `http://127.0.0.1:${remotePort}/http.png`;
-			const httpsUrl = `https://127.0.0.1:${remotePort}/https.png`;
-			const protocolRelativeUrl = `//127.0.0.1:${remotePort}/protocol-relative.png`;
-			const redirectUrl = `http://127.0.0.1:${remotePort}/redirect.png`;
-			const safeLinkUrl = `http://127.0.0.1:${remotePort}/docs`;
+			const httpUrl = `http://network-isolation.test:${remotePort}/http.png`;
+			const httpsUrl = `https://network-isolation.test:${remotePort}/https.png`;
+			const protocolRelativeUrl = `//network-isolation.test:${remotePort}/protocol-relative.png`;
+			const redirectUrl = `http://network-isolation.test:${remotePort}/redirect.png`;
+			const safeLinkUrl = `http://network-isolation.test:${remotePort}/docs`;
 			const blobUrl = "blob:null/00000000-0000-4000-8000-000000000937";
 			const markdown = [
 				`![http-image](${httpUrl})`,
@@ -199,17 +203,22 @@ describe("#937 network-isolated transcript exports", () => {
 
 			expect(remoteConnections).toBe(0);
 			expect(remoteRequests).toEqual([]);
-			expect(dom).toContain(`href="${httpUrl}"`);
-			expect(dom).toContain(`href="${httpsUrl}"`);
-			expect(dom).toContain(`href="https://127.0.0.1:${remotePort}/protocol-relative.png"`);
-			expect(dom).toContain(`href="${redirectUrl}"`);
+			expect(dom).toContain(`data-remote-url="${httpUrl}"`);
+			expect(dom).toContain(`data-remote-url="${httpsUrl}"`);
+			expect(dom).toContain(`data-remote-url="https://network-isolation.test:${remotePort}/protocol-relative.png"`);
+			expect(dom).toContain(`data-remote-url="${redirectUrl}"`);
+			expect(dom).toContain('<button type="button" class="remote-image-link" data-remote-url=');
 			expect(dom).toContain(
 				`<a href="${safeLinkUrl}" target="_blank" rel="noopener noreferrer nofollow" referrerpolicy="no-referrer">safe-link</a>`,
 			);
 			expect(dom).not.toContain(`src="${httpUrl}"`);
 			expect(dom).not.toContain(`src="${httpsUrl}"`);
-			expect(dom).not.toContain(`src="//127.0.0.1:${remotePort}/protocol-relative.png"`);
+			expect(dom).not.toContain(`src="//network-isolation.test:${remotePort}/protocol-relative.png"`);
 			expect(dom).not.toContain(`src="${redirectUrl}"`);
+			expect(dom).not.toContain(`href="${httpUrl}"`);
+			expect(dom).not.toContain(`href="${httpsUrl}"`);
+			expect(dom).not.toContain(`href="https://network-isolation.test:${remotePort}/protocol-relative.png"`);
+			expect(dom).not.toContain(`href="${redirectUrl}"`);
 			expect(dom).toContain("Remote image blocked: http-image");
 			expect(dom).toContain("Remote image blocked: https-image");
 			expect(dom).toContain("Remote image blocked: protocol-relative-image");

--- a/packages/coding-agent/test/suite/regressions/937-network-isolated-exports.test.ts
+++ b/packages/coding-agent/test/suite/regressions/937-network-isolated-exports.test.ts
@@ -1,0 +1,228 @@
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import type { Server } from "node:http";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { exportSessionToHtml } from "../../../src/core/export-html/index.js";
+import { createHarness, type Harness } from "../harness.js";
+
+const ONE_PIXEL_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+function findChromeExecutable(): string | undefined {
+	const candidates = [
+		process.env.CHROME_PATH,
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/usr/bin/google-chrome",
+		"/usr/bin/google-chrome-stable",
+		"/usr/bin/chromium",
+		"/usr/bin/chromium-browser",
+	].filter((candidate): candidate is string => Boolean(candidate));
+	return candidates.find((candidate) => existsSync(candidate));
+}
+
+function listen(server: Server): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve((server.address() as AddressInfo).port);
+		});
+	});
+}
+
+function close(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+}
+
+function dumpDom(chromePath: string, url: string, userDataDir: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		let completedOutput: string | undefined;
+		let pendingError: Error | undefined;
+		let forceKill: NodeJS.Timeout | undefined;
+		const child = spawn(
+			chromePath,
+			[
+				"--headless=new",
+				"--disable-gpu",
+				"--disable-background-networking",
+				"--disable-component-update",
+				"--disable-default-apps",
+				"--disable-dev-shm-usage",
+				"--disable-sync",
+				"--metrics-recording-only",
+				"--no-first-run",
+				`--user-data-dir=${userDataDir}`,
+				"--dump-dom",
+				url,
+			],
+			{ detached: true, stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const stopBrowser = (signal: NodeJS.Signals): void => {
+			if (!child.pid) return;
+			try {
+				process.kill(-child.pid, signal);
+			} catch {
+				child.kill(signal);
+			}
+		};
+		const stdout: Buffer[] = [];
+		const stderr: Buffer[] = [];
+		const timeout = setTimeout(() => {
+			if (settled) return;
+			pendingError = new Error(
+				`Timed out waiting for the export browser smoke test (stdout: ${Buffer.concat(stdout).length} bytes): ${Buffer.concat(stderr).toString("utf8")}`,
+			);
+			stopBrowser("SIGKILL");
+		}, 20_000);
+
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout.push(chunk);
+			const output = Buffer.concat(stdout).toString("utf8");
+			if (!settled && !completedOutput && output.includes("</body></html>")) {
+				completedOutput = output;
+				clearTimeout(timeout);
+				stopBrowser("SIGTERM");
+				forceKill = setTimeout(() => stopBrowser("SIGKILL"), 1_000);
+			}
+		});
+		child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+		child.once("error", (error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			reject(error);
+		});
+		child.once("close", (code) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			if (forceKill) clearTimeout(forceKill);
+			if (pendingError) {
+				reject(pendingError);
+				return;
+			}
+			if (completedOutput) {
+				resolve(completedOutput);
+				return;
+			}
+			if (code !== 0) {
+				reject(new Error(`Chrome exited with ${code}: ${Buffer.concat(stderr).toString("utf8")}`));
+				return;
+			}
+			resolve(Buffer.concat(stdout).toString("utf8"));
+		});
+	});
+}
+
+describe("#937 network-isolated transcript exports", () => {
+	let harness: Harness | undefined;
+	const servers: Server[] = [];
+
+	afterEach(async () => {
+		harness?.cleanup();
+		harness = undefined;
+		await Promise.all(servers.splice(0).map((server) => close(server)));
+	});
+
+	it("ships a CSP that denies implicit network-capable subresources", () => {
+		const templateHtml = readFileSync(
+			new URL("../../../src/core/export-html/template.html", import.meta.url),
+			"utf8",
+		);
+		expect(templateHtml).toContain("default-src 'none'");
+		expect(templateHtml).toContain("img-src data: blob:");
+		expect(templateHtml).toContain("connect-src 'none'");
+		expect(templateHtml).toContain("media-src 'none'");
+		expect(templateHtml).toContain("object-src 'none'");
+		expect(templateHtml).toContain("frame-src 'none'");
+		expect(templateHtml).toContain("base-uri 'none'");
+		expect(templateHtml).toContain("form-action 'none'");
+		expect(templateHtml).toContain('<meta name="referrer" content="no-referrer">');
+	});
+
+	it.skipIf(!findChromeExecutable())(
+		"blocks HTTP, HTTPS, protocol-relative, malformed, and redirect images until explicit navigation",
+		async () => {
+			const chromePath = findChromeExecutable();
+			if (!chromePath) throw new Error("Chrome executable disappeared during the test");
+
+			const remoteRequests: string[] = [];
+			let remoteConnections = 0;
+			const remoteServer = createServer((request, response) => {
+				remoteRequests.push(request.url ?? "");
+				if (request.url === "/redirect.png") {
+					response.writeHead(302, { Location: "/final.png" });
+					response.end();
+					return;
+				}
+				response.writeHead(200, { "Content-Type": "image/png" });
+				response.end(Buffer.from(ONE_PIXEL_PNG, "base64"));
+			});
+			remoteServer.on("connection", () => {
+				remoteConnections += 1;
+			});
+			servers.push(remoteServer);
+			const remotePort = await listen(remoteServer);
+
+			const httpUrl = `http://127.0.0.1:${remotePort}/http.png`;
+			const httpsUrl = `https://127.0.0.1:${remotePort}/https.png`;
+			const protocolRelativeUrl = `//127.0.0.1:${remotePort}/protocol-relative.png`;
+			const redirectUrl = `http://127.0.0.1:${remotePort}/redirect.png`;
+			const safeLinkUrl = `http://127.0.0.1:${remotePort}/docs`;
+			const blobUrl = "blob:null/00000000-0000-4000-8000-000000000937";
+			const markdown = [
+				`![http-image](${httpUrl})`,
+				`![https-image](${httpsUrl})`,
+				`![protocol-relative-image](${protocolRelativeUrl})`,
+				`![redirect-image](${redirectUrl})`,
+				`![data-image](data:image/png;base64,${ONE_PIXEL_PNG})`,
+				`![blob-image](${blobUrl})`,
+				"![malformed-image](http://%)",
+				`[safe-link](${safeLinkUrl})`,
+				"[unsafe-link](javascript:alert(1))",
+			].join("\n\n");
+
+			harness = await createHarness({ persistSession: true });
+			harness.setResponses([fauxAssistantMessage(markdown)]);
+			await harness.session.prompt("render image policy fixtures");
+			const outputPath = join(harness.tempDir, "network-isolation.html");
+			await exportSessionToHtml(harness.sessionManager, undefined, { outputPath });
+
+			const dom = await dumpDom(chromePath, pathToFileURL(outputPath).href, join(harness.tempDir, "chrome"));
+
+			expect(remoteConnections).toBe(0);
+			expect(remoteRequests).toEqual([]);
+			expect(dom).toContain(`href="${httpUrl}"`);
+			expect(dom).toContain(`href="${httpsUrl}"`);
+			expect(dom).toContain(`href="https://127.0.0.1:${remotePort}/protocol-relative.png"`);
+			expect(dom).toContain(`href="${redirectUrl}"`);
+			expect(dom).toContain(
+				`<a href="${safeLinkUrl}" target="_blank" rel="noopener noreferrer nofollow" referrerpolicy="no-referrer">safe-link</a>`,
+			);
+			expect(dom).not.toContain(`src="${httpUrl}"`);
+			expect(dom).not.toContain(`src="${httpsUrl}"`);
+			expect(dom).not.toContain(`src="//127.0.0.1:${remotePort}/protocol-relative.png"`);
+			expect(dom).not.toContain(`src="${redirectUrl}"`);
+			expect(dom).toContain("Remote image blocked: http-image");
+			expect(dom).toContain("Remote image blocked: https-image");
+			expect(dom).toContain("Remote image blocked: protocol-relative-image");
+			expect(dom).toContain("Remote image blocked: redirect-image");
+			expect(dom).toContain('target="_blank" rel="noopener noreferrer nofollow" referrerpolicy="no-referrer"');
+			expect(dom).toContain(`src="data:image/png;base64,${ONE_PIXEL_PNG}"`);
+			expect(dom).toContain(`src="${blobUrl}"`);
+			expect(dom).toContain("Image blocked: malformed-image");
+			expect(dom).not.toContain('href="javascript:alert(1)"');
+
+			await dumpDom(chromePath, redirectUrl, join(harness.tempDir, "chrome-explicit-navigation"));
+			expect(remoteRequests.filter((path) => path !== "/favicon.ico")).toEqual(["/redirect.png", "/final.png"]);
+		},
+		30_000,
+	);
+});


### PR DESCRIPTION
## Summary

- prevent exported transcripts from loading or DNS-prefetching HTTP, HTTPS, protocol-relative, or redirecting images automatically
- render safe raster `data:` and `blob:` images inline while presenting remote images as explicit no-referrer button controls
- apply a restrictive CSP to deny network-capable subresources and harden exported Markdown links
- add browser coverage with a faux-provider export and local request sentinel

## Root cause

The export Markdown renderer inserted arbitrary non-script image URLs directly into `img src`, and the standalone document had no CSP to prevent those resources from loading. Remote URLs now remain outside browser-fetchable attributes until activation, with DNS prefetch disabled for the document.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/export-html-xss.test.ts test/export-html-whitespace.test.ts test/export-html-skill-block.test.ts test/theme-export.test.ts test/suite/regressions/937-network-isolated-exports.test.ts`
- `npm run check`

Fixes #937


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block auto-loading of remote images in exported HTML transcripts
> - Adds a Content-Security-Policy meta tag, `no-referrer` referrer policy, and disabled DNS prefetch to [template.html](https://github.com/PrimeIntellect-ai/prime-agent/pull/973/files#diff-0779e3003fd3a49e9ca0f8b7da648003a268eedce8157ca8d2a819014cb86c76) so exported transcripts make no implicit network requests when opened.
> - Overrides the `marked` image and link renderers in [template.js](https://github.com/PrimeIntellect-ai/prime-agent/pull/973/files#diff-8728c647526efa374399082e679dc04ba40d1cd54fcee0c1b4692bdbb40dd83a) to block `http`/`https` image URLs, replacing them with a labeled notice and an explicit "Open remote image" button that opens in a new tab with `noopener noreferrer`.
> - Only `data:` URLs with allowlisted MIME types and `blob:` URLs are rendered as `<img>` tags; all other image sources are blocked.
> - External links are rewritten to open in a new tab with `rel="noopener noreferrer nofollow"` and `referrerpolicy="no-referrer"`.
> - Behavioral Change: exported transcripts that previously auto-loaded remote images will now show a blocked-image placeholder instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddec5c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->