### PR TITLE
fix(coding-agent): show progress during `/refine`

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
+- Fixed explicit `/refine` commands appearing frozen by showing elapsed progress and supporting cancellation ([#1035](https://github.com/PrimeIntellect-ai/prime-agent/pull/1035) by [@junhoyeo](https://github.com/junhoyeo)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6680,7 +6680,7 @@ export class InteractiveMode {
 		if (this.hasActiveRefineCommand()) {
 			void this.agentConnection.abort();
 		}
-		if (this.isAgentStreaming()) {
+		if (this.isAgentStreaming() || this.hasActiveRefineCommand()) {
 			void this.restoreQueuedMessagesToEditor({ abort: true }).catch((error) => {
 				this.showError(error instanceof Error ? error.message : String(error));
 			});

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -863,6 +863,7 @@ export class InteractiveMode {
 	private admitPendingStartupPrompts: (() => Promise<StartupPromptBarrierOutcome>) | undefined;
 	private agentsViewRequest: InteractiveModeRunResult["type"] | undefined;
 	private loadingAnimation: Loader | undefined = undefined;
+	private workingLoaderKind: "streaming" | "refine" | undefined = undefined;
 	private workingMessage: string | undefined = undefined;
 	private workingVisible = true;
 	private workingIndicatorOptions: LoaderIndicatorOptions | undefined = undefined;
@@ -3122,6 +3123,11 @@ export class InteractiveMode {
 		const status = this.activityTracker.getStatus();
 		// The subagent count/recaps live in the tree above the loader, so the loader
 		// message itself no longer repeats "N subagents running".
+		if (this.hasActiveRefineCommand()) {
+			const progress = elapsed === undefined ? "Refining" : `Refining · ${elapsed}`;
+			const cancelKey = keyText("app.clear");
+			return cancelKey ? `${progress} (${cancelKey} to cancel)` : progress;
+		}
 		if (!this.isAgentStreaming()) {
 			return "";
 		}
@@ -3183,6 +3189,7 @@ export class InteractiveMode {
 
 	private startWorkingLoader(): void {
 		this.stopWorkingLoader();
+		this.workingLoaderKind = this.getWorkingLoaderKind();
 		this.workingStartedAt = Date.now();
 		this.loadingAnimation = this.createWorkingLoader();
 		this.statusContainer.addChild(this.loadingAnimation);
@@ -3197,6 +3204,7 @@ export class InteractiveMode {
 			this.workingTimer = undefined;
 		}
 		this.workingStartedAt = undefined;
+		this.workingLoaderKind = undefined;
 		if (this.loadingAnimation) {
 			this.loadingAnimation.stop();
 			this.loadingAnimation = undefined;
@@ -3339,11 +3347,22 @@ export class InteractiveMode {
 		}
 	}
 
+	private hasActiveRefineCommand(): boolean {
+		const active = this.connectionState?.sessionActions.active;
+		return active?.kind === "session_command" && /^\/refine(?:\s|$)/.test(active.label ?? "");
+	}
+
+	private getWorkingLoaderKind(): "streaming" | "refine" | undefined {
+		if (this.hasActiveRefineCommand()) return "refine";
+		if (this.isAgentStreaming()) return "streaming";
+		return undefined;
+	}
+
 	private shouldShowWorkingLoader(): boolean {
 		// Background subagents (agent turn done, asyncio tasks still running) would
 		// otherwise show a textless spinner; the subagent tree above the loader carries
-		// that state, so the loader only shows while the main agent is itself streaming.
-		return this.workingVisible && this.isAgentStreaming();
+		// that state, so the loader only shows while the main agent is streaming or /refine is active.
+		return this.workingVisible && this.getWorkingLoaderKind() !== undefined;
 	}
 
 	// Reconcile the loader with current state for transitions that fire no live
@@ -3391,8 +3410,14 @@ export class InteractiveMode {
 		if (this.shouldShowWorkingLoader()) {
 			// A bare `loadingAnimation != null` check isn't proof it's on screen:
 			// other paths clear statusContainer without nulling it, orphaning the
-			// loader. Re-attach unless it is actually mounted.
-			if (!this.loadingAnimation || !this.statusContainer.children.includes(this.loadingAnimation)) {
+			// loader. Re-attach unless it is actually mounted, and restart the timer
+			// when ownership changes between a model turn and /refine.
+			const desiredKind = this.getWorkingLoaderKind();
+			if (
+				!this.loadingAnimation ||
+				!this.statusContainer.children.includes(this.loadingAnimation) ||
+				this.workingLoaderKind !== desiredKind
+			) {
 				this.startWorkingLoader();
 			}
 		} else if (this.loadingAnimation) {
@@ -5321,6 +5346,7 @@ export class InteractiveMode {
 					followUp: [...event.actions.followUps],
 				};
 				this.updatePendingMessagesDisplay();
+				this.syncWorkingLoader();
 				this.ui.requestRender();
 				break;
 
@@ -6649,6 +6675,9 @@ export class InteractiveMode {
 		}
 		if (this.isBashRunning()) {
 			void this.agentConnection.abortBash();
+		}
+		if (this.hasActiveRefineCommand()) {
+			void this.agentConnection.abort();
 		}
 		if (this.isAgentStreaming()) {
 			void this.restoreQueuedMessagesToEditor({ abort: true }).catch((error) => {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6534,6 +6534,7 @@ export class InteractiveMode {
 		this.seedSubagentSummary(snapshot.children);
 		this.setSessionHasMessages(context.messages.length > 0);
 		this.applyConnectionStateSnapshot(state);
+		this.syncWorkingLoader();
 		await this.renderSessionContext(context, {
 			updateFooter: true,
 			populateHistory: true,

--- a/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
+++ b/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
@@ -24,7 +24,12 @@ type FakeInteractiveMode = {
 		isCompacting: boolean;
 		isBashRunning: boolean;
 		retryAttempt: number;
-		sessionActions: { queuedCount: number; steering: readonly string[]; followUps: readonly string[] };
+		sessionActions: {
+			queuedCount: number;
+			steering: readonly string[];
+			followUps: readonly string[];
+			active?: { kind: "turn" | "session_command"; phase: "preparing" | "committing" | "running"; label?: string };
+		};
 	};
 	connectionQueue: { steering: string[]; followUp: string[] };
 	agentConnection: {
@@ -150,6 +155,36 @@ describe("InteractiveMode interrupt shortcuts", () => {
 		expect(mode.agentConnection.abortBash).toHaveBeenCalledTimes(1);
 		expect(mode.restoreQueuedMessagesToEditor).toHaveBeenCalledWith({ abort: true });
 		expect(mode.shutdown).not.toHaveBeenCalled();
+	});
+
+	it("cancels an active /refine command without clearing queued prompts or the draft", () => {
+		const mode = createInteractiveFake({ editorText: "draft" });
+		mode.connectionState.sessionActions = {
+			queuedCount: 1,
+			steering: [],
+			followUps: ["queued prompt"],
+			active: { kind: "session_command", phase: "running", label: "/refine --global" },
+		};
+
+		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
+
+		expect(mode.agentConnection.abort).toHaveBeenCalledOnce();
+		expect(mode.agentConnection.abortAndClearQueue).not.toHaveBeenCalled();
+		expect(mode.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
+		expect(mode.editor.getText()).toBe("draft");
+	});
+
+	it("does not use the full-session abort for other active commands", () => {
+		const mode = createInteractiveFake({});
+		mode.connectionState.sessionActions.active = {
+			kind: "session_command",
+			phase: "running",
+			label: "/goal ship it",
+		};
+
+		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
+
+		expect(mode.agentConnection.abort).not.toHaveBeenCalled();
 	});
 
 	it.each([

--- a/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
+++ b/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
@@ -157,7 +157,7 @@ describe("InteractiveMode interrupt shortcuts", () => {
 		expect(mode.shutdown).not.toHaveBeenCalled();
 	});
 
-	it("cancels an active /refine command without clearing queued prompts or the draft", () => {
+	it("cancels an active /refine command and restores queued prompts to the editor", () => {
 		const mode = createInteractiveFake({ editorText: "draft" });
 		mode.connectionState.sessionActions = {
 			queuedCount: 1,
@@ -169,9 +169,7 @@ describe("InteractiveMode interrupt shortcuts", () => {
 		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
 
 		expect(mode.agentConnection.abort).toHaveBeenCalledOnce();
-		expect(mode.agentConnection.abortAndClearQueue).not.toHaveBeenCalled();
-		expect(mode.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
-		expect(mode.editor.getText()).toBe("draft");
+		expect(mode.restoreQueuedMessagesToEditor).toHaveBeenCalledWith({ abort: true });
 	});
 
 	it("does not use the full-session abort for other active commands", () => {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -115,6 +115,127 @@ function createConnectionState(overrides: Partial<AgentConnectionState> = {}): A
 	};
 }
 
+describe("InteractiveMode refinement status", () => {
+	test("shows elapsed progress for an active /refine command", () => {
+		const previousKeybindings = getKeybindings();
+		setKeybindings(new KeybindingsManager());
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-09T01:32:48.000Z"));
+		try {
+			const fakeThis = {
+				connectionState: createConnectionState({
+					sessionActions: {
+						queuedCount: 0,
+						steering: [],
+						followUps: [],
+						active: { kind: "session_command", phase: "running", label: "/refine --global" },
+					},
+				}),
+				workingStartedAt: Date.now() - 86_000,
+				workingMessage: undefined,
+				workingVisible: true,
+				activityTracker: new AgentActivityTracker(),
+			} as unknown as InteractiveMode;
+			Object.setPrototypeOf(fakeThis, InteractiveMode.prototype);
+			const prototype = InteractiveMode.prototype as unknown as {
+				getWorkingLoaderMessage(this: InteractiveMode): string;
+				shouldShowWorkingLoader(this: InteractiveMode): boolean;
+			};
+
+			expect(prototype.getWorkingLoaderMessage.call(fakeThis)).toBe("Refining · 1m 26s (Ctrl+C to cancel)");
+			expect(prototype.shouldShowWorkingLoader.call(fakeThis)).toBe(true);
+
+			(fakeThis as unknown as { connectionState: AgentConnectionState }).connectionState.sessionActions.active = {
+				kind: "session_command",
+				phase: "running",
+				label: "/compact",
+			};
+			expect(prototype.getWorkingLoaderMessage.call(fakeThis)).toBe("");
+			expect(prototype.shouldShowWorkingLoader.call(fakeThis)).toBe(false);
+		} finally {
+			vi.useRealTimers();
+			setKeybindings(previousKeybindings);
+		}
+	});
+
+	test("restarts a mounted streaming loader when a resync observes /refine", () => {
+		const mountedLoader = {};
+		const startWorkingLoader = vi.fn();
+		const fakeThis = {
+			connectionState: createConnectionState({
+				sessionActions: {
+					queuedCount: 0,
+					steering: [],
+					followUps: [],
+					active: { kind: "session_command", phase: "running", label: "/refine" },
+				},
+			}),
+			workingVisible: true,
+			workingLoaderKind: "streaming",
+			loadingAnimation: mountedLoader,
+			statusContainer: { children: [mountedLoader] },
+			autoCompactionLoader: undefined,
+			retryLoader: undefined,
+			startWorkingLoader,
+			stopWorkingLoader: vi.fn(),
+			ui: { requestRender: vi.fn() },
+		} as unknown as InteractiveMode;
+		Object.setPrototypeOf(fakeThis, InteractiveMode.prototype);
+
+		Reflect.get(InteractiveMode.prototype, "syncWorkingLoader").call(fakeThis);
+
+		expect(startWorkingLoader).toHaveBeenCalledOnce();
+	});
+
+	test("reconciles the loader when active session command state changes", async () => {
+		const syncWorkingLoader = vi.fn();
+		const actions = {
+			queuedCount: 0,
+			steering: [],
+			followUps: [],
+			active: { kind: "session_command", phase: "running", label: "/refine" },
+		} as const;
+		const fakeThis = {
+			isInitialized: true,
+			connectionState: createConnectionState(),
+			workingVisible: true,
+			footer: { invalidate: vi.fn() },
+			updateWorkingPulse: vi.fn(),
+			activityTracker: new AgentActivityTracker(),
+			updateWorkingLoaderMessage: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+			syncWorkingLoader,
+			ui: { requestRender: vi.fn() },
+		} as unknown as InteractiveMode;
+		Object.setPrototypeOf(fakeThis, InteractiveMode.prototype);
+
+		await (
+			InteractiveMode.prototype as unknown as {
+				handleEvent(this: InteractiveMode, event: AgentConnectionSessionEvent): Promise<void>;
+			}
+		).handleEvent.call(fakeThis, { type: "session_action_update", actions });
+
+		expect((fakeThis as unknown as { connectionState: AgentConnectionState }).connectionState.sessionActions).toBe(
+			actions,
+		);
+		expect(syncWorkingLoader).toHaveBeenCalledOnce();
+
+		await (
+			InteractiveMode.prototype as unknown as {
+				handleEvent(this: InteractiveMode, event: AgentConnectionSessionEvent): Promise<void>;
+			}
+		).handleEvent.call(fakeThis, {
+			type: "session_action_update",
+			actions: { queuedCount: 0, steering: [], followUps: [] },
+		});
+
+		expect(syncWorkingLoader).toHaveBeenCalledTimes(2);
+		expect(
+			(fakeThis as unknown as { connectionState: AgentConnectionState }).connectionState.sessionActions.active,
+		).toBeUndefined();
+	});
+});
+
 describe("InteractiveMode update notifications", () => {
 	beforeAll(() => {
 		initTheme("dark");

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1374,6 +1374,7 @@ describe("InteractiveMode connection events", () => {
 			seedSubagentSummary: vi.fn(),
 			setSessionHasMessages: vi.fn(),
 			applyConnectionStateSnapshot: vi.fn(),
+			syncWorkingLoader: vi.fn(),
 			renderSessionContext: renderSessionContextMock,
 			restoreStreamingMessageFromSnapshot,
 			showStatus: vi.fn(),
@@ -1402,6 +1403,13 @@ describe("InteractiveMode connection events", () => {
 		});
 		expect(restoreStreamingMessageFromSnapshot).toHaveBeenNthCalledWith(1, undefined);
 		expect(restoreStreamingMessageFromSnapshot).toHaveBeenNthCalledWith(2, streamingMessage);
+		const applySnapshot = (fakeThis as unknown as { applyConnectionStateSnapshot: ReturnType<typeof vi.fn> })
+			.applyConnectionStateSnapshot;
+		const syncWorkingLoader = (fakeThis as unknown as { syncWorkingLoader: ReturnType<typeof vi.fn> })
+			.syncWorkingLoader;
+		expect(syncWorkingLoader).toHaveBeenCalledTimes(2);
+		expect(applySnapshot.mock.invocationCallOrder[0]).toBeLessThan(syncWorkingLoader.mock.invocationCallOrder[0]);
+		expect(applySnapshot.mock.invocationCallOrder[1]).toBeLessThan(syncWorkingLoader.mock.invocationCallOrder[1]);
 	});
 
 	test("clears extension UI when a connection-backed session is replaced", async () => {


### PR DESCRIPTION
## Summary

- show an elapsed `Refining` loader while an explicit `/refine` session command is active
- restart the loader timer when ownership changes between a model turn and refinement, including attach/resync reconciliation
- let the configured interrupt key cancel `/refine` without clearing queued prompts or the editor draft

## Compatibility

This is a TUI-only change that consumes the existing optional `sessionActions.active` snapshot. It adds no daemon command, event, response field, capability, or schema revision; clients attached to older daemons continue to degrade to the existing no-loader behavior.

## Scope and prior work

This fixes the explicit interactive `/refine` path that can otherwise appear frozen during a long model-backed refinement. It deliberately does not add generic lifecycle state for automatic/background refinement.

#447 overlaps with the broader goal, but is currently conflicting and predates the session-action snapshot now on `main`. This PR is the minimal current-main alternative for the interactive slash-command path and does not revive #447's queue/core/protocol changes.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-status.test.ts test/interactive-mode-ctrl-c.test.ts` (174 passed)
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/agent-session-queue.test.ts -t "defers steer heartbeats while a non-streaming session command is running"` (1 passed)
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show elapsed progress and allow cancellation during `/refine` in interactive mode
> - The interactive mode's working loader now activates during active `/refine` session commands (not just agent streaming), showing `Refining · <elapsed> (Ctrl+C to cancel)` in the status area.
> - A new `workingLoaderKind` field tracks whether the loader is owned by streaming or `/refine`, and the loader restarts when ownership changes.
> - Ctrl+C during an active `/refine` command now calls `agentConnection.abort()` and restores any queued prompts to the editor.
> - `syncWorkingLoader()` is called on `session_action_update` events and during initial snapshot rendering to keep loader state current.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f0b233.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->