### PR TITLE
test(ai): add hermetic provider handoff contracts

### DIFF
--- a/packages/ai/test/cross-provider-handoff-hermetic.test.ts
+++ b/packages/ai/test/cross-provider-handoff-hermetic.test.ts
@@ -1,0 +1,427 @@
+import { Buffer } from "node:buffer";
+import { Type } from "typebox";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { getApiProviders } from "../src/api-registry.js";
+import { resetApiProviders } from "../src/providers/register-builtins.js";
+import type { Api, Model, StreamOptions, Tool } from "../src/types.js";
+import {
+	loadProviderHandoffFamilyFile,
+	type ResolvedProviderHandoffFamily,
+	resolveProviderHandoffFamilies,
+} from "./provider-handoff-families.js";
+import {
+	createHandoffContext,
+	type HandoffApi,
+	loadProviderHandoffFixtureFile,
+	parseProviderHandoffFixtureFile,
+} from "./provider-handoff-fixtures.js";
+import { getTargetTransportAttempts, resetTargetTransportAttempts } from "./provider-handoff-target-transport.js";
+
+const fixtureFile = loadProviderHandoffFixtureFile();
+const protocolFixtures = new Map(fixtureFile.fixtures.map((fixture) => [fixture.source.api, fixture]));
+const resolvedFamilies = resolveProviderHandoffFamilies(loadProviderHandoffFamilyFile());
+const fixturePairs = resolvedFamilies.flatMap((source) => resolvedFamilies.map((target) => ({ source, target })));
+
+const inspectFixtureTool: Tool = {
+	name: "inspect_fixture",
+	description: "Inspect a sanitized fixture path.",
+	parameters: Type.Object({ path: Type.String() }),
+};
+
+const CODEX_FIXTURE_TOKEN =
+	"e30.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF9maXh0dXJlIn19.fixture";
+const HERMETIC_BASE_URL = "http://127.0.0.1:9";
+const PAYLOAD_CAPTURED = "provider handoff payload captured";
+const APIS_WITHOUT_REPLAYED_TOOL_IDS = new Set<HandoffApi>(["google-generative-ai", "google-vertex"]);
+const APIS_WITH_EXPLICIT_TOOL_ERRORS = new Set<HandoffApi>([
+	"anthropic-messages",
+	"bedrock-converse-stream",
+	"google-generative-ai",
+	"google-vertex",
+	"mistral-conversations",
+]);
+
+interface PayloadInspection {
+	toolCallIds: string[];
+	toolResultIds: string[];
+	responseItemIds: string[];
+	toolCallNames: string[];
+	toolResultNames: string[];
+	imageData: string[];
+	imageCount: number;
+	hasExplicitToolError: boolean;
+}
+
+let expectedProviderErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeAll(() => {
+	expectedProviderErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterAll(() => {
+	expectedProviderErrorSpy.mockRestore();
+});
+
+describe("hermetic cross-provider handoff contract", () => {
+	it("parses, validates, and serializes the versioned fixtures deterministically", () => {
+		const serialized = JSON.stringify(fixtureFile);
+		const reparsed = parseProviderHandoffFixtureFile(serialized);
+
+		expect(reparsed).toEqual(fixtureFile);
+		expect(JSON.stringify(reparsed)).toBe(serialized);
+		expect(() =>
+			parseProviderHandoffFixtureFile(serialized.replace('"schemaVersion":1', '"schemaVersion":2')),
+		).toThrow("schema validation");
+		expect(serialized).not.toMatch(/(?:api[_-]?key|authorization|bearer|secret|sk-[a-z0-9])/i);
+		expect(fixtureFile.coverage).toEqual({
+			userImages: true,
+			toolResultImages: true,
+			toolErrors: true,
+			providerErrors: true,
+		});
+	});
+
+	it("requires one fixture for every registered built-in API", () => {
+		resetApiProviders();
+		const fixtureApis = [...new Set(fixtureFile.fixtures.map((fixture) => fixture.source.api))].sort();
+		const registeredApis = getApiProviders()
+			.map((provider) => provider.api)
+			.sort();
+
+		expect(fixtureApis).toEqual(registeredApis);
+	});
+
+	it.each(fixturePairs)(
+		"converts $source.fixture.provider/$source.fixture.model history for $target.fixture.provider/$target.fixture.model without transport",
+		async ({ source, target }) => {
+			resetTargetTransportAttempts();
+			expect(getTargetTransportAttempts()).toEqual([]);
+			resetApiProviders();
+			const apiProvider = getApiProviders().find((provider) => provider.api === target.model.api);
+			expect(apiProvider).toBeDefined();
+			if (!apiProvider) throw new Error(`Missing API provider ${target.model.api}`);
+			const sourceProtocol = protocolFixtures.get(source.model.api as HandoffApi);
+			expect(sourceProtocol).toBeDefined();
+			if (!sourceProtocol) throw new Error(`Missing protocol fixture ${source.model.api}`);
+
+			let capturedPayload: unknown;
+			const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+				throw new Error("Network transport must not run in hermetic handoff tests");
+			});
+
+			try {
+				const context = createHandoffContext(sourceProtocol, fixtureFile.images, {
+					api: source.model.api as HandoffApi,
+					provider: source.model.provider,
+					model: source.model.id,
+				});
+				context.tools = [inspectFixtureTool];
+				const response = await apiProvider
+					.stream(
+						createTargetModel(target),
+						context,
+						createCaptureOptions(target.model.api, (payload) => {
+							capturedPayload = payload;
+							throw new Error(PAYLOAD_CAPTURED);
+						}),
+					)
+					.result();
+
+				expect(fetchSpy).not.toHaveBeenCalled();
+				expect(getTargetTransportAttempts()).toEqual([]);
+				expect(response.stopReason).toBe("error");
+				expect(response.errorMessage).toContain(PAYLOAD_CAPTURED);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+
+			expect(capturedPayload).toBeDefined();
+			const serializedPayload = JSON.stringify(capturedPayload);
+			expect(() => JSON.parse(serializedPayload)).not.toThrow();
+			expect(serializedPayload).toContain("fixture tool failure");
+			expect(serializedPayload).not.toContain("fixture provider error");
+			expect(serializedPayload).not.toContain("Partial output from a failed provider response.");
+			expect(serializedPayload).toContain("Sanitized provider reasoning summary.");
+
+			const targetApi = target.model.api as HandoffApi;
+			const inspection = inspectPayload(targetApi, capturedPayload);
+			if (target.model.input.includes("image")) {
+				expect(inspection.imageData).toContain(fixtureFile.images.user.data);
+				expect(inspection.imageData).toContain(fixtureFile.images.toolResult.data);
+				expect(inspection.imageCount).toBe(2);
+			} else {
+				expect(inspection.imageCount).toBe(0);
+				expect(inspection.imageData).toEqual([]);
+				expect(serializedPayload).toContain("(image omitted: model does not support images)");
+				expect(serializedPayload).toContain("(tool image omitted: model does not support images)");
+			}
+			expect(inspection.hasExplicitToolError).toBe(APIS_WITH_EXPLICIT_TOOL_ERRORS.has(targetApi));
+			expect(inspection.toolCallNames).toEqual(["inspect_fixture"]);
+			if (targetApi === "google-generative-ai" || targetApi === "google-vertex") {
+				expect(inspection.toolResultNames).toEqual(["inspect_fixture"]);
+			}
+
+			const googleRequiresIds =
+				(targetApi === "google-generative-ai" || targetApi === "google-vertex") &&
+				(target.model.id.startsWith("claude-") || target.model.id.startsWith("gpt-oss-"));
+			if (APIS_WITHOUT_REPLAYED_TOOL_IDS.has(targetApi) && !googleRequiresIds) {
+				expect(inspection.toolCallIds).toEqual([]);
+				expect(inspection.toolResultIds).toEqual([]);
+			} else {
+				expect(inspection.toolCallIds).toHaveLength(1);
+				expect(inspection.toolResultIds).toEqual(inspection.toolCallIds);
+			}
+			assertNativeToolIdContract(target, inspection);
+			if (
+				(targetApi === "azure-openai-responses" ||
+					targetApi === "openai-codex-responses" ||
+					targetApi === "openai-responses") &&
+				["azure-openai-responses", "openai", "openai-codex", "opencode"].includes(target.model.provider) &&
+				source.model.id === target.model.id &&
+				sourceProtocol.protocol.toolCallId.includes("|")
+			) {
+				expect(inspection.responseItemIds).toHaveLength(1);
+			}
+
+			const isRoundTrip =
+				source.model.api === target.model.api &&
+				source.model.provider === target.model.provider &&
+				source.model.id === target.model.id;
+			const thinkingSignature = sourceProtocol.protocol.thinkingSignature;
+			if (thinkingSignature && thinkingSignature !== "reasoning_content") {
+				const targetSupportsThinkingSignature =
+					targetApi !== "bedrock-converse-stream" || target.model.id.includes("anthropic.claude");
+				expect(serializedPayload.includes(getThinkingSignatureMarker(thinkingSignature))).toBe(
+					isRoundTrip && targetSupportsThinkingSignature,
+				);
+			}
+			const toolThoughtSignature = sourceProtocol.protocol.toolThoughtSignature;
+			if (toolThoughtSignature) {
+				expect(serializedPayload.includes(getToolThoughtSignatureMarker(toolThoughtSignature))).toBe(isRoundTrip);
+			}
+		},
+	);
+});
+
+function createTargetModel(family: ResolvedProviderHandoffFamily): Model<Api> {
+	return {
+		...family.model,
+		baseUrl: HERMETIC_BASE_URL,
+	};
+}
+
+function assertNativeToolIdContract(target: ResolvedProviderHandoffFamily, inspection: PayloadInspection): void {
+	const api = target.model.api as HandoffApi;
+	for (const id of [...inspection.toolCallIds, ...inspection.toolResultIds]) {
+		expect(id).not.toContain("|");
+	}
+
+	switch (api) {
+		case "anthropic-messages":
+		case "bedrock-converse-stream":
+			for (const id of inspection.toolCallIds) {
+				expect(id).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+			}
+			break;
+		case "mistral-conversations":
+			expect(inspection.toolCallIds[0]).toMatch(/^[A-Za-z0-9]{9}$/);
+			break;
+		case "azure-openai-responses":
+		case "openai-codex-responses":
+		case "openai-responses":
+			for (const id of inspection.toolCallIds) expect(id).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+			for (const id of inspection.responseItemIds) {
+				expect(id).toMatch(/^fc_[A-Za-z0-9_-]{1,61}$/);
+			}
+			break;
+		case "google-generative-ai":
+		case "google-vertex":
+			for (const id of inspection.toolCallIds) expect(id).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+			break;
+		case "openai-completions":
+			if (target.model.provider === "openai") {
+				for (const id of inspection.toolCallIds) expect(id.length).toBeLessThanOrEqual(40);
+			}
+			break;
+	}
+}
+
+function getThinkingSignatureMarker(signature: string): string {
+	if (!signature.startsWith("{")) return signature;
+	const parsed = JSON.parse(signature) as { encrypted_content?: unknown };
+	if (typeof parsed.encrypted_content !== "string") {
+		throw new Error("Fixture reasoning signature lacks encrypted_content marker");
+	}
+	return parsed.encrypted_content;
+}
+
+function getToolThoughtSignatureMarker(signature: string): string {
+	if (!signature.startsWith("{")) return signature;
+	const parsed = JSON.parse(signature) as { data?: unknown };
+	if (typeof parsed.data !== "string") throw new Error("Fixture tool signature lacks data marker");
+	return parsed.data;
+}
+
+function createCaptureOptions(api: Api, onPayload: NonNullable<StreamOptions["onPayload"]>): StreamOptions {
+	return {
+		apiKey: api === "openai-codex-responses" ? CODEX_FIXTURE_TOKEN : "fixture-key",
+		onPayload,
+		...(api === "openai-codex-responses" ? { transport: "sse" as const } : {}),
+	};
+}
+
+function inspectPayload(api: HandoffApi, payload: unknown): PayloadInspection {
+	const inspection: PayloadInspection = {
+		toolCallIds: [],
+		toolResultIds: [],
+		responseItemIds: [],
+		toolCallNames: [],
+		toolResultNames: [],
+		imageData: [],
+		imageCount: 0,
+		hasExplicitToolError: false,
+	};
+
+	visit(payload, (record) => {
+		const imageData = extractImageData(record);
+		if (imageData !== undefined) {
+			inspection.imageCount++;
+			inspection.imageData.push(imageData);
+		}
+
+		switch (api) {
+			case "anthropic-messages":
+				if (record.type === "tool_use" && typeof record.id === "string") {
+					inspection.toolCallIds.push(record.id);
+					if (typeof record.name === "string") inspection.toolCallNames.push(record.name);
+				}
+				if (record.type === "tool_result" && typeof record.tool_use_id === "string") {
+					inspection.toolResultIds.push(record.tool_use_id);
+					inspection.hasExplicitToolError ||= record.is_error === true;
+				}
+				break;
+			case "bedrock-converse-stream": {
+				const toolUse = record.toolUse;
+				if (isRecord(toolUse) && typeof toolUse.toolUseId === "string") {
+					inspection.toolCallIds.push(toolUse.toolUseId);
+					if (typeof toolUse.name === "string") inspection.toolCallNames.push(toolUse.name);
+				}
+				const toolResult = record.toolResult;
+				if (isRecord(toolResult) && typeof toolResult.toolUseId === "string") {
+					inspection.toolResultIds.push(toolResult.toolUseId);
+					inspection.hasExplicitToolError ||= toolResult.status === "error";
+				}
+				break;
+			}
+			case "google-generative-ai":
+			case "google-vertex": {
+				const functionCall = record.functionCall;
+				if (isRecord(functionCall) && typeof functionCall.id === "string") {
+					inspection.toolCallIds.push(functionCall.id);
+				}
+				if (isRecord(functionCall) && typeof functionCall.name === "string") {
+					inspection.toolCallNames.push(functionCall.name);
+				}
+				const functionResponse = record.functionResponse;
+				if (isRecord(functionResponse)) {
+					if (typeof functionResponse.id === "string") inspection.toolResultIds.push(functionResponse.id);
+					if (typeof functionResponse.name === "string") inspection.toolResultNames.push(functionResponse.name);
+					const response = functionResponse.response;
+					inspection.hasExplicitToolError ||= isRecord(response) && typeof response.error === "string";
+				}
+				break;
+			}
+			case "mistral-conversations": {
+				if (Array.isArray(record.toolCalls)) {
+					for (const toolCall of record.toolCalls) {
+						if (!isRecord(toolCall)) continue;
+						if (typeof toolCall.id === "string") inspection.toolCallIds.push(toolCall.id);
+						const fn = toolCall.function;
+						if (isRecord(fn) && typeof fn.name === "string") inspection.toolCallNames.push(fn.name);
+					}
+				}
+				if (record.role === "tool" && typeof record.toolCallId === "string") {
+					inspection.toolResultIds.push(record.toolCallId);
+					if (typeof record.name === "string") inspection.toolResultNames.push(record.name);
+					inspection.hasExplicitToolError ||= JSON.stringify(record.content).includes("[tool error]");
+				}
+				break;
+			}
+			case "openai-completions":
+				if (Array.isArray(record.tool_calls)) {
+					for (const toolCall of record.tool_calls) {
+						if (!isRecord(toolCall)) continue;
+						if (typeof toolCall.id === "string") inspection.toolCallIds.push(toolCall.id);
+						const fn = toolCall.function;
+						if (isRecord(fn) && typeof fn.name === "string") inspection.toolCallNames.push(fn.name);
+					}
+				}
+				if (record.role === "tool" && typeof record.tool_call_id === "string") {
+					inspection.toolResultIds.push(record.tool_call_id);
+				}
+				break;
+			case "azure-openai-responses":
+			case "openai-codex-responses":
+			case "openai-responses":
+				if (record.type === "function_call" && typeof record.call_id === "string") {
+					inspection.toolCallIds.push(record.call_id);
+					if (typeof record.id === "string") inspection.responseItemIds.push(record.id);
+					if (typeof record.name === "string") inspection.toolCallNames.push(record.name);
+				}
+				if (record.type === "function_call_output" && typeof record.call_id === "string") {
+					inspection.toolResultIds.push(record.call_id);
+				}
+				break;
+		}
+	});
+
+	return inspection;
+}
+
+function extractImageData(record: Record<string, unknown>): string | undefined {
+	if (isRecord(record.inlineData) && typeof record.inlineData.data === "string") {
+		return record.inlineData.data;
+	}
+
+	if (record.type === "image" && isRecord(record.source) && typeof record.source.data === "string") {
+		return record.source.data;
+	}
+
+	if (record.type === "image_url" && typeof record.imageUrl === "string") {
+		return stripDataUrl(record.imageUrl);
+	}
+
+	if (record.type === "image_url" && isRecord(record.image_url) && typeof record.image_url.url === "string") {
+		return stripDataUrl(record.image_url.url);
+	}
+
+	if (record.type === "input_image" && typeof record.image_url === "string") {
+		return stripDataUrl(record.image_url);
+	}
+
+	if (isRecord(record.image) && isRecord(record.image.source)) {
+		const bytes = record.image.source.bytes;
+		if (bytes instanceof Uint8Array) return Buffer.from(bytes).toString("base64");
+	}
+
+	return undefined;
+}
+
+function stripDataUrl(value: string): string {
+	const separator = value.indexOf(",");
+	return separator === -1 ? value : value.slice(separator + 1);
+}
+
+function visit(value: unknown, callback: (record: Record<string, unknown>) => void): void {
+	if (Array.isArray(value)) {
+		for (const item of value) visit(item, callback);
+		return;
+	}
+	if (!isRecord(value)) return;
+	callback(value);
+	for (const child of Object.values(value)) visit(child, callback);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/packages/ai/test/fixtures/provider-handoffs/v1/families.json
+++ b/packages/ai/test/fixtures/provider-handoffs/v1/families.json
@@ -1,1109 +1,4794 @@
 {
-	"schemaVersion": 1,
+	"schemaVersion": 2,
 	"families": [
 		{
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"model": "amazon.nova-2-lite-v1:0",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Nova 2 Lite",
+				"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.33,
+					"output": 2.75,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"model": "amazon.nova-micro-v1:0",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Nova Micro",
+				"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.035,
+					"output": 0.14,
+					"cacheRead": 0.00875,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"model": "anthropic.claude-fable-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Fable 5",
+				"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 50,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"model": "anthropic.claude-haiku-4-5-20251001-v1:0",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Haiku 4.5",
+				"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 5,
+					"cacheRead": 0.1,
+					"cacheWrite": 1.25
+				},
+				"contextWindow": 200000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"model": "anthropic.claude-opus-4-6-v1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.6",
+				"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"model": "anthropic.claude-opus-4-7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.7",
+				"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"model": "anthropic.claude-opus-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 5",
+				"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "anthropic",
 			"model": "claude-fable-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Fable 5",
+				"baseUrl": "https://api.anthropic.com",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 50,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "anthropic",
 			"model": "claude-haiku-4-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Haiku 4.5 (latest)",
+				"baseUrl": "https://api.anthropic.com",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 5,
+					"cacheRead": 0.1,
+					"cacheWrite": 1.25
+				},
+				"contextWindow": 200000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "anthropic",
 			"model": "claude-opus-4-6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.6",
+				"baseUrl": "https://api.anthropic.com",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "anthropic",
 			"model": "claude-opus-4-7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.7",
+				"baseUrl": "https://api.anthropic.com",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "azure-openai-responses",
 			"provider": "azure-openai-responses",
 			"model": "gpt-4",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-4",
+				"baseUrl": "",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 30,
+					"output": 60,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 8192,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "azure-openai-responses",
 			"provider": "azure-openai-responses",
 			"model": "gpt-4-turbo",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-4 Turbo",
+				"baseUrl": "",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 30,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "azure-openai-responses",
 			"provider": "azure-openai-responses",
 			"model": "gpt-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5",
+				"baseUrl": "",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.25,
+					"output": 10,
+					"cacheRead": 0.125,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "azure-openai-responses",
 			"provider": "azure-openai-responses",
 			"model": "gpt-5.2",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.2",
+				"baseUrl": "",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.75,
+					"output": 14,
+					"cacheRead": 0.175,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "azure-openai-responses",
 			"provider": "azure-openai-responses",
 			"model": "gpt-5.6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.6",
+				"baseUrl": "",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 30,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1050000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "azure-openai-responses",
 			"provider": "azure-openai-responses",
 			"model": "gpt-realtime-2.1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-Realtime-2.1",
+				"baseUrl": "",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 4,
+					"output": 24,
+					"cacheRead": 0.4,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 32000
+			}
 		},
 		{
 			"api": "azure-openai-responses",
 			"provider": "azure-openai-responses",
 			"model": "o3-mini",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "o3-mini",
+				"baseUrl": "",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 1.1,
+					"output": 4.4,
+					"cacheRead": 0.55,
+					"cacheWrite": 0
+				},
+				"contextWindow": 200000,
+				"maxTokens": 100000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "cerebras",
 			"model": "gemma-4-31b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemma 4 31B IT",
+				"baseUrl": "https://api.cerebras.ai/v1",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.99,
+					"output": 1.49,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 40960
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "cerebras",
 			"model": "gpt-oss-120b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT OSS 120B",
+				"baseUrl": "https://api.cerebras.ai/v1",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.35,
+					"output": 0.75,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 40960
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
 			"model": "claude-3-5-haiku",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Haiku 3.5 (latest)",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/anthropic",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.8,
+					"output": 4,
+					"cacheRead": 0.08,
+					"cacheWrite": 1
+				},
+				"contextWindow": 200000,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
 			"model": "claude-3-haiku",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Haiku 3",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/anthropic",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.25,
