### PR TITLE
fix(tui): make packed Quick Start runnable

### DIFF
--- a/docs/superpowers/plans/2026-08-08-tui-packed-quick-start.md
+++ b/docs/superpowers/plans/2026-08-08-tui-packed-quick-start.md
@@ -1,0 +1,29 @@
+# Packed TUI Quick Start Implementation Plan
+
+## Task 1: Add the package-boundary regression
+
+- Add `packages/tui/test/952-packed-quick-start.test.ts` with isolated command, package staging, dependency-closure, README extraction, and child-process helpers.
+- Build and pack the TUI into temporary directories.
+- Extract and compile the exact packed Quick Start in a clean consumer project.
+- Run the compiled example with controlled stdin/stdout, wait for its first render, send Ctrl+C, and assert a clean exit.
+- Run the single test and confirm it fails on the repository-relative theme import before the documentation fix.
+
+## Task 2: Make the Quick Start self-contained
+
+- Replace the test-only theme import with an inline identity `EditorTheme` covering every required editor and select-list style.
+- Keep the package name, TUI behavior, and public exports unchanged.
+- Run the single regression and iterate until it passes.
+
+## Task 3: Document and validate the fix
+
+- Add one attributed TUI `[Unreleased]` changelog bullet.
+- Run `node --test --import tsx test/952-packed-quick-start.test.ts` from `packages/tui`.
+- Run `npm run check` from the repository root and resolve every reported problem.
+- Inspect the final diff for issue-only scope and package-boundary coverage.
+
+## Task 4: Review and publish
+
+- Request an independent review against issue #952 and the approved design.
+- Verify and address each technically applicable finding, rerunning affected checks.
+- Stage only the issue #952 files, commit with `fixes #952`, push `agent/952-packed-tui-quick-start` to `fettpl/prime-agent`, and open a draft PR to `PrimeIntellect-ai/prime-agent:main`.
+- Leave the PR draft and do not tag maintainers or merge.

