### PR TITLE
fix(tui): recover autocomplete after provider rejection

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed autocomplete recovering after provider or extension completion failures ([#939](https://github.com/PrimeIntellect-ai/prime-agent/issues/939)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -32,6 +32,10 @@ function isAtomicMarker(segment: string): boolean {
 	return segment.length >= 10 && (PASTE_MARKER_SINGLE.test(segment) || IMAGE_MARKER_SINGLE.test(segment));
 }
 
+function isAbortError(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "name" in error && error.name === "AbortError";
+}
+
 /**
  * A segmenter that wraps Intl.Segmenter and merges graphemes that fall
  * within paste or image markers into single atomic segments. This makes cursor
@@ -339,6 +343,7 @@ export class Editor implements Component, Focusable {
 
 	public onSubmit?: (text: string) => void;
 	public onChange?: (text: string) => void;
+	public onAutocompleteError?: (error: unknown) => void | Promise<void>;
 	public disableSubmit: boolean = false;
 
 	constructor(tui: TUI, theme: EditorTheme, options: EditorOptions = {}) {
@@ -2353,7 +2358,7 @@ export class Editor implements Component, Focusable {
 	): Promise<void> {
 		const previousTask = this.autocompleteRequestTask;
 		this.autocompleteRequestTask = (async () => {
-			await previousTask;
+			await previousTask.catch(() => undefined);
 			if (startToken !== this.autocompleteStartToken || !this.autocompleteProvider) {
 				return;
 			}
@@ -2365,9 +2370,28 @@ export class Editor implements Component, Focusable {
 			const snapshotLine = this.state.cursorLine;
 			const snapshotCol = this.state.cursorCol;
 
-			await this.runAutocompleteRequest(requestId, controller, snapshotText, snapshotLine, snapshotCol, options);
+			try {
+				await this.runAutocompleteRequest(requestId, controller, snapshotText, snapshotLine, snapshotCol, options);
+			} catch (error) {
+				if (!controller.signal.aborted && !isAbortError(error)) {
+					this.reportAutocompleteError(error);
+				}
+			} finally {
+				if (this.autocompleteAbort === controller) {
+					this.autocompleteAbort = undefined;
+				}
+			}
 		})();
 		await this.autocompleteRequestTask;
+	}
+
+	private reportAutocompleteError(error: unknown): void {
+		try {
+			const result = this.onAutocompleteError?.(error);
+			void Promise.resolve(result).catch(() => undefined);
+		} catch {
+			// Diagnostics must not interrupt editor input or the autocomplete queue.
+		}
 	}
 
 	private getAutocompleteDebounceMs(options: { force: boolean; explicitTab: boolean }): number {

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -37,6 +37,9 @@ export interface EditorComponent extends Component {
 	/** Called when text changes */
 	onChange?: (text: string) => void;
 
+	/** Called when an autocomplete provider fails for reasons other than cancellation */
+	onAutocompleteError?: (error: unknown) => void | Promise<void>;
+
 	// =========================================================================
 	// History support (optional)
 	// =========================================================================

--- a/packages/tui/test/939-autocomplete-rejection-recovery.test.ts
+++ b/packages/tui/test/939-autocomplete-rejection-recovery.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import {
+	type AutocompleteProvider,
+	type AutocompleteSuggestions,
+	CombinedAutocompleteProvider,
+} from "../src/autocomplete.js";
+import { Editor } from "../src/components/editor.js";
+import { TUI } from "../src/tui.js";
+import { defaultEditorTheme } from "./test-themes.js";
+import { VirtualTerminal } from "./virtual-terminal.js";
+
+function applyCompletion(
+	lines: string[],
+	cursorLine: number,
+	cursorCol: number,
+	item: { value: string },
+	prefix: string,
+): { lines: string[]; cursorLine: number; cursorCol: number } {
+	const newLines = [...lines];
+	const line = newLines[cursorLine] ?? "";
+	newLines[cursorLine] = line.slice(0, cursorCol - prefix.length) + item.value + line.slice(cursorCol);
+	return {
+		lines: newLines,
+		cursorLine,
+		cursorCol: cursorCol - prefix.length + item.value.length,
+	};
+}
+
+async function settle(): Promise<void> {
+	await Promise.resolve();
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function waitFor(predicate: () => boolean, message: string): Promise<void> {
+	const deadline = Date.now() + 500;
+	while (!predicate()) {
+		if (Date.now() >= deadline) {
+			assert.fail(message);
+		}
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+function createEditor(): Editor {
+	return new Editor(new TUI(new VirtualTerminal()), defaultEditorTheme);
+}
+
+function suggestions(prefix = ""): AutocompleteSuggestions {
+	return {
+		items: [
+			{ value: "alpha", label: "alpha" },
+			{ value: "beta", label: "beta" },
+		],
+		prefix,
+	};
+}
+
+describe("autocomplete rejection recovery", () => {
+	it("continues with the next request after a provider rejects once", async () => {
+		const editor = createEditor();
+		let calls = 0;
+		let abortsAfterFailure = 0;
+		const failure = new Error("temporary autocomplete failure");
+		const diagnostics: unknown[] = [];
+		const provider: AutocompleteProvider = {
+			getSuggestions: async (_lines, _cursorLine, _cursorCol, options) => {
+				calls += 1;
+				if (calls === 1) {
+					options.signal.addEventListener("abort", () => {
+						abortsAfterFailure += 1;
+					});
+					throw failure;
+				}
+				return suggestions();
+			},
+			applyCompletion,
+		};
+		editor.setAutocompleteProvider(provider);
+		editor.onAutocompleteError = (error) => {
+			diagnostics.push(error);
+		};
+
+		editor.handleInput("\t");
+		await waitFor(() => calls === 1, "first autocomplete request did not run");
+		await settle();
+		editor.handleInput("\t");
+		await waitFor(() => editor.isShowingAutocomplete(), "autocomplete did not recover after rejection");
+
+		assert.strictEqual(calls, 2);
+		assert.deepStrictEqual(diagnostics, [failure]);
+		assert.strictEqual(abortsAfterFailure, 0, "the failed request controller should be cleared in finally");
+	});
+
+	it("silently advances after an active request is aborted", async () => {
+		const editor = createEditor();
+		let calls = 0;
+		let aborts = 0;
+		const diagnostics: unknown[] = [];
+		editor.onAutocompleteError = (error) => {
+			diagnostics.push(error);
+		};
+		editor.setAutocompleteProvider({
+			getSuggestions: async (_lines, _cursorLine, _cursorCol, options) => {
+				calls += 1;
+				if (calls > 1) return suggestions();
+				return await new Promise<AutocompleteSuggestions>((_resolve, reject) => {
+					options.signal.addEventListener(
+						"abort",
+						() => {
+							aborts += 1;
+							reject(new DOMException("Autocomplete cancelled", "AbortError"));
+						},
+						{ once: true },
+					);
+				});
+			},
+			applyCompletion,
+		});
+
+		editor.handleInput("\t");
+		await waitFor(() => calls === 1, "active autocomplete request did not start");
+		editor.handleInput("\t");
+		await waitFor(() => editor.isShowingAutocomplete(), "queue did not advance after abort");
+
+		assert.strictEqual(aborts, 1);
+		assert.strictEqual(calls, 2);
+		assert.deepStrictEqual(diagnostics, []);
+	});
+
+	it("ignores a stale result and accepts a later request", async () => {
+		const editor = createEditor();
+		let calls = 0;
+		let resolveFirst: ((result: AutocompleteSuggestions) => void) | undefined;
+		editor.setAutocompleteProvider({
+			getSuggestions: async () => {
+				calls += 1;
+				if (calls > 1) return suggestions("x");
+				return await new Promise<AutocompleteSuggestions>((resolve) => {
+					resolveFirst = resolve;
+				});
+			},
+			applyCompletion,
+		});
+
+		editor.handleInput("\t");
+		await waitFor(() => resolveFirst !== undefined, "stale autocomplete request did not start");
+		editor.handleInput("x");
+		resolveFirst?.(suggestions());
+		await settle();
+
+		assert.strictEqual(editor.getText(), "x");
+		assert.strictEqual(editor.isShowingAutocomplete(), false);
+
+		editor.handleInput("\t");
+		await waitFor(() => editor.isShowingAutocomplete(), "later autocomplete request did not run");
+		assert.strictEqual(calls, 2);
+	});
+
+	it("retains symbol autocomplete debouncing", async () => {
+		const editor = createEditor();
+		let calls = 0;
+		editor.setAutocompleteProvider({
+			getSuggestions: async (lines, _cursorLine, cursorCol) => {
+				calls += 1;
+				return suggestions((lines[0] ?? "").slice(0, cursorCol));
+			},
+			applyCompletion,
+		});
+
+		for (const character of "@main") {
+			editor.handleInput(character);
+		}
+
+		assert.strictEqual(calls, 0);
+		await waitFor(() => editor.isShowingAutocomplete(), "debounced autocomplete request did not run");
+		assert.strictEqual(calls, 1);
+	});
+
+	it("contains extension argument-completion failures", async () => {
+		const editor = createEditor();
+		let calls = 0;
+		const failure = new Error("extension completion failed");
+		const diagnostics: unknown[] = [];
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{
+					name: "load",
+					getArgumentCompletions: async (prefix) => {
+						calls += 1;
+						if (calls === 1) throw failure;
+						return [{ value: `${prefix}-result`, label: `${prefix}-result` }];
+					},
+				},
+			],
+			process.cwd(),
+		);
+		editor.setAutocompleteProvider(provider);
+		editor.onAutocompleteError = (error) => {
+			diagnostics.push(error);
+		};
+		editor.setText("/load ");
+
+		editor.handleInput("a");
+		await waitFor(() => calls === 1, "extension autocomplete request did not run");
+		await settle();
+		editor.handleInput("b");
+		await waitFor(() => editor.isShowingAutocomplete(), "extension autocomplete did not recover");
+
+		assert.strictEqual(editor.getText(), "/load ab");
+		assert.strictEqual(calls, 2);
+		assert.deepStrictEqual(diagnostics, [failure]);
+	});
+
+	it("recovers after repeated failures even when diagnostics reject", async () => {
+		const editor = createEditor();
+		let calls = 0;
+		let diagnosticCalls = 0;
+		editor.onAutocompleteError = async () => {
+			diagnosticCalls += 1;
+			throw new Error("diagnostic sink unavailable");
+		};
+		editor.setAutocompleteProvider({
+			getSuggestions: async () => {
+				calls += 1;
+				if (calls <= 2) throw new Error(`failure ${calls}`);
+				return suggestions("ab");
+			},
+			applyCompletion,
+		});
+
+		editor.handleInput("\t");
+		await waitFor(() => calls === 1, "first failing request did not run");
+		await settle();
+		editor.handleInput("a");
+		editor.handleInput("\t");
+		await waitFor(() => calls === 2, "second failing request did not run");
+		await settle();
+		editor.handleInput("b");
+		editor.handleInput("\t");
+		await waitFor(() => editor.isShowingAutocomplete(), "request after repeated failures did not recover");
+
+		assert.strictEqual(editor.getText(), "ab");
+		assert.strictEqual(calls, 3);
+		assert.strictEqual(diagnosticCalls, 2);
+	});
+});


### PR DESCRIPTION
## Summary

- contain autocomplete provider and extension completion failures per request
- advance the serialized request queue across rejection and abort barriers
- clear the active request controller in `finally` and expose an optional guarded error diagnostic
- preserve stale-result checks and symbol-completion debouncing

## Root cause

`Editor.startAutocompleteRequest` awaited the preceding request promise directly and allowed `getSuggestions` rejections to escape. A single rejection therefore became both an unhandled promise rejection and the rejected predecessor inherited by every later autocomplete request. The active abort controller was also only cleared on the success path.

## Solution design

Each request now waits through a rejection barrier, contains provider failures within its own queue link, suppresses cancellation errors, and conditionally clears only its own active controller in `finally`. Non-abort failures can be observed through `onAutocompleteError`; synchronous and asynchronous diagnostic failures are isolated from editor input and queue progress.

## Verification

- `node --test --import tsx test/939-autocomplete-rejection-recovery.test.ts` (6 tests passed)
- `node --test --import tsx test/editor.test.ts` (186 tests passed)
- `npm run check`

The focused regressions cover reject-once recovery, active aborts, stale results, attachment debounce behavior, extension argument-completion rejection, repeated failures, controller cleanup, diagnostic failures, and subsequent recovery without provider credentials.

Fixes #939


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix autocomplete queue recovery after provider or extension rejection in TUI editor
> - Wraps `runAutocompleteRequest` in try/catch so provider rejections no longer stall the autocomplete queue; abort errors are silently ignored, other errors are surfaced via a new `onAutocompleteError` callback on `EditorComponent`.
> - Adds a `finally` block to always clear the active `AbortController` after each request completes.
> - Catches rejections from the previously queued task before starting a new one to prevent cascading failures.
> - Adds a test suite in [939-autocomplete-rejection-recovery.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/975/files#diff-2eef31cc13f4cb382adc040fbd7bb777e63859b6ed697df4546efe4799454b20) covering rejection recovery, abort handling, stale results, debounce preservation, and diagnostics callback failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cf9d34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->