+					"output": 1.25,
+					"cacheRead": 0.03,
+					"cacheWrite": 0.3
+				},
+				"contextWindow": 200000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
 			"model": "claude-fable-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Fable 5",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/anthropic",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 50,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
 			"model": "claude-haiku-4-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Haiku 4.5 (latest)",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/anthropic",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 5,
+					"cacheRead": 0.1,
+					"cacheWrite": 1.25
+				},
+				"contextWindow": 200000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
 			"model": "claude-opus-4-6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.6 (latest)",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/anthropic",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
 			"model": "claude-opus-4-7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.7",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/anthropic",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "cloudflare-ai-gateway",
 			"model": "gpt-4",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-4",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/openai",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 30,
+					"output": 60,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 8192,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "cloudflare-ai-gateway",
 			"model": "gpt-4-turbo",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-4 Turbo",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/openai",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 30,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "cloudflare-ai-gateway",
 			"model": "gpt-5.1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.1",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/openai",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.25,
+					"output": 10,
+					"cacheRead": 0.13,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "cloudflare-ai-gateway",
 			"model": "gpt-5.2",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.2",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/openai",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.75,
+					"output": 14,
+					"cacheRead": 0.175,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "cloudflare-ai-gateway",
 			"model": "gpt-5.6-luna",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.6 Luna",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/openai",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 6,
+					"cacheRead": 0.1,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1050000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "cloudflare-ai-gateway",
 			"model": "o1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "o1",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/openai",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 15,
+					"output": 60,
+					"cacheRead": 7.5,
+					"cacheWrite": 0
+				},
+				"contextWindow": 200000,
+				"maxTokens": 100000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "cloudflare-ai-gateway",
 			"model": "o3-mini",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "o3-mini",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/openai",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 1.1,
+					"output": 4.4,
+					"cacheRead": 0.55,
+					"cacheWrite": 0
+				},
+				"contextWindow": 200000,
+				"maxTokens": 100000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "cloudflare-ai-gateway",
 			"model": "workers-ai/@cf/moonshotai/kimi-k2.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K2.5",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/compat",
+				"compat": {
+					"sendSessionAffinityHeaders": true
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.6,
+					"output": 3,
+					"cacheRead": 0.1,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 256000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "cloudflare-ai-gateway",
 			"model": "workers-ai/@cf/nvidia/nemotron-3-120b-a12b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Nemotron 3 Super 120B",
+				"baseUrl": "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/compat",
+				"compat": {
+					"sendSessionAffinityHeaders": true
+				},
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.5,
+					"output": 1.5,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 256000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "cloudflare-workers-ai",
 			"model": "@cf/google/gemma-4-26b-a4b-it",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemma 4 26B A4B IT",
+				"baseUrl": "https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+				"compat": {
+					"sendSessionAffinityHeaders": true
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.1,
+					"output": 0.3,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 16384
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "cloudflare-workers-ai",
 			"model": "@cf/ibm-granite/granite-4.0-h-micro",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Granite 4.0 H Micro",
+				"baseUrl": "https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+				"compat": {
+					"sendSessionAffinityHeaders": true
+				},
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.017,
+					"output": 0.112,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131000,
+				"maxTokens": 131000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "cloudflare-workers-ai",
 			"model": "@cf/meta/llama-4-scout-17b-16e-instruct",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Llama 4 Scout 17B 16E Instruct",
+				"baseUrl": "https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+				"compat": {
+					"sendSessionAffinityHeaders": true
+				},
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.27,
+					"output": 0.85,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131000,
+				"maxTokens": 16384
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "cloudflare-workers-ai",
 			"model": "@cf/nvidia/nemotron-3-120b-a12b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Nemotron 3 Super 120B",
+				"baseUrl": "https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+				"compat": {
+					"sendSessionAffinityHeaders": true
+				},
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.5,
+					"output": 1.5,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 256000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "deepseek",
 			"model": "deepseek-v4-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "DeepSeek V4 Flash",
+				"baseUrl": "https://api.deepseek.com",
+				"compat": {
+					"requiresReasoningContentOnAssistantMessages": true,
+					"thinkingFormat": "deepseek"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": "high",
+					"xhigh": "max"
+				},
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 384000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "fireworks",
 			"model": "accounts/fireworks/models/deepseek-v4-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "DeepSeek V4 Flash",
+				"baseUrl": "https://api.fireworks.ai/inference",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 384000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "fireworks",
 			"model": "accounts/fireworks/models/kimi-k2p6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K2.6",
+				"baseUrl": "https://api.fireworks.ai/inference",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.95,
+					"output": 4,
+					"cacheRead": 0.16,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262000,
+				"maxTokens": 262000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"model": "claude-fable-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Fable 5",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 50,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"model": "claude-haiku-4.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Haiku 4.5 (latest)",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"compat": {
+					"supportsEagerToolInputStreaming": false
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 5,
+					"cacheRead": 0.1,
+					"cacheWrite": 1.25
+				},
+				"contextWindow": 200000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"model": "claude-opus-4.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.5 (latest)",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 200000,
+				"maxTokens": 32000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"model": "claude-opus-4.6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.6",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 32000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"model": "claude-opus-4.7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.7",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 200000,
+				"maxTokens": 32000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"model": "claude-sonnet-4",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Sonnet 4 (latest)",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"compat": {
+					"supportsEagerToolInputStreaming": false
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 3,
+					"output": 15,
+					"cacheRead": 0.3,
+					"cacheWrite": 3.75
+				},
+				"contextWindow": 216000,
+				"maxTokens": 16000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"model": "gemini-2.5-pro",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.5 Pro",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": false
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.25,
+					"output": 10,
+					"cacheRead": 0.125,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"model": "gpt-5-mini",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5 Mini",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.25,
+					"output": 2,
+					"cacheRead": 0.025,
+					"cacheWrite": 0
+				},
+				"contextWindow": 264000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"model": "gpt-5.2",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.2",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.75,
+					"output": 14,
+					"cacheRead": 0.175,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"model": "gpt-5.6-luna",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.6 Luna",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 6,
+					"cacheRead": 0.1,
+					"cacheWrite": 1.25
+				},
+				"contextWindow": 1050000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"model": "mai-code-1-flash-picker",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MAI-Code-1-Flash",
+				"baseUrl": "https://api.individual.githubcopilot.com",
+				"headers": {
+					"User-Agent": "GitHubCopilotChat/0.35.0",
+					"Editor-Version": "vscode/1.107.0",
+					"Editor-Plugin-Version": "copilot-chat/0.35.0",
+					"Copilot-Integration-Id": "vscode-chat"
+				},
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": false
+				},
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.75,
+					"output": 4.5,
+					"cacheRead": 0.075,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "google",
 			"model": "gemini-2.0-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.0 Flash",
+				"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.1,
+					"output": 0.4,
+					"cacheRead": 0.025,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "google",
 			"model": "gemini-2.5-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.5 Flash",
+				"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 2.5,
+					"cacheRead": 0.03,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "google",
 			"model": "gemini-2.5-flash-lite",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.5 Flash-Lite",
+				"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.1,
+					"output": 0.4,
+					"cacheRead": 0.01,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "google",
 			"model": "gemini-2.5-pro",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.5 Pro",
+				"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.25,
+					"output": 10,
+					"cacheRead": 0.125,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "google",
 			"model": "gemini-3-flash-preview",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 3 Flash Preview",
+				"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.5,
+					"output": 3,
+					"cacheRead": 0.05,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "google",
 			"model": "gemini-3-pro-preview",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 3 Pro Preview",
+				"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": null,
+					"low": "LOW",
+					"medium": null,
+					"high": "HIGH"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 2,
+					"output": 12,
+					"cacheRead": 0.2,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "google",
 			"model": "gemini-flash-latest",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini Flash Latest",
+				"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.5,
+					"output": 9,
+					"cacheRead": 0.15,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "google",
 			"model": "gemma-4-26b-a4b-it",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemma 4 26B A4B IT",
+				"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": "MINIMAL",
+					"low": null,
+					"medium": null,
+					"high": "HIGH"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0,
+					"output": 0,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 32768
+			}
 		},
 		{
 			"api": "google-vertex",
 			"provider": "google-vertex",
 			"model": "gemini-1.5-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 1.5 Flash (Vertex)",
+				"baseUrl": "https://{location}-aiplatform.googleapis.com",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.075,
+					"output": 0.3,
+					"cacheRead": 0.01875,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "google-vertex",
 			"provider": "google-vertex",
 			"model": "gemini-2.0-flash-lite",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.0 Flash Lite (Vertex)",
+				"baseUrl": "https://{location}-aiplatform.googleapis.com",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.075,
+					"output": 0.3,
+					"cacheRead": 0.01875,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-vertex",
 			"provider": "google-vertex",
 			"model": "gemini-2.5-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.5 Flash (Vertex)",
+				"baseUrl": "https://{location}-aiplatform.googleapis.com",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 2.5,
+					"cacheRead": 0.03,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-vertex",
 			"provider": "google-vertex",
 			"model": "gemini-2.5-flash-lite",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.5 Flash Lite (Vertex)",
+				"baseUrl": "https://{location}-aiplatform.googleapis.com",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.1,
+					"output": 0.4,
+					"cacheRead": 0.01,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-vertex",
 			"provider": "google-vertex",
 			"model": "gemini-2.5-pro",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.5 Pro (Vertex)",
+				"baseUrl": "https://{location}-aiplatform.googleapis.com",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.25,
+					"output": 10,
+					"cacheRead": 0.125,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-vertex",
 			"provider": "google-vertex",
 			"model": "gemini-3-flash-preview",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 3 Flash Preview (Vertex)",
+				"baseUrl": "https://{location}-aiplatform.googleapis.com",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.5,
+					"output": 3,
+					"cacheRead": 0.05,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-vertex",
 			"provider": "google-vertex",
 			"model": "gemini-3-pro-preview",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 3 Pro Preview (Vertex)",
+				"baseUrl": "https://{location}-aiplatform.googleapis.com",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": null,
+					"low": "LOW",
+					"medium": null,
+					"high": "HIGH"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 2,
+					"output": 12,
+					"cacheRead": 0.2,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "groq",
 			"model": "llama-3.1-8b-instant",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Llama 3.1 8B",
+				"baseUrl": "https://api.groq.com/openai/v1",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.05,
+					"output": 0.08,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "groq",
 			"model": "meta-llama/llama-4-scout-17b-16e-instruct",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Llama 4 Scout 17B 16E",
+				"baseUrl": "https://api.groq.com/openai/v1",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.11,
+					"output": 0.34,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "groq",
 			"model": "openai/gpt-oss-120b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT OSS 120B",
+				"baseUrl": "https://api.groq.com/openai/v1",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.15,
+					"output": 0.6,
+					"cacheRead": 0.075,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "groq",
 			"model": "qwen/qwen3-32b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen3-32B",
+				"baseUrl": "https://api.groq.com/openai/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": "default"
+				},
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.29,
+					"output": 0.59,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 40960
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "huggingface",
 			"model": "MiniMaxAI/MiniMax-M2",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiniMax-M2",
+				"baseUrl": "https://router.huggingface.co/v1",
+				"compat": {
+					"supportsDeveloperRole": false
+				},
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 1.2,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 204800,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "huggingface",
 			"model": "MiniMaxAI/MiniMax-M3",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiniMax-M3",
+				"baseUrl": "https://router.huggingface.co/v1",
+				"compat": {
+					"supportsDeveloperRole": false
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 1.2,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 524288,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "huggingface",
 			"model": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen3-Coder 30B-A3B Instruct",
+				"baseUrl": "https://router.huggingface.co/v1",
+				"compat": {
+					"supportsDeveloperRole": false
+				},
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.07,
+					"output": 0.26,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "huggingface",
 			"model": "moonshotai/Kimi-K3",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K3",
+				"baseUrl": "https://router.huggingface.co/v1",
+				"compat": {
+					"supportsDeveloperRole": false
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": null,
+					"xhigh": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 3,
+					"output": 15,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "kimi-coding",
 			"model": "k3",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K3",
+				"baseUrl": "https://api.kimi.com/coding",
+				"headers": {
+					"User-Agent": "KimiCLI/1.5"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": null,
+					"xhigh": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0,
+					"output": 0,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "minimax",
 			"model": "MiniMax-M2.7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiniMax-M2.7",
+				"baseUrl": "https://api.minimax.io/anthropic",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 1.2,
+					"cacheRead": 0.06,
+					"cacheWrite": 0.375
+				},
+				"contextWindow": 204800,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "minimax-cn",
 			"model": "MiniMax-M2.7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiniMax-M2.7",
+				"baseUrl": "https://api.minimaxi.com/anthropic",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 1.2,
+					"cacheRead": 0.06,
+					"cacheWrite": 0.375
+				},
+				"contextWindow": 204800,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "mistral-conversations",
 			"provider": "mistral",
 			"model": "codestral-latest",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Codestral (latest)",
+				"baseUrl": "https://api.mistral.ai",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 0.9,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "mistral-conversations",
 			"provider": "mistral",
 			"model": "labs-devstral-small-2512",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Devstral Small 2",
+				"baseUrl": "https://api.mistral.ai",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0,
+					"output": 0,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 256000
+			}
 		},
 		{
 			"api": "mistral-conversations",
 			"provider": "mistral",
 			"model": "magistral-medium-latest",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Magistral Medium (latest)",
+				"baseUrl": "https://api.mistral.ai",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 2,
+					"output": 5,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 16384
+			}
 		},
 		{
 			"api": "mistral-conversations",
 			"provider": "mistral",
 			"model": "mistral-medium-2604",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Mistral Medium 3.5",
+				"baseUrl": "https://api.mistral.ai",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.5,
+					"output": 7.5,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 262144
+			}
 		},
 		{
 			"api": "mistral-conversations",
 			"provider": "mistral",
 			"model": "mistral-medium-3.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Mistral Medium 3.5",
+				"baseUrl": "https://api.mistral.ai",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.5,
+					"output": 7.5,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 262144
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "moonshotai",
 			"model": "kimi-k2-0711-preview",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K2 0711",
+				"baseUrl": "https://api.moonshot.ai/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": false,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.6,
+					"output": 2.5,
+					"cacheRead": 0.15,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 16384
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "moonshotai",
 			"model": "kimi-k2.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K2.5",
+				"baseUrl": "https://api.moonshot.ai/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": false,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.6,
+					"output": 3,
+					"cacheRead": 0.1,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 262144
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "moonshotai-cn",
 			"model": "kimi-k2-0711-preview",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K2 0711",
+				"baseUrl": "https://api.moonshot.cn/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": false,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.6,
+					"output": 2.5,
+					"cacheRead": 0.15,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 16384
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "moonshotai-cn",
 			"model": "kimi-k2.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K2.5",
+				"baseUrl": "https://api.moonshot.cn/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": false,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.6,
+					"output": 3,
+					"cacheRead": 0.1,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 262144
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "openai",
 			"model": "gpt-4",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-4",
+				"baseUrl": "https://api.openai.com/v1",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 30,
+					"output": 60,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 8192,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "openai",
 			"model": "gpt-4-turbo",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-4 Turbo",
+				"baseUrl": "https://api.openai.com/v1",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 30,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "openai",
 			"model": "gpt-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5",
+				"baseUrl": "https://api.openai.com/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.25,
+					"output": 10,
+					"cacheRead": 0.125,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "openai",
 			"model": "gpt-5.1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.1",
+				"baseUrl": "https://api.openai.com/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": "none"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.25,
+					"output": 10,
+					"cacheRead": 0.125,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "openai",
 			"model": "gpt-5.2",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.2",
+				"baseUrl": "https://api.openai.com/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": "none",
+					"xhigh": "xhigh"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.75,
+					"output": 14,
+					"cacheRead": 0.175,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "openai",
 			"model": "gpt-5.2-chat-latest",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.2 Chat",
+				"baseUrl": "https://api.openai.com/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.75,
+					"output": 14,
+					"cacheRead": 0.175,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 16384
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "openai",
 			"model": "gpt-5.6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.6",
+				"baseUrl": "https://api.openai.com/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": "none",
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 30,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1050000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "openai",
 			"model": "o3-mini",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "o3-mini",
+				"baseUrl": "https://api.openai.com/v1",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 1.1,
+					"output": 4.4,
+					"cacheRead": 0.55,
+					"cacheWrite": 0
+				},
+				"contextWindow": 200000,
+				"maxTokens": 100000
+			}
 		},
 		{
 			"api": "openai-codex-responses",
 			"provider": "openai-codex",
 			"model": "gpt-5.1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.1",
+				"baseUrl": "https://chatgpt.com/backend-api",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.25,
+					"output": 10,
+					"cacheRead": 0.125,
+					"cacheWrite": 0
+				},
+				"contextWindow": 272000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-codex-responses",
 			"provider": "openai-codex",
 			"model": "gpt-5.1-codex-mini",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.1 Codex Mini",
