### PR TITLE
fix(windows): terminate orphaned process trees, not just their roots

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 - Fixed the agents view collapsing expanded subagent lists when returning from an opened agent ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
 - Kept the subagent summary row visible and selectable while its list is expanded in the agents view, so pressing enter on it collapses the list again ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
+- Fixed worker teardown on Windows leaving detached descendants running. Windows has no process groups, so the kill reached only the named process; it now walks the real process tree ([#917](https://github.com/PrimeIntellect-ai/prime-agent/issues/917)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2897,16 +2897,10 @@ export class DaemonSupervisor {
 					if (!isOrphanProcessIdentityCurrent(orphan)) {
 						continue;
 					}
-					const { pid } = orphan;
-					try {
-						process.kill(-pid, "SIGKILL");
-					} catch {
-						try {
-							process.kill(pid, "SIGKILL");
-						} catch {
-							// The detached resource may already have exited.
-						}
-					}
+					// Tree kill: a detached resource can itself have children, and on
+					// Windows the inlined single-process fallback this replaces left
+					// every one of them running.
+					signalProcessGroupOrProcess(orphan.pid, "SIGKILL");
 				}
 				clearOrphanProcessJournal(orphanProcessJournalPath);
 			} catch (error) {

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, execFileSync } from "node:child_process";
+import { type ChildProcess, execFileSync, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { constants } from "node:os";
 import { basename } from "node:path";
@@ -51,7 +51,22 @@ export function isProcessAlive(pid: number): boolean {
 	return processIdExists(pid) && !isZombieProcess(pid);
 }
 
+/**
+ * Terminate a process and everything it spawned.
+ *
+ * Unix signals the process group, which reaches descendants in one call.
+ * Windows has no process groups to signal: `process.kill(-pid)` fails there and
+ * the fallback terminates exactly one process, so a worker's own children — a
+ * Python kernel, a detached autonomous gate — survive their parent and keep
+ * running until they finish on their own. `taskkill /T` walks the real process
+ * tree instead. It runs synchronously so teardown paths can rely on it having
+ * happened, and it is fast enough (tens of milliseconds) to sit in a shutdown.
+ */
 export function signalProcessGroupOrProcess(pid: number, signal: NodeJS.Signals): void {
+	if (process.platform === "win32") {
+		killWindowsProcessTree(pid);
+		return;
+	}
 	try {
 		process.kill(-pid, signal);
 		return;
@@ -62,6 +77,27 @@ export function signalProcessGroupOrProcess(pid: number, signal: NodeJS.Signals)
 		process.kill(pid, signal);
 	} catch {
 		// The process may already be fully reaped.
+	}
+}
+
+function killWindowsProcessTree(pid: number): void {
+	if (!Number.isInteger(pid) || pid <= 0) {
+		return;
+	}
+	try {
+		// `windowsHide` matters here: a daemon owns no console, having been spawned
+		// detached, and a console child of a console-less parent gets a new console
+		// *with a visible window* that outlives it. A teardown killing many
+		// processes would leave a desktop full of black windows to close by hand.
+		spawnSync("taskkill", ["/F", "/T", "/PID", String(pid)], { stdio: "ignore", windowsHide: true });
+	} catch {
+		// taskkill is unavailable or the tree is already gone; fall back to the
+		// single process so at least the root does not linger.
+		try {
+			process.kill(pid, "SIGKILL");
+		} catch {
+			// Already reaped.
+		}
 	}
 }
 

--- a/packages/coding-agent/test/child-process-tree-kill-windows.test.ts
+++ b/packages/coding-agent/test/child-process-tree-kill-windows.test.ts
@@ -1,0 +1,109 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { signalProcessGroupOrProcess } from "../src/utils/child-process.js";
+
+/**
+ * A parent that spawns one long-lived child and records its pid, then waits.
+ *
+ * The child is `detached`, which is what makes this a real test of the tree
+ * walk. Windows puts an ordinary child in a job object owned by its parent, so
+ * it dies with the parent whether or not anything walks the tree; a detached
+ * child leaves that job and survives a single-process kill. Detached
+ * descendants are exactly what a crashed worker leaves behind.
+ */
+const PARENT_SCRIPT = `
+const { spawn } = require("node:child_process");
+const { writeFileSync } = require("node:fs");
+const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+	detached: true,
+	stdio: "ignore",
+	windowsHide: true,
+});
+child.unref();
+writeFileSync(process.argv[2], String(child.pid));
+setInterval(() => {}, 1000);
+`;
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		// EPERM means the pid exists but is not signalable by us — still alive.
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) {
+			return true;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	return predicate();
+}
+
+/**
+ * Windows only, because the contract differs by platform. A detached child
+ * leaves its parent's process group on Unix too, so the group signal does not
+ * reach it there either — that is the documented behavior of the Unix path and
+ * this change does not touch it. On Windows the tree walk does reach it, which
+ * is the whole point of the branch under test.
+ */
+describe.skipIf(process.platform !== "win32")("signalProcessGroupOrProcess on Windows", () => {
+	const spawnedPids: number[] = [];
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const pid of spawnedPids.splice(0)) {
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch {
+				// Already gone, which is the expected case.
+			}
+		}
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("terminates descendants, not just the named process", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-tree-kill-"));
+		tempDirs.push(dir);
+		const scriptPath = join(dir, "parent.cjs");
+		const childPidPath = join(dir, "child.pid");
+		writeFileSync(scriptPath, PARENT_SCRIPT);
+
+		// Detached so the parent leads its own process group on Unix, which is what
+		// the group signal needs. Windows has no groups and takes the tree walk.
+		const parent = spawn(process.execPath, [scriptPath, childPidPath], {
+			detached: true,
+			stdio: "ignore",
+			windowsHide: true,
+		});
+		const parentPid = parent.pid;
+		expect(parentPid).toBeTypeOf("number");
+		if (parentPid === undefined) {
+			throw new Error("parent did not start");
+		}
+		spawnedPids.push(parentPid);
+
+		expect(
+			await waitUntil(() => existsSync(childPidPath) && readFileSync(childPidPath, "utf8").length > 0, 15_000),
+		).toBe(true);
+		const childPid = Number(readFileSync(childPidPath, "utf8"));
+		expect(Number.isInteger(childPid)).toBe(true);
+		spawnedPids.push(childPid);
+		expect(isAlive(childPid)).toBe(true);
+
+		signalProcessGroupOrProcess(parentPid, "SIGKILL");
+
+		expect(await waitUntil(() => !isAlive(parentPid), 15_000)).toBe(true);
+		expect(await waitUntil(() => !isAlive(childPid), 15_000)).toBe(true);
+	}, 60_000);
+});


