### PR TITLE
docs: improve custom endpoint discoverability for new users

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Improved custom OpenAI-compatible endpoint discoverability in the quickstart and docs index, and documented CLI selection plus common Ollama/vLLM setups ([#534](https://github.com/PrimeIntellect-ai/prime-agent/issues/534) by [@yuzzothecreator](https://github.com/yuzzothecreator)).
+- Improved custom OpenAI-compatible endpoint discoverability in the quickstart and docs index, and documented CLI selection plus common Ollama/vLLM setups ([#976](https://github.com/PrimeIntellect-ai/prime-agent/pull/976) by [@yuzzothecreator](https://github.com/yuzzothecreator)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [Unreleased]
 
-- Improved custom OpenAI-compatible endpoint discoverability in the quickstart and docs index, and documented CLI selection plus common Ollama/vLLM setups ([#534](https://github.com/PrimeIntellect-ai/prime-agent/issues/534) by [@yuzzothecreator](https://github.com/yuzzothecreator)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Improved custom OpenAI-compatible endpoint discoverability in the quickstart and docs index, and documented CLI selection plus common Ollama/vLLM setups ([#534](https://github.com/PrimeIntellect-ai/prime-agent/issues/534) by [@yuzzothecreator](https://github.com/yuzzothecreator)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -29,6 +29,8 @@ Public releases are currently installed from versioned release artifacts. The in
 - [RLM programming model](rlm.md) - programmatic execution, native subagents, Python skills, and durable state.
 - [Long-running and background agents](long-running-agents.md) - daemon workers, messaging, heartbeats, goals, schedules, and autonomous mode.
 - [Providers](providers.md) - subscription and API-key setup for built-in providers.
+- [Custom models](models.md) - Ollama, vLLM, LM Studio, and other OpenAI-compatible endpoints via `models.json`.
+- [Custom providers](custom-provider.md) - implement custom APIs and OAuth flows.
 - [Settings](settings.md) - global and project settings.
 - [Keybindings](keybindings.md) - default shortcuts and custom keybindings.
 - [Sessions](sessions.md) - session management, branching, and tree navigation.
@@ -42,8 +44,6 @@ Public releases are currently installed from versioned release artifacts. The in
 - [Prompt templates](prompt-templates.md) - reusable prompts that expand from slash commands.
 - [Themes](themes.md) - built-in and custom terminal themes.
 - [Prime Agent packages](packages.md) - bundle and share extensions, skills, prompts, and themes.
-- [Custom models](models.md) - add model entries for supported provider APIs.
-- [Custom providers](custom-provider.md) - implement custom APIs and OAuth flows.
 
 ## Programmatic Usage
 

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -4,6 +4,8 @@ Add custom providers and models (Ollama, vLLM, LM Studio, proxies) via `~/.prime
 
 ## Table of Contents
 
+- [Selecting a custom model](#selecting-a-custom-model)
+- [Common setups](#common-setups)
 - [Minimal Example](#minimal-example)
 - [Full Example](#full-example)
 - [Supported APIs](#supported-apis)
@@ -13,6 +15,90 @@ Add custom providers and models (Ollama, vLLM, LM Studio, proxies) via `~/.prime
 - [Per-model Overrides](#per-model-overrides)
 - [Anthropic Messages Compatibility](#anthropic-messages-compatibility)
 - [OpenAI Compatibility](#openai-compatibility)
+
+## Selecting a custom model
+
+After you add a provider to `models.json`, pick it with `/model` (or Ctrl+L), or from the CLI:
+
+```bash
+prime-agent --model ollama/llama3.1:8b
+prime-agent --provider ollama --model llama3.1:8b
+prime-agent --model ollama/llama3.1:8b "Summarize this repository"
+```
+
+The `provider/model` form does not need a separate `--provider` flag. Use `/model` during a session to switch without restarting; `models.json` reloads each time you open `/model`.
+
+If a custom provider entry includes an `apiKey` field, that provider also appears in the `/login` selector so you can store the key in `~/.prime/agent/auth.json` instead of keeping a secret in `models.json`.
+
+## Common setups
+
+Copy one of these into `~/.prime/agent/models.json`, then select the model as shown above.
+
+### Ollama
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://localhost:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        { "id": "llama3.1:8b" },
+        { "id": "qwen2.5-coder:7b" }
+      ]
+    }
+  }
+}
+```
+
+### vLLM
+
+```json
+{
+  "providers": {
+    "vllm": {
+      "baseUrl": "http://localhost:8000/v1",
+      "api": "openai-completions",
+      "apiKey": "vllm",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        { "id": "meta-llama/Meta-Llama-3.1-8B-Instruct" }
+      ]
+    }
+  }
+}
+```
+
+### Generic OpenAI-compatible proxy
+
+```json
+{
+  "providers": {
+    "my-proxy": {
+      "baseUrl": "https://proxy.example.com/v1",
+      "api": "openai-completions",
+      "apiKey": "MY_PROXY_API_KEY",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        { "id": "my-model" }
+      ]
+    }
+  }
+}
+```
+
+If the server rejects the `developer` role or `reasoning_effort`, keep those `compat` flags set to `false`. See [OpenAI Compatibility](#openai-compatibility) for the full flag reference.
 
 ## Minimal Example
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -63,6 +63,31 @@ You can also run `/login` and select an API-key provider to store the key in `~/
 
 See [Providers](providers.md) for all supported providers, environment variables, and cloud-provider setup.
 
+### Option 3: Custom OpenAI-compatible endpoint
+
+Want to use your own endpoint (Ollama, vLLM, LM Studio, or a proxy)? Add it to `~/.prime/agent/models.json`:
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://localhost:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "models": [{ "id": "llama3.1:8b" }]
+    }
+  }
+}
+```
+
+Then select it with `/model`, or from the CLI:
+
+```bash
+prime-agent --model ollama/llama3.1:8b
+```
+
+If the provider entry includes an `apiKey`, it also appears in `/login`. Full examples, `compat` flags, and troubleshooting are in [Custom Models](models.md). For custom APIs or OAuth flows, see [Custom Providers](custom-provider.md).
+
 ## First Session
 
 Once Prime Agent starts, type a request and press Enter:
@@ -160,6 +185,8 @@ Use `--mode json` for JSON event output or `--mode rpc` for process integration.
 
 - [Using Prime Agent](usage.md) - interactive mode, slash commands, sessions, context files, and CLI reference.
 - [Providers](providers.md) - authentication and model setup.
+- [Custom Models](models.md) - Ollama, vLLM, LM Studio, and other OpenAI-compatible endpoints.
+- [Custom Providers](custom-provider.md) - custom APIs and OAuth flows.
 - [Settings](settings.md) - global and project configuration.
 - [Keybindings](keybindings.md) - shortcuts and customization.
 - [Prime Agent Packages](packages.md) - install shared extensions, skills, prompts, and themes.


### PR DESCRIPTION
﻿## Summary
- Make custom OpenAI-compatible endpoints (Ollama, vLLM, LM Studio, proxies) discoverable from the quickstart and docs index.
- Document CLI selection (`--model provider/id`, `--provider`) and note that `models.json` providers with `apiKey` appear in `/login`.
- Add copy-paste common setups for Ollama, vLLM, and a generic OpenAI-compatible proxy with typical `compat` flags.

Closes #534

## Test plan
- [ ] Open `packages/coding-agent/docs/quickstart.md` and confirm Option 3 + Next Steps links to `models.md` / `custom-provider.md`
- [ ] Open `packages/coding-agent/docs/index.md` and confirm Custom models/providers appear under Start Here (not only Customization)
- [ ] Open `packages/coding-agent/docs/models.md` and confirm Selecting / Common setups sections render and TOC anchors work
- [ ] Confirm `CHANGELOG.md` Unreleased bullet is present and existing Unicode glyphs (e.g. `╰─`) are intact


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve discoverability of custom OpenAI-compatible endpoints in docs and quickstart
> - Adds Option 3 (custom OpenAI-compatible endpoint) to [quickstart.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/976/files#diff-23cbacf5e20c0132ac6466ddd518211157234350e0735c29513c748000eee03e), with a minimal `models.json` example for Ollama and instructions for model selection via `/model` or CLI.
> - Expands [models.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/976/files#diff-91f39a31c68931b17a64e079aa0606aa4e3577e1746089d31c63e378b0e85439) with a new "Selecting a custom model" section covering `/model`, CLI flags, and `models.json` reload semantics, plus a "Common setups" section with JSON examples for Ollama, vLLM, and a generic OpenAI-compatible proxy.
> - Relocates custom model and provider links in [docs/index.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/976/files#diff-218d46321638f6fc86d50aefd277a2551b50e631d37a957a72e9abac03aa1d8c) from the Customization section to the Start Here section to surface them earlier.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 867ecd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->