### PR TITLE
Pin workflow actions and minimize release-job secret scope

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -18,8 +18,7 @@ concurrency:
   cancel-in-progress: false
   queue: max
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   release-context:
@@ -34,7 +33,7 @@ jobs:
       publish_production: ${{ steps.context.outputs.publish_production }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -128,7 +127,7 @@ jobs:
       PUBLISH_PRODUCTION: ${{ needs.release-context.outputs.publish_production }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.BUILD_REF }}
           persist-credentials: false
@@ -174,7 +173,7 @@ jobs:
 
       - name: Upload production artifacts
         if: env.PUBLISH_PRODUCTION == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: prime-agent-production
           path: packages/coding-agent/release/production/artifacts/*
@@ -182,7 +181,7 @@ jobs:
 
       - name: Upload beta artifacts
         if: env.PUBLISH_BETA == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: prime-agent-beta
           path: packages/coding-agent/release/beta/artifacts/*
@@ -194,34 +193,29 @@ jobs:
     permissions:
       contents: write
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      AWS_DEFAULT_REGION: auto
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       BETA_VERSION: ${{ needs.release-context.outputs.beta_version }}
       BUILD_REF: ${{ needs.release-context.outputs.build_ref }}
       PRODUCTION_VERSION: ${{ needs.release-context.outputs.production_version }}
       PUBLISH_BETA: ${{ needs.release-context.outputs.publish_beta }}
       PUBLISH_PRODUCTION: ${{ needs.release-context.outputs.publish_production }}
-      R2_BUCKET: ${{ secrets.R2_BUCKET }}
-      R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
       R2_PUBLIC_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.BUILD_REF }}
           persist-credentials: false
 
       - name: Download production artifacts
         if: env.PUBLISH_PRODUCTION == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: prime-agent-production
           path: release-artifacts/production
 
       - name: Download beta artifacts
         if: env.PUBLISH_BETA == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: prime-agent-beta
           path: release-artifacts/beta
@@ -254,6 +248,12 @@ jobs:
 
       - name: Publish production channel to R2
         if: env.PUBLISH_PRODUCTION == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
         run: |
           PRODUCTION_DIR=release-artifacts/production
           RELEASE_PREFIX="releases/v${PRODUCTION_VERSION}"
@@ -322,6 +322,12 @@ jobs:
 
       - name: Publish immutable beta artifacts to R2
         if: env.PUBLISH_BETA == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
         run: |
           BETA_DIR=release-artifacts/beta
           RELEASE_PREFIX="releases/v${BETA_VERSION}"
@@ -346,8 +352,9 @@ jobs:
             --content-type text/plain \
             --cache-control 'public, max-age=31536000, immutable'
 
-      - name: Advance beta release
+      - name: Check whether beta should advance
         if: env.PUBLISH_BETA == 'true'
+        id: beta_context
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -355,9 +362,20 @@ jobs:
           latest_main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${DEFAULT_BRANCH}" --jq .sha)
           if [ "$latest_main_sha" != "$BUILD_REF" ]; then
             echo "A newer main commit exists; keeping its beta pointers in place."
-            exit 0
+            echo "should_advance=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_advance=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Advance beta channel in R2
+        if: env.PUBLISH_BETA == 'true' && steps.beta_context.outputs.should_advance == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+        run: |
           BETA_DIR=release-artifacts/beta
           aws s3 cp "$BETA_DIR/beta.json" "s3://${R2_BUCKET}/beta.json" \
             --endpoint-url "$R2_ENDPOINT_URL" \
@@ -379,6 +397,13 @@ jobs:
             --content-type text/x-shellscript \
             --cache-control no-cache
 
+      - name: Advance beta GitHub release
+        if: env.PUBLISH_BETA == 'true' && steps.beta_context.outputs.should_advance == 'true'
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BETA_DIR=release-artifacts/beta
           printf 'Automated beta build from `%s` (`%s`).\n' "$DEFAULT_BRANCH" "$BUILD_REF" > /tmp/beta-release-notes.md
 
           if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/beta" >/dev/null 2>&1; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,21 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build-check:
     name: Build and check
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -43,10 +44,16 @@ jobs:
       - name: Check
         run: npm run check
 
+      - name: Check workflow security contracts
+        working-directory: packages/coding-agent
+        run: node --test scripts/check-workflow-security.mjs
+
   test:
     name: Test (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -85,10 +92,10 @@ jobs:
             install_uv: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -120,6 +127,7 @@ jobs:
     if: always()
     needs: [build-check, test]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Verify CI results
         env:

--- a/.github/workflows/nightly-process-stress.yml
+++ b/.github/workflows/nightly-process-stress.yml
@@ -9,20 +9,21 @@ concurrency:
   group: nightly-process-stress
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   process-stress:
     name: Process stress
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/packages/coding-agent/scripts/check-workflow-security.mjs
+++ b/packages/coding-agent/scripts/check-workflow-security.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import test from "node:test";
+import { parse } from "yaml";
+
+const workflowsDirectory = new URL("../../../.github/workflows/", import.meta.url);
+const expectedPermissionsByWorkflow = {
+	"build-binaries.yml": {
+		build: { contents: "read" },
+		publish: { contents: "write" },
+		"release-context": { contents: "read" },
+	},
+	"ci.yml": {
+		"build-check": { contents: "read" },
+		"build-check-test": {},
+		test: { contents: "read" },
+	},
+	"nightly-process-stress.yml": {
+		"process-stress": { contents: "read" },
+	},
+};
+
+function isWorkflowFilename(name) {
+	return /\.ya?ml$/i.test(name);
+}
+
+async function readWorkflows() {
+	const names = (await readdir(workflowsDirectory)).filter(isWorkflowFilename).sort();
+	return Promise.all(
+		names.map(async (name) => ({
+			name,
+			source: await readFile(new URL(name, workflowsDirectory), "utf8"),
+		})),
+	);
+}
+
+function getJobBlocks(source) {
+	const lines = source.split("\n");
+	const jobsIndex = lines.findIndex((line) => line === "jobs:");
+	assert.notEqual(jobsIndex, -1, "workflow must define jobs");
+
+	const starts = [];
+	for (let index = jobsIndex + 1; index < lines.length; index += 1) {
+		const match = /^  ([a-zA-Z0-9_-]+):\s*$/.exec(lines[index]);
+		if (match) starts.push({ index, name: match[1] });
+	}
+
+	return starts.map((start, index) => ({
+		name: start.name,
+		source: lines.slice(start.index, starts[index + 1]?.index ?? lines.length).join("\n"),
+	}));
+}
+
+function getNamedSteps(jobSource) {
+	const lines = jobSource.split("\n");
+	const starts = [];
+	for (let index = 0; index < lines.length; index += 1) {
+		const match = /^      - name: (.+)$/.exec(lines[index]);
+		if (match) starts.push({ index, name: match[1] });
+	}
+
+	return new Map(
+		starts.map((start, index) => [
+			start.name,
+			lines.slice(start.index, starts[index + 1]?.index ?? lines.length).join("\n"),
+		]),
+	);
+}
+
+test("third-party actions use full commit SHAs with version comments", async () => {
+	const workflows = await readWorkflows();
+	for (const workflow of workflows) {
+		for (const [index, line] of workflow.source.split("\n").entries()) {
+			const match = /^\s*uses:\s+([^\s@]+)@([^\s#]+)(?:\s+#\s+(.+))?$/.exec(line);
+			if (!match || match[1].startsWith("./") || match[1].startsWith("docker://")) continue;
+
+			assert.match(
+				match[2],
+				/^[0-9a-f]{40}$/,
+				`${workflow.name}:${index + 1} must pin ${match[1]} to a full commit SHA`,
+			);
+			assert.match(
+				match[3] ?? "",
+				/^v\d+(?:\.\d+){1,2}.*$/,
+				`${workflow.name}:${index + 1} must document the pinned action version`,
+			);
+		}
+	}
+});
+
+test("workflow discovery covers both supported YAML extensions", () => {
+	const candidates = ["ignored.json", "nightly.yaml", "release.yml", "UPPER.YAML"];
+	assert.deepEqual(candidates.filter(isWorkflowFilename), ["nightly.yaml", "release.yml", "UPPER.YAML"]);
+});
+
+test("workflows default to no token permissions and grant only allowlisted job permissions", async () => {
+	const workflows = await readWorkflows();
+	assert.deepEqual(
+		workflows.map(({ name }) => name),
+		Object.keys(expectedPermissionsByWorkflow).sort(),
+		"every workflow must have an explicit permission allowlist",
+	);
+
+	for (const workflow of workflows) {
+		const document = parse(workflow.source);
+		assert.deepEqual(document.permissions, {}, `${workflow.name} must default to no token permissions`);
+
+		const expectedJobs = expectedPermissionsByWorkflow[workflow.name];
+		assert.deepEqual(
+			Object.keys(document.jobs ?? {}).sort(),
+			Object.keys(expectedJobs).sort(),
+			`${workflow.name} jobs must match the permission allowlist`,
+		);
+
+		for (const [jobName, expectedPermissions] of Object.entries(expectedJobs)) {
+			assert.deepEqual(
+				document.jobs[jobName].permissions,
+				expectedPermissions,
+				`${workflow.name} job ${jobName} must use only its allowlisted permissions`,
+			);
+		}
+	}
+});
+
+test("R2 secrets are available only to R2 upload steps", async () => {
+	const releaseWorkflow = await readFile(new URL("build-binaries.yml", workflowsDirectory), "utf8");
+	const publishJob = getJobBlocks(releaseWorkflow).find((job) => job.name === "publish");
+	assert.ok(publishJob, "release workflow must define the publish job");
+
+	const steps = getNamedSteps(publishJob.source);
+	const allowedSecretSteps = new Set([
+		"Publish production channel to R2",
+		"Publish immutable beta artifacts to R2",
+		"Advance beta channel in R2",
+	]);
+
+	for (const [name, source] of steps) {
+		if (!source.includes("secrets.R2_")) continue;
+		assert.ok(allowedSecretSteps.has(name), `${name} must not receive R2 secrets`);
+		assert.match(source, /\baws s3 cp\b/, `${name} must upload to R2`);
+		assert.doesNotMatch(source, /\bgh (?:api|release)\b/, `${name} must not mix R2 and GitHub publication`);
+	}
+
+	for (const name of allowedSecretSteps) {
+		const source = steps.get(name);
+		assert.ok(source, `release workflow must define ${name}`);
+		for (const secret of ["R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "R2_BUCKET", "R2_ENDPOINT_URL"]) {
+			assert.match(source, new RegExp(`secrets\\.${secret}\\b`), `${name} must scope ${secret} locally`);
+		}
+	}
+
+	const publishPrefix = publishJob.source.slice(0, publishJob.source.indexOf("    steps:"));
+	assert.doesNotMatch(publishPrefix, /secrets\.R2_/, "publish job must not expose R2 secrets at job scope");
+});
+
+test("beta pointer updates preserve the latest-main guard without sharing R2 credentials", async () => {
+	const releaseWorkflow = await readFile(new URL("build-binaries.yml", workflowsDirectory), "utf8");
+	const publishJob = getJobBlocks(releaseWorkflow).find((job) => job.name === "publish");
+	assert.ok(publishJob, "release workflow must define the publish job");
+	const steps = getNamedSteps(publishJob.source);
+
+	const guard = steps.get("Check whether beta should advance");
+	assert.ok(guard, "beta publication must check the latest main commit");
+	assert.match(guard, /id: beta_context/);
+	assert.match(guard, /should_advance=(?:false|true)/);
+	assert.doesNotMatch(guard, /secrets\.R2_/);
+
+	const condition = /steps\.beta_context\.outputs\.should_advance == 'true'/;
+	assert.match(steps.get("Advance beta channel in R2") ?? "", condition);
+	assert.match(steps.get("Advance beta GitHub release") ?? "", condition);
+	assert.doesNotMatch(steps.get("Advance beta GitHub release") ?? "", /secrets\.R2_/);
+});
+
+test("Dependabot continues updating pinned GitHub Actions", async () => {
+	const dependabot = await readFile(new URL("../../../.github/dependabot.yml", import.meta.url), "utf8");
+	assert.match(dependabot, /package-ecosystem:\s+github-actions/);
+});


### PR DESCRIPTION
## What changed

- Pinned every third-party workflow action to a reviewed full commit SHA with its release version documented inline.
- Changed workflow defaults to no token permissions and declared an exact least-privilege permission map for every job.
- Moved R2 secrets from publish-job scope into the three R2 upload steps.
- Split beta pointer uploads from GitHub release updates while preserving the latest-main guard.
- Added a CI contract that parses every `.yml` and `.yaml` workflow and enforces action pins, permission allowlists, secret scope, beta gating, and Dependabot coverage.

## Why

Mutable action tags can change without a repository diff. Job-scoped R2 secrets also made credentials available to unrelated checkout, artifact, and GitHub release steps in the privileged publish job.

## Impact

The release paths and latest-main beta guard remain unchanged. Workflow actions are reproducible, jobs receive only their declared token access, and R2 credentials exist only while R2 uploads run. This PR does not dispatch or publish a release.

## Root cause

Workflow hardening was applied inconsistently: some actions were pinned while others used moving major tags, workflow-level read permissions were inherited by jobs that did not need them, and publish credentials were configured at job scope.

## Checks

- `node --test scripts/check-workflow-security.mjs` from `packages/coding-agent` (6/6 passed)
- `npm run check`
- YAML parse validation for all workflows and Dependabot configuration
- `git diff --check`
- Independent code review: clean

Fixes #926


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin workflow actions and minimize secret scope in CI and release workflows
> - All GitHub Actions workflows now set top-level permissions to `{}` with explicit job-level grants, reducing the blast radius of a compromised workflow step.
> - Third-party actions (`actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`) are pinned to specific commit SHAs with version comments in all workflows.
> - R2 secrets in [build-binaries.yml](.github/workflows/build-binaries.yml) are moved from job-level `env` to step-local `env` blocks, scoping them only to R2 upload steps and away from GitHub release steps.
> - Beta channel advancement is refactored into a guard step that sets `should_advance` output, gating both the R2 and GitHub release steps without leaking R2 secrets to the release step.
> - A new [check-workflow-security.mjs](packages/coding-agent/scripts/check-workflow-security.mjs) script enforces these policies in CI, failing the build if any workflow violates pinning, permission scoping, R2 secret scoping, or Dependabot coverage rules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfd34f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->