### PR TITLE
fix(ai): reprice Anthropic cache writes from final stream usage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed Anthropic cost reporting using a stale cache-write rate when the final stream usage carries updated cache-creation numbers ([#997](https://github.com/PrimeIntellect-ai/prime-agent/issues/997))
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -6,7 +6,11 @@ import type {
 	MessageParam,
 	RawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages.js";
-import { getAnthropicCacheWriteCost, hasStandardAnthropicCachePricing } from "../cache-pricing.js";
+import {
+	type AnthropicCacheCreationUsage,
+	getAnthropicCacheWriteCost,
+	hasStandardAnthropicCachePricing,
+} from "../cache-pricing.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../models.js";
 import type {
@@ -703,6 +707,20 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					// Anthropic doesn't provide total_tokens, compute from components
 					output.usage.totalTokens =
 						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
+					// Proxies may re-aggregate cache_creation in message_delta; reprice from the
+					// latest breakdown when present, otherwise keep the message_start rate.
+					const deltaCacheCreation = (
+						event.usage as typeof event.usage & {
+							cache_creation?: AnthropicCacheCreationUsage | null;
+						}
+					).cache_creation;
+					if (cacheControl && usesAnthropicCachePricing && deltaCacheCreation !== undefined) {
+						cacheWriteCost = getAnthropicCacheWriteCost(
+							model.cost.input,
+							cacheControl.ttl === "1h" ? "1h" : "5m",
+							deltaCacheCreation,
+						);
+					}
 					calculateCost(
 						model,
 						output.usage,

--- a/packages/ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/ai/test/anthropic-sse-parsing.test.ts
@@ -153,6 +153,54 @@ describe("Anthropic raw SSE parsing", () => {
 		expect(result.usage.cost.cacheWrite).toBeCloseTo(testCase.expectedCacheWriteCost);
 	});
 
+	it("reprices cache writes from the message_delta cache_creation breakdown", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const response = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_cache_delta_test",
+						usage: {
+							input_tokens: 12,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 1000,
+							cache_creation: { ephemeral_5m_input_tokens: 1000, ephemeral_1h_input_tokens: 0 },
+						},
+					},
+				}),
+			},
+			{
+				event: "message_delta",
+				data: JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "end_turn" },
+					usage: {
+						input_tokens: 12,
+						output_tokens: 5,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 1000,
+						cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 1000 },
+					},
+				}),
+			},
+			{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+		]);
+		const result = await streamAnthropic(
+			model,
+			{ messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }] },
+			{
+				client: createFakeAnthropicClient(response),
+				cacheRetention: "long",
+			},
+		).result();
+
+		expect(result.usage.cacheWrite).toBe(1000);
+		expect(result.usage.cost.cacheWrite).toBeCloseTo(0.002, 6);
+	});
+
 	it("preserves configured cache write pricing for non-Anthropic models", async () => {
 		const model = getModel("minimax", "MiniMax-M2.7-highspeed");
 		const response = createSseResponse(


### PR DESCRIPTION
Fixes #997.

## What was broken

The Anthropic provider computes the cache-write per-token rate once from the `cache_creation` TTL breakdown in `message_start` and reuses that value for every later `calculateCost` call. When `message_delta` carries different cache-creation numbers, which proxies like LiteLLM produce when they re-aggregate usage, the reported `cost.cacheWrite` and `cost.total` drift from actual billing. The 1h vs 5m rate gap under `cacheRetention: "long"` makes the drift larger. The SDK type does not declare the breakdown on `MessageDeltaUsage`, but proxies include it at runtime and the raw SSE parser does not validate shapes.

## The fix

The `message_delta` handler reprices cache writes from the latest `event.usage.cache_creation` breakdown when it is present, and keeps the `message_start` rate when it is absent. No event shapes or public API changed.

## Testing

- New regression test in `test/anthropic-sse-parsing.test.ts`: `message_start` reports only 5m writes, `message_delta` reports only 1h writes under `cacheRetention: "long"`, and the final cost must use the 1h rate. Verified the test fails with the fix reverted.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run` on the anthropic test files and neighbors (cache-retention, thinking, oauth, tool-name, copilot): 45 passed, 9 skipped (live-key suites), 0 failed.
- `npm run check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Anthropic cache write repricing using final stream `cache_creation` breakdown
> Anthropic streams can return an updated `cache_creation` breakdown in `message_delta` events that differs from the initial `message_start` rate. Previously, `streamAnthropic` used only the `message_start` cache write cost, leading to stale pricing. Now, when a `cache_creation` breakdown is present in `message_delta`, the cache write cost is recomputed using `getAnthropicCacheWriteCost` with the latest TTL mapping before the final `calculateCost` call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b7d7c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->