### PR TITLE
Agent/harden daemon command journal

### DIFF
--- a/packages/coding-agent/docs/runtime-contracts.md
+++ b/packages/coding-agent/docs/runtime-contracts.md
@@ -118,6 +118,22 @@ K' = H(clientId, commandId, commandType, canonicalPayload).
 
 That change requires a daemon protocol migration; the current journal hardening deliberately preserves the wire format.
 
+### Current integration boundary
+
+`CommandRecoveryJournal.lookup()` accepts an optional `commandType` and validates it before returning a pending or completed entry. The current supervisor preflight still calls `lookup(clientId, commandId)` without that third argument, before its later `begin(..., command.type)` call.
+
+The supervisor integration must be changed to:
+
+```ts
+this.commandJournal.lookup(
+  journalIdentity.clientId,
+  journalIdentity.commandId,
+  command.type,
+)
+```
+
+and covered by a socket-level regression for both pending and completed entries. Until that call site is updated, command-type consistency is enforced during journal admission, result recording, and recovery loading, but not at the supervisor's earliest replay/uncertain-result branch. This limitation is recorded explicitly rather than presenting the journal-only change as an end-to-end exactly-once proof.
+
 ## 3. Linearizable quiescence
 
 A session may report idle only when there is no queued, committing, running, or already-scheduled future work.

