### PR TITLE
fix(ai): parse streamed tool arguments incrementally

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed proxy streams repeatedly reparsing the full accumulated tool-argument JSON for every delta ([#942](https://github.com/PrimeIntellect-ai/prime-agent/issues/942)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -210,8 +210,10 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 				throw new Error("Request aborted by user");
 			}
 
+			materializeOpenProxyToolArguments(partial, toolArgumentAccumulators);
 			stream.end();
 		} catch (error) {
+			materializeOpenProxyToolArguments(partial, toolArgumentAccumulators);
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			const reason = options.signal?.aborted ? "aborted" : "error";
 			partial.stopReason = reason;
@@ -223,6 +225,7 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 			});
 			stream.end();
 		} finally {
+			toolArgumentAccumulators.clear();
 			if (options.signal) {
 				options.signal.removeEventListener("abort", abortHandler);
 			}
@@ -230,6 +233,23 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 	})();
 
 	return stream;
+}
+
+function materializeOpenProxyToolArguments(
+	partial: AssistantMessage,
+	toolArgumentAccumulators: Map<number, StreamingJsonAccumulator<Record<string, unknown>>>,
+): void {
+	for (const [contentIndex, accumulator] of toolArgumentAccumulators) {
+		const content = partial.content[contentIndex];
+		if (content?.type === "toolCall") {
+			try {
+				content.arguments = accumulator.finish();
+			} catch {
+				// Preserve the proxy's terminal error if cleanup parsing fails.
+			}
+		}
+	}
+	toolArgumentAccumulators.clear();
 }
 
 /**
@@ -352,11 +372,13 @@ function processProxyEvent(
 		}
 
 		case "done":
+			materializeOpenProxyToolArguments(partial, toolArgumentAccumulators);
 			partial.stopReason = proxyEvent.reason;
 			partial.usage = proxyEvent.usage;
 			return { type: "done", reason: proxyEvent.reason, message: partial };
 
 		case "error":
+			materializeOpenProxyToolArguments(partial, toolArgumentAccumulators);
 			partial.stopReason = proxyEvent.reason;
 			partial.errorMessage = proxyEvent.errorMessage;
 			partial.usage = proxyEvent.usage;

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -10,10 +10,9 @@ import {
 	type Context,
 	EventStream,
 	type Model,
-	parseStreamingJson,
 	type SimpleStreamOptions,
 	type StopReason,
-	type ToolCall,
+	StreamingJsonAccumulator,
 } from "@earendil-works/pi-ai";
 
 // Create stream class matching ProxyMessageEventStream
@@ -137,6 +136,7 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 		};
 
 		let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+		const toolArgumentAccumulators = new Map<number, StreamingJsonAccumulator<Record<string, unknown>>>();
 
 		const abortHandler = () => {
 			if (reader) {
@@ -197,7 +197,7 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 						const data = line.slice(6).trim();
 						if (data) {
 							const proxyEvent = JSON.parse(data) as ProxyAssistantMessageEvent;
-							const event = processProxyEvent(proxyEvent, partial);
+							const event = processProxyEvent(proxyEvent, partial, toolArgumentAccumulators);
 							if (event) {
 								stream.push(event);
 							}
@@ -238,6 +238,7 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 function processProxyEvent(
 	proxyEvent: ProxyAssistantMessageEvent,
 	partial: AssistantMessage,
+	toolArgumentAccumulators: Map<number, StreamingJsonAccumulator<Record<string, unknown>>>,
 ): AssistantMessageEvent | undefined {
 	switch (proxyEvent.type) {
 		case "start":
@@ -313,15 +314,17 @@ function processProxyEvent(
 				id: proxyEvent.id,
 				name: proxyEvent.toolName,
 				arguments: {},
-				partialJson: "",
-			} satisfies ToolCall & { partialJson: string } as ToolCall;
+			};
+			toolArgumentAccumulators.set(proxyEvent.contentIndex, new StreamingJsonAccumulator());
 			return { type: "toolcall_start", contentIndex: proxyEvent.contentIndex, partial };
 
 		case "toolcall_delta": {
 			const content = partial.content[proxyEvent.contentIndex];
 			if (content?.type === "toolCall") {
-				(content as any).partialJson += proxyEvent.delta;
-				content.arguments = parseStreamingJson((content as any).partialJson) || {};
+				const partialArguments = toolArgumentAccumulators.get(proxyEvent.contentIndex)?.append(proxyEvent.delta);
+				if (partialArguments !== undefined) {
+					content.arguments = partialArguments;
+				}
 				partial.content[proxyEvent.contentIndex] = { ...content }; // Trigger reactivity
 				return {
 					type: "toolcall_delta",
@@ -336,7 +339,8 @@ function processProxyEvent(
 		case "toolcall_end": {
 			const content = partial.content[proxyEvent.contentIndex];
 			if (content?.type === "toolCall") {
-				delete (content as any).partialJson;
+				content.arguments = toolArgumentAccumulators.get(proxyEvent.contentIndex)?.finish() ?? {};
+				toolArgumentAccumulators.delete(proxyEvent.contentIndex);
 				return {
 					type: "toolcall_end",
 					contentIndex: proxyEvent.contentIndex,

--- a/packages/agent/test/proxy.test.ts
+++ b/packages/agent/test/proxy.test.ts
@@ -95,11 +95,18 @@ describe("streamProxy tool arguments", () => {
 
 	it("retains displayable tolerant arguments when the proxy stream is aborted", async () => {
 		const controller = new AbortController();
-		const delta = String.raw`{"path":"A\H","text":"col1	col2"}`;
+		const deltas = ['{"first":"materialized"', ',"x":1}'];
+		expect(deltas.map((delta) => delta.length)).toEqual([23, 7]);
 		const events: ProxyAssistantMessageEvent[] = [
 			{ type: "start" },
 			{ type: "toolcall_start", contentIndex: 0, id: "tool-1", toolName: "edit" },
-			{ type: "toolcall_delta", contentIndex: 0, delta },
+			...deltas.map(
+				(delta): ProxyAssistantMessageEvent => ({
+					type: "toolcall_delta",
+					contentIndex: 0,
+					delta,
+				}),
+			),
 		];
 		vi.stubGlobal(
 			"fetch",
@@ -111,20 +118,25 @@ describe("streamProxy tool arguments", () => {
 			signal: controller.signal,
 		});
 		const seenEvents: AssistantMessageEvent[] = [];
+		let seenDeltaCount = 0;
 
 		for await (const event of stream) {
 			seenEvents.push(event);
 			if (event.type === "toolcall_delta") {
-				controller.abort();
+				seenDeltaCount += 1;
+				if (seenDeltaCount === deltas.length) {
+					controller.abort();
+				}
 			}
 		}
 		const result = await stream.result();
 
-		expect(seenEvents.some((event) => event.type === "toolcall_delta" && event.delta === delta)).toBe(true);
+		expect(seenEvents.filter((event) => event.type === "toolcall_delta").map((event) => event.delta)).toEqual(deltas);
 		expect(result.stopReason).toBe("aborted");
+		expect(result.errorMessage).toBe("Request aborted by user");
 		expect(result.content[0]).toMatchObject({
 			type: "toolCall",
-			arguments: { path: "A\\H", text: "col1\tcol2" },
+			arguments: { first: "materialized", x: 1 },
 		});
 	});
 });

--- a/packages/agent/test/proxy.test.ts
+++ b/packages/agent/test/proxy.test.ts
@@ -1,0 +1,130 @@
+import type { AssistantMessageEvent, Context, Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type ProxyAssistantMessageEvent, streamProxy } from "../src/proxy.js";
+
+const model: Model<"openai-responses"> = {
+	id: "test-model",
+	name: "Test Model",
+	api: "openai-responses",
+	provider: "test",
+	baseUrl: "https://example.test/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 100_000,
+	maxTokens: 10_000,
+};
+
+const context: Context = {
+	messages: [{ role: "user", content: "Use the tool", timestamp: 1 }],
+};
+
+const usage = {
+	input: 1,
+	output: 1,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 2,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function createProxyResponse(events: ProxyAssistantMessageEvent[]): Response {
+	const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+	return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+function createOpenProxyResponse(events: ProxyAssistantMessageEvent[]): Response {
+	const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+	const encodedBody = new TextEncoder().encode(body);
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encodedBody);
+			},
+		}),
+		{ status: 200, headers: { "content-type": "text/event-stream" } },
+	);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("streamProxy tool arguments", () => {
+	it("emits every raw delta and authoritatively finalizes complex JSON", async () => {
+		const expected = {
+			nested: { quote: 'say "hello"', path: "C:\\tmp", emoji: "🫠" },
+			items: [1, true, null],
+		};
+		const json = JSON.stringify(expected);
+		const deltas = json.split("");
+		const events: ProxyAssistantMessageEvent[] = [
+			{ type: "start" },
+			{ type: "toolcall_start", contentIndex: 0, id: "tool-1", toolName: "edit" },
+			...deltas.map(
+				(delta): ProxyAssistantMessageEvent => ({
+					type: "toolcall_delta",
+					contentIndex: 0,
+					delta,
+				}),
+			),
+			{ type: "toolcall_end", contentIndex: 0 },
+			{ type: "done", reason: "toolUse", usage },
+		];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => createProxyResponse(events)),
+		);
+		const stream = streamProxy(model, context, {
+			authToken: "test-token",
+			proxyUrl: "https://proxy.test",
+		});
+		const emittedDeltas: string[] = [];
+
+		for await (const event of stream) {
+			if (event.type === "toolcall_delta") {
+				emittedDeltas.push(event.delta);
+			}
+		}
+		const result = await stream.result();
+
+		expect(emittedDeltas).toEqual(deltas);
+		expect(result.content).toEqual([{ type: "toolCall", id: "tool-1", name: "edit", arguments: expected }]);
+		expect(result.content[0]).not.toHaveProperty("partialJson");
+	});
+
+	it("retains displayable tolerant arguments when the proxy stream is aborted", async () => {
+		const controller = new AbortController();
+		const delta = String.raw`{"path":"A\H","text":"col1	col2"}`;
+		const events: ProxyAssistantMessageEvent[] = [
+			{ type: "start" },
+			{ type: "toolcall_start", contentIndex: 0, id: "tool-1", toolName: "edit" },
+			{ type: "toolcall_delta", contentIndex: 0, delta },
+		];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => createOpenProxyResponse(events)),
+		);
+		const stream = streamProxy(model, context, {
+			authToken: "test-token",
+			proxyUrl: "https://proxy.test",
+			signal: controller.signal,
+		});
+		const seenEvents: AssistantMessageEvent[] = [];
+
+		for await (const event of stream) {
+			seenEvents.push(event);
+			if (event.type === "toolcall_delta") {
+				controller.abort();
+			}
+		}
+		const result = await stream.result();
+
+		expect(seenEvents.some((event) => event.type === "toolcall_delta" && event.delta === delta)).toBe(true);
+		expect(result.stopReason).toBe("aborted");
+		expect(result.content[0]).toMatchObject({
+			type: "toolCall",
+			arguments: { path: "A\\H", text: "col1\tcol2" },
+		});
+	});
+});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed streamed tool arguments repeatedly reparsing their full JSON prefix while preserving raw deltas and tolerant final parsing ([#942](https://github.com/PrimeIntellect-ai/prime-agent/issues/942)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -480,6 +480,17 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			stopReason: "stop",
 			timestamp: Date.now(),
 		};
+		const toolArgumentAccumulators = new Map<number, { accumulator: StreamingJsonAccumulator; block: ToolCall }>();
+		const materializeOpenToolArguments = (): void => {
+			for (const { accumulator, block } of toolArgumentAccumulators.values()) {
+				try {
+					block.arguments = accumulator.finish();
+				} catch {
+					// Preserve the provider's terminal error if cleanup parsing fails.
+				}
+			}
+			toolArgumentAccumulators.clear();
+		};
 
 		try {
 			let client: Anthropic;
@@ -534,7 +545,6 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 
 			type Block = (ThinkingContent | TextContent | ToolCall) & { index: number };
 			const blocks = output.content as Block[];
-			const toolArgumentAccumulators = new Map<number, StreamingJsonAccumulator>();
 
 			for await (const event of iterateAnthropicEvents(response, options?.signal, requestId)) {
 				if (event.type === "message_start") {
@@ -598,7 +608,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 							arguments: (event.content_block.input as Record<string, unknown>) ?? {},
 							index: event.index,
 						};
-						toolArgumentAccumulators.set(event.index, new StreamingJsonAccumulator());
+						toolArgumentAccumulators.set(event.index, {
+							accumulator: new StreamingJsonAccumulator(),
+							block,
+						});
 						output.content.push(block);
 						stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
 					}
@@ -633,7 +646,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 						if (block && block.type === "toolCall") {
 							const partialArguments = toolArgumentAccumulators
 								.get(event.index)
-								?.append(event.delta.partial_json);
+								?.accumulator?.append(event.delta.partial_json);
 							if (partialArguments !== undefined) {
 								block.arguments = partialArguments;
 							}
@@ -672,7 +685,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 								partial: output,
 							});
 						} else if (block.type === "toolCall") {
-							block.arguments = toolArgumentAccumulators.get(event.index)?.finish() ?? {};
+							block.arguments = toolArgumentAccumulators.get(event.index)?.accumulator.finish() ?? {};
 							toolArgumentAccumulators.delete(event.index);
 							stream.push({
 								type: "toolcall_end",
@@ -722,9 +735,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 				throw streamFailureFromStopReason(output.stopReasonRaw, { requestId });
 			}
 
+			materializeOpenToolArguments();
 			stream.push({ type: "done", reason: output.stopReason, message: output });
 			stream.end();
 		} catch (error) {
+			materializeOpenToolArguments();
 			for (const block of output.content) {
 				delete (block as { index?: number }).index;
 			}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -30,7 +30,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
-import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
+import { parseJsonWithRepair, StreamingJsonAccumulator } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
 	classifyStreamFailure,
@@ -532,8 +532,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			const requestId = response.headers.get("request-id") ?? undefined;
 			stream.push({ type: "start", partial: output });
 
-			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
+			type Block = (ThinkingContent | TextContent | ToolCall) & { index: number };
 			const blocks = output.content as Block[];
+			const toolArgumentAccumulators = new Map<number, StreamingJsonAccumulator>();
 
 			for await (const event of iterateAnthropicEvents(response, options?.signal, requestId)) {
 				if (event.type === "message_start") {
@@ -594,10 +595,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 							name: isOAuth
 								? fromClaudeCodeName(event.content_block.name, context.tools)
 								: event.content_block.name,
-							arguments: (event.content_block.input as Record<string, any>) ?? {},
-							partialJson: "",
+							arguments: (event.content_block.input as Record<string, unknown>) ?? {},
 							index: event.index,
 						};
+						toolArgumentAccumulators.set(event.index, new StreamingJsonAccumulator());
 						output.content.push(block);
 						stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
 					}
@@ -630,8 +631,12 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 						const index = blocks.findIndex((b) => b.index === event.index);
 						const block = blocks[index];
 						if (block && block.type === "toolCall") {
-							block.partialJson += event.delta.partial_json;
-							block.arguments = parseStreamingJson(block.partialJson);
+							const partialArguments = toolArgumentAccumulators
+								.get(event.index)
+								?.append(event.delta.partial_json);
+							if (partialArguments !== undefined) {
+								block.arguments = partialArguments;
+							}
 							stream.push({
 								type: "toolcall_delta",
 								contentIndex: index,
@@ -651,7 +656,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					const index = blocks.findIndex((b) => b.index === event.index);
 					const block = blocks[index];
 					if (block) {
-						delete (block as any).index;
+						delete (block as { index?: number }).index;
 						if (block.type === "text") {
 							stream.push({
 								type: "text_end",
@@ -667,10 +672,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 								partial: output,
 							});
 						} else if (block.type === "toolCall") {
-							block.arguments = parseStreamingJson(block.partialJson);
-							// Finalize in-place and strip the scratch buffer so replay only
-							// carries parsed arguments.
-							delete (block as { partialJson?: string }).partialJson;
+							block.arguments = toolArgumentAccumulators.get(event.index)?.finish() ?? {};
+							toolArgumentAccumulators.delete(event.index);
 							stream.push({
 								type: "toolcall_end",
 								contentIndex: index,
@@ -724,8 +727,6 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as { index?: number }).index;
-				// partialJson is only a streaming scratch buffer; never persist it.
-				delete (block as { partialJson?: string }).partialJson;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatStreamFailureMessage(error);

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -29,7 +29,7 @@ import type {
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
-import { parseStreamingJson } from "../utils/json-parse.js";
+import { parseStreamingJson, StreamingJsonAccumulator } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { classifyStreamFailure, StreamFailureError } from "../utils/stream-failure.js";
 import { transformMessages } from "./transform-messages.js";
@@ -289,7 +289,8 @@ export async function processResponsesStream<TApi extends Api>(
 	options?: OpenAIResponsesStreamOptions,
 ): Promise<void> {
 	let currentItem: ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | null = null;
-	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
+	let currentBlock: ThinkingContent | TextContent | ToolCall | null = null;
+	let currentArgumentAccumulator: StreamingJsonAccumulator | null = null;
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
 
@@ -301,11 +302,13 @@ export async function processResponsesStream<TApi extends Api>(
 			if (item.type === "reasoning") {
 				currentItem = item;
 				currentBlock = { type: "thinking", thinking: "" };
+				currentArgumentAccumulator = null;
 				output.content.push(currentBlock);
 				stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
 			} else if (item.type === "message") {
 				currentItem = item;
 				currentBlock = { type: "text", text: "" };
+				currentArgumentAccumulator = null;
 				output.content.push(currentBlock);
 				stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
 			} else if (item.type === "function_call") {
@@ -315,8 +318,8 @@ export async function processResponsesStream<TApi extends Api>(
 					id: `${item.call_id}|${item.id}`,
 					name: item.name,
 					arguments: {},
-					partialJson: item.arguments || "",
 				};
+				currentArgumentAccumulator = new StreamingJsonAccumulator(item.arguments || "");
 				output.content.push(currentBlock);
 				stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
 			}
@@ -408,9 +411,11 @@ export async function processResponsesStream<TApi extends Api>(
 				}
 			}
 		} else if (event.type === "response.function_call_arguments.delta") {
-			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson += event.delta;
-				currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall" && currentArgumentAccumulator) {
+				const partialArguments = currentArgumentAccumulator.append(event.delta);
+				if (partialArguments !== undefined) {
+					currentBlock.arguments = partialArguments;
+				}
 				stream.push({
 					type: "toolcall_delta",
 					contentIndex: blockIndex(),
@@ -419,10 +424,9 @@ export async function processResponsesStream<TApi extends Api>(
 				});
 			}
 		} else if (event.type === "response.function_call_arguments.done") {
-			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				const previousPartialJson = currentBlock.partialJson;
-				currentBlock.partialJson = event.arguments;
-				currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall" && currentArgumentAccumulator) {
+				const previousPartialJson = currentArgumentAccumulator.currentJson();
+				currentBlock.arguments = currentArgumentAccumulator.finish(event.arguments);
 
 				if (event.arguments.startsWith(previousPartialJson)) {
 					const delta = event.arguments.slice(previousPartialJson.length);
@@ -462,17 +466,15 @@ export async function processResponsesStream<TApi extends Api>(
 				});
 				currentBlock = null;
 			} else if (item.type === "function_call") {
-				const args =
-					currentBlock?.type === "toolCall" && currentBlock.partialJson
-						? parseStreamingJson(currentBlock.partialJson)
-						: parseStreamingJson(item.arguments || "{}");
+				const accumulatedJson = currentArgumentAccumulator?.currentJson() ?? "";
+				const finalJson = accumulatedJson || item.arguments || "{}";
+				const args = currentArgumentAccumulator
+					? currentArgumentAccumulator.finish(finalJson)
+					: parseStreamingJson(finalJson);
 
 				let toolCall: ToolCall;
 				if (currentBlock?.type === "toolCall") {
-					// Finalize in-place and strip the scratch buffer so replay only
-					// carries parsed arguments.
 					currentBlock.arguments = args;
-					delete (currentBlock as { partialJson?: string }).partialJson;
 					toolCall = currentBlock;
 				} else {
 					toolCall = {
@@ -484,6 +486,7 @@ export async function processResponsesStream<TApi extends Api>(
 				}
 
 				currentBlock = null;
+				currentArgumentAccumulator = null;
 				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
 			}
 		} else if (event.type === "response.completed") {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -293,8 +293,29 @@ export async function processResponsesStream<TApi extends Api>(
 	let currentArgumentAccumulator: StreamingJsonAccumulator | null = null;
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
+	const materializeOpenToolArguments = (): void => {
+		const block = currentBlock;
+		const accumulator = currentArgumentAccumulator;
+		currentArgumentAccumulator = null;
+		if (block?.type !== "toolCall" || !accumulator) {
+			return;
+		}
+		try {
+			block.arguments = accumulator.finish();
+		} catch {
+			// Preserve the response stream's terminal error if cleanup parsing fails.
+		}
+	};
 
-	for await (const event of openaiStream) {
+	const streamWithTerminalMaterialization = async function* (): AsyncGenerator<ResponseStreamEvent> {
+		try {
+			yield* openaiStream;
+		} finally {
+			materializeOpenToolArguments();
+		}
+	};
+
+	for await (const event of streamWithTerminalMaterialization()) {
 		if (event.type === "response.created") {
 			output.responseId = event.response.id;
 		} else if (event.type === "response.output_item.added") {

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -122,3 +122,63 @@ export function parseStreamingJson<T = Record<string, unknown>>(partialJson: str
 		}
 	}
 }
+
+type StreamingJsonParser<T> = (json: string) => T;
+
+/**
+ * Accumulates streamed JSON while limiting tolerant partial parses to
+ * geometrically increasing prefix lengths. Finalization always parses the
+ * authoritative full value once.
+ */
+export class StreamingJsonAccumulator<T = Record<string, unknown>> {
+	private rawJson: string;
+	private nextPartialParseLength = 1;
+	private finalizedJson: string | undefined;
+	private finalizedValue: T | undefined;
+	private hasFinalizedValue = false;
+
+	constructor(
+		initialJson = "",
+		private readonly parser: StreamingJsonParser<T> = (json) => parseStreamingJson<T>(json),
+	) {
+		this.rawJson = initialJson;
+	}
+
+	append(delta: string): T | undefined {
+		if (delta.length === 0) {
+			return undefined;
+		}
+
+		this.rawJson += delta;
+		this.hasFinalizedValue = false;
+		this.finalizedJson = undefined;
+		this.finalizedValue = undefined;
+
+		if (this.rawJson.length < this.nextPartialParseLength) {
+			return undefined;
+		}
+
+		const value = this.parser(this.rawJson);
+		while (this.nextPartialParseLength <= this.rawJson.length) {
+			this.nextPartialParseLength *= 2;
+		}
+		return value;
+	}
+
+	currentJson(): string {
+		return this.rawJson;
+	}
+
+	finish(finalJson = this.rawJson): T {
+		if (this.hasFinalizedValue && finalJson === this.finalizedJson) {
+			return this.finalizedValue as T;
+		}
+
+		this.rawJson = finalJson;
+		const value = this.parser(finalJson);
+		this.finalizedJson = finalJson;
+		this.finalizedValue = value;
+		this.hasFinalizedValue = true;
+		return value;
+	}
+}

