### PR TITLE
fix(coding-agent): run OAuth refresh outside the auth.json file lock

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed the OAuth token refresh holding the `auth.json` file lock across the network call, blocking other processes for up to 30s on a slow provider ([#999](https://github.com/PrimeIntellect-ai/prime-agent/issues/999))
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -14,7 +14,7 @@ import {
 	type OAuthLoginCallbacks,
 	type OAuthProviderId,
 } from "@earendil-works/pi-ai";
-import { getOAuthApiKey, getOAuthProvider, getOAuthProviders } from "@earendil-works/pi-ai/oauth";
+import { getOAuthProvider, getOAuthProviders } from "@earendil-works/pi-ai/oauth";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
@@ -760,6 +760,11 @@ export class AuthStorage {
 	/**
 	 * Refresh OAuth token with backend locking to prevent race conditions.
 	 * Multiple pi instances may try to refresh simultaneously when tokens expire.
+	 *
+	 * The provider refresh is a network round-trip, so it runs WITHOUT the lock
+	 * held; otherwise a slow provider would block every other process touching
+	 * auth.json. The lock is only held while reading and while persisting, and
+	 * the write is skipped when the stored credentials changed in the meantime.
 	 */
 	private async refreshOAuthTokenWithLock(
 		providerId: OAuthProviderId,
@@ -769,7 +774,40 @@ export class AuthStorage {
 			return null;
 		}
 
-		const result = await this.storage.withLockAsync(async (current) => {
+		type RefreshCheck = {
+			fresh: { apiKey: string; newCredentials: OAuthCredentials } | null;
+			expired: OAuthCredential | null;
+		};
+
+		const check = await this.storage.withLockAsync<RefreshCheck>(async (current) => {
+			const currentData = this.parseStorageData(current);
+			this.data = currentData;
+			this.loadError = null;
+
+			const cred = currentData[providerId];
+			if (cred?.type !== "oauth") {
+				return { result: { fresh: null, expired: null } };
+			}
+
+			if (Date.now() < cred.expires) {
+				return { result: { fresh: { apiKey: provider.getApiKey(cred), newCredentials: cred }, expired: null } };
+			}
+
+			return { result: { fresh: null, expired: cred } };
+		});
+
+		if (check.fresh) {
+			return check.fresh;
+		}
+		const snapshot = check.expired;
+		if (!snapshot) {
+			return null;
+		}
+
+		// Refresh tokens rotate on use, so a discarded duplicate result must never be written.
+		const newCredentials = await provider.refreshToken(snapshot);
+
+		return await this.storage.withLockAsync(async (current) => {
 			const currentData = this.parseStorageData(current);
 			this.data = currentData;
 			this.loadError = null;
@@ -779,32 +817,22 @@ export class AuthStorage {
 				return { result: null };
 			}
 
-			if (Date.now() < cred.expires) {
+			if (cred.refresh !== snapshot.refresh || cred.expires !== snapshot.expires) {
+				// Another process updated the credentials while we refreshed; drop our result.
 				return { result: { apiKey: provider.getApiKey(cred), newCredentials: cred } };
-			}
-
-			const oauthCreds: Record<string, OAuthCredentials> = {};
-			for (const [key, value] of Object.entries(currentData)) {
-				if (value.type === "oauth") {
-					oauthCreds[key] = value;
-				}
-			}
-
-			const refreshed = await getOAuthApiKey(providerId, oauthCreds);
-			if (!refreshed) {
-				return { result: null };
 			}
 
 			const merged: AuthStorageData = {
 				...currentData,
-				[providerId]: { type: "oauth", ...refreshed.newCredentials },
+				[providerId]: { type: "oauth", ...newCredentials },
 			};
 			this.data = merged;
 			this.loadError = null;
-			return { result: refreshed, next: JSON.stringify(merged, null, 2) };
+			return {
+				result: { apiKey: provider.getApiKey(newCredentials), newCredentials },
+				next: JSON.stringify(merged, null, 2),
+			};
 		});
-
-		return result;
 	}
 
 	/**

--- a/packages/coding-agent/test/suite/regressions/999-oauth-refresh-lock.test.ts
+++ b/packages/coding-agent/test/suite/regressions/999-oauth-refresh-lock.test.ts
@@ -1,0 +1,127 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { OAuthCredentials } from "@earendil-works/pi-ai";
+import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import lockfile from "proper-lockfile";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../../../src/core/auth-storage.js";
+
+describe("regression: oauth refresh runs outside the auth.json lock", () => {
+	let tempDir: string;
+	let authJsonPath: string;
+	const providerIds: string[] = [];
+
+	function registerTestProvider(refreshToken: (credentials: OAuthCredentials) => Promise<OAuthCredentials>): string {
+		const providerId = `test-oauth-lock-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		providerIds.push(providerId);
+		registerOAuthProvider({
+			id: providerId,
+			name: "Test OAuth Provider",
+			async login() {
+				throw new Error("Not used in this test");
+			},
+			refreshToken,
+			getApiKey(credentials) {
+				return `Bearer ${credentials.access}`;
+			},
+		});
+		return providerId;
+	}
+
+	function writeAuthJson(data: Record<string, unknown>) {
+		writeFileSync(authJsonPath, JSON.stringify(data));
+	}
+
+	function expiredCredential(overrides: Record<string, unknown> = {}) {
+		return {
+			type: "oauth",
+			refresh: "old-refresh",
+			access: "old-access",
+			expires: Date.now() - 10_000,
+			...overrides,
+		};
+	}
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-oauth-lock-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		authJsonPath = join(tempDir, "auth.json");
+	});
+
+	afterEach(() => {
+		for (const providerId of providerIds.splice(0)) {
+			unregisterOAuthProvider(providerId);
+		}
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not hold the auth.json lock while the token refresh is in flight", async () => {
+		let lockFreeDuringRefresh = false;
+		const providerId = registerTestProvider(async (credentials) => {
+			try {
+				const release = lockfile.lockSync(authJsonPath, { realpath: false });
+				release();
+				lockFreeDuringRefresh = true;
+			} catch {
+				// Lock was still held while refreshing.
+			}
+			return {
+				...credentials,
+				access: "new-access",
+				refresh: "new-refresh",
+				expires: Date.now() + 60_000,
+			};
+		});
+
+		writeAuthJson({ [providerId]: expiredCredential() });
+
+		const authStorage = AuthStorage.create(authJsonPath);
+		const apiKey = await authStorage.getApiKey(providerId);
+
+		expect(apiKey).toBe("Bearer new-access");
+		expect(lockFreeDuringRefresh).toBe(true);
+
+		const stored = JSON.parse(readFileSync(authJsonPath, "utf-8")) as Record<
+			string,
+			{ access: string; refresh: string }
+		>;
+		expect(stored[providerId].access).toBe("new-access");
+		expect(stored[providerId].refresh).toBe("new-refresh");
+	});
+
+	it("does not overwrite a fresher credential written during the refresh", async () => {
+		const providerId = registerTestProvider(async (credentials) => {
+			// Simulate another process refreshing first while our refresh is in flight.
+			writeAuthJson({
+				[providerId]: expiredCredential({
+					refresh: "fresher-refresh",
+					access: "fresher-access",
+					expires: Date.now() + 60_000,
+				}),
+			});
+			return {
+				...credentials,
+				access: "stale-access",
+				refresh: "stale-rotated-refresh",
+				expires: Date.now() + 60_000,
+			};
+		});
+
+		writeAuthJson({ [providerId]: expiredCredential() });
+
+		const authStorage = AuthStorage.create(authJsonPath);
+		const apiKey = await authStorage.getApiKey(providerId);
+
+		expect(apiKey).toBe("Bearer fresher-access");
+
+		const stored = JSON.parse(readFileSync(authJsonPath, "utf-8")) as Record<
+			string,
+			{ access: string; refresh: string }
+		>;
+		expect(stored[providerId].access).toBe("fresher-access");
+		expect(stored[providerId].refresh).toBe("fresher-refresh");
+	});
+});


### PR DESCRIPTION
Fixes #999.

## What was broken

`refreshOAuthTokenWithLock` awaited the provider's token refresh (an HTTP round-trip) inside the `withLockAsync` callback, holding the `auth.json` lock the whole time. A slow or hanging provider blocked every other process reading or writing `auth.json` for up to the 30s stale threshold, and the sync retry path gave up after about 200ms and threw.

## The fix

The lock is now held only for the read and the write:

1. Acquire, read the stored credentials, re-check expiry, release.
2. Refresh over the network with no lock held.
3. Re-acquire and persist only if the stored credentials still match the earlier snapshot. If another process refreshed first, the newer stored credentials win and our result is dropped unwritten, which is required because refresh tokens rotate on use.

Public API, `withLockAsync`, and the `onCompromised` behavior are unchanged.

## Testing

- New regression file `test/suite/regressions/999-oauth-refresh-lock.test.ts`: a refresh stub takes `lockfile.lockSync` on `auth.json` mid-refresh to prove the lock is free while the network call is in flight, and a fresher credential written during the refresh is returned instead of being overwritten.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run` on the new file plus `test/auth-storage.test.ts` and `test/auth-flows.test.ts`: 55 passed, 2 failed. Both failures are pre-existing environment artifacts (a Windows `stat` mode check and a test that reads the machine's real `~/.prime/config.json`), in code paths this change does not touch.
- `npm run check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OAuth token refresh in `AuthStorage` to release auth.json lock before network call
> - `refreshOAuthTokenWithLock` previously held the auth.json file lock during the provider's `refreshToken` network call, risking ~30s blocking on slow providers.
> - The method now reads and snapshots expired credentials, releases the lock, performs the refresh, then reacquires the lock to write results.
> - If another process updated the credentials concurrently, the write is skipped and the fresher stored credentials are returned instead.
> - A regression test in [999-oauth-refresh-lock.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1001/files#diff-ad52fa710df5cf31664125d1967204195cd1570c4b90b97c6c185b295475d1b4) verifies both the lock-release behavior and the stale-write protection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 846b2a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->