--- a/packages/coding-agent/docs/runtime-contracts.md
+++ b/packages/coding-agent/docs/runtime-contracts.md
@@ -1,0 +1,257 @@
+# Prime Agent Runtime Contracts
+
+Prime Agent is a persistent recursive-agent runtime. Coding is one workload; the core repository is responsible for ordering probabilistic work, preserving durable state, recovering from process failure, and reporting completion without losing or duplicating effects.
+
+This document defines the contracts that changes to the scheduler, daemon, kernel bridge, agent messaging, compaction, and continual harness must preserve.
+
+## Runtime model
+
+Represent the runtime state as
+
+\[
+X = (C, E, S, K)
+\]
+
+where:
+
+- `C` is the control plane: action admission, ordering, cancellation, retry, and quiescence;
+- `E` is the execution plane: model streams, tools, IPython kernels, and child agents;
+- `S` is the state plane: transcripts, artifacts, checkpoints, budgets, and harness state; and
+- `K` is the coordination plane: daemon supervision, workers, clients, schedules, and agent messages.
+
+Each observable event advances one state machine:
+
+\[
+X_{n+1} = \delta(X_n, e_n)
+\]
+
+Typical events are prompt admission, tool completion, message arrival, abort, worker crash, restart, compaction, refinement commit, and heartbeat delivery.
+
+The implementation should maximize useful progress subject to safety, liveness, and budget constraints:
+
+\[
+\max \operatorname{Progress}
+\quad \text{subject to} \quad
+\operatorname{Safety}=1,
+\operatorname{Liveness}=1,
+\operatorname{Cost}\le B.
+\]
+
+## 1. Single ownership
+
+Every turn-producing input has exactly one authoritative owner.
+
+\[
+\forall a,\quad |\operatorname{Owner}(a)| = 1.
+\]
+
+`ActionStore` owns session actions. Client, daemon, heartbeat, goal, agent-message, and child-spawn entry points may request admission, but must not create a second direct-dispatch path around the store.
+
+The legal lifecycle is:
+
+```text
+queued
+  -> selected
+  -> preparing
+  -> committing
+  -> running
+  -> completed | failed | cancelled
+```
+
+A rollback from `committing` to `queued` is valid only after dispatch has settled and durable transcript evidence proves that no primary message was committed.
+
+## 2. Effectively-once durable effects
+
+Network delivery can be at-least-once. Durable effects must nevertheless be effectively once.
+
+\[
+\operatorname{AtLeastOnceTransport}
++
+\operatorname{PersistentDeduplication}
+=
+\operatorname{EffectivelyOnceEffect}.
+\]
+
+For each logical command or message:
+
+- its logical identity is stable across transport retries;
+- a durable receipt is written before dispatch;
+- an uncertain receipt without a result is never replayed automatically;
+- a completed result is replayed rather than re-executed; and
+- one identity cannot be reused for a different command or payload.
+
+### Daemon command-journal invariant
+
+The current daemon journal key is
+
+\[
+K = \operatorname{JSON}([clientId, commandId]).
+\]
+
+For a key `K`, exactly one command type is legal:
+
+\[
+\operatorname{Received}(K,t_1)
+\land
+\operatorname{Received}(K,t_2)
+\Rightarrow
+t_1=t_2.
+\]
+
+A durable result must match both the command id and command type in the receipt:
+
+\[
+\operatorname{Result}(K,r)
+\Rightarrow
+r.id=receipt.commandId
+\land
+r.command=receipt.commandType.
+\]
+
+Only one malformed record is tolerated: an unterminated final append produced by a crash. Malformed or inconsistent records before that boundary are ambiguous and recovery must fail closed.
+
+The next protocol revision should add a canonical payload digest:
+
+\[
+K' = H(clientId, commandId, commandType, canonicalPayload).
+\]
+
+That change requires a daemon protocol migration; the current journal hardening deliberately preserves the wire format.
+
+## 3. Linearizable quiescence
+
+A session may report idle only when there is no queued, committing, running, or already-scheduled future work.
+
+\[
+\operatorname{Idle}
+\Rightarrow
+Q=C=R=F=\varnothing,
+\]
+
+where:
+
+- `Q` is queued work;
+- `C` is preparing or committing work;
+- `R` is active provider, tool, kernel, or child work; and
+- `F` is owned future work such as a post-compaction continuation.
+
+A correct external `end_turn` needs a quiescence epoch or lease. Repeating `waitForIdle()` reduces races but is not a linearization point if new work can be admitted between the final check and response publication.
+
+## 4. Recovery XOR
+
+After a crash, every accepted action is either durable or restorable, never both and never neither.
+
+\[
+\operatorname{Durable}(a)
+\oplus
+\operatorname{Restorable}(a).
+\]
+
+The recovery implementation must reject states that would make the following true:
+
+\[
+\operatorname{Durable}(a)
+\land
+\operatorname{Restorable}(a),
+\]
+
+because that permits duplicate effects.
+
+## 5. Monotonic cancellation
+
+Cancellation flows from a parent operation to all descendants.
+
+\[
+\operatorname{Cancel}(p)
+\Rightarrow
+\forall d\in Desc(p),\quad
+\Diamond\operatorname{Terminal}(d).
+\]
+
+Abort listeners remain installed until the child run reaches `done`, `error`, or `cancelled`. Publishing a child session is not terminal settlement and must not detach cancellation propagation.
+
+## 6. Harness view consistency
+
+The harness visible in the system prompt and the harness reachable through the kernel must describe the same logical revision.
+
+\[
+H_{prompt}=H_{query}.
+\]
+
+A child view should be explicit:
+
+\[
+H_{view}=G_r\oplus P_r^{RO}\oplus C_r^{RW},
+\]
+
+where global state and parent-local state are read-only snapshots and child-local state is writable. The view should carry an opaque revision id. Refinement apply is a compare-and-swap operation against that revision.
+
+A preview approval contract requires canonical equivalence:
+
+\[
+Canonical(Preview(plan))=Canonical(Applied(plan)).
+\]
+
+Preview output therefore must include every field that apply may mutate, including path, reference, arguments, and metadata.
+
+## 7. Provider checkpoints are adapter state
+
+Opaque provider checkpoints belong behind a generic provider-checkpoint interface. Core session messages should not acquire one field per provider.
+
+Context knowledge is not just a nullable integer. Prefer an explicit epistemic type:
+
+```ts
+type ContextKnowledge =
+  | { kind: "known"; tokens: number }
+  | { kind: "lower_bound"; tokens: number }
+  | { kind: "bounded"; lower: number; upper: number }
+  | { kind: "unknown"; reason: string };
+```
+
+## 8. Required verification
+
+Changes to the runtime core should include tests for:
+
+- duplicate, delayed, and reordered messages;
+- abort at each await boundary;
+- worker crash before and after durable append;
+- supervisor restart after command receipt and after result persistence;
+- repeated result recording;
+- corrupted interior journal records;
+- false-idle and scheduled-continuation races;
+- parent disposal with live child model/tool execution; and
+- harness preview/apply revision conflicts.
+
+The minimum properties are:
+
+\[
+\forall a,\quad TranscriptCount(a)\le1,
+\]
+
+\[
+Admitted(a)\land Fair\land\neg Cancelled(a)
+\Rightarrow
+\Diamond Terminal(a),
+\]
+
+and
+
+\[
+ReportedIdle(e)
+\Rightarrow
+PendingAtEpoch(e)=0.
+\]
+
+## Upstream integration order
+
+For this fork, integrate upstream work by contract rather than by feature surface:
+
+1. provider accounting and narrow adapter fixes;
+2. daemon startup and retry idempotency;
+3. scheduler liveness and heartbeat cadence;
+4. ACP quiescence as one stacked change;
+5. revisioned harness views followed by canonical preview/apply;
+6. generic provider checkpoints; and
+7. a structured cancellation tree.
+
+Do not combine competing semantics in one integration. In particular, heartbeat phase-preserving coalescing and fixed one-minute retries are alternative scheduling policies and require one explicit decision.

