### PR TITLE
docs: document PRIME_AGENT_KERNEL_PYTHON override contract

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Documented the full PRIME_AGENT_KERNEL_PYTHON override contract, including blocking base packages, optional skill warnings, and a setup/validation snippet ([#undefined](https://github.com/PrimeIntellect-ai/prime-agent/pull/undefined) by [@yuzzothecreator](https://github.com/yuzzothecreator)).
+- Documented the full PRIME_AGENT_KERNEL_PYTHON override contract, including blocking base packages, optional skill warnings, and a setup/validation snippet ([#979](https://github.com/PrimeIntellect-ai/prime-agent/pull/979) by [@yuzzothecreator](https://github.com/yuzzothecreator)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Documented the full PRIME_AGENT_KERNEL_PYTHON override contract, including blocking base packages, optional skill warnings, and a setup/validation snippet ([#954](https://github.com/PrimeIntellect-ai/prime-agent/issues/954) by [@yuzzothecreator](https://github.com/yuzzothecreator)).
+- Documented the full PRIME_AGENT_KERNEL_PYTHON override contract, including blocking base packages, optional skill warnings, and a setup/validation snippet ([#undefined](https://github.com/PrimeIntellect-ai/prime-agent/pull/undefined) by [@yuzzothecreator](https://github.com/yuzzothecreator)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Documented the full PRIME_AGENT_KERNEL_PYTHON override contract, including blocking base packages, optional skill warnings, and a setup/validation snippet ([#954](https://github.com/PrimeIntellect-ai/prime-agent/issues/954) by [@yuzzothecreator](https://github.com/yuzzothecreator)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -68,7 +68,7 @@ prime-agent
 
 Then just talk to Prime Agent. By default, Prime Agent gives the model one tool: `ipython`. The model uses the persistent kernel to read files, run commands, edit code, and inspect data. Add capabilities via [skills](#skills), [prompt templates](#prompt-templates), [extensions](#extensions), or [Prime Agent packages](#prime-agent-packages).
 
-The Python kernel runtime is set up automatically on first invocation. Set `PRIME_AGENT_KERNEL_PYTHON` to use an existing Python environment with `ipykernel`.
+The Python kernel runtime is set up automatically on first invocation. Set `PRIME_AGENT_KERNEL_PYTHON` only if the interpreter meets the full [kernel override contract](docs/rlm-runtime.md#prime_agent_kernel_python-contract) (`ipykernel`, a current `prime-agent-runtime`, and the default Python packages).
 
 **Platform notes:** [Windows](docs/windows.md) | [Termux (Android)](docs/termux.md) | [tmux](docs/tmux.md) | [Terminal setup](docs/terminal-setup.md) | [Shell aliases](docs/shell-aliases.md)
 
@@ -682,7 +682,7 @@ prime-agent --thinking high "Solve this complex problem"
 | `PRIME_API_KEY` | Prime Inference API key; also used for trace sharing if it has `agent_traces` scope |
 | `PRIME_AGENT_TRACES_API_KEY` | Prime API key used only for opt-in trace sharing |
 | `PRIME_AGENT_TRACES_BASE_URL` | Override the Prime Agent trace upload API base URL |
-| `PRIME_AGENT_KERNEL_PYTHON` | Use an existing Python environment with `ipykernel` instead of auto-bootstrapping `~/.prime/agent/kernel-venv` |
+| `PRIME_AGENT_KERNEL_PYTHON` | Use an existing Python instead of auto-bootstrapping `~/.prime/agent/kernel-venv`. Must satisfy the [kernel override contract](docs/rlm-runtime.md#prime_agent_kernel_python-contract) (`ipykernel`, current `prime-agent-runtime`, and default packages); missing Python skills only warn |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 
 The remaining `PI_*` variables in this table are compatibility names still read by the current runtime. They do not change the application name, command, or default `~/.prime/agent` configuration path.

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -27,6 +27,7 @@ Public releases are currently installed from versioned release artifacts. The in
 - [Using Prime Agent](usage.md) - interactive mode, RLM subagents, slash commands, context files, and CLI reference.
 - [Architecture overview](architecture.md) - client, daemon, worker, session, kernel, provider, and storage boundaries.
 - [RLM programming model](rlm.md) - programmatic execution, native subagents, Python skills, and durable state.
+- [RLM Runtime Architecture](rlm-runtime.md) - kernel transport, `PRIME_AGENT_KERNEL_PYTHON` contract, and recursive subagent execution.
 - [Long-running and background agents](long-running-agents.md) - daemon workers, messaging, heartbeats, goals, schedules, and autonomous mode.
 - [Providers](providers.md) - subscription and API-key setup for built-in providers.
 - [Settings](settings.md) - global and project settings.

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -71,7 +71,7 @@ Once Prime Agent starts, type a request and press Enter:
 Summarize this repository and tell me how to run its checks.
 ```
 
-Prime Agent gives the model one built-in tool, `ipython`. The long-lived kernel is a control environment for reading and editing files, running project commands, inspecting data, retaining Python state, and invoking installed skills. The kernel runtime is bootstrapped automatically on first use; set `PRIME_AGENT_KERNEL_PYTHON` to use an existing Python environment with `ipykernel`.
+Prime Agent gives the model one built-in tool, `ipython`. The long-lived kernel is a control environment for reading and editing files, running project commands, inspecting data, retaining Python state, and invoking installed skills. The kernel runtime is bootstrapped automatically on first use. To reuse an existing interpreter, set `PRIME_AGENT_KERNEL_PYTHON` to a Python that satisfies the full [kernel override contract](rlm-runtime.md#prime_agent_kernel_python-contract) (`ipykernel`, a current `prime-agent-runtime`, and the default Python packages)—`ipykernel` alone is not enough.
 
 Prime Agent runs in your current working directory and can modify files there. Use git or another checkpointing workflow if you want easy rollback.
 

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -75,11 +75,74 @@ The Python side does not call providers or implement an agent loop.
 
 The kernel is created lazily on first IPython use. Python resolution is:
 
-1. `PRIME_AGENT_KERNEL_PYTHON`, when it can import `ipykernel`;
+1. `PRIME_AGENT_KERNEL_PYTHON`, when it satisfies the [override contract](#prime_agent_kernel_python-contract) below;
 2. `~/.prime/agent/kernel-venv/bin/python`, bootstrapped with `uv`; or
 3. the XDG data location when `~/.prime` is not writable.
 
-The managed environment includes Python 3.11, `ipykernel`, and `prime-agent-runtime`. A bootstrap marker detects stale environments.
+The managed environment installs Python 3.11, `ipykernel`, `prime-agent-runtime`, `dill` (namespace snapshots), and the [default Python packages](#blocking-base-packages). A bootstrap marker detects stale environments.
+
+### `PRIME_AGENT_KERNEL_PYTHON` contract
+
+Set `PRIME_AGENT_KERNEL_PYTHON` to a Python executable to skip auto-bootstrap of `~/.prime/agent/kernel-venv`. Installing only `ipykernel` is not enough: bootstrap rejects the override when blocking base packages are missing.
+
+Package lists below mirror `DEFAULT_RLM_EXTRA_PACKAGES` and the override checks in `packages/coding-agent/src/core/kernel/bootstrap.ts`. Update docs when those definitions change.
+
+#### Blocking base packages
+
+These must import successfully or kernel start fails with `PRIME_AGENT_KERNEL_PYTHON points to a Python missing ...`:
+
+| Requirement | What bootstrap checks |
+|---|---|
+| `ipykernel` | `import ipykernel` |
+| current `prime-agent-runtime` | importable `rlm` with callable `rlm.run` / `rlm.host_request`, harness CRUD methods, and related readiness asserts |
+| default Python packages | `requests`, `httpx`, `yaml` (PyYAML), `tomli`, `dotenv` (python-dotenv), `pandas`, `numpy`, `scipy`, `bs4` (Beautiful Soup), `lxml`, `pydantic`, `tyro` |
+
+#### Optional skill warnings
+
+Missing Python-backed skills are **not** blocking. Bootstrap prints a warning and disables those skills for the session:
+
+```text
+Warning: Python skills unavailable in PRIME_AGENT_KERNEL_PYTHON and will be disabled: ...
+```
+
+Managed bootstrap installs skills into the kernel venv; with an override, install each skill package into that same interpreter if you need them.
+
+#### Setup and validation
+
+From a Prime Agent source or release tree that includes `prime-agent-runtime/`:
+
+```bash
+export PRIME_AGENT_KERNEL_PYTHON=/path/to/python   # or python.exe on Windows
+
+uv pip install --python "$PRIME_AGENT_KERNEL_PYTHON" \
+  ipykernel \
+  requests httpx pyyaml tomli python-dotenv \
+  pandas numpy scipy beautifulsoup4 lxml pydantic tyro \
+  ./prime-agent-runtime
+```
+
+Validate the blocking contract (must exit 0):
+
+```bash
+"$PRIME_AGENT_KERNEL_PYTHON" - <<'PY'
+import importlib
+import ipykernel  # noqa: F401
+import rlm
+
+assert callable(rlm) and callable(rlm.run) and callable(rlm.host_request)
+assert hasattr(rlm, "harness") and hasattr(rlm, "get_harness_state")
+
+for name in (
+    "requests", "httpx", "yaml", "tomli", "dotenv",
+    "pandas", "numpy", "scipy", "bs4", "lxml", "pydantic", "tyro",
+):
+    importlib.import_module(name)
+
+print("PRIME_AGENT_KERNEL_PYTHON blocking contract OK")
+PY
+```
+
+If validation fails, unset `PRIME_AGENT_KERNEL_PYTHON` and let Prime Agent bootstrap `~/.prime/agent/kernel-venv` instead.
 
 Startup creates a temporary Jupyter connection file with loopback TCP ports and an HMAC key, starts `python -m ipykernel_launcher`, connects shell, IOPub, and control sockets, waits for subscription propagation, and probes readiness with `kernel_info_request`.
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -360,7 +360,7 @@ prime-agent --tools ipython -p "Review the code"
 | `PRIME_API_KEY` | Prime Inference API key; also used for trace sharing when it has `agent_traces` scope |
 | `PRIME_AGENT_TRACES_API_KEY` | Prime API key used only for opt-in trace sharing |
 | `PRIME_AGENT_TRACES_BASE_URL` | Override the Prime Agent trace upload API base URL |
-| `PRIME_AGENT_KERNEL_PYTHON` | Use an existing Python environment with `ipykernel` instead of bootstrapping `~/.prime/agent/kernel-venv` |
+| `PRIME_AGENT_KERNEL_PYTHON` | Use an existing Python instead of bootstrapping `~/.prime/agent/kernel-venv`. Requires the full [kernel override contract](rlm-runtime.md#prime_agent_kernel_python-contract); `ipykernel` alone fails bootstrap |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 
 The remaining `PI_*` variables are compatibility names still read by the current runtime. They do not change the application name, command, or default `~/.prime/agent` configuration path.


### PR DESCRIPTION
﻿## Summary
- Document the full `PRIME_AGENT_KERNEL_PYTHON` override contract: blocking `ipykernel` + current `prime-agent-runtime` + default packages vs optional Python-skill warnings.
- Add setup (`uv pip install`) and validation snippets aligned with `bootstrap.ts`.
- Point quickstart, README, usage env table, and docs index at the canonical section in `rlm-runtime.md`.

Closes #954

## Test plan
- [ ] Compare the documented default package list with `DEFAULT_RLM_EXTRA_PACKAGES` in `packages/coding-agent/src/core/kernel/bootstrap.ts`
- [ ] Confirm override failure modes in docs match `ensureKernelPythonUncached` (blocking vs skill warning)
- [ ] Follow the setup + validation snippet against an isolated venv that only had `ipykernel` and verify the documented failure/success path
- [ ] Check markdown anchors: `rlm-runtime.md#prime_agent_kernel_python-contract` and `#blocking-base-packages`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `PRIME_AGENT_KERNEL_PYTHON` kernel override contract in coding-agent docs
> - Defines the full `PRIME_AGENT_KERNEL_PYTHON` contract: the override Python must be able to import `ipykernel`, the current `prime-agent-runtime` (with specific callable attributes), and a set of default packages (`requests`, `httpx`, `pandas`, `numpy`, `pydantic`, etc.).
> - Updates [README.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/979/files#diff-b28d42a35be05803ac5e2fb345eca35f4a26a730b783c0447e5b5204b6e1211f), [quickstart.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/979/files#diff-23cbacf5e20c0132ac6466ddd518211157234350e0735c29513c748000eee03e), [usage.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/979/files#diff-0f17e8a06507fc67e8078430cb97b8286192379bfde7c3ad308e58625a7a6f3d), and [rlm-runtime.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/979/files#diff-79bbf4140c57cb0c1c56896fb846cf6c65afad43215c13afc4fb6712dfa760d2) to replace the previous "just needs ipykernel" guidance with a link to the new contract section.
> - Adds a setup and validation snippet with `uv pip install` commands and a Python assertion script to verify compliance before use.
> - Missing Python-backed skills under an override emit warnings rather than hard failures; a failed contract check falls back to the auto-bootstrapped venv.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20922b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->