### PR TITLE
Bounded, serialized tool-update delivery in the agent loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ plans/
 collect.sh
 .kernel-venv/
 .worktrees/
+.superpowers/
 
 __pycache__/
 *.pyc

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- Fixed unbounded tool-update buffering during long-running streaming tool calls by replacing the retained-promise chain with a bounded, serialized `ToolUpdateEmitter` (P3-04).
+- Fixed unbounded memory growth from streaming tool updates on long-running tool calls by capping the pending update queue and dropping the oldest queued update on overflow (P3-04).
+- Changed `tool_execution_update` events for a given tool call to always be delivered serially and in order, so a slow consumer under sustained backpressure may miss updates rather than see them out of order (P3-04).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed unbounded tool-update buffering during long-running streaming tool calls by replacing the retained-promise chain with a bounded, serialized `ToolUpdateEmitter` (P3-04).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -119,6 +119,14 @@ Tool execution mode is configurable:
 
 In parallel mode, tool completion events follow tool completion order, but persisted toolResult messages still follow assistant source order.
 
+`tool_execution_update` delivery for a single tool call is serialized and ordered: at most one sink call is in flight at a time, and delivery follows emission order. Updates from different tools running in parallel still interleave.
+
+The pending queue per tool call is bounded at 32 updates. On overflow the oldest queued update is dropped and counted; the newest always survives, so the last-known state always reaches consumers. Consumers must not assume they see every update — this matters for tools that emit incremental deltas rather than cumulative snapshots, since a delta consumer under sustained backpressure can miss chunks.
+
+All of a tool's updates are flushed before its `tool_execution_end`, including when the tool fails without being aborted. A throwing or rejecting update sink fails that tool call: the tool result becomes an error result carrying the sink's message.
+
+On abort, queued updates are discarded and nothing is awaited on them, so abort stays prompt. One already-in-flight sink call cannot be cancelled and may still settle after `tool_execution_end`.
+
 The mode can be set globally via `toolExecution` in the agent config, or per-tool via `executionMode` on `AgentTool`. If any tool call in a batch targets a tool with `executionMode: "sequential"`, the entire batch executes sequentially regardless of the global setting.
 
 The `beforeToolCall` hook runs after `tool_execution_start` and validated argument parsing. It can block execution. The `afterToolCall` hook runs after tool execution finishes and before `tool_execution_end` and final tool result message events are emitted.

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -12,6 +12,7 @@ import {
 	type ToolResultMessage,
 	validateToolArguments,
 } from "@earendil-works/pi-ai";
