### PR TITLE
fix(coding-agent): allow Luna children on empty Codex catalogs

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -978,9 +978,16 @@ export class ModelRegistry {
 			return availableModels.filter((model) => model.provider !== "openai-codex");
 		}
 		const authFingerprint = createHash("sha256").update(auth.apiKey).digest("hex");
+		// An empty successful catalog can be caused by the backend's client-version
+		// gate and does not prove that an authenticated account has no models. Keep
+		// local Codex models executable and let the actual request be authoritative.
+		const filterByCatalog = (ids: Set<string>): Model<Api>[] =>
+			ids.size === 0
+				? availableModels
+				: availableModels.filter((model) => model.provider !== "openai-codex" || ids.has(model.id));
 		const cached = this.openAICodexModelsCache;
 		if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-			return availableModels.filter((model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id));
+			return filterByCatalog(cached.modelIds);
 		}
 
 		const accountId = readOpenAICodexAccountId(auth.apiKey);
@@ -1002,12 +1009,10 @@ export class ModelRegistry {
 			}
 			const modelIds = readOpenAICodexModelIds(await response.json());
 			this.openAICodexModelsCache = { authFingerprint, modelIds, refreshedAt: Date.now() };
-			return availableModels.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
+			return filterByCatalog(modelIds);
 		} catch {
 			if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-				return availableModels.filter(
-					(model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id),
-				);
+				return filterByCatalog(cached.modelIds);
 			}
 			return availableModels.filter((model) => model.provider !== "openai-codex");
 		}

--- a/packages/coding-agent/test/suite/regressions/1011-luna-subagent-selector.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1011-luna-subagent-selector.test.ts
@@ -1,0 +1,56 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { VERSION } from "../../../src/config.js";
+import { createHarness } from "../harness.js";
+
+function openAICodexToken(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+describe("#1011 Luna subagent selection", () => {
+	it("discovers and runs Luna from a Sol parent with Codex subscription auth", async () => {
+		vi.stubEnv("RLM_DEPTH", "0");
+		vi.stubEnv("RLM_MAX_DEPTH", "1");
+		const provider = "openai-codex";
+		const harness = await createHarness({
+			provider,
+			models: [
+				{ id: "gpt-5.6-sol", reasoning: true },
+				{ id: "gpt-5.6-luna", reasoning: true },
+			],
+		});
+		const fetchModels = vi.fn(async (input: string | URL | Request) => {
+			const requestUrl = new URL(input instanceof Request ? input.url : input.toString());
+			expect(requestUrl.searchParams.get("client_version")).toBe(VERSION);
+			return new Response(JSON.stringify({ models: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchModels);
+		try {
+			expect(harness.session.model?.id).toBe("gpt-5.6-sol");
+			harness.authStorage.setRuntimeApiKey(provider, openAICodexToken("account-1"));
+			await expect(harness.session.findRlmModels("luna", 8)).resolves.toMatchObject({
+				models: [{ selector: "openai-codex/gpt-5.6-luna" }],
+			});
+
+			harness.setResponses([fauxAssistantMessage("Luna child completed")]);
+			await expect(
+				harness.session.runRlmChild("Run on Luna", { model: "openai-codex/gpt-5.6-luna" }),
+			).resolves.toMatchObject({ model: "openai-codex/gpt-5.6-luna" });
+			await vi.waitFor(async () => {
+				const child = (await harness.session.listRlmSubagents()).subagents[0];
+				expect(harness.session.getRlmChildSession(child!.rlm_child_id)?.model?.id).toBe("gpt-5.6-luna");
+			});
+			expect(fetchModels).toHaveBeenCalledOnce();
+		} finally {
+			vi.unstubAllGlobals();
+			vi.unstubAllEnvs();
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Allow a Sol parent to discover and explicitly spawn a GPT-5.6 Luna RLM child without pinning Prime Agent to an unrelated Codex CLI version.

The `/codex/models` endpoint currently returns an empty successful catalog when Prime Agent sends its own `client_version`. An empty catalog is not proof that the authenticated account has no usable models: direct Luna requests work with the same credentials.

This change:

- treats an empty successful Codex catalog as inconclusive and keeps locally known Codex models executable;
- keeps non-empty account catalogs authoritative, preserving their filtering;
- keeps authentication preflight unchanged;
- adds an end-to-end regression proving a Sol parent discovers, admits, and retains a Luna child when discovery returns an empty catalog.

Fixes #1011. This overlaps the empty-catalog policy in #696/#717 but adds the exact Sol-to-Luna RLM regression.

## Verification

- Focused tests: 13/13 passed
- `npm run check`: passed
- Real patched-source run against the live service:
  - Sol parent
  - `rlm.find_models("luna")` returned `openai-codex/gpt-5.6-luna`
  - spawn handle reported `openai-codex/gpt-5.6-luna`
  - real child returned `NO_PIN_LUNA_OK`

Please merge this fix (or fold its Sol-to-Luna regression into #717) so explicit Luna children work without maintaining a hard-coded external CLI version.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Luna child model discovery when Codex model catalog returns empty
> - In [`model-registry.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1012/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453), introduces a `filterByCatalog` helper that treats an empty catalog as non-authoritative, leaving all local openai-codex models available instead of filtering them all out.
> - Previously, an empty catalog response (e.g. due to a backend gate) would cause all models to be filtered, breaking Luna subagent discovery.
> - Adds a regression test in [`1011-luna-subagent-selector.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1012/files#diff-79289e73948c6f6fa67cbe21af83b508f8817af73ea140b692ef8c2ed2c2ad78) that stubs an empty catalog fetch and asserts Luna is discoverable and executes successfully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b72703c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->