--- a/docs/superpowers/specs/2026-08-08-tui-packed-quick-start-design.md
+++ b/docs/superpowers/specs/2026-08-08-tui-packed-quick-start-design.md
@@ -1,0 +1,45 @@
+# Packed TUI Quick Start Design
+
+## Context
+
+The first `packages/tui/README.md` example imports `./test/test-themes.ts`. The TUI package publishes `dist/**/*` and `README.md`, so that repository-only test module is absent from a packed artifact. A consumer copying the documented example into a clean project cannot resolve the import.
+
+## Scope
+
+Make the existing Quick Start self-contained without adding a public theme API or changing TUI runtime behavior. Verify the exact documentation sample through the same package boundary a consumer uses.
+
+## Design
+
+The Quick Start will define a complete minimal `EditorTheme` value inline. Its style functions return their input unchanged. This keeps the example dependency-free, demonstrates the required `Editor` contract, and avoids making the generic TUI primitives package maintain a visual default that belongs to the coding-agent theme layer.
+
+No production export, package dependency, or package-name migration is part of this change.
+
+## Package-Contract Regression
+
+Add `packages/tui/test/952-packed-quick-start.test.ts`. The regression will:
+
+1. Compile the TUI package into an isolated staging directory.
+2. Pack the staged package with an isolated npm cache and extract it into a clean consumer project as `node_modules/prime-agent-tui`.
+3. Stage only the dependencies declared by the packed manifest, plus Node declarations needed by the consumer compile.
+4. Extract the exact first TypeScript block beneath `## Quick Start` from the packed README.
+5. Assert that the sample contains no repository-relative test import.
+6. Compile the extracted sample against the packed JavaScript and declarations with NodeNext resolution.
+7. Start the compiled sample in a child process with controlled stdin/stdout pipes, wait until its welcome text renders, send Ctrl+C, and require a clean exit.
+
+The child process will have a bounded timeout and will be terminated during cleanup if it does not exit. Temporary package, npm-cache, and consumer files will always be removed.
+
+## Error Handling
+
+Command failures will include stdout and stderr in the test error. README extraction will fail explicitly if the Quick Start heading or TypeScript fence is missing. Runtime smoke failures will include captured terminal output and distinguish startup timeout, non-zero exit, signal exit, and missing render output.
+
+## Documentation and Release Notes
+
+Update the TUI `[Unreleased]` changelog with the user-visible documentation fix and issue attribution.
+
+## Acceptance Criteria
+
+- The Quick Start contains no repository-relative test import.
+- The example defines every required `EditorTheme` and `SelectListTheme` field inline.
+- The exact packed README example compiles in a clean consumer project.
+- The compiled example renders, accepts Ctrl+C through the documented input listener, stops the TUI, and exits successfully.
+- The TUI package's existing checks remain clean.

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed the TUI Quick Start to define a self-contained editor theme that compiles from packed artifacts ([#952](https://github.com/PrimeIntellect-ai/prime-agent/issues/952)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -31,7 +31,7 @@ Minimal terminal UI framework with differential rendering and synchronized outpu
 ## Quick Start
 
 ```typescript
-import { TUI, Text, Editor, ProcessTerminal, matchesKey } from "prime-agent-tui";
+import { TUI, Text, Editor, ProcessTerminal, matchesKey, type EditorTheme } from "prime-agent-tui";
 
 // Create terminal
 const terminal = new ProcessTerminal();
@@ -42,7 +42,17 @@ const tui = new TUI(terminal);
 // Add components
 tui.addChild(new Text("Welcome to my app!"));
 
-import { defaultEditorTheme as editorTheme } from './test/test-themes.ts';
+const identity = (text: string) => text;
+const editorTheme: EditorTheme = {
+  borderColor: identity,
+  selectList: {
+    selectedPrefix: identity,
+    selectedText: identity,
+    description: identity,
+    scrollInfo: identity,
+    noMatch: identity,
+  },
+};
 const editor = new Editor(tui, editorTheme);
 editor.onSubmit = (text) => {
   console.log("Submitted:", text);
@@ -59,6 +69,7 @@ tui.addInputListener((data) => {
     tui.stop();
     process.exit(0);
   }
+  return undefined;
 });
 
 // Start

--- a/packages/tui/test/952-packed-quick-start.test.ts
+++ b/packages/tui/test/952-packed-quick-start.test.ts
@@ -1,20 +1,8 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import {
-	cpSync,
-	existsSync,
-	mkdirSync,
-	mkdtempSync,
-	readdirSync,
-	readFileSync,
-	realpathSync,
-	rmSync,
-	statSync,
-	symlinkSync,
-	writeFileSync,
-} from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -22,6 +10,11 @@ const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(packageRoot, "../..");
 const installedRepositoryRoot = dirname(realpathSync(join(repositoryRoot, "node_modules")));
 const publicPackageName = "prime-agent-tui";
+const tsgoCli = resolve(
+	dirname(fileURLToPath(import.meta.resolve("@typescript/native-preview/package.json"))),
+	"bin/tsgo.js",
+);
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
 interface PackageManifest {
 	dependencies?: Record<string, string>;
@@ -43,6 +36,11 @@ function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEn
 		maxBuffer: 10 * 1024 * 1024,
 	});
 
+	if (result.error) {
+		throw new Error(`${command} ${args.join(" ")} could not start: ${result.error.message}`, {
+			cause: result.error,
+		});
+	}
 	if (result.status !== 0) {
 		throw new Error(
 			`${command} ${args.join(" ")} failed with exit ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
@@ -53,13 +51,12 @@ function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEn
 }
 
 function stagePackageFiles(source: string, target: string): void {
-	mkdirSync(target, { recursive: true });
-	for (const entry of readdirSync(source, { withFileTypes: true })) {
-		if (entry.name === "node_modules") continue;
-		const entrySource = join(source, entry.name);
-		const entryTarget = join(target, entry.name);
-		symlinkSync(entrySource, entryTarget, statSync(entrySource).isDirectory() ? "junction" : "file");
-	}
+	mkdirSync(dirname(target), { recursive: true });
+	cpSync(source, target, {
+		dereference: true,
+		filter: (entry) => basename(entry) !== "node_modules",
+		recursive: true,
+	});
 }
 
 function resolveInstalledPackage(name: string, issuer: string): string | undefined {
@@ -132,19 +129,28 @@ function extractQuickStart(readme: string): string {
 	return `${codeBlock[1]}\n`;
 }
 
-function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number, output: () => string): Promise<ProcessResult> {
+function waitForClose(child: ReturnType<typeof spawn>): Promise<ProcessResult> {
 	return new Promise((resolveExit, rejectExit) => {
-		const timeout = setTimeout(() => {
-			rejectExit(new Error(`Quick Start did not exit within ${timeoutMs}ms\nOUTPUT:\n${output()}`));
-		}, timeoutMs);
-		child.once("error", (error) => {
-			clearTimeout(timeout);
-			rejectExit(error);
-		});
-		child.once("exit", (code, signal) => {
-			clearTimeout(timeout);
+		child.once("error", rejectExit);
+		child.once("close", (code, signal) => {
 			resolveExit({ code, signal });
 		});
+	});
+}
+
+function withTimeout<T>(operation: Promise<T>, timeoutMs: number, message: () => string): Promise<T> {
+	return new Promise((resolveOperation, rejectOperation) => {
+		const timeout = setTimeout(() => rejectOperation(new Error(message())), timeoutMs);
+		operation.then(
+			(value) => {
+				clearTimeout(timeout);
+				resolveOperation(value);
+			},
+			(error: unknown) => {
+				clearTimeout(timeout);
+				rejectOperation(error);
+			},
+		);
 	});
 }
 
@@ -165,35 +171,40 @@ async function runQuickStart(consumerDir: string): Promise<void> {
 		stderr += chunk;
 	});
 	const output = () => `STDOUT:\n${stdout}\nSTDERR:\n${stderr}`;
-	const exitPromise = waitForExit(child, 10_000, output);
+	const closePromise = waitForClose(child);
 
 	try {
-		await new Promise<void>((resolveRender, rejectRender) => {
-			const timeout = setTimeout(() => {
-				rejectRender(new Error(`Quick Start did not render within 5000ms\n${output()}`));
-			}, 5000);
+		const renderPromise = new Promise<void>((resolveRender) => {
 			const inspectOutput = () => {
 				if (!stdout.includes("Welcome to my app!")) return;
-				clearTimeout(timeout);
 				resolveRender();
 			};
 			child.stdout.on("data", inspectOutput);
-			child.once("exit", (code, signal) => {
-				clearTimeout(timeout);
-				rejectRender(
-					new Error(`Quick Start exited before rendering (code=${code}, signal=${signal})\n${output()}`),
-				);
-			});
 		});
+		await withTimeout(
+			Promise.race([
+				renderPromise,
+				closePromise.then(({ code, signal }) => {
+					throw new Error(`Quick Start exited before rendering (code=${code}, signal=${signal})\n${output()}`);
+				}),
+			]),
+			5000,
+			() => `Quick Start did not render within 5000ms\n${output()}`,
+		);
 
 		child.stdin.write("\x03");
 		child.stdin.end();
-		const result = await exitPromise;
+		const result = await withTimeout(closePromise, 5000, () => `Quick Start did not exit within 5000ms\n${output()}`);
 		assert.equal(result.signal, null, output());
 		assert.equal(result.code, 0, output());
 		assert.match(stdout, /Welcome to my app!/);
 	} finally {
 		if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+		await withTimeout(
+			closePromise,
+			2000,
+			() => `Quick Start did not close within 2000ms after termination\n${output()}`,
+		);
 	}
 }
 
@@ -213,8 +224,9 @@ test("issue #952: packed Quick Start compiles, renders, and stops on Ctrl+C", { 
 		cpSync(join(packageRoot, "package.json"), join(stagingDir, "package.json"));
 		cpSync(join(packageRoot, "README.md"), join(stagingDir, "README.md"));
 		run(
-			resolve(repositoryRoot, "node_modules/.bin/tsgo"),
+			process.execPath,
 			[
+				tsgoCli,
 				"-p",
 				join(packageRoot, "tsconfig.build.json"),
 				"--outDir",
@@ -225,7 +237,7 @@ test("issue #952: packed Quick Start compiles, renders, and stops on Ctrl+C", { 
 			packageRoot,
 		);
 		const tarballName = run(
-			"npm",
+			npmCommand,
 			["pack", stagingDir, "--ignore-scripts", "--silent", "--pack-destination", artifactDir],
 			repositoryRoot,
 			{ npm_config_cache: npmCacheDir },
@@ -273,7 +285,7 @@ test("issue #952: packed Quick Start compiles, renders, and stops on Ctrl+C", { 
 				2,
 			)}\n`,
 		);
-		run(resolve(repositoryRoot, "node_modules/.bin/tsgo"), ["-p", "tsconfig.json"], consumerDir);
+		run(process.execPath, [tsgoCli, "-p", "tsconfig.json"], consumerDir);
 		await runQuickStart(consumerDir);
 	} finally {
 		rmSync(tempRoot, { recursive: true, force: true });

--- a/packages/tui/test/952-packed-quick-start.test.ts
+++ b/packages/tui/test/952-packed-quick-start.test.ts
@@ -1,0 +1,281 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(packageRoot, "../..");
+const installedRepositoryRoot = dirname(realpathSync(join(repositoryRoot, "node_modules")));
+const publicPackageName = "prime-agent-tui";
+
+interface PackageManifest {
+	dependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+	peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
+interface ProcessResult {
+	code: number | null;
+	signal: NodeJS.Signals | null;
+}
+
+function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv = {}): string {
+	const result = spawnSync(command, args, {
+		cwd,
+		encoding: "utf8",
+		env: { ...process.env, npm_config_audit: "false", npm_config_fund: "false", ...env },
+		maxBuffer: 10 * 1024 * 1024,
+	});
+
+	if (result.status !== 0) {
+		throw new Error(
+			`${command} ${args.join(" ")} failed with exit ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+		);
+	}
+
+	return result.stdout.trim();
+}
+
+function stagePackageFiles(source: string, target: string): void {
+	mkdirSync(target, { recursive: true });
+	for (const entry of readdirSync(source, { withFileTypes: true })) {
+		if (entry.name === "node_modules") continue;
+		const entrySource = join(source, entry.name);
+		const entryTarget = join(target, entry.name);
+		symlinkSync(entrySource, entryTarget, statSync(entrySource).isDirectory() ? "junction" : "file");
+	}
+}
+
+function resolveInstalledPackage(name: string, issuer: string): string | undefined {
+	let current = issuer;
+	let relativeToInstallRoot = relative(installedRepositoryRoot, current);
+	while (
+		relativeToInstallRoot === "" ||
+		(!relativeToInstallRoot.startsWith("..") && !isAbsolute(relativeToInstallRoot))
+	) {
+		const candidate = join(current, "node_modules", ...name.split("/"));
+		if (existsSync(join(candidate, "package.json"))) return realpathSync(candidate);
+		const parent = dirname(current);
+		if (parent === current) break;
+		current = parent;
+		relativeToInstallRoot = relative(installedRepositoryRoot, current);
+	}
+	return undefined;
+}
+
+function stageDeclaredDependencyClosure(rootNames: string[], targetRoot: string): void {
+	const stageDependency = (
+		name: string,
+		issuer: string,
+		targetNodeModules: string,
+		ancestorSources: ReadonlyMap<string, string>,
+		optional: boolean,
+	): void => {
+		const source = resolveInstalledPackage(name, issuer);
+		if (!source) {
+			if (optional) return;
+			throw new Error(`Installed dependency ${name} was not found from ${issuer}`);
+		}
+		if (ancestorSources.get(name) === source) return;
+
+		const target = join(targetNodeModules, ...name.split("/"));
+		if (existsSync(target)) return;
+		stagePackageFiles(source, target);
+
+		const manifest = JSON.parse(readFileSync(join(source, "package.json"), "utf8")) as PackageManifest;
+		const childDependencies = new Map<string, boolean>();
+		for (const childName of Object.keys(manifest.dependencies ?? {})) childDependencies.set(childName, false);
+		for (const childName of Object.keys(manifest.optionalDependencies ?? {})) {
+			if (!childDependencies.has(childName)) childDependencies.set(childName, true);
+		}
+		for (const childName of Object.keys(manifest.peerDependencies ?? {})) {
+			if (!childDependencies.has(childName)) {
+				childDependencies.set(childName, manifest.peerDependenciesMeta?.[childName]?.optional === true);
+			}
+		}
+
+		const childAncestors = new Map(ancestorSources);
+		childAncestors.set(name, source);
+		for (const [childName, childOptional] of childDependencies) {
+			stageDependency(childName, source, join(target, "node_modules"), childAncestors, childOptional);
+		}
+	};
+
+	for (const name of rootNames) {
+		stageDependency(name, installedRepositoryRoot, targetRoot, new Map(), false);
+	}
+}
+
+function extractQuickStart(readme: string): string {
+	const heading = "## Quick Start";
+	const headingIndex = readme.indexOf(heading);
+	assert.notEqual(headingIndex, -1, `Packed README is missing ${heading}`);
+	const quickStartSection = readme.slice(headingIndex + heading.length);
+	const codeBlock = quickStartSection.match(/```typescript\r?\n([\s\S]*?)\r?\n```/);
+	assert.ok(codeBlock?.[1], "Packed README is missing the Quick Start TypeScript block");
+	return `${codeBlock[1]}\n`;
+}
+
+function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number, output: () => string): Promise<ProcessResult> {
+	return new Promise((resolveExit, rejectExit) => {
+		const timeout = setTimeout(() => {
+			rejectExit(new Error(`Quick Start did not exit within ${timeoutMs}ms\nOUTPUT:\n${output()}`));
+		}, timeoutMs);
+		child.once("error", (error) => {
+			clearTimeout(timeout);
+			rejectExit(error);
+		});
+		child.once("exit", (code, signal) => {
+			clearTimeout(timeout);
+			resolveExit({ code, signal });
+		});
+	});
+}
+
+async function runQuickStart(consumerDir: string): Promise<void> {
+	const child = spawn(process.execPath, ["--preserve-symlinks", join(consumerDir, "dist/quick-start.js")], {
+		cwd: consumerDir,
+		env: { ...process.env, COLUMNS: "80", FORCE_COLOR: "0", LINES: "24" },
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	child.stdout.setEncoding("utf8");
+	child.stderr.setEncoding("utf8");
+	let stdout = "";
+	let stderr = "";
+	child.stdout.on("data", (chunk: string) => {
+		stdout += chunk;
+	});
+	child.stderr.on("data", (chunk: string) => {
+		stderr += chunk;
+	});
+	const output = () => `STDOUT:\n${stdout}\nSTDERR:\n${stderr}`;
+	const exitPromise = waitForExit(child, 10_000, output);
+
+	try {
+		await new Promise<void>((resolveRender, rejectRender) => {
+			const timeout = setTimeout(() => {
+				rejectRender(new Error(`Quick Start did not render within 5000ms\n${output()}`));
+			}, 5000);
+			const inspectOutput = () => {
+				if (!stdout.includes("Welcome to my app!")) return;
+				clearTimeout(timeout);
+				resolveRender();
+			};
+			child.stdout.on("data", inspectOutput);
+			child.once("exit", (code, signal) => {
+				clearTimeout(timeout);
+				rejectRender(
+					new Error(`Quick Start exited before rendering (code=${code}, signal=${signal})\n${output()}`),
+				);
+			});
+		});
+
+		child.stdin.write("\x03");
+		child.stdin.end();
+		const result = await exitPromise;
+		assert.equal(result.signal, null, output());
+		assert.equal(result.code, 0, output());
+		assert.match(stdout, /Welcome to my app!/);
+	} finally {
+		if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+	}
+}
+
+test("issue #952: packed Quick Start compiles, renders, and stops on Ctrl+C", { timeout: 30_000 }, async () => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "pi-tui-952-package-"));
+	try {
+		const stagingDir = join(tempRoot, "staging");
+		const artifactDir = join(tempRoot, "artifacts");
+		const npmCacheDir = join(tempRoot, "npm-cache");
+		const unpackDir = join(tempRoot, "unpack");
+		const consumerDir = join(tempRoot, "consumer");
+		const installedPackageDir = join(consumerDir, "node_modules", publicPackageName);
+		for (const directory of [stagingDir, artifactDir, npmCacheDir, unpackDir, consumerDir]) {
+			mkdirSync(directory, { recursive: true });
+		}
+
+		cpSync(join(packageRoot, "package.json"), join(stagingDir, "package.json"));
+		cpSync(join(packageRoot, "README.md"), join(stagingDir, "README.md"));
+		run(
+			resolve(repositoryRoot, "node_modules/.bin/tsgo"),
+			[
+				"-p",
+				join(packageRoot, "tsconfig.build.json"),
+				"--outDir",
+				join(stagingDir, "dist"),
+				"--declarationMap",
+				"false",
+			],
+			packageRoot,
+		);
+		const tarballName = run(
+			"npm",
+			["pack", stagingDir, "--ignore-scripts", "--silent", "--pack-destination", artifactDir],
+			repositoryRoot,
+			{ npm_config_cache: npmCacheDir },
+		)
+			.split(/\r?\n/)
+			.at(-1);
+		assert.ok(tarballName, "npm pack did not report a tarball");
+		run("tar", ["-xzf", join(artifactDir, tarballName), "-C", unpackDir], repositoryRoot);
+		cpSync(join(unpackDir, "package"), installedPackageDir, { recursive: true });
+
+		const packedManifest = JSON.parse(
+			readFileSync(join(installedPackageDir, "package.json"), "utf8"),
+		) as PackageManifest;
+		stageDeclaredDependencyClosure(
+			[...Object.keys(packedManifest.dependencies ?? {}), "@types/node"],
+			join(consumerDir, "node_modules"),
+		);
+
+		const quickStart = extractQuickStart(readFileSync(join(installedPackageDir, "README.md"), "utf8"));
+		assert.doesNotMatch(quickStart, /from\s+["']\.\.?\/test\//, "Quick Start imports a repository-only test module");
+		writeFileSync(join(consumerDir, "quick-start.ts"), quickStart);
+		writeFileSync(
+			join(consumerDir, "package.json"),
+			`${JSON.stringify({ private: true, type: "module" }, null, 2)}\n`,
+		);
+		writeFileSync(
+			join(consumerDir, "tsconfig.json"),
+			`${JSON.stringify(
+				{
+					compilerOptions: {
+						lib: ["ES2022"],
+						module: "NodeNext",
+						moduleResolution: "NodeNext",
+						outDir: "dist",
+						preserveSymlinks: true,
+						rootDir: ".",
+						skipLibCheck: false,
+						strict: true,
+						target: "ES2022",
+						types: ["node"],
+					},
+					include: ["quick-start.ts"],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		run(resolve(repositoryRoot, "node_modules/.bin/tsgo"), ["-p", "tsconfig.json"], consumerDir);
+		await runQuickStart(consumerDir);
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});

--- a/packages/tui/test/952-packed-quick-start.test.ts
+++ b/packages/tui/test/952-packed-quick-start.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -14,7 +14,24 @@ const tsgoCli = resolve(
 	dirname(fileURLToPath(import.meta.resolve("@typescript/native-preview/package.json"))),
 	"bin/tsgo.js",
 );
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+
+function resolveNpmCli(): string {
+	const candidates = [
+		process.env.npm_execpath,
+		resolve(dirname(process.execPath), "node_modules/npm/bin/npm-cli.js"),
+		resolve(dirname(process.execPath), "../lib/node_modules/npm/bin/npm-cli.js"),
+	];
+	const npmCli = candidates.find(
+		(candidate): candidate is string =>
+			typeof candidate === "string" && [".cjs", ".js"].includes(extname(candidate)) && existsSync(candidate),
+	);
+	if (!npmCli) {
+		throw new Error(`Could not resolve npm's JavaScript CLI from ${candidates.filter(Boolean).join(", ")}`);
+	}
+	return realpathSync(npmCli);
+}
+
+const npmCli = resolveNpmCli();
 
 interface PackageManifest {
 	dependencies?: Record<string, string>;
@@ -237,8 +254,8 @@ test("issue #952: packed Quick Start compiles, renders, and stops on Ctrl+C", { 
 			packageRoot,
 		);
 		const tarballName = run(
-			npmCommand,
-			["pack", stagingDir, "--ignore-scripts", "--silent", "--pack-destination", artifactDir],
+			process.execPath,
+			[npmCli, "pack", stagingDir, "--ignore-scripts", "--silent", "--pack-destination", artifactDir],
 			repositoryRoot,
 			{ npm_config_cache: npmCacheDir },
 		)


### PR DESCRIPTION
## Summary

- replace the TUI Quick Start's repository-only test-theme import with a complete inline identity editor theme
- validate the exact README sample from a packed artifact in a clean consumer project
- compile, render, send Ctrl+C, and confirm clean TUI shutdown in the regression
- keep the package's runtime exports and dependencies unchanged

## Root cause

The published TUI artifact includes `dist/**/*` and `README.md`, but the Quick Start imported `./test/test-themes.ts`. That test helper is not shipped, so copying the first public example into an installed project failed before it could compile.

## Validation

- `node --test --import tsx test/952-packed-quick-start.test.ts` from `packages/tui` (1 passed)
- `npm run check`
- independent final review clean at `8df24d78`

Fixes #952


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix TUI Quick Start to run from packed npm artifacts
> - Replaces the repository-relative test theme import in the README Quick Start with an inline `EditorTheme` object, making the snippet self-contained and compilable without access to repo internals.
> - Adds a regression test ([952-packed-quick-start.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1017/files#diff-2d524571043ee458fc9d204836737333a1c58ff2255ec210547a8926121029af)) that builds and packs the TUI, compiles the exact README Quick Start against the packed artifacts in an isolated consumer project, runs it, and asserts successful render and clean exit on Ctrl+C.
> - The test constructs a full dependency closure in an isolated `node_modules` and validates that the Quick Start does not import any repository-only modules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8df24d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->