### PR TITLE
fix(coding-agent): coalesce daemon peer synchronization

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
+- Fixed bursty daemon peer updates queuing redundant all-to-all synchronization passes and resending unchanged peer catalogs ([#943](https://github.com/PrimeIntellect-ai/prime-agent/issues/943)).
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 
 ## [0.7.1] - 2026-08-07

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -306,6 +306,18 @@ interface WorkerAttachData {
 	releaseTranscript?: () => void;
 }
 
+interface AgentPeerCatalogWorkerSnapshot {
+	readonly workerId: string;
+	readonly worker: ResidentWorker;
+	readonly client: DaemonWorkerClient;
+	readonly peer?: Readonly<AgentSessionMessageAgentSummary>;
+}
+
+interface AgentPeerCatalogSnapshot {
+	readonly revision: number;
+	readonly workers: readonly AgentPeerCatalogWorkerSnapshot[];
+}
+
 interface SupervisorPromptAdmission {
 	client: DaemonSocketClient;
 	activeSessionId: string;
@@ -604,7 +616,14 @@ export class DaemonSupervisor {
 	private commandJournal!: CommandRecoveryJournal;
 	private readonly streamReconstructor = new CompactAssistantStreamReconstructor();
 	private readonly compactCatchupInProgress = new Set<string>();
-	private agentPeerSyncQueue: Promise<void> = Promise.resolve();
+	private agentPeerSyncDirty = false;
+	private agentPeerSyncDrain?: Promise<void>;
+	private readonly deliveredAgentPeerPayloads = new WeakMap<
+		DaemonWorkerClient,
+		{ revision: number; fingerprint: string }
+	>();
+	private agentPeerCatalogFingerprint?: string;
+	private readonly agentPeerSyncStats = { passes: 0, sends: 0, catalogRevision: 0 };
 	private readonly pendingSessionNames = new Set<string>();
 	private readonly catalog: DaemonCatalogClient;
 	private readonly settingsManager: SettingsManager;
@@ -3052,34 +3071,93 @@ export class DaemonSupervisor {
 	}
 
 	private syncAgentPeers(): Promise<void> {
-		const sync = this.agentPeerSyncQueue
-			.catch(() => undefined)
-			.then(async () => {
-				const readyWorkers = [...this.workers.values()].filter(
+		if (this.shuttingDown) return Promise.resolve();
+		this.agentPeerSyncDirty = true;
+		if (this.agentPeerSyncDrain) return this.agentPeerSyncDrain;
+		const drain = Promise.resolve().then(() => this.drainAgentPeerSync());
+		let trackedDrain!: Promise<void>;
+		trackedDrain = drain.finally(() => {
+			if (this.agentPeerSyncDrain === trackedDrain) this.agentPeerSyncDrain = undefined;
+		});
+		this.agentPeerSyncDrain = trackedDrain;
+		return trackedDrain;
+	}
+
+	private async drainAgentPeerSync(): Promise<void> {
+		let retryAvailable = true;
+		let failures: Error[] = [];
+		while (this.agentPeerSyncDirty && !this.shuttingDown) {
+			this.agentPeerSyncDirty = false;
+			failures = await this.runAgentPeerSyncPass(this.createAgentPeerCatalogSnapshot());
+			if (failures.length > 0 && retryAvailable && !this.shuttingDown) {
+				retryAvailable = false;
+				this.agentPeerSyncDirty = true;
+			}
+		}
+		if (failures.length > 0) {
+			throw new AggregateError(failures, `Could not synchronize agent peers with ${failures.length} worker(s)`);
+		}
+	}
+
+	private createAgentPeerCatalogSnapshot(): AgentPeerCatalogSnapshot {
+		const workers = Object.freeze(
+			[...this.workers.values()]
+				.filter(
 					(worker): worker is ResidentWorker & { client: DaemonWorkerClient } =>
 						this.isVisibleWorker(worker) &&
 						worker.descriptor.lifecycle === "ready" &&
 						worker.client !== undefined,
+				)
+				.map((worker): AgentPeerCatalogWorkerSnapshot => {
+					const root = worker.summaries.get(worker.descriptor.rootActiveSessionId);
+					return Object.freeze({
+						workerId: worker.descriptor.workerId,
+						worker,
+						client: worker.client,
+						...(root ? { peer: Object.freeze(this.agentPeerSummary(root)) } : {}),
+					});
+				}),
+		);
+		const fingerprint = createHash("sha256")
+			.update(JSON.stringify(workers.map((worker) => [worker.workerId, worker.peer])))
+			.digest("base64url");
+		if (fingerprint !== this.agentPeerCatalogFingerprint) {
+			this.agentPeerCatalogFingerprint = fingerprint;
+			this.agentPeerSyncStats.catalogRevision++;
+		}
+		return Object.freeze({ revision: this.agentPeerSyncStats.catalogRevision, workers });
+	}
+
+	private async runAgentPeerSyncPass(snapshot: AgentPeerCatalogSnapshot): Promise<Error[]> {
+		this.agentPeerSyncStats.passes++;
+		const results = await Promise.all(
+			snapshot.workers.map(async (target): Promise<Error | undefined> => {
+				const peers = snapshot.workers.flatMap((candidate) =>
+					candidate.workerId !== target.workerId && candidate.peer ? [candidate.peer] : [],
 				);
-				await Promise.all(
-					readyWorkers.map(async (worker) => {
-						const peers = [
-							...readyWorkers
-								.filter((candidate) => candidate !== worker)
-								.flatMap((candidate) => {
-									const root = candidate.summaries.get(candidate.descriptor.rootActiveSessionId);
-									return root ? [this.agentPeerSummary(root)] : [];
-								}),
-						];
-						const response = await worker.client.requestWorker({ type: "worker_sync_agent_peers", peers }, 5000);
-						if (!response.success) {
-							throw new Error(response.error);
-						}
-					}),
-				);
-			});
-		this.agentPeerSyncQueue = sync;
-		return sync;
+				Object.freeze(peers);
+				const fingerprint = createHash("sha256").update(JSON.stringify(peers)).digest("base64url");
+				if (this.deliveredAgentPeerPayloads.get(target.client)?.fingerprint === fingerprint) return undefined;
+				this.agentPeerSyncStats.sends++;
+				try {
+					const response = await target.client.requestWorker({ type: "worker_sync_agent_peers", peers }, 5000);
+					if (!response.success) throw new Error(response.error);
+					const current = this.workers.get(target.workerId);
+					if (
+						current === target.worker &&
+						current.client === target.client &&
+						this.isVisibleWorker(current) &&
+						current.descriptor.lifecycle === "ready"
+					) {
+						this.deliveredAgentPeerPayloads.set(target.client, { revision: snapshot.revision, fingerprint });
+					}
+					return undefined;
+				} catch (error) {
+					return error instanceof Error ? error : new Error(String(error));
+				}
+			}),
+		);
+		return results.filter((error): error is Error => error !== undefined);
 	}
 
 	private isVisibleWorker(worker: ResidentWorker): boolean {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -134,6 +134,7 @@ const UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS = 90_000;
 // an abandoned prepare leaves the daemon permanently fenced with workers stopped.
 const UPDATE_RESTART_PREPARE_DEADLINE_MS = 100_000;
 const WORKER_RETRY_DELAYS_MS = [250, 1000, 5000] as const;
+const AGENT_PEER_SYNC_RETRY_DELAYS_MS = [250, 1000, 5000] as const;
 const DEFERRED_RECOVERY_RECHECK_MS = 5000;
 const OWNED_WORKER_DISCONNECT_GRACE_MS = 30_000;
 const IDLE_EVICTION_MAX_SWEEP_INTERVAL_MS = 5 * 60_000;
@@ -618,6 +619,8 @@ export class DaemonSupervisor {
 	private readonly compactCatchupInProgress = new Set<string>();
 	private agentPeerSyncDirty = false;
 	private agentPeerSyncDrain?: Promise<void>;
+	private agentPeerSyncRetryTimer?: ReturnType<typeof setTimeout>;
+	private agentPeerSyncRetryAttempt = 0;
 	private readonly deliveredAgentPeerPayloads = new WeakMap<
 		DaemonWorkerClient,
 		{ revision: number; fingerprint: string }
@@ -761,6 +764,12 @@ export class DaemonSupervisor {
 		if (!this.idleEvictionTimer) return;
 		clearTimeout(this.idleEvictionTimer);
 		this.idleEvictionTimer = undefined;
+	}
+
+	private beginShutdown(): void {
+		this.shuttingDown = true;
+		this.agentPeerSyncDirty = false;
+		this.resetAgentPeerSyncRetry();
 	}
 
 	private scheduleIdleEvictionSweep(): void {
@@ -3071,7 +3080,11 @@ export class DaemonSupervisor {
 	}
 
 	private syncAgentPeers(): Promise<void> {
-		if (this.shuttingDown) return Promise.resolve();
+		if (this.shuttingDown) {
+			this.resetAgentPeerSyncRetry();
+			return Promise.resolve();
+		}
+		this.clearAgentPeerSyncRetryTimer();
 		this.agentPeerSyncDirty = true;
 		if (this.agentPeerSyncDrain) return this.agentPeerSyncDrain;
 		const drain = Promise.resolve().then(() => this.drainAgentPeerSync());
@@ -3095,8 +3108,44 @@ export class DaemonSupervisor {
 			}
 		}
 		if (failures.length > 0) {
+			if (this.shuttingDown) this.resetAgentPeerSyncRetry();
+			else this.scheduleAgentPeerSyncRetry();
 			throw new AggregateError(failures, `Could not synchronize agent peers with ${failures.length} worker(s)`);
 		}
+		this.resetAgentPeerSyncRetry();
+	}
+
+	private scheduleAgentPeerSyncRetry(): void {
+		if (this.shuttingDown || this.agentPeerSyncRetryTimer) return;
+		const delayMs =
+			AGENT_PEER_SYNC_RETRY_DELAYS_MS[
+				Math.min(this.agentPeerSyncRetryAttempt, AGENT_PEER_SYNC_RETRY_DELAYS_MS.length - 1)
+			]!;
+		this.agentPeerSyncRetryAttempt = Math.min(
+			this.agentPeerSyncRetryAttempt + 1,
+			AGENT_PEER_SYNC_RETRY_DELAYS_MS.length,
+		);
+		const timer = setTimeout(() => {
+			if (this.agentPeerSyncRetryTimer !== timer) return;
+			this.agentPeerSyncRetryTimer = undefined;
+			if (this.shuttingDown) return;
+			void this.syncAgentPeers().catch((error) => {
+				if (!this.shuttingDown) this.log(`Could not synchronize agent peers during retry: ${String(error)}`);
+			});
+		}, delayMs);
+		timer.unref();
+		this.agentPeerSyncRetryTimer = timer;
+	}
+
+	private clearAgentPeerSyncRetryTimer(): void {
+		if (!this.agentPeerSyncRetryTimer) return;
+		clearTimeout(this.agentPeerSyncRetryTimer);
+		this.agentPeerSyncRetryTimer = undefined;
+	}
+
+	private resetAgentPeerSyncRetry(): void {
+		this.clearAgentPeerSyncRetryTimer();
+		this.agentPeerSyncRetryAttempt = 0;
 	}
 
 	private createAgentPeerCatalogSnapshot(): AgentPeerCatalogSnapshot {
@@ -4785,7 +4834,7 @@ export class DaemonSupervisor {
 	}
 
 	private async cleanupSupervisorResourcesOnce(): Promise<void> {
-		this.shuttingDown = true;
+		this.beginShutdown();
 		this.clearIdleEvictionTimer();
 		await this.idleEvictionSweep?.catch(() => undefined);
 		for (const cleanup of this.signalCleanupHandlers.splice(0)) {
@@ -4884,7 +4933,7 @@ export class DaemonSupervisor {
 		if (this.shuttingDown) {
 			process.exit(exitCode);
 		}
-		this.shuttingDown = true;
+		this.beginShutdown();
 		this.clearIdleEvictionTimer();
 		await this.idleEvictionSweep?.catch(() => undefined);
 		if (closingReason) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3087,10 +3087,21 @@ export class DaemonSupervisor {
 		this.clearAgentPeerSyncRetryTimer();
 		this.agentPeerSyncDirty = true;
 		if (this.agentPeerSyncDrain) return this.agentPeerSyncDrain;
+		return this.startAgentPeerSyncDrain();
+	}
+
+	private startAgentPeerSyncDrain(): Promise<void> {
 		const drain = Promise.resolve().then(() => this.drainAgentPeerSync());
 		let trackedDrain!: Promise<void>;
 		trackedDrain = drain.finally(() => {
-			if (this.agentPeerSyncDrain === trackedDrain) this.agentPeerSyncDrain = undefined;
+			if (this.agentPeerSyncDrain !== trackedDrain) return;
+			this.agentPeerSyncDrain = undefined;
+			if (this.shuttingDown || !this.agentPeerSyncDirty) return;
+			void this.startAgentPeerSyncDrain().catch((error) => {
+				if (!this.shuttingDown) {
+					this.log(`Could not synchronize agent peers after a settling update: ${String(error)}`);
+				}
+			});
 		});
 		this.agentPeerSyncDrain = trackedDrain;
 		return trackedDrain;

--- a/packages/coding-agent/test/daemon-supervisor-peer-sync.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-peer-sync.test.ts
@@ -36,12 +36,17 @@ interface SupervisorPeerSyncInternals {
 	workers: Map<string, PeerWorker>;
 	shuttingDown: boolean;
 	agentPeerSyncStats: PeerSyncStats;
+	agentPeerSyncRetryAttempt: number;
+	agentPeerSyncRetryTimer?: ReturnType<typeof setTimeout>;
+	log: ReturnType<typeof vi.fn>;
+	beginShutdown(): void;
 	syncAgentPeers(): Promise<void>;
 }
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
+	vi.useRealTimers();
 	for (const directory of tempDirs.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
 
@@ -98,6 +103,7 @@ function createSupervisor(workers: readonly PeerWorker[]): SupervisorPeerSyncInt
 		defaultSessionConfig: { agentDir: directory, cwd: directory },
 		descriptorDir: join(directory, "workers"),
 	}) as unknown as SupervisorPeerSyncInternals;
+	supervisor.log = vi.fn();
 	for (const resident of workers) supervisor.workers.set(resident.descriptor.workerId, resident);
 	return supervisor;
 }
@@ -227,6 +233,88 @@ describe("daemon supervisor peer synchronization", () => {
 		expect(first.client?.requestWorker).toHaveBeenCalledOnce();
 		expect(replacement).toHaveBeenCalledOnce();
 		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 3, sends: 4, catalogRevision: 1 });
+	});
+
+	it("keeps one bounded backoff retry alive until the same connection recovers", async () => {
+		vi.useFakeTimers();
+		let attempts = 0;
+		let inFlight = 0;
+		let maxInFlight = 0;
+		const resident = worker(
+			"worker",
+			vi.fn(async () => {
+				attempts++;
+				inFlight++;
+				maxInFlight = Math.max(maxInFlight, inFlight);
+				await Promise.resolve();
+				inFlight--;
+				if (attempts <= 4) throw new Error(`transient peer sync failure ${attempts}`);
+				return workerSyncSuccess();
+			}),
+		);
+		const healthy = worker("healthy");
+		const supervisor = createSupervisor([healthy, resident]);
+
+		await expect(supervisor.syncAgentPeers()).rejects.toThrow("Could not synchronize agent peers");
+		expect(attempts).toBe(2);
+		expect(supervisor.agentPeerSyncRetryTimer).toBeDefined();
+
+		await vi.advanceTimersByTimeAsync(250);
+		expect(attempts).toBe(4);
+		expect(supervisor.agentPeerSyncRetryTimer).toBeDefined();
+
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(attempts).toBe(5);
+		expect(healthy.client?.requestWorker).toHaveBeenCalledOnce();
+		expect(maxInFlight).toBe(1);
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 5, sends: 6, catalogRevision: 1 });
+		expect(supervisor.agentPeerSyncRetryAttempt).toBe(0);
+		expect(supervisor.agentPeerSyncRetryTimer).toBeUndefined();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("cancels a failed connection's pending retry when its replacement synchronizes", async () => {
+		vi.useFakeTimers();
+		const failedRequest = vi.fn(async () => {
+			throw new Error("disconnected peer sync");
+		});
+		const resident = worker("worker", failedRequest);
+		const supervisor = createSupervisor([resident]);
+
+		await expect(supervisor.syncAgentPeers()).rejects.toThrow("Could not synchronize agent peers");
+		expect(failedRequest).toHaveBeenCalledTimes(2);
+		expect(supervisor.agentPeerSyncRetryTimer).toBeDefined();
+
+		const replacementRequest = vi.fn(async () => workerSyncSuccess());
+		resident.client = { requestWorker: replacementRequest };
+		await supervisor.syncAgentPeers();
+
+		expect(replacementRequest).toHaveBeenCalledOnce();
+		expect(supervisor.agentPeerSyncRetryTimer).toBeUndefined();
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(failedRequest).toHaveBeenCalledTimes(2);
+		expect(replacementRequest).toHaveBeenCalledOnce();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("cancels a pending peer retry when shutdown begins", async () => {
+		vi.useFakeTimers();
+		const requestWorker = vi.fn(async () => {
+			throw new Error("persistent peer sync failure");
+		});
+		const supervisor = createSupervisor([worker("worker", requestWorker)]);
+
+		await expect(supervisor.syncAgentPeers()).rejects.toThrow("Could not synchronize agent peers");
+		expect(requestWorker).toHaveBeenCalledTimes(2);
+		expect(supervisor.agentPeerSyncRetryTimer).toBeDefined();
+
+		supervisor.beginShutdown();
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(requestWorker).toHaveBeenCalledTimes(2);
+		expect(supervisor.agentPeerSyncRetryAttempt).toBe(0);
+		expect(supervisor.agentPeerSyncRetryTimer).toBeUndefined();
+		expect(vi.getTimerCount()).toBe(0);
 	});
 
 	it("does not start or follow up peer synchronization after shutdown begins", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-peer-sync.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-peer-sync.test.ts
@@ -35,11 +35,15 @@ interface PeerWorker {
 interface SupervisorPeerSyncInternals {
 	workers: Map<string, PeerWorker>;
 	shuttingDown: boolean;
+	agentPeerSyncDirty: boolean;
+	agentPeerSyncDrain?: Promise<void>;
 	agentPeerSyncStats: PeerSyncStats;
 	agentPeerSyncRetryAttempt: number;
 	agentPeerSyncRetryTimer?: ReturnType<typeof setTimeout>;
 	log: ReturnType<typeof vi.fn>;
 	beginShutdown(): void;
+	resetAgentPeerSyncRetry(): void;
+	scheduleAgentPeerSyncRetry(): void;
 	syncAgentPeers(): Promise<void>;
 }
 
@@ -315,6 +319,63 @@ describe("daemon supervisor peer synchronization", () => {
 		expect(supervisor.agentPeerSyncRetryAttempt).toBe(0);
 		expect(supervisor.agentPeerSyncRetryTimer).toBeUndefined();
 		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("hands fulfilled settlement-window dirtiness to a new drain", async () => {
+		const first = worker("first");
+		const second = worker("second");
+		const supervisor = createSupervisor([first, second]);
+		const resetRetry = supervisor.resetAgentPeerSyncRetry.bind(supervisor);
+		let injected = false;
+		supervisor.resetAgentPeerSyncRetry = () => {
+			resetRetry();
+			if (injected) return;
+			injected = true;
+			queueMicrotask(() => {
+				const updated = summary("second", { isStreaming: true });
+				second.summaries.set(updated.activeSessionId ?? updated.id, updated);
+				void supervisor.syncAgentPeers().catch(() => undefined);
+			});
+		};
+
+		await supervisor.syncAgentPeers();
+		await supervisor.agentPeerSyncDrain;
+
+		expect(first.client?.requestWorker).toHaveBeenCalledTimes(2);
+		expect(second.client?.requestWorker).toHaveBeenCalledOnce();
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 2, sends: 3, catalogRevision: 2 });
+		expect(supervisor.agentPeerSyncDirty).toBe(false);
+		expect(supervisor.agentPeerSyncDrain).toBeUndefined();
+		expect(supervisor.agentPeerSyncRetryTimer).toBeUndefined();
+	});
+
+	it("hands rejected settlement-window dirtiness to a new drain", async () => {
+		let succeeds = false;
+		const requestWorker = vi.fn(async () => {
+			if (!succeeds) throw new Error("settling peer sync failure");
+			return workerSyncSuccess();
+		});
+		const supervisor = createSupervisor([worker("worker", requestWorker)]);
+		const scheduleRetry = supervisor.scheduleAgentPeerSyncRetry.bind(supervisor);
+		let injected = false;
+		supervisor.scheduleAgentPeerSyncRetry = () => {
+			scheduleRetry();
+			if (injected) return;
+			injected = true;
+			queueMicrotask(() => {
+				succeeds = true;
+				void supervisor.syncAgentPeers().catch(() => undefined);
+			});
+		};
+
+		await expect(supervisor.syncAgentPeers()).rejects.toThrow("Could not synchronize agent peers");
+		await supervisor.agentPeerSyncDrain;
+
+		expect(requestWorker).toHaveBeenCalledTimes(3);
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 3, sends: 3, catalogRevision: 1 });
+		expect(supervisor.agentPeerSyncDirty).toBe(false);
+		expect(supervisor.agentPeerSyncDrain).toBeUndefined();
+		expect(supervisor.agentPeerSyncRetryTimer).toBeUndefined();
 	});
 
 	it("does not start or follow up peer synchronization after shutdown begins", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-peer-sync.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-peer-sync.test.ts
@@ -1,0 +1,256 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionMessageAgentSummary } from "../src/core/agent-messages.js";
+import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
+import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+
+interface Deferred<T = void> {
+	promise: Promise<T>;
+	resolve(value: T): void;
+}
+
+interface PeerSyncStats {
+	passes: number;
+	sends: number;
+	catalogRevision: number;
+}
+
+interface PeerClient {
+	requestWorker: ReturnType<typeof vi.fn>;
+}
+
+interface PeerWorker {
+	descriptor: {
+		workerId: string;
+		lifecycle: "ready";
+		rootActiveSessionId: string;
+		ownerClientId?: string;
+	};
+	client?: PeerClient;
+	summaries: Map<string, SessionSummary>;
+}
+
+interface SupervisorPeerSyncInternals {
+	workers: Map<string, PeerWorker>;
+	shuttingDown: boolean;
+	agentPeerSyncStats: PeerSyncStats;
+	syncAgentPeers(): Promise<void>;
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const directory of tempDirs.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function deferred<T = void>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function summary(workerId: string, overrides: Partial<SessionSummary> = {}): SessionSummary {
+	const activeSessionId = `${workerId}-active`;
+	return {
+		id: activeSessionId,
+		activeSessionId,
+		lifecycle: "live",
+		activity: "idle",
+		isSessionActive: false,
+		sessionId: `${workerId}-session`,
+		cwd: "/tmp/project",
+		isStreaming: false,
+		isCompacting: false,
+		attachedClients: 0,
+		messageCount: 1,
+		sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+		...overrides,
+	};
+}
+
+function worker(workerId: string, requestWorker?: PeerClient["requestWorker"]): PeerWorker {
+	const root = summary(workerId);
+	return {
+		descriptor: {
+			workerId,
+			lifecycle: "ready",
+			rootActiveSessionId: root.activeSessionId ?? root.id,
+		},
+		client: {
+			requestWorker: requestWorker ?? vi.fn(async () => workerSyncSuccess()),
+		},
+		summaries: new Map([[root.activeSessionId ?? root.id, root]]),
+	};
+}
+
+function workerSyncSuccess() {
+	return { type: "response" as const, command: "worker_sync_agent_peers", success: true as const };
+}
+
+function createSupervisor(workers: readonly PeerWorker[]): SupervisorPeerSyncInternals {
+	const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-peer-sync-"));
+	tempDirs.push(directory);
+	const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+		defaultSessionConfig: { agentDir: directory, cwd: directory },
+		descriptorDir: join(directory, "workers"),
+	}) as unknown as SupervisorPeerSyncInternals;
+	for (const resident of workers) supervisor.workers.set(resident.descriptor.workerId, resident);
+	return supervisor;
+}
+
+function sentPeers(client: PeerClient, call: number): AgentSessionMessageAgentSummary[] {
+	const command = client.requestWorker.mock.calls[call]?.[0] as
+		| { type: "worker_sync_agent_peers"; peers: AgentSessionMessageAgentSummary[] }
+		| undefined;
+	if (!command) throw new Error(`Missing peer synchronization call ${call}`);
+	return command.peers;
+}
+
+describe("daemon supervisor peer synchronization", () => {
+	it("coalesces a dirty burst into one follow-up pass with linear send count", async () => {
+		const firstPassReached = deferred();
+		const releaseFirstPass = deferred();
+		const residents = Array.from({ length: 12 }, (_, index) =>
+			worker(
+				`worker-${index}`,
+				vi.fn(async () => {
+					firstPassReached.resolve();
+					await releaseFirstPass.promise;
+					return workerSyncSuccess();
+				}),
+			),
+		);
+		const supervisor = createSupervisor(residents);
+
+		const initial = supervisor.syncAgentPeers();
+		await firstPassReached.promise;
+		const burst = Array.from({ length: 100 }, () => supervisor.syncAgentPeers());
+
+		for (const resident of residents) expect(resident.client?.requestWorker).toHaveBeenCalledOnce();
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 1, sends: residents.length });
+
+		releaseFirstPass.resolve();
+		await Promise.all([initial, ...burst]);
+
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 2, sends: residents.length });
+		for (const resident of residents) {
+			expect(resident.client?.requestWorker).toHaveBeenCalledOnce();
+			expect(sentPeers(resident.client!, 0)).toHaveLength(residents.length - 1);
+		}
+	});
+
+	it("publishes one follow-up snapshot when workers join and leave during a pass", async () => {
+		const firstSendReached = deferred();
+		const releaseFirstSend = deferred();
+		const first = worker(
+			"first",
+			vi.fn(async () => {
+				firstSendReached.resolve();
+				await releaseFirstSend.promise;
+				return workerSyncSuccess();
+			}),
+		);
+		const leaving = worker("leaving");
+		const joining = worker("joining");
+		const supervisor = createSupervisor([first, leaving]);
+
+		const initial = supervisor.syncAgentPeers();
+		await firstSendReached.promise;
+		supervisor.workers.delete(leaving.descriptor.workerId);
+		supervisor.workers.set(joining.descriptor.workerId, joining);
+		const dirty = supervisor.syncAgentPeers();
+		releaseFirstSend.resolve();
+		await Promise.all([initial, dirty]);
+
+		expect(sentPeers(first.client!, 0).map((peer) => peer.activeSessionId)).toEqual(["leaving-active"]);
+		expect(sentPeers(first.client!, 1).map((peer) => peer.activeSessionId)).toEqual(["joining-active"]);
+		expect(leaving.client?.requestWorker).toHaveBeenCalledOnce();
+		expect(joining.client?.requestWorker).toHaveBeenCalledOnce();
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 2, sends: 4 });
+	});
+
+	it("keeps an in-flight snapshot immutable and sends a changed follow-up payload", async () => {
+		const firstSendReached = deferred();
+		const releaseFirstSend = deferred();
+		const first = worker(
+			"first",
+			vi.fn(async () => {
+				firstSendReached.resolve();
+				await releaseFirstSend.promise;
+				return workerSyncSuccess();
+			}),
+		);
+		const second = worker("second");
+		const supervisor = createSupervisor([first, second]);
+
+		const initial = supervisor.syncAgentPeers();
+		await firstSendReached.promise;
+		const updated = summary("second", { isStreaming: true, unfinishedActionCount: 2 });
+		second.summaries.set(updated.activeSessionId ?? updated.id, updated);
+		const dirty = supervisor.syncAgentPeers();
+		releaseFirstSend.resolve();
+		await Promise.all([initial, dirty]);
+
+		expect(sentPeers(first.client!, 0)[0]).toMatchObject({ isStreaming: false, unfinishedActionCount: 0 });
+		expect(sentPeers(first.client!, 1)[0]).toMatchObject({ isStreaming: true, unfinishedActionCount: 2 });
+		expect(second.client?.requestWorker).toHaveBeenCalledOnce();
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 2, sends: 3, catalogRevision: 2 });
+	});
+
+	it("retries only failed payloads and resends an unchanged catalog after reconnect", async () => {
+		const first = worker("first");
+		let attempts = 0;
+		const second = worker(
+			"second",
+			vi.fn(async () => {
+				attempts++;
+				if (attempts === 1) throw new Error("transient peer sync failure");
+				return workerSyncSuccess();
+			}),
+		);
+		const supervisor = createSupervisor([first, second]);
+
+		await expect(supervisor.syncAgentPeers()).resolves.toBeUndefined();
+
+		expect(first.client?.requestWorker).toHaveBeenCalledOnce();
+		expect(second.client?.requestWorker).toHaveBeenCalledTimes(2);
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 2, sends: 3, catalogRevision: 1 });
+
+		const replacement = vi.fn(async () => workerSyncSuccess());
+		second.client = { requestWorker: replacement };
+		await supervisor.syncAgentPeers();
+
+		expect(first.client?.requestWorker).toHaveBeenCalledOnce();
+		expect(replacement).toHaveBeenCalledOnce();
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 3, sends: 4, catalogRevision: 1 });
+	});
+
+	it("does not start or follow up peer synchronization after shutdown begins", async () => {
+		const firstSendReached = deferred();
+		const releaseFirstSend = deferred();
+		const resident = worker(
+			"worker",
+			vi.fn(async () => {
+				firstSendReached.resolve();
+				await releaseFirstSend.promise;
+				return workerSyncSuccess();
+			}),
+		);
+		const supervisor = createSupervisor([resident]);
+
+		const initial = supervisor.syncAgentPeers();
+		await firstSendReached.promise;
+		supervisor.shuttingDown = true;
+		await supervisor.syncAgentPeers();
+		releaseFirstSend.resolve();
+		await initial;
+		await supervisor.syncAgentPeers();
+
+		expect(resident.client?.requestWorker).toHaveBeenCalledOnce();
+		expect(supervisor.agentPeerSyncStats).toMatchObject({ passes: 1, sends: 1 });
+	});
+});