+import { ToolUpdateEmitter } from "./tool-update-emitter.js";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -852,48 +853,37 @@ async function executePreparedToolCall(
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 ): Promise<ExecutedToolCallOutcome> {
-	const updateEvents: Promise<void>[] = [];
-	let acceptingUpdates = true;
+	const updates = new ToolUpdateEmitter(emit);
 
 	try {
 		throwIfAborted(signal);
 		const result = await raceWithAbort(
 			prepared.tool.execute(prepared.toolCall.id, prepared.args as never, signal, (partialResult) => {
-				if (!acceptingUpdates || signal?.aborted) {
+				if (signal?.aborted) {
 					return;
 				}
-				updateEvents.push(
-					Promise.resolve(
-						emit({
-							type: "tool_execution_update",
-							toolCallId: prepared.toolCall.id,
-							toolName: prepared.toolCall.name,
-							args: prepared.toolCall.arguments,
-							partialResult,
-						}),
-					),
-				);
+				updates.push({
+					type: "tool_execution_update",
+					toolCallId: prepared.toolCall.id,
+					toolName: prepared.toolCall.name,
+					args: prepared.toolCall.arguments,
+					partialResult,
+				});
 			}),
 			signal,
 		);
-		acceptingUpdates = false;
+		updates.close();
 		try {
-			await raceWithAbort(
-				Promise.all(updateEvents).then(() => undefined),
-				signal,
-			);
+			await raceWithAbort(updates.drain(), signal);
 		} catch (error) {
 			if (!signal?.aborted || !isAbortError(error)) {
 				throw error;
 			}
+			updates.abandon();
 		}
 		return { result, isError: false };
 	} catch (error) {
-		acceptingUpdates = false;
-		await raceWithAbort(
-			Promise.all(updateEvents).then(() => undefined),
-			signal,
-		).catch(() => undefined);
+		updates.abandon();
 		return {
 			result: createErrorToolResult(
 				signal?.aborted ? "Tool execution aborted" : error instanceof Error ? error.message : String(error),

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -883,7 +883,12 @@ async function executePreparedToolCall(
 		}
 		return { result, isError: false };
 	} catch (error) {
-		updates.abandon();
+		if (signal?.aborted) {
+			updates.abandon();
+		} else {
+			updates.close();
+			await raceWithAbort(updates.drain(), signal).catch(() => undefined);
+		}
 		return {
 			result: createErrorToolResult(
 				signal?.aborted ? "Tool execution aborted" : error instanceof Error ? error.message : String(error),

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -883,15 +883,18 @@ async function executePreparedToolCall(
 		}
 		return { result, isError: false };
 	} catch (error) {
-		if (signal?.aborted) {
+		const aborted = signal?.aborted === true;
+		if (aborted) {
 			updates.abandon();
 		} else {
 			updates.close();
-			await raceWithAbort(updates.drain(), signal).catch(() => undefined);
+			await raceWithAbort(updates.drain(), signal).catch(() => {
+				updates.abandon();
+			});
 		}
 		return {
 			result: createErrorToolResult(
-				signal?.aborted ? "Tool execution aborted" : error instanceof Error ? error.message : String(error),
+				aborted ? "Tool execution aborted" : error instanceof Error ? error.message : String(error),
 			),
 			isError: true,
 		};

--- a/packages/agent/src/tool-update-emitter.ts
+++ b/packages/agent/src/tool-update-emitter.ts
@@ -1,0 +1,79 @@
+import type { AgentEventSink } from "./agent-loop.js";
+import type { AgentEvent } from "./types.js";
+
+export const MAX_PENDING_TOOL_UPDATES = 32;
+
+/** Serializes tool update emission so at most one sink call is in flight and no settled promise is retained. */
+export class ToolUpdateEmitter {
+	private readonly emit: AgentEventSink;
+	private readonly maxPending: number;
+	private readonly queue: AgentEvent[] = [];
+	private tail: Promise<void> = Promise.resolve();
+	private pumping = false;
+	private closed = false;
+	private abandoned = false;
+	private failed = false;
+	private dropped = 0;
+
+	constructor(emit: AgentEventSink, maxPending: number = MAX_PENDING_TOOL_UPDATES) {
+		if (!Number.isInteger(maxPending) || maxPending < 1) {
+			throw new Error(`maxPending must be a positive integer, got ${maxPending}`);
+		}
+		this.emit = emit;
+		this.maxPending = maxPending;
+	}
+
+	get droppedUpdates(): number {
+		return this.dropped;
+	}
+
+	get pendingCount(): number {
+		return this.queue.length;
+	}
+
+	push(event: AgentEvent): void {
+		if (this.closed || this.abandoned || this.failed) {
+			return;
+		}
+		this.queue.push(event);
+		if (this.queue.length > this.maxPending) {
+			this.queue.shift();
+			this.dropped += 1;
+		}
+		if (!this.pumping) {
+			this.pumping = true;
+			this.tail = this.pump();
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+	}
+
+	abandon(): void {
+		this.closed = true;
+		this.abandoned = true;
+		this.queue.length = 0;
+	}
+
+	drain(): Promise<void> {
+		if (this.abandoned) {
+			return Promise.resolve();
+		}
+		return this.tail;
+	}
+
+	private async pump(): Promise<void> {
+		while (this.queue.length > 0) {
+			const event = this.queue.shift() as AgentEvent;
+			try {
+				await Promise.resolve(this.emit(event));
+			} catch (err) {
+				this.failed = true;
+				this.queue.length = 0;
+				throw err;
+			}
+		}
+		this.pumping = false;
+	}
+}

--- a/packages/agent/src/tool-update-emitter.ts
+++ b/packages/agent/src/tool-update-emitter.ts
@@ -13,6 +13,7 @@ export class ToolUpdateEmitter {
 	private closed = false;
 	private abandoned = false;
 	private failed = false;
+	private failure: unknown;
 	private dropped = 0;
 
 	constructor(emit: AgentEventSink, maxPending: number = MAX_PENDING_TOOL_UPDATES) {
@@ -56,11 +57,16 @@ export class ToolUpdateEmitter {
 		this.queue.length = 0;
 	}
 
-	drain(): Promise<void> {
-		if (this.abandoned) {
-			return Promise.resolve();
+	async drain(): Promise<void> {
+		// Re-read `this.tail` on every iteration: a `push()` racing with this loop
+		// can start a new pump run, and a stale snapshot would let this resolve
+		// while that new run still has undelivered events.
+		while (!this.abandoned && this.pumping) {
+			await this.tail;
 		}
-		return this.tail;
+		if (!this.abandoned && this.failed) {
+			throw this.failure;
+		}
 	}
 
 	private async pump(): Promise<void> {
@@ -70,8 +76,9 @@ export class ToolUpdateEmitter {
 				await Promise.resolve(this.emit(event));
 			} catch (err) {
 				this.failed = true;
+				this.failure = err;
 				this.queue.length = 0;
-				throw err;
+				break;
 			}
 		}
 		this.pumping = false;

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -658,6 +658,10 @@ describe("agentLoop with AgentMessage", () => {
 		const streamFn = createSingleToolCallStreamFn(assistantMessage);
 
 		const events: AgentEvent[] = [];
+		// Tracks every index whose sink call was actually invoked, independent of whether that
+		// call ever pushes into `events` (index 0's never does — see below). Without this, the
+		// test could pass merely because nothing was ever delivered, which proves nothing.
+		const invoked: number[] = [];
 		let resolveFirstUpdateGate: (() => void) | undefined;
 		const firstUpdateGate = new Promise<void>((resolve) => {
 			resolveFirstUpdateGate = resolve;
@@ -668,10 +672,12 @@ describe("agentLoop with AgentMessage", () => {
 				return;
 			}
 			const index = (event.partialResult as { details: { index: number } }).details.index;
+			invoked.push(index);
 			if (index === 0) {
-				// Held open for the whole test: simulates the one sink call the emitter may
-				// still have in flight at abort time. It never resolves, so by construction
-				// it can never push a late event into `events`.
+				// Held open until after the loop finishes: simulates the one sink call the
+				// emitter may still have in flight at abort time. Released below, once
+				// tool_execution_end/agent_end are already recorded, so any event 1/2 delivery
+				// that leaks through afterward is unambiguously late.
 				return firstUpdateGate;
 			}
 			return new Promise<void>((resolve) => {
@@ -683,11 +689,14 @@ describe("agentLoop with AgentMessage", () => {
 		};
 
 		await runAgentLoop([createUserMessage("Hello")], context, config, sink, controller.signal, streamFn);
-		// Give the 30ms-delayed sink calls for index 1/2 a wide window to land, if they were
-		// ever going to. Only then release the permanently-pending index-0 gate.
-		await new Promise((resolve) => setTimeout(resolve, 200));
+		// Release the gate now, then wait comfortably longer than the two chained 30ms sink
+		// delays (events 1 and 2 are processed serially by the emitter) before asserting. If
+		// abandon() had not cleared the queue, releasing the gate lets the pump drain events 1
+		// and 2 into `events` well after tool_execution_end/agent_end were already recorded.
 		resolveFirstUpdateGate?.();
+		await new Promise((resolve) => setTimeout(resolve, 200));
 
+		expect(invoked.length).toBeGreaterThan(0);
 		const endIndex = events.findIndex((event) => event.type === "tool_execution_end");
 		const agentEndIndex = events.findIndex((event) => event.type === "agent_end");
 		expect(endIndex).toBeGreaterThanOrEqual(0);
@@ -695,6 +704,73 @@ describe("agentLoop with AgentMessage", () => {
 		const updateIndices = events.flatMap((event, i) => (event.type === "tool_execution_update" ? [i] : []));
 		expect(updateIndices.every((i) => i < endIndex)).toBe(true);
 		expect(updateIndices.every((i) => i < agentEndIndex)).toBe(true);
+	});
+
+	it("should flush queued updates before tool_execution_end when a tool throws without an abort", async () => {
+		const toolSchema = Type.Object({});
+		const tool: AgentTool<typeof toolSchema, { index: number }> = {
+			name: "work",
+			label: "Work",
+			description: "Work",
+			parameters: toolSchema,
+			execute: async (_toolCallId, _params, _signal, onUpdate) => {
+				onUpdate?.({ content: [], details: { index: 0 } });
+				onUpdate?.({ content: [], details: { index: 1 } });
+				onUpdate?.({ content: [], details: { index: 2 } });
+				throw new Error("tool exploded");
+			},
+		};
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [tool],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+		};
+		const assistantMessage = createAssistantMessage(
+			[{ type: "toolCall", id: "tool_1", name: "work", arguments: {} }],
+			"toolUse",
+		);
+		const streamFn = createSingleToolCallStreamFn(assistantMessage);
+
+		const events: AgentEvent[] = [];
+		const sink = (event: AgentEvent): Promise<void> | void => {
+			if (event.type !== "tool_execution_update") {
+				events.push(event);
+				return;
+			}
+			// Slow enough that, without a flush, the queued-but-not-yet-invoked updates would
+			// have no chance to land before tool_execution_end is emitted.
+			return new Promise<void>((resolve) => {
+				setTimeout(() => {
+					events.push(event);
+					resolve();
+				}, 20);
+			});
+		};
+
+		const messages = await runAgentLoop([createUserMessage("Hello")], context, config, sink, undefined, streamFn);
+
+		const endIndex = events.findIndex((event) => event.type === "tool_execution_end");
+		expect(endIndex).toBeGreaterThanOrEqual(0);
+		const updatePositions = events.flatMap((event, i) => (event.type === "tool_execution_update" ? [i] : []));
+		const deliveredIndices = events.flatMap((event) =>
+			event.type === "tool_execution_update"
+				? [(event.partialResult as { details: { index: number } }).details.index]
+				: [],
+		);
+		expect(deliveredIndices).toEqual([0, 1, 2]);
+		expect(updatePositions.every((i) => i < endIndex)).toBe(true);
+
+		const toolResult = messages.find((message) => message.role === "toolResult");
+		expect(toolResult?.role).toBe("toolResult");
+		if (toolResult?.role === "toolResult") {
+			expect(toolResult.isError).toBe(true);
+			expect(toolResult.content).toEqual([{ type: "text", text: "tool exploded" }]);
+		}
 	});
 
 	it("should not produce an unhandled rejection when abort races a rejecting update sink", async () => {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -773,6 +773,102 @@ describe("agentLoop with AgentMessage", () => {
 		}
 	});
 
+	it("should keep the tool's own error message and not deliver queued updates after tool_execution_end when abort races the error-path flush", async () => {
+		const controller = new AbortController();
+		const toolSchema = Type.Object({});
+		const tool: AgentTool<typeof toolSchema, { index: number }> = {
+			name: "work",
+			label: "Work",
+			description: "Work",
+			parameters: toolSchema,
+			execute: async (_toolCallId, _params, _signal, onUpdate) => {
+				onUpdate?.({ content: [], details: { index: 0 } });
+				onUpdate?.({ content: [], details: { index: 1 } });
+				onUpdate?.({ content: [], details: { index: 2 } });
+				throw new Error("boom - the real tool failure");
+			},
+		};
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [tool],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+		};
+		const assistantMessage = createAssistantMessage(
+			[{ type: "toolCall", id: "tool_1", name: "work", arguments: {} }],
+			"toolUse",
+		);
+		const streamFn = createSingleToolCallStreamFn(assistantMessage);
+
+		const events: AgentEvent[] = [];
+		// Tracks every index whose sink call was actually invoked, independent of whether that
+		// call ever pushes into `events` (index 0's never does, by construction below).
+		const invoked: number[] = [];
+		let resolveFirstUpdateGate: (() => void) | undefined;
+		const firstUpdateGate = new Promise<void>((resolve) => {
+			resolveFirstUpdateGate = resolve;
+		});
+		const sink = (event: AgentEvent): Promise<void> | void => {
+			if (event.type !== "tool_execution_update") {
+				events.push(event);
+				return;
+			}
+			const index = (event.partialResult as { details: { index: number } }).details.index;
+			invoked.push(index);
+			if (index === 0) {
+				// Held open until after the loop finishes: simulates the one sink call the
+				// emitter may still have in flight when abort races the error-path flush.
+				// Released below, once tool_execution_end/agent_end are already recorded.
+				return firstUpdateGate;
+			}
+			return new Promise<void>((resolve) => {
+				setTimeout(() => {
+					events.push(event);
+					resolve();
+				}, 30);
+			});
+		};
+		// Fires while the flush is waiting on index 0's (held-open) sink call, i.e. while
+		// indices 1 and 2 are still queued and un-invoked.
+		setTimeout(() => controller.abort(), 10);
+
+		const messages = await runAgentLoop(
+			[createUserMessage("Hello")],
+			context,
+			config,
+			sink,
+			controller.signal,
+			streamFn,
+		);
+		// Release the gate, then wait comfortably longer than the two chained 30ms sink delays
+		// before asserting. If the queue had not been cleared, releasing the gate lets the pump
+		// drain events 1 and 2 into `events` well after tool_execution_end/agent_end were
+		// already recorded.
+		resolveFirstUpdateGate?.();
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
+		expect(invoked.length).toBeGreaterThan(0);
+
+		const toolResult = messages.find((message) => message.role === "toolResult");
+		expect(toolResult?.role).toBe("toolResult");
+		if (toolResult?.role === "toolResult") {
+			expect(toolResult.isError).toBe(true);
+			expect(toolResult.content).toEqual([{ type: "text", text: "boom - the real tool failure" }]);
+		}
+
+		const endIndex = events.findIndex((event) => event.type === "tool_execution_end");
+		const agentEndIndex = events.findIndex((event) => event.type === "agent_end");
+		expect(endIndex).toBeGreaterThanOrEqual(0);
+		expect(agentEndIndex).toBeGreaterThanOrEqual(0);
+		const updatePositions = events.flatMap((event, i) => (event.type === "tool_execution_update" ? [i] : []));
+		expect(updatePositions.every((i) => i < endIndex)).toBe(true);
+		expect(updatePositions.every((i) => i < agentEndIndex)).toBe(true);
+	});
+
 	it("should not produce an unhandled rejection when abort races a rejecting update sink", async () => {
 		const controller = new AbortController();
 		const toolSchema = Type.Object({});

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -9,7 +9,14 @@ import {
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
 import { agentLoop, agentLoopContinue, runAgentLoop } from "../src/agent-loop.js";
-import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.js";
+import type {
+	AgentContext,
+	AgentEvent,
+	AgentLoopConfig,
+	AgentMessage,
+	AgentTool,
+	AgentToolResult,
+} from "../src/types.js";
 
 // Mock stream for testing - mimics MockAssistantStream
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
@@ -105,9 +112,73 @@ function createUserMessage(text: string): UserMessage {
 	};
 }
 
+// Returns `toolCallMessage` on the first call, then a plain "stop" message on every call after
+// that. Without this, a mock stream that always replays the same toolUse message drives the
+// agent loop into calling the tool forever (there is nothing else to end the turn).
+function createSingleToolCallStreamFn(toolCallMessage: AssistantMessage): () => MockAssistantStream {
+	let calls = 0;
+	return () => {
+		calls += 1;
+		const isFirstCall = calls === 1;
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+			stream.push({
+				type: "done",
+				reason: isFirstCall ? "toolUse" : "stop",
+				message: isFirstCall ? toolCallMessage : createAssistantMessage([{ type: "text", text: "stop" }], "stop"),
+			});
+		});
+		return stream;
+	};
+}
+
 // Simple identity converter for tests - just passes through standard messages
 function identityConverter(messages: AgentMessage[]): Message[] {
 	return messages.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+// A tool that streams `totalUpdates` synchronous onUpdate calls (indices 0..totalUpdates-1)
+// before resolving. Used to probe how tool_execution_update delivery is ordered/serialized.
+function createManyUpdatesTool(totalUpdates: number): AgentTool<ReturnType<typeof Type.Object>, { index: number }> {
+	return {
+		name: "work",
+		label: "Work",
+		description: "Work",
+		parameters: Type.Object({}),
+		execute: async (_toolCallId, _params, _signal, onUpdate) => {
+			for (let i = 0; i < totalUpdates; i++) {
+				onUpdate?.({ content: [], details: { index: i } });
+			}
+			return { content: [{ type: "text", text: "done" }], details: { index: -1 }, terminate: true };
+		},
+	};
+}
+
+// A sink for tool_execution_update events whose per-call delay shrinks as the index grows,
+// so fully-concurrent delivery would necessarily settle out of order. Also tracks how many
+// sink calls are simultaneously in flight.
+function createDescendingDelaySink(totalUpdates: number, onDeliver: (index: number) => void) {
+	let active = 0;
+	let peak = 0;
+	const sink = (event: AgentEvent): Promise<void> | void => {
+		if (event.type !== "tool_execution_update") {
+			return;
+		}
+		const index = (event.partialResult as { details: { index: number } }).details.index;
+		active += 1;
+		peak = Math.max(peak, active);
+		return new Promise<void>((resolve) => {
+			setTimeout(
+				() => {
+					active -= 1;
+					onDeliver(index);
+					resolve();
+				},
+				(totalUpdates - index) * 1,
+			);
+		});
+	};
+	return { sink, getPeak: () => peak };
 }
 
 describe("agentLoop with AgentMessage", () => {
@@ -495,6 +566,279 @@ describe("agentLoop with AgentMessage", () => {
 			expect(toolResult.content).toEqual([{ type: "text", text: "done" }]);
 		}
 		expect(events.some((event) => event.type === "agent_end")).toBe(true);
+	});
+
+	it("should deliver tool_execution_update partialResults in emission order under an async sink", async () => {
+		const totalUpdates = 40;
+		const tool = createManyUpdatesTool(totalUpdates);
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [tool],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+		};
+		const assistantMessage = createAssistantMessage(
+			[{ type: "toolCall", id: "tool_1", name: "work", arguments: {} }],
+			"toolUse",
+		);
+		const streamFn = createSingleToolCallStreamFn(assistantMessage);
+
+		const deliveredOrder: number[] = [];
+		const { sink } = createDescendingDelaySink(totalUpdates, (index) => {
+			deliveredOrder.push(index);
+		});
+
+		await runAgentLoop([createUserMessage("Hello")], context, config, sink, undefined, streamFn);
+
+		expect(deliveredOrder.length).toBeGreaterThan(1);
+		expect(deliveredOrder).toEqual([...deliveredOrder].sort((a, b) => a - b));
+	});
+
+	it("should keep at most one tool_execution_update sink call in flight for a single tool call", async () => {
+		const totalUpdates = 40;
+		const tool = createManyUpdatesTool(totalUpdates);
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [tool],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+		};
+		const assistantMessage = createAssistantMessage(
+			[{ type: "toolCall", id: "tool_1", name: "work", arguments: {} }],
+			"toolUse",
+		);
+		const streamFn = createSingleToolCallStreamFn(assistantMessage);
+
+		const { sink, getPeak } = createDescendingDelaySink(totalUpdates, () => undefined);
+
+		await runAgentLoop([createUserMessage("Hello")], context, config, sink, undefined, streamFn);
+
+		expect(getPeak()).toBe(1);
+	});
+
+	it("should not deliver a tool_execution_update for a toolCallId after that id's tool_execution_end, nor after agent_end", async () => {
+		const controller = new AbortController();
+		const toolSchema = Type.Object({});
+		const tool: AgentTool<typeof toolSchema, { index: number }> = {
+			name: "work",
+			label: "Work",
+			description: "Work",
+			parameters: toolSchema,
+			execute: async (_toolCallId, _params, _signal, onUpdate) => {
+				onUpdate?.({ content: [], details: { index: 0 } });
+				onUpdate?.({ content: [], details: { index: 1 } });
+				onUpdate?.({ content: [], details: { index: 2 } });
+				controller.abort();
+				// Never resolves; raceWithAbort cuts this short once the signal fires above.
+				return new Promise<AgentToolResult<{ index: number }>>(() => undefined);
+			},
+		};
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [tool],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+		};
+		const assistantMessage = createAssistantMessage(
+			[{ type: "toolCall", id: "tool_1", name: "work", arguments: {} }],
+			"toolUse",
+		);
+		const streamFn = createSingleToolCallStreamFn(assistantMessage);
+
+		const events: AgentEvent[] = [];
+		let resolveFirstUpdateGate: (() => void) | undefined;
+		const firstUpdateGate = new Promise<void>((resolve) => {
+			resolveFirstUpdateGate = resolve;
+		});
+		const sink = (event: AgentEvent): Promise<void> | void => {
+			if (event.type !== "tool_execution_update") {
+				events.push(event);
+				return;
+			}
+			const index = (event.partialResult as { details: { index: number } }).details.index;
+			if (index === 0) {
+				// Held open for the whole test: simulates the one sink call the emitter may
+				// still have in flight at abort time. It never resolves, so by construction
+				// it can never push a late event into `events`.
+				return firstUpdateGate;
+			}
+			return new Promise<void>((resolve) => {
+				setTimeout(() => {
+					events.push(event);
+					resolve();
+				}, 30);
+			});
+		};
+
+		await runAgentLoop([createUserMessage("Hello")], context, config, sink, controller.signal, streamFn);
+		// Give the 30ms-delayed sink calls for index 1/2 a wide window to land, if they were
+		// ever going to. Only then release the permanently-pending index-0 gate.
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		resolveFirstUpdateGate?.();
+
+		const endIndex = events.findIndex((event) => event.type === "tool_execution_end");
+		const agentEndIndex = events.findIndex((event) => event.type === "agent_end");
+		expect(endIndex).toBeGreaterThanOrEqual(0);
+		expect(agentEndIndex).toBeGreaterThanOrEqual(0);
+		const updateIndices = events.flatMap((event, i) => (event.type === "tool_execution_update" ? [i] : []));
+		expect(updateIndices.every((i) => i < endIndex)).toBe(true);
+		expect(updateIndices.every((i) => i < agentEndIndex)).toBe(true);
+	});
+
+	it("should not produce an unhandled rejection when abort races a rejecting update sink", async () => {
+		const controller = new AbortController();
+		const toolSchema = Type.Object({});
+		const tool: AgentTool<typeof toolSchema, { index: number }> = {
+			name: "work",
+			label: "Work",
+			description: "Work",
+			parameters: toolSchema,
+			execute: async (_toolCallId, _params, _signal, onUpdate) => {
+				onUpdate?.({ content: [], details: { index: 0 } });
+				onUpdate?.({ content: [], details: { index: 1 } });
+				// Never resolves; abort (scheduled below, after the rejections below have already
+				// settled) is what ends this. This mirrors the outer catch branch, where nothing
+				// attaches a handler to the update promises until abort forces the issue.
+				return new Promise<AgentToolResult<{ index: number }>>(() => undefined);
+			},
+		};
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [tool],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+		};
+		const assistantMessage = createAssistantMessage(
+			[{ type: "toolCall", id: "tool_1", name: "work", arguments: {} }],
+			"toolUse",
+		);
+		const streamFn = createSingleToolCallStreamFn(assistantMessage);
+
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			const sink = (event: AgentEvent): Promise<void> => {
+				if (event.type === "tool_execution_update") {
+					// Rejects promptly, well before abort fires below, so any handler attached
+					// only once abort forces the issue is already too late to avoid the warning.
+					return new Promise<void>((_resolve, reject) => {
+						setTimeout(() => reject(new Error("sink rejected")), 0);
+					});
+				}
+				return Promise.resolve();
+			};
+			setTimeout(() => controller.abort(), 30);
+
+			const run = runAgentLoop([createUserMessage("Hello")], context, config, sink, controller.signal, streamFn);
+			const result = await Promise.race([
+				run.then(() => "done" as const).catch(() => "done" as const),
+				new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 2000)),
+			]);
+			expect(result).toBe("done");
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
+
+		expect(unhandled).toEqual([]);
+	});
+
+	it("should keep all tool_execution_updates for a tool ahead of its tool_execution_end with a fast sink", async () => {
+		const tool = createManyUpdatesTool(5);
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [tool],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+		};
+		const assistantMessage = createAssistantMessage(
+			[{ type: "toolCall", id: "tool_1", name: "work", arguments: {} }],
+			"toolUse",
+		);
+		const streamFn = createSingleToolCallStreamFn(assistantMessage);
+
+		const events: AgentEvent[] = [];
+		const sink = (event: AgentEvent) => {
+			events.push(event);
+		};
+
+		await runAgentLoop([createUserMessage("Hello")], context, config, sink, undefined, streamFn);
+
+		const endIndex = events.findIndex((event) => event.type === "tool_execution_end");
+		expect(endIndex).toBeGreaterThanOrEqual(0);
+		const updateIndices = events.flatMap((event, i) => (event.type === "tool_execution_update" ? [i] : []));
+		expect(updateIndices.length).toBe(5);
+		expect(updateIndices.every((i) => i < endIndex)).toBe(true);
+	});
+
+	it("should surface a rejecting update sink as an error tool result when there is no abort", async () => {
+		const toolSchema = Type.Object({});
+		const tool: AgentTool<typeof toolSchema, { index: number }> = {
+			name: "work",
+			label: "Work",
+			description: "Work",
+			parameters: toolSchema,
+			execute: async (_toolCallId, _params, _signal, onUpdate) => {
+				onUpdate?.({ content: [], details: { index: 0 } });
+				return { content: [{ type: "text", text: "done" }], details: { index: -1 } };
+			},
+		};
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [tool],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+		};
+		const assistantMessage = createAssistantMessage(
+			[{ type: "toolCall", id: "tool_1", name: "work", arguments: {} }],
+			"toolUse",
+		);
+		const streamFn = createSingleToolCallStreamFn(assistantMessage);
+
+		const sink = (event: AgentEvent): Promise<void> => {
+			if (event.type === "tool_execution_update") {
+				return Promise.reject(new Error("sink rejected for real"));
+			}
+			return Promise.resolve();
+		};
+
+		const messages = await runAgentLoop([createUserMessage("Hello")], context, config, sink, undefined, streamFn);
+
+		const toolResult = messages.find((message) => message.role === "toolResult");
+		expect(toolResult?.role).toBe("toolResult");
+		if (toolResult?.role === "toolResult") {
+			expect(toolResult.isError).toBe(true);
+			expect(toolResult.content).toEqual([{ type: "text", text: "sink rejected for real" }]);
+		}
 	});
 
 	it("should freeze synthetic aborted messages against later partial mutation", async () => {

--- a/packages/agent/test/tool-update-emitter.test.ts
+++ b/packages/agent/test/tool-update-emitter.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "../src/types.js";
+import { MAX_PENDING_TOOL_UPDATES, ToolUpdateEmitter } from "../src/tool-update-emitter.js";
+
+function createDeferred(): {
+	promise: Promise<void>;
+	resolve: () => void;
+} {
+	let resolve = () => {};
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function makeEvent(n: number): AgentEvent {
+	return { type: "tool_execution_update", toolCallId: "t1", toolName: "bash", args: {}, partialResult: n };
+}
+
+describe("ToolUpdateEmitter", () => {
+	it("should deliver events in push order", async () => {
+		const received: number[] = [];
+		const emitter = new ToolUpdateEmitter((event) => {
+			received.push((event as { partialResult: number }).partialResult);
+		});
+
+		for (let i = 0; i < 10; i++) {
+			emitter.push(makeEvent(i));
+		}
+		await emitter.drain();
+
+		expect(received).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+	});
+
+	it("should never have more than one sink call in flight", async () => {
+		let active = 0;
+		let peak = 0;
+		const emitter = new ToolUpdateEmitter(async () => {
+			active += 1;
+			peak = Math.max(peak, active);
+			await new Promise((r) => setTimeout(r, 0));
+			active -= 1;
+		});
+
+		for (let i = 0; i < 100; i++) {
+			emitter.push(makeEvent(i));
+		}
+		await emitter.drain();
+
+		expect(peak).toBe(1);
+	});
+
+	it("should keep pending state bounded and drop oldest under a flood of pushes", async () => {
+		const gate = createDeferred();
+		const received: number[] = [];
+		const emitter = new ToolUpdateEmitter(async (event) => {
+			await gate.promise;
+			received.push((event as { partialResult: number }).partialResult);
+		});
+
+		const total = 100_000;
+		for (let i = 0; i < total; i++) {
+			emitter.push(makeEvent(i));
+			expect(emitter.pendingCount).toBeLessThanOrEqual(MAX_PENDING_TOOL_UPDATES);
+		}
+
+		expect(emitter.droppedUpdates).toBeGreaterThan(0);
+
+		gate.resolve();
+		await emitter.drain();
+
+		expect(received.at(-1)).toBe(total - 1);
+	});
+
+	it("should drop the oldest queued event, keeping relative order of survivors", async () => {
+		const gate = createDeferred();
+		const received: number[] = [];
+		const emitter = new ToolUpdateEmitter(async (event) => {
+			await gate.promise;
+			received.push((event as { partialResult: number }).partialResult);
+		}, 2);
+
+		// First push starts the in-flight (blocked) call; the next four queue up
+		// behind it, overflowing the 2-slot queue down to [3, 4].
+		for (let i = 0; i < 5; i++) {
+			emitter.push(makeEvent(i));
+		}
+
+		expect(emitter.pendingCount).toBe(2);
+		expect(emitter.droppedUpdates).toBe(2);
+
+		gate.resolve();
+		await emitter.drain();
+
+		expect(received).toEqual([0, 3, 4]);
+	});
+
+	it("should resolve drain() only after the final delivery completes", async () => {
+		const gate = createDeferred();
+		let delivered = false;
+		const emitter = new ToolUpdateEmitter(async (event) => {
+			const n = (event as { partialResult: number }).partialResult;
+			if (n === 2) {
+				await gate.promise;
+			}
+			if (n === 2) {
+				delivered = true;
+			}
+		});
+
+		emitter.push(makeEvent(0));
+		emitter.push(makeEvent(1));
+		emitter.push(makeEvent(2));
+
+		const drainPromise = emitter.drain();
+		let drainSettled = false;
+		drainPromise.then(() => {
+			drainSettled = true;
+		});
+
+		await new Promise((r) => setTimeout(r, 10));
+		expect(drainSettled).toBe(false);
+		expect(delivered).toBe(false);
+
+		gate.resolve();
+		await drainPromise;
+
+		expect(drainSettled).toBe(true);
+		expect(delivered).toBe(true);
+	});
+
+	it("should reject drain() with the sink's error and stop delivering afterward", async () => {
+		const gate = createDeferred();
+		const received: number[] = [];
+		const boom = new Error("boom");
+		const emitter = new ToolUpdateEmitter(async (event) => {
+			const n = (event as { partialResult: number }).partialResult;
+			if (n === 1) {
+				await gate.promise;
+				throw boom;
+			}
+			received.push(n);
+		});
+
+		emitter.push(makeEvent(0));
+		emitter.push(makeEvent(1));
+		emitter.push(makeEvent(2));
+
+		gate.resolve();
+
+		await expect(emitter.drain()).rejects.toBe(boom);
+		await expect(emitter.drain()).rejects.toBe(boom);
+
+		expect(received).toEqual([0]);
+
+		emitter.push(makeEvent(3));
+		expect(emitter.pendingCount).toBe(0);
+
+		await expect(emitter.drain()).rejects.toBe(boom);
+		expect(received).toEqual([0]);
+	});
+
+	it("should discard the queue and resolve drain() promptly on abandon()", async () => {
+		const gate = createDeferred();
+		const received: number[] = [];
+		const emitter = new ToolUpdateEmitter(async (event) => {
+			await gate.promise;
+			received.push((event as { partialResult: number }).partialResult);
+		});
+
+		emitter.push(makeEvent(0));
+		emitter.push(makeEvent(1));
+		emitter.push(makeEvent(2));
+
+		expect(emitter.pendingCount).toBe(2);
+
+		let drainSettled = false;
+		emitter.abandon();
+		const drainPromise = emitter.drain().then(() => {
+			drainSettled = true;
+		});
+
+		await new Promise((r) => setImmediate(r));
+		expect(drainSettled).toBe(true);
+		expect(emitter.pendingCount).toBe(0);
+		// The in-flight call for event 0 started before abandon() and is not
+		// cancelled by it, so drain() resolving promptly must not wait for it.
+		expect(received).toEqual([]);
+
+		gate.resolve();
+		await drainPromise;
+		await new Promise((r) => setImmediate(r));
+
+		// Only the already in-flight event may complete; the queued events (1, 2) must not.
+		expect(received).toEqual([0]);
+	});
+
+	it("should ignore push() after close() but still deliver events queued before it", async () => {
+		const received: number[] = [];
+		const emitter = new ToolUpdateEmitter((event) => {
+			received.push((event as { partialResult: number }).partialResult);
+		});
+
+		emitter.push(makeEvent(0));
+		emitter.push(makeEvent(1));
+		emitter.close();
+
+		expect(() => emitter.push(makeEvent(2))).not.toThrow();
+		emitter.push(makeEvent(3));
+
+		await emitter.drain();
+
+		expect(received).toEqual([0, 1]);
+	});
+
+	it("should reject a non-positive-integer maxPending", () => {
+		expect(() => new ToolUpdateEmitter(() => {}, 0)).toThrow();
+		expect(() => new ToolUpdateEmitter(() => {}, -1)).toThrow();
+		expect(() => new ToolUpdateEmitter(() => {}, 1.5)).toThrow();
+	});
+});

--- a/packages/agent/test/tool-update-emitter.test.ts
+++ b/packages/agent/test/tool-update-emitter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { AgentEvent } from "../src/types.js";
 import { MAX_PENDING_TOOL_UPDATES, ToolUpdateEmitter } from "../src/tool-update-emitter.js";
+import type { AgentEvent } from "../src/types.js";
 
 function createDeferred(): {
 	promise: Promise<void>;
@@ -217,5 +217,117 @@ describe("ToolUpdateEmitter", () => {
 		expect(() => new ToolUpdateEmitter(() => {}, 0)).toThrow();
 		expect(() => new ToolUpdateEmitter(() => {}, -1)).toThrow();
 		expect(() => new ToolUpdateEmitter(() => {}, 1.5)).toThrow();
+	});
+
+	it("should not produce an unhandled rejection when an in-flight sink rejects after abandon() (probe A)", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+		try {
+			const gate = createDeferred();
+			const boom = new Error("A: sink rejected after abandon");
+			const emitter = new ToolUpdateEmitter(async () => {
+				await gate.promise;
+				throw boom;
+			});
+
+			emitter.push(makeEvent(0));
+			emitter.abandon();
+			await emitter.drain();
+
+			gate.resolve();
+			await new Promise((r) => setImmediate(r));
+			await new Promise((r) => setImmediate(r));
+
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandledRejection);
+		}
+	});
+
+	it("should not produce an unhandled rejection when the sink rejects and drain() is never called (probe B)", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+		try {
+			const boom = new Error("B: sink rejected, drain never called");
+			const emitter = new ToolUpdateEmitter(async () => {
+				throw boom;
+			});
+
+			emitter.push(makeEvent(0));
+			await new Promise((r) => setImmediate(r));
+			await new Promise((r) => setImmediate(r));
+
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandledRejection);
+		}
+	});
+
+	it("should not produce an unhandled rejection when a later pump run rejects after an earlier drain() already resolved (probe C)", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+		try {
+			const boom = new Error("C: second pump run rejected, only first tail awaited");
+			let calls = 0;
+			const emitter = new ToolUpdateEmitter(async () => {
+				calls += 1;
+				if (calls === 2) throw boom;
+			});
+
+			emitter.push(makeEvent(0));
+			await emitter.drain();
+
+			emitter.push(makeEvent(1));
+			// Deliberately do not await drain() again - this simulates a caller
+			// that already finished up after the first drain() resolved.
+			await new Promise((r) => setImmediate(r));
+			await new Promise((r) => setImmediate(r));
+
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.removeListener("unhandledRejection", onUnhandledRejection);
+		}
+	});
+
+	it("should not resolve drain() from a stale tail when a push races the pump run finishing", async () => {
+		const received: number[] = [];
+		const emitter = new ToolUpdateEmitter(async (event) => {
+			const n = (event as { partialResult: number }).partialResult;
+			// Event 1's delivery is delayed by a macrotask so it cannot land
+			// before a stale (already-settled) drain() promise would resolve -
+			// the assertion below only distinguishes the two implementations if
+			// event 1's delivery is unambiguously later than that.
+			if (n === 1) {
+				await new Promise((r) => setImmediate(r));
+			}
+			received.push(n);
+		});
+
+		emitter.push(makeEvent(0));
+		// Call drain() immediately, while pump run 1 is still in flight (pumping
+		// is still true here - pump() only reaches its first await after this
+		// line runs), exactly matching the reviewer's "push(a); const p =
+		// emitter.drain();" reproduction.
+		const drainPromise = emitter.drain();
+
+		// Yield exactly one microtask tick: enough for pump run 1 (a single
+		// queued event, no internal await) to finish and flip `pumping` back to
+		// false, but landing this push before drain()'s own pending
+		// continuation gets a chance to observe that and resolve.
+		await Promise.resolve();
+		emitter.push(makeEvent(1));
+
+		await drainPromise;
+
+		expect(received).toEqual([0, 1]);
 	});
 });

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -572,6 +572,12 @@ In parallel tool mode:
 - `tool_execution_end` is emitted in tool completion order after each tool is finalized
 - final `toolResult` message events are still emitted later in assistant source order
 
+For a single tool call, `tool_execution_update` delivery is serialized and ordered: at most one handler call is in flight at a time, in emission order. The pending queue per tool call is capped at 32 updates — on overflow the oldest queued update is dropped, so **a handler must not assume it sees every update**. This matters because some tools emit cumulative snapshots (their handler can safely treat each update as the current state) while others, like the IPython tool, emit one update per incremental chunk (a handler accumulating deltas can lose data under sustained backpressure). The cap is only reached when a handler is persistently slower than the tool producing updates.
+
+All of a tool's updates are delivered before its `tool_execution_end`, including when the tool fails without the run being aborted. If a handler throws or rejects, that tool call fails and its result becomes an error result carrying the handler's message.
+
+On abort, any queued updates are discarded without being delivered. A handler call already in flight when the abort happens cannot be cancelled and may still run after `tool_execution_end` fires.
+
 ```typescript
 pi.on("tool_execution_start", async (event, ctx) => {
   // event.toolCallId, event.toolName, event.args


### PR DESCRIPTION
Summary
Fixes #957

This PR improves tool-update handling in the agent loop by ensuring updates are delivered in a bounded, serialized manner and by fixing a race condition in the abort/error path. The change makes tool-update emission more predictable and prevents queued updates from being left behind or dropped when a tool call fails or is aborted.

What changed
Added bounded, serialized delivery for tool-update events.
Wired the tool update emitter into the prepared tool-call execution path.
Fixed a race where aborted state could be overwritten or lost during flush handling.
Ensured queued updates are flushed correctly on non-abort tool failures.
Added regression coverage for the new behavior and updated related documentation.
Why
Previously, tool updates could be emitted in a way that was not reliably bounded or ordered, especially during failure and abort scenarios. This made behavior harder to reason about and could leave the stream in an inconsistent state.

Testing
Added/updated unit tests for the agent loop and tool-update emitter behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize and bound tool_execution_update delivery in the agent loop
> - Replaces ad-hoc Promise accumulation in `executePreparedToolCall` with a new `ToolUpdateEmitter` class that serializes update delivery: only one sink call is in flight at a time, and events are delivered in push order.
> - Caps the pending queue at 32 events; on overflow the oldest queued update is dropped silently.
> - Queued updates are flushed before `tool_execution_end` on both success and tool failure paths. On abort, queued updates are discarded immediately (one already in-flight call may still settle).
> - A rejecting update sink now fails the tool call and produces an error tool result instead of being silently ignored.
> - Risk: Behavioral change — previously queued updates could be delivered concurrently and out of order; now they are strictly serialized and the oldest are dropped under sustained backpressure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d731b84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->