### PR TITLE
feat(coding-agent): inherit local harness state in RLM children

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added copy-on-spawn inheritance of session-local continual harness state for RLM children, with isolated child-owned snapshots ([#1028](https://github.com/PrimeIntellect-ai/prime-agent/pull/1028) by [@shashwatgokhe](https://github.com/shashwatgokhe)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -162,11 +162,13 @@ Unknown options fail instead of being ignored. Model search is bounded to active
 1. Check `RLM_DEPTH < RLM_MAX_DEPTH`.
 2. Resolve the requested model or inherit the parent model.
 3. Create a `sub-xxxxxxxx` child directory under the parent artifact directory.
-4. Admit the task into the parent registry and return its `RLMSpawnHandle`.
-5. In detached work, create a child `SessionManager`, `Agent`, and `AgentSession`.
-6. Reuse provider hooks, resource loader, model registry, tools, transport, retry settings, and thinking configuration.
-7. Run the child prompt, retain its session, and update lifecycle state independently of the admission call.
-8. Attribute child usage to the parent assistant turn and persist the attribution.
+4. Capture the parent's session-local continual harness as an admission-time snapshot.
+5. Admit the task into the parent registry and return its `RLMSpawnHandle`.
+6. In detached work, create a child `SessionManager` and seed the snapshot into its artifact directory.
+7. Create the child `Agent` and `AgentSession`.
+8. Reuse provider hooks, resource loader, model registry, tools, transport, retry settings, and thinking configuration.
+9. Run the child prompt, retain its session, and update lifecycle state independently of the admission call.
+10. Attribute child usage to the parent assistant turn and persist the attribution.
 
 Children receive incremented `RLM_DEPTH`, the inherited maximum depth, and their own `RLM_SESSION_DIR`. The default maximum depth is 1, so root sessions may create children and those children may not create grandchildren unless the limit is configured higher.
 
@@ -209,6 +211,8 @@ On reload, the aggregate is reapplied to the parent message. Context-tree report
 `rlm.harness` is a persisted state ledger for prompt notes, memories, reusable skill descriptions, sub-agent specifications, and refinement events. It is not a second execution engine.
 
 Session-local state lives in the session artifact directory under `harness/harness_state.json`. Explicitly global entries live under `~/.prime/agent/harness/`. The Python store reloads after external modification so host-side `/refine` writes and kernel writes do not overwrite each other.
+
+An RLM child starts with a snapshot of its parent's local prompt notes, memories, skills, and sub-agent specifications. Inheritance metadata records the original source session, immediate parent, inheritance time, and source version. Refinement history is not copied. The child owns the snapshot and can refine it without changing its parent or siblings. Parent changes made after spawn do not alter an existing child, while children spawned later receive the newer state. Nested delegation carries the resulting local state forward again.
 
 `/refine` runs a dedicated review over the current trajectory and applies small create/update/delete edits. Rollback uses recorded before/after snapshots. The base system prompt remains immutable; refinements are supplemental state.
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -11,7 +11,12 @@ import { flushAgentTraceUpload } from "./agent-traces.js";
 import { isNoModelsAvailableMessage } from "./auth-guidance.js";
 import type { ReplacedSessionContext, SessionShutdownEvent, SessionStartEvent } from "./extensions/index.js";
 import { emitSessionShutdownEvent } from "./extensions/runner.js";
-import type { CreateRlmSubagentRuntimeOptions, RlmSubagentRuntime, SubagentRuntimeHost } from "./rlm-runtime.js";
+import {
+	type CreateRlmSubagentRuntimeOptions,
+	type RlmSubagentRuntime,
+	type SubagentRuntimeHost,
+	seedRlmSubagentHarness,
+} from "./rlm-runtime.js";
 import type { CreateAgentSessionResult } from "./sdk.js";
 import { assertSessionCwdExists } from "./session-cwd.js";
 import { SessionImportFileNotFoundError } from "./session-import-errors.js";
@@ -340,6 +345,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 				rlmDepth: options.rlmDepth,
 			});
 		}
