### PR TITLE
fix(ai): drop tool results whose parent tool call was aborted

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed retries after an aborted or errored tool call failing with provider pairing errors by dropping tool results whose parent tool call was skipped ([#984](https://github.com/PrimeIntellect-ai/prime-agent/issues/984)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -157,6 +157,7 @@ export function transformMessages<TApi extends Api>(
 	const result: Message[] = [];
 	let pendingToolCalls: ToolCall[] = [];
 	let existingToolResultIds = new Set<string>();
+	const droppedToolCallIds = new Set<string>();
 	const insertSyntheticToolResults = () => {
 		if (pendingToolCalls.length > 0) {
 			for (const tc of pendingToolCalls) {
@@ -190,6 +191,12 @@ export function transformMessages<TApi extends Api>(
 			// - The model should retry from the last valid state
 			const assistantMsg = msg as AssistantMessage;
 			if (assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") {
+				// Tool calls vanish with the skipped message, so their results must be dropped too
+				for (const block of assistantMsg.content) {
+					if (block.type === "toolCall") {
+						droppedToolCallIds.add(block.id);
+					}
+				}
 				continue;
 			}
 
@@ -202,6 +209,9 @@ export function transformMessages<TApi extends Api>(
 
 			result.push(msg);
 		} else if (msg.role === "toolResult") {
+			if (droppedToolCallIds.has(msg.toolCallId)) {
+				continue;
+			}
 			existingToolResultIds.add(msg.toolCallId);
 			result.push(msg);
 		} else if (msg.role === "user") {

--- a/packages/ai/test/transform-messages-orphaned-tool-results.test.ts
+++ b/packages/ai/test/transform-messages-orphaned-tool-results.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { transformMessages } from "../src/providers/transform-messages.js";
+import type { AssistantMessage, Message, Model, ToolResultMessage } from "../src/types.js";
+
+function makeModel(): Model<"anthropic-messages"> {
+	return {
+		id: "claude-sonnet-4.5",
+		name: "Claude Sonnet 4",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16000,
+	};
+}
+
+function makeAssistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"],
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4.5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function makeToolResult(toolCallId: string, toolName: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text: "done" }],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+describe("Orphaned tool results from aborted or errored assistant turns", () => {
+	it("drops tool results whose parent tool call was aborted", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "run a command", timestamp: Date.now() },
+			makeAssistantMessage(
+				[{ type: "toolCall", id: "call_aborted", name: "bash", arguments: { command: "ls" } }],
+				"aborted",
+			),
+			makeToolResult("call_aborted", "bash"),
+			{ role: "user", content: "try again", timestamp: Date.now() },
+		];
+
+		const result = transformMessages(messages, makeModel());
+
+		expect(result.some((m) => m.role === "assistant")).toBe(false);
+		expect(result.some((m) => m.role === "toolResult")).toBe(false);
+		expect(result.map((m) => m.role)).toEqual(["user", "user"]);
+	});
+
+	it("drops tool results whose parent tool call errored", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "run a command", timestamp: Date.now() },
+			makeAssistantMessage(
+				[{ type: "toolCall", id: "call_errored", name: "bash", arguments: { command: "ls" } }],
+				"error",
+			),
+			makeToolResult("call_errored", "bash"),
+		];
+
+		const result = transformMessages(messages, makeModel());
+
+		expect(result.map((m) => m.role)).toEqual(["user"]);
+	});
+
+	it("keeps tool results belonging to a surviving tool call", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "run two commands", timestamp: Date.now() },
+			makeAssistantMessage(
+				[{ type: "toolCall", id: "call_aborted", name: "bash", arguments: { command: "ls" } }],
+				"aborted",
+			),
+			makeToolResult("call_aborted", "bash"),
+			makeAssistantMessage(
+				[{ type: "toolCall", id: "call_healthy", name: "read", arguments: { path: "README.md" } }],
+				"toolUse",
+			),
+			makeToolResult("call_healthy", "read"),
+			{ role: "user", content: "thanks", timestamp: Date.now() },
+		];
+
+		const result = transformMessages(messages, makeModel());
+		const toolResults = result.filter((m) => m.role === "toolResult") as ToolResultMessage[];
+
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].toolCallId).toBe("call_healthy");
+		expect(result.some((m) => m.role === "assistant")).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #984.

## What was broken

In `transformMessages`, the second pass skips assistant messages with `stopReason` `error` or `aborted`. If the skipped turn had already emitted tool calls and the results were recorded, the tool calls disappeared with the message while the `toolResult` entries were pushed through unconditionally. The next request then carried tool results with IDs that exist nowhere in the conversation, which Anthropic rejects (`tool_use_id was found without tool_use`) and OpenAI/Bedrock reject with equivalent pairing checks. A retry after an aborted tool turn failed hard instead of continuing.

## The fix

When an errored or aborted assistant message is skipped, its tool call IDs are collected and any following `toolResult` message matching one of those IDs is dropped too. Results belonging to healthy tool calls pass through unchanged. This mirrors the existing synthetic-result pass, which already covers the opposite direction (a call without a result).

## Testing

- New offline regression file `test/transform-messages-orphaned-tool-results.test.ts`: aborted turn results dropped, errored turn results dropped, and a healthy call's result preserved next to a dropped aborted one.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/transform-messages-orphaned-tool-results.test.ts test/transform-messages-copilot-openai-to-anthropic.test.ts test/tool-call-without-result.test.ts`: 7 passed (the tool-call-without-result suite skips offline, it needs live API keys).
- `npm run check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop orphaned tool results whose parent tool call was aborted or errored
> When an assistant message is skipped due to `stopReason` being `'error'` or `'aborted'`, the tool call IDs in that message are tracked in a `droppedToolCallIds` set. Any subsequent `toolResult` message referencing one of those IDs is then excluded from the transformed output, preventing provider pairing errors on retry.
>
> New tests in [transform-messages-orphaned-tool-results.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/991/files#diff-aa99dc3b37d2f40b8c620f50690ad34315f6df9dd7feaa35f850d9619e613ac7) cover aborted, errored, and mixed-survival scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7287a5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->