+				"baseUrl": "https://chatgpt.com/backend-api",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"minimal": "medium",
+					"low": "medium",
+					"medium": "medium",
+					"high": "high"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.25,
+					"output": 2,
+					"cacheRead": 0.025,
+					"cacheWrite": 0
+				},
+				"contextWindow": 272000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-codex-responses",
 			"provider": "openai-codex",
 			"model": "gpt-5.2",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.2",
+				"baseUrl": "https://chatgpt.com/backend-api",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"minimal": "low"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.75,
+					"output": 14,
+					"cacheRead": 0.175,
+					"cacheWrite": 0
+				},
+				"contextWindow": 272000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-codex-responses",
 			"provider": "openai-codex",
 			"model": "gpt-5.3-codex-spark",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.3 Codex Spark",
+				"baseUrl": "https://chatgpt.com/backend-api",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"minimal": "low"
+				},
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0,
+					"output": 0,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-codex-responses",
 			"provider": "openai-codex",
 			"model": "gpt-5.6-luna",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.6 Luna",
+				"baseUrl": "https://chatgpt.com/backend-api",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 6,
+					"cacheRead": 0.1,
+					"cacheWrite": 1.25
+				},
+				"contextWindow": 272000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "opencode",
 			"model": "big-pickle",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Big Pickle",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0,
+					"output": 0,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 200000,
+				"maxTokens": 32000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "opencode",
 			"model": "claude-fable-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Fable 5",
+				"baseUrl": "https://opencode.ai/zen",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 50,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "opencode",
 			"model": "claude-haiku-4-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Haiku 4.5",
+				"baseUrl": "https://opencode.ai/zen",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 5,
+					"cacheRead": 0.1,
+					"cacheWrite": 1.25
+				},
+				"contextWindow": 200000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "opencode",
 			"model": "claude-opus-4-6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.6",
+				"baseUrl": "https://opencode.ai/zen",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "opencode",
 			"model": "claude-opus-4-7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.7",
+				"baseUrl": "https://opencode.ai/zen",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "opencode",
 			"model": "deepseek-v4-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "DeepSeek V4 Flash",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"compat": {
+					"requiresReasoningContentOnAssistantMessages": true,
+					"thinkingFormat": "deepseek"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": "high",
+					"xhigh": "max"
+				},
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 384000
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "opencode",
 			"model": "gemini-3-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 3 Flash",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.5,
+					"output": 3,
+					"cacheRead": 0.05,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "opencode",
 			"model": "gemini-3.1-pro",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 3.1 Pro Preview",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": null,
+					"low": "LOW",
+					"medium": null,
+					"high": "HIGH"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 2,
+					"output": 12,
+					"cacheRead": 0.2,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "opencode",
 			"model": "gpt-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.07,
+					"output": 8.5,
+					"cacheRead": 0.107,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "opencode",
 			"model": "gpt-5.2",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.2",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.75,
+					"output": 14,
+					"cacheRead": 0.175,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "opencode",
 			"model": "gpt-5.6-luna",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.6 Luna",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.2,
+					"output": 1.2,
+					"cacheRead": 0.02,
+					"cacheWrite": 0.25
+				},
+				"contextWindow": 1050000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "opencode",
 			"model": "grok-4.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Grok 4.5",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 2,
+					"output": 6,
+					"cacheRead": 0.5,
+					"cacheWrite": 0
+				},
+				"contextWindow": 500000,
+				"maxTokens": 500000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "opencode",
 			"model": "grok-build-0.1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Grok Build 0.1",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 2,
+					"cacheRead": 0.2,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 256000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "opencode",
 			"model": "kimi-k3",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K3",
+				"baseUrl": "https://opencode.ai/zen/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": null,
+					"xhigh": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 3,
+					"output": 15,
+					"cacheRead": 0.3,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"model": "deepseek-v4-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "DeepSeek V4 Flash (New)",
+				"baseUrl": "https://opencode.ai/zen/go/v1",
+				"compat": {
+					"requiresReasoningContentOnAssistantMessages": true,
+					"thinkingFormat": "deepseek"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": "high",
+					"xhigh": "max"
+				},
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 384000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"model": "glm-5.1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GLM-5.1",
+				"baseUrl": "https://opencode.ai/zen/go/v1",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 1.4,
+					"output": 4.4,
+					"cacheRead": 0.26,
+					"cacheWrite": 0
+				},
+				"contextWindow": 202752,
+				"maxTokens": 32768
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "opencode-go",
 			"model": "gpt-5.6-luna",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-5.6 Luna (2x usage)",
+				"baseUrl": "https://opencode.ai/zen/go/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.1,
+					"output": 0.6,
+					"cacheRead": 0.01,
+					"cacheWrite": 0.125
+				},
+				"contextWindow": 1050000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-responses",
 			"provider": "opencode-go",
 			"model": "grok-4.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Grok 4.5",
+				"baseUrl": "https://opencode.ai/zen/go/v1",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 2,
+					"output": 6,
+					"cacheRead": 0.5,
+					"cacheWrite": 0
+				},
+				"contextWindow": 500000,
+				"maxTokens": 500000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"model": "kimi-k2.6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K2.6",
+				"baseUrl": "https://opencode.ai/zen/go/v1",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.95,
+					"output": 4,
+					"cacheRead": 0.16,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"model": "kimi-k3",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K3",
+				"baseUrl": "https://opencode.ai/zen/go/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": null,
+					"xhigh": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 3,
+					"output": 15,
+					"cacheRead": 0.3,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "opencode-go",
 			"model": "minimax-m3",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiniMax-M3",
+				"baseUrl": "https://opencode.ai/zen/go",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 1.2,
+					"cacheRead": 0.06,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"model": "qwen3.6-plus",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen3.6 Plus",
+				"baseUrl": "https://opencode.ai/zen/go/v1",
+				"compat": {
+					"thinkingFormat": "qwen"
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.5,
+					"output": 3,
+					"cacheRead": 0.05,
+					"cacheWrite": 0.625
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "opencode-go",
 			"model": "qwen3.7-max",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen3.7 Max",
+				"baseUrl": "https://opencode.ai/zen/go",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 2.5,
+					"output": 7.5,
+					"cacheRead": 0.5,
+					"cacheWrite": 3.125
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "ai21/jamba-large-1.7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "AI21: Jamba Large 1.7",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 2,
+					"output": 8,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "aion-labs/aion-2.0",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "AionLabs: Aion-2.0",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.7999999999999999,
+					"output": 1.5999999999999999,
+					"cacheRead": 0.19999999999999998,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 32768
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "amazon/nova-2-lite-v1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Amazon: Nova 2 Lite",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 2.5,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 65535
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "amazon/nova-lite-v1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Amazon: Nova Lite 1.0",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.06,
+					"output": 0.24,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 300000,
+				"maxTokens": 5120
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "anthropic/claude-3-haiku",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Anthropic: Claude 3 Haiku",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.25,
+					"output": 1.25,
+					"cacheRead": 0.03,
+					"cacheWrite": 0.3
+				},
+				"contextWindow": 200000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "anthropic/claude-fable-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Anthropic: Claude Fable 5",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 50,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "anthropic/claude-haiku-4.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Anthropic: Claude Haiku 4.5",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 5,
+					"cacheRead": 0.09999999999999999,
+					"cacheWrite": 1.25
+				},
+				"contextWindow": 200000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "anthropic/claude-opus-4.6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Anthropic: Claude Opus 4.6",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "anthropic/claude-opus-4.7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Anthropic: Claude Opus 4.7",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "deepseek/deepseek-v4-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "DeepSeek: DeepSeek V4 Flash",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"compat": {
+					"requiresReasoningContentOnAssistantMessages": true,
+					"thinkingFormat": "deepseek"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": "high",
+					"xhigh": "max"
+				},
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 393216
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "moonshotai/kimi-k3",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MoonshotAI: Kimi K3",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": null,
+					"xhigh": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 3,
+					"output": 15,
+					"cacheRead": 0.3,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 1048576
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "openai/gpt-5.2",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "OpenAI: GPT-5.2",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.75,
+					"output": 14,
+					"cacheRead": 0.175,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"model": "openai/gpt-5.6-luna",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "OpenAI: GPT-5.6 Luna",
+				"baseUrl": "https://openrouter.ai/api/v1",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.09999999999999999,
+					"output": 0.6000000000000001,
+					"cacheRead": 0.01,
+					"cacheWrite": 0.12500000000000003
+				},
+				"contextWindow": 1050000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "anthropic/claude-fable-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Fable 5",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 50,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000,
+				"featured": true
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "anthropic/claude-haiku-4.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Haiku 4.5",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 5,
+					"cacheRead": 0.1,
+					"cacheWrite": 1.25
+				},
+				"contextWindow": 200000,
+				"maxTokens": 64000,
+				"featured": true
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "anthropic/claude-opus-4.6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.6",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000,
+				"featured": true
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "deepseek/deepseek-chat",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Deepseek Chat",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.5,
+					"output": 1.5,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 163840,
+				"maxTokens": 16000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "deepseek/deepseek-chat-v3.1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Deepseek Chat V3.1",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.56,
+					"output": 1.68,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 163840,
+				"maxTokens": 32768
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "deepseek/deepseek-v4-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Deepseek V4 Flash",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false,
+					"requiresReasoningContentOnAssistantMessages": true,
+					"thinkingFormat": "deepseek"
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": "high",
+					"xhigh": "max"
+				},
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 393216,
+				"featured": true
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "google/gemini-2.5-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemini 2.5 Flash",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 2.5,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 65535
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "google/gemma-3-27b-it",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Gemma 3 27B IT",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.119,
+					"output": 0.3,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "moonshotai/kimi-k3",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Kimi K3",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"minimal": null,
+					"low": null,
+					"medium": null,
+					"high": null,
+					"xhigh": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 3,
+					"output": 15,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1048576,
+				"maxTokens": 1048576,
+				"featured": true
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "openai/gpt-5.2",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT 5.2",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.75,
+					"output": 14,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 400000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "openai/gpt-5.6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT 5.6",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 5,
+					"output": 30,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "openai/gpt-5.6-luna",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT 5.6 Luna",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": true,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false
+				},
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"minimal": null,
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1,
+					"output": 6,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1050000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "prime-inference",
 			"model": "z-ai/glm-4.5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GLM 4.5",
+				"baseUrl": "https://api.pinference.ai/api/v1",
+				"compat": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsReasoningEffort": false,
+					"maxTokensField": "max_tokens",
+					"supportsStrictMode": false,
+					"thinkingFormat": "zai"
+				},
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.6,
+					"output": 2.2,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 98304
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "alibaba/qwen-3-14b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen3-14B",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.12,
+					"output": 0.24,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 40960,
+				"maxTokens": 16384
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "alibaba/qwen-3-32b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen 3 32B",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.16,
+					"output": 0.64,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "alibaba/qwen-3.6-max-preview",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen 3.6 Max Preview",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 1.3,
+					"output": 7.8,
+					"cacheRead": 0.26,
+					"cacheWrite": 1.625
+				},
+				"contextWindow": 240000,
+				"maxTokens": 64000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "alibaba/qwen3-235b-a22b-thinking",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen3 VL 235B A22B Thinking",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.39999999999999997,
+					"output": 4,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 32768
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "alibaba/qwen3-coder",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen3 Coder 480B A35B Instruct",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 1.5,
+					"output": 7.5,
+					"cacheRead": 0.3,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "alibaba/qwen3-coder-30b-a3b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen 3 Coder 30B A3B Instruct",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.15,
+					"output": 0.6,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "alibaba/qwen3-vl-235b-a22b-instruct",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Qwen3 VL 235B A22B Instruct",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.39999999999999997,
+					"output": 1.5999999999999999,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 131072,
+				"maxTokens": 129024
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "amazon/nova-lite",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Nova Lite",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.06,
+					"output": 0.24,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 300000,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "anthropic/claude-3-haiku",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude 3 Haiku",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.25,
+					"output": 1.25,
+					"cacheRead": 0.03,
+					"cacheWrite": 0.3
+				},
+				"contextWindow": 200000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "anthropic/claude-fable-5",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Fable 5",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"off": null,
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 10,
+					"output": 50,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "anthropic/claude-opus-4",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 15,
+					"output": 75,
+					"cacheRead": 1.5,
+					"cacheWrite": 18.75
+				},
+				"contextWindow": 200000,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "anthropic/claude-opus-4.6",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.6",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "anthropic/claude-opus-4.7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Claude Opus 4.7",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"thinkingLevelMap": {
+					"xhigh": "xhigh",
+					"max": "max"
+				},
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 5,
+					"output": 25,
+					"cacheRead": 0.5,
+					"cacheWrite": 6.25
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 128000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "cohere/command-a",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Command A",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 2.5,
+					"output": 10,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 256000,
+				"maxTokens": 8000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "deepseek/deepseek-v3.2-thinking",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "DeepSeek V3.2 Thinking",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.62,
+					"output": 1.85,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 8000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "inception/mercury-coder-small",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Mercury Coder Small Beta",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.25,
+					"output": 1,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 32000,
+				"maxTokens": 16384
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "mistral/codestral",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Mistral Codestral",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.3,
+					"output": 0.8999999999999999,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 4000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "mistral/ministral-3b",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Ministral 3B",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.09999999999999999,
+					"output": 0.09999999999999999,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 4000
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "openai/gpt-3.5-turbo",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-3.5 Turbo",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.5,
+					"output": 1.5,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 16385,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "openai/gpt-4o",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GPT-4o",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 2.5,
+					"output": 10,
+					"cacheRead": 1.25,
+					"cacheWrite": 0
+				},
+				"contextWindow": 128000,
+				"maxTokens": 16384
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"model": "zai/glm-4.5v",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GLM 4.5V",
+				"baseUrl": "https://ai-gateway.vercel.sh",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.6,
+					"output": 1.7999999999999998,
+					"cacheRead": 0.11,
+					"cacheWrite": 0
+				},
+				"contextWindow": 66000,
+				"maxTokens": 16000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "xai",
 			"model": "grok-4.20-0309-non-reasoning",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Grok 4.20 (Non-Reasoning)",
+				"baseUrl": "https://api.x.ai/v1",
+				"reasoning": false,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 1.25,
+					"output": 2.5,
+					"cacheRead": 0.2,
+					"cacheWrite": 0
+				},
+				"contextWindow": 1000000,
+				"maxTokens": 30000
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "xai",
 			"model": "grok-code-fast-1",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "Grok Code Fast 1",
+				"baseUrl": "https://api.x.ai/v1",
+				"reasoning": false,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.2,
+					"output": 1.5,
+					"cacheRead": 0.02,
+					"cacheWrite": 0
+				},
+				"contextWindow": 32768,
+				"maxTokens": 8192
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "xiaomi",
 			"model": "mimo-v2-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiMo-V2-Flash",
+				"baseUrl": "https://api.xiaomimimo.com/anthropic",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "xiaomi",
 			"model": "mimo-v2-omni",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiMo-V2-Omni",
+				"baseUrl": "https://api.xiaomimimo.com/anthropic",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "xiaomi-token-plan-ams",
 			"model": "mimo-v2-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiMo-V2-Flash",
+				"baseUrl": "https://token-plan-ams.xiaomimimo.com/anthropic",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "xiaomi-token-plan-ams",
 			"model": "mimo-v2-omni",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiMo-V2-Omni",
+				"baseUrl": "https://token-plan-ams.xiaomimimo.com/anthropic",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "xiaomi-token-plan-cn",
 			"model": "mimo-v2-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiMo-V2-Flash",
+				"baseUrl": "https://token-plan-cn.xiaomimimo.com/anthropic",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "xiaomi-token-plan-cn",
 			"model": "mimo-v2-omni",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiMo-V2-Omni",
+				"baseUrl": "https://token-plan-cn.xiaomimimo.com/anthropic",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "xiaomi-token-plan-sgp",
 			"model": "mimo-v2-flash",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiMo-V2-Flash",
+				"baseUrl": "https://token-plan-sgp.xiaomimimo.com/anthropic",
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 65536
+			}
 		},
 		{
 			"api": "anthropic-messages",
 			"provider": "xiaomi-token-plan-sgp",
 			"model": "mimo-v2-omni",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "MiMo-V2-Omni",
+				"baseUrl": "https://token-plan-sgp.xiaomimimo.com/anthropic",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0.14,
+					"output": 0.28,
+					"cacheRead": 0.0028,
+					"cacheWrite": 0
+				},
+				"contextWindow": 262144,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "openai-completions",
 			"provider": "zai",
 			"model": "glm-4.7",
-			"synthetic": false
+			"synthetic": false,
+			"metadata": {
+				"name": "GLM-4.7",
+				"baseUrl": "https://api.z.ai/api/coding/paas/v4",
+				"compat": {
+					"supportsDeveloperRole": false,
+					"thinkingFormat": "zai",
+					"zaiToolStream": true
+				},
+				"reasoning": true,
+				"input": [
+					"text"
+				],
+				"cost": {
+					"input": 0,
+					"output": 0,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 204800,
+				"maxTokens": 131072
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "opencode",
 			"model": "claude-sonnet-4-5",
-			"synthetic": true
+			"synthetic": true,
+			"metadata": {
+				"name": "Synthetic claude-sonnet-4-5",
+				"baseUrl": "http://127.0.0.1:9",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0,
+					"output": 0,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 32000,
+				"maxTokens": 4096
+			}
 		},
 		{
 			"api": "google-generative-ai",
 			"provider": "opencode",
 			"model": "gpt-oss-120b",
-			"synthetic": true
+			"synthetic": true,
+			"metadata": {
+				"name": "Synthetic gpt-oss-120b",
+				"baseUrl": "http://127.0.0.1:9",
+				"reasoning": true,
+				"input": [
+					"text",
+					"image"
+				],
+				"cost": {
+					"input": 0,
+					"output": 0,
+					"cacheRead": 0,
+					"cacheWrite": 0
+				},
+				"contextWindow": 32000,
+				"maxTokens": 4096
+			}
 		}
 	]
 }

