### PR TITLE
fix(kernel): interrupt IPython subprocess groups

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Fixed interrupted IPython cells leaving child processes running and the kernel busy by isolating each Unix kernel process group and signaling the full tree.
+
+
 ## [0.7.0] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/kernel/fork-server-script.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server-script.ts
@@ -121,7 +121,11 @@ def _serve(control_path):
             continue
 
         if pid == 0:
-            # Child: shed every inherited fd tied to the control channel, then run.
+            # Child: become a session/process-group leader before ipykernel starts.
+            # ipykernel then safely forwards interrupt_request to this kernel and
+            # every subprocess it owns without touching the forkserver or siblings.
+            os.setsid()
+            # Shed every inherited fd tied to the control channel, then run.
             try:
                 sock.close()
                 f.close()

--- a/packages/coding-agent/src/core/kernel/fork-server.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server.ts
@@ -32,6 +32,17 @@ function affectsInterpreterStartup(key: string): boolean {
 	return key.startsWith("PYTHON") || INTERPRETER_STARTUP_ENV_EXACT.includes(key);
 }
 
+function terminateForkedKernel(pid: number): void {
+	try {
+		// Forked kernels call setsid(), so terminate the kernel and descendants.
+		process.kill(-pid, "SIGTERM");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+		// The parent can receive the pid just before the child reaches setsid().
+		process.kill(pid, "SIGTERM");
+	}
+}
+
 export class ForkServerUnavailable extends Error {
 	constructor(message: string) {
 		super(message);
@@ -211,7 +222,7 @@ class ForkServer {
 				// fork succeeded but nobody owns it, so kill the orphan here.
 				if (this.abandoned.delete(msg.id) && typeof msg.pid === "number") {
 					try {
-						process.kill(msg.pid, "SIGTERM");
+						terminateForkedKernel(msg.pid);
 					} catch {
 						// Orphan already exited.
 					}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -45,6 +45,18 @@ const MAX_LATE_SENT_AGENT_MESSAGE_HANDLERS = 256;
 const KERNEL_BUSY_AFTER_INTERRUPT_MESSAGE =
 	"IPython kernel is still running the previously interrupted cell. Wait and try again, or kill the IPython kernel to start fresh.";
 
+function killIsolatedKernelProcessGroup(pid: number, signal: NodeJS.Signals): void {
+	try {
+		// Negative pid addresses the Unix process group created for this kernel.
+		process.kill(-pid, signal);
+	} catch (error) {
+		// A forked child can briefly be visible before setsid(). Fall back to the
+		// leader so startup-abandon cleanup is still effective in that race.
+		if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+		process.kill(pid, signal);
+	}
+}
+
 export class KernelBusyAfterInterruptError extends Error {
 	constructor() {
 		super(KERNEL_BUSY_AFTER_INTERRUPT_MESSAGE);
@@ -648,6 +660,10 @@ export class KernelManager {
 				cwd: this.options.cwd,
 				env: this.options.env ? { ...process.env, ...this.options.env } : process.env,
 				stdio: ["ignore", "pipe", "pipe"],
+				// ipykernel only forwards interrupt_request to descendants when it is
+				// the process-group leader. Isolate each Unix kernel so subprocesses
+				// receive Ctrl+C without signaling Prime Agent or sibling kernels.
+				detached: process.platform !== "win32",
 			});
 			this.kernel = kernel;
 
@@ -1302,11 +1318,20 @@ export class KernelManager {
 		this.iopubPumpPromise = undefined;
 		try {
 			if (this.kernel) {
-				this.kernel.kill(killSignal);
+				const pid = this.kernel.pid;
+				if (process.platform !== "win32" && pid !== undefined) {
+					killIsolatedKernelProcessGroup(pid, killSignal);
+				} else {
+					this.kernel.kill(killSignal);
+				}
 			} else if (this.kernelPid !== undefined && !this.forkedKernelDied()) {
 				// Only signal a forked kernel confirmed still alive: a dead pid may have
 				// been recycled by the OS, and a kill would then hit an unrelated process.
-				process.kill(this.kernelPid, killSignal);
+				if (process.platform !== "win32") {
+					killIsolatedKernelProcessGroup(this.kernelPid, killSignal);
+				} else {
+					process.kill(this.kernelPid, killSignal);
+				}
 			}
 		} catch {
 			// Kernel already exited.

--- a/packages/coding-agent/test/kernel-process-group.test.ts
+++ b/packages/coding-agent/test/kernel-process-group.test.ts
@@ -1,0 +1,122 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { KernelManager } from "../src/core/kernel/index.js";
+
+function resolveKernelPython(): string | null {
+	const candidates = [
+		process.env.PRIME_AGENT_KERNEL_PYTHON,
+		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+	].filter((candidate): candidate is string => Boolean(candidate));
+	for (const python of candidates) {
+		if (!existsSync(python)) continue;
+		const check = spawnSync(python, ["-c", "import ipykernel"], { encoding: "utf8" });
+		if (check.status === 0) return python;
+	}
+	return null;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	return Promise.race([
+		promise,
+		new Promise<never>((_, reject) => {
+			timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+		}),
+	]).finally(() => {
+		if (timer) clearTimeout(timer);
+	});
+}
+
+const python = resolveKernelPython();
+const describeIfKernel = python && process.platform !== "win32" ? describe : describe.skip;
+
+describeIfKernel("kernel process-group isolation (real kernel)", { tags: ["kernel-heavy"] }, () => {
+	let tempDir: string | undefined;
+	let childPid: number | undefined;
+	const originalForkserver = process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+
+	afterEach(() => {
+		if (childPid !== undefined) {
+			try {
+				process.kill(childPid, "SIGKILL");
+			} catch {
+				// The process-group interrupt already reaped it.
+			}
+		}
+		childPid = undefined;
+		if (originalForkserver === undefined) delete process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+		else process.env.PRIME_AGENT_KERNEL_FORKSERVER = originalForkserver;
+		if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	});
+
+	async function expectInterruptReachesDescendants(useForkserver: boolean): Promise<void> {
+		process.env.PRIME_AGENT_KERNEL_FORKSERVER = useForkserver ? "1" : "0";
+		tempDir = mkdtempSync(join(tmpdir(), `prime-agent-kernel-pgrp-${useForkserver ? "fork" : "direct"}-`));
+		const manager = new KernelManager({ python: python as string, cwd: tempDir });
+		const controller = new AbortController();
+		let output = "";
+		let ready!: () => void;
+		const readyPromise = new Promise<void>((resolve) => {
+			ready = resolve;
+		});
+		try {
+			const execution = manager.execute(
+				[
+					"import os, subprocess",
+					"p = subprocess.Popen(['sleep', '30'])",
+					"print(f'READY {os.getpid()} {os.getpgrp()} {p.pid}', flush=True)",
+					"p.wait()",
+				].join("\n"),
+				{
+					signal: controller.signal,
+					onStream: (chunk) => {
+						output += chunk;
+						const match = /READY (\d+) (\d+) (\d+)/.exec(output);
+						if (match) {
+							childPid = Number(match[3]);
+							ready();
+						}
+					},
+				},
+			);
+			await withTimeout(readyPromise, 15_000, "kernel child startup");
+			const match = /READY (\d+) (\d+) (\d+)/.exec(output);
+			expect(match).not.toBeNull();
+			expect(match?.[1]).toBe(match?.[2]);
+
+			controller.abort();
+			await expect(withTimeout(execution, 5_000, "interrupted execution")).resolves.toMatchObject({
+				status: "aborted",
+			});
+			const followUp = await withTimeout(manager.execute("print(123)"), 5_000, "follow-up execution");
+			expect(followUp.status).toBe("ok");
+			expect(followUp.stdout.trim()).toBe("123");
+		} finally {
+			if (childPid !== undefined) {
+				try {
+					process.kill(childPid, "SIGKILL");
+				} catch {
+					// The process-group interrupt already reaped it.
+				}
+				childPid = undefined;
+			}
+			await manager.dispose();
+		}
+	}
+
+	it("interrupts subprocesses launched by a directly spawned kernel", async () => {
+		await expectInterruptReachesDescendants(false);
+	}, 30_000);
+
+	it.runIf(process.platform === "linux")(
+		"interrupts subprocesses launched by a forked kernel",
+		async () => {
+			await expectInterruptReachesDescendants(true);
+		},
+		30_000,
+	);
+});


### PR DESCRIPTION
## Summary

Fixes interrupted IPython cells that stay busy until a subprocess naturally exits.

Prime Agent currently launches direct and forked kernels inside the daemon process group. ipykernel deliberately forwards `interrupt_request` to descendants only when the kernel is its process-group leader; otherwise it signals the kernel PID alone. Commands such as `os.system()`/`subprocess.wait()` can therefore leave their child running while the kernel stays occupied for minutes.

## Changes

- launch direct Unix kernels with `detached: true` so each kernel owns a session/process group
- call `setsid()` in forkserver kernel children before starting ipykernel
- signal the isolated process group during dispose/restart and abandoned-fork cleanup, preventing orphan descendants
- add real-kernel regression coverage for both direct and forkserver launch paths

Windows retains the existing behavior.

## Validation

- `npm run check`
- focused goal/kernel tests: 53/53 passed
- new Linux real-kernel regression: direct and forkserver paths both pass; after abort, the next cell executes immediately

The regression test launches a sleeping subprocess, aborts the cell, verifies kernel PID == PGID, and proves a follow-up cell completes instead of raising `KernelBusyAfterInterruptError`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix interrupt handling in IPython kernels to signal full process groups
> - On non-Windows, directly spawned kernels are started with `detached: true` so they become process-group leaders; forked kernels call `os.setsid()` for the same effect.
> - Termination and interrupt signals now target the kernel's Unix process group (negative PID) rather than just the kernel PID, ensuring child processes spawned during cell execution are also interrupted.
> - Adds `killIsolatedKernelProcessGroup` in [index.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1030/files#diff-14dd18f6926ed763ba0b55625302fb733f4e4209bb611d3051820048732149ac) and `terminateForkedKernel` in [fork-server.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1030/files#diff-65164112dcd341a9e27f5bbd59aa6b335e99b3c538915cde2701e2afa02a5e36) with fallback to direct PID signaling when the group is not yet established.
> - Adds integration tests in [kernel-process-group.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1030/files#diff-76b09b20e5d6adb7a7e9feed76135c10433344a87a7fb0b4931c639c49446203) (skipped on Windows) that verify interrupts reach descendant processes and the kernel remains usable afterward.
> - Behavioral Change: kernels that previously ignored interrupts or left child processes running after abort will now receive SIGTERM/SIGINT across the whole process group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dcfff8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->