### PR DESCRIPTION
## Summary

- replace the daemon supervisor's serial peer-sync promise queue with one in-flight dirty-bit drain
- build one immutable, revisioned peer catalog snapshot per pass and skip payloads already delivered to the same worker connection
- retry failed worker deliveries selectively while forcing a fresh delivery after reconnect
- add deterministic coverage for burst coalescing, N-worker send counts, topology and state mutation during a pass, failure/retry/reconnect, and shutdown

## Root cause

Every lifecycle trigger appended a complete all-to-all synchronization pass to a promise chain. A burst therefore retained every intermediate pass, rebuilt every worker's peer list repeatedly, and resent unchanged catalogs.

## Solution design

The supervisor now holds a single drain promise and a dirty bit. A trigger during an active pass marks one follow-up pass instead of enqueueing another promise. Each pass freezes one catalog snapshot and assigns it an internal revision. If a trigger lands after the drain body settles but before its tracked promise finalizes, that finalizer clears only its own pointer and hands the dirty state to one new microtask-scheduled drain. Per-connection payload fingerprints suppress unchanged sends; successful fingerprints are recorded only while the original worker and client are still current. Failed sends remain unsatisfied: after the immediate dirty follow-up, one deduplicated retry timer backs off from 250 ms to 1 second and then caps at 5 seconds until delivery succeeds, the connection changes, or shutdown begins. A replacement client has no delivery record and is synchronized even when the catalog itself is unchanged.

