### PR TITLE
fix(coding-agent): bound host requests and drain lost-idle executions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Fixed IPython host bridge requests hanging indefinitely when a request, handler, or response is lost, with a configurable 120-second deadline and safe cleanup ([#848](https://github.com/PrimeIntellect-ai/prime-agent/issues/848)).
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 - Fixed IPython host bridge requests hanging indefinitely when a request, handler, or response is lost, with a configurable 120-second deadline and safe cleanup ([#848](https://github.com/PrimeIntellect-ai/prime-agent/issues/848)).
+- Fixed completed IPython cells blocking the serial execution queue when Jupyter drops the matching IOPub idle event ([#848](https://github.com/PrimeIntellect-ai/prime-agent/issues/848)).
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -685,6 +685,7 @@ prime-agent --thinking high "Solve this complex problem"
 | `PRIME_AGENT_TRACES_API_KEY` | Prime API key used only for opt-in trace sharing |
 | `PRIME_AGENT_TRACES_BASE_URL` | Override the Prime Agent trace upload API base URL |
 | `PRIME_AGENT_KERNEL_PYTHON` | Use an existing Python environment with `ipykernel` instead of auto-bootstrapping `~/.prime/agent/kernel-venv` |
+| `PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS` | Set the IPython kernel↔host request deadline in milliseconds (default: `120000`; range: `1`–`3600000`) |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 
 The remaining `PI_*` variables in this table are compatibility names still read by the current runtime. They do not change the application name, command, or default `~/.prime/agent` configuration path.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -44,7 +44,7 @@
 		"postinstall": "node postinstall.cjs",
 		"prepublishOnly": "npm run clean && npm run build",
 		"bundle": "node scripts/bundle.mjs",
-		"test:kernel": "vitest --run --no-file-parallelism --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts test/kernel-goal-skill.test.ts test/kernel-state-roundtrip.test.ts"
+		"test:kernel": "vitest --run --no-file-parallelism --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts test/kernel-goal-skill.test.ts test/kernel-state-roundtrip.test.ts test/kernel-execute-reply-fallback.test.ts"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -157,7 +157,7 @@ export interface AgentSessionMessageSendInput {
 export interface AgentSessionMessageController {
 	listAgents(): AgentSessionMessageListResult | Promise<AgentSessionMessageListResult>;
 	roster?(): AgentFamilyRosterResult | Promise<AgentFamilyRosterResult>;
-	awaitPendingChildPublication?(selector: string): Promise<string | undefined>;
+	awaitPendingChildPublication?(selector: string, signal?: AbortSignal): Promise<string | undefined>;
 	assertSessionNameAvailable?(input: AgentSessionNameAvailabilityInput): void | Promise<void>;
 	setSessionName?(name: string): void | Promise<void>;
 	sendAgentMessage(input: AgentSessionMessageSendInput): Promise<AgentSessionMessageReceipt>;
@@ -522,15 +522,26 @@ export class AgentSessionMessageRateLimiter {
 	}
 }
 
+function throwIfHostRequestAborted(signal: AbortSignal | undefined): void {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error ? signal.reason : new Error("host request aborted");
+}
+
 export function createAgentMessageHostHandlers(
 	controller: Pick<AgentSessionMessageController, "roster" | "sendAgentMessage" | "awaitPendingChildPublication">,
 ): Record<string, HostRequestHandler> {
 	return {
-		"agent_message.list_agents": async () => {
+		"agent_message.list_agents": async (_payload, context) => {
+			const signal = context?.signal;
+			throwIfHostRequestAborted(signal);
 			if (!controller.roster) throw new Error("agent family roster is not available in this session");
-			return (await controller.roster()) as unknown as Record<string, unknown>;
+			const roster = await controller.roster();
+			throwIfHostRequestAborted(signal);
+			return roster as unknown as Record<string, unknown>;
 		},
-		"agent_message.send": async (payload) => {
+		"agent_message.send": async (payload, context) => {
+			const signal = context?.signal;
+			throwIfHostRequestAborted(signal);
 			if (typeof payload.message !== "string") {
 				throw new Error("agent_message.send message must be a string");
 			}
@@ -546,6 +557,7 @@ export function createAgentMessageHostHandlers(
 				}
 				if (!controller.roster) throw new Error("agent family roster is not available in this session");
 				const roster = await controller.roster();
+				throwIfHostRequestAborted(signal);
 				const results = await Promise.allSettled(
 					roster.entries.map((entry) =>
 						controller.sendAgentMessage({
@@ -555,6 +567,7 @@ export function createAgentMessageHostHandlers(
 						}),
 					),
 				);
+				throwIfHostRequestAborted(signal);
 				const receipts = results.map((result, index) =>
 					result.status === "fulfilled"
 						? result.value
@@ -580,9 +593,11 @@ export function createAgentMessageHostHandlers(
 				const selector = typeof receiverName === "string" ? receiverName.trim() : undefined;
 				const publishedId =
 					role === "child" && selector && controller.awaitPendingChildPublication
-						? await controller.awaitPendingChildPublication(selector)
+						? await controller.awaitPendingChildPublication(selector, signal)
 						: undefined;
+				throwIfHostRequestAborted(signal);
 				const roster = await controller.roster();
+				throwIfHostRequestAborted(signal);
 				const matches = roster.entries.filter(
 					(entry) =>
 						entry.relationship === role &&
@@ -597,11 +612,14 @@ export function createAgentMessageHostHandlers(
 				}
 				target = matches[0]!.id;
 			}
-			return (await controller.sendAgentMessage({
+			throwIfHostRequestAborted(signal);
+			const receipt = await controller.sendAgentMessage({
 				target,
 				message: payload.message,
 				receiverRole: payload.receiver_role as AgentFamilyRelationship,
-			})) as unknown as Record<string, unknown>;
+			});
+			throwIfHostRequestAborted(signal);
+			return receipt as unknown as Record<string, unknown>;
 		},
 	};
 }

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -15,7 +15,7 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import {
@@ -673,6 +673,34 @@ interface PreparedPromptPreparation {
 }
 
 class DeferredSessionInputError extends Error {}
+
+function throwIfHostRequestAborted(signal: AbortSignal | undefined): void {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error ? signal.reason : new Error("host request aborted");
+}
+
+function raceWithHostRequestAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+	if (!signal) return promise;
+	throwIfHostRequestAborted(signal);
+	return new Promise<T>((resolve, reject) => {
+		const cleanup = () => signal.removeEventListener("abort", onAbort);
+		const onAbort = () => {
+			cleanup();
+			reject(signal.reason instanceof Error ? signal.reason : new Error("host request aborted"));
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(
+			(value) => {
+				cleanup();
+				resolve(value);
+			},
+			(error: unknown) => {
+				cleanup();
+				reject(error);
+			},
+		);
+	});
+}
 
 /** Wrap a preflight callback so only the first report wins. */
 function oncePreflight(
@@ -8760,31 +8788,52 @@ export class AgentSession {
 	/** Typed handlers for host requests arriving from the IPython kernel comm bridge. */
 	private _createKernelHostHandlers(): HostRequestHandlers {
 		const handlers: HostRequestHandlers = {
-			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode }) => ({
-				...(await this.runRlmChild(prompt, kwargs, cellSourceCode)),
+			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode }, signal) => ({
+				...(await this.runRlmChild(prompt, kwargs, cellSourceCode, signal)),
 			})),
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
 			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target) => this.deleteRlmSubagent(target)),
-			"model.info": async () => ({
-				id: this.model?.id ?? null,
-				provider: this.model?.provider ?? null,
-				input: this.model?.input ?? [],
-			}),
+			"model.info": async (_payload, context) => {
+				throwIfHostRequestAborted(context?.signal);
+				return {
+					id: this.model?.id ?? null,
+					provider: this.model?.provider ?? null,
+					input: this.model?.input ?? [],
+				};
+			},
 		};
 		if (this._includeGoals) {
 			for (const type of ["goal.get", "goal.create", "goal.complete"]) {
-				handlers[type] = async (payload) => this.handleGoalHostRequest(type, payload);
+				handlers[type] = async (payload, context) => {
+					const signal = context?.signal;
+					throwIfHostRequestAborted(signal);
+					const result = await this.handleGoalHostRequest(type, payload);
+					throwIfHostRequestAborted(signal);
+					return result;
+				};
 			}
 		}
 		if (this._includeCompactSkill) {
 			for (const type of ["compact.run", "compact.status"]) {
-				handlers[type] = async (payload) => this.handleCompactHostRequest(type, payload);
+				handlers[type] = async (payload, context) => {
+					const signal = context?.signal;
+					throwIfHostRequestAborted(signal);
+					const result = await this.handleCompactHostRequest(type, payload);
+					throwIfHostRequestAborted(signal);
+					return result;
+				};
 			}
 		}
 		if (this._autoRefineAllowedForSession()) {
 			for (const type of ["refine.run", "refine.status"]) {
-				handlers[type] = async (payload) => this.handleRefineHostRequest(type, payload);
+				handlers[type] = async (payload, context) => {
+					const signal = context?.signal;
+					throwIfHostRequestAborted(signal);
+					const result = await this.handleRefineHostRequest(type, payload);
+					throwIfHostRequestAborted(signal);
+					return result;
+				};
 			}
 		}
 		if (this._rlmHeartbeatController) {
@@ -8794,7 +8843,13 @@ export class AgentSession {
 				"rlm_heartbeat.update",
 				"rlm_heartbeat.delete",
 			]) {
-				handlers[type] = async (payload) => this.handleRlmHeartbeatHostRequest(type, payload);
+				handlers[type] = async (payload, context) => {
+					const signal = context?.signal;
+					throwIfHostRequestAborted(signal);
+					const result = await this.handleRlmHeartbeatHostRequest(type, payload);
+					throwIfHostRequestAborted(signal);
+					return result;
+				};
 			}
 		}
 		const visibleKernelSkillNames = new Set(
@@ -8808,7 +8863,8 @@ export class AgentSession {
 				createAgentMessageHostHandlers({
 					roster: async () =>
 						(await this.handleAgentMessageHostRequest("agent_message.list_agents")) as AgentFamilyRosterResult,
-					awaitPendingChildPublication: (selector) => this._awaitPendingRlmChildPublication(selector),
+					awaitPendingChildPublication: (selector, signal) =>
+						this._awaitPendingRlmChildPublication(selector, signal),
 					sendAgentMessage: async (input) => {
 						const receipt = (await this.handleAgentMessageHostRequest("agent_message.send", {
 							target: input.target,
@@ -9148,7 +9204,7 @@ export class AgentSession {
 		}
 	}
 
-	private async _awaitPendingRlmChildPublication(selector: string): Promise<string | undefined> {
+	private async _awaitPendingRlmChildPublication(selector: string, signal?: AbortSignal): Promise<string | undefined> {
 		const run = [...this._activeRlmChildRuns.values()].find(
 			(candidate) =>
 				(candidate.status === "queued" || candidate.status === "running" || candidate.status === "done") &&
@@ -9156,7 +9212,7 @@ export class AgentSession {
 				(candidate.id === selector || candidate.sessionName === selector),
 		);
 		if (!run) return undefined;
-		await run.publication.promise;
+		await raceWithHostRequestAbort(run.publication.promise, signal);
 		return run.session?.sessionId;
 	}
 
@@ -9685,7 +9741,9 @@ export class AgentSession {
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
+		signal?: AbortSignal,
 	): Promise<RlmSpawnHandle> {
+		throwIfHostRequestAborted(signal);
 		const { name: rawName, model: rawModel, ...unsupported } = kwargs;
 		const unsupportedKwargs = Object.keys(unsupported);
 		if (unsupportedKwargs.length > 0) {
@@ -9708,7 +9766,9 @@ export class AgentSession {
 		let modelSelection: RlmSubagentModelSelection;
 		try {
 			if (requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(requestedSessionName, true);
+			throwIfHostRequestAborted(signal);
 			modelSelection = await this._resolveRlmSubagentModel(requestedModel);
+			throwIfHostRequestAborted(signal);
 		} finally {
 			if (requestedSessionName) this._pendingRlmSubagentSessionNames.delete(requestedSessionName);
 		}
@@ -9717,7 +9777,13 @@ export class AgentSession {
 		const childSessionDir = this._createChildRlmSessionDir();
 		const childNodeId = basename(childSessionDir);
 		const sessionName = requestedSessionName ?? createDefaultRlmSubagentSessionName(prompt, childNodeId);
-		if (!requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(sessionName);
+		try {
+			if (!requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(sessionName);
+			throwIfHostRequestAborted(signal);
+		} catch (error) {
+			rmSync(childSessionDir, { recursive: true, force: true });
+			throw error;
+		}
 		const startedAt = Date.now();
 		const parentAssistantForUsage = this._findLastAssistantMessage();
 		const label = rlmChildLabel(prompt);
@@ -10036,8 +10102,9 @@ export class AgentSession {
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
+		signal?: AbortSignal,
 	): Promise<RlmSpawnHandle> {
-		return this._startRlmChildRun(prompt, kwargs, spawnCode);
+		return this._startRlmChildRun(prompt, kwargs, spawnCode, signal);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -30,6 +30,10 @@ const READY_TIMEOUT_MS = 5000;
 const IOPUB_SUBSCRIBE_DELAY_MS = 50;
 const DEFAULT_MAX_OUTPUT_CHARS = 65536;
 const HOST_REQUEST_DISPOSE_TIMEOUT_MS = 5000;
+const DEFAULT_HOST_REQUEST_TIMEOUT_MS = 120_000;
+const MAX_HOST_REQUEST_TIMEOUT_MS = 3_600_000;
+const HOST_REQUEST_TIMEOUT_FIELD = "_prime_agent_timeout_ms";
+const HOST_REQUEST_EXECUTION_OWNED_FIELD = "_prime_agent_execution_owned";
 const DEFAULT_SNAPSHOT_DEBOUNCE_MS = 1500;
 // How often to poll a forked kernel's pid for unexpected death.
 const FORKED_LIVENESS_POLL_MS = 1000;
@@ -56,25 +60,31 @@ export class KernelBusyAfterInterruptError extends Error {
 export const HOST_COMM_TARGET = "host.request";
 
 /**
- * Handles one typed request from Python code running in the kernel.
- * The returned record is sent back verbatim as the comm reply payload.
- *
- * This legacy unary compatibility alias remains the dispatcher and registration
- * contract while context-aware handlers are staged separately below.
- */
-export type HostRequestHandler = (payload: Record<string, unknown>) => Promise<Record<string, unknown>>;
-
-/**
- * Per-call authority supplied by the host-request dispatcher.
+ * Per-call authority and lifecycle metadata supplied by the host-request dispatcher.
  * `requestId` is an opaque host-minted correlation token and `isCurrent()`
  * lets an implementation reject work after its authority is revoked.
  */
 export interface HostRequestContext {
 	readonly requestId: string;
 	readonly generation: number;
+	readonly requestType: string;
+	readonly timeoutMs: number;
+	/** Aborted with the source execution, when the deadline expires, or when the Comm closes. */
 	readonly signal: AbortSignal;
 	isCurrent(): boolean;
 }
+
+/**
+ * Handles one typed request from Python code running in the kernel.
+ * The returned record is sent back verbatim as the comm reply payload.
+ *
+ * The context remains optional so existing unary handlers stay source-compatible;
+ * the host dispatcher always supplies it.
+ */
+export type HostRequestHandler = (
+	payload: Record<string, unknown>,
+	context?: HostRequestContext,
+) => Promise<Record<string, unknown>>;
 
 const hostRequestHandlerBrand = Symbol("hostRequestHandler");
 
@@ -97,6 +107,11 @@ function assertGenuineHostRequestContext(context: unknown): asserts context is H
 		typeof (context as HostRequestContext).requestId !== "string" ||
 		!(context as HostRequestContext).requestId ||
 		!Number.isSafeInteger((context as HostRequestContext).generation) ||
+		typeof (context as HostRequestContext).requestType !== "string" ||
+		!(context as HostRequestContext).requestType ||
+		!Number.isSafeInteger((context as HostRequestContext).timeoutMs) ||
+		(context as HostRequestContext).timeoutMs < 1 ||
+		(context as HostRequestContext).timeoutMs > MAX_HOST_REQUEST_TIMEOUT_MS ||
 		typeof (context as HostRequestContext).isCurrent !== "function" ||
 		typeof (context as HostRequestContext).signal !== "object" ||
 		(context as HostRequestContext).signal === null ||
@@ -404,12 +419,100 @@ interface Deferred<T> {
 	reject: (error: Error) => void;
 }
 
+interface HostRequestEnvelope {
+	requestType: string;
+	timeoutMs: number;
+	executionOwned: boolean;
+	payload: Record<string, unknown>;
+}
+
+interface InFlightHostRequest {
+	requestType: string;
+	controller: AbortController;
+	closed: boolean;
+	executionSignal?: AbortSignal;
+	onExecutionAbort?: () => void;
+	timeout?: ReturnType<typeof globalThis.setTimeout>;
+}
+
+class HostRequestTimeoutError extends Error {
+	constructor(requestType: string, timeoutMs: number) {
+		super(`host request "${requestType}" timed out after ${timeoutMs}ms`);
+		this.name = "HostRequestTimeoutError";
+	}
+}
+
+class HostRequestClosedError extends Error {
+	constructor(requestType: string) {
+		super(`host request "${requestType}" was aborted because its Comm closed`);
+		this.name = "HostRequestClosedError";
+	}
+}
+
+class HostRequestExecutionAbortedError extends Error {
+	constructor(requestType: string) {
+		super(`host request "${requestType}" was aborted with its IPython execution`);
+		this.name = "HostRequestExecutionAbortedError";
+	}
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function parseHostRequestEnvelope(data: unknown): HostRequestEnvelope {
+	if (!isRecord(data)) {
+		throw new Error("host request payload must be an object");
+	}
+	if (typeof data.type !== "string" || data.type.length === 0) {
+		throw new Error("host request payload must have a string type");
+	}
+	const rawTimeoutMs = data[HOST_REQUEST_TIMEOUT_FIELD];
+	const timeoutMs = rawTimeoutMs === undefined ? DEFAULT_HOST_REQUEST_TIMEOUT_MS : rawTimeoutMs;
+	if (
+		typeof timeoutMs !== "number" ||
+		!Number.isInteger(timeoutMs) ||
+		timeoutMs < 1 ||
+		timeoutMs > MAX_HOST_REQUEST_TIMEOUT_MS
+	) {
+		throw new Error(`${HOST_REQUEST_TIMEOUT_FIELD} must be an integer from 1 to ${MAX_HOST_REQUEST_TIMEOUT_MS}`);
+	}
+	const rawExecutionOwned = data[HOST_REQUEST_EXECUTION_OWNED_FIELD];
+	if (rawExecutionOwned !== undefined && typeof rawExecutionOwned !== "boolean") {
+		throw new Error(`${HOST_REQUEST_EXECUTION_OWNED_FIELD} must be a boolean`);
+	}
+	const executionOwned = rawExecutionOwned ?? true;
+	const payload = { ...data };
+	delete payload[HOST_REQUEST_TIMEOUT_FIELD];
+	delete payload[HOST_REQUEST_EXECUTION_OWNED_FIELD];
+	return { requestType: data.type, timeoutMs, executionOwned, payload };
+}
+
+function raceHostRequestWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted) {
+		return Promise.reject(signal.reason instanceof Error ? signal.reason : new Error("host request aborted"));
+	}
+	return new Promise<T>((resolve, reject) => {
+		let settled = false;
+		const cleanup = () => signal.removeEventListener("abort", onAbort);
+		const finish = (callback: () => void) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			callback();
+		};
+		const onAbort = () =>
+			finish(() => reject(signal.reason instanceof Error ? signal.reason : new Error("host request aborted")));
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(
+			(value) => finish(() => resolve(value)),
+			(error: unknown) => finish(() => reject(error instanceof Error ? error : new Error(String(error)))),
+		);
+	});
 }
 
 function createDeferred<T>(): Deferred<T> {
@@ -616,6 +719,8 @@ export class KernelManager {
 	// attribute their spawning program.
 	private lastCellCode?: string;
 	private readonly inFlightHostRequests = new Set<Promise<void>>();
+	private readonly hostRequestsByCommId = new Map<string, InFlightHostRequest>();
+	private hostRequestGeneration = 0;
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
 	private startPromise?: Promise<void>;
@@ -1273,6 +1378,13 @@ export class KernelManager {
 		if (msgType === "comm_close") {
 			this.commTargets.delete(commId);
 			this.handledHostRequestCommIds.delete(commId);
+			const request = this.hostRequestsByCommId.get(commId);
+			if (request) {
+				request.closed = true;
+				if (!request.controller.signal.aborted) {
+					request.controller.abort(new HostRequestClosedError(request.requestType));
+				}
+			}
 			return;
 		}
 
@@ -1283,67 +1395,138 @@ export class KernelManager {
 			}
 			this.commTargets.set(commId, targetName);
 			if (targetName === HOST_COMM_TARGET) {
-				this.startHostRequestFromComm(commId, content.data);
+				const parentMessageId = (incoming.parent_header as { msg_id?: string }).msg_id;
+				this.startHostRequestFromComm(commId, content.data, parentMessageId);
 			}
 			return;
 		}
 
 		const targetName = this.commTargets.get(commId);
 		if (msgType === "comm_msg" && targetName === HOST_COMM_TARGET) {
-			this.startHostRequestFromComm(commId, content.data);
+			const parentMessageId = (incoming.parent_header as { msg_id?: string }).msg_id;
+			this.startHostRequestFromComm(commId, content.data, parentMessageId);
 		}
 	}
 
-	private startHostRequestFromComm(commId: string, data: unknown): void {
+	private startHostRequestFromComm(commId: string, data: unknown, parentMessageId?: string): void {
 		if (this.handledHostRequestCommIds.has(commId)) {
 			return;
 		}
 		this.handledHostRequestCommIds.add(commId);
 
-		const task = (async () => {
-			try {
-				const result = await this.handleHostRequest(data);
-				try {
-					await this.sendCommMessage(commId, { status: "ok", ...result });
-				} catch (replyError) {
-					this.appendKernelDiagnostic(
-						`failed to send host request ok reply for comm ${commId}: ${errorMessage(replyError)}`,
-					);
-				}
-			} catch (error) {
-				this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
-				try {
-					await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) });
-				} catch (replyError) {
-					this.appendKernelDiagnostic(
-						`failed to send host request error reply for comm ${commId}: ${errorMessage(replyError)}`,
-					);
-				}
-			}
-		})();
+		const task = this.runHostRequestFromComm(commId, data, parentMessageId);
 		this.inFlightHostRequests.add(task);
 		void task.finally(() => {
 			this.inFlightHostRequests.delete(task);
+			this.commTargets.delete(commId);
+			this.handledHostRequestCommIds.delete(commId);
 		});
 	}
 
-	private async handleHostRequest(data: unknown): Promise<Record<string, unknown>> {
-		if (!isRecord(data)) {
-			throw new Error("host request payload must be an object");
-		}
-		if (typeof data.type !== "string" || data.type.length === 0) {
-			throw new Error("host request payload must have a string type");
-		}
+	private async runHostRequestFromComm(commId: string, data: unknown, parentMessageId?: string): Promise<void> {
+		let request: InFlightHostRequest | undefined;
+		try {
+			const envelope = parseHostRequestEnvelope(data);
+			const controller = new AbortController();
+			request = {
+				requestType: envelope.requestType,
+				controller,
+				closed: false,
+			};
+			this.hostRequestsByCommId.set(commId, request);
+			const sourceExecution =
+				envelope.executionOwned && parentMessageId !== undefined ? this.activeExecution : undefined;
+			const executionSignal =
+				sourceExecution && sourceExecution.requestMsgId === parentMessageId
+					? sourceExecution.opts.signal
+					: undefined;
+			if (executionSignal) {
+				request.executionSignal = executionSignal;
+				request.onExecutionAbort = () => {
+					if (!controller.signal.aborted) {
+						controller.abort(new HostRequestExecutionAbortedError(envelope.requestType));
+					}
+				};
+				executionSignal.addEventListener("abort", request.onExecutionAbort, { once: true });
+				if (executionSignal.aborted) request.onExecutionAbort();
+			}
+			request.timeout = globalThis.setTimeout(() => {
+				if (!controller.signal.aborted) {
+					controller.abort(new HostRequestTimeoutError(envelope.requestType, envelope.timeoutMs));
+				}
+			}, envelope.timeoutMs);
+			if (request.timeout && typeof request.timeout === "object" && "unref" in request.timeout) {
+				request.timeout.unref();
+			}
 
-		const handler = this.options.hostHandlers?.[data.type];
-		if (!handler) {
-			throw new Error(`host request type "${data.type}" is not available in this session`);
+			const context: HostRequestContext = Object.freeze({
+				requestId: uuid(),
+				generation: ++this.hostRequestGeneration,
+				requestType: envelope.requestType,
+				timeoutMs: envelope.timeoutMs,
+				signal: controller.signal,
+				isCurrent: () =>
+					request !== undefined &&
+					this.hostRequestsByCommId.get(commId) === request &&
+					!request.closed &&
+					!controller.signal.aborted,
+			});
+			const result = await this.handleHostRequest(envelope, context);
+			if (request.closed) return;
+			try {
+				await this.sendCommMessage(commId, { status: "ok", ...result });
+			} catch (replyError) {
+				this.appendKernelDiagnostic(
+					`failed to send host request ok reply for comm ${commId}: ${errorMessage(replyError)}`,
+				);
+			}
+		} catch (error) {
+			if (request?.closed) return;
+			this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
+			const errorType =
+				error instanceof HostRequestTimeoutError
+					? { error_type: "timeout" }
+					: error instanceof HostRequestExecutionAbortedError
+						? { error_type: "aborted" }
+						: {};
+			try {
+				await this.sendCommMessage(commId, {
+					status: "error",
+					...errorType,
+					error: errorMessage(error),
+				});
+			} catch (replyError) {
+				this.appendKernelDiagnostic(
+					`failed to send host request error reply for comm ${commId}: ${errorMessage(replyError)}`,
+				);
+			}
+		} finally {
+			if (request?.executionSignal && request.onExecutionAbort) {
+				request.executionSignal.removeEventListener("abort", request.onExecutionAbort);
+				request.executionSignal = undefined;
+				request.onExecutionAbort = undefined;
+			}
+			if (request?.timeout) {
+				globalThis.clearTimeout(request.timeout);
+				request.timeout = undefined;
+			}
+			this.hostRequestsByCommId.delete(commId);
 		}
-		// Tag the request with the cell that triggered it. A blocking call is still
-		// the in-flight execution; detached spawns (asyncio.create_task) fire after
-		// the scheduling cell goes idle, so fall back to that last cell's source.
+	}
+
+	private async handleHostRequest(
+		envelope: HostRequestEnvelope,
+		context: HostRequestContext,
+	): Promise<Record<string, unknown>> {
+		const handler = this.options.hostHandlers?.[envelope.requestType];
+		if (!handler) {
+			throw new Error(`host request type "${envelope.requestType}" is not available in this session`);
+		}
+		// Tag the request with the active cell when present. Detached tasks can
+		// publish before or after that cell goes idle, so fall back to its last source.
 		const cellSourceCode = this.activeExecution?.code ?? this.lastCellCode;
-		return handler({ ...data, cellSourceCode });
+		const handlerPromise = handler({ ...envelope.payload, cellSourceCode }, context);
+		return raceHostRequestWithAbort(handlerPromise, context.signal);
 	}
 
 	private async sendCommMessage(commId: string, data: Record<string, unknown>): Promise<void> {
@@ -1364,6 +1547,22 @@ export class KernelManager {
 	private cleanupResources(killSignal: NodeJS.Signals = "SIGTERM"): void {
 		this.clearSnapshotTimer();
 		this.lateSentAgentMessageHandlers.clear();
+		for (const request of this.hostRequestsByCommId.values()) {
+			request.closed = true;
+			if (request.executionSignal && request.onExecutionAbort) {
+				request.executionSignal.removeEventListener("abort", request.onExecutionAbort);
+				request.executionSignal = undefined;
+				request.onExecutionAbort = undefined;
+			}
+			if (request.timeout) {
+				globalThis.clearTimeout(request.timeout);
+				request.timeout = undefined;
+			}
+			if (!request.controller.signal.aborted) {
+				request.controller.abort(new HostRequestClosedError(request.requestType));
+			}
+		}
+		this.hostRequestsByCommId.clear();
 		if (this.forkedLivenessTimer) {
 			globalThis.clearInterval(this.forkedLivenessTimer);
 			this.forkedLivenessTimer = undefined;

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -45,6 +45,9 @@ const SNAPSHOT_DISPOSE_TIMEOUT_MS = 5000;
 const KERNEL_ABORT_GRACE_MS = 1000;
 const KERNEL_BUSY_REUSE_WAIT_MS = 5000;
 const KERNEL_BUSY_INTERRUPT_INTERVAL_MS = 500;
+// Shell execute_reply normally precedes IOPub idle by milliseconds. Preserve a
+// short window for trailing output before treating a missing idle as lost.
+const EXECUTE_REPLY_IDLE_GRACE_MS = 2000;
 const MAX_LATE_SENT_AGENT_MESSAGE_HANDLERS = 256;
 const KERNEL_BUSY_AFTER_INTERRUPT_MESSAGE =
 	"IPython kernel is still running the previously interrupted cell. Wait and try again, or kill the IPython kernel to start fresh.";
@@ -409,6 +412,8 @@ interface ActiveExecution {
 	error?: ExecuteResult["error"];
 	status: ExecuteResult["status"];
 	settled: boolean;
+	executeReplyReceived: boolean;
+	idleGraceTimer?: ReturnType<typeof globalThis.setTimeout>;
 	resolve: (result: ExecuteResult) => void;
 	reject: (error: Error) => void;
 }
@@ -706,6 +711,7 @@ export class KernelManager {
 	private iopub?: Subscriber;
 	private control?: Dealer;
 	private iopubPumpPromise?: Promise<void>;
+	private shellPumpPromise?: Promise<void>;
 	private connection?: ConnectionInfo;
 	private tempDir?: string;
 	private kernelStderr = "";
@@ -889,6 +895,9 @@ export class KernelManager {
 			throw e;
 		}
 
+		// probeReady owns shell.receive() until it returns; only then may the
+		// long-lived pump consume execute_reply messages.
+		this.startShellPump();
 		this.state = "running";
 		this.startForkedLivenessMonitor();
 	}
@@ -1066,6 +1075,7 @@ export class KernelManager {
 			sentAgentMessages: [],
 			status: "ok",
 			settled: false,
+			executeReplyReceived: false,
 			resolve: result.resolve,
 			reject: result.reject,
 		};
@@ -1084,6 +1094,7 @@ export class KernelManager {
 			this.resolveExecution(execution, { clearActive: false });
 		};
 		const onAbort = () => {
+			this.clearExecuteReplyIdleGrace(execution);
 			void this.interrupt().catch(() => undefined);
 			clearAbortTimer();
 			abortTimer = globalThis.setTimeout(forceAbort, KERNEL_ABORT_GRACE_MS);
@@ -1119,6 +1130,93 @@ export class KernelManager {
 			clearAbortTimer();
 			opts.signal?.removeEventListener("abort", onAbort);
 		}
+	}
+
+	private startShellPump(): void {
+		if (this.shellPumpPromise) {
+			return;
+		}
+		this.shellPumpPromise = this.runShellPump();
+	}
+
+	private async runShellPump(): Promise<void> {
+		const shell = this.shell;
+		if (!shell) {
+			return;
+		}
+
+		try {
+			for await (const frames of shell) {
+				const incoming = decode(frames);
+				if (incoming) this.handleShellMessage(incoming);
+			}
+		} catch (error) {
+			// IOPub remains the normal completion channel. A shell pump failure
+			// disables only the lost-idle fallback.
+			if ((this.state as string) !== "shutdown") {
+				this.appendKernelDiagnostic(`shell pump failed: ${errorMessage(error)}`);
+			}
+		} finally {
+			if (this.shell === shell) {
+				this.shellPumpPromise = undefined;
+			}
+		}
+	}
+
+	private handleShellMessage(incoming: JupyterMessage): void {
+		if (incoming.header.msg_type !== "execute_reply") {
+			return;
+		}
+		const execution = this.activeExecution;
+		const parentMessageId = (incoming.parent_header as { msg_id?: string }).msg_id;
+		if (
+			!execution ||
+			parentMessageId !== execution.requestMsgId ||
+			execution.executeReplyReceived ||
+			execution.settled ||
+			execution.opts.signal?.aborted
+		) {
+			return;
+		}
+
+		execution.executeReplyReceived = true;
+		const content = incoming.content as {
+			status?: string;
+			ename?: string;
+			evalue?: string;
+			traceback?: string[];
+		};
+		if ((content.status === "abort" || content.status === "aborted") && execution.status === "ok") {
+			execution.status = "aborted";
+		} else if (content.status === "error" && execution.status === "ok") {
+			execution.status = "error";
+			if (!execution.error && content.ename) {
+				execution.error = {
+					ename: content.ename,
+					evalue: content.evalue ?? "",
+					traceback: content.traceback ?? [],
+				};
+			}
+		}
+
+		const timer = globalThis.setTimeout(() => {
+			if (
+				this.activeExecution !== execution ||
+				execution.requestMsgId !== parentMessageId ||
+				execution.idleGraceTimer !== timer
+			) {
+				return;
+			}
+			execution.idleGraceTimer = undefined;
+			this.appendKernelDiagnostic(
+				`execute_reply for ${execution.requestMsgId} got no IOPub idle within ${EXECUTE_REPLY_IDLE_GRACE_MS}ms; finishing via shell fallback`,
+			);
+			this.finishActiveExecution(execution);
+		}, EXECUTE_REPLY_IDLE_GRACE_MS);
+		if (timer && typeof timer === "object" && "unref" in timer) {
+			timer.unref();
+		}
+		execution.idleGraceTimer = timer;
 	}
 
 	private startIopubPump(): void {
@@ -1230,7 +1328,15 @@ export class KernelManager {
 		this.resolveExecution(execution, { clearActive: true });
 	}
 
+	private clearExecuteReplyIdleGrace(execution: ActiveExecution): void {
+		if (execution.idleGraceTimer) {
+			globalThis.clearTimeout(execution.idleGraceTimer);
+			execution.idleGraceTimer = undefined;
+		}
+	}
+
 	private resolveExecution(execution: ActiveExecution, options: { clearActive: boolean }): void {
+		this.clearExecuteReplyIdleGrace(execution);
 		const didClearActive = options.clearActive && this.activeExecution === execution;
 		if (options.clearActive && this.activeExecution === execution) {
 			this.activeExecution = undefined;
@@ -1304,6 +1410,7 @@ export class KernelManager {
 		if (!execution) {
 			return;
 		}
+		this.clearExecuteReplyIdleGrace(execution);
 		this.activeExecution = undefined;
 		execution.reject(error);
 		this.notifyActiveExecutionIdle();
@@ -1575,6 +1682,7 @@ export class KernelManager {
 		this.iopub = undefined;
 		this.control = undefined;
 		this.iopubPumpPromise = undefined;
+		this.shellPumpPromise = undefined;
 		try {
 			if (this.kernel) {
 				this.kernel.kill(killSignal);
@@ -1621,6 +1729,9 @@ export class KernelManager {
 	}
 
 	async shutdown(opts: { snapshot?: boolean } = {}): Promise<void> {
+		if (this.activeExecution) {
+			this.clearExecuteReplyIdleGrace(this.activeExecution);
+		}
 		if (this.state === "shutdown") {
 			liveKernels.delete(this);
 			this.cleanupResources();
@@ -1774,6 +1885,9 @@ export class KernelManager {
 	/** Graceful cleanup. Waits briefly for in-flight host request handlers before closing sockets. */
 	dispose(): Promise<void> {
 		return (async () => {
+			if (this.activeExecution) {
+				this.clearExecuteReplyIdleGrace(this.activeExecution);
+			}
 			// Final namespace flush while the kernel is still live (session end / reload).
 			await this.flushSnapshotForDispose();
 			this.state = "shutdown";

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -70,8 +70,6 @@ export const HOST_COMM_TARGET = "host.request";
 export interface HostRequestContext {
 	readonly requestId: string;
 	readonly generation: number;
-	readonly requestType: string;
-	readonly timeoutMs: number;
 	/** Aborted with the source execution, when the deadline expires, or when the Comm closes. */
 	readonly signal: AbortSignal;
 	isCurrent(): boolean;
@@ -110,11 +108,6 @@ function assertGenuineHostRequestContext(context: unknown): asserts context is H
 		typeof (context as HostRequestContext).requestId !== "string" ||
 		!(context as HostRequestContext).requestId ||
 		!Number.isSafeInteger((context as HostRequestContext).generation) ||
-		typeof (context as HostRequestContext).requestType !== "string" ||
-		!(context as HostRequestContext).requestType ||
-		!Number.isSafeInteger((context as HostRequestContext).timeoutMs) ||
-		(context as HostRequestContext).timeoutMs < 1 ||
-		(context as HostRequestContext).timeoutMs > MAX_HOST_REQUEST_TIMEOUT_MS ||
 		typeof (context as HostRequestContext).isCurrent !== "function" ||
 		typeof (context as HostRequestContext).signal !== "object" ||
 		(context as HostRequestContext).signal === null ||
@@ -1569,8 +1562,6 @@ export class KernelManager {
 			const context: HostRequestContext = Object.freeze({
 				requestId: uuid(),
 				generation: ++this.hostRequestGeneration,
-				requestType: envelope.requestType,
-				timeoutMs: envelope.timeoutMs,
 				signal: controller.signal,
 				isCurrent: () =>
 					request !== undefined &&

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -9,7 +9,13 @@ import {
 } from "@earendil-works/pi-ai/mcp";
 import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import type { AuthStorage } from "../auth-storage.js";
+import type { HostRequestHandlers } from "../kernel/index.js";
 import type { McpServerConfig } from "../settings-manager.js";
+
+function throwIfHostRequestAborted(signal: AbortSignal | undefined): void {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error ? signal.reason : new Error("host request aborted");
+}
 
 export interface McpManagerOptions {
 	authStorage: AuthStorage;
@@ -153,21 +159,25 @@ export class McpManager {
 	}
 
 	/** Host-request handlers exposed to the kernel. */
-	hostHandlers(): Record<string, (payload: Record<string, unknown>) => Promise<Record<string, unknown>>> {
-		const handlers: Record<string, (payload: Record<string, unknown>) => Promise<Record<string, unknown>>> = {
-			"mcp.refresh": async (payload) => {
+	hostHandlers(): HostRequestHandlers {
+		const handlers: HostRequestHandlers = {
+			"mcp.refresh": async (payload, context) => {
+				const signal = context?.signal;
+				throwIfHostRequestAborted(signal);
 				const server = String(payload.server ?? "");
 				if (!server) throw new Error("mcp.refresh requires a server");
 				// getApiKey refreshes + rewrites auth.json under lock; Python re-reads.
 				// Surface failure (throw) instead of a false success so the kernel can
 				// report a refresh error rather than a misleading "not enabled".
 				const key = await this.authStorage.getApiKey(this.providerId(server));
+				throwIfHostRequestAborted(signal);
 				if (!key) throw new Error(`Could not refresh credentials for ${server}`);
 				return {};
 			},
 			// Resolved config so the kernel skill connects to the same URL the host
 			// registered/authenticated (honors a user's mcpServers `url` override).
-			"mcp.config": async (payload) => {
+			"mcp.config": async (payload, context) => {
+				throwIfHostRequestAborted(context?.signal);
 				const server = String(payload.server ?? "");
 				if (!server) throw new Error("mcp.config requires a server");
 				const integration = this.integrations.get(server);
@@ -183,10 +193,13 @@ export class McpManager {
 		// kernel doesn't get a handler whose only behavior is to throw.
 		const beginLogin = this.beginLogin;
 		if (beginLogin) {
-			handlers["mcp.begin_login"] = async (payload) => {
+			handlers["mcp.begin_login"] = async (payload, context) => {
+				const signal = context?.signal;
+				throwIfHostRequestAborted(signal);
 				const server = String(payload.server ?? "");
 				if (!server) throw new Error("mcp.begin_login requires a server");
 				await beginLogin(server);
+				throwIfHostRequestAborted(signal);
 				return {};
 			};
 		}

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -49,7 +49,7 @@ export interface RlmFindModelsResult {
 	models: RlmModelMatch[];
 }
 
-export type RlmRunHandler = (request: RlmRunRequest) => Promise<Record<string, unknown>>;
+export type RlmRunHandler = (request: RlmRunRequest, signal?: AbortSignal) => Promise<Record<string, unknown>>;
 export type RlmListSubagentsHandler = () => RlmListSubagentsResult | Promise<RlmListSubagentsResult>;
 export type RlmDeleteSubagentHandler = (target: string) => Promise<RlmDeleteSubagentResult>;
 export type RlmFindModelsHandler = (query: string, limit: number) => RlmFindModelsResult | Promise<RlmFindModelsResult>;
@@ -148,26 +148,39 @@ export function findRlmModelMatches(query: string, models: Model<Api>[], limit: 
 		}));
 }
 
+function throwIfHostRequestAborted(signal: AbortSignal | undefined): void {
+	if (!signal?.aborted) return;
+	throw signal.reason instanceof Error ? signal.reason : new Error("host request aborted");
+}
+
 /** Adapt an RlmRunHandler into the typed "rlm.run" handler for the kernel host bridge. */
 export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHandler {
-	return async (payload) => {
+	return async (payload, context) => {
+		const signal = context?.signal;
+		throwIfHostRequestAborted(signal);
 		if (typeof payload.prompt !== "string") {
 			throw new Error("rlm.run prompt must be a string");
 		}
 		const kwargs = isRecord(payload.kwargs) ? payload.kwargs : {};
 		const cellSourceCode = typeof payload.cellSourceCode === "string" ? payload.cellSourceCode : undefined;
-		const result = await handler({
-			prompt: payload.prompt,
-			kwargs,
-			cellSourceCode,
-		});
+		const result = await handler(
+			{
+				prompt: payload.prompt,
+				kwargs,
+				cellSourceCode,
+			},
+			signal,
+		);
+		throwIfHostRequestAborted(signal);
 		return result as unknown as Record<string, unknown>;
 	};
 }
 
 /** Search a bounded authenticated model catalog without adding it to the system prompt. */
 export function createRlmFindModelsHostHandler(handler: RlmFindModelsHandler): HostRequestHandler {
-	return async (payload) => {
+	return async (payload, context) => {
+		const signal = context?.signal;
+		throwIfHostRequestAborted(signal);
 		if (typeof payload.query !== "string") {
 			throw new Error("rlm.find_models query must be a string");
 		}
@@ -175,25 +188,33 @@ export function createRlmFindModelsHostHandler(handler: RlmFindModelsHandler): H
 		if (!Number.isInteger(limit) || (limit as number) < 1 || (limit as number) > MAX_RLM_MODEL_SEARCH_LIMIT) {
 			throw new Error(`rlm.find_models limit must be an integer from 1 to ${MAX_RLM_MODEL_SEARCH_LIMIT}`);
 		}
-		return { models: (await handler(payload.query, limit as number)).models };
+		const models = (await handler(payload.query, limit as number)).models;
+		throwIfHostRequestAborted(signal);
+		return { models };
 	};
 }
 
 /** Expose the current parent session's RLM child registry to its kernel. */
 export function createRlmListSubagentsHostHandler(handler: RlmListSubagentsHandler): HostRequestHandler {
-	return async () => {
+	return async (_payload, context) => {
+		const signal = context?.signal;
+		throwIfHostRequestAborted(signal);
 		const { subagents } = await handler();
+		throwIfHostRequestAborted(signal);
 		return { subagents };
 	};
 }
 
 /** Delete one direct child selected from the current parent session's registry. */
 export function createRlmDeleteSubagentHostHandler(handler: RlmDeleteSubagentHandler): HostRequestHandler {
-	return async (payload) => {
+	return async (payload, context) => {
+		const signal = context?.signal;
+		throwIfHostRequestAborted(signal);
 		if (typeof payload.target !== "string" || !payload.target.trim()) {
 			throw new Error("rlm.delete_subagent target must be a non-empty string");
 		}
 		const { subagent, outcome } = await handler(payload.target.trim());
+		throwIfHostRequestAborted(signal);
 		return outcome === undefined ? { subagent } : { subagent, outcome };
 	};
 }

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -36,6 +36,7 @@ except Exception:
 
 try:
     import rlm as _prime_agent_rlm_module
+    _prime_agent_rlm_module._install_host_request_task_tracking()
     rlm = _prime_agent_rlm_module.rlm
 except Exception as _prime_agent_rlm_error:
     _PRIME_AGENT_RLM_IMPORT_ERROR = str(_prime_agent_rlm_error)

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2893,6 +2893,29 @@ describe("AgentSession rlm recursion", () => {
 		await waitFor(() => rootRun.status === "done");
 	});
 
+	it("propagates host aborts through the rlm admission adapter", async () => {
+		let receivedSignal: AbortSignal | undefined;
+		let release: () => void = () => {};
+		const handler = createRlmRunHostHandler(async (_request, signal) => {
+			receivedSignal = signal;
+			await new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			return {};
+		});
+		const controller = new AbortController();
+		const request = handler(
+			{ type: "rlm.run", prompt: "work", kwargs: {} },
+			{ requestType: "rlm.run", timeoutMs: 100, signal: controller.signal },
+		);
+		await Promise.resolve();
+		expect(receivedSignal).toBe(controller.signal);
+
+		controller.abort(new Error("host request timed out"));
+		release();
+		await expect(request).rejects.toThrow("host request timed out");
+	});
+
 	it("runs parallel rlm comm requests independently", async () => {
 		let active = 0;
 		let maxActive = 0;

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2906,7 +2906,14 @@ describe("AgentSession rlm recursion", () => {
 		const controller = new AbortController();
 		const request = handler(
 			{ type: "rlm.run", prompt: "work", kwargs: {} },
-			{ requestType: "rlm.run", timeoutMs: 100, signal: controller.signal },
+			{
+				requestId: "test-rlm-run-abort",
+				generation: 1,
+				requestType: "rlm.run",
+				timeoutMs: 100,
+				signal: controller.signal,
+				isCurrent: () => !controller.signal.aborted,
+			},
 		);
 		await Promise.resolve();
 		expect(receivedSignal).toBe(controller.signal);

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2909,8 +2909,6 @@ describe("AgentSession rlm recursion", () => {
 			{
 				requestId: "test-rlm-run-abort",
 				generation: 1,
-				requestType: "rlm.run",
-				timeoutMs: 100,
 				signal: controller.signal,
 				isCurrent: () => !controller.signal.aborted,
 			},

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -13,8 +13,6 @@ export function createSyntheticHostRequestContext(): HostRequestContext {
 	return {
 		requestId: `test-host-request-${requestNumber}`,
 		generation: requestNumber,
-		requestType: "test.host_request",
-		timeoutMs: 120_000,
 		signal: controller.signal,
 		isCurrent: () => !controller.signal.aborted,
 	};

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -13,6 +13,8 @@ export function createSyntheticHostRequestContext(): HostRequestContext {
 	return {
 		requestId: `test-host-request-${requestNumber}`,
 		generation: requestNumber,
+		requestType: "test.host_request",
+		timeoutMs: 120_000,
 		signal: controller.signal,
 		isCurrent: () => !controller.signal.aborted,
 	};

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBundledSkillsDir } from "../src/config.js";
+import { createAgentMessageHostHandlers } from "../src/core/agent-messages.js";
 import { KernelManager, type KernelSentAgentMessage } from "../src/core/kernel/index.js";
 import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
 import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
@@ -263,6 +264,41 @@ background_send = asyncio.create_task(send_later())`,
 			receiverRole: "sibling",
 			target: { activeSessionId: "beta", sessionId: "session-beta", sessionName: "Beta" },
 		});
+	});
+
+	it("does not send after abort while waiting for child publication", async () => {
+		let publishChild: (sessionId: string | undefined) => void = () => {};
+		let sendCount = 0;
+		const handlers = createAgentMessageHostHandlers({
+			roster: async () => ({
+				current: { name: "parent", id: "parent-id", depth: 0 },
+				entries: [{ relationship: "child", name: "worker", id: "child-id", depth: 1, status: "idle" }],
+			}),
+			awaitPendingChildPublication: async () =>
+				new Promise<string | undefined>((resolve) => {
+					publishChild = resolve;
+				}),
+			sendAgentMessage: async () => {
+				sendCount += 1;
+				throw new Error("should not send after abort");
+			},
+		});
+		const controller = new AbortController();
+		const request = handlers["agent_message.send"]!(
+			{
+				type: "agent_message.send",
+				message: "hello",
+				receiver_role: "child",
+				receiver_name: "worker",
+			},
+			{ requestType: "agent_message.send", timeoutMs: 100, signal: controller.signal },
+		);
+		await Promise.resolve();
+		controller.abort(new Error("host request timed out"));
+		publishChild("child-id");
+
+		await expect(request).rejects.toThrow("host request timed out");
+		expect(sendCount).toBe(0);
 	});
 
 	it("bounds retained handlers for late sent messages", async () => {

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -294,8 +294,6 @@ background_send = asyncio.create_task(send_later())`,
 			{
 				requestId: "test-agent-message-abort",
 				generation: 1,
-				requestType: "agent_message.send",
-				timeoutMs: 100,
 				signal: controller.signal,
 				isCurrent: () => !controller.signal.aborted,
 			},

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -291,7 +291,14 @@ background_send = asyncio.create_task(send_later())`,
 				receiver_role: "child",
 				receiver_name: "worker",
 			},
-			{ requestType: "agent_message.send", timeoutMs: 100, signal: controller.signal },
+			{
+				requestId: "test-agent-message-abort",
+				generation: 1,
+				requestType: "agent_message.send",
+				timeoutMs: 100,
+				signal: controller.signal,
+				isCurrent: () => !controller.signal.aborted,
+			},
 		);
 		await Promise.resolve();
 		controller.abort(new Error("host request timed out"));

--- a/packages/coding-agent/test/kernel-execute-reply-fallback.test.ts
+++ b/packages/coding-agent/test/kernel-execute-reply-fallback.test.ts
@@ -1,0 +1,361 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { KernelManager } from "../src/core/kernel/index.js";
+
+interface JupyterWireMessage {
+	header: { msg_type: string };
+	parent_header: Record<string, unknown>;
+	metadata: Record<string, unknown>;
+	content: Record<string, unknown>;
+}
+
+interface ActiveExecutionInternals {
+	requestMsgId: string;
+	opts: { internal?: boolean };
+}
+
+interface ManagerInternals {
+	activeExecution?: ActiveExecutionInternals;
+	handleShellMessage: (incoming: JupyterWireMessage) => void;
+	handleExecutionMessage: (incoming: JupyterWireMessage) => void;
+	startHostRequestFromComm: (commId: string, data: unknown, parentMessageId?: string) => void;
+	hostRequestsByCommId: Map<string, unknown>;
+}
+
+const FAKE_CONNECTION = {
+	ip: "127.0.0.1",
+	transport: "tcp",
+	shell_port: 1,
+	iopub_port: 2,
+	stdin_port: 3,
+	control_port: 4,
+	hb_port: 5,
+	signature_scheme: "hmac-sha256",
+	key: "test-key",
+	kernel_name: "python3",
+};
+
+async function waitForCalls(mock: { mock: { calls: unknown[][] } }, count: number): Promise<void> {
+	for (let i = 0; i < 20; i++) {
+		if (mock.mock.calls.length >= count) return;
+		await Promise.resolve();
+	}
+	expect(mock.mock.calls.length).toBeGreaterThanOrEqual(count);
+}
+
+function makeManager(): {
+	manager: KernelManager;
+	internals: ManagerInternals;
+	shellSend: ReturnType<typeof vi.fn>;
+	shellClose: ReturnType<typeof vi.fn>;
+} {
+	const manager = new KernelManager({ cwd: process.cwd() });
+	const shellSend = vi.fn(async (_frames: Buffer[]) => {});
+	const shellClose = vi.fn();
+	Object.assign(manager as unknown as Record<string, unknown>, {
+		state: "running",
+		connection: FAKE_CONNECTION,
+		shell: { send: shellSend, close: shellClose },
+		control: { send: vi.fn(async (_frames: Buffer[]) => {}), close: vi.fn() },
+		start: async () => {},
+	});
+	return { manager, internals: manager as unknown as ManagerInternals, shellSend, shellClose };
+}
+
+function executeReply(requestMsgId: string, content: Record<string, unknown> = { status: "ok" }): JupyterWireMessage {
+	return {
+		header: { msg_type: "execute_reply" },
+		parent_header: { msg_id: requestMsgId },
+		metadata: {},
+		content,
+	};
+}
+
+function iopubMessage(requestMsgId: string, msgType: string, content: Record<string, unknown>): JupyterWireMessage {
+	return {
+		header: { msg_type: msgType },
+		parent_header: { msg_id: requestMsgId },
+		metadata: {},
+		content,
+	};
+}
+
+function iopubIdle(requestMsgId: string): JupyterWireMessage {
+	return iopubMessage(requestMsgId, "status", { execution_state: "idle" });
+}
+
+async function remainsPending<T>(promise: Promise<T>): Promise<boolean> {
+	let settled = false;
+	void promise.finally(() => {
+		settled = true;
+	});
+	await Promise.resolve();
+	return !settled;
+}
+
+describe("KernelManager execute_reply completion fallback", () => {
+	it("finishes the exact execution after the idle grace and drains the serial queue", async () => {
+		vi.useFakeTimers();
+		try {
+			const { manager, internals, shellSend } = makeManager();
+			const firstPromise = manager.execute("print('first')");
+			await waitForCalls(shellSend, 1);
+			const first = internals.activeExecution;
+			expect(first).toBeDefined();
+
+			internals.handleShellMessage(executeReply(first!.requestMsgId));
+			await vi.advanceTimersByTimeAsync(1999);
+			expect(await remainsPending(firstPromise)).toBe(true);
+			await vi.advanceTimersByTimeAsync(1);
+			await expect(firstPromise).resolves.toMatchObject({ status: "ok" });
+
+			const secondPromise = manager.execute("print('second')");
+			await waitForCalls(shellSend, 2);
+			const second = internals.activeExecution;
+			expect(second?.requestMsgId).not.toBe(first?.requestMsgId);
+			internals.handleExecutionMessage(iopubIdle(second!.requestMsgId));
+			await expect(secondPromise).resolves.toMatchObject({ status: "ok" });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps matching IOPub idle authoritative and preserves trailing output", async () => {
+		vi.useFakeTimers();
+		try {
+			const { manager, internals, shellSend } = makeManager();
+			const firstPromise = manager.execute("print('complete')");
+			await waitForCalls(shellSend, 1);
+			const first = internals.activeExecution;
+			internals.handleShellMessage(executeReply(first!.requestMsgId));
+			internals.handleExecutionMessage(
+				iopubMessage(first!.requestMsgId, "stream", { name: "stdout", text: "complete\n" }),
+			);
+			internals.handleExecutionMessage(iopubIdle(first!.requestMsgId));
+			await expect(firstPromise).resolves.toMatchObject({ status: "ok", stdout: "complete\n" });
+
+			const secondPromise = manager.execute("print('next')");
+			await waitForCalls(shellSend, 2);
+			const second = internals.activeExecution;
+			internals.handleShellMessage(executeReply(first!.requestMsgId));
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(internals.activeExecution).toBe(second);
+			expect(await remainsPending(secondPromise)).toBe(true);
+			internals.handleExecutionMessage(iopubIdle(second!.requestMsgId));
+			await expect(secondPromise).resolves.toMatchObject({ status: "ok" });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("ignores execute_reply for a different request", async () => {
+		vi.useFakeTimers();
+		try {
+			const { manager, internals, shellSend } = makeManager();
+			const executePromise = manager.execute("print('active')");
+			await waitForCalls(shellSend, 1);
+			const execution = internals.activeExecution;
+			internals.handleShellMessage(executeReply("stale-request"));
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(internals.activeExecution).toBe(execution);
+			expect(await remainsPending(executePromise)).toBe(true);
+			internals.handleExecutionMessage(iopubIdle(execution!.requestMsgId));
+			await expect(executePromise).resolves.toMatchObject({ status: "ok" });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("clears the fallback timer when the execution is aborted", async () => {
+		vi.useFakeTimers();
+		try {
+			const { manager, internals, shellSend } = makeManager();
+			const controller = new AbortController();
+			const executePromise = manager.execute("while True: pass", { signal: controller.signal });
+			await waitForCalls(shellSend, 1);
+			const execution = internals.activeExecution;
+			internals.handleShellMessage(executeReply(execution!.requestMsgId));
+			controller.abort();
+			await vi.advanceTimersByTimeAsync(1000);
+			await expect(executePromise).resolves.toMatchObject({ status: "aborted" });
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(internals.activeExecution).toBe(execution);
+			internals.handleExecutionMessage(iopubIdle(execution!.requestMsgId));
+			expect(internals.activeExecution).toBeUndefined();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("clears the fallback timer when the manager is disposed", async () => {
+		vi.useFakeTimers();
+		try {
+			const { manager, internals, shellSend, shellClose } = makeManager();
+			const executePromise = manager.execute("print('pending')");
+			void executePromise.catch(() => undefined);
+			await waitForCalls(shellSend, 1);
+			const execution = internals.activeExecution;
+			internals.handleShellMessage(executeReply(execution!.requestMsgId));
+			await manager.dispose();
+			await expect(executePromise).rejects.toThrow("Kernel has been shut down");
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(internals.activeExecution).toBeUndefined();
+			expect(shellClose).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("propagates a terminal execute_reply error when IOPub idle is lost", async () => {
+		vi.useFakeTimers();
+		try {
+			const { manager, internals, shellSend } = makeManager();
+			const executePromise = manager.execute("raise RuntimeError('boom')");
+			await waitForCalls(shellSend, 1);
+			const execution = internals.activeExecution;
+			internals.handleShellMessage(
+				executeReply(execution!.requestMsgId, {
+					status: "error",
+					ename: "RuntimeError",
+					evalue: "boom",
+					traceback: ["Traceback: boom"],
+				}),
+			);
+			await vi.advanceTimersByTimeAsync(2000);
+			await expect(executePromise).resolves.toMatchObject({
+				status: "error",
+				error: { ename: "RuntimeError", evalue: "boom" },
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+function resolveKernelPython(): string | null {
+	const candidates = [
+		process.env.PRIME_AGENT_KERNEL_PYTHON,
+		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+	].filter((candidate): candidate is string => Boolean(candidate));
+	for (const candidate of candidates) {
+		if (!existsSync(candidate)) continue;
+		const check = spawnSync(candidate, ["-c", "import ipykernel, dill"], { encoding: "utf8" });
+		if (check.status === 0) return candidate;
+	}
+	return null;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+	let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_resolve, reject) => {
+				timer = globalThis.setTimeout(() => reject(new Error(message)), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) globalThis.clearTimeout(timer);
+	}
+}
+
+const kernelPython = resolveKernelPython();
+const describeIfKernel = kernelPython ? describe : describe.skip;
+
+describeIfKernel("auto-snapshot lost-idle queue regression (real kernel)", { tags: ["kernel-heavy"] }, () => {
+	let dir = "";
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "prime-agent-snapshot-reply-fallback-"));
+	});
+
+	afterAll(() => {
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("drains a written internal snapshot before the next user cell", async () => {
+		const snapshotPath = join(dir, "kernel-state.dill");
+		const manifestPath = join(dir, "kernel-state.json");
+		const manager = new KernelManager({
+			python: kernelPython as string,
+			cwd: dir,
+			snapshot: { path: snapshotPath, manifestPath, debounceMs: 20 },
+		});
+		const internals = manager as unknown as ManagerInternals;
+		const handleShellMessage = internals.handleShellMessage.bind(manager);
+		const handleExecutionMessage = internals.handleExecutionMessage.bind(manager);
+		const startHostRequestFromComm = internals.startHostRequestFromComm.bind(manager);
+		let hostRequestCount = 0;
+		let droppedInternalIdle = false;
+		let droppedInternalRequestId: string | undefined;
+		let internalRequestId: string | undefined;
+		let resolveInternalReply: () => void = () => {};
+		const internalReply = new Promise<void>((resolve) => {
+			resolveInternalReply = resolve;
+		});
+
+		internals.startHostRequestFromComm = (commId, data, parentMessageId) => {
+			hostRequestCount++;
+			startHostRequestFromComm(commId, data, parentMessageId);
+		};
+		internals.handleShellMessage = (incoming) => {
+			handleShellMessage(incoming);
+			const active = internals.activeExecution;
+			if (
+				incoming.header.msg_type === "execute_reply" &&
+				active?.opts.internal === true &&
+				incoming.parent_header.msg_id === active.requestMsgId
+			) {
+				internalRequestId = active.requestMsgId;
+				resolveInternalReply();
+			}
+		};
+		internals.handleExecutionMessage = (incoming) => {
+			const active = internals.activeExecution;
+			if (
+				!droppedInternalIdle &&
+				active?.opts.internal === true &&
+				incoming.header.msg_type === "status" &&
+				incoming.parent_header.msg_id === active.requestMsgId &&
+				incoming.content.execution_state === "idle"
+			) {
+				droppedInternalIdle = true;
+				droppedInternalRequestId = active.requestMsgId;
+				return;
+			}
+			handleExecutionMessage(incoming);
+		};
+
+		try {
+			const first = await manager.execute("snapshot_value = 41");
+			expect(first.status).toBe("ok");
+			await withTimeout(internalReply, 10_000, "internal snapshot execute_reply did not arrive");
+			expect(internalRequestId).toBeDefined();
+			await expect.poll(() => droppedInternalIdle, { timeout: 1000 }).toBe(true);
+			expect(droppedInternalRequestId).toBe(internalRequestId);
+			await expect.poll(() => existsSync(snapshotPath), { timeout: 1000 }).toBe(true);
+			expect(existsSync(manifestPath)).toBe(true);
+
+			const second = await withTimeout(
+				manager.execute("snapshot_value += 1\nprint(snapshot_value)"),
+				5000,
+				"second user cell stayed queued behind the internal snapshot",
+			);
+			expect(second).toMatchObject({ status: "ok", stdout: "42\n" });
+			expect(hostRequestCount).toBe(0);
+			expect(internals.hostRequestsByCommId.size).toBe(0);
+
+			const third = await withTimeout(
+				manager.execute("print('queue-drained')"),
+				5000,
+				"serial execution queue did not drain",
+			);
+			expect(third).toMatchObject({ status: "ok", stdout: "queue-drained\n" });
+		} finally {
+			await manager.kill();
+		}
+	}, 60_000);
+});

--- a/packages/coding-agent/test/kernel-goal-skill.test.ts
+++ b/packages/coding-agent/test/kernel-goal-skill.test.ts
@@ -1,10 +1,19 @@
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getBundledSkillsDir } from "../src/config.js";
 import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
 import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error(`condition did not become true within ${timeoutMs}ms`);
+		await sleep(1);
+	}
+}
 
 function bundledGoalSkill(): PythonSkillRuntimeInfo {
 	const packagePath = join(getBundledSkillsDir(), "goal");
@@ -80,6 +89,112 @@ print(_completed["goal"]["status"], _completed["completion_budget_report"])
 
 		expect(requests.map((request) => request.type)).toEqual(["goal.create", "goal.complete"]);
 		expect(requests[0].payload).toMatchObject({ type: "goal.create", objective: "ship it", token_budget: 10 });
+	});
+
+	it("bounds a stalled goal request and keeps the live kernel reusable", async () => {
+		let handlerStarted = false;
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			env: { PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS: "250" },
+			pythonSkills: [bundledGoalSkill()],
+			hostHandlers: {
+				"goal.complete": async () => {
+					handlerStarted = true;
+					return new Promise<Record<string, unknown>>(() => {});
+				},
+			},
+		});
+
+		const manager = await provisioner.ensure();
+		const startedAt = Date.now();
+		const timedOut = await manager.execute(`
+_preserved_after_timeout = 42
+try:
+    await goal.complete()
+except TimeoutError as error:
+    print(f"TimeoutError: {error}")
+`);
+		expect(handlerStarted).toBe(true);
+		expect(Date.now() - startedAt).toBeLessThan(2_000);
+		expect(timedOut.status).toBe("ok");
+		expect(timedOut.stdout).toContain('TimeoutError: host request "goal.complete" timed out after 250ms');
+
+		const followUp = await manager.execute("print(_preserved_after_timeout)");
+		expect(followUp.status).toBe("ok");
+		expect(followUp.stdout.trim()).toBe("42");
+	});
+
+	it("does not abort a detached request started by the active cell", async () => {
+		let handlerStarted = false;
+		let handlerSignal: AbortSignal | undefined;
+		let release: () => void = () => {};
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			env: { PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS: "1000" },
+			pythonSkills: [bundledGoalSkill()],
+			hostHandlers: {
+				"goal.complete": async (_payload, context) => {
+					handlerStarted = true;
+					handlerSignal = context?.signal;
+					await new Promise<void>((resolve) => {
+						release = resolve;
+					});
+					return {};
+				},
+			},
+		});
+
+		const manager = await provisioner.ensure();
+		const controller = new AbortController();
+		try {
+			const scheduled = await manager.execute(
+				`background_completion = asyncio.create_task(goal.complete())
+await asyncio.sleep(0.05)
+print("scheduled")`,
+				{ signal: controller.signal },
+			);
+			expect(scheduled.status).toBe("ok");
+			expect(scheduled.stdout.trim()).toBe("scheduled");
+			expect(handlerStarted).toBe(true);
+
+			controller.abort();
+			await sleep(20);
+			expect(handlerSignal?.aborted).toBe(false);
+		} finally {
+			release();
+		}
+
+		const followUp = await manager.execute("print('detached healthy')");
+		expect(followUp.status).toBe("ok");
+		expect(followUp.stdout.trim()).toBe("detached healthy");
+	});
+
+	it("aborts the matching host request and frees the live kernel", async () => {
+		let handlerStarted = false;
+		let handlerSignal: AbortSignal | undefined;
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			env: { PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS: "1000" },
+			pythonSkills: [bundledGoalSkill()],
+			hostHandlers: {
+				"goal.complete": async (_payload, context) => {
+					handlerStarted = true;
+					handlerSignal = context?.signal;
+					return new Promise<Record<string, unknown>>(() => {});
+				},
+			},
+		});
+
+		const manager = await provisioner.ensure();
+		const controller = new AbortController();
+		const execution = manager.execute("await goal.complete()", { signal: controller.signal });
+		execution.catch(() => undefined);
+		await waitFor(() => handlerStarted);
+		controller.abort();
+		await waitFor(() => handlerSignal?.aborted === true, 300);
+
+		const aborted = await execution;
+		expect(aborted.status).toBe("aborted");
+		const followUp = await manager.execute("print('still healthy')");
+		expect(followUp.status).toBe("ok");
+		expect(followUp.stdout.trim()).toBe("still healthy");
 	});
 
 	it("surfaces host errors and missing handlers as Python exceptions", async () => {

--- a/packages/coding-agent/test/kernel-host-request-timeout.test.ts
+++ b/packages/coding-agent/test/kernel-host-request-timeout.test.ts
@@ -1,0 +1,314 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { type HostRequestHandler, KernelManager } from "../src/core/kernel/index.js";
+
+interface TestCommMessage {
+	header: { msg_type: string };
+	parent_header: Record<string, unknown>;
+	metadata: Record<string, unknown>;
+	content: Record<string, unknown>;
+}
+
+interface KernelHostRequestTestApi {
+	handleCommMessage(incoming: TestCommMessage): void;
+	sendCommMessage(commId: string, data: Record<string, unknown>): Promise<void>;
+	inFlightHostRequests: Set<Promise<void>>;
+	hostRequestsByCommId: Map<string, unknown>;
+}
+
+function commClose(commId: string): TestCommMessage {
+	return {
+		header: { msg_type: "comm_close" },
+		parent_header: {},
+		metadata: {},
+		content: { comm_id: commId },
+	};
+}
+
+function commOpen(commId: string, data: Record<string, unknown>, parentMessageId?: string): TestCommMessage {
+	return {
+		header: { msg_type: "comm_open" },
+		parent_header: parentMessageId === undefined ? {} : { msg_id: parentMessageId },
+		metadata: {},
+		content: {
+			comm_id: commId,
+			target_name: "host.request",
+			data,
+		},
+	};
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) {
+			throw new Error(`condition did not become true within ${timeoutMs}ms`);
+		}
+		await sleep(1);
+	}
+}
+
+describe("KernelManager host request deadlines", () => {
+	it("times out a stalled handler and ignores its late result", async () => {
+		let started = false;
+		let signal: AbortSignal | undefined;
+		let release: (value: Record<string, unknown>) => void = () => {};
+		const handler: HostRequestHandler = async (_payload, context) => {
+			started = true;
+			signal = context?.signal;
+			return new Promise<Record<string, unknown>>((resolve) => {
+				release = resolve;
+			});
+		};
+		const manager = new KernelManager({
+			hostHandlers: { "goal.complete": handler },
+		});
+		const kernel = manager as unknown as KernelHostRequestTestApi;
+		const replies: Record<string, unknown>[] = [];
+		kernel.sendCommMessage = async (_commId, data) => {
+			replies.push(data);
+		};
+
+		try {
+			kernel.handleCommMessage(
+				commOpen("comm-timeout", {
+					type: "goal.complete",
+					_prime_agent_timeout_ms: 10,
+				}),
+			);
+			await waitFor(() => started);
+			await waitFor(() => replies.length === 1);
+
+			expect(replies[0]).toEqual({
+				status: "error",
+				error_type: "timeout",
+				error: 'host request "goal.complete" timed out after 10ms',
+			});
+			expect(signal?.aborted).toBe(true);
+			expect(kernel.inFlightHostRequests.size).toBe(0);
+
+			release({ goal: { status: "complete" } });
+			await sleep(0);
+			expect(replies).toHaveLength(1);
+		} finally {
+			release({});
+			await manager.dispose();
+		}
+	});
+
+	it("observes a late handler rejection after timeout", async () => {
+		let rejectHandler: (error: Error) => void = () => {};
+		const manager = new KernelManager({
+			hostHandlers: {
+				"goal.get": async () =>
+					new Promise<Record<string, unknown>>((_resolve, reject) => {
+						rejectHandler = reject;
+					}),
+			},
+		});
+		const kernel = manager as unknown as KernelHostRequestTestApi;
+		const replies: Array<Record<string, unknown>> = [];
+		kernel.sendCommMessage = async (_commId, data) => {
+			replies.push(data);
+		};
+
+		try {
+			kernel.handleCommMessage(commOpen("comm-late-rejection", { type: "goal.get", _prime_agent_timeout_ms: 10 }));
+			await waitFor(() => replies.length === 1);
+			rejectHandler(new Error("late handler failure"));
+			await sleep(0);
+			expect(replies).toHaveLength(1);
+		} finally {
+			await manager.dispose();
+		}
+	});
+
+	it("aborts host work without replying when the kernel closes the Comm", async () => {
+		let started = false;
+		let signal: AbortSignal | undefined;
+		let release: () => void = () => {};
+		const manager = new KernelManager({
+			hostHandlers: {
+				"goal.complete": async (_payload, context) => {
+					started = true;
+					signal = context?.signal;
+					await new Promise<void>((resolve) => {
+						release = resolve;
+					});
+					return { late: true };
+				},
+			},
+		});
+		const kernel = manager as unknown as KernelHostRequestTestApi;
+		const replies: Record<string, unknown>[] = [];
+		kernel.sendCommMessage = async (_commId, data) => {
+			replies.push(data);
+		};
+
+		try {
+			kernel.handleCommMessage(
+				commOpen("comm-close", {
+					type: "goal.complete",
+					_prime_agent_timeout_ms: 1_000,
+				}),
+			);
+			await waitFor(() => started);
+			kernel.handleCommMessage(commClose("comm-close"));
+			await waitFor(() => signal?.aborted === true && kernel.inFlightHostRequests.size === 0);
+
+			expect(replies).toEqual([]);
+			expect(kernel.hostRequestsByCommId.size).toBe(0);
+			release();
+			await sleep(0);
+			expect(replies).toEqual([]);
+		} finally {
+			release();
+			await manager.dispose();
+		}
+	});
+
+	it("does not link a detached request to an unrelated active execution", async () => {
+		let started = false;
+		let signal: AbortSignal | undefined;
+		let release: () => void = () => {};
+		const manager = new KernelManager({
+			hostHandlers: {
+				"goal.get": async (_payload, context) => {
+					started = true;
+					signal = context?.signal;
+					await new Promise<void>((resolve) => {
+						release = resolve;
+					});
+					return {};
+				},
+			},
+		});
+		const kernel = manager as unknown as KernelHostRequestTestApi & {
+			activeExecution?: { requestMsgId: string; opts: { signal: AbortSignal } };
+		};
+		const unrelatedExecution = new AbortController();
+		kernel.activeExecution = {
+			requestMsgId: "active-cell",
+			opts: { signal: unrelatedExecution.signal },
+		};
+		kernel.sendCommMessage = async () => {};
+
+		try {
+			kernel.handleCommMessage(
+				commOpen("comm-detached", { type: "goal.get", _prime_agent_timeout_ms: 1_000 }, "detached-cell"),
+			);
+			await waitFor(() => started);
+			unrelatedExecution.abort();
+			await sleep(0);
+			expect(signal?.aborted).toBe(false);
+
+			kernel.handleCommMessage(commClose("comm-detached"));
+			await waitFor(() => signal?.aborted === true);
+		} finally {
+			kernel.activeExecution = undefined;
+			release();
+			await manager.dispose();
+		}
+	});
+
+	it("rejects an invalid kernel-supplied deadline before dispatch", async () => {
+		let called = false;
+		const manager = new KernelManager({
+			hostHandlers: {
+				"goal.get": async () => {
+					called = true;
+					return {};
+				},
+			},
+		});
+		const kernel = manager as unknown as KernelHostRequestTestApi;
+		const replies: Record<string, unknown>[] = [];
+		kernel.sendCommMessage = async (_commId, data) => {
+			replies.push(data);
+		};
+
+		try {
+			kernel.handleCommMessage(
+				commOpen("comm-invalid", {
+					type: "goal.get",
+					_prime_agent_timeout_ms: 0,
+				}),
+			);
+			await waitFor(() => replies.length === 1);
+			expect(called).toBe(false);
+			expect(replies[0]).toEqual({
+				status: "error",
+				error: "_prime_agent_timeout_ms must be an integer from 1 to 3600000",
+			});
+		} finally {
+			await manager.dispose();
+		}
+	});
+
+	it("rejects an invalid execution ownership marker before dispatch", async () => {
+		const handler = vi.fn(async () => ({}));
+		const manager = new KernelManager({ hostHandlers: { "goal.get": handler } });
+		const kernel = manager as unknown as KernelHostRequestTestApi;
+		const replies: Array<Record<string, unknown>> = [];
+		kernel.sendCommMessage = async (_commId, data) => {
+			replies.push(data);
+		};
+
+		try {
+			kernel.handleCommMessage(
+				commOpen("comm-invalid-owner", {
+					type: "goal.get",
+					_prime_agent_execution_owned: "yes",
+				}),
+			);
+			await waitFor(() => replies.length === 1);
+
+			expect(replies[0]).toEqual({
+				status: "error",
+				error: "_prime_agent_execution_owned must be a boolean",
+			});
+			expect(handler).not.toHaveBeenCalled();
+		} finally {
+			await manager.dispose();
+		}
+	});
+
+	it("bounds dispose when a legacy handler never settles", async () => {
+		vi.useFakeTimers();
+		let started = false;
+		let signal: AbortSignal | undefined;
+		let release: () => void = () => {};
+		const manager = new KernelManager({
+			hostHandlers: {
+				"goal.get": async (_payload, context) => {
+					started = true;
+					signal = context?.signal;
+					await new Promise<void>((resolve) => {
+						release = resolve;
+					});
+					return {};
+				},
+			},
+		});
+		const kernel = manager as unknown as KernelHostRequestTestApi;
+		kernel.sendCommMessage = async () => {};
+
+		try {
+			kernel.handleCommMessage(commOpen("comm-dispose", { type: "goal.get" }));
+			for (let i = 0; i < 10 && !started; i++) await Promise.resolve();
+			expect(started).toBe(true);
+
+			const dispose = manager.dispose();
+			await vi.advanceTimersByTimeAsync(5_000);
+			await dispose;
+
+			expect(signal?.aborted).toBe(true);
+			expect(kernel.inFlightHostRequests.size).toBe(0);
+			expect(kernel.hostRequestsByCommId.size).toBe(0);
+		} finally {
+			release();
+			vi.useRealTimers();
+			await manager.dispose();
+		}
+	});
+});

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import types
 from dataclasses import dataclass
@@ -22,6 +23,52 @@ except Exception:  # pragma: no cover - only available in kernels
     get_ipython = None  # type: ignore[assignment]
 
 HOST_COMM_TARGET = "host.request"
+HOST_REQUEST_TIMEOUT_ENV = "PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS"
+DEFAULT_HOST_REQUEST_TIMEOUT_MS = 120_000
+MAX_HOST_REQUEST_TIMEOUT_MS = 3_600_000
+_HOST_REQUEST_TIMEOUT_FIELD = "_prime_agent_timeout_ms"
+_HOST_REQUEST_EXECUTION_OWNED_FIELD = "_prime_agent_execution_owned"
+_host_request_execution_task: asyncio.Task[Any] | None = None
+_host_request_task_tracking_installed = False
+
+
+def _set_host_request_execution_task(*_args: Any) -> None:
+    global _host_request_execution_task
+    _host_request_execution_task = asyncio.current_task()
+
+
+def _clear_host_request_execution_task(*_args: Any) -> None:
+    global _host_request_execution_task
+    _host_request_execution_task = None
+
+
+def _install_host_request_task_tracking() -> None:
+    """Track the task that owns a top-level IPython execution."""
+    global _host_request_task_tracking_installed
+    if _host_request_task_tracking_installed or get_ipython is None:
+        return
+    shell = get_ipython()
+    if shell is None:
+        return
+    try:
+        shell.events.register("pre_run_cell", _set_host_request_execution_task)
+        try:
+            shell.events.register("post_run_cell", _clear_host_request_execution_task)
+        except Exception:
+            shell.events.unregister("pre_run_cell", _set_host_request_execution_task)
+            raise
+    except Exception:
+        return
+    _host_request_task_tracking_installed = True
+
+
+def _host_request_is_execution_owned() -> bool:
+    if not _host_request_task_tracking_installed:
+        return True
+    return asyncio.current_task() is _host_request_execution_task
+
+
+_install_host_request_task_tracking()
 
 
 @dataclass(frozen=True)
@@ -81,18 +128,49 @@ def _spawn_handle_from_payload(payload: Any) -> RLMSpawnHandle:
     )
 
 
-async def host_request(request_type: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+def _resolve_host_request_timeout_ms(timeout_ms: int | None) -> int:
+    value: object = os.environ.get(HOST_REQUEST_TIMEOUT_ENV) if timeout_ms is None else timeout_ms
+    if value is None:
+        return DEFAULT_HOST_REQUEST_TIMEOUT_MS
+    if isinstance(value, str):
+        try:
+            value = int(value)
+        except ValueError as error:
+            raise ValueError(
+                f"{HOST_REQUEST_TIMEOUT_ENV} must be an integer from 1 to {MAX_HOST_REQUEST_TIMEOUT_MS}"
+            ) from error
+    if isinstance(value, bool) or not isinstance(value, int):
+        name = "timeout_ms" if timeout_ms is not None else HOST_REQUEST_TIMEOUT_ENV
+        raise TypeError(f"{name} must be an int")
+    if value < 1 or value > MAX_HOST_REQUEST_TIMEOUT_MS:
+        name = "timeout_ms" if timeout_ms is not None else HOST_REQUEST_TIMEOUT_ENV
+        raise ValueError(f"{name} must be from 1 to {MAX_HOST_REQUEST_TIMEOUT_MS}")
+    return value
+
+
+async def host_request(
+    request_type: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout_ms: int | None = None,
+) -> dict[str, Any]:
     """Send a typed request to the Prime Agent host and await its reply.
 
     This is the kernel side of the generic host bridge: Python skills call
     ``await host_request("<type>", {...})`` and the TypeScript host dispatches
-    on the type. Raises RuntimeError when the host reports an error or when no
-    handler for the type is registered in this session.
+    on the type. Requests time out after 120 seconds by default. Override the
+    deadline per call with ``timeout_ms`` or for the kernel with
+    ``PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS`` (1..3,600,000 ms).
+
+    Raises RuntimeError when the host reports an error or no handler for the
+    type is registered, and TimeoutError when the request, handler, or reply
+    does not complete before the deadline.
     """
     if not isinstance(request_type, str) or not request_type:
         raise TypeError("request_type must be a non-empty str")
     if payload is not None and not isinstance(payload, dict):
         raise TypeError(f"payload must be a dict or None, got {type(payload).__name__}")
+    resolved_timeout_ms = _resolve_host_request_timeout_ms(timeout_ms)
     if Comm is None:
         raise RuntimeError("Jupyter comm support is unavailable in this kernel")
     _install_control_comm_handlers()
@@ -100,6 +178,15 @@ async def host_request(request_type: str, payload: dict[str, Any] | None = None)
     loop = asyncio.get_running_loop()
     future: asyncio.Future[dict[str, Any]] = loop.create_future()
     comm = Comm(target_name=HOST_COMM_TARGET, primary=False)
+
+    def _schedule(callback: Any) -> None:
+        if future.done():
+            return
+        try:
+            loop.call_soon_threadsafe(callback)
+        except RuntimeError:
+            # The loop can close while a late comm reply is being dispatched.
+            return
 
     def _on_msg(msg: dict[str, Any]) -> None:
         content = msg.get("content", {})
@@ -109,35 +196,63 @@ async def host_request(request_type: str, payload: dict[str, Any] | None = None)
 
         status = reply.get("status")
         if status == "ok":
+
             def _resolve_result() -> None:
                 if not future.done():
                     future.set_result({k: v for k, v in reply.items() if k != "status"})
-                    comm.close()
 
-            loop.call_soon_threadsafe(_resolve_result)
+            _schedule(_resolve_result)
             return
         if status == "error":
             message = reply.get("error") or f"host request {request_type} failed"
+            error_type = TimeoutError if reply.get("error_type") == "timeout" else RuntimeError
+
             def _resolve_error() -> None:
                 if not future.done():
-                    future.set_exception(RuntimeError(str(message)))
-                    comm.close()
+                    future.set_exception(error_type(str(message)))
 
-            loop.call_soon_threadsafe(_resolve_error)
+            _schedule(_resolve_error)
             return
 
         unexpected = f"host request {request_type} returned unexpected status: {status!r}"
+
         def _resolve_unexpected() -> None:
             if not future.done():
                 future.set_exception(RuntimeError(unexpected))
-                comm.close()
 
-        loop.call_soon_threadsafe(_resolve_unexpected)
+        _schedule(_resolve_unexpected)
 
     comm.on_msg(_on_msg)
-    # request_type goes last so a payload "type" key cannot reroute the request.
-    comm.open(data={**(payload or {}), "type": request_type})
-    return await future
+    try:
+        # Reserved bridge metadata and request_type go last so payload keys
+        # cannot change the deadline or reroute the request.
+        comm.open(
+            data={
+                **(payload or {}),
+                _HOST_REQUEST_TIMEOUT_FIELD: resolved_timeout_ms,
+                _HOST_REQUEST_EXECUTION_OWNED_FIELD: _host_request_is_execution_owned(),
+                "type": request_type,
+            }
+        )
+        try:
+            return await asyncio.wait_for(future, resolved_timeout_ms / 1000)
+        except asyncio.TimeoutError as error:
+            raise TimeoutError(
+                f'host request "{request_type}" timed out after {resolved_timeout_ms}ms; '
+                "its outcome is unknown because the request, handler, or reply may have stalled; "
+                "inspect host state before retrying"
+            ) from error
+    finally:
+        if not future.done():
+            future.cancel()
+        try:
+            comm.on_msg(None)
+        except Exception:
+            pass
+        try:
+            comm.close()
+        except Exception:
+            pass
 
 
 async def run(prompt: str, **kwargs: Any) -> RLMSpawnHandle:

--- a/prime-agent-runtime/test/test_host_request.py
+++ b/prime-agent-runtime/test/test_host_request.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import unittest
+from unittest.mock import patch
+
+
+rlm_module = importlib.import_module("rlm")
+
+
+class FakeComm:
+    instances: list["FakeComm"] = []
+
+    def __init__(self, *, target_name: str, primary: bool) -> None:
+        self.target_name = target_name
+        self.primary = primary
+        self.callback = None
+        self.last_callback = None
+        self.open_data: dict[str, object] | None = None
+        self.closed = False
+        self.__class__.instances.append(self)
+
+    def on_msg(self, callback) -> None:
+        self.callback = callback
+        if callback is not None:
+            self.last_callback = callback
+
+    def open(self, *, data: dict[str, object]) -> None:
+        self.open_data = data
+
+    def close(self) -> None:
+        self.closed = True
+
+    def deliver(self, data: dict[str, object]) -> None:
+        if self.callback is not None:
+            self.callback({"content": {"data": data}})
+
+
+class HostRequestTest(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeComm.instances.clear()
+
+    def test_round_trips_a_normal_reply_and_closes_the_comm(self) -> None:
+        async def run() -> dict[str, object]:
+            with (
+                patch.object(rlm_module, "Comm", FakeComm),
+                patch.object(rlm_module, "_install_control_comm_handlers"),
+            ):
+                request = asyncio.create_task(
+                    rlm_module.host_request("goal.get", timeout_ms=100)
+                )
+                await asyncio.sleep(0)
+                FakeComm.instances[0].deliver(
+                    {"status": "ok", "goal": {"status": "active"}}
+                )
+                return await request
+
+        self.assertEqual(asyncio.run(run()), {"goal": {"status": "active"}})
+        comm = FakeComm.instances[0]
+        self.assertEqual(
+            comm.open_data,
+            {
+                "_prime_agent_timeout_ms": 100,
+                "_prime_agent_execution_owned": True,
+                "type": "goal.get",
+            },
+        )
+        self.assertTrue(comm.closed)
+        self.assertIsNone(comm.callback)
+
+    def test_times_out_a_lost_host_request_and_closes_the_comm(self) -> None:
+        async def run() -> None:
+            with (
+                patch.object(rlm_module, "Comm", FakeComm),
+                patch.object(rlm_module, "_install_control_comm_handlers"),
+            ):
+                with self.assertRaisesRegex(
+                    TimeoutError,
+                    'host request "goal.complete" timed out after 10ms',
+                ):
+                    await rlm_module.host_request("goal.complete", timeout_ms=10)
+
+        asyncio.run(run())
+        self.assertEqual(len(FakeComm.instances), 1)
+        self.assertTrue(FakeComm.instances[0].closed)
+        self.assertIsNone(FakeComm.instances[0].callback)
+
+    def test_maps_a_host_deadline_reply_to_timeout_error(self) -> None:
+        async def run() -> None:
+            with (
+                patch.object(rlm_module, "Comm", FakeComm),
+                patch.object(rlm_module, "_install_control_comm_handlers"),
+            ):
+                request = asyncio.create_task(
+                    rlm_module.host_request("rlm.run", timeout_ms=100)
+                )
+                await asyncio.sleep(0)
+                FakeComm.instances[0].deliver(
+                    {
+                        "status": "error",
+                        "error_type": "timeout",
+                        "error": 'host request "rlm.run" timed out after 100ms',
+                    }
+                )
+                with self.assertRaisesRegex(TimeoutError, "rlm.run"):
+                    await request
+
+        asyncio.run(run())
+        self.assertTrue(FakeComm.instances[0].closed)
+
+    def test_ignores_a_reply_that_arrives_after_timeout(self) -> None:
+        loop_errors: list[dict[str, object]] = []
+
+        async def run() -> None:
+            loop = asyncio.get_running_loop()
+            loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+            with (
+                patch.object(rlm_module, "Comm", FakeComm),
+                patch.object(rlm_module, "_install_control_comm_handlers"),
+            ):
+                with self.assertRaises(TimeoutError):
+                    await rlm_module.host_request("goal.complete", timeout_ms=5)
+                comm = FakeComm.instances[0]
+                self.assertIsNone(comm.callback)
+                assert comm.last_callback is not None
+                comm.last_callback(
+                    {"content": {"data": {"status": "ok", "goal": {"status": "complete"}}}}
+                )
+                await asyncio.sleep(0)
+
+        asyncio.run(run())
+        self.assertEqual(loop_errors, [])
+
+    def test_cancellation_closes_the_comm_and_cancels_the_future(self) -> None:
+        async def run() -> None:
+            with (
+                patch.object(rlm_module, "Comm", FakeComm),
+                patch.object(rlm_module, "_install_control_comm_handlers"),
+            ):
+                request = asyncio.create_task(
+                    rlm_module.host_request("agent_message.send", timeout_ms=100)
+                )
+                await asyncio.sleep(0)
+                request.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await request
+
+        asyncio.run(run())
+        comm = FakeComm.instances[0]
+        self.assertTrue(comm.closed)
+        self.assertIsNone(comm.callback)
+
+    def test_marks_a_detached_task_as_not_execution_owned(self) -> None:
+        async def run() -> None:
+            owner_task = asyncio.current_task()
+            with (
+                patch.object(rlm_module, "Comm", FakeComm),
+                patch.object(rlm_module, "_install_control_comm_handlers"),
+                patch.object(rlm_module, "_host_request_task_tracking_installed", True),
+                patch.object(rlm_module, "_host_request_execution_task", owner_task),
+            ):
+                request = asyncio.create_task(
+                    rlm_module.host_request("goal.get", timeout_ms=100)
+                )
+                await asyncio.sleep(0)
+                self.assertFalse(
+                    FakeComm.instances[0].open_data["_prime_agent_execution_owned"]
+                )
+                FakeComm.instances[0].deliver({"status": "ok"})
+                await request
+
+        asyncio.run(run())
+
+    def test_validates_per_call_and_environment_timeout_bounds(self) -> None:
+        invalid_call_values = (0, -1, 3_600_001, True, 1.5)
+        for value in invalid_call_values:
+            with self.subTest(timeout_ms=value):
+                with self.assertRaises((TypeError, ValueError)):
+                    asyncio.run(rlm_module.host_request("goal.get", timeout_ms=value))
+        self.assertEqual(FakeComm.instances, [])
+
+        for value in ("0", "3600001", "not-an-int"):
+            with self.subTest(environment=value):
+                with patch.dict(
+                    os.environ,
+                    {"PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS": value},
+                ):
+                    with self.assertRaises((TypeError, ValueError)):
+                        asyncio.run(rlm_module.host_request("goal.get"))
+        self.assertEqual(FakeComm.instances, [])
+
+    def test_accepts_the_inclusive_timeout_boundaries(self) -> None:
+        self.assertEqual(rlm_module._resolve_host_request_timeout_ms(1), 1)
+        self.assertEqual(
+            rlm_module._resolve_host_request_timeout_ms(3_600_000),
+            3_600_000,
+        )
+
+    def test_reads_the_timeout_from_the_environment(self) -> None:
+        async def run() -> None:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS": "25"},
+                ),
+                patch.object(rlm_module, "Comm", FakeComm),
+                patch.object(rlm_module, "_install_control_comm_handlers"),
+            ):
+                request = asyncio.create_task(rlm_module.host_request("goal.get"))
+                await asyncio.sleep(0)
+                FakeComm.instances[0].deliver({"status": "ok"})
+                await request
+
+        asyncio.run(run())
+        self.assertEqual(
+            FakeComm.instances[0].open_data,
+            {
+                "_prime_agent_timeout_ms": 25,
+                "_prime_agent_execution_owned": True,
+                "type": "goal.get",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a finite, configurable deadline to every `rlm.host_request()` on both sides of the kernel↔host bridge
- close and detach Python Futures/Comms, abort host handlers on timeout, execution cancellation, Comm close, and kernel disposal, and ignore late results safely
- distinguish top-level requests from detached `asyncio` tasks so cancelling a cell does not cancel legitimate background host requests
- propagate request cancellation through RLM admission, child publication/message delivery, goal/compact/refine/heartbeat, and MCP handler boundaries
- drain the serialized Jupyter execution queue when the matching shell `execute_reply` arrives but IOPub drops its terminal `status: idle`

## Diagnosis and timeout boundaries

### Host-request bridge

- The kernel-side bridge previously opened a Comm and awaited a Future with no deadline.
- The host dispatched handlers with no per-request timeout and kept in-flight bookkeeping until the handler settled or the kernel shut down.
- In the observed `goal.complete()` incident, durable goal state remained `active`; that proves the synchronous completion mutation did not finish, but it does not identify whether the Comm open, handler dispatch, or reply path stalled.
- The bridge fix therefore applies independent 120-second deadlines at the narrow Python↔host Comm seam.

### Lost-IOPub-idle execution queue

A separate incident never entered the host-request bridge. An internal auto-snapshot reached the kernel and wrote its state artifacts, but the host never observed its terminal IOPub `idle`. Because `KernelManager` serializes every user and internal cell behind the prior execution promise, the later user cell remained queued before Jupyter assigned it a request ID. The 120-second `host_request()` deadline could not apply.

The fix starts the shell receive pump after readiness probing and accepts only an `execute_reply` whose `parent_header.msg_id` exactly matches the active execution. IOPub `idle` remains authoritative. If it does not arrive, the manager waits a bounded two-second grace for trailing IOPub output, then finishes from the matching shell reply. Reply/timer state is bound to the exact execution and cleared on normal idle, abort, rejection, shutdown, and disposal, so stale replies or timers cannot settle a newer cell.

## Behavior

`host_request(..., timeout_ms=...)` defaults to 120 seconds and accepts `1..3_600_000` ms. `PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS` configures the kernel default. Timeouts raise `TimeoutError` with the request type, elapsed deadline, and an explicit warning that the remote outcome may be unknown; callers should inspect state before retrying.

Existing one-argument host handlers remain source-compatible. New handlers may consume `HostRequestContext.signal` for cooperative cancellation. The kernel and namespace remain live after timeout or cancellation; restart is not part of this change.

For ordinary executions, IOPub `idle` behavior is unchanged. The shell fallback applies only when an exact matching `execute_reply` arrives without `idle`; it preserves output received during the grace and propagates terminal shell abort/error status.

## Regression seam

`kernel-execute-reply-fallback.test.ts` covers exact request-ID matching, normal idle/output preservation, the two-second fallback, stale reply/timer isolation, abort/dispose cleanup, and shell error propagation.

Its real-kernel regression exercises the hidden predecessor directly: a user cell schedules an internal auto-snapshot; the test waits for the snapshot manifest and dill artifact, drops only that snapshot request's exact IOPub `idle`, observes its exact shell reply, and requires two subsequent user cells to complete. It also instruments the Comm entry point and proves `hostRequestCount === 0` and no in-flight host request, demonstrating that this failure is outside the host-request timeout layer.

## Alternatives rejected

- An outer tool timeout alone leaves the top-level await and serial kernel queue active; #865 handles that broader recovery layer separately.
- Restarting the kernel discards user namespace and background work and is unnecessary when shell completion proves the cell has terminated.
- A bare elapsed-time race could release the serial queue while the kernel is still executing and permit overlapping cells.
- The prior experimental recovery commits mixed tool timeout, execute-reply recovery, and restart escalation, making them too broad to cherry-pick.

## Validation

Lost-idle candidate `7b0da32b1802be442521fd71493d0a1847c6baea`:

- `kernel-execute-reply-fallback.test.ts` — 6 unit tests passed, 1 real-kernel test skipped in normal mode
- `kernel-execute-reply-fallback.test.ts --tagsFilter kernel-heavy` — 1 real-kernel auto-snapshot regression passed, 6 unit tests filtered out
- `kernel-host-request-timeout.test.ts` — 7 passed
- `kernel-abort.test.ts` — 5 passed
- live `kernel-goal-skill.test.ts` — 6 passed
- live `kernel-state-roundtrip.test.ts` — 6 passed
- `kernel-startup.test.ts` — 1 passed
- `npm run check` — Biome checked 902 files with no fixes, `tsgo --noEmit`, installer render, and browser smoke passed
- `git diff --check` — passed
- independent exact-SHA review — PASS with no actionable findings; verified request identity, grace/timer isolation, all cleanup paths, output preservation, internal snapshot queue drainage, zero host Comm participation, and compatibility

Earlier host-request validation retained on this branch:

- `prime-agent-runtime/.venv/bin/python -m unittest discover -s prime-agent-runtime/test` — 73 passed
- 200 relevant coding-agent tests passed across recursion, host skills, MCP, kernel abort/bootstrap, and provisioner coverage
- independent adversarial review found two lifecycle gaps in its first pass; both were fixed and the second pass approved with no Critical or Important findings

## Compatibility

This update adds no daemon command, event, response-shape, protocol-version, dependency, or configuration requirement. The lost-idle change is internal to kernel execution lifecycle handling. Existing host-request timeout and abort semantics remain intact.

Addresses the host-request hang and lost-idle queue failure described in #848 and complements, rather than duplicates, #865.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound host requests with deadlines and drain lost-idle executions in KernelManager
> - `rlm.host_request` in [rlm/__init__.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/1038/files#diff-8f05bb028ac34c9ff421f45f913f35be2a99010ef924da344d7a427869c7ead3) now enforces a configurable deadline (default 120 s, overridable via `PRIME_AGENT_HOST_REQUEST_TIMEOUT_MS`) and raises `TimeoutError` on local timeout; the Comm is always closed and the callback unregistered on exit.
> - [KernelManager](https://github.com/PrimeIntellect-ai/prime-agent/pull/1038/files#diff-14dd18f6926ed763ba0b55625302fb733f4e4209bb611d3051820048732149ac) now pumps the shell channel and uses an `execute_reply` fallback: if IOPub idle is not received within 2 s of `execute_reply`, execution is force-finished, preventing the serial queue from stalling when Jupyter drops the idle event.
> - Host request handlers across `KernelManager`, `AgentSession`, `McpManager`, and `RlmRuntime` now receive an `AbortSignal` via a `HostRequestContext` and abort cooperatively on timeout, Comm closure, or parent execution abort.
> - Execution-owned host requests (flagged via `_prime_agent_execution_owned`) are linked to the triggering cell's `AbortSignal`, so aborting a cell also cancels its in-flight host requests.
> - Risk: existing unary host request handlers continue to work, but handlers that were previously unbounded may now timeout after 120 s by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9489fda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->