--- a/packages/ai/test/fixtures/provider-handoffs/v1/families.json
+++ b/packages/ai/test/fixtures/provider-handoffs/v1/families.json
@@ -1,0 +1,1109 @@
+{
+	"schemaVersion": 1,
+	"families": [
+		{
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"model": "amazon.nova-2-lite-v1:0",
+			"synthetic": false
+		},
+		{
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"model": "amazon.nova-micro-v1:0",
+			"synthetic": false
+		},
+		{
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"model": "anthropic.claude-fable-5",
+			"synthetic": false
+		},
+		{
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"model": "anthropic.claude-haiku-4-5-20251001-v1:0",
+			"synthetic": false
+		},
+		{
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"model": "anthropic.claude-opus-4-6-v1",
+			"synthetic": false
+		},
+		{
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"model": "anthropic.claude-opus-4-7",
+			"synthetic": false
+		},
+		{
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"model": "anthropic.claude-opus-5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"model": "claude-fable-5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"model": "claude-haiku-4-5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"model": "claude-opus-4-6",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"model": "claude-opus-4-7",
+			"synthetic": false
+		},
+		{
+			"api": "azure-openai-responses",
+			"provider": "azure-openai-responses",
+			"model": "gpt-4",
+			"synthetic": false
+		},
+		{
+			"api": "azure-openai-responses",
+			"provider": "azure-openai-responses",
+			"model": "gpt-4-turbo",
+			"synthetic": false
+		},
+		{
+			"api": "azure-openai-responses",
+			"provider": "azure-openai-responses",
+			"model": "gpt-5",
+			"synthetic": false
+		},
+		{
+			"api": "azure-openai-responses",
+			"provider": "azure-openai-responses",
+			"model": "gpt-5.2",
+			"synthetic": false
+		},
+		{
+			"api": "azure-openai-responses",
+			"provider": "azure-openai-responses",
+			"model": "gpt-5.6",
+			"synthetic": false
+		},
+		{
+			"api": "azure-openai-responses",
+			"provider": "azure-openai-responses",
+			"model": "gpt-realtime-2.1",
+			"synthetic": false
+		},
+		{
+			"api": "azure-openai-responses",
+			"provider": "azure-openai-responses",
+			"model": "o3-mini",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "cerebras",
+			"model": "gemma-4-31b",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "cerebras",
+			"model": "gpt-oss-120b",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"model": "claude-3-5-haiku",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"model": "claude-3-haiku",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"model": "claude-fable-5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"model": "claude-haiku-4-5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"model": "claude-opus-4-6",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"model": "claude-opus-4-7",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "cloudflare-ai-gateway",
+			"model": "gpt-4",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "cloudflare-ai-gateway",
+			"model": "gpt-4-turbo",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "cloudflare-ai-gateway",
+			"model": "gpt-5.1",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "cloudflare-ai-gateway",
+			"model": "gpt-5.2",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "cloudflare-ai-gateway",
+			"model": "gpt-5.6-luna",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "cloudflare-ai-gateway",
+			"model": "o1",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "cloudflare-ai-gateway",
+			"model": "o3-mini",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "cloudflare-ai-gateway",
+			"model": "workers-ai/@cf/moonshotai/kimi-k2.5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "cloudflare-ai-gateway",
+			"model": "workers-ai/@cf/nvidia/nemotron-3-120b-a12b",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "cloudflare-workers-ai",
+			"model": "@cf/google/gemma-4-26b-a4b-it",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "cloudflare-workers-ai",
+			"model": "@cf/ibm-granite/granite-4.0-h-micro",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "cloudflare-workers-ai",
+			"model": "@cf/meta/llama-4-scout-17b-16e-instruct",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "cloudflare-workers-ai",
+			"model": "@cf/nvidia/nemotron-3-120b-a12b",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "deepseek",
+			"model": "deepseek-v4-flash",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "fireworks",
+			"model": "accounts/fireworks/models/deepseek-v4-flash",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "fireworks",
+			"model": "accounts/fireworks/models/kimi-k2p6",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"model": "claude-fable-5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"model": "claude-haiku-4.5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"model": "claude-opus-4.5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"model": "claude-opus-4.6",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"model": "claude-opus-4.7",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"model": "claude-sonnet-4",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"model": "gemini-2.5-pro",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"model": "gpt-5-mini",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"model": "gpt-5.2",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"model": "gpt-5.6-luna",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"model": "mai-code-1-flash-picker",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "google",
+			"model": "gemini-2.0-flash",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "google",
+			"model": "gemini-2.5-flash",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "google",
+			"model": "gemini-2.5-flash-lite",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "google",
+			"model": "gemini-2.5-pro",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "google",
+			"model": "gemini-3-flash-preview",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "google",
+			"model": "gemini-3-pro-preview",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "google",
+			"model": "gemini-flash-latest",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "google",
+			"model": "gemma-4-26b-a4b-it",
+			"synthetic": false
+		},
+		{
+			"api": "google-vertex",
+			"provider": "google-vertex",
+			"model": "gemini-1.5-flash",
+			"synthetic": false
+		},
+		{
+			"api": "google-vertex",
+			"provider": "google-vertex",
+			"model": "gemini-2.0-flash-lite",
+			"synthetic": false
+		},
+		{
+			"api": "google-vertex",
+			"provider": "google-vertex",
+			"model": "gemini-2.5-flash",
+			"synthetic": false
+		},
+		{
+			"api": "google-vertex",
+			"provider": "google-vertex",
+			"model": "gemini-2.5-flash-lite",
+			"synthetic": false
+		},
+		{
+			"api": "google-vertex",
+			"provider": "google-vertex",
+			"model": "gemini-2.5-pro",
+			"synthetic": false
+		},
+		{
+			"api": "google-vertex",
+			"provider": "google-vertex",
+			"model": "gemini-3-flash-preview",
+			"synthetic": false
+		},
+		{
+			"api": "google-vertex",
+			"provider": "google-vertex",
+			"model": "gemini-3-pro-preview",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "groq",
+			"model": "llama-3.1-8b-instant",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "groq",
+			"model": "meta-llama/llama-4-scout-17b-16e-instruct",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "groq",
+			"model": "openai/gpt-oss-120b",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "groq",
+			"model": "qwen/qwen3-32b",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"model": "MiniMaxAI/MiniMax-M2",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"model": "MiniMaxAI/MiniMax-M3",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"model": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"model": "moonshotai/Kimi-K3",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "kimi-coding",
+			"model": "k3",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "minimax",
+			"model": "MiniMax-M2.7",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "minimax-cn",
+			"model": "MiniMax-M2.7",
+			"synthetic": false
+		},
+		{
+			"api": "mistral-conversations",
+			"provider": "mistral",
+			"model": "codestral-latest",
+			"synthetic": false
+		},
+		{
+			"api": "mistral-conversations",
+			"provider": "mistral",
+			"model": "labs-devstral-small-2512",
+			"synthetic": false
+		},
+		{
+			"api": "mistral-conversations",
+			"provider": "mistral",
+			"model": "magistral-medium-latest",
+			"synthetic": false
+		},
+		{
+			"api": "mistral-conversations",
+			"provider": "mistral",
+			"model": "mistral-medium-2604",
+			"synthetic": false
+		},
+		{
+			"api": "mistral-conversations",
+			"provider": "mistral",
+			"model": "mistral-medium-3.5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "moonshotai",
+			"model": "kimi-k2-0711-preview",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "moonshotai",
+			"model": "kimi-k2.5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "moonshotai-cn",
+			"model": "kimi-k2-0711-preview",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "moonshotai-cn",
+			"model": "kimi-k2.5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "openai",
+			"model": "gpt-4",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "openai",
+			"model": "gpt-4-turbo",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "openai",
+			"model": "gpt-5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "openai",
+			"model": "gpt-5.1",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "openai",
+			"model": "gpt-5.2",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "openai",
+			"model": "gpt-5.2-chat-latest",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "openai",
+			"model": "gpt-5.6",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "openai",
+			"model": "o3-mini",
+			"synthetic": false
+		},
+		{
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"model": "gpt-5.1",
+			"synthetic": false
+		},
+		{
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"model": "gpt-5.1-codex-mini",
+			"synthetic": false
+		},
+		{
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"model": "gpt-5.2",
+			"synthetic": false
+		},
+		{
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"model": "gpt-5.3-codex-spark",
+			"synthetic": false
+		},
+		{
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"model": "gpt-5.6-luna",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "opencode",
+			"model": "big-pickle",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "opencode",
+			"model": "claude-fable-5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "opencode",
+			"model": "claude-haiku-4-5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "opencode",
+			"model": "claude-opus-4-6",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "opencode",
+			"model": "claude-opus-4-7",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "opencode",
+			"model": "deepseek-v4-flash",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "opencode",
+			"model": "gemini-3-flash",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "opencode",
+			"model": "gemini-3.1-pro",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "opencode",
+			"model": "gpt-5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "opencode",
+			"model": "gpt-5.2",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "opencode",
+			"model": "gpt-5.6-luna",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "opencode",
+			"model": "grok-4.5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "opencode",
+			"model": "grok-build-0.1",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "opencode",
+			"model": "kimi-k3",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"model": "deepseek-v4-flash",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"model": "glm-5.1",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "opencode-go",
+			"model": "gpt-5.6-luna",
+			"synthetic": false
+		},
+		{
+			"api": "openai-responses",
+			"provider": "opencode-go",
+			"model": "grok-4.5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"model": "kimi-k2.6",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"model": "kimi-k3",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "opencode-go",
+			"model": "minimax-m3",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"model": "qwen3.6-plus",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "opencode-go",
+			"model": "qwen3.7-max",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "ai21/jamba-large-1.7",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "aion-labs/aion-2.0",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "amazon/nova-2-lite-v1",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "amazon/nova-lite-v1",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "anthropic/claude-3-haiku",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "anthropic/claude-fable-5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "anthropic/claude-haiku-4.5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "anthropic/claude-opus-4.6",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "anthropic/claude-opus-4.7",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "deepseek/deepseek-v4-flash",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "moonshotai/kimi-k3",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "openai/gpt-5.2",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"model": "openai/gpt-5.6-luna",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "anthropic/claude-fable-5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "anthropic/claude-haiku-4.5",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "anthropic/claude-opus-4.6",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "deepseek/deepseek-chat",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "deepseek/deepseek-chat-v3.1",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "deepseek/deepseek-v4-flash",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "google/gemini-2.5-flash",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "google/gemma-3-27b-it",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "moonshotai/kimi-k3",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "openai/gpt-5.2",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "openai/gpt-5.6",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "openai/gpt-5.6-luna",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "prime-inference",
+			"model": "z-ai/glm-4.5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "alibaba/qwen-3-14b",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "alibaba/qwen-3-32b",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "alibaba/qwen-3.6-max-preview",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "alibaba/qwen3-235b-a22b-thinking",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "alibaba/qwen3-coder",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "alibaba/qwen3-coder-30b-a3b",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "alibaba/qwen3-vl-235b-a22b-instruct",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "amazon/nova-lite",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "anthropic/claude-3-haiku",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "anthropic/claude-fable-5",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "anthropic/claude-opus-4",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "anthropic/claude-opus-4.6",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "anthropic/claude-opus-4.7",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "cohere/command-a",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "deepseek/deepseek-v3.2-thinking",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "inception/mercury-coder-small",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "mistral/codestral",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "mistral/ministral-3b",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "openai/gpt-3.5-turbo",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "openai/gpt-4o",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"model": "zai/glm-4.5v",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "xai",
+			"model": "grok-4.20-0309-non-reasoning",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "xai",
+			"model": "grok-code-fast-1",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "xiaomi",
+			"model": "mimo-v2-flash",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "xiaomi",
+			"model": "mimo-v2-omni",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "xiaomi-token-plan-ams",
+			"model": "mimo-v2-flash",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "xiaomi-token-plan-ams",
+			"model": "mimo-v2-omni",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "xiaomi-token-plan-cn",
+			"model": "mimo-v2-flash",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "xiaomi-token-plan-cn",
+			"model": "mimo-v2-omni",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "xiaomi-token-plan-sgp",
+			"model": "mimo-v2-flash",
+			"synthetic": false
+		},
+		{
+			"api": "anthropic-messages",
+			"provider": "xiaomi-token-plan-sgp",
+			"model": "mimo-v2-omni",
+			"synthetic": false
+		},
+		{
+			"api": "openai-completions",
+			"provider": "zai",
+			"model": "glm-4.7",
+			"synthetic": false
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "opencode",
+			"model": "claude-sonnet-4-5",
+			"synthetic": true
+		},
+		{
+			"api": "google-generative-ai",
+			"provider": "opencode",
+			"model": "gpt-oss-120b",
+			"synthetic": true
+		}
+	]
+}