--- a/packages/ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/ai/test/anthropic-sse-parsing.test.ts
@@ -117,6 +117,71 @@ function createCacheUsageEvents(cacheCreation: {
 	];
 }
 
+function createToolUseEvents(
+	deltas: string[],
+	options: { complete?: boolean; stopReason?: "tool_use" | "end_turn" } = {},
+): Array<{ event: string; data: string }> {
+	const events: Array<{ event: string; data: string }> = [
+		{
+			event: "message_start",
+			data: JSON.stringify({
+				type: "message_start",
+				message: {
+					id: "msg_tool_test",
+					usage: {
+						input_tokens: 12,
+						output_tokens: 0,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				},
+			}),
+		},
+		{
+			event: "content_block_start",
+			data: JSON.stringify({
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "tool_use", id: "toolu_test", name: "edit", input: {} },
+			}),
+		},
+		...deltas.map((partialJson) => ({
+			event: "content_block_delta",
+			data: JSON.stringify({
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: partialJson },
+			}),
+		})),
+	];
+
+	if (options.complete === false) {
+		return events;
+	}
+
+	events.push(
+		{
+			event: "content_block_stop",
+			data: JSON.stringify({ type: "content_block_stop", index: 0 }),
+		},
+		{
+			event: "message_delta",
+			data: JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: options.stopReason ?? "tool_use" },
+				usage: {
+					input_tokens: 12,
+					output_tokens: 5,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+			}),
+		},
+		{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+	);
+	return events;
+}
+
 describe("Anthropic raw SSE parsing", () => {
 	it.each([
 		{
@@ -274,5 +339,58 @@ describe("Anthropic raw SSE parsing", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(result.errorMessage).toBeUndefined();
 		expect(result.content).toEqual([{ type: "text", text: "Hello" }]);
+	});
+
+	it("emits every raw tool delta and finalizes complex arguments exactly", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const expected = {
+			nested: { quote: 'say "hello"', path: "C:\\tmp", emoji: "🫠" },
+			items: [1, true, null],
+		};
+		const argumentsJson = JSON.stringify(expected);
+		const deltas = argumentsJson.split("");
+		const response = createSseResponse(createToolUseEvents(deltas));
+		const stream = streamAnthropic(
+			model,
+			{ messages: [{ role: "user", content: "Use the edit tool.", timestamp: Date.now() }] },
+			{ client: createFakeAnthropicClient(response) },
+		);
+		const emittedDeltas: string[] = [];
+
+		for await (const event of stream) {
+			if (event.type === "toolcall_delta") {
+				emittedDeltas.push(event.delta);
+			}
+		}
+		const result = await stream.result();
+
+		expect(emittedDeltas).toEqual(deltas);
+		expect(result.content[0]).toMatchObject({ type: "toolCall", arguments: expected });
+	});
+
+	it("keeps emitted deltas and displayable partial arguments when SSE ends prematurely", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const delta = '{"nested":{"kept":true}}';
+		const response = createSseResponse(createToolUseEvents([delta], { complete: false }));
+		const stream = streamAnthropic(
+			model,
+			{ messages: [{ role: "user", content: "Use the edit tool.", timestamp: Date.now() }] },
+			{ client: createFakeAnthropicClient(response) },
+		);
+		const emittedDeltas: string[] = [];
+
+		for await (const event of stream) {
+			if (event.type === "toolcall_delta") {
+				emittedDeltas.push(event.delta);
+			}
+		}
+		const result = await stream.result();
+
+		expect(emittedDeltas).toEqual([delta]);
+		expect(result.stopReason).toBe("error");
+		expect(result.content[0]).toMatchObject({
+			type: "toolCall",
+			arguments: { nested: { kept: true } },
+		});
 	});
 });

