### PR TITLE
feat(openrouter): support server web search

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added configurable OpenRouter server-side web search to OpenAI-compatible completion requests.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -21,6 +21,7 @@ import type {
 	Message,
 	Model,
 	OpenAICompletionsCompat,
+	OpenRouterWebSearch,
 	SimpleStreamOptions,
 	StopReason,
 	StreamFunction,
@@ -85,8 +86,12 @@ interface OpenAICompatCacheControl {
 	ttl?: string;
 }
 
-type ResolvedOpenAICompletionsCompat = Omit<Required<OpenAICompletionsCompat>, "cacheControlFormat"> & {
+type ResolvedOpenAICompletionsCompat = Omit<
+	Required<OpenAICompletionsCompat>,
+	"cacheControlFormat" | "openRouterWebSearch"
+> & {
 	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+	openRouterWebSearch?: OpenAICompletionsCompat["openRouterWebSearch"];
 };
 
 type ChatCompletionInstructionMessageParam = ChatCompletionDeveloperMessageParam | ChatCompletionSystemMessageParam;
@@ -97,6 +102,11 @@ type ChatCompletionTextPartWithCacheControl = ChatCompletionContentPartText & {
 
 type ChatCompletionToolWithCacheControl = OpenAI.Chat.Completions.ChatCompletionTool & {
 	cache_control?: OpenAICompatCacheControl;
+};
+
+type OpenRouterWebSearchTool = {
+	type: "openrouter:web_search";
+	parameters?: OpenRouterWebSearch;
 };
 
 function resolveCacheRetention(cacheRetention?: CacheRetention): CacheRetention {
@@ -557,6 +567,8 @@ function buildParams(
 		applyAnthropicCacheControl(messages, params.tools, cacheControl);
 	}
 
+	appendOpenRouterWebSearchTool(params, model);
+
 	if (options?.toolChoice) {
 		params.tool_choice = options.toolChoice;
 	}
@@ -613,6 +625,23 @@ function buildParams(
 	}
 
 	return params;
+}
+
+function appendOpenRouterWebSearchTool(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	model: Model<"openai-completions">,
+): void {
+	const webSearch = model.compat?.openRouterWebSearch;
+	if (!webSearch || !model.baseUrl.includes("openrouter.ai")) {
+		return;
+	}
+
+	const tools = (params.tools ?? []) as Array<OpenAI.Chat.Completions.ChatCompletionTool | OpenRouterWebSearchTool>;
+	tools.push({
+		type: "openrouter:web_search",
+		...(Object.keys(webSearch).length > 0 ? { parameters: webSearch } : {}),
+	});
+	(params as unknown as { tools: typeof tools }).tools = tools;
 }
 
 function getCompatCacheControl(

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -312,6 +312,8 @@ export interface OpenAICompletionsCompat {
 	thinkingFormat?: "openai" | "openrouter" | "deepseek" | "zai" | "qwen" | "qwen-chat-template";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;
+	/** OpenRouter server-side web search configuration. Only used when baseUrl points to OpenRouter. */
+	openRouterWebSearch?: OpenRouterWebSearch;
 	/** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */
 	vercelGatewayRouting?: VercelGatewayRouting;
 	/** Whether z.ai supports top-level `tool_stream: true` for streaming tool call deltas. Default: false. */
@@ -421,6 +423,29 @@ export interface OpenRouterRouting {
 				/** Maximum latency in seconds at the 99th percentile. */
 				p99?: number;
 		  };
+}
+
+/**
+ * Configuration for OpenRouter's server-side `openrouter:web_search` tool.
+ * @see https://openrouter.ai/docs/guides/features/server-tools/web-search
+ */
+export interface OpenRouterWebSearch {
+	engine?: "auto" | "native" | "exa" | "firecrawl" | "parallel" | "perplexity";
+	mode?: "instant" | "fast" | "auto" | "deep-lite" | "deep" | "deep-reasoning" | "turbo" | "basic" | "advanced";
+	max_results?: number;
+	max_uses?: number;
+	max_total_results?: number;
+	search_context_size?: "low" | "medium" | "high";
+	max_characters?: number;
+	allowed_domains?: string[];
+	excluded_domains?: string[];
+	user_location?: {
+		type: "approximate";
+		city?: string;
+		region?: string;
+		country?: string;
+		timezone?: string;
+	};
 }
 
 /**

--- a/packages/ai/test/openai-completions-reasoning-replay.test.ts
+++ b/packages/ai/test/openai-completions-reasoning-replay.test.ts
@@ -24,6 +24,7 @@ const compat = {
 	requiresReasoningContentOnAssistantMessages: false,
 	thinkingFormat: "openai",
 	openRouterRouting: {},
+	openRouterWebSearch: {},
 	vercelGatewayRouting: {},
 	zaiToolStream: false,
 	supportsStrictMode: true,

--- a/packages/ai/test/openai-completions-thinking-as-text.test.ts
+++ b/packages/ai/test/openai-completions-thinking-as-text.test.ts
@@ -33,6 +33,7 @@ const compat = {
 	requiresReasoningContentOnAssistantMessages: false,
 	thinkingFormat: "openai",
 	openRouterRouting: {},
+	openRouterWebSearch: {},
 	vercelGatewayRouting: {},
 	zaiToolStream: false,
 	supportsStrictMode: true,

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -156,6 +156,44 @@ describe("openai-completions tool_choice", () => {
 		expect("strict" in (tool ?? {})).toBe(false);
 	});
 
+	it("adds configured OpenRouter web search beside function tools", async () => {
+		const baseModel = getModel("openrouter", "anthropic/claude-sonnet-4")!;
+		const model = {
+			...baseModel,
+			compat: {
+				...baseModel.compat,
+				openRouterWebSearch: { engine: "exa", max_results: 3, max_total_results: 9 },
+			},
+		} as const;
+		const tools: Tool[] = [
+			{
+				name: "ping",
+				description: "Ping tool",
+				parameters: Type.Object({ ok: Type.Boolean() }),
+			},
+		];
+
+		await streamSimple(
+			model,
+			{
+				messages: [{ role: "user", content: "Search for current information", timestamp: Date.now() }],
+				tools,
+			},
+			{ apiKey: "test" },
+		).result();
+
+		const params = mockState.lastParams as {
+			tools?: Array<{ type: string; parameters?: Record<string, unknown>; function?: { name: string } }>;
+		};
+		expect(params.tools).toEqual([
+			expect.objectContaining({ type: "function", function: expect.objectContaining({ name: "ping" }) }),
+			{
+				type: "openrouter:web_search",
+				parameters: { engine: "exa", max_results: 3, max_total_results: 9 },
+			},
+		]);
+	});
+
 	it("keeps normal reasoning_effort for groq models without compat mapping", async () => {
 		const model = getModel("groq", "openai/gpt-oss-20b")!;
 		let payload: unknown;

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -31,6 +31,7 @@ const compat: Required<OpenAICompletionsCompat> = {
 	requiresReasoningContentOnAssistantMessages: false,
 	thinkingFormat: "openai",
 	openRouterRouting: {},
+	openRouterWebSearch: {},
 	vercelGatewayRouting: {},
 	zaiToolStream: false,
 	supportsStrictMode: true,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added `compat.openRouterWebSearch` for enabling OpenRouter server-side web search on selected models.
+
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -392,6 +392,33 @@ For providers with partial OpenAI compatibility, use the `compat` field.
 
 `cacheControlFormat: "anthropic"` is for OpenAI-compatible providers that expose Anthropic-style prompt caching through `cache_control` markers on text content and tool definitions.
 
+### OpenRouter Server-Side Web Search
+
+OpenRouter's deprecated `:online` model suffix has been replaced by its `openrouter:web_search` server tool. Enable it for a built-in OpenRouter model with a `modelOverrides` entry:
+
+```json
+{
+  "providers": {
+    "openrouter": {
+      "modelOverrides": {
+        "anthropic/claude-sonnet-4": {
+          "compat": {
+            "openRouterWebSearch": {
+              "engine": "auto",
+              "max_results": 5,
+              "max_uses": 3,
+              "max_total_results": 15
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Prime Agent adds the server tool to requests for that model alongside its own function tools. OpenRouter executes searches itself when the model decides they are needed. The optional settings mirror OpenRouter's web-search parameters: `engine`, `mode`, `max_results`, `max_uses`, `max_total_results`, `search_context_size`, `max_characters`, `allowed_domains`, `excluded_domains`, and `user_location`.
+
 Example:
 
 ```json

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -83,6 +83,48 @@ const OpenRouterRoutingSchema = Type.Object({
 	preferred_max_latency: Type.Optional(Type.Union([Type.Number(), PercentileCutoffsSchema])),
 });
 
+const OpenRouterWebSearchSchema = Type.Object({
+	engine: Type.Optional(
+		Type.Union([
+			Type.Literal("auto"),
+			Type.Literal("native"),
+			Type.Literal("exa"),
+			Type.Literal("firecrawl"),
+			Type.Literal("parallel"),
+			Type.Literal("perplexity"),
+		]),
+	),
+	mode: Type.Optional(
+		Type.Union([
+			Type.Literal("instant"),
+			Type.Literal("fast"),
+			Type.Literal("auto"),
+			Type.Literal("deep-lite"),
+			Type.Literal("deep"),
+			Type.Literal("deep-reasoning"),
+			Type.Literal("turbo"),
+			Type.Literal("basic"),
+			Type.Literal("advanced"),
+		]),
+	),
+	max_results: Type.Optional(Type.Integer({ minimum: 1, maximum: 25 })),
+	max_uses: Type.Optional(Type.Integer({ minimum: 1 })),
+	max_total_results: Type.Optional(Type.Integer({ minimum: 1 })),
+	search_context_size: Type.Optional(Type.Union([Type.Literal("low"), Type.Literal("medium"), Type.Literal("high")])),
+	max_characters: Type.Optional(Type.Integer({ minimum: 1, maximum: 100_000 })),
+	allowed_domains: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
+	excluded_domains: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
+	user_location: Type.Optional(
+		Type.Object({
+			type: Type.Literal("approximate"),
+			city: Type.Optional(Type.String()),
+			region: Type.Optional(Type.String()),
+			country: Type.Optional(Type.String()),
+			timezone: Type.Optional(Type.String()),
+		}),
+	),
+});
+
 // Schema for Vercel AI Gateway routing preferences
 const VercelGatewayRoutingSchema = Type.Object({
 	only: Type.Optional(Type.Array(Type.String())),
@@ -123,6 +165,7 @@ const OpenAICompletionsCompatSchema = Type.Object({
 	),
 	cacheControlFormat: Type.Optional(Type.Literal("anthropic")),
 	openRouterRouting: Type.Optional(OpenRouterRoutingSchema),
+	openRouterWebSearch: Type.Optional(OpenRouterWebSearchSchema),
 	vercelGatewayRouting: Type.Optional(VercelGatewayRoutingSchema),
 	supportsStrictMode: Type.Optional(Type.Boolean()),
 	supportsLongCacheRetention: Type.Optional(Type.Boolean()),

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -663,6 +663,27 @@ describe("ModelRegistry", () => {
 			expect(compat?.openRouterRouting).toEqual({ only: ["amazon-bedrock"] });
 		});
 
+		test("model override enables OpenRouter server-side web search", () => {
+			writeRawModelsJson({
+				openrouter: {
+					modelOverrides: {
+						"anthropic/claude-sonnet-4": {
+							compat: {
+								openRouterWebSearch: { engine: "exa", max_results: 3 },
+							},
+						},
+					},
+				},
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const sonnet = getModelsForProvider(registry, "openrouter").find(
+				(model) => model.id === "anthropic/claude-sonnet-4",
+			);
+			const compat = sonnet?.compat as OpenAICompletionsCompat | undefined;
+			expect(compat?.openRouterWebSearch).toEqual({ engine: "exa", max_results: 3 });
+		});
+
 		test("model override deep merges compat settings", () => {
 			writeRawModelsJson({
 				openrouter: {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add OpenRouter server-side web search tool support to OpenAI completions
- Adds `openRouterWebSearch` to the `OpenAICompletionsCompat` interface in [types.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1033/files#diff-4e994148bdf4c9a53c6e89c8c80bc67c04413fe32a6ede53d9ea0d53be95f4c7), accepting engine, mode, limits, domain filters, and optional user location fields.
- In `buildParams` ([openai-completions.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1033/files#diff-d3f9c03940767ab76191513078367a64d9e38e58fbdff99f5ad7bf65786b4246)), appends an `openrouter:web_search` tool to the request payload when `model.compat.openRouterWebSearch` is set and `model.baseUrl` targets `openrouter.ai`.
- Extends the model registry's `OpenAICompletionsCompatSchema` in [model-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1033/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453) to validate `openRouterWebSearch` config from `models.json` overrides.
- Behavioral Change: models using OpenRouter with `compat.openRouterWebSearch` configured will now have an extra tool injected into every request, which affects tool_choice handling if the model or caller assumes a fixed tool list.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b613cdb.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->