--- a/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
@@ -1,5 +1,6 @@
 import { chmodSync, closeSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeSync } from "node:fs";
 import { dirname } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import type { DaemonClientId, DaemonCommandId, DaemonResponse } from "./daemon-protocol.js";
 
 interface ReceivedRecord {
@@ -70,7 +71,7 @@ function assertResponseMatchesReceipt(entry: JournalEntry, key: string, response
 }
 
 function responsesEqual(left: DaemonResponse, right: DaemonResponse): boolean {
-	return JSON.stringify(left) === JSON.stringify(right);
+	return isDeepStrictEqual(left, right);
 }
 
 /**

--- a/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
@@ -45,10 +45,43 @@ export function createCommandIdempotencyKey(clientId: DaemonClientId, commandId:
 	return JSON.stringify([clientId, commandId]);
 }
 
+function journalCorruption(lineNumber: number, reason: string): Error {
+	return new Error(`Invalid command recovery journal record at line ${lineNumber}: ${reason}`);
+}
+
+function assertCommandTypeMatches(entry: JournalEntry, key: string, commandType: string): void {
+	if (entry.received.commandType === commandType) return;
+	throw new Error(
+		`Daemon idempotency key ${key} was already received as ${entry.received.commandType} and cannot be reused as ${commandType}`,
+	);
+}
+
+function assertResponseMatchesReceipt(entry: JournalEntry, key: string, response: DaemonResponse): void {
+	if (response.id !== entry.received.commandId) {
+		throw new Error(
+			`Daemon response id ${response.id} does not match received command id ${entry.received.commandId} for ${key}`,
+		);
+	}
+	if (response.command !== entry.received.commandType) {
+		throw new Error(
+			`Daemon response command ${response.command} does not match received command type ${entry.received.commandType} for ${key}`,
+		);
+	}
+}
+
+function responsesEqual(left: DaemonResponse, right: DaemonResponse): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
 /**
  * Append-only command journal used at the supervisor boundary. A received
  * record is durable before a mutating command is dispatched; a missing result
  * after a crash is therefore treated as uncertain and is never replayed.
+ *
+ * The pair [clientId, commandId] identifies one logical command for the life of
+ * the journal. Reusing that key for a different command type or recording a
+ * response whose id/type does not match the durable receipt is rejected before
+ * the inconsistent state can be persisted.
  */
 export class CommandRecoveryJournal {
 	private readonly entries = new Map<string, JournalEntry>();
@@ -72,8 +105,11 @@ export class CommandRecoveryJournal {
 
 	begin(clientId: DaemonClientId, commandId: DaemonCommandId, commandType: string): CommandJournalBeginResult {
 		const key = createCommandIdempotencyKey(clientId, commandId);
-		const existing = this.lookup(clientId, commandId);
-		if (existing) return existing;
+		const entry = this.entries.get(key);
+		if (entry) {
+			assertCommandTypeMatches(entry, key, commandType);
+			return entry.response ? { status: "complete", response: entry.response } : { status: "pending" };
+		}
 		const received: ReceivedRecord = {
 			version: 1,
 			type: "received",
@@ -93,6 +129,11 @@ export class CommandRecoveryJournal {
 		const entry = this.entries.get(key);
 		if (!entry) {
 			throw new Error(`Cannot record a result before command receipt: ${key}`);
+		}
+		assertResponseMatchesReceipt(entry, key, response);
+		if (entry.response) {
+			if (responsesEqual(entry.response, response)) return;
+			throw new Error(`Cannot replace the durable result for daemon command ${key} with a conflicting response`);
 		}
 		const record: ResultRecord = {
 			version: 1,
@@ -135,39 +176,82 @@ export class CommandRecoveryJournal {
 			}
 			throw error;
 		}
-		for (const line of contents.split("\n")) {
-			if (!line) {
-				continue;
-			}
-			let record: JournalRecord;
+
+		const lines = contents.split("\n");
+		const partialTailIndex = contents.endsWith("\n") ? -1 : lines.length - 1;
+		for (let index = 0; index < lines.length; index++) {
+			const line = lines[index];
+			if (!line) continue;
+
+			let parsedValue: unknown;
 			try {
-				record = JSON.parse(line) as JournalRecord;
+				parsedValue = JSON.parse(line);
 			} catch {
-				// A crash may leave only the final append truncated.
-				continue;
+				// A crash may leave exactly one unterminated final append. Corruption in
+				// any earlier record is ambiguous and must stop recovery rather than be
+				// skipped while later effects are replayed.
+				if (index === partialTailIndex) continue;
+				throw journalCorruption(index + 1, "malformed JSON outside the final partial append");
 			}
-			if (record.version !== 1 || typeof record.key !== "string") {
-				continue;
+
+			if (typeof parsedValue !== "object" || parsedValue === null || Array.isArray(parsedValue)) {
+				throw journalCorruption(index + 1, "record must be a JSON object");
 			}
+			const parsed = parsedValue as Record<string, unknown>;
+			if (parsed.version !== 1 || typeof parsed.type !== "string" || typeof parsed.key !== "string") {
+				throw journalCorruption(index + 1, "unsupported version or missing type/key");
+			}
+			if (parsed.type !== "received" && parsed.type !== "result" && parsed.type !== "acknowledged") {
+				throw journalCorruption(index + 1, `unknown record type ${JSON.stringify(parsed.type)}`);
+			}
+
+			const record = parsed as unknown as JournalRecord;
 			this.recordCount++;
 			if (record.type === "received") {
 				if (
-					typeof record.clientId === "string" &&
-					typeof record.commandId === "string" &&
-					typeof record.commandType === "string"
+					typeof record.clientId !== "string" ||
+					typeof record.commandId !== "string" ||
+					typeof record.commandType !== "string"
 				) {
-					this.entries.set(record.key, { received: record });
+					throw journalCorruption(index + 1, "received record is missing clientId, commandId, or commandType");
 				}
+				const expectedKey = createCommandIdempotencyKey(record.clientId, record.commandId);
+				if (record.key !== expectedKey) {
+					throw journalCorruption(index + 1, `non-canonical key ${record.key}; expected ${expectedKey}`);
+				}
+				const existing = this.entries.get(record.key);
+				if (existing) {
+					try {
+						assertCommandTypeMatches(existing, record.key, record.commandType);
+					} catch (error) {
+						throw journalCorruption(index + 1, (error as Error).message);
+					}
+					continue;
+				}
+				this.entries.set(record.key, { received: record });
 				continue;
+			}
+
+			const entry = this.entries.get(record.key);
+			if (!entry) {
+				throw journalCorruption(index + 1, `${record.type} record has no preceding received record`);
 			}
 			if (record.type === "acknowledged") {
 				this.entries.delete(record.key);
 				continue;
 			}
-			const entry = this.entries.get(record.key);
-			if (entry && record.response?.type === "response") {
-				entry.response = record.response;
+			if (!record.response || record.response.type !== "response") {
+				throw journalCorruption(index + 1, "result record is missing a daemon response");
 			}
+			try {
+				assertResponseMatchesReceipt(entry, record.key, record.response);
+			} catch (error) {
+				throw journalCorruption(index + 1, (error as Error).message);
+			}
+			if (entry.response && !responsesEqual(entry.response, record.response)) {
+				throw journalCorruption(index + 1, "conflicting durable results for one idempotency key");
+			}
+			entry.response = record.response;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
@@ -95,8 +95,13 @@ export class CommandRecoveryJournal {
 	lookup(
 		clientId: DaemonClientId,
 		commandId: DaemonCommandId,
+		commandType?: string,
 	): Exclude<CommandJournalBeginResult, { status: "new" }> | undefined {
-		const existing = this.entries.get(createCommandIdempotencyKey(clientId, commandId));
+		const key = createCommandIdempotencyKey(clientId, commandId);
+		const existing = this.entries.get(key);
+		if (existing && commandType !== undefined) {
+			assertCommandTypeMatches(existing, key, commandType);
+		}
 		if (existing?.response) {
 			return { status: "complete", response: existing.response };
 		}

--- a/packages/coding-agent/test/command-recovery-journal.test.ts
+++ b/packages/coding-agent/test/command-recovery-journal.test.ts
@@ -29,10 +29,13 @@ describe("CommandRecoveryJournal", () => {
 		const journal = new CommandRecoveryJournal(createPath());
 		expect(journal.begin("client-a", "command-a", "prompt")).toEqual({ status: "new" });
 
+		expect(() => journal.lookup("client-a", "command-a", "shutdown")).toThrow(
+			/already received as prompt and cannot be reused as shutdown/,
+		);
 		expect(() => journal.begin("client-a", "command-a", "shutdown")).toThrow(
 			/already received as prompt and cannot be reused as shutdown/,
 		);
-		expect(journal.lookup("client-a", "command-a")).toEqual({ status: "pending" });
+		expect(journal.lookup("client-a", "command-a", "prompt")).toEqual({ status: "pending" });
 	});
 
 	it("looks up prior commands without inserting new receipts", () => {

--- a/packages/coding-agent/test/command-recovery-journal.test.ts
+++ b/packages/coding-agent/test/command-recovery-journal.test.ts
@@ -2,7 +2,7 @@ import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { CommandRecoveryJournal } from "../src/modes/daemon/command-recovery-journal.js";
+import { CommandRecoveryJournal, createCommandIdempotencyKey } from "../src/modes/daemon/command-recovery-journal.js";
 
 describe("CommandRecoveryJournal", () => {
 	const roots: string[] = [];
@@ -23,6 +23,16 @@ describe("CommandRecoveryJournal", () => {
 		const journal = new CommandRecoveryJournal(createPath());
 		expect(journal.begin("client-a", "command-a", "prompt")).toEqual({ status: "new" });
 		expect(journal.begin("client-a", "command-a", "prompt")).toEqual({ status: "pending" });
+	});
+
+	it("rejects reusing one idempotency key for a different command type", () => {
+		const journal = new CommandRecoveryJournal(createPath());
+		expect(journal.begin("client-a", "command-a", "prompt")).toEqual({ status: "new" });
+
+		expect(() => journal.begin("client-a", "command-a", "shutdown")).toThrow(
+			/already received as prompt and cannot be reused as shutdown/,
+		);
+		expect(journal.lookup("client-a", "command-a")).toEqual({ status: "pending" });
 	});
 
 	it("looks up prior commands without inserting new receipts", () => {
@@ -61,6 +71,51 @@ describe("CommandRecoveryJournal", () => {
 		});
 	});
 
+	it("requires durable response metadata to match the received command", () => {
+		const journal = new CommandRecoveryJournal(createPath());
+		journal.begin("client-a", "command-a", "prompt");
+
+		expect(() =>
+			journal.recordResult("client-a", "command-a", {
+				id: "different-id",
+				type: "response",
+				command: "prompt",
+				success: true,
+			}),
+		).toThrow(/does not match received command id/);
+		expect(() =>
+			journal.recordResult("client-a", "command-a", {
+				id: "command-a",
+				type: "response",
+				command: "shutdown",
+				success: true,
+			}),
+		).toThrow(/does not match received command type/);
+		expect(journal.lookup("client-a", "command-a")).toEqual({ status: "pending" });
+	});
+
+	it("accepts an identical repeated result but rejects a conflicting replacement", () => {
+		const journal = new CommandRecoveryJournal(createPath());
+		journal.begin("client-a", "command-a", "prompt");
+		const response = {
+			id: "command-a",
+			type: "response" as const,
+			command: "prompt" as const,
+			success: true as const,
+		};
+		journal.recordResult("client-a", "command-a", response);
+		expect(() => journal.recordResult("client-a", "command-a", response)).not.toThrow();
+		expect(() =>
+			journal.recordResult("client-a", "command-a", {
+				id: "command-a",
+				type: "response",
+				command: "prompt",
+				success: false,
+				error: "conflicting result",
+			}),
+		).toThrow(/conflicting response/);
+	});
+
 	it("ignores a truncated final append", () => {
 		const path = createPath();
 		const journal = new CommandRecoveryJournal(path);
@@ -69,6 +124,54 @@ describe("CommandRecoveryJournal", () => {
 
 		const restored = new CommandRecoveryJournal(path);
 		expect(restored.begin("client-a", "command-a", "prompt")).toEqual({ status: "pending" });
+	});
+
+	it("fails closed on malformed journal data before the final partial append", () => {
+		const path = createPath();
+		const journal = new CommandRecoveryJournal(path);
+		journal.begin("client-a", "command-a", "prompt");
+		appendFileSync(path, "{not valid json}\n");
+
+		expect(() => new CommandRecoveryJournal(path)).toThrow(/line 2: malformed JSON/);
+	});
+
+	it("fails closed when a received record carries a non-canonical key", () => {
+		const path = createPath();
+		appendFileSync(
+			path,
+			`${JSON.stringify({
+				version: 1,
+				type: "received",
+				key: createCommandIdempotencyKey("other-client", "other-command"),
+				clientId: "client-a",
+				commandId: "command-a",
+				commandType: "prompt",
+				recordedAt: new Date().toISOString(),
+			})}\n`,
+		);
+
+		expect(() => new CommandRecoveryJournal(path)).toThrow(/non-canonical key/);
+	});
+
+	it("fails closed when a result has no preceding durable receipt", () => {
+		const path = createPath();
+		appendFileSync(
+			path,
+			`${JSON.stringify({
+				version: 1,
+				type: "result",
+				key: createCommandIdempotencyKey("client-a", "command-a"),
+				response: {
+					id: "command-a",
+					type: "response",
+					command: "prompt",
+					success: true,
+				},
+				recordedAt: new Date().toISOString(),
+			})}\n`,
+		);
+
+		expect(() => new CommandRecoveryJournal(path)).toThrow(/no preceding received record/);
 	});
 
 	it("durably removes acknowledged results", () => {

--- a/packages/coding-agent/test/command-recovery-journal.test.ts
+++ b/packages/coding-agent/test/command-recovery-journal.test.ts
@@ -97,7 +97,7 @@ describe("CommandRecoveryJournal", () => {
 		expect(journal.lookup("client-a", "command-a")).toEqual({ status: "pending" });
 	});
 
-	it("accepts an identical repeated result but rejects a conflicting replacement", () => {
+	it("accepts a structurally identical repeated result but rejects a conflicting replacement", () => {
 		const journal = new CommandRecoveryJournal(createPath());
 		journal.begin("client-a", "command-a", "prompt");
 		const response = {
@@ -107,7 +107,13 @@ describe("CommandRecoveryJournal", () => {
 			success: true as const,
 		};
 		journal.recordResult("client-a", "command-a", response);
-		expect(() => journal.recordResult("client-a", "command-a", response)).not.toThrow();
+		const sameResponseDifferentKeyOrder = {
+			success: true as const,
+			command: "prompt" as const,
+			type: "response" as const,
+			id: "command-a",
+		};
+		expect(() => journal.recordResult("client-a", "command-a", sameResponseDifferentKeyOrder)).not.toThrow();
 		expect(() =>
 			journal.recordResult("client-a", "command-a", {
 				id: "command-a",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Harden `CommandRecoveryJournal` to fail closed on corrupt or inconsistent journal records
- Rewrites journal loading in [`command-recovery-journal.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1043/files#diff-ad9ad93f7564a34f4c838495026b460ad85292338ab337c5cdca8f48161ecd3a) to validate record shape, canonical key equality, and type/id consistency; only the final partial (truncated) append is tolerated.
- Adds strict validation to `begin` and `recordResult`: reusing an idempotency key for a different command type throws, and recorded results must match the receipt's `commandId` and `commandType`.
- Repeated identical results are treated as idempotent no-ops; conflicting result replacements are rejected.
- Extends the test suite to cover all new failure paths including malformed JSON, non-canonical keys, missing receipts, and conflicting results.
- Risk: journal recovery now throws on previously-tolerated malformed records, so agents replaying old journals with inconsistencies will fail rather than continuing.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2114211.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->