### PR TITLE
fix(coding-agent): revive archived sessions on prompt instead of dead-ending

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed prompts to archived daemon sessions failing with unknown-session errors instead of reviving the saved session.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -963,6 +963,7 @@ async function createDaemonClientConnection(options: {
 				supportsExtensionUi: options.supportsExtensionUi,
 				recoverDaemon: () => ensureInteractiveDaemonRunning(options.socketPath),
 				telemetryDisabled: options.config.telemetryDisabled,
+				reviveConfig: options.config,
 			});
 			return { connection, summary };
 		};

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -325,9 +325,22 @@ export class DaemonAgentConnection implements AgentConnection {
 				entryActiveSessionId,
 				resumeCursor,
 			);
+			// The daemon queues events that land during an attach snapshot and
+			// delivers them as a catch-up resync; one addressed to the target
+			// while it was still pending had no waiter and was buffered. Apply
+			// it now that the binding has published, so the intervening events
+			// are not lost behind the older attach snapshot.
+			const catchup = this.pendingBindingCatchupSnapshots.get(this.activeSessionId);
+			if (catchup) {
+				this.pendingBindingCatchupSnapshots.delete(this.activeSessionId);
+				this.applyReplacementSnapshot(catchup);
+			}
 		} finally {
 			if (admitPendingTarget) {
+				// A failed or superseded transition discards its buffered
+				// catch-up along with the admission.
 				this.pendingReattachActiveSessionIds.delete(targetActiveSessionId);
+				this.pendingBindingCatchupSnapshots.delete(targetActiveSessionId);
 			}
 		}
 	}
@@ -2197,6 +2210,15 @@ export class DaemonAgentConnection implements AgentConnection {
 						break;
 					}
 					this.completedSnapshots.delete(oldest);
+				}
+				if (!isForPublishedBinding) {
+					// An unsolicited catch-up (the daemon queues events that land
+					// during an attach snapshot and delivers them as a resync) for
+					// a still-pending binding target has no waiter: buffer the
+					// newest one per target so the attach can apply it once the
+					// binding publishes, instead of losing the intervening events
+					// behind the older attach snapshot.
+					this.pendingBindingCatchupSnapshots.set(message.activeSessionId, snapshot);
 				}
 			}
 		}

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -384,9 +384,16 @@ export class DaemonAgentConnection implements AgentConnection {
 		}
 		this.lastEventSequence = maxEventSequence(this.lastEventSequence, getAttachLastEventSequence(result));
 		if ("snapshot" in result) {
+			const appliedActiveSessionId = this.activeSessionId;
 			const snapshot = result.snapshotStream
 				? await this.waitForSnapshot(result.snapshotStream.id)
 				: result.snapshot;
+			if (this.activeSessionId !== appliedActiveSessionId) {
+				// A concurrent transition rebound the connection while the
+				// streamed snapshot was in flight; applying the late snapshot
+				// would describe a session this connection no longer shows.
+				throw new Error(`Session attach superseded: binding moved from ${appliedActiveSessionId}`);
+			}
 			this.latestSnapshot = mapDaemonSessionSnapshot(snapshot, result.replay);
 			if (this.lastEventSequence !== undefined) {
 				this.latestSnapshot.lastEventSequence = this.lastEventSequence;
@@ -970,7 +977,7 @@ export class DaemonAgentConnection implements AgentConnection {
 				// worker matches the selector anymore.
 				void this.requestOk({ type: "detach", activeSessionId: sourceActiveSessionId }).catch(() => undefined);
 			}
-			if (snapshot) {
+			if (snapshot && this.activeSessionId === revivedActiveSessionId) {
 				void this.emit({ type: "session_resynced", snapshot });
 			}
 			return revivedActiveSessionId;
@@ -2148,14 +2155,23 @@ export class DaemonAgentConnection implements AgentConnection {
 			lastEventSequence: message.lastEventSequence,
 			lastEventCursor: message.lastEventCursor,
 		};
-		if (message.lastEventCursor) {
-			this.observeEventCursor(message.lastEventCursor);
+		// A snapshot admitted for a pending binding transition may complete while
+		// the published binding is (still, or again) a different session; its
+		// waiter gets the resolved snapshot below, but the shared identity and
+		// snapshot cache must only describe the published binding.
+		const isForPublishedBinding = message.activeSessionId === this.activeSessionId;
+		let mappedSnapshot: AgentConnectionSnapshot | undefined;
+		if (isForPublishedBinding) {
+			if (message.lastEventCursor) {
+				this.observeEventCursor(message.lastEventCursor);
+			}
+			this.lastEventSequence = maxEventSequence(this.lastEventSequence, message.lastEventSequence);
+			this.attachedSessionId = snapshot.state.sessionId;
+			this.attachedSessionFile = snapshot.state.sessionFile;
+			mappedSnapshot = mapDaemonSessionSnapshot(snapshot);
+			this.latestSnapshot = mappedSnapshot;
+			this.latestSnapshotIsFresh = true;
 		}
-		this.lastEventSequence = maxEventSequence(this.lastEventSequence, message.lastEventSequence);
-		this.attachedSessionId = snapshot.state.sessionId;
-		this.attachedSessionFile = snapshot.state.sessionFile;
-		this.latestSnapshot = mapDaemonSessionSnapshot(snapshot);
-		this.latestSnapshotIsFresh = true;
 		assembly.resolve(snapshot);
 		const purpose = assembly.begin.purpose ?? "attach";
 		clearTimeout(assembly.timeout);
@@ -2172,10 +2188,10 @@ export class DaemonAgentConnection implements AgentConnection {
 				}
 			}
 		}
-		if (purpose === "replacement") {
+		if (purpose === "replacement" && isForPublishedBinding) {
 			await this.emit({ type: "session_replaced", state: snapshot.state, messages });
-		} else if (purpose === "resync") {
-			await this.emit({ type: "session_resynced", snapshot: this.latestSnapshot });
+		} else if (purpose === "resync" && mappedSnapshot) {
+			await this.emit({ type: "session_resynced", snapshot: mappedSnapshot });
 		}
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -226,6 +226,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly snapshotAssemblies = new Map<string, DaemonSnapshotAssembly>();
 	private readonly completedSnapshots = new Map<string, DaemonSessionSnapshot>();
 	private readonly pendingBindingCatchupSnapshots = new Map<string, DaemonSessionSnapshot>();
+	private readonly pendingBindingCatchupFailures = new Set<string>();
 	private readonly pendingReattachActiveSessionIds = new Set<string>();
 	private readonly snapshotRecoveryPromises = new Map<string, Promise<void>>();
 	private readonly ignoredSnapshotIds = new Set<string>();
@@ -333,14 +334,23 @@ export class DaemonAgentConnection implements AgentConnection {
 			const catchup = this.pendingBindingCatchupSnapshots.get(this.activeSessionId);
 			if (catchup) {
 				this.pendingBindingCatchupSnapshots.delete(this.activeSessionId);
+				this.pendingBindingCatchupFailures.delete(this.activeSessionId);
 				this.applyReplacementSnapshot(catchup);
+			} else if (this.pendingBindingCatchupFailures.delete(this.activeSessionId)) {
+				// A catch-up FAILED while the target was pending and no later one
+				// succeeded: the cached attach snapshot predates the events that
+				// catch-up carried. Invalidate it so the transition's mandatory
+				// read actually re-reads from the daemon instead of serving the
+				// stale cache.
+				this.latestSnapshotIsFresh = false;
 			}
 		} finally {
 			if (admitPendingTarget) {
 				// A failed or superseded transition discards its buffered
-				// catch-up along with the admission.
+				// catch-up and failure marker along with the admission.
 				this.pendingReattachActiveSessionIds.delete(targetActiveSessionId);
 				this.pendingBindingCatchupSnapshots.delete(targetActiveSessionId);
+				this.pendingBindingCatchupFailures.delete(targetActiveSessionId);
 			}
 		}
 	}
@@ -1760,9 +1770,15 @@ export class DaemonAgentConnection implements AgentConnection {
 			// Recovery re-reads state for the PUBLISHED binding; running it for a
 			// pending transition target would query the old (typically archived)
 			// selector and could emit a terminal close while the transition can
-			// still succeed. A failed pending catch-up needs no recovery: once
-			// the binding publishes, the transition re-reads fresh state anyway,
-			// and on supersession the buffered state is discarded.
+			// still succeed. A failed pending catch-up needs no recovery: the
+			// failure is recorded so the transition invalidates its cached
+			// attach snapshot at publication and re-reads fresh state, and on
+			// supersession the marker is discarded.
+			const isPendingCatchupFailure =
+				(purpose === "replacement" || purpose === "resync") && message.activeSessionId !== this.activeSessionId;
+			if (isPendingCatchupFailure && this.pendingReattachActiveSessionIds.has(message.activeSessionId)) {
+				this.pendingBindingCatchupFailures.add(message.activeSessionId);
+			}
 			const recoveryPromise =
 				(purpose === "replacement" || purpose === "resync") && message.activeSessionId === this.activeSessionId
 					? this.recoverFailedSnapshot(purpose, snapshotError)
@@ -2056,6 +2072,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		this.snapshotAssemblies.clear();
 		this.completedSnapshots.clear();
 		this.pendingBindingCatchupSnapshots.clear();
+		this.pendingBindingCatchupFailures.clear();
 		this.snapshotRecoveryPromises.clear();
 		this.ignoredSnapshotIds.clear();
 	}
@@ -2223,8 +2240,10 @@ export class DaemonAgentConnection implements AgentConnection {
 					// a still-pending binding target has no waiter: buffer the
 					// newest one per target so the attach can apply it once the
 					// binding publishes, instead of losing the intervening events
-					// behind the older attach snapshot.
+					// behind the older attach snapshot. A success supersedes any
+					// earlier failed catch-up for the target.
 					this.pendingBindingCatchupSnapshots.set(message.activeSessionId, snapshot);
+					this.pendingBindingCatchupFailures.delete(message.activeSessionId);
 				}
 			}
 		}

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -1618,7 +1618,17 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (error.activeSessionId === sourceActiveSessionId) {
 				return { cancelled: false };
 			}
