### PR TITLE
skills: add yantrikdb built-in MCP integration (persistent memory)

### DIFF
--- a/packages/coding-agent/skills/yantrikdb/SKILL.md
+++ b/packages/coding-agent/skills/yantrikdb/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: yantrikdb
+description: Persistent cross-session memory via a self-hosted YantrikDB MCP server. Semantic recall, remember, belief revision, knowledge graph, contradiction detection, and procedural learning. Tools are auto-discovered from the server at runtime.
+---
+
+# YantrikDB
+
+Talk to a self-hosted [YantrikDB](https://github.com/yantrikos/yantrikdb-mcp)
+memory server from the IPython kernel. Memory persists across sessions and
+across harnesses: what you `remember` here, a future session — or another
+agent pointed at the same database — can `recall` by meaning, not phrasing.
+
+## Setup
+
+This integration targets a server the user runs themselves; there is no
+hosted endpoint. It enables when `YANTRIKDB_API_KEY` is set and the server
+is reachable:
+
+```bash
+pip install yantrikdb-mcp
+export YANTRIKDB_API_KEY=<token>   # same value in the shell that launches Prime Agent
+yantrikdb-mcp --transport streamable-http --host 127.0.0.1 --port 8420
+```
+
+The URL defaults to `http://127.0.0.1:8420/mcp`; a `yantrikdb` entry under
+`mcpServers` in settings overrides it. If a call raises `NotEnabled`, the
+`YANTRIKDB_API_KEY` environment variable is not visible to Prime Agent —
+don't ask the user to log in; ask them to set the variable and start the
+server.
+
+## Usage
+
+The tool set is defined by the server, not by this skill, so **discover
+before you call** — don't assume tool names or argument names:
+
+```python
+import yantrikdb
+
+# 1. Discover available tools
+for tool in await yantrikdb.list_tools():
+    print(tool["name"], "-", tool["description"])
+
+# 2. Inspect a specific tool's arguments (rendered from its JSON Schema)
+help(yantrikdb.recall)
+
+# 3. Store a durable fact, then retrieve it by meaning
+await yantrikdb.remember(text="User prefers dark mode in the editor", importance=0.7)
+hits = await yantrikdb.recall(query="what editor settings does the user like")
+print(hits)
+```
+
+Notes:
+- Every tool is an `async` method — always `await`.
+- Results are already-parsed Python (a `dict` for structured output, otherwise a
+  string). No need to `json.loads` them.
+- When a stored fact changes, prefer the server's `correct` tool over a second
+  `remember` — it revises with history instead of creating a contradiction.
+- For tools whose names aren't valid Python identifiers, use the escape hatch:
+  `await yantrikdb.call_tool("tool-name", {"arg": "value"})`.

--- a/packages/coding-agent/skills/yantrikdb/pyproject.toml
+++ b/packages/coding-agent/skills/yantrikdb/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "prime-agent-skill-yantrikdb"
+version = "0.1.0"
+description = "YantrikDB persistent-memory integration skill for Prime Agent."
+requires-python = ">=3.10"
+dependencies = ["mcp", "httpx", "prime-agent-runtime"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/yantrikdb"]

--- a/packages/coding-agent/skills/yantrikdb/src/yantrikdb/__init__.py
+++ b/packages/coding-agent/skills/yantrikdb/src/yantrikdb/__init__.py
@@ -1,0 +1,39 @@
+"""YantrikDB integration: persistent-memory tools auto-discovered from the MCP server.
+
+Usage in the kernel:
+
+    import yantrikdb
+    hits = await yantrikdb.recall(query="past decisions about the deploy")
+"""
+
+from __future__ import annotations
+
+from rlm import McpIntegration
+
+__all__ = ["YantrikDB", "yantrikdb"]
+
+
+class YantrikDB(McpIntegration):
+    server = "yantrikdb"
+    # Fallback when no mcpServers["yantrikdb"] entry exists in settings.json;
+    # the host config wins when present.
+    url = "http://127.0.0.1:8420/mcp"
+    # Without this every call raises NotEnabled: the host only injects OAuth
+    # tokens from auth.json, and yantrikdb-mcp uses a static bearer token.
+    bearer_token_env = "YANTRIKDB_API_KEY"
+
+
+yantrikdb = YantrikDB()
+
+# Names the kernel bootstrap probes to decide if a module is a callable skill.
+# Forwarding them would make `getattr(module, "run")` return an MCP tool stub
+# and the module would be wrapped as callable, breaking `await yantrikdb.<tool>()`.
+_RESERVED = {"run", "__wrapped__", "__call__"}
+
+
+def __getattr__(name: str):
+    # Forward bare module-level access (e.g. yantrikdb.recall) to the instance,
+    # so `import yantrikdb; await yantrikdb.recall(...)` works without `.yantrikdb`.
+    if name.startswith("_") or name in _RESERVED:
+        raise AttributeError(name)
+    return getattr(yantrikdb, name)


### PR DESCRIPTION
## What

A built-in `McpIntegration` skill for [YantrikDB](https://github.com/yantrikos/yantrikdb-mcp) — a self-hosted persistent-memory MCP server (semantic recall, belief revision with history, knowledge graph, contradiction detection, procedural learning; local SQLite; MIT server, AGPL engine). It gives the kernel durable memory that survives across sessions and is shared with any other MCP client pointed at the same database.

Follows the `linear`/`notion` skill structure exactly (SKILL.md + pyproject + `McpIntegration` subclass with the module-forwarding `__getattr__`). One difference, stated in the SKILL.md: there is no hosted endpoint, so it enables via `bearer_token_env = "YANTRIKDB_API_KEY"` + a locally running server instead of OAuth, and ships inert until then — same as the other built-ins ship disabled until login.

## Verified before submitting

Ran end-to-end on prime-agent 0.7.1 (fresh install, WSL Ubuntu) against yantrikdb-mcp 0.14.0 over streamable-http:

- `await yantrikdb.list_tools()` discovered all 20 server tools.
- `remember` returned `{"rid": "019fe43b-...", "status": "recorded"}`; `recall` on a paraphrased query returned the same rid with the text intact.
- With `bearer_token_env` in the class, the round-trip passes on the first call of a fresh session with no setup beyond the env var. Without it, every call raises `NotEnabled` (the host only injects OAuth tokens from auth.json) — that line is the whole reason a built-in helps here.

## Why upstream

Persistent memory is a natural companion to the Continual Harness: the harness persists the agent state it owns (prompts, skills, sub-agents), and this covers the part it does not — facts recalled by meaning, revised without contradiction, shared across harnesses. If you would rather keep server-dependent integrations out of the built-ins, closing this is fine — the skill also lives in our repo and installs with a `cp -r` ([guide](https://github.com/yantrikos/yantrikdb-mcp/blob/main/docs/prime-agent.md)).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add YantrikDB built-in MCP skill for persistent memory
> - Adds a new `yantrikdb` skill package under `packages/coding-agent/skills/yantrikdb` that wraps a self-hosted YantrikDB MCP server as an `rlm.McpIntegration` subclass.
> - The integration connects to `http://127.0.0.1:8420/mcp` by default and reads the bearer token from `YANTRIKDB_API_KEY`.
> - A module-level `__getattr__` hook forwards attribute access (e.g. `await yantrikdb.recall(...)`) to the module-level `YantrikDB` instance, so callers can use the module directly without manual instantiation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 518a414.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->