### PR DESCRIPTION
## Problem

Windows has no process groups. `signalProcessGroupOrProcess` tries `process.kill(-pid)` first and falls back to `process.kill(pid)`; on Windows the first call always fails, so the fallback terminates exactly one process. Worker recovery inlined the same two-step kill for each journaled orphan, with the same result.

A crashed worker therefore leaves its detached descendants running — a Python kernel, an autonomous gate — until they finish on their own. They are recorded in the orphan journal, and recovery reads that journal, but the kill it issues cannot reach them.

## Fix

`taskkill /F /T` walks the real process tree. Both call sites now go through `signalProcessGroupOrProcess`, so recovery and teardown share one implementation instead of two copies that disagree by platform.

Unix is unchanged: it still signals the process group in a single call.

`windowsHide` on the taskkill spawn is not cosmetic. A daemon is spawned detached and owns no console, and a console child of a console-less parent gets a new console *with a visible window* that outlives it, so a teardown killing many processes would leave a desktop full of windows to close by hand.

## Why the test looks the way it does

Two details are load-bearing, and both are easy to get wrong:

- **The child is detached.** Windows puts an ordinary child in a job object owned by its parent, so it dies with the parent whether or not anything walks the tree. A test with a non-detached child passes with the fix reverted. Detached descendants are what a crashed worker actually leaves behind.
- **Windows only.** A detached child leaves its parent's process group on Unix too, so the group signal does not reach it there either. That is the existing Unix behavior and this change does not touch it.

Removing the Windows branch fails the test. I verified that in both directions rather than assuming it.

## Verification

- The new test passes on Windows 11 and fails with the branch reverted.
- `test/orphan-process-journal.test.ts` passes.
- `biome`, `tsgo --noEmit`, and the root `npm run check` pass.
- Note for reviewers: `test/daemon-supervisor-process.test.ts` fails 8 cases on Windows on this branch — and fails the same 8 on unmodified `main`, with "Supervisor exited before becoming ready". That is the un-ported Windows daemon state, not a regression from this change. I checked the baseline before writing this.

## Relationship to #744

A job object is the better containment primitive and I would rather see that land than this. It does not make the journal redundant: a job object only covers processes assigned to it, and this issue is precisely about the descendants that were not. A tree kill over the journal is the backstop for those, so the two compose.

Fixes #917.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows orphaned process teardown to kill entire process trees, not just root PIDs
> - `signalProcessGroupOrProcess` in [`child-process.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1002/files#diff-a9f6b77c57772609afaa172c89bf3bfb5dd1e9d8ab775b567e40388a0f78fe96) now runs `taskkill /F /T /PID <pid>` on Windows to recursively terminate all descendants, falling back to `process.kill` if `taskkill` fails.
> - [`DaemonSupervisor`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1002/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) worker teardown now routes orphan PIDs through `signalProcessGroupOrProcess` instead of calling `process.kill` directly, picking up tree-kill behavior.
> - A Windows-only integration test in [`child-process-tree-kill-windows.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1002/files#diff-a2834ffefa4687fab1835c616d3cf3754fb0fcbc2539fe0737f6529da57d4c50) verifies that both a detached parent and its detached child are killed.
> - Behavioral Change: on Windows, orphaned worker processes that previously survived teardown (detached descendants) will now be forcibly terminated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31435c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->