Worker sends remain concurrent, so one slow worker does not prevent requests from reaching its peers. Shutdown stops new passes and suppresses dirty follow-ups.

## Compatibility

This is a backward-compatible internal scheduling change. It does not change any daemon command, event, response shape, startup behavior, worker wire payload, capability, `DAEMON_PROTOCOL_VERSION`, or `DAEMON_SCHEMA_REVISION`.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-supervisor-lazy-subagents.test.ts test/daemon-supervisor-monitor.test.ts test/daemon-supervisor-peer-sync.test.ts` (70 passed)
- `npm run check`

Fixes #943


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bursty daemon peer synchronization by coalescing passes and deduplicating sends
> - Replaces a serial queue-based sync with a dirty/drain model in `DaemonSupervisor`: bursts of peer updates are coalesced into a single pass rather than queuing redundant all-to-all syncs.
> - Adds payload fingerprinting per client so unchanged peer catalogs are not resent; a catalog-level fingerprint tracks whether the worker set has changed between passes.
> - Adds bounded backoff retries (`[250ms, 1000ms, 5000ms]`) only for failed deliveries, replacing the previous no-retry behavior.
> - Shutdown now cancels in-flight retry timers via the new `beginShutdown` method.
> - Adds a Vitest suite covering coalescing, reconnection resends, backoff bounds, and shutdown cancellation in [daemon-supervisor-peer-sync.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/981/files#diff-07111bfecad23ba4b7d91093615b443441abd4b9199017f31961aaebd1776333).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74d3dfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->