### PR TITLE
fix(ai): flush trailing SSE events and keep unparented text deltas

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Fixed the Codex SSE parser dropping the terminal event when a stream ends without a trailing blank line, losing final usage ([#995](https://github.com/PrimeIntellect-ai/prime-agent/issues/995))
+- Fixed Responses streams losing assistant text when a text delta arrives without a preceding content part event ([#995](https://github.com/PrimeIntellect-ai/prime-agent/issues/995))
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -543,32 +543,25 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
 		while (true) {
 			const { done, value } = await reader.read();
 			if (done) break;
-			buffer += decoder.decode(value, { stream: true });
+			buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n");
 
 			let idx = buffer.indexOf("\n\n");
 			while (idx !== -1) {
 				const chunk = buffer.slice(0, idx);
 				buffer = buffer.slice(idx + 2);
 
-				const dataLines = chunk
-					.split("\n")
-					.filter((l) => l.startsWith("data:"))
-					.map((l) => l.slice(5).trim());
-				if (dataLines.length > 0) {
-					const data = dataLines.join("\n").trim();
-					if (data && data !== "[DONE]") {
-						try {
-							yield JSON.parse(data) as Record<string, unknown>;
-						} catch (cause) {
-							throw new CodexProtocolError(`Invalid Codex SSE JSON: ${formatThrownValue(cause)}`, {
-								cause,
-								payload: data,
-							});
-						}
-					}
+				const parsed = parseSSEEvent(chunk);
+				if (parsed !== undefined) {
+					yield parsed;
 				}
 				idx = buffer.indexOf("\n\n");
 			}
+		}
+
+		buffer += decoder.decode().replace(/\r\n/g, "\n");
+		const parsed = parseSSEEvent(buffer);
+		if (parsed !== undefined) {
+			yield parsed;
 		}
 	} finally {
 		// Best-effort stream teardown: the reader may already be closed or errored.
@@ -582,6 +575,24 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
 		} catch {
 			// Lock already released.
 		}
+	}
+}
+
+function parseSSEEvent(chunk: string): Record<string, unknown> | undefined {
+	const dataLines = chunk
+		.split("\n")
+		.filter((l) => l.startsWith("data:"))
+		.map((l) => l.slice(5).trim());
+	if (dataLines.length === 0) return undefined;
+	const data = dataLines.join("\n").trim();
+	if (!data || data === "[DONE]") return undefined;
+	try {
+		return JSON.parse(data) as Record<string, unknown>;
+	} catch (cause) {
+		throw new CodexProtocolError(`Invalid Codex SSE JSON: ${formatThrownValue(cause)}`, {
+			cause,
+			payload: data,
+		});
 	}
 }
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -375,37 +375,38 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.output_text.delta") {
 			if (currentItem?.type === "message" && currentBlock?.type === "text") {
-				if (!currentItem.content || currentItem.content.length === 0) {
-					continue;
+				currentItem.content = currentItem.content || [];
+				let lastPart = currentItem.content[currentItem.content.length - 1];
+				// Some endpoints stream deltas without a preceding content_part.added
+				if (lastPart?.type !== "output_text") {
+					lastPart = { type: "output_text", text: "", annotations: [] };
+					currentItem.content.push(lastPart);
 				}
-				const lastPart = currentItem.content[currentItem.content.length - 1];
-				if (lastPart?.type === "output_text") {
-					currentBlock.text += event.delta;
-					lastPart.text += event.delta;
-					stream.push({
-						type: "text_delta",
-						contentIndex: blockIndex(),
-						delta: event.delta,
-						partial: output,
-					});
-				}
+				currentBlock.text += event.delta;
+				lastPart.text += event.delta;
+				stream.push({
+					type: "text_delta",
+					contentIndex: blockIndex(),
+					delta: event.delta,
+					partial: output,
+				});
 			}
 		} else if (event.type === "response.refusal.delta") {
 			if (currentItem?.type === "message" && currentBlock?.type === "text") {
-				if (!currentItem.content || currentItem.content.length === 0) {
-					continue;
+				currentItem.content = currentItem.content || [];
+				let lastPart = currentItem.content[currentItem.content.length - 1];
+				if (lastPart?.type !== "refusal") {
+					lastPart = { type: "refusal", refusal: "" };
+					currentItem.content.push(lastPart);
 				}
-				const lastPart = currentItem.content[currentItem.content.length - 1];
-				if (lastPart?.type === "refusal") {
-					currentBlock.text += event.delta;
-					lastPart.refusal += event.delta;
-					stream.push({
-						type: "text_delta",
-						contentIndex: blockIndex(),
-						delta: event.delta,
-						partial: output,
-					});
-				}
+				currentBlock.text += event.delta;
+				lastPart.refusal += event.delta;
+				stream.push({
+					type: "text_delta",
+					contentIndex: blockIndex(),
+					delta: event.delta,
+					partial: output,
+				});
 			}
 		} else if (event.type === "response.function_call_arguments.delta") {
 			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -311,6 +311,64 @@ describe("openai-codex streaming", () => {
 		expect(result.stopReason).toBe("length");
 	});
 
+	it("delivers the terminal event when the SSE stream ends without a trailing blank line", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const encoder = new TextEncoder();
+		const sse = buildSSEPayload({ status: "completed" }).slice(0, -2);
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(model, context, { apiKey: token, transport: "sse" }).result();
+
+		expect(result.content.find((c) => c.type === "text")?.text).toBe("Hello");
+		expect(result.stopReason).toBe("stop");
+		expect(result.usage.input).toBe(5);
+		expect(result.usage.output).toBe(3);
+		expect(result.usage.totalTokens).toBe(8);
+	});
+
 	it("sets session_id/x-client-request-id headers and prompt_cache_key when sessionId is provided", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
 		process.env.PI_CODING_AGENT_DIR = tempDir;

--- a/packages/ai/test/openai-responses-missing-content-part.test.ts
+++ b/packages/ai/test/openai-responses-missing-content-part.test.ts
@@ -1,0 +1,107 @@
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import { describe, expect, it, vi } from "vitest";
+import { processResponsesStream } from "../src/providers/openai-responses-shared.js";
+import type { AssistantMessage, AssistantMessageEvent, Model } from "../src/types.js";
+import { AssistantMessageEventStream } from "../src/utils/event-stream.js";
+
+function createOutput(model: Model<"openai-responses">): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "gpt-5-mini",
+		name: "GPT-5 Mini",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+	};
+}
+
+function messageAddedEvent(): ResponseStreamEvent {
+	return {
+		type: "response.output_item.added",
+		item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+	} as unknown as ResponseStreamEvent;
+}
+
+function messageDoneEvent(content: Array<Record<string, unknown>>): ResponseStreamEvent {
+	return {
+		type: "response.output_item.done",
+		item: { type: "message", id: "msg_1", role: "assistant", status: "completed", content },
+	} as unknown as ResponseStreamEvent;
+}
+
+describe("openai responses deltas without content_part.added", () => {
+	it("appends output_text.delta when no content_part.added preceded it", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+		const pushSpy = vi.spyOn(stream, "push");
+
+		async function* events(): AsyncIterable<ResponseStreamEvent> {
+			yield messageAddedEvent();
+			yield { type: "response.output_text.delta", delta: "Hello" } as ResponseStreamEvent;
+			yield { type: "response.output_text.delta", delta: " world" } as ResponseStreamEvent;
+			yield messageDoneEvent([{ type: "output_text", text: "Hello world" }]);
+		}
+
+		await processResponsesStream(events(), output, stream, model);
+
+		const emitted = pushSpy.mock.calls.map(([event]) => event as AssistantMessageEvent);
+		const deltas = emitted.filter((event) => event.type === "text_delta").map((event) => event.delta);
+		expect(deltas).toEqual(["Hello", " world"]);
+
+		expect(output.content).toHaveLength(1);
+		expect(output.content[0]?.type).toBe("text");
+		if (output.content[0]?.type === "text") {
+			expect(output.content[0].text).toBe("Hello world");
+		}
+	});
+
+	it("appends refusal.delta when no content_part.added preceded it", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+		const pushSpy = vi.spyOn(stream, "push");
+
+		async function* events(): AsyncIterable<ResponseStreamEvent> {
+			yield messageAddedEvent();
+			yield { type: "response.refusal.delta", delta: "I cannot" } as ResponseStreamEvent;
+			yield messageDoneEvent([{ type: "refusal", refusal: "I cannot" }]);
+		}
+
+		await processResponsesStream(events(), output, stream, model);
+
+		const emitted = pushSpy.mock.calls.map(([event]) => event as AssistantMessageEvent);
+		const deltas = emitted.filter((event) => event.type === "text_delta").map((event) => event.delta);
+		expect(deltas).toEqual(["I cannot"]);
+
+		expect(output.content).toHaveLength(1);
+		expect(output.content[0]?.type).toBe("text");
+		if (output.content[0]?.type === "text") {
+			expect(output.content[0].text).toBe("I cannot");
+		}
+	});
+});


