### PR TITLE
fix(installer): handle missing POSIX shell on Windows

### DIFF
--- a/scripts/check-installer-render.mjs
+++ b/scripts/check-installer-render.mjs
@@ -10,6 +10,16 @@ const ansiPattern = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 const syncEnd = "\x1b[?2026l";
 const failures = [];
 
+const shellProbe = spawnSync("sh", ["-c", ":"], { encoding: "utf-8" });
+if (shellProbe.error?.code === "ENOENT" && process.platform === "win32") {
+	console.log("Installer render check skipped: POSIX sh is not available on Windows.");
+	process.exit(0);
+}
+if (shellProbe.error || shellProbe.status !== 0) {
+	console.error(`Installer render check failed: could not start POSIX sh.${formatSpawnFailure(shellProbe)}`);
+	process.exit(1);
+}
+
 if (mainCallIndex === -1) {
 	console.error('Installer render check failed: could not find final main "$@" call.');
 	process.exit(1);
@@ -169,7 +179,7 @@ function runCase(name, initialCols, initialRows, resizedCols, resizedRows) {
 		encoding: "utf-8",
 	});
 	if (result.status !== 0) {
-		failures.push(`${name}: harness exited with ${result.status ?? "unknown"}\n${result.stderr}${result.stdout}`);
+		failures.push(`${name}: harness exited with ${result.status ?? "unknown"}${formatSpawnFailure(result)}`);
 		return emptyParsedCase();
 	}
 
@@ -312,4 +322,18 @@ function emptyParsedCase() {
 		screens: {},
 		progress: [],
 	};
+}
+
+function formatSpawnFailure(result) {
+	const details = [];
+	if (result.error) {
+		details.push(result.error.message);
+	}
+	if (result.stderr) {
+		details.push(result.stderr.trimEnd());
+	}
+	if (result.stdout) {
+		details.push(result.stdout.trimEnd());
+	}
+	return details.length > 0 ? `\n${details.join("\n")}` : "";
 }

--- a/scripts/check-installer-render.mjs
+++ b/scripts/check-installer-render.mjs
@@ -10,6 +10,11 @@ const ansiPattern = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 const syncEnd = "\x1b[?2026l";
 const failures = [];
 
+if (mainCallIndex === -1) {
+	console.error('Installer render check failed: could not find final main "$@" call.');
+	process.exit(1);
+}
+
 const shellProbe = spawnSync("sh", ["-c", ":"], { encoding: "utf-8" });
 if (shellProbe.error?.code === "ENOENT" && process.platform === "win32") {
 	console.log("Installer render check skipped: POSIX sh is not available on Windows.");
@@ -17,11 +22,6 @@ if (shellProbe.error?.code === "ENOENT" && process.platform === "win32") {
 }
 if (shellProbe.error || shellProbe.status !== 0) {
 	console.error(`Installer render check failed: could not start POSIX sh.${formatSpawnFailure(shellProbe)}`);
-	process.exit(1);
-}
-
-if (mainCallIndex === -1) {
-	console.error('Installer render check failed: could not find final main "$@" call.');
 	process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

- probe POSIX `sh` before running the installer render harness
- skip the installer-specific render check only on Windows when `sh` is unavailable
- report the actual spawn error instead of `unknown / undefinedundefined`

## Root cause

`scripts/check-installer-render.mjs` unconditionally spawned `sh` and inspected only the child status and output. On native Windows without a POSIX shell, `spawnSync` returned an `ENOENT` error before creating a child, leaving `status`, `stdout`, and `stderr` empty. This made the required repository check fail with no actionable diagnostic.

## Impact

Native Windows contributors can run the required `npm run check` without an undocumented Git Bash dependency. Installer hosts and CI still execute the complete render harness whenever `sh` is available. Other shell startup failures remain fatal and now include their actual error.

## Validation

- `npm run check:installer` from PowerShell without `sh` on `PATH`: explicit Windows skip, exit 0
- `npm run check`: pass
- pre-commit `npm run check` from Git Bash environment: complete installer render check passed
- Biome: 900 files checked, no fixes
- TypeScript and browser smoke check: pass

Fixes #1023


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip installer render check when POSIX shell is unavailable on Windows
> - Adds a `sh` availability probe in [check-installer-render.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/1026/files#diff-22dc1ee148ea8609089fbf10f9465e8ca5e6375523e99bb314a55b9c0381ae5e) using `spawnSync("sh", ["-c", ":"])` before running any test cases.
> - On Windows where `sh` is missing (`ENOENT`), the script exits 0 with a skip message instead of failing.
> - Introduces `formatSpawnFailure` to produce consistent diagnostic output (error message, stderr, stdout) for both the probe and test case failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b208553.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->