### PR TITLE
fix(ai): make OAuth waits terminal and leak-free

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed OAuth login callback waits hanging on terminal errors and leaking abort listeners during GitHub Copilot polling ([#938](https://github.com/PrimeIntellect-ai/prime-agent/issues/938))
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -30,6 +30,8 @@ export type {
 	OAuthAuthInfo,
 	OAuthCredentials,
 	OAuthLoginCallbacks,
+	OAuthLoginErrorCode,
+	OAuthLoginErrorSource,
 	OAuthPrompt,
 	OAuthProvider,
 	OAuthProviderId,
@@ -38,6 +40,7 @@ export type {
 	OAuthSelectOption,
 	OAuthSelectPrompt,
 } from "./utils/oauth/types.js";
+export { OAuthLoginError } from "./utils/oauth/types.js";
 export * from "./utils/overflow.js";
 export * from "./utils/stream-failure.js";
 export * from "./utils/typebox-helpers.js";

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -4,7 +4,18 @@
 import type { Server } from "node:http";
 import { oauthErrorHtml, oauthSuccessHtml } from "../utils/oauth/oauth-page.js";
 import { generatePKCE } from "../utils/oauth/pkce.js";
-import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "../utils/oauth/types.js";
+import {
+	connectOAuthManualInput,
+	createOAuthTerminalWaiter,
+	type OAuthTerminalWaiter,
+	toOAuthLoginError,
+} from "../utils/oauth/terminal-waiter.js";
+import {
+	type OAuthCredentials,
+	type OAuthLoginCallbacks,
+	OAuthLoginError,
+	type OAuthProviderInterface,
+} from "../utils/oauth/types.js";
 
 const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 // A range (not one port) so a leaked/concurrent login can't wedge all logins with EADDRINUSE.
@@ -107,25 +118,19 @@ async function registerClient(registrationEndpoint: string, label: string): Prom
 	return data.client_id;
 }
 
-type CallbackResult = { code: string; state: string } | null;
+type CallbackResult = { code: string; state: string };
 
-async function startCallbackServer(label: string): Promise<{
+async function startCallbackServer(
+	label: string,
+	expectedState: string,
+	options?: { callbackTimeoutMs?: number; signal?: AbortSignal },
+): Promise<{
 	server: Server;
 	redirectUri: string;
-	cancel: () => void;
-	waitForCode: () => Promise<CallbackResult>;
+	waiter: OAuthTerminalWaiter<CallbackResult>;
 }> {
 	const { createServer } = await import("node:http");
-	let settle: ((value: CallbackResult) => void) | undefined;
-	const waitPromise = new Promise<CallbackResult>((resolve) => {
-		let settled = false;
-		settle = (value) => {
-			if (!settled) {
-				settled = true;
-				resolve(value);
-			}
-		};
-	});
+	let waiter: OAuthTerminalWaiter<CallbackResult> | undefined;
 
 	const handler = (req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => {
 		const url = new URL(req.url || "", "http://localhost");
@@ -137,19 +142,26 @@ async function startCallbackServer(label: string): Promise<{
 		const error = url.searchParams.get("error");
 		const code = url.searchParams.get("code");
 		const state = url.searchParams.get("state");
-		res.writeHead(error || !code ? 400 : 200, { "Content-Type": "text/html; charset=utf-8" });
+		res.writeHead(error || !code || !state || state !== expectedState ? 400 : 200, {
+			"Content-Type": "text/html; charset=utf-8",
+		});
 		if (error) {
 			res.end(oauthErrorHtml(`${label} authentication failed.`, `Error: ${error}`));
-			settle?.(null);
+			waiter?.fail(new OAuthLoginError("authorization_error", "browser", `${label} authorization failed: ${error}`));
 			return;
 		}
 		if (!code || !state) {
 			res.end(oauthErrorHtml("Missing code or state parameter."));
-			settle?.(null);
+			waiter?.fail(new OAuthLoginError("invalid_callback", "browser", "Missing code or state parameter"));
+			return;
+		}
+		if (state !== expectedState) {
+			res.end(oauthErrorHtml("State mismatch."));
+			waiter?.fail(new OAuthLoginError("state_mismatch", "browser", "OAuth state mismatch"));
 			return;
 		}
 		res.end(oauthSuccessHtml(`${label} authentication completed. You can close this window.`));
-		settle?.({ code, state });
+		waiter?.succeed({ code, state });
 	};
 
 	// Try each candidate port with a FRESH server (a server that failed to listen
@@ -159,7 +171,13 @@ async function startCallbackServer(label: string): Promise<{
 		const server = createServer(handler);
 		// Persistent handler so a post-bind 'error' is never an unhandled crash.
 		let bindErr: ((err: unknown) => void) | undefined;
-		server.on("error", (err) => bindErr?.(err));
+		server.on("error", (err) => {
+			if (bindErr) {
+				bindErr(err);
+				return;
+			}
+			waiter?.fail(toOAuthLoginError(err, "callback_server_error", "server"));
+		});
 		try {
 			const bound = await new Promise<boolean>((resolve) => {
 				bindErr = () => resolve(false);
@@ -169,11 +187,14 @@ async function startCallbackServer(label: string): Promise<{
 				});
 			});
 			if (bound) {
+				waiter = createOAuthTerminalWaiter<CallbackResult>({
+					timeoutMs: options?.callbackTimeoutMs,
+					signal: options?.signal,
+				});
 				return {
 					server,
 					redirectUri: redirectUriFor(port),
-					cancel: () => settle?.(null),
-					waitForCode: () => waitPromise,
+					waiter,
 				};
 			}
 			lastError = `port ${port} in use`;
@@ -194,20 +215,26 @@ function parseRedirectInput(input: string, expectedState: string): { code: strin
 	const value = input.trim();
 	let code: string | undefined;
 	let state: string | undefined;
+	let error: string | undefined;
 	try {
 		const url = new URL(value);
 		code = url.searchParams.get("code") ?? undefined;
 		state = url.searchParams.get("state") ?? undefined;
+		error = url.searchParams.get("error") ?? undefined;
 	} catch {
 		const params = new URLSearchParams(value);
 		code = params.get("code") ?? value;
 		state = params.get("state") ?? undefined;
+		error = params.get("error") ?? undefined;
+	}
+	if (error) {
+		throw new OAuthLoginError("authorization_error", "manual", `${error}`);
 	}
 	if (state && state !== expectedState) {
-		throw new Error("OAuth state mismatch");
+		throw new OAuthLoginError("state_mismatch", "manual", "OAuth state mismatch");
 	}
 	if (!code) {
-		throw new Error("Missing authorization code");
+		throw new OAuthLoginError("invalid_callback", "manual", "Missing authorization code");
 	}
 	return { code, state: state ?? expectedState };
 }
@@ -251,6 +278,9 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): OAuthProviderInt
 	const label = config.label ?? config.server;
 
 	async function login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+		if (callbacks.signal?.aborted) {
+			throw new OAuthLoginError("cancelled", "signal", "Login cancelled");
+		}
 		const meta = await discover(config.url);
 		callbacks.onProgress?.(`Discovered ${meta.issuer ?? new URL(config.url).origin}`);
 
@@ -271,7 +301,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): OAuthProviderInt
 		// secret used at token exchange, while `state` is echoed on the redirect URL.
 		const state = randomState();
 		const scope = config.scopes ?? meta.scopes_supported?.join(" ");
-		const cb = await startCallbackServer(label);
+		const cb = await startCallbackServer(label, state, callbacks);
 		try {
 			const authParams = new URLSearchParams({
 				client_id: clientId,
@@ -289,55 +319,15 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): OAuthProviderInt
 					"Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.",
 			});
 
-			// Race the local callback server against a manual paste (browser on
-			// another machine). The login dialog supplies onManualCodeInput; when
-			// absent we fall back to a blocking prompt after the callback resolves.
-			let result: { code: string; state: string } | null;
-			let manualCancelled = false;
-			let manualError: Error | undefined;
+			// Race the local callback server against a manual paste from another machine.
 			if (callbacks.onManualCodeInput) {
-				// Manual paste races the browser callback. A real paste cancels the
-				// callback waiter (we're done). On manual cancellation we still settle
-				// the waiter to avoid hanging when no redirect arrives — but only after
-				// a short grace period so an in-flight browser redirect can win first.
-				const manual = callbacks
-					.onManualCodeInput()
-					.then((input) => {
-						const parsed = parseRedirectInput(input, state); // may throw a validation error
-						cb.cancel();
-						return parsed;
-					})
-					.catch(async (err) => {
-						// A validation error on a real paste (bad state / no code) is a genuine
-						// failure to surface; a UI cancellation is not. .catch also prevents an
-						// unhandled rejection when the callback wins the race.
-						if (err instanceof Error && /state mismatch|authorization code/i.test(err.message)) {
-							manualError = err;
-						} else {
-							manualCancelled = true;
-						}
-						await new Promise((r) => setTimeout(r, 500));
-						cb.cancel();
-						return null;
-					});
-				const fromCallback = await cb.waitForCode();
-				result = fromCallback ?? (await manual);
-				if (!result && manualError) throw manualError;
-			} else {
-				result = await cb.waitForCode();
-				if (!result) {
-					const input = await callbacks.onPrompt({
-						message: "Paste the authorization code or full redirect URL:",
-						placeholder: cb.redirectUri,
-					});
-					result = parseRedirectInput(input, state);
-				}
+				connectOAuthManualInput(cb.waiter, callbacks.onManualCodeInput, (input) =>
+					parseRedirectInput(input, state),
+				);
 			}
-			if (!result) {
-				throw new Error(manualCancelled ? "Login cancelled" : "Missing authorization code");
-			}
+			const result = await cb.waiter.wait();
 			if (result.state !== state) {
-				throw new Error("OAuth state mismatch");
+				throw new OAuthLoginError("state_mismatch", "browser", "OAuth state mismatch");
 			}
 
 			callbacks.onProgress?.("Exchanging authorization code for tokens…");
@@ -350,6 +340,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): OAuthProviderInt
 			});
 			return toCredentials(token, meta.token_endpoint, clientId);
 		} finally {
+			cb.waiter.fail(new OAuthLoginError("cancelled", "server", "OAuth callback wait closed"));
 			cb.server.close();
 		}
 	}

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -171,6 +171,7 @@ async function startCallbackServer(
 		const server = createServer(handler);
 		// Persistent handler so a post-bind 'error' is never an unhandled crash.
 		let bindErr: ((err: unknown) => void) | undefined;
+		let bindFailure: unknown;
 		server.on("error", (err) => {
 			if (bindErr) {
 				bindErr(err);
@@ -180,7 +181,10 @@ async function startCallbackServer(
 		});
 		try {
 			const bound = await new Promise<boolean>((resolve) => {
-				bindErr = () => resolve(false);
+				bindErr = (error) => {
+					bindFailure = error;
+					resolve(false);
+				};
 				server.listen(port, CALLBACK_HOST, () => {
 					bindErr = undefined;
 					resolve(true);
@@ -197,17 +201,20 @@ async function startCallbackServer(
 					waiter,
 				};
 			}
-			lastError = `port ${port} in use`;
+			lastError = bindFailure ?? new Error(`port ${port} in use`);
 			server.close();
 		} catch (err) {
 			lastError = err;
 			server.close();
 		}
 	}
-	throw new Error(
+	throw new OAuthLoginError(
+		"callback_server_error",
+		"server",
 		`Could not start the OAuth callback server: ports ${CALLBACK_PORT_BASE}-${
 			CALLBACK_PORT_BASE + CALLBACK_PORT_COUNT - 1
 		} are all in use. Close other login attempts and retry. (${String(lastError)})`,
+		{ cause: lastError },
 	);
 }
 

--- a/packages/ai/src/utils/oauth/anthropic.ts
+++ b/packages/ai/src/utils/oauth/anthropic.ts
@@ -8,13 +8,27 @@
 import type { Server } from "node:http";
 import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
 import { generatePKCE } from "./pkce.js";
-import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from "./types.js";
+import {
+	connectOAuthManualInput,
+	createOAuthTerminalWaiter,
+	type OAuthTerminalWaiter,
+	toOAuthLoginError,
+} from "./terminal-waiter.js";
+import {
+	type OAuthCredentials,
+	type OAuthLoginCallbacks,
+	OAuthLoginError,
+	type OAuthLoginErrorSource,
+	type OAuthPrompt,
+	type OAuthProviderInterface,
+} from "./types.js";
+
+type AuthorizationResult = { code: string; state: string };
 
 type CallbackServerInfo = {
 	server: Server;
 	redirectUri: string;
-	cancelWait: () => void;
-	waitForCode: () => Promise<{ code: string; state: string } | null>;
+	waiter: OAuthTerminalWaiter<AuthorizationResult>;
 };
 
 type NodeApis = {
@@ -48,7 +62,7 @@ async function getNodeApis(): Promise<NodeApis> {
 	return nodeApis;
 }
 
-function parseAuthorizationInput(input: string): { code?: string; state?: string } {
+function parseAuthorizationInput(input: string): { code?: string; state?: string; error?: string } {
 	const value = input.trim();
 	if (!value) return {};
 
@@ -57,6 +71,7 @@ function parseAuthorizationInput(input: string): { code?: string; state?: string
 		return {
 			code: url.searchParams.get("code") ?? undefined,
 			state: url.searchParams.get("state") ?? undefined,
+			error: url.searchParams.get("error") ?? undefined,
 		};
 	} catch {
 		// not a URL
@@ -67,11 +82,12 @@ function parseAuthorizationInput(input: string): { code?: string; state?: string
 		return { code, state };
 	}
 
-	if (value.includes("code=")) {
+	if (value.includes("=")) {
 		const params = new URLSearchParams(value);
 		return {
 			code: params.get("code") ?? undefined,
 			state: params.get("state") ?? undefined,
+			error: params.get("error") ?? undefined,
 		};
 	}
 
@@ -95,19 +111,15 @@ function formatErrorDetails(error: unknown): string {
 	return String(error);
 }
 
-async function startCallbackServer(expectedState: string): Promise<CallbackServerInfo> {
+async function startCallbackServer(
+	expectedState: string,
+	options?: { callbackTimeoutMs?: number; signal?: AbortSignal },
+): Promise<CallbackServerInfo> {
 	const { createServer } = await getNodeApis();
 
 	return new Promise((resolve, reject) => {
-		let settleWait: ((value: { code: string; state: string } | null) => void) | undefined;
-		const waitForCodePromise = new Promise<{ code: string; state: string } | null>((resolveWait) => {
-			let settled = false;
-			settleWait = (value) => {
-				if (settled) return;
-				settled = true;
-				resolveWait(value);
-			};
-		});
+		let waiter: OAuthTerminalWaiter<AuthorizationResult> | undefined;
+		let listening = false;
 
 		const server = createServer((req, res) => {
 			try {
@@ -125,45 +137,75 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
 				if (error) {
 					res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
 					res.end(oauthErrorHtml("Anthropic authentication did not complete.", `Error: ${error}`));
+					waiter?.fail(
+						new OAuthLoginError("authorization_error", "browser", `Anthropic authorization failed: ${error}`),
+					);
 					return;
 				}
 
 				if (!code || !state) {
 					res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
 					res.end(oauthErrorHtml("Missing code or state parameter."));
+					waiter?.fail(new OAuthLoginError("invalid_callback", "browser", "Missing code or state parameter"));
 					return;
 				}
 
 				if (state !== expectedState) {
 					res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
 					res.end(oauthErrorHtml("State mismatch."));
+					waiter?.fail(new OAuthLoginError("state_mismatch", "browser", "OAuth state mismatch"));
 					return;
 				}
 
 				res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
 				res.end(oauthSuccessHtml("Anthropic authentication completed. You can close this window."));
-				settleWait?.({ code, state });
-			} catch {
+				waiter?.succeed({ code, state });
+			} catch (error) {
 				res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
 				res.end("Internal error");
+				waiter?.fail(toOAuthLoginError(error, "invalid_callback", "browser"));
 			}
 		});
 
-		server.on("error", (err) => {
-			reject(err);
+		server.on("error", (error) => {
+			if (listening) {
+				waiter?.fail(toOAuthLoginError(error, "callback_server_error", "server"));
+				return;
+			}
+			reject(error);
 		});
 
 		server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
+			listening = true;
+			waiter = createOAuthTerminalWaiter<AuthorizationResult>({
+				timeoutMs: options?.callbackTimeoutMs,
+				signal: options?.signal,
+			});
 			resolve({
 				server,
 				redirectUri: REDIRECT_URI,
-				cancelWait: () => {
-					settleWait?.(null);
-				},
-				waitForCode: () => waitForCodePromise,
+				waiter,
 			});
 		});
 	});
+}
+
+function parseAuthorizationResult(
+	input: string,
+	expectedState: string,
+	source: OAuthLoginErrorSource,
+): AuthorizationResult {
+	const parsed = parseAuthorizationInput(input);
+	if (parsed.error) {
+		throw new OAuthLoginError("authorization_error", source, `Anthropic authorization failed: ${parsed.error}`);
+	}
+	if (parsed.state && parsed.state !== expectedState) {
+		throw new OAuthLoginError("state_mismatch", source, "OAuth state mismatch");
+	}
+	if (!parsed.code) {
+		throw new OAuthLoginError("invalid_callback", source, "Missing authorization code");
+	}
+	return { code: parsed.code, state: parsed.state ?? expectedState };
 }
 
 async function postJson(url: string, body: Record<string, string | number>): Promise<string> {
@@ -232,9 +274,14 @@ export async function loginAnthropic(options: {
 	onPrompt: (prompt: OAuthPrompt) => Promise<string>;
 	onProgress?: (message: string) => void;
 	onManualCodeInput?: () => Promise<string>;
+	signal?: AbortSignal;
+	callbackTimeoutMs?: number;
 }): Promise<OAuthCredentials> {
+	if (options.signal?.aborted) {
+		throw new OAuthLoginError("cancelled", "signal", "Login cancelled");
+	}
 	const { verifier, challenge } = await generatePKCE();
-	const server = await startCallbackServer(verifier);
+	const server = await startCallbackServer(verifier, options);
 
 	let code: string | undefined;
 	let state: string | undefined;
@@ -259,72 +306,23 @@ export async function loginAnthropic(options: {
 		});
 
 		if (options.onManualCodeInput) {
-			let manualInput: string | undefined;
-			let manualError: Error | undefined;
-			const manualPromise = options
-				.onManualCodeInput()
-				.then((input) => {
-					manualInput = input;
-					server.cancelWait();
-				})
-				.catch((err) => {
-					manualError = err instanceof Error ? err : new Error(String(err));
-					server.cancelWait();
-				});
-
-			const result = await server.waitForCode();
-
-			if (manualError) {
-				throw manualError;
-			}
-
-			if (result?.code) {
-				code = result.code;
-				state = result.state;
-				redirectUriForExchange = REDIRECT_URI;
-			} else if (manualInput) {
-				const parsed = parseAuthorizationInput(manualInput);
-				if (parsed.state && parsed.state !== verifier) {
-					throw new Error("OAuth state mismatch");
-				}
-				code = parsed.code;
-				state = parsed.state ?? verifier;
-			}
-
-			if (!code) {
-				await manualPromise;
-				if (manualError) {
-					throw manualError;
-				}
-				if (manualInput) {
-					const parsed = parseAuthorizationInput(manualInput);
-					if (parsed.state && parsed.state !== verifier) {
-						throw new Error("OAuth state mismatch");
-					}
-					code = parsed.code;
-					state = parsed.state ?? verifier;
-				}
-			}
-		} else {
-			const result = await server.waitForCode();
-			if (result?.code) {
-				code = result.code;
-				state = result.state;
-				redirectUriForExchange = REDIRECT_URI;
-			}
+			connectOAuthManualInput(server.waiter, options.onManualCodeInput, (input) =>
+				parseAuthorizationResult(input, verifier, "manual"),
+			);
 		}
+		const result = await server.waiter.wait();
+		code = result.code;
+		state = result.state;
+		redirectUriForExchange = REDIRECT_URI;
 
 		if (!code) {
 			const input = await options.onPrompt({
 				message: "Paste the authorization code or full redirect URL:",
 				placeholder: REDIRECT_URI,
 			});
-			const parsed = parseAuthorizationInput(input);
-			if (parsed.state && parsed.state !== verifier) {
-				throw new Error("OAuth state mismatch");
-			}
+			const parsed = parseAuthorizationResult(input, verifier, "manual");
 			code = parsed.code;
-			state = parsed.state ?? verifier;
+			state = parsed.state;
 		}
 
 		if (!code) {
@@ -338,6 +336,7 @@ export async function loginAnthropic(options: {
 		options.onProgress?.("Exchanging authorization code for tokens...");
 		return exchangeAuthorizationCode(code, state, verifier, redirectUriForExchange);
 	} finally {
+		server.waiter.fail(new OAuthLoginError("cancelled", "server", "OAuth callback wait closed"));
 		server.server.close();
 	}
 }
@@ -389,6 +388,8 @@ export const anthropicOAuthProvider: OAuthProviderInterface = {
 			onPrompt: callbacks.onPrompt,
 			onProgress: callbacks.onProgress,
 			onManualCodeInput: callbacks.onManualCodeInput,
+			signal: callbacks.signal,
+			callbackTimeoutMs: callbacks.callbackTimeoutMs,
 		});
 	},
 

--- a/packages/ai/src/utils/oauth/anthropic.ts
+++ b/packages/ai/src/utils/oauth/anthropic.ts
@@ -172,7 +172,7 @@ async function startCallbackServer(
 				waiter?.fail(toOAuthLoginError(error, "callback_server_error", "server"));
 				return;
 			}
-			reject(error);
+			reject(toOAuthLoginError(error, "callback_server_error", "server"));
 		});
 
 		server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {

--- a/packages/ai/src/utils/oauth/github-copilot.ts
+++ b/packages/ai/src/utils/oauth/github-copilot.ts
@@ -4,7 +4,12 @@
 
 import { getModels } from "../../models.js";
 import type { Api, Model } from "../../types.js";
-import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+import {
+	type OAuthCredentials,
+	type OAuthLoginCallbacks,
+	OAuthLoginError,
+	type OAuthProviderInterface,
+} from "./types.js";
 
 type CopilotCredentials = OAuthCredentials & {
 	enterpriseUrl?: string;
@@ -150,20 +155,21 @@ async function startDeviceFlow(domain: string): Promise<DeviceCodeResponse> {
 function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
 	return new Promise((resolve, reject) => {
 		if (signal?.aborted) {
-			reject(new Error("Login cancelled"));
+			reject(new OAuthLoginError("cancelled", "signal", "Login cancelled"));
 			return;
 		}
 
-		const timeout = setTimeout(resolve, ms);
+		const onAbort = () => {
+			clearTimeout(timeout);
+			signal?.removeEventListener("abort", onAbort);
+			reject(new OAuthLoginError("cancelled", "signal", "Login cancelled"));
+		};
+		const timeout = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
 
-		signal?.addEventListener(
-			"abort",
-			() => {
-				clearTimeout(timeout);
-				reject(new Error("Login cancelled"));
-			},
-			{ once: true },
-		);
+		signal?.addEventListener("abort", onAbort, { once: true });
 	});
 }
 
@@ -182,7 +188,7 @@ async function pollForGitHubAccessToken(
 
 	while (Date.now() < deadline) {
 		if (signal?.aborted) {
-			throw new Error("Login cancelled");
+			throw new OAuthLoginError("cancelled", "signal", "Login cancelled");
 		}
 
 		const remainingMs = deadline - Date.now();
@@ -330,6 +336,9 @@ export async function loginGitHubCopilot(options: {
 	onProgress?: (message: string) => void;
 	signal?: AbortSignal;
 }): Promise<OAuthCredentials> {
+	if (options.signal?.aborted) {
+		throw new OAuthLoginError("cancelled", "signal", "Login cancelled");
+	}
 	const input = await options.onPrompt({
 		message: "GitHub Enterprise URL/domain (blank for github.com)",
 		placeholder: "company.ghe.com",
@@ -337,7 +346,7 @@ export async function loginGitHubCopilot(options: {
 	});
 
 	if (options.signal?.aborted) {
-		throw new Error("Login cancelled");
+		throw new OAuthLoginError("cancelled", "signal", "Login cancelled");
 	}
 
 	const trimmed = input.trim();

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -19,7 +19,20 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
 
 import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js";
 import { generatePKCE } from "./pkce.js";
-import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from "./types.js";
+import {
+	connectOAuthManualInput,
+	createOAuthTerminalWaiter,
+	type OAuthTerminalWaiter,
+	toOAuthLoginError,
+} from "./terminal-waiter.js";
+import {
+	type OAuthCredentials,
+	type OAuthLoginCallbacks,
+	OAuthLoginError,
+	type OAuthLoginErrorSource,
+	type OAuthPrompt,
+	type OAuthProviderInterface,
+} from "./types.js";
 
 const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -47,7 +60,7 @@ function createState(): string {
 	return _randomBytes(16).toString("hex");
 }
 
-function parseAuthorizationInput(input: string): { code?: string; state?: string } {
+function parseAuthorizationInput(input: string): { code?: string; state?: string; error?: string } {
 	const value = input.trim();
 	if (!value) return {};
 
@@ -56,6 +69,7 @@ function parseAuthorizationInput(input: string): { code?: string; state?: string
 		return {
 			code: url.searchParams.get("code") ?? undefined,
 			state: url.searchParams.get("state") ?? undefined,
+			error: url.searchParams.get("error") ?? undefined,
 		};
 	} catch {
 		// not a URL
@@ -66,11 +80,12 @@ function parseAuthorizationInput(input: string): { code?: string; state?: string
 		return { code, state };
 	}
 
-	if (value.includes("code=")) {
+	if (value.includes("=")) {
 		const params = new URLSearchParams(value);
 		return {
 			code: params.get("code") ?? undefined,
 			state: params.get("state") ?? undefined,
+			error: params.get("error") ?? undefined,
 		};
 	}
 
@@ -205,26 +220,29 @@ async function createAuthorizationFlow(
 	return { verifier, state, url: url.toString() };
 }
 
-type OAuthServerInfo = {
-	close: () => void;
-	cancelWait: () => void;
-	waitForCode: () => Promise<{ code: string } | null>;
-};
+type OAuthCode = { code: string };
 
-function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
+type OAuthServerInfo =
+	| {
+			available: true;
+			close: () => void;
+			waiter: OAuthTerminalWaiter<OAuthCode>;
+	  }
+	| {
+			available: false;
+			close: () => void;
+	  };
+
+function startLocalOAuthServer(
+	state: string,
+	options?: { callbackTimeoutMs?: number; signal?: AbortSignal },
+): Promise<OAuthServerInfo> {
 	if (!_http) {
 		throw new Error("OpenAI Codex OAuth is only available in Node.js environments");
 	}
 
-	let settleWait: ((value: { code: string } | null) => void) | undefined;
-	const waitForCodePromise = new Promise<{ code: string } | null>((resolve) => {
-		let settled = false;
-		settleWait = (value) => {
-			if (settled) return;
-			settled = true;
-			resolve(value);
-		};
-	});
+	let waiter: OAuthTerminalWaiter<OAuthCode> | undefined;
+	let listening = false;
 
 	const server = _http.createServer((req, res) => {
 		try {
@@ -235,10 +253,21 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 				res.end(oauthErrorHtml("Callback route not found."));
 				return;
 			}
+			const error = url.searchParams.get("error");
+			if (error) {
+				res.statusCode = 400;
+				res.setHeader("Content-Type", "text/html; charset=utf-8");
+				res.end(oauthErrorHtml("OpenAI authentication did not complete.", `Error: ${error}`));
+				waiter?.fail(
+					new OAuthLoginError("authorization_error", "browser", `OpenAI authorization failed: ${error}`),
+				);
+				return;
+			}
 			if (url.searchParams.get("state") !== state) {
 				res.statusCode = 400;
 				res.setHeader("Content-Type", "text/html; charset=utf-8");
 				res.end(oauthErrorHtml("State mismatch."));
+				waiter?.fail(new OAuthLoginError("state_mismatch", "browser", "OAuth state mismatch"));
 				return;
 			}
 			const code = url.searchParams.get("code");
@@ -246,33 +275,42 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 				res.statusCode = 400;
 				res.setHeader("Content-Type", "text/html; charset=utf-8");
 				res.end(oauthErrorHtml("Missing authorization code."));
+				waiter?.fail(new OAuthLoginError("invalid_callback", "browser", "Missing authorization code"));
 				return;
 			}
 			res.statusCode = 200;
 			res.setHeader("Content-Type", "text/html; charset=utf-8");
 			res.end(oauthSuccessHtml("OpenAI authentication completed. You can close this window."));
-			settleWait?.({ code });
-		} catch {
+			waiter?.succeed({ code });
+		} catch (error) {
 			res.statusCode = 500;
 			res.setHeader("Content-Type", "text/html; charset=utf-8");
 			res.end(oauthErrorHtml("Internal error while processing OAuth callback."));
+			waiter?.fail(toOAuthLoginError(error, "invalid_callback", "browser"));
 		}
 	});
 
 	return new Promise((resolve) => {
 		server
 			.listen(1455, CALLBACK_HOST, () => {
+				listening = true;
+				waiter = createOAuthTerminalWaiter<OAuthCode>({
+					timeoutMs: options?.callbackTimeoutMs,
+					signal: options?.signal,
+				});
 				resolve({
+					available: true,
 					close: () => server.close(),
-					cancelWait: () => {
-						settleWait?.(null);
-					},
-					waitForCode: () => waitForCodePromise,
+					waiter,
 				});
 			})
-			.on("error", (_err: NodeJS.ErrnoException) => {
-				settleWait?.(null);
+			.on("error", (error: NodeJS.ErrnoException) => {
+				if (listening) {
+					waiter?.fail(toOAuthLoginError(error, "callback_server_error", "server"));
+					return;
+				}
 				resolve({
+					available: false,
 					close: () => {
 						try {
 							server.close();
@@ -280,11 +318,23 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 							// ignore
 						}
 					},
-					cancelWait: () => {},
-					waitForCode: async () => null,
 				});
 			});
 	});
+}
+
+function parseAuthorizationResult(input: string, state: string, source: OAuthLoginErrorSource): OAuthCode {
+	const parsed = parseAuthorizationInput(input);
+	if (parsed.error) {
+		throw new OAuthLoginError("authorization_error", source, `OpenAI authorization failed: ${parsed.error}`);
+	}
+	if (parsed.state && parsed.state !== state) {
+		throw new OAuthLoginError("state_mismatch", source, "OAuth state mismatch");
+	}
+	if (!parsed.code) {
+		throw new OAuthLoginError("invalid_callback", source, "Missing authorization code");
+	}
+	return { code: parsed.code };
 }
 
 function getAccountId(accessToken: string): string | null {
@@ -311,67 +361,33 @@ export async function loginOpenAICodex(options: {
 	onProgress?: (message: string) => void;
 	onManualCodeInput?: () => Promise<string>;
 	originator?: string;
+	signal?: AbortSignal;
+	callbackTimeoutMs?: number;
 }): Promise<OAuthCredentials> {
+	if (options.signal?.aborted) {
+		throw new OAuthLoginError("cancelled", "signal", "Login cancelled");
+	}
 	const { verifier, state, url } = await createAuthorizationFlow(options.originator);
-	const server = await startLocalOAuthServer(state);
-
-	options.onAuth({ url, instructions: "A browser window should open. Complete login to finish." });
+	const server = await startLocalOAuthServer(state, options);
 
 	let code: string | undefined;
 	try {
-		if (options.onManualCodeInput) {
-			// Race between browser callback and manual input
-			let manualCode: string | undefined;
-			let manualError: Error | undefined;
-			const manualPromise = options
-				.onManualCodeInput()
-				.then((input) => {
-					manualCode = input;
-					server.cancelWait();
-				})
-				.catch((err) => {
-					manualError = err instanceof Error ? err : new Error(String(err));
-					server.cancelWait();
-				});
+		options.onAuth({ url, instructions: "A browser window should open. Complete login to finish." });
 
-			const result = await server.waitForCode();
-
-			// If manual input was cancelled, throw that error
-			if (manualError) {
-				throw manualError;
+		if (server.available) {
+			if (options.onManualCodeInput) {
+				connectOAuthManualInput(server.waiter, options.onManualCodeInput, (input) =>
+					parseAuthorizationResult(input, state, "manual"),
+				);
 			}
-
-			if (result?.code) {
-				// Browser callback won
-				code = result.code;
-			} else if (manualCode) {
-				// Manual input won (or callback timed out and user had entered code)
-				const parsed = parseAuthorizationInput(manualCode);
-				if (parsed.state && parsed.state !== state) {
-					throw new Error("State mismatch");
-				}
-				code = parsed.code;
-			}
-
-			// If still no code, wait for manual promise to complete and try that
-			if (!code) {
-				await manualPromise;
-				if (manualError) {
-					throw manualError;
-				}
-				if (manualCode) {
-					const parsed = parseAuthorizationInput(manualCode);
-					if (parsed.state && parsed.state !== state) {
-						throw new Error("State mismatch");
-					}
-					code = parsed.code;
-				}
-			}
+			code = (await server.waiter.wait()).code;
 		} else {
-			// Original flow: wait for callback, then prompt if needed
-			const result = await server.waitForCode();
-			if (result?.code) {
-				code = result.code;
+			if (options.onManualCodeInput) {
+				try {
+					code = parseAuthorizationResult(await options.onManualCodeInput(), state, "manual").code;
+				} catch (error) {
+					throw toOAuthLoginError(error, "cancelled", "manual");
+				}
 			}
 		}
 
@@ -380,11 +396,7 @@ export async function loginOpenAICodex(options: {
 			const input = await options.onPrompt({
 				message: "Paste the authorization code (or full redirect URL):",
 			});
-			const parsed = parseAuthorizationInput(input);
-			if (parsed.state && parsed.state !== state) {
-				throw new Error("State mismatch");
-			}
-			code = parsed.code;
+			code = parseAuthorizationResult(input, state, "manual").code;
 		}
 
 		if (!code) {
@@ -408,6 +420,9 @@ export async function loginOpenAICodex(options: {
 			accountId,
 		};
 	} finally {
+		if (server.available) {
+			server.waiter.fail(new OAuthLoginError("cancelled", "server", "OAuth callback wait closed"));
+		}
 		server.close();
 	}
 }
@@ -445,6 +460,8 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 			onPrompt: callbacks.onPrompt,
 			onProgress: callbacks.onProgress,
 			onManualCodeInput: callbacks.onManualCodeInput,
+			signal: callbacks.signal,
+			callbackTimeoutMs: callbacks.callbackTimeoutMs,
 		});
 	},
 

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -371,6 +371,7 @@ export async function loginOpenAICodex(options: {
 	const server = await startLocalOAuthServer(state, options);
 
 	let code: string | undefined;
+	let manualWaiter: OAuthTerminalWaiter<OAuthCode> | undefined;
 	try {
 		options.onAuth({ url, instructions: "A browser window should open. Complete login to finish." });
 
@@ -382,21 +383,20 @@ export async function loginOpenAICodex(options: {
 			}
 			code = (await server.waiter.wait()).code;
 		} else {
-			if (options.onManualCodeInput) {
-				try {
-					code = parseAuthorizationResult(await options.onManualCodeInput(), state, "manual").code;
-				} catch (error) {
-					throw toOAuthLoginError(error, "cancelled", "manual");
-				}
-			}
-		}
-
-		// Fallback to onPrompt if still no code
-		if (!code) {
-			const input = await options.onPrompt({
-				message: "Paste the authorization code (or full redirect URL):",
+			manualWaiter = createOAuthTerminalWaiter<OAuthCode>({
+				timeoutMs: options.callbackTimeoutMs,
+				signal: options.signal,
 			});
-			code = parseAuthorizationResult(input, state, "manual").code;
+			connectOAuthManualInput(
+				manualWaiter,
+				options.onManualCodeInput ??
+					(() =>
+						options.onPrompt({
+							message: "Paste the authorization code (or full redirect URL):",
+						})),
+				(input) => parseAuthorizationResult(input, state, "manual"),
+			);
+			code = (await manualWaiter.wait()).code;
 		}
 
 		if (!code) {
@@ -420,6 +420,7 @@ export async function loginOpenAICodex(options: {
 			accountId,
 		};
 	} finally {
+		manualWaiter?.fail(new OAuthLoginError("cancelled", "server", "OAuth manual callback wait closed"));
 		if (server.available) {
 			server.waiter.fail(new OAuthLoginError("cancelled", "server", "OAuth callback wait closed"));
 		}

--- a/packages/ai/src/utils/oauth/terminal-waiter.ts
+++ b/packages/ai/src/utils/oauth/terminal-waiter.ts
@@ -1,0 +1,113 @@
+import { OAuthLoginError, type OAuthLoginErrorCode, type OAuthLoginErrorSource } from "./types.js";
+
+export const DEFAULT_OAUTH_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface OAuthTerminalWaiter<T> {
+	wait: () => Promise<T>;
+	succeed: (value: T) => boolean;
+	fail: (error: OAuthLoginError) => boolean;
+}
+
+export function toOAuthLoginError(
+	error: unknown,
+	code: OAuthLoginErrorCode,
+	source: OAuthLoginErrorSource,
+): OAuthLoginError {
+	if (error instanceof OAuthLoginError) return error;
+	return new OAuthLoginError(code, source, error instanceof Error ? error.message : String(error));
+}
+
+export function createOAuthTerminalWaiter<T>(options?: {
+	timeoutMs?: number;
+	signal?: AbortSignal;
+}): OAuthTerminalWaiter<T> {
+	const requestedTimeout = options?.timeoutMs ?? DEFAULT_OAUTH_CALLBACK_TIMEOUT_MS;
+	const timeoutMs = Number.isFinite(requestedTimeout)
+		? Math.max(1, requestedTimeout)
+		: DEFAULT_OAUTH_CALLBACK_TIMEOUT_MS;
+	let settled = false;
+	let abortListenerAttached = false;
+	let resolveWait: ((value: T) => void) | undefined;
+	let rejectWait: ((error: OAuthLoginError) => void) | undefined;
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+
+	const waitPromise = new Promise<T>((resolve, reject) => {
+		resolveWait = resolve;
+		rejectWait = reject;
+	});
+	void waitPromise.catch(() => {});
+
+	const onAbort = () => {
+		fail(new OAuthLoginError("cancelled", "signal", "Login cancelled"));
+	};
+
+	const cleanup = () => {
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+			timeout = undefined;
+		}
+		if (abortListenerAttached) {
+			options?.signal?.removeEventListener("abort", onAbort);
+			abortListenerAttached = false;
+		}
+	};
+
+	const succeed = (value: T): boolean => {
+		if (settled) return false;
+		settled = true;
+		cleanup();
+		resolveWait?.(value);
+		return true;
+	};
+
+	const fail = (error: OAuthLoginError): boolean => {
+		if (settled) return false;
+		settled = true;
+		cleanup();
+		rejectWait?.(error);
+		return true;
+	};
+
+	if (options?.signal?.aborted) {
+		fail(new OAuthLoginError("cancelled", "signal", "Login cancelled"));
+	} else {
+		options?.signal?.addEventListener("abort", onAbort, { once: true });
+		abortListenerAttached = options?.signal !== undefined;
+		timeout = setTimeout(() => {
+			fail(new OAuthLoginError("timeout", "timeout", "OAuth callback timed out"));
+		}, timeoutMs);
+	}
+
+	return {
+		wait: () => waitPromise,
+		succeed,
+		fail,
+	};
+}
+
+export function connectOAuthManualInput<T>(
+	waiter: OAuthTerminalWaiter<T>,
+	readInput: () => Promise<string>,
+	parseInput: (input: string) => T,
+): void {
+	let inputPromise: Promise<string>;
+	try {
+		inputPromise = readInput();
+	} catch (error) {
+		waiter.fail(toOAuthLoginError(error, "cancelled", "manual"));
+		return;
+	}
+
+	void inputPromise.then(
+		(input) => {
+			try {
+				waiter.succeed(parseInput(input));
+			} catch (error) {
+				waiter.fail(toOAuthLoginError(error, "invalid_callback", "manual"));
+			}
+		},
+		(error) => {
+			waiter.fail(toOAuthLoginError(error, "cancelled", "manual"));
+		},
+	);
+}

--- a/packages/ai/src/utils/oauth/terminal-waiter.ts
+++ b/packages/ai/src/utils/oauth/terminal-waiter.ts
@@ -14,7 +14,7 @@ export function toOAuthLoginError(
 	source: OAuthLoginErrorSource,
 ): OAuthLoginError {
 	if (error instanceof OAuthLoginError) return error;
-	return new OAuthLoginError(code, source, error instanceof Error ? error.message : String(error));
+	return new OAuthLoginError(code, source, error instanceof Error ? error.message : String(error), { cause: error });
 }
 
 export function createOAuthTerminalWaiter<T>(options?: {

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -37,8 +37,8 @@ export class OAuthLoginError extends Error {
 	readonly code: OAuthLoginErrorCode;
 	readonly source: OAuthLoginErrorSource;
 
-	constructor(code: OAuthLoginErrorCode, source: OAuthLoginErrorSource, message: string) {
-		super(message);
+	constructor(code: OAuthLoginErrorCode, source: OAuthLoginErrorSource, message: string, options?: ErrorOptions) {
+		super(message, options);
 		this.name = "OAuthLoginError";
 		this.code = code;
 		this.source = source;

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -23,6 +23,28 @@ export type OAuthAuthInfo = {
 	instructions?: string;
 };
 
+export type OAuthLoginErrorCode =
+	| "authorization_error"
+	| "invalid_callback"
+	| "callback_server_error"
+	| "state_mismatch"
+	| "timeout"
+	| "cancelled";
+
+export type OAuthLoginErrorSource = "browser" | "manual" | "server" | "signal" | "timeout";
+
+export class OAuthLoginError extends Error {
+	readonly code: OAuthLoginErrorCode;
+	readonly source: OAuthLoginErrorSource;
+
+	constructor(code: OAuthLoginErrorCode, source: OAuthLoginErrorSource, message: string) {
+		super(message);
+		this.name = "OAuthLoginError";
+		this.code = code;
+		this.source = source;
+	}
+}
+
 export type OAuthSelectOption = {
 	id: string;
 	label: string;
@@ -41,6 +63,8 @@ export interface OAuthLoginCallbacks {
 	/** Show an interactive selector and return the selected option id, or undefined on cancel. */
 	onSelect?: (prompt: OAuthSelectPrompt) => Promise<string | undefined>;
 	signal?: AbortSignal;
+	/** Maximum time to wait for a browser or manual callback. */
+	callbackTimeoutMs?: number;
 }
 
 export interface OAuthProviderInterface {

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loginAnthropic, refreshAnthropicToken } from "../src/utils/oauth/anthropic.js";
+import type { OAuthLoginError } from "../src/utils/oauth/types.js";
+
+const fetchFromNetwork = globalThis.fetch.bind(globalThis);
 
 function jsonResponse(body: unknown, status: number = 200): Response {
 	return new Response(JSON.stringify(body), {
@@ -71,6 +74,113 @@ describe.sequential("Anthropic OAuth", () => {
 		expect(credentials.access).toBe("access-token");
 		expect(credentials.refresh).toBe("refresh-token");
 		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("settles a manual authorization error with a typed error", async () => {
+		let authUrl = "";
+		const loginPromise = loginAnthropic({
+			onAuth: ({ url }) => {
+				authUrl = url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const url = new URL(authUrl);
+				const state = url.searchParams.get("state") ?? "";
+				const redirectUri = url.searchParams.get("redirect_uri") ?? "";
+				return `${redirectUri}?error=access_denied&state=${encodeURIComponent(state)}`;
+			},
+		});
+
+		await expect(loginPromise).rejects.toMatchObject({
+			code: "authorization_error",
+			source: "manual",
+		});
+	});
+
+	it.each([
+		{
+			name: "authorization error",
+			query: (state: string) => `error=access_denied&state=${encodeURIComponent(state)}`,
+			code: "authorization_error",
+		},
+		{
+			name: "missing code",
+			query: (state: string) => `state=${encodeURIComponent(state)}`,
+			code: "invalid_callback",
+		},
+		{
+			name: "state mismatch",
+			query: () => "code=browser-code&state=wrong-state",
+			code: "state_mismatch",
+		},
+	])("settles the $name browser callback with a typed error", async ({ query, code }) => {
+		let callbackRequest: Promise<Response> | undefined;
+		const loginPromise = loginAnthropic({
+			onAuth: ({ url }) => {
+				const authUrl = new URL(url);
+				const state = authUrl.searchParams.get("state") ?? "";
+				const redirectUri = authUrl.searchParams.get("redirect_uri") ?? "";
+				callbackRequest = fetchFromNetwork(`${redirectUri}?${query(state)}`);
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: () => new Promise<string>(() => {}),
+		});
+
+		await expect(loginPromise).rejects.toMatchObject({
+			name: "OAuthLoginError",
+			code,
+			source: "browser",
+		});
+		expect((await callbackRequest)?.status).toBe(400);
+	});
+
+	it("uses the browser result when it settles before manual input", async () => {
+		let callbackRequest: Promise<Response> | undefined;
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			expect(getUrl(input)).toBe("https://platform.claude.com/v1/oauth/token");
+			expect(getJsonBody(init).code).toBe("browser-code");
+			return jsonResponse({ access_token: "access-token", refresh_token: "refresh-token", expires_in: 3600 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await loginAnthropic({
+			onAuth: ({ url }) => {
+				const authUrl = new URL(url);
+				const state = authUrl.searchParams.get("state") ?? "";
+				const redirectUri = authUrl.searchParams.get("redirect_uri") ?? "";
+				callbackRequest = fetchFromNetwork(`${redirectUri}?code=browser-code&state=${encodeURIComponent(state)}`);
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: () => new Promise<string>(() => {}),
+		});
+
+		expect(credentials.access).toBe("access-token");
+		expect((await callbackRequest)?.status).toBe(200);
+	});
+
+	it("rejects with a typed error after the callback timeout", async () => {
+		const onPrompt = vi.fn(async () => "unused");
+		const loginPromise = loginAnthropic({
+			onAuth: () => {},
+			onPrompt,
+			callbackTimeoutMs: 5,
+		});
+
+		await expect(loginPromise).rejects.toMatchObject({ code: "timeout", source: "timeout" });
+		expect(onPrompt).not.toHaveBeenCalled();
+	});
+
+	it("rejects with a typed cancellation when aborted during the callback wait", async () => {
+		const controller = new AbortController();
+		const loginPromise = loginAnthropic({
+			onAuth: () => controller.abort(),
+			onPrompt: async () => "",
+			signal: controller.signal,
+		});
+
+		await expect(loginPromise).rejects.toEqual(
+			expect.objectContaining<Partial<OAuthLoginError>>({ code: "cancelled", source: "signal" }),
+		);
 	});
 
 	it("omits scope from refresh token requests", async () => {

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,6 +1,7 @@
+import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loginAnthropic, refreshAnthropicToken } from "../src/utils/oauth/anthropic.js";
-import type { OAuthLoginError } from "../src/utils/oauth/types.js";
+import { OAuthLoginError } from "../src/utils/oauth/types.js";
 
 const fetchFromNetwork = globalThis.fetch.bind(globalThis);
 
@@ -31,6 +32,20 @@ function getJsonBody(init?: RequestInit): Record<string, string> {
 		throw new Error(`Expected string request body, got ${typeof init?.body}`);
 	}
 	return JSON.parse(init.body) as Record<string, string>;
+}
+
+async function occupyCallbackPort(port: number): Promise<Server | undefined> {
+	const server = createServer();
+	const bound = await new Promise<boolean>((resolve) => {
+		server.once("error", () => resolve(false));
+		server.listen(port, "127.0.0.1", () => resolve(true));
+	});
+	return bound ? server : undefined;
+}
+
+async function closeServer(server: Server | undefined): Promise<void> {
+	if (!server) return;
+	await new Promise<void>((resolve) => server.close(() => resolve()));
 }
 
 describe.sequential("Anthropic OAuth", () => {
@@ -181,6 +196,26 @@ describe.sequential("Anthropic OAuth", () => {
 		await expect(loginPromise).rejects.toEqual(
 			expect.objectContaining<Partial<OAuthLoginError>>({ code: "cancelled", source: "signal" }),
 		);
+	});
+
+	it("returns a typed callback-server error when the callback port is occupied", async () => {
+		const blocker = await occupyCallbackPort(53692);
+		try {
+			const error = await loginAnthropic({ onAuth: () => {}, onPrompt: async () => "" }).then(
+				() => undefined,
+				(reason: unknown) => reason,
+			);
+
+			expect(error).toBeInstanceOf(OAuthLoginError);
+			expect(error).toMatchObject({
+				code: "callback_server_error",
+				source: "server",
+				cause: expect.objectContaining({ code: "EADDRINUSE" }),
+			});
+			expect((error as Error).message).toMatch(/EADDRINUSE|address already in use/i);
+		} finally {
+			await closeServer(blocker);
+		}
 	});
 
 	it("omits scope from refresh token requests", async () => {

--- a/packages/ai/test/github-copilot-oauth.test.ts
+++ b/packages/ai/test/github-copilot-oauth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loginGitHubCopilot } from "../src/utils/oauth/github-copilot.js";
+import type { OAuthLoginError } from "../src/utils/oauth/types.js";
 
 function jsonResponse(body: unknown, status: number = 200): Response {
 	return new Response(JSON.stringify(body), {
@@ -25,6 +26,7 @@ function getUrl(input: unknown): string {
 
 describe("GitHub Copilot OAuth device flow", () => {
 	afterEach(() => {
+		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
 		vi.useRealTimers();
 	});
@@ -192,5 +194,108 @@ describe("GitHub Copilot OAuth device flow", () => {
 			startTime.getTime() + 20000,
 			startTime.getTime() + 25000,
 		]);
+	});
+
+	it("removes each abort listener after repeated polling sleeps", async () => {
+		vi.useFakeTimers();
+		const controller = new AbortController();
+		const addListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+		let polls = 0;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+				if (url.endsWith("/login/device/code")) {
+					return jsonResponse({
+						device_code: "device-code",
+						user_code: "ABCD-EFGH",
+						verification_uri: "https://github.com/login/device",
+						interval: 1,
+						expires_in: 60,
+					});
+				}
+				if (url.endsWith("/login/oauth/access_token")) {
+					polls += 1;
+					return polls < 20
+						? jsonResponse({ error: "authorization_pending" })
+						: jsonResponse({ access_token: "ghu_refresh_token" });
+				}
+				if (url.includes("/copilot_internal/v2/token")) {
+					return jsonResponse({
+						token: "tid=test;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;",
+						expires_at: 9999999999,
+					});
+				}
+				if (url.includes("/models/") && url.endsWith("/policy")) {
+					return new Response("", { status: 200 });
+				}
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			}),
+		);
+
+		const loginPromise = loginGitHubCopilot({
+			onAuth: () => {},
+			onPrompt: async () => "",
+			signal: controller.signal,
+		});
+		await vi.runAllTimersAsync();
+		await loginPromise;
+
+		const abortAdds = addListener.mock.calls.filter(([type]) => type === "abort");
+		const abortRemovals = removeListener.mock.calls.filter(([type]) => type === "abort");
+		expect(abortAdds).toHaveLength(20);
+		expect(abortRemovals).toHaveLength(abortAdds.length);
+	});
+
+	it("rejects a pre-aborted login before prompting or fetching", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const onPrompt = vi.fn(async () => "");
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(loginGitHubCopilot({ onAuth: () => {}, onPrompt, signal: controller.signal })).rejects.toEqual(
+			expect.objectContaining<Partial<OAuthLoginError>>({ code: "cancelled", source: "signal" }),
+		);
+		expect(onPrompt).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects when aborted during a polling sleep and removes the listener", async () => {
+		vi.useFakeTimers();
+		const controller = new AbortController();
+		const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+				if (url.endsWith("/login/device/code")) {
+					return jsonResponse({
+						device_code: "device-code",
+						user_code: "ABCD-EFGH",
+						verification_uri: "https://github.com/login/device",
+						interval: 5,
+						expires_in: 60,
+					});
+				}
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			}),
+		);
+
+		const loginPromise = loginGitHubCopilot({
+			onAuth: () => {},
+			onPrompt: async () => "",
+			signal: controller.signal,
+		});
+		const rejection = expect(loginPromise).rejects.toEqual(
+			expect.objectContaining<Partial<OAuthLoginError>>({ code: "cancelled", source: "signal" }),
+		);
+		await vi.advanceTimersByTimeAsync(0);
+		controller.abort();
+
+		await rejection;
+		expect(removeListener).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/ai/test/mcp-oauth.test.ts
+++ b/packages/ai/test/mcp-oauth.test.ts
@@ -1,6 +1,7 @@
+import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMcpOAuthProvider } from "../src/mcp/oauth.js";
-import type { OAuthLoginError } from "../src/utils/oauth/types.js";
+import { OAuthLoginError } from "../src/utils/oauth/types.js";
 
 const fetchFromNetwork = globalThis.fetch.bind(globalThis);
 
@@ -22,6 +23,32 @@ const META = {
 	registration_endpoint: "https://srv.test/register",
 	scopes_supported: ["read", "write"],
 };
+
+const CALLBACK_PORT_BASE = Number(process.env.PI_MCP_OAUTH_CALLBACK_PORT || 53700);
+
+async function occupyCallbackPort(port: number): Promise<Server | undefined> {
+	const server = createServer();
+	const bound = await new Promise<boolean>((resolve) => {
+		server.once("error", () => resolve(false));
+		server.listen(port, "127.0.0.1", () => resolve(true));
+	});
+	return bound ? server : undefined;
+}
+
+async function closeServers(servers: ReadonlyArray<Server | undefined>): Promise<void> {
+	await Promise.all(
+		servers.map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					if (!server) {
+						resolve();
+						return;
+					}
+					server.close(() => resolve());
+				}),
+		),
+	);
+}
 
 describe.sequential("MCP OAuth provider", () => {
 	afterEach(() => {
@@ -78,13 +105,12 @@ describe.sequential("MCP OAuth provider", () => {
 	});
 
 	it("falls back to the next port when the base callback port is in use", async () => {
-		const http = await import("node:http");
 		// Occupy the base callback port. If something already holds it (e.g. a stray
 		// local daemon), that satisfies the precondition too — bind best-effort.
-		const blocker = http.createServer();
+		const blocker = createServer();
 		const blockerBound = await new Promise<boolean>((resolve) => {
 			blocker.once("error", () => resolve(false));
-			blocker.listen(53700, "127.0.0.1", () => resolve(true));
+			blocker.listen(CALLBACK_PORT_BASE, "127.0.0.1", () => resolve(true));
 		});
 		try {
 			let authUrl = "";
@@ -112,8 +138,9 @@ describe.sequential("MCP OAuth provider", () => {
 			expect(creds.access).toBe("a");
 			// Did NOT use the blocked base port.
 			const redirect = new URL(authUrl).searchParams.get("redirect_uri") ?? "";
-			expect(redirect).not.toContain(":53700/");
-			expect(redirect).toContain(":5370");
+			const redirectPort = Number(new URL(redirect).port);
+			expect(redirectPort).toBeGreaterThan(CALLBACK_PORT_BASE);
+			expect(redirectPort).toBeLessThan(CALLBACK_PORT_BASE + 10);
 		} finally {
 			if (blockerBound) await new Promise<void>((resolve) => blocker.close(() => resolve()));
 		}
@@ -265,6 +292,41 @@ describe.sequential("MCP OAuth provider", () => {
 		);
 	});
 
+	it("returns a typed callback-server error when every callback port is occupied", async () => {
+		const blockers = await Promise.all(
+			Array.from({ length: 10 }, (_, index) => occupyCallbackPort(CALLBACK_PORT_BASE + index)),
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		try {
+			const provider = createMcpOAuthProvider({
+				server: "demo",
+				url: "https://srv.test/mcp",
+				clientId: "client",
+			});
+			const error = await provider.login({ onAuth: () => {}, onPrompt: async () => "" }).then(
+				() => undefined,
+				(reason: unknown) => reason,
+			);
+
+			expect(error).toBeInstanceOf(OAuthLoginError);
+			expect(error).toMatchObject({
+				code: "callback_server_error",
+				source: "server",
+				cause: expect.objectContaining({ code: "EADDRINUSE" }),
+			});
+			expect((error as Error).message).toMatch(/ports .* are all in use/i);
+		} finally {
+			await closeServers(blockers);
+		}
+	});
+
 	it("refreshes tokens, keeping the prior refresh token when omitted", async () => {
 		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
 			const url = urlOf(input);
@@ -308,4 +370,4 @@ describe.sequential("MCP OAuth provider", () => {
 	});
 });
 
-const REDIRECT = `http://localhost:${process.env.PI_MCP_OAUTH_CALLBACK_PORT || 53700}/callback`;
+const REDIRECT = `http://localhost:${CALLBACK_PORT_BASE}/callback`;

--- a/packages/ai/test/mcp-oauth.test.ts
+++ b/packages/ai/test/mcp-oauth.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMcpOAuthProvider } from "../src/mcp/oauth.js";
+import type { OAuthLoginError } from "../src/utils/oauth/types.js";
+
+const fetchFromNetwork = globalThis.fetch.bind(globalThis);
 
 function jsonResponse(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
@@ -114,6 +117,152 @@ describe.sequential("MCP OAuth provider", () => {
 		} finally {
 			if (blockerBound) await new Promise<void>((resolve) => blocker.close(() => resolve()));
 		}
+	});
+
+	it.each([
+		{
+			name: "authorization error",
+			query: (state: string) => `error=access_denied&state=${encodeURIComponent(state)}`,
+			code: "authorization_error",
+		},
+		{
+			name: "missing code",
+			query: (state: string) => `state=${encodeURIComponent(state)}`,
+			code: "invalid_callback",
+		},
+		{
+			name: "state mismatch",
+			query: () => "code=browser-code&state=wrong-state",
+			code: "state_mismatch",
+		},
+	])("settles the $name browser callback with a typed error", async ({ query, code }) => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		let callbackRequest: Promise<Response> | undefined;
+		const provider = createMcpOAuthProvider({ server: "demo", url: "https://srv.test/mcp", clientId: "client" });
+		const loginPromise = provider.login({
+			onAuth: ({ url }) => {
+				const authUrl = new URL(url);
+				const state = authUrl.searchParams.get("state") ?? "";
+				const redirectUri = authUrl.searchParams.get("redirect_uri") ?? "";
+				callbackRequest = fetchFromNetwork(`${redirectUri}?${query(state)}`);
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: () => new Promise<string>(() => {}),
+		});
+
+		await expect(loginPromise).rejects.toMatchObject({
+			name: "OAuthLoginError",
+			code,
+			source: "browser",
+		});
+		expect((await callbackRequest)?.status).toBe(400);
+	});
+
+	it("uses the browser result when it settles before manual input", async () => {
+		let callbackRequest: Promise<Response> | undefined;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = urlOf(input);
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				if (url === META.token_endpoint) {
+					expect(new URLSearchParams(String(init?.body)).get("code")).toBe("browser-code");
+					return jsonResponse({ access_token: "access", refresh_token: "refresh", expires_in: 3600 });
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const provider = createMcpOAuthProvider({ server: "demo", url: "https://srv.test/mcp", clientId: "client" });
+
+		const credentials = await provider.login({
+			onAuth: ({ url }) => {
+				const authUrl = new URL(url);
+				const state = authUrl.searchParams.get("state") ?? "";
+				const redirectUri = authUrl.searchParams.get("redirect_uri") ?? "";
+				callbackRequest = fetchFromNetwork(`${redirectUri}?code=browser-code&state=${encodeURIComponent(state)}`);
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: () => new Promise<string>(() => {}),
+		});
+
+		expect(credentials.access).toBe("access");
+		expect((await callbackRequest)?.status).toBe(200);
+	});
+
+	it("settles a manual authorization error with a typed error", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		let authUrl = "";
+		const provider = createMcpOAuthProvider({ server: "demo", url: "https://srv.test/mcp", clientId: "client" });
+		const loginPromise = provider.login({
+			onAuth: ({ url }) => {
+				authUrl = url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const url = new URL(authUrl);
+				const state = url.searchParams.get("state") ?? "";
+				const redirectUri = url.searchParams.get("redirect_uri") ?? "";
+				return `${redirectUri}?error=access_denied&state=${encodeURIComponent(state)}`;
+			},
+		});
+
+		await expect(loginPromise).rejects.toMatchObject({
+			code: "authorization_error",
+			source: "manual",
+		});
+	});
+
+	it("rejects with a typed error after the callback timeout", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const onPrompt = vi.fn(async () => "unused");
+		const provider = createMcpOAuthProvider({ server: "demo", url: "https://srv.test/mcp", clientId: "client" });
+		const loginPromise = provider.login({ onAuth: () => {}, onPrompt, callbackTimeoutMs: 5 });
+
+		await expect(loginPromise).rejects.toMatchObject({ code: "timeout", source: "timeout" });
+		expect(onPrompt).not.toHaveBeenCalled();
+	});
+
+	it("rejects with a typed cancellation when aborted during the callback wait", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const controller = new AbortController();
+		const provider = createMcpOAuthProvider({ server: "demo", url: "https://srv.test/mcp", clientId: "client" });
+		const loginPromise = provider.login({
+			onAuth: () => controller.abort(),
+			onPrompt: async () => "",
+			signal: controller.signal,
+		});
+
+		await expect(loginPromise).rejects.toEqual(
+			expect.objectContaining<Partial<OAuthLoginError>>({ code: "cancelled", source: "signal" }),
+		);
 	});
 
 	it("refreshes tokens, keeping the prior refresh token when omitted", async () => {

--- a/packages/ai/test/oauth-terminal-waiter.test.ts
+++ b/packages/ai/test/oauth-terminal-waiter.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { connectOAuthManualInput, createOAuthTerminalWaiter } from "../src/utils/oauth/terminal-waiter.js";
+import { OAuthLoginError } from "../src/utils/oauth/types.js";
+
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (error: unknown) => void;
+} {
+	let resolvePromise: ((value: T) => void) | undefined;
+	let rejectPromise: ((error: unknown) => void) | undefined;
+	const promise = new Promise<T>((resolve, reject) => {
+		resolvePromise = resolve;
+		rejectPromise = reject;
+	});
+	return {
+		promise,
+		resolve: (value) => resolvePromise?.(value),
+		reject: (error) => rejectPromise?.(error),
+	};
+}
+
+describe("OAuth terminal waiter", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("uses deterministic first-settler semantics for manual input", async () => {
+		const manual = deferred<string>();
+		const waiter = createOAuthTerminalWaiter<string>();
+		connectOAuthManualInput(
+			waiter,
+			() => manual.promise,
+			(input) => input,
+		);
+
+		manual.resolve("manual-code");
+		expect(await waiter.wait()).toBe("manual-code");
+		expect(waiter.succeed("browser-code")).toBe(false);
+		expect(waiter.fail(new OAuthLoginError("authorization_error", "browser", "late browser error"))).toBe(false);
+	});
+
+	it("ignores a late manual rejection after the browser settles", async () => {
+		const manual = deferred<string>();
+		const waiter = createOAuthTerminalWaiter<string>();
+		connectOAuthManualInput(
+			waiter,
+			() => manual.promise,
+			(input) => input,
+		);
+
+		expect(waiter.succeed("browser-code")).toBe(true);
+		expect(await waiter.wait()).toBe("browser-code");
+		manual.reject(new Error("late manual cancellation"));
+		await Promise.resolve();
+		expect(waiter.succeed("second-browser-code")).toBe(false);
+	});
+
+	it("settles a manual cancellation once with a typed error", async () => {
+		const waiter = createOAuthTerminalWaiter<string>();
+		connectOAuthManualInput(
+			waiter,
+			async () => {
+				throw new Error("dialog cancelled");
+			},
+			(input) => input,
+		);
+
+		await expect(waiter.wait()).rejects.toMatchObject({
+			name: "OAuthLoginError",
+			code: "cancelled",
+			source: "manual",
+			message: "dialog cancelled",
+		});
+		expect(waiter.succeed("late-browser-code")).toBe(false);
+	});
+
+	it("preserves a typed manual validation error", async () => {
+		const waiter = createOAuthTerminalWaiter<string>();
+		connectOAuthManualInput(
+			waiter,
+			async () => "bad-state",
+			() => {
+				throw new OAuthLoginError("state_mismatch", "manual", "OAuth state mismatch");
+			},
+		);
+
+		await expect(waiter.wait()).rejects.toMatchObject({ code: "state_mismatch", source: "manual" });
+	});
+
+	it("rejects with a typed timeout and removes its abort listener", async () => {
+		vi.useFakeTimers();
+		const controller = new AbortController();
+		const addListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+		const waiter = createOAuthTerminalWaiter<string>({ timeoutMs: 25, signal: controller.signal });
+		const rejection = expect(waiter.wait()).rejects.toMatchObject({
+			name: "OAuthLoginError",
+			code: "timeout",
+			source: "timeout",
+		});
+
+		await vi.advanceTimersByTimeAsync(25);
+		await rejection;
+		expect(addListener).toHaveBeenCalledOnce();
+		expect(removeListener).toHaveBeenCalledOnce();
+	});
+
+	it("rejects a pre-aborted wait without attaching a listener", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const addListener = vi.spyOn(controller.signal, "addEventListener");
+		const waiter = createOAuthTerminalWaiter<string>({ signal: controller.signal });
+
+		await expect(waiter.wait()).rejects.toMatchObject({ code: "cancelled", source: "signal" });
+		expect(addListener).not.toHaveBeenCalled();
+	});
+
+	it("rejects an active wait on abort and removes its listener", async () => {
+		const controller = new AbortController();
+		const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+		const waiter = createOAuthTerminalWaiter<string>({ signal: controller.signal });
+		const rejection = expect(waiter.wait()).rejects.toMatchObject({ code: "cancelled", source: "signal" });
+
+		controller.abort();
+		await rejection;
+		expect(removeListener).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -1,3 +1,4 @@
+import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loginOpenAICodex, refreshOpenAICodexToken } from "../src/utils/oauth/openai-codex.js";
 import type { OAuthLoginError } from "../src/utils/oauth/types.js";
@@ -18,6 +19,20 @@ function tokenResponse(): Response {
 		JSON.stringify({ access_token: accessToken(), refresh_token: "refresh-token", expires_in: 3600 }),
 		{ status: 200, headers: { "Content-Type": "application/json" } },
 	);
+}
+
+async function occupyCallbackPort(port: number): Promise<Server | undefined> {
+	const server = createServer();
+	const bound = await new Promise<boolean>((resolve) => {
+		server.once("error", () => resolve(false));
+		server.listen(port, "127.0.0.1", () => resolve(true));
+	});
+	return bound ? server : undefined;
+}
+
+async function closeServer(server: Server | undefined): Promise<void> {
+	if (!server) return;
+	await new Promise<void>((resolve) => server.close(() => resolve()));
 }
 
 describe.sequential("OpenAI Codex OAuth", () => {
@@ -169,5 +184,49 @@ describe.sequential("OpenAI Codex OAuth", () => {
 		await expect(loginPromise).rejects.toEqual(
 			expect.objectContaining<Partial<OAuthLoginError>>({ code: "cancelled", source: "signal" }),
 		);
+	});
+
+	it("times out pending manual input when the callback port is occupied", async () => {
+		const blocker = await occupyCallbackPort(1455);
+		const onPrompt = vi.fn(async () => "unused");
+		try {
+			const loginPromise = loginOpenAICodex({
+				onAuth: () => {},
+				onPrompt,
+				onManualCodeInput: () => new Promise<string>(() => {}),
+				callbackTimeoutMs: 5,
+			});
+
+			await expect(loginPromise).rejects.toMatchObject({ code: "timeout", source: "timeout" });
+			expect(onPrompt).not.toHaveBeenCalled();
+		} finally {
+			await closeServer(blocker);
+		}
+	});
+
+	it("cancels a pending manual prompt when the callback port is occupied", async () => {
+		const blocker = await occupyCallbackPort(1455);
+		const controller = new AbortController();
+		let markPromptStarted: () => void = () => {};
+		const promptStarted = new Promise<void>((resolve) => {
+			markPromptStarted = resolve;
+		});
+		try {
+			const loginPromise = loginOpenAICodex({
+				onAuth: () => {},
+				onPrompt: () => {
+					markPromptStarted();
+					return new Promise<string>(() => {});
+				},
+				signal: controller.signal,
+			});
+			const rejection = expect(loginPromise).rejects.toMatchObject({ code: "cancelled", source: "signal" });
+
+			await promptStarted;
+			controller.abort();
+			await rejection;
+		} finally {
+			await closeServer(blocker);
+		}
 	});
 });

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -1,7 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { refreshOpenAICodexToken } from "../src/utils/oauth/openai-codex.js";
+import { loginOpenAICodex, refreshOpenAICodexToken } from "../src/utils/oauth/openai-codex.js";
+import type { OAuthLoginError } from "../src/utils/oauth/types.js";
 
-describe("OpenAI Codex OAuth", () => {
+const fetchFromNetwork = globalThis.fetch.bind(globalThis);
+
+function accessToken(): string {
+	const payload = btoa(
+		JSON.stringify({
+			"https://api.openai.com/auth": { chatgpt_account_id: "account-id" },
+		}),
+	);
+	return `e30.${payload}.signature`;
+}
+
+function tokenResponse(): Response {
+	return new Response(
+		JSON.stringify({ access_token: accessToken(), refresh_token: "refresh-token", expires_in: 3600 }),
+		{ status: 200, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+describe.sequential("OpenAI Codex OAuth", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
@@ -28,5 +47,127 @@ describe("OpenAI Codex OAuth", () => {
 			/OpenAI Codex token refresh failed \(401\).*Could not validate your token/,
 		);
 		expect(consoleError).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{
+			name: "authorization error",
+			query: (state: string) => `error=access_denied&state=${encodeURIComponent(state)}`,
+			code: "authorization_error",
+		},
+		{
+			name: "missing code",
+			query: (state: string) => `state=${encodeURIComponent(state)}`,
+			code: "invalid_callback",
+		},
+		{
+			name: "state mismatch",
+			query: () => "code=browser-code&state=wrong-state",
+			code: "state_mismatch",
+		},
+	])("settles the $name browser callback with a typed error", async ({ query, code }) => {
+		let callbackRequest: Promise<Response> | undefined;
+		const loginPromise = loginOpenAICodex({
+			onAuth: ({ url }) => {
+				const state = new URL(url).searchParams.get("state") ?? "";
+				callbackRequest = fetchFromNetwork(`http://127.0.0.1:1455/auth/callback?${query(state)}`);
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: () => new Promise<string>(() => {}),
+		});
+
+		await expect(loginPromise).rejects.toMatchObject({
+			name: "OAuthLoginError",
+			code,
+			source: "browser",
+		});
+		expect((await callbackRequest)?.status).toBe(400);
+	});
+
+	it("exchanges a manual result", async () => {
+		let authUrl = "";
+		const fetchMock = vi.fn(async (_input: unknown, _init?: RequestInit): Promise<Response> => tokenResponse());
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await loginOpenAICodex({
+			onAuth: ({ url }) => {
+				authUrl = url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const state = new URL(authUrl).searchParams.get("state") ?? "";
+				return `manual-code#${state}`;
+			},
+		});
+
+		expect(credentials.accountId).toBe("account-id");
+		const params = new URLSearchParams(String(fetchMock.mock.calls[0]?.[1]?.body));
+		expect(params.get("code")).toBe("manual-code");
+	});
+
+	it("settles a manual authorization error with a typed error", async () => {
+		let authUrl = "";
+		const loginPromise = loginOpenAICodex({
+			onAuth: ({ url }) => {
+				authUrl = url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const state = new URL(authUrl).searchParams.get("state") ?? "";
+				return `http://localhost:1455/auth/callback?error=access_denied&state=${encodeURIComponent(state)}`;
+			},
+		});
+
+		await expect(loginPromise).rejects.toMatchObject({
+			code: "authorization_error",
+			source: "manual",
+		});
+	});
+
+	it("uses the browser result when it settles before manual input", async () => {
+		let callbackRequest: Promise<Response> | undefined;
+		const fetchMock = vi.fn(async (_input: unknown, _init?: RequestInit): Promise<Response> => tokenResponse());
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await loginOpenAICodex({
+			onAuth: ({ url }) => {
+				const state = new URL(url).searchParams.get("state") ?? "";
+				callbackRequest = fetchFromNetwork(
+					`http://127.0.0.1:1455/auth/callback?code=browser-code&state=${encodeURIComponent(state)}`,
+				);
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: () => new Promise<string>(() => {}),
+		});
+
+		expect(credentials.accountId).toBe("account-id");
+		expect((await callbackRequest)?.status).toBe(200);
+		const params = new URLSearchParams(String(fetchMock.mock.calls[0]?.[1]?.body));
+		expect(params.get("code")).toBe("browser-code");
+	});
+
+	it("rejects with a typed error after the callback timeout", async () => {
+		const onPrompt = vi.fn(async () => "unused");
+		const loginPromise = loginOpenAICodex({
+			onAuth: () => {},
+			onPrompt,
+			callbackTimeoutMs: 5,
+		});
+
+		await expect(loginPromise).rejects.toMatchObject({ code: "timeout", source: "timeout" });
+		expect(onPrompt).not.toHaveBeenCalled();
+	});
+
+	it("rejects with a typed cancellation when aborted during the callback wait", async () => {
+		const controller = new AbortController();
+		const loginPromise = loginOpenAICodex({
+			onAuth: () => controller.abort(),
+			onPrompt: async () => "",
+			signal: controller.signal,
+		});
+
+		await expect(loginPromise).rejects.toEqual(
+			expect.objectContaining<Partial<OAuthLoginError>>({ code: "cancelled", source: "signal" }),
+		);
 	});
 });


### PR DESCRIPTION
## Summary

- add one exactly-once terminal waiter for browser callbacks, manual entry, cancellation, and timeout
- return typed `OAuthLoginError` failures from OpenAI Codex, Anthropic, and MCP callback flows
- keep occupied-port manual fallback bounded and signal-aware, and type callback-server startup failures
- remove GitHub Copilot abort listeners after every completed or cancelled polling sleep
- cover provider success, error, malformed callback, state mismatch, timeout, manual/browser races, abort, and repeated polling

## Problem

OpenAI Codex and Anthropic callback handlers rendered OAuth errors without settling the promises awaited by login. MCP had separate race behavior, including a grace period that made manual/browser ordering timing-dependent. GitHub Copilot added one abort listener per polling sleep and removed none after successful delays.

These paths could leave a login hung indefinitely or trigger listener warnings during a long device flow.

## Reproduction

1. Start OpenAI Codex or Anthropic OAuth login.
2. Send the local callback an OAuth error, a missing code, or a mismatched state.
3. Observe that the browser receives an error page while the terminal login remains pending.
4. For GitHub Copilot, allow more than ten `authorization_pending` polling cycles on one `AbortSignal` and inspect its abort listeners.

## Solution design

`createOAuthTerminalWaiter` owns a single promise and accepts only the first browser, manual, abort, server-error, or timeout result. Settlement clears its timer and signal listener. The default callback deadline is five minutes and callers may supply a finite `callbackTimeoutMs` override.

OpenAI Codex, Anthropic, and MCP now use this waiter and surface typed error codes for authorization errors, malformed callbacks, state mismatches, callback-server errors, timeout, and cancellation. Browser and manual inputs call the same waiter, so event order determines the winner without a grace period. Late results are handled and ignored.

When OpenAI port 1455 is unavailable, its manual input or prompt uses a manual-only terminal waiter with the same timeout and abort behavior. Anthropic bind failures and MCP all-port exhaustion are `callback_server_error` failures that retain the underlying error as `cause`.

GitHub Copilot polling now removes each abort listener both when its sleep completes and when it is cancelled.

## Acceptance criteria

- [x] Every terminal callback path settles once with a typed error or cancellation.
- [x] Callback servers have a bounded timeout.
- [x] Polling sleeps remove listeners on resolve and reject.
- [x] Repeated polling does not accumulate abort listeners.
- [x] Manual/browser races use deterministic first-settler semantics.

## Verification

- `cd packages/ai && npx tsx ../../node_modules/vitest/dist/cli.js --run test/oauth-terminal-waiter.test.ts test/openai-codex-oauth.test.ts test/anthropic-oauth.test.ts test/github-copilot-oauth.test.ts test/mcp-oauth.test.ts` — 46 tests passed
- `npm run check` — passed, including TypeScript, installer rendering, and browser smoke checks

## Compatibility and risk

- `OAuthLoginError`, its discriminants, and `callbackTimeoutMs` are additive public API.
- Existing error messages remain available through `Error.message`; cancellation still reports `Login cancelled`.
- No daemon command, event, response shape, schema revision, or protocol version changes.
- The main behavior change is intentional: a callback wait that previously hung indefinitely now fails after five minutes.

Fixes #938


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OAuth callback waits to terminate on errors and remove abort listener leaks
> - Introduces `OAuthTerminalWaiter<T>` in [terminal-waiter.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/974/files#diff-fd6fed8e27967c791493a2a345cfa5a2d7a0c61fe499301d111d49368a595279) to coordinate OAuth completion with timeout, `AbortSignal` support, and proper listener cleanup, replacing bespoke promise/cancel patterns across all providers.
> - Adds `OAuthLoginError` with typed `code` and `source` fields to replace generic errors for cancellations, state mismatches, authorization errors, and server failures across Anthropic, MCP, OpenAI Codex, and GitHub Copilot flows.
> - GitHub Copilot polling now removes abort listeners after each sleep and throws `OAuthLoginError('cancelled','signal')` instead of a generic `Error` on abort.
> - All provider login functions gain a pre-abort guard and use `waiter.wait()` to race browser callback against manual input, with cleanup in `finally` to prevent hangs.
> - Behavioral Change: callback waits now time out after `callbackTimeoutMs` (default `DEFAULT_OAUTH_CALLBACK_TIMEOUT_MS`) and reject with a typed error rather than hanging indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c81cfb3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->