### PR TITLE
fix(coding-agent): show onboarding skip hint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
+- Fixed first-run onboarding not indicating that Prime login can be skipped with Escape ([#1021](https://github.com/PrimeIntellect-ai/prime-agent/pull/1021) by [@NACC96](https://github.com/NACC96)).
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 
 ## [0.7.1] - 2026-08-07

--- a/packages/coding-agent/src/modes/interactive/components/prime-onboarding-splash.ts
+++ b/packages/coding-agent/src/modes/interactive/components/prime-onboarding-splash.ts
@@ -123,6 +123,14 @@ export class PrimeOnboardingSplashComponent implements Component {
 		];
 	}
 
+	private formatSkipHint(): PanelTextLine {
+		return [
+			{ text: "Press ", tone: "muted" },
+			{ text: "ESC", tone: "accent", bold: true },
+			{ text: " to skip", tone: "muted" },
+		];
+	}
+
 	private formatBrandLine(): PanelTextLine {
 		return [
 			{ text: "Welcome to ", tone: "text" },
@@ -142,6 +150,9 @@ export class PrimeOnboardingSplashComponent implements Component {
 		lines.push({ left: 0, parts: [] });
 		lines.push(this.centerParts(this.formatBrandLine(), width));
 		lines.push(this.centerParts(this.formatContinueHint(), width));
+		if (!this.progressMessage) {
+			lines.push(this.centerParts(this.formatSkipHint(), width));
+		}
 
 		return lines;
 	}

--- a/packages/coding-agent/test/prime-onboarding-splash.test.ts
+++ b/packages/coding-agent/test/prime-onboarding-splash.test.ts
@@ -31,6 +31,7 @@ describe("PrimeOnboardingSplashComponent", () => {
 		expect(lines).toHaveLength(36);
 		expect(output).toContain("Welcome to PRIME Agent");
 		expect(output).toContain("Press Enter to login with Prime Intellect");
+		expect(output).toContain("Press ESC to skip");
 		expect(output).toContain("·");
 		expect(output).not.toContain("prime agent");
 		expect(output).not.toContain("Research and infrastructure assistant for high-context work.");
@@ -88,6 +89,7 @@ describe("PrimeOnboardingSplashComponent", () => {
 		const output = stripAnsi(component.render(100).join("\n"));
 
 		expect(output).toContain("Press Enter to choose a model");
+		expect(output).toContain("Press ESC to skip");
 		expect(output).not.toContain("Press Enter to login with Prime Intellect");
 	});
 
@@ -103,6 +105,7 @@ describe("PrimeOnboardingSplashComponent", () => {
 		const output = stripAnsi(component.render(100).join("\n"));
 		expect(output).toContain("Preparing models...");
 		expect(output).not.toContain("Press Enter");
+		expect(output).not.toContain("Press ESC");
 		expect(onSelect).not.toHaveBeenCalled();
 		expect(onCancel).not.toHaveBeenCalled();
 	});
@@ -131,6 +134,7 @@ describe("PrimeOnboardingSplashComponent", () => {
 		expect(secondRender).not.toBe(firstRender);
 		expect(secondRender).toContain("Welcome to PRIME Agent");
 		expect(secondRender).toContain("Press Enter to login with Prime Intellect");
+		expect(secondRender).toContain("Press ESC to skip");
 	});
 
 	it("centers stacked content in narrow terminals", () => {
@@ -143,9 +147,11 @@ describe("PrimeOnboardingSplashComponent", () => {
 		const logoLine = rendered.find((line) => line.includes(PRIME_BUTTERFLY_LOGO.split("\n")[0].trim()));
 		const brandLine = rendered.find((line) => line.includes("Welcome to PRIME Agent"));
 		const hintLine = rendered.find((line) => line.includes("Press Enter to login with Prime Intellect"));
+		const skipHintLine = rendered.find((line) => line.includes("Press ESC to skip"));
 
 		expect(logoLine?.search(/\S/)).toBeGreaterThan(0);
 		expect(brandLine?.search(/\S/)).toBeGreaterThan(0);
 		expect(hintLine?.search(/\S/)).toBeGreaterThan(0);
+		expect(skipHintLine?.search(/\S/)).toBeGreaterThan(0);
 	});
 });


### PR DESCRIPTION
## Summary

- show `Press ESC to skip` on the Prime onboarding splash
- hide the skip hint while onboarding progress disables input
- cover the login, model-selection, progress, animation, and narrow-terminal render states

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/prime-onboarding-splash.test.ts`
- `npm run check`

Closes #992


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show 'Press ESC to skip' hint on Prime onboarding splash screen
> Adds a centered 'Press ESC to skip' hint to the onboarding splash panel in [prime-onboarding-splash.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1021/files#diff-62488b6fe8f54db2a34bdae0e96afbf3066bae56d66608940863d4a34b9dd612). The hint is only shown when no progress message is active, and the `ESC` label is styled as accent and bold.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c523d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->