### PR TITLE
fix(coding-agent): kill the background install command on installer interrupt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,8 @@ prime_agent_screen_layout_lab_width=0
 prime_agent_screen_render_lab_width=0
 prime_agent_screen_compact=0
 prime_agent_download_dir=
+prime_agent_animation_command_pid=
+prime_agent_animation_output_dir=
 prime_agent_bootstrap_kernel_on_install=0
 prime_agent_screen_title=
 prime_agent_screen_status=
@@ -162,6 +164,7 @@ prime_agent_install_traps() {
 
 prime_agent_cleanup() {
 	status=$?
+	prime_agent_stop_animation_command
 	if [ -n "${prime_agent_download_dir:-}" ] && [ -d "$prime_agent_download_dir" ]; then
 		rm -rf "$prime_agent_download_dir"
 	fi
@@ -172,6 +175,30 @@ prime_agent_cleanup() {
 prime_agent_signal_cleanup() {
 	prime_agent_restore_terminal
 	exit "$1"
+}
+
+prime_agent_stop_animation_command() {
+	if [ -z "${prime_agent_animation_command_pid:-}" ]; then
+		return
+	fi
+	if kill -0 "$prime_agent_animation_command_pid" 2>/dev/null; then
+		kill -TERM "$prime_agent_animation_command_pid" 2>/dev/null || true
+		grace_ticks=0
+		while kill -0 "$prime_agent_animation_command_pid" 2>/dev/null; do
+			grace_ticks=$((grace_ticks + 1))
+			if [ "$grace_ticks" -gt 10 ]; then
+				kill -KILL "$prime_agent_animation_command_pid" 2>/dev/null || true
+				break
+			fi
+			sleep 0.05
+		done
+	fi
+	wait "$prime_agent_animation_command_pid" 2>/dev/null || true
+	prime_agent_animation_command_pid=
+	if [ -n "${prime_agent_animation_output_dir:-}" ] && [ -d "$prime_agent_animation_output_dir" ]; then
+		rm -rf "$prime_agent_animation_output_dir"
+	fi
+	prime_agent_animation_output_dir=
 }
 
 prime_agent_restore_terminal() {
@@ -781,6 +808,8 @@ prime_agent_run_quiet_with_animation_command() {
 	output_file="$output_dir/output"
 	"$@" >"$output_file" 2>&1 &
 	command_pid=$!
+	prime_agent_animation_command_pid=$command_pid
+	prime_agent_animation_output_dir=$output_dir
 	prime_agent_animation_frame=0
 
 	while kill -0 "$command_pid" 2>/dev/null; do
@@ -802,6 +831,8 @@ prime_agent_run_quiet_with_animation_command() {
 		cat "$output_file" >&2
 	fi
 	rm -rf "$output_dir"
+	prime_agent_animation_command_pid=
+	prime_agent_animation_output_dir=
 	return "$command_status"
 }
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed interrupting the installer leaving the background install command running and a temporary directory behind ([#1008](https://github.com/PrimeIntellect-ai/prime-agent/issues/1008))
 
 ## [0.7.1] - 2026-08-07
 


### PR DESCRIPTION
Fixes #1008.

## What was broken

`prime_agent_run_quiet_with_animation_command` runs the install command in the background and polls it. The signal handler only restored the terminal and exited, and the EXIT trap only removed the download dir. The animation function's own temp output dir was removed only on the normal path. Since a non-interactive shell does not SIGHUP background jobs on exit, a Ctrl-C during "Installing Prime Agent" left npm running orphaned and leaked the temp dir.

## The fix

The active child pid and its output dir are now tracked in script globals, and a `prime_agent_stop_animation_command` helper runs from the EXIT trap: TERM, a short grace period, then KILL, then reap, then remove the output dir. On the normal path the globals are cleared so the trap is a no-op. The prompt and consent flow is untouched.

## Testing

- Reproduced against the unmodified script with a `sleep 30` stand-in: orphaned child and leaked temp dir confirmed.
- With the fix: SIGTERM (the MSYS2 environment here cannot deliver SIGINT to a trap, same code path) kills and reaps the child, removes the temp dir, and exits 143. Normal success and failure paths behave as before, including dumping the output file on failure.
- `sh -n` and `bash -n` pass. `npm run check` clean, including the installer render check.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix installer interrupt to kill background install command and clean up temp files
> When the installer was interrupted, the background install command kept running and left a temporary directory behind. This fix tracks the background command PID and temp output dir in globals, then terminates the process (SIGTERM → SIGKILL) and removes the temp dir during cleanup.
>
> - Adds `prime_agent_animation_command_pid` and `prime_agent_animation_output_dir` globals in [install.sh](https://github.com/PrimeIntellect-ai/prime-agent/pull/1009/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f) to track the background command state.
> - Introduces `prime_agent_stop_animation_command` to terminate the tracked process and remove its temp output dir.
> - Updates `prime_agent_cleanup` to call the new stopper before restoring the terminal.
> - Updates `prime_agent_run_quiet_with_animation_command` to record and clear the PID and output dir around the background command lifecycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e44d64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->