+		seedRlmSubagentHarness(options, sessionManager);
 		const runtime = await this.scopedBuild(() =>
 			createAgentSessionRuntime(this.createRuntime, {
 				cwd: sessionManager.getCwd(),

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -231,6 +231,7 @@ import {
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
 	type SubagentRuntimeHost,
+	seedRlmSubagentHarness,
 } from "./rlm-runtime.js";
 import {
 	ActionStore,
@@ -8934,8 +8935,10 @@ export class AgentSession {
 		sessionDir: string;
 		model: Model<any>;
 	}): CreateRlmSubagentRuntimeOptions {
+		const parentHarnessStateDir = this._localHarnessStateDir();
 		return {
 			parentSession: this,
+			inheritedHarnessState: parentHarnessStateDir ? loadHarnessState(parentHarnessStateDir, "local") : undefined,
 			id: options.id,
 			prompt: options.prompt,
 			sessionName: options.sessionName,
@@ -8973,6 +8976,7 @@ export class AgentSession {
 				rlmDepth: options.rlmDepth,
 			});
 		}
+		seedRlmSubagentHarness(options, childSessionManager);
 		childSessionManager.appendModelChange(options.model.provider, options.model.id);
 		childSessionManager.appendThinkingLevelChange(options.thinkingLevel);
 		childSessionManager.appendServiceTierChange(options.serviceTier);

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -358,6 +358,44 @@ export function saveHarnessState(harnessStateDir: string, state: HarnessState): 
 	return statePath;
 }
 
+export function seedInheritedHarnessState(
+	parent: HarnessState,
+	childStateDir: string,
+	parentSessionId: string,
+	createdAt: string = new Date().toISOString(),
+): boolean {
+	if (existsSync(getHarnessStatePath(childStateDir))) {
+		return false;
+	}
+	const inherited = emptyHarnessState();
+	inherited.schema = parent.schema;
+	for (const kind of Object.keys(inherited.entries) as RefinementKind[]) {
+		for (const [id, entry] of Object.entries(parent.entries[kind])) {
+			const cloned = cloneEntry(entry)!;
+			const previousInheritance = objectRecord(cloned.metadata.inheritance);
+			const originSessionId =
+				typeof previousInheritance?.originSessionId === "string"
+					? previousInheritance.originSessionId
+					: parentSessionId;
+			inherited.entries[kind][id] = {
+				...cloned,
+				scope: "local",
+				metadata: {
+					...cloned.metadata,
+					inheritance: {
+						originSessionId,
+						immediateParentSessionId: parentSessionId,
+						inheritedAt: createdAt,
+						inheritedVersion: cloned.version,
+					},
+				},
+			};
+		}
+	}
+	saveHarnessState(childStateDir, inherited);
+	return true;
+}
+
 export function getRefinementHistoryPath(harnessStateDir: string = getGlobalHarnessStateDir()): string {
 	return join(harnessStateDir, REFINEMENT_HISTORY_FILE_NAME);
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -3,6 +3,8 @@ import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
 import type { HostRequestHandler } from "./kernel/index.js";
+import { getLocalHarnessStateDir, type HarnessState, seedInheritedHarnessState } from "./refinement/index.js";
+import type { SessionManager } from "./session-manager.js";
 
 export interface RlmRunRequest {
 	prompt: string;
@@ -204,6 +206,7 @@ export interface RlmSubagentRuntime {
 
 export interface CreateRlmSubagentRuntimeOptions {
 	parentSession: AgentSession;
+	inheritedHarnessState?: HarnessState;
 	id: string;
 	prompt: string;
 	sessionName: string;
@@ -224,6 +227,17 @@ export interface CreateRlmSubagentRuntimeOptions {
 	spawnCode?: string;
 	/** Publish the session to the parent before a host makes the runtime addressable. */
 	onSessionPublished?: (session: AgentSession) => void;
+}
+
+export function seedRlmSubagentHarness(
+	options: CreateRlmSubagentRuntimeOptions,
+	sessionManager: SessionManager,
+): boolean {
+	const childStateDir = getLocalHarnessStateDir(sessionManager.getSessionArtifactDir());
+	if (!options.inheritedHarnessState || !childStateDir) {
+		return false;
+	}
+	return seedInheritedHarnessState(options.inheritedHarnessState, childStateDir, options.parentSession.sessionId);
 }
 
 export interface SubagentRuntimeHost {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -100,7 +100,11 @@ import {
 } from "../../core/cron-jobs.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js";
 import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
-import type { CreateRlmSubagentRuntimeOptions, SubagentRuntimeHost } from "../../core/rlm-runtime.js";
+import {
+	type CreateRlmSubagentRuntimeOptions,
+	type SubagentRuntimeHost,
+	seedRlmSubagentHarness,
+} from "../../core/rlm-runtime.js";
 import {
 	canPassivateSession,
 	type IdleEvictionMinutes,
@@ -2309,6 +2313,7 @@ export class AgentDaemon {
 			parentSession: options.parentSession.sessionFile,
 			rlmDepth: options.rlmDepth,
 		});
+		seedRlmSubagentHarness(options, sessionManager);
 		let stateRef: ActiveSessionState | undefined;
 		// Subagents inherit the parent's client env (e.g. herdr pane identity).
 		const runtime = await withClientEnv(parentState.clientEnv, () =>

--- a/packages/coding-agent/test/suite/regressions/819-parent-local-harness.test.ts
+++ b/packages/coding-agent/test/suite/regressions/819-parent-local-harness.test.ts
@@ -1,0 +1,147 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ENV_AGENT_DIR } from "../../../src/config.js";
+import {
+	getHarnessStatePath,
+	getLocalHarnessStateDir,
+	type HarnessEntry,
+	type HarnessState,
+	loadHarnessState,
+	saveHarnessState,
+	seedInheritedHarnessState,
+} from "../../../src/core/refinement/index.js";
+import { SessionManager } from "../../../src/core/session-manager.js";
+import { createHarness, type Harness } from "../harness.js";
+
+function memory(content: string): HarnessEntry {
+	const timestamp = new Date().toISOString();
+	return {
+		id: "coordination",
+		kind: "memory",
+		title: "Coordination state",
+		content,
+		path: "task/coordination",
+		scope: "local",
+		reference: {},
+		arguments: {},
+		metadata: {},
+		source: "test",
+		created_at: timestamp,
+		updated_at: timestamp,
+		version: 1,
+	};
+}
+
+function stateWith(entry: HarnessEntry): HarnessState {
+	return {
+		schema: 1,
+		entries: {
+			prompt: {},
+			memory: { [entry.id]: entry },
+			skill: {},
+			subagent: {},
+		},
+		refinements: [],
+	};
+}
+
+async function childStateDir(cwd: string, sessionDir: string): Promise<string> {
+	let childSessionPath: string | undefined;
+	await vi.waitFor(async () => {
+		const sessions = await SessionManager.list(cwd, sessionDir);
+		childSessionPath = sessions[0]?.path;
+		expect(childSessionPath).toBeDefined();
+	});
+	const manager = SessionManager.open(childSessionPath!, sessionDir);
+	const stateDir = getLocalHarnessStateDir(manager.getSessionArtifactDir());
+	if (!stateDir) {
+		throw new Error("Missing child harness state directory");
+	}
+	return stateDir;
+}
+
+describe("parent-local continual harness inheritance", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+		vi.unstubAllEnvs();
+	});
+
+	it("gives each RLM child an isolated snapshot from its spawn time", async () => {
+		const harness = await createHarness({ persistSession: true, rlmDepth: 0, rlmMaxDepth: 1 });
+		harnesses.push(harness);
+		vi.stubEnv(ENV_AGENT_DIR, harness.tempDir);
+		const parentStateDir = getLocalHarnessStateDir(harness.sessionManager.getSessionArtifactDir());
+		if (!parentStateDir) {
+			throw new Error("Missing parent harness state directory");
+		}
+		const parentState = stateWith(memory("Initial parent context"));
+		parentState.schema = 7;
+		parentState.refinements.push({
+			id: "refine_0001",
+			trigger: "parent-only history",
+			changes: ["created coordination memory"],
+			evidence: "parent task",
+			outcome: "pending",
+			created_at: new Date().toISOString(),
+		});
+		saveHarnessState(parentStateDir, parentState);
+		const childSystemPrompts: string[] = [];
+		harness.setResponses([
+			(context) => {
+				childSystemPrompts.push(context.systemPrompt ?? "");
+				return fauxAssistantMessage("child done");
+			},
+			fauxAssistantMessage("child done"),
+		]);
+
+		const first = await harness.session.runRlmChild("Read the coordination state", { name: "first-child" });
+		const firstStateDir = await childStateDir(harness.tempDir, first.session_dir);
+		expect(existsSync(getHarnessStatePath(firstStateDir))).toBe(true);
+		const inheritedState = loadHarnessState(firstStateDir, "local");
+		const inheritedEntry = inheritedState.entries.memory.coordination;
+		expect(inheritedState.schema).toBe(7);
+		expect(inheritedEntry?.content).toBe("Initial parent context");
+		expect(inheritedEntry?.metadata.inheritance).toMatchObject({
+			originSessionId: harness.session.sessionId,
+			immediateParentSessionId: harness.session.sessionId,
+			inheritedAt: expect.any(String),
+			inheritedVersion: 1,
+		});
+		expect(inheritedState.refinements).toEqual([]);
+		await vi.waitFor(() => expect(childSystemPrompts).toHaveLength(1));
+		expect(childSystemPrompts[0]).toContain("Initial parent context");
+
+		saveHarnessState(parentStateDir, stateWith(memory("Updated parent context")));
+		expect(
+			seedInheritedHarnessState(loadHarnessState(parentStateDir, "local"), firstStateDir, harness.session.sessionId),
+		).toBe(false);
+		const laterChildStateDir = join(harness.tempDir, "later-child-harness");
+		expect(
+			seedInheritedHarnessState(
+				loadHarnessState(parentStateDir, "local"),
+				laterChildStateDir,
+				harness.session.sessionId,
+			),
+		).toBe(true);
+		expect(loadHarnessState(laterChildStateDir, "local").entries.memory.coordination?.content).toBe(
+			"Updated parent context",
+		);
+		expect(loadHarnessState(firstStateDir, "local").entries.memory.coordination?.content).toBe(
+			"Initial parent context",
+		);
+
+		const firstState = loadHarnessState(firstStateDir, "local");
+		firstState.entries.memory.coordination!.content = "First child context";
+		saveHarnessState(firstStateDir, firstState);
+
+		expect(loadHarnessState(parentStateDir, "local").entries.memory.coordination?.content).toBe(
+			"Updated parent context",
+		);
+	});
+});


### PR DESCRIPTION
Addresses the parent-local harness gap described in #819. This complements #889, which covers overview ranking and global store reachability.

## Summary

- Capture the parent's session-local continual harness at child admission time.
- Seed the snapshot into the child's actual session artifact before constructing its agent runtime.
- Give each child an isolated, editable copy without copying global entries or refinement history.
- Preserve schema and provenance across nested delegation while keeping resumed child stores idempotent.

## Design

Prime Agent recommends local harness state for current task progress and session coordination, but RLM children previously started with an empty local store. Delegation therefore dropped the most relevant task-specific memory.

This uses copy-on-spawn inheritance instead of a live parent mount. The child can refine its own branch of prompt notes, memories, skills, and subagent specifications without mutating its parent or siblings. Capturing the state at admission keeps the result deterministic even when runtime startup is delayed.

## Validation

- `npm run check`
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/819-parent-local-harness.test.ts`
- Related AgentSessionRuntime, subagent runtime host, and daemon tests: 216 passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Inherit parent local harness state in RLM child sessions at spawn time
> - When an RLM child session is spawned, the parent's session-local harness state (prompt notes, memories, skills, sub-agent specs) is snapshot-copied into the child's harness directory via a new `seedRlmSubagentHarness` utility in [rlm-runtime.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1028/files#diff-e2f3586cb159b174f953a03ce37d872c059275b629a160203d8ef5c8db5d30e7).
> - Inheritance metadata (origin session ID, immediate parent session ID, timestamp, version) is recorded in each child snapshot; refinement history is not copied.
> - Snapshots are isolated per child — later parent updates do not affect already-spawned children, but children spawned later inherit newer state.
> - Seeding is applied across all three spawn paths: inline subagent, `AgentSessionRuntime`, and daemon mode.
> - Behavioral Change: RLM child sessions now start with pre-populated harness state instead of an empty one; seeding is a no-op if a state already exists in the child directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc3a02f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->