### PR TITLE
fix(coding-agent): acquire the bootstrap lock with an atomic rename

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed the kernel bootstrap lock reclaiming a stale lock non-atomically, which could let two processes run venv rebuilds at the same time ([#1005](https://github.com/PrimeIntellect-ai/prime-agent/issues/1005))
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants, existsSync, readdirSync, readFileSync } from "node:fs";
-import { access, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { stderr, stdin } from "node:process";
@@ -89,6 +89,12 @@ function errorMessage(error: unknown): string {
 
 function isNodeError(error: unknown, code: string): boolean {
 	return error instanceof Error && "code" in error && error.code === code;
+}
+
+function isLockDirExistsError(error: unknown): boolean {
+	if (isNodeError(error, "EEXIST") || isNodeError(error, "ENOTEMPTY")) return true;
+	// Windows fails any directory rename onto an existing target with EPERM.
+	return process.platform === "win32" && isNodeError(error, "EPERM");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -474,21 +480,33 @@ async function lockMissingPidIsStale(lockDir: string): Promise<boolean> {
 	}
 }
 
-async function acquireBootstrapLock(venv: string): Promise<() => Promise<void>> {
+export async function acquireBootstrapLock(venv: string): Promise<() => Promise<void>> {
 	const lockDir = bootstrapLockDir(venv);
 	await mkdir(path.dirname(lockDir), { recursive: true });
 
 	for (;;) {
+		const token = randomUUID();
+		const candidateDir = `${lockDir}.candidate-${process.pid}-${token}`;
+		await mkdir(candidateDir);
+		await writeFile(path.join(candidateDir, "pid"), `${process.pid}\n`, "utf8");
 		try {
-			await mkdir(lockDir);
-			await writeFile(path.join(lockDir, "pid"), `${process.pid}\n`, "utf8");
+			await rename(candidateDir, lockDir);
 			return () => rm(lockDir, { recursive: true, force: true });
 		} catch (error) {
-			if (!isNodeError(error, "EEXIST")) throw error;
+			await rm(candidateDir, { recursive: true, force: true });
+			if (!isLockDirExistsError(error)) throw error;
 
 			const pid = await readLockPid(lockDir);
 			if (pid === null ? await lockMissingPidIsStale(lockDir) : !processIsRunning(pid)) {
-				await rm(lockDir, { recursive: true, force: true });
+				// Rename aside before removing so a lock another process creates in the
+				// meantime is never destroyed; the rename fails harmlessly if it is gone.
+				const staleDir = `${lockDir}.stale-${process.pid}-${token}`;
+				try {
+					await rename(lockDir, staleDir);
+					await rm(staleDir, { recursive: true, force: true });
+				} catch (reclaimError) {
+					if (!isNodeError(reclaimError, "ENOENT")) throw reclaimError;
+				}
 				continue;
 			}
 

--- a/packages/coding-agent/test/suite/regressions/1005-bootstrap-lock.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1005-bootstrap-lock.test.ts
@@ -1,0 +1,116 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { acquireBootstrapLock } from "../../../src/core/kernel/bootstrap.js";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return { ...actual, rm: vi.fn(actual.rm) };
+});
+
+let tempDir = "";
+let venv = "";
+let lockDir = "";
+let passthroughRm: typeof rm;
+
+function deadProcessPid(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+		child.on("error", reject);
+		child.on("exit", () => {
+			if (child.pid === undefined) {
+				reject(new Error("child pid unavailable"));
+				return;
+			}
+			resolve(child.pid);
+		});
+	});
+}
+
+function writeLockPid(pid: number): void {
+	mkdirSync(lockDir, { recursive: true });
+	writeFileSync(join(lockDir, "pid"), `${pid}\n`);
+}
+
+describe("bootstrap lock race", () => {
+	beforeEach(async () => {
+		tempDir = mkdtempSync(join(tmpdir(), "prime-agent-bootstrap-lock-"));
+		venv = join(tempDir, "kernel-venv");
+		lockDir = `${venv}.bootstrap.lock`;
+		passthroughRm = (await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises")).rm;
+		vi.mocked(rm).mockClear();
+		vi.mocked(rm).mockImplementation(passthroughRm);
+	});
+
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("serializes concurrent acquires on the same venv", async () => {
+		const releaseFirst = await acquireBootstrapLock(venv);
+
+		let secondAcquired = false;
+		const second = acquireBootstrapLock(venv).then((release) => {
+			secondAcquired = true;
+			return release;
+		});
+
+		await sleep(250);
+		expect(secondAcquired).toBe(false);
+
+		await releaseFirst();
+		const releaseSecond = await second;
+		expect(secondAcquired).toBe(true);
+		expect(readFileSync(join(lockDir, "pid"), "utf8").trim()).toBe(String(process.pid));
+
+		await releaseSecond();
+		expect(existsSync(lockDir)).toBe(false);
+	});
+
+	it("reclaims a lock left by a dead process", async () => {
+		writeLockPid(await deadProcessPid());
+
+		const release = await acquireBootstrapLock(venv);
+		expect(readFileSync(join(lockDir, "pid"), "utf8").trim()).toBe(String(process.pid));
+		expect(
+			readdirSync(tempDir).filter((entry) => entry.includes(".candidate-") || entry.includes(".stale-")),
+		).toEqual([]);
+
+		await release();
+	});
+
+	it("does not destroy a live lock created while reclaiming a stale lock", async () => {
+		writeLockPid(await deadProcessPid());
+
+		let injectedLiveLock = false;
+		vi.mocked(rm).mockImplementation(async (target, options) => {
+			if (!injectedLiveLock && String(target).includes(".stale-")) {
+				injectedLiveLock = true;
+				// A live holder creates a fresh lock between the stale rename-aside and the rm.
+				writeLockPid(process.pid);
+				writeFileSync(join(lockDir, "marker"), "live");
+			}
+			return passthroughRm(target, options);
+		});
+
+		const acquirePromise = acquireBootstrapLock(venv);
+		await vi.waitFor(() => expect(injectedLiveLock).toBe(true));
+		await sleep(250);
+
+		// Reclaim must never remove the lock directory itself.
+		expect(vi.mocked(rm).mock.calls.some(([target]) => String(target) === lockDir)).toBe(false);
+		expect(readFileSync(join(lockDir, "marker"), "utf8")).toBe("live");
+
+		rmSync(lockDir, { recursive: true, force: true });
+		const release = await acquirePromise;
+		expect(readFileSync(join(lockDir, "pid"), "utf8").trim()).toBe(String(process.pid));
+		await release();
+	});
+});


### PR DESCRIPTION
Fixes #1005.

## What was broken

`acquireBootstrapLock` reclaimed a stale lock with `rm(lockDir)` and then retried `mkdir`. Two processes can both judge the same lock stale, and one process's `rm` can delete a lock directory the other just created, with the loser's pid write landing inside the winner's directory. Both then return believing they hold the lock, so two venv rebuilds run concurrently and can corrupt the environment. Fresh installs and fleet boots are where several processes start together.

## The fix

Adopts the pattern the daemon launch lock and session leases already use: create a uniquely named candidate directory, write the pid file inside it, and atomically rename it onto the lock path (rename fails if the target exists). Stale reclamation renames the lock aside before deleting it, so a live lock created in the interim is never touched. One wrinkle: Windows fails a directory rename onto an existing target with `EPERM` rather than `EEXIST`, so that is treated as a lock-held signal too.

Signature and staleness semantics are unchanged.

## Testing

- New regression file `test/suite/regressions/1005-bootstrap-lock.test.ts`: concurrent acquires serialize, a dead-pid lock is reclaimed with no leftover candidate or stale dirs, and a live lock injected between the stale rename-aside and the delete survives untouched.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/1005-bootstrap-lock.test.ts test/kernel-bootstrap.test.ts`: the 3 new tests pass; the 17 kernel-bootstrap failures reproduce identically on unmodified main (the suite's fakes are POSIX-only shell scripts that cannot spawn on Windows).
- `npm run check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `acquireBootstrapLock` to use atomic rename preventing concurrent venv rebuilds
> - Rewrites lock acquisition in [`bootstrap.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1006/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) to use an atomic directory rename: creates a UUID+PID candidate directory, writes a PID file, then renames it to the lock path atomically.
> - Fixes a race where stale lock reclamation could delete a newly created lock from another process; now renames the stale lock aside before removing it, ignoring `ENOENT` if it disappears.
> - Adds `isLockDirExistsError` to handle `EEXIST`, `ENOTEMPTY`, and Windows `EPERM` as lock-exists conditions during rename.
> - Adds regression tests in [`1005-bootstrap-lock.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1006/files#diff-07d80959317ad8b6749db6cfc89a6a1504e86b9f0a289ed9f4eeb5b7286e1129) covering concurrent acquires, dead-process reclaim, and the live-lock-during-reclaim edge case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf38413.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->