### PR TITLE
fix(packaging): support branded R2 package artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Check
         run: npm run check
 
+      - name: Check release packages
+        run: npm run check:release-packages
+
   test:
     name: Test (${{ matrix.name }})
     runs-on: ubuntu-latest

--- a/docs/superpowers/specs/2026-08-08-supported-package-artifacts-design.md
+++ b/docs/superpowers/specs/2026-08-08-supported-package-artifacts-design.md
@@ -1,0 +1,76 @@
+# Supported SDK and Library Artifacts
+
+## Context
+
+Prime Agent publishes four branded npm-format tarballs with every stable and beta R2 release, but its library documentation currently points at package names that do not resolve from npm. The branded registry names return 404, while the inherited `@earendil-works/pi-*` names resolve releases from another project. The current stable R2 artifacts install successfully and expose the documented branded imports.
+
+## Decision
+
+The R2 release channel is the only supported external distribution path for the SDK and libraries in this change. The supported public package identities are:
+
+| Artifact | Public package/import | Purpose |
+| --- | --- | --- |
+| `prime-agent-<version>.tgz` | `prime-agent` | CLI and Node.js SDK |
+| `prime-agent-ai-<version>.tgz` | `prime-agent-ai` | Provider and model toolkit |
+| `prime-agent-core-<version>.tgz` | `prime-agent-core` | Stateful agent runtime |
+| `prime-agent-tui-<version>.tgz` | `prime-agent-tui` | Terminal UI primitives |
+
+Stable consumers resolve the version from `stable` or `latest.json`; beta consumers resolve it from `beta` or `beta.json`. Installation uses the resulting immutable `/releases/v<version>/<artifact>` URL. The JSON manifests and per-release `SHA256SUMS` remain the integrity metadata.
+
+The inherited `@earendil-works/pi-*` names remain internal workspace and extension-runtime compatibility specifiers. They are not supported registry install targets. Retiring the legacy local npm publishing commands is explicitly deferred to issue #934.
+
+## Documentation Contract
+
+A canonical SDK/library installation guide will:
+
+- list every supported public artifact, import name, and Node.js requirement;
+- provide stable and beta version resolution for POSIX shells and PowerShell;
+- install immutable tarball URLs rather than nonexistent registry packages;
+- explain SHA-256 verification, lockfile integrity, and reproducible pinning;
+- explain that updates require resolving the channel again and installing the new immutable URL;
+- distinguish public branded imports from internal inherited compatibility specifiers.
+
+The AI, core, TUI, and SDK entry documentation will link to that guide and use branded imports. Programmatic SDK documentation will import from `prime-agent`; source-only examples may retain inherited workspace specifiers when clearly identified as repository development examples. Extension documentation may retain inherited runtime specifiers, but must not claim they are supported registry packages.
+
+The TUI quick start will be self-contained instead of importing an unpublished test theme. The SDK, AI, core, and TUI quick starts must compile against their packed artifacts.
+
+## AI Command Identity
+
+The AI package will expose `prime-agent-ai` as the supported command while retaining `pi-ai` as a compatibility alias. Help and error output will show `npx prime-agent-ai`; it will not direct users to the unrelated inherited npm package.
+
+## Automated Contract Verification
+
+A repository check dedicated to release packages will run after the existing build in pull-request CI. It will:
+
+1. Pack the four artifacts with the existing release packer and a loopback artifact base URL.
+2. Serve the generated immutable artifacts from the same URL shape used by R2.
+3. Install each advertised package into a separate clean temporary project.
+4. Extract and compile the corresponding documentation quick start against the installed package.
+5. Load representative public exports at runtime.
+6. Reject reintroduced bare npm install instructions for the nonexistent branded registry packages or the inherited SDK package.
+
+The check will use the repository's existing compiler, a temporary npm cache, and no provider credentials. It will clean all temporary files and terminate the loopback server on success or failure. Ordinary `npm run check` will remain usable without prebuilt `dist` directories; CI will invoke the artifact contract check separately after `npm run build`.
+
+## Failure Handling
+
+The contract check will fail with the affected package and subprocess output when packing, installation, type checking, or runtime loading fails. The loopback server will only serve an allowlist of generated artifact filenames, so unexpected dependency requests fail instead of escaping the temporary artifact root.
+
+Documentation will state that channel pointers are mutable discovery metadata and immutable release URLs are the dependency identity. Consumers should commit the resulting lockfile and should not expect npm semver ranges, dist-tags, or `npm outdated` to update R2 artifacts.
+
+## Non-goals
+
+- Publishing branded packages to npm.
+- Renaming source workspace manifests or internal imports.
+- Retiring or redesigning legacy local npm publishing commands (#934).
+- Changing R2 credentials, upload permissions, release tags, or production release sequencing.
+- Providing backward compatibility for unsupported registry installation commands.
+
+## Acceptance Criteria
+
+- All documented external SDK/library installs resolve an artifact from the current stable or beta release.
+- Public examples import `prime-agent`, `prime-agent-ai`, `prime-agent-core`, or `prime-agent-tui` as appropriate.
+- Inherited names are described only as internal/runtime compatibility specifiers, not install targets.
+- Stable and beta discovery, immutable pinning, SHA-256 verification, and update behavior are documented.
+- The AI artifact exposes `prime-agent-ai`, retains `pi-ai`, and emits branded help text.
+- Clean-project CI installs and validates every packed public artifact and compiles each package quick start.
+- Legacy local npm publishing behavior and the production release workflow are unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5323,7 +5323,8 @@
 				"zod-to-json-schema": "^3.24.6"
 			},
 			"bin": {
-				"pi-ai": "dist/cli.js"
+				"pi-ai": "dist/cli.js",
+				"prime-agent-ai": "dist/cli.js"
 			},
 			"devDependencies": {
 				"@types/node": "^24.3.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"check": "biome check --write --error-on-warnings . && tsgo --noEmit && npm run check:installer && npm run check:browser-smoke",
 		"check:installer": "node scripts/check-installer-render.mjs",
 		"check:browser-smoke": "node scripts/check-browser-smoke.mjs",
+		"check:release-packages": "node scripts/check-release-package-contract.mjs",
 		"profile:tui": "node scripts/profile-coding-agent-node.mjs --mode tui",
 		"profile:rpc": "node scripts/profile-coding-agent-node.mjs --mode rpc",
 		"test": "npm run test --workspaces --if-present",

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed the documented core installation path to use branded, immutable Prime Agent release artifacts ([#949](https://github.com/PrimeIntellect-ai/prime-agent/issues/949)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -13,13 +13,19 @@
   Stateful agent runtime.
 </p>
 
-Release docs use the Prime Agent package names. The source workspace manifests still keep inherited package names until the namespace migration is complete.
+External releases use the branded `prime-agent-core` and `prime-agent-ai` package names. The inherited source workspace names are not supported npm registry install targets.
 
-## Workspace Package
+## Installation
 
 ```bash
-npm install prime-agent-core
+release_base=https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev
+release_version="$(curl -fsSL "$release_base/stable")"
+npm install \
+  "$release_base/releases/$release_version/prime-agent-ai-${release_version#v}.tgz" \
+  "$release_base/releases/$release_version/prime-agent-core-${release_version#v}.tgz"
 ```
+
+This installs the immutable artifacts for the current stable release. See [SDK and library artifacts](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/docs/package-artifacts.md) for beta releases, PowerShell, integrity verification, pinning, and updates.
 
 ## Quick Start
 
@@ -30,7 +36,7 @@ import { getModel } from "prime-agent-ai";
 const agent = new Agent({
   initialState: {
     systemPrompt: "You are a helpful assistant.",
-    model: getModel("anthropic", "claude-sonnet-4-20250514"),
+    model: getModel("anthropic", "claude-sonnet-4-6"),
   },
 });
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed the documented AI installation path and added the branded `prime-agent-ai` command alias ([#949](https://github.com/PrimeIntellect-ai/prime-agent/issues/949)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -13,7 +13,7 @@
   LLM provider toolkit.
 </p>
 
-Release docs use the Prime Agent package name. The source workspace manifest still keeps an inherited package name until the namespace migration is complete.
+External releases use the branded `prime-agent-ai` package name. The inherited source workspace name is not a supported npm registry install target.
 
 Unified LLM API with automatic model discovery, provider configuration, token and cost tracking, and simple context persistence and hand-off to other models mid-session.
 
@@ -91,8 +91,12 @@ Unified LLM API with automatic model discovery, provider configuration, token an
 ## Installation
 
 ```bash
-npm install prime-agent-ai
+release_base=https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev
+release_version="$(curl -fsSL "$release_base/stable")"
+npm install "$release_base/releases/$release_version/prime-agent-ai-${release_version#v}.tgz"
 ```
+
+This installs the immutable artifact for the current stable release. See [SDK and library artifacts](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/docs/package-artifacts.md) for beta releases, PowerShell, integrity verification, pinning, and updates.
 
 TypeBox exports are re-exported from `prime-agent-ai`: `Type`, `Static`, and `TSchema`.
 
@@ -116,7 +120,7 @@ const tools: Tool[] = [{
 // Build a conversation context (easily serializable and transferable between models)
 const context: Context = {
   systemPrompt: 'You are a helpful assistant.',
-  messages: [{ role: 'user', content: 'What time is it?' }],
+  messages: [{ role: 'user', content: 'What time is it?', timestamp: Date.now() }],
   tools
 };
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -56,7 +56,8 @@
 		}
 	},
 	"bin": {
-		"pi-ai": "./dist/cli.js"
+		"pi-ai": "./dist/cli.js",
+		"prime-agent-ai": "./dist/cli.js"
 	},
 	"files": [
 		"dist",

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -6,6 +6,7 @@ import { getOAuthProvider, getOAuthProviders } from "./utils/oauth/index.js";
 import type { OAuthCredentials, OAuthProviderId } from "./utils/oauth/types.js";
 
 const AUTH_FILE = "auth.json";
+const COMMAND_NAME = "prime-agent-ai";
 const PROVIDERS = getOAuthProviders();
 
 function prompt(rl: ReturnType<typeof createInterface>, question: string): Promise<string> {
@@ -64,7 +65,7 @@ async function main(): Promise<void> {
 
 	if (!command || command === "help" || command === "--help" || command === "-h") {
 		const providerList = PROVIDERS.map((p) => `  ${p.id.padEnd(20)} ${p.name}`).join("\n");
-		console.log(`Usage: npx @earendil-works/pi-ai <command> [provider]
+		console.log(`Usage: npx ${COMMAND_NAME} <command> [provider]
 
 Commands:
   login [provider]  Login to an OAuth provider
@@ -74,9 +75,9 @@ Providers:
 ${providerList}
 
 Examples:
-  npx @earendil-works/pi-ai login              # interactive provider selection
-  npx @earendil-works/pi-ai login anthropic    # login to specific provider
-  npx @earendil-works/pi-ai list               # list providers
+  npx ${COMMAND_NAME} login              # interactive provider selection
+  npx ${COMMAND_NAME} login anthropic    # login to specific provider
+  npx ${COMMAND_NAME} list               # list providers
 `);
 		return;
 	}
@@ -113,7 +114,7 @@ Examples:
 
 		if (!PROVIDERS.some((p) => p.id === provider)) {
 			console.error(`Unknown provider: ${provider}`);
-			console.error(`Use 'npx @earendil-works/pi-ai list' to see available providers`);
+			console.error(`Use 'npx ${COMMAND_NAME} list' to see available providers`);
 			process.exit(1);
 		}
 
@@ -123,7 +124,7 @@ Examples:
 	}
 
 	console.error(`Unknown command: ${command}`);
-	console.error(`Use 'npx @earendil-works/pi-ai --help' for usage`);
+	console.error(`Use 'npx ${COMMAND_NAME} --help' for usage`);
 	process.exit(1);
 }
 

--- a/packages/ai/test/cli-branding.test.ts
+++ b/packages/ai/test/cli-branding.test.ts
@@ -1,0 +1,37 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const tsxLoader = require.resolve("tsx/esm");
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("Prime Agent AI command branding", () => {
+	it("exposes the branded command and keeps the compatibility alias", () => {
+		const packageJson = require(join(packageRoot, "package.json")) as {
+			bin?: Record<string, string>;
+		};
+
+		expect(packageJson.bin).toEqual({
+			"pi-ai": "./dist/cli.js",
+			"prime-agent-ai": "./dist/cli.js",
+		});
+	});
+
+	it("uses the branded command in help output", () => {
+		const result = spawnSync(
+			process.execPath,
+			["--import", tsxLoader, join(packageRoot, "src", "cli.ts"), "--help"],
+			{
+				cwd: packageRoot,
+				encoding: "utf8",
+			},
+		);
+
+		expect(result.status, result.stderr).toBe(0);
+		expect(result.stdout).toContain("Usage: npx prime-agent-ai <command> [provider]");
+		expect(result.stdout).not.toContain("@earendil-works/pi-ai");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed SDK and library installation guidance to use branded, immutable Prime Agent release artifacts ([#949](https://github.com/PrimeIntellect-ai/prime-agent/issues/949)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -9,7 +9,7 @@ LLMs have limited context windows. When conversations grow too long, Prime Agent
 - [`session-manager.ts`](../src/core/session-manager.ts) - Entry types (`CompactionEntry`, `BranchSummaryEntry`)
 - [`extensions/types.ts`](../src/core/extensions/types.ts) - Extension event types
 
-For TypeScript definitions in your project, inspect `node_modules/@earendil-works/pi-coding-agent/dist/`.
+For TypeScript definitions in an external project, inspect `node_modules/prime-agent/dist/` after following the [SDK installation guide](package-artifacts.md).
 
 ## Overview
 
@@ -308,6 +308,8 @@ pi.on("session_before_compact", async (event, ctx) => {
 #### Converting Messages to Text
 
 To generate a summary with your own model, convert messages to text using `serializeConversation`:
+
+The following snippet runs inside the extension host, so it uses the inherited `@earendil-works/pi-coding-agent` runtime compatibility specifier. External applications import the same APIs from `prime-agent`.
 
 ```typescript
 import { convertToLlm, serializeConversation } from "@earendil-works/pi-coding-agent";

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -47,6 +47,7 @@ Public releases are currently installed from versioned release artifacts. The in
 
 ## Programmatic Usage
 
+- [SDK and library artifacts](package-artifacts.md) - install branded, immutable SDK and library releases.
 - [SDK](sdk.md) - embed Prime Agent in Node.js applications.
 - [ACP mode](acp.md) - drive Prime Agent from any Agent Client Protocol client.
 - [RPC mode](rpc.md) - integrate over stdin/stdout JSONL.

--- a/packages/coding-agent/docs/package-artifacts.md
+++ b/packages/coding-agent/docs/package-artifacts.md
@@ -1,0 +1,85 @@
+# SDK and Library Artifacts
+
+Prime Agent distributes its Node.js SDK and libraries as branded npm-format tarballs through the same R2 stable and beta channels as the CLI. These artifacts are the supported external install path; they are not published under the branded names in the npm registry.
+
+## Packages
+
+| Package and import | Artifact | Node.js | Use |
+| --- | --- | --- | --- |
+| `prime-agent` | `prime-agent-<version>.tgz` | 22.8 or newer | CLI and Node.js SDK |
+| `prime-agent-ai` | `prime-agent-ai-<version>.tgz` | 20 or newer | Provider and model toolkit |
+| `prime-agent-core` | `prime-agent-core-<version>.tgz` | 20 or newer | Stateful agent runtime |
+| `prime-agent-tui` | `prime-agent-tui-<version>.tgz` | 20 or newer | Terminal UI primitives |
+
+`prime-agent-core` examples also use `prime-agent-ai`, and the full SDK guide uses both `prime-agent` and `prime-agent-ai`. Install both artifacts for those cases.
+
+## Install the Current Stable Release
+
+POSIX shell:
+
+```bash
+release_base=https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev
+release_version="$(curl -fsSL "$release_base/stable")"
+package=prime-agent-ai
+npm install "$release_base/releases/$release_version/$package-${release_version#v}.tgz"
+```
+
+Set `package` to `prime-agent`, `prime-agent-ai`, `prime-agent-core`, or `prime-agent-tui`. Install multiple URLs in one `npm install` command when an example uses more than one package.
+
+PowerShell:
+
+```powershell
+$ReleaseBase = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev"
+$ReleaseVersion = (Invoke-RestMethod "$ReleaseBase/stable").Trim()
+$PlainVersion = $ReleaseVersion.TrimStart("v")
+$Package = "prime-agent-ai"
+npm install "$ReleaseBase/releases/$ReleaseVersion/$Package-$PlainVersion.tgz"
+```
+
+The `stable` pointer contains the active version with its `v` prefix. `latest.json` exposes the same version plus the CLI tarball path and SHA-256 metadata for every package.
+
+## Install a Beta Release
+
+Use the beta pointer instead of the stable pointer:
+
+```bash
+release_base=https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev
+release_version="$(curl -fsSL "$release_base/beta")"
+package=prime-agent-ai
+npm install "$release_base/releases/$release_version/$package-${release_version#v}.tgz"
+```
+
+In PowerShell, resolve `"$ReleaseBase/beta"` instead. `beta.json` provides the structured beta manifest. Beta versions follow the latest successful `main` build and are not promoted to stable automatically.
+
+## Integrity and Reproducible Installs
+
+Channel pointers are mutable discovery metadata. The resolved `/releases/v<version>/...` URL is immutable and is the dependency identity to commit to `package.json` and `package-lock.json`.
+
+Verify an artifact before installation when you do not want npm to download it directly:
+
+```bash
+release_base=https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev
+release_version="$(curl -fsSL "$release_base/stable")"
+artifact="prime-agent-ai-${release_version#v}.tgz"
+release_url="$release_base/releases/$release_version"
+
+curl -fsSLO "$release_url/$artifact"
+curl -fsSLO "$release_url/SHA256SUMS"
+grep -F "  $artifact" SHA256SUMS > SHA256SUMS.selected
+sha256sum -c SHA256SUMS.selected
+npm install "./$artifact"
+```
+
+On macOS, replace the verification command with `shasum -a 256 -c SHA256SUMS.selected`. On PowerShell, compare `(Get-FileHash -Algorithm SHA256 $Artifact).Hash.ToLower()` with the package's `sha256` value from `latest.json` or `beta.json` before installation.
+
+npm records the resolved URL and integrity in `package-lock.json`. Commit the lockfile so CI and collaborators use the same release.
+
+## Updating
+
+R2 artifacts do not have npm dist-tags or semver range discovery. `npm outdated` does not discover a newer Prime Agent artifact.
+
+To update, resolve `stable` or `beta` again, review the new version and manifest checksum, then rerun `npm install` with the new immutable URL. Review and commit the resulting `package.json` and `package-lock.json` changes. To stay pinned, keep the existing immutable URL.
+
+## Internal Compatibility Names
+
+The source workspace and extension runtime retain `@earendil-works/pi-*` specifiers for compatibility. Those names are internal implementation or extension peer-dependency identifiers, not supported registry install targets for Prime Agent SDK/library consumers. External applications should import only the branded names in the table above.

--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -161,7 +161,7 @@ If no `pi` manifest is present, Prime Agent auto-discovers resources from these 
 
 Third party runtime dependencies belong in `dependencies` in `package.json`. Dependencies that do not register extensions, skills, prompt templates, or themes also belong in `dependencies`. When Prime Agent installs a package from npm or git, it runs `npm install`, so those dependencies are installed automatically.
 
-Prime Agent bundles core packages for extensions and skills. The workspace still publishes these inherited package names; if you import any of them, list them in `peerDependencies` with a `"*"` range and do not bundle them: `@earendil-works/pi-ai`, `@earendil-works/pi-agent-core`, `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, `typebox`.
+Prime Agent exposes inherited package names as runtime compatibility specifiers for extensions and skills. They are not supported npm registry install targets. If you import any of them, list them in `peerDependencies` with a `"*"` range and do not bundle them: `@earendil-works/pi-ai`, `@earendil-works/pi-agent-core`, `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, `typebox`.
 
 Other resource packages must be bundled in your tarball. Add them to `dependencies` and `bundledDependencies`, then reference their resources through `node_modules/` paths. Prime Agent loads packages with separate module roots, so separate installs do not collide or share modules.
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -2,7 +2,7 @@
 
 RPC mode enables headless operation of the coding agent via a JSON protocol over stdin/stdout. This is useful for embedding the agent in other applications, IDEs, or custom UIs.
 
-**Note for Node.js/TypeScript users**: If you're building a Node.js application, consider using `AgentSession` directly from `@earendil-works/pi-coding-agent` instead of spawning a subprocess. See [`src/core/agent-session.ts`](../src/core/agent-session.ts) for the API. For a subprocess-based TypeScript client, see [`src/modes/rpc/rpc-client.ts`](../src/modes/rpc/rpc-client.ts).
+**Note for Node.js/TypeScript users**: If you're building a Node.js application, consider using `AgentSession` directly from `prime-agent` instead of spawning a subprocess. Follow the [SDK installation guide](package-artifacts.md), then see [`src/core/agent-session.ts`](../src/core/agent-session.ts) for the API. For a subprocess-based TypeScript client, see [`src/modes/rpc/rpc-client.ts`](../src/modes/rpc/rpc-client.ts).
 
 ## Starting RPC Mode
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -16,7 +16,7 @@ See [examples/sdk/](../examples/sdk/) for working examples from minimal to full 
 ## Quick Start
 
 ```typescript
-import { AuthStorage, createAgentSession, ModelRegistry, SessionManager } from "@earendil-works/pi-coding-agent";
+import { AuthStorage, createAgentSession, ModelRegistry, SessionManager } from "prime-agent";
 
 // Set up credential storage and model registry
 const authStorage = AuthStorage.create();
@@ -40,10 +40,14 @@ await session.prompt("What files are in the current directory?");
 ## Installation
 
 ```bash
-npm install @earendil-works/pi-coding-agent
+release_base=https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev
+release_version="$(curl -fsSL "$release_base/stable")"
+npm install \
+  "$release_base/releases/$release_version/prime-agent-${release_version#v}.tgz" \
+  "$release_base/releases/$release_version/prime-agent-ai-${release_version#v}.tgz"
 ```
 
-The SDK is included in the main package. No separate installation needed.
+The SDK is included in the `prime-agent` artifact. This guide also imports `getModel` from `prime-agent-ai`, so the command installs both branded artifacts from the same immutable release. See [SDK and library artifacts](package-artifacts.md) for beta releases, PowerShell, integrity verification, pinning, and updates.
 
 ## Core Concepts
 
@@ -54,7 +58,7 @@ The main factory function for a single `AgentSession`.
 `createAgentSession()` uses a `ResourceLoader` to supply extensions, skills, prompt templates, themes, and context files. If you do not provide one, it uses `DefaultResourceLoader` with standard discovery.
 
 ```typescript
-import { createAgentSession } from "@earendil-works/pi-coding-agent";
+import { createAgentSession } from "prime-agent";
 
 // Minimal: defaults with DefaultResourceLoader
 const { session } = await createAgentSession();
@@ -132,7 +136,7 @@ import {
   createAgentSessionServices,
   getAgentDir,
   SessionManager,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
   const services = await createAgentSessionServices({ cwd });
@@ -239,7 +243,7 @@ Both `steer()` and `followUp()` expand file-based prompt templates but error on 
 
 ### Agent and AgentState
 
-The `Agent` class (from `@earendil-works/pi-agent-core`) handles the core LLM interaction. Access it via `session.agent`.
+The `Agent` class (from `prime-agent-core`) handles the core LLM interaction. Access it via `session.agent`.
 
 ```typescript
 // Access current state
@@ -368,8 +372,8 @@ When you pass a custom `ResourceLoader`, `cwd` and `agentDir` no longer control 
 ### Model
 
 ```typescript
-import { getModel } from "@earendil-works/pi-ai";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { getModel } from "prime-agent-ai";
+import { AuthStorage, ModelRegistry } from "prime-agent";
 
 const authStorage = AuthStorage.create();
 const modelRegistry = ModelRegistry.create(authStorage);
@@ -416,7 +420,7 @@ API key resolution priority (handled by AuthStorage):
 4. Fallback resolver (for custom provider keys from `models.json`)
 
 ```typescript
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { AuthStorage, ModelRegistry } from "prime-agent";
 
 // Default: uses ~/.prime/agent/auth.json and ~/.prime/agent/models.json
 const authStorage = AuthStorage.create();
@@ -452,7 +456,7 @@ const simpleRegistry = ModelRegistry.inMemory(authStorage);
 Use a `ResourceLoader` to override the system prompt:
 
 ```typescript
-import { createAgentSession, DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
+import { createAgentSession, DefaultResourceLoader } from "prime-agent";
 
 const loader = new DefaultResourceLoader({
   systemPromptOverride: () => "You are a helpful assistant.",
@@ -487,7 +491,7 @@ import {
   createIpythonToolDefinition,
   createBashToolDefinition,
   createEditToolDefinition,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 const cwd = "/path/to/project";
 
@@ -514,7 +518,7 @@ const { session } = await createAgentSession({
 
 ```typescript
 import { Type } from "typebox";
-import { createAgentSession, defineTool } from "@earendil-works/pi-coding-agent";
+import { createAgentSession, defineTool } from "prime-agent";
 
 // Inline custom tool
 const myTool = defineTool({
@@ -547,7 +551,7 @@ Custom tools passed via `customTools` are combined with extension-registered too
 Extensions are loaded by the `ResourceLoader`. `DefaultResourceLoader` discovers extensions from `~/.prime/agent/extensions/`, `.prime/agent/extensions/`, and `settings.json` extension sources.
 
 ```typescript
-import { createAgentSession, DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
+import { createAgentSession, DefaultResourceLoader } from "prime-agent";
 
 const loader = new DefaultResourceLoader({
   additionalExtensionPaths: ["/path/to/my-extension.ts"],
@@ -569,7 +573,7 @@ Extensions can register tools, subscribe to events, add commands, and more. See 
 **Event Bus:** Extensions can communicate via `pi.events`. Pass a shared `eventBus` to `DefaultResourceLoader` if you need to emit or listen from outside:
 
 ```typescript
-import { createEventBus, DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
+import { createEventBus, DefaultResourceLoader } from "prime-agent";
 
 const eventBus = createEventBus();
 const loader = new DefaultResourceLoader({
@@ -589,7 +593,7 @@ import {
   createAgentSession,
   DefaultResourceLoader,
   type Skill,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 const customSkill: Skill = {
   name: "my-skill",
@@ -615,7 +619,7 @@ const { session } = await createAgentSession({ resourceLoader: loader });
 ### Context Files
 
 ```typescript
-import { createAgentSession, DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
+import { createAgentSession, DefaultResourceLoader } from "prime-agent";
 
 const loader = new DefaultResourceLoader({
   agentsFilesOverride: (current) => ({
@@ -639,7 +643,7 @@ import {
   createAgentSession,
   DefaultResourceLoader,
   type PromptTemplate,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 const customCommand: PromptTemplate = {
   name: "deploy",
@@ -674,7 +678,7 @@ import {
   createAgentSessionServices,
   getAgentDir,
   SessionManager,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 // In-memory (no persistence)
 const { session } = await createAgentSession({
@@ -768,7 +772,7 @@ sm.createBranchedSession(leafId);       // Extract path to new file
 ### Settings Management
 
 ```typescript
-import { createAgentSession, SettingsManager, SessionManager } from "@earendil-works/pi-coding-agent";
+import { createAgentSession, SettingsManager, SessionManager } from "prime-agent";
 
 // Default: loads from files (global + project merged)
 const { session } = await createAgentSession({
@@ -824,7 +828,7 @@ Use `DefaultResourceLoader` to discover extensions, skills, prompts, themes, and
 import {
   DefaultResourceLoader,
   getAgentDir,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 const loader = new DefaultResourceLoader({
   cwd,
@@ -865,7 +869,7 @@ interface LoadExtensionsResult {
 ## Complete Example
 
 ```typescript
-import { getModel } from "@earendil-works/pi-ai";
+import { getModel } from "prime-agent-ai";
 import { Type } from "typebox";
 import {
  AuthStorage,
@@ -875,7 +879,7 @@ import {
   ModelRegistry,
   SessionManager,
   SettingsManager,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 // Set up auth storage (custom location)
 const authStorage = AuthStorage.create("/custom/agent/auth.json");
@@ -960,7 +964,7 @@ import {
   getAgentDir,
   InteractiveMode,
   SessionManager,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
   const services = await createAgentSessionServices({ cwd });
@@ -1000,7 +1004,7 @@ import {
   getAgentDir,
   runPrintMode,
   SessionManager,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
   const services = await createAgentSessionServices({ cwd });
@@ -1037,7 +1041,7 @@ import {
   getAgentDir,
   runRpcMode,
   SessionManager,
-} from "@earendil-works/pi-coding-agent";
+} from "prime-agent";
 
 const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
   const services = await createAgentSessionServices({ cwd });

--- a/packages/coding-agent/docs/session-format.md
+++ b/packages/coding-agent/docs/session-format.md
@@ -33,7 +33,7 @@ Existing sessions are automatically migrated to the current version (v3) when lo
 - [`packages/ai/src/types.ts`](../../ai/src/types.ts) - Base message types (`UserMessage`, `AssistantMessage`, `ToolResultMessage`)
 - [`packages/agent/src/types.ts`](../../agent/src/types.ts) - `AgentMessage` union type
 
-For TypeScript definitions in your project, inspect `node_modules/@earendil-works/pi-coding-agent/dist/` and `node_modules/@earendil-works/pi-ai/dist/`.
+For TypeScript definitions in an external project, inspect `node_modules/prime-agent/dist/` and `node_modules/prime-agent-ai/dist/` after following the [SDK installation guide](package-artifacts.md).
 
 ## Message Types
 

--- a/packages/coding-agent/examples/sdk/README.md
+++ b/packages/coding-agent/examples/sdk/README.md
@@ -2,9 +2,10 @@
 
 Programmatic usage of the Prime Agent SDK via `createAgentSession()` and `createAgentSessionRuntime()`.
 
-The published TypeScript packages still use inherited `@earendil-works/pi-*`
-identifiers. Those identifiers are API names, not a dependency on the upstream
-Pi monorepo.
+These repository examples use inherited `@earendil-works/pi-*` workspace
+specifiers so they run directly from source. External consumers install and
+import the branded release artifacts documented in
+[SDK and library artifacts](../../docs/package-artifacts.md).
 
 The runtime example shows how to build a recreate function that closes over process-global fixed inputs and recreates cwd-bound services and sessions as the active session cwd changes.
 

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -126,7 +126,7 @@ function getDefaultAgentDir(): string {
  * const { session } = await createAgentSession();
  *
  * // With explicit model
- * import { getModel } from '@earendil-works/pi-ai';
+ * import { getModel } from 'prime-agent-ai';
  * const { session } = await createAgentSession({
  *   model: getModel('anthropic', 'claude-opus-4-5'),
  *   thinkingLevel: 'high',

--- a/packages/coding-agent/test/release-package-documentation.test.ts
+++ b/packages/coding-agent/test/release-package-documentation.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(packageRoot, "..", "..");
+
+function readRepoFile(relativePath: string): string {
+	return readFileSync(join(repoRoot, relativePath), "utf8");
+}
+
+describe("release package documentation", () => {
+	it("defines stable, beta, integrity, and update guidance for immutable artifacts", () => {
+		const guide = readRepoFile("packages/coding-agent/docs/package-artifacts.md");
+
+		expect(guide).toContain("/stable");
+		expect(guide).toContain("/beta");
+		expect(guide).toContain("SHA256SUMS");
+		expect(guide).toContain("package-lock.json");
+		expect(guide).toContain("prime-agent-ai");
+		expect(guide).toContain("prime-agent-core");
+		expect(guide).toContain("prime-agent-tui");
+	});
+
+	it("does not advertise unsupported registry installs in public entry documentation", () => {
+		const publicEntryDocs = [
+			"packages/agent/README.md",
+			"packages/ai/README.md",
+			"packages/tui/README.md",
+			"packages/coding-agent/docs/sdk.md",
+		].map(readRepoFile);
+
+		for (const document of publicEntryDocs) {
+			expect(document).not.toMatch(
+				/npm install (?:prime-agent(?:-(?:ai|core|tui))?|@earendil-works\/pi-(?:agent-core|ai|coding-agent|tui))/,
+			);
+		}
+	});
+
+	it("uses branded package identities in external programmatic documentation", () => {
+		const externalProgrammaticDocs = [
+			"packages/coding-agent/docs/sdk.md",
+			"packages/coding-agent/docs/rpc.md",
+			"packages/coding-agent/docs/session-format.md",
+		].map(readRepoFile);
+
+		for (const document of externalProgrammaticDocs) {
+			expect(document).not.toContain("@earendil-works/pi-");
+		}
+
+		const sdk = externalProgrammaticDocs[0];
+		expect(sdk).toContain('from "prime-agent"');
+		expect(sdk).toContain('from "prime-agent-ai"');
+		const sdkSource = readRepoFile("packages/coding-agent/src/core/sdk.ts");
+		expect(sdkSource).not.toContain("import { getModel } from '@earendil-works/pi-ai';");
+		expect(sdkSource).toContain("import { getModel } from 'prime-agent-ai';");
+
+		const compaction = readRepoFile("packages/coding-agent/docs/compaction.md");
+		expect(compaction).toContain("node_modules/prime-agent/dist/");
+		expect(compaction).toContain("runtime compatibility specifier");
+	});
+
+	it("keeps the TUI quick start independent of unpublished test files", () => {
+		const tuiReadme = readRepoFile("packages/tui/README.md");
+		const quickStart = tuiReadme.split("## Quick Start", 2)[1]?.split("## Core API", 1)[0];
+
+		expect(quickStart).toBeDefined();
+		expect(quickStart).not.toContain("./test/");
+	});
+
+	it("labels inherited package names as runtime compatibility specifiers", () => {
+		const packageGuide = readRepoFile("packages/coding-agent/docs/packages.md");
+
+		expect(packageGuide).toContain("runtime compatibility specifiers");
+		expect(packageGuide).not.toContain("The workspace still publishes these inherited package names");
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed the documented TUI installation path and made the published quick start self-contained ([#949](https://github.com/PrimeIntellect-ai/prime-agent/issues/949)).
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -13,7 +13,7 @@
   Terminal UI primitives.
 </p>
 
-Release docs use the Prime Agent package name. The source workspace manifest still keeps an inherited package name until the namespace migration is complete.
+External releases use the branded `prime-agent-tui` package name. The inherited source workspace name is not a supported npm registry install target.
 
 Minimal terminal UI framework with differential rendering and synchronized output for flicker-free interactive CLI applications.
 
@@ -28,10 +28,20 @@ Minimal terminal UI framework with differential rendering and synchronized outpu
 - **Image Support**: Renders terminal graphics or compact image metadata
 - **Autocomplete Support**: File paths and slash commands
 
+## Installation
+
+```bash
+release_base=https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev
+release_version="$(curl -fsSL "$release_base/stable")"
+npm install "$release_base/releases/$release_version/prime-agent-tui-${release_version#v}.tgz"
+```
+
+This installs the immutable artifact for the current stable release. See [SDK and library artifacts](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/docs/package-artifacts.md) for beta releases, PowerShell, integrity verification, pinning, and updates.
+
 ## Quick Start
 
 ```typescript
-import { TUI, Text, Editor, ProcessTerminal, matchesKey } from "prime-agent-tui";
+import { Key, ProcessTerminal, Text, TUI, matchesKey } from "prime-agent-tui";
 
 // Create terminal
 const terminal = new ProcessTerminal();
@@ -42,23 +52,13 @@ const tui = new TUI(terminal);
 // Add components
 tui.addChild(new Text("Welcome to my app!"));
 
-import { defaultEditorTheme as editorTheme } from './test/test-themes.ts';
-const editor = new Editor(tui, editorTheme);
-editor.onSubmit = (text) => {
-  console.log("Submitted:", text);
-  tui.addChild(new Text(`You said: ${text}`));
-};
-tui.addChild(editor);
-
-// Focus the editor so it receives keyboard input
-tui.setFocus(editor);
-
 // In raw mode Ctrl+C doesn't send SIGINT — intercept it here to allow exit
 tui.addInputListener((data) => {
-  if (matchesKey(data, 'ctrl+c')) {
+  if (matchesKey(data, Key.ctrl("c"))) {
     tui.stop();
-    process.exit(0);
+    return { consume: true };
   }
+  return undefined;
 });
 
 // Start

--- a/scripts/check-release-package-contract.mjs
+++ b/scripts/check-release-package-contract.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createReadStream } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const releaseRoot = join(repoRoot, "packages", "coding-agent", "release");
+const contractVersion = "0.0.0-contract";
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const typeScriptCli = join(repoRoot, "node_modules", "typescript", "bin", "tsc");
+
+const packages = [
+	{
+		name: "prime-agent-ai",
+		readme: "packages/ai/README.md",
+		install: ["prime-agent-ai"],
+		runtime: `import { Type, getModel } from "prime-agent-ai";
+if (typeof Type !== "object" || typeof getModel !== "function") throw new Error("prime-agent-ai exports missing");
+`,
+	},
+	{
+		name: "prime-agent-core",
+		readme: "packages/agent/README.md",
+		install: ["prime-agent-ai", "prime-agent-core"],
+		runtime: `import { Agent } from "prime-agent-core";
+import { getModel } from "prime-agent-ai";
+if (typeof Agent !== "function" || typeof getModel !== "function") throw new Error("prime-agent-core exports missing");
+`,
+	},
+	{
+		name: "prime-agent-tui",
+		readme: "packages/tui/README.md",
+		install: ["prime-agent-tui"],
+		runtime: `import { TUI, Text } from "prime-agent-tui";
+if (typeof TUI !== "function" || typeof Text !== "function") throw new Error("prime-agent-tui exports missing");
+`,
+	},
+	{
+		name: "prime-agent",
+		readme: "packages/coding-agent/docs/sdk.md",
+		install: ["prime-agent", "prime-agent-ai"],
+		runtime: `import { AuthStorage, createAgentSession } from "prime-agent";
+import { getModel } from "prime-agent-ai";
+if (typeof AuthStorage !== "function" || typeof createAgentSession !== "function" || typeof getModel !== "function") {
+	throw new Error("prime-agent SDK exports missing");
+}
+`,
+	},
+];
+
+function artifactFile(packageName) {
+	return `${packageName}-${contractVersion}.tgz`;
+}
+
+function readRepoFile(relativePath) {
+	return readFileSync(join(repoRoot, relativePath), "utf8");
+}
+
+function extractQuickStart(relativePath) {
+	const markdown = readRepoFile(relativePath);
+	const heading = "## Quick Start";
+	const headingIndex = markdown.indexOf(heading);
+	if (headingIndex === -1) {
+		throw new Error(`${relativePath}: missing ${heading}`);
+	}
+
+	const afterHeading = markdown.slice(headingIndex + heading.length);
+	const nextHeadingIndex = afterHeading.search(/^## /m);
+	const section = nextHeadingIndex === -1 ? afterHeading : afterHeading.slice(0, nextHeadingIndex);
+	const codeBlock = section.match(/```typescript\r?\n([\s\S]*?)\r?\n```/);
+	if (!codeBlock) {
+		throw new Error(`${relativePath}: missing TypeScript quick start block`);
+	}
+	return codeBlock[1];
+}
+
+function assertDocumentationContract() {
+	const unsupportedInstalls =
+		/npm install (?:prime-agent(?:-(?:ai|core|tui))?|@earendil-works\/pi-(?:agent-core|ai|coding-agent|tui))/;
+	for (const packageContract of packages) {
+		const readme = readRepoFile(packageContract.readme);
+		if (unsupportedInstalls.test(readme)) {
+			throw new Error(`${packageContract.readme}: contains an unsupported registry install command`);
+		}
+	}
+
+	const externalProgrammaticDocs = [
+		"packages/coding-agent/docs/sdk.md",
+		"packages/coding-agent/docs/rpc.md",
+		"packages/coding-agent/docs/session-format.md",
+	];
+	for (const relativePath of externalProgrammaticDocs) {
+		if (readRepoFile(relativePath).includes("@earendil-works/pi-")) {
+			throw new Error(`${relativePath}: contains inherited external package guidance`);
+		}
+	}
+	const sdkSource = readRepoFile("packages/coding-agent/src/core/sdk.ts");
+	if (sdkSource.includes("import { getModel } from '@earendil-works/pi-ai';")) {
+		throw new Error("packages/coding-agent/src/core/sdk.ts: contains an inherited package import in public JSDoc");
+	}
+
+	const compaction = readRepoFile("packages/coding-agent/docs/compaction.md");
+	if (!compaction.includes("runtime compatibility specifier")) {
+		throw new Error("packages/coding-agent/docs/compaction.md: does not identify its extension runtime import");
+	}
+
+	const tuiQuickStart = extractQuickStart("packages/tui/README.md");
+	if (tuiQuickStart.includes("./test/")) {
+		throw new Error("packages/tui/README.md: quick start imports an unpublished test file");
+	}
+}
+
+function run(command, args, options = {}) {
+	return new Promise((resolveRun, rejectRun) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd ?? repoRoot,
+			env: { ...process.env, ...options.env },
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.once("error", rejectRun);
+		child.once("close", (code) => {
+			if (code === 0) {
+				resolveRun({ stdout, stderr });
+				return;
+			}
+			rejectRun(
+				new Error(
+					`${command} ${args.join(" ")} failed with exit code ${code ?? "unknown"}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`,
+				),
+			);
+		});
+	});
+}
+
+async function listen(server) {
+	await new Promise((resolveListen, rejectListen) => {
+		const onError = (error) => rejectListen(error);
+		server.once("error", onError);
+		server.listen(0, "127.0.0.1", () => {
+			server.off("error", onError);
+			resolveListen();
+		});
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Loopback artifact server did not report a TCP port");
+	}
+	return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server) {
+	if (!server.listening) return;
+	await new Promise((resolveClose, rejectClose) => {
+		server.close((error) => (error ? rejectClose(error) : resolveClose()));
+	});
+}
+
+function createArtifactServer(artifactsDir) {
+	const prefix = `/releases/v${contractVersion}/`;
+	const allowedFiles = new Set(packages.map((packageContract) => artifactFile(packageContract.name)));
+
+	return createServer((request, response) => {
+		const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+		if (!requestUrl.pathname.startsWith(prefix)) {
+			response.writeHead(404).end();
+			return;
+		}
+
+		const requestedFile = decodeURIComponent(requestUrl.pathname.slice(prefix.length));
+		if (requestedFile !== basename(requestedFile) || !allowedFiles.has(requestedFile)) {
+			response.writeHead(404).end();
+			return;
+		}
+
+		const artifactPath = join(artifactsDir, requestedFile);
+		if (!existsSync(artifactPath)) {
+			response.writeHead(404).end();
+			return;
+		}
+
+		response.writeHead(200, { "content-type": "application/gzip" });
+		const stream = createReadStream(artifactPath);
+		stream.once("error", (error) => response.destroy(error));
+		stream.pipe(response);
+	});
+}
+
+async function validatePackage(packageContract, baseUrl, tempRoot, npmCache) {
+	const consumerDir = join(tempRoot, packageContract.name);
+	mkdirSync(consumerDir, { recursive: true });
+	writeFileSync(
+		join(consumerDir, "package.json"),
+		`${JSON.stringify({ name: `${packageContract.name}-contract`, private: true, type: "module" }, null, 2)}\n`,
+	);
+
+	const installUrls = packageContract.install.map(
+		(packageName) => `${baseUrl}/releases/v${contractVersion}/${artifactFile(packageName)}`,
+	);
+	await run(
+		npmCommand,
+		["install", "--ignore-scripts", "--no-audit", "--no-fund", "--package-lock=false", ...installUrls],
+		{
+			cwd: consumerDir,
+			env: { npm_config_cache: npmCache },
+		},
+	);
+
+	writeFileSync(join(consumerDir, "quick-start.ts"), `${extractQuickStart(packageContract.readme)}\n`);
+	writeFileSync(join(consumerDir, "runtime.mjs"), packageContract.runtime);
+	writeFileSync(
+		join(consumerDir, "tsconfig.json"),
+		`${JSON.stringify(
+			{
+				compilerOptions: {
+					module: "NodeNext",
+					moduleResolution: "NodeNext",
+					noEmit: true,
+					skipLibCheck: true,
+					strict: true,
+					target: "ES2022",
+				},
+				files: ["quick-start.ts"],
+			},
+			null,
+			2,
+		)}\n`,
+	);
+
+	await run(process.execPath, [typeScriptCli, "--project", "tsconfig.json"], { cwd: consumerDir });
+	await run(process.execPath, ["runtime.mjs"], { cwd: consumerDir });
+	console.log(`Validated ${packageContract.name}`);
+}
+
+async function main() {
+	assertDocumentationContract();
+	mkdirSync(releaseRoot, { recursive: true });
+	const outputDir = mkdtempSync(join(releaseRoot, "contract-"));
+	const tempRoot = mkdtempSync(join(tmpdir(), "prime-agent-release-contract-"));
+	const npmCache = join(tempRoot, "npm-cache");
+	const artifactsDir = join(outputDir, "artifacts");
+	const server = createArtifactServer(artifactsDir);
+
+	try {
+		const baseUrl = await listen(server);
+		await run(process.execPath, [
+			join(repoRoot, "scripts", "pack-prime-agent-release.mjs"),
+			"--channel",
+			"stable",
+			"--version",
+			contractVersion,
+			"--base-url",
+			baseUrl,
+			"--out-dir",
+			outputDir,
+		]);
+
+		for (const packageContract of packages) {
+			await validatePackage(packageContract, baseUrl, tempRoot, npmCache);
+		}
+	} finally {
+		await close(server);
+		rmSync(outputDir, { force: true, recursive: true });
+		rmSync(tempRoot, { force: true, recursive: true });
+	}
+
+	console.log("Release package contract passed.");
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+});


### PR DESCRIPTION
Fixes #949

## Summary

- documents immutable R2 tarballs as the supported external SDK/library install path for `prime-agent`, `prime-agent-ai`, `prime-agent-core`, and `prime-agent-tui`
- adds stable/beta discovery, SHA-256 verification, lockfile pinning, and update guidance while distinguishing extension-runtime compatibility specifiers
- adds the `prime-agent-ai` command alias, retains `pi-ai`, and brands AI CLI help output
- validates all four packed artifacts in separate clean projects after the existing PR build

## Design

Public examples use branded imports and immutable release URLs resolved from the stable or beta channel. The release-package contract serves locally packed tarballs from the production URL shape, installs them without provider credentials, compiles each documented quick start, and loads representative exports.

Legacy local npm publishing retirement remains scoped to #934. This PR does not change production release sequencing or perform any release, upload, or tag action.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/cli-branding.test.ts` from `packages/ai` (2 passed)
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/release-package-documentation.test.ts` from `packages/coding-agent` (5 passed)
- `node scripts/check-release-package-contract.mjs` (all four artifacts passed)
- `npm run check`
- independent code review: clean


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add branded R2 package artifacts and CI contract verification for release packages
> - Adds branded CLI aliases and package identities: `prime-agent-ai`, `prime-agent`, and `prime-agent-tui` are now the canonical install targets via immutable R2 URLs, replacing inherited `@earendil-works/pi-*` names in all public docs and CLI help text.
> - Adds [scripts/check-release-package-contract.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/1019/files#diff-83e2972fea7507aece8234001a0bd0622fe39aa0dde1c4a5c97c33459adf7360), a standalone verifier that packs release artifacts, serves them via a loopback HTTP server, installs them into clean temp projects, compiles quick-start TypeScript, and validates runtime exports.
> - Adds a `check:release-packages` npm script and a corresponding CI step in [.github/workflows/ci.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/1019/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) to run the contract verifier on every build.
> - Updates SDK, RPC, TUI, and compaction docs to reference branded import paths and immutable artifact installs with integrity verification.
> - Behavioral Change: `@earendil-works/pi-*` names are now explicitly documented as unsupported npm registry install targets (runtime compatibility specifiers only).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85c63cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->