### PR TITLE
fix(windows): give a starting kernel long enough to publish its ports

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 - Fixed the agents view collapsing expanded subagent lists when returning from an opened agent ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
 - Kept the subagent summary row visible and selectable while its list is expanded in the agents view, so pressing enter on it collapses the list again ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
+- Fixed a slow IPython kernel start on Windows being reported as a broken kernel. The wait for resolved ports is 15s there, unchanged elsewhere.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -24,7 +24,16 @@ import {
 
 const DELIM = Buffer.from("<IDS|MSG>");
 const PROTOCOL_VERSION = "5.3";
-const PORTS_RESOLVE_TIMEOUT_MS = 5000;
+/**
+ * How long to wait for a starting kernel to publish its resolved ports.
+ *
+ * Windows pays a much slower interpreter start than Linux or macOS, and several
+ * kernels starting at once — a sharded test run, or a daemon bringing up
+ * sessions in parallel — pushes it past five seconds. The wait loop below exits
+ * early when the kernel dies, so a longer budget never delays a real failure;
+ * it only stops a slow start being reported as a broken one.
+ */
+const PORTS_RESOLVE_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 5000;
 const READY_TIMEOUT_MS = 5000;
 // Loopback PUB/SUB subscription propagation is usually sub-ms, but keep a small guard before first execute.
 const IOPUB_SUBSCRIBE_DELAY_MS = 50;


### PR DESCRIPTION
## Problem

A kernel that has not written resolved ports within five seconds is reported as broken:

```
Kernel did not resolve connection ports within 5000ms. stderr tail:
(empty)
```

The empty stderr tail is the tell. A kernel that actually failed says why; a kernel that is merely slow says nothing, because it is still starting.

On Windows five seconds is not a generous budget. The interpreter start alone costs more than on Linux, and several kernels coming up at once — a sharded test run, or a daemon opening sessions in parallel — pushes past it. On a full local run of the coding-agent suite, three separate suites failed this way, all with the same empty tail.

## Fix

Fifteen seconds on Windows, unchanged elsewhere.

The wait loop already exits as soon as the kernel dies, so the longer budget cannot delay a genuine failure — a crashed kernel still reports immediately, with its stderr. It only stops a slow start being called a broken one.

## Verification

Measured on the Windows branch where the kernel port is complete: with the old budget, `kernel-agent-message-skill`, `kernel-agent-observe-skill`, and `ipython-bootstrap` failed on a full sharded run; with this change, all three pass and the whole suite is green across the three shards.

Note for reviewers: the kernel suites cannot run on Windows on unmodified `main`, because bootstrap fails earlier at `ensureKernelPythonUncached` with "First-time setup needs internet to install uv, Python, ipykernel" — the venv interpreter gap that #663 and #695 address. That is why the measurement above comes from a branch with those fixes applied. This change is one constant and cannot affect that path.

`biome`, `tsgo --noEmit`, and the root `npm run check` pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend kernel port resolution timeout to 15s on Windows
> IPython kernels start more slowly on Windows, causing the previous 5s timeout to misreport a still-starting kernel as broken. The `PORTS_RESOLVE_TIMEOUT_MS` constant in [index.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1004/files#diff-14dd18f6926ed763ba0b55625302fb733f4e4209bb611d3051820048732149ac) is now set to 15,000 ms on Windows and unchanged at 5,000 ms elsewhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7b6fc7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->