### PR TITLE
fix(coding-agent): implement standard cron semantics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed cron schedules to use standard day-of-month/day-of-week matching, support long-horizon dates and conventional aliases, and document local-time DST behavior ([#940](https://github.com/PrimeIntellect-ai/prime-agent/issues/940)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -516,7 +516,7 @@ prime-agent schedule add <agent> <schedule> -- <message>
 prime-agent schedule cancel <job-id>
 ```
 
-Schedules run prompts later or repeatedly. A schedule can be a supported one-time expression such as `in 5m` or a cron expression.
+Schedules run prompts later or repeatedly. A schedule can be a supported one-time expression such as `in 5m` or a standard five-field cron expression. Cron schedules use the host process's local timezone; see [Cron schedule semantics](docs/long-running-agents.md#cron-schedule-semantics) for fields, aliases, day matching, and DST behavior.
 
 ### Package and Update Commands
 

--- a/packages/coding-agent/docs/long-running-agents.md
+++ b/packages/coding-agent/docs/long-running-agents.md
@@ -169,6 +169,21 @@ prime-agent schedule cancel <job-id>
 
 Scheduled jobs are persisted per session and continue while the UI is detached. Due ticks are claimed before delivery so a crash does not replay an uncertain prompt, and missed ticks are coalesced rather than accumulated into an unbounded backlog.
 
+#### Cron schedule semantics
+
+Recurring schedules use Vixie/POSIX-style five-field expressions in the order `minute hour day-of-month month day-of-week`:
+
+- minute is `0-59`, hour is `0-23`, day of month is `1-31`, month is `1-12`, and day of week is `0-7`, where both `0` and `7` mean Sunday;
+- fields accept comma-separated lists, inclusive ranges, and steps after a range or `*`;
+- month names `JAN`-`DEC` and weekday names `SUN`-`SAT` are case-insensitive and work anywhere a number does; and
+- `@yearly`/`@annually`, `@monthly`, `@weekly`, `@daily`/`@midnight`, and `@hourly` are supported. `@reboot` is not a time-based schedule and is rejected.
+
+The day fields follow conventional cron matching. If both day of month and day of week are restricted, either field may match; otherwise both fields must match. Only a bare `*` is unrestricted, so a stepped wildcard such as `*/2` is a restriction for this rule.
+
+Cron fields are evaluated in the worker process's local timezone. There is no per-job timezone override. During a daylight-saving gap, nonexistent local times are skipped. During a fold, a repeated wall-clock time runs once at its earlier occurrence and is not repeated after the clock moves back. Missed runs are not replayed.
+
+The scheduler jumps between matching calendar fields and checks a complete 400-year Gregorian cycle. Sparse valid schedules such as leap day can therefore be created from any year, while impossible combinations fail instead of scanning forever.
+
 ## Persistent Goals
 
 A goal is a durable objective that the harness continues to present across turns until it is complete, paused, budget-limited, errored, or cleared. Start one explicitly from the TUI:

--- a/packages/coding-agent/docs/long-running-agents.md
+++ b/packages/coding-agent/docs/long-running-agents.md
@@ -178,7 +178,7 @@ Recurring schedules use Vixie/POSIX-style five-field expressions in the order `m
 - month names `JAN`-`DEC` and weekday names `SUN`-`SAT` are case-insensitive and work anywhere a number does; and
 - `@yearly`/`@annually`, `@monthly`, `@weekly`, `@daily`/`@midnight`, and `@hourly` are supported. `@reboot` is not a time-based schedule and is rejected.
 
-The day fields follow conventional cron matching. If both day of month and day of week are restricted, either field may match; otherwise both fields must match. Only a bare `*` is unrestricted, so a stepped wildcard such as `*/2` is a restriction for this rule.
+The day fields follow Vixie cron matching. A field whose raw text starts with `*` is starred, including a stepped wildcard such as `*/2`. If neither day of month nor day of week is starred, either field may match; if either is starred, both fields must match.
 
 Cron fields are evaluated in the worker process's local timezone. There is no per-job timezone override. During a daylight-saving gap, nonexistent local times are skipped. During a fold, a repeated wall-clock time runs once at its earlier occurrence and is not repeated after the clock moves back. Missed runs are not replayed.
 

--- a/packages/coding-agent/src/core/cron-expression.ts
+++ b/packages/coding-agent/src/core/cron-expression.ts
@@ -26,7 +26,7 @@ const WEEKDAY_NAMES = new Map([
 interface CronField {
 	values: readonly number[];
 	valueSet: ReadonlySet<number>;
-	unrestricted: boolean;
+	starred: boolean;
 }
 
 interface CronFields {
@@ -131,9 +131,6 @@ function parseCronField(field: string, min: number, max: number, names?: Readonl
 		} else {
 			const rangeParts = rangeText.split("-");
 			if (rangeParts.length === 1) {
-				if (stepParts[1] !== undefined) {
-					throw new Error(`Cron steps require a range or wildcard: ${part}`);
-				}
 				start = parseCronValue(rangeParts[0], min, max, names);
 				end = start;
 			} else if (rangeParts.length === 2) {
@@ -151,7 +148,7 @@ function parseCronField(field: string, min: number, max: number, names?: Readonl
 		}
 	}
 	const sortedValues = [...values].sort((left, right) => left - right);
-	return { values: sortedValues, valueSet: new Set(sortedValues), unrestricted: field === "*" };
+	return { values: sortedValues, valueSet: new Set(sortedValues), starred: field.startsWith("*") };
 }
 
 function parseCronValue(
@@ -187,7 +184,7 @@ function normalizeWeekdays(field: CronField): CronField {
 function matchesCronDay(wall: Date, fields: CronFields): boolean {
 	const dayOfMonthMatches = fields.dayOfMonth.valueSet.has(wall.getUTCDate());
 	const dayOfWeekMatches = fields.dayOfWeek.valueSet.has(wall.getUTCDay());
-	if (!fields.dayOfMonth.unrestricted && !fields.dayOfWeek.unrestricted) {
+	if (!fields.dayOfMonth.starred && !fields.dayOfWeek.starred) {
 		return dayOfMonthMatches || dayOfWeekMatches;
 	}
 	return dayOfMonthMatches && dayOfWeekMatches;

--- a/packages/coding-agent/src/core/cron-expression.ts
+++ b/packages/coding-agent/src/core/cron-expression.ts
@@ -131,6 +131,9 @@ function parseCronField(field: string, min: number, max: number, names?: Readonl
 		} else {
 			const rangeParts = rangeText.split("-");
 			if (rangeParts.length === 1) {
+				if (stepParts[1] !== undefined) {
+					throw new Error(`Cron steps require a range or wildcard: ${part}`);
+				}
 				start = parseCronValue(rangeParts[0], min, max, names);
 				end = start;
 			} else if (rangeParts.length === 2) {

--- a/packages/coding-agent/src/core/cron-expression.ts
+++ b/packages/coding-agent/src/core/cron-expression.ts
@@ -1,0 +1,259 @@
+const MONTH_NAMES = new Map([
+	["jan", 1],
+	["feb", 2],
+	["mar", 3],
+	["apr", 4],
+	["may", 5],
+	["jun", 6],
+	["jul", 7],
+	["aug", 8],
+	["sep", 9],
+	["oct", 10],
+	["nov", 11],
+	["dec", 12],
+]);
+
+const WEEKDAY_NAMES = new Map([
+	["sun", 0],
+	["mon", 1],
+	["tue", 2],
+	["wed", 3],
+	["thu", 4],
+	["fri", 5],
+	["sat", 6],
+]);
+
+interface CronField {
+	values: readonly number[];
+	valueSet: ReadonlySet<number>;
+	unrestricted: boolean;
+}
+
+interface CronFields {
+	minute: CronField;
+	hour: CronField;
+	dayOfMonth: CronField;
+	month: CronField;
+	dayOfWeek: CronField;
+}
+
+export function nextCronRunAfter(expression: string, after: Date): Date {
+	if (!Number.isFinite(after.getTime())) {
+		throw new Error("Cron schedule requires a valid reference date");
+	}
+	const fields = parseCronExpression(expression);
+	const wall = localTimeAsUtcDate(after);
+	wall.setUTCMinutes(wall.getUTCMinutes() + 1);
+	const finalYear = wall.getUTCFullYear() + 400;
+
+	while (wall.getUTCFullYear() <= finalYear) {
+		if (!fields.month.valueSet.has(wall.getUTCMonth() + 1)) {
+			advanceToAllowedMonth(wall, fields.month.values);
+			continue;
+		}
+		if (!matchesCronDay(wall, fields)) {
+			advanceWallDay(wall);
+			continue;
+		}
+		if (!fields.hour.valueSet.has(wall.getUTCHours())) {
+			advanceToAllowedHour(wall, fields.hour.values);
+			continue;
+		}
+		if (!fields.minute.valueSet.has(wall.getUTCMinutes())) {
+			advanceToAllowedMinute(wall, fields.minute.values);
+			continue;
+		}
+
+		const instant = wallTimeToLocalInstant(wall);
+		if (sameWallTime(instant, wall) && instant.getTime() > after.getTime()) {
+			return instant;
+		}
+		wall.setUTCMinutes(wall.getUTCMinutes() + 1);
+	}
+
+	throw new Error(`Cron schedule has no future occurrence in a 400-year Gregorian cycle: ${expression}`);
+}
+
+export function normalizeCronAlias(text: string): string {
+	switch (text.toLowerCase()) {
+		case "@yearly":
+		case "@annually":
+			return "0 0 1 1 *";
+		case "@monthly":
+			return "0 0 1 * *";
+		case "@weekly":
+			return "0 0 * * 0";
+		case "@daily":
+		case "@midnight":
+			return "0 0 * * *";
+		case "@hourly":
+			return "0 * * * *";
+		case "@reboot":
+			throw new Error("@reboot is unsupported because scheduled prompts require a time-based recurrence");
+		default:
+			return text;
+	}
+}
+
+function parseCronExpression(expression: string): CronFields {
+	const parts = expression.trim().split(/\s+/);
+	if (parts.length !== 5) {
+		throw new Error(
+			"Unsupported cron schedule. Use 'in 10m', 'at <ISO date>', a supported @ alias, or five fields: minute hour day month weekday",
+		);
+	}
+	return {
+		minute: parseCronField(parts[0]!, 0, 59),
+		hour: parseCronField(parts[1]!, 0, 23),
+		dayOfMonth: parseCronField(parts[2]!, 1, 31),
+		month: parseCronField(parts[3]!, 1, 12, MONTH_NAMES),
+		dayOfWeek: normalizeWeekdays(parseCronField(parts[4]!, 0, 7, WEEKDAY_NAMES)),
+	};
+}
+
+function parseCronField(field: string, min: number, max: number, names?: ReadonlyMap<string, number>): CronField {
+	const values = new Set<number>();
+	for (const part of field.split(",")) {
+		if (!part) {
+			throw new Error(`Invalid cron field: ${field}`);
+		}
+		const stepParts = part.split("/");
+		if (stepParts.length > 2) {
+			throw new Error(`Invalid cron step: ${part}`);
+		}
+		const rangeText = stepParts[0]!;
+		const step = stepParts[1] === undefined ? 1 : parseCronNumber(stepParts[1], 1, max);
+		let start: number;
+		let end: number;
+		if (rangeText === "*") {
+			start = min;
+			end = max;
+		} else {
+			const rangeParts = rangeText.split("-");
+			if (rangeParts.length === 1) {
+				if (stepParts[1] !== undefined) {
+					throw new Error(`Cron steps require a range or wildcard: ${part}`);
+				}
+				start = parseCronValue(rangeParts[0], min, max, names);
+				end = start;
+			} else if (rangeParts.length === 2) {
+				start = parseCronValue(rangeParts[0], min, max, names);
+				end = parseCronValue(rangeParts[1], min, max, names);
+				if (start > end) {
+					throw new Error(`Invalid cron range: ${rangeText}`);
+				}
+			} else {
+				throw new Error(`Invalid cron range: ${rangeText}`);
+			}
+		}
+		for (let value = start; value <= end; value += step) {
+			values.add(value);
+		}
+	}
+	const sortedValues = [...values].sort((left, right) => left - right);
+	return { values: sortedValues, valueSet: new Set(sortedValues), unrestricted: field === "*" };
+}
+
+function parseCronValue(
+	value: string | undefined,
+	min: number,
+	max: number,
+	names?: ReadonlyMap<string, number>,
+): number {
+	const named = value === undefined ? undefined : names?.get(value.toLowerCase());
+	if (named !== undefined) {
+		return named;
+	}
+	return parseCronNumber(value, min, max);
+}
+
+function parseCronNumber(value: string | undefined, min: number, max: number): number {
+	if (!value || !/^\d+$/.test(value)) {
+		throw new Error(`Invalid cron number or name: ${value ?? ""}`);
+	}
+	const parsed = Number.parseInt(value, 10);
+	if (parsed < min || parsed > max) {
+		throw new Error(`Cron number out of range: ${value}`);
+	}
+	return parsed;
+}
+
+function normalizeWeekdays(field: CronField): CronField {
+	const valueSet = new Set(field.values.map((value) => (value === 7 ? 0 : value)));
+	const values = [...valueSet].sort((left, right) => left - right);
+	return { ...field, values, valueSet };
+}
+
+function matchesCronDay(wall: Date, fields: CronFields): boolean {
+	const dayOfMonthMatches = fields.dayOfMonth.valueSet.has(wall.getUTCDate());
+	const dayOfWeekMatches = fields.dayOfWeek.valueSet.has(wall.getUTCDay());
+	if (!fields.dayOfMonth.unrestricted && !fields.dayOfWeek.unrestricted) {
+		return dayOfMonthMatches || dayOfWeekMatches;
+	}
+	return dayOfMonthMatches && dayOfWeekMatches;
+}
+
+function localTimeAsUtcDate(date: Date): Date {
+	const wall = new Date(0);
+	wall.setUTCFullYear(date.getFullYear(), date.getMonth(), date.getDate());
+	wall.setUTCHours(date.getHours(), date.getMinutes(), 0, 0);
+	return wall;
+}
+
+function wallTimeToLocalInstant(wall: Date): Date {
+	const instant = new Date(
+		wall.getUTCFullYear(),
+		wall.getUTCMonth(),
+		wall.getUTCDate(),
+		wall.getUTCHours(),
+		wall.getUTCMinutes(),
+		0,
+		0,
+	);
+	if (wall.getUTCFullYear() >= 0 && wall.getUTCFullYear() < 100) {
+		instant.setFullYear(wall.getUTCFullYear());
+	}
+	return instant;
+}
+
+function sameWallTime(instant: Date, wall: Date): boolean {
+	return (
+		instant.getFullYear() === wall.getUTCFullYear() &&
+		instant.getMonth() === wall.getUTCMonth() &&
+		instant.getDate() === wall.getUTCDate() &&
+		instant.getHours() === wall.getUTCHours() &&
+		instant.getMinutes() === wall.getUTCMinutes()
+	);
+}
+
+function advanceToAllowedMonth(wall: Date, months: readonly number[]): void {
+	const currentMonth = wall.getUTCMonth() + 1;
+	const nextMonth = months.find((month) => month > currentMonth);
+	const year = nextMonth === undefined ? wall.getUTCFullYear() + 1 : wall.getUTCFullYear();
+	const month = nextMonth ?? months[0]!;
+	wall.setUTCFullYear(year, month - 1, 1);
+	wall.setUTCHours(0, 0, 0, 0);
+}
+
+function advanceWallDay(wall: Date): void {
+	wall.setUTCDate(wall.getUTCDate() + 1);
+	wall.setUTCHours(0, 0, 0, 0);
+}
+
+function advanceToAllowedHour(wall: Date, hours: readonly number[]): void {
+	const nextHour = hours.find((hour) => hour > wall.getUTCHours());
+	if (nextHour === undefined) {
+		advanceWallDay(wall);
+		return;
+	}
+	wall.setUTCHours(nextHour, 0, 0, 0);
+}
+
+function advanceToAllowedMinute(wall: Date, minutes: readonly number[]): void {
+	const nextMinute = minutes.find((minute) => minute > wall.getUTCMinutes());
+	if (nextMinute === undefined) {
+		wall.setUTCHours(wall.getUTCHours() + 1, 0, 0, 0);
+		return;
+	}
+	wall.setUTCMinutes(nextMinute, 0, 0);
+}

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -95,6 +95,7 @@ export interface HeartbeatCronSessionActivity {
 interface CronJobsFile {
 	jobs?: unknown;
 	dispatches?: unknown;
+	scheduleSemanticsRevision?: unknown;
 }
 
 interface AgentCronDispatchRecord {
@@ -107,6 +108,7 @@ interface AgentCronDispatchRecord {
 interface CronJobsState {
 	jobs: AgentCronJob[];
 	dispatches: AgentCronDispatchRecord[];
+	scheduleSemanticsRevision: number;
 }
 
 export const SESSION_SCHEDULED_JOBS_FILENAME = "scheduled-jobs.json";
@@ -114,6 +116,7 @@ export const SESSION_SCHEDULED_JOBS_FILENAME = "scheduled-jobs.json";
 const MAX_TIMEOUT_MS = 2_147_483_647;
 const ONE_SECOND_MS = 1000;
 const ONE_MINUTE_MS = 60_000;
+const CRON_SCHEDULE_SEMANTICS_REVISION = 1;
 export const DEFAULT_HEARTBEAT_SCHEDULE = "every 5m";
 export const DEFAULT_HEARTBEAT_DELIVERY_MODE: AgentHeartbeatDeliveryMode = "steer";
 
@@ -764,6 +767,16 @@ export class AgentCronJobStore {
 		return recovered;
 	}
 
+	prepareForScheduling(now = new Date()): AgentCronJob[] {
+		const recovered: AgentCronJob[] = [];
+		this.mutateStates((state) => {
+			recoverInterruptedInState(state, now, recovered);
+			upgradeCronScheduleSemanticsInState(state, now);
+			return [];
+		});
+		return recovered;
+	}
+
 	recoverInterruptedDispatchesById(dispatchIds: readonly string[], now = new Date()): AgentCronJob[] {
 		const recovered: AgentCronJob[] = [];
 		const interruptedDispatchIds = new Set(dispatchIds);
@@ -834,6 +847,18 @@ export class AgentCronJobStore {
 				const currentBySessionId = new Map(
 					[...this.sessionArtifactFiles].map(([sessionId, path]) => [sessionId, readJobsState(path)]),
 				);
+				const scheduleRevisionByJobId = new Map<string, number>();
+				for (const state of currentBySessionId.values()) {
+					for (const job of state.jobs) {
+						const revision = scheduleRevisionByJobId.get(job.id);
+						scheduleRevisionByJobId.set(
+							job.id,
+							revision === undefined
+								? state.scheduleSemanticsRevision
+								: Math.min(revision, state.scheduleSemanticsRevision),
+						);
+					}
+				}
 				const incomingById = new Map(jobs.map((job) => [job.id, job]));
 				const mergedJobsBySessionId = new Map<string, AgentCronJob[]>();
 				for (const [sessionId, current] of currentBySessionId) {
@@ -856,10 +881,20 @@ export class AgentCronJobStore {
 				);
 				const dispatches = [...currentBySessionId.values()].flatMap((state) => state.dispatches);
 				for (const [sessionId, path] of this.sessionArtifactFiles) {
-					const current = currentBySessionId.get(sessionId) ?? { jobs: [], dispatches: [] };
+					const current = currentBySessionId.get(sessionId) ?? {
+						jobs: [],
+						dispatches: [],
+						scheduleSemanticsRevision: CRON_SCHEDULE_SEMANTICS_REVISION,
+					};
+					const nextJobs = mergedJobsBySessionId.get(sessionId) ?? [];
+					const scheduleSemanticsRevision = nextJobs.reduce(
+						(revision, job) => Math.min(revision, scheduleRevisionByJobId.get(job.id) ?? revision),
+						current.scheduleSemanticsRevision,
+					);
 					const nextState = {
-						jobs: mergedJobsBySessionId.get(sessionId) ?? [],
+						jobs: nextJobs,
 						dispatches: dispatches.filter((dispatch) => sessionIdByJobId.get(dispatch.jobId) === sessionId),
+						scheduleSemanticsRevision,
 					};
 					if (JSON.stringify(current) !== JSON.stringify(nextState)) {
 						writeJobsState(path, nextState);
@@ -899,6 +934,7 @@ export function migrateLegacyCronJobsToSessionArtifacts(
 	const now = options.now ?? new Date();
 	const legacyState = readJobsState(filePath);
 	recoverInterruptedInState(legacyState, now, []);
+	upgradeCronScheduleSemanticsInState(legacyState, now);
 	const jobs = legacyState.jobs.map((job) => {
 		if (
 			!options.isSessionOwned ||
@@ -947,7 +983,7 @@ export class AgentCronScheduler {
 		this.stopped = false;
 		if (!this.hasStarted) {
 			this.hasStarted = true;
-			this.store.recoverInterruptedDispatches(this.now());
+			this.store.prepareForScheduling(this.now());
 		}
 		this.scheduleNext();
 	}
@@ -1422,12 +1458,18 @@ function withCronJobsStateLocks<T>(paths: readonly string[], action: () => T): T
 
 function readJobsState(path: string): CronJobsState {
 	if (!existsSync(path)) {
-		return { jobs: [], dispatches: [] };
+		return { jobs: [], dispatches: [], scheduleSemanticsRevision: CRON_SCHEDULE_SEMANTICS_REVISION };
 	}
 	const parsed = JSON.parse(readFileSync(path, "utf-8")) as CronJobsFile;
 	return {
 		jobs: Array.isArray(parsed.jobs) ? parsed.jobs.filter(isAgentCronJob) : [],
 		dispatches: Array.isArray(parsed.dispatches) ? parsed.dispatches.filter(isAgentCronDispatchRecord) : [],
+		scheduleSemanticsRevision:
+			typeof parsed.scheduleSemanticsRevision === "number" &&
+			Number.isInteger(parsed.scheduleSemanticsRevision) &&
+			parsed.scheduleSemanticsRevision >= 0
+				? parsed.scheduleSemanticsRevision
+				: 0,
 	};
 }
 
@@ -1436,6 +1478,7 @@ function writeJobsFile(path: string, jobs: readonly AgentCronJob[], mergeCurrent
 	writeJobsState(path, {
 		jobs: mergeCurrent ? mergeFreshJobs(current.jobs, jobs) : [...jobs],
 		dispatches: current.dispatches,
+		scheduleSemanticsRevision: current.scheduleSemanticsRevision,
 	});
 }
 
@@ -1461,6 +1504,29 @@ function writeJobsState(path: string, state: CronJobsState): void {
 	} catch {
 		// Directory fsync is unavailable on some platforms; the atomic rename still protects readers.
 	}
+}
+
+function upgradeCronScheduleSemanticsInState(state: CronJobsState, now: Date): void {
+	if (state.scheduleSemanticsRevision >= CRON_SCHEDULE_SEMANTICS_REVISION) {
+		return;
+	}
+	state.jobs = state.jobs.map((job) => {
+		if (job.status !== "active" || job.schedule.kind !== "cron") {
+			return job;
+		}
+		const persistedNextRunAt = job.nextRunAt === undefined ? Number.NaN : Date.parse(job.nextRunAt);
+		// Keep one already-due occurrence eligible for normal claiming; recalculating
+		// from startup time would silently discard it.
+		if (Number.isFinite(persistedNextRunAt) && persistedNextRunAt <= now.getTime()) {
+			return job;
+		}
+		const nextRunAt = nextCronRunAfter(job.schedule.expression, now).toISOString();
+		if (nextRunAt === job.nextRunAt) {
+			return job;
+		}
+		return { ...job, nextRunAt, updatedAt: now.toISOString() };
+	});
+	state.scheduleSemanticsRevision = CRON_SCHEDULE_SEMANTICS_REVISION;
 }
 
 function claimDueInState(state: CronJobsState, dueAt: Date, claimedAt: Date): AgentCronDispatch[] {

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { lockSync } from "proper-lockfile";
+import { nextCronRunAfter, normalizeCronAlias } from "./cron-expression.js";
 
 export type AgentCronJobStatus = "active" | "paused" | "completed" | "cancelled";
 export type AgentCronScheduleKind = "once" | "cron" | "interval";
@@ -1369,115 +1370,6 @@ export function shouldDeferHeartbeatCronJob(job: AgentCronJob, activity: Heartbe
 		return false;
 	}
 	return activity.isStreaming;
-}
-
-function nextCronRunAfter(expression: string, after: Date): Date {
-	const fields = parseCronExpression(expression);
-	const candidate = new Date(after.getTime());
-	candidate.setSeconds(0, 0);
-	candidate.setMinutes(candidate.getMinutes() + 1);
-
-	const deadline = candidate.getTime() + 366 * 24 * 60 * ONE_MINUTE_MS;
-	while (candidate.getTime() <= deadline) {
-		if (matchesCronFields(candidate, fields)) {
-			return candidate;
-		}
-		candidate.setMinutes(candidate.getMinutes() + 1);
-	}
-	throw new Error(`Cron schedule did not match within one year: ${expression}`);
-}
-
-function parseCronExpression(expression: string): CronFields {
-	const parts = expression.trim().split(/\s+/);
-	if (parts.length !== 5) {
-		throw new Error(
-			"Unsupported cron schedule. Use 'in 10m', 'at <ISO date>', @hourly, or five fields: minute hour day month weekday",
-		);
-	}
-	return {
-		minute: parseCronField(parts[0]!, 0, 59),
-		hour: parseCronField(parts[1]!, 0, 23),
-		dayOfMonth: parseCronField(parts[2]!, 1, 31),
-		month: parseCronField(parts[3]!, 1, 12),
-		dayOfWeek: parseCronField(parts[4]!, 0, 7),
-	};
-}
-
-interface CronFields {
-	minute: Set<number>;
-	hour: Set<number>;
-	dayOfMonth: Set<number>;
-	month: Set<number>;
-	dayOfWeek: Set<number>;
-}
-
-function parseCronField(field: string, min: number, max: number): Set<number> {
-	const values = new Set<number>();
-	for (const part of field.split(",")) {
-		if (!part) {
-			throw new Error(`Invalid cron field: ${field}`);
-		}
-		const [rangeText, stepText] = part.split("/");
-		const step = stepText === undefined ? 1 : parseCronNumber(stepText, 1, max);
-		let start: number;
-		let end: number;
-		if (rangeText === "*") {
-			start = min;
-			end = max;
-		} else if (rangeText?.includes("-")) {
-			const [startText, endText] = rangeText.split("-");
-			start = parseCronNumber(startText, min, max);
-			end = parseCronNumber(endText, min, max);
-			if (start > end) {
-				throw new Error(`Invalid cron range: ${rangeText}`);
-			}
-		} else {
-			start = parseCronNumber(rangeText, min, max);
-			end = start;
-		}
-		for (let value = start; value <= end; value += step) {
-			values.add(value);
-		}
-	}
-	return values;
-}
-
-function parseCronNumber(value: string | undefined, min: number, max: number): number {
-	if (!value || !/^\d+$/.test(value)) {
-		throw new Error(`Invalid cron number: ${value ?? ""}`);
-	}
-	const parsed = Number.parseInt(value, 10);
-	if (parsed < min || parsed > max) {
-		throw new Error(`Cron number out of range: ${value}`);
-	}
-	return parsed;
-}
-
-function matchesCronFields(date: Date, fields: CronFields): boolean {
-	const day = date.getDay();
-	const dayMatches = fields.dayOfWeek.has(day) || (day === 0 && fields.dayOfWeek.has(7));
-	return (
-		fields.minute.has(date.getMinutes()) &&
-		fields.hour.has(date.getHours()) &&
-		fields.dayOfMonth.has(date.getDate()) &&
-		fields.month.has(date.getMonth() + 1) &&
-		dayMatches
-	);
-}
-
-function normalizeCronAlias(text: string): string {
-	switch (text) {
-		case "@hourly":
-			return "0 * * * *";
-		case "@daily":
-			return "0 0 * * *";
-		case "@weekly":
-			return "0 0 * * 0";
-		case "@monthly":
-			return "0 0 1 * *";
-		default:
-			return text;
-	}
 }
 
 function stripMatchingQuotes(value: string): string {

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -210,9 +210,11 @@ export class AgentCronJobStore {
 		}
 		return withCronJobsStateLocks([path], () => {
 			const state = readJobsState(path);
+			const before = JSON.stringify(state);
 			const recovered: AgentCronJob[] = [];
-			if (state.dispatches.length > 0) {
-				recoverInterruptedInState(state, now, recovered);
+			recoverInterruptedInState(state, now, recovered);
+			upgradeCronScheduleSemanticsInState(state, now);
+			if (JSON.stringify(state) !== before) {
 				writeJobsState(path, state);
 			}
 			return recovered;

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -63,7 +63,7 @@ describe("five-field cron semantics", () => {
 		).toEqual(["2026-03-31T00:00:00.000Z", "2026-05-31T00:00:00.000Z"]);
 	});
 
-	it("uses OR semantics when both day fields are restricted", () => {
+	it("uses Vixie day-field combination rules", () => {
 		expect(
 			parseCronCasesInTimeZone("UTC", [
 				{ expression: "0 0 1 * 1", after: "2026-01-01T00:00:00.000Z" },
@@ -75,7 +75,7 @@ describe("five-field cron semantics", () => {
 			"2026-01-05T00:00:00.000Z",
 			"2026-02-01T00:00:00.000Z",
 			"2026-01-05T00:00:00.000Z",
-			"2026-01-07T00:00:00.000Z",
+			"2026-01-19T00:00:00.000Z",
 		]);
 	});
 
@@ -118,7 +118,6 @@ describe("five-field cron semantics", () => {
 			"0 0 * *",
 			"0 0 * * MONDAY",
 			"0 0 * * 1-5/0",
-			"0 0 * * 1/2",
 			"0 0 * * 1//2",
 			"0 0 * * 1,",
 			"0 0 * 13 *",
@@ -500,6 +499,90 @@ describe("AgentCronJobStore", () => {
 			id: heartbeat.id,
 			status: "paused",
 			updatedAt: "2026-01-01T12:35:00.000Z",
+		});
+	});
+
+	it("normalizes legacy active cron schedules once before scheduler startup", () => {
+		const storePath = makeStorePath(tempDirs);
+		const normalizationNow = new Date(2026, 0, 1, 0, 0);
+		const legacyNextRunAt = new Date(2026, 5, 1, 0, 0).toISOString();
+		const activeCron = makePersistedScheduleJob("active-cron", {
+			nextRunAt: legacyNextRunAt,
+			schedule: { kind: "cron", expression: "0 0 1 * 1" },
+		});
+		const pausedCron = makePersistedScheduleJob("paused-cron", {
+			status: "paused",
+			nextRunAt: legacyNextRunAt,
+			schedule: { kind: "cron", expression: "0 0 1 * 1" },
+		});
+		const activeOnce = makePersistedScheduleJob("active-once", {
+			nextRunAt: legacyNextRunAt,
+			schedule: { kind: "once", expression: "at 2026-06-01T00:00:00.000Z" },
+		});
+		writeFileSync(
+			storePath,
+			`${JSON.stringify({ jobs: [activeCron, pausedCron, activeOnce], dispatches: [] }, null, 2)}\n`,
+		);
+		const staleWriter = new AgentCronJobStore(storePath);
+		const staleSnapshot = staleWriter.list();
+		const store = new AgentCronJobStore(storePath);
+		const scheduler = new AgentCronScheduler(store, {
+			now: () => normalizationNow,
+			runJob: async () => undefined,
+		});
+
+		scheduler.start();
+		scheduler.stop();
+
+		const expectedNextRunAt = new Date(2026, 0, 5, 0, 0).toISOString();
+		expect(store.list().find((job) => job.id === activeCron.id)).toMatchObject({
+			nextRunAt: expectedNextRunAt,
+			updatedAt: normalizationNow.toISOString(),
+		});
+		expect(store.list().find((job) => job.id === pausedCron.id)).toEqual(pausedCron);
+		expect(store.list().find((job) => job.id === activeOnce.id)).toEqual(activeOnce);
+		expect(JSON.parse(readFileSync(storePath, "utf8"))).toMatchObject({ scheduleSemanticsRevision: 1 });
+		writeJobsForTest(staleWriter, staleSnapshot);
+		expect(store.list().find((job) => job.id === activeCron.id)).toMatchObject({
+			nextRunAt: expectedNextRunAt,
+			updatedAt: normalizationNow.toISOString(),
+		});
+		expect(JSON.parse(readFileSync(storePath, "utf8"))).toMatchObject({ scheduleSemanticsRevision: 1 });
+
+		const secondScheduler = new AgentCronScheduler(store, {
+			now: () => new Date(2026, 0, 2, 0, 0),
+			runJob: async () => undefined,
+		});
+		secondScheduler.start();
+		secondScheduler.stop();
+		expect(store.list().find((job) => job.id === activeCron.id)).toMatchObject({
+			nextRunAt: expectedNextRunAt,
+			updatedAt: normalizationNow.toISOString(),
+		});
+	});
+
+	it("preserves one overdue legacy cron occurrence for normal claiming", async () => {
+		const storePath = makeStorePath(tempDirs);
+		const now = new Date(2026, 0, 6, 0, 0);
+		const overdue = makePersistedScheduleJob("overdue-cron", {
+			nextRunAt: new Date(2026, 0, 5, 0, 0).toISOString(),
+			schedule: { kind: "cron", expression: "0 0 1 * 1" },
+		});
+		writeFileSync(storePath, `${JSON.stringify({ jobs: [overdue], dispatches: [] }, null, 2)}\n`);
+		const store = new AgentCronJobStore(storePath);
+		const startup = new AgentCronScheduler(store, { now: () => now, runJob: async () => undefined });
+		startup.start();
+		startup.stop();
+		expect(store.list()[0]?.nextRunAt).toBe(overdue.nextRunAt);
+
+		const runJob = vi.fn(async () => undefined);
+		const runner = new AgentCronScheduler(store, { now: () => now, runJob });
+		expect(await runner.runDue(now)).toBe(1);
+		expect(await runner.runDue(now)).toBe(0);
+		expect(runJob).toHaveBeenCalledOnce();
+		expect(store.list()[0]).toMatchObject({
+			nextRunAt: new Date(2026, 0, 12, 0, 0).toISOString(),
+			runCount: 1,
 		});
 	});
 
@@ -1603,6 +1686,23 @@ function makeTempDir(tempDirs: string[]): string {
 	const dir = mkdtempSync(join(tmpdir(), "prime-agent-cron-"));
 	tempDirs.push(dir);
 	return dir;
+}
+
+function makePersistedScheduleJob(id: string, overrides: Partial<AgentCronJob> = {}): AgentCronJob {
+	return {
+		id,
+		status: "active",
+		activeSessionId: "active-1",
+		sessionId: "session-1",
+		sessionFile: "/tmp/session.jsonl",
+		cwd: "/tmp/project",
+		prompt: `run ${id}`,
+		schedule: { kind: "cron", expression: "0 0 * * *" },
+		createdAt: "2025-01-01T00:00:00.000Z",
+		updatedAt: "2025-01-01T00:00:00.000Z",
+		runCount: 0,
+		...overrides,
+	};
 }
 
 function parseCronCasesInTimeZone(

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -37,8 +38,115 @@ describe("parseAgentCronSchedule", () => {
 		expect(parsed.nextRunAt.toISOString()).toBe("2026-01-01T12:34:30.000Z");
 	});
 
-	it("rejects unsupported cron syntax", () => {
-		expect(() => parseAgentCronSchedule("0 9 * * MON", start)).toThrow("Invalid cron number");
+	it("rejects malformed cron syntax", () => {
+		expect(() => parseAgentCronSchedule("0 9 * * MONDAY", start)).toThrow("Invalid cron number or name");
+	});
+});
+
+describe("five-field cron semantics", () => {
+	it("finds leap-day schedules from multiple non-leap years", () => {
+		expect(
+			parseCronCasesInTimeZone("UTC", [
+				{ expression: "0 0 29 2 *", after: "2025-03-01T00:00:00.000Z" },
+				{ expression: "0 0 29 2 *", after: "2026-03-01T00:00:00.000Z" },
+				{ expression: "0 0 29 2 *", after: "2027-03-01T00:00:00.000Z" },
+			]),
+		).toEqual(["2028-02-29T00:00:00.000Z", "2028-02-29T00:00:00.000Z", "2028-02-29T00:00:00.000Z"]);
+	});
+
+	it("skips months that do not contain the requested day", () => {
+		expect(
+			parseCronCasesInTimeZone("UTC", [
+				{ expression: "0 0 31 * *", after: "2026-02-01T00:00:00.000Z" },
+				{ expression: "0 0 31 * *", after: "2026-04-01T00:00:00.000Z" },
+			]),
+		).toEqual(["2026-03-31T00:00:00.000Z", "2026-05-31T00:00:00.000Z"]);
+	});
+
+	it("uses OR semantics when both day fields are restricted", () => {
+		expect(
+			parseCronCasesInTimeZone("UTC", [
+				{ expression: "0 0 1 * 1", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "0 0 1 * 1", after: "2026-01-31T00:00:00.000Z" },
+				{ expression: "0 0 * * 1", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "0 0 */2 * 1", after: "2026-01-05T00:00:00.000Z" },
+			]),
+		).toEqual([
+			"2026-01-05T00:00:00.000Z",
+			"2026-02-01T00:00:00.000Z",
+			"2026-01-05T00:00:00.000Z",
+			"2026-01-07T00:00:00.000Z",
+		]);
+	});
+
+	it("accepts both Sunday numbers and case-insensitive weekday names", () => {
+		expect(
+			parseCronCasesInTimeZone("UTC", [
+				{ expression: "0 0 * * 0", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "0 0 * * 7", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "0 0 * * sun", after: "2026-01-01T00:00:00.000Z" },
+			]),
+		).toEqual(["2026-01-04T00:00:00.000Z", "2026-01-04T00:00:00.000Z", "2026-01-04T00:00:00.000Z"]);
+	});
+
+	it("supports lists, ranges, steps, month names, weekday names, and standard aliases", () => {
+		expect(
+			parseCronCasesInTimeZone("UTC", [
+				{ expression: "15 9-17/4 * JAN,MAR MON-FRI", after: "2026-01-05T09:15:00.000Z" },
+				{ expression: "@yearly", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "@annually", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "@monthly", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "@weekly", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "@daily", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "@midnight", after: "2026-01-01T00:00:00.000Z" },
+				{ expression: "@hourly", after: "2026-01-01T00:00:00.000Z" },
+			]),
+		).toEqual([
+			"2026-01-05T13:15:00.000Z",
+			"2027-01-01T00:00:00.000Z",
+			"2027-01-01T00:00:00.000Z",
+			"2026-02-01T00:00:00.000Z",
+			"2026-01-04T00:00:00.000Z",
+			"2026-01-02T00:00:00.000Z",
+			"2026-01-02T00:00:00.000Z",
+			"2026-01-01T01:00:00.000Z",
+		]);
+	});
+
+	it("rejects malformed fields and unsupported reboot aliases", () => {
+		for (const expression of [
+			"0 0 * *",
+			"0 0 * * MONDAY",
+			"0 0 * * 1-5/0",
+			"0 0 * * 1/2",
+			"0 0 * * 1//2",
+			"0 0 * * 1,",
+			"0 0 * 13 *",
+			"@reboot",
+		]) {
+			expect(() => parseAgentCronSchedule(expression, start), expression).toThrow();
+		}
+	});
+
+	it("terminates impossible schedules after a complete Gregorian cycle", () => {
+		expect(() => parseAgentCronSchedule("0 0 31 2 *", start)).toThrow("no future occurrence in a 400-year");
+	});
+
+	it("skips nonexistent DST wall times in the host timezone", () => {
+		expect(
+			parseCronCasesInTimeZone("America/New_York", [
+				{ expression: "30 2 * * *", after: "2026-03-07T08:00:00.000Z" },
+			]),
+		).toEqual(["2026-03-09T06:30:00.000Z"]);
+	});
+
+	it("runs repeated DST wall times once at the earlier occurrence", () => {
+		expect(
+			parseCronCasesInTimeZone("America/New_York", [
+				{ expression: "30 1 * * *", after: "2026-10-31T06:00:00.000Z" },
+				{ expression: "30 1 * * *", after: "2026-11-01T05:30:00.000Z" },
+			]),
+		).toEqual(["2026-11-01T05:30:00.000Z", "2026-11-02T06:30:00.000Z"]);
 	});
 });
 
@@ -1495,4 +1603,24 @@ function makeTempDir(tempDirs: string[]): string {
 	const dir = mkdtempSync(join(tmpdir(), "prime-agent-cron-"));
 	tempDirs.push(dir);
 	return dir;
+}
+
+function parseCronCasesInTimeZone(
+	timeZone: string,
+	cases: ReadonlyArray<{ expression: string; after: string }>,
+): string[] {
+	const moduleUrl = new URL("../src/core/cron-jobs.ts", import.meta.url).href;
+	const script = `
+		import { parseAgentCronSchedule } from ${JSON.stringify(moduleUrl)};
+		const cases = ${JSON.stringify(cases)};
+		process.stdout.write(JSON.stringify(cases.map(({ expression, after }) =>
+			parseAgentCronSchedule(expression, new Date(after)).nextRunAt.toISOString()
+		)));
+	`;
+	const output = execFileSync(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], {
+		cwd: new URL("..", import.meta.url),
+		env: { ...process.env, TZ: timeZone },
+		encoding: "utf8",
+	});
+	return JSON.parse(output) as string[];
 }

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -118,6 +118,7 @@ describe("five-field cron semantics", () => {
 			"0 0 * *",
 			"0 0 * * MONDAY",
 			"0 0 * * 1-5/0",
+			"0 0 * * 1/2",
 			"0 0 * * 1//2",
 			"0 0 * * 1,",
 			"0 0 * 13 *",
@@ -559,6 +560,46 @@ describe("AgentCronJobStore", () => {
 			nextRunAt: expectedNextRunAt,
 			updatedAt: normalizationNow.toISOString(),
 		});
+	});
+
+	it("normalizes a legacy session artifact registered after the scheduler starts empty", () => {
+		const root = makeTempDir(tempDirs);
+		const sessionId = "late-session";
+		const artifactDir = join(root, "session-artifacts", sessionId);
+		const artifactPath = join(artifactDir, SESSION_SCHEDULED_JOBS_FILENAME);
+		const normalizationNow = new Date(2026, 0, 1, 0, 0);
+		const activeCron = makePersistedScheduleJob("late-active-cron", {
+			sessionId,
+			nextRunAt: new Date(2026, 5, 1, 0, 0).toISOString(),
+			schedule: { kind: "cron", expression: "0 0 1 * 1" },
+		});
+		mkdirSync(artifactDir, { recursive: true });
+		writeFileSync(artifactPath, `${JSON.stringify({ jobs: [activeCron], dispatches: [] }, null, 2)}\n`);
+		const store = AgentCronJobStore.forSessionArtifacts();
+		const scheduler = new AgentCronScheduler(store, {
+			now: () => normalizationNow,
+			runJob: async () => undefined,
+		});
+		scheduler.start();
+
+		expect(store.registerSessionArtifact(sessionId, artifactDir)).toBe(true);
+		expect(store.recoverSessionArtifact(sessionId, normalizationNow)).toEqual([]);
+		scheduler.wake();
+		expect(store.list()).toEqual([
+			expect.objectContaining({
+				id: activeCron.id,
+				nextRunAt: new Date(2026, 0, 5, 0, 0).toISOString(),
+				updatedAt: normalizationNow.toISOString(),
+			}),
+		]);
+		expect(JSON.parse(readFileSync(artifactPath, "utf8"))).toMatchObject({ scheduleSemanticsRevision: 1 });
+
+		const normalizedFile = readFileSync(artifactPath, "utf8");
+		expect(store.registerSessionArtifact(sessionId, artifactDir)).toBe(false);
+		expect(store.recoverSessionArtifact(sessionId, new Date(2026, 0, 2, 0, 0))).toEqual([]);
+		scheduler.start();
+		scheduler.stop();
+		expect(readFileSync(artifactPath, "utf8")).toBe(normalizedFile);
 	});
 
 	it("preserves one overdue legacy cron occurrence for normal claiming", async () => {


### PR DESCRIPTION
## Summary

- replace the one-year minute scan with a dependency-free field-jumping scheduler that checks a complete Gregorian cycle
- implement Vixie/POSIX-style day-of-month/day-of-week matching, Sunday `0`/`7`, names, lists, ranges, steps, and standard time-based aliases
- normalize persisted active cron schedules once under the existing store lock when the semantics revision changes
- document host-local timezone behavior, including skipped DST gaps and one execution at the earlier occurrence of a repeated wall time

## Problem

Leap-day schedules created more than 366 days before the next leap day were rejected. Expressions that restricted both day of month and day of week also required both fields to match instead of using conventional cron OR semantics.

## Solution design

The parser expands each field into validated sorted values and records whether each raw day field starts with `*`. The scheduler advances a timezone-neutral wall-clock cursor by month, day, hour, and minute, then converts matching wall times into instants in the worker process's local timezone. A 400-year Gregorian search cycle guarantees termination for impossible expressions without a minute-by-minute horizon.

Scheduled-job files persist `scheduleSemanticsRevision`. On first scheduler startup after an upgrade, interrupted claims are recovered and active cron jobs with future stale next-run times are normalized atomically under the existing file locks. Session artifacts registered after an empty scheduler has started perform the same locked recovery and normalization before the scheduler is woken. Inactive and one-shot jobs are unchanged, while an already-overdue cron occurrence remains eligible for one normal claim.

The selected behavior is:

- five fields: `minute hour day-of-month month day-of-week`
- day-of-month/day-of-week OR when neither raw field starts with `*`; otherwise AND, including `*/N`
- Sunday accepted as `0`, `7`, or `SUN`
- numeric and named lists/ranges plus steps after ranges or `*`
- `@yearly`/`@annually`, `@monthly`, `@weekly`, `@daily`/`@midnight`, and `@hourly`; `@reboot` remains unsupported
- worker-process local timezone; nonexistent DST times are skipped and repeated times run once at the earlier occurrence

## Acceptance criteria

- [x] leap-day schedules resolve from multiple non-leap years
- [x] month lengths and impossible dates are handled without an arbitrary one-year horizon
- [x] day-of-month/day-of-week matching follows Vixie `DOM_STAR`/`DOW_STAR` behavior
- [x] Sunday aliases, ranges, steps, names, standard aliases, and malformed fields are covered
- [x] DST gap and fold behavior is deterministic and documented
- [x] persisted active cron jobs are normalized once without rewriting inactive or one-shot jobs
- [x] legacy session artifacts registered after empty scheduler startup are normalized once before scheduling
- [x] daemon command, event, response, protocol version, and schema revision remain unchanged

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/cron-jobs.test.ts` (64 tests passed)
- `npm run check`

## Residual risk

Cron schedules continue to inherit the worker process timezone; changing the host timezone changes future calculations. Per-job timezones are outside this issue.

Fixes #940


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cron scheduling to use standard Vixie/POSIX five-field semantics
> - Replaces the previous cron parsing logic with a new [`cron-expression.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/977/files#diff-d2f022ad143d3a0305ed354033cb0cd97553557d7183420d59fa40b7147f76b1) module implementing standard five-field Vixie/POSIX semantics, including named months/weekdays, step expressions, `@yearly`/`@monthly`/`@weekly`/`@daily`/`@hourly` aliases, and Vixie day-of-month/day-of-week starred matching rules.
> - Evaluation runs in the worker's local timezone with correct DST gap/fold handling (skips nonexistent times, avoids duplicate runs in folds), and the search bound is extended to a 400-year Gregorian cycle.
> - Persisted cron job state gains a `scheduleSemanticsRevision` field; on startup and session artifact recovery, active jobs have their `nextRunAt` recomputed under the new semantics via `upgradeCronScheduleSemanticsInState`.
> - Behavioral Change: existing scheduled jobs will have their next run time recomputed on first startup after upgrade, which may shift previously stored `nextRunAt` values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64e0970.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->