### PR TITLE
fix(coding-agent): isolate throwing tool_call extension handlers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed a throwing `tool_call` extension handler aborting the remaining handlers and failing the tool call; errors are now reported as extension errors and handling continues ([#985](https://github.com/PrimeIntellect-ai/prime-agent/issues/985))
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -810,13 +810,24 @@ export class ExtensionRunner {
 			if (!handlers || handlers.length === 0) continue;
 
 			for (const handler of handlers) {
-				const handlerResult = await handler(event, ctx);
+				try {
+					const handlerResult = await handler(event, ctx);
 
-				if (handlerResult) {
-					result = handlerResult as ToolCallEventResult;
-					if (result.block) {
-						return result;
+					if (handlerResult) {
+						result = handlerResult as ToolCallEventResult;
+						if (result.block) {
+							return result;
+						}
 					}
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					const stack = err instanceof Error ? err.stack : undefined;
+					this.emitError({
+						extensionPath: ext.path,
+						event: "tool_call",
+						error: message,
+						stack,
+					});
 				}
 			}
 		}

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -9,10 +9,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { createExtensionRuntime, discoverAndLoadExtensions } from "../src/core/extensions/loader.js";
 import { ExtensionRunner } from "../src/core/extensions/runner.js";
-import type { ExtensionActions, ExtensionContextActions, ProviderConfig } from "../src/core/extensions/types.js";
+import type {
+	Extension,
+	ExtensionActions,
+	ExtensionContextActions,
+	ProviderConfig,
+} from "../src/core/extensions/types.js";
 import { KeybindingsManager, type KeyId } from "../src/core/keybindings.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import { SessionManager } from "../src/core/session-manager.js";
+import { createSyntheticSourceInfo } from "../src/core/source-info.js";
 
 describe("ExtensionRunner", () => {
 	let tempDir: string;
@@ -695,6 +701,88 @@ describe("ExtensionRunner", () => {
 				details: { source: "ext1" },
 				isError: true,
 			});
+		});
+	});
+
+	describe("tool_call error isolation", () => {
+		const makeToolCallExtension = (extPath: string, handler: () => Promise<unknown>): Extension => ({
+			path: extPath,
+			resolvedPath: extPath,
+			sourceInfo: createSyntheticSourceInfo(extPath, { source: "local" }),
+			handlers: new Map([["tool_call", [handler]]]),
+			tools: new Map(),
+			messageRenderers: new Map(),
+			commands: new Map(),
+			flags: new Map(),
+			shortcuts: new Map(),
+		});
+
+		it("runs remaining handlers when one throws and routes the error through onError", async () => {
+			let secondRan = false;
+			const throwing = makeToolCallExtension("/ext/tool-call-throws.ts", async () => {
+				throw new Error("broken tool_call handler");
+			});
+			const second = makeToolCallExtension("/ext/tool-call-second.ts", async () => {
+				secondRan = true;
+			});
+			const runner = new ExtensionRunner(
+				[throwing, second],
+				createExtensionRuntime(),
+				tempDir,
+				sessionManager,
+				modelRegistry,
+			);
+			const errors: Array<{ extensionPath: string; event: string; error: string }> = [];
+			runner.onError((err) => {
+				errors.push(err);
+			});
+
+			const emitted = await runner.emitToolCall({
+				type: "tool_call",
+				toolName: "my_tool",
+				toolCallId: "call-1",
+				input: {},
+			});
+
+			expect(emitted).toBeUndefined();
+			expect(secondRan).toBe(true);
+			expect(errors.length).toBe(1);
+			expect(errors[0].error).toContain("broken tool_call handler");
+			expect(errors[0].event).toBe("tool_call");
+			expect(errors[0].extensionPath).toBe("/ext/tool-call-throws.ts");
+		});
+
+		it("still short-circuits on a block result", async () => {
+			let secondRan = false;
+			const blocker = makeToolCallExtension("/ext/tool-call-block.ts", async () => ({
+				block: true,
+				reason: "not allowed",
+			}));
+			const second = makeToolCallExtension("/ext/tool-call-second.ts", async () => {
+				secondRan = true;
+			});
+			const runner = new ExtensionRunner(
+				[blocker, second],
+				createExtensionRuntime(),
+				tempDir,
+				sessionManager,
+				modelRegistry,
+			);
+			const errors: string[] = [];
+			runner.onError((err) => {
+				errors.push(err.error);
+			});
+
+			const emitted = await runner.emitToolCall({
+				type: "tool_call",
+				toolName: "my_tool",
+				toolCallId: "call-2",
+				input: {},
+			});
+
+			expect(emitted).toEqual({ block: true, reason: "not allowed" });
+			expect(secondRan).toBe(false);
+			expect(errors).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
Fixes #985.

## What was broken

`emitToolCall` awaited each extension handler with no try/catch. Every other emit method in the runner wraps handlers and routes failures through `emitError`, so one broken extension cannot take down the rest. For `tool_call` events a throw propagated out of the runner, the remaining handlers never ran, and the tool call failed with the extension's error. One buggy extension could break tool execution for the whole session.

## The fix

`emitToolCall` now wraps the handler invocation in the same try/catch + `emitError` pattern as its siblings. A throwing handler is reported as an extension error and the loop continues to the next handler. `block` results still short-circuit exactly as before.

## Testing

- New `tool_call error isolation` tests in `test/extensions-runner.test.ts`: a throwing first handler still lets the second run and surfaces exactly one extension error, and a `block` result still short-circuits with no error emitted.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/extensions-runner.test.ts -t "tool_call error isolation"`: 2 passed. `test/agent-session-concurrent.test.ts`: 11 passed.
- The other failures in `extensions-runner.test.ts` reproduce on unmodified main in a fresh checkout: they come from the jiti extension loader needing built `dist/` folders that do not exist in a source-only worktree, and are unrelated to this change.
- `npm run check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate throwing `tool_call` extension handlers in `ExtensionRunner.emitToolCall`
> Previously, an exception in any `tool_call` handler would abort all remaining handlers and fail the tool call. Now each handler is wrapped in a try/catch: errors are reported via `onError` with the extension path and event context, and processing continues to subsequent handlers. Block results still short-circuit execution as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f78f5f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->