--- a/packages/ai/test/fixtures/provider-handoffs/v1/fixtures.json
+++ b/packages/ai/test/fixtures/provider-handoffs/v1/fixtures.json
@@ -1,0 +1,147 @@
+{
+	"schemaVersion": 1,
+	"coverage": {
+		"userImages": true,
+		"toolResultImages": true,
+		"toolErrors": true,
+		"providerErrors": true
+	},
+	"images": {
+		"user": {
+			"mimeType": "image/png",
+			"data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+		},
+		"toolResult": {
+			"mimeType": "image/png",
+			"data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg=="
+		}
+	},
+	"fixtures": [
+		{
+			"id": "anthropic-claude",
+			"source": {
+				"api": "anthropic-messages",
+				"provider": "anthropic",
+				"model": "claude-sonnet-4-5"
+			},
+			"protocol": {
+				"toolCallId": "toolu_01FixtureHandoff",
+				"thinkingSignature": "anthropic-signature-marker-v1",
+				"toolThoughtSignature": null,
+				"signatureMarker": "anthropic-signature-marker-v1"
+			}
+		},
+		{
+			"id": "azure-openai-responses",
+			"source": {
+				"api": "azure-openai-responses",
+				"provider": "azure-openai-responses",
+				"model": "gpt-5-mini"
+			},
+			"protocol": {
+				"toolCallId": "call_azure_fixture|fc_azure_fixture",
+				"thinkingSignature": "{\"id\":\"rs_azure_fixture\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Sanitized provider reasoning summary.\"}],\"encrypted_content\":\"azure-signature-marker-v1\"}",
+				"toolThoughtSignature": null,
+				"signatureMarker": "azure-signature-marker-v1"
+			}
+		},
+		{
+			"id": "bedrock-claude",
+			"source": {
+				"api": "bedrock-converse-stream",
+				"provider": "amazon-bedrock",
+				"model": "anthropic.claude-3-7-sonnet-20250219-v1:0"
+			},
+			"protocol": {
+				"toolCallId": "bedrock_tool_fixture_01",
+				"thinkingSignature": "bedrock-signature-marker-v1",
+				"toolThoughtSignature": null,
+				"signatureMarker": "bedrock-signature-marker-v1"
+			}
+		},
+		{
+			"id": "google-gemini",
+			"source": {
+				"api": "google-generative-ai",
+				"provider": "google",
+				"model": "gemini-3-flash-preview"
+			},
+			"protocol": {
+				"toolCallId": "google_function_call_fixture",
+				"thinkingSignature": "Z29vZ2xlLWdlbi1zaWduYXR1cmU=",
+				"toolThoughtSignature": "Z29vZ2xlLWdlbi10b29sLXNpZw==",
+				"signatureMarker": "Z29vZ2xlLWdlbi1zaWduYXR1cmU="
+			}
+		},
+		{
+			"id": "google-vertex-gemini",
+			"source": {
+				"api": "google-vertex",
+				"provider": "google-vertex",
+				"model": "gemini-3-flash-preview"
+			},
+			"protocol": {
+				"toolCallId": "vertex_function_call_fixture",
+				"thinkingSignature": "dmVydGV4LXNpZ25hdHVyZS12MQ==",
+				"toolThoughtSignature": "dmVydGV4LXRvb2wtc2lnbmF0dXJl",
+				"signatureMarker": "dmVydGV4LXNpZ25hdHVyZS12MQ=="
+			}
+		},
+		{
+			"id": "mistral-devstral",
+			"source": {
+				"api": "mistral-conversations",
+				"provider": "mistral",
+				"model": "devstral-medium-latest"
+			},
+			"protocol": {
+				"toolCallId": "Mistral01",
+				"thinkingSignature": null,
+				"toolThoughtSignature": null,
+				"signatureMarker": null
+			}
+		},
+		{
+			"id": "openai-codex-responses",
+			"source": {
+				"api": "openai-codex-responses",
+				"provider": "openai-codex",
+				"model": "gpt-5.2-codex"
+			},
+			"protocol": {
+				"toolCallId": "call_codex_fixture|fc_codex_fixture",
+				"thinkingSignature": "{\"id\":\"rs_codex_fixture\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Sanitized provider reasoning summary.\"}],\"encrypted_content\":\"codex-signature-marker-v1\"}",
+				"toolThoughtSignature": null,
+				"signatureMarker": "codex-signature-marker-v1"
+			}
+		},
+		{
+			"id": "openai-chat-completions",
+			"source": {
+				"api": "openai-completions",
+				"provider": "openai",
+				"model": "gpt-5-mini"
+			},
+			"protocol": {
+				"toolCallId": "call_openai_completions_fixture",
+				"thinkingSignature": "reasoning_content",
+				"toolThoughtSignature": "{\"type\":\"reasoning.encrypted\",\"data\":\"completions-signature-marker-v1\"}",
+				"signatureMarker": "completions-signature-marker-v1"
+			}
+		},
+		{
+			"id": "openai-responses",
+			"source": {
+				"api": "openai-responses",
+				"provider": "openai",
+				"model": "gpt-5-mini"
+			},
+			"protocol": {
+				"toolCallId": "call_openai_fixture|fc_openai_fixture",
+				"thinkingSignature": "{\"id\":\"rs_openai_fixture\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Sanitized provider reasoning summary.\"}],\"encrypted_content\":\"responses-signature-marker-v1\"}",
+				"toolThoughtSignature": null,
+				"signatureMarker": "responses-signature-marker-v1"
+			}
+		}
+	]
+}

--- a/packages/ai/test/fixtures/provider-handoffs/v1/responses.json
+++ b/packages/ai/test/fixtures/provider-handoffs/v1/responses.json
@@ -1,0 +1,207 @@
+{
+	"schemaVersion": 1,
+	"responses": [
+		{
+			"id": "anthropic-messages-v1",
+			"api": "anthropic-messages",
+			"transport": "anthropic-sse",
+			"success": [
+				{"event":"message_start","data":{"type":"message_start","message":{"id":"msg_fixture_anthropic","usage":{"input_tokens":3,"output_tokens":0}}}},
+				{"event":"content_block_start","data":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}},
+				{"event":"content_block_delta","data":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"anthropic raw thinking"}}},
+				{"event":"content_block_delta","data":{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"anthropic-raw-signature-v1"}}},
+				{"event":"content_block_stop","data":{"type":"content_block_stop","index":0}},
+				{"event":"content_block_start","data":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_raw_fixture_01","name":"inspect_fixture","input":{}}}},
+				{"event":"content_block_delta","data":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"raw.txt\"}"}}},
+				{"event":"content_block_stop","data":{"type":"content_block_stop","index":1}},
+				{"event":"message_delta","data":{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":7}}},
+				{"event":"message_stop","data":{"type":"message_stop"}}
+			],
+			"error": [
+				{"event":"error","data":{"type":"error","error":{"type":"overloaded_error","message":"anthropic raw fixture overload"},"request_id":"req_fixture_anthropic"}}
+			],
+			"expected": {
+				"thinkingText": "anthropic raw thinking",
+				"thinkingSignatureMarker": "anthropic-raw-signature-v1",
+				"toolThoughtSignatureMarker": null,
+				"toolCallId": "toolu_raw_fixture_01",
+				"errorMarker": "anthropic raw fixture overload"
+			}
+		},
+		{
+			"id": "azure-openai-responses-v1",
+			"api": "azure-openai-responses",
+			"transport": "openai-events",
+			"success": [
+				{"type":"response.created","response":{"id":"resp_fixture_azure"}},
+				{"type":"response.output_item.added","item":{"id":"rs_fixture_azure","type":"reasoning","summary":[],"encrypted_content":"azure-raw-signature-v1"}},
+				{"type":"response.reasoning_summary_part.added","part":{"type":"summary_text","text":""}},
+				{"type":"response.reasoning_summary_text.delta","delta":"azure raw thinking"},
+				{"type":"response.output_item.done","item":{"id":"rs_fixture_azure","type":"reasoning","summary":[{"type":"summary_text","text":"azure raw thinking"}],"encrypted_content":"azure-raw-signature-v1"}},
+				{"type":"response.output_item.added","item":{"id":"fc_fixture_azure","type":"function_call","call_id":"call_fixture_azure","name":"inspect_fixture","arguments":""}},
+				{"type":"response.function_call_arguments.delta","delta":"{\"path\":\"raw.txt\"}"},
+				{"type":"response.output_item.done","item":{"id":"fc_fixture_azure","type":"function_call","call_id":"call_fixture_azure","name":"inspect_fixture","arguments":"{\"path\":\"raw.txt\"}"}},
+				{"type":"response.completed","response":{"id":"resp_fixture_azure","status":"completed","usage":{"input_tokens":3,"output_tokens":7,"total_tokens":10,"input_tokens_details":{"cached_tokens":0}}}}
+			],
+			"error": [
+				{"type":"error","code":"server_error","message":"azure raw fixture failure"}
+			],
+			"expected": {
+				"thinkingText": "azure raw thinking",
+				"thinkingSignatureMarker": "azure-raw-signature-v1",
+				"toolThoughtSignatureMarker": null,
+				"toolCallId": "call_fixture_azure|fc_fixture_azure",
+				"errorMarker": "azure raw fixture failure"
+			}
+		},
+		{
+			"id": "bedrock-converse-stream-v1",
+			"api": "bedrock-converse-stream",
+			"transport": "smithy-events",
+			"success": [
+				{"messageStart":{"role":"assistant"}},
+				{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":"bedrock raw thinking","signature":"bedrock-raw-signature-v1"}}}},
+				{"contentBlockStop":{"contentBlockIndex":0}},
+				{"contentBlockStart":{"contentBlockIndex":1,"start":{"toolUse":{"toolUseId":"bedrock_raw_tool_01","name":"inspect_fixture"}}}},
+				{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"toolUse":{"input":"{\"path\":\"raw.txt\"}"}}}},
+				{"contentBlockStop":{"contentBlockIndex":1}},
+				{"messageStop":{"stopReason":"tool_use"}},
+				{"metadata":{"usage":{"inputTokens":3,"outputTokens":7,"totalTokens":10}}}
+			],
+			"error": [
+				{"throttlingException":{"name":"ThrottlingException","message":"bedrock raw fixture throttled"}}
+			],
+			"expected": {
+				"thinkingText": "bedrock raw thinking",
+				"thinkingSignatureMarker": "bedrock-raw-signature-v1",
+				"toolThoughtSignatureMarker": null,
+				"toolCallId": "bedrock_raw_tool_01",
+				"errorMarker": "bedrock raw fixture throttled"
+			}
+		},
+		{
+			"id": "google-generative-ai-v1",
+			"api": "google-generative-ai",
+			"transport": "google-events",
+			"success": [
+				{"responseId":"resp_fixture_google","candidates":[{"content":{"parts":[{"thought":true,"text":"google raw thinking","thoughtSignature":"Z29vZ2xlLXJhdy1zaWduYXR1cmU="},{"functionCall":{"id":"google_raw_tool_01","name":"inspect_fixture","args":{"path":"raw.txt"}},"thoughtSignature":"Z29vZ2xlLXJhdy10b29sLXNpZw=="}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":7,"totalTokenCount":10}}
+			],
+			"error": [
+				{"responseId":"resp_fixture_google_error","candidates":[{"content":{"parts":[]},"finishReason":"SAFETY"}]}
+			],
+			"expected": {
+				"thinkingText": "google raw thinking",
+				"thinkingSignatureMarker": "Z29vZ2xlLXJhdy1zaWduYXR1cmU=",
+				"toolThoughtSignatureMarker": "Z29vZ2xlLXJhdy10b29sLXNpZw==",
+				"toolCallId": "google_raw_tool_01",
+				"errorMarker": "SAFETY"
+			}
+		},
+		{
+			"id": "google-vertex-v1",
+			"api": "google-vertex",
+			"transport": "google-events",
+			"success": [
+				{"responseId":"resp_fixture_vertex","candidates":[{"content":{"parts":[{"thought":true,"text":"vertex raw thinking","thoughtSignature":"dmVydGV4LXJhdy1zaWduYXR1cmU="},{"functionCall":{"id":"vertex_raw_tool_01","name":"inspect_fixture","args":{"path":"raw.txt"}},"thoughtSignature":"dmVydGV4LXJhdy10b29sLXNpZw=="}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":7,"totalTokenCount":10}}
+			],
+			"error": [
+				{"responseId":"resp_fixture_vertex_error","candidates":[{"content":{"parts":[]},"finishReason":"SAFETY"}]}
+			],
+			"expected": {
+				"thinkingText": "vertex raw thinking",
+				"thinkingSignatureMarker": "dmVydGV4LXJhdy1zaWduYXR1cmU=",
+				"toolThoughtSignatureMarker": "dmVydGV4LXJhdy10b29sLXNpZw==",
+				"toolCallId": "vertex_raw_tool_01",
+				"errorMarker": "SAFETY"
+			}
+		},
+		{
+			"id": "mistral-conversations-v1",
+			"api": "mistral-conversations",
+			"transport": "mistral-events",
+			"success": [
+				{"data":{"id":"resp_fixture_mistral","choices":[{"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":"mistral raw thinking"}]}],"toolCalls":[{"index":0,"id":"Mistral01","function":{"name":"inspect_fixture","arguments":"{\"path\":\"raw.txt\"}"}}]},"finishReason":"tool_calls"}],"usage":{"promptTokens":3,"completionTokens":7,"totalTokens":10}}}
+			],
+			"error": [
+				{"data":{"id":"resp_fixture_mistral_error","choices":[{"delta":{"content":null},"finishReason":"error"}]}}
+			],
+			"expected": {
+				"thinkingText": "mistral raw thinking",
+				"thinkingSignatureMarker": null,
+				"toolThoughtSignatureMarker": null,
+				"toolCallId": "Mistral01",
+				"errorMarker": "error"
+			}
+		},
+		{
+			"id": "openai-codex-responses-v1",
+			"api": "openai-codex-responses",
+			"transport": "codex-sse",
+			"success": [
+				{"type":"response.created","response":{"id":"resp_fixture_codex"}},
+				{"type":"response.output_item.added","item":{"id":"rs_fixture_codex","type":"reasoning","summary":[],"encrypted_content":"codex-raw-signature-v1"}},
+				{"type":"response.reasoning_summary_part.added","part":{"type":"summary_text","text":""}},
+				{"type":"response.reasoning_summary_text.delta","delta":"codex raw thinking"},
+				{"type":"response.output_item.done","item":{"id":"rs_fixture_codex","type":"reasoning","summary":[{"type":"summary_text","text":"codex raw thinking"}],"encrypted_content":"codex-raw-signature-v1"}},
+				{"type":"response.output_item.added","item":{"id":"fc_fixture_codex","type":"function_call","call_id":"call_fixture_codex","name":"inspect_fixture","arguments":""}},
+				{"type":"response.function_call_arguments.delta","delta":"{\"path\":\"raw.txt\"}"},
+				{"type":"response.output_item.done","item":{"id":"fc_fixture_codex","type":"function_call","call_id":"call_fixture_codex","name":"inspect_fixture","arguments":"{\"path\":\"raw.txt\"}"}},
+				{"type":"response.done","response":{"id":"resp_fixture_codex","status":"completed","usage":{"input_tokens":3,"output_tokens":7,"total_tokens":10,"input_tokens_details":{"cached_tokens":0}}}}
+			],
+			"error": [
+				{"type":"error","code":"server_error","message":"codex raw fixture failure"}
+			],
+			"expected": {
+				"thinkingText": "codex raw thinking",
+				"thinkingSignatureMarker": "codex-raw-signature-v1",
+				"toolThoughtSignatureMarker": null,
+				"toolCallId": "call_fixture_codex|fc_fixture_codex",
+				"errorMarker": "codex raw fixture failure"
+			}
+		},
+		{
+			"id": "openai-completions-v1",
+			"api": "openai-completions",
+			"transport": "openai-chunks",
+			"success": [
+				{"id":"chatcmpl_fixture","model":"gpt-5-mini","choices":[{"index":0,"delta":{"reasoning_content":"completions raw thinking","tool_calls":[{"index":0,"id":"call_raw_openai_01","type":"function","function":{"name":"inspect_fixture","arguments":"{\"path\":\"raw.txt\"}"}}],"reasoning_details":[{"type":"reasoning.encrypted","id":"call_raw_openai_01","data":"completions-raw-tool-signature-v1"}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":7,"total_tokens":10}}
+			],
+			"error": [
+				{"id":"chatcmpl_fixture_error","model":"gpt-5-mini","choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}]}
+			],
+			"expected": {
+				"thinkingText": "completions raw thinking",
+				"thinkingSignatureMarker": "reasoning_content",
+				"toolThoughtSignatureMarker": "completions-raw-tool-signature-v1",
+				"toolCallId": "call_raw_openai_01",
+				"errorMarker": "content_filter"
+			}
+		},
+		{
+			"id": "openai-responses-v1",
+			"api": "openai-responses",
+			"transport": "openai-events",
+			"success": [
+				{"type":"response.created","response":{"id":"resp_fixture_openai"}},
+				{"type":"response.output_item.added","item":{"id":"rs_fixture_openai","type":"reasoning","summary":[],"encrypted_content":"responses-raw-signature-v1"}},
+				{"type":"response.reasoning_summary_part.added","part":{"type":"summary_text","text":""}},
+				{"type":"response.reasoning_summary_text.delta","delta":"responses raw thinking"},
+				{"type":"response.output_item.done","item":{"id":"rs_fixture_openai","type":"reasoning","summary":[{"type":"summary_text","text":"responses raw thinking"}],"encrypted_content":"responses-raw-signature-v1"}},
+				{"type":"response.output_item.added","item":{"id":"fc_fixture_openai","type":"function_call","call_id":"call_fixture_openai","name":"inspect_fixture","arguments":""}},
+				{"type":"response.function_call_arguments.delta","delta":"{\"path\":\"raw.txt\"}"},
+				{"type":"response.output_item.done","item":{"id":"fc_fixture_openai","type":"function_call","call_id":"call_fixture_openai","name":"inspect_fixture","arguments":"{\"path\":\"raw.txt\"}"}},
+				{"type":"response.completed","response":{"id":"resp_fixture_openai","status":"completed","usage":{"input_tokens":3,"output_tokens":7,"total_tokens":10,"input_tokens_details":{"cached_tokens":0}}}}
+			],
+			"error": [
+				{"type":"error","code":"server_error","message":"responses raw fixture failure"}
+			],
+			"expected": {
+				"thinkingText": "responses raw thinking",
+				"thinkingSignatureMarker": "responses-raw-signature-v1",
+				"toolThoughtSignatureMarker": null,
+				"toolCallId": "call_fixture_openai|fc_fixture_openai",
+				"errorMarker": "responses raw fixture failure"
+			}
+		}
+	]
+}

--- a/packages/ai/test/provider-handoff-families.ts
+++ b/packages/ai/test/provider-handoff-families.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from "node:fs";
+import Type, { type Static } from "typebox";
+import Schema from "typebox/schema";
+import { MODELS } from "../src/models.generated.js";
+import type { Api, Model } from "../src/types.js";
+
+const handoffApiSchema = Type.Union([
+	Type.Literal("anthropic-messages"),
+	Type.Literal("azure-openai-responses"),
+	Type.Literal("bedrock-converse-stream"),
+	Type.Literal("google-generative-ai"),
+	Type.Literal("google-vertex"),
+	Type.Literal("mistral-conversations"),
+	Type.Literal("openai-codex-responses"),
+	Type.Literal("openai-completions"),
+	Type.Literal("openai-responses"),
+]);
+
+const providerHandoffFamilyFileSchema = Type.Object(
+	{
+		schemaVersion: Type.Literal(1),
+		families: Type.Array(
+			Type.Object(
+				{
+					api: handoffApiSchema,
+					provider: Type.String({ minLength: 1 }),
+					model: Type.String({ minLength: 1 }),
+					synthetic: Type.Boolean(),
+				},
+				{ additionalProperties: false },
+			),
+			{ minItems: 1 },
+		),
+	},
+	{ additionalProperties: false },
+);
+
+const providerHandoffFamilyFileValidator = Schema.Compile(providerHandoffFamilyFileSchema);
+const supportedHandoffApis = new Set<string>([
+	"anthropic-messages",
+	"azure-openai-responses",
+	"bedrock-converse-stream",
+	"google-generative-ai",
+	"google-vertex",
+	"mistral-conversations",
+	"openai-codex-responses",
+	"openai-completions",
+	"openai-responses",
+]);
+
+export type ProviderHandoffFamilyFile = Static<typeof providerHandoffFamilyFileSchema>;
+export type ProviderHandoffFamily = ProviderHandoffFamilyFile["families"][number];
+
+export interface ResolvedProviderHandoffFamily {
+	fixture: ProviderHandoffFamily;
+	model: Model<Api>;
+}
+
+export function parseProviderHandoffFamilyFile(serialized: string): ProviderHandoffFamilyFile {
+	const parsed: unknown = JSON.parse(serialized);
+	if (!providerHandoffFamilyFileValidator.Check(parsed)) {
+		throw new Error(
+			`Provider handoff family fixture failed schema validation: ${JSON.stringify(providerHandoffFamilyFileValidator.Errors(parsed))}`,
+		);
+	}
+	return parsed;
+}
+
+export function loadProviderHandoffFamilyFile(): ProviderHandoffFamilyFile {
+	const fixtureUrl = new URL("./fixtures/provider-handoffs/v1/families.json", import.meta.url);
+	return parseProviderHandoffFamilyFile(readFileSync(fixtureUrl, "utf8"));
+}
+
+export function resolveProviderHandoffFamilies(file: ProviderHandoffFamilyFile): ResolvedProviderHandoffFamily[] {
+	const catalog = MODELS as unknown as Record<string, Record<string, Model<Api>>>;
+	return file.families.map((fixture) => {
+		if (fixture.synthetic) {
+			return { fixture, model: createSyntheticModel(fixture) };
+		}
+		const model = catalog[fixture.provider]?.[fixture.model];
+		if (!model) throw new Error(`Unknown provider handoff family model: ${fixture.provider}/${fixture.model}`);
+		if (model.api !== fixture.api) {
+			throw new Error(
+				`Provider handoff family API mismatch for ${fixture.provider}/${fixture.model}: ${model.api} != ${fixture.api}`,
+			);
+		}
+		return { fixture, model };
+	});
+}
+
+export function getCatalogProviderHandoffModels(): ResolvedProviderHandoffFamily[] {
+	const catalog = MODELS as unknown as Record<string, Record<string, Model<Api>>>;
+	const families: ResolvedProviderHandoffFamily[] = [];
+	for (const [provider, models] of Object.entries(catalog)) {
+		for (const model of Object.values(models)) {
+			if (!supportedHandoffApis.has(model.api)) {
+				throw new Error(`Unsupported catalog handoff API: ${model.api}`);
+			}
+			families.push({
+				fixture: {
+					api: model.api as ProviderHandoffFamily["api"],
+					provider,
+					model: model.id,
+					synthetic: false,
+				},
+				model,
+			});
+		}
+	}
+	return families;
+}
+
+function createSyntheticModel(fixture: ProviderHandoffFamily): Model<Api> {
+	if (fixture.api !== "google-generative-ai") {
+		throw new Error(
+			`Unsupported synthetic provider handoff family: ${fixture.api}/${fixture.provider}/${fixture.model}`,
+		);
+	}
+	return {
+		id: fixture.model,
+		name: `Synthetic ${fixture.model}`,
+		api: fixture.api,
+		provider: fixture.provider,
+		baseUrl: "http://127.0.0.1:9",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	};
+}

--- a/packages/ai/test/provider-handoff-families.ts
+++ b/packages/ai/test/provider-handoff-families.ts
@@ -1,8 +1,62 @@
 import { readFileSync } from "node:fs";
 import Type, { type Static } from "typebox";
 import Schema from "typebox/schema";
-import { MODELS } from "../src/models.generated.js";
-import type { Api, Model } from "../src/types.js";
+import type { Api, KnownApi, KnownProvider, Model } from "../src/types.js";
+
+export const PROVIDER_HANDOFF_FAMILY_SCHEMA_VERSION = 2;
+
+export const STABLE_HANDOFF_APIS = requireAllKnownApis(
+	[
+		"anthropic-messages",
+		"azure-openai-responses",
+		"bedrock-converse-stream",
+		"google-generative-ai",
+		"google-vertex",
+		"mistral-conversations",
+		"openai-codex-responses",
+		"openai-completions",
+		"openai-responses",
+	] as const,
+	{},
+);
+
+export const STABLE_HANDOFF_PROVIDERS = requireAllKnownProviders(
+	[
+		"amazon-bedrock",
+		"anthropic",
+		"azure-openai-responses",
+		"cerebras",
+		"cloudflare-ai-gateway",
+		"cloudflare-workers-ai",
+		"deepseek",
+		"fireworks",
+		"github-copilot",
+		"google",
+		"google-vertex",
+		"groq",
+		"huggingface",
+		"kimi-coding",
+		"minimax",
+		"minimax-cn",
+		"mistral",
+		"moonshotai",
+		"moonshotai-cn",
+		"openai",
+		"openai-codex",
+		"opencode",
+		"opencode-go",
+		"openrouter",
+		"prime-inference",
+		"vercel-ai-gateway",
+		"xai",
+		"xiaomi",
+		"xiaomi-token-plan-ams",
+		"xiaomi-token-plan-cn",
+		"xiaomi-token-plan-sgp",
+		"zai",
+	] as const,
+	{},
+);
 
 const handoffApiSchema = Type.Union([
 	Type.Literal("anthropic-messages"),
@@ -16,37 +70,54 @@ const handoffApiSchema = Type.Union([
 	Type.Literal("openai-responses"),
 ]);
 
+const modelMetadataSchema = Type.Object(
+	{
+		name: Type.String({ minLength: 1 }),
+		baseUrl: Type.String(),
+		reasoning: Type.Boolean(),
+		thinkingLevelMap: Type.Optional(Type.Record(Type.String(), Type.Union([Type.String(), Type.Null()]))),
+		input: Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]), {
+			minItems: 1,
+			uniqueItems: true,
+		}),
+		cost: Type.Object(
+			{
+				input: Type.Number(),
+				output: Type.Number(),
+				cacheRead: Type.Number(),
+				cacheWrite: Type.Number(),
+			},
+			{ additionalProperties: false },
+		),
+		contextWindow: Type.Number(),
+		maxTokens: Type.Number(),
+		featured: Type.Optional(Type.Boolean()),
+		headers: Type.Optional(Type.Record(Type.String(), Type.String())),
+		compat: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+	},
+	{ additionalProperties: false },
+);
+
+const providerHandoffFamilySchema = Type.Object(
+	{
+		api: handoffApiSchema,
+		provider: Type.String({ minLength: 1 }),
+		model: Type.String({ minLength: 1 }),
+		synthetic: Type.Boolean(),
+		metadata: modelMetadataSchema,
+	},
+	{ additionalProperties: false },
+);
+
 const providerHandoffFamilyFileSchema = Type.Object(
 	{
-		schemaVersion: Type.Literal(1),
-		families: Type.Array(
-			Type.Object(
-				{
-					api: handoffApiSchema,
-					provider: Type.String({ minLength: 1 }),
-					model: Type.String({ minLength: 1 }),
-					synthetic: Type.Boolean(),
-				},
-				{ additionalProperties: false },
-			),
-			{ minItems: 1 },
-		),
+		schemaVersion: Type.Literal(PROVIDER_HANDOFF_FAMILY_SCHEMA_VERSION),
+		families: Type.Array(providerHandoffFamilySchema, { minItems: 1 }),
 	},
 	{ additionalProperties: false },
 );
 
 const providerHandoffFamilyFileValidator = Schema.Compile(providerHandoffFamilyFileSchema);
-const supportedHandoffApis = new Set<string>([
-	"anthropic-messages",
-	"azure-openai-responses",
-	"bedrock-converse-stream",
-	"google-generative-ai",
-	"google-vertex",
-	"mistral-conversations",
-	"openai-codex-responses",
-	"openai-completions",
-	"openai-responses",
-]);
 
 export type ProviderHandoffFamilyFile = Static<typeof providerHandoffFamilyFileSchema>;
 export type ProviderHandoffFamily = ProviderHandoffFamilyFile["families"][number];
@@ -72,60 +143,39 @@ export function loadProviderHandoffFamilyFile(): ProviderHandoffFamilyFile {
 }
 
 export function resolveProviderHandoffFamilies(file: ProviderHandoffFamilyFile): ResolvedProviderHandoffFamily[] {
-	const catalog = MODELS as unknown as Record<string, Record<string, Model<Api>>>;
-	return file.families.map((fixture) => {
-		if (fixture.synthetic) {
-			return { fixture, model: createSyntheticModel(fixture) };
-		}
-		const model = catalog[fixture.provider]?.[fixture.model];
-		if (!model) throw new Error(`Unknown provider handoff family model: ${fixture.provider}/${fixture.model}`);
-		if (model.api !== fixture.api) {
-			throw new Error(
-				`Provider handoff family API mismatch for ${fixture.provider}/${fixture.model}: ${model.api} != ${fixture.api}`,
-			);
-		}
-		return { fixture, model };
-	});
+	return file.families.map((fixture) => ({
+		fixture,
+		model: {
+			id: fixture.model,
+			api: fixture.api,
+			provider: fixture.provider,
+			...fixture.metadata,
+		} as Model<Api>,
+	}));
 }
 
-export function getCatalogProviderHandoffModels(): ResolvedProviderHandoffFamily[] {
-	const catalog = MODELS as unknown as Record<string, Record<string, Model<Api>>>;
-	const families: ResolvedProviderHandoffFamily[] = [];
-	for (const [provider, models] of Object.entries(catalog)) {
-		for (const model of Object.values(models)) {
-			if (!supportedHandoffApis.has(model.api)) {
-				throw new Error(`Unsupported catalog handoff API: ${model.api}`);
-			}
-			families.push({
-				fixture: {
-					api: model.api as ProviderHandoffFamily["api"],
-					provider,
-					model: model.id,
-					synthetic: false,
-				},
-				model,
-			});
-		}
-	}
-	return families;
+export function snapshotProviderHandoffFamily(model: Model<Api>, synthetic: boolean): ProviderHandoffFamily {
+	const serializedModel = JSON.parse(JSON.stringify(model)) as Record<string, unknown>;
+	const { id, api, provider, ...metadata } = serializedModel;
+	const parsed = parseProviderHandoffFamilyFile(
+		JSON.stringify({
+			schemaVersion: PROVIDER_HANDOFF_FAMILY_SCHEMA_VERSION,
+			families: [{ api, provider, model: id, synthetic, metadata }],
+		}),
+	);
+	return parsed.families[0];
 }
 
-function createSyntheticModel(fixture: ProviderHandoffFamily): Model<Api> {
-	if (fixture.api !== "google-generative-ai") {
-		throw new Error(
-			`Unsupported synthetic provider handoff family: ${fixture.api}/${fixture.provider}/${fixture.model}`,
-		);
-	}
-	return {
-		id: fixture.model,
-		name: `Synthetic ${fixture.model}`,
-		api: fixture.api,
-		provider: fixture.provider,
-		baseUrl: "http://127.0.0.1:9",
-		reasoning: true,
-		input: ["text", "image"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 32_000,
-		maxTokens: 4_096,
-	};
+function requireAllKnownApis<const T extends readonly KnownApi[]>(
+	apis: T,
+	_missing: Record<Exclude<KnownApi, T[number]>, never>,
+): T {
+	return apis;
+}
+
+function requireAllKnownProviders<const T extends readonly KnownProvider[]>(
+	providers: T,
+	_missing: Record<Exclude<KnownProvider, T[number]>, never>,
+): T {
+	return providers;
 }

--- a/packages/ai/test/provider-handoff-family-catalog-audit.ts
+++ b/packages/ai/test/provider-handoff-family-catalog-audit.ts
@@ -1,0 +1,29 @@
+import { MODELS } from "../src/models.generated.js";
+import type { Api, Model } from "../src/types.js";
+import {
+	type ResolvedProviderHandoffFamily,
+	STABLE_HANDOFF_APIS,
+	snapshotProviderHandoffFamily,
+} from "./provider-handoff-families.js";
+
+const supportedHandoffApis = new Set<string>(STABLE_HANDOFF_APIS);
+
+export function getCatalogProviderHandoffModels(): ResolvedProviderHandoffFamily[] {
+	const catalog = MODELS as unknown as Record<string, Record<string, Model<Api>>>;
+	const families: ResolvedProviderHandoffFamily[] = [];
+	for (const [provider, models] of Object.entries(catalog)) {
+		for (const model of Object.values(models)) {
+			if (!supportedHandoffApis.has(model.api)) {
+				throw new Error(`Unsupported catalog handoff API: ${model.api}`);
+			}
+			if (model.provider !== provider) {
+				throw new Error(`Catalog provider mismatch for ${provider}/${model.id}: ${model.provider}`);
+			}
+			families.push({
+				fixture: snapshotProviderHandoffFamily(model, false),
+				model,
+			});
+		}
+	}
+	return families;
+}

--- a/packages/ai/test/provider-handoff-family-completeness.test.ts
+++ b/packages/ai/test/provider-handoff-family-completeness.test.ts
@@ -1,0 +1,214 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { getApiProviders } from "../src/api-registry.js";
+import { resetApiProviders } from "../src/providers/register-builtins.js";
+import type { Api, Model, SimpleStreamOptions, ThinkingLevel, Tool } from "../src/types.js";
+import {
+	getCatalogProviderHandoffModels,
+	loadProviderHandoffFamilyFile,
+	parseProviderHandoffFamilyFile,
+	type ResolvedProviderHandoffFamily,
+	resolveProviderHandoffFamilies,
+} from "./provider-handoff-families.js";
+import { createHandoffContext, loadProviderHandoffFixtureFile } from "./provider-handoff-fixtures.js";
+import { getTargetTransportAttempts, resetTargetTransportAttempts } from "./provider-handoff-target-transport.js";
+
+const familyFile = loadProviderHandoffFamilyFile();
+const resolvedFamilies = resolveProviderHandoffFamilies(familyFile);
+const handoffFixtureFile = loadProviderHandoffFixtureFile();
+const sourceFixture = getCanonicalSourceFixture();
+
+const REQUIRED_SYNTHETIC_FAMILIES = new Set([
+	"google-generative-ai|opencode|claude-sonnet-4-5",
+	"google-generative-ai|opencode|gpt-oss-120b",
+]);
+const thinkingLevels = requireAllThinkingLevels(["minimal", "low", "medium", "high", "xhigh", "max"] as const, {});
+const reasoningProfiles = [undefined, ...thinkingLevels] as const;
+const inspectFixtureTool: Tool = {
+	name: "inspect_fixture",
+	description: "Inspect a sanitized fixture path.",
+	parameters: Type.Object({ path: Type.String() }),
+};
+const CODEX_FIXTURE_TOKEN =
+	"e30.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF9maXh0dXJlIn19.fixture";
+const PAYLOAD_CAPTURED = "provider family payload captured";
+const HERMETIC_BASE_URL = "http://127.0.0.1:9";
+
+function requireAllThinkingLevels<const T extends readonly ThinkingLevel[]>(
+	levels: T,
+	_missing: Record<Exclude<ThinkingLevel, T[number]>, never>,
+): T {
+	return levels;
+}
+
+describe("provider handoff behavior-family completeness", () => {
+	it("validates and deterministically serializes the versioned family manifest", () => {
+		const serialized = JSON.stringify(familyFile);
+		expect(JSON.stringify(parseProviderHandoffFamilyFile(serialized))).toBe(serialized);
+		expect(() =>
+			parseProviderHandoffFamilyFile(serialized.replace('"schemaVersion":1', '"schemaVersion":2')),
+		).toThrow("schema validation");
+	});
+
+	it("requires one representative for every effective catalog payload shape", async () => {
+		const syntheticFamilies = resolvedFamilies.filter(({ fixture }) => fixture.synthetic);
+		expect(
+			new Set(syntheticFamilies.map(({ fixture }) => `${fixture.api}|${fixture.provider}|${fixture.model}`)),
+		).toEqual(REQUIRED_SYNTHETIC_FAMILIES);
+
+		resetApiProviders();
+		const expectedCandidates = [...getCatalogProviderHandoffModels(), ...syntheticFamilies];
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		let expectedGroups: Map<string, ResolvedProviderHandoffFamily[]>;
+		let manifestGroups: Map<string, ResolvedProviderHandoffFamily[]>;
+		try {
+			expectedGroups = await groupByFingerprint(expectedCandidates);
+			manifestGroups = await groupByFingerprint(resolvedFamilies);
+		} finally {
+			errorSpy.mockRestore();
+		}
+		const duplicateManifestGroups = [...manifestGroups.values()].filter((group) => group.length > 1);
+		const expectedFingerprints = [...expectedGroups.keys()].sort();
+		const manifestFingerprints = [...manifestGroups.keys()].sort();
+		const fingerprintsDiffer = JSON.stringify(manifestFingerprints) !== JSON.stringify(expectedFingerprints);
+		const suggestedManifest = {
+			schemaVersion: 1,
+			families: [...expectedGroups.values()].map(([family]) => family.fixture),
+		};
+		if (
+			(duplicateManifestGroups.length > 0 || fingerprintsDiffer) &&
+			process.env.UPDATE_PROVIDER_HANDOFF_FAMILIES === "1"
+		) {
+			const fixtureUrl = new URL("./fixtures/provider-handoffs/v1/families.json", import.meta.url);
+			writeFileSync(fixtureUrl, `${JSON.stringify(suggestedManifest, null, "\t")}\n`);
+			return;
+		}
+
+		expect(duplicateManifestGroups).toEqual([]);
+		if (fingerprintsDiffer) {
+			throw new Error(
+				`Provider handoff payload-family completeness failure. Suggested manifest:\n${JSON.stringify(suggestedManifest, null, 2)}`,
+			);
+		}
+		expect(new Set(resolvedFamilies.map(({ model }) => model.api)).size).toBe(9);
+	});
+});
+
+async function groupByFingerprint(
+	families: ResolvedProviderHandoffFamily[],
+): Promise<Map<string, ResolvedProviderHandoffFamily[]>> {
+	const groups = new Map<string, ResolvedProviderHandoffFamily[]>();
+	for (const family of families) {
+		const fingerprint = await captureBehaviorFingerprint(family);
+		const group = groups.get(fingerprint) ?? [];
+		group.push(family);
+		groups.set(fingerprint, group);
+	}
+	return groups;
+}
+
+async function captureBehaviorFingerprint(family: ResolvedProviderHandoffFamily): Promise<string> {
+	const payloads: unknown[] = [];
+	for (const reasoning of reasoningProfiles) {
+		payloads.push(await capturePayload(family, reasoning));
+	}
+
+	const canonical = canonicalize(
+		{
+			api: family.model.api,
+			provider: family.model.provider,
+			explicitBranch: getExplicitBranch(family.model),
+			payloads,
+		},
+		family.model.id,
+	);
+	return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+function getExplicitBranch(model: Model<Api>): string | undefined {
+	if (model.api !== "google-generative-ai" && model.api !== "google-vertex") return undefined;
+	if (model.id.startsWith("claude-")) return "google-claude";
+	if (model.id.startsWith("gpt-oss-")) return "google-gpt-oss";
+	return undefined;
+}
+
+async function capturePayload(
+	family: ResolvedProviderHandoffFamily,
+	reasoning: SimpleStreamOptions["reasoning"],
+): Promise<unknown> {
+	const apiProvider = getApiProviders().find((provider) => provider.api === family.model.api);
+	if (!apiProvider) throw new Error(`Missing API provider ${family.model.api}`);
+
+	const context = createHandoffContext(sourceFixture, handoffFixtureFile.images, {
+		api: sourceFixture.source.api,
+		provider: "fixture-source-provider",
+		model: "fixture-source-model",
+	});
+	context.tools = [inspectFixtureTool];
+	let capturedPayload: unknown;
+	resetTargetTransportAttempts();
+	const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+		throw new Error("Network transport must not run in provider family fingerprinting");
+	});
+
+	try {
+		const captureModel = {
+			...family.model,
+			baseUrl: createHermeticBaseUrl(family.model.baseUrl),
+		} satisfies Model<Api>;
+		const response = await apiProvider
+			.streamSimple(captureModel, context, {
+				apiKey: family.model.api === "openai-codex-responses" ? CODEX_FIXTURE_TOKEN : "fixture-key",
+				cacheRetention: "long",
+				maxTokens: 4_096,
+				onPayload: (payload) => {
+					capturedPayload = payload;
+					throw new Error(PAYLOAD_CAPTURED);
+				},
+				reasoning,
+				sessionId: "fixture-session",
+				temperature: 0.2,
+				...(family.model.api === "openai-codex-responses" ? { transport: "sse" as const } : {}),
+			})
+			.result();
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(getTargetTransportAttempts()).toEqual([]);
+		expect(response.errorMessage).toContain(PAYLOAD_CAPTURED);
+	} finally {
+		fetchSpy.mockRestore();
+	}
+
+	if (capturedPayload === undefined) {
+		throw new Error(`Provider family did not expose a payload: ${family.fixture.provider}/${family.fixture.model}`);
+	}
+	return capturedPayload;
+}
+
+function getCanonicalSourceFixture() {
+	const fixture = handoffFixtureFile.fixtures.find((candidate) => candidate.source.api === "anthropic-messages");
+	if (!fixture) throw new Error("Missing canonical Anthropic handoff fixture");
+	return fixture;
+}
+
+function createHermeticBaseUrl(baseUrl: string): string {
+	if (!baseUrl) return HERMETIC_BASE_URL;
+	return baseUrl.replace(/\{[A-Z_][A-Z0-9_]*\}/g, "fixture");
+}
+
+function canonicalize(value: unknown, modelId: string): unknown {
+	if (typeof value === "string") return value.split(modelId).join("<model-id>");
+	if (value instanceof Uint8Array) return { bytes: Buffer.from(value).toString("base64") };
+	if (Array.isArray(value)) return value.map((item) => canonicalize(item, modelId));
+	if (typeof value !== "object" || value === null) return value;
+
+	const result: Record<string, unknown> = {};
+	for (const key of Object.keys(value).sort()) {
+		const child = (value as Record<string, unknown>)[key];
+		if (child !== undefined) result[key] = canonicalize(child, modelId);
+	}
+	return result;
+}

--- a/packages/ai/test/provider-handoff-family-completeness.test.ts
+++ b/packages/ai/test/provider-handoff-family-completeness.test.ts
@@ -7,12 +7,15 @@ import { getApiProviders } from "../src/api-registry.js";
 import { resetApiProviders } from "../src/providers/register-builtins.js";
 import type { Api, Model, SimpleStreamOptions, ThinkingLevel, Tool } from "../src/types.js";
 import {
-	getCatalogProviderHandoffModels,
 	loadProviderHandoffFamilyFile,
+	PROVIDER_HANDOFF_FAMILY_SCHEMA_VERSION,
 	parseProviderHandoffFamilyFile,
 	type ResolvedProviderHandoffFamily,
 	resolveProviderHandoffFamilies,
+	STABLE_HANDOFF_APIS,
+	STABLE_HANDOFF_PROVIDERS,
 } from "./provider-handoff-families.js";
+import { getCatalogProviderHandoffModels } from "./provider-handoff-family-catalog-audit.js";
 import { createHandoffContext, loadProviderHandoffFixtureFile } from "./provider-handoff-fixtures.js";
 import { getTargetTransportAttempts, resetTargetTransportAttempts } from "./provider-handoff-target-transport.js";
 
@@ -49,51 +52,93 @@ describe("provider handoff behavior-family completeness", () => {
 		const serialized = JSON.stringify(familyFile);
 		expect(JSON.stringify(parseProviderHandoffFamilyFile(serialized))).toBe(serialized);
 		expect(() =>
-			parseProviderHandoffFamilyFile(serialized.replace('"schemaVersion":1', '"schemaVersion":2')),
+			parseProviderHandoffFamilyFile(serialized.replace('"schemaVersion":2', '"schemaVersion":3')),
 		).toThrow("schema validation");
 	});
 
-	it("requires one representative for every effective catalog payload shape", async () => {
+	it("resolves snapshotted behavior after a model is removed from the generated catalog", () => {
+		const removedCatalogFamily = familyFile.families.find(
+			(family) => family.provider === "github-copilot" && family.model === "gemini-2.5-pro",
+		);
+		if (!removedCatalogFamily) throw new Error("Missing GitHub Copilot catalog-removal regression family");
+
+		const renamedFamily = {
+			...removedCatalogFamily,
+			model: "removed-from-generated-catalog",
+		};
+		const [resolved] = resolveProviderHandoffFamilies({
+			...familyFile,
+			families: [renamedFamily],
+		});
+
+		expect(resolved.model.id).toBe("removed-from-generated-catalog");
+		expect(resolved.model.api).toBe(removedCatalogFamily.api);
+		expect(resolved.model.provider).toBe(removedCatalogFamily.provider);
+	});
+
+	it("covers every stable built-in API and provider definition", () => {
+		resetApiProviders();
+		expect([...new Set(getApiProviders().map(({ api }) => api))].sort()).toEqual([...STABLE_HANDOFF_APIS].sort());
+		expect([...new Set(familyFile.families.map(({ api }) => api))].sort()).toEqual([...STABLE_HANDOFF_APIS].sort());
+		expect([...new Set(familyFile.families.map(({ provider }) => provider))].sort()).toEqual(
+			[...STABLE_HANDOFF_PROVIDERS].sort(),
+		);
+	});
+
+	it("requires one representative for every snapshotted payload shape", async () => {
 		const syntheticFamilies = resolvedFamilies.filter(({ fixture }) => fixture.synthetic);
 		expect(
 			new Set(syntheticFamilies.map(({ fixture }) => `${fixture.api}|${fixture.provider}|${fixture.model}`)),
 		).toEqual(REQUIRED_SYNTHETIC_FAMILIES);
 
 		resetApiProviders();
-		const expectedCandidates = [...getCatalogProviderHandoffModels(), ...syntheticFamilies];
 		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-		let expectedGroups: Map<string, ResolvedProviderHandoffFamily[]>;
 		let manifestGroups: Map<string, ResolvedProviderHandoffFamily[]>;
 		try {
-			expectedGroups = await groupByFingerprint(expectedCandidates);
 			manifestGroups = await groupByFingerprint(resolvedFamilies);
 		} finally {
 			errorSpy.mockRestore();
 		}
 		const duplicateManifestGroups = [...manifestGroups.values()].filter((group) => group.length > 1);
+		expect(duplicateManifestGroups).toEqual([]);
+		expect(new Set(resolvedFamilies.map(({ model }) => model.api)).size).toBe(STABLE_HANDOFF_APIS.length);
+	});
+
+	it("compares the manifest with the live catalog only during an explicit audit", async () => {
+		const auditRequested =
+			process.env.AUDIT_PROVIDER_HANDOFF_CATALOG === "1" || process.env.UPDATE_PROVIDER_HANDOFF_FAMILIES === "1";
+		if (!auditRequested) return;
+
+		const syntheticFamilies = resolvedFamilies.filter(({ fixture }) => fixture.synthetic);
+		resetApiProviders();
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		let expectedGroups: Map<string, ResolvedProviderHandoffFamily[]>;
+		let manifestGroups: Map<string, ResolvedProviderHandoffFamily[]>;
+		try {
+			expectedGroups = await groupByFingerprint([...getCatalogProviderHandoffModels(), ...syntheticFamilies]);
+			manifestGroups = await groupByFingerprint(resolvedFamilies);
+		} finally {
+			errorSpy.mockRestore();
+		}
+
 		const expectedFingerprints = [...expectedGroups.keys()].sort();
 		const manifestFingerprints = [...manifestGroups.keys()].sort();
 		const fingerprintsDiffer = JSON.stringify(manifestFingerprints) !== JSON.stringify(expectedFingerprints);
 		const suggestedManifest = {
-			schemaVersion: 1,
+			schemaVersion: PROVIDER_HANDOFF_FAMILY_SCHEMA_VERSION,
 			families: [...expectedGroups.values()].map(([family]) => family.fixture),
 		};
-		if (
-			(duplicateManifestGroups.length > 0 || fingerprintsDiffer) &&
-			process.env.UPDATE_PROVIDER_HANDOFF_FAMILIES === "1"
-		) {
+		if (fingerprintsDiffer && process.env.UPDATE_PROVIDER_HANDOFF_FAMILIES === "1") {
 			const fixtureUrl = new URL("./fixtures/provider-handoffs/v1/families.json", import.meta.url);
 			writeFileSync(fixtureUrl, `${JSON.stringify(suggestedManifest, null, "\t")}\n`);
 			return;
 		}
 
-		expect(duplicateManifestGroups).toEqual([]);
 		if (fingerprintsDiffer) {
 			throw new Error(
 				`Provider handoff payload-family completeness failure. Suggested manifest:\n${JSON.stringify(suggestedManifest, null, 2)}`,
 			);
 		}
-		expect(new Set(resolvedFamilies.map(({ model }) => model.api)).size).toBe(9);
 	});
 });
 

--- a/packages/ai/test/provider-handoff-fixtures.ts
+++ b/packages/ai/test/provider-handoff-fixtures.ts
@@ -1,0 +1,225 @@
+import { Buffer } from "node:buffer";
+import { readFileSync } from "node:fs";
+import Type, { type Static } from "typebox";
+import Schema from "typebox/schema";
+import type { AssistantMessage, Context, Message, Usage } from "../src/types.js";
+
+export const PROVIDER_HANDOFF_FIXTURE_SCHEMA_VERSION = 1;
+
+const handoffApiSchema = Type.Union([
+	Type.Literal("anthropic-messages"),
+	Type.Literal("azure-openai-responses"),
+	Type.Literal("bedrock-converse-stream"),
+	Type.Literal("google-generative-ai"),
+	Type.Literal("google-vertex"),
+	Type.Literal("mistral-conversations"),
+	Type.Literal("openai-codex-responses"),
+	Type.Literal("openai-completions"),
+	Type.Literal("openai-responses"),
+]);
+
+const nullableStringSchema = Type.Union([Type.String({ minLength: 1 }), Type.Null()]);
+
+const providerHandoffFixtureFileSchema = Type.Object(
+	{
+		schemaVersion: Type.Literal(PROVIDER_HANDOFF_FIXTURE_SCHEMA_VERSION),
+		coverage: Type.Object(
+			{
+				userImages: Type.Literal(true),
+				toolResultImages: Type.Literal(true),
+				toolErrors: Type.Literal(true),
+				providerErrors: Type.Literal(true),
+			},
+			{ additionalProperties: false },
+		),
+		images: Type.Object(
+			{
+				user: Type.Object(
+					{ mimeType: Type.Literal("image/png"), data: Type.String({ minLength: 1 }) },
+					{ additionalProperties: false },
+				),
+				toolResult: Type.Object(
+					{ mimeType: Type.Literal("image/png"), data: Type.String({ minLength: 1 }) },
+					{ additionalProperties: false },
+				),
+			},
+			{ additionalProperties: false },
+		),
+		fixtures: Type.Array(
+			Type.Object(
+				{
+					id: Type.String({ minLength: 1 }),
+					source: Type.Object(
+						{
+							api: handoffApiSchema,
+							provider: Type.String({ minLength: 1 }),
+							model: Type.String({ minLength: 1 }),
+						},
+						{ additionalProperties: false },
+					),
+					protocol: Type.Object(
+						{
+							toolCallId: Type.String({ minLength: 1 }),
+							thinkingSignature: nullableStringSchema,
+							toolThoughtSignature: nullableStringSchema,
+							signatureMarker: nullableStringSchema,
+						},
+						{ additionalProperties: false },
+					),
+				},
+				{ additionalProperties: false },
+			),
+			{ minItems: 1 },
+		),
+	},
+	{ additionalProperties: false },
+);
+
+const providerHandoffFixtureFileValidator = Schema.Compile(providerHandoffFixtureFileSchema);
+
+export type ProviderHandoffFixtureFile = Static<typeof providerHandoffFixtureFileSchema>;
+export type ProviderHandoffFixture = ProviderHandoffFixtureFile["fixtures"][number];
+export type ProviderHandoffImages = ProviderHandoffFixtureFile["images"];
+export type HandoffApi = ProviderHandoffFixture["source"]["api"];
+
+interface HandoffSource {
+	api: HandoffApi;
+	provider: string;
+	model: string;
+}
+
+const ZERO_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+export function parseProviderHandoffFixtureFile(serialized: string): ProviderHandoffFixtureFile {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(serialized);
+	} catch (error) {
+		throw new Error("Provider handoff fixture is not valid JSON", { cause: error });
+	}
+
+	if (!providerHandoffFixtureFileValidator.Check(parsed)) {
+		const errors = providerHandoffFixtureFileValidator.Errors(parsed);
+		throw new Error(`Provider handoff fixture failed schema validation: ${JSON.stringify(errors)}`);
+	}
+
+	validateFixtureInvariants(parsed);
+	return parsed;
+}
+
+export function loadProviderHandoffFixtureFile(): ProviderHandoffFixtureFile {
+	const fixtureUrl = new URL("./fixtures/provider-handoffs/v1/fixtures.json", import.meta.url);
+	return parseProviderHandoffFixtureFile(readFileSync(fixtureUrl, "utf8"));
+}
+
+export function createHandoffContext(
+	fixture: ProviderHandoffFixture,
+	images: ProviderHandoffImages,
+	source: HandoffSource = fixture.source,
+): Context {
+	const assistant: AssistantMessage = {
+		role: "assistant",
+		content: [
+			{
+				type: "thinking",
+				thinking: "Sanitized provider reasoning summary.",
+				...(fixture.protocol.thinkingSignature ? { thinkingSignature: fixture.protocol.thinkingSignature } : {}),
+			},
+			{ type: "text", text: "I will inspect the fixture." },
+			{
+				type: "toolCall",
+				id: fixture.protocol.toolCallId,
+				name: "inspect_fixture",
+				arguments: { path: "sanitized.txt" },
+				...(fixture.protocol.toolThoughtSignature
+					? { thoughtSignature: fixture.protocol.toolThoughtSignature }
+					: {}),
+			},
+		],
+		api: source.api,
+		provider: source.provider,
+		model: source.model,
+		usage: ZERO_USAGE,
+		stopReason: "toolUse",
+		timestamp: 1_700_000_000_001,
+	};
+
+	const providerError: AssistantMessage = {
+		role: "assistant",
+		content: [{ type: "text", text: "Partial output from a failed provider response." }],
+		api: source.api,
+		provider: source.provider,
+		model: source.model,
+		usage: ZERO_USAGE,
+		stopReason: "error",
+		errorMessage: "fixture provider error; request identifiers redacted",
+		timestamp: 1_700_000_000_003,
+	};
+
+	const messages: Message[] = [
+		{
+			role: "user",
+			content: [
+				{ type: "text", text: "Inspect this sanitized image." },
+				{ type: "image", data: images.user.data, mimeType: images.user.mimeType },
+			],
+			timestamp: 1_700_000_000_000,
+		},
+		assistant,
+		{
+			role: "toolResult",
+			toolCallId: fixture.protocol.toolCallId,
+			toolName: "inspect_fixture",
+			content: [
+				{ type: "text", text: "fixture tool failure" },
+				{ type: "image", data: images.toolResult.data, mimeType: images.toolResult.mimeType },
+			],
+			isError: true,
+			timestamp: 1_700_000_000_002,
+		},
+		providerError,
+	];
+
+	return {
+		systemPrompt: "Exercise the sanitized handoff contract.",
+		messages,
+	};
+}
+
+function validateFixtureInvariants(file: ProviderHandoffFixtureFile): void {
+	const pngSignature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+	for (const [name, image] of Object.entries(file.images)) {
+		const decoded = Buffer.from(image.data, "base64");
+		if (decoded.toString("base64") !== image.data || !decoded.subarray(0, pngSignature.length).equals(pngSignature)) {
+			throw new Error(`Provider handoff ${name} image is not canonical PNG data`);
+		}
+	}
+	if (file.images.user.data === file.images.toolResult.data) {
+		throw new Error("Provider handoff user and tool-result images must be distinguishable");
+	}
+
+	const ids = new Set<string>();
+
+	for (const fixture of file.fixtures) {
+		if (ids.has(fixture.id)) throw new Error(`Duplicate provider handoff fixture id: ${fixture.id}`);
+		ids.add(fixture.id);
+
+		const { signatureMarker, thinkingSignature, toolThoughtSignature } = fixture.protocol;
+		const signatures = [thinkingSignature, toolThoughtSignature].filter(
+			(signature): signature is string => signature !== null,
+		);
+		if (signatureMarker === null && signatures.length > 0) {
+			throw new Error(`Fixture ${fixture.id} has a signature without a signature marker`);
+		}
+		if (signatureMarker !== null && !signatures.some((signature) => signature.includes(signatureMarker))) {
+			throw new Error(`Fixture ${fixture.id} signature marker is not present in a signature`);
+		}
+	}
+}

--- a/packages/ai/test/provider-handoff-target-transport.ts
+++ b/packages/ai/test/provider-handoff-target-transport.ts
@@ -1,0 +1,106 @@
+import { vi } from "vitest";
+
+const targetTransportTrap = vi.hoisted(() => ({
+	attempts: [] as string[],
+	attempt(api: string): never {
+		this.attempts.push(api);
+		throw new Error(`Unexpected target transport attempt: ${api}`);
+	},
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	class FakeAnthropic {
+		messages = { create: () => targetTransportTrap.attempt("anthropic") };
+	}
+	return { default: FakeAnthropic };
+});
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeServiceException extends Error {}
+	class BedrockRuntimeClient {
+		send() {
+			return targetTransportTrap.attempt("bedrock");
+		}
+	}
+	class ConverseStreamCommand {
+		constructor(readonly input: unknown) {}
+	}
+	return {
+		BedrockRuntimeClient,
+		BedrockRuntimeServiceException,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+});
+
+vi.mock("@google/genai", () => {
+	class GoogleGenAI {
+		models = { generateContentStream: () => targetTransportTrap.attempt("google") };
+	}
+	return {
+		GoogleGenAI,
+		FinishReason: {
+			STOP: "STOP",
+			MAX_TOKENS: "MAX_TOKENS",
+			BLOCKLIST: "BLOCKLIST",
+			PROHIBITED_CONTENT: "PROHIBITED_CONTENT",
+			SPII: "SPII",
+			SAFETY: "SAFETY",
+			IMAGE_SAFETY: "IMAGE_SAFETY",
+			IMAGE_PROHIBITED_CONTENT: "IMAGE_PROHIBITED_CONTENT",
+			IMAGE_RECITATION: "IMAGE_RECITATION",
+			IMAGE_OTHER: "IMAGE_OTHER",
+			RECITATION: "RECITATION",
+			FINISH_REASON_UNSPECIFIED: "FINISH_REASON_UNSPECIFIED",
+			OTHER: "OTHER",
+			LANGUAGE: "LANGUAGE",
+			MALFORMED_FUNCTION_CALL: "MALFORMED_FUNCTION_CALL",
+			UNEXPECTED_TOOL_CALL: "UNEXPECTED_TOOL_CALL",
+			NO_IMAGE: "NO_IMAGE",
+		},
+		FunctionCallingConfigMode: { AUTO: "AUTO", NONE: "NONE", ANY: "ANY" },
+		ResourceScope: { COLLECTION: "COLLECTION" },
+		ThinkingLevel: {
+			THINKING_LEVEL_UNSPECIFIED: "THINKING_LEVEL_UNSPECIFIED",
+			MINIMAL: "MINIMAL",
+			LOW: "LOW",
+			MEDIUM: "MEDIUM",
+			HIGH: "HIGH",
+		},
+	};
+});
+
+vi.mock("@mistralai/mistralai", () => {
+	class Mistral {
+		chat = { stream: () => targetTransportTrap.attempt("mistral") };
+	}
+	return { Mistral };
+});
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = { completions: { create: () => targetTransportTrap.attempt("openai-completions") } };
+		responses = { create: () => targetTransportTrap.attempt("openai-responses") };
+	}
+	class FakeAzureOpenAI extends FakeOpenAI {}
+	return { default: FakeOpenAI, AzureOpenAI: FakeAzureOpenAI };
+});
+
+export function resetTargetTransportAttempts(): void {
+	targetTransportTrap.attempts = [];
+}
+
+export function getTargetTransportAttempts(): string[] {
+	return [...targetTransportTrap.attempts];
+}

--- a/packages/ai/test/provider-response-handoff-fixtures.test.ts
+++ b/packages/ai/test/provider-response-handoff-fixtures.test.ts
@@ -1,0 +1,381 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const transportMock = vi.hoisted(() => ({
+	events: [] as unknown[],
+	calls: 0,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	class FakeAnthropic {
+		messages = {
+			create: () => ({
+				asResponse: async () => {
+					transportMock.calls++;
+					const body = transportMock.events
+						.map((entry) => {
+							const event = entry as { event: string; data: unknown };
+							return `event: ${event.event}\ndata: ${JSON.stringify(event.data)}\n\n`;
+						})
+						.join("");
+					return new Response(body, { status: 200, headers: { "request-id": "req_fixture" } });
+				},
+			}),
+		};
+	}
+	return { default: FakeAnthropic };
+});
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeServiceException extends Error {}
+	class BedrockRuntimeClient {
+		async send() {
+			transportMock.calls++;
+			return {
+				$metadata: { httpStatusCode: 200, requestId: "req_fixture_bedrock" },
+				stream: createAsyncIterable(transportMock.events),
+			};
+		}
+	}
+	class ConverseStreamCommand {
+		constructor(readonly input: unknown) {}
+	}
+	return {
+		BedrockRuntimeClient,
+		BedrockRuntimeServiceException,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+
+	function createAsyncIterable(events: unknown[]) {
+		return {
+			async *[Symbol.asyncIterator]() {
+				for (const event of events) yield event;
+			},
+		};
+	}
+});
+
+vi.mock("@google/genai", () => {
+	class GoogleGenAI {
+		models = {
+			generateContentStream: async () => {
+				transportMock.calls++;
+				return createAsyncIterable(transportMock.events);
+			},
+		};
+	}
+	return {
+		GoogleGenAI,
+		FinishReason: {
+			STOP: "STOP",
+			MAX_TOKENS: "MAX_TOKENS",
+			BLOCKLIST: "BLOCKLIST",
+			PROHIBITED_CONTENT: "PROHIBITED_CONTENT",
+			SPII: "SPII",
+			SAFETY: "SAFETY",
+			IMAGE_SAFETY: "IMAGE_SAFETY",
+			IMAGE_PROHIBITED_CONTENT: "IMAGE_PROHIBITED_CONTENT",
+			IMAGE_RECITATION: "IMAGE_RECITATION",
+			IMAGE_OTHER: "IMAGE_OTHER",
+			RECITATION: "RECITATION",
+			FINISH_REASON_UNSPECIFIED: "FINISH_REASON_UNSPECIFIED",
+			OTHER: "OTHER",
+			LANGUAGE: "LANGUAGE",
+			MALFORMED_FUNCTION_CALL: "MALFORMED_FUNCTION_CALL",
+			UNEXPECTED_TOOL_CALL: "UNEXPECTED_TOOL_CALL",
+			NO_IMAGE: "NO_IMAGE",
+		},
+		FunctionCallingConfigMode: { AUTO: "AUTO", NONE: "NONE", ANY: "ANY" },
+		ResourceScope: { COLLECTION: "COLLECTION" },
+		ThinkingLevel: {
+			THINKING_LEVEL_UNSPECIFIED: "THINKING_LEVEL_UNSPECIFIED",
+			MINIMAL: "MINIMAL",
+			LOW: "LOW",
+			MEDIUM: "MEDIUM",
+			HIGH: "HIGH",
+		},
+	};
+
+	function createAsyncIterable(events: unknown[]) {
+		return {
+			async *[Symbol.asyncIterator]() {
+				for (const event of events) yield event;
+			},
+		};
+	}
+});
+
+vi.mock("@mistralai/mistralai", () => {
+	class Mistral {
+		chat = {
+			stream: async () => {
+				transportMock.calls++;
+				return createAsyncIterable(transportMock.events);
+			},
+		};
+	}
+	return { Mistral };
+
+	function createAsyncIterable(events: unknown[]) {
+		return {
+			async *[Symbol.asyncIterator]() {
+				for (const event of events) yield event;
+			},
+		};
+	}
+});
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = { completions: { create: () => createResponsePromise() } };
+		responses = { create: () => createResponsePromise() };
+	}
+
+	class FakeAzureOpenAI extends FakeOpenAI {}
+
+	return { default: FakeOpenAI, AzureOpenAI: FakeAzureOpenAI };
+
+	function createResponsePromise() {
+		transportMock.calls++;
+		const stream = {
+			async *[Symbol.asyncIterator]() {
+				for (const event of transportMock.events) yield event;
+			},
+		};
+		return Object.assign(Promise.resolve(stream), {
+			withResponse: async () => ({
+				data: stream,
+				response: { status: 200, headers: new Headers({ "x-request-id": "req_fixture" }) },
+			}),
+		});
+	}
+});
+
+import { getApiProviders } from "../src/api-registry.js";
+import { streamBedrock } from "../src/providers/amazon-bedrock.js";
+import { streamAnthropic } from "../src/providers/anthropic.js";
+import { streamAzureOpenAIResponses } from "../src/providers/azure-openai-responses.js";
+import { streamGoogle } from "../src/providers/google.js";
+import { streamGoogleVertex } from "../src/providers/google-vertex.js";
+import { streamMistral } from "../src/providers/mistral.js";
+import { streamOpenAICodexResponses } from "../src/providers/openai-codex-responses.js";
+import { streamOpenAICompletions } from "../src/providers/openai-completions.js";
+import { streamOpenAIResponses } from "../src/providers/openai-responses.js";
+import { resetApiProviders } from "../src/providers/register-builtins.js";
+import type { Api, AssistantMessageEventStream, Context, Model, StreamOptions } from "../src/types.js";
+import {
+	assertProviderResponseFixtureApiCompleteness,
+	loadProviderResponseFixtureFile,
+	type ProviderResponseFixture,
+	parseProviderResponseFixtureFile,
+} from "./provider-response-handoff-fixtures.js";
+
+const fixtureFile = loadProviderResponseFixtureFile();
+const HERMETIC_BASE_URL = "http://127.0.0.1:9";
+const CODEX_FIXTURE_TOKEN =
+	"e30.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF9maXh0dXJlIn19.fixture";
+const context: Context = {
+	messages: [{ role: "user", content: "Replay the raw response fixture.", timestamp: 1_700_000_000_000 }],
+};
+
+beforeEach(() => {
+	transportMock.events = [];
+	transportMock.calls = 0;
+});
+
+describe("provider response handoff fixtures", () => {
+	it("validates and deterministically serializes versioned raw provider responses", () => {
+		const serialized = JSON.stringify(fixtureFile);
+		expect(JSON.stringify(parseProviderResponseFixtureFile(serialized))).toBe(serialized);
+		expect(() =>
+			parseProviderResponseFixtureFile(serialized.replace('"schemaVersion":1', '"schemaVersion":2')),
+		).toThrow("schema validation");
+	});
+
+	it("rejects raw fixtures containing auth material or unsanitized provider IDs", () => {
+		const serialized = JSON.stringify(fixtureFile);
+		expect(() =>
+			parseProviderResponseFixtureFile(
+				serialized.replace('"type":"message_start"', '"type":"message_start","authorization":"Bearer live-secret"'),
+			),
+		).toThrow("sanitization");
+		expect(() =>
+			parseProviderResponseFixtureFile(serialized.replace("req_fixture_anthropic", "req_live_4f8a62b5")),
+		).toThrow("sanitization");
+
+		for (const key of [
+			"x-api-key",
+			"api_token",
+			"client_secret",
+			"auth_token",
+			"id_token",
+			"refresh_token",
+			"password",
+			"private_key",
+			"secret_key",
+			"secret_access_key",
+			"credential",
+			"credentials",
+			"token",
+		]) {
+			expect(() =>
+				parseProviderResponseFixtureFile(
+					serialized.replace('"type":"message_start"', `"type":"message_start","${key}":"live-credential"`),
+				),
+			).toThrow("sanitization");
+		}
+		expect(() =>
+			parseProviderResponseFixtureFile(serialized.replace("resp_fixture_google", "resp_live_google_4f8a62b5")),
+		).toThrow("sanitization");
+		expect(() =>
+			parseProviderResponseFixtureFile(
+				serialized.replace(
+					'"type":"message_start"',
+					'"type":"message_start","providerRequestId":"req_live_provider_4f8a62b5"',
+				),
+			),
+		).toThrow("sanitization");
+		expect(() =>
+			parseProviderResponseFixtureFile(serialized.replace("msg_fixture_anthropic", "msg_live_anthropic_4f8a62b5")),
+		).toThrow("sanitization");
+		expect(() =>
+			parseProviderResponseFixtureFile(serialized.replace("resp_fixture_openai", "resp_live_openai_4f8a62b5")),
+		).toThrow("sanitization");
+	});
+
+	it("requires exactly one raw parser fixture for every registered built-in API", () => {
+		resetApiProviders();
+		const registeredApis = getApiProviders().map((provider) => provider.api);
+		expect(() => assertProviderResponseFixtureApiCompleteness(fixtureFile, registeredApis)).not.toThrow();
+		expect(() =>
+			assertProviderResponseFixtureApiCompleteness(
+				{ ...fixtureFile, responses: fixtureFile.responses.slice(1) },
+				registeredApis,
+			),
+		).toThrow("completeness");
+	});
+
+	it.each(fixtureFile.responses)("parses $id through its production source stream", async (fixture) => {
+		const message = await replayFixture(fixture, fixture.success);
+
+		expect(transportMock.calls).toBe(1);
+		expect(message.stopReason).toBe("toolUse");
+		const thinking = message.content.find((block) => block.type === "thinking");
+		const toolCall = message.content.find((block) => block.type === "toolCall");
+		expect(thinking?.thinking).toContain(fixture.expected.thinkingText);
+		if (fixture.expected.thinkingSignatureMarker === null) {
+			expect(thinking?.thinkingSignature).toBeUndefined();
+		} else {
+			expect(thinking?.thinkingSignature).toContain(fixture.expected.thinkingSignatureMarker);
+		}
+		expect(toolCall?.id).toBe(fixture.expected.toolCallId);
+		expect(toolCall?.arguments).toEqual({ path: "raw.txt" });
+		if (fixture.expected.toolThoughtSignatureMarker !== null) {
+			expect(toolCall?.thoughtSignature).toContain(fixture.expected.toolThoughtSignatureMarker);
+		}
+	});
+
+	it.each(fixtureFile.responses)("parses $id provider errors without transport", async (fixture) => {
+		const message = await replayFixture(fixture, fixture.error);
+
+		expect(transportMock.calls).toBe(1);
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain(fixture.expected.errorMarker);
+	});
+});
+
+async function replayFixture(fixture: ProviderResponseFixture, events: unknown[]) {
+	transportMock.events = events;
+	const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+		if (fixture.api !== "openai-codex-responses") {
+			throw new Error(`Unexpected fetch transport for ${fixture.api}`);
+		}
+		transportMock.calls++;
+		return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	});
+
+	try {
+		return await createFixtureStream(fixture).result();
+	} finally {
+		if (fixture.api === "openai-codex-responses") {
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+		} else {
+			expect(fetchSpy).not.toHaveBeenCalled();
+		}
+		fetchSpy.mockRestore();
+	}
+}
+
+function createFixtureStream(fixture: ProviderResponseFixture): AssistantMessageEventStream {
+	const model = createFixtureModel(fixture);
+	const options: StreamOptions = {
+		apiKey: fixture.api === "openai-codex-responses" ? CODEX_FIXTURE_TOKEN : "fixture-key",
+		transport: "sse",
+		cacheRetention: "none",
+	};
+
+	switch (fixture.api) {
+		case "anthropic-messages":
+			return streamAnthropic(model as Model<"anthropic-messages">, context, options);
+		case "azure-openai-responses":
+			return streamAzureOpenAIResponses(model as Model<"azure-openai-responses">, context, options);
+		case "bedrock-converse-stream":
+			return streamBedrock(model as Model<"bedrock-converse-stream">, context, options);
+		case "google-generative-ai":
+			return streamGoogle(model as Model<"google-generative-ai">, context, options);
+		case "google-vertex":
+			return streamGoogleVertex(model as Model<"google-vertex">, context, options);
+		case "mistral-conversations":
+			return streamMistral(model as Model<"mistral-conversations">, context, options);
+		case "openai-codex-responses":
+			return streamOpenAICodexResponses(model as Model<"openai-codex-responses">, context, options);
+		case "openai-completions":
+			return streamOpenAICompletions(model as Model<"openai-completions">, context, options);
+		case "openai-responses":
+			return streamOpenAIResponses(model as Model<"openai-responses">, context, options);
+	}
+}
+
+function createFixtureModel(fixture: ProviderResponseFixture): Model<Api> {
+	const metadata = {
+		"anthropic-messages": { provider: "anthropic", model: "claude-sonnet-4-5" },
+		"azure-openai-responses": { provider: "azure-openai-responses", model: "gpt-5-mini" },
+		"bedrock-converse-stream": {
+			provider: "amazon-bedrock",
+			model: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+		},
+		"google-generative-ai": { provider: "google", model: "gemini-3-flash-preview" },
+		"google-vertex": { provider: "google-vertex", model: "gemini-3-flash-preview" },
+		"mistral-conversations": { provider: "mistral", model: "devstral-medium-latest" },
+		"openai-codex-responses": { provider: "openai-codex", model: "gpt-5.2-codex" },
+		"openai-completions": { provider: "openai", model: "gpt-5-mini" },
+		"openai-responses": { provider: "openai", model: "gpt-5-mini" },
+	}[fixture.api];
+
+	return {
+		id: metadata.model,
+		name: `Raw fixture ${fixture.api}`,
+		api: fixture.api,
+		provider: metadata.provider,
+		baseUrl: HERMETIC_BASE_URL,
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	};
+}

--- a/packages/ai/test/provider-response-handoff-fixtures.ts
+++ b/packages/ai/test/provider-response-handoff-fixtures.ts
@@ -1,0 +1,161 @@
+import { readFileSync } from "node:fs";
+import Type, { type Static } from "typebox";
+import Schema from "typebox/schema";
+import type { HandoffApi } from "./provider-handoff-fixtures.js";
+
+const handoffApiSchema = Type.Union([
+	Type.Literal("anthropic-messages"),
+	Type.Literal("azure-openai-responses"),
+	Type.Literal("bedrock-converse-stream"),
+	Type.Literal("google-generative-ai"),
+	Type.Literal("google-vertex"),
+	Type.Literal("mistral-conversations"),
+	Type.Literal("openai-codex-responses"),
+	Type.Literal("openai-completions"),
+	Type.Literal("openai-responses"),
+]);
+
+const nullableStringSchema = Type.Union([Type.String({ minLength: 1 }), Type.Null()]);
+const rawEventSchema = Type.Record(Type.String(), Type.Unknown());
+const sensitiveFixtureKeys = new Set(["auth", "authorization", "passwd", "token"]);
+
+const providerResponseFixtureFileSchema = Type.Object(
+	{
+		schemaVersion: Type.Literal(1),
+		responses: Type.Array(
+			Type.Object(
+				{
+					id: Type.String({ minLength: 1 }),
+					api: handoffApiSchema,
+					transport: Type.Union([
+						Type.Literal("anthropic-sse"),
+						Type.Literal("codex-sse"),
+						Type.Literal("google-events"),
+						Type.Literal("mistral-events"),
+						Type.Literal("openai-chunks"),
+						Type.Literal("openai-events"),
+						Type.Literal("smithy-events"),
+					]),
+					success: Type.Array(rawEventSchema, { minItems: 1 }),
+					error: Type.Array(rawEventSchema, { minItems: 1 }),
+					expected: Type.Object(
+						{
+							thinkingText: Type.String({ minLength: 1 }),
+							thinkingSignatureMarker: nullableStringSchema,
+							toolThoughtSignatureMarker: nullableStringSchema,
+							toolCallId: Type.String({ minLength: 1 }),
+							errorMarker: Type.String({ minLength: 1 }),
+						},
+						{ additionalProperties: false },
+					),
+				},
+				{ additionalProperties: false },
+			),
+			{ minItems: 1 },
+		),
+	},
+	{ additionalProperties: false },
+);
+
+const providerResponseFixtureFileValidator = Schema.Compile(providerResponseFixtureFileSchema);
+
+export type ProviderResponseFixtureFile = Static<typeof providerResponseFixtureFileSchema>;
+export type ProviderResponseFixture = ProviderResponseFixtureFile["responses"][number];
+
+export function parseProviderResponseFixtureFile(serialized: string): ProviderResponseFixtureFile {
+	const parsed: unknown = JSON.parse(serialized);
+	if (!providerResponseFixtureFileValidator.Check(parsed)) {
+		throw new Error(
+			`Provider response fixture failed schema validation: ${JSON.stringify(providerResponseFixtureFileValidator.Errors(parsed))}`,
+		);
+	}
+
+	const ids = new Set<string>();
+	const apis = new Set<HandoffApi>();
+	for (const fixture of parsed.responses) {
+		if (ids.has(fixture.id)) throw new Error(`Duplicate provider response fixture id: ${fixture.id}`);
+		if (apis.has(fixture.api)) throw new Error(`Duplicate provider response fixture api: ${fixture.api}`);
+		ids.add(fixture.id);
+		apis.add(fixture.api);
+	}
+	validateFixtureSanitization(parsed);
+	return parsed;
+}
+
+export function assertProviderResponseFixtureApiCompleteness(
+	file: ProviderResponseFixtureFile,
+	registeredApis: readonly string[],
+): void {
+	const fixtureApis = file.responses.map((fixture) => fixture.api).sort();
+	const expectedApis = [...registeredApis].sort();
+	if (
+		fixtureApis.length !== new Set(fixtureApis).size ||
+		expectedApis.length !== new Set(expectedApis).size ||
+		JSON.stringify(fixtureApis) !== JSON.stringify(expectedApis)
+	) {
+		throw new Error(
+			`Provider response fixture completeness failure: fixtures=${JSON.stringify(fixtureApis)}, registered=${JSON.stringify(expectedApis)}`,
+		);
+	}
+}
+
+export function loadProviderResponseFixtureFile(): ProviderResponseFixtureFile {
+	const fixtureUrl = new URL("./fixtures/provider-handoffs/v1/responses.json", import.meta.url);
+	return parseProviderResponseFixtureFile(readFileSync(fixtureUrl, "utf8"));
+}
+
+function validateFixtureSanitization(file: ProviderResponseFixtureFile): void {
+	for (const fixture of file.responses) {
+		const allowedToolIds = new Set(fixture.expected.toolCallId.split("|"));
+		visitFixture([fixture.success, fixture.error], (key, value) => {
+			const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+			if (isSensitiveFixtureKey(normalizedKey)) {
+				throw new Error(`Provider response fixture sanitization rejected auth field: ${key}`);
+			}
+			if (
+				isProviderIdentifierKey(normalizedKey) &&
+				typeof value === "string" &&
+				!allowedToolIds.has(value) &&
+				!isFixtureMarkedIdentifier(value)
+			) {
+				throw new Error(`Provider response fixture sanitization rejected provider ID: ${value}`);
+			}
+			if (
+				typeof value === "string" &&
+				/(?:\bbearer\s+[a-z0-9._-]{8,}|\bsk-[a-z0-9_-]{8,}|\bAIza[a-z0-9_-]{20,}|\bAKIA[A-Z0-9]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|\beyJ[a-z0-9_-]{10,}\.[a-z0-9_-]{10,}\.[a-z0-9_-]{10,})/i.test(
+					value,
+				)
+			) {
+				throw new Error("Provider response fixture sanitization rejected credential-like content");
+			}
+		});
+	}
+}
+
+function isSensitiveFixtureKey(normalizedKey: string): boolean {
+	return (
+		sensitiveFixtureKeys.has(normalizedKey) ||
+		/(?:apikey|credential|credentials|password|privatekey|secret|secretaccesskey|secretkey)$/.test(normalizedKey) ||
+		/(?:access|api|auth|csrf|id|refresh|session)token$/.test(normalizedKey)
+	);
+}
+
+function isProviderIdentifierKey(normalizedKey: string): boolean {
+	return normalizedKey.endsWith("id");
+}
+
+function isFixtureMarkedIdentifier(value: string): boolean {
+	return /^[a-z0-9_-]+$/i.test(value) && /(?:^|[_-])fixture(?:[_-]|$)/i.test(value);
+}
+
+function visitFixture(value: unknown, callback: (key: string, value: unknown) => void): void {
+	if (Array.isArray(value)) {
+		for (const item of value) visitFixture(item, callback);
+		return;
+	}
+	if (typeof value !== "object" || value === null) return;
+	for (const [key, child] of Object.entries(value)) {
+		callback(key, child);
+		visitFixture(child, callback);
+	}
+}


### PR DESCRIPTION
## Summary

- Added schema-versioned, sanitized provider-shaped response fixtures for all nine registered built-in APIs.
- Replayed success and error fixtures through the production source parsers using deterministic fake SDK transports.
- Added self-contained model snapshots for 184 distinct effective target-payload families, with stable API/provider completeness gates and an explicit live-catalog audit path.
- Added a 33,858-case source/target handoff matrix covering native tool IDs, thinking text and signatures, tool thought signatures, distinct user/tool-result images, tool errors, and failed-provider-history filtering.

## Design

The raw-response fixtures prove parsing and serialization rather than constructing normalized `AssistantMessage` values directly. The target matrix then converts normalized history through every snapshotted provider/model payload shape.

Family fixtures contain the model metadata that drives adapter behavior, so routine hermetic tests do not depend on the regenerated model catalog. Exhaustive typed `KnownApi` and `KnownProvider` definitions, registered APIs, and fixture sets gate completeness. `AUDIT_PROVIDER_HANDOFF_CATALOG=1` compares canonical payload fingerprints with the live catalog, while `UPDATE_PROVIDER_HANDOFF_FAMILIES=1` explicitly refreshes the manifest.

The matrix asserts provider-native tool ID constraints, source/target signature preservation rules, image preservation or explicit omission, and removal of provider error text and partial failed output from subsequent requests. A registered-API gate requires exactly one raw parser fixture for each built-in API.

## Hermeticity

- No credentials, network calls, DNS, or paid provider requests are used.
- Anthropic, Bedrock/Smithy, Google/Vertex, Mistral, OpenAI/Azure, fetch, and Codex SSE transports are trapped or replaced with deterministic fixtures.
- Raw fixtures reject credential-bearing keys and values plus non-synthetic provider identifiers.
- The existing optional live cross-provider canary remains separate and unchanged.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/provider-handoff-family-completeness.test.ts` — 5 passed
- `AUDIT_PROVIDER_HANDOFF_CATALOG=1 npx tsx ../../node_modules/vitest/dist/cli.js --run test/provider-handoff-family-completeness.test.ts` — 5 passed
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/provider-response-handoff-fixtures.test.ts` — 21 passed
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/cross-provider-handoff-hermetic.test.ts` — 33,858 passed
- `npm run check`

Fixes #947


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hermetic cross-provider handoff contract tests for AI provider streaming
> - Adds a hermetic test suite in [cross-provider-handoff-hermetic.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1010/files#diff-f44d541852d9d440a7fb08c21c0c718478f246df84622bc1863f4ec5e392d010) that streams Cartesian pairs of source/target provider families and validates payload structure (tool IDs, names, error flags, image handling, reasoning signatures) without hitting real network transports.
> - Adds [provider-handoff-family-completeness.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1010/files#diff-5f866ab1f97a31ee5fc30b62cb45eb941ed1d6acf615e717637bae2fdab9ff8c) to verify deterministic serialization of the family manifest and behavior fingerprint consistency across providers.
> - Adds [provider-response-handoff-fixtures.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1010/files#diff-af5b87b2a3cf4e5eaa69598b67d39d7660140a436b1ff0347149306800c101f1) to replay raw provider response fixtures and validate parser output including thinking content, tool calls, and error handling.
> - Introduces versioned fixture files ([families.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/1010/files#diff-b9fd31c4397b293bf1bb3232fd78fd2f68dcc994dcf57e2b3ed20b08f83af704), [fixtures.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/1010/files#diff-d401adadf904979a649caefd7b0b0a59ba111f3f29dd3591c9e9823d79445591), [responses.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/1010/files#diff-c2ce501bc33f8bfc90266e11d3408e0c964a81a73afa917ea6de320223e9275a)) covering Anthropic, Bedrock, Azure OpenAI, Google, Mistral, and OpenAI.
> - Adds [provider-handoff-target-transport.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1010/files#diff-3bbb356fce678912b0013ca2bfbb62eef04dd49d76233c51fcfe2ca2dc7dddfc) which mocks all provider SDKs to throw and record any attempted real transport calls during hermetic tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff9b2ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->