### PR DESCRIPTION
Fixes #995.

## What was broken

Two silent data-loss bugs in the Responses-family stream parsers:

1. The Codex `parseSSE` only processed events delimited by a blank line inside the read loop. A server that closes the connection right after the final `data:` line (no trailing blank line) lost its terminal `response.completed` event, taking the final usage and stop reason with it. CRLF line endings were also not tolerated.
2. The shared Responses handler discarded `output_text.delta` and `refusal.delta` events when no `content_part.added` had created the content part first. Non-compliant endpoints (Azure, OpenRouter, proxies) do this, and the streamed text vanished without any error.

## The fix

- `parseSSE` drains the `TextDecoder` after the read loop, flushes any remaining buffered event, and normalizes CRLF before splitting. Same approach as the Anthropic provider's `iterateSseMessages`.
- The delta handlers lazily create the missing content part before appending, instead of dropping the delta.

## Testing

- New regression coverage: a Codex stream ending without a trailing blank line still delivers `response.completed` with text, stop reason, and usage; deltas without a preceding `content_part.added` still emit text.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run` on the new/changed files plus the neighboring Responses and Codex suites: 48 passed, 4 skipped (live-key tests skip offline).
- `npm run check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SSE parser to flush trailing events and handle unparented text deltas
> - The `parseSSE` generator in [openai-codex-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/996/files#diff-69623a8c4e616b30339182296d1b69ed62a9d7fcce14b744ed6e638ecf357abc) now flushes any buffered data after the read loop ends, yielding the final SSE event even when the stream has no trailing blank line. CRLF line endings are also normalized to LF.
> - `processResponsesStream` in [openai-responses-shared.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/996/files#diff-75a92c85369ffe30444d6da4b398bb4fd5b852ff45a5eea02f95b3b2fa48df48) no longer drops `output_text.delta` and `refusal.delta` events that arrive without a preceding `response.content_part.added` event — it now creates the missing content part on demand and emits the delta normally.
> - Behavioral Change: streams that previously silently discarded the terminal SSE event or lost assistant text will now surface that content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2c73f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->