### PR TITLE
docs(coding-agent): document Moonshot and Vertex API-key auth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Documented Moonshot AI API-key auth and the Google Vertex AI API-key route in `providers.md`, and added a test that every built-in provider is documented ([#955](https://github.com/PrimeIntellect-ai/prime-agent/issues/955)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Documented Moonshot AI API-key auth and the Google Vertex AI API-key route in `providers.md`, and added a test that every built-in provider is documented ([#955](https://github.com/PrimeIntellect-ai/prime-agent/issues/955)).
+- Documented Moonshot AI API-key auth and the Google Vertex AI API-key route in `providers.md`, and added a test that every built-in provider is documented ([#955](https://github.com/PrimeIntellect-ai/prime-agent/issues/955), [#987](https://github.com/PrimeIntellect-ai/prime-agent/pull/987) by [@himanshu231204](https://github.com/himanshu231204)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -48,12 +48,14 @@ prime-agent
 
 | Provider | Environment Variable | `auth.json` key |
 |----------|----------------------|------------------|
-| Anthropic | `ANTHROPIC_API_KEY` | `anthropic` |
+| Amazon Bedrock | (uses AWS credentials) | `amazon-bedrock` |
+| Anthropic | `ANTHROPIC_OAUTH_TOKEN`, `ANTHROPIC_API_KEY` | `anthropic` |
 | Azure OpenAI Responses | `AZURE_OPENAI_API_KEY` | `azure-openai-responses` |
 | OpenAI | `OPENAI_API_KEY` | `openai` |
 | Prime Inference | `PRIME_API_KEY` | `prime-inference` |
 | DeepSeek | `DEEPSEEK_API_KEY` | `deepseek` |
 | Google Gemini | `GEMINI_API_KEY` | `google` |
+| Google Vertex AI | `GOOGLE_CLOUD_API_KEY` | `google-vertex` |
 | Mistral | `MISTRAL_API_KEY` | `mistral` |
 | Groq | `GROQ_API_KEY` | `groq` |
 | Cerebras | `CEREBRAS_API_KEY` | `cerebras` |
@@ -76,6 +78,7 @@ prime-agent
 | Xiaomi MiMo Token Plan (China) | `XIAOMI_TOKEN_PLAN_CN_API_KEY` | `xiaomi-token-plan-cn` |
 | Xiaomi MiMo Token Plan (Amsterdam) | `XIAOMI_TOKEN_PLAN_AMS_API_KEY` | `xiaomi-token-plan-ams` |
 | Xiaomi MiMo Token Plan (Singapore) | `XIAOMI_TOKEN_PLAN_SGP_API_KEY` | `xiaomi-token-plan-sgp` |
+| GitHub Copilot | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | `github-copilot` |
 
 Reference for environment variables and `auth.json` keys: [`env-api-keys.ts`](../../ai/src/env-api-keys.ts).
 
@@ -227,15 +230,13 @@ Prime Agent automatically sets `x-session-affinity` for [prefix caching](https:/
 
 Vertex AI supports two authentication routes: an API key or Application Default Credentials (ADC).
 
-**Option 1: API key**
+**Option 1: API key** (only `GOOGLE_CLOUD_API_KEY` required)
 
 ```bash
 export GOOGLE_CLOUD_API_KEY=...
-export GOOGLE_CLOUD_PROJECT=your-project
-export GOOGLE_CLOUD_LOCATION=us-central1
 ```
 
-**Option 2: Application Default Credentials**
+**Option 2: Application Default Credentials** (requires project and location)
 
 ```bash
 gcloud auth application-default login
@@ -243,7 +244,7 @@ export GOOGLE_CLOUD_PROJECT=your-project
 export GOOGLE_CLOUD_LOCATION=us-central1
 ```
 
-Or set `GOOGLE_APPLICATION_CREDENTIALS` to a service account key file.
+Or set `GOOGLE_APPLICATION_CREDENTIALS` to a service account key file (also requires project and location).
 
 ## Custom Providers
 

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -70,6 +70,8 @@ prime-agent
 | Kimi For Coding | `KIMI_API_KEY` | `kimi-coding` |
 | MiniMax | `MINIMAX_API_KEY` | `minimax` |
 | MiniMax (China) | `MINIMAX_CN_API_KEY` | `minimax-cn` |
+| Moonshot AI | `MOONSHOT_API_KEY` | `moonshotai` |
+| Moonshot AI (China) | `MOONSHOT_API_KEY` | `moonshotai-cn` |
 | Xiaomi MiMo | `XIAOMI_API_KEY` | `xiaomi` |
 | Xiaomi MiMo Token Plan (China) | `XIAOMI_TOKEN_PLAN_CN_API_KEY` | `xiaomi-token-plan-cn` |
 | Xiaomi MiMo Token Plan (Amsterdam) | `XIAOMI_TOKEN_PLAN_AMS_API_KEY` | `xiaomi-token-plan-ams` |
@@ -88,6 +90,8 @@ Store credentials in `~/.prime/agent/auth.json`:
   "prime-inference": { "type": "api_key", "key": "..." },
   "deepseek": { "type": "api_key", "key": "sk-..." },
   "google": { "type": "api_key", "key": "..." },
+  "moonshotai": { "type": "api_key", "key": "..." },
+  "moonshotai-cn": { "type": "api_key", "key": "..." },
   "opencode": { "type": "api_key", "key": "..." },
   "opencode-go": { "type": "api_key", "key": "..." },
   "xiaomi": { "type": "api_key", "key": "..." },
@@ -221,7 +225,17 @@ Prime Agent automatically sets `x-session-affinity` for [prefix caching](https:/
 
 ### Google Vertex AI
 
-Uses Application Default Credentials:
+Vertex AI supports two authentication routes: an API key or Application Default Credentials (ADC).
+
+**Option 1: API key**
+
+```bash
+export GOOGLE_CLOUD_API_KEY=...
+export GOOGLE_CLOUD_PROJECT=your-project
+export GOOGLE_CLOUD_LOCATION=us-central1
+```
+
+**Option 2: Application Default Credentials**
 
 ```bash
 gcloud auth application-default login

--- a/packages/coding-agent/test/providers-doc-coverage.test.ts
+++ b/packages/coding-agent/test/providers-doc-coverage.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../src/core/provider-display-names.js";
+
+const providersDoc = readFileSync(resolve(__dirname, "../docs/providers.md"), "utf-8");
+
+describe("providers.md coverage", () => {
+	it("documents every built-in provider", () => {
+		const missing = Object.entries(BUILT_IN_PROVIDER_DISPLAY_NAMES)
+			// prime-agent-traces is a telemetry-only provider, not an auth provider.
+			.filter(([id]) => id !== "prime-agent-traces")
+			.filter(([, name]) => !providersDoc.includes(name))
+			.map(([id, name]) => `${id} (${name})`);
+
+		expect(missing).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/providers-doc-coverage.test.ts
+++ b/packages/coding-agent/test/providers-doc-coverage.test.ts
@@ -1,12 +1,268 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import type { KnownProvider } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../src/core/provider-display-names.js";
 
 const providersDoc = readFileSync(resolve(__dirname, "../docs/providers.md"), "utf-8");
 
+/**
+ * Canonical credential matrix derived from env-api-keys.ts and provider definitions.
+ * This is the single source of truth for what credentials each provider supports.
+ */
+interface ProviderCredentialSpec {
+	providerId: KnownProvider;
+	displayName: string;
+	envVars: readonly string[];
+	authJsonKey: string;
+	/** Additional ambient/delegated auth methods not captured by env vars */
+	ambientAuth?: readonly string[];
+	/** Whether this provider uses OAuth (not API key) */
+	isOAuth?: boolean;
+	/** Whether this provider uses a shared env var with another provider */
+	sharedEnvVar?: string;
+}
+
+const CREDENTIAL_MATRIX: ProviderCredentialSpec[] = [
+	{
+		providerId: "anthropic",
+		displayName: "Anthropic",
+		envVars: ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
+		authJsonKey: "anthropic",
+		ambientAuth: [],
+		isOAuth: true,
+	},
+	{
+		providerId: "amazon-bedrock",
+		displayName: "Amazon Bedrock",
+		envVars: [],
+		authJsonKey: "amazon-bedrock",
+		ambientAuth: [
+			"AWS_PROFILE",
+			"AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY",
+			"AWS_BEARER_TOKEN_BEDROCK",
+			"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+			"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+			"AWS_WEB_IDENTITY_TOKEN_FILE",
+		],
+	},
+	{
+		providerId: "azure-openai-responses",
+		displayName: "Azure OpenAI Responses",
+		envVars: ["AZURE_OPENAI_API_KEY"],
+		authJsonKey: "azure-openai-responses",
+		ambientAuth: [],
+	},
+	{
+		providerId: "openai",
+		displayName: "OpenAI",
+		envVars: ["OPENAI_API_KEY"],
+		authJsonKey: "openai",
+		ambientAuth: [],
+	},
+	{
+		providerId: "prime-inference",
+		displayName: "Prime Inference",
+		envVars: ["PRIME_API_KEY"],
+		authJsonKey: "prime-inference",
+		ambientAuth: [],
+	},
+	{
+		providerId: "deepseek",
+		displayName: "DeepSeek",
+		envVars: ["DEEPSEEK_API_KEY"],
+		authJsonKey: "deepseek",
+		ambientAuth: [],
+	},
+	{
+		providerId: "google",
+		displayName: "Google Gemini",
+		envVars: ["GEMINI_API_KEY"],
+		authJsonKey: "google",
+		ambientAuth: [],
+	},
+	{
+		providerId: "google-vertex",
+		displayName: "Google Vertex AI",
+		envVars: ["GOOGLE_CLOUD_API_KEY"],
+		authJsonKey: "google-vertex",
+		ambientAuth: [
+			"GOOGLE_APPLICATION_CREDENTIALS",
+			"ADC default path (~/.config/gcloud/application_default_credentials.json)",
+		],
+	},
+	{
+		providerId: "groq",
+		displayName: "Groq",
+		envVars: ["GROQ_API_KEY"],
+		authJsonKey: "groq",
+		ambientAuth: [],
+	},
+	{
+		providerId: "cerebras",
+		displayName: "Cerebras",
+		envVars: ["CEREBRAS_API_KEY"],
+		authJsonKey: "cerebras",
+		ambientAuth: [],
+	},
+	{
+		providerId: "xai",
+		displayName: "xAI",
+		envVars: ["XAI_API_KEY"],
+		authJsonKey: "xai",
+		ambientAuth: [],
+	},
+	{
+		providerId: "openrouter",
+		displayName: "OpenRouter",
+		envVars: ["OPENROUTER_API_KEY"],
+		authJsonKey: "openrouter",
+		ambientAuth: [],
+	},
+	{
+		providerId: "vercel-ai-gateway",
+		displayName: "Vercel AI Gateway",
+		envVars: ["AI_GATEWAY_API_KEY"],
+		authJsonKey: "vercel-ai-gateway",
+		ambientAuth: [],
+	},
+	{
+		providerId: "zai",
+		displayName: "ZAI",
+		envVars: ["ZAI_API_KEY"],
+		authJsonKey: "zai",
+		ambientAuth: [],
+	},
+	{
+		providerId: "mistral",
+		displayName: "Mistral",
+		envVars: ["MISTRAL_API_KEY"],
+		authJsonKey: "mistral",
+		ambientAuth: [],
+	},
+	{
+		providerId: "minimax",
+		displayName: "MiniMax",
+		envVars: ["MINIMAX_API_KEY"],
+		authJsonKey: "minimax",
+		ambientAuth: [],
+	},
+	{
+		providerId: "minimax-cn",
+		displayName: "MiniMax (China)",
+		envVars: ["MINIMAX_CN_API_KEY"],
+		authJsonKey: "minimax-cn",
+		ambientAuth: [],
+	},
+	{
+		providerId: "moonshotai",
+		displayName: "Moonshot AI",
+		envVars: ["MOONSHOT_API_KEY"],
+		authJsonKey: "moonshotai",
+		ambientAuth: [],
+		sharedEnvVar: "MOONSHOT_API_KEY",
+	},
+	{
+		providerId: "moonshotai-cn",
+		displayName: "Moonshot AI (China)",
+		envVars: ["MOONSHOT_API_KEY"],
+		authJsonKey: "moonshotai-cn",
+		ambientAuth: [],
+		sharedEnvVar: "MOONSHOT_API_KEY",
+	},
+	{
+		providerId: "huggingface",
+		displayName: "Hugging Face",
+		envVars: ["HF_TOKEN"],
+		authJsonKey: "huggingface",
+		ambientAuth: [],
+	},
+	{
+		providerId: "fireworks",
+		displayName: "Fireworks",
+		envVars: ["FIREWORKS_API_KEY"],
+		authJsonKey: "fireworks",
+		ambientAuth: [],
+	},
+	{
+		providerId: "opencode",
+		displayName: "OpenCode Zen",
+		envVars: ["OPENCODE_API_KEY"],
+		authJsonKey: "opencode",
+		ambientAuth: [],
+		sharedEnvVar: "OPENCODE_API_KEY",
+	},
+	{
+		providerId: "opencode-go",
+		displayName: "OpenCode Go",
+		envVars: ["OPENCODE_API_KEY"],
+		authJsonKey: "opencode-go",
+		ambientAuth: [],
+		sharedEnvVar: "OPENCODE_API_KEY",
+	},
+	{
+		providerId: "kimi-coding",
+		displayName: "Kimi For Coding",
+		envVars: ["KIMI_API_KEY"],
+		authJsonKey: "kimi-coding",
+		ambientAuth: [],
+	},
+	{
+		providerId: "cloudflare-workers-ai",
+		displayName: "Cloudflare Workers AI",
+		envVars: ["CLOUDFLARE_API_KEY"],
+		authJsonKey: "cloudflare-workers-ai",
+		ambientAuth: [],
+		sharedEnvVar: "CLOUDFLARE_API_KEY",
+	},
+	{
+		providerId: "cloudflare-ai-gateway",
+		displayName: "Cloudflare AI Gateway",
+		envVars: ["CLOUDFLARE_API_KEY"],
+		authJsonKey: "cloudflare-ai-gateway",
+		ambientAuth: [],
+		sharedEnvVar: "CLOUDFLARE_API_KEY",
+	},
+	{
+		providerId: "xiaomi",
+		displayName: "Xiaomi MiMo",
+		envVars: ["XIAOMI_API_KEY"],
+		authJsonKey: "xiaomi",
+		ambientAuth: [],
+	},
+	{
+		providerId: "xiaomi-token-plan-cn",
+		displayName: "Xiaomi MiMo Token Plan (China)",
+		envVars: ["XIAOMI_TOKEN_PLAN_CN_API_KEY"],
+		authJsonKey: "xiaomi-token-plan-cn",
+		ambientAuth: [],
+	},
+	{
+		providerId: "xiaomi-token-plan-ams",
+		displayName: "Xiaomi MiMo Token Plan (Amsterdam)",
+		envVars: ["XIAOMI_TOKEN_PLAN_AMS_API_KEY"],
+		authJsonKey: "xiaomi-token-plan-ams",
+		ambientAuth: [],
+	},
+	{
+		providerId: "xiaomi-token-plan-sgp",
+		displayName: "Xiaomi MiMo Token Plan (Singapore)",
+		envVars: ["XIAOMI_TOKEN_PLAN_SGP_API_KEY"],
+		authJsonKey: "xiaomi-token-plan-sgp",
+		ambientAuth: [],
+	},
+	{
+		providerId: "github-copilot",
+		displayName: "GitHub Copilot",
+		envVars: ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"],
+		authJsonKey: "github-copilot",
+		ambientAuth: [],
+		isOAuth: true,
+	},
+];
+
 describe("providers.md coverage", () => {
-	it("documents every built-in provider", () => {
+	it("documents every built-in provider by display name", () => {
 		const missing = Object.entries(BUILT_IN_PROVIDER_DISPLAY_NAMES)
 			// prime-agent-traces is a telemetry-only provider, not an auth provider.
 			.filter(([id]) => id !== "prime-agent-traces")
@@ -14,5 +270,147 @@ describe("providers.md coverage", () => {
 			.map(([id, name]) => `${id} (${name})`);
 
 		expect(missing).toEqual([]);
+	});
+
+	it("documents every provider's environment variable(s) in the API Keys table", () => {
+		const missing: string[] = [];
+
+		for (const spec of CREDENTIAL_MATRIX) {
+			for (const envVar of spec.envVars) {
+				if (!providersDoc.includes(envVar)) {
+					missing.push(`${spec.providerId}: missing env var ${envVar} in API Keys table`);
+				}
+			}
+		}
+
+		expect(missing).toEqual([]);
+	});
+
+	it("documents every provider's auth.json key in the API Keys table", () => {
+		const missing: string[] = [];
+
+		for (const spec of CREDENTIAL_MATRIX) {
+			// The auth.json key should appear in the table - check for the provider row
+			// The table uses display names, so we check for the auth.json key in backticks
+			const authKeyPattern = `\`${spec.authJsonKey}\``;
+			if (!providersDoc.includes(authKeyPattern)) {
+				missing.push(`${spec.providerId}: missing auth.json key ${spec.authJsonKey} in API Keys table`);
+			}
+		}
+
+		expect(missing).toEqual([]);
+	});
+
+	it("documents ambient/delegated auth methods for providers that support them", () => {
+		const missing: string[] = [];
+
+		for (const spec of CREDENTIAL_MATRIX) {
+			if (spec.ambientAuth && spec.ambientAuth.length > 0) {
+				// Check if at least one ambient auth method is documented
+				const documented = spec.ambientAuth.some((a) => providersDoc.includes(a));
+				if (!documented) {
+					missing.push(`${spec.providerId}: missing ambient auth documentation (e.g., ${spec.ambientAuth[0]})`);
+				}
+			}
+		}
+
+		expect(missing).toEqual([]);
+	});
+
+	it("documents shared environment variables correctly (same env var for multiple providers)", () => {
+		// MOONSHOT_API_KEY is shared between moonshotai and moonshotai-cn
+		expect(providersDoc).toContain("MOONSHOT_API_KEY");
+		expect(providersDoc).toContain("moonshotai");
+		expect(providersDoc).toContain("moonshotai-cn");
+
+		// OPENCODE_API_KEY is shared between opencode and opencode-go
+		expect(providersDoc).toContain("OPENCODE_API_KEY");
+		expect(providersDoc).toContain("opencode");
+		expect(providersDoc).toContain("opencode-go");
+
+		// CLOUDFLARE_API_KEY is shared between cloudflare-workers-ai and cloudflare-ai-gateway
+		expect(providersDoc).toContain("CLOUDFLARE_API_KEY");
+		expect(providersDoc).toContain("cloudflare-workers-ai");
+		expect(providersDoc).toContain("cloudflare-ai-gateway");
+	});
+});
+
+describe("negative drift regressions - credential matrix integrity", () => {
+	/**
+	 * These tests ensure that removing or misspelling credentials will FAIL.
+	 * They validate the credential matrix against the actual documentation.
+	 */
+
+	it("fails if MOONSHOT_API_KEY is removed from documentation", () => {
+		// This test will fail if someone removes MOONSHOT_API_KEY from providers.md
+		expect(providersDoc).toContain("MOONSHOT_API_KEY");
+	});
+
+	it("fails if moonshotai-cn provider is removed from documentation", () => {
+		// This test will fail if someone removes moonshotai-cn from providers.md
+		expect(providersDoc).toContain("moonshotai-cn");
+	});
+
+	it("fails if GOOGLE_CLOUD_API_KEY is removed from documentation", () => {
+		expect(providersDoc).toContain("GOOGLE_CLOUD_API_KEY");
+	});
+
+	it("fails if google-vertex provider is removed from documentation", () => {
+		// The table uses "Google Vertex AI" as display name
+		expect(providersDoc).toContain("Google Vertex AI");
+	});
+
+	it("fails if ANTHROPIC_API_KEY is removed from documentation", () => {
+		expect(providersDoc).toContain("ANTHROPIC_API_KEY");
+	});
+
+	it("fails if OPENAI_API_KEY is removed from documentation", () => {
+		expect(providersDoc).toContain("OPENAI_API_KEY");
+	});
+
+	it("validates all KnownProvider types have credential specs", () => {
+		const knownProviders: KnownProvider[] = [
+			"amazon-bedrock",
+			"anthropic",
+			"google",
+			"google-vertex",
+			"openai",
+			"azure-openai-responses",
+			"openai-codex",
+			"prime-inference",
+			"deepseek",
+			"github-copilot",
+			"xai",
+			"groq",
+			"cerebras",
+			"openrouter",
+			"vercel-ai-gateway",
+			"zai",
+			"mistral",
+			"minimax",
+			"minimax-cn",
+			"moonshotai",
+			"moonshotai-cn",
+			"huggingface",
+			"fireworks",
+			"opencode",
+			"opencode-go",
+			"kimi-coding",
+			"cloudflare-workers-ai",
+			"cloudflare-ai-gateway",
+			"xiaomi",
+			"xiaomi-token-plan-cn",
+			"xiaomi-token-plan-ams",
+			"xiaomi-token-plan-sgp",
+		];
+
+		const matrixProviderIds = new Set(CREDENTIAL_MATRIX.map((s) => s.providerId));
+		const missing = knownProviders.filter((p) => !matrixProviderIds.has(p));
+
+		// openai-codex and prime-agent-traces are special cases
+		const allowedMissing = new Set(["openai-codex", "prime-agent-traces"]);
+		const unexpectedMissing = missing.filter((p) => !allowedMissing.has(p));
+
+		expect(unexpectedMissing).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/955-moonshot-vertex-api-key-auth.test.ts
+++ b/packages/coding-agent/test/suite/regressions/955-moonshot-vertex-api-key-auth.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression test for issue #955 / PR #987
+ * Validates Moonshot AI and Google Vertex AI API-key auth documentation
+ * and credential matrix integrity.
+ */
+const providersDoc = readFileSync(resolve(__dirname, "../../../docs/providers.md"), "utf-8");
+
+describe("regression: #955 Moonshot and Vertex API-key auth", () => {
+	describe("Moonshot AI (moonshotai and moonshotai-cn)", () => {
+		it("documents MOONSHOT_API_KEY as the environment variable for both providers", () => {
+			expect(providersDoc).toContain("MOONSHOT_API_KEY");
+			// Both providers should be listed with the same env var
+			expect(providersDoc).toContain("| Moonshot AI | `MOONSHOT_API_KEY` | `moonshotai` |");
+			expect(providersDoc).toContain("| Moonshot AI (China) | `MOONSHOT_API_KEY` | `moonshotai-cn` |");
+		});
+
+		it("documents both moonshotai and moonshotai-cn auth.json keys", () => {
+			expect(providersDoc).toContain('"moonshotai": { "type": "api_key"');
+			expect(providersDoc).toContain('"moonshotai-cn": { "type": "api_key"');
+		});
+
+		it("documents shared MOONSHOT_API_KEY for both providers in the table", () => {
+			// Verify the table shows both providers using the same env var
+			const moonshotRows = providersDoc.match(/\| Moonshot AI.*?\|/g) || [];
+			expect(moonshotRows.length).toBeGreaterThanOrEqual(2);
+		});
+	});
+
+	describe("Google Vertex AI (google-vertex)", () => {
+		it("documents API key route with ONLY GOOGLE_CLOUD_API_KEY (no project/location)", () => {
+			// The API key option should only require GOOGLE_CLOUD_API_KEY
+			expect(providersDoc).toContain("Option 1: API key");
+			expect(providersDoc).toContain("GOOGLE_CLOUD_API_KEY");
+			// Should NOT require project/location for API key
+			const apiKeySection = providersDoc.substring(
+				providersDoc.indexOf("Option 1: API key"),
+				providersDoc.indexOf("Option 2:"),
+			);
+			expect(apiKeySection).not.toContain("GOOGLE_CLOUD_PROJECT");
+			expect(apiKeySection).not.toContain("GOOGLE_CLOUD_LOCATION");
+		});
+
+		it("documents ADC route with project and location required", () => {
+			const adcSection = providersDoc.substring(providersDoc.indexOf("Option 2: Application Default Credentials"));
+			expect(adcSection).toContain("GOOGLE_CLOUD_PROJECT");
+			expect(adcSection).toContain("GOOGLE_CLOUD_LOCATION");
+			expect(adcSection).toContain("gcloud auth application-default login");
+		});
+
+		it("documents GOOGLE_APPLICATION_CREDENTIALS as alternative ADC path", () => {
+			expect(providersDoc).toContain("GOOGLE_APPLICATION_CREDENTIALS");
+		});
+
+		it("documents google-vertex auth.json key", () => {
+			expect(providersDoc).toContain("| Google Vertex AI | `GOOGLE_CLOUD_API_KEY` | `google-vertex` |");
+		});
+	});
+
+	describe("Credential matrix completeness", () => {
+		it("includes all providers from KnownProvider in the API Keys table", () => {
+			// These are the providers that should have API key entries
+			// The table uses display names, not provider IDs
+			const apiKeyProviders = [
+				"Amazon Bedrock",
+				"Anthropic",
+				"Azure OpenAI Responses",
+				"OpenAI",
+				"Prime Inference",
+				"DeepSeek",
+				"Google Gemini",
+				"Google Vertex AI",
+				"Mistral",
+				"Groq",
+				"Cerebras",
+				"Cloudflare AI Gateway",
+				"Cloudflare Workers AI",
+				"xAI",
+				"OpenRouter",
+				"Vercel AI Gateway",
+				"ZAI",
+				"OpenCode Zen",
+				"OpenCode Go",
+				"Hugging Face",
+				"Fireworks",
+				"Kimi For Coding",
+				"MiniMax",
+				"MiniMax (China)",
+				"Moonshot AI",
+				"Moonshot AI (China)",
+				"Xiaomi MiMo",
+				"Xiaomi MiMo Token Plan (China)",
+				"Xiaomi MiMo Token Plan (Amsterdam)",
+				"Xiaomi MiMo Token Plan (Singapore)",
+				"GitHub Copilot",
+			];
+
+			for (const provider of apiKeyProviders) {
+				expect(providersDoc).toContain(`| ${provider} |`);
+			}
+		});
+
+		it("documents auth.json example with all API key providers", () => {
+			const authJsonSection = providersDoc.substring(
+				providersDoc.indexOf("Auth File"),
+				providersDoc.indexOf("Key Resolution"),
+			);
+
+			// Check key providers are in the auth.json example
+			expect(authJsonSection).toContain('"anthropic"');
+			expect(authJsonSection).toContain('"openai"');
+			expect(authJsonSection).toContain('"google"');
+			expect(authJsonSection).toContain('"moonshotai"');
+			expect(authJsonSection).toContain('"moonshotai-cn"');
+			expect(authJsonSection).toContain('"opencode"');
+			expect(authJsonSection).toContain('"opencode-go"');
+			expect(authJsonSection).toContain('"xiaomi"');
+			expect(authJsonSection).toContain('"xiaomi-token-plan-cn"');
+			expect(authJsonSection).toContain('"xiaomi-token-plan-ams"');
+			expect(authJsonSection).toContain('"xiaomi-token-plan-sgp"');
+		});
+	});
+
+	describe("Shared environment variables", () => {
+		it("documents MOONSHOT_API_KEY shared between moonshotai and moonshotai-cn", () => {
+			// Both providers should reference the same env var
+			const moonshotAIRow = providersDoc.match(/\| Moonshot AI \| `MOONSHOT_API_KEY` \| `moonshotai` \|/);
+			const moonshotCNRow = providersDoc.match(
+				/\| Moonshot AI \(China\) \| `MOONSHOT_API_KEY` \| `moonshotai-cn` \|/,
+			);
+			expect(moonshotAIRow).not.toBeNull();
+			expect(moonshotCNRow).not.toBeNull();
+		});
+
+		it("documents OPENCODE_API_KEY shared between opencode and opencode-go", () => {
+			const opencodeRow = providersDoc.match(/\| OpenCode Zen \| `OPENCODE_API_KEY` \| `opencode` \|/);
+			const opencodeGoRow = providersDoc.match(/\| OpenCode Go \| `OPENCODE_API_KEY` \| `opencode-go` \|/);
+			expect(opencodeRow).not.toBeNull();
+			expect(opencodeGoRow).not.toBeNull();
+		});
+
+		it("documents CLOUDFLARE_API_KEY shared between cloudflare-workers-ai and cloudflare-ai-gateway", () => {
+			const workersRow = providersDoc.match(/\| Cloudflare Workers AI \| `CLOUDFLARE_API_KEY/);
+			const gatewayRow = providersDoc.match(/\| Cloudflare AI Gateway \| `CLOUDFLARE_API_KEY/);
+			expect(workersRow).not.toBeNull();
+			expect(gatewayRow).not.toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Closes #955. Documents Moonshot AI and Google Vertex AI API-key authentication in `providers.md`, and adds a CI coverage check that prevents provider-to-doc drift.

## Changes

- **`packages/coding-agent/docs/providers.md`**
  - Added Moonshot AI and Moonshot AI (China) rows to the API Keys table (`MOONSHOT_API_KEY` → `moonshotai` / `moonshotai-cn`).
  - Added `moonshotai` / `moonshotai-cn` entries to the `auth.json` example.
  - Rewrote the Google Vertex AI section to document both auth routes: API key (`GOOGLE_CLOUD_API_KEY`) and Application Default Credentials (ADC).
- **`packages/coding-agent/test/providers-doc-coverage.test.ts`** (new)
  - Validates every built-in provider in `BUILT_IN_PROVIDER_DISPLAY_NAMES` is documented in `providers.md`, preventing future drift.
- **`packages/coding-agent/CHANGELOG.md`**
  - Added an entry under `[Unreleased]`.

## Verification

- New test passes: `providers-doc-coverage.test.ts` (1 passed).
- `npm run check` passes (Biome, tsgo, installer render, browser smoke).

## Acceptance Criteria

- [x] Both Moonshot regions documented.
- [x] Vertex API-key auth documented.
- [x] Every built-in API-key provider covered or explicitly delegated to another auth section.
- [x] CI coverage check prevents drift.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document Moonshot AI and Google Vertex AI API-key auth in providers.md
> - Adds entries for Moonshot AI, Moonshot AI (China), and Google Vertex AI to the API keys table in [providers.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/987/files#diff-a34db0fc9d6b1fe2b19d444bd41071cc7c754abead3f8e6188d1506a7a929df9), including env vars and `auth.json` keys.
> - Expands the Google Vertex AI section to document two auth routes: API key (via `GOOGLE_CLOUD_API_KEY`) and ADC (via `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and optionally `GOOGLE_APPLICATION_CREDENTIALS`).
> - Adds a coverage test in [providers-doc-coverage.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/987/files#diff-4cdeacbaa64884c1f5edc63c1768556c8809035619374a48ec43c492f4670d4d) that fails if any built-in provider's display name, env var, or `auth.json` key is missing from `providers.md`.
> - Adds regression tests in [955-moonshot-vertex-api-key-auth.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/987/files#diff-a4c2da495471c5a1367bc0ad79d54d121e8445bb47cadcbe32da06f5a2decda5) that enforce the exact documented structure for Moonshot and Vertex auth routes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a31becb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->