### PR TITLE
fix(tui): stop wrap recursion on wide graphemes and recover from lost paste end

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Fixed the editor crashing with a stack overflow when a single emoji or CJK character was wider than the terminal ([#982](https://github.com/PrimeIntellect-ai/prime-agent/issues/982)).
+- Fixed input getting stuck forever when a bracketed paste end marker never arrived; the buffered text now flushes as normal input after a timeout ([#982](https://github.com/PrimeIntellect-ai/prime-agent/issues/982)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -173,7 +173,7 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 			wrapOppIndex = -1;
 		}
 
-		if (gWidth > maxWidth) {
+		if (gWidth > maxWidth && isAtomicMarker(grapheme)) {
 			// Single atomic segment wider than maxWidth (e.g. paste marker
 			// in a narrow terminal). Re-wrap it at grapheme granularity.
 
@@ -187,6 +187,15 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 			const last = subChunks[subChunks.length - 1]!;
 			chunkStart = charIndex + last.startIndex;
 			currentWidth = visibleWidth(last.text);
+			wrapOppIndex = -1;
+			continue;
+		}
+
+		if (gWidth > maxWidth) {
+			// Single grapheme wider than maxWidth (e.g. emoji or CJK in a
+			// very narrow terminal). It cannot be split; keep it as its own
+			// chunk and let it overflow visually instead of recursing.
+			currentWidth = gWidth;
 			wrapOppIndex = -1;
 			continue;
 		}

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -237,6 +237,12 @@ export type StdinBufferOptions = {
 	 * After this time, the buffer is flushed even if incomplete
 	 */
 	timeout?: number;
+	/**
+	 * Maximum time to wait for the bracketed paste end marker (default: 5000ms).
+	 * After this time, paste mode is exited and the buffered content is
+	 * flushed through the normal input path
+	 */
+	pasteTimeout?: number;
 };
 
 export type StdinBufferEventMap = {
@@ -254,11 +260,14 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 	private readonly timeoutMs: number;
 	private pasteMode: boolean = false;
 	private pasteBuffer: string = "";
+	private pasteTimeout: ReturnType<typeof setTimeout> | null = null;
+	private readonly pasteTimeoutMs: number;
 	private pendingKittyPrintableCodepoint: number | undefined;
 
 	constructor(options: StdinBufferOptions = {}) {
 		super();
 		this.timeoutMs = options.timeout ?? 10;
+		this.pasteTimeoutMs = options.pasteTimeout ?? 5000;
 	}
 
 	public process(data: string | Buffer): void {
@@ -301,12 +310,15 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				this.pasteMode = false;
 				this.pasteBuffer = "";
 				this.pendingKittyPrintableCodepoint = undefined;
+				this.clearPasteTimeout();
 
 				this.emit("paste", pastedContent);
 
 				if (remaining.length > 0) {
 					this.process(remaining);
 				}
+			} else {
+				this.armPasteTimeout();
 			}
 			return;
 		}
@@ -335,12 +347,15 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				this.pasteMode = false;
 				this.pasteBuffer = "";
 				this.pendingKittyPrintableCodepoint = undefined;
+				this.clearPasteTimeout();
 
 				this.emit("paste", pastedContent);
 
 				if (remaining.length > 0) {
 					this.process(remaining);
 				}
+			} else {
+				this.armPasteTimeout();
 			}
 			return;
 		}
@@ -374,6 +389,34 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		this.emit("data", sequence);
 	}
 
+	private armPasteTimeout(): void {
+		this.clearPasteTimeout();
+		this.pasteTimeout = setTimeout(() => {
+			this.pasteTimeout = null;
+			if (!this.pasteMode) {
+				return;
+			}
+			// The end marker never arrived (e.g. mangled over tmux/SSH).
+			// Exit paste mode and flush the buffered content through the
+			// normal input path so the user keeps typing.
+			const buffered = this.pasteBuffer;
+			this.pasteMode = false;
+			this.pasteBuffer = "";
+			this.pendingKittyPrintableCodepoint = undefined;
+			if (buffered.length > 0) {
+				this.process(buffered);
+			}
+		}, this.pasteTimeoutMs);
+		this.pasteTimeout.unref?.();
+	}
+
+	private clearPasteTimeout(): void {
+		if (this.pasteTimeout) {
+			clearTimeout(this.pasteTimeout);
+			this.pasteTimeout = null;
+		}
+	}
+
 	flush(): string[] {
 		if (this.timeout) {
 			clearTimeout(this.timeout);
@@ -395,6 +438,7 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			clearTimeout(this.timeout);
 			this.timeout = null;
 		}
+		this.clearPasteTimeout();
 		this.buffer = "";
 		this.pasteMode = false;
 		this.pasteBuffer = "";

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1079,6 +1079,33 @@ describe("Editor component", () => {
 			const reconstructed = chunks.map((c) => line.slice(c.startIndex, c.endIndex)).join("");
 			assert.strictEqual(reconstructed, line);
 		});
+
+		it("emits wide grapheme wider than maxWidth as its own chunk without recursing", () => {
+			// Regression: a single emoji (width 2) with maxWidth 1 used to
+			// recurse with identical arguments until the stack overflowed.
+			const chunks = wordWrapLine("😀", 1);
+
+			assert.deepStrictEqual(chunks, [{ text: "😀", startIndex: 0, endIndex: 2 }]);
+		});
+
+		it("emits CJK character wider than maxWidth as its own chunk without recursing", () => {
+			const chunks = wordWrapLine("你", 1);
+
+			assert.deepStrictEqual(chunks, [{ text: "你", startIndex: 0, endIndex: 1 }]);
+		});
+
+		it("isolates wide graphemes into their own chunks in mixed content", () => {
+			const line = "a😀b";
+			const chunks = wordWrapLine(line, 1);
+
+			assert.deepStrictEqual(
+				chunks.map((c) => c.text),
+				["a", "😀", "b"],
+			);
+
+			const reconstructed = chunks.map((c) => line.slice(c.startIndex, c.endIndex)).join("");
+			assert.strictEqual(reconstructed, line);
+		});
 	});
 
 	describe("Kill ring", () => {

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -413,6 +413,62 @@ describe("StdinBuffer", () => {
 			assert.deepStrictEqual(emittedPaste, ["Hello 世界 🎉"]);
 			assert.deepStrictEqual(emittedSequences, []);
 		});
+
+		it("should flush buffered paste as normal input when end marker never arrives", async () => {
+			const local = new StdinBuffer({ timeout: 10, pasteTimeout: 20 });
+			const sequences: string[] = [];
+			const pastes: string[] = [];
+			local.on("data", (sequence) => sequences.push(sequence));
+			local.on("paste", (data) => pastes.push(data));
+
+			local.process("\x1b[200~");
+			local.process("abc");
+			assert.deepStrictEqual(sequences, []);
+			assert.deepStrictEqual(pastes, []);
+
+			// Wait for the paste timeout to flush the buffered content
+			await wait(30);
+
+			assert.deepStrictEqual(pastes, []);
+			assert.deepStrictEqual(sequences, ["a", "b", "c"]);
+
+			// Paste mode is cleared: subsequent input flows normally
+			local.process("d");
+			assert.deepStrictEqual(sequences, ["a", "b", "c", "d"]);
+
+			local.destroy();
+		});
+
+		it("should not flush paste content when the end marker arrives before the timeout", async () => {
+			const local = new StdinBuffer({ timeout: 10, pasteTimeout: 20 });
+			const sequences: string[] = [];
+			const pastes: string[] = [];
+			local.on("data", (sequence) => sequences.push(sequence));
+			local.on("paste", (data) => pastes.push(data));
+
+			local.process("\x1b[200~abc\x1b[201~");
+			assert.deepStrictEqual(pastes, ["abc"]);
+
+			// Wait past the paste timeout; nothing else may be emitted
+			await wait(30);
+			assert.deepStrictEqual(sequences, []);
+
+			local.destroy();
+		});
+
+		it("should clear the paste timeout on clear", async () => {
+			const local = new StdinBuffer({ timeout: 10, pasteTimeout: 20 });
+			const sequences: string[] = [];
+			local.on("data", (sequence) => sequences.push(sequence));
+
+			local.process("\x1b[200~abc");
+			local.clear();
+
+			await wait(30);
+			assert.deepStrictEqual(sequences, []);
+
+			local.destroy();
+		});
 	});
 
 	describe("Destroy", () => {


### PR DESCRIPTION
Fixes #982.

## What was broken

Two input-handling bugs in the TUI:

1. `wordWrapLine` in `packages/tui/src/components/editor.ts` re-wraps a single grapheme wider than `maxWidth` by calling itself with the same grapheme and the same width. That branch is meant for atomic paste markers, but nothing checked that the grapheme actually is one. A width-2 grapheme (emoji, CJK) in a 1-column content width recurses identically forever and the process dies with `RangeError: Maximum call stack size exceeded`.

2. `StdinBuffer` buffers everything between `\x1b[200~` and `\x1b[201~`. If the end marker never arrives (tmux or SSH hiccup, mangled marker), every keystroke including ctrl+c is swallowed forever and the app has to be restarted.

## The fix

- The wide-grapheme branch now only recurses for atomic markers. Any other wide grapheme becomes its own chunk and overflows visually instead of crashing.
- `StdinBuffer` gains a paste timeout (default 5s, sliding window re-armed per arriving chunk so slow legitimate pastes are not cut off). On timeout it exits paste mode and re-feeds the buffered content through the normal input path. The timer is unref'd and cleared on end marker, `clear()`, and `destroy()`.

## Testing

- New regression tests in `test/editor.test.ts` (`wordWrapLine("😀", 1)`, CJK at width 1, mixed content) and `test/stdin-buffer.test.ts` (lost end marker recovers, timely end marker unaffected, `clear()` cancels the timer).
- `node --test --import tsx test/editor.test.ts test/stdin-buffer.test.ts test/wrap-ansi.test.ts`: 268 passed, 0 failed.
- `npm run check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stack overflow on wide graphemes in `wordWrapLine` and recover from missing bracketed paste end marker
> - Fixes a stack overflow in `wordWrapLine` ([editor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/988/files#diff-7b6fb102370899178db8d26e334f97123c72bc2127ed9a8d7b4952049b423d42)) when a single emoji or CJK grapheme is wider than `maxWidth`; the grapheme is now emitted as its own chunk instead of triggering infinite recursion.
> - Adds a `pasteTimeout` (default 5000ms) to [`StdinBuffer`](https://github.com/PrimeIntellect-ai/prime-agent/pull/988/files#diff-7b620d86f2de6487fe7b511d8c5a30fd4354c236b43afbc9fb7ed22f79c31ef8) that exits paste mode and flushes buffered input as normal `data` events when the bracketed paste end marker never arrives.
> - Behavioral Change: pasted content that previously stalled indefinitely (due to a missing end marker) will now be processed as normal input after the timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca30312.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->