### PR TITLE
feat(coding-agent): add context-efficient MCP integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,112 @@ prime-agent update [--force]         # Update Prime Agent
 prime-agent shutdown [--force]       # Stop every agent, worker, and background service
 ```
 
+## Context-Efficient Tools in This Fork
+
+This fork adds context-efficient retrieval and output handling without changing Prime Agent's single-tool model. The model still receives `ipython`; the extra capabilities are Python skills called from the persistent kernel. For local MCP integrations, the call path is:
+
+```text
+IPython → Python skill → host bridge → lazy stdio MCP sidecar
+```
+
+The host owns each sidecar's command, environment, working directory, startup, serialization, restart, and shutdown. Process settings and secrets are not copied into the kernel. A timed-out tool call that may already have reached a server is not automatically retried; the tainted sidecar is cleaned up before another call is dispatched.
+
+### jCodeMunch: structured code retrieval
+
+`jcodemunch` retrieves symbols and focused code context instead of loading whole repositories into the model's context. Use it to find definitions, inspect outlines and exact implementations, trace references/importers, assemble ranked context, or estimate a refactor's blast radius.
+
+```python
+import jcodemunch
+
+status = await jcodemunch.available()
+if status["configured"]:
+    tools = await jcodemunch.list_tools()  # The server owns the schemas
+    hits = await jcodemunch.search_symbols(
+        repo="prime-agent", query="McpIntegration", detail_level="compact"
+    )
+    source = await jcodemunch.get_symbol_source(
+        repo="prime-agent", symbol_id=hits[0]["symbol_id"], verify=True
+    )
+```
+
+The Python skill is bundled, but the `jcodemunch-mcp` sidecar is separate and optional. Importing the skill never installs, indexes, upgrades, or purges it. When the command is unavailable, `available()` returns a diagnostic and the agent can fall back to normal file inspection.
+
+### Context Mode: bounded large-output processing
+
+`context_mode` is for large logs, documents, web pages, and command output where a small derived result is more useful than raw content. It can process a file in isolation, execute bounded analysis, batch commands, or index and search fetched content.
+
+```python
+import context_mode
+
+summary = await context_mode.ctx_execute_file(
+    path="logs/server.log",
+    language="python",
+    code=(
+        "errors=[line for line in FILE_CONTENT.splitlines() if 'ERROR' in line]; "
+        "print(len(errors)); print('\n'.join(errors[:10]))"
+    ),
+    intent="Find the first recurring production failure.",
+)
+```
+
+The bundled skill exposes only collection, execution, indexing, and search operations; maintenance operations such as upgrade and purge are blocked. The separately installed `context-mode` sidecar still runs with its own filesystem and network permissions. Context Mode limits what enters the model context; it is not a security sandbox.
+
+Both sidecars default to lazy host-managed stdio when their commands are installed. Override the command, environment, working directory, tool filters, or transport under `mcpServers`, or disable one explicitly:
+
+```jsonc
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "type": "stdio",
+      "command": "/path/to/jcodemunch-mcp"
+    },
+    "context-mode": {
+      "type": "stdio",
+      "command": "context-mode",
+      "enabled": false
+    }
+  }
+}
+```
+
+Both skills can also connect to a configured streamable HTTP MCP endpoint. See the [MCP integration guide](packages/coding-agent/docs/mcp-integrations.md#optional-local-sidecars) for transport, authentication, and tool-filter settings.
+
+### Bounded IPython output artifacts
+
+Large IPython stdout, stderr, results, and tracebacks are automatically materialized as artifacts instead of being injected wholesale into the conversation. Prime Agent returns a bounded preview plus an opaque handle. The agent can then page or search only the relevant channel:
+
+```python
+import rlm
+
+page = await rlm.host_request(
+    "artifact.read",
+    {"handle": "artifact_…", "channel": "stdout", "offset": 0, "max_chars": 4000},
+)
+matches = await rlm.host_request(
+    "artifact.search",
+    {"handle": "artifact_…", "channel": "stdout", "query": "ERROR"},
+)
+```
+
+Artifacts use bounded previews, chunked search, sparse seek checkpoints, atomic publication, and code-point-safe boundaries. Failed or cancelled executions dispose temporary captures rather than leaving open files behind.
+
+### Optional context-routing policy
+
+The example context-routing extension can steer broad reads toward these tools:
+
+```bash
+prime-agent \
+  -e ./packages/coding-agent/examples/extensions/context-routing.ts \
+  --context-routing advisory
+
+# Block high-confidence large raw reads instead of only advising:
+prime-agent \
+  -e ./packages/coding-agent/examples/extensions/context-routing.ts \
+  --context-routing strict-large-read
+```
+
+`advisory` recommends jCodeMunch for source retrieval and Context Mode for large documents or logs. `strict-large-read` additionally blocks high-confidence raw `cat`/download output and directly printed unbounded Python file reads while allowing bounded reads, scalar reductions, builds, tests, git commands, and writes. It is a routing policy, not a security control; see the [extension documentation](packages/coding-agent/examples/extensions/context-routing.md) for its bypass marker, limitations, and optional fast reindex behavior.
+
 ## Built for Long-Running Work
 Prime Agent is built for long-running work, especially for evaluations in research. These features are available in the TUI, and when run autonomously. 
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Added host-managed local stdio MCP servers with serialized calls, restart handling, and cleanup on reload or session disposal.
+- Added bounded IPython output artifacts with opaque retrieval handles for oversized stdout, stderr, results, and tracebacks.
+- Added optional `jcodemunch` and `context-mode` Python skills for host-managed stdio or HTTP sidecars, with bounded retrieval/processing surfaces and graceful unavailable diagnostics.
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added bounded IPython output artifacts with opaque retrieval handles for oversized stdout, stderr, results, and tracebacks.
 - Added bundled `jcodemunch` and `context-mode` Python skills enabled by default through lazy host-managed stdio defaults, with HTTP overrides, curated tool surfaces, and graceful unavailable diagnostics.
 - Fixed host-managed stdio MCP sidecars crashing on closed stdin, retrying possibly delivered tool calls, accepting invalid handshakes/settings, or returning before process cleanup completed.
+- Fixed Python host bridge requests waiting forever or leaking comms after timeouts and cancellation, and corrected the bundled Context Mode file-processing example.
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added bundled `jcodemunch` and `context-mode` Python skills enabled by default through lazy host-managed stdio defaults, with HTTP overrides, curated tool surfaces, and graceful unavailable diagnostics.
 - Fixed host-managed stdio MCP sidecars crashing on closed stdin, retrying possibly delivered tool calls, accepting invalid handshakes/settings, or returning before process cleanup completed.
 - Fixed Python host bridge requests waiting forever or leaking comms after timeouts and cancellation, and corrected the bundled Context Mode file-processing example.
+- Fixed bounded IPython artifacts using unbounded append/search memory, rescanning from byte zero, leaking failed captures, publishing partial artifacts, or splitting Unicode boundaries.
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added host-managed local stdio MCP servers with serialized calls, restart handling, and cleanup on reload or session disposal.
 - Added bounded IPython output artifacts with opaque retrieval handles for oversized stdout, stderr, results, and tracebacks.
-- Added optional `jcodemunch` and `context-mode` Python skills for host-managed stdio or HTTP sidecars, with bounded retrieval/processing surfaces and graceful unavailable diagnostics.
+- Added bundled `jcodemunch` and `context-mode` Python skills enabled by default through lazy host-managed stdio defaults, with HTTP overrides, curated tool surfaces, and graceful unavailable diagnostics.
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added host-managed local stdio MCP servers with serialized calls, restart handling, and cleanup on reload or session disposal.
 - Added bounded IPython output artifacts with opaque retrieval handles for oversized stdout, stderr, results, and tracebacks.
 - Added bundled `jcodemunch` and `context-mode` Python skills enabled by default through lazy host-managed stdio defaults, with HTTP overrides, curated tool surfaces, and graceful unavailable diagnostics.
+- Fixed host-managed stdio MCP sidecars crashing on closed stdin, retrying possibly delivered tool calls, accepting invalid handshakes/settings, or returning before process cleanup completed.
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed host-managed stdio MCP sidecars crashing on closed stdin, retrying possibly delivered tool calls, accepting invalid handshakes/settings, or returning before process cleanup completed.
 - Fixed Python host bridge requests waiting forever or leaking comms after timeouts and cancellation, and corrected the bundled Context Mode file-processing example.
 - Fixed bounded IPython artifacts using unbounded append/search memory, rescanning from byte zero, leaking failed captures, publishing partial artifacts, or splitting Unicode boundaries.
+- Fixed strict context routing bypasses around fallback guards, descriptor redirects, unbounded pipeline tails, and mixed Python reads while allowing scalar reductions.
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -362,13 +362,13 @@ The base class uses the configured HTTP transport through the official `mcp` SDK
 
 See [docs/mcp-integrations.md](docs/mcp-integrations.md) for the full authoring guide (package layout, auth options, the `McpIntegration` API, and caveats).
 
-Optional bundled retrieval skills, `jcodemunch` and `context-mode`, connect to
-separately installed MCP sidecars over host-managed stdio or streamable HTTP
-for structured code retrieval and bounded large-output processing. They
-degrade cleanly when neither transport is configured; they never install,
-upgrade, purge, or otherwise manage sidecars. Configure the separately
-installed `jcodemunch-mcp` / `context-mode` commands or an HTTP endpoint as
-documented in [MCP integrations](docs/mcp-integrations.md#optional-local-sidecars).
+Bundled retrieval skills, `jcodemunch` and `context-mode`, are available by
+default and resolve to separately installed `jcodemunch-mcp` / `context-mode`
+commands over lazy host-managed stdio. User settings can override either
+transport or disable either skill; the skills also support streamable HTTP for
+structured code retrieval and bounded large-output processing. Missing
+sidecars produce diagnostics without installing, launching, upgrading,
+purging, or otherwise managing them. See [MCP integrations](docs/mcp-integrations.md#optional-local-sidecars).
 
 ### Extensions
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -331,7 +331,7 @@ Built-in integrations for Linear and Notion ship disabled. **Logging in enables 
 /mcp logout <name>   disconnect
 ```
 
-Credentials are stored once in `~/.prime/agent/auth.json` (under `mcp:<name>`); the kernel reads them directly and the host refreshes expired tokens. Enablement is derived from whether valid credentials exist, so there is no separate on/off switch.
+Credentials are stored once in `~/.prime/agent/auth.json` (under `mcp:<name>`); the kernel reads them directly and the host refreshes expired tokens. HTTP enablement is derived from valid credentials, while `enabled: false` explicitly disables a user server. Local stdio servers are enabled by configuration and do not use `auth.json`.
 
 **Add your own server.** Declare it under `mcpServers` in settings, then ship a tiny Python skill package that subclasses `McpIntegration`:
 
@@ -358,9 +358,17 @@ def __getattr__(name):     # so `import acme; await acme.<tool>(...)` works
     return getattr(acme, name)
 ```
 
-The base class connects with the official `mcp` SDK, injects the bearer token from `auth.json`, and binds the server's tools as async methods. Use `await acme.call_tool("name", {...})` for tools whose names aren't valid Python identifiers, or a static `bearerTokenEnvVar` instead of OAuth.
+The base class uses the configured HTTP transport through the official `mcp` SDK or dispatches host-managed stdio through the host bridge, then binds the server's tools as async methods. Use `await acme.call_tool("name", {...})` for tools whose names aren't valid Python identifiers, or a static `bearerTokenEnvVar` instead of OAuth for HTTP.
 
 See [docs/mcp-integrations.md](docs/mcp-integrations.md) for the full authoring guide (package layout, auth options, the `McpIntegration` API, and caveats).
+
+Optional bundled retrieval skills, `jcodemunch` and `context-mode`, connect to
+separately installed MCP sidecars over host-managed stdio or streamable HTTP
+for structured code retrieval and bounded large-output processing. They
+degrade cleanly when neither transport is configured; they never install,
+upgrade, purge, or otherwise manage sidecars. Configure the separately
+installed `jcodemunch-mcp` / `context-mode` commands or an HTTP endpoint as
+documented in [MCP integrations](docs/mcp-integrations.md#optional-local-sidecars).
 
 ### Extensions
 

--- a/packages/coding-agent/docs/mcp-integrations.md
+++ b/packages/coding-agent/docs/mcp-integrations.md
@@ -26,6 +26,7 @@ credentials in `auth.json`.
   - [Authentication](#authentication)
 - [The `McpIntegration` API](#the-mcpintegration-api)
 - [Enable-by-login lifecycle](#enable-by-login-lifecycle)
+- [Optional local sidecars](#optional-local-sidecars)
 - [Caveats](#caveats)
 
 ## Using a built-in integration
@@ -40,8 +41,9 @@ Built-in integrations (Linear, Notion) ship **disabled**. Logging in enables the
   disconnects.
 
 Credentials are stored once in `~/.prime/agent/auth.json` under `mcp:<name>`.
-Enablement is derived from whether valid credentials exist — there is no separate
-on/off switch.
+HTTP enablement is derived from valid credentials (or a configured bearer-token
+environment variable). Set `enabled: false` to explicitly disable any user
+server, including a local stdio server.
 
 ## How a call works
 
@@ -67,8 +69,10 @@ result = await linear.list_issues(team="Engineering")
   text, or a list of content blocks otherwise. No need to `json.loads` them.
 - A tool whose name isn't a valid Python identifier (e.g. Notion's `notion-search`)
   is called via the escape hatch: `await notion.call_tool("notion-search", {...})`.
-- A call against an integration with no credentials raises `NotEnabled` (telling
-  the user to `/mcp login`); a tool that returns an error raises `McpToolError`.
+- A call against an HTTP integration with no credentials raises `NotEnabled`
+  (telling the user to `/mcp login`); explicitly disabled integrations raise
+  `Disabled`; a tool that returns an error raises `McpToolError`. Local stdio
+  integrations do not use `auth.json` and are enabled by their settings entry.
 
 ## Authoring your own integration
 
@@ -94,8 +98,7 @@ Add it under `mcpServers` in `~/.prime/agent/settings.json` (or project
 }
 ```
 
-Currently only remote `"http"` servers are supported by `McpIntegration`. HTTP
-server fields:
+HTTP server fields:
 
 | Field | Meaning |
 |-------|---------|
@@ -105,9 +108,21 @@ server fields:
 | `bearerTokenEnvVar` | Name of an env var holding a static bearer token, instead of OAuth |
 | `headers` | Extra static HTTP headers sent on every request |
 | `enabled` | Set `false` to force-disable even when credentials exist |
+| `enabledTools` / `disabledTools` | Optional tool allow/deny lists |
 
-> `stdio` (local-subprocess) servers are not yet wired through to the kernel —
-> the host drops non-HTTP entries — so an integration must target an HTTP endpoint.
+Local `"stdio"` servers are launched lazily by the host, not by the Python
+kernel. Their command, arguments, environment, and working directory remain
+host-side; the kernel uses a host bridge for `list_tools` and `call_tool`.
+
+| Field | Meaning |
+|-------|---------|
+| `type` | Must be `"stdio"` |
+| `command` | Executable passed directly to the subprocess (no shell is used) |
+| `args` | Optional argv arguments |
+| `cwd` | Optional working directory, resolved relative to the active workspace |
+| `env` | Optional child-process environment additions |
+| `enabled` | Set `false` to prevent launch and tool calls |
+| `enabledTools` / `disabledTools` | Optional host-side tool allow/deny lists |
 
 ### 2. Ship the skill package
 
@@ -160,10 +175,12 @@ def __getattr__(name):
     return getattr(acme, name)
 ```
 
-The base class connects with the `mcp` SDK, resolves the URL/headers from the host
-(honoring the `mcpServers` config), injects the bearer token from `auth.json`
-(refreshing when expired), and binds the server's tools as async methods. Authoring
-is a few lines — the package above is the whole integration.
+The base class resolves the configured transport from the host. For HTTP it
+connects with the `mcp` SDK, resolves URL/headers, injects the bearer token from
+`auth.json` (refreshing when expired), and binds the server's tools as async
+methods. For host-managed stdio it keeps command, arguments, environment, and
+cwd in the host and dispatches `list_tools` / `call_tool` through the host
+bridge. Authoring is a few lines — the package above is the whole integration.
 
 ### Authentication
 
@@ -229,6 +246,84 @@ the auth mode you configured:
   do *not* point them at `/mcp login`, which has no provider for a bearer-only
   server and reports "Unknown MCP integration".
 
+## Optional local sidecars
+
+The bundled `jcodemunch` and `context-mode` skills target separately installed
+sidecars for structured code retrieval and bounded large-output processing.
+They are intentionally optional: importing either package never installs,
+launches, indexes, upgrades, or purges a sidecar. Each skill supports either a
+host-managed local stdio server or a streamable HTTP endpoint and reports a
+diagnostic from `available()` when neither is configured.
+
+### Host-managed stdio
+
+Install the sidecar separately and configure its documented stdio command in
+`mcpServers`. The command names for these two optional sidecars are known:
+
+```jsonc
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "type": "stdio",
+      "command": "jcodemunch-mcp"
+    },
+    "context-mode": {
+      "type": "stdio",
+      "command": "context-mode"
+    }
+  }
+}
+```
+
+The host launches configured stdio servers lazily and keeps their command,
+arguments, environment, and working directory host-side; the Python skill
+uses the host bridge for `list_tools` and `call_tool`. Do not add undocumented
+arguments or put secret values in a skill or diagnostic. For another sidecar
+whose CLI syntax is not known, use a safe placeholder and confirm its docs
+before enabling it:
+
+```jsonc
+{
+  "mcpServers": {
+    "acme": {
+      "type": "stdio",
+      "command": "/path/to/separately-installed-mcp-server"
+    }
+  }
+}
+```
+
+### Streamable HTTP
+
+Configure an HTTP endpoint in `mcpServers` (or the documented skill-specific
+`*_MCP_URL` environment variable). The endpoint and token names below are
+examples rather than sidecar defaults:
+
+```jsonc
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "type": "http",
+      "url": "https://localhost.example/jcodemunch/mcp",
+      "bearerTokenEnvVar": "JCODEMUNCH_MCP_TOKEN"
+    },
+    "context-mode": {
+      "type": "http",
+      "url": "https://localhost.example/context-mode/mcp",
+      "bearerTokenEnvVar": "CONTEXT_MODE_MCP_TOKEN"
+    }
+  }
+}
+```
+
+The Python adapters open an HTTP session only for an HTTP configuration; they
+do not launch or attach to stdio themselves. Context Mode exposes a deliberate
+allowlist for execution, file processing, batch processing, fetch-and-index,
+and search. It blocks `ctx_purge`, `ctx_upgrade`, and other maintenance tools.
+Review the separately installed jCodeMunch sidecar's license terms before use;
+the bundled skill does not include or copy that sidecar. Neither skill
+automatically installs, upgrades, reindexes, removes, or purges a sidecar.
+
 ## Caveats
 
 - **Discover before assuming.** Tool names and argument schemas come from the
@@ -246,5 +341,7 @@ the auth mode you configured:
 - **Multi-session daemon.** OAuth provider registration is process-global; a
   user-declared server unique to one daemon session is re-registered on that
   session's next reload.
+- **Stdio lifecycle.** Local sidecars are owned by the session's host manager,
+  started on first use, serialized per server, and stopped on reload/disposal.
 
 See also: [Skills](skills.md), [Settings](settings.md).

--- a/packages/coding-agent/docs/mcp-integrations.md
+++ b/packages/coding-agent/docs/mcp-integrations.md
@@ -250,15 +250,19 @@ the auth mode you configured:
 
 The bundled `jcodemunch` and `context-mode` skills target separately installed
 sidecars for structured code retrieval and bounded large-output processing.
-They are intentionally optional: importing either package never installs,
-launches, indexes, upgrades, or purges a sidecar. Each skill supports either a
-host-managed local stdio server or a streamable HTTP endpoint and reports a
-diagnostic from `available()` when neither is configured.
+The skills are available by default, while the sidecars remain separately
+installed and optional. When no user `mcpServers` entry overrides either name,
+Prime Agent resolves `jcodemunch` to the `jcodemunch-mcp` command and
+`context-mode` to the `context-mode` command as lazy host-managed stdio
+integrations. Importing either package never installs, launches, indexes,
+upgrades, or purges a sidecar; `available()` reports diagnostics when a command
+is missing.
 
 ### Host-managed stdio
 
-Install the sidecar separately and configure its documented stdio command in
-`mcpServers`. The command names for these two optional sidecars are known:
+Install the sidecar separately if you want to use it. The following explicit
+configuration is equivalent to Prime Agent's defaults and is useful when you
+need to add args, env, cwd, tool filters, or an explicit `enabled` setting:
 
 ```jsonc
 {
@@ -275,12 +279,31 @@ Install the sidecar separately and configure its documented stdio command in
 }
 ```
 
+To disable one default without disabling the other, keep its required command
+and set `enabled` to `false`:
+
+```jsonc
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "type": "stdio",
+      "command": "jcodemunch-mcp",
+      "enabled": false
+    }
+  }
+}
+```
+
 The host launches configured stdio servers lazily and keeps their command,
 arguments, environment, and working directory host-side; the Python skill
-uses the host bridge for `list_tools` and `call_tool`. Do not add undocumented
-arguments or put secret values in a skill or diagnostic. For another sidecar
-whose CLI syntax is not known, use a safe placeholder and confirm its docs
-before enabling it:
+uses the host bridge for `list_tools` and `call_tool`. Implicit defaults enforce
+the same curated tool surfaces as the bundled skills for both operations. A user
+entry replaces the matching default, including its transport and tool filters;
+`{ "enabled": false }` disables it without falling back to an environment URL.
+Do not add undocumented arguments or put secret values in a skill or diagnostic.
+For another sidecar whose CLI
+syntax is not known, use a safe placeholder and confirm its docs before
+enabling it:
 
 ```jsonc
 {

--- a/packages/coding-agent/docs/mcp-integrations.md
+++ b/packages/coding-agent/docs/mcp-integrations.md
@@ -12,9 +12,14 @@ import linear
 issues = await linear.list_issues(team="Engineering")
 ```
 
-The MCP connection runs inside the kernel via the official `mcp` Python SDK. The
-host's only jobs are interactive login (browser OAuth) and minting/refreshing
-credentials in `auth.json`.
+HTTP MCP integrations run inside the kernel via the official `mcp` Python SDK.
+The host handles interactive login (browser OAuth) and minting/refreshing
+credentials in `auth.json`, but does not proxy ordinary HTTP tool calls.
+
+Local stdio integrations are different: the host owns their sidecar processes,
+including command, environment, working directory, startup, and shutdown. The
+kernel receives only a host bridge for tool discovery and calls; it never spawns
+the sidecar or receives its process configuration.
 
 ## Table of Contents
 
@@ -216,6 +221,7 @@ Methods:
 Exceptions (both importable from `rlm`):
 
 - `NotEnabled` — raised when no usable credentials exist (not logged in).
+- `Disabled` — raised when an integration is explicitly disabled.
 - `McpToolError` — raised when a tool call returns a result flagged as an error.
 
 ## Enable-by-login lifecycle

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -233,6 +233,35 @@ Disable the built-in `websearch` skill while keeping normal skill discovery enab
 }
 ```
 
+### MCP integrations
+
+`jcodemunch` and `context-mode` are resolved as lazy host-managed stdio
+integrations by default, using the separately installed `jcodemunch-mcp` and
+`context-mode` commands. A matching `mcpServers` entry overrides that default
+and may change the transport, command, args, environment, cwd, tool filters,
+or enabled state. The host never installs or starts a default sidecar during
+discovery; it launches only when the first tool or health request needs it.
+
+```jsonc
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "type": "stdio",
+      "command": "jcodemunch-mcp",
+      "enabled": false
+    },
+    "context-mode": {
+      "type": "http",
+      "url": "https://localhost.example/context-mode/mcp"
+    }
+  }
+}
+```
+
+Set `enabled` to `false` to disable a default reliably; it does not fall back
+to a skill environment URL. See [MCP integrations](mcp-integrations.md) for
+all HTTP/stdio fields and the separate-sidecar license boundary.
+
 #### packages
 
 String form loads all resources from a package:

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -51,6 +51,8 @@ Prime Agent ships with built-in skills that load by default:
 - `prime-intellect` - Prime Intellect products and workflows via the prime CLI: verifiers environments and the Environments Hub, evaluations (local and hosted), Hosted Training and prime-rl, sandboxes, tunnels, Prime Inference, GPU compute, and storage. Reference docs for each area load on demand from the skill's `references/` directory.
 - `skill-creator` - teaches the agent to create new skills: markdown skill layout, frontmatter rules, placement and precedence, and the full Python-backed skill contract (package layout, `run()` convention, optional CLI, kernel venv behavior) with a working template in `references/python-skills.md`.
 - `websearch` - a Python-backed Google search skill using the [Serper](https://serper.dev) API.
+- `jcodemunch` - optional structured code retrieval through a separately installed MCP sidecar over host-managed stdio or HTTP.
+- `context-mode` - optional bounded web, documentation, log, and isolated-processing support through a separately installed MCP sidecar over host-managed stdio or HTTP.
 
 Built-in skills behave like any other skill but have the lowest precedence: a user, project, package, or `--skill` skill with the same name overrides the built-in one.
 
@@ -105,6 +107,20 @@ To disable all built-in skills, set `enableBuiltinSkills` to `false` in `setting
   "skills": ["-prime-intellect/SKILL.md"]
 }
 ```
+
+### Optional retrieval sidecars
+
+`jcodemunch` and `context-mode` are bundled Python-backed skills but depend on
+separately installed sidecars. They are safe to leave unconfigured: imports do
+not install, launch, index, upgrade, or purge anything, and
+`await <module>.available()` returns an actionable diagnostic. Configure either
+a host-managed stdio entry in `mcpServers` using the separately installed
+command, or a streamable HTTP endpoint with `mcpServers` or the skill's
+`JCODEMUNCH_MCP_URL` / `CONTEXT_MODE_MCP_URL` environment variable. The host
+keeps stdio command and environment settings out of the Python skill; the
+adapter opens a Python session only for HTTP. See each skill and [MCP
+integrations](mcp-integrations.md#optional-local-sidecars) for concrete
+command and HTTP examples.
 
 ### Using Skills from Other Harnesses
 

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -51,8 +51,8 @@ Prime Agent ships with built-in skills that load by default:
 - `prime-intellect` - Prime Intellect products and workflows via the prime CLI: verifiers environments and the Environments Hub, evaluations (local and hosted), Hosted Training and prime-rl, sandboxes, tunnels, Prime Inference, GPU compute, and storage. Reference docs for each area load on demand from the skill's `references/` directory.
 - `skill-creator` - teaches the agent to create new skills: markdown skill layout, frontmatter rules, placement and precedence, and the full Python-backed skill contract (package layout, `run()` convention, optional CLI, kernel venv behavior) with a working template in `references/python-skills.md`.
 - `websearch` - a Python-backed Google search skill using the [Serper](https://serper.dev) API.
-- `jcodemunch` - optional structured code retrieval through a separately installed MCP sidecar over host-managed stdio or HTTP.
-- `context-mode` - optional bounded web, documentation, log, and isolated-processing support through a separately installed MCP sidecar over host-managed stdio or HTTP.
+- `jcodemunch` - structured code retrieval through a separately installed MCP sidecar over host-managed stdio or HTTP.
+- `context-mode` - bounded web, documentation, log, and isolated-processing support through a separately installed MCP sidecar over host-managed stdio or HTTP.
 
 Built-in skills behave like any other skill but have the lowest precedence: a user, project, package, or `--skill` skill with the same name overrides the built-in one.
 
@@ -110,15 +110,17 @@ To disable all built-in skills, set `enableBuiltinSkills` to `false` in `setting
 
 ### Optional retrieval sidecars
 
-`jcodemunch` and `context-mode` are bundled Python-backed skills but depend on
-separately installed sidecars. They are safe to leave unconfigured: imports do
-not install, launch, index, upgrade, or purge anything, and
-`await <module>.available()` returns an actionable diagnostic. Configure either
-a host-managed stdio entry in `mcpServers` using the separately installed
-command, or a streamable HTTP endpoint with `mcpServers` or the skill's
-`JCODEMUNCH_MCP_URL` / `CONTEXT_MODE_MCP_URL` environment variable. The host
-keeps stdio command and environment settings out of the Python skill; the
-adapter opens a Python session only for HTTP. See each skill and [MCP
+`jcodemunch` and `context-mode` are bundled Python-backed skills and are
+available by default. When a user has not declared an entry for either name,
+Prime Agent resolves it as a lazy host-managed stdio integration using the
+separately installed `jcodemunch-mcp` or `context-mode` command. A user
+`mcpServers` entry can override the transport, command, args, environment,
+working directory, tool filters, or `enabled` state; `{ "enabled": false }`
+reliably disables the default. Imports never install, launch, index, upgrade,
+or purge anything, and `await <module>.available()` returns an actionable
+diagnostic when a separately installed command is missing. The host keeps
+stdio command and environment settings out of the Python skill; the adapter
+opens a Python session only for HTTP. See each skill and [MCP
 integrations](mcp-integrations.md#optional-local-sidecars) for concrete
 command and HTTP examples.
 

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -38,6 +38,7 @@ cp permission-gate.ts ~/.prime/agent/extensions/
 | `built-in-tool-renderer.ts` | Custom compact rendering for built-in tools (bash and edit) while keeping original behavior |
 | `minimal-mode.ts` | Override built-in tool rendering for minimal display (only tool calls, no output in collapsed mode) |
 | `truncated-tool.ts` | Wraps ripgrep with proper output truncation (50KB/2000 lines) |
+| `context-routing.ts` | Advisory/strict-large-read routing plus bounded, optional fast reindexing after IPython edits |
 | `ssh.ts` | Delegate bash and edit to a remote machine via SSH using pluggable operations |
 | `subagent/` | Delegate tasks to specialized subagents with isolated context windows |
 

--- a/packages/coding-agent/examples/extensions/context-routing.md
+++ b/packages/coding-agent/examples/extensions/context-routing.md
@@ -46,15 +46,28 @@ shell recognition. It blocks:
 - immediately printed unbounded `open(...).read()` or
   `Path(...).read_text()` expressions.
 
-It allows bounded reads such as `read(200)`, `read_text()[:200]`, or a
-`head`/`tail` pipeline, stat-able files of 16 KiB or less, redirects (`curl
-URL > response`, `cat file > out`), normal builds/tests/git commands, and
-writes. Unknown shell syntax is allowed
-rather than guessed to be a violation.
+Fallbacks are branch-scoped rather than cell-scoped. An `ImportError` branch is
+exempt only when its surrounding range names an integration such as
+jCodeMunch, and a `command -v`/`which` `||` branch is exempt only when the
+availability check names that integration. A `# context-routing: fallback`
+marker exempts the following fallback statement only; reads elsewhere in the
+cell are still inspected.
 
-If a jCodeMunch or Context Mode integration is unavailable, a clear
-`try/except ImportError` or `command -v ... ||` fallback is allowed. A
-`# context-routing: fallback` marker can document another fallback shape.
+Stdout is considered materialized only when a redirect target is a literal file
+path or `/dev/null`. Relative targets are resolved against the inspection cwd,
+including `..` traversal. Descriptor targets (`&1`, `&2`, `-`, `/dev/stdout`,
+`/dev/stderr`, `/dev/fd/*`, and all `/proc/*` paths) are not safe redirects.
+Pipelines are bounded
+only when the last relevant `head`/`tail` stage has a numeric bound (for
+example `head -5` or `tail -n 5`); `tail -n +1` and `--lines=+1` remain
+unbounded.
+
+Python output inspects every read in every printed argument. Direct content,
+including `str`, `repr`, f-string interpolation, and unbounded slices, remains
+guarded; scalar reducers such as `len`, `hash`, `count`, `sum`, and comparisons
+are allowed. Bounded reads, stat-able files of 16 KiB or less, normal
+builds/tests/git commands, and writes remain allowed. Unknown shell syntax is
+allowed rather than guessed to be a violation.
 
 For an intentional exception, put this as the first non-blank line in the
 IPython cell:

--- a/packages/coding-agent/examples/extensions/context-routing.md
+++ b/packages/coding-agent/examples/extensions/context-routing.md
@@ -1,0 +1,101 @@
+# Context routing extension
+
+`context-routing.ts` is a project-local Prime Agent extension example. It is a
+routing policy, not a security control: the strict mode intentionally favors
+false negatives over false positives and can be bypassed.
+
+## Enable it
+
+```bash
+pi -e ./context-routing.ts --context-routing advisory
+pi -e ./context-routing.ts --context-routing strict-large-read
+pi -e ./context-routing.ts --context-routing advisory --context-routing-fast-reindex=off
+```
+
+The available modes are:
+
+- `off`: no prompt guidance and no inspection.
+- `advisory`: adds concise per-turn guidance. Use jCodeMunch before opening
+  whole source files, use Context Mode for web pages, documentation, logs, and
+  large data, and keep edits, tests, builds, and git work in Prime Agent.
+- `strict-large-read`: adds the advisory and blocks only high-confidence
+  context-expanding IPython cells.
+
+The advisory fast-reindex path is enabled by default. Disable it with:
+
+```bash
+pi -e ./context-routing.ts --context-routing-fast-reindex=off
+```
+
+The mode can also be changed during a session:
+
+```text
+/context-routing off
+/context-routing advisory
+/context-routing strict-large-read
+/context-routing stats
+```
+
+## Strict-large-read behavior
+
+The extension parses an IPython `%%bash` header before applying conservative
+shell recognition. It blocks:
+
+- raw `curl` stdout and `wget -qO-`/`wget -O -` stdout;
+- broad `cat` file dumps when the files are not stat-able as small files; and
+- immediately printed unbounded `open(...).read()` or
+  `Path(...).read_text()` expressions.
+
+It allows bounded reads such as `read(200)`, `read_text()[:200]`, or a
+`head`/`tail` pipeline, stat-able files of 16 KiB or less, redirects (`curl
+URL > response`, `cat file > out`), normal builds/tests/git commands, and
+writes. Unknown shell syntax is allowed
+rather than guessed to be a violation.
+
+If a jCodeMunch or Context Mode integration is unavailable, a clear
+`try/except ImportError` or `command -v ... ||` fallback is allowed. A
+`# context-routing: fallback` marker can document another fallback shape.
+
+For an intentional exception, put this as the first non-blank line in the
+IPython cell:
+
+```python
+# context-routing: bypass
+print(open("generated-report.txt").read())
+```
+
+The bypass is an explicit routing choice, not an authorization mechanism.
+
+## Telemetry and limitations
+
+`installContextRouting()` accepts an optional telemetry hook and returns live
+counters. The `/context-routing stats` command displays the same counters.
+Telemetry failures are ignored so instrumentation cannot change routing.
+
+This example does not inspect Prime Agent's central MCP, output, or settings
+code. It only observes `tool_call` for the built-in `ipython` tool. Recognition
+is deliberately conservative: it is not a shell AST, does not evaluate
+variables or aliases, and does not promise to catch every broad read. It also
+does not block direct Prime Agent edits, tests, builds, git commands, or writes.
+
+## Fast reindex behavior
+
+After a successful built-in `ipython` tool result with `details.status === "ok"`
+and one or more `IpythonToolDetails.diffs`, the extension resolves each diff
+path against the session working directory and immediately enqueues a best-effort
+`jcodemunch-mcp index-file --no-ai-summaries <absolute-path>` invocation. At
+most two invocations run at once, duplicate paths are coalesced, and failures
+(including a missing `jcodemunch-mcp`) are ignored. The edit result is never
+awaited on this queue.
+
+Only existing regular files are eligible. Deleted paths, directories, generated
+paths (`dist`, `build`, `generated`, `*.generated.*`, and similar), and other
+non-file paths are skipped. The child process uses no shell, receives ignored
+stdio, and gets only a minimal environment; its output and errors are not
+returned to the agent. The jCodeMunch watcher remains authoritative and will
+catch up when this advisory path is unavailable or disabled.
+
+This example launches the separately installed CLI directly because the
+extension event API does not expose the host-managed MCP transport. Deployments
+that require host-managed-only sidecars should leave the fast path off; normal
+context routing and watcher behavior are unchanged.

--- a/packages/coding-agent/examples/extensions/context-routing.ts
+++ b/packages/coding-agent/examples/extensions/context-routing.ts
@@ -39,7 +39,11 @@ export type ContextRoutingMode = (typeof CONTEXT_ROUTING_MODES)[number];
 /** Whole-file reads at or below this size are treated as small when stat-able. */
 export const SMALL_FILE_BYTES = 16 * 1024;
 
-export type ContextRoutingPattern = "curl/wget stdout" | "cat whole-file dump" | "python whole-file print";
+export type ContextRoutingPattern =
+	| "curl/wget stdout"
+	| "cat whole-file dump"
+	| "python whole-file print"
+	| "unbounded head/tail reader";
 
 export interface ContextRoutingInspection {
 	decision: "allow" | "block";
@@ -216,29 +220,38 @@ interface ParsedBashCell {
 	body: string;
 }
 
+interface GuardedRange {
+	start: number;
+	end: number;
+}
+
 interface ShellSegment {
 	text: string;
-	stdoutRedirected: boolean;
+	start: number;
+	end: number;
+	separatorBefore?: "&&" | "||" | "newline" | ";";
+}
+
+interface ShellStage {
+	text: string;
+	start: number;
+	end: number;
+}
+
+type RedirectSafety = "none" | "safe" | "unsafe";
+
+interface ShellRedirections {
+	stdout: RedirectSafety;
+	ranges: Array<{ start: number; end: number }>;
 }
 
 const BASH_CELL_PATTERN = /^(?:[ \t]*\r?\n)*[ \t]*%%bash\b[^\r\n]*(?:\r?\n|$)/;
 const BYPASS_MARKER_PATTERN = /^#\s*context-routing\s*:\s*(?:allow|bypass)\s*$/i;
 const FALLBACK_MARKER_PATTERN = /^#\s*context-routing\s*:\s*fallback\s*$/i;
-const IMPORT_FALLBACK_PATTERN =
-	/\btry\b[\s\S]{0,1000}\bexcept\s+(?:ImportError|ModuleNotFoundError)(?:\s+as\s+[A-Za-z_][A-Za-z0-9_]*)?\s*:/i;
-const SHELL_FALLBACK_PATTERN = /\b(?:command\s+-v|which)\s+[^\r\n;|&]+(?:\s[^\r\n;|&]+)?\s*\|\|/i;
-const INTEGRATION_FALLBACK_PATTERN =
-	/\b(?:jcodemunch|context[-_ ]?mode|mcp)\b[\s\S]{0,120}\b(?:unavailable|not available|missing|fallback)\b/i;
-const SHELL_KEYWORD_PATTERN = /^(?:(?:if|then|else|elif|do|while|until|for|case|!|command)\s+)+/i;
+const INTEGRATION_IDENTIFIER_PATTERN = /^(?:jcodemunch(?:-mcp)?|context[-_ ]?mode|mcp(?:[-_][a-z0-9_-]+)?)$/i;
+const SHELL_KEYWORD_PATTERN = /^(?:(?:if|then|else|elif|do|while|until|for|case|!)\s+)+/i;
 const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=(?:[^\s]*|"[^"]*"|'[^']*')\s+/;
-const CURL_OUTPUT_PATTERN = /(?:^|\s)(?:-o|--output|--output-document)(?:=|\s+)(?:"[^"]*"|'[^']*'|\S+)/i;
-const CURL_STDOUT_OUTPUT_PATTERN = /(?:^|\s)(?:-o|--output|--output-document)(?:=|\s+)(?:-|"-"|'-')(?=\s|$)/i;
-const CURL_FILE_OUTPUT_PATTERN = /(?:^|\s)(?:-O|--remote-name)(?=\s|$)/i;
-const WGET_STDOUT_PATTERN =
-	/(?:^|\s)(?:-O(?:\s+|-)?-|--output-document(?:=|\s+)(?:-|"-"|'-')|-[A-Za-z]*q[A-Za-z]*O-)(?=\s|$)/i;
-const WGET_OUTPUT_PATTERN = /(?:^|\s)(?:-O|--output-document)(?:=|\s+)(?:"[^"]*"|'[^']*'|\S+)/i;
 const HEAD_REQUEST_PATTERN = /(?:^|\s)(?:-I|--head)(?=\s|$)/i;
-const BOUNDED_PIPELINE_PATTERN = /\|\s*(?:head|tail)(?:\s|$)/i;
 
 function normalizeMode(value: boolean | string | undefined): ContextRoutingMode {
 	return typeof value === "string" && (CONTEXT_ROUTING_MODES as readonly string[]).includes(value)
@@ -258,23 +271,56 @@ function hasLeadingMarker(code: string, pattern: RegExp): boolean {
 	return firstLine !== undefined && pattern.test(firstLine);
 }
 
-function hasFallbackGuard(code: string): boolean {
-	const bashCell = parseBashCell(code);
-	const fallbackText = bashCell
-		? bashCell.body.replace(/(^|\r?\n)[ \t]*#.*(?=\r?$)/gm, "$1")
-		: maskPythonStrings(code);
-	return (
-		hasLeadingMarker(code, FALLBACK_MARKER_PATTERN) ||
-		IMPORT_FALLBACK_PATTERN.test(fallbackText) ||
-		SHELL_FALLBACK_PATTERN.test(fallbackText) ||
-		INTEGRATION_FALLBACK_PATTERN.test(fallbackText)
-	);
-}
-
 function parseBashCell(code: string): ParsedBashCell | undefined {
 	const match = BASH_CELL_PATTERN.exec(code);
 	if (!match) return undefined;
 	return { body: code.slice(match[0].length) };
+}
+
+function maskRanges(source: string, ranges: readonly GuardedRange[]): string {
+	if (ranges.length === 0) return source;
+	const characters = source.split("");
+	for (const range of ranges) {
+		for (let index = Math.max(0, range.start); index < Math.min(characters.length, range.end); index += 1) {
+			if (characters[index] !== "\n" && characters[index] !== "\r") characters[index] = " ";
+		}
+	}
+	return characters.join("");
+}
+
+function lineRanges(source: string): Array<{ start: number; end: number; text: string }> {
+	const ranges: Array<{ start: number; end: number; text: string }> = [];
+	let start = 0;
+	for (const match of source.matchAll(/.*(?:\r?\n|$)/g)) {
+		const text = match[0];
+		if (text.length === 0) break;
+		const end = start + text.length;
+		ranges.push({ start, end, text: text.replace(/\r?\n$/, "") });
+		start = end;
+	}
+	return ranges;
+}
+
+function findFallbackMarkerRanges(source: string): GuardedRange[] {
+	const lines = lineRanges(source);
+	const ranges: GuardedRange[] = [];
+	for (let index = 0; index < lines.length; index += 1) {
+		if (!FALLBACK_MARKER_PATTERN.test(lines[index]!.text.trim())) continue;
+		let next = index + 1;
+		while (next < lines.length && lines[next]!.text.trim().length === 0) next += 1;
+		if (next >= lines.length) continue;
+		const markerIndent = lines[index]!.text.match(/^\s*/)?.[0].length ?? 0;
+		const nextIndent = lines[next]!.text.match(/^\s*/)?.[0].length ?? 0;
+		let end = lines[next]!.end;
+		for (let continuation = next + 1; continuation < lines.length; continuation += 1) {
+			const text = lines[continuation]!.text;
+			const indent = text.match(/^\s*/)?.[0].length ?? 0;
+			if (text.trim().length > 0 && indent <= markerIndent && indent <= nextIndent) break;
+			end = lines[continuation]!.end;
+		}
+		ranges.push({ start: lines[next]!.start, end });
+	}
+	return ranges;
 }
 
 function splitShellSegments(body: string): ShellSegment[] {
@@ -282,13 +328,24 @@ function splitShellSegments(body: string): ShellSegment[] {
 	let start = 0;
 	let quote: "single" | "double" | undefined;
 	let escaped = false;
-	let stdoutRedirected = false;
+	let separatorBefore: ShellSegment["separatorBefore"];
 
 	const push = (end: number) => {
-		const text = body.slice(start, end).trim();
-		if (text.length > 0) segments.push({ text, stdoutRedirected });
+		const raw = body.slice(start, end);
+		const leading = raw.match(/^\s*/)?.[0].length ?? 0;
+		const trailing = raw.match(/\s*$/)?.[0].length ?? 0;
+		const trimmedStart = start + leading;
+		const trimmedEnd = Math.max(trimmedStart, end - trailing);
+		if (trimmedEnd > trimmedStart) {
+			segments.push({
+				text: body.slice(trimmedStart, trimmedEnd),
+				start: trimmedStart,
+				end: trimmedEnd,
+				separatorBefore,
+			});
+		}
 		start = end;
-		stdoutRedirected = false;
+		separatorBefore = undefined;
 	};
 
 	for (let index = 0; index < body.length; index += 1) {
@@ -323,18 +380,15 @@ function splitShellSegments(body: string): ShellSegment[] {
 			index = newline - 1;
 			continue;
 		}
-		if (character === ">") {
-			const previous = body[index - 1];
-			if (previous !== "2") stdoutRedirected = true;
-			continue;
-		}
 		if (character === "\n" || character === ";") {
 			push(index);
+			separatorBefore = character === ";" ? ";" : "newline";
 			start = index + 1;
 			continue;
 		}
 		if ((character === "&" || character === "|") && body[index + 1] === character) {
 			push(index);
+			separatorBefore = character === "&" ? "&&" : "||";
 			index += 1;
 			start = index + 1;
 		}
@@ -354,7 +408,9 @@ function shellWords(text: string): string[] {
 		current = "";
 	};
 
-	for (const character of text.trim()) {
+	const trimmed = text.trim();
+	for (let index = 0; index < trimmed.length; index += 1) {
+		const character = trimmed[index];
 		if (escaped) {
 			current += character;
 			escaped = false;
@@ -374,6 +430,7 @@ function shellWords(text: string): string[] {
 			else current += character;
 			continue;
 		}
+		if (character === "#" && (index === 0 || /\s/.test(trimmed[index - 1] ?? ""))) break;
 		if (character === "'") quote = "single";
 		else if (character === '"') quote = "double";
 		else if (/\s/.test(character)) push();
@@ -406,46 +463,397 @@ function commandAfterShellPreamble(text: string): string {
 	return result.trim();
 }
 
-function inspectBashCell(cell: ParsedBashCell, cwd: string | undefined): ContextRoutingInspection {
-	for (const segment of splitShellSegments(cell.body)) {
-		const command = commandAfterShellPreamble(segment.text);
-		const words = shellWords(command);
-		const executable = words[0]?.toLowerCase();
-		if (!executable || segment.stdoutRedirected || BOUNDED_PIPELINE_PATTERN.test(command)) continue;
+function splitPipelineStages(text: string, offset: number): ShellStage[] {
+	const stages: ShellStage[] = [];
+	let start = 0;
+	let quote: "single" | "double" | undefined;
+	let escaped = false;
+	const push = (end: number) => {
+		const raw = text.slice(start, end);
+		const leading = raw.match(/^\s*/)?.[0].length ?? 0;
+		const trailing = raw.match(/\s*$/)?.[0].length ?? 0;
+		const stageStart = start + leading;
+		const stageEnd = Math.max(stageStart, end - trailing);
+		if (stageEnd > stageStart)
+			stages.push({ text: text.slice(stageStart, stageEnd), start: offset + stageStart, end: offset + stageEnd });
+		start = end;
+	};
+	for (let index = 0; index < text.length; index += 1) {
+		const character = text[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (character === "\\" && quote !== "single") {
+			escaped = true;
+			continue;
+		}
+		if (quote === "single") {
+			if (character === "'") quote = undefined;
+			continue;
+		}
+		if (quote === "double") {
+			if (character === '"') quote = undefined;
+			continue;
+		}
+		if (character === "'") quote = "single";
+		else if (character === '"') quote = "double";
+		else if (character === "#" && (index === 0 || /\s/.test(text[index - 1] ?? ""))) break;
+		else if (character === "|" && text[index + 1] !== "|") {
+			push(index);
+			if (text[index + 1] === "&") index += 1;
+			start = index + 1;
+		}
+	}
+	push(text.length);
+	return stages;
+}
 
-		if ((executable === "curl" || executable === "curl.exe") && !HEAD_REQUEST_PATTERN.test(command)) {
-			if (
-				(!CURL_OUTPUT_PATTERN.test(command) && !CURL_FILE_OUTPUT_PATTERN.test(command)) ||
-				CURL_STDOUT_OUTPUT_PATTERN.test(command)
-			) {
-				return {
-					decision: "block",
-					pattern: "curl/wget stdout",
-					reason: "Raw curl output would expand context; redirect it to a file or use a bounded parser.",
-				};
+function readShellToken(source: string, start: number): { end: number; value: string } | undefined {
+	let index = start;
+	while (/\s/.test(source[index] ?? "")) index += 1;
+	if (index >= source.length || /[;|&]/.test(source[index] ?? "")) return undefined;
+	const valueStart = index;
+	let value = "";
+	let quote: "single" | "double" | undefined;
+	let escaped = false;
+	for (; index < source.length; index += 1) {
+		const character = source[index];
+		if (escaped) {
+			value += character;
+			escaped = false;
+			continue;
+		}
+		if (character === "\\" && quote !== "single") {
+			escaped = true;
+			continue;
+		}
+		if (quote === "single") {
+			if (character === "'") quote = undefined;
+			else value += character;
+			continue;
+		}
+		if (quote === "double") {
+			if (character === '"') quote = undefined;
+			else value += character;
+			continue;
+		}
+		if (character === "'") quote = "single";
+		else if (character === '"') quote = "double";
+		else if (/\s|[;|&]/.test(character)) break;
+		else value += character;
+	}
+	return { end: index === valueStart ? index + 1 : index, value };
+}
+
+function entersDescriptorNamespace(target: string): boolean {
+	const components: string[] = [];
+	for (const component of target.split("/")) {
+		if (!component || component === ".") continue;
+		if (component === "..") {
+			components.pop();
+			continue;
+		}
+		components.push(component);
+		if (components[0] === "dev" && components[1] === "fd") return true;
+		if (
+			components[0] === "proc" &&
+			/^(?:self|thread-self|\d+)$/.test(components[1] ?? "") &&
+			(components[2] === "fd" ||
+				(components[2] === "task" && /^\d+$/.test(components[3] ?? "") && components[4] === "fd"))
+		)
+			return true;
+	}
+	return false;
+}
+
+function isSafeRedirectTarget(target: string | undefined, cwd: string | undefined): boolean {
+	if (!target || target === "-" || target.startsWith("&") || target.startsWith("~")) return false;
+	if (/^\d+$/.test(target)) return false;
+	if (entersDescriptorNamespace(target)) return false;
+	const normalized = target.startsWith("/")
+		? path.posix.normalize(target)
+		: cwd
+			? path.posix.resolve(cwd, target)
+			: target;
+	if (/^\/dev\/null$/.test(normalized)) return true;
+	if (/^\d+$/.test(normalized) || /^\/dev\/(?:stdin|stdout|stderr|fd\/\d+)$/.test(normalized)) return false;
+	if (normalized === "/proc" || normalized.startsWith("/proc/")) return false;
+	return !normalized.startsWith("~") && !/[$`*?{}<>|;]/.test(normalized);
+}
+
+function parseShellRedirections(text: string, cwd: string | undefined): ShellRedirections {
+	const ranges: Array<{ start: number; end: number }> = [];
+	let stdout: RedirectSafety = "none";
+	let quote: "single" | "double" | undefined;
+	let escaped = false;
+	for (let index = 0; index < text.length; index += 1) {
+		const character = text[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (character === "\\" && quote !== "single") {
+			escaped = true;
+			continue;
+		}
+		if (quote === "single") {
+			if (character === "'") quote = undefined;
+			continue;
+		}
+		if (quote === "double") {
+			if (character === '"') quote = undefined;
+			continue;
+		}
+		if (character === "'") {
+			quote = "single";
+			continue;
+		}
+		if (character === '"') {
+			quote = "double";
+			continue;
+		}
+		if (character === "#" && (index === 0 || /\s/.test(text[index - 1] ?? ""))) break;
+		let start = index;
+		let fd: number | "all" | undefined;
+		let operatorEnd: number | undefined;
+		if (character === "&" && text[index + 1] === ">") {
+			fd = "all";
+			operatorEnd = index + (text[index + 2] === ">" ? 3 : 2);
+		} else if (character === ">") {
+			operatorEnd = index + (text[index + 1] === ">" ? 2 : 1);
+			if (text[operatorEnd] === "&") operatorEnd += 1;
+			let digitStart = index;
+			while (digitStart > 0 && /\d/.test(text[digitStart - 1] ?? "")) digitStart -= 1;
+			if (digitStart < index && (digitStart === 0 || /\s|[;|&]/.test(text[digitStart - 1] ?? ""))) {
+				start = digitStart;
+				fd = Number(text.slice(digitStart, index));
 			}
 		}
+		if (operatorEnd === undefined) continue;
+		const target = readShellToken(text, operatorEnd);
+		const safe = isSafeRedirectTarget(target?.value, cwd);
+		ranges.push({ start, end: target?.end ?? operatorEnd });
+		if (fd === undefined || fd === 1 || fd === "all") stdout = safe ? "safe" : "unsafe";
+		index = (target?.end ?? operatorEnd) - 1;
+	}
+	return { stdout, ranges };
+}
 
-		if (executable === "wget" || executable === "wget.exe") {
-			if (
-				WGET_STDOUT_PATTERN.test(command) ||
-				(!WGET_OUTPUT_PATTERN.test(command) && /(?:^|\s)-qO-?(?:\s|$)/i.test(command))
-			) {
+function shellWordsWithoutRedirections(text: string, redirections: ShellRedirections): string[] {
+	return shellWords(maskRanges(text, redirections.ranges));
+}
+
+function classifyOutputTarget(target: string | undefined, cwd: string | undefined): RedirectSafety {
+	return isSafeRedirectTarget(target, cwd) ? "safe" : "unsafe";
+}
+
+function outputOptionSafety(words: string[], executable: string, cwd: string | undefined): RedirectSafety {
+	let result: RedirectSafety = "none";
+	const isCurl = executable === "curl" || executable === "curl.exe";
+	for (let index = 1; index < words.length; index += 1) {
+		const word = words[index]!;
+		if (isCurl && (word === "-O" || word === "--remote-name")) {
+			result = "safe";
+			continue;
+		}
+		if (isCurl && /^--(?:output|output-document)=/.test(word)) {
+			result = classifyOutputTarget(word.slice(word.indexOf("=") + 1), cwd);
+			continue;
+		}
+		if (isCurl && /^-o.+/.test(word)) {
+			result = classifyOutputTarget(word.slice(2), cwd);
+			continue;
+		}
+		if (isCurl && (word === "-o" || word === "--output" || word === "--output-document")) {
+			result = classifyOutputTarget(words[++index], cwd);
+			continue;
+		}
+		if (!isCurl && word === "-O") {
+			result = classifyOutputTarget(words[++index], cwd);
+			continue;
+		}
+		if (!isCurl && /^--output-document=/.test(word)) {
+			result = classifyOutputTarget(word.slice(word.indexOf("=") + 1), cwd);
+			continue;
+		}
+		if (!isCurl && /^-[A-Za-z]*O(?:.+)?$/.test(word)) {
+			const target = word.replace(/^-.*?O/, "");
+			result = classifyOutputTarget(target || words[++index], cwd);
+		}
+	}
+	return result;
+}
+
+function limiterInfo(words: string[]): { isLimiter: boolean; bounded: boolean } {
+	const executable = words[0]?.toLowerCase();
+	if (executable !== "head" && executable !== "head.exe" && executable !== "tail" && executable !== "tail.exe") {
+		return { isLimiter: false, bounded: false };
+	}
+	for (let index = 1; index < words.length; index += 1) {
+		const word = words[index]!;
+		const inline = /^(?:--(?:lines|bytes)=|-?[nc])(.+)$/.exec(word);
+		if (word === "-n" || word === "-c" || word === "--lines" || word === "--bytes") {
+			const value = words[++index];
+			return { isLimiter: true, bounded: /^\d+$/.test(value ?? "") };
+		}
+		if (/^\+[0-9]+$/.test(word)) return { isLimiter: true, bounded: false };
+		if (/^-[nc]\d+$/.test(word) || /^-\d+$/.test(word)) return { isLimiter: true, bounded: true };
+		if (inline) return { isLimiter: true, bounded: /^\d+$/.test(inline[1] ?? "") };
+	}
+	return { isLimiter: true, bounded: true };
+}
+
+function isPassThroughPipelineStage(words: string[]): boolean {
+	const executable = words[0]?.toLowerCase();
+	if (!executable) return false;
+	if ((executable === "cat" || executable === "cat.exe") && words.length === 1) return true;
+	if (executable === "tee" || executable === "tee.exe" || executable === "wc" || executable === "wc.exe") return true;
+	if (executable === "tr" || executable === "tr.exe") return true;
+
+	const hasNoInputFile = (consumingOptions: ReadonlySet<string>, maxExpressions: number): boolean => {
+		let expressions = 0;
+		for (let index = 1; index < words.length; index += 1) {
+			const word = words[index]!;
+			if (word === "--") return index + 1 === words.length;
+			if (word.startsWith("-")) {
+				if (consumingOptions.has(word)) index += 1;
+				continue;
+			}
+			expressions += 1;
+			if (expressions > maxExpressions) return false;
+		}
+		return true;
+	};
+
+	if (executable === "grep" || executable === "grep.exe" || executable === "egrep" || executable === "fgrep") {
+		let hasPattern = false;
+		for (let index = 1; index < words.length; index += 1) {
+			const word = words[index]!;
+			if (word === "--") {
+				if (hasPattern && index + 1 < words.length) return false;
+				continue;
+			}
+			if (word === "-e" || word === "--regexp" || word === "-f" || word === "--file") {
+				hasPattern = true;
+				index += 1;
+				continue;
+			}
+			if (word.startsWith("-")) continue;
+			if (hasPattern) return false;
+			hasPattern = true;
+		}
+		return true;
+	}
+	if (executable === "sed" || executable === "sed.exe") {
+		return hasNoInputFile(new Set(["-e", "--expression", "-f", "--file"]), 1);
+	}
+	if (executable === "awk" || executable === "gawk") return hasNoInputFile(new Set(["-f", "--file"]), 1);
+	if (executable === "cut")
+		return hasNoInputFile(new Set(["-b", "-c", "-d", "-f", "--bytes", "--characters", "--delimiter", "--fields"]), 0);
+	if (executable === "sort" || executable === "uniq" || executable === "fold" || executable === "fmt") {
+		return hasNoInputFile(new Set(), 0);
+	}
+	return false;
+}
+
+function boundedPipelineLimiter(stages: ShellStage[], cwd: string | undefined): number | undefined {
+	let lastLimiter: number | undefined;
+	let lastLimiterBounded = false;
+	for (let index = 0; index < stages.length; index += 1) {
+		const redirections = parseShellRedirections(stages[index]!.text, cwd);
+		const words = shellWordsWithoutRedirections(stages[index]!.text, redirections);
+		const info = limiterInfo(words);
+		if (info.isLimiter) {
+			lastLimiter = index;
+			lastLimiterBounded = info.bounded;
+		}
+	}
+	if (lastLimiter === undefined || !lastLimiterBounded) return undefined;
+	for (let index = lastLimiter + 1; index < stages.length; index += 1) {
+		const redirections = parseShellRedirections(stages[index]!.text, cwd);
+		if (!isPassThroughPipelineStage(shellWordsWithoutRedirections(stages[index]!.text, redirections)))
+			return undefined;
+	}
+	return lastLimiter;
+}
+
+function shellAvailabilityCheck(text: string): boolean {
+	const command = commandAfterShellPreamble(text);
+	const match = /^(?:command\s+-v|which)\s+([^\s;&|]+)/i.exec(command);
+	return match !== null && INTEGRATION_IDENTIFIER_PATTERN.test(match[1] ?? "");
+}
+
+function findShellFallbackRanges(body: string, segments: readonly ShellSegment[]): GuardedRange[] {
+	const ranges = findFallbackMarkerRanges(body);
+	for (let index = 1; index < segments.length; index += 1) {
+		if (segments[index]!.separatorBefore !== "||" || !shellAvailabilityCheck(segments[index - 1]!.text)) continue;
+		ranges.push({ start: segments[index]!.start, end: segments[index]!.end });
+	}
+	return ranges;
+}
+
+function inspectBashCell(
+	cell: ParsedBashCell,
+	cwd: string | undefined,
+	guardedRanges: readonly GuardedRange[],
+): ContextRoutingInspection {
+	const segments = splitShellSegments(cell.body);
+	for (const segment of segments) {
+		if (guardedRanges.some((range) => segment.start >= range.start && segment.start < range.end)) continue;
+		const stages = splitPipelineStages(segment.text, segment.start);
+		const limiter = boundedPipelineLimiter(stages, cwd);
+		for (let index = 0; index < stages.length; index += 1) {
+			const stage = stages[index]!;
+			const redirections = parseShellRedirections(stage.text, cwd);
+			const words = shellWordsWithoutRedirections(stage.text, redirections);
+			const command = commandAfterShellPreamble(words.join(" "));
+			const executable = command.split(/\s+/, 1)[0]?.toLowerCase();
+			if (!executable) continue;
+			const directLimiter = limiterInfo(words);
+			const pipelineBounded = limiter !== undefined && index <= limiter && redirections.stdout !== "unsafe";
+			if (directLimiter.isLimiter && !directLimiter.bounded && !pipelineBounded) {
 				return {
 					decision: "block",
-					pattern: "curl/wget stdout",
-					reason: "Raw wget output would expand context; redirect it to a file or use a bounded parser.",
+					pattern: "unbounded head/tail reader",
+					reason: "An unbounded head/tail read would expand context; use a numeric bound or a bounded pipeline.",
 				};
 			}
-		}
+			if (
+				redirections.stdout === "safe" ||
+				pipelineBounded ||
+				(limiter !== undefined && index > limiter && isPassThroughPipelineStage(words))
+			)
+				continue;
 
-		if (executable === "cat" || executable === "cat.exe") {
-			if (!allCatInputsAreSmall(words, cwd)) {
-				return {
-					decision: "block",
-					pattern: "cat whole-file dump",
-					reason: "A broad cat dump would expand context; use a bounded slice or redirect it to a file.",
-				};
+			if ((executable === "curl" || executable === "curl.exe") && !HEAD_REQUEST_PATTERN.test(command)) {
+				if (outputOptionSafety(words, executable, cwd) !== "safe") {
+					return {
+						decision: "block",
+						pattern: "curl/wget stdout",
+						reason: "Raw curl output would expand context; redirect it to a real file or use a bounded parser.",
+					};
+				}
+			}
+
+			if (executable === "wget" || executable === "wget.exe") {
+				if (outputOptionSafety(words, executable, cwd) !== "safe") {
+					return {
+						decision: "block",
+						pattern: "curl/wget stdout",
+						reason: "Raw wget output would expand context; redirect it to a real file or use a bounded parser.",
+					};
+				}
+			}
+
+			if (executable === "cat" || executable === "cat.exe") {
+				if (!allCatInputsAreSmall(words, cwd)) {
+					return {
+						decision: "block",
+						pattern: "cat whole-file dump",
+						reason: "A broad cat dump would expand context; use a bounded slice or redirect it to a file.",
+					};
+				}
 			}
 		}
 	}
@@ -455,6 +863,8 @@ function inspectBashCell(cell: ParsedBashCell, cwd: string | undefined): Context
 interface CallExpression {
 	name: string;
 	argumentsText: string;
+	start: number;
+	open: number;
 	end: number;
 }
 
@@ -494,7 +904,7 @@ function findCalls(source: string, names: readonly string[]): CallExpression[] {
 		const match = /[A-Za-z_][A-Za-z0-9_.]*/y;
 		match.lastIndex = index;
 		const identifier = match.exec(source)?.[0];
-		if (!identifier || !names.includes(identifier)) continue;
+		if (!identifier || !names.some((name) => identifier === name || identifier.endsWith(`.${name}`))) continue;
 		let open = index + identifier.length;
 		while (/\s/.test(source[open] ?? "")) open += 1;
 		if (source[open] !== "(") continue;
@@ -529,7 +939,13 @@ function findCalls(source: string, names: readonly string[]): CallExpression[] {
 			}
 		}
 		if (depth === 0) {
-			calls.push({ name: identifier, argumentsText: source.slice(open + 1, end - 1), end });
+			calls.push({
+				name: identifier,
+				argumentsText: source.slice(open + 1, end - 1),
+				start: index,
+				open,
+				end,
+			});
 			index = end - 1;
 		}
 	}
@@ -538,7 +954,8 @@ function findCalls(source: string, names: readonly string[]): CallExpression[] {
 
 function extractLiteralPath(expression: string): string | undefined {
 	const match = /\b(?:Path|open)\s*\(\s*(["'])([^"']+)\1/.exec(expression);
-	return match?.[2];
+	if (match) return match[2];
+	return /^\s*(["'])([^"']+)\1/.exec(expression)?.[2];
 }
 
 function maskPythonStrings(expression: string): string {
@@ -587,29 +1004,259 @@ function maskPythonStrings(expression: string): string {
 	return masked;
 }
 
-function readIsBounded(expression: string): boolean {
-	return (
-		/\.(?:read_text|read)\s*\([^)]*\)\s*\[\s*(?:\d*\s*:\s*)?\d+\s*\]/.test(expression) ||
-		/\.read\s*\(\s*\d+\s*\)/.test(expression)
-	);
+function isReadCallBounded(call: CallExpression): boolean {
+	return call.name === "read" && /^\s*\d+\s*$/.test(call.argumentsText);
+}
+
+function findMatchingDelimiter(source: string, start: number, open: string, close: string): number | undefined {
+	let depth = 0;
+	let quote: "single" | "double" | undefined;
+	let escaped = false;
+	for (let index = start; index < source.length; index += 1) {
+		const character = source[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (character === "\\" && quote !== "single") {
+			escaped = true;
+			continue;
+		}
+		if (quote === "single") {
+			if (character === "'") quote = undefined;
+			continue;
+		}
+		if (quote === "double") {
+			if (character === '"') quote = undefined;
+			continue;
+		}
+		if (character === "'") quote = "single";
+		else if (character === '"') quote = "double";
+		else if (character === open) depth += 1;
+		else if (character === close) {
+			depth -= 1;
+			if (depth === 0) return index;
+		}
+	}
+	return undefined;
+}
+
+function isBoundedSliceAfterRead(expression: string, call: CallExpression): boolean {
+	let index = call.end;
+	while (/\s/.test(expression[index] ?? "")) index += 1;
+	if (expression[index] !== "[") return false;
+	const close = findMatchingDelimiter(expression, index, "[", "]");
+	if (close === undefined) return false;
+	const slice = expression.slice(index + 1, close).trim();
+	if (!slice.includes(":")) return /^\d+$/.test(slice);
+	const upper = slice.split(":", 2)[1]?.trim() ?? "";
+	return /^\d+$/.test(upper);
+}
+
+function splitPythonArguments(source: string): string[] {
+	const argumentsText: string[] = [];
+	let start = 0;
+	let parens = 0;
+	let brackets = 0;
+	let braces = 0;
+	let quote: "single" | "double" | undefined;
+	let escaped = false;
+	for (let index = 0; index < source.length; index += 1) {
+		const character = source[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (character === "\\" && quote !== "single") {
+			escaped = true;
+			continue;
+		}
+		if (quote === "single") {
+			if (character === "'") quote = undefined;
+			continue;
+		}
+		if (quote === "double") {
+			if (character === '"') quote = undefined;
+			continue;
+		}
+		if (character === "'") quote = "single";
+		else if (character === '"') quote = "double";
+		else if (character === "(") parens += 1;
+		else if (character === ")") parens -= 1;
+		else if (character === "[") brackets += 1;
+		else if (character === "]") brackets -= 1;
+		else if (character === "{") braces += 1;
+		else if (character === "}") braces -= 1;
+		else if (character === "," && parens === 0 && brackets === 0 && braces === 0) {
+			argumentsText.push(source.slice(start, index));
+			start = index + 1;
+		}
+	}
+	argumentsText.push(source.slice(start));
+	return argumentsText;
+}
+
+function resolvePathForRead(expression: string, read: CallExpression): string | undefined {
+	const pathCalls = findCalls(expression, ["open", "Path"])
+		.filter((call) => call.end <= read.start && /^\s*\.\s*$/.test(expression.slice(call.end, read.start)))
+		.sort((left, right) => right.end - left.end);
+	return pathCalls.length > 0 ? extractLiteralPath(pathCalls[0]!.argumentsText) : undefined;
+}
+
+function pythonDelimiterDepths(source: string): number[] {
+	const depths = new Array<number>(source.length + 1).fill(0);
+	let depth = 0;
+	for (let index = 0; index < source.length; index += 1) {
+		depths[index] = depth;
+		if (/[([{]/.test(source[index] ?? "")) depth += 1;
+		else if (source[index] === ")" || source[index] === "]" || source[index] === "}") depth = Math.max(0, depth - 1);
+	}
+	depths[source.length] = depth;
+	return depths;
+}
+
+function hasScalarBoundary(masked: string, start: number, end: number, depths: number[], maxDepth: number): boolean {
+	for (let index = start; index < end; index += 1) {
+		if ((depths[index] ?? 0) > maxDepth) continue;
+		if (masked[index] === ",") return true;
+		const keyword = /[A-Za-z_]/.test(masked[index] ?? "")
+			? /^[A-Za-z_][A-Za-z0-9_]*/.exec(masked.slice(index))?.[0]
+			: undefined;
+		if (keyword && /^(?:and|or|if|else|for)$/.test(keyword)) return true;
+		if (keyword) index += keyword.length - 1;
+	}
+	return false;
+}
+
+function comparisonConsumesRead(masked: string, read: CallExpression): boolean {
+	const depths = pythonDelimiterDepths(masked);
+	const comparisons = /(?:\bnot\s+in\b|\bis(?:\s+not)?\b|==|!=|<=|>=|<|>|\bin\b)/g;
+	for (const match of masked.matchAll(comparisons)) {
+		const operatorStart = match.index ?? 0;
+		const operatorEnd = operatorStart + match[0].length;
+		const readDepth = depths[read.start] ?? 0;
+		const operatorDepth = depths[operatorStart] ?? 0;
+		if (operatorDepth > readDepth) continue;
+		const readIsLeftOperand = read.end <= operatorStart;
+		const readIsRightOperand = read.start >= operatorEnd;
+		if (!readIsLeftOperand && !readIsRightOperand) continue;
+		const gapStart = readIsLeftOperand ? read.end : operatorEnd;
+		const gapEnd = readIsLeftOperand ? operatorStart : read.start;
+		const sharedDepth = Math.min(depths[read.start] ?? 0, depths[operatorStart] ?? 0);
+		if (!hasScalarBoundary(masked, gapStart, gapEnd, depths, sharedDepth)) return true;
+	}
+	return false;
+}
+
+function readHasScalarReducerAncestor(expression: string, read: CallExpression): boolean {
+	const scalarReducers = findCalls(expression, ["len", "hash", "sum", "bool", "any", "all"]);
+	return scalarReducers.some((call) => call.start < read.start && call.end >= read.end);
+}
+
+function readIsScalar(expression: string, read: CallExpression): boolean {
+	const masked = maskPythonStrings(expression);
+	if (comparisonConsumesRead(masked, read)) return true;
+	if (readHasScalarReducerAncestor(expression, read)) return true;
+	let after = read.end;
+	while (/\s/.test(expression[after] ?? "")) after += 1;
+	return /^(?:\.\s*(?:count|find|index|startswith|endswith|isascii)\s*\()/.test(expression.slice(after));
+}
+
+function isWholeFileReadExpression(expression: string, cwd: string | undefined): boolean {
+	const reads = findCalls(expression, ["read", "read_text"]);
+	for (const read of reads) {
+		if (isReadCallBounded(read) || isBoundedSliceAfterRead(expression, read) || readIsScalar(expression, read))
+			continue;
+		const fileName = resolvePathForRead(expression, read);
+		if (!resolveSmallFile(fileName, cwd)) return true;
+	}
+	return false;
+}
+
+function findFStringInterpolations(source: string): string[] {
+	const interpolations: string[] = [];
+	for (let index = 0; index < source.length; index += 1) {
+		if (!/[fF]/.test(source[index] ?? "") || (index > 0 && /[A-Za-z0-9_]/.test(source[index - 1] ?? ""))) continue;
+		const quoteIndex = source[index + 1] === "r" || source[index + 1] === "R" ? index + 2 : index + 1;
+		const quote = source[quoteIndex];
+		if (quote !== "'" && quote !== '"') continue;
+		const end = skipPythonString(source, quoteIndex);
+		const content = source.slice(quoteIndex + 1, Math.max(quoteIndex + 1, end - 1));
+		for (let contentIndex = 0; contentIndex < content.length; contentIndex += 1) {
+			if (content[contentIndex] !== "{" || content[contentIndex + 1] === "{") continue;
+			const close = findMatchingDelimiter(content, contentIndex, "{", "}");
+			if (close === undefined) break;
+			interpolations.push(content.slice(contentIndex + 1, close));
+			contentIndex = close;
+		}
+		index = Math.max(index, end - 1);
+	}
+	return interpolations;
 }
 
 function isWholeFilePrint(expression: string, cwd: string | undefined): boolean {
-	const maskedExpression = maskPythonStrings(expression);
-	if (!/\b(?:read_text|read)\s*\(/.test(maskedExpression)) return false;
-	if (readIsBounded(maskedExpression)) return false;
-	const fileName = extractLiteralPath(expression);
-	return !resolveSmallFile(fileName, cwd);
+	for (const argument of splitPythonArguments(expression)) {
+		if (isWholeFileReadExpression(argument, cwd)) return true;
+		if (findFStringInterpolations(argument).some((interpolation) => isWholeFileReadExpression(interpolation, cwd)))
+			return true;
+	}
+	return false;
 }
 
-function inspectPythonCode(code: string, cwd: string | undefined): ContextRoutingInspection {
-	for (const call of findCalls(code, ["print", "display", "stdout.write", "sys.stdout.write"])) {
-		if (isWholeFilePrint(call.argumentsText, cwd)) {
+function hasIntegrationIdentifier(text: string): boolean {
+	return maskPythonStrings(text)
+		.split(/\s+/)
+		.some((word) => INTEGRATION_IDENTIFIER_PATTERN.test(word.replace(/[^A-Za-z0-9_-]/g, "")));
+}
+
+function findPythonFallbackRanges(code: string): GuardedRange[] {
+	const lines = lineRanges(code);
+	const ranges = findFallbackMarkerRanges(code);
+	for (let index = 0; index < lines.length; index += 1) {
+		const tryMatch = /^(\s*)try\s*:\s*$/.exec(lines[index]!.text);
+		if (!tryMatch) continue;
+		const tryIndent = tryMatch[1]!.length;
+		let exceptIndex = index + 1;
+		while (exceptIndex < lines.length) {
+			const line = lines[exceptIndex]!.text;
+			const indent = line.match(/^\s*/)?.[0].length ?? 0;
+			if (line.trim().length > 0 && indent <= tryIndent) {
+				if (
+					indent === tryIndent &&
+					/^except\s+\(?[^:]*\b(?:ImportError|ModuleNotFoundError)\b[^:]*\)?\s*:/.test(line.trim())
+				)
+					break;
+				if (indent < tryIndent) break;
+			}
+			exceptIndex += 1;
+		}
+		if (exceptIndex >= lines.length) continue;
+		let end = lines[exceptIndex]!.end;
+		for (let bodyIndex = exceptIndex + 1; bodyIndex < lines.length; bodyIndex += 1) {
+			const line = lines[bodyIndex]!.text;
+			const indent = line.match(/^\s*/)?.[0].length ?? 0;
+			if (line.trim().length > 0 && indent <= tryIndent) break;
+			end = lines[bodyIndex]!.end;
+		}
+		const guardedText = code.slice(lines[index]!.start, end);
+		if (hasIntegrationIdentifier(guardedText)) ranges.push({ start: lines[exceptIndex]!.start, end });
+	}
+	return ranges;
+}
+
+function inspectPythonCode(
+	code: string,
+	cwd: string | undefined,
+	guardedRanges: readonly GuardedRange[],
+): ContextRoutingInspection {
+	const inspectedCode = maskRanges(code, guardedRanges);
+	for (const call of findCalls(inspectedCode, ["print", "display", "stdout.write", "sys.stdout.write"])) {
+		if (isWholeFilePrint(inspectedCode.slice(call.start, call.end), cwd)) {
 			return {
 				decision: "block",
 				pattern: "python whole-file print",
 				reason:
-					"Printing an unbounded Python file read would expand context; use a bounded slice or stat-able small file.",
+					"Printing an unbounded Python file read would expand context; use a bounded slice, a scalar reducer, or a stat-able small file.",
 			};
 		}
 	}
@@ -624,11 +1271,13 @@ export function inspectContextRoutingCode(code: string, cwd?: string): ContextRo
 	if (hasLeadingMarker(code, BYPASS_MARKER_PATTERN)) {
 		return { decision: "allow", reason: "Explicit context-routing bypass marker." };
 	}
-	if (hasFallbackGuard(code)) {
-		return { decision: "allow", reason: "Unavailable-integration fallback detected." };
-	}
 	const bashCell = parseBashCell(code);
-	return bashCell ? inspectBashCell(bashCell, cwd) : inspectPythonCode(code, cwd);
+	if (bashCell) {
+		const segments = splitShellSegments(bashCell.body);
+		const guardedRanges = findShellFallbackRanges(bashCell.body, segments);
+		return inspectBashCell(bashCell, cwd, guardedRanges);
+	}
+	return inspectPythonCode(code, cwd, findPythonFallbackRanges(code));
 }
 
 function formatStats(mode: ContextRoutingMode, stats: ContextRoutingStats): string {

--- a/packages/coding-agent/examples/extensions/context-routing.ts
+++ b/packages/coding-agent/examples/extensions/context-routing.ts
@@ -1,0 +1,744 @@
+/**
+ * Context-routing policy example.
+ *
+ * This is a routing aid, not a security boundary. It nudges the model toward
+ * jCodeMunch for whole source files and Context Mode for web/docs/logs/large
+ * data, while keeping edits, tests, builds, and git work in Prime Agent.
+ *
+ * Usage:
+ *   pi -e ./context-routing.ts --context-routing advisory
+ *   pi -e ./context-routing.ts --context-routing strict-large-read
+ *   pi -e ./context-routing.ts --context-routing advisory --context-routing-fast-reindex=off
+ *
+ * Runtime controls:
+ *   /context-routing off|advisory|strict-large-read
+ *   /context-routing stats
+ *
+ * Successful IPython edit results also enqueue bounded, best-effort jCodeMunch
+ * reindexes for changed regular source files. The path is advisory because the
+ * watcher remains authoritative; use `--context-routing-fast-reindex=off` to
+ * disable this direct CLI fast path.
+ *
+ * Strict mode has intentionally narrow recognition. To explicitly bypass a
+ * routing block, put `# context-routing: bypass` as the first non-blank line
+ * of the IPython cell. `# context-routing: fallback` is for a documented
+ * unavailable-integration fallback.
+ */
+
+import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
+import path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { IpythonToolResultEvent } from "../../src/core/extensions/types.js";
+
+export const CONTEXT_ROUTING_FLAG = "context-routing";
+export const CONTEXT_ROUTING_FAST_REINDEX_FLAG = "context-routing-fast-reindex";
+export const CONTEXT_ROUTING_MODES = ["off", "advisory", "strict-large-read"] as const;
+export type ContextRoutingMode = (typeof CONTEXT_ROUTING_MODES)[number];
+
+/** Whole-file reads at or below this size are treated as small when stat-able. */
+export const SMALL_FILE_BYTES = 16 * 1024;
+
+export type ContextRoutingPattern = "curl/wget stdout" | "cat whole-file dump" | "python whole-file print";
+
+export interface ContextRoutingInspection {
+	decision: "allow" | "block";
+	pattern?: ContextRoutingPattern;
+	reason: string;
+}
+
+export interface ContextRoutingTelemetryEvent {
+	kind: "turn-guidance" | "inspection";
+	mode: ContextRoutingMode;
+	action: "advisory" | "allow" | "block";
+	pattern?: ContextRoutingPattern;
+}
+
+export type ContextRoutingTelemetryHook = (event: ContextRoutingTelemetryEvent) => void;
+
+export interface ContextRoutingStats {
+	turnsGuided: number;
+	cellsInspected: number;
+	allowed: number;
+	blocked: number;
+}
+
+export interface ContextRoutingFastReindexQueueOptions {
+	command?: string;
+	concurrency?: number;
+	reindexFile?: (absolutePath: string, cwd: string) => Promise<void> | void;
+	spawnProcess?: typeof spawn;
+}
+
+export interface ContextRoutingInstallOptions {
+	telemetry?: ContextRoutingTelemetryHook;
+	/** Disable the advisory fast path while leaving the watcher authoritative. */
+	fastReindex?: boolean;
+	fastReindexCommand?: string;
+	fastReindexConcurrency?: number;
+	/** Test hook; production uses the separately installed jCodeMunch CLI. */
+	reindexFile?: (absolutePath: string, cwd: string) => Promise<void> | void;
+}
+
+const JCODEMUNCH_COMMAND = "jcodemunch-mcp";
+const FAST_REINDEX_CONCURRENCY = 2;
+const GENERATED_PATH_PATTERN =
+	/(?:^|\/)(?:\.git|node_modules|dist|build|coverage|out|target|generated|gen|__pycache__|\.next)(?:\/|$)|(?:^|\/)[^/]*\.(?:generated|gen)\.[^/]+$/i;
+
+function safeChildEnvironment(): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {};
+	for (const key of [
+		"PATH",
+		"HOME",
+		"USERPROFILE",
+		"SystemRoot",
+		"TMPDIR",
+		"TMP",
+		"TEMP",
+		"JCODEMUNCH_HOME",
+		"JCODEMUNCH_CONFIG",
+	]) {
+		const value = process.env[key];
+		if (value !== undefined) env[key] = value;
+	}
+	return env;
+}
+
+/** Return an absolute, existing regular file that is safe for the advisory path. */
+export function resolveFastReindexPath(changedPath: unknown, cwd: string): string | undefined {
+	if (typeof changedPath !== "string" || changedPath.trim().length === 0) return undefined;
+	const absolutePath = path.resolve(cwd, changedPath);
+	if (GENERATED_PATH_PATTERN.test(absolutePath.replaceAll("\\", "/"))) return undefined;
+	try {
+		return statSync(absolutePath).isFile() ? absolutePath : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function normalizeConcurrency(value: number | undefined): number {
+	if (!Number.isFinite(value)) return FAST_REINDEX_CONCURRENCY;
+	return Math.min(FAST_REINDEX_CONCURRENCY, Math.max(1, Math.floor(value ?? FAST_REINDEX_CONCURRENCY)));
+}
+
+function normalizeFastReindexFlag(value: boolean | string | undefined): boolean {
+	if (typeof value === "boolean") return value;
+	return !["off", "false", "0", "disabled", "no"].includes(value?.trim().toLowerCase() ?? "");
+}
+
+function reindexWithJCodeMunch(
+	command: string,
+	absolutePath: string,
+	cwd: string,
+	spawnProcess: typeof spawn,
+): Promise<void> {
+	return new Promise((resolve) => {
+		try {
+			const child = spawnProcess(command, ["index-file", "--no-ai-summaries", absolutePath], {
+				cwd,
+				shell: false,
+				stdio: "ignore",
+				windowsHide: true,
+				env: safeChildEnvironment(),
+			});
+			child.once("error", () => resolve());
+			child.once("close", () => resolve());
+		} catch {
+			resolve();
+		}
+	});
+}
+
+/**
+ * Queue best-effort file reindexes without making tool-result delivery wait.
+ * The watcher remains the source of truth if this process or sidecar is absent.
+ */
+export function createFastReindexQueue(options: ContextRoutingFastReindexQueueOptions = {}) {
+	const pending = new Map<string, string>();
+	const active = new Set<string>();
+	const waiters: Array<() => void> = [];
+	const concurrency = normalizeConcurrency(options.concurrency);
+	const reindexFile =
+		options.reindexFile ??
+		((absolutePath: string, cwd: string) =>
+			reindexWithJCodeMunch(
+				options.command ?? JCODEMUNCH_COMMAND,
+				absolutePath,
+				cwd,
+				options.spawnProcess ?? spawn,
+			));
+	let running = 0;
+
+	const resolveIdle = () => {
+		if (running !== 0 || pending.size !== 0) return;
+		for (const resolve of waiters.splice(0)) resolve();
+	};
+
+	const drain = () => {
+		while (running < concurrency && pending.size > 0) {
+			const entry = pending.entries().next().value as [string, string] | undefined;
+			if (!entry) break;
+			const [absolutePath, cwd] = entry;
+			pending.delete(absolutePath);
+			active.add(absolutePath);
+			running += 1;
+			void (async () => {
+				try {
+					if (resolveFastReindexPath(absolutePath, cwd)) await reindexFile(absolutePath, cwd);
+				} catch {
+					// Reindexing is advisory; the watcher will retry or catch up later.
+				} finally {
+					active.delete(absolutePath);
+					running -= 1;
+					drain();
+					resolveIdle();
+				}
+			})();
+		}
+		resolveIdle();
+	};
+
+	return {
+		enqueue(paths: readonly string[], cwd: string): void {
+			for (const absolutePath of paths) {
+				if (!active.has(absolutePath) && !pending.has(absolutePath)) pending.set(absolutePath, cwd);
+			}
+			drain();
+		},
+		whenIdle(): Promise<void> {
+			if (running === 0 && pending.size === 0) return Promise.resolve();
+			return new Promise((resolve) => waiters.push(resolve));
+		},
+	};
+}
+
+interface ParsedBashCell {
+	body: string;
+}
+
+interface ShellSegment {
+	text: string;
+	stdoutRedirected: boolean;
+}
+
+const BASH_CELL_PATTERN = /^(?:[ \t]*\r?\n)*[ \t]*%%bash\b[^\r\n]*(?:\r?\n|$)/;
+const BYPASS_MARKER_PATTERN = /^#\s*context-routing\s*:\s*(?:allow|bypass)\s*$/i;
+const FALLBACK_MARKER_PATTERN = /^#\s*context-routing\s*:\s*fallback\s*$/i;
+const IMPORT_FALLBACK_PATTERN =
+	/\btry\b[\s\S]{0,1000}\bexcept\s+(?:ImportError|ModuleNotFoundError)(?:\s+as\s+[A-Za-z_][A-Za-z0-9_]*)?\s*:/i;
+const SHELL_FALLBACK_PATTERN = /\b(?:command\s+-v|which)\s+[^\r\n;|&]+(?:\s[^\r\n;|&]+)?\s*\|\|/i;
+const INTEGRATION_FALLBACK_PATTERN =
+	/\b(?:jcodemunch|context[-_ ]?mode|mcp)\b[\s\S]{0,120}\b(?:unavailable|not available|missing|fallback)\b/i;
+const SHELL_KEYWORD_PATTERN = /^(?:(?:if|then|else|elif|do|while|until|for|case|!|command)\s+)+/i;
+const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=(?:[^\s]*|"[^"]*"|'[^']*')\s+/;
+const CURL_OUTPUT_PATTERN = /(?:^|\s)(?:-o|--output|--output-document)(?:=|\s+)(?:"[^"]*"|'[^']*'|\S+)/i;
+const CURL_STDOUT_OUTPUT_PATTERN = /(?:^|\s)(?:-o|--output|--output-document)(?:=|\s+)(?:-|"-"|'-')(?=\s|$)/i;
+const CURL_FILE_OUTPUT_PATTERN = /(?:^|\s)(?:-O|--remote-name)(?=\s|$)/i;
+const WGET_STDOUT_PATTERN =
+	/(?:^|\s)(?:-O(?:\s+|-)?-|--output-document(?:=|\s+)(?:-|"-"|'-')|-[A-Za-z]*q[A-Za-z]*O-)(?=\s|$)/i;
+const WGET_OUTPUT_PATTERN = /(?:^|\s)(?:-O|--output-document)(?:=|\s+)(?:"[^"]*"|'[^']*'|\S+)/i;
+const HEAD_REQUEST_PATTERN = /(?:^|\s)(?:-I|--head)(?=\s|$)/i;
+const BOUNDED_PIPELINE_PATTERN = /\|\s*(?:head|tail)(?:\s|$)/i;
+
+function normalizeMode(value: boolean | string | undefined): ContextRoutingMode {
+	return typeof value === "string" && (CONTEXT_ROUTING_MODES as readonly string[]).includes(value)
+		? (value as ContextRoutingMode)
+		: "off";
+}
+
+function firstNonBlankLine(code: string): string | undefined {
+	return code
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.find((line) => line.length > 0);
+}
+
+function hasLeadingMarker(code: string, pattern: RegExp): boolean {
+	const firstLine = firstNonBlankLine(parseBashCell(code)?.body ?? code);
+	return firstLine !== undefined && pattern.test(firstLine);
+}
+
+function hasFallbackGuard(code: string): boolean {
+	const bashCell = parseBashCell(code);
+	const fallbackText = bashCell
+		? bashCell.body.replace(/(^|\r?\n)[ \t]*#.*(?=\r?$)/gm, "$1")
+		: maskPythonStrings(code);
+	return (
+		hasLeadingMarker(code, FALLBACK_MARKER_PATTERN) ||
+		IMPORT_FALLBACK_PATTERN.test(fallbackText) ||
+		SHELL_FALLBACK_PATTERN.test(fallbackText) ||
+		INTEGRATION_FALLBACK_PATTERN.test(fallbackText)
+	);
+}
+
+function parseBashCell(code: string): ParsedBashCell | undefined {
+	const match = BASH_CELL_PATTERN.exec(code);
+	if (!match) return undefined;
+	return { body: code.slice(match[0].length) };
+}
+
+function splitShellSegments(body: string): ShellSegment[] {
+	const segments: ShellSegment[] = [];
+	let start = 0;
+	let quote: "single" | "double" | undefined;
+	let escaped = false;
+	let stdoutRedirected = false;
+
+	const push = (end: number) => {
+		const text = body.slice(start, end).trim();
+		if (text.length > 0) segments.push({ text, stdoutRedirected });
+		start = end;
+		stdoutRedirected = false;
+	};
+
+	for (let index = 0; index < body.length; index += 1) {
+		const character = body[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (character === "\\" && quote !== "single") {
+			escaped = true;
+			continue;
+		}
+		if (quote === "single") {
+			if (character === "'") quote = undefined;
+			continue;
+		}
+		if (quote === "double") {
+			if (character === '"') quote = undefined;
+			continue;
+		}
+		if (character === "'") {
+			quote = "single";
+			continue;
+		}
+		if (character === '"') {
+			quote = "double";
+			continue;
+		}
+		if (character === "#" && (index === 0 || /\s/.test(body[index - 1] ?? ""))) {
+			const newline = body.indexOf("\n", index);
+			if (newline === -1) break;
+			index = newline - 1;
+			continue;
+		}
+		if (character === ">") {
+			const previous = body[index - 1];
+			if (previous !== "2") stdoutRedirected = true;
+			continue;
+		}
+		if (character === "\n" || character === ";") {
+			push(index);
+			start = index + 1;
+			continue;
+		}
+		if ((character === "&" || character === "|") && body[index + 1] === character) {
+			push(index);
+			index += 1;
+			start = index + 1;
+		}
+	}
+	push(body.length);
+	return segments;
+}
+
+function shellWords(text: string): string[] {
+	const words: string[] = [];
+	let current = "";
+	let quote: "single" | "double" | undefined;
+	let escaped = false;
+
+	const push = () => {
+		if (current.length > 0) words.push(current);
+		current = "";
+	};
+
+	for (const character of text.trim()) {
+		if (escaped) {
+			current += character;
+			escaped = false;
+			continue;
+		}
+		if (character === "\\" && quote !== "single") {
+			escaped = true;
+			continue;
+		}
+		if (quote === "single") {
+			if (character === "'") quote = undefined;
+			else current += character;
+			continue;
+		}
+		if (quote === "double") {
+			if (character === '"') quote = undefined;
+			else current += character;
+			continue;
+		}
+		if (character === "'") quote = "single";
+		else if (character === '"') quote = "double";
+		else if (/\s/.test(character)) push();
+		else current += character;
+	}
+	push();
+	return words;
+}
+
+function resolveSmallFile(fileName: string | undefined, cwd: string | undefined): boolean {
+	if (!fileName || !cwd || fileName === "-" || /[$*?{}<>|&;]/.test(fileName)) return false;
+	const unquoted = fileName.replace(/^['"]|['"]$/g, "");
+	if (unquoted.startsWith("~")) return false;
+	try {
+		const stats = statSync(path.isAbsolute(unquoted) ? unquoted : path.resolve(cwd, unquoted));
+		return stats.isFile() && stats.size <= SMALL_FILE_BYTES;
+	} catch {
+		return false;
+	}
+}
+
+function allCatInputsAreSmall(words: string[], cwd: string | undefined): boolean {
+	const inputs = words.slice(1).filter((word) => !word.startsWith("-"));
+	return inputs.length > 0 && !inputs.includes("-") && inputs.every((fileName) => resolveSmallFile(fileName, cwd));
+}
+
+function commandAfterShellPreamble(text: string): string {
+	let result = text.trim().replace(SHELL_KEYWORD_PATTERN, "");
+	while (ENV_ASSIGNMENT_PATTERN.test(result)) result = result.replace(ENV_ASSIGNMENT_PATTERN, "");
+	return result.trim();
+}
+
+function inspectBashCell(cell: ParsedBashCell, cwd: string | undefined): ContextRoutingInspection {
+	for (const segment of splitShellSegments(cell.body)) {
+		const command = commandAfterShellPreamble(segment.text);
+		const words = shellWords(command);
+		const executable = words[0]?.toLowerCase();
+		if (!executable || segment.stdoutRedirected || BOUNDED_PIPELINE_PATTERN.test(command)) continue;
+
+		if ((executable === "curl" || executable === "curl.exe") && !HEAD_REQUEST_PATTERN.test(command)) {
+			if (
+				(!CURL_OUTPUT_PATTERN.test(command) && !CURL_FILE_OUTPUT_PATTERN.test(command)) ||
+				CURL_STDOUT_OUTPUT_PATTERN.test(command)
+			) {
+				return {
+					decision: "block",
+					pattern: "curl/wget stdout",
+					reason: "Raw curl output would expand context; redirect it to a file or use a bounded parser.",
+				};
+			}
+		}
+
+		if (executable === "wget" || executable === "wget.exe") {
+			if (
+				WGET_STDOUT_PATTERN.test(command) ||
+				(!WGET_OUTPUT_PATTERN.test(command) && /(?:^|\s)-qO-?(?:\s|$)/i.test(command))
+			) {
+				return {
+					decision: "block",
+					pattern: "curl/wget stdout",
+					reason: "Raw wget output would expand context; redirect it to a file or use a bounded parser.",
+				};
+			}
+		}
+
+		if (executable === "cat" || executable === "cat.exe") {
+			if (!allCatInputsAreSmall(words, cwd)) {
+				return {
+					decision: "block",
+					pattern: "cat whole-file dump",
+					reason: "A broad cat dump would expand context; use a bounded slice or redirect it to a file.",
+				};
+			}
+		}
+	}
+	return { decision: "allow", reason: "No high-confidence broad-read pattern recognized." };
+}
+
+interface CallExpression {
+	name: string;
+	argumentsText: string;
+	end: number;
+}
+
+function skipPythonString(source: string, start: number): number {
+	const quote = source[start] as "'" | '"' | undefined;
+	if (quote !== "'" && quote !== '"') return start + 1;
+	const triple = source.startsWith(quote.repeat(3), start);
+	const delimiter = triple ? quote.repeat(3) : quote;
+	let escaped = false;
+	for (let index = start + delimiter.length; index < source.length; index += 1) {
+		const character = source[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (character === "\\" && quote !== "'") {
+			escaped = true;
+			continue;
+		}
+		if (source.startsWith(delimiter, index)) return index + delimiter.length;
+	}
+	return source.length;
+}
+
+function findCalls(source: string, names: readonly string[]): CallExpression[] {
+	const calls: CallExpression[] = [];
+	for (let index = 0; index < source.length; index += 1) {
+		if (source[index] === "#") {
+			const newline = source.indexOf("\n", index);
+			index = newline === -1 ? source.length : newline;
+			continue;
+		}
+		if (source[index] === "'" || source[index] === '"') {
+			index = skipPythonString(source, index) - 1;
+			continue;
+		}
+		const match = /[A-Za-z_][A-Za-z0-9_.]*/y;
+		match.lastIndex = index;
+		const identifier = match.exec(source)?.[0];
+		if (!identifier || !names.includes(identifier)) continue;
+		let open = index + identifier.length;
+		while (/\s/.test(source[open] ?? "")) open += 1;
+		if (source[open] !== "(") continue;
+
+		let depth = 1;
+		let quote: string | undefined;
+		let escaped = false;
+		let end = open + 1;
+		for (; end < source.length && depth > 0; end += 1) {
+			const character = source[end];
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (character === "\\" && quote !== "'") {
+				escaped = true;
+				continue;
+			}
+			if (quote) {
+				if (character === quote) quote = undefined;
+				continue;
+			}
+			if (character === "'" || character === '"') {
+				end = skipPythonString(source, end) - 1;
+			} else if (character === "#") {
+				const newline = source.indexOf("\n", end);
+				end = newline === -1 ? source.length : newline;
+			} else if (character === "(") {
+				depth += 1;
+			} else if (character === ")") {
+				depth -= 1;
+			}
+		}
+		if (depth === 0) {
+			calls.push({ name: identifier, argumentsText: source.slice(open + 1, end - 1), end });
+			index = end - 1;
+		}
+	}
+	return calls;
+}
+
+function extractLiteralPath(expression: string): string | undefined {
+	const match = /\b(?:Path|open)\s*\(\s*(["'])([^"']+)\1/.exec(expression);
+	return match?.[2];
+}
+
+function maskPythonStrings(expression: string): string {
+	let masked = "";
+	let quote: "'" | '"' | undefined;
+	let triple = false;
+	let escaped = false;
+	let comment = false;
+	for (let index = 0; index < expression.length; index += 1) {
+		const character = expression[index];
+		if (comment) {
+			if (character === "\n" || character === "\r") comment = false;
+			masked += character === "\n" || character === "\r" ? character : " ";
+			continue;
+		}
+		if (quote) {
+			if (triple && expression.startsWith(quote.repeat(3), index)) {
+				masked += "   ";
+				index += 2;
+				quote = undefined;
+				triple = false;
+			} else {
+				if (escaped) escaped = false;
+				else if (character === "\\" && quote === '"') escaped = true;
+				else if (!triple && character === quote) quote = undefined;
+				masked += character === "\n" || character === "\r" ? character : " ";
+			}
+			continue;
+		}
+		if (character === "#") {
+			comment = true;
+			masked += " ";
+		} else if (expression.startsWith("'''", index) || expression.startsWith('"""', index)) {
+			quote = character === "'" ? "'" : '"';
+			triple = true;
+			masked += "   ";
+			index += 2;
+		} else if (character === "'" || character === '"') {
+			quote = character;
+			triple = false;
+			masked += " ";
+		} else {
+			masked += character;
+		}
+	}
+	return masked;
+}
+
+function readIsBounded(expression: string): boolean {
+	return (
+		/\.(?:read_text|read)\s*\([^)]*\)\s*\[\s*(?:\d*\s*:\s*)?\d+\s*\]/.test(expression) ||
+		/\.read\s*\(\s*\d+\s*\)/.test(expression)
+	);
+}
+
+function isWholeFilePrint(expression: string, cwd: string | undefined): boolean {
+	const maskedExpression = maskPythonStrings(expression);
+	if (!/\b(?:read_text|read)\s*\(/.test(maskedExpression)) return false;
+	if (readIsBounded(maskedExpression)) return false;
+	const fileName = extractLiteralPath(expression);
+	return !resolveSmallFile(fileName, cwd);
+}
+
+function inspectPythonCode(code: string, cwd: string | undefined): ContextRoutingInspection {
+	for (const call of findCalls(code, ["print", "display", "stdout.write", "sys.stdout.write"])) {
+		if (isWholeFilePrint(call.argumentsText, cwd)) {
+			return {
+				decision: "block",
+				pattern: "python whole-file print",
+				reason:
+					"Printing an unbounded Python file read would expand context; use a bounded slice or stat-able small file.",
+			};
+		}
+	}
+	return { decision: "allow", reason: "No high-confidence broad-read pattern recognized." };
+}
+
+/**
+ * Inspect one IPython cell without executing it. This is intentionally
+ * conservative: unknown syntax is allowed rather than treated as a violation.
+ */
+export function inspectContextRoutingCode(code: string, cwd?: string): ContextRoutingInspection {
+	if (hasLeadingMarker(code, BYPASS_MARKER_PATTERN)) {
+		return { decision: "allow", reason: "Explicit context-routing bypass marker." };
+	}
+	if (hasFallbackGuard(code)) {
+		return { decision: "allow", reason: "Unavailable-integration fallback detected." };
+	}
+	const bashCell = parseBashCell(code);
+	return bashCell ? inspectBashCell(bashCell, cwd) : inspectPythonCode(code, cwd);
+}
+
+function formatStats(mode: ContextRoutingMode, stats: ContextRoutingStats): string {
+	return `Context routing: ${mode}; turns guided ${stats.turnsGuided}; cells inspected ${stats.cellsInspected}; allowed ${stats.allowed}; blocked ${stats.blocked}`;
+}
+
+/** Install the example policy and return live counters for tests or telemetry. */
+export function installContextRouting(
+	pi: ExtensionAPI,
+	options: ContextRoutingInstallOptions = {},
+): ContextRoutingStats {
+	pi.registerFlag(CONTEXT_ROUTING_FLAG, {
+		description: "Context routing: off, advisory, or strict-large-read",
+		type: "string",
+		default: "off",
+	});
+	pi.registerFlag(CONTEXT_ROUTING_FAST_REINDEX_FLAG, {
+		description: "Advisory jCodeMunch fast reindex: on or off",
+		type: "string",
+		default: "on",
+	});
+
+	let mode = normalizeMode(pi.getFlag(CONTEXT_ROUTING_FLAG));
+	const fastReindexQueue =
+		options.fastReindex === false || !normalizeFastReindexFlag(pi.getFlag(CONTEXT_ROUTING_FAST_REINDEX_FLAG))
+			? undefined
+			: createFastReindexQueue({
+					command: options.fastReindexCommand,
+					concurrency: options.fastReindexConcurrency,
+					reindexFile: options.reindexFile,
+				});
+	const stats: ContextRoutingStats = { turnsGuided: 0, cellsInspected: 0, allowed: 0, blocked: 0 };
+	const emit = (event: ContextRoutingTelemetryEvent) => {
+		try {
+			options.telemetry?.(event);
+		} catch {
+			// Telemetry must never change routing behavior.
+		}
+	};
+
+	pi.registerCommand("context-routing", {
+		description: "Set or inspect context-routing mode",
+		getArgumentCompletions: (prefix) =>
+			[...CONTEXT_ROUTING_MODES, "stats"]
+				.filter((candidate) => candidate.startsWith(prefix.trim()))
+				.map((value) => ({ value, label: value })),
+		handler: async (args, ctx) => {
+			const value = args.trim();
+			if (value === "stats" || value === "") {
+				ctx.ui.notify(formatStats(mode, stats), "info");
+				return;
+			}
+			if (!(CONTEXT_ROUTING_MODES as readonly string[]).includes(value)) {
+				ctx.ui.notify(`Unknown context-routing mode: ${value}`, "warning");
+				return;
+			}
+			mode = value as ContextRoutingMode;
+			ctx.ui.notify(`Context routing set to ${mode}`, "info");
+		},
+	});
+
+	pi.on("before_agent_start", async (event) => {
+		if (mode === "off") return;
+		stats.turnsGuided += 1;
+		emit({ kind: "turn-guidance", mode, action: "advisory" });
+		const strictLine =
+			mode === "strict-large-read"
+				? "Strict-large-read blocks only recognized raw curl/wget stdout, broad cat dumps, and immediately printed unbounded Python reads."
+				: "This is advisory guidance; direct bounded reads are allowed.";
+		return {
+			systemPrompt: `${event.systemPrompt}\n\n## Context routing (${mode})\nBefore opening whole source files, use jCodeMunch. Use Context Mode for web pages, docs, logs, and large data. Direct bounded reads are fine. Keep edits, tests, builds, and git work in Prime Agent. ${strictLine} This is routing guidance, not security.`,
+		};
+	});
+
+	pi.on("tool_call", async (event, ctx) => {
+		if (mode !== "strict-large-read" || event.toolName !== "ipython") return undefined;
+		const code = event.input.code;
+		if (typeof code !== "string") return undefined;
+		stats.cellsInspected += 1;
+		const inspection = inspectContextRoutingCode(code, ctx.cwd);
+		stats[inspection.decision === "block" ? "blocked" : "allowed"] += 1;
+		emit({
+			kind: "inspection",
+			mode,
+			action: inspection.decision,
+			pattern: inspection.pattern,
+		});
+		if (inspection.decision === "block")
+			return {
+				block: true,
+				reason: `${inspection.reason} Add '# context-routing: bypass' as the first non-blank line to proceed explicitly.`,
+			};
+		return undefined;
+	});
+
+	pi.on("tool_result", (event, ctx) => {
+		if (!fastReindexQueue || event.toolName !== "ipython") return;
+		const ipythonEvent = event as IpythonToolResultEvent;
+		if (ipythonEvent.isError || ipythonEvent.details?.status !== "ok") return;
+		const paths = new Set<string>();
+		for (const diff of ipythonEvent.details.diffs ?? []) {
+			const absolutePath = resolveFastReindexPath(diff.path, ctx.cwd);
+			if (absolutePath) paths.add(absolutePath);
+		}
+		if (paths.size > 0) fastReindexQueue.enqueue([...paths], ctx.cwd);
+	});
+
+	return stats;
+}
+
+export default function contextRoutingExtension(pi: ExtensionAPI): void {
+	installContextRouting(pi);
+}

--- a/packages/coding-agent/skills/context-mode/SKILL.md
+++ b/packages/coding-agent/skills/context-mode/SKILL.md
@@ -19,8 +19,11 @@ print([tool["name"] for tool in await context_mode.list_tools()])
 
 ## Setup
 
-Install and operate Context Mode separately. When the separately installed
-sidecar documents its stdio command, configure the host-managed transport:
+Install and operate Context Mode separately. The skill is bundled and
+available by default; when `mcpServers.context-mode` is absent, Prime Agent
+uses the separately installed `context-mode` command as a lazy host-managed
+stdio transport. Add an explicit entry when you need to override its command,
+args, environment, cwd, tool filters, or enabled state:
 
 ```jsonc
 {
@@ -35,8 +38,10 @@ sidecar documents its stdio command, configure the host-managed transport:
 
 The host launches configured stdio servers lazily and keeps command, args,
 environment, and cwd host-side. The Python skill uses the host bridge for
-`list_tools` and `call_tool`; it never launches a process itself. If a sidecar's
-CLI syntax is not documented, use a safe placeholder such as
+`list_tools` and `call_tool`; it never launches a process itself. Set
+`"enabled": false` to disable the default without falling back to an
+environment URL. If a sidecar's CLI syntax is not documented, use a safe
+placeholder such as
 `/path/to/separately-installed-mcp-server` rather than guessing flags or
 secrets.
 

--- a/packages/coding-agent/skills/context-mode/SKILL.md
+++ b/packages/coding-agent/skills/context-mode/SKILL.md
@@ -82,8 +82,8 @@ Discover schemas with `list_tools()` before calling. This skill permits only:
 ```python
 summary = await context_mode.ctx_execute_file(
     path="logs/server.log",
-    language="text",
-    code="Summarize errors by root cause; return at most ten findings.",
+    language="python",
+    code="errors=[l for l in FILE_CONTENT.splitlines() if 'ERROR' in l]; print(len(errors)); print('\\n'.join(errors[:10]))",
     intent="Find the first recurring production failure."
 )
 

--- a/packages/coding-agent/skills/context-mode/SKILL.md
+++ b/packages/coding-agent/skills/context-mode/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: context-mode
+description: Bounded large-output processing through an optional, separately installed Context Mode MCP sidecar over host-managed stdio or HTTP. Use for large web pages, documentation, changelogs, logs, and isolated file or command analysis when a compact derived result is preferable.
+---
+
+# Context Mode
+
+Use Context Mode only for bounded collection, indexing, search, and isolated
+processing. It is not a security sandbox: a configured sidecar uses its own
+filesystem and network permissions. Importing this skill never installs,
+starts, upgrades, purges, or changes a sidecar.
+
+```python
+import context_mode
+
+print(await context_mode.available())
+print([tool["name"] for tool in await context_mode.list_tools()])
+```
+
+## Setup
+
+Install and operate Context Mode separately. When the separately installed
+sidecar documents its stdio command, configure the host-managed transport:
+
+```jsonc
+{
+  "mcpServers": {
+    "context-mode": {
+      "type": "stdio",
+      "command": "context-mode"
+    }
+  }
+}
+```
+
+The host launches configured stdio servers lazily and keeps command, args,
+environment, and cwd host-side. The Python skill uses the host bridge for
+`list_tools` and `call_tool`; it never launches a process itself. If a sidecar's
+CLI syntax is not documented, use a safe placeholder such as
+`/path/to/separately-installed-mcp-server` rather than guessing flags or
+secrets.
+
+Alternatively, configure a streamable HTTP endpoint using
+`CONTEXT_MODE_MCP_URL` or Prime Agent settings:
+
+```jsonc
+{
+  "mcpServers": {
+    "context-mode": {
+      "type": "http",
+      "url": "https://localhost.example/context-mode/mcp",
+      "bearerTokenEnvVar": "CONTEXT_MODE_MCP_TOKEN"
+    }
+  }
+}
+```
+
+The endpoint and token names are examples, not assumed sidecar defaults. Add
+an authorization header through `headers` when required. This skill never
+auto-installs, upgrades, reindexes, removes, or purges the sidecar.
+
+## Allowed tools
+
+Discover schemas with `list_tools()` before calling. This skill permits only:
+
+- `ctx_execute(language, code, timeout?, cwd?, intent?)` for bounded derived
+  analysis of a command or snippet.
+- `ctx_execute_file(path, language, code, timeout?, intent?)` for isolated
+  processing of a large source, data file, or log.
+- `ctx_batch_execute(...)` for bounded parallel collection followed by immediate
+  query extraction.
+- `ctx_fetch_and_index(...)`, then `ctx_search(...)`, for large web pages,
+  docs, specs, and changelogs.
+- `ctx_index(...)`, then `ctx_search(...)`, for caller-supplied content that
+  should be available to later bounded searches.
+
+```python
+summary = await context_mode.ctx_execute_file(
+    path="logs/server.log",
+    language="text",
+    code="Summarize errors by root cause; return at most ten findings.",
+    intent="Find the first recurring production failure."
+)
+
+await context_mode.ctx_fetch_and_index(url="https://example.com/release-notes")
+notes = await context_mode.ctx_search(queries=["breaking changes", "deprecations"])
+```
+
+`ctx_purge`, `ctx_upgrade`, and every other maintenance or autonomous operation
+are deliberately blocked. Do not bypass this allowlist, and do not treat this
+integration as permission isolation. Review any separately installed sidecar's
+license terms; this skill does not include or copy the sidecar.

--- a/packages/coding-agent/skills/context-mode/pyproject.toml
+++ b/packages/coding-agent/skills/context-mode/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "prime-agent-skill-context-mode"
+version = "0.1.0"
+description = "Optional Context Mode MCP skill for bounded web, documentation, and log processing."
+requires-python = ">=3.10"
+dependencies = ["mcp", "httpx", "prime-agent-runtime"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/context_mode"]

--- a/packages/coding-agent/skills/context-mode/src/context_mode/__init__.py
+++ b/packages/coding-agent/skills/context-mode/src/context_mode/__init__.py
@@ -1,0 +1,156 @@
+"""Optional MCP adapter for a separately installed Context Mode sidecar."""
+
+from __future__ import annotations
+
+import inspect
+import os
+import shutil
+from contextlib import AsyncExitStack
+from typing import Any
+
+from rlm import McpIntegration, mcp_base
+
+__all__ = ["ContextMode", "SidecarUnavailable", "context_mode"]
+
+
+class SidecarUnavailable(RuntimeError):
+    """Raised when no HTTP or host-managed stdio transport is configured."""
+
+
+class ContextMode(McpIntegration):
+    """A deliberately narrow, non-maintenance Context Mode tool surface."""
+
+    server = "context-mode"
+    url = None
+    bearer_token_env = "CONTEXT_MODE_MCP_TOKEN"
+    executable = "context-mode"
+    endpoint_env = "CONTEXT_MODE_MCP_URL"
+    supported_tools = frozenset(
+        {
+            "ctx_execute",
+            "ctx_execute_file",
+            "ctx_batch_execute",
+            "ctx_fetch_and_index",
+            "ctx_index",
+            "ctx_search",
+        }
+    )
+
+    async def _resolve_config(self) -> tuple[str | None, dict[str, str]]:
+        try:
+            url, headers = await super()._resolve_config()
+        except mcp_base.Disabled as exc:
+            raise SidecarUnavailable(
+                "Context Mode is disabled in Prime Agent settings. Enable "
+                "mcpServers.context-mode before using this skill."
+            ) from exc
+        return url or os.environ.get(self.endpoint_env, "").strip() or None, headers
+
+    async def available(self) -> dict[str, Any]:
+        """Return a diagnostic without installing, starting, or upgrading a sidecar."""
+        try:
+            config = await self._resolve_host_config()
+        except mcp_base.Disabled:
+            config = {}
+            disabled = True
+        else:
+            disabled = False
+
+        host_stdio = (
+            not disabled
+            and config.get("type") == "stdio"
+            and config.get("bridge") == "host"
+        )
+        url = None
+        if not disabled:
+            url = config.get("url")
+            if not isinstance(url, str) or not url:
+                url = self.url
+            if not url:
+                url = os.environ.get(self.endpoint_env, "").strip() or None
+        endpoint = None if disabled or host_stdio else url
+        executable = shutil.which(self.executable)
+        return {
+            "configured": host_stdio or endpoint is not None,
+            "disabled": disabled,
+            "endpoint": endpoint,
+            "transport": "stdio" if host_stdio else "http" if endpoint else None,
+            "executable": executable,
+            "stdio_only": (
+                not disabled and not host_stdio and executable is not None and endpoint is None
+            ),
+        }
+
+    async def _open_session(self, stack: AsyncExitStack):
+        url, extra_headers = await self._resolve_config()
+        if not url:
+            diagnostic = await self.available()
+            if diagnostic["stdio_only"]:
+                raise SidecarUnavailable(
+                    "Context Mode is installed as a local command, but it is not configured "
+                    "as a host-managed stdio server. Add mcpServers.context-mode with type "
+                    "'stdio' and the separately installed command, or configure "
+                    "CONTEXT_MODE_MCP_URL / an HTTP mcpServers entry."
+                )
+            raise SidecarUnavailable(
+                "Context Mode is unavailable: configure CONTEXT_MODE_MCP_URL or "
+                "mcpServers.context-mode with an HTTP endpoint, or configure a host-managed "
+                "stdio command. The skill does not install, start, upgrade, or purge sidecars."
+            )
+        from mcp import ClientSession  # noqa: PLC0415
+
+        # Local HTTP sidecars are frequently unauthenticated. Preserve hosted
+        # bearer/OAuth behavior when credentials exist, but do not make them a
+        # prerequisite for an endpoint that accepts no Authorization header.
+        try:
+            token = await self._resolve_token()
+        except mcp_base.NotEnabled:
+            token = None
+        headers = dict(extra_headers)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        transport = mcp_base._resolve_streamable_http()
+        params = inspect.signature(transport).parameters
+        if "headers" in params:
+            cm = transport(url, headers=headers)
+        elif "http_client" in params:
+            import httpx  # noqa: PLC0415
+
+            client = await stack.enter_async_context(httpx.AsyncClient(headers=headers))
+            cm = transport(url, http_client=client)
+        else:
+            raise RuntimeError(
+                f"unsupported mcp streamable-HTTP client signature: {tuple(params)}"
+            )
+
+        read, write, *_ = await stack.enter_async_context(cm)
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+        return session
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        tools = await super().list_tools()
+        return [tool for tool in tools if tool["name"] in self.supported_tools]
+
+    async def call_tool(self, tool: str, arguments: dict[str, Any] | None = None) -> Any:
+        if tool not in self.supported_tools:
+            raise PermissionError(
+                f"Context Mode tool '{tool}' is not exposed by this skill; maintenance tools are disabled"
+            )
+        tools = {item["name"] for item in await super().list_tools()}
+        if tool not in tools:
+            available = ", ".join(sorted(tools & self.supported_tools)) or "(none)"
+            raise AttributeError(f"Context Mode does not provide '{tool}'. Available: {available}")
+        return await super().call_tool(tool, arguments)
+
+
+context_mode = ContextMode()
+
+_RESERVED = {"run", "__wrapped__", "__call__"}
+
+
+def __getattr__(name: str):
+    if name.startswith("_") or name in _RESERVED:
+        raise AttributeError(name)
+    return getattr(context_mode, name)

--- a/packages/coding-agent/skills/context-mode/test/test_context_mode.py
+++ b/packages/coding-agent/skills/context-mode/test/test_context_mode.py
@@ -1,12 +1,45 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+import selectors
+import shutil
+import subprocess
+import tempfile
+import time
 import unittest
 from contextlib import AsyncExitStack
+from pathlib import Path
 from unittest import mock
 
 import context_mode
 from rlm import McpIntegration, mcp_base
+
+
+SUPPORTED_LANGUAGES = frozenset(
+    {
+        "javascript",
+        "typescript",
+        "python",
+        "shell",
+        "ruby",
+        "go",
+        "rust",
+        "php",
+        "perl",
+        "r",
+        "elixir",
+        "csharp",
+    }
+)
+EXAMPLE_PATH = "logs/server.log"
+EXAMPLE_LANGUAGE = "python"
+EXAMPLE_CODE = (
+    "errors=[l for l in FILE_CONTENT.splitlines() if 'ERROR' in l]; "
+    "print(len(errors)); print('\\n'.join(errors[:10]))"
+)
+EXAMPLE_INTENT = "Find the first recurring production failure."
 
 
 def run(coro):
@@ -32,6 +65,33 @@ class FakeSession:
     async def call_tool(self, name, arguments):
         self.calls.append((name, arguments))
         return type("Result", (), {"structuredContent": {"ok": True}, "content": []})()
+
+
+def _stdio_request(process, request_id, method, params, timeout=10.0):
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write(
+        json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+        + "\n"
+    )
+    process.stdin.flush()
+
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ)
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or not selector.select(remaining):
+                raise AssertionError(f"timed out waiting for stdio response {request_id}")
+            line = process.stdout.readline()
+            if not line:
+                raise AssertionError("Context Mode stdio server closed stdout")
+            response = json.loads(line)
+            if response.get("id") == request_id:
+                return response
+    finally:
+        selector.close()
 
 
 class ContextModeTest(unittest.TestCase):
@@ -103,17 +163,39 @@ class ContextModeTest(unittest.TestCase):
              ):
             diagnostic = run(integration.available())
             tools = run(integration.list_tools())
-            result = run(integration.ctx_execute_file(path="large.log", language="text", code="Summarize."))
+            result = run(
+                integration.ctx_execute_file(
+                    path=EXAMPLE_PATH,
+                    language=EXAMPLE_LANGUAGE,
+                    code=EXAMPLE_CODE,
+                    intent=EXAMPLE_INTENT,
+                )
+            )
         self.assertEqual(diagnostic["endpoint"], "https://sidecar.test/mcp")
         self.assertEqual([tool["name"] for tool in tools], ["ctx_execute_file"])
         self.assertEqual(result, {"ok": True})
-        self.assertEqual(session.calls, [("ctx_execute_file", {"path": "large.log", "language": "text", "code": "Summarize."})])
+        self.assertEqual(
+            session.calls,
+            [
+                (
+                    "ctx_execute_file",
+                    {
+                        "path": EXAMPLE_PATH,
+                        "language": EXAMPLE_LANGUAGE,
+                        "code": EXAMPLE_CODE,
+                        "intent": EXAMPLE_INTENT,
+                    },
+                )
+            ],
+        )
+        self.assertIn(session.calls[0][1]["language"], SUPPORTED_LANGUAGES)
+        self.assertIn("FILE_CONTENT", session.calls[0][1]["code"])
 
     def test_host_stdio_dispatches_list_and_call_without_opening_http_session(self):
         integration = context_mode.ContextMode()
         calls = []
 
-        async def host_request_bridge(req_type, payload):
+        async def host_request_bridge(req_type, payload, **kwargs):
             calls.append((req_type, payload))
             if req_type == "mcp.config":
                 return {
@@ -139,14 +221,115 @@ class ContextModeTest(unittest.TestCase):
             mock.patch.object(integration, "_open_session", side_effect=AssertionError("HTTP session opened")),
         ):
             tools = run(integration.list_tools())
-            result = run(integration.ctx_execute_file(path="large.log", language="text", code="Summarize."))
+            result = run(
+                integration.ctx_execute_file(
+                    path=EXAMPLE_PATH,
+                    language=EXAMPLE_LANGUAGE,
+                    code=EXAMPLE_CODE,
+                    intent=EXAMPLE_INTENT,
+                )
+            )
             indexed = run(integration.call_tool("ctx_index", {"content": "adapter", "source": "test"}))
 
         self.assertEqual([tool["name"] for tool in tools], ["ctx_execute_file", "ctx_index"])
-        self.assertEqual(result, {"ok": {"path": "large.log", "language": "text", "code": "Summarize."}})
+        self.assertEqual(
+            result,
+            {
+                "ok": {
+                    "path": EXAMPLE_PATH,
+                    "language": EXAMPLE_LANGUAGE,
+                    "code": EXAMPLE_CODE,
+                    "intent": EXAMPLE_INTENT,
+                }
+            },
+        )
+        example_call = next(
+            payload["arguments"]
+            for req_type, payload in calls
+            if req_type == "mcp.call_tool" and payload.get("tool") == "ctx_execute_file"
+        )
+        self.assertIn(example_call["language"], SUPPORTED_LANGUAGES)
+        self.assertIn("FILE_CONTENT", example_call["code"])
         self.assertEqual(indexed, {"ok": {"content": "adapter", "source": "test"}})
         self.assertIn("mcp.list_tools", [req_type for req_type, _ in calls])
         self.assertIn("mcp.call_tool", [req_type for req_type, _ in calls])
+
+    def test_skill_example_executes_against_real_stdio_sidecar(self):
+        executable = shutil.which("context-mode")
+        if executable is None:
+            self.skipTest("context-mode executable is not installed")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+            log_path = workspace / EXAMPLE_PATH
+            log_path.parent.mkdir(parents=True)
+            log_path.write_text("INFO one\nERROR first\nERROR second\n")
+            env = os.environ.copy()
+            env["CONTEXT_MODE_DIR"] = str(workspace / ".context-mode")
+            env["CONTEXT_MODE_PROJECT_DIR"] = str(workspace)
+            env["CLAUDE_PROJECT_DIR"] = str(workspace)
+            env["PWD"] = str(workspace)
+            process = subprocess.Popen(
+                [executable],
+                cwd=workspace,
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            try:
+                initialized = _stdio_request(
+                    process,
+                    1,
+                    "initialize",
+                    {
+                        "protocolVersion": "2025-06-18",
+                        "capabilities": {},
+                        "clientInfo": {"name": "context-mode-skill-test", "version": "1"},
+                    },
+                )
+                self.assertIn("result", initialized)
+                self.assertIn("tools", initialized["result"]["capabilities"])
+                assert process.stdin is not None
+                process.stdin.write(
+                    json.dumps(
+                        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+                    )
+                    + "\n"
+                )
+                process.stdin.flush()
+                response = _stdio_request(
+                    process,
+                    2,
+                    "tools/call",
+                    {
+                        "name": "ctx_execute_file",
+                        "arguments": {
+                            "path": EXAMPLE_PATH,
+                            "language": EXAMPLE_LANGUAGE,
+                            "code": EXAMPLE_CODE,
+                            "intent": EXAMPLE_INTENT,
+                        },
+                    },
+                )
+                self.assertNotIn("error", response)
+                text = response["result"]["content"][0]["text"]
+                self.assertIn("2", text)
+                self.assertIn("ERROR first", text)
+                self.assertIn("ERROR second", text)
+            finally:
+                if process.poll() is None:
+                    process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+                if process.stdin is not None:
+                    process.stdin.close()
+                if process.stdout is not None:
+                    process.stdout.close()
 
     def test_maintenance_tools_are_blocked_even_when_server_advertises_them(self):
         integration = context_mode.ContextMode()

--- a/packages/coding-agent/skills/context-mode/test/test_context_mode.py
+++ b/packages/coding-agent/skills/context-mode/test/test_context_mode.py
@@ -59,6 +59,8 @@ class ContextModeTest(unittest.TestCase):
         self.assertTrue(diagnostic["configured"])
         self.assertEqual(diagnostic["transport"], "stdio")
         self.assertIsNone(diagnostic["endpoint"])
+        self.assertIsNone(diagnostic["executable"])
+        self.assertFalse(diagnostic["stdio_only"])
         self.assertNotIn("command", diagnostic)
         self.assertNotIn("env", diagnostic)
         self.assertNotIn("secret", repr(diagnostic))

--- a/packages/coding-agent/skills/context-mode/test/test_context_mode.py
+++ b/packages/coding-agent/skills/context-mode/test/test_context_mode.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from contextlib import AsyncExitStack
+from unittest import mock
+
+import context_mode
+from rlm import McpIntegration, mcp_base
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    async def list_tools(self):
+        tools = []
+        for name in ("ctx_execute_file", "ctx_purge"):
+            tool = type("Tool", (), {})()
+            tool.name = name
+            tool.description = name
+            tool.inputSchema = {"type": "object"}
+            tools.append(tool)
+        response = type("Response", (), {})()
+        response.tools = tools
+        return response
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return type("Result", (), {"structuredContent": {"ok": True}, "content": []})()
+
+
+class ContextModeTest(unittest.TestCase):
+    def test_import_and_diagnostic_do_not_install_or_start_a_sidecar(self):
+        integration = context_mode.ContextMode()
+        with mock.patch.object(
+            McpIntegration, "_resolve_host_config", new=mock.AsyncMock(return_value={})
+        ), mock.patch.object(context_mode.shutil, "which", return_value=None) as which:
+            diagnostic = run(integration.available())
+        self.assertFalse(diagnostic["configured"])
+        which.assert_called_once_with("context-mode")
+
+    def test_host_stdio_setup_is_configured_without_exposing_process_settings(self):
+        integration = context_mode.ContextMode()
+        config = {
+            "type": "stdio",
+            "bridge": "host",
+            "command": "secret-context-mode",
+            "env": {"TOKEN": "secret"},
+        }
+        with mock.patch.object(
+            McpIntegration, "_resolve_host_config", new=mock.AsyncMock(return_value=config)
+        ), mock.patch.object(context_mode.shutil, "which", return_value=None):
+            diagnostic = run(integration.available())
+        self.assertTrue(diagnostic["configured"])
+        self.assertEqual(diagnostic["transport"], "stdio")
+        self.assertIsNone(diagnostic["endpoint"])
+        self.assertNotIn("command", diagnostic)
+        self.assertNotIn("env", diagnostic)
+        self.assertNotIn("secret", repr(diagnostic))
+
+    def test_stdio_only_setup_has_actionable_error(self):
+        integration = context_mode.ContextMode()
+        with mock.patch.object(
+            McpIntegration, "_resolve_host_config", new=mock.AsyncMock(return_value={})
+        ), mock.patch.object(context_mode.shutil, "which", return_value="/usr/bin/context-mode"):
+            with self.assertRaisesRegex(context_mode.SidecarUnavailable, "local command"):
+                run(integration._open_session(AsyncExitStack()))
+
+    def test_disabled_config_is_unavailable_before_creating_a_transport(self):
+        integration = context_mode.ContextMode()
+        transport = mock.MagicMock()
+        with mock.patch.object(
+            McpIntegration,
+            "_resolve_host_config",
+            new=mock.AsyncMock(side_effect=mcp_base.Disabled("context-mode")),
+        ), mock.patch.object(context_mode.mcp_base, "_resolve_streamable_http", return_value=transport):
+            diagnostic = run(integration.available())
+            with self.assertRaisesRegex(context_mode.SidecarUnavailable, "disabled"):
+                run(integration._open_session(AsyncExitStack()))
+        self.assertFalse(diagnostic["configured"])
+        self.assertTrue(diagnostic["disabled"])
+        transport.assert_not_called()
+
+    def test_configured_endpoint_forwards_allowed_tool_and_hides_disallowed_tools(self):
+        integration = context_mode.ContextMode()
+        session = FakeSession()
+
+        async def open_session(stack):
+            return session
+
+        with mock.patch.object(integration, "_open_session", open_session), \
+             mock.patch.object(
+                 McpIntegration,
+                 "_resolve_host_config",
+                 new=mock.AsyncMock(return_value={"url": "https://sidecar.test/mcp"}),
+             ):
+            diagnostic = run(integration.available())
+            tools = run(integration.list_tools())
+            result = run(integration.ctx_execute_file(path="large.log", language="text", code="Summarize."))
+        self.assertEqual(diagnostic["endpoint"], "https://sidecar.test/mcp")
+        self.assertEqual([tool["name"] for tool in tools], ["ctx_execute_file"])
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(session.calls, [("ctx_execute_file", {"path": "large.log", "language": "text", "code": "Summarize."})])
+
+    def test_host_stdio_dispatches_list_and_call_without_opening_http_session(self):
+        integration = context_mode.ContextMode()
+        calls = []
+
+        async def host_request_bridge(req_type, payload):
+            calls.append((req_type, payload))
+            if req_type == "mcp.config":
+                return {
+                    "type": "stdio",
+                    "bridge": "host",
+                    "command": "secret-context-mode",
+                    "env": {"TOKEN": "secret"},
+                }
+            if req_type == "mcp.list_tools":
+                return {
+                    "tools": [
+                        {"name": "ctx_execute_file", "description": "Execute", "inputSchema": {}},
+                        {"name": "ctx_index", "description": "Index", "inputSchema": {}},
+                        {"name": "ctx_purge", "description": "Maintenance", "inputSchema": {}},
+                    ]
+                }
+            if req_type == "mcp.call_tool":
+                return {"result": {"structuredContent": {"ok": payload["arguments"]}, "content": []}}
+            raise AssertionError(req_type)
+
+        with (
+            mock.patch.object(context_mode.mcp_base, "host_request", host_request_bridge),
+            mock.patch.object(integration, "_open_session", side_effect=AssertionError("HTTP session opened")),
+        ):
+            tools = run(integration.list_tools())
+            result = run(integration.ctx_execute_file(path="large.log", language="text", code="Summarize."))
+            indexed = run(integration.call_tool("ctx_index", {"content": "adapter", "source": "test"}))
+
+        self.assertEqual([tool["name"] for tool in tools], ["ctx_execute_file", "ctx_index"])
+        self.assertEqual(result, {"ok": {"path": "large.log", "language": "text", "code": "Summarize."}})
+        self.assertEqual(indexed, {"ok": {"content": "adapter", "source": "test"}})
+        self.assertIn("mcp.list_tools", [req_type for req_type, _ in calls])
+        self.assertIn("mcp.call_tool", [req_type for req_type, _ in calls])
+
+    def test_maintenance_tools_are_blocked_even_when_server_advertises_them(self):
+        integration = context_mode.ContextMode()
+        session = FakeSession()
+
+        async def open_session(stack):
+            return session
+
+        with mock.patch.object(integration, "_open_session", open_session):
+            with self.assertRaisesRegex(PermissionError, "disabled"):
+                run(integration.call_tool("ctx_purge", {}))
+            with self.assertRaisesRegex(PermissionError, "disabled"):
+                run(integration.ctx_purge())
+        with self.assertRaisesRegex(PermissionError, "disabled"):
+            run(integration.call_tool("ctx_upgrade", {}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/coding-agent/skills/jcodemunch/SKILL.md
+++ b/packages/coding-agent/skills/jcodemunch/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: jcodemunch
+description: Structured code retrieval through an optional, separately installed jCodeMunch MCP sidecar over host-managed stdio or HTTP. Use to locate symbols, inspect bounded source/context, trace references, assess refactor blast radius, or map changed symbols without loading a repository wholesale.
+---
+
+# jCodeMunch
+
+Use jCodeMunch for precision code retrieval. It is optional: importing this
+skill never installs, starts, indexes, upgrades, or otherwise changes a sidecar.
+Call `available()` first when setup is unknown. If unavailable, use Prime
+Agent's normal file tools instead.
+
+```python
+import jcodemunch
+
+print(await jcodemunch.available())
+tools = await jcodemunch.list_tools()
+print([tool["name"] for tool in tools])
+```
+
+## Setup
+
+Install and operate jCodeMunch separately, and review the sidecar's license
+terms before use. This skill does not include or copy jCodeMunch. When the
+separately installed sidecar provides its documented stdio command, configure
+the host-managed transport:
+
+```jsonc
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "type": "stdio",
+      "command": "jcodemunch-mcp"
+    }
+  }
+}
+```
+
+The host launches configured stdio servers lazily and keeps command, args,
+environment, and cwd host-side. The Python skill uses the host bridge for
+`list_tools` and `call_tool`; it never launches a process itself. If a sidecar's
+CLI syntax is not documented, use a safe placeholder such as
+`/path/to/separately-installed-mcp-server` rather than guessing flags or
+secrets.
+
+Alternatively, configure a **streamable HTTP** endpoint either with
+`JCODEMUNCH_MCP_URL` or in Prime Agent settings:
+
+```jsonc
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "type": "http",
+      "url": "https://localhost.example/jcodemunch/mcp",
+      "bearerTokenEnvVar": "JCODEMUNCH_MCP_TOKEN"
+    }
+  }
+}
+```
+
+The URL and token names are examples, not sidecar defaults. For an endpoint
+that needs no token, omit `bearerTokenEnvVar`. For one that does, export
+`JCODEMUNCH_MCP_TOKEN` or supply its authorization header in `headers`.
+Do not auto-install, start, reindex, upgrade, remove, or purge the sidecar.
+
+## Retrieval workflow
+
+Discover server-owned schemas before relying on optional arguments. The skill
+exposes only the retrieval tools below; use `call_tool(name, arguments)` for
+exact server names and dynamic schemas.
+
+1. `search_symbols`: find candidate symbol IDs.
+2. `get_file_outline`: inspect file structure before retrieving source.
+3. `get_symbol_source`: retrieve the exact implementation; use server-supported
+   verification options when drift matters.
+4. `get_context_bundle` or `get_ranked_context`: obtain bounded, task-focused
+   code plus dependencies/imports.
+5. `find_references` or `find_importers`: verify usage and file dependencies.
+6. `get_blast_radius`: assess impact before a rename, deletion, or refactor.
+7. `get_changed_symbols`: map a local indexed diff or PR range to symbols.
+8. `plan_turn`: create or continue a server-supported retrieval plan.
+9. `assemble_task_context`: assemble bounded context for the current retrieval task.
+
+```python
+hits = await jcodemunch.search_symbols(
+    repo="prime-agent", query="McpIntegration", detail_level="compact"
+)
+outline = await jcodemunch.get_file_outline(
+    repo="prime-agent", file_path="prime-agent-runtime/src/rlm/mcp_base.py"
+)
+source = await jcodemunch.get_symbol_source(
+    repo="prime-agent", symbol_id=hits[0]["symbol_id"], verify=True
+)
+context = await jcodemunch.get_context_bundle(
+    repo="prime-agent", symbol_id=hits[0]["symbol_id"], token_budget=4000
+)
+references = await jcodemunch.find_references(
+    repo="prime-agent", identifier="McpIntegration", max_results=50
+)
+impact = await jcodemunch.get_blast_radius(
+    repo="prime-agent", symbol="McpIntegration", depth=2
+)
+changed = await jcodemunch.get_changed_symbols(
+    repo="prime-agent", since_sha="main", until_sha="HEAD"
+)
+```
+
+The server remains the source of truth for parameter names and availability.
+Common advanced options include token budgets, file/language filters, semantic
+or fusion ranking, source context lines, and call-chain depth; inspect
+`list_tools()` before using them. Preserve the server's license boundary: this
+skill only exposes the allowlisted retrieval surface and does not include,
+copy, or manage the separately installed sidecar.

--- a/packages/coding-agent/skills/jcodemunch/SKILL.md
+++ b/packages/coding-agent/skills/jcodemunch/SKILL.md
@@ -21,9 +21,11 @@ print([tool["name"] for tool in tools])
 ## Setup
 
 Install and operate jCodeMunch separately, and review the sidecar's license
-terms before use. This skill does not include or copy jCodeMunch. When the
-separately installed sidecar provides its documented stdio command, configure
-the host-managed transport:
+terms before use. This skill does not include or copy jCodeMunch. The skill is
+bundled and available by default; when `mcpServers.jcodemunch` is absent, Prime
+Agent uses the separately installed `jcodemunch-mcp` command as a lazy
+host-managed stdio transport. Add an explicit entry when you need to override
+its command, args, environment, cwd, tool filters, or enabled state:
 
 ```jsonc
 {
@@ -38,8 +40,10 @@ the host-managed transport:
 
 The host launches configured stdio servers lazily and keeps command, args,
 environment, and cwd host-side. The Python skill uses the host bridge for
-`list_tools` and `call_tool`; it never launches a process itself. If a sidecar's
-CLI syntax is not documented, use a safe placeholder such as
+`list_tools` and `call_tool`; it never launches a process itself. Set
+`"enabled": false` to disable the default without falling back to an
+environment URL. If a sidecar's CLI syntax is not documented, use a safe
+placeholder such as
 `/path/to/separately-installed-mcp-server` rather than guessing flags or
 secrets.
 

--- a/packages/coding-agent/skills/jcodemunch/pyproject.toml
+++ b/packages/coding-agent/skills/jcodemunch/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "prime-agent-skill-jcodemunch"
+version = "0.1.0"
+description = "Optional jCodeMunch structured code-retrieval skill for Prime Agent."
+requires-python = ">=3.10"
+dependencies = ["mcp", "httpx", "prime-agent-runtime"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/jcodemunch"]

--- a/packages/coding-agent/skills/jcodemunch/src/jcodemunch/__init__.py
+++ b/packages/coding-agent/skills/jcodemunch/src/jcodemunch/__init__.py
@@ -1,0 +1,159 @@
+"""Optional MCP adapter for a separately installed jCodeMunch sidecar."""
+
+from __future__ import annotations
+
+import inspect
+import os
+import shutil
+from contextlib import AsyncExitStack
+from typing import Any
+
+from rlm import McpIntegration, mcp_base
+
+__all__ = ["JCodeMunch", "SidecarUnavailable", "jcodemunch"]
+
+
+class SidecarUnavailable(RuntimeError):
+    """Raised when no HTTP or host-managed stdio transport is configured."""
+
+
+class JCodeMunch(McpIntegration):
+    """jCodeMunch's stable structured retrieval surface, discovered at runtime."""
+
+    server = "jcodemunch"
+    url = None
+    bearer_token_env = "JCODEMUNCH_MCP_TOKEN"
+    executable = "jcodemunch-mcp"
+    endpoint_env = "JCODEMUNCH_MCP_URL"
+    supported_tools = frozenset(
+        {
+            "search_symbols",
+            "get_file_outline",
+            "get_symbol_source",
+            "get_context_bundle",
+            "get_ranked_context",
+            "find_references",
+            "find_importers",
+            "get_blast_radius",
+            "get_changed_symbols",
+            "plan_turn",
+            "assemble_task_context",
+        }
+    )
+
+    async def _resolve_config(self) -> tuple[str | None, dict[str, str]]:
+        try:
+            url, headers = await super()._resolve_config()
+        except mcp_base.Disabled as exc:
+            raise SidecarUnavailable(
+                "jCodeMunch is disabled in Prime Agent settings. Enable "
+                "mcpServers.jcodemunch before using this skill."
+            ) from exc
+        return url or os.environ.get(self.endpoint_env, "").strip() or None, headers
+
+    async def available(self) -> dict[str, Any]:
+        """Return a diagnostic without installing, starting, or upgrading a sidecar."""
+        try:
+            config = await self._resolve_host_config()
+        except mcp_base.Disabled:
+            config = {}
+            disabled = True
+        else:
+            disabled = False
+
+        host_stdio = (
+            not disabled
+            and config.get("type") == "stdio"
+            and config.get("bridge") == "host"
+        )
+        url = None
+        if not disabled:
+            url = config.get("url")
+            if not isinstance(url, str) or not url:
+                url = self.url
+            if not url:
+                url = os.environ.get(self.endpoint_env, "").strip() or None
+        endpoint = None if disabled or host_stdio else url
+        executable = shutil.which(self.executable)
+        return {
+            "configured": host_stdio or endpoint is not None,
+            "disabled": disabled,
+            "endpoint": endpoint,
+            "transport": "stdio" if host_stdio else "http" if endpoint else None,
+            "executable": executable,
+            "stdio_only": (
+                not disabled and not host_stdio and executable is not None and endpoint is None
+            ),
+        }
+
+    async def _open_session(self, stack: AsyncExitStack):
+        url, extra_headers = await self._resolve_config()
+        if not url:
+            diagnostic = await self.available()
+            if diagnostic["stdio_only"]:
+                raise SidecarUnavailable(
+                    "jCodeMunch is installed as a local command, but it is not configured "
+                    "as a host-managed stdio server. Add mcpServers.jcodemunch with type "
+                    "'stdio' and the separately installed command, or configure "
+                    "JCODEMUNCH_MCP_URL / an HTTP mcpServers entry."
+                )
+            raise SidecarUnavailable(
+                "jCodeMunch is unavailable: configure JCODEMUNCH_MCP_URL or "
+                "mcpServers.jcodemunch with an HTTP endpoint, or configure a host-managed "
+                "stdio command. The skill does not install, start, upgrade, or purge sidecars."
+            )
+        from mcp import ClientSession  # noqa: PLC0415
+
+        # Local HTTP sidecars are frequently unauthenticated. Preserve hosted
+        # bearer/OAuth behavior when credentials exist, but do not make them a
+        # prerequisite for an endpoint that accepts no Authorization header.
+        try:
+            token = await self._resolve_token()
+        except mcp_base.NotEnabled:
+            token = None
+        headers = dict(extra_headers)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        transport = mcp_base._resolve_streamable_http()
+        params = inspect.signature(transport).parameters
+        if "headers" in params:
+            cm = transport(url, headers=headers)
+        elif "http_client" in params:
+            import httpx  # noqa: PLC0415
+
+            client = await stack.enter_async_context(httpx.AsyncClient(headers=headers))
+            cm = transport(url, http_client=client)
+        else:
+            raise RuntimeError(
+                f"unsupported mcp streamable-HTTP client signature: {tuple(params)}"
+            )
+
+        read, write, *_ = await stack.enter_async_context(cm)
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+        return session
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        tools = await super().list_tools()
+        return [tool for tool in tools if tool["name"] in self.supported_tools]
+
+    async def call_tool(self, tool: str, arguments: dict[str, Any] | None = None) -> Any:
+        if tool not in self.supported_tools:
+            raise AttributeError(f"jCodeMunch tool '{tool}' is not part of this skill's retrieval surface")
+        tools = {item["name"] for item in await super().list_tools()}
+        if tool not in tools:
+            available = ", ".join(sorted(tools & self.supported_tools)) or "(none)"
+            raise AttributeError(f"jCodeMunch does not provide '{tool}'. Available: {available}")
+        return await super().call_tool(tool, arguments)
+
+
+jcodemunch = JCodeMunch()
+
+_RESERVED = {"run", "__wrapped__", "__call__"}
+
+
+def __getattr__(name: str):
+    if name.startswith("_") or name in _RESERVED:
+        raise AttributeError(name)
+    return getattr(jcodemunch, name)

--- a/packages/coding-agent/skills/jcodemunch/test/test_jcodemunch.py
+++ b/packages/coding-agent/skills/jcodemunch/test/test_jcodemunch.py
@@ -106,9 +106,11 @@ class JCodeMunchTest(unittest.TestCase):
 
     def test_host_stdio_dispatches_list_and_call_without_opening_http_session(self):
         integration = jcodemunch.JCodeMunch()
+        integration.host_request_timeout = 12.5
         calls = []
 
-        async def host_request_bridge(req_type, payload):
+        async def host_request_bridge(req_type, payload, *, timeout):
+            self.assertEqual(timeout, 12.5)
             calls.append((req_type, payload))
             if req_type == "mcp.config":
                 return {

--- a/packages/coding-agent/skills/jcodemunch/test/test_jcodemunch.py
+++ b/packages/coding-agent/skills/jcodemunch/test/test_jcodemunch.py
@@ -57,6 +57,8 @@ class JCodeMunchTest(unittest.TestCase):
         self.assertTrue(diagnostic["configured"])
         self.assertEqual(diagnostic["transport"], "stdio")
         self.assertIsNone(diagnostic["endpoint"])
+        self.assertIsNone(diagnostic["executable"])
+        self.assertFalse(diagnostic["stdio_only"])
         self.assertNotIn("command", diagnostic)
         self.assertNotIn("env", diagnostic)
         self.assertNotIn("secret", repr(diagnostic))

--- a/packages/coding-agent/skills/jcodemunch/test/test_jcodemunch.py
+++ b/packages/coding-agent/skills/jcodemunch/test/test_jcodemunch.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from contextlib import AsyncExitStack
+from unittest import mock
+
+import jcodemunch
+from rlm import McpIntegration, mcp_base
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    async def list_tools(self):
+        tool = type("Tool", (), {})()
+        tool.name = "search_symbols"
+        tool.description = "Search"
+        tool.inputSchema = {"type": "object"}
+        response = type("Response", (), {})()
+        response.tools = [tool]
+        return response
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return type("Result", (), {"structuredContent": {"ok": True}, "content": []})()
+
+
+class JCodeMunchTest(unittest.TestCase):
+    def test_import_and_diagnostic_do_not_install_or_start_a_sidecar(self):
+        integration = jcodemunch.JCodeMunch()
+        with mock.patch.object(
+            McpIntegration, "_resolve_host_config", new=mock.AsyncMock(return_value={})
+        ), mock.patch.object(jcodemunch.shutil, "which", return_value=None) as which:
+            diagnostic = run(integration.available())
+        self.assertFalse(diagnostic["configured"])
+        self.assertIsNone(diagnostic["executable"])
+        which.assert_called_once_with("jcodemunch-mcp")
+
+    def test_host_stdio_setup_is_configured_without_exposing_process_settings(self):
+        integration = jcodemunch.JCodeMunch()
+        config = {
+            "type": "stdio",
+            "bridge": "host",
+            "command": "secret-jcodemunch",
+            "env": {"TOKEN": "secret"},
+        }
+        with mock.patch.object(
+            McpIntegration, "_resolve_host_config", new=mock.AsyncMock(return_value=config)
+        ), mock.patch.object(jcodemunch.shutil, "which", return_value=None):
+            diagnostic = run(integration.available())
+        self.assertTrue(diagnostic["configured"])
+        self.assertEqual(diagnostic["transport"], "stdio")
+        self.assertIsNone(diagnostic["endpoint"])
+        self.assertNotIn("command", diagnostic)
+        self.assertNotIn("env", diagnostic)
+        self.assertNotIn("secret", repr(diagnostic))
+
+    def test_stdio_only_setup_has_actionable_error(self):
+        integration = jcodemunch.JCodeMunch()
+        with mock.patch.object(
+            McpIntegration, "_resolve_host_config", new=mock.AsyncMock(return_value={})
+        ), mock.patch.object(jcodemunch.shutil, "which", return_value="/usr/bin/jcodemunch-mcp"):
+            with self.assertRaisesRegex(jcodemunch.SidecarUnavailable, "local command"):
+                run(integration._open_session(AsyncExitStack()))
+
+    def test_disabled_config_is_unavailable_before_creating_a_transport(self):
+        integration = jcodemunch.JCodeMunch()
+        transport = mock.MagicMock()
+        with mock.patch.object(
+            McpIntegration,
+            "_resolve_host_config",
+            new=mock.AsyncMock(side_effect=mcp_base.Disabled("jcodemunch")),
+        ), mock.patch.object(jcodemunch.mcp_base, "_resolve_streamable_http", return_value=transport):
+            diagnostic = run(integration.available())
+            with self.assertRaisesRegex(jcodemunch.SidecarUnavailable, "disabled"):
+                run(integration._open_session(AsyncExitStack()))
+        self.assertFalse(diagnostic["configured"])
+        self.assertTrue(diagnostic["disabled"])
+        transport.assert_not_called()
+
+    def test_configured_endpoint_forwards_supported_tool_and_arguments(self):
+        integration = jcodemunch.JCodeMunch()
+        session = FakeSession()
+
+        async def open_session(stack):
+            return session
+
+        with mock.patch.object(integration, "_open_session", open_session), \
+             mock.patch.object(
+                 McpIntegration,
+                 "_resolve_host_config",
+                 new=mock.AsyncMock(return_value={"url": "https://sidecar.test/mcp"}),
+             ):
+            diagnostic = run(integration.available())
+            self.assertEqual(run(integration.search_symbols(repo="demo", query="Thing")), {"ok": True})
+        self.assertEqual(diagnostic["endpoint"], "https://sidecar.test/mcp")
+        self.assertEqual(session.calls, [("search_symbols", {"repo": "demo", "query": "Thing"})])
+
+    def test_host_stdio_dispatches_list_and_call_without_opening_http_session(self):
+        integration = jcodemunch.JCodeMunch()
+        calls = []
+
+        async def host_request_bridge(req_type, payload):
+            calls.append((req_type, payload))
+            if req_type == "mcp.config":
+                return {
+                    "type": "stdio",
+                    "bridge": "host",
+                    "command": "secret-jcodemunch",
+                    "env": {"TOKEN": "secret"},
+                }
+            if req_type == "mcp.list_tools":
+                return {
+                    "tools": [
+                        {"name": "search_symbols", "description": "Search", "inputSchema": {}},
+                        {"name": "plan_turn", "description": "Plan", "inputSchema": {}},
+                        {"name": "assemble_task_context", "description": "Context", "inputSchema": {}},
+                        {"name": "upgrade", "description": "Maintenance", "inputSchema": {}},
+                        {"name": "purge", "description": "Maintenance", "inputSchema": {}},
+                        {"name": "not_exposed", "description": "Other", "inputSchema": {}},
+                    ]
+                }
+            if req_type == "mcp.call_tool":
+                return {"result": {"structuredContent": {"ok": payload["arguments"]}, "content": []}}
+            raise AssertionError(req_type)
+
+        with (
+            mock.patch.object(jcodemunch.mcp_base, "host_request", host_request_bridge),
+            mock.patch.object(integration, "_open_session", side_effect=AssertionError("HTTP session opened")),
+        ):
+            tools = run(integration.list_tools())
+            result = run(integration.search_symbols(repo="demo", query="Thing"))
+            plan = run(integration.call_tool("plan_turn", {"task": "Find the adapter"}))
+            context = run(integration.call_tool("assemble_task_context", {"task": "Review it"}))
+
+        self.assertEqual(
+            [tool["name"] for tool in tools],
+            ["search_symbols", "plan_turn", "assemble_task_context"],
+        )
+        self.assertEqual(result, {"ok": {"repo": "demo", "query": "Thing"}})
+        self.assertEqual(plan, {"ok": {"task": "Find the adapter"}})
+        self.assertEqual(context, {"ok": {"task": "Review it"}})
+        with self.assertRaisesRegex(AttributeError, "not part of this skill"):
+            run(integration.call_tool("upgrade", {}))
+        self.assertIn("mcp.list_tools", [req_type for req_type, _ in calls])
+        self.assertIn("mcp.call_tool", [req_type for req_type, _ in calls])
+
+    def test_unauthenticated_http_endpoint_preserves_static_headers(self):
+        integration = jcodemunch.JCodeMunch()
+        captured = {}
+
+        class TransportContext:
+            async def __aenter__(self):
+                return ("read", "write", None)
+
+            async def __aexit__(self, *args):
+                return False
+
+        def transport(url, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return TransportContext()
+
+        with mock.patch.object(
+            McpIntegration,
+            "_resolve_config",
+            new=mock.AsyncMock(return_value=("https://sidecar.test/mcp", {"X-Trace": "1"})),
+        ), mock.patch.object(integration, "_resolve_token", new=mock.AsyncMock(return_value=None)), \
+             mock.patch.object(jcodemunch.mcp_base, "_resolve_streamable_http", return_value=transport), \
+             mock.patch("mcp.ClientSession") as session_class:
+            session = mock.MagicMock()
+            session.initialize = mock.AsyncMock()
+            session_class.return_value.__aenter__ = mock.AsyncMock(return_value=session)
+            session_class.return_value.__aexit__ = mock.AsyncMock(return_value=False)
+            run(integration._open_session(AsyncExitStack()))
+        self.assertEqual(captured, {"url": "https://sidecar.test/mcp", "headers": {"X-Trace": "1"}})
+
+    def test_missing_server_capability_is_actionable(self):
+        integration = jcodemunch.JCodeMunch()
+        session = FakeSession()
+
+        async def open_session(stack):
+            return session
+
+        with mock.patch.object(integration, "_open_session", open_session):
+            with self.assertRaisesRegex(AttributeError, "does not provide 'get_file_outline'"):
+                run(integration.call_tool("get_file_outline", {"repo": "demo", "file_path": "a.py"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -179,6 +179,7 @@ export async function createAgentSessionServices(
 	// integration skills by whether the user is logged in (enable-by-login).
 	const mcpManager = new McpManager({
 		authStorage,
+		cwd,
 		getUserServers: () => settingsManager.getMcpServers(),
 	});
 	// refresh() resets the OAuth registry to built-ins; re-add user MCP providers too.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3944,6 +3944,11 @@ export class AgentSession {
 		} catch {
 			// a failed kernel startup already cleaned up after itself
 		}
+		try {
+			await this._mcpManager?.dispose();
+		} catch {
+			// Sidecar cleanup is best-effort; sync disposal below is the final guard.
+		}
 		this.dispose();
 	}
 
@@ -3986,6 +3991,7 @@ export class AgentSession {
 				if (outcome.delivery) this._settleAgentMessage(agentMessageId, "delivery", deliveryError);
 				if (outcome.completion) this._settleAgentMessage(agentMessageId, "completion", completionError);
 			}
+			this._mcpManager?.disposeSync();
 			this._cancelSessionActions(() => true, deliveryError);
 			this.agent.clearAllQueues();
 			this._extensionRunner.invalidate(

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -99,6 +99,8 @@ export interface ExecuteOptions {
 	/** Aborting interrupts the kernel via the control channel. */
 	signal?: AbortSignal;
 	onStream?: (chunk: string, name: "stdout" | "stderr") => void;
+	/** Receives the complete text/plain execute result before the bounded result is returned. */
+	onResult?: (result: string) => void;
 	onLateSentAgentMessage?: (message: KernelSentAgentMessage) => void;
 	/** Cap stdout / stderr / result at this many characters. Default 65536. */
 	maxOutputChars?: number;
@@ -563,6 +565,11 @@ export class KernelManager {
 		return this.options.sessionId;
 	}
 
+	registerHostHandlers(handlers: HostRequestHandlers): void {
+		this.options.hostHandlers ??= {};
+		Object.assign(this.options.hostHandlers, handlers);
+	}
+
 	private appendKernelDiagnostic(message: string): void {
 		this.kernelStderr += `[kernel] ${message.endsWith("\n") ? message : `${message}\n`}`;
 	}
@@ -1016,7 +1023,10 @@ export class KernelManager {
 			execution.opts.onStream?.(c.text, c.name);
 		} else if (t === "execute_result") {
 			const c = incoming.content as { data: Record<string, string> };
-			if (c.data["text/plain"]) execution.result = c.data["text/plain"];
+			if (c.data["text/plain"]) {
+				execution.result = c.data["text/plain"];
+				execution.opts.onResult?.(c.data["text/plain"]);
+			}
 		} else if (t === "display_data" || t === "update_display_data") {
 			const c = incoming.content as { data?: Record<string, unknown> };
 			const diff = parseDiffDisplay(c.data?.[DIFF_DISPLAY_MIME]);

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -11,7 +11,7 @@ import {
 import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import type { AuthStorage } from "../auth-storage.js";
 import type { McpServerConfig } from "../settings-manager.js";
-import { isRetryableStdioMcpError, StdioMcpClient } from "./stdio-mcp-client.js";
+import { isRetryableStdioMcpError, isStdioMcpRequestNotSentError, StdioMcpClient } from "./stdio-mcp-client.js";
 
 export interface McpManagerOptions {
 	authStorage: AuthStorage;
@@ -97,6 +97,7 @@ export class McpManager {
 	private readonly stdioClients = new Map<string, StdioMcpClient>();
 	private readonly stdioOperationQueues = new Map<string, Promise<void>>();
 	private disposed = false;
+	private lifecycleGeneration = 0;
 	/** Provider ids we registered for user servers, so refresh can drop removed ones. */
 	private registeredUserProviderIds = new Set<string>();
 
@@ -112,7 +113,11 @@ export class McpManager {
 
 	/** Re-read settings and re-register providers; call after a session reload. */
 	refresh(): void {
+		this.lifecycleGeneration += 1;
 		this.disposed = false;
+		// Refresh is an intentional lifecycle resurrection after session reload;
+		// re-register so process-exit cleanup covers newly lazy-started sidecars.
+		registerMcpExitCleanup(this);
 		// Reload is a lifecycle boundary: never leave an old command/environment
 		// running after settings are re-read. New processes remain lazy.
 		this.disposeStdioClientsSync();
@@ -122,12 +127,29 @@ export class McpManager {
 
 	/** Stop every sidecar owned by this workspace/session. */
 	async dispose(): Promise<void> {
+		const generation = this.lifecycleGeneration;
 		this.disposed = true;
-		liveMcpManagers.delete(this);
-		const clients = [...this.stdioClients.values()];
-		this.stdioClients.clear();
+		const clients = [...this.stdioClients.entries()];
 		this.stdioOperationQueues.clear();
-		await Promise.allSettled(clients.map((client) => client.dispose()));
+		const results = await Promise.allSettled(clients.map(([, client]) => client.dispose()));
+		const failures: unknown[] = [];
+		for (const [index, result] of results.entries()) {
+			const [server, client] = clients[index];
+			if (result.status === "fulfilled") {
+				if (this.stdioClients.get(server) === client) this.stdioClients.delete(server);
+			} else {
+				failures.push(result.reason);
+			}
+		}
+		if (failures.length > 0) {
+			// Keep failed clients owned and keep this manager live so a caller or the
+			// process-exit hook can retry cleanup after a bounded shutdown failure.
+			liveMcpManagers.add(this);
+			const messages = failures.map((error) => (error instanceof Error ? error.message : String(error)));
+			throw new AggregateError(failures, `Failed to dispose MCP stdio clients: ${messages.join("; ")}`);
+		}
+		if (generation === this.lifecycleGeneration) liveMcpManagers.delete(this);
+		else liveMcpManagers.add(this);
 	}
 
 	/** Synchronous best-effort cleanup for process-exit/session replacement paths. */
@@ -317,7 +339,7 @@ export class McpManager {
 	private async withStdioClient<T>(
 		server: string,
 		operation: (client: StdioMcpClient) => Promise<T>,
-		options: { retryTransport?: boolean } = {},
+		options: { retryTransport?: boolean; retryOnlyIfRequestNotSent?: boolean } = {},
 	): Promise<T> {
 		const previous = this.stdioOperationQueues.get(server) ?? Promise.resolve();
 		const queued = previous.then(async () => {
@@ -325,9 +347,14 @@ export class McpManager {
 			try {
 				return await operation(client);
 			} catch (error) {
-				// A failed transport gets one bounded restart. Protocol/tool errors are
-				// returned directly and are not retried.
-				if (options.retryTransport === false || !isRetryableStdioMcpError(error)) throw error;
+				// Read-only discovery can retry any transport failure. Tool calls may have
+				// reached the server, so only a failure proven to precede the write is safe.
+				if (
+					options.retryTransport === false ||
+					!isRetryableStdioMcpError(error) ||
+					(options.retryOnlyIfRequestNotSent && !isStdioMcpRequestNotSentError(error))
+				)
+					throw error;
 				await new Promise<void>((resolve) => {
 					const timer = globalThis.setTimeout(resolve, 100);
 					timer.unref?.();
@@ -410,8 +437,10 @@ export class McpManager {
 				) {
 					throw new Error("mcp.call_tool arguments must be an object");
 				}
-				const result = await this.withStdioClient(server, (client) =>
-					client.callTool(tool, (arguments_ ?? {}) as Record<string, unknown>),
+				const result = await this.withStdioClient(
+					server,
+					(client) => client.callTool(tool, (arguments_ ?? {}) as Record<string, unknown>),
+					{ retryOnlyIfRequestNotSent: true },
 				);
 				return { result };
 			},

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -44,6 +44,38 @@ interface ResolvedIntegration {
 	userDeclared?: boolean;
 }
 
+const DEFAULT_LOCAL_MCP_SERVERS = {
+	jcodemunch: {
+		label: "jCodeMunch",
+		command: "jcodemunch-mcp",
+		enabledTools: [
+			"search_symbols",
+			"get_file_outline",
+			"get_symbol_source",
+			"get_context_bundle",
+			"get_ranked_context",
+			"find_references",
+			"find_importers",
+			"get_blast_radius",
+			"get_changed_symbols",
+			"plan_turn",
+			"assemble_task_context",
+		],
+	},
+	"context-mode": {
+		label: "Context Mode",
+		command: "context-mode",
+		enabledTools: [
+			"ctx_execute",
+			"ctx_execute_file",
+			"ctx_index",
+			"ctx_search",
+			"ctx_fetch_and_index",
+			"ctx_batch_execute",
+		],
+	},
+} as const;
+
 const liveMcpManagers = new Set<McpManager>();
 let mcpExitCleanupInstalled = false;
 
@@ -118,6 +150,21 @@ export class McpManager {
 				type: "http",
 				url: entry.url,
 				usesOAuth: entry.oauth?.kind === "oauth",
+			});
+		}
+		// These bundled Python skills are available without a settings entry. The
+		// command is only passed to StdioMcpClient here; construction does not spawn.
+		for (const [server, { label, command, enabledTools }] of Object.entries(DEFAULT_LOCAL_MCP_SERVERS)) {
+			integrations.set(server, {
+				server,
+				label,
+				type: "stdio",
+				command,
+				args: [],
+				cwd: this.cwd,
+				env: {},
+				enabledTools: [...enabledTools],
+				usesOAuth: false,
 			});
 		}
 		for (const [server, config] of Object.entries(this.getUserServers() ?? {})) {

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -1,6 +1,7 @@
 // Host side of MCP integrations. The protocol itself runs Python-side in the kernel; the host
-// only registers OAuth providers, gates integration skills by auth, and serves mcp.* host-requests.
+// registers OAuth providers, gates integration skills by auth, owns stdio sidecars, and serves mcp.* host-requests.
 
+import { resolve } from "node:path";
 import {
 	BUILTIN_MCP_CATALOG,
 	createMcpOAuthProvider,
@@ -10,9 +11,12 @@ import {
 import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import type { AuthStorage } from "../auth-storage.js";
 import type { McpServerConfig } from "../settings-manager.js";
+import { isRetryableStdioMcpError, StdioMcpClient } from "./stdio-mcp-client.js";
 
 export interface McpManagerOptions {
 	authStorage: AuthStorage;
+	/** Effective workspace cwd used to resolve relative stdio server cwd values. */
+	cwd?: string;
 	/** Reads the current Settings.mcpServers (name → config). Re-read on refresh(). */
 	getUserServers?: () => Record<string, McpServerConfig> | undefined;
 	/** Start an interactive host-side login for a server. Provided by the UI mode. */
@@ -23,36 +27,82 @@ export interface McpManagerOptions {
 interface ResolvedIntegration {
 	server: string;
 	label: string;
-	url: string;
+	type: "http" | "stdio";
+	url?: string;
+	command?: string;
+	args?: string[];
+	cwd?: string;
+	env?: Record<string, string>;
 	usesOAuth: boolean;
 	bearerTokenEnvVar?: string;
 	enabled?: boolean;
 	/** Extra static HTTP headers from the user config. */
 	headers?: Record<string, string>;
+	enabledTools?: string[];
+	disabledTools?: string[];
 	/** True when this came from Settings.mcpServers (may override a catalog name). */
 	userDeclared?: boolean;
 }
 
+const liveMcpManagers = new Set<McpManager>();
+let mcpExitCleanupInstalled = false;
+
+function registerMcpExitCleanup(manager: McpManager): void {
+	liveMcpManagers.add(manager);
+	if (mcpExitCleanupInstalled) return;
+	mcpExitCleanupInstalled = true;
+	process.once("exit", () => {
+		for (const liveManager of liveMcpManagers) liveManager.disposeSync();
+	});
+}
+
 export class McpManager {
 	private readonly authStorage: AuthStorage;
+	private readonly cwd: string;
 	private readonly getUserServers: () => Record<string, McpServerConfig> | undefined;
 	private readonly beginLogin?: (server: string) => Promise<void>;
 	private integrations = new Map<string, ResolvedIntegration>();
+	private readonly stdioClients = new Map<string, StdioMcpClient>();
+	private readonly stdioOperationQueues = new Map<string, Promise<void>>();
+	private disposed = false;
 	/** Provider ids we registered for user servers, so refresh can drop removed ones. */
 	private registeredUserProviderIds = new Set<string>();
 
 	constructor(options: McpManagerOptions) {
 		this.authStorage = options.authStorage;
+		this.cwd = options.cwd ?? process.cwd();
 		this.getUserServers = options.getUserServers ?? (() => undefined);
 		this.beginLogin = options.beginLogin;
 		this.resolveIntegrations();
 		this.registerProviders();
+		registerMcpExitCleanup(this);
 	}
 
 	/** Re-read settings and re-register providers; call after a session reload. */
 	refresh(): void {
+		this.disposed = false;
+		// Reload is a lifecycle boundary: never leave an old command/environment
+		// running after settings are re-read. New processes remain lazy.
+		this.disposeStdioClientsSync();
 		this.resolveIntegrations();
 		this.registerProviders();
+	}
+
+	/** Stop every sidecar owned by this workspace/session. */
+	async dispose(): Promise<void> {
+		this.disposed = true;
+		liveMcpManagers.delete(this);
+		const clients = [...this.stdioClients.values()];
+		this.stdioClients.clear();
+		this.stdioOperationQueues.clear();
+		await Promise.allSettled(clients.map((client) => client.dispose()));
+	}
+
+	/** Synchronous best-effort cleanup for process-exit/session replacement paths. */
+	disposeSync(): void {
+		this.disposed = true;
+		liveMcpManagers.delete(this);
+		this.disposeStdioClientsSync();
 	}
 
 	private providerId(server: string): string {
@@ -65,24 +115,50 @@ export class McpManager {
 			integrations.set(entry.server, {
 				server: entry.server,
 				label: entry.label,
+				type: "http",
 				url: entry.url,
 				usesOAuth: entry.oauth?.kind === "oauth",
 			});
 		}
 		for (const [server, config] of Object.entries(this.getUserServers() ?? {})) {
-			if (config.type !== "http") continue; // stdio servers self-manage in Python
+			if (config.type === "http") {
+				integrations.set(server, {
+					server,
+					label: server,
+					type: "http",
+					url: config.url,
+					usesOAuth: config.oauth === true,
+					bearerTokenEnvVar: config.bearerTokenEnvVar,
+					enabled: config.enabled,
+					headers: config.headers,
+					enabledTools: config.enabledTools,
+					disabledTools: config.disabledTools,
+					userDeclared: true,
+				});
+				continue;
+			}
 			integrations.set(server, {
 				server,
 				label: server,
-				url: config.url,
-				usesOAuth: config.oauth === true,
-				bearerTokenEnvVar: config.bearerTokenEnvVar,
+				type: "stdio",
+				command: config.command,
+				args: [...(config.args ?? [])],
+				cwd: config.cwd ? resolve(this.cwd, config.cwd) : this.cwd,
+				env: { ...config.env },
+				usesOAuth: false,
 				enabled: config.enabled,
-				headers: config.headers,
+				enabledTools: config.enabledTools,
+				disabledTools: config.disabledTools,
 				userDeclared: true,
 			});
 		}
 		this.integrations = integrations;
+	}
+
+	private disposeStdioClientsSync(): void {
+		for (const client of this.stdioClients.values()) client.disposeSync();
+		this.stdioClients.clear();
+		this.stdioOperationQueues.clear();
 	}
 
 	private registerProviders(): void {
@@ -100,7 +176,7 @@ export class McpManager {
 		for (const integration of this.integrations.values()) {
 			if (!integration.userDeclared) continue;
 			const id = this.providerId(integration.server);
-			if (integration.usesOAuth) {
+			if (integration.usesOAuth && integration.type === "http" && integration.url) {
 				// Register pointing at the user's URL (overrides a catalog default too).
 				current.add(id);
 				registerOAuthProvider(
@@ -126,6 +202,8 @@ export class McpManager {
 	/** True when valid credentials exist for the integration (drives enablement). */
 	private isAuthed(integration: ResolvedIntegration): boolean {
 		if (integration.enabled === false) return false;
+		// Local stdio servers are enabled by configuration; they do not use auth.json.
+		if (integration.type === "stdio") return true;
 		if (integration.bearerTokenEnvVar && process.env[integration.bearerTokenEnvVar]?.trim()) {
 			return true;
 		}
@@ -152,12 +230,84 @@ export class McpManager {
 		return overrides;
 	}
 
+	private getStdioIntegration(server: string): ResolvedIntegration {
+		if (this.disposed) throw new Error("MCP manager is disposed");
+		const integration = this.integrations.get(server);
+		if (!integration || integration.type !== "stdio") {
+			throw new Error(`MCP server ${server} is not configured as stdio`);
+		}
+		if (integration.enabled === false) {
+			throw new Error(`MCP server ${server} is disabled`);
+		}
+		if (!integration.command || !integration.cwd) {
+			throw new Error(`MCP server ${server} has an invalid stdio configuration`);
+		}
+		return integration;
+	}
+
+	private getStdioClient(server: string): StdioMcpClient {
+		const integration = this.getStdioIntegration(server);
+		const existing = this.stdioClients.get(server);
+		if (existing) return existing;
+		const client = new StdioMcpClient({
+			server,
+			command: integration.command!,
+			args: integration.args ?? [],
+			cwd: integration.cwd!,
+			// Keep the configured env private to this child. It is never returned in a
+			// host response or included in a diagnostic.
+			env: { ...process.env, ...(integration.env ?? {}) },
+		});
+		this.stdioClients.set(server, client);
+		return client;
+	}
+
+	private isToolAllowed(integration: ResolvedIntegration, tool: string): boolean {
+		if (integration.enabledTools && !integration.enabledTools.includes(tool)) return false;
+		return !integration.disabledTools?.includes(tool);
+	}
+
+	private async withStdioClient<T>(
+		server: string,
+		operation: (client: StdioMcpClient) => Promise<T>,
+		options: { retryTransport?: boolean } = {},
+	): Promise<T> {
+		const previous = this.stdioOperationQueues.get(server) ?? Promise.resolve();
+		const queued = previous.then(async () => {
+			const client = this.getStdioClient(server);
+			try {
+				return await operation(client);
+			} catch (error) {
+				// A failed transport gets one bounded restart. Protocol/tool errors are
+				// returned directly and are not retried.
+				if (options.retryTransport === false || !isRetryableStdioMcpError(error)) throw error;
+				await new Promise<void>((resolve) => {
+					const timer = globalThis.setTimeout(resolve, 100);
+					timer.unref?.();
+				});
+				await client.restart();
+				return operation(client);
+			}
+		});
+		const settled = queued.then(
+			() => undefined,
+			() => undefined,
+		);
+		this.stdioOperationQueues.set(server, settled);
+		try {
+			return await queued;
+		} finally {
+			if (this.stdioOperationQueues.get(server) === settled) this.stdioOperationQueues.delete(server);
+		}
+	}
+
 	/** Host-request handlers exposed to the kernel. */
 	hostHandlers(): Record<string, (payload: Record<string, unknown>) => Promise<Record<string, unknown>>> {
 		const handlers: Record<string, (payload: Record<string, unknown>) => Promise<Record<string, unknown>>> = {
 			"mcp.refresh": async (payload) => {
 				const server = String(payload.server ?? "");
 				if (!server) throw new Error("mcp.refresh requires a server");
+				if (this.integrations.get(server)?.type === "stdio") return {};
 				// getApiKey refreshes + rewrites auth.json under lock; Python re-reads.
 				// Surface failure (throw) instead of a false success so the kernel can
 				// report a refresh error rather than a misleading "not enabled".
@@ -170,13 +320,66 @@ export class McpManager {
 			"mcp.config": async (payload) => {
 				const server = String(payload.server ?? "");
 				if (!server) throw new Error("mcp.config requires a server");
+				if (this.disposed) return { enabled: false };
 				const integration = this.integrations.get(server);
 				if (!integration) return {};
+				// `enabled: false` is an explicit user boundary, not an authentication
+				// hint. Return no endpoint so Python integrations cannot fall back to an
+				// environment URL or establish an anonymous connection.
+				if (integration.enabled === false) return { enabled: false };
+				if (integration.type === "stdio") {
+					// The command, cwd, and env stay host-side. Python receives only a
+					// transport marker and uses the durable host bridge below.
+					return { type: "stdio", bridge: "host" };
+				}
 				const config: Record<string, unknown> = { url: integration.url };
 				if (integration.headers && Object.keys(integration.headers).length > 0) {
 					config.headers = integration.headers;
 				}
+				if (integration.enabledTools) config.enabledTools = integration.enabledTools;
+				if (integration.disabledTools) config.disabledTools = integration.disabledTools;
 				return config;
+			},
+			"mcp.list_tools": async (payload) => {
+				const server = String(payload.server ?? "");
+				if (!server) throw new Error("mcp.list_tools requires a server");
+				const integration = this.getStdioIntegration(server);
+				const tools = await this.withStdioClient(server, (client) => client.listTools());
+				return { tools: tools.filter((tool) => this.isToolAllowed(integration, tool.name)) };
+			},
+			"mcp.call_tool": async (payload) => {
+				const server = String(payload.server ?? "");
+				const tool = String(payload.tool ?? "");
+				if (!server) throw new Error("mcp.call_tool requires a server");
+				if (!tool) throw new Error("mcp.call_tool requires a tool");
+				const integration = this.getStdioIntegration(server);
+				if (!this.isToolAllowed(integration, tool)) {
+					throw new Error(`MCP tool ${server}/${tool} is not allowed by settings`);
+				}
+				const arguments_ = payload.arguments;
+				if (
+					arguments_ !== undefined &&
+					(typeof arguments_ !== "object" || arguments_ === null || Array.isArray(arguments_))
+				) {
+					throw new Error("mcp.call_tool arguments must be an object");
+				}
+				const result = await this.withStdioClient(server, (client) =>
+					client.callTool(tool, (arguments_ ?? {}) as Record<string, unknown>),
+				);
+				return { result };
+			},
+			"mcp.health": async (payload) => {
+				const server = String(payload.server ?? "");
+				if (!server) throw new Error("mcp.health requires a server");
+				await this.withStdioClient(server, (client) => client.health());
+				return { healthy: true };
+			},
+			"mcp.restart": async (payload) => {
+				const server = String(payload.server ?? "");
+				if (!server) throw new Error("mcp.restart requires a server");
+				this.getStdioIntegration(server);
+				await this.withStdioClient(server, (client) => client.restart(), { retryTransport: false });
+				return { healthy: true };
 			},
 		};
 		// Only expose begin_login when an interactive login is actually wired, so the

--- a/packages/coding-agent/src/core/mcp/stdio-mcp-client.ts
+++ b/packages/coding-agent/src/core/mcp/stdio-mcp-client.ts
@@ -1,9 +1,10 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { setTimeout as sleep } from "node:timers/promises";
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
 const DEFAULT_CALL_TIMEOUT_MS = 30_000;
 const STOP_TIMEOUT_MS = 1_000;
+
+export const SUPPORTED_PROTOCOL_VERSIONS = ["2024-11-05", "2025-03-26", "2025-06-18"] as const;
 
 export interface StdioMcpClientOptions {
 	server: string;
@@ -24,10 +25,21 @@ export interface StdioMcpTool {
 
 export class StdioMcpTransportError extends Error {
 	readonly retryable = true;
+	readonly requestNotSent: boolean = false;
 
 	constructor(message: string) {
 		super(message);
 		this.name = "StdioMcpTransportError";
+	}
+}
+
+/** A transport failure that is known to have happened before the request was sent. */
+export class StdioMcpRequestNotSentError extends StdioMcpTransportError {
+	readonly requestNotSent = true;
+
+	constructor(message: string) {
+		super(message);
+		this.name = "StdioMcpRequestNotSentError";
 	}
 }
 
@@ -42,6 +54,10 @@ export class StdioMcpProtocolError extends Error {
 
 export function isRetryableStdioMcpError(error: unknown): boolean {
 	return error instanceof StdioMcpTransportError;
+}
+
+export function isStdioMcpRequestNotSentError(error: unknown): boolean {
+	return error instanceof StdioMcpRequestNotSentError;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -59,7 +75,11 @@ export class StdioMcpClient {
 	private child?: ChildProcessWithoutNullStreams;
 	private startPromise?: Promise<void>;
 	private initialized = false;
+	private toolsSupported = false;
 	private disposed = false;
+	private tainted = false;
+	private taintError?: StdioMcpTransportError;
+	private stopping?: Promise<void>;
 	private nextRequestId = 1;
 	private inputBuffer = "";
 	private readonly pending = new Map<number, PendingRequest>();
@@ -68,6 +88,7 @@ export class StdioMcpClient {
 
 	async listTools(): Promise<StdioMcpTool[]> {
 		await this.start();
+		this.ensureToolsSupported();
 		const result = await this.request("tools/list", {}, this.callTimeoutMs);
 		if (!isRecord(result) || !Array.isArray(result.tools)) {
 			throw new StdioMcpProtocolError(`MCP server ${this.options.server} returned invalid tools`);
@@ -77,6 +98,7 @@ export class StdioMcpClient {
 
 	async callTool(tool: string, arguments_: Record<string, unknown>): Promise<unknown> {
 		await this.start();
+		this.ensureToolsSupported();
 		return this.request("tools/call", { name: tool, arguments: arguments_ }, this.callTimeoutMs);
 	}
 
@@ -89,8 +111,21 @@ export class StdioMcpClient {
 		if (this.disposed) {
 			throw new StdioMcpTransportError(`MCP server ${this.options.server} is disposed`);
 		}
-		await this.stop();
-		await this.start();
+		try {
+			if (this.tainted) {
+				await this.waitForTaintCleanup(true);
+			} else {
+				this.tainted = true;
+				await this.stop();
+			}
+			this.tainted = false;
+			this.taintError = undefined;
+			await this.start();
+		} catch (error) {
+			this.tainted = true;
+			this.taintError = this.toTransportError(error);
+			throw error;
+		}
 	}
 
 	async dispose(): Promise<void> {
@@ -119,6 +154,7 @@ export class StdioMcpClient {
 		if (this.disposed) {
 			throw new StdioMcpTransportError(`MCP server ${this.options.server} is disposed`);
 		}
+		if (this.tainted) await this.waitForTaintCleanup(false);
 		if (this.initialized && this.child) return;
 		if (!this.startPromise) {
 			const start = this.startInternal();
@@ -146,6 +182,7 @@ export class StdioMcpClient {
 		});
 		this.child = child;
 		this.initialized = false;
+		this.toolsSupported = false;
 		this.inputBuffer = "";
 		child.stdout.setEncoding("utf8");
 		child.stderr.setEncoding("utf8");
@@ -153,6 +190,7 @@ export class StdioMcpClient {
 		// Keep stderr private. MCP servers often print credentials or request payloads.
 		child.stderr.on("data", () => undefined);
 		child.on("error", (error) => this.handleChildFailure(child, error));
+		child.stdin.on("error", (error) => this.handleChildFailure(child, error));
 		child.on("exit", () => this.handleChildFailure(child, new Error("process exited")));
 
 		try {
@@ -168,6 +206,22 @@ export class StdioMcpClient {
 			if (!isRecord(initializeResult) || typeof initializeResult.protocolVersion !== "string") {
 				throw new StdioMcpProtocolError(`MCP server ${this.options.server} returned an invalid initialize result`);
 			}
+			if (
+				!SUPPORTED_PROTOCOL_VERSIONS.includes(
+					initializeResult.protocolVersion as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number],
+				)
+			) {
+				throw new StdioMcpProtocolError(
+					`MCP server ${this.options.server} negotiated unsupported protocol version ${initializeResult.protocolVersion}; supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")}`,
+				);
+			}
+			if (!isRecord(initializeResult.serverInfo)) {
+				throw new StdioMcpProtocolError(`MCP server ${this.options.server} returned invalid serverInfo`);
+			}
+			if (!isRecord(initializeResult.capabilities)) {
+				throw new StdioMcpProtocolError(`MCP server ${this.options.server} returned invalid capabilities`);
+			}
+			this.toolsSupported = isRecord(initializeResult.capabilities.tools);
 			this.sendNotification("notifications/initialized", {});
 			this.initialized = true;
 			if (this.disposed)
@@ -182,21 +236,30 @@ export class StdioMcpClient {
 	private request(method: string, params: Record<string, unknown>, timeoutMs: number): Promise<unknown> {
 		const child = this.child;
 		if (!child || child.stdin.destroyed) {
-			return Promise.reject(new StdioMcpTransportError(`MCP server ${this.options.server} is not running`));
+			return Promise.reject(new StdioMcpRequestNotSentError(`MCP server ${this.options.server} is not running`));
 		}
 		const id = this.nextRequestId++;
 		return new Promise<unknown>((resolve, reject) => {
 			const timer = globalThis.setTimeout(() => {
 				this.pending.delete(id);
+				this.taintAndStop();
 				reject(new StdioMcpTransportError(`MCP server ${this.options.server} timed out during ${method}`));
 			}, timeoutMs);
 			this.pending.set(id, { resolve, reject, timer });
-			try {
-				child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
-			} catch {
+			const request = `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`;
+			const rejectRequestNotSent = (error?: Error): void => {
+				if (!this.pending.has(id)) return;
 				globalThis.clearTimeout(timer);
 				this.pending.delete(id);
-				reject(new StdioMcpTransportError(`MCP server ${this.options.server} request failed`));
+				const detail = error?.message ? `: ${error.message}` : "";
+				reject(new StdioMcpRequestNotSentError(`MCP server ${this.options.server} request failed${detail}`));
+			};
+			try {
+				child.stdin.write(request, "utf8", (error?: Error | null) => {
+					if (error) rejectRequestNotSent(error);
+				});
+			} catch (error) {
+				rejectRequestNotSent(error instanceof Error ? error : undefined);
 			}
 		});
 	}
@@ -205,9 +268,11 @@ export class StdioMcpClient {
 		const child = this.child;
 		if (!child || child.stdin.destroyed) return;
 		try {
-			child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
-		} catch {
-			// The next request will surface the transport failure.
+			child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`, (error?: Error | null) => {
+				if (error) this.handleChildFailure(child, error);
+			});
+		} catch (error) {
+			this.handleChildFailure(child, error instanceof Error ? error : new Error("notification write failed"));
 		}
 	}
 
@@ -255,9 +320,24 @@ export class StdioMcpClient {
 
 	private handleChildFailure(child: ChildProcessWithoutNullStreams, _error: Error): void {
 		if (this.child !== child) return;
-		this.child = undefined;
-		this.initialized = false;
-		this.failPending(new StdioMcpTransportError(`MCP server ${this.options.server} stopped`));
+		if (child.exitCode !== null || child.signalCode !== null) {
+			this.child = undefined;
+			this.initialized = false;
+			this.toolsSupported = false;
+			this.tainted = true;
+			this.taintError = undefined;
+			this.failPending(new StdioMcpTransportError(`MCP server ${this.options.server} stopped`));
+			return;
+		}
+		this.taintAndStop();
+	}
+
+	private ensureToolsSupported(): void {
+		if (!this.toolsSupported) {
+			throw new StdioMcpProtocolError(
+				`MCP server ${this.options.server} did not negotiate tool support (initialize capabilities.tools is missing)`,
+			);
+		}
 	}
 
 	private failPending(error: Error): void {
@@ -268,24 +348,144 @@ export class StdioMcpClient {
 		}
 	}
 
-	private async stop(): Promise<void> {
-		const child = this.child;
-		this.child = undefined;
-		this.initialized = false;
-		this.failPending(new StdioMcpTransportError(`MCP server ${this.options.server} stopped`));
-		if (!child || child.exitCode !== null) return;
-		this.killProcessTree(child, "SIGTERM");
-		await Promise.race([new Promise<void>((resolve) => child.once("exit", () => resolve())), sleep(STOP_TIMEOUT_MS)]);
-		if (child.exitCode === null) this.killProcessTree(child, "SIGKILL");
+	private toTransportError(error: unknown): StdioMcpTransportError {
+		if (error instanceof StdioMcpTransportError) return error;
+		const detail = error instanceof Error && error.message ? `: ${error.message}` : "";
+		return new StdioMcpTransportError(`MCP server ${this.options.server} cleanup failed${detail}`);
 	}
 
+	private taintAndStop(): void {
+		this.tainted = true;
+		const stopping = this.stop();
+		void stopping.then(
+			() => undefined,
+			(error) => {
+				this.taintError = this.toTransportError(error);
+			},
+		);
+	}
+
+	private async waitForTaintCleanup(retryOnFailure: boolean): Promise<void> {
+		const stopping = this.stopping;
+		if (stopping) {
+			try {
+				await stopping;
+			} catch (error) {
+				if (!retryOnFailure) throw error;
+				if (this.stopping === stopping) this.stopping = undefined;
+				this.taintError = undefined;
+				await this.stop();
+			}
+			if (this.stopping === stopping) this.stopping = undefined;
+		}
+		if (this.taintError) {
+			if (!retryOnFailure) throw this.taintError;
+			this.taintError = undefined;
+			await this.stop();
+		}
+		this.tainted = false;
+		this.taintError = undefined;
+	}
+
+	private stop(): Promise<void> {
+		if (this.stopping) return this.stopping;
+		const stopping = Promise.resolve().then(() => this.stopInternal());
+		this.stopping = stopping;
+		stopping.then(
+			() => {
+				if (this.stopping === stopping) this.stopping = undefined;
+			},
+			() => {
+				if (this.stopping === stopping) this.stopping = undefined;
+			},
+		);
+		return stopping;
+	}
+
+	private async stopInternal(): Promise<void> {
+		const child = this.child;
+		this.initialized = false;
+		this.toolsSupported = false;
+		this.failPending(new StdioMcpTransportError(`MCP server ${this.options.server} stopped`));
+		if (!child || child.exitCode !== null || child.signalCode !== null) {
+			if (this.child === child) this.child = undefined;
+			return;
+		}
+
+		// MCP stdio shutdown starts with EOF on stdin. Signals are escalation only.
+		try {
+			if (!child.stdin.destroyed) child.stdin.end();
+		} catch {
+			// The child may have exited between the state check and end().
+		}
+		if (await this.waitForExit(child)) {
+			if (this.child === child) this.child = undefined;
+			return;
+		}
+		if (child.exitCode !== null || child.signalCode !== null) {
+			if (this.child === child) this.child = undefined;
+			return;
+		}
+
+		this.killProcessTree(child, "SIGTERM");
+		if (await this.waitForExit(child)) {
+			if (this.child === child) this.child = undefined;
+			return;
+		}
+		if (child.exitCode !== null || child.signalCode !== null) {
+			if (this.child === child) this.child = undefined;
+			return;
+		}
+
+		this.killProcessTree(child, "SIGKILL");
+		// Do not return until the child has actually emitted exit. This gives callers
+		// a cleanup guarantee instead of merely confirming that a signal was sent.
+		if (await this.waitForExit(child)) {
+			if (this.child === child) this.child = undefined;
+			return;
+		}
+		if (child.exitCode !== null || child.signalCode !== null) {
+			if (this.child === child) this.child = undefined;
+			return;
+		}
+
+		// Keep the live child reference so a later dispose() can retry cleanup. Its
+		// exit handler will clear the reference if the process exits asynchronously.
+		if (this.child === undefined) this.child = child;
+		throw new StdioMcpTransportError(`MCP server ${this.options.server} did not exit after SIGKILL`);
+	}
+
+	/** Synchronous SIGKILL-only cleanup for process-exit hooks; async waits are impossible. */
 	private stopSync(): void {
 		const child = this.child;
 		this.child = undefined;
 		this.initialized = false;
+		this.toolsSupported = false;
 		this.failPending(new StdioMcpTransportError(`MCP server ${this.options.server} stopped`));
 		if (!child || child.exitCode !== null) return;
 		this.killProcessTree(child, "SIGKILL");
+	}
+
+	private waitForExit(child: ChildProcessWithoutNullStreams): Promise<boolean> {
+		if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+		return new Promise<boolean>((resolve) => {
+			let settled = false;
+			let timer: ReturnType<typeof globalThis.setTimeout>;
+			const onExit = (): void => {
+				if (settled) return;
+				settled = true;
+				globalThis.clearTimeout(timer);
+				resolve(true);
+			};
+			timer = globalThis.setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				child.off("exit", onExit);
+				resolve(false);
+			}, STOP_TIMEOUT_MS);
+			timer.unref?.();
+			child.once("exit", onExit);
+		});
 	}
 
 	private killProcessTree(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {

--- a/packages/coding-agent/src/core/mcp/stdio-mcp-client.ts
+++ b/packages/coding-agent/src/core/mcp/stdio-mcp-client.ts
@@ -1,0 +1,306 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
+const DEFAULT_CALL_TIMEOUT_MS = 30_000;
+const STOP_TIMEOUT_MS = 1_000;
+
+export interface StdioMcpClientOptions {
+	server: string;
+	command: string;
+	args: string[];
+	cwd: string;
+	env: Record<string, string | undefined>;
+	startupTimeoutMs?: number;
+	callTimeoutMs?: number;
+}
+
+export interface StdioMcpTool {
+	name: string;
+	description?: string;
+	inputSchema?: unknown;
+	[key: string]: unknown;
+}
+
+export class StdioMcpTransportError extends Error {
+	readonly retryable = true;
+
+	constructor(message: string) {
+		super(message);
+		this.name = "StdioMcpTransportError";
+	}
+}
+
+export class StdioMcpProtocolError extends Error {
+	readonly retryable = false;
+
+	constructor(message: string) {
+		super(message);
+		this.name = "StdioMcpProtocolError";
+	}
+}
+
+export function isRetryableStdioMcpError(error: unknown): boolean {
+	return error instanceof StdioMcpTransportError;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface PendingRequest {
+	resolve: (value: unknown) => void;
+	reject: (error: Error) => void;
+	timer: ReturnType<typeof globalThis.setTimeout>;
+}
+
+/** A bounded, long-lived MCP JSON-RPC client for one configured stdio server. */
+export class StdioMcpClient {
+	private child?: ChildProcessWithoutNullStreams;
+	private startPromise?: Promise<void>;
+	private initialized = false;
+	private disposed = false;
+	private nextRequestId = 1;
+	private inputBuffer = "";
+	private readonly pending = new Map<number, PendingRequest>();
+
+	constructor(private readonly options: StdioMcpClientOptions) {}
+
+	async listTools(): Promise<StdioMcpTool[]> {
+		await this.start();
+		const result = await this.request("tools/list", {}, this.callTimeoutMs);
+		if (!isRecord(result) || !Array.isArray(result.tools)) {
+			throw new StdioMcpProtocolError(`MCP server ${this.options.server} returned invalid tools`);
+		}
+		return result.tools.filter((tool): tool is StdioMcpTool => isRecord(tool) && typeof tool.name === "string");
+	}
+
+	async callTool(tool: string, arguments_: Record<string, unknown>): Promise<unknown> {
+		await this.start();
+		return this.request("tools/call", { name: tool, arguments: arguments_ }, this.callTimeoutMs);
+	}
+
+	async health(): Promise<void> {
+		await this.start();
+		await this.request("ping", {}, this.callTimeoutMs);
+	}
+
+	async restart(): Promise<void> {
+		if (this.disposed) {
+			throw new StdioMcpTransportError(`MCP server ${this.options.server} is disposed`);
+		}
+		await this.stop();
+		await this.start();
+	}
+
+	async dispose(): Promise<void> {
+		this.disposed = true;
+		const starting = this.startPromise;
+		await this.stop();
+		if (starting) {
+			await starting.catch(() => undefined);
+		}
+	}
+
+	disposeSync(): void {
+		this.disposed = true;
+		this.stopSync();
+	}
+
+	private get startupTimeoutMs(): number {
+		return this.options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
+	}
+
+	private get callTimeoutMs(): number {
+		return this.options.callTimeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
+	}
+
+	private async start(): Promise<void> {
+		if (this.disposed) {
+			throw new StdioMcpTransportError(`MCP server ${this.options.server} is disposed`);
+		}
+		if (this.initialized && this.child) return;
+		if (!this.startPromise) {
+			const start = this.startInternal();
+			this.startPromise = start;
+			start.then(
+				() => {
+					if (this.startPromise === start) this.startPromise = undefined;
+				},
+				() => {
+					if (this.startPromise === start) this.startPromise = undefined;
+				},
+			);
+		}
+		return this.startPromise;
+	}
+
+	private async startInternal(): Promise<void> {
+		const child = spawn(this.options.command, this.options.args, {
+			cwd: this.options.cwd,
+			env: this.options.env,
+			stdio: ["pipe", "pipe", "pipe"],
+			// Put the sidecar in its own group where supported so shutdown also
+			// reaps descendants a server may have spawned.
+			detached: process.platform !== "win32",
+		});
+		this.child = child;
+		this.initialized = false;
+		this.inputBuffer = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => this.handleStdout(chunk));
+		// Keep stderr private. MCP servers often print credentials or request payloads.
+		child.stderr.on("data", () => undefined);
+		child.on("error", (error) => this.handleChildFailure(child, error));
+		child.on("exit", () => this.handleChildFailure(child, new Error("process exited")));
+
+		try {
+			const initializeResult = await this.request(
+				"initialize",
+				{
+					protocolVersion: "2024-11-05",
+					capabilities: {},
+					clientInfo: { name: "prime-agent", version: "0.7.1" },
+				},
+				this.startupTimeoutMs,
+			);
+			if (!isRecord(initializeResult) || typeof initializeResult.protocolVersion !== "string") {
+				throw new StdioMcpProtocolError(`MCP server ${this.options.server} returned an invalid initialize result`);
+			}
+			this.sendNotification("notifications/initialized", {});
+			this.initialized = true;
+			if (this.disposed)
+				throw new StdioMcpTransportError(`MCP server ${this.options.server} was disposed during startup`);
+		} catch (error) {
+			await this.stop();
+			if (error instanceof StdioMcpTransportError || error instanceof StdioMcpProtocolError) throw error;
+			throw new StdioMcpTransportError(`MCP server ${this.options.server} failed to start`);
+		}
+	}
+
+	private request(method: string, params: Record<string, unknown>, timeoutMs: number): Promise<unknown> {
+		const child = this.child;
+		if (!child || child.stdin.destroyed) {
+			return Promise.reject(new StdioMcpTransportError(`MCP server ${this.options.server} is not running`));
+		}
+		const id = this.nextRequestId++;
+		return new Promise<unknown>((resolve, reject) => {
+			const timer = globalThis.setTimeout(() => {
+				this.pending.delete(id);
+				reject(new StdioMcpTransportError(`MCP server ${this.options.server} timed out during ${method}`));
+			}, timeoutMs);
+			this.pending.set(id, { resolve, reject, timer });
+			try {
+				child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+			} catch {
+				globalThis.clearTimeout(timer);
+				this.pending.delete(id);
+				reject(new StdioMcpTransportError(`MCP server ${this.options.server} request failed`));
+			}
+		});
+	}
+
+	private sendNotification(method: string, params: Record<string, unknown>): void {
+		const child = this.child;
+		if (!child || child.stdin.destroyed) return;
+		try {
+			child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+		} catch {
+			// The next request will surface the transport failure.
+		}
+	}
+
+	private handleStdout(chunk: string): void {
+		this.inputBuffer += chunk;
+		while (true) {
+			const newline = this.inputBuffer.indexOf("\n");
+			if (newline < 0) return;
+			const line = this.inputBuffer.slice(0, newline).trim();
+			this.inputBuffer = this.inputBuffer.slice(newline + 1);
+			if (!line) continue;
+			let message: unknown;
+			try {
+				message = JSON.parse(line);
+			} catch {
+				this.failPending(new StdioMcpProtocolError(`MCP server ${this.options.server} returned invalid JSON`));
+				continue;
+			}
+			if (!isRecord(message)) continue;
+			const id = message.id;
+			if (typeof id !== "number") continue;
+			const pending = this.pending.get(id);
+			if (!pending) continue;
+			this.pending.delete(id);
+			globalThis.clearTimeout(pending.timer);
+			const hasResult = Object.hasOwn(message, "result");
+			const hasError = Object.hasOwn(message, "error");
+			if (message.jsonrpc !== "2.0" || hasResult === hasError) {
+				pending.reject(new StdioMcpProtocolError(`MCP server ${this.options.server} returned an invalid response`));
+			} else if (hasError) {
+				if (!isRecord(message.error)) {
+					pending.reject(new StdioMcpProtocolError(`MCP server ${this.options.server} returned an invalid error`));
+				} else {
+					pending.reject(
+						new StdioMcpProtocolError(
+							`MCP server ${this.options.server} rejected ${String(message.error.code ?? "request")}`,
+						),
+					);
+				}
+			} else {
+				pending.resolve(message.result);
+			}
+		}
+	}
+
+	private handleChildFailure(child: ChildProcessWithoutNullStreams, _error: Error): void {
+		if (this.child !== child) return;
+		this.child = undefined;
+		this.initialized = false;
+		this.failPending(new StdioMcpTransportError(`MCP server ${this.options.server} stopped`));
+	}
+
+	private failPending(error: Error): void {
+		for (const [id, pending] of this.pending) {
+			globalThis.clearTimeout(pending.timer);
+			pending.reject(error);
+			this.pending.delete(id);
+		}
+	}
+
+	private async stop(): Promise<void> {
+		const child = this.child;
+		this.child = undefined;
+		this.initialized = false;
+		this.failPending(new StdioMcpTransportError(`MCP server ${this.options.server} stopped`));
+		if (!child || child.exitCode !== null) return;
+		this.killProcessTree(child, "SIGTERM");
+		await Promise.race([new Promise<void>((resolve) => child.once("exit", () => resolve())), sleep(STOP_TIMEOUT_MS)]);
+		if (child.exitCode === null) this.killProcessTree(child, "SIGKILL");
+	}
+
+	private stopSync(): void {
+		const child = this.child;
+		this.child = undefined;
+		this.initialized = false;
+		this.failPending(new StdioMcpTransportError(`MCP server ${this.options.server} stopped`));
+		if (!child || child.exitCode !== null) return;
+		this.killProcessTree(child, "SIGKILL");
+	}
+
+	private killProcessTree(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
+		try {
+			if (process.platform !== "win32" && child.pid) {
+				process.kill(-child.pid, signal);
+			} else {
+				child.kill(signal);
+			}
+		} catch {
+			try {
+				child.kill(signal);
+			} catch {
+				// Already exited.
+			}
+		}
+	}
+}

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -169,7 +169,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// Ensure MCP providers are registered and built-in MCP skills are gated by
 	// auth even on the bare SDK path (not just the CLI's createAgentSessionServices).
 	const mcpManager =
-		options.mcpManager ?? new McpManager({ authStorage, getUserServers: () => settingsManager.getMcpServers() });
+		options.mcpManager ?? new McpManager({ authStorage, cwd, getUserServers: () => settingsManager.getMcpServers() });
 	modelRegistry.setOnOAuthProvidersReset(() => mcpManager.registerUserProviders());
 
 	if (!resourceLoader) {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -90,10 +90,12 @@ export type PackageSource =
 	  };
 
 /**
- * Remote/local MCP server an integration connects to. Built-in integrations
- * (Linear/Notion) are defined in the ai/mcp catalog; this is for user-declared
- * servers. HTTP integrations read creds from auth.json (`mcp:<name>`);
- * stdio integrations stay host-side and are launched lazily.
+ * Remote/local MCP server an integration connects to. Built-in HTTP integrations
+ * (Linear/Notion) are defined in the ai/mcp catalog; the bundled Python
+ * integrations (jCodeMunch/Context Mode) have host defaults, while this is for
+ * explicit overrides and additional user-declared servers. HTTP integrations
+ * read creds from auth.json (`mcp:<name>`); stdio integrations stay host-side
+ * and are launched lazily.
  */
 export type McpServerConfig =
 	| {
@@ -145,7 +147,7 @@ export interface Settings {
 	quietStartup?: boolean;
 	shellCommandPrefix?: string; // Prefix prepended to every bash command (e.g., "shopt -s expand_aliases" for alias support)
 	npmCommand?: string[]; // Command used for npm package lookup/install operations, argv-style (e.g., ["mise", "exec", "node@20", "--", "npm"])
-	mcpServers?: Record<string, McpServerConfig>; // User-declared MCP servers (name → config); built-ins are in the ai/mcp catalog
+	mcpServers?: Record<string, McpServerConfig>; // Explicit MCP overrides/additional servers (name → config); local Python defaults are implicit
 	packages?: PackageSource[]; // Array of npm/git package sources (string or object with filtering)
 	extensions?: string[]; // Array of local extension file paths or directories
 	skills?: string[]; // Array of local skill file paths or directories

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -123,6 +123,61 @@ export type McpServerConfig =
 			disabledTools?: string[];
 	  };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+	return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function optionalString(value: Record<string, unknown>, field: string): boolean {
+	return value[field] === undefined || typeof value[field] === "string";
+}
+
+function optionalBoolean(value: Record<string, unknown>, field: string): boolean {
+	return value[field] === undefined || typeof value[field] === "boolean";
+}
+
+function optionalStringArray(value: Record<string, unknown>, field: string): boolean {
+	return value[field] === undefined || isStringArray(value[field]);
+}
+
+/** Validate untrusted JSON before a user-declared MCP server reaches the host manager. */
+export function parseMcpServerConfig(name: string, value: unknown): { config: McpServerConfig } | { error: string } {
+	const invalid = (reason: string): { error: string } => ({ error: `MCP server "${name}" ${reason}` });
+	if (!isRecord(value)) return invalid("must be an object");
+	if (value.type !== "http" && value.type !== "stdio") return invalid('type must be "http" or "stdio"');
+	if (!optionalBoolean(value, "enabled")) return invalid('"enabled" must be a boolean');
+	if (!optionalStringArray(value, "enabledTools")) return invalid('"enabledTools" must be an array of strings');
+	if (!optionalStringArray(value, "disabledTools")) return invalid('"disabledTools" must be an array of strings');
+
+	if (value.type === "http") {
+		if (typeof value.url !== "string" || value.url.trim().length === 0)
+			return invalid('"url" must be a non-empty string');
+		if (!optionalString(value, "bearerTokenEnvVar")) return invalid('"bearerTokenEnvVar" must be a string');
+		if (!optionalBoolean(value, "oauth")) return invalid('"oauth" must be a boolean');
+		if (value.headers !== undefined && !isStringRecord(value.headers)) {
+			return invalid('"headers" must be an object with string values');
+		}
+		return { config: value as McpServerConfig };
+	}
+
+	if (typeof value.command !== "string" || value.command.trim().length === 0) {
+		return invalid('"command" must be a non-empty string');
+	}
+	if (value.args !== undefined && !isStringArray(value.args)) return invalid('"args" must be an array of strings');
+	if (!optionalString(value, "cwd")) return invalid('"cwd" must be a string');
+	if (value.env !== undefined && !isStringRecord(value.env)) {
+		return invalid('"env" must be an object with string values');
+	}
+	return { config: value as McpServerConfig };
+}
+
 export interface Settings {
 	onboardingShown?: boolean;
 	onboardingCompleted?: boolean;
@@ -312,6 +367,7 @@ export class SettingsManager {
 	private projectSettingsLoadError: Error | null = null; // Track if project settings file had parse errors
 	private writeQueue: Promise<void> = Promise.resolve();
 	private errors: SettingsError[];
+	private readonly reportedMcpServerErrors = new Set<string>();
 
 	private constructor(
 		storage: SettingsStorage,
@@ -463,6 +519,7 @@ export class SettingsManager {
 
 	async reload(): Promise<void> {
 		await this.writeQueue;
+		this.reportedMcpServerErrors.clear();
 		const globalLoad = SettingsManager.tryLoadFromStorage(this.storage, "global");
 		if (!globalLoad.error) {
 			this.globalSettings = globalLoad.settings;
@@ -1166,7 +1223,35 @@ export class SettingsManager {
 	}
 
 	getMcpServers(): Record<string, McpServerConfig> | undefined {
-		return this.settings.mcpServers;
+		const configured = this.settings.mcpServers as unknown;
+		if (configured === undefined) return undefined;
+		if (!isRecord(configured)) {
+			const message = "MCP servers setting must be an object keyed by server name";
+			if (!this.reportedMcpServerErrors.has(message)) {
+				this.reportedMcpServerErrors.add(message);
+				this.recordError("global", new Error(message));
+			}
+			return {};
+		}
+
+		const valid: Record<string, McpServerConfig> = {};
+		for (const [name, value] of Object.entries(configured)) {
+			const parsed = parseMcpServerConfig(name, value);
+			if ("error" in parsed) {
+				const scope =
+					isRecord(this.projectSettings.mcpServers) && this.projectSettings.mcpServers[name] === value
+						? "project"
+						: "global";
+				const key = `${scope}:${parsed.error}`;
+				if (!this.reportedMcpServerErrors.has(key)) {
+					this.reportedMcpServerErrors.add(key);
+					this.recordError(scope, new Error(parsed.error));
+				}
+				continue;
+			}
+			valid[name] = parsed.config;
+		}
+		return valid;
 	}
 
 	setEnabledModels(patterns: string[] | undefined): void {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -92,8 +92,8 @@ export type PackageSource =
 /**
  * Remote/local MCP server an integration connects to. Built-in integrations
  * (Linear/Notion) are defined in the ai/mcp catalog; this is for user-declared
- * servers. The kernel-side integration package reads creds from auth.json
- * (`mcp:<name>`); login/refresh run host-side.
+ * servers. HTTP integrations read creds from auth.json (`mcp:<name>`);
+ * stdio integrations stay host-side and are launched lazily.
  */
 export type McpServerConfig =
 	| {
@@ -113,6 +113,8 @@ export type McpServerConfig =
 			type: "stdio";
 			command: string;
 			args?: string[];
+			/** Working directory, resolved relative to the active workspace cwd. */
+			cwd?: string;
 			env?: Record<string, string>;
 			enabled?: boolean;
 			enabledTools?: string[];

--- a/packages/coding-agent/src/core/tools/context-artifact-store.ts
+++ b/packages/coding-agent/src/core/tools/context-artifact-store.ts
@@ -8,17 +8,19 @@ import {
 	readFileSync,
 	renameSync,
 	rmSync,
+	statSync,
 	writeFileSync,
 	writeSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
-import { createInterface } from "node:readline";
 
 export const DEFAULT_CONTEXT_ARTIFACT_INLINE_CHARS = 12_000;
 export const DEFAULT_CONTEXT_ARTIFACT_PREVIEW_CHARS = 2_400;
 export const DEFAULT_CONTEXT_ARTIFACT_RETRIEVAL_MAX_CHARS = 16_000;
 
-const ARTIFACT_SCHEMA = 1;
+const ARTIFACT_SCHEMA = 2;
+const LEGACY_ARTIFACT_SCHEMA = 1;
+const CHECKPOINT_INTERVAL_CHARS = 256_000;
 const ARTIFACT_HANDLE_PREFIX = "ipython-output-";
 const CHANNELS = ["stdout", "stderr", "result", "traceback"] as const;
 const CHANNEL_HANDLE_PATTERN = /^[a-z]+$/;
@@ -78,6 +80,11 @@ export interface ContextArtifactMaterialization {
 	oversized: boolean;
 }
 
+interface ArtifactCheckpoint {
+	chars: number;
+	bytes: number;
+}
+
 interface FinalizedCapture {
 	channel: ArtifactChannel;
 	text?: string;
@@ -87,6 +94,51 @@ interface FinalizedCapture {
 	digest: string;
 	preview: string;
 	storageFailed: boolean;
+	checkpoints: readonly ArtifactCheckpoint[];
+}
+
+function isHighSurrogate(code: number): boolean {
+	return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isLowSurrogate(code: number): boolean {
+	return code >= 0xdc00 && code <= 0xdfff;
+}
+
+/** Slice UTF-16 text without returning a partial surrogate pair. */
+function codePointSafeSlice(text: string, start = 0, end = text.length): string {
+	let from = Math.max(0, Math.min(Math.floor(start), text.length));
+	let to = Math.max(from, Math.min(Math.floor(end), text.length));
+	if (from < to && isLowSurrogate(text.charCodeAt(from))) from += 1;
+	for (let index = from; index < to; index += 1) {
+		const code = text.charCodeAt(index);
+		if (isHighSurrogate(code)) {
+			if (index + 1 >= text.length || !isLowSurrogate(text.charCodeAt(index + 1))) {
+				to = index;
+				break;
+			}
+			if (index + 2 > to) {
+				to = index;
+				break;
+			}
+			index += 1;
+		} else if (isLowSurrogate(code)) {
+			to = index;
+			break;
+		}
+	}
+	return text.slice(from, Math.max(from, to));
+}
+
+function lastCodePointSafeSlice(text: string, maxChars: number): string {
+	const limit = Math.max(0, Math.floor(maxChars));
+	return codePointSafeSlice(text, Math.max(0, text.length - limit), text.length);
+}
+
+function countNewlines(text: string): number {
+	let count = 0;
+	for (let index = text.indexOf("\n"); index >= 0; index = text.indexOf("\n", index + 1)) count += 1;
+	return count;
 }
 
 function clampPositive(value: number | undefined, fallback: number, maximum: number): number {
@@ -95,19 +147,23 @@ function clampPositive(value: number | undefined, fallback: number, maximum: num
 }
 
 function boundedPreview(text: string, maxChars: number): string {
-	if (text.length <= maxChars) return text;
-	const budget = Math.max(1, maxChars - PREVIEW_OMISSION.length);
+	const limit = Number.isFinite(maxChars) ? Math.max(0, Math.floor(maxChars)) : maxChars > 0 ? text.length : 0;
+	if (text.length <= limit) return codePointSafeSlice(text);
+	if (limit <= PREVIEW_OMISSION.length) return codePointSafeSlice(text, 0, limit);
+	const budget = limit - PREVIEW_OMISSION.length;
 	const headChars = Math.ceil(budget / 2);
 	const tailChars = Math.max(0, budget - headChars);
-	return `${text.slice(0, headChars)}${PREVIEW_OMISSION}${tailChars > 0 ? text.slice(-tailChars) : ""}`;
+	return `${codePointSafeSlice(text, 0, headChars)}${PREVIEW_OMISSION}${tailChars > 0 ? lastCodePointSafeSlice(text, tailChars) : ""}`;
 }
 
 function boundedPreviewFromEdges(prefix: string, suffix: string, totalChars: number, maxChars: number): string {
-	if (totalChars <= maxChars) return prefix.slice(0, totalChars);
-	const budget = Math.max(1, maxChars - PREVIEW_OMISSION.length);
+	const limit = Number.isFinite(maxChars) ? Math.max(0, Math.floor(maxChars)) : maxChars > 0 ? totalChars : 0;
+	if (totalChars <= limit) return codePointSafeSlice(prefix, 0, totalChars);
+	if (limit <= PREVIEW_OMISSION.length) return codePointSafeSlice(prefix, 0, limit);
+	const budget = limit - PREVIEW_OMISSION.length;
 	const headChars = Math.ceil(budget / 2);
 	const tailChars = Math.max(0, budget - headChars);
-	return `${prefix.slice(0, headChars)}${PREVIEW_OMISSION}${tailChars > 0 ? suffix.slice(-tailChars) : ""}`;
+	return `${codePointSafeSlice(prefix, 0, headChars)}${PREVIEW_OMISSION}${tailChars > 0 ? lastCodePointSafeSlice(suffix, tailChars) : ""}`;
 }
 
 function safeChannel(channel: unknown): ArtifactChannel {
@@ -133,7 +189,7 @@ function readMetadata(
 	handle: string,
 ): {
 	handle: string;
-	channels: Record<ArtifactChannel, { chars: number; bytes: number }>;
+	channels: Record<ArtifactChannel, { chars: number; bytes: number; checkpoints?: readonly ArtifactCheckpoint[] }>;
 	totalChars: number;
 } {
 	const artifactDir = join(rootDir, handle);
@@ -142,12 +198,21 @@ function readMetadata(
 	const parsed = JSON.parse(readFileSync(metadataPath, "utf8")) as {
 		schema?: unknown;
 		handle?: unknown;
-		channels?: Partial<Record<ArtifactChannel, { chars?: unknown; bytes?: unknown }>>;
+		channels?: Partial<
+			Record<
+				ArtifactChannel,
+				{
+					chars?: unknown;
+					bytes?: unknown;
+					checkpoints?: unknown;
+				}
+			>
+		>;
 		totalChars?: unknown;
 	};
 	const totalChars = parsed.totalChars;
 	if (
-		parsed.schema !== ARTIFACT_SCHEMA ||
+		(parsed.schema !== ARTIFACT_SCHEMA && parsed.schema !== LEGACY_ARTIFACT_SCHEMA) ||
 		parsed.handle !== handle ||
 		!parsed.channels ||
 		typeof totalChars !== "number" ||
@@ -156,7 +221,10 @@ function readMetadata(
 	) {
 		throw new Error("Artifact metadata is invalid");
 	}
-	const channels = {} as Record<ArtifactChannel, { chars: number; bytes: number }>;
+	const channels = {} as Record<
+		ArtifactChannel,
+		{ chars: number; bytes: number; checkpoints?: readonly ArtifactCheckpoint[] }
+	>;
 	for (const [rawChannel, rawInfo] of Object.entries(parsed.channels)) {
 		const channel = safeChannel(rawChannel);
 		const chars = rawInfo?.chars;
@@ -172,7 +240,35 @@ function readMetadata(
 		) {
 			throw new Error("Artifact metadata is invalid");
 		}
-		channels[channel] = { chars, bytes };
+		let checkpoints: ArtifactCheckpoint[] | undefined;
+		if (rawInfo.checkpoints !== undefined) {
+			if (!Array.isArray(rawInfo.checkpoints)) throw new Error("Artifact metadata is invalid");
+			checkpoints = [];
+			let previousChars = -1;
+			let previousBytes = -1;
+			for (const rawCheckpoint of rawInfo.checkpoints) {
+				const checkpoint = rawCheckpoint as { chars?: unknown; bytes?: unknown };
+				if (
+					!checkpoint ||
+					typeof checkpoint.chars !== "number" ||
+					!Number.isSafeInteger(checkpoint.chars) ||
+					checkpoint.chars < 0 ||
+					checkpoint.chars > chars ||
+					typeof checkpoint.bytes !== "number" ||
+					!Number.isSafeInteger(checkpoint.bytes) ||
+					checkpoint.bytes < 0 ||
+					checkpoint.bytes > bytes ||
+					checkpoint.chars <= previousChars ||
+					checkpoint.bytes <= previousBytes
+				) {
+					throw new Error("Artifact metadata is invalid");
+				}
+				checkpoints.push({ chars: checkpoint.chars, bytes: checkpoint.bytes });
+				previousChars = checkpoint.chars;
+				previousBytes = checkpoint.bytes;
+			}
+		}
+		channels[channel] = { chars, bytes, ...(checkpoints ? { checkpoints } : {}) };
 	}
 	return { handle, channels, totalChars };
 }
@@ -191,8 +287,19 @@ export class ContextArtifactCapture {
 	private totalBytes = 0;
 	private readonly digest = createHash("sha256");
 	private prefix = "";
+	private prefixPendingHigh?: string;
+	private prefixSaturated = false;
+	private pendingHigh?: string;
 	private suffix = "";
+	private suffixPendingHigh?: string;
 	private storageFailed = false;
+	private readonly checkpoints: ArtifactCheckpoint[] = [];
+	private nextCheckpointChars = CHECKPOINT_INTERVAL_CHARS;
+	private persistedChars = 0;
+	private persistedBytes = 0;
+	private finalized?: FinalizedCapture;
+	private consumed = false;
+	private disposed = false;
 
 	constructor(
 		private readonly store: ContextArtifactStore,
@@ -200,39 +307,62 @@ export class ContextArtifactCapture {
 	) {}
 
 	append(chunk: string): void {
-		if (!chunk) return;
+		if (!chunk || this.disposed || this.finalized) return;
 		this.totalChars += chunk.length;
-		this.totalBytes += Buffer.byteLength(chunk, "utf8");
-		this.digest.update(chunk, "utf8");
-		this.prefix = `${this.prefix}${chunk}`.slice(0, this.store.previewChars);
-		this.suffix = `${this.suffix}${chunk}`.slice(-this.store.previewChars);
+		this.appendPrefixPreview(chunk);
+		this.updateSuffixPreview(chunk);
 
+		let value = chunk;
+		if (this.pendingHigh) {
+			if (isLowSurrogate(value.charCodeAt(0))) {
+				this.appendEncodedText(`${this.pendingHigh}${value[0]}`);
+				value = value.slice(1);
+			} else {
+				this.appendEncodedText(this.pendingHigh);
+			}
+			this.pendingHigh = undefined;
+		}
+		if (value && isHighSurrogate(value.charCodeAt(value.length - 1))) {
+			this.pendingHigh = value[value.length - 1];
+			value = value.slice(0, -1);
+		}
+		this.appendEncodedText(value);
+	}
+
+	private appendEncodedText(text: string): void {
+		if (!text) return;
+		this.totalBytes += Buffer.byteLength(text, "utf8");
+		this.digest.update(text, "utf8");
 		if (this.storageFailed) return;
 		try {
 			if (this.fd !== undefined) {
-				writeSync(this.fd, chunk, null, "utf8");
+				this.writeSpilledText(text);
 				return;
 			}
-			if (this.inlineText.length + chunk.length <= this.store.inlineChars) {
-				this.inlineText += chunk;
+			if (this.inlineText.length + text.length <= this.store.inlineChars) {
+				this.inlineText += text;
 				return;
 			}
 			this.startSpill();
-			if (this.fd !== undefined) {
-				writeSync(this.fd, chunk, null, "utf8");
-			}
+			if (this.fd !== undefined) this.writeSpilledText(text);
 		} catch {
-			this.storageFailed = true;
-			this.close();
-			if (this.tempPath) rmSync(this.tempPath, { force: true });
-			this.tempPath = undefined;
-			this.inlineText = "";
+			this.markStorageFailed();
 		}
 	}
 
+	private flushPendingHigh(): void {
+		if (!this.pendingHigh) return;
+		const pendingHigh = this.pendingHigh;
+		this.pendingHigh = undefined;
+		this.appendEncodedText(pendingHigh);
+	}
+
 	finalize(): FinalizedCapture {
+		if (this.finalized) return this.finalized;
+		this.flushPendingHigh();
+		this.recordFinalCheckpoint();
 		this.close();
-		return {
+		this.finalized = {
 			channel: this.channel,
 			text: this.tempPath || this.storageFailed ? undefined : this.inlineText,
 			tempPath: this.tempPath,
@@ -244,7 +374,160 @@ export class ContextArtifactCapture {
 					? boundedPreviewFromEdges(this.prefix, this.suffix, this.totalChars, this.store.previewChars)
 					: boundedPreview(this.inlineText, this.store.previewChars),
 			storageFailed: this.storageFailed,
+			checkpoints: [...this.checkpoints],
 		};
+		return this.finalized;
+	}
+
+	/** Mark a capture as owned by the materialized result; dispose then only closes it. */
+	markConsumed(): void {
+		this.consumed = true;
+	}
+
+	/** Close and remove any private spill file. Safe to call repeatedly. */
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.flushPendingHigh();
+		this.close();
+		if (!this.consumed && this.tempPath) rmSync(this.tempPath, { force: true });
+		this.tempPath = undefined;
+		this.inlineText = "";
+	}
+
+	private appendPrefixPreview(chunk: string): void {
+		if (this.prefixSaturated) return;
+		const maxChars = this.store.previewChars;
+		let index = 0;
+		if (this.prefixPendingHigh) {
+			if (!isLowSurrogate(chunk.charCodeAt(index))) {
+				this.prefixPendingHigh = undefined;
+				this.prefixSaturated = true;
+				return;
+			}
+			if (this.prefix.length + 2 > maxChars) {
+				this.prefixPendingHigh = undefined;
+				this.prefixSaturated = true;
+				return;
+			}
+			this.prefix += `${this.prefixPendingHigh}${chunk[index]}`;
+			this.prefixPendingHigh = undefined;
+			index += 1;
+		}
+		while (index < chunk.length && this.prefix.length < maxChars) {
+			const code = chunk.charCodeAt(index);
+			if (isHighSurrogate(code)) {
+				if (index + 1 >= chunk.length) {
+					this.prefixPendingHigh = chunk[index];
+					return;
+				}
+				if (!isLowSurrogate(chunk.charCodeAt(index + 1)) || this.prefix.length + 2 > maxChars) {
+					this.prefixSaturated = true;
+					return;
+				}
+				this.prefix += chunk.slice(index, index + 2);
+				index += 2;
+				continue;
+			}
+			if (isLowSurrogate(code)) {
+				this.prefixSaturated = true;
+				return;
+			}
+			this.prefix += chunk[index];
+			index += 1;
+		}
+	}
+
+	private updateSuffixPreview(chunk: string): void {
+		let index = 0;
+		if (this.suffixPendingHigh) {
+			if (isLowSurrogate(chunk.charCodeAt(index))) {
+				this.appendSuffixSegment(`${this.suffixPendingHigh}${chunk[index]}`);
+				index += 1;
+			}
+			this.suffixPendingHigh = undefined;
+		}
+		let segmentStart = index;
+		while (index < chunk.length) {
+			const code = chunk.charCodeAt(index);
+			if (isHighSurrogate(code)) {
+				if (index + 1 < chunk.length && isLowSurrogate(chunk.charCodeAt(index + 1))) {
+					index += 2;
+					continue;
+				}
+				this.appendSuffixSegment(chunk.slice(segmentStart, index));
+				if (index + 1 >= chunk.length) this.suffixPendingHigh = chunk[index];
+				index += 1;
+				segmentStart = index;
+				continue;
+			}
+			if (isLowSurrogate(code)) {
+				this.appendSuffixSegment(chunk.slice(segmentStart, index));
+				index += 1;
+				segmentStart = index;
+				continue;
+			}
+			index += 1;
+		}
+		this.appendSuffixSegment(chunk.slice(segmentStart));
+	}
+
+	private appendSuffixSegment(segment: string): void {
+		if (!segment) return;
+		const maxChars = this.store.previewChars;
+		this.suffix += segment;
+		if (this.suffix.length > maxChars + 1) this.suffix = this.suffix.slice(-(maxChars + 1));
+		this.suffix = lastCodePointSafeSlice(this.suffix, maxChars);
+	}
+
+	private markStorageFailed(): void {
+		this.storageFailed = true;
+		this.close();
+		if (this.tempPath) rmSync(this.tempPath, { force: true });
+		this.tempPath = undefined;
+		this.inlineText = "";
+	}
+
+	private writeSpilledText(text: string): void {
+		let offset = 0;
+		while (offset < text.length) {
+			let end = text.length;
+			const charsUntilCheckpoint = this.nextCheckpointChars - this.persistedChars;
+			if (charsUntilCheckpoint <= text.length - offset) {
+				end = offset + charsUntilCheckpoint;
+				if (
+					end < text.length &&
+					isHighSurrogate(text.charCodeAt(end - 1)) &&
+					isLowSurrogate(text.charCodeAt(end))
+				) {
+					end += 1;
+				}
+			}
+			const segment = text.slice(offset, end);
+			writeSync(this.fd!, segment, null, "utf8");
+			this.persistedChars += segment.length;
+			this.persistedBytes += Buffer.byteLength(segment, "utf8");
+			offset = end;
+			if (this.persistedChars >= this.nextCheckpointChars) {
+				this.checkpoints.push({ chars: this.persistedChars, bytes: this.persistedBytes });
+				while (this.nextCheckpointChars <= this.persistedChars) {
+					this.nextCheckpointChars += CHECKPOINT_INTERVAL_CHARS;
+				}
+			}
+		}
+	}
+
+	private recordFinalCheckpoint(): void {
+		if (
+			this.fd === undefined ||
+			this.pendingHigh ||
+			this.totalChars < CHECKPOINT_INTERVAL_CHARS ||
+			this.persistedChars !== this.totalChars
+		) {
+			return;
+		}
+		if (this.checkpoints.at(-1)?.chars === this.totalChars) return;
+		this.checkpoints.push({ chars: this.persistedChars, bytes: this.persistedBytes });
 	}
 
 	private startSpill(): void {
@@ -256,9 +539,11 @@ export class ContextArtifactCapture {
 		}
 		this.fd = openSync(tempPath, "w", 0o600);
 		this.tempPath = tempPath;
+		this.checkpoints.push({ chars: 0, bytes: 0 });
 		if (this.inlineText) {
-			writeSync(this.fd!, this.inlineText, null, "utf8");
+			const inlineText = this.inlineText;
 			this.inlineText = "";
+			this.writeSpilledText(inlineText);
 		}
 	}
 
@@ -313,6 +598,9 @@ export class ContextArtifactStore {
 		fallbacks: Partial<Record<ArtifactChannel, string | undefined>> = {},
 	): ContextArtifactMaterialization {
 		const finalized: FinalizedCapture[] = [];
+		const inputCaptures = Object.values(captures).filter(
+			(capture): capture is ContextArtifactCapture => capture !== undefined,
+		);
 		for (const channel of CHANNELS) {
 			const capture = captures[channel];
 			if (capture) {
@@ -335,6 +623,7 @@ export class ContextArtifactStore {
 		const totalChars = finalized.reduce((sum, item) => sum + item.totalChars, 0);
 		const oversized = totalChars > this.inlineChars || finalized.some((item) => item.totalChars > this.inlineChars);
 		if (!oversized) {
+			for (const capture of inputCaptures) capture.markConsumed();
 			return {
 				values: Object.fromEntries(
 					finalized.filter((item) => item.text !== undefined).map((item) => [item.channel, item.text]),
@@ -346,11 +635,18 @@ export class ContextArtifactStore {
 		const values: Partial<Record<ArtifactChannel, string>> = {};
 		for (const item of finalized) values[item.channel] = item.preview;
 		const artifact = this.persist(finalized, totalChars);
+		if (artifact) {
+			for (const capture of inputCaptures) capture.markConsumed();
+		}
 		return { values, oversized: true, artifact };
 	}
 
 	private persist(captures: readonly FinalizedCapture[], totalChars: number): ContextArtifactReference | undefined {
-		if (!this.artifactRoot || captures.some((capture) => capture.storageFailed)) return undefined;
+		if (!this.artifactRoot || captures.some((capture) => capture.storageFailed)) {
+			this.cleanupTempFiles(captures);
+			return undefined;
+		}
+		let stagingDir: string | undefined;
 		try {
 			this.ensureRoots();
 			const handleDigest = createHash("sha256");
@@ -359,32 +655,49 @@ export class ContextArtifactStore {
 			}
 			const handle = `${ARTIFACT_HANDLE_PREFIX}${handleDigest.digest("hex")}`;
 			const artifactDir = join(this.artifactRoot, handle);
-			if (!existsSync(artifactDir)) mkdirSync(artifactDir, { recursive: true, mode: 0o700 });
-			for (const capture of captures) {
-				const path = join(artifactDir, `${capture.channel}.txt`);
-				if (capture.tempPath) {
-					if (!existsSync(path)) renameSync(capture.tempPath, path);
-					else rmSync(capture.tempPath, { force: true });
-				} else if (!existsSync(path)) {
-					const tempPath = join(artifactDir, `.${capture.channel}.${randomUUID()}.tmp`);
-					writeFileSync(tempPath, capture.text ?? "", { encoding: "utf8", mode: 0o600, flag: "wx" });
-					renameSync(tempPath, path);
+			const finalDirectoryExists = existsSync(artifactDir) && statSync(artifactDir).isDirectory();
+			if (!finalDirectoryExists) {
+				stagingDir = join(this.artifactRoot, `.staging.${randomUUID()}`);
+				mkdirSync(stagingDir, { recursive: false, mode: 0o700 });
+				for (const capture of captures) {
+					const path = join(stagingDir, `${capture.channel}.txt`);
+					if (capture.tempPath) {
+						renameSync(capture.tempPath, path);
+					} else {
+						writeFileSync(path, capture.text ?? "", { encoding: "utf8", mode: 0o600, flag: "wx" });
+					}
 				}
-			}
-			const metadataPath = join(artifactDir, "metadata.json");
-			if (!existsSync(metadataPath)) {
 				const metadata = {
 					schema: ARTIFACT_SCHEMA,
 					handle,
 					createdAt: new Date().toISOString(),
 					totalChars,
 					channels: Object.fromEntries(
-						captures.map((capture) => [capture.channel, { chars: capture.totalChars, bytes: capture.bytes }]),
+						captures.map((capture) => [
+							capture.channel,
+							{
+								chars: capture.totalChars,
+								bytes: capture.bytes,
+								...(capture.checkpoints.length > 0 ? { checkpoints: capture.checkpoints } : {}),
+							},
+						]),
 					),
 				};
-				const tempMetadata = join(artifactDir, `.metadata.${randomUUID()}.tmp`);
-				writeFileSync(tempMetadata, `${JSON.stringify(metadata)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
-				renameSync(tempMetadata, metadataPath);
+				writeFileSync(join(stagingDir, "metadata.json"), `${JSON.stringify(metadata)}\n`, {
+					encoding: "utf8",
+					mode: 0o600,
+					flag: "wx",
+				});
+				try {
+					renameSync(stagingDir, artifactDir);
+					stagingDir = undefined;
+				} catch (error) {
+					if (!(existsSync(artifactDir) && statSync(artifactDir).isDirectory())) throw error;
+					if (stagingDir) rmSync(stagingDir, { recursive: true, force: true });
+					stagingDir = undefined;
+				}
+			} else {
+				this.cleanupTempFiles(captures);
 			}
 			const channels = captures.map((capture) => capture.channel);
 			const firstChannel = channels[0] ?? "stdout";
@@ -402,10 +715,15 @@ export class ContextArtifactStore {
 				},
 			};
 		} catch {
-			for (const capture of captures) {
-				if (capture.tempPath) rmSync(capture.tempPath, { force: true });
-			}
+			if (stagingDir) rmSync(stagingDir, { recursive: true, force: true });
+			this.cleanupTempFiles(captures);
 			return undefined;
+		}
+	}
+
+	private cleanupTempFiles(captures: readonly FinalizedCapture[]): void {
+		for (const capture of captures) {
+			if (capture.tempPath) rmSync(capture.tempPath, { force: true });
 		}
 	}
 
@@ -444,18 +762,22 @@ export class ContextArtifactStore {
 			? Math.max(1, Math.min(Math.floor(requested), this.retrievalMaxChars))
 			: this.retrievalMaxChars;
 		const filePath = this.channelPath(handle, channel);
+		const checkpoint = channelMetadata.checkpoints?.filter((candidate) => candidate.chars <= offset).at(-1);
+		const stream = checkpoint
+			? createReadStream(filePath, { encoding: "utf8", start: checkpoint.bytes })
+			: createReadStream(filePath, { encoding: "utf8" });
 		// Offsets are UTF-16 character offsets (the same unit used by totalChars),
-		// not byte offsets. Read from the beginning with a bounded UTF-8 stream so
-		// multibyte text cannot seek into the middle of a code point.
-		let skipped = 0;
+		// while checkpoints seek by UTF-8 byte offsets. Old schema-1 artifacts have
+		// no checkpoints and intentionally use the bounded full scan fallback.
+		let skipped = checkpoint ? offset - checkpoint.chars : offset;
 		let remaining = maxChars;
 		let text = "";
-		for await (const chunk of createReadStream(filePath, { encoding: "utf8" })) {
+		for await (const chunk of stream) {
 			if (remaining <= 0) break;
 			const value = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-			if (skipped < offset) {
-				const skip = Math.min(offset - skipped, value.length);
-				skipped += skip;
+			if (skipped > 0) {
+				const skip = Math.min(skipped, value.length);
+				skipped -= skip;
 				if (skip < value.length) {
 					const part = value.slice(skip, skip + remaining);
 					text += part;
@@ -467,6 +789,7 @@ export class ContextArtifactStore {
 				remaining -= part.length;
 			}
 		}
+		text = codePointSafeSlice(text, 0, maxChars);
 		return {
 			handle,
 			channel,
@@ -480,28 +803,107 @@ export class ContextArtifactStore {
 	private async search(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
 		const handle = safeHandle(payload.handle);
 		const channel = safeChannel(payload.channel ?? "stdout");
-		const query = typeof payload.query === "string" ? payload.query.slice(0, 256) : "";
+		const query = typeof payload.query === "string" ? codePointSafeSlice(payload.query, 0, 256) : "";
 		if (!query) throw new Error("artifact.search requires a non-empty query");
 		const requested = typeof payload.max_chars === "number" ? payload.max_chars : this.retrievalMaxChars;
-		const maxChars = Math.max(1, Math.min(Math.floor(requested), this.retrievalMaxChars));
+		const maxChars = Number.isFinite(requested)
+			? Math.max(1, Math.min(Math.floor(requested), this.retrievalMaxChars))
+			: this.retrievalMaxChars;
+		const queryCodePointLength = Array.from(query).length;
+		if (maxChars < query.length) {
+			throw new Error(
+				`artifact.search max_chars must be at least ${query.length} UTF-16 characters to include the full query (${queryCodePointLength} code points); received ${maxChars}`,
+			);
+		}
 		const requestedMatches = typeof payload.max_results === "number" ? payload.max_results : 20;
-		const maxResults = Math.max(1, Math.min(Math.floor(requestedMatches), 50));
+		const maxResults = Number.isFinite(requestedMatches)
+			? Math.max(1, Math.min(Math.floor(requestedMatches), 50))
+			: 20;
 		this.requireMetadata(handle);
 		const filePath = this.channelPath(handle, channel);
 		const matches: ContextArtifactSearchMatch[] = [];
+		const needle = query.toLowerCase();
+		const contextBudget = Math.max(0, maxChars - query.length);
+		const beforeChars = Math.floor(contextBudget / 2);
+		const afterChars = contextBudget - beforeChars;
+		const carryChars = Math.max(0, query.length - 1);
+		const pending: Array<{ line: number; text: string; remainingAfter: number }> = [];
 		let returnedChars = 0;
-		let lineNumber = 0;
-		const needle = query.toLocaleLowerCase();
-		const input = createInterface({ input: createReadStream(filePath), crlfDelay: Infinity });
-		for await (const line of input) {
-			lineNumber += 1;
-			if (!line.toLocaleLowerCase().includes(needle)) continue;
-			const text = line.slice(0, Math.min(line.length, maxChars - returnedChars));
-			matches.push({ line: lineNumber, text });
-			returnedChars += text.length;
-			if (matches.length >= maxResults || returnedChars >= maxChars) break;
+		let lineNumber = 1;
+		let carry = "";
+		let history = "";
+		let truncated = false;
+		let stop = false;
+		let resultLimitReached = false;
+
+		const flush = (force: boolean) => {
+			while (pending.length > 0 && !stop) {
+				const candidate = pending[0];
+				if (!force && candidate.remainingAfter > 0) break;
+				pending.shift();
+				let text = candidate.text;
+				const remaining = maxChars - returnedChars;
+				if (text.length > remaining) text = codePointSafeSlice(text, 0, remaining);
+				if (text) {
+					matches.push({ line: candidate.line, text });
+					returnedChars += text.length;
+				}
+				if (matches.length >= maxResults || returnedChars >= maxChars) {
+					truncated = true;
+					stop = true;
+				}
+			}
+		};
+
+		const input = createReadStream(filePath, { encoding: "utf8" });
+		for await (const chunk of input) {
+			const value = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+			for (const candidate of pending) {
+				if (candidate.remainingAfter <= 0) continue;
+				const take = Math.min(candidate.remainingAfter, value.length);
+				candidate.text += value.slice(0, take);
+				candidate.remainingAfter -= take;
+			}
+
+			const scan = `${carry}${value}`;
+			const scanLower = scan.toLowerCase();
+			const scanLineStart = lineNumber - countNewlines(carry);
+			for (
+				let index = scanLower.indexOf(needle);
+				index >= 0 && !resultLimitReached;
+				index = scanLower.indexOf(needle, index + 1)
+			) {
+				if (index + needle.length <= carry.length) continue;
+				if (matches.length + pending.length >= maxResults) {
+					truncated = true;
+					resultLimitReached = true;
+					break;
+				}
+				const relativeStart = index - carry.length;
+				const prefix =
+					relativeStart >= 0
+						? lastCodePointSafeSlice(`${history}${value.slice(0, relativeStart)}`, beforeChars)
+						: lastCodePointSafeSlice(
+								history.slice(0, Math.max(0, history.length - (carry.length - index))),
+								beforeChars,
+							);
+				const matchText = scan.slice(index, index + query.length);
+				const availableAfter = scan.slice(index + query.length, index + query.length + afterChars);
+				pending.push({
+					line: scanLineStart + countNewlines(scan.slice(0, index)),
+					text: `${prefix}${matchText}${availableAfter}`,
+					remainingAfter: Math.max(0, afterChars - availableAfter.length),
+				});
+			}
+
+			history = lastCodePointSafeSlice(`${history}${value}`, beforeChars);
+			lineNumber += countNewlines(value);
+			carry = lastCodePointSafeSlice(scan, carryChars);
+			flush(false);
+			if (stop || (resultLimitReached && pending.length === 0)) break;
 		}
-		return { handle, channel, query, matches, truncated: matches.length >= maxResults || returnedChars >= maxChars };
+		flush(true);
+		return { handle, channel, query, matches, truncated };
 	}
 
 	private requireMetadata(handle: string) {

--- a/packages/coding-agent/src/core/tools/context-artifact-store.ts
+++ b/packages/coding-agent/src/core/tools/context-artifact-store.ts
@@ -1,0 +1,535 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+	closeSync,
+	createReadStream,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+	writeSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+export const DEFAULT_CONTEXT_ARTIFACT_INLINE_CHARS = 12_000;
+export const DEFAULT_CONTEXT_ARTIFACT_PREVIEW_CHARS = 2_400;
+export const DEFAULT_CONTEXT_ARTIFACT_RETRIEVAL_MAX_CHARS = 16_000;
+
+const ARTIFACT_SCHEMA = 1;
+const ARTIFACT_HANDLE_PREFIX = "ipython-output-";
+const CHANNELS = ["stdout", "stderr", "result", "traceback"] as const;
+const CHANNEL_HANDLE_PATTERN = /^[a-z]+$/;
+const HANDLE_PATTERN = /^ipython-output-[a-f0-9]{64}$/;
+const PREVIEW_OMISSION = "\n[… output omitted …]\n";
+
+type ArtifactChannel = (typeof CHANNELS)[number];
+
+export interface ContextArtifactStoreOptions {
+	/** Maximum total output chars kept inline before an artifact is created. */
+	inlineChars?: number;
+	/** Maximum chars included in an inline preview of a spilled channel. */
+	previewChars?: number;
+	/** Maximum chars returned by one bounded read/search request. */
+	retrievalMaxChars?: number;
+}
+
+export interface ContextArtifactReference {
+	handle: string;
+	kind: "ipython-output";
+	channels: ArtifactChannel[];
+	totalChars: number;
+	bytes: number;
+	inlinePreview: string;
+	/** Host-bridge examples intentionally contain no filesystem path. */
+	retrieval: {
+		read: string;
+		search: string;
+	};
+}
+
+export interface ContextArtifactReadResult {
+	handle: string;
+	channel: ArtifactChannel;
+	offset: number;
+	text: string;
+	truncated: boolean;
+	totalChars: number;
+}
+
+export interface ContextArtifactSearchMatch {
+	line: number;
+	text: string;
+}
+
+export interface ContextArtifactSearchResult {
+	handle: string;
+	channel: ArtifactChannel;
+	query: string;
+	matches: ContextArtifactSearchMatch[];
+	truncated: boolean;
+}
+
+export interface ContextArtifactMaterialization {
+	values: Partial<Record<ArtifactChannel, string>>;
+	artifact?: ContextArtifactReference;
+	oversized: boolean;
+}
+
+interface FinalizedCapture {
+	channel: ArtifactChannel;
+	text?: string;
+	tempPath?: string;
+	totalChars: number;
+	bytes: number;
+	digest: string;
+	preview: string;
+	storageFailed: boolean;
+}
+
+function clampPositive(value: number | undefined, fallback: number, maximum: number): number {
+	if (!Number.isFinite(value) || value === undefined) return fallback;
+	return Math.max(1, Math.min(Math.floor(value), maximum));
+}
+
+function boundedPreview(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	const budget = Math.max(1, maxChars - PREVIEW_OMISSION.length);
+	const headChars = Math.ceil(budget / 2);
+	const tailChars = Math.max(0, budget - headChars);
+	return `${text.slice(0, headChars)}${PREVIEW_OMISSION}${tailChars > 0 ? text.slice(-tailChars) : ""}`;
+}
+
+function boundedPreviewFromEdges(prefix: string, suffix: string, totalChars: number, maxChars: number): string {
+	if (totalChars <= maxChars) return prefix.slice(0, totalChars);
+	const budget = Math.max(1, maxChars - PREVIEW_OMISSION.length);
+	const headChars = Math.ceil(budget / 2);
+	const tailChars = Math.max(0, budget - headChars);
+	return `${prefix.slice(0, headChars)}${PREVIEW_OMISSION}${tailChars > 0 ? suffix.slice(-tailChars) : ""}`;
+}
+
+function safeChannel(channel: unknown): ArtifactChannel {
+	if (
+		typeof channel !== "string" ||
+		!CHANNEL_HANDLE_PATTERN.test(channel) ||
+		!CHANNELS.includes(channel as ArtifactChannel)
+	) {
+		throw new Error("Unknown artifact channel");
+	}
+	return channel as ArtifactChannel;
+}
+
+function safeHandle(handle: unknown): string {
+	if (typeof handle !== "string" || !HANDLE_PATTERN.test(handle)) {
+		throw new Error("Invalid artifact handle");
+	}
+	return handle;
+}
+
+function readMetadata(
+	rootDir: string,
+	handle: string,
+): {
+	handle: string;
+	channels: Record<ArtifactChannel, { chars: number; bytes: number }>;
+	totalChars: number;
+} {
+	const artifactDir = join(rootDir, handle);
+	const metadataPath = join(artifactDir, "metadata.json");
+	if (!existsSync(metadataPath)) throw new Error("Artifact not found");
+	const parsed = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+		schema?: unknown;
+		handle?: unknown;
+		channels?: Partial<Record<ArtifactChannel, { chars?: unknown; bytes?: unknown }>>;
+		totalChars?: unknown;
+	};
+	const totalChars = parsed.totalChars;
+	if (
+		parsed.schema !== ARTIFACT_SCHEMA ||
+		parsed.handle !== handle ||
+		!parsed.channels ||
+		typeof totalChars !== "number" ||
+		!Number.isSafeInteger(totalChars) ||
+		totalChars < 0
+	) {
+		throw new Error("Artifact metadata is invalid");
+	}
+	const channels = {} as Record<ArtifactChannel, { chars: number; bytes: number }>;
+	for (const [rawChannel, rawInfo] of Object.entries(parsed.channels)) {
+		const channel = safeChannel(rawChannel);
+		const chars = rawInfo?.chars;
+		const bytes = rawInfo?.bytes;
+		if (
+			!rawInfo ||
+			typeof chars !== "number" ||
+			!Number.isSafeInteger(chars) ||
+			chars < 0 ||
+			typeof bytes !== "number" ||
+			!Number.isSafeInteger(bytes) ||
+			bytes < 0
+		) {
+			throw new Error("Artifact metadata is invalid");
+		}
+		channels[channel] = { chars, bytes };
+	}
+	return { handle, channels, totalChars };
+}
+
+/**
+ * Incrementally captures a stream without retaining unbounded output in memory.
+ * Once the inline threshold is crossed, bytes are written to a private temporary
+ * file owned by ContextArtifactStore. The capture's preview and digest are always
+ * maintained, even if disk persistence fails.
+ */
+export class ContextArtifactCapture {
+	private inlineText = "";
+	private tempPath?: string;
+	private fd?: number;
+	private totalChars = 0;
+	private totalBytes = 0;
+	private readonly digest = createHash("sha256");
+	private prefix = "";
+	private suffix = "";
+	private storageFailed = false;
+
+	constructor(
+		private readonly store: ContextArtifactStore,
+		readonly channel: ArtifactChannel,
+	) {}
+
+	append(chunk: string): void {
+		if (!chunk) return;
+		this.totalChars += chunk.length;
+		this.totalBytes += Buffer.byteLength(chunk, "utf8");
+		this.digest.update(chunk, "utf8");
+		this.prefix = `${this.prefix}${chunk}`.slice(0, this.store.previewChars);
+		this.suffix = `${this.suffix}${chunk}`.slice(-this.store.previewChars);
+
+		if (this.storageFailed) return;
+		try {
+			if (this.fd !== undefined) {
+				writeSync(this.fd, chunk, null, "utf8");
+				return;
+			}
+			if (this.inlineText.length + chunk.length <= this.store.inlineChars) {
+				this.inlineText += chunk;
+				return;
+			}
+			this.startSpill();
+			if (this.fd !== undefined) {
+				writeSync(this.fd, chunk, null, "utf8");
+			}
+		} catch {
+			this.storageFailed = true;
+			this.close();
+			if (this.tempPath) rmSync(this.tempPath, { force: true });
+			this.tempPath = undefined;
+			this.inlineText = "";
+		}
+	}
+
+	finalize(): FinalizedCapture {
+		this.close();
+		return {
+			channel: this.channel,
+			text: this.tempPath || this.storageFailed ? undefined : this.inlineText,
+			tempPath: this.tempPath,
+			totalChars: this.totalChars,
+			bytes: this.totalBytes,
+			digest: this.digest.digest("hex"),
+			preview:
+				this.tempPath || this.storageFailed
+					? boundedPreviewFromEdges(this.prefix, this.suffix, this.totalChars, this.store.previewChars)
+					: boundedPreview(this.inlineText, this.store.previewChars),
+			storageFailed: this.storageFailed,
+		};
+	}
+
+	private startSpill(): void {
+		const tempPath = this.store.createTempPath(this.channel);
+		if (!tempPath) {
+			this.storageFailed = true;
+			this.inlineText = "";
+			return;
+		}
+		this.fd = openSync(tempPath, "w", 0o600);
+		this.tempPath = tempPath;
+		if (this.inlineText) {
+			writeSync(this.fd!, this.inlineText, null, "utf8");
+			this.inlineText = "";
+		}
+	}
+
+	private close(): void {
+		if (this.fd !== undefined) {
+			closeSync(this.fd);
+			this.fd = undefined;
+		}
+	}
+}
+
+/**
+ * Durable, path-safe storage for context that is too large for the model's
+ * inline tool result. The store intentionally exposes opaque handles only.
+ */
+export class ContextArtifactStore {
+	readonly inlineChars: number;
+	readonly previewChars: number;
+	private readonly retrievalMaxChars: number;
+	private readonly rootDir?: string;
+	private readonly artifactRoot?: string;
+	private readonly tempRoot?: string;
+
+	constructor(rootDir: string | undefined, options: ContextArtifactStoreOptions = {}) {
+		this.inlineChars = clampPositive(options.inlineChars, DEFAULT_CONTEXT_ARTIFACT_INLINE_CHARS, 2_000_000);
+		this.previewChars = clampPositive(options.previewChars, DEFAULT_CONTEXT_ARTIFACT_PREVIEW_CHARS, 2_000_000);
+		this.retrievalMaxChars = clampPositive(
+			options.retrievalMaxChars,
+			DEFAULT_CONTEXT_ARTIFACT_RETRIEVAL_MAX_CHARS,
+			2_000_000,
+		);
+		if (rootDir) {
+			this.rootDir = resolve(rootDir);
+			this.artifactRoot = join(this.rootDir, "ipython-output");
+			this.tempRoot = join(this.artifactRoot, ".tmp");
+		}
+	}
+
+	createCapture(channel: ArtifactChannel): ContextArtifactCapture {
+		return new ContextArtifactCapture(this, channel);
+	}
+
+	createHostRequestHandlers(): Record<string, (payload: Record<string, unknown>) => Promise<Record<string, unknown>>> {
+		return {
+			"artifact.read": async (payload) => this.read(payload),
+			"artifact.search": async (payload) => this.search(payload),
+		};
+	}
+
+	materialize(
+		captures: Partial<Record<ArtifactChannel, ContextArtifactCapture>>,
+		fallbacks: Partial<Record<ArtifactChannel, string | undefined>> = {},
+	): ContextArtifactMaterialization {
+		const finalized: FinalizedCapture[] = [];
+		for (const channel of CHANNELS) {
+			const capture = captures[channel];
+			if (capture) {
+				const result = capture.finalize();
+				if (result.totalChars === 0) {
+					if (fallbacks[channel] === undefined) continue;
+					const fallbackCapture = this.createCapture(channel);
+					fallbackCapture.append(fallbacks[channel]!);
+					finalized.push(fallbackCapture.finalize());
+				} else {
+					finalized.push(result);
+				}
+			} else if (fallbacks[channel] !== undefined) {
+				const fallbackCapture = this.createCapture(channel);
+				fallbackCapture.append(fallbacks[channel]!);
+				finalized.push(fallbackCapture.finalize());
+			}
+		}
+
+		const totalChars = finalized.reduce((sum, item) => sum + item.totalChars, 0);
+		const oversized = totalChars > this.inlineChars || finalized.some((item) => item.totalChars > this.inlineChars);
+		if (!oversized) {
+			return {
+				values: Object.fromEntries(
+					finalized.filter((item) => item.text !== undefined).map((item) => [item.channel, item.text]),
+				) as Partial<Record<ArtifactChannel, string>>,
+				oversized: false,
+			};
+		}
+
+		const values: Partial<Record<ArtifactChannel, string>> = {};
+		for (const item of finalized) values[item.channel] = item.preview;
+		const artifact = this.persist(finalized, totalChars);
+		return { values, oversized: true, artifact };
+	}
+
+	private persist(captures: readonly FinalizedCapture[], totalChars: number): ContextArtifactReference | undefined {
+		if (!this.artifactRoot || captures.some((capture) => capture.storageFailed)) return undefined;
+		try {
+			this.ensureRoots();
+			const handleDigest = createHash("sha256");
+			for (const capture of captures) {
+				handleDigest.update(`${capture.channel}:${capture.totalChars}:${capture.digest}\n`);
+			}
+			const handle = `${ARTIFACT_HANDLE_PREFIX}${handleDigest.digest("hex")}`;
+			const artifactDir = join(this.artifactRoot, handle);
+			if (!existsSync(artifactDir)) mkdirSync(artifactDir, { recursive: true, mode: 0o700 });
+			for (const capture of captures) {
+				const path = join(artifactDir, `${capture.channel}.txt`);
+				if (capture.tempPath) {
+					if (!existsSync(path)) renameSync(capture.tempPath, path);
+					else rmSync(capture.tempPath, { force: true });
+				} else if (!existsSync(path)) {
+					const tempPath = join(artifactDir, `.${capture.channel}.${randomUUID()}.tmp`);
+					writeFileSync(tempPath, capture.text ?? "", { encoding: "utf8", mode: 0o600, flag: "wx" });
+					renameSync(tempPath, path);
+				}
+			}
+			const metadataPath = join(artifactDir, "metadata.json");
+			if (!existsSync(metadataPath)) {
+				const metadata = {
+					schema: ARTIFACT_SCHEMA,
+					handle,
+					createdAt: new Date().toISOString(),
+					totalChars,
+					channels: Object.fromEntries(
+						captures.map((capture) => [capture.channel, { chars: capture.totalChars, bytes: capture.bytes }]),
+					),
+				};
+				const tempMetadata = join(artifactDir, `.metadata.${randomUUID()}.tmp`);
+				writeFileSync(tempMetadata, `${JSON.stringify(metadata)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+				renameSync(tempMetadata, metadataPath);
+			}
+			const channels = captures.map((capture) => capture.channel);
+			const firstChannel = channels[0] ?? "stdout";
+			const inlinePreview = captures.map((capture) => `${capture.channel}:\n${capture.preview}`).join("\n\n");
+			return {
+				handle,
+				kind: "ipython-output",
+				channels,
+				totalChars,
+				bytes: captures.reduce((sum, capture) => sum + capture.bytes, 0),
+				inlinePreview: boundedPreview(inlinePreview, this.previewChars),
+				retrieval: {
+					read: `await rlm.host_request("artifact.read", {"handle": "${handle}", "channel": "${firstChannel}"})`,
+					search: `await rlm.host_request("artifact.search", {"handle": "${handle}", "channel": "${firstChannel}", "query": "..."})`,
+				},
+			};
+		} catch {
+			for (const capture of captures) {
+				if (capture.tempPath) rmSync(capture.tempPath, { force: true });
+			}
+			return undefined;
+		}
+	}
+
+	private ensureRoots(): void {
+		if (!this.artifactRoot || !this.tempRoot) return;
+		mkdirSync(this.artifactRoot, { recursive: true, mode: 0o700 });
+		mkdirSync(this.tempRoot, { recursive: true, mode: 0o700 });
+	}
+
+	createTempPath(channel: ArtifactChannel): string | undefined {
+		if (!this.tempRoot) return undefined;
+		try {
+			this.ensureRoots();
+			const path = join(this.tempRoot, `${channel}-${randomUUID()}.tmp`);
+			const fd = openSync(path, "w", 0o600);
+			closeSync(fd);
+			return path;
+		} catch {
+			return undefined;
+		}
+	}
+
+	private async read(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+		const handle = safeHandle(payload.handle);
+		const channel = safeChannel(payload.channel ?? "stdout");
+		const metadata = this.requireMetadata(handle);
+		const channelMetadata = metadata.channels[channel];
+		if (!channelMetadata) throw new Error("Artifact channel not found");
+		const requestedOffset =
+			typeof payload.offset === "number" && Number.isFinite(payload.offset)
+				? Math.max(0, Math.floor(payload.offset))
+				: 0;
+		const offset = Math.min(requestedOffset, channelMetadata.chars);
+		const requested = typeof payload.max_chars === "number" ? payload.max_chars : this.retrievalMaxChars;
+		const maxChars = Number.isFinite(requested)
+			? Math.max(1, Math.min(Math.floor(requested), this.retrievalMaxChars))
+			: this.retrievalMaxChars;
+		const filePath = this.channelPath(handle, channel);
+		// Offsets are UTF-16 character offsets (the same unit used by totalChars),
+		// not byte offsets. Read from the beginning with a bounded UTF-8 stream so
+		// multibyte text cannot seek into the middle of a code point.
+		let skipped = 0;
+		let remaining = maxChars;
+		let text = "";
+		for await (const chunk of createReadStream(filePath, { encoding: "utf8" })) {
+			if (remaining <= 0) break;
+			const value = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+			if (skipped < offset) {
+				const skip = Math.min(offset - skipped, value.length);
+				skipped += skip;
+				if (skip < value.length) {
+					const part = value.slice(skip, skip + remaining);
+					text += part;
+					remaining -= part.length;
+				}
+			} else {
+				const part = value.slice(0, remaining);
+				text += part;
+				remaining -= part.length;
+			}
+		}
+		return {
+			handle,
+			channel,
+			offset,
+			text,
+			truncated: offset + text.length < channelMetadata.chars,
+			totalChars: channelMetadata.chars,
+		};
+	}
+
+	private async search(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+		const handle = safeHandle(payload.handle);
+		const channel = safeChannel(payload.channel ?? "stdout");
+		const query = typeof payload.query === "string" ? payload.query.slice(0, 256) : "";
+		if (!query) throw new Error("artifact.search requires a non-empty query");
+		const requested = typeof payload.max_chars === "number" ? payload.max_chars : this.retrievalMaxChars;
+		const maxChars = Math.max(1, Math.min(Math.floor(requested), this.retrievalMaxChars));
+		const requestedMatches = typeof payload.max_results === "number" ? payload.max_results : 20;
+		const maxResults = Math.max(1, Math.min(Math.floor(requestedMatches), 50));
+		this.requireMetadata(handle);
+		const filePath = this.channelPath(handle, channel);
+		const matches: ContextArtifactSearchMatch[] = [];
+		let returnedChars = 0;
+		let lineNumber = 0;
+		const needle = query.toLocaleLowerCase();
+		const input = createInterface({ input: createReadStream(filePath), crlfDelay: Infinity });
+		for await (const line of input) {
+			lineNumber += 1;
+			if (!line.toLocaleLowerCase().includes(needle)) continue;
+			const text = line.slice(0, Math.min(line.length, maxChars - returnedChars));
+			matches.push({ line: lineNumber, text });
+			returnedChars += text.length;
+			if (matches.length >= maxResults || returnedChars >= maxChars) break;
+		}
+		return { handle, channel, query, matches, truncated: matches.length >= maxResults || returnedChars >= maxChars };
+	}
+
+	private requireMetadata(handle: string) {
+		if (!this.artifactRoot) throw new Error("No durable artifact store is available for this session");
+		return readMetadata(this.artifactRoot, handle);
+	}
+
+	private channelPath(handle: string, channel: ArtifactChannel): string {
+		if (!this.artifactRoot) throw new Error("No durable artifact store is available for this session");
+		const path = resolve(this.artifactRoot, handle, `${channel}.txt`);
+		const root = `${resolve(this.artifactRoot)}${"/"}`;
+		if (!path.startsWith(root) || !HANDLE_PATTERN.test(handle) || !CHANNELS.includes(channel)) {
+			throw new Error("Invalid artifact path");
+		}
+		if (!existsSync(path)) throw new Error("Artifact channel not found");
+		return path;
+	}
+}
+
+export function boundedArtifactPreview(text: string, maxChars: number): string {
+	return boundedPreview(text, maxChars);
+}
+
+export function artifactRetrievalGuidance(reference: ContextArtifactReference): string {
+	return [
+		`Oversized IPython output was materialized as ${reference.handle} (${reference.totalChars.toLocaleString()} chars).`,
+		`The inline preview is bounded; retrieve more with ${reference.retrieval.read} or search with ${reference.retrieval.search}.`,
+	].join(" ");
+}
+
+export type { ArtifactChannel };

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -18,6 +18,13 @@ import {
 } from "../kernel/index.js";
 import { manifestPathIn, type RestoreResult, snapshotPathIn } from "../kernel/state-snapshot.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
+import {
+	artifactRetrievalGuidance,
+	boundedArtifactPreview,
+	type ContextArtifactReference,
+	ContextArtifactStore,
+	type ContextArtifactStoreOptions,
+} from "./context-artifact-store.js";
 import { parseIpythonBashCell } from "./ipython-cell-code.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
@@ -258,6 +265,8 @@ export interface IpythonToolDetails {
 	attachments?: KernelAttachment[];
 	/** Agent messages sent from this cell. */
 	sentAgentMessages?: KernelSentAgentMessage[];
+	/** Opaque durable handles for output materialized outside the model transcript. */
+	artifacts?: ContextArtifactReference[];
 	/** True when this result came after killing and restarting a busy kernel. */
 	kernelRestarted?: boolean;
 	error?: {
@@ -281,6 +290,8 @@ export interface IpythonToolOptions {
 	pythonSkills?: readonly PythonSkillRuntimeInfo[];
 	/** Per-session artifact dir where the kernel namespace snapshot is stored. Omit to disable snapshots. */
 	snapshotDir?: string;
+	/** Narrow controls for oversized IPython output materialization. */
+	outputMaterialization?: ContextArtifactStoreOptions;
 	/** Resolves before this kernel starts — e.g. the previous provisioner's dispose, so a
 	 * /reload's old-kernel snapshot flush can't race the new kernel's restore. */
 	readyGate?: Promise<unknown>;
@@ -346,6 +357,17 @@ export class IpythonKernelProvisioner {
 	/** The kernel manager, once a startup has completed successfully. */
 	get manager(): KernelManager | undefined {
 		return this.startedManager;
+	}
+
+	/** Add host handlers after construction; shared tools can extend the provisioner safely. */
+	registerHostHandlers(handlers: HostRequestHandlers): void {
+		if (!this.options) return;
+		if (this.options.hostHandlers) {
+			Object.assign(this.options.hostHandlers, handlers);
+		} else {
+			this.options.hostHandlers = handlers;
+		}
+		this.startedManager?.registerHostHandlers(handlers);
 	}
 
 	/** Result of reviving a prior session's namespace on the last kernel start, if any. */
@@ -570,6 +592,7 @@ async function executeWithBusyKernelChoice(
 	code: string,
 	signal: AbortSignal | undefined,
 	onStream: (chunk: string, name: "stdout" | "stderr") => void,
+	onResult: (result: string) => void,
 	onWorkingMessage: (message?: string) => void,
 	onLateSentAgentMessage: ((toolCallId: string, message: KernelSentAgentMessage) => void) | undefined,
 	ctx: ExtensionContext | undefined,
@@ -582,6 +605,7 @@ async function executeWithBusyKernelChoice(
 				result: await m.execute(code, {
 					signal,
 					onStream,
+					onResult,
 					onLateSentAgentMessage: onLateSentAgentMessage
 						? (message) => onLateSentAgentMessage(toolCallId, message)
 						: undefined,
@@ -620,7 +644,21 @@ export function createIpythonToolDefinition(
 	cwd: string,
 	options?: IpythonToolOptions,
 ): ToolDefinition<typeof ipythonSchema, IpythonToolDetails> {
-	const provisioner = options?.provisioner ?? new IpythonKernelProvisioner(cwd, options);
+	const artifactStore = new ContextArtifactStore(options?.snapshotDir, options?.outputMaterialization);
+	const artifactHandlers = artifactStore.createHostRequestHandlers();
+	const { provisioner: suppliedProvisioner, ...provisionerOptions } = options ?? {};
+	if (suppliedProvisioner && typeof suppliedProvisioner.registerHostHandlers === "function") {
+		suppliedProvisioner.registerHostHandlers(artifactHandlers);
+	}
+	const provisioner =
+		suppliedProvisioner ??
+		new IpythonKernelProvisioner(cwd, {
+			...provisionerOptions,
+			hostHandlers: {
+				...provisionerOptions.hostHandlers,
+				...artifactHandlers,
+			},
+		});
 
 	return {
 		name: "ipython",
@@ -647,28 +685,42 @@ export function createIpythonToolDefinition(
 
 			try {
 				const code = applyShellSettingsToBashMagicCell(params.code, options);
+				const stdoutCapture = artifactStore.createCapture("stdout");
+				const stderrCapture = artifactStore.createCapture("stderr");
+				const resultCapture = artifactStore.createCapture("result");
+				const tracebackCapture = artifactStore.createCapture("traceback");
 				const { result: r, kernelRestarted } = await executeWithBusyKernelChoice(
 					provisioner,
 					reportStartupProgress,
 					toolCallId,
 					code,
 					signal,
-					(chunk) => {
+					(chunk, name) => {
+						(name === "stdout" ? stdoutCapture : stderrCapture).append(chunk);
 						onUpdate?.({
 							content: [{ type: "text", text: chunk }],
 							details: { status: "ok" },
 						});
 					},
+					(result) => resultCapture.append(result),
 					setToolWorkingMessage,
 					options?.onLateSentAgentMessage,
 					ctx,
 				);
 
-				let text = r.stdout;
-				if (r.stderr) text += (text ? "\n" : "") + r.stderr;
-				if (r.result) text += (text ? "\n" : "") + r.result;
-				if (r.status === "error" && r.error) {
-					text += (text ? "\n" : "") + r.error.traceback.join("\n");
+				const traceback = r.error?.traceback.join("\n");
+				const output = artifactStore.materialize(
+					{ stdout: stdoutCapture, stderr: stderrCapture, result: resultCapture, traceback: tracebackCapture },
+					{ stdout: r.stdout, stderr: r.stderr, result: r.result, traceback },
+				);
+				let text = output.values.stdout ?? "";
+				if (output.values.stderr) text += (text ? "\n" : "") + output.values.stderr;
+				if (output.values.result) text += (text ? "\n" : "") + output.values.result;
+				if (output.values.traceback) text += (text ? "\n" : "") + output.values.traceback;
+				if (output.artifact) {
+					text += `${text ? "\n\n" : ""}${artifactRetrievalGuidance(output.artifact)}`;
+				} else if (output.oversized) {
+					text += `${text ? "\n\n" : ""}Oversized IPython output was bounded, but this transient session has no durable artifact directory for retrieval.`;
 				}
 				if (kernelRestarted) {
 					text = text ? `${KERNEL_RESTART_NOTICE}\n\n${text}` : KERNEL_RESTART_NOTICE;
@@ -676,6 +728,15 @@ export function createIpythonToolDefinition(
 
 				const imageBlocks = imageBlocksFromAttachments(r.attachments);
 				const content: (TextContent | ImageContent)[] = [{ type: "text", text: text || "" }, ...imageBlocks];
+				const safeError = r.error
+					? {
+							...r.error,
+							// Keep a pathological exception value from bypassing the output
+							// materialization bound when no traceback was emitted.
+							evalue: boundedArtifactPreview(r.error.evalue, artifactStore.previewChars),
+							traceback: (output.values.traceback ?? "").split("\n").filter((line) => line.length > 0),
+						}
+					: undefined;
 
 				return {
 					content,
@@ -683,14 +744,15 @@ export function createIpythonToolDefinition(
 						durationMs: r.durationMs,
 						status: r.status,
 						errorEname: r.error?.ename,
-						stdout: r.stdout,
-						stderr: r.stderr,
-						result: r.result,
+						stdout: output.values.stdout,
+						stderr: output.values.stderr,
+						result: output.values.result,
 						diffs: r.diffs,
 						attachments: r.attachments,
 						sentAgentMessages: r.sentAgentMessages,
+						artifacts: output.artifact ? [output.artifact] : undefined,
 						kernelRestarted,
-						error: r.error,
+						error: safeError,
 					},
 					isError: r.status === "error" || r.status === "aborted",
 				};

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -671,6 +671,13 @@ export function createIpythonToolDefinition(
 		parameters: ipythonSchema,
 		execute: async (toolCallId, params, signal, onUpdate, ctx) => {
 			let hasWorkingMessage = false;
+			const captures = [
+				artifactStore.createCapture("stdout"),
+				artifactStore.createCapture("stderr"),
+				artifactStore.createCapture("result"),
+				artifactStore.createCapture("traceback"),
+			] as const;
+			const [stdoutCapture, stderrCapture, resultCapture, tracebackCapture] = captures;
 			const setToolWorkingMessage = (message?: string) => {
 				setWorkingMessage(ctx, message);
 				hasWorkingMessage = message !== undefined;
@@ -685,10 +692,6 @@ export function createIpythonToolDefinition(
 
 			try {
 				const code = applyShellSettingsToBashMagicCell(params.code, options);
-				const stdoutCapture = artifactStore.createCapture("stdout");
-				const stderrCapture = artifactStore.createCapture("stderr");
-				const resultCapture = artifactStore.createCapture("result");
-				const tracebackCapture = artifactStore.createCapture("traceback");
 				const { result: r, kernelRestarted } = await executeWithBusyKernelChoice(
 					provisioner,
 					reportStartupProgress,
@@ -757,6 +760,7 @@ export function createIpythonToolDefinition(
 					isError: r.status === "error" || r.status === "aborted",
 				};
 			} finally {
+				for (const capture of captures) capture.dispose();
 				if (hasWorkingMessage) {
 					setToolWorkingMessage();
 				}

--- a/packages/coding-agent/test/builtin-skills.test.ts
+++ b/packages/coding-agent/test/builtin-skills.test.ts
@@ -254,6 +254,20 @@ describe("builtin skills", () => {
 			expect(rlmHeartbeat?.kind === "python" && rlmHeartbeat.python.importName).toBe("rlm_heartbeat");
 		});
 
+		it("loads the bundled MCP adapter skills as Python skills", () => {
+			const { skills } = loadSkillsFromDir({ dir: getBundledSkillsDir(), source: "builtin" });
+
+			for (const [name, importName] of [
+				["jcodemunch", "jcodemunch"],
+				["context-mode", "context_mode"],
+			] as const) {
+				const skill = skills.find((candidate) => candidate.name === name);
+				expect(skill).toBeDefined();
+				expect(skill?.kind).toBe("python");
+				expect(skill?.kind === "python" && skill.python.importName).toBe(importName);
+			}
+		});
+
 		it("does not ship orchestration heartbeat as a built-in skill", () => {
 			const { skills } = loadSkillsFromDir({ dir: getBundledSkillsDir(), source: "builtin" });
 

--- a/packages/coding-agent/test/context-artifact-store.test.ts
+++ b/packages/coding-agent/test/context-artifact-store.test.ts
@@ -1,0 +1,141 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ContextArtifactStore } from "../src/core/tools/context-artifact-store.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function createRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "prime-agent-context-artifact-"));
+	roots.push(root);
+	return root;
+}
+
+describe("ContextArtifactStore", () => {
+	it("keeps small output inline without creating an artifact", () => {
+		const store = new ContextArtifactStore(createRoot(), { inlineChars: 100, previewChars: 40 });
+		const stdout = store.createCapture("stdout");
+		stdout.append("hello from IPython");
+
+		const result = store.materialize({ stdout });
+
+		expect(result.oversized).toBe(false);
+		expect(result.artifact).toBeUndefined();
+		expect(result.values.stdout).toBe("hello from IPython");
+		expect(existsSync(join(roots[0], "ipython-output"))).toBe(false);
+	});
+
+	it("spills oversized output, keeps a bounded preview, and emits a stable opaque handle", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 32, previewChars: 100 });
+		const fullText = `prefix\n${"middle-secret-value\n".repeat(30)}suffix`;
+		const stdout = store.createCapture("stdout");
+		stdout.append(fullText);
+
+		const result = store.materialize({ stdout });
+		const reference = result.artifact;
+
+		expect(result.oversized).toBe(true);
+		expect(reference?.handle).toMatch(/^ipython-output-[a-f0-9]{64}$/);
+		expect(result.values.stdout).toContain("prefix");
+		expect(result.values.stdout).toContain("suffix");
+		expect(result.values.stdout).not.toContain(fullText);
+		expect(JSON.stringify(result)).not.toContain(fullText);
+		expect(reference?.handle).not.toContain(root);
+
+		const handlers = store.createHostRequestHandlers();
+		const read = await handlers["artifact.read"]({
+			handle: reference?.handle,
+			channel: "stdout",
+			max_chars: fullText.length,
+		});
+		expect(read.text).toBe(fullText);
+		expect(read.truncated).toBe(false);
+
+		const repeat = new ContextArtifactStore(root, { inlineChars: 32, previewChars: 100 });
+		const repeatCapture = repeat.createCapture("stdout");
+		repeatCapture.append(fullText);
+		expect(repeat.materialize({ stdout: repeatCapture }).artifact?.handle).toBe(reference?.handle);
+	});
+
+	it("preserves the traceback tail while spilling the complete traceback", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 80, previewChars: 100 });
+		const tracebackText = `Traceback (most recent call last):\n${"frame with private payload\n".repeat(20)}ValueError: final traceback detail`;
+		const traceback = store.createCapture("traceback");
+		traceback.append(tracebackText);
+
+		const result = store.materialize({ traceback });
+
+		expect(result.values.traceback).toContain("ValueError: final traceback detail");
+		expect(result.values.traceback).toContain("output omitted");
+		expect(result.values.traceback).not.toBe(tracebackText);
+		const read = await store.createHostRequestHandlers()["artifact.read"]({
+			handle: result.artifact?.handle,
+			channel: "traceback",
+			max_chars: 200,
+		});
+		expect(read.text).toBe(tracebackText.slice(0, 200));
+	});
+
+	it("recovers bounded reads and literal searches from a fresh store instance", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 20, previewChars: 32, retrievalMaxChars: 100 });
+		const stdout = store.createCapture("stdout");
+		stdout.append("first line\nneedle appears here\nlast line\n");
+		const reference = store.materialize({ stdout }).artifact!;
+
+		const resumedStore = new ContextArtifactStore(root, { retrievalMaxChars: 100 });
+		const handlers = resumedStore.createHostRequestHandlers();
+		const read = await handlers["artifact.read"]({ handle: reference.handle, channel: "stdout", max_chars: 8 });
+		const search = await handlers["artifact.search"]({
+			handle: reference.handle,
+			channel: "stdout",
+			query: "needle appears",
+			max_chars: 100,
+		});
+
+		expect(read.text).toBe("first li");
+		expect(read.truncated).toBe(true);
+		expect(search.matches).toEqual([{ line: 2, text: "needle appears here" }]);
+	});
+
+	it("reads UTF-8 artifacts using character offsets rather than byte offsets", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 4, previewChars: 16, retrievalMaxChars: 16 });
+		const fullText = "α😀prefix\nneedle\n";
+		const stdout = store.createCapture("stdout");
+		stdout.append(fullText);
+		const reference = store.materialize({ stdout }).artifact!;
+
+		const read = await store.createHostRequestHandlers()["artifact.read"]({
+			handle: reference.handle,
+			channel: "stdout",
+			offset: "α😀".length,
+			max_chars: 6,
+		});
+
+		expect(read.text).toBe(fullText.slice("α😀".length, "α😀".length + 6));
+	});
+
+	it("does not expose an absolute path or an oversized secret in returned metadata", () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 24, previewChars: 36 });
+		const secret = "UNIQUE_FULL_SECRET_SHOULD_NOT_BE_INLINE";
+		const stdout = store.createCapture("stdout");
+		stdout.append(`head\n${"safe filler\n".repeat(10)}${secret}\nend`);
+		const result = store.materialize({ stdout });
+		const encoded = JSON.stringify(result);
+
+		expect(encoded).not.toContain(root);
+		expect(encoded).not.toContain(secret);
+		expect(readFileSync(join(root, "ipython-output", result.artifact!.handle, "stdout.txt"), "utf8")).toContain(
+			secret,
+		);
+	});
+});

--- a/packages/coding-agent/test/context-artifact-store.test.ts
+++ b/packages/coding-agent/test/context-artifact-store.test.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ContextArtifactStore } from "../src/core/tools/context-artifact-store.js";
+import { boundedArtifactPreview, ContextArtifactStore } from "../src/core/tools/context-artifact-store.js";
 
 const roots: string[] = [];
 
@@ -14,6 +14,21 @@ function createRoot(): string {
 	const root = mkdtempSync(join(tmpdir(), "prime-agent-context-artifact-"));
 	roots.push(root);
 	return root;
+}
+
+function hasLoneSurrogate(text: string): boolean {
+	for (let index = 0; index < text.length; index += 1) {
+		const code = text.charCodeAt(index);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			if (index + 1 >= text.length || text.charCodeAt(index + 1) < 0xdc00 || text.charCodeAt(index + 1) > 0xdfff) {
+				return true;
+			}
+			index += 1;
+		} else if (code >= 0xdc00 && code <= 0xdfff) {
+			return true;
+		}
+	}
+	return false;
 }
 
 describe("ContextArtifactStore", () => {
@@ -61,6 +76,7 @@ describe("ContextArtifactStore", () => {
 		const repeatCapture = repeat.createCapture("stdout");
 		repeatCapture.append(fullText);
 		expect(repeat.materialize({ stdout: repeatCapture }).artifact?.handle).toBe(reference?.handle);
+		expect(readdirSync(join(root, "ipython-output", ".tmp"))).toHaveLength(0);
 	});
 
 	it("preserves the traceback tail while spilling the complete traceback", async () => {
@@ -102,7 +118,10 @@ describe("ContextArtifactStore", () => {
 
 		expect(read.text).toBe("first li");
 		expect(read.truncated).toBe(true);
-		expect(search.matches).toEqual([{ line: 2, text: "needle appears here" }]);
+		const searchMatches = search.matches as Array<{ line: number; text: string }>;
+		expect(searchMatches).toHaveLength(1);
+		expect(searchMatches[0]).toMatchObject({ line: 2 });
+		expect(searchMatches[0]?.text).toContain("needle appears here");
 	});
 
 	it("reads UTF-8 artifacts using character offsets rather than byte offsets", async () => {
@@ -137,5 +156,412 @@ describe("ContextArtifactStore", () => {
 		expect(readFileSync(join(root, "ipython-output", result.artifact!.handle, "stdout.txt"), "utf8")).toContain(
 			secret,
 		);
+	});
+
+	it("keeps append previews bounded for huge and interleaved chunks", () => {
+		const store = new ContextArtifactStore(createRoot(), { inlineChars: 8, previewChars: 48 });
+		const fullText = `head${"x".repeat(100_000)}tail`;
+		const stdout = store.createCapture("stdout");
+		stdout.append(fullText.slice(0, 12));
+		stdout.append(fullText.slice(12));
+
+		const result = store.materialize({ stdout });
+		expect(result.values.stdout).toBe(boundedArtifactPreview(fullText, 48));
+		expect(result.values.stdout!.length).toBeLessThanOrEqual(48);
+	});
+
+	it("searches a newline-free 5MB artifact with a bounded centered window", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 32, retrievalMaxChars: 128 });
+		const fullText = `${"x".repeat(5 * 1024 * 1024)}needle${"y".repeat(200)}`;
+		const stdout = store.createCapture("stdout");
+		stdout.append(fullText);
+		const reference = store.materialize({ stdout }).artifact!;
+
+		const search = await store.createHostRequestHandlers()["artifact.search"]({
+			handle: reference.handle,
+			channel: "stdout",
+			query: "NEEDLE",
+			max_chars: 80,
+		});
+		const text = (search.matches as Array<{ text: string }>)[0]?.text;
+		expect(text).toContain("needle");
+		expect(text?.length).toBeLessThanOrEqual(80);
+		expect(search.truncated).toBe(true);
+	});
+
+	it("rejects search windows smaller than the full query", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 32 });
+		const stdout = store.createCapture("stdout");
+		stdout.append("needle appears here");
+		const reference = store.materialize({ stdout }).artifact!;
+		const search = store.createHostRequestHandlers()["artifact.search"];
+
+		await expect(
+			search({ handle: reference.handle, channel: "stdout", query: "needle", max_chars: 1 }),
+		).rejects.toThrow("max_chars must be at least 6 UTF-16 characters");
+	});
+
+	it("keeps a Unicode query intact at the smallest valid search window", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 32 });
+		const stdout = store.createCapture("stdout");
+		stdout.append("prefix 😀 suffix");
+		const reference = store.materialize({ stdout }).artifact!;
+		const search = store.createHostRequestHandlers()["artifact.search"];
+
+		await expect(search({ handle: reference.handle, channel: "stdout", query: "😀", max_chars: 1 })).rejects.toThrow(
+			"max_chars must be at least 2 UTF-16 characters",
+		);
+		const result = await search({ handle: reference.handle, channel: "stdout", query: "😀", max_chars: 2 });
+		const text = (result.matches as Array<{ text: string }>)[0]?.text;
+		expect(text).toBe("😀");
+		expect(Array.from(text ?? "")).toHaveLength(1);
+		expect(text?.length).toBeLessThanOrEqual(2);
+	});
+
+	it("preserves split surrogate pairs before and after spill", async () => {
+		const fullText = "a😀b";
+		const inlineStore = new ContextArtifactStore(createRoot(), { inlineChars: 8, previewChars: 32 });
+		const inlineCapture = inlineStore.createCapture("stdout");
+		inlineCapture.append("a\ud83d");
+		inlineCapture.append("\ude00b");
+		expect(inlineStore.materialize({ stdout: inlineCapture }).values.stdout).toBe(fullText);
+
+		const spillRoot = createRoot();
+		const spillStore = new ContextArtifactStore(spillRoot, { inlineChars: 2, previewChars: 32 });
+		const spillCapture = spillStore.createCapture("stdout");
+		spillCapture.append("a\ud83d");
+		spillCapture.append("\ude00b");
+		const spilled = spillStore.materialize({ stdout: spillCapture }).artifact!;
+		const expectedStore = new ContextArtifactStore(createRoot(), { inlineChars: 2, previewChars: 32 });
+		const expectedCapture = expectedStore.createCapture("stdout");
+		expectedCapture.append(fullText);
+		const expected = expectedStore.materialize({ stdout: expectedCapture }).artifact!;
+
+		expect(spilled.handle).toBe(expected.handle);
+		expect(spilled.bytes).toBe(expected.bytes);
+		expect(readFileSync(join(spillRoot, "ipython-output", spilled.handle, "stdout.txt"), "utf8")).toBe(fullText);
+
+		const read = spillStore.createHostRequestHandlers()["artifact.read"];
+		expect((await read({ handle: spilled.handle, channel: "stdout", offset: 0, max_chars: 16 })).text).toBe(fullText);
+		const search = spillStore.createHostRequestHandlers()["artifact.search"];
+		const searchResult = await search({ handle: spilled.handle, channel: "stdout", query: "😀", max_chars: 2 });
+		expect((searchResult.matches as Array<{ text: string }>)[0]?.text).toBe("😀");
+	});
+
+	it("keeps checkpoint byte offsets after a split surrogate at a boundary", () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 32 });
+		const capture = store.createCapture("stdout");
+		const chunkWithHigh = `${"x".repeat(256_000 - 1)}\ud83d`;
+		const chunkWithLow = `\ude00y`;
+		capture.append(chunkWithHigh);
+		capture.append(chunkWithLow);
+		const fullText = `${chunkWithHigh}${chunkWithLow}`;
+		const reference = store.materialize({ stdout: capture }).artifact!;
+		const metadata = JSON.parse(
+			readFileSync(join(root, "ipython-output", reference.handle, "metadata.json"), "utf8"),
+		) as { channels: { stdout: { checkpoints: Array<{ chars: number; bytes: number }> } } };
+
+		expect(metadata.channels.stdout.checkpoints).toEqual([
+			{ chars: 0, bytes: 0 },
+			{ chars: 256_001, bytes: Buffer.byteLength(fullText.slice(0, 256_001), "utf8") },
+			{ chars: fullText.length, bytes: Buffer.byteLength(fullText, "utf8") },
+		]);
+	});
+
+	it("emits intermediate checkpoints within one large ASCII append", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 32, retrievalMaxChars: 512 });
+		const fullText = "0123456789".repeat(70_000);
+		const capture = store.createCapture("stdout");
+		capture.append(fullText);
+		const reference = store.materialize({ stdout: capture }).artifact!;
+		const metadataPath = join(root, "ipython-output", reference.handle, "metadata.json");
+		const metadata = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+			channels: { stdout: { checkpoints?: Array<{ chars: number; bytes: number }> } };
+		};
+		const checkpoints = metadata.channels.stdout.checkpoints!;
+		expect(checkpoints.map((checkpoint) => checkpoint.chars)).toEqual([0, 256_000, 512_000, fullText.length]);
+		for (const checkpoint of checkpoints) {
+			expect(checkpoint.bytes).toBe(Buffer.byteLength(fullText.slice(0, checkpoint.chars), "utf8"));
+		}
+
+		const read = store.createHostRequestHandlers()["artifact.read"];
+		const offsets = [0, 255_999, 256_000, 512_000, fullText.length - 37];
+		const sparseResults = new Map<number, string>();
+		for (const offset of offsets) {
+			sparseResults.set(
+				offset,
+				(await read({ handle: reference.handle, channel: "stdout", offset, max_chars: 37 })).text as string,
+			);
+		}
+		const legacyMetadata = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+			schema: number;
+			channels: Record<string, { checkpoints?: Array<{ chars: number; bytes: number }> }>;
+		};
+		legacyMetadata.schema = 1;
+		for (const channel of Object.values(legacyMetadata.channels)) delete channel.checkpoints;
+		writeFileSync(metadataPath, `${JSON.stringify(legacyMetadata)}\n`);
+		for (const offset of offsets) {
+			const legacyResult = await read({ handle: reference.handle, channel: "stdout", offset, max_chars: 37 });
+			expect(legacyResult.text).toBe(sparseResults.get(offset));
+		}
+	});
+
+	it("emits code-point-aligned checkpoints within one large multibyte append", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 32, retrievalMaxChars: 512 });
+		const unit = "α😀β🚀\n";
+		const fullText = unit.repeat(150_000);
+		const capture = store.createCapture("stdout");
+		capture.append(fullText);
+		const reference = store.materialize({ stdout: capture }).artifact!;
+		const metadataPath = join(root, "ipython-output", reference.handle, "metadata.json");
+		const metadata = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+			channels: { stdout: { checkpoints?: Array<{ chars: number; bytes: number }> } };
+		};
+		const checkpoints = metadata.channels.stdout.checkpoints!;
+		expect(checkpoints.map((checkpoint) => checkpoint.chars)).toEqual([
+			0,
+			256_000,
+			512_000,
+			768_001,
+			1_024_001,
+			fullText.length,
+		]);
+		for (const checkpoint of checkpoints) {
+			const prefix = fullText.slice(0, checkpoint.chars);
+			expect(hasLoneSurrogate(prefix)).toBe(false);
+			expect(checkpoint.bytes).toBe(Buffer.byteLength(prefix, "utf8"));
+		}
+
+		const read = store.createHostRequestHandlers()["artifact.read"];
+		const offsets = [0, 255_999, 256_000, 511_999, 768_000, 768_001, fullText.length - 41];
+		const sparseResults = new Map<number, string>();
+		for (const offset of offsets) {
+			sparseResults.set(
+				offset,
+				(await read({ handle: reference.handle, channel: "stdout", offset, max_chars: 41 })).text as string,
+			);
+		}
+		const legacyMetadata = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+			schema: number;
+			channels: Record<string, { checkpoints?: Array<{ chars: number; bytes: number }> }>;
+		};
+		legacyMetadata.schema = 1;
+		for (const channel of Object.values(legacyMetadata.channels)) delete channel.checkpoints;
+		writeFileSync(metadataPath, `${JSON.stringify(legacyMetadata)}\n`);
+		for (const offset of offsets) {
+			const legacyResult = await read({ handle: reference.handle, channel: "stdout", offset, max_chars: 41 });
+			expect(legacyResult.text).toBe(sparseResults.get(offset));
+		}
+	});
+
+	it("flushes an unmatched final high surrogate consistently", async () => {
+		const source = "a\ud83d";
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 1, previewChars: 32 });
+		const capture = store.createCapture("stdout");
+		capture.append("a");
+		capture.append("\ud83d");
+		const reference = store.materialize({ stdout: capture }).artifact!;
+		const expectedStore = new ContextArtifactStore(createRoot(), { inlineChars: 1, previewChars: 32 });
+		const expectedCapture = expectedStore.createCapture("stdout");
+		expectedCapture.append(source);
+		const expected = expectedStore.materialize({ stdout: expectedCapture }).artifact!;
+
+		expect(reference.handle).toBe(expected.handle);
+		expect(reference.bytes).toBe(Buffer.byteLength(source, "utf8"));
+		expect(readFileSync(join(root, "ipython-output", reference.handle, "stdout.txt"), "utf8")).toBe("a�");
+
+		const read = store.createHostRequestHandlers()["artifact.read"];
+		expect((await read({ handle: reference.handle, channel: "stdout", offset: 0, max_chars: 16 })).text).toBe("a�");
+
+		const disposableRoot = createRoot();
+		const disposableStore = new ContextArtifactStore(disposableRoot, { inlineChars: 1, previewChars: 32 });
+		const disposableCapture = disposableStore.createCapture("stdout");
+		disposableCapture.append(source);
+		disposableCapture.dispose();
+		expect(readdirSync(join(disposableRoot, "ipython-output", ".tmp"))).toHaveLength(0);
+	});
+
+	it("finds matches straddling UTF-8 read chunks and centers the returned window", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 32 });
+		const stdout = store.createCapture("stdout");
+		const streamChunkSize = 64 * 1024;
+		stdout.append(`${"a".repeat(streamChunkSize - 3)}str`);
+		stdout.append(`addled${"b".repeat(80)}`);
+		const reference = store.materialize({ stdout }).artifact!;
+
+		const search = await store.createHostRequestHandlers()["artifact.search"]({
+			handle: reference.handle,
+			channel: "stdout",
+			query: "STRADDLED",
+			max_chars: 32,
+		});
+		expect(search.matches).toHaveLength(1);
+		expect((search.matches as Array<{ text: string }>)[0]?.text).toContain("straddled");
+		expect((search.matches as Array<{ text: string }>)[0]?.text.length).toBeLessThanOrEqual(32);
+	});
+
+	it("uses persisted checkpoints for multi-page Unicode reads and falls back for schema 1", async () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 32, retrievalMaxChars: 256 });
+		const unit = "α😀\n";
+		let fullText = "";
+		const stdout = store.createCapture("stdout");
+		for (let index = 0; index < 12; index += 1) {
+			const chunk = unit.repeat(20_000);
+			fullText += chunk;
+			stdout.append(chunk);
+		}
+		const reference = store.materialize({ stdout }).artifact!;
+		const metadataPath = join(root, "ipython-output", reference.handle, "metadata.json");
+		const metadata = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+			schema: number;
+			channels: { stdout: { checkpoints?: Array<{ chars: number; bytes: number }> } };
+		};
+		expect(metadata.schema).toBe(2);
+		expect(metadata.channels.stdout.checkpoints!.length).toBeGreaterThanOrEqual(3);
+
+		const read = store.createHostRequestHandlers()["artifact.read"];
+		for (const offset of [0, 80_000, 320_000, 640_000, 960_000]) {
+			const result = await read({ handle: reference.handle, channel: "stdout", offset, max_chars: 60 });
+			expect(result.text).toBe(fullText.slice(offset, offset + 60));
+		}
+
+		const legacyMetadata = JSON.parse(readFileSync(metadataPath, "utf8")) as Record<string, unknown>;
+		legacyMetadata.schema = 1;
+		for (const channel of Object.values(legacyMetadata.channels as Record<string, Record<string, unknown>>)) {
+			delete channel.checkpoints;
+		}
+		writeFileSync(metadataPath, `${JSON.stringify(legacyMetadata)}\n`);
+		const legacyRead = await read({ handle: reference.handle, channel: "stdout", offset: 640_000, max_chars: 60 });
+		expect(legacyRead.text).toBe(fullText.slice(640_000, 640_060));
+	});
+
+	it("does not split emoji at preview or read boundaries", async () => {
+		const root = createRoot();
+		const source = `${"a".repeat(19)}😀${"b".repeat(20)}`;
+		const omissionLength = "\n[… output omitted …]\n".length;
+		for (const maxChars of [omissionLength - 1, omissionLength, omissionLength + 1, omissionLength + 10]) {
+			expect(boundedArtifactPreview("a".repeat(100), maxChars).length).toBe(maxChars);
+		}
+		for (const maxChars of [0, 1, 2, 10, 23]) {
+			const preview = boundedArtifactPreview(source, maxChars);
+			expect(hasLoneSurrogate(preview)).toBe(false);
+			expect(preview.length).toBeLessThanOrEqual(maxChars);
+		}
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 64 });
+		const stdout = store.createCapture("stdout");
+		stdout.append(source);
+		const reference = store.materialize({ stdout }).artifact!;
+		const read = store.createHostRequestHandlers()["artifact.read"];
+		const emojiOffset = 19;
+		expect(
+			(await read({ handle: reference.handle, channel: "stdout", offset: emojiOffset, max_chars: 1 })).text,
+		).toBe("");
+		expect(
+			(await read({ handle: reference.handle, channel: "stdout", offset: emojiOffset, max_chars: 2 })).text,
+		).toBe("😀");
+		expect(
+			(await read({ handle: reference.handle, channel: "stdout", offset: emojiOffset + 1, max_chars: 2 })).text,
+		).toBe("b");
+	});
+
+	it("does not refill a head preview after a surrogate pair cannot fit", () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 1, previewChars: 5 });
+		const capture = store.createCapture("stdout");
+		const chunks = ["abcd\ud83d", "\ude00", "fghijkl"];
+		for (const chunk of chunks) capture.append(chunk);
+		const fullText = chunks.join("");
+		const result = store.materialize({ stdout: capture });
+
+		expect(result.values.stdout).toBe(boundedArtifactPreview(fullText, 5));
+		expect(result.values.stdout).toBe("abcd");
+	});
+
+	it("latches the head after an unmatched high surrogate across chunk splits", () => {
+		const root = createRoot();
+		const source = "abcd\ud83deFGHI";
+		const store = new ContextArtifactStore(root, { inlineChars: 1, previewChars: 5 });
+		for (let split = 0; split <= source.length; split += 1) {
+			const capture = store.createCapture("stdout");
+			capture.append(source.slice(0, split));
+			capture.append(source.slice(split));
+			const result = store.materialize({ stdout: capture });
+			expect(result.values.stdout).toBe("abcd");
+		}
+	});
+
+	it("keeps previews and persistence chunk-independent for mixed surrogate sequences", () => {
+		const root = createRoot();
+		const high = String.fromCharCode(0xd83d);
+		const low = String.fromCharCode(0xdc00);
+		const sequences = [`abcd${high}eFGHI`, `😀x${high}yZ`, `p😀q${high}r`, `a${low}b😀c`, `x😀${high}y${low}z`];
+		for (const source of sequences) {
+			for (const previewChars of [1, 2, 3, 4, 5, 6, 7, 8, 9, 12]) {
+				const oneStore = new ContextArtifactStore(root, { inlineChars: 1, previewChars });
+				const oneCapture = oneStore.createCapture("stdout");
+				oneCapture.append(source);
+				const one = oneStore.materialize({ stdout: oneCapture });
+				const oneReference = one.artifact!;
+				expect(hasLoneSurrogate(one.values.stdout as string)).toBe(false);
+				for (let split = 0; split <= source.length; split += 1) {
+					const splitStore = new ContextArtifactStore(root, { inlineChars: 1, previewChars });
+					const splitCapture = splitStore.createCapture("stdout");
+					splitCapture.append(source.slice(0, split));
+					splitCapture.append(source.slice(split));
+					const splitResult = splitStore.materialize({ stdout: splitCapture });
+					expect(splitResult.values.stdout).toBe(one.values.stdout);
+					expect(splitResult.artifact?.handle).toBe(oneReference.handle);
+					expect(splitResult.artifact?.bytes).toBe(oneReference.bytes);
+				}
+				const persisted = Buffer.from(source, "utf8").toString("utf8");
+				expect(readFileSync(join(root, "ipython-output", oneReference.handle, "stdout.txt"), "utf8")).toBe(
+					persisted,
+				);
+				expect(oneReference.bytes).toBe(Buffer.byteLength(source, "utf8"));
+			}
+		}
+	});
+
+	it("matches bounded previews across capacities and every chunk split", () => {
+		const root = createRoot();
+		const source = `${"a".repeat(4)}😀${"m".repeat(30)}🚀tail`;
+		for (const previewChars of [1, 2, 3, 4, 5, 6, 7, 8, 32]) {
+			const store = new ContextArtifactStore(root, { inlineChars: 1, previewChars });
+			for (let split = 0; split <= source.length; split += 1) {
+				const capture = store.createCapture("stdout");
+				capture.append(source.slice(0, split));
+				capture.append(source.slice(split));
+				const result = store.materialize({ stdout: capture });
+				expect(result.values.stdout).toBe(boundedArtifactPreview(source, previewChars));
+			}
+		}
+	});
+
+	it("cleans staging and spill files when atomic publication fails", () => {
+		const root = createRoot();
+		const store = new ContextArtifactStore(root, { inlineChars: 8, previewChars: 32 });
+		const fullText = "x".repeat(100);
+		const first = store.createCapture("stdout");
+		first.append(fullText);
+		const reference = store.materialize({ stdout: first }).artifact!;
+		const artifactDir = join(root, "ipython-output", reference.handle);
+		rmSync(artifactDir, { recursive: true, force: true });
+		writeFileSync(artifactDir, "not a directory");
+		const second = store.createCapture("stdout");
+		second.append(fullText);
+		const result = store.materialize({ stdout: second });
+
+		expect(result.artifact).toBeUndefined();
+		expect(readdirSync(join(root, "ipython-output")).filter((entry) => entry.startsWith(".staging.")).length).toBe(0);
+		expect(readdirSync(join(root, "ipython-output", ".tmp"))).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/context-routing.test.ts
+++ b/packages/coding-agent/test/context-routing.test.ts
@@ -48,6 +48,14 @@ describe("context-routing policy", () => {
 			expect(
 				inspectContextRoutingCode('from pathlib import Path\nprint(Path("large.txt").read_text())', cwd).decision,
 			).toBe("block");
+			for (const code of [
+				"%%bash\ntail -n +1 large.txt",
+				"%%bash\ntail --lines=+5 large.txt",
+				"%%bash\nhead +5 large.txt",
+				"%%bash\nhead -n+5 large.txt",
+			]) {
+				expect(inspectContextRoutingCode(code, cwd), code).toMatchObject({ decision: "block" });
+			}
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
 		}
@@ -61,6 +69,10 @@ describe("context-routing policy", () => {
 				"%%bash\nwget -O response.html https://example.com",
 				"%%bash\ncat large.txt > response.txt",
 				"%%bash\ncat large.txt | head -n 20",
+				"%%bash\ntail large.txt",
+				"%%bash\nhead -5 large.txt",
+				"%%bash\ntail -n 5 large.txt",
+				"%%bash\nhead -n 5 large.txt",
 				"%%bash\ncurl https://example.com | head -c 200",
 				"npm test",
 				"git status --short",
@@ -108,6 +120,181 @@ describe("context-routing policy", () => {
 					cwd,
 				).decision,
 			).toBe("block");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("scopes fallback guards to integration branches and ranges", () => {
+		const cwd = createTempFiles();
+		try {
+			expect(
+				inspectContextRoutingCode(
+					'try:\n    import unrelated\nexcept ImportError:\n    print(open("large.txt").read())',
+					cwd,
+				).decision,
+			).toBe("block");
+			expect(
+				inspectContextRoutingCode(
+					'try:\n    import jcodemunch\nexcept ImportError:\n    print(open("large.txt").read())\nprint(open("large.txt").read())',
+					cwd,
+				).decision,
+			).toBe("block");
+			expect(inspectContextRoutingCode("%%bash\ncommand -v unrelated || cat large.txt", cwd).decision).toBe("block");
+			expect(inspectContextRoutingCode("%%bash\ncommand -v jcodemunch || cat large.txt", cwd).decision).toBe(
+				"allow",
+			);
+			expect(
+				inspectContextRoutingCode("%%bash\n# context-routing: fallback\ncat large.txt\ncat large.txt", cwd)
+					.decision,
+			).toBe("block");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects unsafe redirections and only accepts genuinely bounded pipelines", () => {
+		const cwd = createTempFiles();
+		try {
+			const blocked = [
+				"%%bash\ncat large.txt >&2",
+				"%%bash\ncat large.txt >/dev/stdout",
+				"%%bash\ncat large.txt >/dev/stderr",
+				"%%bash\ncat large.txt >/dev/stdin",
+				"%%bash\ncat large.txt >/dev/fd/0",
+				"%%bash\ncat large.txt >/dev/fd/1",
+				"%%bash\ncat large.txt >/dev/fd/2",
+				"%%bash\ncat large.txt >/dev//fd/1",
+				"%%bash\ncat large.txt >/dev//fd/2",
+				"%%bash\ncat large.txt >/dev/./fd/1",
+				"%%bash\ncat large.txt >/dev/./fd/2",
+				"%%bash\ncat large.txt >/dev/fd/../fd/1",
+				"%%bash\ncat large.txt >/dev/fd/../fd/2",
+				"%%bash\ncat large.txt >//dev/fd/1",
+				"%%bash\ncat large.txt >//dev/fd/2",
+				"%%bash\ncat large.txt >/proc/self/fd/0",
+				"%%bash\ncat large.txt >/proc/self/fd/1",
+				"%%bash\ncat large.txt >/proc/self/fd/2",
+				"%%bash\ncat large.txt >/proc/thread-self/fd/1",
+				"%%bash\ncat large.txt >/proc/thread-self/fd/2",
+				"%%bash\ncat large.txt >/proc/12345/fd/1",
+				"%%bash\ncat large.txt >/proc/12345/fd/2",
+				"%%bash\ncat large.txt >/proc/12345/task/67890/fd/1",
+				"%%bash\ncat large.txt >/proc/12345/task/67890/fd/2",
+				"%%bash\ncat large.txt >/proc/12345/task/67890/fd/../fd/1",
+				"%%bash\ncat large.txt >/proc/thread-self/fd/../fd/2",
+				"%%bash\ncat large.txt >/proc/self/root/proc/self/fd/1",
+				"%%bash\ncat large.txt >/proc/self/root/proc/self/fd/2",
+				"%%bash\ncat large.txt >/proc/self/root/dev/fd/1",
+				"%%bash\ncat large.txt >/proc/self/root/dev/fd/2",
+				"%%bash\ncat large.txt >/proc/self/cwd/proc/self/fd/1",
+				"%%bash\ncat large.txt >/proc/self/cwd/proc/self/fd/2",
+				"%%bash\ncat large.txt >/proc/self/cwd/dev/fd/1",
+				"%%bash\ncat large.txt >/proc/self/cwd/dev/fd/2",
+				"%%bash\ncat large.txt >//proc//self//root//proc//self//fd//1",
+				"%%bash\ncat large.txt >//proc//self//root//proc//self//fd//2",
+				"%%bash\ncat large.txt >//proc//self//cwd//dev//fd//1",
+				"%%bash\ncat large.txt >//proc//self//cwd//dev//fd//2",
+				"%%bash\ncat large.txt >/proc/self/root/../root/proc/self/fd/1",
+				"%%bash\ncat large.txt >/proc/self/root/../root/proc/self/fd/2",
+				"%%bash\ncat large.txt >-",
+				"%%bash\ncat large.txt | tail -n +1",
+				"%%bash\ncat large.txt | tail --lines=+1",
+				"%%bash\ncat large.txt | head -5 | tail -n +1",
+				"%%bash\ncat large.txt | head -5 | grep x other.txt",
+			];
+			for (const code of blocked)
+				expect(inspectContextRoutingCode(code, cwd), code).toMatchObject({ decision: "block" });
+
+			const allowed = [
+				"%%bash\ncat large.txt >/dev/null",
+				"%%bash\ncat large.txt > response.txt",
+				"%%bash\ncat large.txt | head -5",
+				"%%bash\ncat large.txt | head -n 5",
+				"%%bash\ncat large.txt | tail -n 5",
+				"%%bash\ncat large.txt | head -5 | cat",
+				"%%bash\ncat large.txt | head -5 | grep x",
+			];
+			for (const code of allowed)
+				expect(inspectContextRoutingCode(code, cwd), code).toMatchObject({ decision: "allow" });
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves relative redirects against the inspection cwd", () => {
+		const cwd = createTempFiles();
+		const nestedCwd = "/tmp/prime-agent-context-routing-nested";
+		try {
+			const rootBlocked = [
+				"%%bash\ncat large.txt > proc/self/root/proc/self/fd/1",
+				"%%bash\ncurl https://example.com > proc/self/root/proc/self/fd/1",
+				"%%bash\ncurl https://example.com -o proc/self/root/proc/self/fd/1",
+				"%%bash\ncurl https://example.com > 'proc/self/root/proc/self/fd/2'",
+				'%%bash\ncurl https://example.com > "proc/self/cwd/dev/fd/1"',
+				"%%bash\ncurl https://example.com > //proc//self//root//proc//self//fd//2",
+				"%%bash\ncurl https://example.com > proc/self/cwd/../../root/proc/self/fd/1",
+			];
+			for (const code of rootBlocked)
+				expect(inspectContextRoutingCode(code, "/"), code).toMatchObject({ decision: "block" });
+
+			const nestedBlocked = [
+				"%%bash\ncat large.txt > ../../proc/self/fd/1",
+				"%%bash\ncurl https://example.com > ../../proc/self/fd/1",
+				'%%bash\nwget -O "../../proc/self/fd/2" https://example.com',
+				'%%bash\ncurl https://example.com > "../../proc/self/root/dev/fd/2"',
+				"%%bash\ncurl https://example.com > ../../proc//self/./root/../root/proc/self/fd/1",
+			];
+			for (const code of nestedBlocked)
+				expect(inspectContextRoutingCode(code, nestedCwd), code).toMatchObject({ decision: "block" });
+
+			const allowed = [
+				"%%bash\ncurl https://example.com > response.html",
+				'%%bash\ncurl https://example.com > "../response.html"',
+			];
+			for (const code of allowed)
+				expect(inspectContextRoutingCode(code, cwd), code).toMatchObject({ decision: "allow" });
+			expect(inspectContextRoutingCode("%%bash\ncurl https://example.com > tmp/response.html", "/").decision).toBe(
+				"allow",
+			);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("inspects every direct read while allowing scalar reductions", () => {
+		const cwd = createTempFiles();
+		try {
+			const blocked = [
+				'print(open("small.txt").read(), open("large.txt").read())',
+				'print(open("large.txt").read(200), open("large.txt").read())',
+				'print(str(open("large.txt").read()))',
+				'print(open("large.txt").read() if flag == "x" else "")',
+				'print((flag == "x") and open("large.txt").read())',
+				'print(open("large.txt").read() + str(flag == "x"))',
+				'print(open("large.txt").read() + ("suffix" if flag == "x" else ""))',
+				'print(list([open("large.txt").read()]))',
+				'print(min([open("large.txt").read(), "z"]))',
+				'print(max((open("large.txt").read(), "z")))',
+				'print(tuple(({"content": [open("large.txt").read()]},)))',
+				"print(f\"{open('large.txt').read()}\")",
+			];
+			for (const code of blocked)
+				expect(inspectContextRoutingCode(code, cwd), code).toMatchObject({ decision: "block" });
+
+			const allowed = [
+				'print(len(open("large.txt").read()))',
+				'print(hash(open("large.txt").read()))',
+				'print(open("large.txt").read().count("x"))',
+				'print(open("large.txt").read() == "x")',
+				'print(open("large.txt").read()[:200])',
+				'print(len([open("large.txt").read()]))',
+				'print(bool({"content": (open("large.txt").read(),)}))',
+				'print(hash(tuple([open("large.txt").read()])))',
+				"print(f\"{len(open('large.txt').read())}\")",
+			];
+			for (const code of allowed)
+				expect(inspectContextRoutingCode(code, cwd), code).toMatchObject({ decision: "allow" });
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/context-routing.test.ts
+++ b/packages/coding-agent/test/context-routing.test.ts
@@ -1,0 +1,312 @@
+import type { ChildProcess, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+	type ContextRoutingTelemetryEvent,
+	createFastReindexQueue,
+	inspectContextRoutingCode,
+	installContextRouting,
+	SMALL_FILE_BYTES,
+} from "../examples/extensions/context-routing.js";
+import type { ExtensionAPI } from "../src/core/extensions/index.js";
+
+type CapturedHandler = (event: unknown, ctx?: unknown) => unknown;
+
+function createApi(initialMode: string, initialFastReindex = "on") {
+	const handlers = new Map<string, CapturedHandler>();
+	const commands = new Map<string, { handler: (args: string, ctx: unknown) => unknown }>();
+	const api = {
+		on: (event: string, handler: unknown) => {
+			handlers.set(event, handler as CapturedHandler);
+		},
+		registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => unknown }) => {
+			commands.set(name, command);
+		},
+		registerFlag: vi.fn(),
+		getFlag: vi.fn((name: string) => (name === "context-routing-fast-reindex" ? initialFastReindex : initialMode)),
+	} as unknown as ExtensionAPI;
+	return { api, handlers, commands };
+}
+
+function createTempFiles() {
+	const cwd = mkdtempSync(path.join(os.tmpdir(), "prime-agent-context-routing-"));
+	writeFileSync(path.join(cwd, "large.txt"), "x".repeat(SMALL_FILE_BYTES + 1));
+	writeFileSync(path.join(cwd, "small.txt"), "small\n");
+	return cwd;
+}
+
+describe("context-routing policy", () => {
+	it("blocks only high-confidence broad reads", () => {
+		const cwd = createTempFiles();
+		try {
+			expect(inspectContextRoutingCode("%%bash\ncurl https://example.com", cwd).decision).toBe("block");
+			expect(inspectContextRoutingCode("%%bash\nwget -qO- https://example.com", cwd).decision).toBe("block");
+			expect(inspectContextRoutingCode("%%bash\ncat large.txt", cwd).decision).toBe("block");
+			expect(inspectContextRoutingCode('print(open("large.txt").read())', cwd).decision).toBe("block");
+			expect(
+				inspectContextRoutingCode('from pathlib import Path\nprint(Path("large.txt").read_text())', cwd).decision,
+			).toBe("block");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("allows bounded reads, small files, redirects, normal development commands, and fallback paths", () => {
+		const cwd = createTempFiles();
+		try {
+			const allowed = [
+				"%%bash\ncurl https://example.com > response.html",
+				"%%bash\nwget -O response.html https://example.com",
+				"%%bash\ncat large.txt > response.txt",
+				"%%bash\ncat large.txt | head -n 20",
+				"%%bash\ncurl https://example.com | head -c 200",
+				"npm test",
+				"git status --short",
+				"echo generated > output.txt",
+				'print(open("large.txt").read(200))',
+				'print(Path("large.txt").read_text()[:200])',
+				'print(Path("small.txt").read_text())',
+				"try:\n    import jcodemunch\nexcept ImportError:\n    print(open('large.txt').read())",
+				"# context-routing: bypass\nprint(open('large.txt').read())",
+				"%%bash\n# context-routing: bypass\ncat large.txt",
+				"%%bash\n# context-routing: fallback\ncat large.txt",
+			];
+			for (const code of allowed) {
+				expect(inspectContextRoutingCode(code, cwd), code).toMatchObject({ decision: "allow" });
+			}
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("ignores comments and unknown syntax instead of guessing", () => {
+		const cwd = createTempFiles();
+		try {
+			expect(inspectContextRoutingCode("%%bash\n# cat large.txt\nnpm test", cwd).decision).toBe("allow");
+			expect(inspectContextRoutingCode("%%bash\nprintf '%s' 'cat large.txt'", cwd).decision).toBe("allow");
+			expect(inspectContextRoutingCode("some_unknown_helper('large.txt')", cwd).decision).toBe("allow");
+			expect(inspectContextRoutingCode('print("read_text() is mentioned, not called")', cwd).decision).toBe("allow");
+			expect(inspectContextRoutingCode('""" print(open("large.txt").read()) """', cwd).decision).toBe("allow");
+			expect(inspectContextRoutingCode("# print(open('large.txt').read())", cwd).decision).toBe("allow");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not treat error words in strings as an unavailable fallback", () => {
+		const cwd = createTempFiles();
+		try {
+			expect(
+				inspectContextRoutingCode('print("ImportError; unavailable")\nprint(open("large.txt").read())', cwd)
+					.decision,
+			).toBe("block");
+			expect(
+				inspectContextRoutingCode(
+					'try:\n    print("ImportError in documentation")\nexcept Exception:\n    print(open("large.txt").read())',
+					cwd,
+				).decision,
+			).toBe("block");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("injects advisory guidance per turn and blocks strict cells with telemetry", async () => {
+		const events: ContextRoutingTelemetryEvent[] = [];
+		const { api, handlers, commands } = createApi("strict-large-read");
+		const stats = installContextRouting(api, { telemetry: (event) => events.push(event) });
+		const beforeAgentStart = handlers.get("before_agent_start");
+		const toolCall = handlers.get("tool_call");
+		expect(beforeAgentStart).toBeDefined();
+		expect(toolCall).toBeDefined();
+
+		const prompt = (await beforeAgentStart?.({ systemPrompt: "base" })) as { systemPrompt: string };
+		expect(prompt.systemPrompt).toContain("jCodeMunch");
+		expect(prompt.systemPrompt).toContain("Context Mode");
+		expect(prompt.systemPrompt).toContain("routing guidance, not security");
+
+		const result = await toolCall?.(
+			{ toolName: "ipython", input: { code: "%%bash\ncurl https://example.com" } },
+			{ cwd: process.cwd() },
+		);
+		expect(result).toMatchObject({ block: true });
+		expect(stats).toMatchObject({ turnsGuided: 1, cellsInspected: 1, blocked: 1 });
+		expect(events).toEqual([
+			{ kind: "turn-guidance", mode: "strict-large-read", action: "advisory" },
+			{ kind: "inspection", mode: "strict-large-read", action: "block", pattern: "curl/wget stdout" },
+		]);
+		expect(commands.has("context-routing")).toBe(true);
+	});
+
+	it("supports advisory mode and runtime mode changes", async () => {
+		const { api, handlers, commands } = createApi("advisory");
+		installContextRouting(api);
+		const prompt = (await handlers.get("before_agent_start")?.({ systemPrompt: "base" })) as { systemPrompt: string };
+		expect(prompt.systemPrompt).toContain("Context routing (advisory)");
+		expect(
+			await handlers.get("tool_call")?.(
+				{ toolName: "ipython", input: { code: "%%bash\ncurl https://example.com" } },
+				{ cwd: process.cwd() },
+			),
+		).toBeUndefined();
+
+		const ui = { notify: vi.fn() };
+		await commands.get("context-routing")?.handler("strict-large-read", { ui });
+		expect(
+			await handlers.get("tool_call")?.(
+				{ toolName: "ipython", input: { code: "%%bash\ncurl https://example.com" } },
+				{ cwd: process.cwd() },
+			),
+		).toMatchObject({ block: true });
+		await commands.get("context-routing")?.handler("off", { ui });
+		expect(
+			await handlers.get("tool_call")?.(
+				{ toolName: "ipython", input: { code: "%%bash\ncurl https://example.com" } },
+				{ cwd: process.cwd() },
+			),
+		).toBeUndefined();
+	});
+
+	it("does not inject or inspect in off mode", async () => {
+		const { api, handlers } = createApi("off");
+		const stats = installContextRouting(api);
+		expect(await handlers.get("before_agent_start")?.({ systemPrompt: "base" })).toBeUndefined();
+		expect(
+			await handlers.get("tool_call")?.(
+				{ toolName: "ipython", input: { code: "%%bash\ncat large.txt" } },
+				{ cwd: process.cwd() },
+			),
+		).toBeUndefined();
+		expect(stats).toEqual({ turnsGuided: 0, cellsInspected: 0, allowed: 0, blocked: 0 });
+	});
+
+	it("queues only successful IPython edit diffs and skips unsafe paths", async () => {
+		const cwd = mkdtempSync(path.join(os.tmpdir(), "prime-agent-context-routing-reindex-"));
+		try {
+			const sourceDir = path.join(cwd, "src");
+			mkdirSync(sourceDir);
+			const changedPath = path.join(sourceDir, "changed.ts");
+			const generatedPath = path.join(sourceDir, "models.generated.ts");
+			const directoryPath = path.join(sourceDir, "directory");
+			const deletedPath = path.join(sourceDir, "deleted.ts");
+			writeFileSync(changedPath, "changed\n");
+			writeFileSync(generatedPath, "generated\n");
+			mkdirSync(directoryPath);
+			const calls: string[] = [];
+			const { api, handlers } = createApi("off");
+			installContextRouting(api, {
+				reindexFile: (absolutePath) => {
+					calls.push(absolutePath);
+				},
+			});
+			const toolResult = handlers.get("tool_result");
+
+			await toolResult?.(
+				{
+					toolName: "ipython",
+					isError: false,
+					details: {
+						status: "ok",
+						diffs: [
+							{ path: changedPath },
+							{ path: path.relative(cwd, changedPath) },
+							{ path: generatedPath },
+							{ path: directoryPath },
+							{ path: deletedPath },
+						],
+					},
+				},
+				{ cwd },
+			);
+			await toolResult?.(
+				{ toolName: "ipython", isError: true, details: { status: "error", diffs: [{ path: changedPath }] } },
+				{ cwd },
+			);
+
+			expect(calls).toEqual([changedPath]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("honors the fast-reindex off switch", async () => {
+		const cwd = mkdtempSync(path.join(os.tmpdir(), "prime-agent-context-routing-reindex-off-"));
+		try {
+			const changedPath = path.join(cwd, "changed.ts");
+			writeFileSync(changedPath, "changed\n");
+			const calls: string[] = [];
+			const { api, handlers } = createApi("off", "off");
+			installContextRouting(api, {
+				reindexFile: (absolutePath) => {
+					calls.push(absolutePath);
+				},
+			});
+			await handlers.get("tool_result")?.(
+				{ toolName: "ipython", isError: false, details: { status: "ok", diffs: [{ path: changedPath }] } },
+				{ cwd },
+			);
+			expect(calls).toEqual([]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("coalesces duplicate paths and bounds concurrent reindexes", async () => {
+		const cwd = mkdtempSync(path.join(os.tmpdir(), "prime-agent-context-routing-queue-"));
+		try {
+			const paths = ["a.ts", "b.ts", "c.ts", "d.ts"].map((name) => path.join(cwd, name));
+			for (const filePath of paths) writeFileSync(filePath, `${filePath}\n`);
+			let active = 0;
+			let maximumActive = 0;
+			const calls: string[] = [];
+			const queue = createFastReindexQueue({
+				concurrency: 2,
+				reindexFile: async (absolutePath) => {
+					calls.push(absolutePath);
+					active += 1;
+					maximumActive = Math.max(maximumActive, active);
+					await new Promise((resolve) => setTimeout(resolve, 5));
+					active -= 1;
+				},
+			});
+			queue.enqueue([...paths, paths[0]!], cwd);
+			queue.enqueue([paths[1]!], cwd);
+			await queue.whenIdle();
+
+			expect(calls).toHaveLength(paths.length);
+			expect(new Set(calls)).toEqual(new Set(paths));
+			expect(maximumActive).toBe(2);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("runs the CLI without a shell or inherited secret environment", async () => {
+		const cwd = mkdtempSync(path.join(os.tmpdir(), "prime-agent-context-routing-cli-"));
+		try {
+			const changedPath = path.join(cwd, "changed.ts");
+			writeFileSync(changedPath, "changed\n");
+			const child = { once: vi.fn() } as unknown as ChildProcess;
+			const spawnMock = vi.fn((_command: string, _args: readonly string[], _options: object) => child);
+			const queue = createFastReindexQueue({ spawnProcess: spawnMock as unknown as typeof spawn });
+			queue.enqueue([changedPath], cwd);
+			const closeListener = (child.once as unknown as ReturnType<typeof vi.fn>).mock.calls.find(
+				([event]) => event === "close",
+			)?.[1] as (() => void) | undefined;
+			closeListener?.();
+			await queue.whenIdle();
+
+			expect(spawnMock).toHaveBeenCalledWith(
+				"jcodemunch-mcp",
+				["index-file", "--no-ai-summaries", changedPath],
+				expect.objectContaining({ shell: false, stdio: "ignore" }),
+			);
+			const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+			expect(spawnOptions?.env).not.toHaveProperty("OPENAI_API_KEY");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/ipython-output-materialization.test.ts
+++ b/packages/coding-agent/test/ipython-output-materialization.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExecuteOptions, ExecuteResult } from "../src/core/kernel/index.js";
+import { createIpythonToolDefinition, type IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("IPython oversized output materialization", () => {
+	it("keeps the model-facing result bounded while retaining full stdout and result behind one handle", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-ipython-output-"));
+		roots.push(root);
+		const fullStdout = `stdout-head\n${"private output payload\n".repeat(900)}stdout-tail`;
+		const fullResult = `result-head\n${"private result payload\n".repeat(900)}result-tail`;
+		const execute = async (_code: string, executeOptions: ExecuteOptions): Promise<ExecuteResult> => {
+			executeOptions.onStream?.(fullStdout, "stdout");
+			executeOptions.onResult?.(fullResult);
+			return {
+				stdout: fullStdout.slice(0, 65_536),
+				stderr: "",
+				result: fullResult.slice(0, 65_536),
+				status: "ok",
+				durationMs: 1,
+			};
+		};
+		const fakeProvisioner = {
+			ensure: async () => ({ execute }),
+			registerHostHandlers: () => {},
+		} as unknown as IpythonKernelProvisioner;
+		const tool = createIpythonToolDefinition(process.cwd(), {
+			provisioner: fakeProvisioner,
+			snapshotDir: root,
+			outputMaterialization: { inlineChars: 512, previewChars: 300 },
+		});
+
+		const response = await tool.execute(
+			"call-1",
+			{ code: "print('large')" },
+			undefined,
+			undefined,
+			undefined as never,
+		);
+		const text = (response.content[0] as { type: "text"; text: string }).text;
+		const details = response.details;
+
+		expect(details.artifacts).toHaveLength(1);
+		expect(text).toContain("stdout-head");
+		expect(text).toContain("stdout-tail");
+		expect(text).toContain("artifact.read");
+		expect(text).not.toContain(fullStdout);
+		expect(text).not.toContain(fullResult);
+		expect(details.stdout).not.toContain(fullStdout);
+		expect(details.result).not.toContain(fullResult);
+		expect(JSON.stringify(response)).not.toContain(fullStdout);
+		expect(JSON.stringify(response)).not.toContain(fullResult);
+	});
+
+	it("bounds a huge exception value even when no traceback was emitted", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-ipython-error-"));
+		roots.push(root);
+		const fullEvalue = `private exception payload\n${"private error detail\n".repeat(900)}`;
+		const execute = async (): Promise<ExecuteResult> => ({
+			stdout: "",
+			stderr: "",
+			result: "",
+			status: "error",
+			durationMs: 1,
+			error: { ename: "ValueError", evalue: fullEvalue, traceback: [] },
+		});
+		const fakeProvisioner = {
+			ensure: async () => ({ execute }),
+			registerHostHandlers: () => {},
+		} as unknown as IpythonKernelProvisioner;
+		const tool = createIpythonToolDefinition(process.cwd(), {
+			provisioner: fakeProvisioner,
+			snapshotDir: root,
+			outputMaterialization: { previewChars: 300 },
+		});
+
+		const response = await tool.execute(
+			"call-2",
+			{ code: "raise ValueError('large')" },
+			undefined,
+			undefined,
+			undefined as never,
+		);
+
+		const encoded = JSON.stringify(response);
+		expect(response.details.error?.evalue).not.toBe(fullEvalue);
+		expect(response.details.error?.evalue).toContain("output omitted");
+		expect(encoded).not.toContain(fullEvalue);
+	});
+});

--- a/packages/coding-agent/test/ipython-output-materialization.test.ts
+++ b/packages/coding-agent/test/ipython-output-materialization.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -94,5 +94,29 @@ describe("IPython oversized output materialization", () => {
 		expect(response.details.error?.evalue).not.toBe(fullEvalue);
 		expect(response.details.error?.evalue).toContain("output omitted");
 		expect(encoded).not.toContain(fullEvalue);
+	});
+
+	it("disposes spilled captures when execution is rejected", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-agent-ipython-output-rejected-"));
+		roots.push(root);
+		const fullStdout = "private rejected output\n".repeat(200);
+		const execute = async (_code: string, executeOptions: ExecuteOptions): Promise<ExecuteResult> => {
+			executeOptions.onStream?.(fullStdout, "stdout");
+			throw new Error("execution rejected");
+		};
+		const fakeProvisioner = {
+			ensure: async () => ({ execute }),
+			registerHostHandlers: () => {},
+		} as unknown as IpythonKernelProvisioner;
+		const tool = createIpythonToolDefinition(process.cwd(), {
+			provisioner: fakeProvisioner,
+			snapshotDir: root,
+			outputMaterialization: { inlineChars: 32, previewChars: 32 },
+		});
+
+		await expect(
+			tool.execute("call-rejected", { code: "print('large')" }, undefined, undefined, undefined as never),
+		).rejects.toThrow("execution rejected");
+		expect(readdirSync(join(root, "ipython-output", ".tmp"))).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/mcp-manager.test.ts
+++ b/packages/coding-agent/test/mcp-manager.test.ts
@@ -1,10 +1,11 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getOAuthProvider, resetOAuthProviders } from "@earendil-works/pi-ai/oauth";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { McpManager } from "../src/core/mcp/mcp-manager.js";
+import { StdioMcpClient } from "../src/core/mcp/stdio-mcp-client.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import type { McpServerConfig } from "../src/core/settings-manager.js";
 
@@ -75,7 +76,14 @@ describe("McpManager", () => {
 	it("exposes only mcp.refresh when no interactive login is wired", async () => {
 		const manager = new McpManager({ authStorage });
 		const handlers = manager.hostHandlers();
-		expect(Object.keys(handlers).sort()).toEqual(["mcp.config", "mcp.refresh"]);
+		expect(Object.keys(handlers).sort()).toEqual([
+			"mcp.call_tool",
+			"mcp.config",
+			"mcp.health",
+			"mcp.list_tools",
+			"mcp.refresh",
+			"mcp.restart",
+		]);
 
 		// refresh with no credentials fails (so the kernel reports a refresh error,
 		// not a false success), and a missing server arg is rejected.
@@ -92,7 +100,15 @@ describe("McpManager", () => {
 			},
 		});
 		const handlers = manager.hostHandlers();
-		expect(Object.keys(handlers).sort()).toEqual(["mcp.begin_login", "mcp.config", "mcp.refresh"]);
+		expect(Object.keys(handlers).sort()).toEqual([
+			"mcp.begin_login",
+			"mcp.call_tool",
+			"mcp.config",
+			"mcp.health",
+			"mcp.list_tools",
+			"mcp.refresh",
+			"mcp.restart",
+		]);
 		await handlers["mcp.begin_login"]({ server: "linear" });
 		expect(called).toBe("linear");
 	});
@@ -101,15 +117,34 @@ describe("McpManager", () => {
 		const manager = new McpManager({
 			authStorage,
 			getUserServers: () => ({
-				linear: { type: "http", url: "https://proxy.test/mcp", oauth: true, headers: { "X-Extra": "1" } },
+				linear: {
+					type: "http",
+					url: "https://proxy.test/mcp",
+					oauth: true,
+					headers: { "X-Extra": "1" },
+					enabledTools: ["allowed"],
+					disabledTools: ["blocked"],
+				},
 			}),
 		});
 		const handlers = manager.hostHandlers();
 		expect(await handlers["mcp.config"]({ server: "linear" })).toEqual({
 			url: "https://proxy.test/mcp",
 			headers: { "X-Extra": "1" },
+			enabledTools: ["allowed"],
+			disabledTools: ["blocked"],
 		});
 		expect(await handlers["mcp.config"]({ server: "notion" })).toEqual({ url: "https://mcp.notion.com/mcp" });
+	});
+
+	it("mcp.config denies an explicitly disabled user server", async () => {
+		const manager = new McpManager({
+			authStorage,
+			getUserServers: () => ({
+				jcodemunch: { type: "http", url: "https://sidecar.test/mcp", enabled: false },
+			}),
+		});
+		expect(await manager.hostHandlers()["mcp.config"]({ server: "jcodemunch" })).toEqual({ enabled: false });
 	});
 
 	it("does not treat an oauth override of a catalog name as authed via the official stored cred", () => {
@@ -175,5 +210,102 @@ describe("McpManager", () => {
 		servers = {};
 		manager.refresh();
 		expect(getOAuthProvider("mcp:acme")).toBeUndefined();
+	});
+
+	it("lazily launches one durable stdio process, filters tools host-side, and restarts it", async () => {
+		const marker = join(tempDir, "stdio-marker");
+		const serverScript = join(tempDir, "stdio-server.mjs");
+		writeFileSync(
+			serverScript,
+			String.raw`
+import { appendFileSync } from "node:fs";
+const marker = process.env.MARKER;
+let input = "";
+let starts = 0;
+const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+  while (input.includes("\n")) {
+    const index = input.indexOf("\n");
+    const line = input.slice(0, index).trim();
+    input = input.slice(index + 1);
+    if (!line) continue;
+    const message = JSON.parse(line);
+    if (message.method === "initialize") {
+      starts += 1;
+      appendFileSync(marker, "start:" + starts + "\n");
+      reply(message.id, { protocolVersion: "2024-11-05", capabilities: {}, serverInfo: { name: "test", version: "1" } });
+    } else if (message.method === "tools/list") {
+      reply(message.id, { tools: [
+        { name: "allowed", description: "allowed", inputSchema: { type: "object" } },
+        { name: "blocked", description: "blocked", inputSchema: { type: "object" } },
+      ] });
+    } else if (message.method === "tools/call") {
+      reply(message.id, { structuredContent: { tool: message.params.name, cwd: process.cwd(), arguments: message.params.arguments }, content: [] });
+    } else if (message.method === "ping") {
+      reply(message.id, {});
+    }
+  }
+});
+`,
+		);
+		const manager = new McpManager({
+			authStorage,
+			cwd: tempDir,
+			getUserServers: () => ({
+				local: {
+					type: "stdio",
+					command: process.execPath,
+					args: [serverScript],
+					cwd: ".",
+					env: { MARKER: marker },
+					enabledTools: ["allowed"],
+					disabledTools: ["blocked"],
+				},
+			}),
+		});
+		const handlers = manager.hostHandlers();
+		expect(await handlers["mcp.config"]({ server: "local" })).toEqual({ type: "stdio", bridge: "host" });
+		expect(() => readFileSync(marker, "utf8")).toThrow();
+
+		expect((await handlers["mcp.list_tools"]({ server: "local" })).tools).toEqual([
+			expect.objectContaining({ name: "allowed" }),
+		]);
+		expect(readFileSync(marker, "utf8")).toContain("start:1");
+		const callResult = await handlers["mcp.call_tool"]({ server: "local", tool: "allowed", arguments: { value: 1 } });
+		expect(callResult).toEqual({
+			result: {
+				structuredContent: { tool: "allowed", cwd: realpathSync(tempDir), arguments: { value: 1 } },
+				content: [],
+			},
+		});
+		await expect(handlers["mcp.call_tool"]({ server: "local", tool: "blocked" })).rejects.toThrow("not allowed");
+		await handlers["mcp.health"]({ server: "local" });
+		await handlers["mcp.restart"]({ server: "local" });
+		expect(readFileSync(marker, "utf8")).toContain("start:1\nstart:1");
+		await manager.dispose();
+	});
+
+	it("rejects malformed JSON-RPC responses instead of treating them as success", async () => {
+		const serverScript = join(tempDir, "malformed-stdio-server.mjs");
+		writeFileSync(
+			serverScript,
+			String.raw`
+process.stdin.on("data", () => process.stdout.write(JSON.stringify({ id: 1, result: { protocolVersion: "2024-11-05" } }) + "\n"));
+`,
+		);
+		const client = new StdioMcpClient({
+			server: "malformed",
+			command: process.execPath,
+			args: [serverScript],
+			cwd: tempDir,
+			env: process.env,
+		});
+		try {
+			await expect(client.listTools()).rejects.toThrow("invalid response");
+		} finally {
+			await client.dispose();
+		}
 	});
 });

--- a/packages/coding-agent/test/mcp-manager.test.ts
+++ b/packages/coding-agent/test/mcp-manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getOAuthProvider, resetOAuthProviders } from "@earendil-works/pi-ai/oauth";
@@ -8,6 +8,36 @@ import { McpManager } from "../src/core/mcp/mcp-manager.js";
 import { StdioMcpClient } from "../src/core/mcp/stdio-mcp-client.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import type { McpServerConfig } from "../src/core/settings-manager.js";
+
+function writeMcpServerExecutable(path: string, toolNames: string[]): void {
+	writeFileSync(
+		path,
+		String.raw`#!/usr/bin/env node
+const toolNames = ${JSON.stringify(toolNames)};
+let input = "";
+const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+  while (input.includes("\n")) {
+    const index = input.indexOf("\n");
+    const line = input.slice(0, index).trim();
+    input = input.slice(index + 1);
+    if (!line) continue;
+    const message = JSON.parse(line);
+    if (message.method === "initialize") {
+      reply(message.id, { protocolVersion: "2024-11-05", capabilities: {}, serverInfo: { name: "default", version: "1" } });
+    } else if (message.method === "tools/list") {
+      reply(message.id, { tools: toolNames.map((name) => ({ name, inputSchema: { type: "object" } })) });
+    } else if (message.method === "tools/call") {
+      reply(message.id, { content: [] });
+    }
+  }
+});
+`,
+	);
+	chmodSync(path, 0o755);
+}
 
 describe("McpManager", () => {
 	let tempDir: string;
@@ -29,6 +59,157 @@ describe("McpManager", () => {
 		const overrides = manager.getDisabledBuiltinSkillOverrides();
 		expect(overrides).toContain("-linear/SKILL.md");
 		expect(overrides).toContain("-notion/SKILL.md");
+	});
+
+	it("resolves bundled Python integrations as lazy stdio defaults", async () => {
+		const manager = new McpManager({ authStorage });
+		expect(manager.listStatus()).toEqual(
+			expect.arrayContaining([
+				{ server: "jcodemunch", label: "jCodeMunch", enabled: true, usesOAuth: false },
+				{ server: "context-mode", label: "Context Mode", enabled: true, usesOAuth: false },
+			]),
+		);
+		const handlers = manager.hostHandlers();
+		// Resolving the default config must not construct or launch either sidecar.
+		expect(await handlers["mcp.config"]({ server: "jcodemunch" })).toEqual({
+			type: "stdio",
+			bridge: "host",
+		});
+		expect(await handlers["mcp.config"]({ server: "context-mode" })).toEqual({
+			type: "stdio",
+			bridge: "host",
+		});
+		manager.disposeSync();
+	});
+
+	it("launches the default command only when its first tool is requested", async () => {
+		const marker = join(tempDir, "default-stdio-marker");
+		const executable = join(tempDir, "jcodemunch-mcp");
+		writeFileSync(
+			executable,
+			String.raw`#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+const marker = process.env.MARKER;
+let input = "";
+const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+  while (input.includes("\n")) {
+    const index = input.indexOf("\n");
+    const line = input.slice(0, index).trim();
+    input = input.slice(index + 1);
+    if (!line) continue;
+    const message = JSON.parse(line);
+    if (message.method === "initialize") {
+      appendFileSync(marker, "started\n");
+      reply(message.id, { protocolVersion: "2024-11-05", capabilities: {}, serverInfo: { name: "default", version: "1" } });
+    } else if (message.method === "tools/list") {
+      reply(message.id, { tools: [{ name: "search_symbols", inputSchema: { type: "object" } }] });
+    }
+  }
+});
+`,
+		);
+		chmodSync(executable, 0o755);
+		const previousPath = process.env.PATH;
+		const previousMarker = process.env.MARKER;
+		process.env.PATH = `${tempDir}:${previousPath ?? ""}`;
+		process.env.MARKER = marker;
+		const manager = new McpManager({ authStorage });
+		try {
+			expect(() => readFileSync(marker, "utf8")).toThrow();
+			expect(await manager.hostHandlers()["mcp.config"]({ server: "jcodemunch" })).toEqual({
+				type: "stdio",
+				bridge: "host",
+			});
+			expect(() => readFileSync(marker, "utf8")).toThrow();
+			expect((await manager.hostHandlers()["mcp.list_tools"]({ server: "jcodemunch" })).tools).toEqual([
+				expect.objectContaining({ name: "search_symbols" }),
+			]);
+			expect(readFileSync(marker, "utf8")).toBe("started\n");
+		} finally {
+			await manager.dispose();
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+			if (previousMarker === undefined) delete process.env.MARKER;
+			else process.env.MARKER = previousMarker;
+		}
+	});
+
+	it("enforces curated default tool surfaces for list and call", async () => {
+		const jcodemunchTools = [
+			"search_symbols",
+			"get_file_outline",
+			"get_symbol_source",
+			"get_context_bundle",
+			"get_ranked_context",
+			"find_references",
+			"find_importers",
+			"get_blast_radius",
+			"get_changed_symbols",
+			"plan_turn",
+			"assemble_task_context",
+		];
+		const contextModeTools = [
+			"ctx_execute",
+			"ctx_execute_file",
+			"ctx_index",
+			"ctx_search",
+			"ctx_fetch_and_index",
+			"ctx_batch_execute",
+		];
+		writeMcpServerExecutable(join(tempDir, "jcodemunch-mcp"), [...jcodemunchTools, "index_repo", "summarize_repo"]);
+		writeMcpServerExecutable(join(tempDir, "context-mode"), [...contextModeTools, "ctx_upgrade", "ctx_purge"]);
+		const previousPath = process.env.PATH;
+		process.env.PATH = `${tempDir}:${previousPath ?? ""}`;
+		const manager = new McpManager({ authStorage });
+		try {
+			const handlers = manager.hostHandlers();
+			for (const [server, allowedTools, blockedTools] of [
+				["jcodemunch", jcodemunchTools, ["index_repo", "summarize_repo"]],
+				["context-mode", contextModeTools, ["ctx_upgrade", "ctx_purge"]],
+			] as const) {
+				const result = await handlers["mcp.list_tools"]({ server });
+				const listedTools = (result.tools as Array<{ name: string }> | undefined)?.map((tool) => tool.name);
+				expect(listedTools).toEqual(allowedTools);
+				for (const tool of blockedTools) {
+					await expect(handlers["mcp.call_tool"]({ server, tool })).rejects.toThrow("not allowed");
+				}
+			}
+		} finally {
+			await manager.dispose();
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("allows settings to override or disable bundled local integrations", async () => {
+		const manager = new McpManager({
+			authStorage,
+			getUserServers: () => ({
+				jcodemunch: {
+					type: "http",
+					url: "https://proxy.test/jcodemunch",
+					enabledTools: ["search_symbols"],
+					disabledTools: ["get_blast_radius"],
+				},
+				"context-mode": {
+					type: "stdio",
+					command: process.execPath,
+					enabled: false,
+				},
+			}),
+		});
+		const handlers = manager.hostHandlers();
+		expect(await handlers["mcp.config"]({ server: "jcodemunch" })).toEqual({
+			url: "https://proxy.test/jcodemunch",
+			enabledTools: ["search_symbols"],
+			disabledTools: ["get_blast_radius"],
+		});
+		expect(await handlers["mcp.config"]({ server: "context-mode" })).toEqual({ enabled: false });
+		expect(manager.listStatus().find((status) => status.server === "context-mode")?.enabled).toBe(false);
+		manager.disposeSync();
 	});
 
 	it("enables an integration once credentials are stored", () => {

--- a/packages/coding-agent/test/mcp-manager.test.ts
+++ b/packages/coding-agent/test/mcp-manager.test.ts
@@ -2,20 +2,56 @@ import { chmodSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSy
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getOAuthProvider, resetOAuthProviders } from "@earendil-works/pi-ai/oauth";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { McpManager } from "../src/core/mcp/mcp-manager.js";
-import { StdioMcpClient } from "../src/core/mcp/stdio-mcp-client.js";
+import {
+	StdioMcpClient,
+	StdioMcpRequestNotSentError,
+	StdioMcpTransportError,
+} from "../src/core/mcp/stdio-mcp-client.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import type { McpServerConfig } from "../src/core/settings-manager.js";
 
-function writeMcpServerExecutable(path: string, toolNames: string[]): void {
+interface TestMcpServerOptions {
+	protocolVersion?: string;
+	capabilities?: unknown;
+	serverInfo?: unknown;
+	includeCapabilities?: boolean;
+	includeServerInfo?: boolean;
+	callDelayMs?: number;
+	callCounterFile?: string;
+	pidFile?: string;
+	closeStdinAfterInitialize?: boolean;
+}
+
+function writeMcpServerExecutable(path: string, toolNames: string[], options: TestMcpServerOptions = {}): void {
+	const protocolVersion = JSON.stringify(options.protocolVersion ?? "2024-11-05");
+	const capabilities = JSON.stringify(Object.hasOwn(options, "capabilities") ? options.capabilities : { tools: {} });
+	const serverInfo = JSON.stringify(
+		Object.hasOwn(options, "serverInfo") ? options.serverInfo : { name: "default", version: "1" },
+	);
+	const callDelayMs = options.callDelayMs ?? 0;
+	const callCounterFile = JSON.stringify(options.callCounterFile ?? null);
+	const pidFile = JSON.stringify(options.pidFile ?? null);
+	const includeCapabilities = options.includeCapabilities !== false;
+	const includeServerInfo = options.includeServerInfo !== false;
+	const initializeFields = [
+		`protocolVersion: ${protocolVersion}`,
+		...(includeCapabilities ? [`capabilities: ${capabilities}`] : []),
+		...(includeServerInfo ? [`serverInfo: ${serverInfo}`] : []),
+	].join(", ");
 	writeFileSync(
 		path,
 		String.raw`#!/usr/bin/env node
+import { appendFileSync, writeFileSync } from "node:fs";
 const toolNames = ${JSON.stringify(toolNames)};
+const callDelayMs = ${callDelayMs};
+const callCounterFile = ${callCounterFile};
+const pidFile = ${pidFile};
 let input = "";
 const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+if (pidFile) writeFileSync(pidFile, String(process.pid));
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => {
   input += chunk;
@@ -26,11 +62,15 @@ process.stdin.on("data", (chunk) => {
     if (!line) continue;
     const message = JSON.parse(line);
     if (message.method === "initialize") {
-      reply(message.id, { protocolVersion: "2024-11-05", capabilities: {}, serverInfo: { name: "default", version: "1" } });
+      reply(message.id, { ${initializeFields} });
+      ${options.closeStdinAfterInitialize ? "setTimeout(() => process.stdin.destroy(), 25);" : ""}
     } else if (message.method === "tools/list") {
       reply(message.id, { tools: toolNames.map((name) => ({ name, inputSchema: { type: "object" } })) });
     } else if (message.method === "tools/call") {
-      reply(message.id, { content: [] });
+      if (callCounterFile) appendFileSync(callCounterFile, message.params.name + "\n");
+      const respond = () => reply(message.id, { content: [] });
+      if (callDelayMs > 0) setTimeout(respond, callDelayMs);
+      else respond();
     }
   }
 });
@@ -39,9 +79,23 @@ process.stdin.on("data", (chunk) => {
 	chmodSync(path, 0o755);
 }
 
+async function waitForProcessExit(pid: number, timeoutMs = 3_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			process.kill(pid, 0);
+		} catch {
+			return;
+		}
+		await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 20));
+	}
+	throw new Error(`process ${pid} did not exit within ${timeoutMs}ms`);
+}
+
 describe("McpManager", () => {
 	let tempDir: string;
 	let authStorage: AuthStorage;
+	const managers = new Set<McpManager>();
 
 	beforeEach(() => {
 		tempDir = mkdtempSync(join(tmpdir(), "mcp-mgr-"));
@@ -49,7 +103,9 @@ describe("McpManager", () => {
 		resetOAuthProviders();
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
+		await Promise.allSettled([...managers].map((manager) => manager.dispose()));
+		managers.clear();
 		resetOAuthProviders();
 		rmSync(tempDir, { recursive: true, force: true });
 	});
@@ -103,7 +159,7 @@ process.stdin.on("data", (chunk) => {
     const message = JSON.parse(line);
     if (message.method === "initialize") {
       appendFileSync(marker, "started\n");
-      reply(message.id, { protocolVersion: "2024-11-05", capabilities: {}, serverInfo: { name: "default", version: "1" } });
+      reply(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "default", version: "1" } });
     } else if (message.method === "tools/list") {
       reply(message.id, { tools: [{ name: "search_symbols", inputSchema: { type: "object" } }] });
     }
@@ -405,6 +461,7 @@ let input = "";
 let starts = 0;
 const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
 process.stdin.setEncoding("utf8");
+process.stdin.on("end", () => process.exit(0));
 process.stdin.on("data", (chunk) => {
   input += chunk;
   while (input.includes("\n")) {
@@ -416,7 +473,8 @@ process.stdin.on("data", (chunk) => {
     if (message.method === "initialize") {
       starts += 1;
       appendFileSync(marker, "start:" + starts + "\n");
-      reply(message.id, { protocolVersion: "2024-11-05", capabilities: {}, serverInfo: { name: "test", version: "1" } });
+      appendFileSync(marker, "pid:" + process.pid + "\n");
+      reply(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "test", version: "1" } });
     } else if (message.method === "tools/list") {
       reply(message.id, { tools: [
         { name: "allowed", description: "allowed", inputSchema: { type: "object" } },
@@ -446,6 +504,7 @@ process.stdin.on("data", (chunk) => {
 				},
 			}),
 		});
+		managers.add(manager);
 		const handlers = manager.hostHandlers();
 		expect(await handlers["mcp.config"]({ server: "local" })).toEqual({ type: "stdio", bridge: "host" });
 		expect(() => readFileSync(marker, "utf8")).toThrow();
@@ -464,8 +523,477 @@ process.stdin.on("data", (chunk) => {
 		await expect(handlers["mcp.call_tool"]({ server: "local", tool: "blocked" })).rejects.toThrow("not allowed");
 		await handlers["mcp.health"]({ server: "local" });
 		await handlers["mcp.restart"]({ server: "local" });
-		expect(readFileSync(marker, "utf8")).toContain("start:1\nstart:1");
+		expect(
+			readFileSync(marker, "utf8")
+				.split("\n")
+				.filter((line) => line === "start:1"),
+		).toHaveLength(2);
 		await manager.dispose();
+		const pidLine = readFileSync(marker, "utf8")
+			.split("\n")
+			.filter((line) => line.startsWith("pid:"))
+			.at(-1);
+		expect(pidLine).toBeDefined();
+		await waitForProcessExit(Number(pidLine!.slice("pid:".length)));
+	});
+
+	it("retains failed client cleanup for a later manager retry", async () => {
+		const manager = new McpManager({ authStorage, cwd: tempDir });
+		managers.add(manager);
+		const failedClient = new StdioMcpClient({
+			server: "failed",
+			command: process.execPath,
+			args: [],
+			cwd: tempDir,
+			env: process.env,
+		});
+		const successfulClient = new StdioMcpClient({
+			server: "successful",
+			command: process.execPath,
+			args: [],
+			cwd: tempDir,
+			env: process.env,
+		});
+		const cleanupError = new Error("cleanup failed");
+		const failedDispose = vi
+			.spyOn(failedClient, "dispose")
+			.mockRejectedValueOnce(cleanupError)
+			.mockResolvedValue(undefined);
+		const successfulDispose = vi.spyOn(successfulClient, "dispose").mockResolvedValue(undefined);
+		const clients = (manager as unknown as { stdioClients: Map<string, StdioMcpClient> }).stdioClients;
+		clients.set("failed", failedClient);
+		clients.set("successful", successfulClient);
+
+		try {
+			await expect(manager.dispose()).rejects.toThrow("cleanup failed");
+			expect(failedDispose).toHaveBeenCalledTimes(1);
+			expect(successfulDispose).toHaveBeenCalledTimes(1);
+			expect(clients.get("failed")).toBe(failedClient);
+			expect(clients.has("successful")).toBe(false);
+
+			await manager.dispose();
+			expect(failedDispose).toHaveBeenCalledTimes(2);
+			expect(clients.size).toBe(0);
+		} finally {
+			await manager.dispose().catch(() => undefined);
+		}
+	});
+
+	it("keeps refreshed clients under exit cleanup while an old dispose is pending", async () => {
+		const manager = new McpManager({ authStorage, cwd: tempDir });
+		managers.add(manager);
+		const oldClient = new StdioMcpClient({
+			server: "old",
+			command: process.execPath,
+			args: [],
+			cwd: tempDir,
+			env: process.env,
+		});
+		const newClient = new StdioMcpClient({
+			server: "new",
+			command: process.execPath,
+			args: [],
+			cwd: tempDir,
+			env: process.env,
+		});
+		let resolveOldDispose!: () => void;
+		const oldDisposeCompletion = new Promise<void>((resolve) => {
+			resolveOldDispose = resolve;
+		});
+		const oldDispose = vi.spyOn(oldClient, "dispose").mockReturnValue(oldDisposeCompletion);
+		const oldDisposeSync = vi.spyOn(oldClient, "disposeSync").mockImplementation(() => undefined);
+		const newDisposeSync = vi.spyOn(newClient, "disposeSync").mockImplementation(() => undefined);
+		const clients = (manager as unknown as { stdioClients: Map<string, StdioMcpClient> }).stdioClients;
+		clients.set("local", oldClient);
+
+		const oldManagerDispose = manager.dispose();
+		try {
+			expect(oldDispose).toHaveBeenCalledTimes(1);
+			manager.refresh();
+			expect(oldDisposeSync).toHaveBeenCalledTimes(1);
+			clients.set("local", newClient);
+
+			resolveOldDispose();
+			await oldManagerDispose;
+			expect(clients.get("local")).toBe(newClient);
+
+			const cleanup = process.listeners("exit").find((listener) => listener.toString().includes("liveMcpManagers"));
+			expect(cleanup).toBeDefined();
+			(cleanup as ((code: number) => void) | undefined)?.(0);
+			expect(newDisposeSync).toHaveBeenCalledTimes(1);
+		} finally {
+			resolveOldDispose();
+			await oldManagerDispose;
+			await manager.dispose().catch(() => undefined);
+		}
+	});
+
+	it("retries a call when the request was definitely not sent", async () => {
+		const manager = new McpManager({
+			authStorage,
+			getUserServers: () => ({ local: { type: "stdio", command: process.execPath } }),
+		});
+		const client = new StdioMcpClient({
+			server: "local",
+			command: process.execPath,
+			args: [],
+			cwd: tempDir,
+			env: process.env,
+		});
+		const callTool = vi
+			.spyOn(client, "callTool")
+			.mockRejectedValueOnce(new StdioMcpRequestNotSentError("MCP server local is not running"))
+			.mockResolvedValueOnce({ ok: true });
+		const restart = vi.spyOn(client, "restart").mockResolvedValue(undefined);
+		(manager as unknown as { stdioClients: Map<string, StdioMcpClient> }).stdioClients.set("local", client);
+		try {
+			expect(await manager.hostHandlers()["mcp.call_tool"]({ server: "local", tool: "allowed" })).toEqual({
+				result: { ok: true },
+			});
+			expect(callTool).toHaveBeenCalledTimes(2);
+			expect(restart).toHaveBeenCalledTimes(1);
+		} finally {
+			await manager.dispose();
+		}
+	});
+
+	it("does not retry a possibly-delivered timed-out tool call", async () => {
+		const counterFile = join(tempDir, "tool-calls");
+		const serverScript = join(tempDir, "slow-stdio-server.mjs");
+		writeMcpServerExecutable(serverScript, ["allowed"], { callDelayMs: 200, callCounterFile: counterFile });
+		const manager = new McpManager({
+			authStorage,
+			cwd: tempDir,
+			getUserServers: () => ({
+				local: { type: "stdio", command: process.execPath, args: [serverScript], cwd: tempDir },
+			}),
+		});
+		const client = new StdioMcpClient({
+			server: "local",
+			command: process.execPath,
+			args: [serverScript],
+			cwd: tempDir,
+			env: process.env,
+			callTimeoutMs: 30,
+		});
+		const restart = vi.spyOn(client, "restart");
+		(manager as unknown as { stdioClients: Map<string, StdioMcpClient> }).stdioClients.set("local", client);
+		try {
+			await expect(manager.hostHandlers()["mcp.call_tool"]({ server: "local", tool: "allowed" })).rejects.toThrow(
+				"timed out during tools/call",
+			);
+			expect(readFileSync(counterFile, "utf8")).toBe("allowed\n");
+			expect(restart).not.toHaveBeenCalled();
+		} finally {
+			await manager.dispose();
+		}
+	});
+
+	it("waits for a timed-out tool's process to exit before dispatching the next call", async () => {
+		const timelineFile = join(tempDir, "timeout-timeline");
+		const counterFile = join(tempDir, "timeout-counter");
+		const serverScript = join(tempDir, "timeout-serialization-server.mjs");
+		writeFileSync(
+			serverScript,
+			String.raw`import { appendFileSync } from "node:fs";
+const timeline = ${JSON.stringify(timelineFile)};
+const counter = ${JSON.stringify(counterFile)};
+const pid = process.pid;
+const log = (event, value) => appendFileSync(timeline, event + ":" + value + ":" + Date.now() + ":" + pid + "\n");
+const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+let input = "";
+process.on("exit", () => log("exit", "process"));
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+  while (input.includes("\n")) {
+    const index = input.indexOf("\n");
+    const line = input.slice(0, index).trim();
+    input = input.slice(index + 1);
+    if (!line) continue;
+    const message = JSON.parse(line);
+    if (message.method === "initialize") {
+      log("ready", "process");
+      reply(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "timeout", version: "1" } });
+    } else if (message.method === "tools/call") {
+      const name = message.params.name;
+      appendFileSync(counter, name + "\n");
+      log("start", name);
+      const finish = () => {
+        log("end", name);
+        reply(message.id, { content: [] });
+      };
+      if (name === "first") setTimeout(finish, 250);
+      else finish();
+    }
+  }
+});
+`,
+		);
+		const manager = new McpManager({
+			authStorage,
+			cwd: tempDir,
+			getUserServers: () => ({
+				local: {
+					type: "stdio",
+					command: process.execPath,
+					args: [serverScript],
+					cwd: tempDir,
+					enabledTools: ["first", "second"],
+				},
+			}),
+		});
+		const client = new StdioMcpClient({
+			server: "local",
+			command: process.execPath,
+			args: [serverScript],
+			cwd: tempDir,
+			env: process.env,
+			startupTimeoutMs: 1_000,
+			callTimeoutMs: 80,
+		});
+		(manager as unknown as { stdioClients: Map<string, StdioMcpClient> }).stdioClients.set("local", client);
+		try {
+			await expect(manager.hostHandlers()["mcp.call_tool"]({ server: "local", tool: "first" })).rejects.toThrow(
+				"timed out during tools/call",
+			);
+			await expect(manager.hostHandlers()["mcp.call_tool"]({ server: "local", tool: "second" })).resolves.toEqual({
+				result: { content: [] },
+			});
+
+			const events = readFileSync(timelineFile, "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => line.split(":"));
+			const firstStarts = events.filter((event) => event[0] === "start" && event[1] === "first");
+			const firstEnds = events.filter((event) => event[0] === "end" && event[1] === "first");
+			const secondStarts = events.filter((event) => event[0] === "start" && event[1] === "second");
+			expect(firstStarts).toHaveLength(1);
+			expect(firstEnds).toHaveLength(1);
+			expect(secondStarts).toHaveLength(1);
+			const firstPid = firstStarts[0][3];
+			const firstExit = events.find((event) => event[0] === "exit" && event[3] === firstPid);
+			expect(firstExit).toBeDefined();
+			expect(Number(secondStarts[0][2])).toBeGreaterThanOrEqual(Number(firstExit![2]));
+			expect(readFileSync(counterFile, "utf8").trim().split("\n")).toEqual(["first", "second"]);
+		} finally {
+			await manager.dispose();
+		}
+	});
+
+	it("validates the initialize handshake and tool capability", async () => {
+		const cases = [
+			{
+				name: "unsupported version",
+				options: { protocolVersion: "2099-01-01" },
+				error: "unsupported protocol version",
+			},
+			{ name: "missing capabilities", options: { includeCapabilities: false }, error: "invalid capabilities" },
+			{ name: "missing serverInfo", options: { includeServerInfo: false }, error: "invalid serverInfo" },
+			{ name: "missing tools", options: { capabilities: {} }, error: "did not negotiate tool support" },
+		] as const;
+		for (const testCase of cases) {
+			const serverScript = join(tempDir, `${testCase.name.replaceAll(" ", "-")}.mjs`);
+			writeMcpServerExecutable(serverScript, ["allowed"], testCase.options);
+			const client = new StdioMcpClient({
+				server: testCase.name,
+				command: process.execPath,
+				args: [serverScript],
+				cwd: tempDir,
+				env: process.env,
+				startupTimeoutMs: 500,
+				callTimeoutMs: 500,
+			});
+			try {
+				await expect(client.listTools()).rejects.toThrow(testCase.error);
+				if (testCase.name === "missing tools") {
+					await expect(client.callTool("allowed", {})).rejects.toThrow("did not negotiate tool support");
+				}
+			} finally {
+				await client.dispose();
+			}
+		}
+	});
+
+	it("handles a server closing stdin without an unhandled EPIPE", async () => {
+		const serverScript = join(tempDir, "close-stdin-server.mjs");
+		writeMcpServerExecutable(serverScript, ["allowed"]);
+		const client = new StdioMcpClient({
+			server: "close-stdin",
+			command: process.execPath,
+			args: [serverScript],
+			cwd: tempDir,
+			env: process.env,
+			startupTimeoutMs: 500,
+			callTimeoutMs: 100,
+		});
+		try {
+			await client.listTools();
+			const child = (client as unknown as { child?: { stdin: { destroy: () => void } } }).child;
+			expect(child).toBeDefined();
+			child?.stdin.destroy();
+			await expect(client.callTool("allowed", {})).rejects.toBeInstanceOf(StdioMcpTransportError);
+		} finally {
+			await client.dispose();
+		}
+	});
+
+	it("shuts down an EOF-aware sidecar without signal escalation", async () => {
+		const marker = join(tempDir, "eof-marker");
+		const pidFile = join(tempDir, "eof-pid");
+		const serverScript = join(tempDir, "eof-server.mjs");
+		writeFileSync(
+			serverScript,
+			String.raw`import { appendFileSync, writeFileSync } from "node:fs";
+const marker = ${JSON.stringify(marker)};
+const pidFile = ${JSON.stringify(pidFile)};
+writeFileSync(pidFile, String(process.pid));
+let input = "";
+const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+process.stdin.setEncoding("utf8");
+process.stdin.on("end", () => { appendFileSync(marker, "eof\n"); process.exit(0); });
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+  while (input.includes("\n")) {
+    const index = input.indexOf("\n");
+    const message = JSON.parse(input.slice(0, index));
+    input = input.slice(index + 1);
+    if (message.method === "initialize") reply(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "eof", version: "1" } });
+    else if (message.method === "tools/list") reply(message.id, { tools: [] });
+  }
+});
+`,
+		);
+		chmodSync(serverScript, 0o755);
+		const client = new StdioMcpClient({
+			server: "eof",
+			command: process.execPath,
+			args: [serverScript],
+			cwd: tempDir,
+			env: process.env,
+			startupTimeoutMs: 500,
+		});
+		try {
+			await client.listTools();
+			const pid = Number(readFileSync(pidFile, "utf8"));
+			await client.dispose();
+			expect(readFileSync(marker, "utf8")).toBe("eof\n");
+			await waitForProcessExit(pid);
+		} finally {
+			await client.dispose();
+		}
+	});
+
+	it("escalates EOF to SIGTERM and SIGKILL, waiting for exit", async () => {
+		const marker = join(tempDir, "escalation-marker");
+		const pidFile = join(tempDir, "escalation-pid");
+		const serverScript = join(tempDir, "escalation-server.mjs");
+		writeFileSync(
+			serverScript,
+			String.raw`import { appendFileSync, writeFileSync } from "node:fs";
+const marker = ${JSON.stringify(marker)};
+const pidFile = ${JSON.stringify(pidFile)};
+writeFileSync(pidFile, String(process.pid));
+let input = "";
+const reply = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+process.stdin.setEncoding("utf8");
+process.stdin.on("end", () => appendFileSync(marker, "eof\n"));
+process.on("SIGTERM", () => appendFileSync(marker, "term\n"));
+setInterval(() => undefined, 1000);
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+  while (input.includes("\n")) {
+    const index = input.indexOf("\n");
+    const message = JSON.parse(input.slice(0, index));
+    input = input.slice(index + 1);
+    if (message.method === "initialize") reply(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "escalation", version: "1" } });
+    else if (message.method === "tools/list") reply(message.id, { tools: [] });
+  }
+});
+`,
+		);
+		chmodSync(serverScript, 0o755);
+		const client = new StdioMcpClient({
+			server: "escalation",
+			command: process.execPath,
+			args: [serverScript],
+			cwd: tempDir,
+			env: process.env,
+			startupTimeoutMs: 500,
+		});
+		try {
+			await client.listTools();
+			const pid = Number(readFileSync(pidFile, "utf8"));
+			await client.dispose();
+			expect(readFileSync(marker, "utf8")).toContain("eof\n");
+			expect(readFileSync(marker, "utf8")).toContain("term\n");
+			await waitForProcessExit(pid);
+		} finally {
+			await client.dispose();
+		}
+	});
+
+	it("surfaces a transport error when SIGKILL exit remains unobserved", async () => {
+		type TestChild = {
+			exitCode: number | null;
+			signalCode: NodeJS.Signals | null;
+			stdin: { destroyed: boolean; end: () => void };
+		};
+		type ClientInternals = {
+			child?: TestChild;
+			waitForExit: (child: TestChild) => Promise<boolean>;
+			killProcessTree: (child: TestChild, signal: NodeJS.Signals) => void;
+			handleChildFailure: (child: TestChild, error: Error) => void;
+		};
+		const client = new StdioMcpClient({
+			server: "unobserved-exit",
+			command: process.execPath,
+			args: [],
+			cwd: tempDir,
+			env: process.env,
+		});
+		const internals = client as unknown as ClientInternals;
+		const child: TestChild = {
+			exitCode: null,
+			signalCode: null,
+			stdin: { destroyed: false, end: vi.fn() },
+		};
+		internals.child = child;
+		const waitForExit = vi.spyOn(internals, "waitForExit").mockResolvedValue(false);
+		const killProcessTree = vi.spyOn(internals, "killProcessTree").mockImplementation(() => undefined);
+
+		await expect(client.dispose()).rejects.toThrow("did not exit after SIGKILL");
+		expect(waitForExit).toHaveBeenCalledTimes(3);
+		expect(killProcessTree).toHaveBeenNthCalledWith(1, child, "SIGTERM");
+		expect(killProcessTree).toHaveBeenNthCalledWith(2, child, "SIGKILL");
+		expect(internals.child).toBe(child);
+
+		child.exitCode = 0;
+		internals.handleChildFailure(child, new Error("process exited"));
+		expect(internals.child).toBeUndefined();
+	});
+
+	it("re-registers a disposed manager for process-exit cleanup after refresh", async () => {
+		const pidFile = join(tempDir, "refresh-pid");
+		const serverScript = join(tempDir, "refresh-server.mjs");
+		writeMcpServerExecutable(serverScript, ["allowed"], { pidFile });
+		const manager = new McpManager({
+			authStorage,
+			cwd: tempDir,
+			getUserServers: () => ({
+				local: { type: "stdio", command: process.execPath, args: [serverScript], cwd: tempDir },
+			}),
+		});
+		managers.add(manager);
+		await manager.hostHandlers()["mcp.list_tools"]({ server: "local" });
+		await manager.dispose();
+		manager.refresh();
+		await manager.hostHandlers()["mcp.list_tools"]({ server: "local" });
+		const pid = Number(readFileSync(pidFile, "utf8"));
+		const cleanup = process.listeners("exit").find((listener) => listener.toString().includes("liveMcpManagers"));
+		expect(cleanup).toBeDefined();
+		(cleanup as ((code: number) => void) | undefined)?.(0);
+		await waitForProcessExit(pid);
 	});
 
 	it("rejects malformed JSON-RPC responses instead of treating them as success", async () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -531,6 +531,46 @@ describe("SettingsManager", () => {
 			expect(servers?.shared).toEqual({ type: "http", url: "https://project.shared/mcp" });
 		});
 	});
+	it("skips malformed MCP servers and records actionable diagnostics", () => {
+		const valid = {
+			type: "http",
+			url: "https://mcp.valid.test/mcp",
+			headers: { "X-Test": "1" },
+			enabledTools: ["read"],
+		};
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({
+				mcpServers: {
+					valid,
+					argsString: { type: "stdio", command: "node", args: "server.mjs" },
+					envArray: { type: "stdio", command: "node", env: [] },
+					missingCommand: { type: "stdio" },
+					unknownType: { type: "ftp", url: "ftp://mcp.test" },
+					invalidHeaders: { type: "http", url: "https://mcp.test", headers: [] },
+					invalidEnabled: { type: "stdio", command: "node", enabled: "yes" },
+				},
+			}),
+		);
+
+		const manager = SettingsManager.create(projectDir, agentDir);
+		expect(manager.getMcpServers()).toEqual({ valid });
+		const errors = manager.drainErrors();
+		expect(errors).toHaveLength(6);
+		for (const name of [
+			"argsString",
+			"envArray",
+			"missingCommand",
+			"unknownType",
+			"invalidHeaders",
+			"invalidEnabled",
+		]) {
+			expect(errors.some(({ error }) => error.message.includes(`MCP server "${name}"`))).toBe(true);
+		}
+		expect(manager.getMcpServers()).toEqual({ valid });
+		expect(manager.drainErrors()).toEqual([]);
+	});
+
 	describe("idle worker eviction", () => {
 		it("defaults to 90 minutes and treats none as off", () => {
 			const manager = SettingsManager.create(projectDir, agentDir);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -477,6 +477,35 @@ describe("SettingsManager", () => {
 			expect(manager.getMcpServers()).toBeUndefined();
 		});
 
+		it("preserves stdio server command, cwd, env, and tool filters", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({
+					mcpServers: {
+						local: {
+							type: "stdio",
+							command: "node",
+							args: ["server.mjs"],
+							cwd: "./tools",
+							env: { TOKEN: "secret" },
+							enabledTools: ["read"],
+							disabledTools: ["write"],
+						},
+					},
+				}),
+			);
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getMcpServers()?.local).toEqual({
+				type: "stdio",
+				command: "node",
+				args: ["server.mjs"],
+				cwd: "./tools",
+				env: { TOKEN: "secret" },
+				enabledTools: ["read"],
+				disabledTools: ["write"],
+			});
+		});
+
 		it("merges global and project mcpServers, project winning per key", () => {
 			writeFileSync(
 				join(agentDir, "settings.json"),

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -316,6 +316,7 @@ __all__ = [
     "HarnessEntry",
     "HarnessScope",
     "HarnessState",
+    "Disabled",
     "McpIntegration",
     "McpToolError",
     "NotEnabled",
@@ -335,7 +336,7 @@ __all__ = [
 
 # Lazily re-export the MCP base class. Kept lazy so `import rlm` never requires
 # the optional `mcp` SDK — only integration packages that subclass it do.
-_LAZY_MCP = {"McpIntegration", "McpToolError", "NotEnabled"}
+_LAZY_MCP = {"Disabled", "McpIntegration", "McpToolError", "NotEnabled"}
 
 
 def __getattr__(name: str) -> Any:  # noqa: D401 - module-level lazy attr hook

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import math
+import os
 import sys
 import types
 from dataclasses import dataclass
@@ -22,6 +24,30 @@ except Exception:  # pragma: no cover - only available in kernels
     get_ipython = None  # type: ignore[assignment]
 
 HOST_COMM_TARGET = "host.request"
+DEFAULT_HOST_REQUEST_TIMEOUT_SECONDS = 300.0
+_HOST_REQUEST_TIMEOUT_ENV = "RLM_HOST_REQUEST_TIMEOUT"
+
+
+def _resolve_host_request_timeout(timeout: float | None) -> float:
+    """Resolve a positive host-request timeout from an explicit value or env."""
+    if timeout is not None:
+        if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+            raise TypeError(f"timeout must be a number or None, got {type(timeout).__name__}")
+        value = float(timeout)
+    else:
+        raw = os.environ.get(_HOST_REQUEST_TIMEOUT_ENV, "").strip()
+        if not raw:
+            return DEFAULT_HOST_REQUEST_TIMEOUT_SECONDS
+        try:
+            value = float(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"{_HOST_REQUEST_TIMEOUT_ENV} must be a positive number of seconds"
+            ) from exc
+
+    if not math.isfinite(value) or value < 0:
+        raise ValueError("host request timeout must be a finite non-negative number")
+    return value
 
 
 @dataclass(frozen=True)
@@ -81,13 +107,20 @@ def _spawn_handle_from_payload(payload: Any) -> RLMSpawnHandle:
     )
 
 
-async def host_request(request_type: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+async def host_request(
+    request_type: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout: float | None = None,
+) -> dict[str, Any]:
     """Send a typed request to the Prime Agent host and await its reply.
 
     This is the kernel side of the generic host bridge: Python skills call
     ``await host_request("<type>", {...})`` and the TypeScript host dispatches
-    on the type. Raises RuntimeError when the host reports an error or when no
-    handler for the type is registered in this session.
+    on the type. Requests are bounded by ``timeout`` seconds; when omitted,
+    ``RLM_HOST_REQUEST_TIMEOUT`` overrides the default 300-second budget.
+    Raises RuntimeError when the host reports an error or when no handler for
+    the type is registered in this session.
     """
     if not isinstance(request_type, str) or not request_type:
         raise TypeError("request_type must be a non-empty str")
@@ -95,11 +128,33 @@ async def host_request(request_type: str, payload: dict[str, Any] | None = None)
         raise TypeError(f"payload must be a dict or None, got {type(payload).__name__}")
     if Comm is None:
         raise RuntimeError("Jupyter comm support is unavailable in this kernel")
+    timeout_seconds = _resolve_host_request_timeout(timeout)
     _install_control_comm_handlers()
 
     loop = asyncio.get_running_loop()
     future: asyncio.Future[dict[str, Any]] = loop.create_future()
     comm = Comm(target_name=HOST_COMM_TARGET, primary=False)
+    comm_closed = False
+
+    def _close_comm() -> None:
+        nonlocal comm_closed
+        if comm_closed:
+            return
+        comm_closed = True
+        try:
+            comm.close()
+        except Exception:
+            # A late callback must never turn a completed request into an
+            # event-loop exception. The close attempt is still idempotent.
+            pass
+
+    def _schedule(callback) -> None:
+        try:
+            loop.call_soon_threadsafe(callback)
+        except RuntimeError:
+            # The loop may have been closed after cancellation while a comm
+            # callback was already in flight. The comm still needs closing.
+            _close_comm()
 
     def _on_msg(msg: dict[str, Any]) -> None:
         content = msg.get("content", {})
@@ -110,34 +165,52 @@ async def host_request(request_type: str, payload: dict[str, Any] | None = None)
         status = reply.get("status")
         if status == "ok":
             def _resolve_result() -> None:
-                if not future.done():
-                    future.set_result({k: v for k, v in reply.items() if k != "status"})
-                    comm.close()
+                try:
+                    if not future.done():
+                        future.set_result({k: v for k, v in reply.items() if k != "status"})
+                finally:
+                    _close_comm()
 
-            loop.call_soon_threadsafe(_resolve_result)
+            _schedule(_resolve_result)
             return
         if status == "error":
             message = reply.get("error") or f"host request {request_type} failed"
-            def _resolve_error() -> None:
-                if not future.done():
-                    future.set_exception(RuntimeError(str(message)))
-                    comm.close()
 
-            loop.call_soon_threadsafe(_resolve_error)
+            def _resolve_error() -> None:
+                try:
+                    if not future.done():
+                        future.set_exception(RuntimeError(str(message)))
+                finally:
+                    _close_comm()
+
+            _schedule(_resolve_error)
             return
 
         unexpected = f"host request {request_type} returned unexpected status: {status!r}"
+
         def _resolve_unexpected() -> None:
-            if not future.done():
-                future.set_exception(RuntimeError(unexpected))
-                comm.close()
+            try:
+                if not future.done():
+                    future.set_exception(RuntimeError(unexpected))
+            finally:
+                _close_comm()
 
-        loop.call_soon_threadsafe(_resolve_unexpected)
+        _schedule(_resolve_unexpected)
 
-    comm.on_msg(_on_msg)
-    # request_type goes last so a payload "type" key cannot reroute the request.
-    comm.open(data={**(payload or {}), "type": request_type})
-    return await future
+    try:
+        comm.on_msg(_on_msg)
+        # request_type goes last so a payload "type" key cannot reroute the request.
+        comm.open(data={**(payload or {}), "type": request_type})
+        try:
+            return await asyncio.wait_for(future, timeout_seconds)
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(
+                f"host request {request_type} timed out after {timeout_seconds:g}s"
+            ) from exc
+        except asyncio.CancelledError as exc:
+            raise asyncio.CancelledError(f"host request {request_type} was cancelled") from exc
+    finally:
+        _close_comm()
 
 
 async def run(prompt: str, **kwargs: Any) -> RLMSpawnHandle:

--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from . import host_request
 
-__all__ = ["McpIntegration", "McpToolError", "NotEnabled"]
+__all__ = ["Disabled", "McpIntegration", "McpToolError", "NotEnabled"]
 
 # Stored access tokens are treated as expired this many seconds early so a token
 # never dies mid-request. Mirrors the host's refresh buffer.
@@ -46,6 +46,18 @@ class NotEnabled(RuntimeError):
             f"The '{server}' integration is not enabled: no credentials found. "
             f"Tell the user to run `/mcp login {server}` in Prime Agent to connect it. "
             f"Do not ask them to set environment variables."
+        )
+
+
+class Disabled(NotEnabled):
+    """Raised when the host has explicitly disabled an MCP integration."""
+
+    def __init__(self, server: str):
+        self.server = server
+        RuntimeError.__init__(
+            self,
+            f"The '{server}' integration is disabled in Prime Agent settings. "
+            "Enable its mcpServers entry before using it.",
         )
 
 
@@ -189,15 +201,43 @@ class McpIntegration:
 
     # -- connection ---------------------------------------------------------
 
-    async def _resolve_config(self) -> tuple[str | None, dict[str, str]]:
-        """Host-resolved (url, extra_headers), honoring a user's mcpServers override.
-        Falls back to the class ``url`` and no extra headers on host error."""
+    async def _resolve_host_config(self) -> dict[str, Any]:
+        """Read host transport metadata without importing or holding a live client."""
         try:
             cfg = await host_request("mcp.config", {"server": self.server})
         except RuntimeError:
-            cfg = {}
-        url = cfg.get("url") if isinstance(cfg, dict) else None
-        headers = cfg.get("headers") if isinstance(cfg, dict) else None
+            return {}
+        if isinstance(cfg, dict) and cfg.get("enabled") is False:
+            raise Disabled(self.server)
+        return cfg if isinstance(cfg, dict) else {}
+
+    @staticmethod
+    def _is_host_bridge_config(cfg: dict[str, Any]) -> bool:
+        return cfg.get("type") == "stdio" and cfg.get("bridge") == "host"
+
+    async def _uses_host_bridge(self) -> bool:
+        cfg = await self._resolve_host_config()
+        return self._is_host_bridge_config(cfg)
+
+    @staticmethod
+    def _tool_allowed_from_config(tool: str, cfg: dict[str, Any]) -> bool:
+        enabled = cfg.get("enabledTools")
+        if isinstance(enabled, list) and tool not in enabled:
+            return False
+        disabled = cfg.get("disabledTools")
+        return not isinstance(disabled, list) or tool not in disabled
+
+    async def _tool_allowed(self, tool: str, config: dict[str, Any] | None = None) -> bool:
+        """Apply host-configured tool allow/deny lists to an optional config snapshot."""
+        cfg = config if config is not None else await self._resolve_host_config()
+        return self._tool_allowed_from_config(tool, cfg)
+
+    async def _resolve_config(self) -> tuple[str | None, dict[str, str]]:
+        """Host-resolved (url, extra_headers), honoring a user's mcpServers override.
+        Falls back to the class ``url`` and no extra headers on host error."""
+        cfg = await self._resolve_host_config()
+        url = cfg.get("url")
+        headers = cfg.get("headers")
         if not (isinstance(url, str) and url):
             url = self.url
         extra = headers if isinstance(headers, dict) else {}
@@ -247,15 +287,30 @@ class McpIntegration:
 
     async def list_tools(self) -> list[dict[str, Any]]:
         """Return the server's tools as ``[{name, description, inputSchema}]``."""
-        await self._ensure_tools()
-        return [dict(t) for t in (self._tools or {}).values()]
+        config = await self._ensure_tools()
+        tools = [dict(t) for t in (self._tools or {}).values()]
+        return [tool for tool in tools if self._tool_allowed_from_config(str(tool["name"]), config)]
 
-    async def _ensure_tools(self) -> None:
-        if self._tools is not None:
-            return
+    async def _ensure_tools(self) -> dict[str, Any]:
         async with self._lock:
+            config = await self._resolve_host_config()
             if self._tools is not None:
-                return
+                return config
+            if self._is_host_bridge_config(config):
+                payload = await host_request("mcp.list_tools", {"server": self.server})
+                tools = payload.get("tools") if isinstance(payload, dict) else None
+                if not isinstance(tools, list):
+                    raise RuntimeError("mcp.list_tools returned an invalid tools list")
+                self._tools = {
+                    tool["name"]: {
+                        "name": tool["name"],
+                        "description": tool.get("description", "") or "",
+                        "inputSchema": tool.get("inputSchema") or {},
+                    }
+                    for tool in tools
+                    if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+                }
+                return config
             async with AsyncExitStack() as stack:
                 session = await self._open_session(stack)
                 resp = await session.list_tools()
@@ -267,14 +322,27 @@ class McpIntegration:
                     }
                     for t in resp.tools
                 }
+            return config
 
     async def call_tool(self, tool: str, arguments: dict[str, Any] | None = None) -> Any:
         """Call ``tool`` on the server and return its parsed result.
 
-        Opens a fresh session per call: MCP sessions are not safe to hold across
-        the kernel's snapshot/restore, and per-call connect keeps this robust to
-        idle sessions and token rotation at modest latency cost.
+        Stdio integrations use the host bridge: the TypeScript host owns one
+        long-lived process per configured server, so snapshot/restore never
+        serializes a process, pipe, SDK session, or event-loop transport.
+        HTTP integrations retain the existing fresh-session behavior.
         """
+        config = await self._resolve_host_config()
+        if not self._tool_allowed_from_config(tool, config):
+            raise PermissionError(f"MCP tool '{tool}' is not allowed by settings")
+        if self._is_host_bridge_config(config):
+            payload = await host_request(
+                "mcp.call_tool",
+                {"server": self.server, "tool": tool, "arguments": arguments or {}},
+            )
+            if not isinstance(payload, dict) or "result" not in payload:
+                raise RuntimeError("mcp.call_tool returned an invalid result")
+            return _parse_result(payload["result"])
         async with AsyncExitStack() as stack:
             session = await self._open_session(stack)
             result = await session.call_tool(tool, arguments or {})
@@ -309,15 +377,23 @@ def _parse_result(result: Any) -> Any:
     Raises McpToolError when the server flags the result as an error, so a failed
     tool call doesn't look like a successful one to the caller.
     """
+    if isinstance(result, dict):
+        blocks = result.get("content") or []
+        is_error = bool(result.get("isError", False))
+        structured = result.get("structuredContent")
+    else:
+        blocks = getattr(result, "content", None) or []
+        is_error = bool(getattr(result, "isError", False))
+        structured = getattr(result, "structuredContent", None)
+
     texts: list[str] = []
-    for block in getattr(result, "content", None) or []:
-        text = getattr(block, "text", None)
+    for block in blocks:
+        text = block.get("text") if isinstance(block, dict) else getattr(block, "text", None)
         if text is not None:
-            texts.append(text)
-    if getattr(result, "isError", False):
+            texts.append(str(text))
+    if is_error:
         raise McpToolError("\n".join(texts) or "MCP tool returned an error")
 
-    structured = getattr(result, "structuredContent", None)
     if structured is not None:  # falsy-but-valid payloads ({} / []) are real results
         return structured
     if texts:
@@ -325,7 +401,6 @@ def _parse_result(result: Any) -> Any:
 
     # Non-text content (images, embedded resources): return them as plain dicts
     # rather than the opaque SDK object so callers get usable data.
-    blocks = getattr(result, "content", None) or []
     if blocks:
         return [b.model_dump(mode="json") if hasattr(b, "model_dump") else b for b in blocks]
     return result

--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -139,11 +139,23 @@ class McpIntegration:
     #: Optional env var holding a static bearer token (used instead of auth.json OAuth).
     bearer_token_env: str | None = None
 
+    #: Per-integration host bridge timeout in seconds. ``None`` uses the runtime
+    #: default or the ``RLM_HOST_REQUEST_TIMEOUT`` environment override.
+    host_request_timeout: float | None = None
+
     def __init__(self) -> None:
         if not self.server:
             raise ValueError(f"{type(self).__name__} must set a non-empty `server`")
         self._tools: dict[str, Any] | None = None
         self._lock = asyncio.Lock()
+
+    async def _host_request(
+        self,
+        request_type: str,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Forward a host request with this integration's timeout policy."""
+        return await host_request(request_type, payload, timeout=self.host_request_timeout)
 
     # -- credentials --------------------------------------------------------
 
@@ -185,7 +197,7 @@ class McpIntegration:
         if _read_auth(self._provider_id) is not None:
             refresh_error: Exception | None = None
             try:
-                await host_request("mcp.refresh", {"server": self.server})
+                await self._host_request("mcp.refresh", {"server": self.server})
             except RuntimeError as exc:
                 refresh_error = exc
             token = self._token()
@@ -204,7 +216,7 @@ class McpIntegration:
     async def _resolve_host_config(self) -> dict[str, Any]:
         """Read host transport metadata without importing or holding a live client."""
         try:
-            cfg = await host_request("mcp.config", {"server": self.server})
+            cfg = await self._host_request("mcp.config", {"server": self.server})
         except RuntimeError:
             return {}
         if isinstance(cfg, dict) and cfg.get("enabled") is False:
@@ -297,7 +309,7 @@ class McpIntegration:
             if self._tools is not None:
                 return config
             if self._is_host_bridge_config(config):
-                payload = await host_request("mcp.list_tools", {"server": self.server})
+                payload = await self._host_request("mcp.list_tools", {"server": self.server})
                 tools = payload.get("tools") if isinstance(payload, dict) else None
                 if not isinstance(tools, list):
                     raise RuntimeError("mcp.list_tools returned an invalid tools list")
@@ -336,7 +348,7 @@ class McpIntegration:
         if not self._tool_allowed_from_config(tool, config):
             raise PermissionError(f"MCP tool '{tool}' is not allowed by settings")
         if self._is_host_bridge_config(config):
-            payload = await host_request(
+            payload = await self._host_request(
                 "mcp.call_tool",
                 {"server": self.server, "tool": tool, "arguments": arguments or {}},
             )

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -253,6 +253,73 @@ class McpIntegrationTest(unittest.TestCase):
         self._run_open_session_with_transport(transport)
         self.assertIsNotNone(captured["http_client"])
 
+    def test_resolve_config_denies_an_explicitly_disabled_server(self):
+        async def host_disabled(req_type, payload):
+            return {"enabled": False}
+
+        with mock.patch.object(mcp_base, "host_request", host_disabled):
+            with self.assertRaisesRegex(mcp_base.Disabled, "disabled"):
+                _run(_Integration()._resolve_config())
+
+    def test_stdio_bridge_uses_host_process_without_opening_python_sessions(self):
+        calls = []
+
+        async def host_request_bridge(req_type, payload):
+            calls.append((req_type, payload))
+            if req_type == "mcp.config":
+                return {"type": "stdio", "bridge": "host"}
+            if req_type == "mcp.list_tools":
+                return {"tools": [{"name": "echo", "description": "Echo", "inputSchema": {}}]}
+            if req_type == "mcp.call_tool":
+                return {"result": {"structuredContent": {"ok": payload["arguments"]}, "content": []}}
+            raise AssertionError(req_type)
+
+        with mock.patch.object(mcp_base, "host_request", host_request_bridge):
+            with mock.patch.object(_Integration, "_open_session", side_effect=AssertionError("HTTP session opened")):
+                integration = _Integration()
+                self.assertEqual(_run(integration.list_tools()), [{"name": "echo", "description": "Echo", "inputSchema": {}}])
+                self.assertEqual(_run(integration.call_tool("echo", {"value": 1})), {"ok": {"value": 1}})
+        self.assertEqual(
+            [call[0] for call in calls],
+            ["mcp.config", "mcp.list_tools", "mcp.config", "mcp.call_tool"],
+        )
+
+    def test_list_tools_resolves_filter_config_once_for_many_tools(self):
+        calls = []
+
+        async def host_request_many_tools(req_type, payload):
+            calls.append((req_type, payload))
+            if req_type == "mcp.config":
+                return {
+                    "type": "stdio",
+                    "bridge": "host",
+                    "enabledTools": ["tool-0", "tool-2"],
+                }
+            if req_type == "mcp.list_tools":
+                return {
+                    "tools": [
+                        {"name": f"tool-{index}", "description": "", "inputSchema": {}}
+                        for index in range(81)
+                    ]
+                }
+            raise AssertionError(req_type)
+
+        with mock.patch.object(mcp_base, "host_request", host_request_many_tools):
+            tools = _run(_Integration().list_tools())
+
+        self.assertEqual([tool["name"] for tool in tools], ["tool-0", "tool-2"])
+        self.assertEqual([call[0] for call in calls], ["mcp.config", "mcp.list_tools"])
+
+    def test_host_bridge_parses_error_result(self):
+        async def host_request_error(req_type, payload):
+            if req_type == "mcp.config":
+                return {"type": "stdio", "bridge": "host"}
+            return {"result": {"isError": True, "content": [{"text": "boom"}]}}
+
+        with mock.patch.object(mcp_base, "host_request", host_request_error):
+            with self.assertRaisesRegex(McpToolError, "boom"):
+                _run(_Integration().call_tool("echo"))
+
     def test_resolve_config_prefers_host_override_and_headers(self):
         async def host_with_override(req_type, payload):
             return {"url": "https://override.test/mcp", "headers": {"X-Extra": "1"}}
@@ -268,6 +335,23 @@ class McpIntegrationTest(unittest.TestCase):
             url, headers = _run(_Integration()._resolve_config())
             self.assertEqual(url, _Integration.url)
             self.assertEqual(headers, {})
+
+
+    def test_host_tool_allowlists_apply_to_http_integrations(self):
+        integration = _Integration()
+        integration._tools = {
+            "allowed": {"name": "allowed", "description": "", "inputSchema": {}},
+            "blocked": {"name": "blocked", "description": "", "inputSchema": {}},
+        }
+
+        async def host_config(req_type, payload):
+            self.assertEqual(req_type, "mcp.config")
+            return {"url": _Integration.url, "enabledTools": ["allowed"]}
+
+        with mock.patch.object(mcp_base, "host_request", host_config):
+            self.assertEqual([tool["name"] for tool in _run(integration.list_tools())], ["allowed"])
+            with self.assertRaisesRegex(PermissionError, "not allowed"):
+                _run(integration.call_tool("blocked"))
 
 
 if __name__ == "__main__":

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -9,6 +9,7 @@ from contextlib import AsyncExitStack
 from pathlib import Path
 from unittest import mock
 
+import rlm as rlm_module
 from rlm import mcp_base
 from rlm.mcp_base import McpIntegration, McpToolError, NotEnabled
 
@@ -47,6 +48,72 @@ class _FakeSession:
 class _Integration(McpIntegration):
     server = "demo"
     url = "https://example.test/mcp"
+
+
+class _FakeComm:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._on_msg = None
+        self.close_calls = 0
+        self.open_data = None
+        type(self).instances.append(self)
+
+    def on_msg(self, callback):
+        self._on_msg = callback
+
+    def open(self, data=None):
+        self.open_data = data
+
+    def close(self):
+        self.close_calls += 1
+
+    def deliver(self, data):
+        assert self._on_msg is not None
+        self._on_msg({"content": {"data": data}})
+
+
+class HostRequestTest(unittest.TestCase):
+    def setUp(self):
+        _FakeComm.instances.clear()
+
+    def test_timeout_uses_env_override_and_closes_comm(self):
+        async def exercise():
+            with mock.patch.object(rlm_module, "Comm", _FakeComm), mock.patch.dict(
+                "os.environ", {"RLM_HOST_REQUEST_TIMEOUT": "0.01"}
+            ):
+                with self.assertRaisesRegex(TimeoutError, "mcp.timeout"):
+                    await rlm_module.host_request("mcp.timeout")
+
+        _run(exercise())
+        self.assertEqual(len(_FakeComm.instances), 1)
+        self.assertEqual(_FakeComm.instances[0].close_calls, 1)
+
+    def test_cancellation_closes_comm_and_names_request(self):
+        async def exercise():
+            with mock.patch.object(rlm_module, "Comm", _FakeComm):
+                task = asyncio.create_task(rlm_module.host_request("mcp.cancel"))
+                await asyncio.sleep(0)
+                task.cancel()
+                with self.assertRaisesRegex(asyncio.CancelledError, "mcp.cancel"):
+                    await task
+
+        _run(exercise())
+        self.assertEqual(len(_FakeComm.instances), 1)
+        self.assertEqual(_FakeComm.instances[0].close_calls, 1)
+
+    def test_late_reply_after_timeout_is_ignored_and_does_not_reclose(self):
+        async def exercise():
+            with mock.patch.object(rlm_module, "Comm", _FakeComm):
+                with self.assertRaises(TimeoutError):
+                    await rlm_module.host_request("mcp.late", timeout=0.01)
+                comm = _FakeComm.instances[0]
+                comm.deliver({"status": "ok", "value": "late"})
+                await asyncio.sleep(0)
+                self.assertEqual(comm.close_calls, 1)
+
+        _run(exercise())
 
 
 class McpIntegrationTest(unittest.TestCase):
@@ -94,7 +161,7 @@ class McpIntegrationTest(unittest.TestCase):
             {"type": "oauth", "access": "old", "refresh": "r", "expires": (time.time() - 10) * 1000}
         )
 
-        async def fake_host_request(req_type, payload):
+        async def fake_host_request(req_type, payload, **kwargs):
             self.assertEqual(req_type, "mcp.refresh")
             self.assertEqual(payload, {"server": "demo"})
             # Simulate the host rewriting auth.json with a fresh token.
@@ -113,7 +180,7 @@ class McpIntegrationTest(unittest.TestCase):
             {"type": "oauth", "access": "stale", "refresh": "r", "expires": (time.time() - 10) * 1000}
         )
 
-        async def fake_host_request(req_type, payload):
+        async def fake_host_request(req_type, payload, **kwargs):
             return {}  # no-op: token stays expired
 
         with mock.patch.object(mcp_base, "host_request", fake_host_request):
@@ -127,7 +194,7 @@ class McpIntegrationTest(unittest.TestCase):
             {"type": "oauth", "access": "stale", "refresh": "r", "expires": (time.time() - 10) * 1000}
         )
 
-        async def failing_host_request(req_type, payload):
+        async def failing_host_request(req_type, payload, **kwargs):
             raise RuntimeError("network down")
 
         with mock.patch.object(mcp_base, "host_request", failing_host_request):
@@ -163,7 +230,9 @@ class McpIntegrationTest(unittest.TestCase):
         self._write_auth(
             {"type": "oauth", "access": "t", "refresh": "r", "expires": (time.time() + 3600) * 1000}
         )
-        with self._patch_session(session):
+        with self._patch_session(session), mock.patch.object(
+            _Integration, "_resolve_host_config", new=mock.AsyncMock(return_value={})
+        ):
             integration = _Integration()
             out = _run(integration.list_issues(team="Eng"))
         self.assertEqual(out, {"issues": [1, 2]})
@@ -174,7 +243,9 @@ class McpIntegrationTest(unittest.TestCase):
         self._write_auth(
             {"type": "oauth", "access": "t", "refresh": "r", "expires": (time.time() + 3600) * 1000}
         )
-        with self._patch_session(session):
+        with self._patch_session(session), mock.patch.object(
+            _Integration, "_resolve_host_config", new=mock.AsyncMock(return_value={})
+        ):
             integration = _Integration()
             with self.assertRaises(AttributeError) as ctx:
                 _run(integration.nonexistent_tool())
@@ -202,7 +273,7 @@ class McpIntegrationTest(unittest.TestCase):
             {"type": "oauth", "access": "tok-xyz", "refresh": "r", "expires": (time.time() + 3600) * 1000}
         )
 
-        async def fake_host_request(req_type, payload):
+        async def fake_host_request(req_type, payload, **kwargs):
             return {}  # no host URL override; _resolve_url falls back to self.url
 
         with mock.patch.object(mcp_base, "host_request", fake_host_request), \
@@ -254,7 +325,7 @@ class McpIntegrationTest(unittest.TestCase):
         self.assertIsNotNone(captured["http_client"])
 
     def test_resolve_config_denies_an_explicitly_disabled_server(self):
-        async def host_disabled(req_type, payload):
+        async def host_disabled(req_type, payload, **kwargs):
             return {"enabled": False}
 
         with mock.patch.object(mcp_base, "host_request", host_disabled):
@@ -264,7 +335,7 @@ class McpIntegrationTest(unittest.TestCase):
     def test_stdio_bridge_uses_host_process_without_opening_python_sessions(self):
         calls = []
 
-        async def host_request_bridge(req_type, payload):
+        async def host_request_bridge(req_type, payload, **kwargs):
             calls.append((req_type, payload))
             if req_type == "mcp.config":
                 return {"type": "stdio", "bridge": "host"}
@@ -284,10 +355,39 @@ class McpIntegrationTest(unittest.TestCase):
             ["mcp.config", "mcp.list_tools", "mcp.config", "mcp.call_tool"],
         )
 
+    def test_host_request_timeout_propagates_through_bridge_calls(self):
+        calls = []
+
+        async def host_request_bridge(req_type, payload, **kwargs):
+            calls.append((req_type, kwargs.get("timeout")))
+            if req_type == "mcp.config":
+                return {"type": "stdio", "bridge": "host"}
+            if req_type == "mcp.list_tools":
+                return {"tools": [{"name": "echo", "description": "", "inputSchema": {}}]}
+            if req_type == "mcp.call_tool":
+                return {"result": {"structuredContent": {"ok": True}, "content": []}}
+            raise AssertionError(req_type)
+
+        with mock.patch.object(mcp_base, "host_request", host_request_bridge):
+            integration = _Integration()
+            integration.host_request_timeout = 0.25
+            self.assertEqual(_run(integration.list_tools())[0]["name"], "echo")
+            self.assertEqual(_run(integration.call_tool("echo")), {"ok": True})
+
+        self.assertEqual(
+            calls,
+            [
+                ("mcp.config", 0.25),
+                ("mcp.list_tools", 0.25),
+                ("mcp.config", 0.25),
+                ("mcp.call_tool", 0.25),
+            ],
+        )
+
     def test_list_tools_resolves_filter_config_once_for_many_tools(self):
         calls = []
 
-        async def host_request_many_tools(req_type, payload):
+        async def host_request_many_tools(req_type, payload, **kwargs):
             calls.append((req_type, payload))
             if req_type == "mcp.config":
                 return {
@@ -311,7 +411,7 @@ class McpIntegrationTest(unittest.TestCase):
         self.assertEqual([call[0] for call in calls], ["mcp.config", "mcp.list_tools"])
 
     def test_host_bridge_parses_error_result(self):
-        async def host_request_error(req_type, payload):
+        async def host_request_error(req_type, payload, **kwargs):
             if req_type == "mcp.config":
                 return {"type": "stdio", "bridge": "host"}
             return {"result": {"isError": True, "content": [{"text": "boom"}]}}
@@ -321,10 +421,10 @@ class McpIntegrationTest(unittest.TestCase):
                 _run(_Integration().call_tool("echo"))
 
     def test_resolve_config_prefers_host_override_and_headers(self):
-        async def host_with_override(req_type, payload):
+        async def host_with_override(req_type, payload, **kwargs):
             return {"url": "https://override.test/mcp", "headers": {"X-Extra": "1"}}
 
-        async def host_empty(req_type, payload):
+        async def host_empty(req_type, payload, **kwargs):
             return {}
 
         with mock.patch.object(mcp_base, "host_request", host_with_override):
@@ -344,7 +444,7 @@ class McpIntegrationTest(unittest.TestCase):
             "blocked": {"name": "blocked", "description": "", "inputSchema": {}},
         }
 
-        async def host_config(req_type, payload):
+        async def host_config(req_type, payload, **kwargs):
             self.assertEqual(req_type, "mcp.config")
             return {"url": _Integration.url, "enabledTools": ["allowed"]}
 


### PR DESCRIPTION
## Summary

- add host-managed stdio MCP integrations and bundled context-mode/jCodeMunch sidecars
- materialize oversized IPython output into bounded, seekable artifacts
- add strict/advisory context routing for large shell and Python reads
- harden the implementation against the full A1-A8, B1-B7, C1-C5, and D1-D2 review set

## Review finding map

- **A1-A8** — `a8b65c878`: stdin/write failure handling, spec-compliant shutdown, cleanup re-registration, no retry of possibly-delivered calls, handshake/tool-capability validation, runtime settings validation/diagnostics, process-backed cleanup tests, and MCP docs
- **B1-B7** — `71cc0d76a`: bounded capture append/search, sparse seek checkpoints, failed-capture disposal, atomic staging publication, exact preview limits, and code-point-safe Unicode behavior
- **C1-C5** — `d59412a31`: scoped fallback guards, safe redirect target parsing, bounded head/tail semantics, per-read Python output analysis, and scalar-reducer handling
- **D1-D2** — `7a3ba25a4`: bounded/cancellable host bridge requests with guaranteed comm cleanup, timeout propagation, valid Context Mode examples, and real-stdio test coverage

## Validation

- `npm run check`
- focused Vitest suite: **106 passed**
  - `mcp-manager.test.ts`
  - `settings-manager.test.ts`
  - `context-artifact-store.test.ts`
  - `ipython-output-materialization.test.ts`
  - `context-routing.test.ts`
- Python runtime MCP suite: **26 passed**
- Context Mode suite, including real stdio example: **8 passed**
- jCodeMunch canary suite: **8 passed**
- independent adversarial review/fuzzing completed with no remaining findings


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add host-managed stdio MCP integrations for jcodemunch and context-mode with bounded IPython output artifacts
> - Adds `StdioMcpClient` and extends `McpManager` to own lazy stdio MCP sidecar processes, auto-registering `jcodemunch` and `context-mode` as bundled defaults with curated tool allowlists; sidecars start on first tool use and are stopped on reload or disposal.
> - Adds `mcp.list_tools`, `mcp.call_tool`, `mcp.health`, and `mcp.restart` host request handlers so Python skills can invoke stdio-backed tools via the host bridge without spawning processes themselves.
> - Adds `ContextMode` and `JCodeMunch` Python MCP adapter classes that connect via HTTP when configured or delegate to the host bridge for stdio; raises `SidecarUnavailable` (a `Disabled` subclass) when no usable transport is found.
> - Adds `ContextArtifactStore` to materialize oversized IPython outputs as opaque file-backed artifacts, injecting bounded inline previews and retrieval guidance into model-visible output.
> - Adds `context-routing.ts` extension with advisory and strict-large-read routing modes to intercept broad file reads before they reach the model.
> - Extends `mcp_base.McpIntegration` with per-tool allow/deny enforcement, a `Disabled` exception for explicitly disabled integrations, and `host_request` timeout support with env override via `RLM_HOST_REQUEST_TIMEOUT`.
> - Risk: stdio integrations bypass `auth.json`; tool allowlists are the only gating mechanism, so misconfigured `enabledTools`/`disabledTools` in settings could expose unintended tool surfaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96aab93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->