### PR TITLE
feat(coding-agent): accept cwd on rlm spawn so children load project context

### DIFF
--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -333,7 +333,10 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	}
 
 	async createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime> {
-		const sessionManager = SessionManager.create(options.parentSession.sessionManager.getCwd(), options.sessionDir);
+		// A requested child cwd rebuilds cwd-bound services there, so the child's
+		// project context files (AGENTS.md and friends) load from the child cwd.
+		const childCwd = options.cwd ?? options.parentSession.sessionManager.getCwd();
+		const sessionManager = SessionManager.create(childCwd, options.sessionDir);
 		if (options.parentSession.sessionFile) {
 			sessionManager.newSession({
 				parentSession: options.parentSession.sessionFile,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -15,7 +15,7 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import {
@@ -222,6 +222,7 @@ import {
 	createRlmListSubagentsHostHandler,
 	createRlmRunHostHandler,
 	findRlmModelMatches,
+	normalizeRequestedRlmSubagentCwd,
 	normalizeRequestedRlmSubagentModel,
 	normalizeRequestedRlmSubagentSessionName,
 	type RlmDeleteSubagentResult,
@@ -8932,6 +8933,7 @@ export class AgentSession {
 		sessionName: string;
 		spawnCode?: string;
 		sessionDir: string;
+		cwd?: string;
 		model: Model<any>;
 	}): CreateRlmSubagentRuntimeOptions {
 		return {
@@ -8941,6 +8943,7 @@ export class AgentSession {
 			sessionName: options.sessionName,
 			spawnCode: options.spawnCode,
 			sessionDir: options.sessionDir,
+			cwd: options.cwd,
 			model: options.model,
 			thinkingLevel: clampThinkingLevel(options.model, this.thinkingLevel) as ThinkingLevel,
 			serviceTier:
@@ -8966,7 +8969,12 @@ export class AgentSession {
 	}
 
 	private _createInlineRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): RlmSubagentRuntime {
-		const childSessionManager = SessionManager.create(this._cwd, options.sessionDir);
+		// The inline runtime reuses the parent's resource loader, so a child with a
+		// different cwd runs there (tools, kernel, session) but inherits the
+		// parent's loaded context files. A subagent runtime host rebuilds
+		// cwd-bound services and loads the child cwd's project context.
+		const childCwd = options.cwd ?? this._cwd;
+		const childSessionManager = SessionManager.create(childCwd, options.sessionDir);
 		if (options.parentSession.sessionFile) {
 			childSessionManager.newSession({
 				parentSession: options.parentSession.sessionFile,
@@ -9004,7 +9012,7 @@ export class AgentSession {
 			agent: childAgent,
 			sessionManager: childSessionManager,
 			settingsManager: this.settingsManager,
-			cwd: this._cwd,
+			cwd: childCwd,
 			agentDir: this._agentDir,
 			scopedModels: options.scopedModels,
 			resourceLoader: this._resourceLoader,
@@ -9606,13 +9614,21 @@ export class AgentSession {
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
 	): Promise<RlmSpawnHandle> {
-		const { name: rawName, model: rawModel, ...unsupported } = kwargs;
+		const { name: rawName, model: rawModel, cwd: rawCwd, ...unsupported } = kwargs;
 		const unsupportedKwargs = Object.keys(unsupported);
 		if (unsupportedKwargs.length > 0) {
 			throw new Error(`Unsupported rlm.run kwargs: ${unsupportedKwargs.sort().join(", ")}`);
 		}
 		const requestedSessionName = normalizeRequestedRlmSubagentSessionName(rawName);
 		const requestedModel = normalizeRequestedRlmSubagentModel(rawModel);
+		const requestedCwd = normalizeRequestedRlmSubagentCwd(rawCwd);
+		let childCwd: string | undefined;
+		if (requestedCwd !== undefined) {
+			childCwd = resolve(this._cwd, requestedCwd);
+			if (!existsSync(childCwd) || !statSync(childCwd).isDirectory()) {
+				throw new Error(`rlm.run cwd is not an existing directory: ${childCwd}`);
+			}
+		}
 		if (requestedSessionName) assertDirectAgentMessageTarget(requestedSessionName);
 		if (this._rlmDepth >= this._rlmMaxDepth) {
 			throw new Error(
@@ -9701,6 +9717,7 @@ export class AgentSession {
 				sessionName,
 				spawnCode,
 				sessionDir: childSessionDir,
+				cwd: childCwd,
 				model: modelSelection.model,
 			}),
 			onSessionPublished: publishChildSession,

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -127,7 +127,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 		parts.push(
 			"",
 			"A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, and `model`; it never waits for or returns the child's answer.",
-			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.",
+			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name. Pass `cwd='/path/to/project'` to start the child in another working directory so that project's context files load for it.",
 			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
 		);
 		if (hasAgentMessage) {

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -76,6 +76,21 @@ export function normalizeRequestedRlmSubagentSessionName(value: unknown): string
 	return name;
 }
 
+/** Validate and normalize an orchestrator-supplied subagent working directory. */
+export function normalizeRequestedRlmSubagentCwd(value: unknown): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new Error("rlm.run cwd must be a string");
+	}
+	const cwd = value.trim();
+	if (!cwd) {
+		throw new Error("rlm.run cwd must not be empty");
+	}
+	return cwd;
+}
+
 /** Validate and normalize an orchestrator-supplied subagent model reference. */
 export function normalizeRequestedRlmSubagentModel(value: unknown): string | undefined {
 	if (value === undefined) {
@@ -208,6 +223,8 @@ export interface CreateRlmSubagentRuntimeOptions {
 	prompt: string;
 	sessionName: string;
 	sessionDir: string;
+	/** Working directory for the child session; defaults to the parent's cwd. */
+	cwd?: string;
 	model: Model<any>;
 	thinkingLevel: ThinkingLevel;
 	serviceTier: ServiceTier;

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2168,6 +2168,29 @@ describe("AgentSession rlm recursion", () => {
 		);
 	});
 
+	it("starts a child in a requested cwd and rejects a missing one", async () => {
+		const projectDir = join(tempDir, "project-worktree");
+		mkdirSync(projectDir, { recursive: true });
+		const root = createSession();
+
+		const spawned = await root.runRlmChild("work in the project", { cwd: projectDir });
+		await waitFor(() => root.getRlmChildSession(spawned.rlm_child_id) !== undefined);
+		const child = root.getRlmChildSession(spawned.rlm_child_id);
+		if (!child) throw new Error("Missing retained child session");
+		expect(child.sessionManager.getCwd()).toBe(projectDir);
+		await waitFor(() => (root as unknown as InspectableRlmSession)._activeRlmChildRuns.size === 0);
+
+		const unchanged = await root.runRlmChild("work in the parent cwd");
+		await waitFor(() => root.getRlmChildSession(unchanged.rlm_child_id) !== undefined);
+		expect(root.getRlmChildSession(unchanged.rlm_child_id)?.sessionManager.getCwd()).toBe(tempDir);
+		await waitFor(() => (root as unknown as InspectableRlmSession)._activeRlmChildRuns.size === 0);
+
+		await expect(root.runRlmChild("bad cwd", { cwd: join(tempDir, "missing-dir") })).rejects.toThrow(
+			"rlm.run cwd is not an existing directory",
+		);
+		await expect(root.runRlmChild("empty cwd", { cwd: "   " })).rejects.toThrow("rlm.run cwd must not be empty");
+	});
+
 	it("cancels active rlm children when the parent session is disposed", async () => {
 		let releaseChild: () => void = () => {};
 		const release = new Promise<void>((resolve) => {

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -144,6 +144,8 @@ async def run(prompt: str, **kwargs: Any) -> RLMSpawnHandle:
     """Spawn a recursive Prime Agent child and return once its task is admitted.
 
     ``model`` selects a child with an exact ``provider/model`` selector.
+    ``cwd`` starts the child in another working directory so that project's
+    context files load for it.
     """
     if not isinstance(prompt, str):
         raise TypeError(f"prompt must be str, got {type(prompt).__name__}")


### PR DESCRIPTION
## Problem

`rlm('task')` children always start in the parent's working directory. When an orchestrating agent fans work out across project worktrees, each child lands in the orchestrator's cwd, so the target project's context files (AGENTS.md and friends) never load and the child's tools and kernel run in the wrong directory.

## Fix

`rlm.run` accepts an optional `cwd` kwarg: `await rlm('sub-task', cwd='/path/to/worktree')`.

- The path is resolved against the parent cwd and must be an existing directory; bad input fails the spawn loudly.
- Inline runtime: the child's session manager, tools, and IPython kernel run in the requested cwd.
- Subagent runtime host: cwd-bound services are rebuilt for the child cwd, so the child's project context files load naturally.
- Omitting `cwd` keeps today's behavior exactly.

Docs updated in the RLM system prompt section and the Python runtime docstring.

## Testing

- New test in `agent-session-recursion.test.ts` covering: child starts in the requested cwd, default stays the parent cwd, missing directory rejected, empty cwd rejected.
- Full `agent-session-recursion` suite run; the one failure (`cancels nested rlm child runs through the root session`) also fails on unmodified `main` in this environment.
- `npm run check` clean.

_Written by an AI agent._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept `cwd` argument in `rlm.run` so child agent sessions load project context from a requested directory
> - `rlm.run` now accepts an optional `cwd` kwarg; the child session's `SessionManager` and `AgentSession` are initialized with this directory instead of always inheriting the parent cwd.
> - Invalid `cwd` values (non-string, empty, non-existent, or non-directory paths) are rejected with descriptive errors via the new `normalizeRequestedRlmSubagentCwd` validator in [rlm-runtime.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1025/files#diff-e2f3586cb159b174f953a03ce37d872c059275b629a160203d8ef5c8db5d30e7).
> - Both inline and spawned (RLM) subagent runtime paths are updated in [agent-session.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1025/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae) and [agent-session-runtime.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1025/files#diff-1994b08ce23faef00deaf413d3713bcc738413c2e2cfea08b90663cffc8c9381) to propagate the validated child cwd.
> - Behavioral Change: child sessions previously always ran in the parent cwd; they now run in the caller-supplied directory when provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66ad9fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->