-			return this.reattachSession(sourceActiveSessionId, error.activeSessionId);
+			const result = await this.reattachSession(sourceActiveSessionId, error.activeSessionId);
+			if (options?.cwdOverride) {
+				// The transcript is live under another worker, but the user still
+				// selected a fallback cwd because its recorded directory is
+				// missing; a later revival of this transcript needs the same
+				// override or its recreate fails on that directory. Keyed by the
+				// reattached transcript's canonical file when known - the caller's
+				// path spelling may differ.
+				this.switchCwdOverride = { sessionPath: this.attachedSessionFile ?? sessionPath, cwd: options.cwdOverride };
+			}
+			return result;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -241,7 +241,8 @@ export class DaemonAgentConnection implements AgentConnection {
 	private reconnectPromise?: Promise<void>;
 	private reviveSession?: { promise: Promise<RevivedSessionBinding>; sourceActiveSessionId: string };
 	private lastAttachCreatedAttachment = false;
-	private reviveConfigSessionFile: string | undefined;
+	/** undefined = not yet captured; null = captured for a fileless (in-memory) session. */
+	private reviveConfigSessionFile: string | null | undefined;
 	private lastAttachPublishedIdentity: { sessionId: string; sessionFile: string | undefined } | undefined;
 	private switchCwdOverride: { sessionPath: string; cwd: string } | undefined;
 	private readonly definitiveRequestErrors = new WeakSet<Error>();
@@ -419,8 +420,9 @@ export class DaemonAgentConnection implements AgentConnection {
 			summary.sessionFile ?? ("snapshot" in result ? result.snapshot.state.sessionFile : undefined);
 		// The invocation's reviveConfig was computed for the transcript this
 		// connection first attached to; later transcripts (session switches)
-		// must not inherit its cwd.
-		this.reviveConfigSessionFile ??= this.attachedSessionFile;
+		// must not inherit its cwd. A fileless first attach (--no-session)
+		// records null so a transcript resumed later still counts as foreign.
+		this.reviveConfigSessionFile ??= this.attachedSessionFile ?? null;
 		// Recorded before the snapshot await below: a replacement snapshot
 		// landing mid-stream can rewrite the attached identity, and a caller
 		// capturing it afterwards would adopt the switched transcript as its

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -421,8 +421,12 @@ export class DaemonAgentConnection implements AgentConnection {
 		// The invocation's reviveConfig was computed for the transcript this
 		// connection first attached to; later transcripts (session switches)
 		// must not inherit its cwd. A fileless first attach (--no-session)
-		// records null so a transcript resumed later still counts as foreign.
-		this.reviveConfigSessionFile ??= this.attachedSessionFile ?? null;
+		// records null so a transcript resumed later still counts as foreign -
+		// checked strictly against undefined because ??= would re-assign over
+		// the null marker on the next reconnect attach.
+		if (this.reviveConfigSessionFile === undefined) {
+			this.reviveConfigSessionFile = this.attachedSessionFile ?? null;
+		}
 		// Recorded before the snapshot await below: a replacement snapshot
 		// landing mid-stream can rewrite the attached identity, and a caller
 		// capturing it afterwards would adopt the switched transcript as its

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -232,6 +232,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly ignoredSnapshotIds = new Set<string>();
 	private reconnectPromise?: Promise<void>;
 	private reviveSession?: { promise: Promise<RevivedSessionBinding>; sourceActiveSessionId: string };
+	private lastAttachCreatedAttachment = false;
 	private readonly definitiveRequestErrors = new WeakSet<Error>();
 	private disposing = false;
 	private disposed = false;
@@ -386,6 +387,12 @@ export class DaemonAgentConnection implements AgentConnection {
 							...resumeCursor,
 						},
 		});
+		// Recorded before any supersession throw: cleanup paths need to know
+		// whether THIS attach created the socket's attachment entry (a sibling
+		// connection on the shared client may already hold it, in which case a
+		// detach would remove the sibling's subscription). Older daemons omit
+		// the field; the conservative default is "did not create it".
+		this.lastAttachCreatedAttachment = "wasAttached" in result && result.wasAttached === false;
 		if (this.activeSessionId !== entryActiveSessionId) {
 			throw new Error(`Session attach superseded: binding moved from ${entryActiveSessionId}`);
 		}
@@ -1024,8 +1031,12 @@ export class DaemonAgentConnection implements AgentConnection {
 				await this.attachSessionBinding(revivedActiveSessionId, true);
 			} catch (error) {
 				// Supersede errors are thrown after a successful attach response,
-				// so only they prove this revival acquired the attachment.
-				const attachAcquired = DaemonAgentConnection.isAttachSupersededError(error);
+				// and the response's wasAttached tells whether that attach CREATED
+				// the socket's attachment entry - a sibling connection may already
+				// have held it, in which case a detach would remove the sibling's
+				// subscription rather than ours.
+				const attachAcquired =
+					DaemonAgentConnection.isAttachSupersededError(error) && this.lastAttachCreatedAttachment;
 				if (this.disposed || this.disposing) {
 					this.releaseRevivedSession(revivedActiveSessionId, attachAcquired);
 					throw error;
@@ -1067,7 +1078,10 @@ export class DaemonAgentConnection implements AgentConnection {
 			}
 			this.activeSideQuestionIds.clear();
 			if (this.disposed) {
-				this.releaseRevivedSession(revivedActiveSessionId, true);
+				// The attach succeeded, but it only ACQUIRED the attachment when it
+				// created the socket entry; a sibling's pre-existing attachment
+				// must survive this cleanup.
+				this.releaseRevivedSession(revivedActiveSessionId, this.lastAttachCreatedAttachment);
 				throw new Error("Connection was disposed during session revival");
 			}
 			if (sourceActiveSessionId !== revivedActiveSessionId) {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -109,6 +109,171 @@ const MAX_COMPLETED_SNAPSHOTS = 128;
 const OWNED_SESSION_DISPOSE_RECONNECT_WAIT_MS = 10_000;
 const updateTransportReconnects = new WeakMap<DaemonClient, Promise<void>>();
 
+type LocalAttachmentOwner = object;
+
+interface LocalAttachmentAttempt {
+	readonly activeSessionId: string;
+}
+
+interface LocalAttachmentEntry {
+	readonly holders: Set<LocalAttachmentOwner>;
+	readonly pending: Set<LocalAttachmentAttempt>;
+	attached: boolean;
+	deferredCleanup?: () => Promise<void>;
+}
+
+/**
+ * Mirrors the daemon's per-socket attachment Set with per-connection holders.
+ * Legacy daemons cannot say whether an attach inserted that Set entry, so the
+ * only safe cleanup point is when no local connection holds or is attempting
+ * the id. A displaced binding keeps its known attached state until its caller
+ * explicitly requests refcounted cleanup.
+ */
+class LocalAttachmentTracker {
+	private readonly entries = new Map<string, LocalAttachmentEntry>();
+	private readonly bindings = new Map<LocalAttachmentOwner, string>();
+
+	begin(activeSessionId: string): LocalAttachmentAttempt {
+		const attempt = { activeSessionId };
+		this.entry(activeSessionId).pending.add(attempt);
+		return attempt;
+	}
+
+	fail(attempt: LocalAttachmentAttempt): void {
+		const entry = this.entries.get(attempt.activeSessionId);
+		if (!entry || !entry.pending.delete(attempt)) return;
+		this.flushDeferredCleanup(attempt.activeSessionId, entry);
+	}
+
+	/** Atomically publish a successful attempt before deferred cleanup can observe it as idle. */
+	commit(owner: LocalAttachmentOwner, attempt: LocalAttachmentAttempt): string | undefined {
+		const entry = this.entries.get(attempt.activeSessionId);
+		if (!entry || !entry.pending.delete(attempt)) {
+			throw new Error(`Local attachment attempt is no longer pending: ${attempt.activeSessionId}`);
+		}
+		entry.attached = true;
+		entry.holders.add(owner);
+		const previousActiveSessionId = this.bindings.get(owner);
+		if (previousActiveSessionId !== undefined && previousActiveSessionId !== attempt.activeSessionId) {
+			this.entries.get(previousActiveSessionId)?.holders.delete(owner);
+		}
+		this.bindings.set(owner, attempt.activeSessionId);
+		return previousActiveSessionId === attempt.activeSessionId ? undefined : previousActiveSessionId;
+	}
+
+	/** Finish a successful attempt that was superseded before it could publish. */
+	abandon(attempt: LocalAttachmentAttempt, cleanup?: () => Promise<void>): void {
+		const entry = this.entries.get(attempt.activeSessionId);
+		if (!entry || !entry.pending.delete(attempt)) return;
+		entry.attached = true;
+		entry.deferredCleanup ??= cleanup;
+		this.flushDeferredCleanup(attempt.activeSessionId, entry);
+	}
+
+	/** The socket closed, so its entire server attachment Set disappeared. */
+	markAllServerDetached(): void {
+		for (const [activeSessionId, entry] of this.entries) {
+			entry.attached = false;
+			entry.deferredCleanup = undefined;
+			this.deleteEmpty(activeSessionId, entry);
+		}
+	}
+
+	release(
+		owner: LocalAttachmentOwner,
+		fallbackActiveSessionId: string,
+		cleanup: (activeSessionId: string) => Promise<void>,
+	): Promise<void> | undefined {
+		const boundActiveSessionId = this.bindings.get(owner);
+		const activeSessionId = boundActiveSessionId ?? fallbackActiveSessionId;
+		if (boundActiveSessionId !== undefined) {
+			this.bindings.delete(owner);
+			this.entries.get(boundActiveSessionId)?.holders.delete(owner);
+		}
+		const entry = this.entries.get(activeSessionId);
+		// Preserve the historical best-effort detach after an attach request
+		// failed before publishing a binding, but only when no tracked sibling
+		// can own or be acquiring the same socket entry.
+		if (!entry) return cleanup(activeSessionId);
+		return this.requestCleanup(activeSessionId, () => cleanup(activeSessionId));
+	}
+
+	requestCleanup(
+		activeSessionId: string,
+		cleanup: () => Promise<void>,
+		cleanupIfUntracked = false,
+	): Promise<void> | undefined {
+		const entry = this.entries.get(activeSessionId);
+		if (!entry) return cleanupIfUntracked ? cleanup() : undefined;
+		if (!entry.attached) {
+			this.deleteEmpty(activeSessionId, entry);
+			return undefined;
+		}
+		// Persist the cleanup request across both holders and pending attempts.
+		// In particular, a failed pending attach must still release the known
+		// attachment inherited from a binding that moved away.
+		entry.deferredCleanup ??= cleanup;
+		if (entry.holders.size > 0 || entry.pending.size > 0) return undefined;
+		return this.runDeferredCleanup(activeSessionId, entry);
+	}
+
+	forget(owner: LocalAttachmentOwner): void {
+		const activeSessionId = this.bindings.get(owner);
+		if (activeSessionId === undefined) return;
+		this.bindings.delete(owner);
+		const entry = this.entries.get(activeSessionId);
+		entry?.holders.delete(owner);
+		if (entry && entry.holders.size === 0) {
+			entry.attached = false;
+			entry.deferredCleanup = undefined;
+		}
+		this.deleteEmpty(activeSessionId, entry);
+	}
+
+	private entry(activeSessionId: string): LocalAttachmentEntry {
+		let entry = this.entries.get(activeSessionId);
+		if (!entry) {
+			entry = { holders: new Set(), pending: new Set(), attached: false };
+			this.entries.set(activeSessionId, entry);
+		}
+		return entry;
+	}
+
+	private flushDeferredCleanup(activeSessionId: string, entry: LocalAttachmentEntry): void {
+		if (entry.pending.size > 0 || entry.holders.size > 0 || !entry.attached || !entry.deferredCleanup) {
+			this.deleteEmpty(activeSessionId, entry);
+			return;
+		}
+		void this.runDeferredCleanup(activeSessionId, entry)?.catch(() => undefined);
+	}
+
+	private runDeferredCleanup(activeSessionId: string, entry: LocalAttachmentEntry): Promise<void> | undefined {
+		const cleanup = entry.deferredCleanup;
+		if (!cleanup) return undefined;
+		entry.deferredCleanup = undefined;
+		entry.attached = false;
+		this.deleteEmpty(activeSessionId, entry);
+		return cleanup();
+	}
+
+	private deleteEmpty(activeSessionId: string, entry: LocalAttachmentEntry | undefined): void {
+		if (entry && !entry.attached && entry.holders.size === 0 && entry.pending.size === 0 && !entry.deferredCleanup) {
+			this.entries.delete(activeSessionId);
+		}
+	}
+}
+
+const localAttachmentTrackers = new WeakMap<DaemonClient, LocalAttachmentTracker>();
+
+function getLocalAttachmentTracker(client: DaemonClient): LocalAttachmentTracker {
+	let tracker = localAttachmentTrackers.get(client);
+	if (!tracker) {
+		tracker = new LocalAttachmentTracker();
+		localAttachmentTrackers.set(client, tracker);
+	}
+	return tracker;
+}
+
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -217,6 +382,8 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly unsubscribeDaemonMessages: () => void;
 	private readonly unsubscribeDaemonClose: () => void;
 	private readonly clientId = `daemon-agent-connection:${randomUUID()}`;
+	private readonly attachmentOwner: LocalAttachmentOwner = {};
+	private readonly localAttachments: LocalAttachmentTracker;
 	private ownedSessionPromotionTail = Promise.resolve();
 	private lastEventCursor: DaemonEventCursor | undefined;
 	private readonly retiredEventGenerations = new Set<string>();
@@ -235,12 +402,11 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly completedSnapshots = new Map<string, DaemonSessionSnapshot>();
 	private readonly pendingBindingCatchupSnapshots = new Map<string, DaemonSessionSnapshot>();
 	private readonly pendingBindingCatchupFailures = new Set<string>();
-	private readonly pendingReattachActiveSessionIds = new Set<string>();
+	private readonly pendingBindingActiveSessionIds = new Set<string>();
 	private readonly snapshotRecoveryPromises = new Map<string, Promise<void>>();
 	private readonly ignoredSnapshotIds = new Set<string>();
 	private reconnectPromise?: Promise<void>;
 	private reviveSession?: { promise: Promise<RevivedSessionBinding>; sourceActiveSessionId: string };
-	private lastAttachCreatedAttachment = false;
 	/** undefined = not yet captured; null = captured for a fileless (in-memory) session. */
 	private reviveConfigSessionFile: string | null | undefined;
 	private lastAttachPublishedIdentity: { sessionId: string; sessionFile: string | undefined } | undefined;
@@ -254,6 +420,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		private activeSessionId: string,
 		private readonly options: DaemonAgentConnectionOptions = {},
 	) {
+		this.localAttachments = getLocalAttachmentTracker(client);
 		if (options.recoverDaemon) {
 			this.client.enableRequestRecovery();
 		}
@@ -271,6 +438,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		});
 		this.captureDaemonLogPath();
 		this.unsubscribeDaemonClose = this.client.onClose((error) => {
+			this.localAttachments.markAllServerDetached();
 			this.rejectSnapshotAssemblies(error);
 			if (this.disposed || this.terminalCloseEmitted) {
 				return;
@@ -330,10 +498,11 @@ export class DaemonAgentConnection implements AgentConnection {
 		// here is lost (the snapshot assembly then times out or rejects).
 		const admitPendingTarget = targetActiveSessionId !== entryActiveSessionId;
 		if (admitPendingTarget) {
-			this.pendingReattachActiveSessionIds.add(targetActiveSessionId);
+			this.pendingBindingActiveSessionIds.add(targetActiveSessionId);
 		}
+		let displacedActiveSessionId: string | undefined;
 		try {
-			await this.attachSessionBindingAdmitted(
+			displacedActiveSessionId = await this.attachSessionBindingAdmitted(
 				targetActiveSessionId,
 				resetCursors,
 				entryActiveSessionId,
@@ -358,10 +527,13 @@ export class DaemonAgentConnection implements AgentConnection {
 				this.latestSnapshotIsFresh = false;
 			}
 		} finally {
+			if (displacedActiveSessionId !== undefined) {
+				void this.releaseLocalAttachment(displacedActiveSessionId);
+			}
 			if (admitPendingTarget) {
 				// A failed or superseded transition discards its buffered
 				// catch-up and failure marker along with the admission.
-				this.pendingReattachActiveSessionIds.delete(targetActiveSessionId);
+				this.pendingBindingActiveSessionIds.delete(targetActiveSessionId);
 				this.pendingBindingCatchupSnapshots.delete(targetActiveSessionId);
 				this.pendingBindingCatchupFailures.delete(targetActiveSessionId);
 			}
@@ -373,39 +545,53 @@ export class DaemonAgentConnection implements AgentConnection {
 		resetCursors: boolean,
 		entryActiveSessionId: string,
 		resumeCursor: DaemonEventCursor | undefined,
-	): Promise<void> {
+	): Promise<string | undefined> {
 		const supportsExtensionUi = this.options.supportsExtensionUi !== false;
-		const result = await this.requestData<SessionSummary | DaemonAttachResult>({
-			type: "attach",
-			activeSessionId: targetActiveSessionId,
-			supportsExtensionUi,
-			clientId: this.clientId,
-			capabilities: [
-				"attach_snapshot",
-				"event_sequence",
-				...(supportsExtensionUi ? (["extension_ui"] as const) : []),
-				"slim_attach",
-				"chunked_snapshot",
-				...(this.options.ownedSession ? (["client_owned_sessions"] as const) : []),
-			],
-			env: this.options.sendClientEnv ? collectDaemonClientEnv() : undefined,
-			launchEnv: this.options.ownedSession ? collectDaemonLaunchEnv() : undefined,
-			telemetryDisabled: this.options.telemetryDisabled,
-			resumeCursor:
-				resumeCursor === undefined
-					? undefined
-					: {
-							activeSessionId: targetActiveSessionId,
-							...resumeCursor,
-						},
-		});
-		// Recorded before any supersession throw: cleanup paths need to know
-		// whether THIS attach created the socket's attachment entry (a sibling
-		// connection on the shared client may already hold it, in which case a
-		// detach would remove the sibling's subscription). Older daemons omit
-		// the field; the conservative default is "did not create it".
-		this.lastAttachCreatedAttachment = "wasAttached" in result && result.wasAttached === false;
+		const attachmentAttempt = this.localAttachments.begin(targetActiveSessionId);
+		let result: SessionSummary | DaemonAttachResult;
+		try {
+			result = await this.requestData<SessionSummary | DaemonAttachResult>({
+				type: "attach",
+				activeSessionId: targetActiveSessionId,
+				supportsExtensionUi,
+				clientId: this.clientId,
+				capabilities: [
+					"attach_snapshot",
+					"event_sequence",
+					...(supportsExtensionUi ? (["extension_ui"] as const) : []),
+					"slim_attach",
+					"chunked_snapshot",
+					...(this.options.ownedSession ? (["client_owned_sessions"] as const) : []),
+				],
+				env: this.options.sendClientEnv ? collectDaemonClientEnv() : undefined,
+				launchEnv: this.options.ownedSession ? collectDaemonLaunchEnv() : undefined,
+				telemetryDisabled: this.options.telemetryDisabled,
+				resumeCursor:
+					resumeCursor === undefined
+						? undefined
+						: {
+								activeSessionId: targetActiveSessionId,
+								...resumeCursor,
+							},
+			});
+		} catch (error) {
+			this.localAttachments.fail(attachmentAttempt);
+			throw error;
+		}
+		const attachCreatedAttachment = "wasAttached" in result && result.wasAttached === false;
 		if (this.activeSessionId !== entryActiveSessionId) {
+			// The response registered the socket attachment, but the binding can no
+			// longer publish. End the successful attempt and request its cleanup as
+			// one tracker transition so an earlier deferred cleanup is neither early
+			// nor duplicated. Legacy daemons cannot report ownership, so local
+			// refcounting is the conservative authority there.
+			this.localAttachments.abandon(
+				attachmentAttempt,
+				this.client.supportsServerCapability("attach_ownership") && !attachCreatedAttachment
+					? undefined
+					: () =>
+							this.requestOk({ type: "detach", activeSessionId: targetActiveSessionId }).catch(() => undefined),
+			);
 			throw new Error(`Session attach superseded: binding moved from ${entryActiveSessionId}`);
 		}
 		if (resetCursors) {
@@ -414,84 +600,93 @@ export class DaemonAgentConnection implements AgentConnection {
 			this.retiredEventGenerations.clear();
 		}
 		this.activeSessionId = getAttachActiveSessionId(result);
-		const summary = "snapshot" in result ? result.snapshot.summary : result;
-		this.attachedSessionId = summary.sessionId;
-		this.attachedSessionFile =
-			summary.sessionFile ?? ("snapshot" in result ? result.snapshot.state.sessionFile : undefined);
-		// The invocation's reviveConfig was computed for the transcript this
-		// connection first attached to; later transcripts (session switches)
-		// must not inherit its cwd. A fileless first attach (--no-session)
-		// records null so a transcript resumed later still counts as foreign -
-		// checked strictly against undefined because ??= would re-assign over
-		// the null marker on the next reconnect attach.
-		if (this.reviveConfigSessionFile === undefined) {
-			this.reviveConfigSessionFile = this.attachedSessionFile ?? null;
-		}
-		// Recorded before the snapshot await below: a replacement snapshot
-		// landing mid-stream can rewrite the attached identity, and a caller
-		// capturing it afterwards would adopt the switched transcript as its
-		// own.
-		this.lastAttachPublishedIdentity = { sessionId: summary.sessionId, sessionFile: this.attachedSessionFile };
-		this.captureDaemonLogPath();
-		this.updateReconnectFailed = false;
-		this.terminalCloseEmitted = false;
-		const attachCursor = getAttachLastEventCursor(result);
-		if (attachCursor) {
-			this.observeEventCursor(attachCursor);
-		}
-		this.lastEventSequence = maxEventSequence(this.lastEventSequence, getAttachLastEventSequence(result));
-		if ("snapshot" in result) {
-			const appliedActiveSessionId = this.activeSessionId;
-			const preAwaitSnapshot = this.latestSnapshot;
-			const snapshot = result.snapshotStream
-				? await this.waitForSnapshot(result.snapshotStream.id)
-				: result.snapshot;
-			if (this.activeSessionId !== appliedActiveSessionId) {
-				// A concurrent transition rebound the connection while the
-				// streamed snapshot was in flight; applying the late snapshot
-				// would describe a session this connection no longer shows.
-				throw new Error(`Session attach superseded: binding moved from ${appliedActiveSessionId}`);
+		const displacedActiveSessionId = this.publishLocalAttachment(attachmentAttempt);
+		try {
+			const summary = "snapshot" in result ? result.snapshot.summary : result;
+			this.attachedSessionId = summary.sessionId;
+			this.attachedSessionFile =
+				summary.sessionFile ?? ("snapshot" in result ? result.snapshot.state.sessionFile : undefined);
+			// The invocation's reviveConfig was computed for the transcript this
+			// connection first attached to; later transcripts (session switches)
+			// must not inherit its cwd. A fileless first attach (--no-session)
+			// records null so a transcript resumed later still counts as foreign -
+			// checked strictly against undefined because ??= would re-assign over
+			// the null marker on the next reconnect attach.
+			if (this.reviveConfigSessionFile === undefined) {
+				this.reviveConfigSessionFile = this.attachedSessionFile ?? null;
 			}
-			// The daemon can deliver the attach snapshot's end frame and a queued
-			// catch-up resync in one socket read; the resync then lands on the
-			// published binding via completeSnapshotAssembly before this
-			// continuation resumes. Newest wins by event sequence: overwriting
-			// it with the older attach snapshot would drop the intervening
-			// events. The identity checks come first because a sequence is only
-			// comparable within one session: an unchanged object can still
-			// describe the previous binding, and a live event's spread-copy can
-			// change the object while carrying the previous session's state.
-			// Freshness deliberately does NOT gate the choice - a live event
-			// clearing the flag must not resurrect the older attach snapshot.
-			const concurrent = this.latestSnapshot;
-			const concurrentSeq = concurrent?.lastEventSequence;
-			const keepConcurrentlyAppliedSnapshot =
-				concurrent !== undefined &&
-				concurrent !== preAwaitSnapshot &&
-				concurrent.state.sessionId === this.attachedSessionId &&
-				concurrentSeq !== undefined &&
-				(snapshot.lastEventSequence === undefined || concurrentSeq > snapshot.lastEventSequence);
-			if (!keepConcurrentlyAppliedSnapshot) {
-				this.latestSnapshot = mapDaemonSessionSnapshot(snapshot, result.replay);
-				if (this.lastEventSequence !== undefined) {
-					this.latestSnapshot.lastEventSequence = this.lastEventSequence;
-				}
-				if (this.lastEventCursor) {
-					this.latestSnapshot.lastEventCursor = this.lastEventCursor;
-				}
-				// A live event parsed between the snapshot's end frame and this
-				// continuation advanced the connection cursor past the snapshot's
-				// content; marking such a cache fresh would serve state whose
-				// stamped cursor claims it includes an event it does not. The
-				// invalidation is preserved so the next read re-reads.
-				this.latestSnapshotIsFresh =
-					this.lastEventSequence === undefined ||
-					snapshot.lastEventSequence === undefined ||
-					this.lastEventSequence <= snapshot.lastEventSequence;
+			// Recorded before the snapshot await below: a replacement snapshot
+			// landing mid-stream can rewrite the attached identity, and a caller
+			// capturing it afterwards would adopt the switched transcript as its
+			// own.
+			this.lastAttachPublishedIdentity = { sessionId: summary.sessionId, sessionFile: this.attachedSessionFile };
+			this.captureDaemonLogPath();
+			this.updateReconnectFailed = false;
+			this.terminalCloseEmitted = false;
+			const attachCursor = getAttachLastEventCursor(result);
+			if (attachCursor) {
+				this.observeEventCursor(attachCursor);
 			}
-		} else {
-			this.latestSnapshot = undefined;
-			this.latestSnapshotIsFresh = false;
+			this.lastEventSequence = maxEventSequence(this.lastEventSequence, getAttachLastEventSequence(result));
+			if ("snapshot" in result) {
+				const appliedActiveSessionId = this.activeSessionId;
+				const preAwaitSnapshot = this.latestSnapshot;
+				const snapshot = result.snapshotStream
+					? await this.waitForSnapshot(result.snapshotStream.id)
+					: result.snapshot;
+				if (this.activeSessionId !== appliedActiveSessionId) {
+					// A concurrent transition rebound the connection while the
+					// streamed snapshot was in flight; applying the late snapshot
+					// would describe a session this connection no longer shows.
+					throw new Error(`Session attach superseded: binding moved from ${appliedActiveSessionId}`);
+				}
+				// The daemon can deliver the attach snapshot's end frame and a queued
+				// catch-up resync in one socket read; the resync then lands on the
+				// published binding via completeSnapshotAssembly before this
+				// continuation resumes. Newest wins by event sequence: overwriting
+				// it with the older attach snapshot would drop the intervening
+				// events. The identity checks come first because a sequence is only
+				// comparable within one session: an unchanged object can still
+				// describe the previous binding, and a live event's spread-copy can
+				// change the object while carrying the previous session's state.
+				// Freshness deliberately does NOT gate the choice - a live event
+				// clearing the flag must not resurrect the older attach snapshot.
+				const concurrent = this.latestSnapshot;
+				const concurrentSeq = concurrent?.lastEventSequence;
+				const keepConcurrentlyAppliedSnapshot =
+					concurrent !== undefined &&
+					concurrent !== preAwaitSnapshot &&
+					concurrent.state.sessionId === this.attachedSessionId &&
+					concurrentSeq !== undefined &&
+					(snapshot.lastEventSequence === undefined || concurrentSeq > snapshot.lastEventSequence);
+				if (!keepConcurrentlyAppliedSnapshot) {
+					this.latestSnapshot = mapDaemonSessionSnapshot(snapshot, result.replay);
+					if (this.lastEventSequence !== undefined) {
+						this.latestSnapshot.lastEventSequence = this.lastEventSequence;
+					}
+					if (this.lastEventCursor) {
+						this.latestSnapshot.lastEventCursor = this.lastEventCursor;
+					}
+					// A live event parsed between the snapshot's end frame and this
+					// continuation advanced the connection cursor past the snapshot's
+					// content; marking such a cache fresh would serve state whose
+					// stamped cursor claims it includes an event it does not. The
+					// invalidation is preserved so the next read re-reads.
+					this.latestSnapshotIsFresh =
+						this.lastEventSequence === undefined ||
+						snapshot.lastEventSequence === undefined ||
+						this.lastEventSequence <= snapshot.lastEventSequence;
+				}
+			} else {
+				this.latestSnapshot = undefined;
+				this.latestSnapshotIsFresh = false;
+			}
+			return displacedActiveSessionId;
+		} catch (error) {
+			if (displacedActiveSessionId !== undefined) {
+				void this.releaseLocalAttachment(displacedActiveSessionId);
+			}
+			throw error;
 		}
 	}
 
@@ -992,7 +1187,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	/**
-	 * Resume this connection's saved session file into the daemon and reattach.
+	 * Resume this connection's saved session file into the daemon and attach to it.
 	 * The daemon's create-with-sessionPath is idempotent: a session that is
 	 * still (or again) resident is reused instead of resumed twice.
 	 *
@@ -1072,7 +1267,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			);
 			const revivedActiveSessionId = readCreatedActiveSessionId(summary);
 			if (this.disposed || this.disposing) {
-				this.releaseRevivedSession(revivedActiveSessionId, false);
+				this.releaseRevivedSession(revivedActiveSessionId);
 				throw new Error("Connection was disposed during session revival");
 			}
 			if (this.activeSessionId !== sourceActiveSessionId) {
@@ -1084,37 +1279,23 @@ export class DaemonAgentConnection implements AgentConnection {
 				// session file), releasing it would detach the currently
 				// published binding and leave the connection deaf to its events.
 				if (this.activeSessionId !== revivedActiveSessionId) {
-					this.releaseRevivedSession(revivedActiveSessionId, false);
+					this.releaseRevivedSession(revivedActiveSessionId);
 				}
 				throw new Error(`Session revival superseded: binding moved from ${sourceActiveSessionId}`);
 			}
 			try {
 				await this.attachSessionBinding(revivedActiveSessionId, true);
 			} catch (error) {
-				// Supersede errors are thrown after a successful attach response,
-				// and the response's wasAttached tells whether that attach CREATED
-				// the socket's attachment entry - a sibling connection may already
-				// have held it, in which case a detach would remove the sibling's
-				// subscription rather than ours. Reliance on the field is gated on
-				// the negotiated capability: a pre-revision-15 daemon never
-				// reports ownership, and skipping the detach there would leave a
-				// stale attachment that blocks the worker's idle eviction until
-				// the socket closes - so legacy daemons keep the historical
-				// unconditional detach instead.
-				const attachAcquired =
-					DaemonAgentConnection.isAttachSupersededError(error) &&
-					(this.client.supportsServerCapability("attach_ownership") ? this.lastAttachCreatedAttachment : true);
 				if (this.disposed || this.disposing) {
-					this.releaseRevivedSession(revivedActiveSessionId, attachAcquired);
+					this.releaseRevivedSession(revivedActiveSessionId);
 					throw error;
 				}
 				if (this.activeSessionId !== revivedActiveSessionId) {
-					// The attach did not publish the revived binding (transient
-					// failure or supersession); drop the attachment bookkeeping
-					// only when this attach actually registered it, and complete
-					// an owned revived worker so it cannot outlive the failed
-					// revival.
-					this.releaseRevivedSession(revivedActiveSessionId, attachAcquired);
+					// A failed request acquired nothing; a successful superseded
+					// attempt already finalized its tracker cleanup transaction.
+					// Complete an owned revived worker so it cannot outlive the
+					// failed revival.
+					this.releaseRevivedSession(revivedActiveSessionId);
 					throw error;
 				}
 				// The attach response was applied — the binding is published and
@@ -1148,21 +1329,10 @@ export class DaemonAgentConnection implements AgentConnection {
 			}
 			this.activeSideQuestionIds.clear();
 			if (this.disposed) {
-				// The attach succeeded, but it only ACQUIRED the attachment when it
-				// created the socket entry; a sibling's pre-existing attachment
-				// must survive this cleanup. Without the negotiated ownership
-				// report, legacy daemons keep the historical unconditional detach.
-				this.releaseRevivedSession(
-					revivedActiveSessionId,
-					this.client.supportsServerCapability("attach_ownership") ? this.lastAttachCreatedAttachment : true,
-				);
+				// publishLocalAttachment already released a non-owned binding (or
+				// forgot an owned one) when disposal won the race.
+				this.releaseRevivedSession(revivedActiveSessionId);
 				throw new Error("Connection was disposed during session revival");
-			}
-			if (sourceActiveSessionId !== revivedActiveSessionId) {
-				// The dead id lingers in the shared socket client's attachment
-				// bookkeeping; the supervisor's detach cleans it even when no
-				// worker matches the selector anymore.
-				void this.requestOk({ type: "detach", activeSessionId: sourceActiveSessionId }).catch(() => undefined);
 			}
 			// The emission must verify the full binding identity, not just the
 			// id: an in-worker switch landing during the snapshot read keeps the
@@ -1212,45 +1382,34 @@ export class DaemonAgentConnection implements AgentConnection {
 		})();
 	}
 
-	/**
-	 * Best-effort cleanup for a session revived after disposal began or after
-	 * the revival was superseded: dispose() only released the previous
-	 * binding, so an owned revived session would otherwise outlive this
-	 * connection indefinitely.
-	 *
-	 * The detach is conditional on THIS revival having acquired the socket
-	 * attachment. The supervisor tracks attachedActiveSessionIds once per
-	 * socket (no refcount), and a DaemonClient can be shared by sibling
-	 * connections: detaching an id we never attached would deafen a sibling
-	 * attached to the session the create returned. create alone never
-	 * attaches — only attachSessionBinding does — so pre-attach call-sites
-	 * pass false. Completing an owned session stays unconditional: the create
-	 * claimed ownership regardless of any attachment.
-	 */
-	private releaseRevivedSession(revivedActiveSessionId: string, detachAttachment: boolean): void {
+	/** Complete an owned worker that a failed or superseded revival created. */
+	private releaseRevivedSession(revivedActiveSessionId: string): void {
 		if (this.options.ownedSession) {
 			void this.requestOk({ type: "complete_owned_session", activeSessionId: revivedActiveSessionId }).catch(
 				() => undefined,
 			);
 		}
-		if (detachAttachment) {
-			void this.requestOk({ type: "detach", activeSessionId: revivedActiveSessionId }).catch(() => undefined);
-		}
 	}
 
-	/**
-	 * attachSessionBinding throws its supersession errors strictly AFTER a
-	 * successful attach response — i.e. after the supervisor registered this
-	 * socket's attachment. Any other attach failure (transport, rejected
-	 * request) acquired nothing. A server-side registration whose response
-	 * was lost client-side without a supersede error is the residual
-	 * trade-off: it may leave a stale socket attachment (inflating the
-	 * supervisor's attachedClients until the socket closes) but cannot
-	 * deafen a sibling connection; with a per-socket attachment Set both
-	 * cannot be avoided at once, and deafening a live sibling is worse.
-	 */
-	private static isAttachSupersededError(error: unknown): boolean {
-		return error instanceof Error && error.message.startsWith("Session attach superseded");
+	private publishLocalAttachment(attempt: LocalAttachmentAttempt): string | undefined {
+		const displacedActiveSessionId = this.localAttachments.commit(this.attachmentOwner, attempt);
+		if (!this.disposed) return displacedActiveSessionId;
+		if (this.options.ownedSession) {
+			this.localAttachments.forget(this.attachmentOwner);
+			return displacedActiveSessionId;
+		}
+		void this.localAttachments.release(this.attachmentOwner, attempt.activeSessionId, (releasedActiveSessionId) =>
+			this.requestOk({ type: "detach", activeSessionId: releasedActiveSessionId }).catch(() => undefined),
+		);
+		return displacedActiveSessionId;
+	}
+
+	private releaseLocalAttachment(activeSessionId: string): Promise<void> | undefined {
+		return this.localAttachments.requestCleanup(
+			activeSessionId,
+			() => this.requestOk({ type: "detach", activeSessionId }).catch(() => undefined),
+			true,
+		);
 	}
 
 	private async promptWithAdmissionCancellation(
@@ -1624,7 +1783,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (error.activeSessionId === sourceActiveSessionId) {
 				return { cancelled: false };
 			}
-			const result = await this.reattachSession(sourceActiveSessionId, error.activeSessionId);
+			const result = await this.attachLiveSession(error.activeSessionId);
 			if (options?.cwdOverride) {
 				// The transcript is live under another worker, but the user still
 				// selected a fallback cwd because its recorded directory is
@@ -1638,82 +1797,16 @@ export class DaemonAgentConnection implements AgentConnection {
 		}
 	}
 
-	private async reattachSession(
-		sourceActiveSessionId: string,
-		targetActiveSessionId: string,
-	): Promise<{ cancelled: false }> {
-		const previousState = {
-			lastEventCursor: this.lastEventCursor,
-			lastEventSequence: this.lastEventSequence,
-			latestSnapshot: this.latestSnapshot,
-			latestSnapshotIsFresh: this.latestSnapshotIsFresh,
-			retiredEventGenerations: new Set(this.retiredEventGenerations),
-		};
-		this.activeSessionId = targetActiveSessionId;
-		this.lastEventCursor = undefined;
-		this.lastEventSequence = undefined;
-		this.latestSnapshot = undefined;
-		this.latestSnapshotIsFresh = false;
-		this.retiredEventGenerations.clear();
-		this.pendingReattachActiveSessionIds.add(targetActiveSessionId);
-		let reattached = false;
-		try {
-			const supportsExtensionUi = this.options.supportsExtensionUi !== false;
-			const result = await this.requestData<DaemonAttachResult>({
-				type: "reattach",
-				activeSessionId: sourceActiveSessionId,
-				targetActiveSessionId,
-				supportsExtensionUi,
-				clientId: this.clientId,
-				capabilities: [
-					"attach_snapshot",
-					"event_sequence",
-					...(supportsExtensionUi ? (["extension_ui"] as const) : []),
-					"slim_attach",
-					"chunked_snapshot",
-					...(this.options.ownedSession ? (["client_owned_sessions"] as const) : []),
-				],
-				env: this.options.sendClientEnv ? collectDaemonClientEnv() : undefined,
-				launchEnv: this.options.ownedSession ? collectDaemonLaunchEnv() : undefined,
-				telemetryDisabled: this.options.telemetryDisabled,
-			});
-			reattached = true;
-			this.activeSessionId = result.activeSessionId;
-			this.activeSideQuestionIds.clear();
-			if (result.snapshotStream) {
-				try {
-					await this.waitForSnapshot(result.snapshotStream.id);
-				} catch (snapshotError) {
-					await this.snapshotRecoveryPromises.get(result.snapshotStream.id);
-					if (!this.latestSnapshotIsFresh) {
-						throw snapshotError;
-					}
-				}
-			} else {
-				this.applyReplacementSnapshot(result.snapshot, result.replay);
-				await this.emit({
-					type: "session_replaced",
-					state: result.snapshot.state,
-					messages: result.snapshot.messages,
-				});
-			}
-			return { cancelled: false };
-		} catch (error) {
-			if (!reattached) {
-				this.activeSessionId = sourceActiveSessionId;
-				this.lastEventCursor = previousState.lastEventCursor;
-				this.lastEventSequence = previousState.lastEventSequence;
-				this.latestSnapshot = previousState.latestSnapshot;
-				this.latestSnapshotIsFresh = previousState.latestSnapshotIsFresh;
-				this.retiredEventGenerations.clear();
-				for (const generation of previousState.retiredEventGenerations) {
-					this.retiredEventGenerations.add(generation);
-				}
-			}
-			throw error;
-		} finally {
-			this.pendingReattachActiveSessionIds.delete(targetActiveSessionId);
-		}
+	private async attachLiveSession(targetActiveSessionId: string): Promise<{ cancelled: false }> {
+		await this.attachSessionBinding(targetActiveSessionId, true);
+		this.activeSideQuestionIds.clear();
+		const snapshot = await this.getInitialSnapshot();
+		await this.emit({
+			type: "session_replaced",
+			state: snapshot.state,
+			messages: snapshot.messages,
+		});
+		return { cancelled: false };
 	}
 
 	async fork(
@@ -1836,12 +1929,16 @@ export class DaemonAgentConnection implements AgentConnection {
 		await Promise.allSettled([...this.activeSideQuestionIds].map((id) => this.abortSideQuestion(id)));
 		this.unsubscribeDaemonMessages();
 		this.unsubscribeDaemonClose();
+		const disposeActiveSessionId = this.activeSessionId;
 		if (this.options.ownedSession) {
-			await this.requestOk({ type: "complete_owned_session", activeSessionId: this.activeSessionId }).catch(
+			this.localAttachments.forget(this.attachmentOwner);
+			await this.requestOk({ type: "complete_owned_session", activeSessionId: disposeActiveSessionId }).catch(
 				() => undefined,
 			);
 		} else {
-			await this.requestOk({ type: "detach", activeSessionId: this.activeSessionId }).catch(() => undefined);
+			await this.localAttachments.release(this.attachmentOwner, disposeActiveSessionId, (releasedActiveSessionId) =>
+				this.requestOk({ type: "detach", activeSessionId: releasedActiveSessionId }).catch(() => undefined),
+			);
 		}
 		if (this.options.closeClientOnDispose) {
 			this.client.close();
@@ -1982,7 +2079,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			// supersession the marker is discarded.
 			const isPendingCatchupFailure =
 				(purpose === "replacement" || purpose === "resync") && message.activeSessionId !== this.activeSessionId;
-			if (isPendingCatchupFailure && this.pendingReattachActiveSessionIds.has(message.activeSessionId)) {
+			if (isPendingCatchupFailure && this.pendingBindingActiveSessionIds.has(message.activeSessionId)) {
 				this.pendingBindingCatchupFailures.add(message.activeSessionId);
 				// Newest wins in both directions: this failure is newer than any
 				// buffered success, whose snapshot now predates the events the
@@ -2436,7 +2533,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		clearTimeout(assembly.timeout);
 		if (purpose !== "attach") {
 			this.snapshotAssemblies.delete(message.snapshotId);
-			if (this.pendingReattachActiveSessionIds.has(message.activeSessionId)) {
+			if (this.pendingBindingActiveSessionIds.has(message.activeSessionId)) {
 				this.completedSnapshots.set(message.snapshotId, snapshot);
 				while (this.completedSnapshots.size > MAX_COMPLETED_SNAPSHOTS) {
 					const oldest = this.completedSnapshots.keys().next().value;
@@ -2496,7 +2593,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		// supersession they belong to a session this window no longer shows.
 		return (
 			message.activeSessionId !== undefined &&
-			this.pendingReattachActiveSessionIds.has(message.activeSessionId) &&
+			this.pendingBindingActiveSessionIds.has(message.activeSessionId) &&
 			isSnapshotTransferMessage(message)
 		);
 	}

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -945,8 +945,10 @@ export class DaemonAgentConnection implements AgentConnection {
 				if (this.activeSessionId !== revivedActiveSessionId) {
 					// The attach did not publish the revived binding (transient
 					// failure or supersession); drop any server-side attachment
-					// bookkeeping the request may have registered before failing.
-					void this.requestOk({ type: "detach", activeSessionId: revivedActiveSessionId }).catch(() => undefined);
+					// bookkeeping the request may have registered before failing,
+					// and complete an owned revived worker so it cannot outlive
+					// the failed revival.
+					this.releaseRevivedSession(revivedActiveSessionId);
 					throw error;
 				}
 				// The attach response was applied — the binding is published and

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -1757,8 +1757,14 @@ export class DaemonAgentConnection implements AgentConnection {
 			const assembly = this.getSnapshotAssembly(message.snapshotId);
 			const purpose = assembly.begin?.purpose ?? "attach";
 			const snapshotError = new Error(message.error);
+			// Recovery re-reads state for the PUBLISHED binding; running it for a
+			// pending transition target would query the old (typically archived)
+			// selector and could emit a terminal close while the transition can
+			// still succeed. A failed pending catch-up needs no recovery: once
+			// the binding publishes, the transition re-reads fresh state anyway,
+			// and on supersession the buffered state is discarded.
 			const recoveryPromise =
-				purpose === "replacement" || purpose === "resync"
+				(purpose === "replacement" || purpose === "resync") && message.activeSessionId === this.activeSessionId
 					? this.recoverFailedSnapshot(purpose, snapshotError)
 					: undefined;
 			if (recoveryPromise) {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -97,6 +97,8 @@ interface DaemonSnapshotAssembly {
 
 export const DAEMON_REFINE_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+const REVIVAL_RESYNC_RETRY_MS = 250;
+const REVIVAL_RESYNC_MAX_ATTEMPTS = 8;
 export const DAEMON_RECONNECT_TIMEOUT_MS = 60_000;
 export const DAEMON_SNAPSHOT_TIMEOUT_MS = 30_000;
 const MAX_IGNORED_SNAPSHOT_IDS = 128;
@@ -227,6 +229,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly snapshotRecoveryPromises = new Map<string, Promise<void>>();
 	private readonly ignoredSnapshotIds = new Set<string>();
 	private reconnectPromise?: Promise<void>;
+	private reviveSession?: { promise: Promise<void>; sourceActiveSessionId: string };
 	private readonly definitiveRequestErrors = new WeakSet<Error>();
 	private disposing = false;
 	private disposed = false;
@@ -293,10 +296,51 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async attach(): Promise<void> {
+		await this.attachSessionBinding(this.activeSessionId, false);
+	}
+
+	/**
+	 * Attach to targetActiveSessionId and publish it as this connection's
+	 * binding only once the attach response has been applied. If another
+	 * lifecycle transition (revival, reconnect, update recovery, session
+	 * switch) rebinds the connection while the request is in flight, the
+	 * stale response is rejected instead of rebinding backwards, and the
+	 * current binding is left untouched.
+	 */
+	private async attachSessionBinding(targetActiveSessionId: string, resetCursors: boolean): Promise<void> {
+		const entryActiveSessionId = this.activeSessionId;
+		const resumeCursor = resetCursors ? undefined : this.lastEventCursor;
+		// Admit the target's frames before the request goes out: response and
+		// snapshot frames can share one socket buffer, and a frame filtered out
+		// here is lost (the snapshot assembly then times out or rejects).
+		const admitPendingTarget = targetActiveSessionId !== entryActiveSessionId;
+		if (admitPendingTarget) {
+			this.pendingReattachActiveSessionIds.add(targetActiveSessionId);
+		}
+		try {
+			await this.attachSessionBindingAdmitted(
+				targetActiveSessionId,
+				resetCursors,
+				entryActiveSessionId,
+				resumeCursor,
+			);
+		} finally {
+			if (admitPendingTarget) {
+				this.pendingReattachActiveSessionIds.delete(targetActiveSessionId);
+			}
+		}
+	}
+
+	private async attachSessionBindingAdmitted(
+		targetActiveSessionId: string,
+		resetCursors: boolean,
+		entryActiveSessionId: string,
+		resumeCursor: DaemonEventCursor | undefined,
+	): Promise<void> {
 		const supportsExtensionUi = this.options.supportsExtensionUi !== false;
 		const result = await this.requestData<SessionSummary | DaemonAttachResult>({
 			type: "attach",
-			activeSessionId: this.activeSessionId,
+			activeSessionId: targetActiveSessionId,
 			supportsExtensionUi,
 			clientId: this.clientId,
 			capabilities: [
@@ -311,13 +355,21 @@ export class DaemonAgentConnection implements AgentConnection {
 			launchEnv: this.options.ownedSession ? collectDaemonLaunchEnv() : undefined,
 			telemetryDisabled: this.options.telemetryDisabled,
 			resumeCursor:
-				this.lastEventCursor === undefined
+				resumeCursor === undefined
 					? undefined
 					: {
-							activeSessionId: this.activeSessionId,
-							...this.lastEventCursor,
+							activeSessionId: targetActiveSessionId,
+							...resumeCursor,
 						},
 		});
+		if (this.activeSessionId !== entryActiveSessionId) {
+			throw new Error(`Session attach superseded: binding moved from ${entryActiveSessionId}`);
+		}
+		if (resetCursors) {
+			this.lastEventSequence = undefined;
+			this.lastEventCursor = undefined;
+			this.retiredEventGenerations.clear();
+		}
 		this.activeSessionId = getAttachActiveSessionId(result);
 		const summary = "snapshot" in result ? result.snapshot.summary : result;
 		this.attachedSessionId = summary.sessionId;
@@ -732,11 +784,219 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async prompt(message: string, options?: AgentConnectionPromptOptions): Promise<void> {
-		await this.promptWithAdmissionCancellation("prompt", message, options);
+		await this.promptWithSessionRevival("prompt", message, options);
 	}
 
 	async promptAndWait(message: string, options?: AgentConnectionPromptOptions): Promise<void> {
-		await this.promptWithAdmissionCancellation("prompt_and_wait", message, options);
+		await this.promptWithSessionRevival("prompt_and_wait", message, options);
+	}
+
+	/**
+	 * Deliver a prompt, transparently reviving the session from its saved
+	 * session file when the daemon no longer has it resident.
+	 *
+	 * A window can outlive its session: the daemon archives an RLM subagent
+	 * after it delivers its final answer, evicts idle workers, and parents
+	 * delete finished children. Without revival every keystroke in a window
+	 * attached to such a session dead-ends in "Unknown active session" even
+	 * though the transcript is saved and resumable — the exact affordance the
+	 * agents view already offers via resume-on-open and resume-on-reply.
+	 * Typing a message is an explicit "continue this session" request, so it
+	 * gets the same treatment here. That deliberately includes sessions the
+	 * daemon reported as killed: the agents view reply flow already resumes
+	 * those, and a revived transcript is strictly recoverable.
+	 */
+	private async promptWithSessionRevival(
+		type: "prompt" | "prompt_and_wait",
+		message: string,
+		options?: AgentConnectionPromptOptions,
+	): Promise<void> {
+		const attemptedActiveSessionId = this.activeSessionId;
+		try {
+			await this.promptWithAdmissionCancellation(type, message, options);
+		} catch (error) {
+			if (!this.canReviveFromSavedSession(error, attemptedActiveSessionId)) {
+				throw error;
+			}
+			if (this.activeSessionId === attemptedActiveSessionId) {
+				try {
+					await this.reviveFromSavedSession();
+				} catch {
+					// Surface the original unknown-session error: it names the session
+					// the caller targeted, which is more actionable than a revival
+					// failure for a session that may have been deleted outright.
+					throw error;
+				}
+				await this.promptWithAdmissionCancellation(type, message, options);
+				return;
+			}
+			// The binding moved while this prompt was in flight. Join only a
+			// sibling revival of the SAME session this prompt targeted; joining
+			// any other transition (a revival of a different session, an explicit
+			// session switch) would inject this prompt into another transcript.
+			const revival = this.reviveSession;
+			if (!revival || revival.sourceActiveSessionId !== attemptedActiveSessionId) {
+				throw error;
+			}
+			try {
+				await revival.promise;
+			} catch {
+				throw error;
+			}
+			await this.promptWithAdmissionCancellation(type, message, options);
+		}
+	}
+
+	private canReviveFromSavedSession(error: unknown, attemptedActiveSessionId: string): boolean {
+		return (
+			!this.disposed &&
+			!this.disposing &&
+			this.attachedSessionFile !== undefined &&
+			error instanceof Error &&
+			// Exact match, bound to the id this prompt actually targeted: an
+			// unknown-session error about any other selector (another target id,
+			// or an id this one merely prefixes) must not trigger a revival.
+			error.message === `Unknown active session: ${attemptedActiveSessionId}`
+		);
+	}
+
+	/**
+	 * Resume this connection's saved session file into the daemon and reattach.
+	 * The daemon's create-with-sessionPath is idempotent: a session that is
+	 * still (or again) resident is reused instead of resumed twice.
+	 *
+	 * The revived binding is never published early: the connection keeps its
+	 * previous binding until the attach to the revived session has succeeded,
+	 * so no concurrently started prompt can target a session this client has
+	 * not attached to, and there is no rollback that could stomp a newer
+	 * binding installed by a concurrent transition (session switch, reconnect,
+	 * update recovery). A revival superseded by such a transition fails and
+	 * leaves the newer binding untouched.
+	 */
+	private reviveFromSavedSession(): Promise<void> {
+		if (this.reviveSession) {
+			return this.reviveSession.promise;
+		}
+		const sourceActiveSessionId = this.activeSessionId;
+		const revival = (async () => {
+			// Lifecycle transitions (daemon reconnect, update recovery) rebind the
+			// same state this revival reads; let any in-flight one settle first.
+			await this.updateReconnectPromise?.catch(() => undefined);
+			await this.reconnectPromise?.catch(() => undefined);
+			const sessionFile = this.attachedSessionFile;
+			if (!sessionFile) {
+				throw new Error("The session is no longer active and has no saved session file to resume");
+			}
+			if (this.activeSessionId !== sourceActiveSessionId) {
+				throw new Error(`Session revival superseded: binding moved from ${sourceActiveSessionId}`);
+			}
+			const summary = await this.requestData<unknown>(
+				{
+					type: "create",
+					sessionPath: sessionFile,
+					continueRecent: false,
+					...(this.options.ownedSession ? { lifecycle: "client_owned" as const } : {}),
+				},
+				DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS,
+			);
+			const revivedActiveSessionId = readCreatedActiveSessionId(summary);
+			if (this.disposed || this.disposing) {
+				this.releaseRevivedSession(revivedActiveSessionId);
+				throw new Error("Connection was disposed during session revival");
+			}
+			if (this.activeSessionId !== sourceActiveSessionId) {
+				// A concurrent transition rebound the connection while the daemon
+				// was resuming the session; the newer binding wins. The revived
+				// worker stays resident for the idle sweeps unless it is owned.
+				this.releaseRevivedSession(revivedActiveSessionId);
+				throw new Error(`Session revival superseded: binding moved from ${sourceActiveSessionId}`);
+			}
+			try {
+				await this.attachSessionBinding(revivedActiveSessionId, true);
+			} catch (error) {
+				if (this.disposed || this.disposing) {
+					this.releaseRevivedSession(revivedActiveSessionId);
+				} else if (this.activeSessionId !== revivedActiveSessionId) {
+					// The attach did not publish the revived binding (transient
+					// failure or supersession); drop any server-side attachment
+					// bookkeeping the request may have registered before failing.
+					void this.requestOk({ type: "detach", activeSessionId: revivedActiveSessionId }).catch(() => undefined);
+				}
+				throw error;
+			}
+			let snapshot: AgentConnectionSnapshot | undefined;
+			try {
+				snapshot = await this.getInitialSnapshot();
+			} catch {
+				// The connection is coherently bound AND attached to the revived
+				// session (a legacy attach result leaves the snapshot to separate
+				// reads, which can fail transiently); only the resync emission is
+				// missing. Retry it in the background instead of failing a revival
+				// whose prompts already work.
+				this.scheduleRevivalResync(this.activeSessionId);
+			}
+			this.activeSideQuestionIds.clear();
+			if (this.disposed) {
+				return;
+			}
+			if (sourceActiveSessionId !== revivedActiveSessionId) {
+				// The dead id lingers in the shared socket client's attachment
+				// bookkeeping; the supervisor's detach cleans it even when no
+				// worker matches the selector anymore.
+				void this.requestOk({ type: "detach", activeSessionId: sourceActiveSessionId }).catch(() => undefined);
+			}
+			if (snapshot) {
+				void this.emit({ type: "session_resynced", snapshot });
+			}
+		})().finally(() => {
+			if (this.reviveSession?.promise === revival) {
+				this.reviveSession = undefined;
+			}
+		});
+		this.reviveSession = { promise: revival, sourceActiveSessionId };
+		return revival;
+	}
+
+	/**
+	 * The revival attached successfully but its resync snapshot read failed;
+	 * without the session_resynced emission the window keeps rendering the
+	 * dead transcript even though prompts already reach the revived session.
+	 * Retry in the background until the snapshot lands or the binding moves.
+	 */
+	private scheduleRevivalResync(revivedActiveSessionId: string): void {
+		void (async () => {
+			for (let attempt = 1; attempt <= REVIVAL_RESYNC_MAX_ATTEMPTS; attempt++) {
+				await delay(attempt * REVIVAL_RESYNC_RETRY_MS);
+				if (this.disposed || this.activeSessionId !== revivedActiveSessionId) {
+					return;
+				}
+				try {
+					const snapshot = await this.getInitialSnapshot();
+					if (this.disposed || this.activeSessionId !== revivedActiveSessionId) {
+						return;
+					}
+					void this.emit({ type: "session_resynced", snapshot });
+					return;
+				} catch {
+					// Keep retrying: the next prompt cannot repair the stale render.
+				}
+			}
+		})();
+	}
+
+	/**
+	 * Best-effort cleanup for a session revived after disposal began or after
+	 * the revival was superseded: dispose() only released the previous
+	 * binding, so an owned revived session would otherwise outlive this
+	 * connection indefinitely.
+	 */
+	private releaseRevivedSession(revivedActiveSessionId: string): void {
+		if (this.options.ownedSession) {
+			void this.requestOk({ type: "complete_owned_session", activeSessionId: revivedActiveSessionId }).catch(
+				() => undefined,
+			);
+		}
+		void this.requestOk({ type: "detach", activeSessionId: revivedActiveSessionId }).catch(() => undefined);
 	}
 
 	private async promptWithAdmissionCancellation(
@@ -1911,7 +2171,14 @@ export class DaemonAgentConnection implements AgentConnection {
 		if (!("activeSessionId" in message)) {
 			return false;
 		}
-		return message.activeSessionId === this.activeSessionId;
+		// A binding transition's target is admitted alongside the published
+		// binding: the daemon starts streaming the target's attach snapshot in
+		// the same socket buffer as the attach response, so its frames can be
+		// parsed before the awaiting continuation publishes the new binding.
+		return (
+			message.activeSessionId === this.activeSessionId ||
+			(message.activeSessionId !== undefined && this.pendingReattachActiveSessionIds.has(message.activeSessionId))
+		);
 	}
 
 	private isStaleSequencedMessage(message: DaemonOutbound): boolean {
@@ -1976,6 +2243,23 @@ export class DaemonAgentConnection implements AgentConnection {
 			this.activeSideQuestionIds.delete(event.id);
 		}
 	}
+}
+
+function readCreatedActiveSessionId(value: unknown): string {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("Daemon returned an invalid session summary");
+	}
+	const summary = value as { id?: unknown; activeSessionId?: unknown };
+	const activeSessionId =
+		typeof summary.activeSessionId === "string"
+			? summary.activeSessionId
+			: typeof summary.id === "string"
+				? summary.id
+				: undefined;
+	if (!activeSessionId) {
+		throw new Error("Daemon returned a revived session without an active session id");
+	}
+	return activeSessionId;
 }
 
 function readSessionSummaries(value: unknown): SessionSummary[] {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -1074,7 +1074,7 @@ export class DaemonAgentConnection implements AgentConnection {
 				// reads, which can fail transiently); only the resync emission is
 				// missing. Retry it in the background instead of failing a revival
 				// whose prompts already work.
-				this.scheduleRevivalResync(revivedActiveSessionId);
+				this.scheduleRevivalResync(revivedBinding);
 			}
 			this.activeSideQuestionIds.clear();
 			if (this.disposed) {
@@ -1113,16 +1113,20 @@ export class DaemonAgentConnection implements AgentConnection {
 	 * dead transcript even though prompts already reach the revived session.
 	 * Retry in the background until the snapshot lands or the binding moves.
 	 */
-	private scheduleRevivalResync(revivedActiveSessionId: string): void {
+	private scheduleRevivalResync(revivedBinding: RevivedSessionBinding): void {
 		void (async () => {
 			for (let attempt = 1; attempt <= REVIVAL_RESYNC_MAX_ATTEMPTS; attempt++) {
 				await delay(attempt * REVIVAL_RESYNC_RETRY_MS);
-				if (this.disposed || this.activeSessionId !== revivedActiveSessionId) {
+				// The full transcript identity gates every step: an in-worker
+				// switch replaces the transcript WITHOUT changing the active id,
+				// and emitting a pre-switch snapshot after its session_replaced
+				// would revert the window.
+				if (this.disposed || !this.matchesRevivedBinding(revivedBinding)) {
 					return;
 				}
 				try {
 					const snapshot = await this.getInitialSnapshot();
-					if (this.disposed || this.activeSessionId !== revivedActiveSessionId) {
+					if (this.disposed || !this.matchesRevivedBinding(revivedBinding)) {
 						return;
 					}
 					void this.emit({ type: "session_resynced", snapshot });

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -1076,7 +1076,11 @@ export class DaemonAgentConnection implements AgentConnection {
 				// worker matches the selector anymore.
 				void this.requestOk({ type: "detach", activeSessionId: sourceActiveSessionId }).catch(() => undefined);
 			}
-			if (snapshot && this.activeSessionId === revivedActiveSessionId) {
+			// The emission must verify the full binding identity, not just the
+			// id: an in-worker switch landing during the snapshot read keeps the
+			// active id but replaces the transcript, and emitting the pre-switch
+			// snapshot after its session_replaced would revert the window.
+			if (snapshot && this.matchesRevivedBinding(revivedBinding)) {
 				void this.emit({ type: "session_resynced", snapshot });
 			}
 			return revivedBinding;

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -2215,13 +2215,21 @@ export class DaemonAgentConnection implements AgentConnection {
 		if (!("activeSessionId" in message)) {
 			return false;
 		}
+		if (message.activeSessionId === this.activeSessionId) {
+			return true;
+		}
 		// A binding transition's target is admitted alongside the published
-		// binding: the daemon starts streaming the target's attach snapshot in
-		// the same socket buffer as the attach response, so its frames can be
-		// parsed before the awaiting continuation publishes the new binding.
+		// binding, but ONLY for snapshot transfer frames: the daemon starts
+		// streaming the target's attach snapshot in the same socket buffer as
+		// the attach response, so those frames can be parsed before the
+		// awaiting continuation publishes the new binding. Live frames
+		// (session_event, session_status, session_closed, ...) for a pending
+		// target must not be processed against the published binding — after a
+		// supersession they belong to a session this window no longer shows.
 		return (
-			message.activeSessionId === this.activeSessionId ||
-			(message.activeSessionId !== undefined && this.pendingReattachActiveSessionIds.has(message.activeSessionId))
+			message.activeSessionId !== undefined &&
+			this.pendingReattachActiveSessionIds.has(message.activeSessionId) &&
+			isSnapshotTransferMessage(message)
 		);
 	}
 
@@ -2287,6 +2295,15 @@ export class DaemonAgentConnection implements AgentConnection {
 			this.activeSideQuestionIds.delete(event.id);
 		}
 	}
+}
+
+function isSnapshotTransferMessage(message: DaemonOutbound): boolean {
+	return (
+		message.type === "session_snapshot_begin" ||
+		message.type === "session_snapshot_chunk" ||
+		message.type === "session_snapshot_end" ||
+		message.type === "session_snapshot_failed"
+	);
 }
 
 function readCreatedActiveSessionId(value: unknown): string {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -4,6 +4,7 @@ import type { ImageContent, ServiceTier, Transport } from "@earendil-works/pi-ai
 import { appendRotatingLog, getAgentLogPath, getDaemonLogPath } from "../../config.js";
 import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { AgentSessionEvent } from "../../core/agent-session.js";
+import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
@@ -171,6 +172,13 @@ export interface DaemonAgentConnectionOptions {
 	ownedSession?: boolean;
 	/** Require the target worker to have been created with telemetry disabled. */
 	telemetryDisabled?: true;
+	/**
+	 * Runtime config to recreate the session with when a prompt revives it
+	 * from its saved session file. Without it the daemon merges against its
+	 * defaults, so the revived worker can silently run with different tools,
+	 * system prompt, or model than the invocation that owns this window.
+	 */
+	reviveConfig?: AgentSessionRuntimeConfig;
 }
 
 /**
@@ -995,17 +1003,32 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (this.activeSessionId !== sourceActiveSessionId) {
 				throw new Error(`Session revival superseded: binding moved from ${sourceActiveSessionId}`);
 			}
+			// Mirror the original create's launch context: without the runtime
+			// config the daemon merges against its defaults, and without the
+			// client environment extensions load without the invocation's pane
+			// identity - the retried prompt could silently run with different
+			// tools, system prompt, or model. The telemetry opt-out is folded in
+			// regardless: without it the worker starts under the daemon's default
+			// policy and assertTelemetryAttachAllowed rejects the attach after
+			// the worker already launched.
+			const reviveConfig = this.options.reviveConfig
+				? {
+						...this.options.reviveConfig,
+						...(this.options.telemetryDisabled ? { telemetryDisabled: true as const } : {}),
+					}
+				: this.options.telemetryDisabled
+					? { telemetryDisabled: true as const }
+					: undefined;
 			const summary = await this.requestData<unknown>(
 				{
 					type: "create",
 					sessionPath: sessionFile,
 					continueRecent: false,
-					// The revived worker must carry this invocation's telemetry
-					// opt-out: without it the worker starts under the daemon's
-					// default policy and assertTelemetryAttachAllowed rejects the
-					// attach after the worker already launched.
-					...(this.options.telemetryDisabled ? { config: { telemetryDisabled: true as const } } : {}),
-					...(this.options.ownedSession ? { lifecycle: "client_owned" as const } : {}),
+					...(reviveConfig ? { config: reviveConfig } : {}),
+					env: this.options.sendClientEnv ? collectDaemonClientEnv() : undefined,
+					...(this.options.ownedSession
+						? { lifecycle: "client_owned" as const, launchEnv: collectDaemonLaunchEnv() }
+						: {}),
 				},
 				DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS,
 			);

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -231,7 +231,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly snapshotRecoveryPromises = new Map<string, Promise<void>>();
 	private readonly ignoredSnapshotIds = new Set<string>();
 	private reconnectPromise?: Promise<void>;
-	private reviveSession?: { promise: Promise<string>; sourceActiveSessionId: string };
+	private reviveSession?: { promise: Promise<RevivedSessionBinding>; sourceActiveSessionId: string };
 	private readonly definitiveRequestErrors = new WeakSet<Error>();
 	private disposing = false;
 	private disposed = false;
@@ -888,20 +888,22 @@ export class DaemonAgentConnection implements AgentConnection {
 				throw error;
 			}
 			if (this.activeSessionId === attemptedActiveSessionId) {
-				let revivedActiveSessionId: string;
+				let revived: RevivedSessionBinding;
 				try {
-					revivedActiveSessionId = await this.reviveFromSavedSession();
+					revived = await this.reviveFromSavedSession();
 				} catch {
 					// Surface the original unknown-session error: it names the session
 					// the caller targeted, which is more actionable than a revival
 					// failure for a session that may have been deleted outright.
 					throw error;
 				}
-				// A transition that lands between the revival resolving and this
-				// continuation running (e.g. a switch to an already-active session)
-				// rebinds the connection; sending the failed prompt there would
-				// inject it into another transcript.
-				if (this.activeSessionId !== revivedActiveSessionId) {
+				// A transition that lands during the revival's tail or between it
+				// resolving and this continuation running rebinds the connection —
+				// or, for an in-worker session switch, replaces the transcript
+				// WITHOUT changing the active id. Verify the full identity before
+				// re-sending; injecting the prompt into another transcript is
+				// worse than surfacing the original error.
+				if (!this.matchesRevivedBinding(revived)) {
 					throw error;
 				}
 				await this.promptWithAdmissionCancellation(type, message, options);
@@ -915,17 +917,32 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (!revival || revival.sourceActiveSessionId !== attemptedActiveSessionId) {
 				throw error;
 			}
-			let revivedActiveSessionId: string;
+			let revived: RevivedSessionBinding;
 			try {
-				revivedActiveSessionId = await revival.promise;
+				revived = await revival.promise;
 			} catch {
 				throw error;
 			}
-			if (this.activeSessionId !== revivedActiveSessionId) {
+			if (!this.matchesRevivedBinding(revived)) {
 				throw error;
 			}
 			await this.promptWithAdmissionCancellation(type, message, options);
 		}
+	}
+
+	/**
+	 * Whether the connection still shows the exact binding a revival resolved
+	 * with: same active id AND same transcript identity. An in-worker session
+	 * switch replaces the transcript while keeping the active id, so the id
+	 * comparison alone would let a failed prompt retry into the newly
+	 * selected transcript.
+	 */
+	private matchesRevivedBinding(revived: RevivedSessionBinding): boolean {
+		return (
+			this.activeSessionId === revived.activeSessionId &&
+			this.attachedSessionId === revived.sessionId &&
+			this.attachedSessionFile === revived.sessionFile
+		);
 	}
 
 	private canReviveFromSavedSession(error: unknown, attemptedActiveSessionId: string): boolean {
@@ -954,7 +971,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	 * update recovery). A revival superseded by such a transition fails and
 	 * leaves the newer binding untouched.
 	 */
-	private reviveFromSavedSession(): Promise<string> {
+	private reviveFromSavedSession(): Promise<RevivedSessionBinding> {
 		if (this.reviveSession) {
 			return this.reviveSession.promise;
 		}
@@ -1025,6 +1042,15 @@ export class DaemonAgentConnection implements AgentConnection {
 				// and lose the prompt; fall through to the snapshot reads below,
 				// which recover or schedule a background resync.
 			}
+			// Capture the transcript identity the attach established: an
+			// in-worker session switch replaces the runtime transcript without
+			// changing the active-session id, so the retry must verify this
+			// identity — not just the id — before re-sending the prompt.
+			const revivedBinding: RevivedSessionBinding = {
+				activeSessionId: revivedActiveSessionId,
+				sessionId: this.attachedSessionId,
+				sessionFile: this.attachedSessionFile,
+			};
 			let snapshot: AgentConnectionSnapshot | undefined;
 			try {
 				snapshot = await this.getInitialSnapshot();
@@ -1050,7 +1076,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (snapshot && this.activeSessionId === revivedActiveSessionId) {
 				void this.emit({ type: "session_resynced", snapshot });
 			}
-			return revivedActiveSessionId;
+			return revivedBinding;
 		})().finally(() => {
 			if (this.reviveSession?.promise === revival) {
 				this.reviveSession = undefined;
@@ -2402,6 +2428,17 @@ function isSnapshotTransferMessage(message: DaemonOutbound): boolean {
 		message.type === "session_snapshot_end" ||
 		message.type === "session_snapshot_failed"
 	);
+}
+
+/**
+ * The identity a revival resolved with: the retry must verify not just the
+ * active id but the transcript identity, because an in-worker session switch
+ * replaces the runtime transcript without changing the active-session id.
+ */
+interface RevivedSessionBinding {
+	activeSessionId: string;
+	sessionId: string | undefined;
+	sessionFile: string | undefined;
 }
 
 function readCreatedActiveSessionId(value: unknown): string {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -242,6 +242,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private reviveSession?: { promise: Promise<RevivedSessionBinding>; sourceActiveSessionId: string };
 	private lastAttachCreatedAttachment = false;
 	private reviveConfigSessionFile: string | undefined;
+	private lastAttachPublishedIdentity: { sessionId: string; sessionFile: string | undefined } | undefined;
 	private readonly definitiveRequestErrors = new WeakSet<Error>();
 	private disposing = false;
 	private disposed = false;
@@ -419,6 +420,11 @@ export class DaemonAgentConnection implements AgentConnection {
 		// connection first attached to; later transcripts (session switches)
 		// must not inherit its cwd.
 		this.reviveConfigSessionFile ??= this.attachedSessionFile;
+		// Recorded before the snapshot await below: a replacement snapshot
+		// landing mid-stream can rewrite the attached identity, and a caller
+		// capturing it afterwards would adopt the switched transcript as its
+		// own.
+		this.lastAttachPublishedIdentity = { sessionId: summary.sessionId, sessionFile: this.attachedSessionFile };
 		this.captureDaemonLogPath();
 		this.updateReconnectFailed = false;
 		this.terminalCloseEmitted = false;
@@ -1104,14 +1110,17 @@ export class DaemonAgentConnection implements AgentConnection {
 				// and lose the prompt; fall through to the snapshot reads below,
 				// which recover or schedule a background resync.
 			}
-			// Capture the transcript identity the attach established: an
-			// in-worker session switch replaces the runtime transcript without
-			// changing the active-session id, so the retry must verify this
-			// identity — not just the id — before re-sending the prompt.
+			// Capture the transcript identity the attach RESPONSE published (not
+			// the current fields): an in-worker session switch replaces the
+			// runtime transcript without changing the active-session id, and a
+			// replacement snapshot landing while the attach snapshot streamed
+			// can rewrite the attached identity before this line runs. Adopting
+			// the switched transcript here would let matchesRevivedBinding pass
+			// and resend the failed prompt into it.
 			const revivedBinding: RevivedSessionBinding = {
 				activeSessionId: revivedActiveSessionId,
-				sessionId: this.attachedSessionId,
-				sessionFile: this.attachedSessionFile,
+				sessionId: this.lastAttachPublishedIdentity?.sessionId ?? this.attachedSessionId,
+				sessionFile: this.lastAttachPublishedIdentity?.sessionFile ?? this.attachedSessionFile,
 			};
 			let snapshot: AgentConnectionSnapshot | undefined;
 			try {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -981,8 +981,14 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (this.activeSessionId !== sourceActiveSessionId) {
 				// A concurrent transition rebound the connection while the daemon
 				// was resuming the session; the newer binding wins. The revived
-				// worker stays resident for the idle sweeps unless it is owned.
-				this.releaseRevivedSession(revivedActiveSessionId);
+				// worker stays resident for the idle sweeps unless it is owned —
+				// but when the concurrent transition bound this connection to the
+				// SAME session the create just revived (a switch to the saved
+				// session file), releasing it would detach the currently
+				// published binding and leave the connection deaf to its events.
+				if (this.activeSessionId !== revivedActiveSessionId) {
+					this.releaseRevivedSession(revivedActiveSessionId);
+				}
 				throw new Error(`Session revival superseded: binding moved from ${sourceActiveSessionId}`);
 			}
 			try {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -409,6 +409,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		this.lastEventSequence = maxEventSequence(this.lastEventSequence, getAttachLastEventSequence(result));
 		if ("snapshot" in result) {
 			const appliedActiveSessionId = this.activeSessionId;
+			const preAwaitSnapshot = this.latestSnapshot;
 			const snapshot = result.snapshotStream
 				? await this.waitForSnapshot(result.snapshotStream.id)
 				: result.snapshot;
@@ -418,14 +419,31 @@ export class DaemonAgentConnection implements AgentConnection {
 				// would describe a session this connection no longer shows.
 				throw new Error(`Session attach superseded: binding moved from ${appliedActiveSessionId}`);
 			}
-			this.latestSnapshot = mapDaemonSessionSnapshot(snapshot, result.replay);
-			if (this.lastEventSequence !== undefined) {
-				this.latestSnapshot.lastEventSequence = this.lastEventSequence;
+			// The daemon can deliver the attach snapshot's end frame and a queued
+			// catch-up resync in one socket read; the resync then lands on the
+			// published binding via completeSnapshotAssembly before this
+			// continuation resumes. Newest wins by event sequence: overwriting
+			// it with the older attach snapshot would drop the intervening
+			// events. The identity check comes first because a sequence is only
+			// comparable within one session: an unchanged snapshot here can
+			// still describe the previous binding (its sequence is unrelated).
+			const concurrentSeq = this.latestSnapshot?.lastEventSequence;
+			const keepConcurrentlyAppliedSnapshot =
+				this.latestSnapshotIsFresh &&
+				this.latestSnapshot !== undefined &&
+				this.latestSnapshot !== preAwaitSnapshot &&
+				concurrentSeq !== undefined &&
+				(snapshot.lastEventSequence === undefined || concurrentSeq > snapshot.lastEventSequence);
+			if (!keepConcurrentlyAppliedSnapshot) {
+				this.latestSnapshot = mapDaemonSessionSnapshot(snapshot, result.replay);
+				if (this.lastEventSequence !== undefined) {
+					this.latestSnapshot.lastEventSequence = this.lastEventSequence;
+				}
+				if (this.lastEventCursor) {
+					this.latestSnapshot.lastEventCursor = this.lastEventCursor;
+				}
+				this.latestSnapshotIsFresh = true;
 			}
-			if (this.lastEventCursor) {
-				this.latestSnapshot.lastEventCursor = this.lastEventCursor;
-			}
-			this.latestSnapshotIsFresh = true;
 		} else {
 			this.latestSnapshot = undefined;
 			this.latestSnapshotIsFresh = false;

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -225,6 +225,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly activeSideQuestionIds = new Set<string>();
 	private readonly snapshotAssemblies = new Map<string, DaemonSnapshotAssembly>();
 	private readonly completedSnapshots = new Map<string, DaemonSessionSnapshot>();
+	private readonly pendingBindingCatchupSnapshots = new Map<string, DaemonSessionSnapshot>();
 	private readonly pendingReattachActiveSessionIds = new Set<string>();
 	private readonly snapshotRecoveryPromises = new Map<string, Promise<void>>();
 	private readonly ignoredSnapshotIds = new Set<string>();
@@ -822,6 +823,14 @@ export class DaemonAgentConnection implements AgentConnection {
 		try {
 			await this.promptWithAdmissionCancellation(type, message, options);
 		} catch (error) {
+			// A cancelled prompt must never restart an archived session: when the
+			// abort races the unknown-session response, the admission wrapper
+			// rethrows it carrying the same message, and reviving would create
+			// and attach a worker only for the retry to observe the aborted
+			// signal and reject.
+			if (options?.signal?.aborted) {
+				throw error;
+			}
 			if (!this.canReviveFromSavedSession(error, attemptedActiveSessionId)) {
 				throw error;
 			}
@@ -2027,6 +2036,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		}
 		this.snapshotAssemblies.clear();
 		this.completedSnapshots.clear();
+		this.pendingBindingCatchupSnapshots.clear();
 		this.snapshotRecoveryPromises.clear();
 		this.ignoredSnapshotIds.clear();
 	}

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -1004,7 +1004,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			);
 			const revivedActiveSessionId = readCreatedActiveSessionId(summary);
 			if (this.disposed || this.disposing) {
-				this.releaseRevivedSession(revivedActiveSessionId);
+				this.releaseRevivedSession(revivedActiveSessionId, false);
 				throw new Error("Connection was disposed during session revival");
 			}
 			if (this.activeSessionId !== sourceActiveSessionId) {
@@ -1016,24 +1016,27 @@ export class DaemonAgentConnection implements AgentConnection {
 				// session file), releasing it would detach the currently
 				// published binding and leave the connection deaf to its events.
 				if (this.activeSessionId !== revivedActiveSessionId) {
-					this.releaseRevivedSession(revivedActiveSessionId);
+					this.releaseRevivedSession(revivedActiveSessionId, false);
 				}
 				throw new Error(`Session revival superseded: binding moved from ${sourceActiveSessionId}`);
 			}
 			try {
 				await this.attachSessionBinding(revivedActiveSessionId, true);
 			} catch (error) {
+				// Supersede errors are thrown after a successful attach response,
+				// so only they prove this revival acquired the attachment.
+				const attachAcquired = DaemonAgentConnection.isAttachSupersededError(error);
 				if (this.disposed || this.disposing) {
-					this.releaseRevivedSession(revivedActiveSessionId);
+					this.releaseRevivedSession(revivedActiveSessionId, attachAcquired);
 					throw error;
 				}
 				if (this.activeSessionId !== revivedActiveSessionId) {
 					// The attach did not publish the revived binding (transient
-					// failure or supersession); drop any server-side attachment
-					// bookkeeping the request may have registered before failing,
-					// and complete an owned revived worker so it cannot outlive
-					// the failed revival.
-					this.releaseRevivedSession(revivedActiveSessionId);
+					// failure or supersession); drop the attachment bookkeeping
+					// only when this attach actually registered it, and complete
+					// an owned revived worker so it cannot outlive the failed
+					// revival.
+					this.releaseRevivedSession(revivedActiveSessionId, attachAcquired);
 					throw error;
 				}
 				// The attach response was applied — the binding is published and
@@ -1064,7 +1067,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			}
 			this.activeSideQuestionIds.clear();
 			if (this.disposed) {
-				this.releaseRevivedSession(revivedActiveSessionId);
+				this.releaseRevivedSession(revivedActiveSessionId, true);
 				throw new Error("Connection was disposed during session revival");
 			}
 			if (sourceActiveSessionId !== revivedActiveSessionId) {
@@ -1118,14 +1121,40 @@ export class DaemonAgentConnection implements AgentConnection {
 	 * the revival was superseded: dispose() only released the previous
 	 * binding, so an owned revived session would otherwise outlive this
 	 * connection indefinitely.
+	 *
+	 * The detach is conditional on THIS revival having acquired the socket
+	 * attachment. The supervisor tracks attachedActiveSessionIds once per
+	 * socket (no refcount), and a DaemonClient can be shared by sibling
+	 * connections: detaching an id we never attached would deafen a sibling
+	 * attached to the session the create returned. create alone never
+	 * attaches — only attachSessionBinding does — so pre-attach call-sites
+	 * pass false. Completing an owned session stays unconditional: the create
+	 * claimed ownership regardless of any attachment.
 	 */
-	private releaseRevivedSession(revivedActiveSessionId: string): void {
+	private releaseRevivedSession(revivedActiveSessionId: string, detachAttachment: boolean): void {
 		if (this.options.ownedSession) {
 			void this.requestOk({ type: "complete_owned_session", activeSessionId: revivedActiveSessionId }).catch(
 				() => undefined,
 			);
 		}
-		void this.requestOk({ type: "detach", activeSessionId: revivedActiveSessionId }).catch(() => undefined);
+		if (detachAttachment) {
+			void this.requestOk({ type: "detach", activeSessionId: revivedActiveSessionId }).catch(() => undefined);
+		}
+	}
+
+	/**
+	 * attachSessionBinding throws its supersession errors strictly AFTER a
+	 * successful attach response — i.e. after the supervisor registered this
+	 * socket's attachment. Any other attach failure (transport, rejected
+	 * request) acquired nothing. A server-side registration whose response
+	 * was lost client-side without a supersede error is the residual
+	 * trade-off: it may leave a stale socket attachment (inflating the
+	 * supervisor's attachedClients until the socket closes) but cannot
+	 * deafen a sibling connection; with a per-socket attachment Set both
+	 * cannot be avoided at once, and deafening a live sibling is worse.
+	 */
+	private static isAttachSupersededError(error: unknown): boolean {
+		return error instanceof Error && error.message.startsWith("Session attach superseded");
 	}
 
 	private async promptWithAdmissionCancellation(

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -229,7 +229,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly snapshotRecoveryPromises = new Map<string, Promise<void>>();
 	private readonly ignoredSnapshotIds = new Set<string>();
 	private reconnectPromise?: Promise<void>;
-	private reviveSession?: { promise: Promise<void>; sourceActiveSessionId: string };
+	private reviveSession?: { promise: Promise<string>; sourceActiveSessionId: string };
 	private readonly definitiveRequestErrors = new WeakSet<Error>();
 	private disposing = false;
 	private disposed = false;
@@ -819,12 +819,20 @@ export class DaemonAgentConnection implements AgentConnection {
 				throw error;
 			}
 			if (this.activeSessionId === attemptedActiveSessionId) {
+				let revivedActiveSessionId: string;
 				try {
-					await this.reviveFromSavedSession();
+					revivedActiveSessionId = await this.reviveFromSavedSession();
 				} catch {
 					// Surface the original unknown-session error: it names the session
 					// the caller targeted, which is more actionable than a revival
 					// failure for a session that may have been deleted outright.
+					throw error;
+				}
+				// A transition that lands between the revival resolving and this
+				// continuation running (e.g. a switch to an already-active session)
+				// rebinds the connection; sending the failed prompt there would
+				// inject it into another transcript.
+				if (this.activeSessionId !== revivedActiveSessionId) {
 					throw error;
 				}
 				await this.promptWithAdmissionCancellation(type, message, options);
@@ -838,9 +846,13 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (!revival || revival.sourceActiveSessionId !== attemptedActiveSessionId) {
 				throw error;
 			}
+			let revivedActiveSessionId: string;
 			try {
-				await revival.promise;
+				revivedActiveSessionId = await revival.promise;
 			} catch {
+				throw error;
+			}
+			if (this.activeSessionId !== revivedActiveSessionId) {
 				throw error;
 			}
 			await this.promptWithAdmissionCancellation(type, message, options);
@@ -873,7 +885,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	 * update recovery). A revival superseded by such a transition fails and
 	 * leaves the newer binding untouched.
 	 */
-	private reviveFromSavedSession(): Promise<void> {
+	private reviveFromSavedSession(): Promise<string> {
 		if (this.reviveSession) {
 			return this.reviveSession.promise;
 		}
@@ -895,6 +907,11 @@ export class DaemonAgentConnection implements AgentConnection {
 					type: "create",
 					sessionPath: sessionFile,
 					continueRecent: false,
+					// The revived worker must carry this invocation's telemetry
+					// opt-out: without it the worker starts under the daemon's
+					// default policy and assertTelemetryAttachAllowed rejects the
+					// attach after the worker already launched.
+					...(this.options.telemetryDisabled ? { config: { telemetryDisabled: true as const } } : {}),
 					...(this.options.ownedSession ? { lifecycle: "client_owned" as const } : {}),
 				},
 				DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS,
@@ -916,13 +933,20 @@ export class DaemonAgentConnection implements AgentConnection {
 			} catch (error) {
 				if (this.disposed || this.disposing) {
 					this.releaseRevivedSession(revivedActiveSessionId);
-				} else if (this.activeSessionId !== revivedActiveSessionId) {
+					throw error;
+				}
+				if (this.activeSessionId !== revivedActiveSessionId) {
 					// The attach did not publish the revived binding (transient
 					// failure or supersession); drop any server-side attachment
 					// bookkeeping the request may have registered before failing.
 					void this.requestOk({ type: "detach", activeSessionId: revivedActiveSessionId }).catch(() => undefined);
+					throw error;
 				}
-				throw error;
+				// The attach response was applied — the binding is published and
+				// the client is attached server-side — but the streamed snapshot
+				// failed. Failing the revival here would strand a coherent binding
+				// and lose the prompt; fall through to the snapshot reads below,
+				// which recover or schedule a background resync.
 			}
 			let snapshot: AgentConnectionSnapshot | undefined;
 			try {
@@ -933,11 +957,12 @@ export class DaemonAgentConnection implements AgentConnection {
 				// reads, which can fail transiently); only the resync emission is
 				// missing. Retry it in the background instead of failing a revival
 				// whose prompts already work.
-				this.scheduleRevivalResync(this.activeSessionId);
+				this.scheduleRevivalResync(revivedActiveSessionId);
 			}
 			this.activeSideQuestionIds.clear();
 			if (this.disposed) {
-				return;
+				this.releaseRevivedSession(revivedActiveSessionId);
+				throw new Error("Connection was disposed during session revival");
 			}
 			if (sourceActiveSessionId !== revivedActiveSessionId) {
 				// The dead id lingers in the shared socket client's attachment
@@ -948,6 +973,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (snapshot) {
 				void this.emit({ type: "session_resynced", snapshot });
 			}
+			return revivedActiveSessionId;
 		})().finally(() => {
 			if (this.reviveSession?.promise === revival) {
 				this.reviveSession = undefined;

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -241,6 +241,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private reconnectPromise?: Promise<void>;
 	private reviveSession?: { promise: Promise<RevivedSessionBinding>; sourceActiveSessionId: string };
 	private lastAttachCreatedAttachment = false;
+	private reviveConfigSessionFile: string | undefined;
 	private readonly definitiveRequestErrors = new WeakSet<Error>();
 	private disposing = false;
 	private disposed = false;
@@ -414,6 +415,10 @@ export class DaemonAgentConnection implements AgentConnection {
 		this.attachedSessionId = summary.sessionId;
 		this.attachedSessionFile =
 			summary.sessionFile ?? ("snapshot" in result ? result.snapshot.state.sessionFile : undefined);
+		// The invocation's reviveConfig was computed for the transcript this
+		// connection first attached to; later transcripts (session switches)
+		// must not inherit its cwd.
+		this.reviveConfigSessionFile ??= this.attachedSessionFile;
 		this.captureDaemonLogPath();
 		this.updateReconnectFailed = false;
 		this.terminalCloseEmitted = false;
@@ -1011,9 +1016,23 @@ export class DaemonAgentConnection implements AgentConnection {
 			// regardless: without it the worker starts under the daemon's default
 			// policy and assertTelemetryAttachAllowed rejects the attach after
 			// the worker already launched.
-			const reviveConfig = this.options.reviveConfig
+			let invocationConfig = this.options.reviveConfig;
+			if (
+				invocationConfig?.cwd !== undefined &&
+				this.reviveConfigSessionFile !== undefined &&
+				this.reviveConfigSessionFile !== sessionFile
+			) {
+				// A session switch replaced the transcript this config was
+				// computed for; its cwd would act as an explicit override and run
+				// the retried prompt's tools in the previous project. Dropping it
+				// resumes in the switched transcript's own directory, matching
+				// standard resume semantics.
+				const { cwd: _previousCwd, ...transcriptNeutralConfig } = invocationConfig;
+				invocationConfig = transcriptNeutralConfig;
+			}
+			const reviveConfig = invocationConfig
 				? {
-						...this.options.reviveConfig,
+						...invocationConfig,
 						...(this.options.telemetryDisabled ? { telemetryDisabled: true as const } : {}),
 					}
 				: this.options.telemetryDisabled
@@ -1057,9 +1076,15 @@ export class DaemonAgentConnection implements AgentConnection {
 				// and the response's wasAttached tells whether that attach CREATED
 				// the socket's attachment entry - a sibling connection may already
 				// have held it, in which case a detach would remove the sibling's
-				// subscription rather than ours.
+				// subscription rather than ours. Reliance on the field is gated on
+				// the negotiated capability: a pre-revision-15 daemon never
+				// reports ownership, and skipping the detach there would leave a
+				// stale attachment that blocks the worker's idle eviction until
+				// the socket closes - so legacy daemons keep the historical
+				// unconditional detach instead.
 				const attachAcquired =
-					DaemonAgentConnection.isAttachSupersededError(error) && this.lastAttachCreatedAttachment;
+					DaemonAgentConnection.isAttachSupersededError(error) &&
+					(this.client.supportsServerCapability("attach_ownership") ? this.lastAttachCreatedAttachment : true);
 				if (this.disposed || this.disposing) {
 					this.releaseRevivedSession(revivedActiveSessionId, attachAcquired);
 					throw error;
@@ -1103,8 +1128,12 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (this.disposed) {
 				// The attach succeeded, but it only ACQUIRED the attachment when it
 				// created the socket entry; a sibling's pre-existing attachment
-				// must survive this cleanup.
-				this.releaseRevivedSession(revivedActiveSessionId, this.lastAttachCreatedAttachment);
+				// must survive this cleanup. Without the negotiated ownership
+				// report, legacy daemons keep the historical unconditional detach.
+				this.releaseRevivedSession(
+					revivedActiveSessionId,
+					this.client.supportsServerCapability("attach_ownership") ? this.lastAttachCreatedAttachment : true,
+				);
 				throw new Error("Connection was disposed during session revival");
 			}
 			if (sourceActiveSessionId !== revivedActiveSessionId) {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -243,6 +243,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private lastAttachCreatedAttachment = false;
 	private reviveConfigSessionFile: string | undefined;
 	private lastAttachPublishedIdentity: { sessionId: string; sessionFile: string | undefined } | undefined;
+	private switchCwdOverride: { sessionPath: string; cwd: string } | undefined;
 	private readonly definitiveRequestErrors = new WeakSet<Error>();
 	private disposing = false;
 	private disposed = false;
@@ -1036,6 +1037,12 @@ export class DaemonAgentConnection implements AgentConnection {
 				const { cwd: _previousCwd, ...transcriptNeutralConfig } = invocationConfig;
 				invocationConfig = transcriptNeutralConfig;
 			}
+			if (this.switchCwdOverride?.sessionPath === sessionFile) {
+				// The transcript only opened because the user selected a fallback
+				// cwd for its missing recorded directory; the recreate needs the
+				// same override or it fails on that directory again.
+				invocationConfig = { ...(invocationConfig ?? {}), cwd: this.switchCwdOverride.cwd };
+			}
 			const reviveConfig = invocationConfig
 				? {
 						...invocationConfig,
@@ -1586,12 +1593,21 @@ export class DaemonAgentConnection implements AgentConnection {
 	): Promise<{ cancelled: boolean }> {
 		const sourceActiveSessionId = this.activeSessionId;
 		try {
-			return await this.requestData<{ cancelled: boolean }>({
+			const result = await this.requestData<{ cancelled: boolean }>({
 				type: "switch_session",
 				activeSessionId: sourceActiveSessionId,
 				sessionPath,
 				cwdOverride: options?.cwdOverride,
 			});
+			if (!result.cancelled) {
+				// A transcript switched in with a user-selected fallback cwd only
+				// opened BECAUSE of that override (its recorded directory is
+				// missing). Reviving it later must reuse the same override or the
+				// recreate fails on the missing directory and the prompt
+				// dead-ends again.
+				this.switchCwdOverride = options?.cwdOverride ? { sessionPath, cwd: options.cwdOverride } : undefined;
+			}
+			return result;
 		} catch (error) {
 			if (!(error instanceof SessionAlreadyActiveError) || !error.activeSessionId) {
 				throw error;

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -424,14 +424,18 @@ export class DaemonAgentConnection implements AgentConnection {
 			// published binding via completeSnapshotAssembly before this
 			// continuation resumes. Newest wins by event sequence: overwriting
 			// it with the older attach snapshot would drop the intervening
-			// events. The identity check comes first because a sequence is only
-			// comparable within one session: an unchanged snapshot here can
-			// still describe the previous binding (its sequence is unrelated).
-			const concurrentSeq = this.latestSnapshot?.lastEventSequence;
+			// events. The identity checks come first because a sequence is only
+			// comparable within one session: an unchanged object can still
+			// describe the previous binding, and a live event's spread-copy can
+			// change the object while carrying the previous session's state.
+			// Freshness deliberately does NOT gate the choice - a live event
+			// clearing the flag must not resurrect the older attach snapshot.
+			const concurrent = this.latestSnapshot;
+			const concurrentSeq = concurrent?.lastEventSequence;
 			const keepConcurrentlyAppliedSnapshot =
-				this.latestSnapshotIsFresh &&
-				this.latestSnapshot !== undefined &&
-				this.latestSnapshot !== preAwaitSnapshot &&
+				concurrent !== undefined &&
+				concurrent !== preAwaitSnapshot &&
+				concurrent.state.sessionId === this.attachedSessionId &&
 				concurrentSeq !== undefined &&
 				(snapshot.lastEventSequence === undefined || concurrentSeq > snapshot.lastEventSequence);
 			if (!keepConcurrentlyAppliedSnapshot) {
@@ -442,7 +446,15 @@ export class DaemonAgentConnection implements AgentConnection {
 				if (this.lastEventCursor) {
 					this.latestSnapshot.lastEventCursor = this.lastEventCursor;
 				}
-				this.latestSnapshotIsFresh = true;
+				// A live event parsed between the snapshot's end frame and this
+				// continuation advanced the connection cursor past the snapshot's
+				// content; marking such a cache fresh would serve state whose
+				// stamped cursor claims it includes an event it does not. The
+				// invalidation is preserved so the next read re-reads.
+				this.latestSnapshotIsFresh =
+					this.lastEventSequence === undefined ||
+					snapshot.lastEventSequence === undefined ||
+					this.lastEventSequence <= snapshot.lastEventSequence;
 			}
 		} else {
 			this.latestSnapshot = undefined;

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -1778,6 +1778,11 @@ export class DaemonAgentConnection implements AgentConnection {
 				(purpose === "replacement" || purpose === "resync") && message.activeSessionId !== this.activeSessionId;
 			if (isPendingCatchupFailure && this.pendingReattachActiveSessionIds.has(message.activeSessionId)) {
 				this.pendingBindingCatchupFailures.add(message.activeSessionId);
+				// Newest wins in both directions: this failure is newer than any
+				// buffered success, whose snapshot now predates the events the
+				// failed catch-up carried. Drop it so publication consumes the
+				// marker and re-reads instead of serving the stale buffer.
+				this.pendingBindingCatchupSnapshots.delete(message.activeSessionId);
 			}
 			const recoveryPromise =
 				(purpose === "replacement" || purpose === "resync") && message.activeSessionId === this.activeSessionId

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -319,6 +319,21 @@ export function resolveAgentsViewOpenCwd(
 	};
 }
 
+/**
+ * The runtime config an agents-view chat uses to (re)create the session from
+ * its saved file — the same computation resumeSavedAgentsViewSession performs,
+ * shared so the connection's revival fallback recreates with the identical
+ * launch context instead of daemon defaults.
+ * @internal Exported to pin the revive-config parity without a live daemon.
+ */
+export function agentsViewSessionRuntimeConfig(
+	config: AgentSessionRuntimeConfig,
+	summary: SessionSummary,
+): AgentSessionRuntimeConfig {
+	const { overrideCwd } = resolveAgentsViewOpenCwd(summary, config.cwd);
+	return createAgentsViewResumeConfig(config, overrideCwd);
+}
+
 async function openAgentsViewSession(
 	options: AgentsViewModeOptions,
 	summary: SessionSummary,
@@ -333,6 +348,7 @@ async function openAgentsViewSession(
 				recoverDaemon: options.recoverDaemon,
 				reconnectTimeoutMs: options.reconnectTimeoutMs,
 				telemetryDisabled: options.config.telemetryDisabled,
+				reviveConfig: agentsViewSessionRuntimeConfig(options.config, summary),
 			});
 			return { connection, summary };
 		} catch (error) {
@@ -356,6 +372,7 @@ async function openAgentsViewSession(
 			recoverDaemon: options.recoverDaemon,
 			reconnectTimeoutMs: options.reconnectTimeoutMs,
 			telemetryDisabled: options.config.telemetryDisabled,
+			reviveConfig: resumed.reviveConfig,
 		});
 		return { connection, summary: resumed.summary, cwdFallbackNotice: resumed.cwdFallbackNotice };
 	} catch (error) {
@@ -373,14 +390,20 @@ async function resumeSavedAgentsViewSession(
 	client: DaemonClient,
 	config: AgentSessionRuntimeConfig,
 	summary: SessionSummary,
-): Promise<{ summary: SessionSummary; activeSessionId: string; cwdFallbackNotice?: string }> {
+): Promise<{
+	summary: SessionSummary;
+	activeSessionId: string;
+	cwdFallbackNotice?: string;
+	reviveConfig: AgentSessionRuntimeConfig;
+}> {
 	if (!summary.sessionFile) {
 		throw new Error("Cannot resume a session without a saved session file");
 	}
-	const { overrideCwd, notice } = resolveAgentsViewOpenCwd(summary, config.cwd);
+	const { notice } = resolveAgentsViewOpenCwd(summary, config.cwd);
+	const resumeConfig = agentsViewSessionRuntimeConfig(config, summary);
 	const response = await client.request({
 		type: "create",
-		config: createAgentsViewResumeConfig(config, overrideCwd),
+		config: resumeConfig,
 		sessionPath: summary.sessionFile,
 	});
 	const createdSummary = expectSessionSummary(requireDaemonData(response));
@@ -388,6 +411,9 @@ async function resumeSavedAgentsViewSession(
 		summary: createdSummary,
 		activeSessionId: getRequiredActiveSessionId(createdSummary),
 		cwdFallbackNotice: notice,
+		// The connection's revival fallback recreates with the same launch
+		// context this resume used.
+		reviveConfig: resumeConfig,
 	};
 }
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1769,7 +1769,7 @@ export class AgentsViewMode implements Component, Focusable {
 			}
 			const behavior = delivery === "followUp" ? "followUp" : liveSummary?.isStreaming ? "steer" : undefined;
 			this.setStatusMessage("Sending reply...");
-			await this.sendPrompt(activeSessionId, text, behavior);
+			await this.sendPrompt(activeSessionId, text, behavior, liveSummary ?? target.summary);
 			// The fallback-directory notice must outlive the transient send statuses.
 			if (cwdFallbackNotice) this.setStatusMessage(cwdFallbackNotice, { sticky: true });
 			else this.setStatusMessage("Reply sent");
@@ -2118,6 +2118,7 @@ export class AgentsViewMode implements Component, Focusable {
 		activeSessionId: string,
 		message: string,
 		streamingBehavior?: "steer" | "followUp",
+		targetSummary?: SessionSummary,
 	): Promise<void> {
 		if (this.options.config.telemetryDisabled) {
 			const client = await this.connectDedicatedClient();
@@ -2127,6 +2128,11 @@ export class AgentsViewMode implements Component, Focusable {
 				recoverDaemon: this.options.recoverDaemon,
 				reconnectTimeoutMs: this.options.reconnectTimeoutMs,
 				telemetryDisabled: true,
+				// The reply's revival fallback must recreate with the agents-view
+				// launch context, not daemon defaults.
+				...(targetSummary
+					? { reviveConfig: agentsViewSessionRuntimeConfig(this.options.config, targetSummary) }
+					: {}),
 			});
 			try {
 				await connection.prompt(message, streamingBehavior === undefined ? undefined : { streamingBehavior });

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -1745,6 +1745,7 @@ export class AgentsViewMode implements Component, Focusable {
 		let activeSessionId = currentSummary.activeSessionId;
 		let liveSummary = activeSessionId ? currentSummary : undefined;
 		let cwdFallbackNotice: string | undefined;
+		let resumedReviveConfig: AgentSessionRuntimeConfig | undefined;
 		let didResume = false;
 		try {
 			if (!activeSessionId) {
@@ -1762,6 +1763,10 @@ export class AgentsViewMode implements Component, Focusable {
 				// streaming state for scheduling the prompt.
 				liveSummary = resumed.summary;
 				cwdFallbackNotice = resumed.cwdFallbackNotice;
+				// The config the resume just created with (including any fallback
+				// cwd for a missing recorded directory) also governs a revival of
+				// the delivery connection.
+				resumedReviveConfig = resumed.reviveConfig;
 				this.inactiveAgentIdentities.delete(getSummaryIdentity(target.summary));
 				// The resume and delivery still belong to this submission, but selection
 				// belongs to the current composer. Do not steal it after cancellation.
@@ -1769,7 +1774,7 @@ export class AgentsViewMode implements Component, Focusable {
 			}
 			const behavior = delivery === "followUp" ? "followUp" : liveSummary?.isStreaming ? "steer" : undefined;
 			this.setStatusMessage("Sending reply...");
-			await this.sendPrompt(activeSessionId, text, behavior, liveSummary ?? target.summary);
+			await this.sendPrompt(activeSessionId, text, behavior, liveSummary ?? target.summary, resumedReviveConfig);
 			// The fallback-directory notice must outlive the transient send statuses.
 			if (cwdFallbackNotice) this.setStatusMessage(cwdFallbackNotice, { sticky: true });
 			else this.setStatusMessage("Reply sent");
@@ -2119,20 +2124,25 @@ export class AgentsViewMode implements Component, Focusable {
 		message: string,
 		streamingBehavior?: "steer" | "followUp",
 		targetSummary?: SessionSummary,
+		reviveConfig?: AgentSessionRuntimeConfig,
 	): Promise<void> {
 		if (this.options.config.telemetryDisabled) {
 			const client = await this.connectDedicatedClient();
+			// The reply's revival fallback must recreate with the agents-view
+			// launch context, not daemon defaults. A config carried from the
+			// resume that just ran wins: recomputing from the now-live summary
+			// would strip a fallback cwd the resume was opened with (its
+			// recorded directory is missing), and revival would fail on it.
+			const revivalConfig =
+				reviveConfig ??
+				(targetSummary ? agentsViewSessionRuntimeConfig(this.options.config, targetSummary) : undefined);
 			const connection = await DaemonAgentConnection.attach(client, activeSessionId, {
 				closeClientOnDispose: true,
 				supportsExtensionUi: false,
 				recoverDaemon: this.options.recoverDaemon,
 				reconnectTimeoutMs: this.options.reconnectTimeoutMs,
 				telemetryDisabled: true,
-				// The reply's revival fallback must recreate with the agents-view
-				// launch context, not daemon defaults.
-				...(targetSummary
-					? { reviveConfig: agentsViewSessionRuntimeConfig(this.options.config, targetSummary) }
-					: {}),
+				...(revivalConfig ? { reviveConfig: revivalConfig } : {}),
 			});
 			try {
 				await connection.prompt(message, streamingBehavior === undefined ? undefined : { streamingBehavior });

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -98,7 +98,12 @@ export type DaemonServerCapability =
 	// identity). Clients must check before sending.
 	| "transient_bash"
 	| "session_input_admission"
-	| "prompt_admission_cancellation";
+	| "prompt_admission_cancellation"
+	// Attach results report wasAttached (whether the attach created the
+	// socket's attachment entry). Clients must check before relying on the
+	// field for cleanup decisions; without it they fall back to the legacy
+	// unconditional detach.
+	| "attach_ownership";
 
 export type DaemonReplayStatus = "complete" | "partial" | "unavailable";
 
@@ -136,6 +141,7 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"transient_bash",
 	"session_input_admission",
 	"prompt_admission_cancellation",
+	"attach_ownership",
 ];
 
 export interface DaemonRuntimeIdentity {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -293,6 +293,14 @@ export interface DaemonAttachResult {
 		messageCount: number;
 		targetChunkBytes: number;
 	};
+	/**
+	 * False when this attach created the socket's attachment entry for the
+	 * session, true when the socket was already attached (a sibling
+	 * connection on the shared client). Lets a failed transition decide
+	 * whether a cleanup detach would remove its own registration or a
+	 * sibling's. Absent on older daemons.
+	 */
+	wasAttached?: boolean;
 	client: {
 		id: DaemonClientId;
 		capabilities: DaemonClientCapability[];

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -101,8 +101,10 @@ export type DaemonServerCapability =
 	| "prompt_admission_cancellation"
 	// Attach results report wasAttached (whether the attach created the
 	// socket's attachment entry). Clients must check before relying on the
-	// field for cleanup decisions; without it they fall back to the legacy
-	// unconditional detach.
+	// field for cleanup decisions; without it shared DaemonClient users need
+	// client-local holder/pending-attach tracking before detaching. Protocol
+	// reattach always removes its source from the socket, so clients sharing a
+	// socket must switch with target attach plus refcounted source cleanup.
 	| "attach_ownership";
 
 export type DaemonReplayStatus = "complete" | "partial" | "unavailable";

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -57,8 +57,10 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 12 publishes idle-residency metadata on session summary rows.
 // Revision 13 narrows agent-origin reach and roster wire shapes to the nuclear family.
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
-export const DAEMON_SCHEMA_REVISION = 14;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-14-816309b1cd50";
+// Revision 15 reports attach ownership (wasAttached) on attach results so shared-client
+// cleanup can tell its own attachment from a sibling connection's.
+export const DAEMON_SCHEMA_REVISION = 15;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-15-816309b1cd50";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3402,6 +3402,11 @@ export class DaemonSupervisor {
 				...result,
 				state: result.state ? publicSummary : undefined,
 				snapshot: { ...result.snapshot, summary: publicSummary },
+				// Whether this attach created the socket's attachment entry: a
+				// client sharing the socket between connections needs this to
+				// know whether a cleanup detach would remove its own
+				// registration or a sibling's.
+				wasAttached,
 				client: { id: client.id, capabilities: [...client.capabilities] },
 			};
 			if (publicResult.state && publicResult.messages) {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1841,6 +1841,99 @@ describe("DaemonAgentConnection", () => {
 		);
 	});
 
+	it("keeps a newer catch-up applied to the published binding while the attach snapshot was streaming", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const catchupMessages: AgentMessage[] = [{ role: "user", content: "post-publication-catch-up", timestamp: 12 }];
+		let revivedSnapshotHeader: Record<string, unknown> | undefined;
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			revivedSnapshotHeader = snapshotHeader;
+			// No frames yet: the attach response resolves, the continuation
+			// publishes the revived binding and parks on waitForSnapshot.
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-post-pub", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		// One socket read delivers the attach snapshot end AND the queued
+		// catch-up resync: both land on the (already published) revived binding
+		// before the waitForSnapshot continuation resumes.
+		fakeClient.emitMessage({
+			type: "session_snapshot_begin",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-post-pub",
+			snapshot: revivedSnapshotHeader as never,
+			messageCount: 0,
+			targetChunkBytes: 512 * 1024,
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_end",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-post-pub",
+			chunkCount: 0,
+			lastEventSequence: 23,
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_begin",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-post-pub-catchup",
+			snapshot: revivedSnapshotHeader as never,
+			messageCount: catchupMessages.length,
+			targetChunkBytes: 512 * 1024,
+			purpose: "resync",
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_chunk",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-post-pub-catchup",
+			index: 0,
+			messages: [catchupMessages[0]!],
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_end",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-post-pub-catchup",
+			chunkCount: 1,
+			lastEventSequence: 33,
+		});
+		await prompt;
+
+		// The newer resync must survive the attach continuation: the revival's
+		// own resync emission (served from the still-cached snapshot) must not
+		// regress to the older attach snapshot.
+		await vi.waitFor(() => {
+			const resyncs = events.filter(
+				(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+					event.type === "session_resynced",
+			);
+			expect(resyncs.length).toBeGreaterThan(0);
+			expect(resyncs[resyncs.length - 1]?.snapshot.messages).toEqual(catchupMessages);
+			expect(resyncs[resyncs.length - 1]?.snapshot.lastEventSequence).toBe(33);
+		});
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1301,6 +1301,80 @@ describe("DaemonAgentConnection", () => {
 		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true));
 	});
 
+	it("discards a late revived snapshot when a switch lands during the stream and releases the revived session", async () => {
+		const fakeClient = new FakeDaemonClient();
+		let emitRevivedSnapshot = () => {};
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			emitRevivedSnapshot = () => {
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-race",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-race",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+			};
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-revive-race", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		const prompt = connection.prompt("continue");
+		// Wait until the revived attach response has been applied (its snapshot
+		// stream is still pending), then complete a switch to another session.
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		await connection.switchSession("/tmp/session-b.jsonl");
+		emitRevivedSnapshot();
+
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+		// The late revived snapshot must not masquerade as the switched session:
+		// no resync describing the revived session, and the revived attachment
+		// is released.
+		const resyncs = events.filter(
+			(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+				event.type === "session_resynced",
+		);
+		expect(resyncs.every((event) => event.snapshot.state.sessionId !== "session-revived")).toBe(true);
+		await vi.waitFor(() =>
+			expect(fakeClient.requests).toContainEqual(
+				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+			),
+		);
+		await connection.prompt("next");
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts[prompts.length - 1]).toMatchObject({ activeSessionId: "active-b" });
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1314,6 +1314,69 @@ describe("DaemonAgentConnection", () => {
 		});
 	});
 
+	it("does not retry into a transcript replaced by an in-worker switch during revival", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			// Bare-summary attach: the revival's snapshot comes from separate
+			// reads, giving a concurrent in-worker switch a window to land
+			// during the revival's tail.
+			return {
+				id: command.activeSessionId,
+				activeSessionId: command.activeSessionId,
+				sessionId: "session-revived",
+				sessionFile: "/tmp/session-current.jsonl",
+			} as unknown as DaemonAttachResult;
+		};
+		let releaseStateRead = () => {};
+		fakeClient.connectionStateGate = new Promise<void>((resolve) => {
+			releaseStateRead = resolve;
+		});
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "get_connection_state" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		// An in-worker switch replaces the runtime transcript WITHOUT changing
+		// the active-session id: the daemon streams a replacement snapshot for
+		// the newly selected session under the same id.
+		const replacement = createAttachResult("active-revived", undefined, undefined, 40, {
+			state: createConnectionState("active-revived", "session-b"),
+		});
+		const { messages: _replacementMessages, ...replacementHeader } = replacement.snapshot;
+		fakeClient.emitMessage({
+			type: "session_snapshot_begin",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-inworker-switch",
+			snapshot: replacementHeader,
+			messageCount: 0,
+			targetChunkBytes: 512 * 1024,
+			purpose: "replacement",
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_end",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-inworker-switch",
+			chunkCount: 0,
+			lastEventSequence: 40,
+		});
+		releaseStateRead();
+
+		// The failed prompt targeted the revived transcript; re-sending it now
+		// would inject it into the switched one. Surface the original error.
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1"]);
+	});
+
 	it("carries the telemetry opt-out into the revived worker's create command", async () => {
 		const fakeClient = new FakeDaemonClient();
 		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -54,6 +54,7 @@ class FakeDaemonClient {
 	promptResponseError: string | undefined;
 	readonly deadActiveSessionIds = new Set<string>();
 	readonly attachedIds = new Set<string>();
+	omitWasAttached = false;
 	createResponseError: string | undefined;
 	createGate: Promise<void> | undefined;
 	revivedAttachGate: Promise<void> | undefined;
@@ -157,7 +158,8 @@ class FakeDaemonClient {
 				}
 				{
 					// Mirror the supervisor's per-socket attachment Set: wasAttached
-					// reports whether this attach created the entry.
+					// reports whether this attach created the entry. omitWasAttached
+					// models a pre-revision-15 daemon.
 					const wasAttached = this.attachedIds.has(command.activeSessionId);
 					this.attachedIds.add(command.activeSessionId);
 					return {
@@ -167,7 +169,7 @@ class FakeDaemonClient {
 						data: {
 							...(this.attachResultFactory?.(command) ??
 								createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12)),
-							wasAttached,
+							...(this.omitWasAttached ? {} : { wasAttached }),
 						},
 					};
 				}
@@ -2319,6 +2321,110 @@ describe("DaemonAgentConnection", () => {
 		// The sibling must still be live on the shared socket.
 		emitSequencedQueueUpdate(fakeClient, "active-revived", 24);
 		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
+	});
+
+	it("defaults to not detaching when an older daemon omits attach ownership", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.omitWasAttached = true;
+		let emitRevivedSnapshot = () => {};
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23);
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			emitRevivedSnapshot = () => {
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-legacy-owner",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-legacy-owner",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+			};
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-legacy-owner", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		await connection.switchSession("/tmp/session-b.jsonl");
+		emitRevivedSnapshot();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+
+		// Without the revision-15 ownership report the client cannot prove the
+		// attach created the socket entry, so the conservative default keeps
+		// the possible sibling attachment (accepting a stale entry instead).
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+		);
+	});
+
+	it("suppresses a background revival resync after an in-worker transcript switch", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			// Legacy bare-summary attach: the resync comes from separate reads.
+			return {
+				id: command.activeSessionId,
+				activeSessionId: command.activeSessionId,
+				sessionId: "session-revived",
+				sessionFile: "/tmp/session-revived.jsonl",
+			} as unknown as DaemonAttachResult;
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+		// The revival's synchronous snapshot read fails, scheduling the
+		// background retry.
+		fakeClient.connectionStateFailures = 1;
+
+		await connection.prompt("continue");
+		expect(events.some((event) => event.type === "session_resynced")).toBe(false);
+
+		// An in-worker switch replaces the transcript WITHOUT changing the
+		// active id before the background retry fires.
+		fakeClient.emitMessage({
+			type: "session_replaced",
+			activeSessionId: "active-revived",
+			state: createConnectionState("active-revived", "session-b"),
+			messages: [],
+		});
+
+		// The background retry must observe the moved transcript identity and
+		// stay silent: a resync of the pre-switch snapshot would revert the
+		// window. Wait past the retry window before asserting.
+		await new Promise((resolveDelay) => setTimeout(resolveDelay, 900));
+		const resyncs = events.filter(
+			(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+				event.type === "session_resynced",
+		);
+		expect(resyncs).toHaveLength(0);
 	});
 
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -2682,6 +2682,42 @@ describe("DaemonAgentConnection", () => {
 		);
 	});
 
+	it("drops the launch cwd when a fileless chat later revives a resumed transcript", async () => {
+		const fakeClient = new FakeDaemonClient();
+		// A --no-session chat: the initial attach has no session file.
+		fakeClient.attachResultFactory = (command) => {
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			if (command.activeSessionId !== "active-1") {
+				return full;
+			}
+			const state = { ...full.snapshot.state, sessionFile: undefined };
+			return { ...full, snapshot: { ...full.snapshot, state, summary: { ...full.snapshot.summary } } };
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+			reviveConfig: { cwd: "/tmp/launch-dir", model: "test-provider/test-model" } as never,
+		});
+		fakeClient.attachResultFactory = undefined;
+		// The user resumes a saved transcript in-worker; the launch cwd belongs
+		// to the fileless session, not to this transcript.
+		fakeClient.emitMessage({
+			type: "session_replaced",
+			activeSessionId: "active-1",
+			state: createConnectionState("active-1", "session-b"),
+			messages: [],
+		});
+		await vi.waitFor(() => expect(fakeClient.requests.length).toBeGreaterThan(0));
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		const create = fakeClient.requests.find((request) => request.type === "create");
+		expect(create).toMatchObject({
+			sessionPath: "/tmp/session-b.jsonl",
+			config: { model: "test-provider/test-model" },
+		});
+		expect(create && "config" in create ? create.config?.cwd : "present").toBeUndefined();
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1043,6 +1043,28 @@ describe("DaemonAgentConnection", () => {
 		});
 	});
 
+	it("completes an owned revived session when the post-revival attach fails", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+			ownedSession: true,
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.attachFailures = 1;
+
+		await expect(connection.prompt("continue")).rejects.toThrow("Unknown active session: active-1");
+		// An owned revived worker must not outlive the failed revival: the
+		// failed/superseded attach releases it with complete_owned_session in
+		// addition to the detach.
+		await vi.waitFor(() => {
+			expect(fakeClient.requests).toContainEqual(
+				expect.objectContaining({ type: "complete_owned_session", activeSessionId: "active-revived" }),
+			);
+			expect(fakeClient.requests).toContainEqual(
+				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+			);
+		});
+	});
+
 	it("ignores an unknown-session error whose id the attempted id merely prefixes", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptResponseError = "Unknown active session: active-10";

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -81,6 +81,7 @@ class FakeDaemonClient {
 		this.requestTimeouts.push(timeoutMs);
 		switch (command.type) {
 			case "prompt":
+				if (this.promptGate) await this.promptGate;
 				if (this.deadActiveSessionIds.has(command.activeSessionId)) {
 					return {
 						type: "response",
@@ -89,7 +90,6 @@ class FakeDaemonClient {
 						error: `Unknown active session: ${command.activeSessionId}`,
 					};
 				}
-				if (this.promptGate) await this.promptGate;
 				if (this.promptError) throw this.promptError;
 				if (this.promptResponseError) {
 					return { type: "response", command: command.type, success: false, error: this.promptResponseError };
@@ -1220,6 +1220,85 @@ describe("DaemonAgentConnection", () => {
 		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true), {
 			timeout: 3000,
 		});
+	});
+
+	it("carries the telemetry opt-out into the revived worker's create command", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+			telemetryDisabled: true,
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		expect(fakeClient.requests.find((request) => request.type === "create")).toMatchObject({
+			sessionPath: "/tmp/session-current.jsonl",
+			config: { telemetryDisabled: true },
+		});
+	});
+
+	it("does not revive or retry when the binding moved to another session before the failure", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+		let releasePrompt = () => {};
+		fakeClient.promptGate = new Promise<void>((resolve) => {
+			releasePrompt = resolve;
+		});
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.filter((request) => request.type === "prompt")).toHaveLength(1),
+		);
+		await connection.switchSession("/tmp/session-b.jsonl");
+		releasePrompt();
+
+		// The prompt targeted the dead session; after the user switched to
+		// another transcript the failure must surface instead of the message
+		// being revived-and-retried into the switched session.
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+		expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(0);
+		expect(fakeClient.requests.filter((request) => request.type === "prompt")).toHaveLength(1);
+	});
+
+	it("recovers via snapshot reads when the revived attach stream fails after publication", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23);
+			queueMicrotask(() => {
+				fakeClient.emitMessage({
+					type: "session_snapshot_failed",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-fail",
+					error: "snapshot encoder failed",
+				});
+			});
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-revive-fail", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		// The attach response was applied (binding published, client attached);
+		// only the streamed snapshot failed. The revival must not strand that
+		// coherent binding: it falls through to the snapshot reads and the
+		// prompt is still delivered.
+		await connection.prompt("continue");
+
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1", "active-revived"]);
+		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true));
 	});
 
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -53,6 +53,7 @@ class FakeDaemonClient {
 	promptError: Error | undefined;
 	promptResponseError: string | undefined;
 	readonly deadActiveSessionIds = new Set<string>();
+	readonly attachedIds = new Set<string>();
 	createResponseError: string | undefined;
 	createGate: Promise<void> | undefined;
 	revivedAttachGate: Promise<void> | undefined;
@@ -154,14 +155,22 @@ class FakeDaemonClient {
 						error: "Unknown active session: missing",
 					};
 				}
-				return {
-					type: "response",
-					command: command.type,
-					success: true,
-					data:
-						this.attachResultFactory?.(command) ??
-						createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12),
-				};
+				{
+					// Mirror the supervisor's per-socket attachment Set: wasAttached
+					// reports whether this attach created the entry.
+					const wasAttached = this.attachedIds.has(command.activeSessionId);
+					this.attachedIds.add(command.activeSessionId);
+					return {
+						type: "response",
+						command: command.type,
+						success: true,
+						data: {
+							...(this.attachResultFactory?.(command) ??
+								createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12)),
+							wasAttached,
+						},
+					};
+				}
 			case "get_queue":
 				return {
 					type: "response",
@@ -402,7 +411,11 @@ class FakeDaemonClient {
 			case "set_scoped_models":
 			case "rename_saved_session":
 			case "extension_ui_response":
+				return { type: "response", command: command.type, success: true };
 			case "detach":
+				if (typeof command.activeSessionId === "string") {
+					this.attachedIds.delete(command.activeSessionId);
+				}
 				return { type: "response", command: command.type, success: true };
 			case "cancel_rlm_child":
 				if (command.childId === "stale-daemon") {
@@ -2239,6 +2252,73 @@ describe("DaemonAgentConnection", () => {
 				{ role: "user", content: "current prompt", timestamp: 4 },
 			]);
 		});
+	});
+
+	it("does not detach a sibling's attachment when a superseded revival had a duplicate attach", async () => {
+		const fakeClient = new FakeDaemonClient();
+		// A sibling connection on the shared client already holds the
+		// attachment for the session the revival will resume.
+		const sibling = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-revived");
+		const siblingEvents: AgentConnectionEvent[] = [];
+		sibling.subscribe((event) => {
+			siblingEvents.push(event);
+		});
+		let emitRevivedSnapshot = () => {};
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23);
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			emitRevivedSnapshot = () => {
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-dup-attach",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-dup-attach",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+			};
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-dup-attach", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(2),
+		);
+		// The switch supersedes the revival while its snapshot streams. The
+		// revival's attach got a response, but it was a DUPLICATE attach
+		// (wasAttached) - the socket entry belongs to the sibling, and the
+		// cleanup must not remove it.
+		await connection.switchSession("/tmp/session-b.jsonl");
+		emitRevivedSnapshot();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+		);
+		// The sibling must still be live on the shared socket.
+		emitSequencedQueueUpdate(fakeClient, "active-revived", 24);
+		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
 	});
 
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1039,8 +1039,46 @@ describe("DaemonAgentConnection", () => {
 		expect(revivedPrompts).toHaveLength(2);
 	});
 
-	it("releases a session revived after disposal began", async () => {
+	it("releases an owned session revived after disposal began without touching its attachment", async () => {
 		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+			ownedSession: true,
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+		let releaseCreate = () => {};
+		fakeClient.createGate = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1),
+		);
+		const dispose = connection.dispose();
+		releaseCreate();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+		await dispose;
+
+		// The create claimed ownership, so the owned session is completed; but
+		// this revival never attached, so no detach may be issued — on a shared
+		// socket it would deafen a sibling connection attached to the same id.
+		await vi.waitFor(() =>
+			expect(fakeClient.requests).toContainEqual(
+				expect.objectContaining({ type: "complete_owned_session", activeSessionId: "active-revived" }),
+			),
+		);
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+		);
+	});
+
+	it("does not detach a revived id a sibling connection is attached to on the shared client", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const sibling = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-revived");
+		const siblingEvents: AgentConnectionEvent[] = [];
+		sibling.subscribe((event) => {
+			siblingEvents.push(event);
+		});
 		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
 		fakeClient.deadActiveSessionIds.add("active-1");
 		let releaseCreate = () => {};
@@ -1057,11 +1095,12 @@ describe("DaemonAgentConnection", () => {
 		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
 		await dispose;
 
-		await vi.waitFor(() =>
-			expect(fakeClient.requests).toContainEqual(
-				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
-			),
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
 		);
+		// The sibling must still be live on the shared socket.
+		emitSequencedQueueUpdate(fakeClient, "active-revived", 13);
+		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
 	});
 
 	it("propagates the client-owned lifecycle when reviving an owned session", async () => {
@@ -1089,16 +1128,17 @@ describe("DaemonAgentConnection", () => {
 
 		await expect(connection.prompt("continue")).rejects.toThrow("Unknown active session: active-1");
 		// An owned revived worker must not outlive the failed revival: the
-		// failed/superseded attach releases it with complete_owned_session in
-		// addition to the detach.
+		// failed attach releases it with complete_owned_session. The attach
+		// THREW without a supersede, so it acquired no attachment - a detach
+		// here could deafen a sibling connection on the shared socket.
 		await vi.waitFor(() => {
 			expect(fakeClient.requests).toContainEqual(
 				expect.objectContaining({ type: "complete_owned_session", activeSessionId: "active-revived" }),
 			);
-			expect(fakeClient.requests).toContainEqual(
-				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
-			);
 		});
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+		);
 	});
 
 	it("ignores an unknown-session error whose id the attempted id merely prefixes", async () => {
@@ -1143,7 +1183,7 @@ describe("DaemonAgentConnection", () => {
 		]);
 	});
 
-	it("cedes to a session switch that lands during revival and releases the revived session", async () => {
+	it("cedes to a session switch that lands during revival without detaching the unacquired id", async () => {
 		const fakeClient = new FakeDaemonClient();
 		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
 		fakeClient.deadActiveSessionIds.add("active-1");
@@ -1161,12 +1201,12 @@ describe("DaemonAgentConnection", () => {
 		releaseCreate();
 		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
 
-		// The revival must not stomp the switched binding nor leave the revived
-		// session attached: the next prompt targets the switched session.
-		await vi.waitFor(() =>
-			expect(fakeClient.requests).toContainEqual(
-				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
-			),
+		// The revival must not stomp the switched binding, and — having never
+		// attached to the revived id — must not detach it either (on a shared
+		// socket that could deafen a sibling attached to the same id). The
+		// revived worker stays resident for the idle sweeps.
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
 		);
 		await connection.prompt("next");
 		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -59,6 +59,7 @@ class FakeDaemonClient {
 	createGate: Promise<void> | undefined;
 	revivedAttachGate: Promise<void> | undefined;
 	switchSessionAlreadyActiveId: string | undefined;
+	switchSessionSucceeds = false;
 	connectionStateFailures = 0;
 	cancelPromptAdmissionStatus: "cancelled" | "owned" | "unknown" = "owned";
 	serverCapabilities = new Set<string>();
@@ -508,6 +509,9 @@ class FakeDaemonClient {
 					data: createAttachResult(command.targetActiveSessionId, command.clientId, command.capabilities, 30),
 				};
 			case "switch_session":
+				if (this.switchSessionSucceeds) {
+					return { type: "response", command: command.type, success: true, data: { cancelled: false } };
+				}
 				if (this.switchSessionAlreadyActiveId) {
 					return {
 						type: "response",
@@ -2557,6 +2561,37 @@ describe("DaemonAgentConnection", () => {
 		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
 		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
 		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1"]);
+	});
+
+	it("revives a switched transcript with the fallback cwd it was opened with", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.switchSessionSucceeds = true;
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+			reviveConfig: { cwd: "/tmp/original-project", model: "test-provider/test-model" } as never,
+		});
+		// The user resumes a transcript whose recorded directory is missing,
+		// selecting a fallback cwd - the switch only succeeds because of it.
+		await connection.switchSession("/tmp/session-b.jsonl", { cwdOverride: "/tmp/fallback-b" });
+		fakeClient.emitMessage({
+			type: "session_replaced",
+			activeSessionId: "active-1",
+			state: createConnectionState("active-1", "session-b"),
+			messages: [],
+		});
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.some((request) => request.type === "switch_session")).toBe(true),
+		);
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		// Reviving the switched transcript must reuse the selected fallback
+		// cwd: without it the recreate fails on the missing recorded directory
+		// and the prompt dead-ends again.
+		expect(fakeClient.requests.find((request) => request.type === "create")).toMatchObject({
+			sessionPath: "/tmp/session-b.jsonl",
+			config: { model: "test-provider/test-model", cwd: "/tmp/fallback-b" },
+		});
 	});
 
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -918,6 +918,34 @@ describe("DaemonAgentConnection", () => {
 		expect(promptRequests.map((request) => request.activeSessionId)).toEqual(["active-1", "active-revived"]);
 	});
 
+	it("does not revive when the prompt's admission was cancelled by its abort signal", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.cancelPromptAdmissionStatus = "cancelled";
+		let releasePrompt = () => {};
+		fakeClient.promptGate = new Promise<void>((resolve) => {
+			releasePrompt = resolve;
+		});
+		const controller = new AbortController();
+
+		const prompt = connection.prompt("continue", { signal: controller.signal });
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.filter((request) => request.type === "prompt")).toHaveLength(1),
+		);
+		// The abort races the unknown-session response: the admission wrapper
+		// rethrows the failure carrying the same message, which must not
+		// authorize a revival that restarts the session the user just
+		// cancelled out of.
+		controller.abort();
+		releasePrompt();
+
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+		expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(0);
+		const promptRequests = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(promptRequests.map((request) => request.activeSessionId)).toEqual(["active-1"]);
+	});
+
 	it("surfaces the original unknown-session error when revival fails", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.createResponseError = "Session not found: /tmp/session-current.jsonl";

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1968,6 +1968,167 @@ describe("DaemonAgentConnection", () => {
 		});
 	});
 
+	it("re-reads when a live event lands between the attach snapshot end and the continuation", async () => {
+		const fakeClient = new FakeDaemonClient();
+		let revivedSnapshotHeader: Record<string, unknown> | undefined;
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			revivedSnapshotHeader = snapshotHeader;
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-live-race", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		// The attach snapshot ends at sequence 23 and a live event with
+		// sequence 24 is parsed before the continuation resumes: the cursor now
+		// claims 24 while the attach snapshot's content stops at 23.
+		fakeClient.emitMessage({
+			type: "session_snapshot_begin",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-live-race",
+			snapshot: revivedSnapshotHeader as never,
+			messageCount: 0,
+			targetChunkBytes: 512 * 1024,
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_end",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-live-race",
+			chunkCount: 0,
+			lastEventSequence: 23,
+		});
+		emitSequencedQueueUpdate(fakeClient, "active-revived", 24);
+		await prompt;
+
+		// The cache must not be served as fresh state that silently omits the
+		// live event: the revival's resync comes from a re-read.
+		await vi.waitFor(() => {
+			const resyncs = events.filter(
+				(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+					event.type === "session_resynced",
+			);
+			expect(resyncs.length).toBeGreaterThan(0);
+			expect(resyncs[resyncs.length - 1]?.snapshot.messages).toEqual([
+				{ role: "user", content: "current prompt", timestamp: 4 },
+			]);
+		});
+		expect(fakeClient.requests.filter((request) => request.type === "get_connection_state").length).toBeGreaterThan(
+			0,
+		);
+	});
+
+	it("keeps a newer catch-up even when a live event cleared the freshness flag", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const catchupMessages: AgentMessage[] = [{ role: "user", content: "catch-up-then-live", timestamp: 13 }];
+		let revivedSnapshotHeader: Record<string, unknown> | undefined;
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			revivedSnapshotHeader = snapshotHeader;
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-live-race2", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		fakeClient.emitMessage({
+			type: "session_snapshot_begin",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-live-race2",
+			snapshot: revivedSnapshotHeader as never,
+			messageCount: 0,
+			targetChunkBytes: 512 * 1024,
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_end",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-live-race2",
+			chunkCount: 0,
+			lastEventSequence: 23,
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_begin",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-live-catchup",
+			snapshot: revivedSnapshotHeader as never,
+			messageCount: catchupMessages.length,
+			targetChunkBytes: 512 * 1024,
+			purpose: "resync",
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_chunk",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-live-catchup",
+			index: 0,
+			messages: [catchupMessages[0]!],
+		});
+		fakeClient.emitMessage({
+			type: "session_snapshot_end",
+			activeSessionId: "active-revived",
+			snapshotId: "snapshot-live-catchup",
+			chunkCount: 1,
+			lastEventSequence: 33,
+		});
+		emitSequencedQueueUpdate(fakeClient, "active-revived", 34);
+		await prompt;
+
+		// The live event cleared the freshness flag; that must not let the
+		// older attach snapshot overwrite the newer catch-up, and the final
+		// state must come from a re-read that includes everything.
+		await vi.waitFor(() => {
+			const resyncs = events.filter(
+				(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+					event.type === "session_resynced",
+			);
+			expect(resyncs.length).toBeGreaterThan(0);
+			expect(resyncs[resyncs.length - 1]?.snapshot.messages).toEqual([
+				{ role: "user", content: "current prompt", timestamp: 4 },
+			]);
+		});
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -2427,6 +2427,39 @@ describe("DaemonAgentConnection", () => {
 		expect(resyncs).toHaveLength(0);
 	});
 
+	it("recreates the revived session with the invocation's launch context", async () => {
+		const fakeClient = new FakeDaemonClient();
+		vi.stubEnv("HERDR_PANE_ID", "pane-42");
+		try {
+			const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+				sendClientEnv: true,
+				reviveConfig: {
+					cwd: "/tmp/project",
+					model: "test-provider/test-model",
+					systemPromptOverride: "custom prompt",
+				} as never,
+			});
+			fakeClient.deadActiveSessionIds.add("active-1");
+
+			await connection.prompt("continue");
+
+			// The original launch context travels with the recreate: runtime
+			// config and the client environment, so the revived worker does not
+			// silently run under daemon defaults.
+			expect(fakeClient.requests.find((request) => request.type === "create")).toMatchObject({
+				sessionPath: "/tmp/session-current.jsonl",
+				config: {
+					cwd: "/tmp/project",
+					model: "test-provider/test-model",
+					systemPromptOverride: "custom prompt",
+				},
+				env: { HERDR_PANE_ID: "pane-42" },
+			});
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -2258,6 +2258,7 @@ describe("DaemonAgentConnection", () => {
 
 	it("does not detach a sibling's attachment when a superseded revival had a duplicate attach", async () => {
 		const fakeClient = new FakeDaemonClient();
+		fakeClient.serverCapabilities.add("attach_ownership");
 		// A sibling connection on the shared client already holds the
 		// attachment for the session the revival will resume.
 		const sibling = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-revived");
@@ -2323,7 +2324,7 @@ describe("DaemonAgentConnection", () => {
 		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
 	});
 
-	it("defaults to not detaching when an older daemon omits attach ownership", async () => {
+	it("keeps the legacy detach when the daemon cannot report attach ownership", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.omitWasAttached = true;
 		let emitRevivedSnapshot = () => {};
@@ -2372,11 +2373,14 @@ describe("DaemonAgentConnection", () => {
 		emitRevivedSnapshot();
 		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
 
-		// Without the revision-15 ownership report the client cannot prove the
-		// attach created the socket entry, so the conservative default keeps
-		// the possible sibling attachment (accepting a stale entry instead).
-		expect(fakeClient.requests).not.toContainEqual(
-			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+		// A daemon that cannot report attach ownership gets the historical
+		// unconditional detach: skipping it would leave a stale attachment
+		// that blocks the revived worker's idle eviction until the socket
+		// closes, which is worse than the pre-existing shared-client edge.
+		await vi.waitFor(() =>
+			expect(fakeClient.requests).toContainEqual(
+				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+			),
 		);
 	});
 
@@ -2458,6 +2462,36 @@ describe("DaemonAgentConnection", () => {
 		} finally {
 			vi.unstubAllEnvs();
 		}
+	});
+
+	it("drops the invocation cwd when reviving a transcript adopted by a session switch", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+			reviveConfig: { cwd: "/tmp/original-project", model: "test-provider/test-model" } as never,
+		});
+		// An in-worker switch replaces the transcript without changing the
+		// active id; the invocation config's cwd belongs to the previous
+		// project.
+		fakeClient.emitMessage({
+			type: "session_replaced",
+			activeSessionId: "active-1",
+			state: createConnectionState("active-1", "session-b"),
+			messages: [],
+		});
+		await vi.waitFor(() => expect(fakeClient.requests.length).toBeGreaterThan(0));
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		const create = fakeClient.requests.find((request) => request.type === "create");
+		// The switched transcript revives in ITS own directory: the stale cwd
+		// would act as an explicit override into the previous project, while
+		// the rest of the invocation config still applies.
+		expect(create).toMatchObject({
+			sessionPath: "/tmp/session-b.jsonl",
+			config: { model: "test-provider/test-model" },
+		});
+		expect(create && "config" in create ? create.config?.cwd : "present").toBeUndefined();
 	});
 
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -52,6 +52,12 @@ class FakeDaemonClient {
 	promptGate: Promise<void> | undefined;
 	promptError: Error | undefined;
 	promptResponseError: string | undefined;
+	readonly deadActiveSessionIds = new Set<string>();
+	createResponseError: string | undefined;
+	createGate: Promise<void> | undefined;
+	revivedAttachGate: Promise<void> | undefined;
+	switchSessionAlreadyActiveId: string | undefined;
+	connectionStateFailures = 0;
 	cancelPromptAdmissionStatus: "cancelled" | "owned" | "unknown" = "owned";
 	serverCapabilities = new Set<string>();
 	updateRestartSessions: Array<Record<string, unknown>> = [];
@@ -75,6 +81,14 @@ class FakeDaemonClient {
 		this.requestTimeouts.push(timeoutMs);
 		switch (command.type) {
 			case "prompt":
+				if (this.deadActiveSessionIds.has(command.activeSessionId)) {
+					return {
+						type: "response",
+						command: command.type,
+						success: false,
+						error: `Unknown active session: ${command.activeSessionId}`,
+					};
+				}
 				if (this.promptGate) await this.promptGate;
 				if (this.promptError) throw this.promptError;
 				if (this.promptResponseError) {
@@ -82,8 +96,29 @@ class FakeDaemonClient {
 				}
 				return { type: "response", command: command.type, success: true };
 			case "prompt_and_wait":
+				if (this.deadActiveSessionIds.has(command.activeSessionId)) {
+					return {
+						type: "response",
+						command: command.type,
+						success: false,
+						error: `Unknown active session: ${command.activeSessionId}`,
+					};
+				}
 				if (this.promptGate) await this.promptGate;
 				if (this.promptError) throw this.promptError;
+				return { type: "response", command: command.type, success: true };
+			case "create":
+				if (this.createGate) await this.createGate;
+				if (this.createResponseError) {
+					return { type: "response", command: command.type, success: false, error: this.createResponseError };
+				}
+				return {
+					type: "response",
+					command: command.type,
+					success: true,
+					data: { id: "active-revived", activeSessionId: "active-revived", sessionId: "session-revived" },
+				};
+			case "complete_owned_session":
 				return { type: "response", command: command.type, success: true };
 			case "cancel_prompt_admission":
 				return {
@@ -103,6 +138,9 @@ class FakeDaemonClient {
 				if (this.attachFailures > 0) {
 					this.attachFailures--;
 					throw new Error("attach failed");
+				}
+				if (command.activeSessionId === "active-revived" && this.revivedAttachGate) {
+					await this.revivedAttachGate;
 				}
 				if (command.activeSessionId === "active-restored" && this.restoredAttachGate) {
 					await this.restoredAttachGate;
@@ -133,6 +171,10 @@ class FakeDaemonClient {
 				};
 			case "get_connection_state":
 				await this.connectionStateGate;
+				if (this.connectionStateFailures > 0) {
+					this.connectionStateFailures--;
+					return { type: "response", command: command.type, success: false, error: "state read failed" };
+				}
 				return {
 					type: "response",
 					command: command.type,
@@ -435,7 +477,27 @@ class FakeDaemonClient {
 						},
 					},
 				};
+			case "reattach":
+				return {
+					type: "response",
+					command: command.type,
+					success: true,
+					data: createAttachResult(command.targetActiveSessionId, command.clientId, command.capabilities, 30),
+				};
 			case "switch_session":
+				if (this.switchSessionAlreadyActiveId) {
+					return {
+						type: "response",
+						command: command.type,
+						success: false,
+						error: "Session already active",
+						errorInfo: {
+							code: "session_already_active",
+							sessionPath: command.sessionPath,
+							activeSessionId: this.switchSessionAlreadyActiveId,
+						},
+					};
+				}
 				return {
 					type: "response",
 					command: command.type,
@@ -823,6 +885,341 @@ describe("DaemonAgentConnection", () => {
 		releasePrompt();
 
 		await expect(prompt).rejects.toThrow("post-ownership validation failed");
+	});
+
+	it("revives an archived session from its saved file when a prompt hits an unknown session", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		expect(fakeClient.requests.find((request) => request.type === "create")).toMatchObject({
+			sessionPath: "/tmp/session-current.jsonl",
+			continueRecent: false,
+		});
+		const promptRequests = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(promptRequests.map((request) => request.activeSessionId)).toEqual(["active-1", "active-revived"]);
+		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true));
+	});
+
+	it("revives an archived session for a signal-carrying prompt", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue", { signal: new AbortController().signal });
+
+		const promptRequests = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(promptRequests.map((request) => request.activeSessionId)).toEqual(["active-1", "active-revived"]);
+	});
+
+	it("surfaces the original unknown-session error when revival fails", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.createResponseError = "Session not found: /tmp/session-current.jsonl";
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await expect(connection.prompt("continue")).rejects.toThrow("Unknown active session: active-1");
+		expect(fakeClient.requests.filter((request) => request.type === "prompt")).toHaveLength(1);
+	});
+
+	it("does not attempt revival without a saved session file", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await expect(connection.prompt("continue")).rejects.toThrow("Unknown active session: active-1");
+		expect(fakeClient.requests.map((request) => request.type)).toEqual(["prompt"]);
+	});
+
+	it("revives via promptAndWait and detaches the dead session id", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.promptAndWait("continue");
+
+		const waitRequests = fakeClient.requests.filter((request) => request.type === "prompt_and_wait");
+		expect(waitRequests.map((request) => request.activeSessionId)).toEqual(["active-1", "active-revived"]);
+		await vi.waitFor(() =>
+			expect(fakeClient.requests).toContainEqual(
+				expect.objectContaining({ type: "detach", activeSessionId: "active-1" }),
+			),
+		);
+	});
+
+	it("ignores an unknown-session error naming a different session than the prompt targeted", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.promptResponseError = "Unknown active session: some-other-session";
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+
+		await expect(connection.prompt("continue")).rejects.toThrow("Unknown active session: some-other-session");
+		expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(0);
+	});
+
+	it("rolls back the binding when the post-revival attach fails, then recovers on the next prompt", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.attachFailures = 1;
+
+		await expect(connection.prompt("first")).rejects.toThrow("Unknown active session: active-1");
+		// The rolled-back binding must keep targeting the original session, not
+		// the half-revived one this client never attached to.
+		const promptsAfterRollback = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(promptsAfterRollback.map((request) => request.activeSessionId)).toEqual(["active-1"]);
+
+		await connection.prompt("second");
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1", "active-1", "active-revived"]);
+	});
+
+	it("shares a single revival between concurrent failing prompts", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		let releaseCreate = () => {};
+		fakeClient.createGate = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+
+		const first = connection.prompt("first");
+		const second = connection.prompt("second");
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1),
+		);
+		releaseCreate();
+		await Promise.all([first, second]);
+
+		expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1);
+		const revivedPrompts = fakeClient.requests.filter(
+			(request) => request.type === "prompt" && request.activeSessionId === "active-revived",
+		);
+		expect(revivedPrompts).toHaveLength(2);
+	});
+
+	it("releases a session revived after disposal began", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		let releaseCreate = () => {};
+		fakeClient.createGate = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1),
+		);
+		const dispose = connection.dispose();
+		releaseCreate();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+		await dispose;
+
+		await vi.waitFor(() =>
+			expect(fakeClient.requests).toContainEqual(
+				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+			),
+		);
+	});
+
+	it("propagates the client-owned lifecycle when reviving an owned session", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+			ownedSession: true,
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		expect(fakeClient.requests.find((request) => request.type === "create")).toMatchObject({
+			sessionPath: "/tmp/session-current.jsonl",
+			lifecycle: "client_owned",
+		});
+	});
+
+	it("ignores an unknown-session error whose id the attempted id merely prefixes", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.promptResponseError = "Unknown active session: active-10";
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+
+		await expect(connection.prompt("continue")).rejects.toThrow("Unknown active session: active-10");
+		expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(0);
+	});
+
+	it("keeps prompts on the dead binding until the revived attach completes", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		let releaseAttach = () => {};
+		fakeClient.revivedAttachGate = new Promise<void>((resolve) => {
+			releaseAttach = resolve;
+		});
+
+		const first = connection.prompt("first");
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.filter((request) => request.type === "attach")).toHaveLength(2),
+		);
+		// The revived binding must not be observable while its attach is still in
+		// flight: a prompt started now targets the (dead) published binding and
+		// joins the revival instead of racing ahead of the attach.
+		const third = connection.prompt("third");
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.filter((request) => request.type === "prompt")).toHaveLength(2),
+		);
+		releaseAttach();
+		await Promise.all([first, third]);
+
+		expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1);
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts.map((request) => request.activeSessionId)).toEqual([
+			"active-1",
+			"active-1",
+			"active-revived",
+			"active-revived",
+		]);
+	});
+
+	it("cedes to a session switch that lands during revival and releases the revived session", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+		let releaseCreate = () => {};
+		fakeClient.createGate = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1),
+		);
+		await connection.switchSession("/tmp/session-b.jsonl");
+		releaseCreate();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+
+		// The revival must not stomp the switched binding nor leave the revived
+		// session attached: the next prompt targets the switched session.
+		await vi.waitFor(() =>
+			expect(fakeClient.requests).toContainEqual(
+				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+			),
+		);
+		await connection.prompt("next");
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts[prompts.length - 1]).toMatchObject({ activeSessionId: "active-b" });
+		expect(prompts.every((request) => request.activeSessionId !== "active-revived")).toBe(true);
+	});
+
+	it("admits revived-session snapshot frames that arrive before the attach response continuation", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const messages: AgentMessage[] = [{ role: "user", content: "revived history", timestamp: 1 }];
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+				messages,
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			// Model the daemon writing the response and the snapshot frames into
+			// one socket buffer: the frames are processed before the awaiting
+			// attach continuation publishes the revived binding.
+			queueMicrotask(() => {
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revived",
+					snapshot: snapshotHeader,
+					messageCount: messages.length,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_chunk",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revived",
+					index: 0,
+					messages: [messages[0]!],
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revived",
+					chunkCount: 1,
+					lastEventSequence: 23,
+				});
+			});
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: {
+					id: "snapshot-revived",
+					messageCount: messages.length,
+					targetChunkBytes: 512 * 1024,
+				},
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+			snapshotTimeoutMs: 200,
+		});
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1", "active-revived"]);
+		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true));
+		const resynced = events.find(
+			(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+				event.type === "session_resynced",
+		);
+		expect(resynced?.snapshot.messages).toEqual(messages);
+	});
+
+	it("retries the resync in the background when a legacy revived attach cannot read its snapshot", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			// Legacy daemons answer attach with a bare summary; the snapshot then
+			// comes from separate reads that can fail transiently.
+			return {
+				id: command.activeSessionId,
+				activeSessionId: command.activeSessionId,
+				sessionId: "session-revived",
+				sessionFile: "/tmp/session-revived.jsonl",
+			} as unknown as DaemonAttachResult;
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.connectionStateFailures = 1;
+
+		// The prompt must succeed even though the revival's resync read failed…
+		await connection.prompt("continue");
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1", "active-revived"]);
+		expect(events.some((event) => event.type === "session_resynced")).toBe(false);
+
+		// …and the background retry must deliver the resync so the window does
+		// not keep rendering the dead transcript.
+		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true), {
+			timeout: 3000,
+		});
 	});
 
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1643,6 +1643,106 @@ describe("DaemonAgentConnection", () => {
 		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
 		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1", "active-revived"]);
 		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true));
+		// The failed catch-up carried events the cached attach snapshot predates;
+		// the revival's resync must come from a fresh daemon read, not the cache.
+		const resynced = events.find(
+			(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+				event.type === "session_resynced",
+		);
+		expect(resynced?.snapshot.messages).toEqual([{ role: "user", content: "current prompt", timestamp: 4 }]);
+	});
+
+	it("prefers a later successful catch-up over an earlier failed one for a pending target", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const catchupMessages: AgentMessage[] = [{ role: "user", content: "caught-up-after-failure", timestamp: 11 }];
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			queueMicrotask(() => {
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-attach3",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-attach3",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-fail2",
+					snapshot: snapshotHeader,
+					messageCount: 1,
+					targetChunkBytes: 512 * 1024,
+					purpose: "resync",
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_failed",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-fail2",
+					error: "catch-up encoder failed",
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-late",
+					snapshot: snapshotHeader,
+					messageCount: catchupMessages.length,
+					targetChunkBytes: 512 * 1024,
+					purpose: "resync",
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_chunk",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-late",
+					index: 0,
+					messages: [catchupMessages[0]!],
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-late",
+					chunkCount: 1,
+					lastEventSequence: 31,
+				});
+			});
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-revive-attach3", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true));
+		const resynced = events.find(
+			(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+				event.type === "session_resynced",
+		);
+		// Newest wins: the successful catch-up supersedes the earlier failure, is
+		// applied from the buffer, and no re-read is forced.
+		expect(resynced?.snapshot.messages).toEqual(catchupMessages);
+		expect(resynced?.snapshot.lastEventSequence).toBe(31);
+		expect(fakeClient.requests.filter((request) => request.type === "get_connection_state")).toHaveLength(0);
 	});
 
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -171,6 +171,14 @@ class FakeDaemonClient {
 				};
 			case "get_connection_state":
 				await this.connectionStateGate;
+				if (this.deadActiveSessionIds.has(command.activeSessionId)) {
+					return {
+						type: "response",
+						command: command.type,
+						success: false,
+						error: `Unknown active session: ${command.activeSessionId}`,
+					};
+				}
 				if (this.connectionStateFailures > 0) {
 					this.connectionStateFailures--;
 					return { type: "response", command: command.type, success: false, error: "state read failed" };
@@ -1567,6 +1575,74 @@ describe("DaemonAgentConnection", () => {
 		// (the newer events), not the older attach snapshot it raced.
 		expect(resynced?.snapshot.messages).toEqual(catchupMessages);
 		expect(resynced?.snapshot.lastEventSequence).toBe(30);
+	});
+
+	it("does not run terminal snapshot recovery for a catch-up that fails while its target is pending", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			queueMicrotask(() => {
+				// The attach snapshot completes, and a catch-up resync FAILS, both
+				// before the attach continuation publishes the revived binding.
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-attach2",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-attach2",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-fail",
+					snapshot: snapshotHeader,
+					messageCount: 1,
+					targetChunkBytes: 512 * 1024,
+					purpose: "resync",
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_failed",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-fail",
+					error: "catch-up encoder failed",
+				});
+			});
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-revive-attach2", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		// Recovery for the failed pending catch-up would read state against the
+		// still-published archived selector, fail, and emit a terminal close —
+		// killing the window even though the revival is about to succeed.
+		await connection.prompt("continue");
+
+		expect(events.filter((event) => event.type === "closed")).toHaveLength(0);
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1", "active-revived"]);
+		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true));
 	});
 
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -2494,6 +2494,71 @@ describe("DaemonAgentConnection", () => {
 		expect(create && "config" in create ? create.config?.cwd : "present").toBeUndefined();
 	});
 
+	it("does not adopt a mid-stream replacement as the revived transcript identity", async () => {
+		const fakeClient = new FakeDaemonClient();
+		let emitFrames = () => {};
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			emitFrames = () => {
+				// The attach snapshot completes, and an in-worker switch's
+				// replacement rewrites the attached identity in the same parse
+				// batch - both processed before the awaiting attach continuation
+				// resumes and the revival captures its transcript identity.
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-identity-race",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-identity-race",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+				fakeClient.emitMessage({
+					type: "session_replaced",
+					activeSessionId: command.activeSessionId,
+					state: createConnectionState(command.activeSessionId, "session-b"),
+					messages: [],
+				});
+			};
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-identity-race", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		emitFrames();
+
+		// The revived binding must be the identity the attach RESPONSE
+		// published (session-revived), not the switched transcript - adopting
+		// the replacement would let the retry inject the failed prompt into it.
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1"]);
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1375,6 +1375,10 @@ describe("DaemonAgentConnection", () => {
 			releaseStateRead = resolve;
 		});
 		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
 		fakeClient.deadActiveSessionIds.add("active-1");
 
 		const prompt = connection.prompt("continue");
@@ -1415,6 +1419,11 @@ describe("DaemonAgentConnection", () => {
 		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
 		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
 		expect(prompts.map((request) => request.activeSessionId)).toEqual(["active-1"]);
+		// And the revival's own resync must not follow the session_replaced
+		// with a pre-switch snapshot, which would revert the window to the
+		// replaced transcript.
+		expect(events.some((event) => event.type === "session_replaced")).toBe(true);
+		expect(events.filter((event) => event.type === "session_resynced")).toHaveLength(0);
 	});
 
 	it("carries the telemetry opt-out into the revived worker's create command", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1397,6 +1397,70 @@ describe("DaemonAgentConnection", () => {
 		expect(prompts[prompts.length - 1]).toMatchObject({ activeSessionId: "active-b" });
 	});
 
+	it("drops non-snapshot frames addressed to a pending revival target", async () => {
+		const fakeClient = new FakeDaemonClient();
+		let emitRevivedSnapshot = () => {};
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23);
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			emitRevivedSnapshot = () => {
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-filter",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-filter",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+			};
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-revive-filter", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		// The switch supersedes the revival while its snapshot is still in
+		// flight; the revived id stays admitted (pending) until the waiter
+		// finishes. Live frames addressed to it must be dropped: admitting the
+		// session_closed would emit a terminal close for a session this window
+		// is no longer showing.
+		await connection.switchSession("/tmp/session-b.jsonl");
+		fakeClient.emitMessage({ type: "session_closed", activeSessionId: "active-revived", reason: "killed" });
+		emitRevivedSnapshot();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+
+		expect(events.filter((event) => event.type === "closed")).toHaveLength(0);
+		await connection.prompt("next");
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts[prompts.length - 1]).toMatchObject({ activeSessionId: "active-b" });
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1489,6 +1489,86 @@ describe("DaemonAgentConnection", () => {
 		expect(prompts[prompts.length - 1]).toMatchObject({ activeSessionId: "active-b" });
 	});
 
+	it("applies a catch-up resync buffered while the revived binding was pending", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const catchupMessages: AgentMessage[] = [{ role: "user", content: "caught-up", timestamp: 9 }];
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			queueMicrotask(() => {
+				// The attach snapshot and a daemon catch-up resync (events that
+				// landed during the attach) share the socket buffer and complete
+				// before the attach continuation publishes the revived binding.
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-attach",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-attach",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-catchup",
+					snapshot: snapshotHeader,
+					messageCount: catchupMessages.length,
+					targetChunkBytes: 512 * 1024,
+					purpose: "resync",
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_chunk",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-catchup",
+					index: 0,
+					messages: [catchupMessages[0]!],
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-catchup",
+					chunkCount: 1,
+					lastEventSequence: 30,
+				});
+			});
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-revive-attach", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true));
+		const resynced = events.find(
+			(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+				event.type === "session_resynced",
+		);
+		// The resync delivered after revival must carry the buffered catch-up
+		// (the newer events), not the older attach snapshot it raced.
+		expect(resynced?.snapshot.messages).toEqual(catchupMessages);
+		expect(resynced?.snapshot.lastEventSequence).toBe(30);
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -2594,6 +2594,94 @@ describe("DaemonAgentConnection", () => {
 		});
 	});
 
+	it("retains the fallback cwd when the switch lands as a reattach to a live worker", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+
+		// The transcript's recorded directory is missing; the user selects a
+		// fallback cwd, and the switch resolves as a reattach because another
+		// worker already owns the transcript.
+		await connection.switchSession("/tmp/session-b.jsonl", { cwdOverride: "/tmp/fallback-b" });
+		fakeClient.deadActiveSessionIds.add("active-b");
+
+		await connection.prompt("continue");
+
+		// Reviving the reattached transcript must reuse the selected fallback
+		// cwd, exactly like an in-worker switch. The override is keyed to the
+		// canonical file the reattach reported (the fake's default state), not
+		// the caller's path spelling.
+		expect(fakeClient.requests.find((request) => request.type === "create")).toMatchObject({
+			sessionPath: "/tmp/session-current.jsonl",
+			config: { cwd: "/tmp/fallback-b" },
+		});
+	});
+
+	it("behaves like an old client when the ownership capability is absent despite the field", async () => {
+		const fakeClient = new FakeDaemonClient();
+		// New daemon (field present in responses), old-client behavior (no
+		// negotiated capability): the field must be ignored entirely, keeping
+		// the pre-revision-15 semantics - the mirror direction of the
+		// omitted-field test above.
+		expect(fakeClient.serverCapabilities.has("attach_ownership")).toBe(false);
+		const sibling = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-revived");
+		void sibling;
+		let emitRevivedSnapshot = () => {};
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23);
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			emitRevivedSnapshot = () => {
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-old-client",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-old-client",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+			};
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-old-client", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(2),
+		);
+		await connection.switchSession("/tmp/session-b.jsonl");
+		emitRevivedSnapshot();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+
+		// wasAttached=true travels in the response (the sibling attached
+		// first), but without the capability the client keeps the historical
+		// unconditional detach - identical to a client predating the field.
+		await vi.waitFor(() =>
+			expect(fakeClient.requests).toContainEqual(
+				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+			),
+		);
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -2718,6 +2718,46 @@ describe("DaemonAgentConnection", () => {
 		expect(create && "config" in create ? create.config?.cwd : "present").toBeUndefined();
 	});
 
+	it("keeps the fileless marker across reconnect attaches", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.attachResultFactory = (command) => {
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			if (command.activeSessionId !== "active-1") {
+				return full;
+			}
+			const state = { ...full.snapshot.state, sessionFile: undefined };
+			return { ...full, snapshot: { ...full.snapshot, state, summary: { ...full.snapshot.summary } } };
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1", {
+			reviveConfig: { cwd: "/tmp/launch-dir", model: "test-provider/test-model" } as never,
+		});
+		fakeClient.attachResultFactory = undefined;
+		// Resume a saved transcript in-worker, then re-attach (reconnect): the
+		// second attach must not adopt the resumed transcript as the config's
+		// own - the launch cwd still belongs to the fileless session.
+		fakeClient.emitMessage({
+			type: "session_replaced",
+			activeSessionId: "active-1",
+			state: createConnectionState("active-1", "session-b"),
+			messages: [],
+		});
+		await vi.waitFor(() => expect(fakeClient.requests.length).toBeGreaterThan(0));
+		// The reconnect attach reports the now-current resumed transcript.
+		fakeClient.attachResultFactory = (command) =>
+			createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 13, {
+				state: createConnectionState(command.activeSessionId, "session-b"),
+			});
+		await connection.attach();
+		fakeClient.attachResultFactory = undefined;
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		const create = fakeClient.requests.find((request) => request.type === "create");
+		expect(create).toMatchObject({ sessionPath: "/tmp/session-b.jsonl" });
+		expect(create && "config" in create ? create.config?.cwd : "present").toBeUndefined();
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -44,6 +44,8 @@ class FakeDaemonClient {
 	resetTransportCount = 0;
 	reconnectError: Error | undefined;
 	attachFailures = 0;
+	readonly attachGates = new Map<string, Promise<void>>();
+	readonly attachFailureIds = new Set<string>();
 	connectionStateGate: Promise<void> | undefined;
 	connectionStateFactory: ((activeSessionId: string) => AgentConnectionState) | undefined;
 	abortBashUnknownCommand = false;
@@ -141,6 +143,10 @@ class FakeDaemonClient {
 				if (this.attachFailures > 0) {
 					this.attachFailures--;
 					throw new Error("attach failed");
+				}
+				await this.attachGates.get(command.activeSessionId);
+				if (this.attachFailureIds.delete(command.activeSessionId)) {
+					throw new Error(`attach failed: ${command.activeSessionId}`);
 				}
 				if (command.activeSessionId === "active-revived" && this.revivedAttachGate) {
 					await this.revivedAttachGate;
@@ -501,13 +507,6 @@ class FakeDaemonClient {
 						},
 					},
 				};
-			case "reattach":
-				return {
-					type: "response",
-					command: command.type,
-					success: true,
-					data: createAttachResult(command.targetActiveSessionId, command.clientId, command.capabilities, 30),
-				};
 			case "switch_session":
 				if (this.switchSessionSucceeds) {
 					return { type: "response", command: command.type, success: true, data: { cancelled: false } };
@@ -580,6 +579,7 @@ class FakeDaemonClient {
 	}
 
 	emitClose(error: Error): void {
+		this.attachedIds.clear();
 		for (const listener of [...this.closeListeners]) {
 			listener(error);
 		}
@@ -763,6 +763,42 @@ function createAttachResult(
 			),
 		},
 	};
+}
+
+function gateFirstRevivedAttachSnapshot(client: FakeDaemonClient, snapshotId: string): () => void {
+	let armed = true;
+	let emitSnapshot: () => void = () => {
+		throw new Error(`Revived attach ${snapshotId} has not started`);
+	};
+	client.attachResultFactory = (command) => {
+		const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23);
+		if (command.activeSessionId !== "active-revived" || !armed) return full;
+		armed = false;
+		const { messages: _messages, ...snapshotHeader } = full.snapshot;
+		emitSnapshot = () => {
+			client.emitMessage({
+				type: "session_snapshot_begin",
+				activeSessionId: command.activeSessionId,
+				snapshotId,
+				snapshot: snapshotHeader,
+				messageCount: 0,
+				targetChunkBytes: 512 * 1024,
+			});
+			client.emitMessage({
+				type: "session_snapshot_end",
+				activeSessionId: command.activeSessionId,
+				snapshotId,
+				chunkCount: 0,
+				lastEventSequence: 23,
+			});
+		};
+		return {
+			...full,
+			snapshot: { ...full.snapshot, messages: [] },
+			snapshotStream: { id: snapshotId, messageCount: 0, targetChunkBytes: 512 * 1024 },
+		};
+	};
+	return () => emitSnapshot();
 }
 
 function emitSequencedQueueUpdate(client: FakeDaemonClient, activeSessionId: string, sequence: number): void {
@@ -1526,6 +1562,9 @@ describe("DaemonAgentConnection", () => {
 
 	it("discards a late revived snapshot when a switch lands during the stream and releases the revived session", async () => {
 		const fakeClient = new FakeDaemonClient();
+		// A negotiated ownership response proves this revival created the
+		// attachment, so superseded cleanup can safely release it.
+		fakeClient.serverCapabilities.add("attach_ownership");
 		let emitRevivedSnapshot = () => {};
 		fakeClient.attachResultFactory = (command) => {
 			if (command.activeSessionId !== "active-revived") {
@@ -2328,9 +2367,14 @@ describe("DaemonAgentConnection", () => {
 		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
 	});
 
-	it("keeps the legacy detach when the daemon cannot report attach ownership", async () => {
+	it("keeps a legacy daemon sibling attached when revival ownership is unknowable", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.omitWasAttached = true;
+		const sibling = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-revived");
+		const siblingEvents: AgentConnectionEvent[] = [];
+		sibling.subscribe((event) => {
+			siblingEvents.push(event);
+		});
 		let emitRevivedSnapshot = () => {};
 		fakeClient.attachResultFactory = (command) => {
 			if (command.activeSessionId !== "active-revived") {
@@ -2371,21 +2415,164 @@ describe("DaemonAgentConnection", () => {
 				fakeClient.requests.filter(
 					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
 				),
+			).toHaveLength(2),
+		);
+		await connection.switchSession("/tmp/session-b.jsonl");
+		emitRevivedSnapshot();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+
+		// Legacy responses cannot prove which connection created the shared
+		// socket attachment. Cleanup must preserve it rather than risk removing
+		// the sibling's subscription.
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+		);
+		emitSequencedQueueUpdate(fakeClient, "active-revived", 24);
+		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
+	});
+
+	it("detaches a legacy revival with no sibling so idle eviction stays possible", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.omitWasAttached = true;
+		const emitRevivedSnapshot = gateFirstRevivedAttachSnapshot(fakeClient, "snapshot-legacy-only");
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
 			).toHaveLength(1),
 		);
 		await connection.switchSession("/tmp/session-b.jsonl");
 		emitRevivedSnapshot();
 		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
 
-		// A daemon that cannot report attach ownership gets the historical
-		// unconditional detach: skipping it would leave a stale attachment
-		// that blocks the revived worker's idle eviction until the socket
-		// closes, which is worse than the pre-existing shared-client edge.
 		await vi.waitFor(() =>
 			expect(fakeClient.requests).toContainEqual(
 				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
 			),
 		);
+		expect(fakeClient.attachedIds.has("active-revived")).toBe(false);
+	});
+
+	it("defers legacy revival cleanup across a sibling attach in flight", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.omitWasAttached = true;
+		const emitRevivedSnapshot = gateFirstRevivedAttachSnapshot(fakeClient, "snapshot-legacy-pending-sibling");
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		let releaseSiblingAttach = () => {};
+		fakeClient.revivedAttachGate = new Promise<void>((resolve) => {
+			releaseSiblingAttach = resolve;
+		});
+		const siblingAttach = DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-revived");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(2),
+		);
+
+		await connection.switchSession("/tmp/session-b.jsonl");
+		emitRevivedSnapshot();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+		);
+
+		releaseSiblingAttach();
+		const sibling = await siblingAttach;
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+		);
+		await sibling.dispose();
+		expect(fakeClient.attachedIds.has("active-revived")).toBe(false);
+		await connection.dispose();
+		expect(fakeClient.attachedIds.size).toBe(0);
+	});
+
+	it("detaches a displaced revival source after a pending sibling attach fails", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.omitWasAttached = true;
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		let releaseSiblingAttach = () => {};
+		fakeClient.attachGates.set(
+			"active-1",
+			new Promise<void>((resolve) => {
+				releaseSiblingAttach = resolve;
+			}),
+		);
+		fakeClient.attachFailureIds.add("active-1");
+		const siblingAttach = DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-1",
+				),
+			).toHaveLength(2),
+		);
+
+		await connection.prompt("continue");
+		// Publishing the revived binding moved the only holder off active-1,
+		// but its known socket attachment must survive until the pending sibling
+		// resolves. A failed sibling then exposes the deferred cleanup.
+		expect(fakeClient.attachedIds.has("active-1")).toBe(true);
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-1" }),
+		);
+
+		releaseSiblingAttach();
+		await expect(siblingAttach).rejects.toThrow("attach failed: active-1");
+		await vi.waitFor(() => expect(fakeClient.attachedIds.has("active-1")).toBe(false));
+		expect(fakeClient.requests).toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-1" }),
+		);
+
+		await connection.dispose();
+		expect(fakeClient.attachedIds.size).toBe(0);
+	});
+
+	it("detaches a legacy revival disposed after its attach response", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.omitWasAttached = true;
+		const emitRevivedSnapshot = gateFirstRevivedAttachSnapshot(fakeClient, "snapshot-legacy-disposed");
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-revived",
+				),
+			).toHaveLength(1),
+		);
+		await connection.dispose();
+		emitRevivedSnapshot();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+
+		const revivedDetaches = fakeClient.requests.filter(
+			(request) => request.type === "detach" && request.activeSessionId === "active-revived",
+		);
+		expect(revivedDetaches).toHaveLength(1);
+		expect(fakeClient.attachedIds.has("active-revived")).toBe(false);
 	});
 
 	it("suppresses a background revival resync after an in-worker transcript switch", async () => {
@@ -2594,22 +2781,22 @@ describe("DaemonAgentConnection", () => {
 		});
 	});
 
-	it("retains the fallback cwd when the switch lands as a reattach to a live worker", async () => {
+	it("retains the fallback cwd when the switch attaches to a live worker", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.switchSessionAlreadyActiveId = "active-b";
 		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
 
 		// The transcript's recorded directory is missing; the user selects a
-		// fallback cwd, and the switch resolves as a reattach because another
+		// fallback cwd, and the switch resolves as an attach because another
 		// worker already owns the transcript.
 		await connection.switchSession("/tmp/session-b.jsonl", { cwdOverride: "/tmp/fallback-b" });
 		fakeClient.deadActiveSessionIds.add("active-b");
 
 		await connection.prompt("continue");
 
-		// Reviving the reattached transcript must reuse the selected fallback
+		// Reviving the attached transcript must reuse the selected fallback
 		// cwd, exactly like an in-worker switch. The override is keyed to the
-		// canonical file the reattach reported (the fake's default state), not
+		// canonical file the attach reported (the fake's default state), not
 		// the caller's path spelling.
 		expect(fakeClient.requests.find((request) => request.type === "create")).toMatchObject({
 			sessionPath: "/tmp/session-current.jsonl",
@@ -2617,15 +2804,218 @@ describe("DaemonAgentConnection", () => {
 		});
 	});
 
-	it("behaves like an old client when the ownership capability is absent despite the field", async () => {
+	it.each([
+		{ mode: "legacy", negotiated: false },
+		{ mode: "negotiated", negotiated: true },
+	])("preserves a source sibling during a $mode live-session switch", async ({ negotiated }) => {
 		const fakeClient = new FakeDaemonClient();
-		// New daemon (field present in responses), old-client behavior (no
-		// negotiated capability): the field must be ignored entirely, keeping
-		// the pre-revision-15 semantics - the mirror direction of the
-		// omitted-field test above.
+		fakeClient.omitWasAttached = !negotiated;
+		if (negotiated) fakeClient.serverCapabilities.add("attach_ownership");
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const sibling = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const siblingEvents: AgentConnectionEvent[] = [];
+		sibling.subscribe((event) => {
+			siblingEvents.push(event);
+		});
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		await connection.switchSession("/tmp/session-b.jsonl");
+
+		// Protocol reattach would remove active-1 from the shared socket and
+		// deafen the sibling. Plain attach keeps both Set entries until each
+		// logical holder releases its binding.
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "reattach", activeSessionId: "active-1" }),
+		);
+		expect(fakeClient.requests).toContainEqual(
+			expect.objectContaining({ type: "attach", activeSessionId: "active-b" }),
+		);
+		expect(fakeClient.attachedIds).toEqual(new Set(["active-1", "active-b"]));
+		emitSequencedQueueUpdate(fakeClient, "active-1", 13);
+		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
+
+		await connection.dispose();
+		expect(fakeClient.attachedIds).toEqual(new Set(["active-1"]));
+		await sibling.dispose();
+		expect(fakeClient.attachedIds.size).toBe(0);
+	});
+
+	it("keeps the source binding and snapshot when the live switch target attach fails", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const before = await connection.getInitialSnapshot();
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+		fakeClient.attachFailureIds.add("active-b");
+
+		await expect(connection.switchSession("/tmp/session-b.jsonl")).rejects.toThrow("attach failed: active-b");
+
+		expect(fakeClient.attachedIds).toEqual(new Set(["active-1"]));
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-1" }),
+		);
+		await expect(connection.getInitialSnapshot()).resolves.toBe(before);
+		await connection.prompt("still source");
+		expect(fakeClient.requests.at(-1)).toMatchObject({ type: "prompt", activeSessionId: "active-1" });
+		await connection.dispose();
+	});
+
+	it("preserves a source sibling that attaches while the switch target is pending", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+		let releaseTargetAttach = () => {};
+		fakeClient.attachGates.set(
+			"active-b",
+			new Promise<void>((resolve) => {
+				releaseTargetAttach = resolve;
+			}),
+		);
+
+		const switching = connection.switchSession("/tmp/session-b.jsonl");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-b",
+				),
+			).toHaveLength(1),
+		);
+
+		// This source attach starts after switching has begun, but before the
+		// target attach can publish. It must acquire a holder before source
+		// cleanup is requested, rather than racing an atomic server-side delete.
+		const sibling = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const siblingEvents: AgentConnectionEvent[] = [];
+		sibling.subscribe((event) => {
+			siblingEvents.push(event);
+		});
+		releaseTargetAttach();
+		await switching;
+
+		expect(fakeClient.requests).not.toContainEqual(expect.objectContaining({ type: "reattach" }));
+		expect(fakeClient.attachedIds).toEqual(new Set(["active-1", "active-b"]));
+		emitSequencedQueueUpdate(fakeClient, "active-1", 13);
+		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
+
+		await connection.dispose();
+		expect(fakeClient.attachedIds).toEqual(new Set(["active-1"]));
+		await sibling.dispose();
+		expect(fakeClient.attachedIds.size).toBe(0);
+	});
+
+	it("commits a successful pending source attach before deferred cleanup", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.omitWasAttached = true;
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		let releaseSiblingAttach = () => {};
+		fakeClient.attachGates.set(
+			"active-1",
+			new Promise<void>((resolve) => {
+				releaseSiblingAttach = resolve;
+			}),
+		);
+		const siblingAttach = DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-1",
+				),
+			).toHaveLength(2),
+		);
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		await connection.switchSession("/tmp/session-b.jsonl");
+		// The source cleanup is deferred while the sibling attempt is pending.
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-1" }),
+		);
+
+		releaseSiblingAttach();
+		const sibling = await siblingAttach;
+		// Successful completion publishes the holder in the same tracker step
+		// that removes the pending attempt, so deferred cleanup cannot run in
+		// between and deafen the newly attached sibling.
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-1" }),
+		);
+		const siblingEvents: AgentConnectionEvent[] = [];
+		sibling.subscribe((event) => {
+			siblingEvents.push(event);
+		});
+		emitSequencedQueueUpdate(fakeClient, "active-1", 13);
+		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
+
+		await connection.dispose();
+		expect(fakeClient.attachedIds).toEqual(new Set(["active-1"]));
+		await sibling.dispose();
+		expect(fakeClient.attachedIds.size).toBe(0);
+		expect(
+			fakeClient.requests.filter((request) => request.type === "detach" && request.activeSessionId === "active-1"),
+		).toHaveLength(1);
+	});
+
+	it("defers switch source cleanup through a pending sibling attach failure", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		let releaseSiblingAttach = () => {};
+		fakeClient.attachGates.set(
+			"active-1",
+			new Promise<void>((resolve) => {
+				releaseSiblingAttach = resolve;
+			}),
+		);
+		fakeClient.attachFailureIds.add("active-1");
+		const siblingAttach = DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		await vi.waitFor(() =>
+			expect(
+				fakeClient.requests.filter(
+					(request) => request.type === "attach" && request.activeSessionId === "active-1",
+				),
+			).toHaveLength(2),
+		);
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		await connection.switchSession("/tmp/session-b.jsonl");
+		expect(fakeClient.requests).not.toContainEqual(expect.objectContaining({ type: "reattach" }));
+		expect(fakeClient.attachedIds.has("active-1")).toBe(true);
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-1" }),
+		);
+
+		releaseSiblingAttach();
+		await expect(siblingAttach).rejects.toThrow("attach failed: active-1");
+		await vi.waitFor(() => expect(fakeClient.attachedIds.has("active-1")).toBe(false));
+		await connection.dispose();
+		expect(fakeClient.attachedIds.size).toBe(0);
+	});
+
+	it("attaches the target before releasing an unshared switch source", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.switchSessionAlreadyActiveId = "active-b";
+
+		await connection.switchSession("/tmp/session-b.jsonl");
+
+		expect(fakeClient.requests.map((request) => request.type)).toEqual([
+			"attach",
+			"switch_session",
+			"attach",
+			"detach",
+		]);
+		expect(fakeClient.attachedIds).toEqual(new Set(["active-b"]));
+		await connection.dispose();
+		expect(fakeClient.attachedIds.size).toBe(0);
+	});
+
+	it("ignores unnegotiated ownership fields and keeps the sibling attached", async () => {
+		const fakeClient = new FakeDaemonClient();
+		// New daemon field without the negotiated capability must be ignored;
+		// ownership remains unknowable, just as when an old daemon omits it.
 		expect(fakeClient.serverCapabilities.has("attach_ownership")).toBe(false);
 		const sibling = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-revived");
-		void sibling;
+		const siblingEvents: AgentConnectionEvent[] = [];
+		sibling.subscribe((event) => {
+			siblingEvents.push(event);
+		});
 		let emitRevivedSnapshot = () => {};
 		fakeClient.attachResultFactory = (command) => {
 			if (command.activeSessionId !== "active-revived") {
@@ -2672,14 +3062,13 @@ describe("DaemonAgentConnection", () => {
 		emitRevivedSnapshot();
 		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
 
-		// wasAttached=true travels in the response (the sibling attached
-		// first), but without the capability the client keeps the historical
-		// unconditional detach - identical to a client predating the field.
-		await vi.waitFor(() =>
-			expect(fakeClient.requests).toContainEqual(
-				expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
-			),
+		// wasAttached=true travels in the response, but without the capability
+		// it cannot authorize cleanup of the shared attachment.
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
 		);
+		emitSequencedQueueUpdate(fakeClient, "active-revived", 24);
+		await vi.waitFor(() => expect(siblingEvents.some((event) => event.type === "session_event")).toBe(true));
 	});
 
 	it("drops the launch cwd when a fileless chat later revives a resumed transcript", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1745,6 +1745,102 @@ describe("DaemonAgentConnection", () => {
 		expect(fakeClient.requests.filter((request) => request.type === "get_connection_state")).toHaveLength(0);
 	});
 
+	it("drops a buffered catch-up when a later one fails for a pending target", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const staleCatchupMessages: AgentMessage[] = [{ role: "user", content: "stale-catch-up", timestamp: 10 }];
+		fakeClient.attachResultFactory = (command) => {
+			if (command.activeSessionId !== "active-revived") {
+				return createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 12);
+			}
+			const full = createAttachResult(command.activeSessionId, command.clientId, command.capabilities, 23, {
+				state: createConnectionState(command.activeSessionId, "session-revived"),
+			});
+			const { messages: _messages, ...snapshotHeader } = full.snapshot;
+			queueMicrotask(() => {
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-attach4",
+					snapshot: snapshotHeader,
+					messageCount: 0,
+					targetChunkBytes: 512 * 1024,
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-revive-attach4",
+					chunkCount: 0,
+					lastEventSequence: 23,
+				});
+				// A catch-up SUCCEEDS at T1…
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-t1",
+					snapshot: snapshotHeader,
+					messageCount: staleCatchupMessages.length,
+					targetChunkBytes: 512 * 1024,
+					purpose: "resync",
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_chunk",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-t1",
+					index: 0,
+					messages: [staleCatchupMessages[0]!],
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_end",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-t1",
+					chunkCount: 1,
+					lastEventSequence: 27,
+				});
+				// …and a NEWER catch-up fails at T2: the buffered T1 snapshot now
+				// predates the events the failed catch-up carried.
+				fakeClient.emitMessage({
+					type: "session_snapshot_begin",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-t2",
+					snapshot: snapshotHeader,
+					messageCount: 1,
+					targetChunkBytes: 512 * 1024,
+					purpose: "resync",
+				});
+				fakeClient.emitMessage({
+					type: "session_snapshot_failed",
+					activeSessionId: command.activeSessionId,
+					snapshotId: "snapshot-catchup-t2",
+					error: "catch-up encoder failed",
+				});
+			});
+			return {
+				...full,
+				snapshot: { ...full.snapshot, messages: [] },
+				snapshotStream: { id: "snapshot-revive-attach4", messageCount: 0, targetChunkBytes: 512 * 1024 },
+			};
+		};
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		const events: AgentConnectionEvent[] = [];
+		connection.subscribe((event) => {
+			events.push(event);
+		});
+		fakeClient.deadActiveSessionIds.add("active-1");
+
+		await connection.prompt("continue");
+
+		await vi.waitFor(() => expect(events.some((event) => event.type === "session_resynced")).toBe(true));
+		const resynced = events.find(
+			(event): event is Extract<AgentConnectionEvent, { type: "session_resynced" }> =>
+				event.type === "session_resynced",
+		);
+		// The re-read must supersede the stale buffered snapshot.
+		expect(resynced?.snapshot.messages).toEqual([{ role: "user", content: "current prompt", timestamp: 4 }]);
+		expect(fakeClient.requests.filter((request) => request.type === "get_connection_state").length).toBeGreaterThan(
+			0,
+		);
+	});
+
 	it("treats a lost prompt response plus unknown cancellation as uncertain", async () => {
 		const fakeClient = new FakeDaemonClient();
 		fakeClient.promptError = new Error("lost response");

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -1174,6 +1174,40 @@ describe("DaemonAgentConnection", () => {
 		expect(prompts.every((request) => request.activeSessionId !== "active-revived")).toBe(true);
 	});
 
+	it("does not release the revived session when a concurrent switch published the same binding", async () => {
+		const fakeClient = new FakeDaemonClient();
+		const connection = await DaemonAgentConnection.attach(asDaemonClient(fakeClient), "active-1");
+		fakeClient.deadActiveSessionIds.add("active-1");
+		// The concurrent switch lands on the SAME session the create revives:
+		// the daemon reports it as already active under the revived id.
+		fakeClient.switchSessionAlreadyActiveId = "active-revived";
+		let releaseCreate = () => {};
+		fakeClient.createGate = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+
+		const prompt = connection.prompt("continue");
+		await vi.waitFor(() =>
+			expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1),
+		);
+		await connection.switchSession("/tmp/session-current.jsonl");
+		releaseCreate();
+		await expect(prompt).rejects.toThrow("Unknown active session: active-1");
+
+		// The switch owns the binding and it IS the revived session: releasing
+		// it would detach the currently published binding and leave the
+		// connection deaf to daemon events.
+		await connection.prompt("next");
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "detach", activeSessionId: "active-revived" }),
+		);
+		expect(fakeClient.requests).not.toContainEqual(
+			expect.objectContaining({ type: "complete_owned_session", activeSessionId: "active-revived" }),
+		);
+		const prompts = fakeClient.requests.filter((request) => request.type === "prompt");
+		expect(prompts[prompts.length - 1]).toMatchObject({ activeSessionId: "active-revived" });
+	});
+
 	it("admits revived-session snapshot frames that arrive before the attach response continuation", async () => {
 		const fakeClient = new FakeDaemonClient();
 		const messages: AgentMessage[] = [{ role: "user", content: "revived history", timestamp: 1 }];

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -129,6 +129,9 @@ describe("agents view reply on inactive sessions", () => {
 			"wake up",
 			"steer",
 			expect.objectContaining({ activeSessionId: "active-9" }),
+			// The delivery connection revives with the config the resume just
+			// created with, not one recomputed from the live summary.
+			expect.any(Object),
 		);
 		expect(self.selectSummary).toHaveBeenCalledWith(expect.objectContaining({ activeSessionId: "active-9" }));
 		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
@@ -176,6 +179,7 @@ describe("agents view reply on inactive sessions", () => {
 			"wake up",
 			undefined,
 			expect.objectContaining({ activeSessionId: "active-9" }),
+			expect.any(Object),
 		);
 		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
 	});
@@ -350,6 +354,7 @@ describe("agents view reply on inactive sessions", () => {
 			"wake up",
 			undefined,
 			expect.objectContaining({ activeSessionId: "active-new" }),
+			expect.any(Object),
 		);
 		expect(self.sendPrompt).not.toHaveBeenCalledWith("active-dead", expect.anything(), expect.anything());
 	});
@@ -373,6 +378,7 @@ describe("agents view reply on inactive sessions", () => {
 			"hello",
 			undefined,
 			expect.objectContaining({ activeSessionId: "active-1" }),
+			undefined,
 		);
 
 		liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live", isStreaming: true });
@@ -382,6 +388,7 @@ describe("agents view reply on inactive sessions", () => {
 			"change course",
 			"steer",
 			expect.objectContaining({ activeSessionId: "active-1" }),
+			undefined,
 		);
 
 		await invoke("sendReply", self, target(), "later please", "followUp");
@@ -390,6 +397,7 @@ describe("agents view reply on inactive sessions", () => {
 			"later please",
 			"followUp",
 			expect.objectContaining({ activeSessionId: "active-1" }),
+			undefined,
 		);
 
 		expect(request).not.toHaveBeenCalled();

--- a/packages/coding-agent/test/agents-view-inactive-reply.test.ts
+++ b/packages/coding-agent/test/agents-view-inactive-reply.test.ts
@@ -124,7 +124,12 @@ describe("agents view reply on inactive sessions", () => {
 		expect(request).toHaveBeenCalledWith(
 			expect.objectContaining({ type: "create", sessionPath: savedSummary.sessionFile }),
 		);
-		expect(self.sendPrompt).toHaveBeenCalledWith("active-9", "wake up", "steer");
+		expect(self.sendPrompt).toHaveBeenCalledWith(
+			"active-9",
+			"wake up",
+			"steer",
+			expect.objectContaining({ activeSessionId: "active-9" }),
+		);
 		expect(self.selectSummary).toHaveBeenCalledWith(expect.objectContaining({ activeSessionId: "active-9" }));
 		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
 		expect(self.setReplyTarget).not.toHaveBeenCalled();
@@ -166,7 +171,12 @@ describe("agents view reply on inactive sessions", () => {
 		await expect(reply).resolves.toBe(true);
 		expect(selectSummary).not.toHaveBeenCalled();
 		expect(selection.activeSessionId).toBe("active-2");
-		expect(sendPrompt).toHaveBeenCalledWith("active-9", "wake up", undefined);
+		expect(sendPrompt).toHaveBeenCalledWith(
+			"active-9",
+			"wake up",
+			undefined,
+			expect.objectContaining({ activeSessionId: "active-9" }),
+		);
 		expect(self.inactiveAgentIdentities).not.toContain("file:/tmp/sessions/saved-1.jsonl");
 	});
 
@@ -335,7 +345,12 @@ describe("agents view reply on inactive sessions", () => {
 		expect(request).toHaveBeenCalledWith(
 			expect.objectContaining({ type: "create", sessionPath: savedSummary.sessionFile }),
 		);
-		expect(self.sendPrompt).toHaveBeenCalledWith("active-new", "wake up", undefined);
+		expect(self.sendPrompt).toHaveBeenCalledWith(
+			"active-new",
+			"wake up",
+			undefined,
+			expect.objectContaining({ activeSessionId: "active-new" }),
+		);
 		expect(self.sendPrompt).not.toHaveBeenCalledWith("active-dead", expect.anything(), expect.anything());
 	});
 
@@ -353,14 +368,29 @@ describe("agents view reply on inactive sessions", () => {
 		const target = () => ({ key: "active-1", summary: liveSummary });
 
 		await invoke("sendReply", self, target(), "hello");
-		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "hello", undefined);
+		expect(self.sendPrompt).toHaveBeenCalledWith(
+			"active-1",
+			"hello",
+			undefined,
+			expect.objectContaining({ activeSessionId: "active-1" }),
+		);
 
 		liveSummary = summary({ activeSessionId: "active-1", lifecycle: "live", isStreaming: true });
 		await invoke("sendReply", self, target(), "change course");
-		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "change course", "steer");
+		expect(self.sendPrompt).toHaveBeenCalledWith(
+			"active-1",
+			"change course",
+			"steer",
+			expect.objectContaining({ activeSessionId: "active-1" }),
+		);
 
 		await invoke("sendReply", self, target(), "later please", "followUp");
-		expect(self.sendPrompt).toHaveBeenCalledWith("active-1", "later please", "followUp");
+		expect(self.sendPrompt).toHaveBeenCalledWith(
+			"active-1",
+			"later please",
+			"followUp",
+			expect.objectContaining({ activeSessionId: "active-1" }),
+		);
 
 		expect(request).not.toHaveBeenCalled();
 		expect(self.selectSummary).not.toHaveBeenCalled();

--- a/packages/coding-agent/test/agents-view-mode.test.ts
+++ b/packages/coding-agent/test/agents-view-mode.test.ts
@@ -8,7 +8,9 @@ import type { AgentConnectionSavedSessionInfo } from "../src/modes/agent-connect
 import {
 	AgentsViewMode,
 	type AgentsViewPersistentState,
+	agentsViewSessionRuntimeConfig,
 	combineAgentsViewStartupNotices,
+	createAgentsViewResumeConfig,
 	createInitialAgentsViewPersistentState,
 	runAgentsViewMode,
 } from "../src/modes/agents-view/agents-view-mode.js";
@@ -675,6 +677,25 @@ describe("AgentsViewMode persistent catalog state", () => {
 		});
 
 		expect(runs).toBe(2);
+	});
+});
+
+describe("agents view revive config", () => {
+	it("matches the resume config for both attach paths, including the cwd fallback", () => {
+		const config = { cwd: process.cwd(), model: "test-provider/test-model" } as never;
+		// The revive config a chat connection carries must be byte-identical to
+		// what resumeSavedAgentsViewSession would send: the connection's
+		// revival fallback recreates the session through the same create.
+		const intactCwdSummary = summary({ cwd: process.cwd() });
+		expect(agentsViewSessionRuntimeConfig(config, intactCwdSummary)).toEqual(
+			createAgentsViewResumeConfig(config, undefined),
+		);
+		const missingCwdSummary = summary({
+			cwd: "/definitely/not/a/real/dir/for/this/test",
+		});
+		expect(agentsViewSessionRuntimeConfig(config, missingCwdSummary)).toEqual(
+			createAgentsViewResumeConfig(config, process.cwd()),
+		);
 	});
 });
 


### PR DESCRIPTION
## Problem

A terminal window attached to a daemon session can outlive the session: the daemon archives an RLM subagent after it delivers its final answer, evicts idle workers, and parents delete finished children. The window receives `session_closed`, shows the "The daemon stopped this agent session…" banner, and stays open — but every subsequent prompt sends the stale `activeSessionId` and dead-ends with `Unknown active session: <id>` forever.

The transcript is saved and resumable the whole time. The agents view already offers exactly this affordance twice — resume-on-open (`openAgentsViewSession` catches the unknown-session error and resumes the saved file) and resume-on-reply for inactive rows — but the open chat window had no revive path at all.

Observed in the wild: a subagent window left open after the child replied to its parent; the parent archived the child ~20s later, and every keystroke in the still-open window produced `Supervisor command prompt failed: Error: Unknown active session: f4e077f832dc` with no recovery.

## Fix

`DaemonAgentConnection.prompt`/`promptAndWait` now treat a typed message as "resume & send": on an unknown-session failure they resume the connection's saved session file via the daemon's idempotent `create {sessionPath}`, re-attach, emit `session_resynced`, and retry the prompt once. Revival failure surfaces the original unknown-session error.

Design points (each pinned by a test):

- **The revived binding is never published early.** `attach()` is refactored into `attachSessionBinding(target, resetCursors)`; the connection keeps its previous (dead) binding until the attach to the revived session has succeeded. A concurrently started prompt therefore targets the dead id, fails, and joins the in-flight revival — it structurally cannot race ahead into a session this client has not attached to. Because nothing mutates before attach success, there is no rollback path that could stomp a newer binding.
- **Supersession is safe.** Revival captures its source binding and re-checks ownership before trusting `create` and inside the attach (`attachSessionBinding` rejects a response whose binding moved mid-flight instead of rebinding backwards). A session switch / reconnect / update recovery landing mid-revival wins; the revival releases the revived session's attachment (plus `complete_owned_session` for owned lifecycles, also when disposal begins mid-revival).
- **Wire-order race handled.** The daemon can write the attach response and the first `session_snapshot_begin` for the revived session into one socket buffer, so those frames can be parsed before the awaiting continuation publishes the new binding. `isMessageForActiveSession` now also admits ids in `pendingReattachActiveSessionIds` (the same set `reattachSession` already maintains), and `attachSessionBinding` registers a foreign target there for the duration of the attach. Pre-existing attach paths always target the published id, so their behavior is unchanged. The regression test for this was verified red-green against the unfixed filter.
- **No cross-session injection.** The unknown-session match is exact and bound to the id the prompt actually targeted, and a prompt only joins a sibling revival tagged with that same source id; any other rebinding surfaces the original error.
- **Legacy attach shape.** With a bare-`SessionSummary` attach result the resync snapshot comes from separate reads; if those fail the revival still succeeds (the binding is coherently bound and attached, prompts work) and a bounded background retry delivers the `session_resynced` so the window cannot keep rendering the dead transcript silently.
- **Reviving a killed session on a later prompt is deliberate**: the agents view reply flow already resumes killed sessions, the client cannot distinguish "user killed" from "parent archived finished child" (both close with reason `killed`), and a revived transcript is strictly recoverable. Documented in the revival docstring.

## Tests

17 new tests in `agent-connection-daemon.test.ts` (80 total in the file, all passing): happy path + `promptAndWait`, signal-carrying prompts, revival failure surfacing the original error, no-session-file and wrong-id negatives (including an id the attempted id merely prefixes), attach-failure recovery on the next prompt, concurrent prompts sharing a single `create`, dispose-during-create releasing the revived session, owned-lifecycle propagation, prompts staying on the dead binding until the revived attach completes, a mid-revival session switch winning with cleanup, the same-buffer snapshot-frame ordering, and the background resync retry.

`daemon-mode`, `daemon-supervisor-eviction`, `daemon-supervisor-lazy-subagents`, `agents-view-mode`, and `agents-view-inactive-reply` suites all pass unchanged (265 tests).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revive archived daemon sessions on prompt instead of returning unknown-session errors
> - When a prompt targets an archived or killed daemon session, `DaemonAgentConnection` now transparently revives the session from its saved file and continues, rather than surfacing an unknown-session error.
> - A new `LocalAttachmentTracker` tracks per-socket attachment ownership so shared `DaemonClient` users don't accidentally detach a sibling connection's session.
> - `reviveConfig` is threaded from call sites (agents-view and main attach) through to `DaemonAgentConnection.attach`, ensuring revived workers use the same runtime config as the original session, including cwd overrides.
> - Attach/switch binding transitions now buffer catch-up snapshots and gate emissions on the published binding identity to avoid lost or stale snapshots during transitions.
> - Protocol schema bumped to revision 15; attach responses include a new `wasAttached` flag to support ownership-aware cleanup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5bc1ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->