### PR TITLE
fix(ai): declare Smithy dependencies used by Bedrock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5330,6 +5330,7 @@
 			"devDependencies": {
 				"@types/node": "^24.3.0",
 				"canvas": "^3.2.0",
+				"esbuild": "^0.28.1",
 				"vitest": "^4.1.9"
 			},
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5312,6 +5312,8 @@
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
 				"@aws-sdk/client-bedrock-runtime": "^3.1083.0",
+				"@smithy/node-http-handler": "^4.9.4",
+				"@smithy/types": "^4.16.0",
 				"@google/genai": "^1.40.0",
 				"@mistralai/mistralai": "^2.2.0",
 				"chalk": "^5.6.2",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed Bedrock proxy and forced-HTTP/1 transports to resolve their declared Smithy dependencies from isolated package installations ([#948](https://github.com/PrimeIntellect-ai/prime-agent/issues/948)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -74,6 +74,8 @@
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.91.1",
 		"@aws-sdk/client-bedrock-runtime": "^3.1083.0",
+		"@smithy/node-http-handler": "^4.9.4",
+		"@smithy/types": "^4.16.0",
 		"@google/genai": "^1.40.0",
 		"@mistralai/mistralai": "^2.2.0",
 		"typebox": "^1.1.24",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -109,6 +109,7 @@
 	"devDependencies": {
 		"@types/node": "^24.3.0",
 		"canvas": "^3.2.0",
+		"esbuild": "^0.28.1",
 		"vitest": "^4.1.9"
 	}
 }

--- a/packages/ai/src/providers/amazon-bedrock-node-transport.ts
+++ b/packages/ai/src/providers/amazon-bedrock-node-transport.ts
@@ -1,0 +1,27 @@
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { ProxyAgent } from "proxy-agent";
+
+const BEDROCK_PROXY_ENV_KEYS = [
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+] as const;
+
+export function createBedrockNodeRequestHandler(env: NodeJS.ProcessEnv): NodeHttpHandler | undefined {
+	if (BEDROCK_PROXY_ENV_KEYS.some((key) => env[key])) {
+		const agent = new ProxyAgent();
+		return new NodeHttpHandler({
+			httpAgent: agent,
+			httpsAgent: agent,
+		});
+	}
+
+	if (env.AWS_BEDROCK_FORCE_HTTP1 === "1") {
+		return new NodeHttpHandler();
+	}
+
+	return undefined;
+}

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -44,6 +44,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { recordStreamFailure, streamFailureFromStopReason } from "../utils/stream-failure.js";
+import { createBedrockNodeRequestHandler } from "./amazon-bedrock-node-transport.js";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -157,30 +158,9 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				};
 			}
 