--- a/packages/ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/ai/test/anthropic-sse-parsing.test.ts
@@ -370,8 +370,9 @@ describe("Anthropic raw SSE parsing", () => {
 
 	it("keeps emitted deltas and displayable partial arguments when SSE ends prematurely", async () => {
 		const model = getModel("anthropic", "claude-haiku-4-5");
-		const delta = '{"nested":{"kept":true}}';
-		const response = createSseResponse(createToolUseEvents([delta], { complete: false }));
+		const deltas = ['{"first":"materialized"', ',"x":1}'];
+		expect(deltas.map((delta) => delta.length)).toEqual([23, 7]);
+		const response = createSseResponse(createToolUseEvents(deltas, { complete: false }));
 		const stream = streamAnthropic(
 			model,
 			{ messages: [{ role: "user", content: "Use the edit tool.", timestamp: Date.now() }] },
@@ -386,11 +387,12 @@ describe("Anthropic raw SSE parsing", () => {
 		}
 		const result = await stream.result();
 
-		expect(emittedDeltas).toEqual([delta]);
+		expect(emittedDeltas).toEqual(deltas);
 		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("stream ended before message_stop");
 		expect(result.content[0]).toMatchObject({
 			type: "toolCall",
-			arguments: { nested: { kept: true } },
+			arguments: { first: "materialized", x: 1 },
 		});
 	});
 });

--- a/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
+++ b/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
@@ -60,7 +60,7 @@ async function* createFunctionCallEvents(
 	} as ResponseStreamEvent;
 }
 
-async function* createInterruptedFunctionCallEvents(delta: string): AsyncIterable<ResponseStreamEvent> {
+async function* createInterruptedFunctionCallEvents(deltas: string[]): AsyncIterable<ResponseStreamEvent> {
 	yield {
 		type: "response.output_item.added",
 		item: {
@@ -71,10 +71,12 @@ async function* createInterruptedFunctionCallEvents(delta: string): AsyncIterabl
 			arguments: "",
 		},
 	} as ResponseStreamEvent;
-	yield {
-		type: "response.function_call_arguments.delta",
-		delta,
-	} as ResponseStreamEvent;
+	for (const delta of deltas) {
+		yield {
+			type: "response.function_call_arguments.delta",
+			delta,
+		} as ResponseStreamEvent;
+	}
 	throw new Error("interrupted response stream");
 }
 
@@ -141,21 +143,24 @@ describe("openai responses partialJson cleanup", () => {
 	});
 
 	it("keeps emitted deltas and displayable partial arguments when the stream is interrupted", async () => {
-		const delta = '{"nested":{"kept":true}}';
+		const deltas = ['{"first":"materialized"', ',"x":1}'];
+		expect(deltas.map((delta) => delta.length)).toEqual([23, 7]);
 		const output = createOutput(model);
 		const stream = new AssistantMessageEventStream();
 		const pushSpy = vi.spyOn(stream, "push");
 
 		await expect(
-			processResponsesStream(createInterruptedFunctionCallEvents(delta), output, stream, model),
+			processResponsesStream(createInterruptedFunctionCallEvents(deltas), output, stream, model),
 		).rejects.toThrow("interrupted response stream");
 
 		const emittedEvents = pushSpy.mock.calls.map(([event]) => event as AssistantMessageEvent);
-		expect(emittedEvents.some((event) => event.type === "toolcall_delta" && event.delta === delta)).toBe(true);
+		expect(emittedEvents.filter((event) => event.type === "toolcall_delta").map((event) => event.delta)).toEqual(
+			deltas,
+		);
 		expect(emittedEvents.some((event) => event.type === "toolcall_end")).toBe(false);
 		expect(output.content[0]).toMatchObject({
 			type: "toolCall",
-			arguments: { nested: { kept: true } },
+			arguments: { first: "materialized", x: 1 },
 		});
 	});
 });

--- a/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
+++ b/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
@@ -24,7 +24,10 @@ function createOutput(model: Model<"openai-responses">): AssistantMessage {
 	};
 }
 
-async function* createFunctionCallEvents(argumentsJson: string): AsyncIterable<ResponseStreamEvent> {
+async function* createFunctionCallEvents(
+	argumentsJson: string,
+	deltas = ['{"path":"README.md"', ',"content":"updated"}'],
+): AsyncIterable<ResponseStreamEvent> {
 	yield {
 		type: "response.output_item.added",
 		item: {
@@ -35,14 +38,12 @@ async function* createFunctionCallEvents(argumentsJson: string): AsyncIterable<R
 			arguments: "",
 		},
 	} as ResponseStreamEvent;
-	yield {
-		type: "response.function_call_arguments.delta",
-		delta: '{"path":"README.md"',
-	} as ResponseStreamEvent;
-	yield {
-		type: "response.function_call_arguments.delta",
-		delta: ',"content":"updated"}',
-	} as ResponseStreamEvent;
+	for (const delta of deltas) {
+		yield {
+			type: "response.function_call_arguments.delta",
+			delta,
+		} as ResponseStreamEvent;
+	}
 	yield {
 		type: "response.function_call_arguments.done",
 		arguments: argumentsJson,
@@ -59,20 +60,39 @@ async function* createFunctionCallEvents(argumentsJson: string): AsyncIterable<R
 	} as ResponseStreamEvent;
 }
 
+async function* createInterruptedFunctionCallEvents(delta: string): AsyncIterable<ResponseStreamEvent> {
+	yield {
+		type: "response.output_item.added",
+		item: {
+			type: "function_call",
+			id: "fc_test",
+			call_id: "call_test",
+			name: "edit",
+			arguments: "",
+		},
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.function_call_arguments.delta",
+		delta,
+	} as ResponseStreamEvent;
+	throw new Error("interrupted response stream");
+}
+
+const model: Model<"openai-responses"> = {
+	id: "gpt-5-mini",
+	name: "GPT-5 Mini",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400000,
+	maxTokens: 128000,
+};
+
 describe("openai responses partialJson cleanup", () => {
 	it("removes partialJson from persisted tool-call blocks at output_item.done", async () => {
-		const model: Model<"openai-responses"> = {
-			id: "gpt-5-mini",
-			name: "GPT-5 Mini",
-			api: "openai-responses",
-			provider: "openai",
-			baseUrl: "https://api.openai.com/v1",
-			reasoning: true,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 400000,
-			maxTokens: 128000,
-		};
 		const output = createOutput(model);
 		const stream = new AssistantMessageEventStream();
 		const pushSpy = vi.spyOn(stream, "push");
@@ -97,5 +117,45 @@ describe("openai responses partialJson cleanup", () => {
 		}
 		expect(toolCallEnd.toolCall).toBe(persistedToolCall);
 		expect("partialJson" in toolCallEnd.toolCall).toBe(false);
+	});
+
+	it("emits every raw delta and finalizes complex arguments exactly", async () => {
+		const expected = {
+			nested: { quote: 'say "hello"', path: "C:\\tmp", emoji: "🫠" },
+			items: [1, true, null],
+		};
+		const argumentsJson = JSON.stringify(expected);
+		const deltas = argumentsJson.split("");
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+		const pushSpy = vi.spyOn(stream, "push");
+
+		await processResponsesStream(createFunctionCallEvents(argumentsJson, deltas), output, stream, model);
+
+		const emittedDeltas = pushSpy.mock.calls
+			.map(([event]) => event as AssistantMessageEvent)
+			.filter((event) => event.type === "toolcall_delta")
+			.map((event) => event.delta);
+		expect(emittedDeltas).toEqual(deltas);
+		expect(output.content[0]).toMatchObject({ type: "toolCall", arguments: expected });
+	});
+
+	it("keeps emitted deltas and displayable partial arguments when the stream is interrupted", async () => {
+		const delta = '{"nested":{"kept":true}}';
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+		const pushSpy = vi.spyOn(stream, "push");
+
+		await expect(
+			processResponsesStream(createInterruptedFunctionCallEvents(delta), output, stream, model),
+		).rejects.toThrow("interrupted response stream");
+
+		const emittedEvents = pushSpy.mock.calls.map(([event]) => event as AssistantMessageEvent);
+		expect(emittedEvents.some((event) => event.type === "toolcall_delta" && event.delta === delta)).toBe(true);
+		expect(emittedEvents.some((event) => event.type === "toolcall_end")).toBe(false);
+		expect(output.content[0]).toMatchObject({
+			type: "toolCall",
+			arguments: { nested: { kept: true } },
+		});
 	});
 });

--- a/packages/ai/test/streaming-json-accumulator.test.ts
+++ b/packages/ai/test/streaming-json-accumulator.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseStreamingJson, StreamingJsonAccumulator } from "../src/utils/json-parse.js";
+
+function appendByCodeUnit(accumulator: StreamingJsonAccumulator<Record<string, unknown>>, json: string): void {
+	for (let index = 0; index < json.length; index++) {
+		accumulator.append(json[index]);
+	}
+}
+
+describe("StreamingJsonAccumulator", () => {
+	it.each([1024, 64 * 1024, 2 * 1024 * 1024])(
+		"bounds full-prefix parsing for %i-byte streams with tiny deltas",
+		(payloadSize) => {
+			let parsedCharacters = 0;
+			const parser = vi.fn((json: string) => {
+				parsedCharacters += json.length;
+				return parseStreamingJson(json);
+			});
+			const accumulator = new StreamingJsonAccumulator<Record<string, unknown>>("", parser);
+			const payload = "x".repeat(payloadSize);
+			const json = JSON.stringify({ payload });
+
+			appendByCodeUnit(accumulator, json);
+			const result = accumulator.finish();
+
+			expect(result).toEqual({ payload });
+			expect(parser.mock.calls.length).toBeLessThanOrEqual(Math.ceil(Math.log2(json.length)) + 2);
+			expect(parsedCharacters).toBeLessThan(json.length * 4);
+		},
+	);
+
+	it("preserves nested JSON, escapes, and Unicode split across code units", () => {
+		const expected = {
+			nested: { quotes: 'say "hello"', slash: "C:\\tmp", emoji: "🫠", line: "one\ntwo" },
+			items: [1, true, null, { value: "café" }],
+		};
+		const json = JSON.stringify(expected);
+		const accumulator = new StreamingJsonAccumulator<Record<string, unknown>>();
+
+		appendByCodeUnit(accumulator, json);
+
+		expect(accumulator.finish()).toEqual(expected);
+	});
+
+	it.each(['{"outer":{"value":"unfinished', String.raw`{"path":"A\H","text":"col1	col2"}`, '{"items":[1,2,'])(
+		"matches tolerant final parsing for incomplete or malformed JSON: %s",
+		(json) => {
+			const accumulator = new StreamingJsonAccumulator<Record<string, unknown>>();
+			appendByCodeUnit(accumulator, json);
+
+			expect(accumulator.finish()).toEqual(parseStreamingJson(json));
+		},
+	);
+
+	it("uses a replacement final value authoritatively and caches repeated finalization", () => {
+		const parser = vi.fn(parseStreamingJson<Record<string, unknown>>);
+		const accumulator = new StreamingJsonAccumulator<Record<string, unknown>>("", parser);
+		appendByCodeUnit(accumulator, '{"value":"partial');
+		const finalJson = '{"value":"final","complete":true}';
+		const callsBeforeFinish = parser.mock.calls.length;
+
+		expect(accumulator.finish(finalJson)).toEqual({ value: "final", complete: true });
+		expect(accumulator.finish(finalJson)).toEqual({ value: "final", complete: true });
+		expect(parser.mock.calls.length).toBe(callsBeforeFinish + 1);
+	});
+});


### PR DESCRIPTION
## Summary

- replace per-delta full-prefix JSON parsing with a shared accumulator that materializes tolerant partial objects at geometric length thresholds
- preserve every raw `toolcall_delta` and perform one cached authoritative parse when Anthropic, OpenAI Responses, or proxy tool arguments finish
- materialize buffered trailing arguments before terminal errors, premature ends, or aborts without masking the original failure
- keep incomplete and malformed arguments displayable without persisting parser scratch state

## Problem

Anthropic and OpenAI Responses appended each tool-argument delta and reparsed the entire accumulated JSON prefix. A deterministic one-code-unit probe showed cumulative parsed input growing quadratically:

| Payload length | Full-prefix parse calls | Cumulative parsed characters |
| ---: | ---: | ---: |
| 1,047 | 1,047 | 548,628 |
| 2,071 | 2,071 | 2,145,556 |
| 4,119 | 4,119 | 8,485,140 |

The agent proxy reconstruction path had the same behavior after receiving compact raw deltas.

## Solution design

`StreamingJsonAccumulator` retains one raw JSON value and invokes the existing tolerant parser only when the prefix crosses geometrically increasing code-unit thresholds. This bounds the number of common-path full-prefix parses logarithmically and cumulative parsed characters linearly while retaining O(n) payload memory.

Providers and proxy reconstruction always emit the original raw delta. Partial `arguments` remain displayable from the latest materialization. Completion parses the authoritative provider value exactly once and caches that result when OpenAI repeats the same final value in adjacent completion events.

Terminal cleanup finalizes any still-open accumulator into its tool block before an error message is exposed. Cleanup parsing is guarded so it cannot replace the original provider, response-stream, or proxy failure, and accumulator state is cleared afterward.

No daemon command, event, response shape, protocol version, or schema revision changes.

## Acceptance criteria

- [x] common delta paths avoid reparsing every full prefix
- [x] final arguments preserve existing tolerant parse semantics
- [x] incomplete and malformed JSON remains displayable
- [x] terminal error and abort messages include trailing below-threshold arguments without changing the original failure
- [x] memory remains bounded by the accumulated payload and latest parsed object
- [x] Anthropic, OpenAI Responses, and proxy streams preserve raw delta ordering and final event behavior
- [x] nested JSON, escapes, Unicode split across surrogate code units, many tiny chunks, multi-megabyte payloads, malformed final input, interruption, premature end, and abort are covered

## Verification

- `cd packages/ai && npx tsx ../../node_modules/vitest/dist/cli.js --run test/streaming-json-accumulator.test.ts test/anthropic-sse-parsing.test.ts test/openai-responses-partial-json-cleanup.test.ts` (19 passed)
- `cd packages/agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/proxy.test.ts` (2 passed)
- `npm run check`

The deterministic scaling regression covers 1 KiB, 64 KiB, and 2 MiB payloads split into one-code-unit deltas. It asserts at most `ceil(log2(n)) + 2` parser calls and fewer than `4n` cumulative parsed characters; it does not rely on wall-clock timing.

## Residual risk

Partial structured arguments update less frequently as a tool call grows. Raw deltas still arrive unchanged on every event, and final structured arguments are authoritative. The regression suite fixes this tradeoff as intentional behavior.

Fixes #942


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parse streamed tool-call arguments incrementally using `StreamingJsonAccumulator`
> - Replaces per-delta full-prefix JSON reparsing with a new `StreamingJsonAccumulator` class ([json-parse.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/980/files#diff-77e0781eb08fb6dbe9c71a2343a1245f2481e3525365953f99dcdd8228affa94)) that accumulates deltas and only re-parses at geometrically increasing length thresholds.
> - Updates the Anthropic, OpenAI Responses, and proxy stream handlers to use accumulators per tool-call content block, finalizing arguments at block stop or stream termination (including errors and aborts).
> - Raw argument deltas are still emitted unchanged; only the final `arguments` value on each tool-call block is affected.
> - Behavioral Change: partial/interrupted streams now tolerantly materialize the best available parsed arguments rather than leaving `arguments` unset or holding a partial string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7620aec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->