-			if (
-				process.env.HTTP_PROXY ||
-				process.env.HTTPS_PROXY ||
-				process.env.NO_PROXY ||
-				process.env.http_proxy ||
-				process.env.https_proxy ||
-				process.env.no_proxy
-			) {
-				const nodeHttpHandler = await import("@smithy/node-http-handler");
-				const proxyAgent = await import("proxy-agent");
-
-				const agent = new proxyAgent.ProxyAgent();
-
-				// Bedrock runtime uses NodeHttp2Handler by default since v3.798.0, which is based
-				// on `http2` module and has no support for http agent.
-				// Use NodeHttpHandler to support http agent.
-				config.requestHandler = new nodeHttpHandler.NodeHttpHandler({
-					httpAgent: agent,
-					httpsAgent: agent,
-				});
-			} else if (process.env.AWS_BEDROCK_FORCE_HTTP1 === "1") {
-				// Some custom endpoints require HTTP/1.1 instead of HTTP/2
-				const nodeHttpHandler = await import("@smithy/node-http-handler");
-				config.requestHandler = new nodeHttpHandler.NodeHttpHandler();
+			const requestHandler = createBedrockNodeRequestHandler(process.env);
+			if (requestHandler) {
+				config.requestHandler = requestHandler;
 			}
 		} else {
 			// Non-Node environment (browser): fall back to us-east-1 since

--- a/packages/ai/test/bedrock-node-transport.test.ts
+++ b/packages/ai/test/bedrock-node-transport.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const transportMock = vi.hoisted(() => ({
+	clientConfigs: [] as Array<Record<string, unknown>>,
+	handlerOptions: [] as unknown[],
+	proxyAgents: [] as object[],
+}));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeServiceException extends Error {}
+
+	class BedrockRuntimeClient {
+		constructor(config: Record<string, unknown>) {
+			transportMock.clientConfigs.push(config);
+		}
+
+		send(): Promise<never> {
+			return Promise.reject(new Error("mock send"));
+		}
+	}
+
+	class ConverseStreamCommand {}
+
+	return {
+		BedrockRuntimeClient,
+		BedrockRuntimeServiceException,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+});
+
+vi.mock("@smithy/node-http-handler", () => ({
+	NodeHttpHandler: class {
+		constructor(options?: unknown) {
+			transportMock.handlerOptions.push(options);
+		}
+	},
+}));
+
+vi.mock("proxy-agent", () => ({
+	ProxyAgent: class {
+		constructor() {
+			transportMock.proxyAgents.push(this);
+		}
+	},
+}));
+
+import { streamBedrock } from "../src/providers/amazon-bedrock.js";
+import type { Context, Model } from "../src/types.js";
+
+const ENV_KEYS = [
+	"AWS_BEDROCK_FORCE_HTTP1",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+] as const;
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+};
+const model: Model<"bedrock-converse-stream"> = {
+	id: "test-model",
+	name: "Test model",
+	api: "bedrock-converse-stream",
+	provider: "amazon-bedrock",
+	baseUrl: "https://bedrock.example.test",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 4096,
+	maxTokens: 128,
+};
+
+beforeEach(() => {
+	transportMock.clientConfigs.length = 0;
+	transportMock.handlerOptions.length = 0;
+	transportMock.proxyAgents.length = 0;
+	for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+	for (const key of ENV_KEYS) {
+		const value = originalEnv[key];
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+async function captureClientConfig(): Promise<Record<string, unknown>> {
+	await streamBedrock(model, context, { region: "us-east-1" }).result();
+	expect(transportMock.clientConfigs).toHaveLength(1);
+	return transportMock.clientConfigs[0];
+}
+
+describe("Bedrock Node transport selection", () => {
+	it("uses a statically imported Node HTTP/1 handler when forced", async () => {
+		process.env.AWS_BEDROCK_FORCE_HTTP1 = "1";
+
+		const config = await captureClientConfig();
+
+		expect(transportMock.handlerOptions).toEqual([undefined]);
+		expect(transportMock.proxyAgents).toHaveLength(0);
+		expect(config.requestHandler).toBeDefined();
+	});
+
+	it("configures the Node HTTP/1 handler with one proxy agent for both protocols", async () => {
+		process.env.HTTPS_PROXY = "http://proxy.example.test:8080";
+		process.env.AWS_BEDROCK_FORCE_HTTP1 = "1";
+
+		const config = await captureClientConfig();
+
+		expect(transportMock.proxyAgents).toHaveLength(1);
+		expect(transportMock.handlerOptions).toEqual([
+			{
+				httpAgent: transportMock.proxyAgents[0],
+				httpsAgent: transportMock.proxyAgents[0],
+			},
+		]);
+		expect(config.requestHandler).toBeDefined();
+	});
+
+	it("leaves the SDK default transport unchanged without proxy or force configuration", async () => {
+		const config = await captureClientConfig();
+
+		expect(transportMock.handlerOptions).toHaveLength(0);
+		expect(transportMock.proxyAgents).toHaveLength(0);
+		expect(config.requestHandler).toBeUndefined();
+	});
+});

--- a/packages/ai/test/bedrock-package-contract.test.ts
+++ b/packages/ai/test/bedrock-package-contract.test.ts
@@ -1,0 +1,148 @@
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(packageRoot, "../..");
+const packageJson = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as {
+	name: string;
+	dependencies: Record<string, string>;
+};
+
+function run(command: string, args: string[], cwd: string): string {
+	const result = spawnSync(command, args, {
+		cwd,
+		encoding: "utf8",
+		env: { ...process.env, npm_config_audit: "false", npm_config_fund: "false" },
+	});
+
+	if (result.status !== 0) {
+		throw new Error(
+			`${command} ${args.join(" ")} failed with exit ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+		);
+	}
+
+	return result.stdout.trim();
+}
+
+function linkPackage(source: string, target: string): void {
+	mkdirSync(dirname(target), { recursive: true });
+	symlinkSync(source, target, "junction");
+}
+
+describe("Bedrock package contract", () => {
+	it("packs with owned Smithy dependencies and resolves declarations and Node transport paths in isolation", () => {
+		expect(packageJson.dependencies["@smithy/types"]).toBe("^4.16.0");
+		expect(packageJson.dependencies["@smithy/node-http-handler"]).toBe("^4.9.4");
+
+		const tempRoot = mkdtempSync(join(tmpdir(), "pi-ai-bedrock-package-"));
+		try {
+			const stagingDir = join(tempRoot, "staging");
+			const artifactDir = join(tempRoot, "artifacts");
+			const unpackDir = join(tempRoot, "unpack");
+			const consumerDir = join(tempRoot, "consumer");
+			const installedPackageDir = join(consumerDir, "node_modules", ...packageJson.name.split("/"));
+			mkdirSync(stagingDir, { recursive: true });
+			mkdirSync(artifactDir, { recursive: true });
+			mkdirSync(unpackDir, { recursive: true });
+			mkdirSync(consumerDir, { recursive: true });
+
+			cpSync(join(packageRoot, "package.json"), join(stagingDir, "package.json"));
+			cpSync(join(packageRoot, "README.md"), join(stagingDir, "README.md"));
+			run(
+				resolve(repositoryRoot, "node_modules/.bin/tsgo"),
+				[
+					"-p",
+					join(packageRoot, "tsconfig.build.json"),
+					"--outDir",
+					join(stagingDir, "dist"),
+					"--declarationMap",
+					"false",
+				],
+				packageRoot,
+			);
+			const tarballName = run(
+				"npm",
+				["pack", stagingDir, "--ignore-scripts", "--silent", "--pack-destination", artifactDir],
+				repositoryRoot,
+			)
+				.split(/\r?\n/)
+				.at(-1);
+			expect(tarballName).toBeTruthy();
+			run("tar", ["-xzf", join(artifactDir, tarballName!), "-C", unpackDir], repositoryRoot);
+			const packedPackageJson = JSON.parse(readFileSync(join(unpackDir, "package/package.json"), "utf8")) as {
+				dependencies: Record<string, string>;
+			};
+			expect(packedPackageJson.dependencies["@smithy/types"]).toBe("^4.16.0");
+			expect(packedPackageJson.dependencies["@smithy/node-http-handler"]).toBe("^4.9.4");
+			cpSync(join(unpackDir, "package"), installedPackageDir, { recursive: true });
+
+			for (const dependency of Object.keys(packageJson.dependencies)) {
+				linkPackage(
+					join(repositoryRoot, "node_modules", ...dependency.split("/")),
+					join(consumerDir, "node_modules", ...dependency.split("/")),
+				);
+			}
+			linkPackage(join(repositoryRoot, "node_modules/@types/node"), join(consumerDir, "node_modules/@types/node"));
+
+			writeFileSync(
+				join(consumerDir, "type-consumer.ts"),
+				`import type { BedrockOptions, BedrockThinkingDisplay } from ${JSON.stringify(packageJson.name)};\n` +
+					`const display: BedrockThinkingDisplay = "summarized";\n` +
+					`const options: BedrockOptions = { region: "us-east-1", thinkingDisplay: display };\n` +
+					`void options;\n`,
+			);
+			writeFileSync(
+				join(consumerDir, "tsconfig.json"),
+				`${JSON.stringify(
+					{
+						compilerOptions: {
+							lib: ["ES2022", "DOM"],
+							module: "NodeNext",
+							moduleResolution: "NodeNext",
+							noEmit: true,
+							preserveSymlinks: true,
+							skipLibCheck: true,
+							strict: true,
+							target: "ES2022",
+							types: ["node"],
+						},
+						include: ["type-consumer.ts"],
+					},
+					null,
+					2,
+				)}\n`,
+			);
+			run(resolve(repositoryRoot, "node_modules/.bin/tsgo"), ["-p", "tsconfig.json"], consumerDir);
+
+			writeFileSync(
+				join(consumerDir, "runtime-consumer.mjs"),
+				`const { bedrockProviderModule } = await import(${JSON.stringify(`${packageJson.name}/bedrock-provider`)});\n` +
+					`if (typeof bedrockProviderModule.streamBedrock !== "function") throw new Error("Bedrock provider did not resolve");\n`,
+			);
+			run(process.execPath, ["runtime-consumer.mjs"], consumerDir);
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	}, 30_000);
+
+	it("keeps the Node Bedrock transport outside the browser root bundle", async () => {
+		const result = await build({
+			bundle: true,
+			entryPoints: [join(packageRoot, "src/index.ts")],
+			format: "esm",
+			metafile: true,
+			platform: "browser",
+			write: false,
+		});
+		const inputs = Object.keys(result.metafile.inputs);
+
+		expect(inputs.some((input) => input.includes("amazon-bedrock-node"))).toBe(false);
+		expect(inputs.some((input) => input.includes("@smithy/node-http-handler"))).toBe(false);
+		expect(inputs.some((input) => input.includes("proxy-agent"))).toBe(false);
+	});
+});

--- a/packages/ai/test/bedrock-package-contract.test.ts
+++ b/packages/ai/test/bedrock-package-contract.test.ts
@@ -1,23 +1,36 @@
 import { spawnSync } from "node:child_process";
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { describe, expect, it } from "vitest";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(packageRoot, "../..");
+const installedRepositoryRoot = dirname(realpathSync(join(repositoryRoot, "node_modules")));
 const packageJson = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as {
 	name: string;
 	dependencies: Record<string, string>;
 };
 
-function run(command: string, args: string[], cwd: string): string {
+function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv = {}): string {
 	const result = spawnSync(command, args, {
 		cwd,
 		encoding: "utf8",
-		env: { ...process.env, npm_config_audit: "false", npm_config_fund: "false" },
+		env: { ...process.env, npm_config_audit: "false", npm_config_fund: "false", ...env },
 	});
 
 	if (result.status !== 0) {
@@ -29,9 +42,93 @@ function run(command: string, args: string[], cwd: string): string {
 	return result.stdout.trim();
 }
 
-function linkPackage(source: string, target: string): void {
-	mkdirSync(dirname(target), { recursive: true });
-	symlinkSync(source, target, "junction");
+function stagePackageFiles(source: string, target: string): void {
+	mkdirSync(target, { recursive: true });
+	for (const entry of readdirSync(source, { withFileTypes: true })) {
+		if (entry.name === "node_modules") continue;
+		const entrySource = join(source, entry.name);
+		const entryTarget = join(target, entry.name);
+		symlinkSync(entrySource, entryTarget, statSync(entrySource).isDirectory() ? "junction" : "file");
+	}
+}
+
+function readPackageVersion(packagePath: string): string {
+	const manifest = JSON.parse(readFileSync(packagePath, "utf8")) as { version?: unknown };
+	if (typeof manifest.version !== "string") throw new Error(`Missing package version in ${packagePath}`);
+	return manifest.version;
+}
+
+interface InstalledPackageManifest {
+	dependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+	peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
+function resolveInstalledPackage(name: string, issuer: string): string | undefined {
+	let current = issuer;
+	let relativeToInstallRoot = relative(installedRepositoryRoot, current);
+	while (
+		relativeToInstallRoot === "" ||
+		(!relativeToInstallRoot.startsWith("..") && !isAbsolute(relativeToInstallRoot))
+	) {
+		const candidate = join(current, "node_modules", ...name.split("/"));
+		if (existsSync(join(candidate, "package.json"))) return realpathSync(candidate);
+		const parent = dirname(current);
+		if (parent === current) break;
+		current = parent;
+		relativeToInstallRoot = relative(installedRepositoryRoot, current);
+	}
+	return undefined;
+}
+
+function stageDeclaredDependencyClosure(rootNames: string[], targetRoot: string): Map<string, string[]> {
+	const targetsBySource = new Map<string, string[]>();
+
+	const stageDependency = (
+		name: string,
+		issuer: string,
+		targetNodeModules: string,
+		ancestorSources: ReadonlyMap<string, string>,
+		optional: boolean,
+	): void => {
+		const source = resolveInstalledPackage(name, issuer);
+		if (!source) {
+			if (optional) return;
+			throw new Error(`Installed dependency ${name} was not found from ${issuer}`);
+		}
+		if (ancestorSources.get(name) === source) return;
+
+		const target = join(targetNodeModules, ...name.split("/"));
+		if (existsSync(target)) return;
+		stagePackageFiles(source, target);
+		const targets = targetsBySource.get(source) ?? [];
+		targets.push(target);
+		targetsBySource.set(source, targets);
+
+		const manifest = JSON.parse(readFileSync(join(source, "package.json"), "utf8")) as InstalledPackageManifest;
+		const childDependencies = new Map<string, boolean>();
+		for (const childName of Object.keys(manifest.dependencies ?? {})) childDependencies.set(childName, false);
+		for (const childName of Object.keys(manifest.optionalDependencies ?? {})) {
+			if (!childDependencies.has(childName)) childDependencies.set(childName, true);
+		}
+		for (const childName of Object.keys(manifest.peerDependencies ?? {})) {
+			if (!childDependencies.has(childName)) {
+				childDependencies.set(childName, manifest.peerDependenciesMeta?.[childName]?.optional === true);
+			}
+		}
+
+		const childAncestors = new Map(ancestorSources);
+		childAncestors.set(name, source);
+		for (const [childName, childOptional] of childDependencies) {
+			stageDependency(childName, source, join(target, "node_modules"), childAncestors, childOptional);
+		}
+	};
+
+	for (const name of rootNames) {
+		stageDependency(name, installedRepositoryRoot, targetRoot, new Map(), false);
+	}
+	return targetsBySource;
 }
 
 describe("Bedrock package contract", () => {
@@ -43,11 +140,13 @@ describe("Bedrock package contract", () => {
 		try {
 			const stagingDir = join(tempRoot, "staging");
 			const artifactDir = join(tempRoot, "artifacts");
+			const npmCacheDir = join(tempRoot, "npm-cache");
 			const unpackDir = join(tempRoot, "unpack");
 			const consumerDir = join(tempRoot, "consumer");
 			const installedPackageDir = join(consumerDir, "node_modules", ...packageJson.name.split("/"));
 			mkdirSync(stagingDir, { recursive: true });
 			mkdirSync(artifactDir, { recursive: true });
+			mkdirSync(npmCacheDir, { recursive: true });
 			mkdirSync(unpackDir, { recursive: true });
 			mkdirSync(consumerDir, { recursive: true });
 
@@ -69,6 +168,7 @@ describe("Bedrock package contract", () => {
 				"npm",
 				["pack", stagingDir, "--ignore-scripts", "--silent", "--pack-destination", artifactDir],
 				repositoryRoot,
+				{ npm_config_cache: npmCacheDir },
 			)
 				.split(/\r?\n/)
 				.at(-1);
@@ -81,23 +181,32 @@ describe("Bedrock package contract", () => {
 			expect(packedPackageJson.dependencies["@smithy/node-http-handler"]).toBe("^4.9.4");
 			cpSync(join(unpackDir, "package"), installedPackageDir, { recursive: true });
 
-			for (const dependency of Object.keys(packageJson.dependencies)) {
-				linkPackage(
-					join(repositoryRoot, "node_modules", ...dependency.split("/")),
-					join(consumerDir, "node_modules", ...dependency.split("/")),
-				);
-			}
-			linkPackage(join(repositoryRoot, "node_modules/@types/node"), join(consumerDir, "node_modules/@types/node"));
+			const stagedTargets = stageDeclaredDependencyClosure(
+				[...Object.keys(packedPackageJson.dependencies), "@types/node"],
+				join(consumerDir, "node_modules"),
+			);
+			const nodeFetchSource = resolveInstalledPackage("node-fetch", installedRepositoryRoot);
+			const getUriSource = resolveInstalledPackage("get-uri", installedRepositoryRoot);
+			expect(nodeFetchSource).toBeDefined();
+			expect(getUriSource).toBeDefined();
+			const nodeFetchTarget = stagedTargets.get(nodeFetchSource!)?.[0];
+			const getUriTarget = stagedTargets.get(getUriSource!)?.[0];
+			expect(nodeFetchTarget).toBeDefined();
+			expect(getUriTarget).toBeDefined();
+			expect(readPackageVersion(join(nodeFetchTarget!, "node_modules/data-uri-to-buffer/package.json"))).toBe(
+				"4.0.1",
+			);
+			expect(readPackageVersion(join(getUriTarget!, "node_modules/data-uri-to-buffer/package.json"))).toBe("6.0.2");
 
 			writeFileSync(
-				join(consumerDir, "type-consumer.ts"),
+				join(consumerDir, "public-type-consumer.ts"),
 				`import type { BedrockOptions, BedrockThinkingDisplay } from ${JSON.stringify(packageJson.name)};\n` +
 					`const display: BedrockThinkingDisplay = "summarized";\n` +
 					`const options: BedrockOptions = { region: "us-east-1", thinkingDisplay: display };\n` +
 					`void options;\n`,
 			);
 			writeFileSync(
-				join(consumerDir, "tsconfig.json"),
+				join(consumerDir, "tsconfig.public.json"),
 				`${JSON.stringify(
 					{
 						compilerOptions: {
@@ -106,25 +215,63 @@ describe("Bedrock package contract", () => {
 							moduleResolution: "NodeNext",
 							noEmit: true,
 							preserveSymlinks: true,
+							// The root barrel exposes unrelated Anthropic and Google declarations whose
+							// optional multi-layout imports are not strict-clean in this isolated fixture.
 							skipLibCheck: true,
 							strict: true,
 							target: "ES2022",
 							types: ["node"],
 						},
-						include: ["type-consumer.ts"],
+						include: ["public-type-consumer.ts"],
 					},
 					null,
 					2,
 				)}\n`,
 			);
-			run(resolve(repositoryRoot, "node_modules/.bin/tsgo"), ["-p", "tsconfig.json"], consumerDir);
+			run(resolve(repositoryRoot, "node_modules/.bin/tsc"), ["-p", "tsconfig.public.json"], consumerDir);
+
+			writeFileSync(
+				join(consumerDir, "smithy-type-consumer.ts"),
+				`import type { BedrockOptions, BedrockThinkingDisplay } from ${JSON.stringify(
+					`./node_modules/${packageJson.name}/dist/providers/amazon-bedrock.js`,
+				)};\n` +
+					`import type { createBedrockNodeRequestHandler } from ${JSON.stringify(
+						`./node_modules/${packageJson.name}/dist/providers/amazon-bedrock-node-transport.js`,
+					)};\n` +
+					`const display: BedrockThinkingDisplay = "summarized";\n` +
+					`const options: BedrockOptions = { region: "us-east-1", thinkingDisplay: display };\n` +
+					`const requestHandler: ReturnType<typeof createBedrockNodeRequestHandler> = undefined;\n` +
+					`void options;\n` +
+					`void requestHandler;\n`,
+			);
+			writeFileSync(
+				join(consumerDir, "tsconfig.smithy.json"),
+				`${JSON.stringify(
+					{
+						compilerOptions: {
+							lib: ["ES2022", "DOM"],
+							module: "NodeNext",
+							moduleResolution: "NodeNext",
+							noEmit: true,
+							preserveSymlinks: true,
+							strict: true,
+							target: "ES2022",
+							types: ["node"],
+						},
+						include: ["smithy-type-consumer.ts"],
+					},
+					null,
+					2,
+				)}\n`,
+			);
+			run(resolve(repositoryRoot, "node_modules/.bin/tsc"), ["-p", "tsconfig.smithy.json"], consumerDir);
 
 			writeFileSync(
 				join(consumerDir, "runtime-consumer.mjs"),
-				`const { bedrockProviderModule } = await import(${JSON.stringify(`${packageJson.name}/bedrock-provider`)});\n` +
+				`import { bedrockProviderModule } from ${JSON.stringify(`${packageJson.name}/bedrock-provider`)};\n` +
 					`if (typeof bedrockProviderModule.streamBedrock !== "function") throw new Error("Bedrock provider did not resolve");\n`,
 			);
-			run(process.execPath, ["runtime-consumer.mjs"], consumerDir);
+			run(process.execPath, ["--preserve-symlinks", "runtime-consumer.mjs"], consumerDir);
 		} finally {
 			rmSync(tempRoot, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

- declare `@smithy/types` and `@smithy/node-http-handler` as direct `pi-ai` dependencies using the versions already present in the lockfile
- move Bedrock proxy and forced-HTTP/1 request-handler wiring into a statically imported Node adapter
- verify isolated packed-artifact public types/runtime resolution and strict Smithy declarations while keeping the Node transport out of browser root bundles

## Root cause

The Bedrock provider consumed Smithy modules through `@aws-sdk/client-bedrock-runtime`'s transitive dependency layout. Non-hoisted installs could therefore fail to resolve the provider's public declarations or proxy/forced-HTTP1 runtime path. Those runtime branches also used prohibited inline imports.

## Impact

Bedrock proxy and `AWS_BEDROCK_FORCE_HTTP1=1` configurations now resolve dependencies owned by `pi-ai`. Browser consumers retain the existing lazy Node-provider boundary and do not bundle the Node handler, proxy agent, or Node builtins.

The packed-artifact test builds an issuer-relative tree from declared dependency closures and preserves nested versions. Its public root consumer uses `skipLibCheck` because unrelated Anthropic/Google upstream declarations are not strict-clean in that topology; a separate strict consumer checks the packed Bedrock provider and Node transport declarations without suppressing Smithy diagnostics.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/bedrock-node-transport.test.ts test/bedrock-package-contract.test.ts test/bedrock-endpoint-resolution.test.ts test/bedrock-thinking-payload.test.ts test/bedrock-models.test.ts test/lazy-module-load.test.ts` (24 passed)
- `npm run check`
- independent review: clean

Fixes #948


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Declare `@smithy/node-http-handler` and `@smithy/types` as explicit dependencies in the AI package
> - Adds `@smithy/node-http-handler` and `@smithy/types` as declared runtime dependencies in [package.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/1013/files#diff-3758ea4fd63e4789bf712baab7b4b0227fce843a17e2ed535091b9c3b83ff2df) so they resolve correctly from isolated installs rather than relying on transitive hoisting.
> - Extracts proxy and HTTP/1 transport selection into a new `createBedrockNodeRequestHandler` helper in [amazon-bedrock-node-transport.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1013/files#diff-6cc0f0cbabfb30800a7c8123cd3e3779b4687a6326f7448f4c66302979cd94f9), replacing inline dynamic import logic in the Bedrock provider.
> - Adds a contract test in [bedrock-package-contract.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1013/files#diff-395d5e0016710ad7b9211ef5245d6a87d418a534ae6fa8702819adce5103ec68) that packs the tarball, installs it in isolation, and verifies dependency resolution, type compilation, and that browser bundles exclude Node-specific transport code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a60d91a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->