### PR TITLE
refactor(ai): share one stream consumer and request builder across the Google adapters

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [Unreleased]
+
+### Changed
+
+- Changed the Google Gemini and Vertex providers to share one stream consumer and one request builder, so the duplicated stream state machine and payload assembly no longer have to be kept in sync by hand ([#956](https://github.com/PrimeIntellect-ai/prime-agent/issues/956)).
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -2,8 +2,30 @@
  * Shared utilities for Google Generative AI and Google Vertex providers.
  */
 
-import { type Content, FinishReason, FunctionCallingConfigMode, type Part } from "@google/genai";
-import type { Context, ImageContent, Model, StopReason, TextContent, ThinkingBudgets, Tool } from "../types.js";
+import {
+	type Content,
+	FinishReason,
+	FunctionCallingConfigMode,
+	type GenerateContentConfig,
+	type GenerateContentParameters,
+	type GenerateContentResponse,
+	type Part,
+	type ThinkingConfig,
+} from "@google/genai";
+import { calculateCost } from "../models.js";
+import type {
+	AssistantMessage,
+	Context,
+	ImageContent,
+	Model,
+	StopReason,
+	TextContent,
+	ThinkingBudgets,
+	ThinkingContent,
+	Tool,
+	ToolCall,
+} from "../types.js";
+import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -373,4 +395,275 @@ export function mapStopReasonString(reason: string): StopReason {
 		default:
 			return "error";
 	}
+}
+
+// =============================================================================
+// Stream processing
+// =============================================================================
+
+// Counter for generating unique tool call IDs. Shared across both adapters so a
+// Gemini and a Vertex stream running concurrently cannot mint the same id.
+let toolCallCounter = 0;
+
+/**
+ * Consume a Gemini/Vertex `generateContentStream` and push normalized events.
+ *
+ * Both Google adapters speak the same wire format via `@google/genai`, so the
+ * block state machine, tool-call handling, finish-reason mapping and usage
+ * accounting live here; the adapters own only client construction, auth, and the
+ * API-specific `thinkingConfig` shape.
+ *
+ * Mutates `output` in place and pushes to `stream`. It does not push `done`,
+ * `error`, or `start`, and does not inspect the abort signal -- the adapter owns
+ * the stream lifecycle so it can attach its own request metadata to failures.
+ */
+export async function processGoogleStream(
+	googleStream: AsyncIterable<GenerateContentResponse>,
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	model: Model<GoogleApiType>,
+): Promise<void> {
+	let currentBlock: TextContent | ThinkingContent | null = null;
+	const blocks = output.content;
+	const blockIndex = () => blocks.length - 1;
+
+	const endCurrentBlock = () => {
+		if (!currentBlock) return;
+		if (currentBlock.type === "text") {
+			stream.push({
+				type: "text_end",
+				contentIndex: blockIndex(),
+				content: currentBlock.text,
+				partial: output,
+			});
+		} else {
+			stream.push({
+				type: "thinking_end",
+				contentIndex: blockIndex(),
+				content: currentBlock.thinking,
+				partial: output,
+			});
+		}
+	};
+
+	for await (const chunk of googleStream) {
+		// @google/genai documents GenerateContentResponse.responseId as an output-only
+		// field used to identify each response. Keep the first non-empty one.
+		output.responseId ||= chunk.responseId;
+		const candidate = chunk.candidates?.[0];
+		if (candidate?.content?.parts) {
+			for (const part of candidate.content.parts) {
+				if (part.text !== undefined) {
+					const isThinking = isThinkingPart(part);
+					if (
+						!currentBlock ||
+						(isThinking && currentBlock.type !== "thinking") ||
+						(!isThinking && currentBlock.type !== "text")
+					) {
+						endCurrentBlock();
+						if (isThinking) {
+							currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
+							output.content.push(currentBlock);
+							stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+						} else {
+							currentBlock = { type: "text", text: "" };
+							output.content.push(currentBlock);
+							stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+						}
+					}
+					if (currentBlock.type === "thinking") {
+						currentBlock.thinking += part.text;
+						currentBlock.thinkingSignature = retainThoughtSignature(
+							currentBlock.thinkingSignature,
+							part.thoughtSignature,
+						);
+						stream.push({
+							type: "thinking_delta",
+							contentIndex: blockIndex(),
+							delta: part.text,
+							partial: output,
+						});
+					} else {
+						currentBlock.text += part.text;
+						currentBlock.textSignature = retainThoughtSignature(
+							currentBlock.textSignature,
+							part.thoughtSignature,
+						);
+						stream.push({
+							type: "text_delta",
+							contentIndex: blockIndex(),
+							delta: part.text,
+							partial: output,
+						});
+					}
+				}
+
+				if (part.functionCall) {
+					if (currentBlock) {
+						endCurrentBlock();
+						currentBlock = null;
+					}
+
+					// Generate unique ID if not provided or if it's a duplicate
+					const providedId = part.functionCall.id;
+					const needsNewId =
+						!providedId || output.content.some((b) => b.type === "toolCall" && b.id === providedId);
+					const toolCallId = needsNewId
+						? `${part.functionCall.name}_${Date.now()}_${++toolCallCounter}`
+						: providedId;
+
+					const toolCall: ToolCall = {
+						type: "toolCall",
+						id: toolCallId,
+						name: part.functionCall.name || "",
+						arguments: (part.functionCall.args as Record<string, any>) ?? {},
+						...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
+					};
+
+					output.content.push(toolCall);
+					stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+					stream.push({
+						type: "toolcall_delta",
+						contentIndex: blockIndex(),
+						delta: JSON.stringify(toolCall.arguments),
+						partial: output,
+					});
+					stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
+				}
+			}
+		}
+
+		if (candidate?.finishReason) {
+			output.stopReason = mapStopReason(candidate.finishReason);
+			if (output.content.some((b) => b.type === "toolCall")) {
+				output.stopReason = "toolUse";
+			}
+			if (output.stopReason === "error") {
+				output.stopReasonRaw = candidate.finishReason;
+			}
+		}
+
+		if (chunk.usageMetadata) {
+			output.usage = {
+				input: (chunk.usageMetadata.promptTokenCount || 0) - (chunk.usageMetadata.cachedContentTokenCount || 0),
+				output: (chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
+				cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
+				cacheWrite: 0,
+				totalTokens: chunk.usageMetadata.totalTokenCount || 0,
+				cost: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					total: 0,
+				},
+			};
+			calculateCost(model, output.usage);
+		}
+	}
+
+	endCurrentBlock();
+}
+
+// =============================================================================
+// Request configuration
+// =============================================================================
+
+export interface GoogleThinkingOptions {
+	enabled: boolean;
+	budgetTokens?: number; // -1 for dynamic, 0 to disable
+	level?: GoogleThinkingLevel;
+}
+
+export interface BuildGoogleParamsOptions {
+	temperature?: number;
+	maxTokens?: number;
+	toolChoice?: "auto" | "none" | "any";
+	thinking?: GoogleThinkingOptions;
+	signal?: AbortSignal;
+}
+
+export interface GoogleThinkingConfigBuilder {
+	/**
+	 * Build the `thinkingConfig` for a model whose thinking is enabled. Gemini and
+	 * Vertex take the same levels but different value types: the Gemini API accepts
+	 * the raw string, Vertex requires the SDK's `ThinkingLevel` enum member.
+	 */
+	enabled: (thinking: GoogleThinkingOptions) => ThinkingConfig;
+	/** Build the `thinkingConfig` that suppresses thinking for this model. */
+	disabled: (modelId: string) => ThinkingConfig;
+}
+
+/**
+ * Build `GenerateContentParameters` for either Google API.
+ *
+ * Everything except `thinkingConfig` is identical between the two; the caller
+ * supplies that via `thinkingConfigBuilder`.
+ */
+export function buildGoogleParams(
+	model: Model<GoogleApiType>,
+	context: Context,
+	options: BuildGoogleParamsOptions,
+	thinkingConfigBuilder: GoogleThinkingConfigBuilder,
+): GenerateContentParameters {
+	const contents = convertMessages(model, context);
+
+	const generationConfig: GenerateContentConfig = {};
+	if (options.temperature !== undefined) {
+		generationConfig.temperature = options.temperature;
+	}
+	if (options.maxTokens !== undefined) {
+		generationConfig.maxOutputTokens = options.maxTokens;
+	}
+
+	const config: GenerateContentConfig = {
+		...(Object.keys(generationConfig).length > 0 && generationConfig),
+		...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
+		...(context.tools && context.tools.length > 0 && { tools: convertTools(context.tools) }),
+	};
+
+	if (context.tools && context.tools.length > 0 && options.toolChoice) {
+		config.toolConfig = {
+			functionCallingConfig: {
+				mode: mapToolChoice(options.toolChoice),
+			},
+		};
+	} else {
+		config.toolConfig = undefined;
+	}
+
+	if (options.thinking?.enabled && model.reasoning) {
+		config.thinkingConfig = thinkingConfigBuilder.enabled(options.thinking);
+	} else if (model.reasoning && options.thinking && !options.thinking.enabled) {
+		config.thinkingConfig = thinkingConfigBuilder.disabled(model.id);
+	}
+
+	if (options.signal) {
+		if (options.signal.aborted) {
+			throw new Error("Request aborted");
+		}
+		config.abortSignal = options.signal;
+	}
+
+	return {
+		model: model.id,
+		contents,
+		config,
+	};
+}
+
+// =============================================================================
+// Model family detection
+// =============================================================================
+
+export function isGemma4Model(modelId: string): boolean {
+	return /gemma-?4/.test(modelId.toLowerCase());
+}
+
+export function isGemini3ProModel(modelId: string): boolean {
+	return /gemini-3(?:\.\d+)?-pro/.test(modelId.toLowerCase());
+}
+
+export function isGemini3FlashModel(modelId: string): boolean {
+	return /gemini-3(?:\.\d+)?-flash/.test(modelId.toLowerCase());
 }

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -1,5 +1,4 @@
 import {
-	type GenerateContentConfig,
 	type GenerateContentParameters,
 	GoogleGenAI,
 	type HttpOptions,
@@ -7,7 +6,7 @@ import {
 	type ThinkingConfig,
 	ThinkingLevel,
 } from "@google/genai";
-import { calculateCost, clampThinkingLevel } from "../models.js";
+import { clampThinkingLevel } from "../models.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -17,36 +16,26 @@ import type {
 	SimpleStreamOptions,
 	StreamFunction,
 	StreamOptions,
-	TextContent,
-	ThinkingContent,
-	ToolCall,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
-import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
 	formatStreamFailureMessage,
 	recordStreamFailure,
 	streamFailureFromStopReason,
 } from "../utils/stream-failure.js";
-import type { GoogleThinkingLevel } from "./google-shared.js";
+import type { GoogleThinkingLevel, GoogleThinkingOptions } from "./google-shared.js";
 import {
-	convertMessages,
-	convertTools,
+	buildGoogleParams,
 	getGoogleThinkingBudget,
-	isThinkingPart,
-	mapStopReason,
-	mapToolChoice,
-	retainThoughtSignature,
+	isGemini3FlashModel,
+	isGemini3ProModel,
+	processGoogleStream,
 } from "./google-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
 export interface GoogleVertexOptions extends StreamOptions {
 	toolChoice?: "auto" | "none" | "any";
-	thinking?: {
-		enabled: boolean;
-		budgetTokens?: number; // -1 for dynamic, 0 to disable
-		level?: GoogleThinkingLevel;
-	};
+	thinking?: GoogleThinkingOptions;
 	project?: string;
 	location?: string;
 }
@@ -61,9 +50,6 @@ const THINKING_LEVEL_MAP: Record<GoogleThinkingLevel, ThinkingLevel> = {
 	MEDIUM: ThinkingLevel.MEDIUM,
 	HIGH: ThinkingLevel.HIGH,
 };
-
-// Counter for generating unique tool call IDs
-let toolCallCounter = 0;
 
 export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOptions> = (
 	model: Model<"google-vertex">,
@@ -105,173 +91,8 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 			const googleStream = await client.models.generateContentStream(params);
 
 			stream.push({ type: "start", partial: output });
-			let currentBlock: TextContent | ThinkingContent | null = null;
-			const blocks = output.content;
-			const blockIndex = () => blocks.length - 1;
-			for await (const chunk of googleStream) {
-				// Vertex uses the same @google/genai GenerateContentResponse type as Gemini.
-				// responseId is documented there as an output-only identifier for each response.
-				output.responseId ||= chunk.responseId;
-				const candidate = chunk.candidates?.[0];
-				if (candidate?.content?.parts) {
-					for (const part of candidate.content.parts) {
-						if (part.text !== undefined) {
-							const isThinking = isThinkingPart(part);
-							if (
-								!currentBlock ||
-								(isThinking && currentBlock.type !== "thinking") ||
-								(!isThinking && currentBlock.type !== "text")
-							) {
-								if (currentBlock) {
-									if (currentBlock.type === "text") {
-										stream.push({
-											type: "text_end",
-											contentIndex: blocks.length - 1,
-											content: currentBlock.text,
-											partial: output,
-										});
-									} else {
-										stream.push({
-											type: "thinking_end",
-											contentIndex: blockIndex(),
-											content: currentBlock.thinking,
-											partial: output,
-										});
-									}
-								}
-								if (isThinking) {
-									currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
-									output.content.push(currentBlock);
-									stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
-								} else {
-									currentBlock = { type: "text", text: "" };
-									output.content.push(currentBlock);
-									stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-								}
-							}
-							if (currentBlock.type === "thinking") {
-								currentBlock.thinking += part.text;
-								currentBlock.thinkingSignature = retainThoughtSignature(
-									currentBlock.thinkingSignature,
-									part.thoughtSignature,
-								);
-								stream.push({
-									type: "thinking_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							} else {
-								currentBlock.text += part.text;
-								currentBlock.textSignature = retainThoughtSignature(
-									currentBlock.textSignature,
-									part.thoughtSignature,
-								);
-								stream.push({
-									type: "text_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							}
-						}
 
-						if (part.functionCall) {
-							if (currentBlock) {
-								if (currentBlock.type === "text") {
-									stream.push({
-										type: "text_end",
-										contentIndex: blockIndex(),
-										content: currentBlock.text,
-										partial: output,
-									});
-								} else {
-									stream.push({
-										type: "thinking_end",
-										contentIndex: blockIndex(),
-										content: currentBlock.thinking,
-										partial: output,
-									});
-								}
-								currentBlock = null;
-							}
-
-							const providedId = part.functionCall.id;
-							const needsNewId =
-								!providedId || output.content.some((b) => b.type === "toolCall" && b.id === providedId);
-							const toolCallId = needsNewId
-								? `${part.functionCall.name}_${Date.now()}_${++toolCallCounter}`
-								: providedId;
-
-							const toolCall: ToolCall = {
-								type: "toolCall",
-								id: toolCallId,
-								name: part.functionCall.name || "",
-								arguments: (part.functionCall.args as Record<string, any>) ?? {},
-								...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
-							};
-
-							output.content.push(toolCall);
-							stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
-							stream.push({
-								type: "toolcall_delta",
-								contentIndex: blockIndex(),
-								delta: JSON.stringify(toolCall.arguments),
-								partial: output,
-							});
-							stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
-						}
-					}
-				}
-
-				if (candidate?.finishReason) {
-					output.stopReason = mapStopReason(candidate.finishReason);
-					if (output.content.some((b) => b.type === "toolCall")) {
-						output.stopReason = "toolUse";
-					}
-					if (output.stopReason === "error") {
-						output.stopReasonRaw = candidate.finishReason;
-					}
-				}
-
-				if (chunk.usageMetadata) {
-					output.usage = {
-						input:
-							(chunk.usageMetadata.promptTokenCount || 0) - (chunk.usageMetadata.cachedContentTokenCount || 0),
-						output:
-							(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
-						cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
-						cacheWrite: 0,
-						totalTokens: chunk.usageMetadata.totalTokenCount || 0,
-						cost: {
-							input: 0,
-							output: 0,
-							cacheRead: 0,
-							cacheWrite: 0,
-							total: 0,
-						},
-					};
-					calculateCost(model, output.usage);
-				}
-			}
-
-			if (currentBlock) {
-				if (currentBlock.type === "text") {
-					stream.push({
-						type: "text_end",
-						contentIndex: blockIndex(),
-						content: currentBlock.text,
-						partial: output,
-					});
-				} else {
-					stream.push({
-						type: "thinking_end",
-						contentIndex: blockIndex(),
-						content: currentBlock.thinking,
-						partial: output,
-					});
-				}
-			}
+			await processGoogleStream(googleStream, output, stream, model);
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
@@ -316,14 +137,13 @@ export const streamSimpleGoogleVertex: StreamFunction<"google-vertex", SimpleStr
 
 	const clampedReasoning = clampThinkingLevel(model, options.reasoning);
 	const effort = (clampedReasoning === "off" ? "high" : clampedReasoning) as ClampedThinkingLevel;
-	const geminiModel = model as unknown as Model<"google-generative-ai">;
 
-	if (isGemini3ProModel(geminiModel) || isGemini3FlashModel(geminiModel)) {
+	if (isGemini3ProModel(model.id) || isGemini3FlashModel(model.id)) {
 		return streamGoogleVertex(model, context, {
 			...base,
 			thinking: {
 				enabled: true,
-				level: getGemini3ThinkingLevel(effort, geminiModel),
+				level: getGemini3ThinkingLevel(effort, model.id),
 			},
 		} satisfies GoogleVertexOptions);
 	}
@@ -332,7 +152,7 @@ export const streamSimpleGoogleVertex: StreamFunction<"google-vertex", SimpleStr
 		...base,
 		thinking: {
 			enabled: true,
-			budgetTokens: getGoogleThinkingBudget(geminiModel.id, effort, options.thinkingBudgets),
+			budgetTokens: getGoogleThinkingBudget(model.id, effort, options.thinkingBudgets),
 		},
 	} satisfies GoogleVertexOptions);
 };
@@ -438,79 +258,30 @@ function buildParams(
 	context: Context,
 	options: GoogleVertexOptions = {},
 ): GenerateContentParameters {
-	const contents = convertMessages(model, context);
-
-	const generationConfig: GenerateContentConfig = {};
-	if (options.temperature !== undefined) {
-		generationConfig.temperature = options.temperature;
-	}
-	if (options.maxTokens !== undefined) {
-		generationConfig.maxOutputTokens = options.maxTokens;
-	}
-
-	const config: GenerateContentConfig = {
-		...(Object.keys(generationConfig).length > 0 && generationConfig),
-		...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
-		...(context.tools && context.tools.length > 0 && { tools: convertTools(context.tools) }),
-	};
-
-	if (context.tools && context.tools.length > 0 && options.toolChoice) {
-		config.toolConfig = {
-			functionCallingConfig: {
-				mode: mapToolChoice(options.toolChoice),
-			},
-		};
-	} else {
-		config.toolConfig = undefined;
-	}
-
-	if (options.thinking?.enabled && model.reasoning) {
-		const thinkingConfig: ThinkingConfig = { includeThoughts: true };
-		if (options.thinking.level !== undefined) {
-			thinkingConfig.thinkingLevel = THINKING_LEVEL_MAP[options.thinking.level];
-		} else if (options.thinking.budgetTokens !== undefined) {
-			thinkingConfig.thinkingBudget = options.thinking.budgetTokens;
-		}
-		config.thinkingConfig = thinkingConfig;
-	} else if (model.reasoning && options.thinking && !options.thinking.enabled) {
-		config.thinkingConfig = getDisabledThinkingConfig(model);
-	}
-
-	if (options.signal) {
-		if (options.signal.aborted) {
-			throw new Error("Request aborted");
-		}
-		config.abortSignal = options.signal;
-	}
-
-	const params: GenerateContentParameters = {
-		model: model.id,
-		contents,
-		config,
-	};
-
-	return params;
+	return buildGoogleParams(model, context, options, {
+		enabled: (thinking) => {
+			const thinkingConfig: ThinkingConfig = { includeThoughts: true };
+			if (thinking.level !== undefined) {
+				thinkingConfig.thinkingLevel = THINKING_LEVEL_MAP[thinking.level];
+			} else if (thinking.budgetTokens !== undefined) {
+				thinkingConfig.thinkingBudget = thinking.budgetTokens;
+			}
+			return thinkingConfig;
+		},
+		disabled: getDisabledThinkingConfig,
+	});
 }
 
 type ClampedThinkingLevel = Exclude<PiThinkingLevel, "xhigh" | "max">;
 
-function isGemini3ProModel(model: Model<"google-generative-ai">): boolean {
-	return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());
-}
-
-function isGemini3FlashModel(model: Model<"google-generative-ai">): boolean {
-	return /gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
-}
-
-function getDisabledThinkingConfig(model: Model<"google-vertex">): ThinkingConfig {
+function getDisabledThinkingConfig(modelId: string): ThinkingConfig {
 	// Google docs: Gemini 3.1 Pro cannot disable thinking, and Gemini 3 Flash / Flash-Lite
 	// do not support full thinking-off either. For Gemini 3 models, use the lowest supported
 	// thinkingLevel without includeThoughts so hidden thinking remains invisible to pi.
-	const geminiModel = model as unknown as Model<"google-generative-ai">;
-	if (isGemini3ProModel(geminiModel)) {
+	if (isGemini3ProModel(modelId)) {
 		return { thinkingLevel: ThinkingLevel.LOW };
 	}
-	if (isGemini3FlashModel(geminiModel)) {
+	if (isGemini3FlashModel(modelId)) {
 		return { thinkingLevel: ThinkingLevel.MINIMAL };
 	}
 
@@ -518,11 +289,8 @@ function getDisabledThinkingConfig(model: Model<"google-vertex">): ThinkingConfi
 	return { thinkingBudget: 0 };
 }
 
-function getGemini3ThinkingLevel(
-	effort: ClampedThinkingLevel,
-	model: Model<"google-generative-ai">,
-): GoogleThinkingLevel {
-	if (isGemini3ProModel(model)) {
+function getGemini3ThinkingLevel(effort: ClampedThinkingLevel, modelId: string): GoogleThinkingLevel {
+	if (isGemini3ProModel(modelId)) {
 		switch (effort) {
 			case "minimal":
 			case "low":

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -1,11 +1,6 @@
-import {
-	type GenerateContentConfig,
-	type GenerateContentParameters,
-	GoogleGenAI,
-	type ThinkingConfig,
-} from "@google/genai";
+import { type GenerateContentParameters, GoogleGenAI, type ThinkingConfig } from "@google/genai";
 import { getEnvApiKey } from "../env-api-keys.js";
-import { calculateCost, clampThinkingLevel } from "../models.js";
+import { clampThinkingLevel } from "../models.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -14,41 +9,29 @@ import type {
 	SimpleStreamOptions,
 	StreamFunction,
 	StreamOptions,
-	TextContent,
-	ThinkingContent,
 	ThinkingLevel,
-	ToolCall,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
-import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
 	formatStreamFailureMessage,
 	recordStreamFailure,
 	streamFailureFromStopReason,
 } from "../utils/stream-failure.js";
-import type { GoogleThinkingLevel } from "./google-shared.js";
+import type { GoogleThinkingLevel, GoogleThinkingOptions } from "./google-shared.js";
 import {
-	convertMessages,
-	convertTools,
+	buildGoogleParams,
 	getGoogleThinkingBudget,
-	isThinkingPart,
-	mapStopReason,
-	mapToolChoice,
-	retainThoughtSignature,
+	isGemini3FlashModel,
+	isGemini3ProModel,
+	isGemma4Model,
+	processGoogleStream,
 } from "./google-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
 export interface GoogleOptions extends StreamOptions {
 	toolChoice?: "auto" | "none" | "any";
-	thinking?: {
-		enabled: boolean;
-		budgetTokens?: number; // -1 for dynamic, 0 to disable
-		level?: GoogleThinkingLevel;
-	};
+	thinking?: GoogleThinkingOptions;
 }
-
-// Counter for generating unique tool call IDs
-let toolCallCounter = 0;
 
 export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions> = (
 	model: Model<"google-generative-ai">,
@@ -87,174 +70,8 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 			const googleStream = await client.models.generateContentStream(params);
 
 			stream.push({ type: "start", partial: output });
-			let currentBlock: TextContent | ThinkingContent | null = null;
-			const blocks = output.content;
-			const blockIndex = () => blocks.length - 1;
-			for await (const chunk of googleStream) {
-				// @google/genai documents GenerateContentResponse.responseId as an output-only field
-				// used to identify each response. Keep the first non-empty one from the stream.
-				output.responseId ||= chunk.responseId;
-				const candidate = chunk.candidates?.[0];
-				if (candidate?.content?.parts) {
-					for (const part of candidate.content.parts) {
-						if (part.text !== undefined) {
-							const isThinking = isThinkingPart(part);
-							if (
-								!currentBlock ||
-								(isThinking && currentBlock.type !== "thinking") ||
-								(!isThinking && currentBlock.type !== "text")
-							) {
-								if (currentBlock) {
-									if (currentBlock.type === "text") {
-										stream.push({
-											type: "text_end",
-											contentIndex: blocks.length - 1,
-											content: currentBlock.text,
-											partial: output,
-										});
-									} else {
-										stream.push({
-											type: "thinking_end",
-											contentIndex: blockIndex(),
-											content: currentBlock.thinking,
-											partial: output,
-										});
-									}
-								}
-								if (isThinking) {
-									currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
-									output.content.push(currentBlock);
-									stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
-								} else {
-									currentBlock = { type: "text", text: "" };
-									output.content.push(currentBlock);
-									stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-								}
-							}
-							if (currentBlock.type === "thinking") {
-								currentBlock.thinking += part.text;
-								currentBlock.thinkingSignature = retainThoughtSignature(
-									currentBlock.thinkingSignature,
-									part.thoughtSignature,
-								);
-								stream.push({
-									type: "thinking_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							} else {
-								currentBlock.text += part.text;
-								currentBlock.textSignature = retainThoughtSignature(
-									currentBlock.textSignature,
-									part.thoughtSignature,
-								);
-								stream.push({
-									type: "text_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							}
-						}
 
-						if (part.functionCall) {
-							if (currentBlock) {
-								if (currentBlock.type === "text") {
-									stream.push({
-										type: "text_end",
-										contentIndex: blockIndex(),
-										content: currentBlock.text,
-										partial: output,
-									});
-								} else {
-									stream.push({
-										type: "thinking_end",
-										contentIndex: blockIndex(),
-										content: currentBlock.thinking,
-										partial: output,
-									});
-								}
-								currentBlock = null;
-							}
-
-							// Generate unique ID if not provided or if it's a duplicate
-							const providedId = part.functionCall.id;
-							const needsNewId =
-								!providedId || output.content.some((b) => b.type === "toolCall" && b.id === providedId);
-							const toolCallId = needsNewId
-								? `${part.functionCall.name}_${Date.now()}_${++toolCallCounter}`
-								: providedId;
-
-							const toolCall: ToolCall = {
-								type: "toolCall",
-								id: toolCallId,
-								name: part.functionCall.name || "",
-								arguments: (part.functionCall.args as Record<string, any>) ?? {},
-								...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
-							};
-
-							output.content.push(toolCall);
-							stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
-							stream.push({
-								type: "toolcall_delta",
-								contentIndex: blockIndex(),
-								delta: JSON.stringify(toolCall.arguments),
-								partial: output,
-							});
-							stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
-						}
-					}
-				}
-
-				if (candidate?.finishReason) {
-					output.stopReason = mapStopReason(candidate.finishReason);
-					if (output.content.some((b) => b.type === "toolCall")) {
-						output.stopReason = "toolUse";
-					}
-					if (output.stopReason === "error") {
-						output.stopReasonRaw = candidate.finishReason;
-					}
-				}
-
-				if (chunk.usageMetadata) {
-					output.usage = {
-						input:
-							(chunk.usageMetadata.promptTokenCount || 0) - (chunk.usageMetadata.cachedContentTokenCount || 0),
-						output:
-							(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
-						cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
-						cacheWrite: 0,
-						totalTokens: chunk.usageMetadata.totalTokenCount || 0,
-						cost: {
-							input: 0,
-							output: 0,
-							cacheRead: 0,
-							cacheWrite: 0,
-							total: 0,
-						},
-					};
-					calculateCost(model, output.usage);
-				}
-			}
-
-			if (currentBlock) {
-				if (currentBlock.type === "text") {
-					stream.push({
-						type: "text_end",
-						contentIndex: blockIndex(),
-						content: currentBlock.text,
-						partial: output,
-					});
-				} else {
-					stream.push({
-						type: "thinking_end",
-						contentIndex: blockIndex(),
-						content: currentBlock.thinking,
-						partial: output,
-					});
-				}
-			}
+			await processGoogleStream(googleStream, output, stream, model);
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
@@ -303,12 +120,12 @@ export const streamSimpleGoogle: StreamFunction<"google-generative-ai", SimpleSt
 	const effort = (clampedReasoning === "off" ? "high" : clampedReasoning) as ClampedThinkingLevel;
 	const googleModel = model as Model<"google-generative-ai">;
 
-	if (isGemini3ProModel(googleModel) || isGemini3FlashModel(googleModel) || isGemma4Model(googleModel)) {
+	if (isGemini3ProModel(googleModel.id) || isGemini3FlashModel(googleModel.id) || isGemma4Model(googleModel.id)) {
 		return streamGoogle(model, context, {
 			...base,
 			thinking: {
 				enabled: true,
-				level: getThinkingLevel(effort, googleModel),
+				level: getThinkingLevel(effort, googleModel.id),
 			},
 		} satisfies GoogleOptions);
 	}
@@ -347,86 +164,34 @@ function buildParams(
 	context: Context,
 	options: GoogleOptions = {},
 ): GenerateContentParameters {
-	const contents = convertMessages(model, context);
-
-	const generationConfig: GenerateContentConfig = {};
-	if (options.temperature !== undefined) {
-		generationConfig.temperature = options.temperature;
-	}
-	if (options.maxTokens !== undefined) {
-		generationConfig.maxOutputTokens = options.maxTokens;
-	}
-
-	const config: GenerateContentConfig = {
-		...(Object.keys(generationConfig).length > 0 && generationConfig),
-		...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
-		...(context.tools && context.tools.length > 0 && { tools: convertTools(context.tools) }),
-	};
-
-	if (context.tools && context.tools.length > 0 && options.toolChoice) {
-		config.toolConfig = {
-			functionCallingConfig: {
-				mode: mapToolChoice(options.toolChoice),
-			},
-		};
-	} else {
-		config.toolConfig = undefined;
-	}
-
-	if (options.thinking?.enabled && model.reasoning) {
-		const thinkingConfig: ThinkingConfig = { includeThoughts: true };
-		if (options.thinking.level !== undefined) {
-			// Cast to any since our GoogleThinkingLevel mirrors Google's ThinkingLevel enum values
-			thinkingConfig.thinkingLevel = options.thinking.level as any;
-		} else if (options.thinking.budgetTokens !== undefined) {
-			thinkingConfig.thinkingBudget = options.thinking.budgetTokens;
-		}
-		config.thinkingConfig = thinkingConfig;
-	} else if (model.reasoning && options.thinking && !options.thinking.enabled) {
-		config.thinkingConfig = getDisabledThinkingConfig(model);
-	}
-
-	if (options.signal) {
-		if (options.signal.aborted) {
-			throw new Error("Request aborted");
-		}
-		config.abortSignal = options.signal;
-	}
-
-	const params: GenerateContentParameters = {
-		model: model.id,
-		contents,
-		config,
-	};
-
-	return params;
+	return buildGoogleParams(model, context, options, {
+		enabled: (thinking) => {
+			const thinkingConfig: ThinkingConfig = { includeThoughts: true };
+			if (thinking.level !== undefined) {
+				// Cast to any since our GoogleThinkingLevel mirrors Google's ThinkingLevel enum values
+				thinkingConfig.thinkingLevel = thinking.level as any;
+			} else if (thinking.budgetTokens !== undefined) {
+				thinkingConfig.thinkingBudget = thinking.budgetTokens;
+			}
+			return thinkingConfig;
+		},
+		disabled: getDisabledThinkingConfig,
+	});
 }
 
 type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh" | "max">;
 
-function isGemma4Model(model: Model<"google-generative-ai">): boolean {
-	return /gemma-?4/.test(model.id.toLowerCase());
-}
-
-function isGemini3ProModel(model: Model<"google-generative-ai">): boolean {
-	return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());
-}
-
-function isGemini3FlashModel(model: Model<"google-generative-ai">): boolean {
-	return /gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
-}
-
-function getDisabledThinkingConfig(model: Model<"google-generative-ai">): ThinkingConfig {
+function getDisabledThinkingConfig(modelId: string): ThinkingConfig {
 	// Google docs: Gemini 3.1 Pro cannot disable thinking, and Gemini 3 Flash / Flash-Lite
 	// do not support full thinking-off either. For Gemini 3 models, use the lowest supported
 	// thinkingLevel without includeThoughts so hidden thinking remains invisible to pi.
-	if (isGemini3ProModel(model)) {
+	if (isGemini3ProModel(modelId)) {
 		return { thinkingLevel: "LOW" as any };
 	}
-	if (isGemini3FlashModel(model)) {
+	if (isGemini3FlashModel(modelId)) {
 		return { thinkingLevel: "MINIMAL" as any };
 	}
-	if (isGemma4Model(model)) {
+	if (isGemma4Model(modelId)) {
 		return { thinkingLevel: "MINIMAL" as any };
 	}
 
@@ -434,8 +199,8 @@ function getDisabledThinkingConfig(model: Model<"google-generative-ai">): Thinki
 	return { thinkingBudget: 0 };
 }
 
-function getThinkingLevel(effort: ClampedThinkingLevel, model: Model<"google-generative-ai">): GoogleThinkingLevel {
-	if (isGemini3ProModel(model)) {
+function getThinkingLevel(effort: ClampedThinkingLevel, modelId: string): GoogleThinkingLevel {
+	if (isGemini3ProModel(modelId)) {
 		switch (effort) {
 			case "minimal":
 			case "low":
@@ -445,7 +210,7 @@ function getThinkingLevel(effort: ClampedThinkingLevel, model: Model<"google-gen
 				return "HIGH";
 		}
 	}
-	if (isGemma4Model(model)) {
+	if (isGemma4Model(modelId)) {
 		switch (effort) {
 			case "minimal":
 			case "low":

--- a/packages/ai/test/google-shared-stream-parity.test.ts
+++ b/packages/ai/test/google-shared-stream-parity.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * One provider-neutral fixture corpus, run through both Google adapters.
+ *
+ * Gemini and Vertex speak the same `@google/genai` wire format, so identical
+ * chunks must produce identical normalized events. This pins that contract so
+ * the shared consumer cannot drift back into two implementations.
+ */
+
+const genAiMock = vi.hoisted(() => ({
+	chunks: [] as unknown[],
+}));
+
+vi.mock("@google/genai", () => {
+	class GoogleGenAI {
+		models = {
+			generateContentStream: async function* () {
+				for (const chunk of genAiMock.chunks) {
+					yield chunk;
+				}
+			},
+		};
+	}
+
+	return {
+		GoogleGenAI,
+		FinishReason: {
+			STOP: "STOP",
+			MAX_TOKENS: "MAX_TOKENS",
+			SAFETY: "SAFETY",
+			MALFORMED_FUNCTION_CALL: "MALFORMED_FUNCTION_CALL",
+		},
+		FunctionCallingConfigMode: { AUTO: "AUTO", NONE: "NONE", ANY: "ANY" },
+		ResourceScope: { COLLECTION: "COLLECTION" },
+		ThinkingLevel: {
+			THINKING_LEVEL_UNSPECIFIED: "THINKING_LEVEL_UNSPECIFIED",
+			MINIMAL: "MINIMAL",
+			LOW: "LOW",
+			MEDIUM: "MEDIUM",
+			HIGH: "HIGH",
+		},
+	};
+});
+
+import { getModel } from "../src/models.js";
+import { streamGoogle } from "../src/providers/google.js";
+import { streamGoogleVertex } from "../src/providers/google-vertex.js";
+import type { AssistantMessageEvent, Context } from "../src/types.js";
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: 0 }],
+};
+
+const usageMetadata = {
+	promptTokenCount: 30,
+	candidatesTokenCount: 7,
+	thoughtsTokenCount: 3,
+	cachedContentTokenCount: 10,
+	totalTokenCount: 40,
+};
+
+interface Fixture {
+	name: string;
+	chunks: unknown[];
+	/** Set when the fixture is expected to end in the error path. */
+	expectError?: boolean;
+}
+
+const FIXTURES: Fixture[] = [
+	{
+		name: "text only",
+		chunks: [
+			{ responseId: "r1", candidates: [{ content: { parts: [{ text: "Hel" }] } }] },
+			{ candidates: [{ content: { parts: [{ text: "lo" }] } }] },
+			{ candidates: [{ finishReason: "STOP" }], usageMetadata },
+		],
+	},
+	{
+		name: "thinking then text, signature only on the first delta",
+		chunks: [
+			{
+				responseId: "r2",
+				candidates: [{ content: { parts: [{ thought: true, text: "ponder", thoughtSignature: "c2ln" }] } }],
+			},
+			{ candidates: [{ content: { parts: [{ thought: true, text: " more" }] } }] },
+			{ candidates: [{ content: { parts: [{ text: "answer" }] } }] },
+			{ candidates: [{ finishReason: "STOP" }], usageMetadata },
+		],
+	},
+	{
+		name: "tool call closes an open text block",
+		chunks: [
+			{
+				responseId: "r3",
+				candidates: [{ content: { parts: [{ text: "calling" }] } }],
+			},
+			{
+				candidates: [
+					{
+						content: {
+							parts: [{ functionCall: { id: "call_1", name: "read", args: { path: "a.ts" } } }],
+						},
+					},
+				],
+			},
+			{ candidates: [{ finishReason: "STOP" }], usageMetadata },
+		],
+	},
+	{
+		name: "duplicate tool call id is regenerated",
+		chunks: [
+			{
+				responseId: "r4",
+				candidates: [
+					{
+						content: {
+							parts: [
+								{ functionCall: { id: "dup", name: "read", args: { path: "a.ts" } } },
+								{ functionCall: { id: "dup", name: "read", args: { path: "b.ts" } } },
+							],
+						},
+					},
+				],
+			},
+			{ candidates: [{ finishReason: "STOP" }], usageMetadata },
+		],
+	},
+	{
+		name: "tool call carries a thought signature",
+		chunks: [
+			{
+				responseId: "r5",
+				candidates: [
+					{
+						content: {
+							parts: [{ functionCall: { id: "call_2", name: "write", args: {} }, thoughtSignature: "c2ln" }],
+						},
+					},
+				],
+			},
+			{ candidates: [{ finishReason: "STOP" }], usageMetadata },
+		],
+	},
+	{
+		name: "length stop reason",
+		chunks: [
+			{ responseId: "r6", candidates: [{ content: { parts: [{ text: "truncated" }] } }] },
+			{ candidates: [{ finishReason: "MAX_TOKENS" }], usageMetadata },
+		],
+	},
+	{
+		name: "safety block maps to the error path",
+		chunks: [
+			{ responseId: "r7", candidates: [{ content: { parts: [{ text: "partial" }] } }] },
+			{ candidates: [{ finishReason: "SAFETY" }], usageMetadata },
+		],
+		expectError: true,
+	},
+	{
+		name: "malformed function call maps to the error path",
+		chunks: [{ responseId: "r8", candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL" }], usageMetadata }],
+		expectError: true,
+	},
+	{
+		name: "empty stream",
+		chunks: [],
+	},
+	{
+		name: "unterminated text block still emits text_end",
+		chunks: [{ responseId: "r9", candidates: [{ content: { parts: [{ text: "no finish reason" }] } }] }],
+	},
+];
+
+/**
+ * Strip the fields that are legitimately adapter-specific or non-deterministic:
+ * the API/provider/model identity, wall-clock timestamps, the generated portion
+ * of a tool call id (which embeds `Date.now()` and a process-wide counter), and
+ * diagnostic stack traces (which name the throwing adapter's own file).
+ */
+function normalize(events: AssistantMessageEvent[]): unknown {
+	return JSON.parse(
+		JSON.stringify(events, (key, value) => {
+			if (key === "timestamp" || key === "api" || key === "provider" || key === "model") return undefined;
+			if (key === "stack") return undefined;
+			if (key === "id" && typeof value === "string") {
+				// Generated ids look like `<name>_<epoch-ms>_<counter>`.
+				return value.replace(/_\d+_\d+$/, "_<generated>");
+			}
+			return value;
+		}),
+	);
+}
+
+async function collect(
+	run: () => { [Symbol.asyncIterator](): AsyncIterator<AssistantMessageEvent> },
+): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of run()) {
+		events.push(event);
+	}
+	return events;
+}
+
+describe("Google stream parity across adapters", () => {
+	// Same underlying model on both APIs, so cost/reasoning metadata matches and
+	// any difference in the normalized events comes from the adapters themselves.
+	const geminiModel = getModel("google", "gemini-2.5-flash");
+	const vertexModel = getModel("google-vertex", "gemini-2.5-flash");
+
+	it.each(FIXTURES)("produces equivalent events for: $name", async ({ chunks, expectError }) => {
+		genAiMock.chunks = chunks;
+		const gemini = await collect(() => streamGoogle(geminiModel, context, { apiKey: "fake-key" }));
+
+		genAiMock.chunks = chunks;
+		const vertex = await collect(() =>
+			streamGoogleVertex(vertexModel, context, { apiKey: "AIzaSyFakeVertexKey1234567890" }),
+		);
+
+		expect(normalize(vertex)).toEqual(normalize(gemini));
+
+		const terminal = gemini[gemini.length - 1];
+		expect(terminal?.type).toBe(expectError ? "error" : "done");
+	});
+
+	it("reports identical usage and cost on both adapters", async () => {
+		genAiMock.chunks = FIXTURES[0]!.chunks;
+		const gemini = await streamGoogle(geminiModel, context, { apiKey: "fake-key" }).result();
+
+		genAiMock.chunks = FIXTURES[0]!.chunks;
+		const vertex = await streamGoogleVertex(vertexModel, context, {
+			apiKey: "AIzaSyFakeVertexKey1234567890",
+		}).result();
+
+		// input excludes the cached tokens; output includes thinking tokens.
+		expect(gemini.usage).toMatchObject({ input: 20, output: 10, cacheRead: 10, totalTokens: 40 });
+		expect(vertex.usage).toEqual(gemini.usage);
+	});
+
+	const ABORT_CHUNKS = [
+		{ responseId: "abort", candidates: [{ content: { parts: [{ text: "partial" }] } }] },
+		{ candidates: [{ finishReason: "STOP" }], usageMetadata },
+	];
+
+	it("reports an abort raised after the request starts identically", async () => {
+		// Each adapter gets its own controller, aborted at the same point in its own
+		// lifecycle: after `buildParams` has run, before the stream is drained.
+		genAiMock.chunks = ABORT_CHUNKS;
+		const geminiController = new AbortController();
+		const geminiStream = streamGoogle(geminiModel, context, {
+			apiKey: "fake-key",
+			signal: geminiController.signal,
+		});
+		geminiController.abort();
+		const gemini = await geminiStream.result();
+
+		genAiMock.chunks = ABORT_CHUNKS;
+		const vertexController = new AbortController();
+		const vertexStream = streamGoogleVertex(vertexModel, context, {
+			apiKey: "AIzaSyFakeVertexKey1234567890",
+			signal: vertexController.signal,
+		});
+		vertexController.abort();
+		const vertex = await vertexStream.result();
+
+		expect(gemini.stopReason).toBe("aborted");
+		expect(gemini.errorMessage).toBe("Request was aborted");
+		expect(vertex.stopReason).toBe(gemini.stopReason);
+		expect(vertex.errorMessage).toBe(gemini.errorMessage);
+	});
+
+	it("rejects an already-aborted signal identically", async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		genAiMock.chunks = ABORT_CHUNKS;
+		const gemini = await streamGoogle(geminiModel, context, {
+			apiKey: "fake-key",
+			signal: controller.signal,
+		}).result();
+
+		genAiMock.chunks = ABORT_CHUNKS;
+		const vertex = await streamGoogleVertex(vertexModel, context, {
+			apiKey: "AIzaSyFakeVertexKey1234567890",
+			signal: controller.signal,
+		}).result();
+
+		// Both bail out of `buildGoogleParams` before any request is made.
+		expect(gemini.stopReason).toBe("aborted");
+		expect(gemini.errorMessage).toBe("Request aborted");
+		expect(vertex.stopReason).toBe(gemini.stopReason);
+		expect(vertex.errorMessage).toBe(gemini.errorMessage);
+	});
+});


### PR DESCRIPTION
## What

Extracts the duplicated Google streaming logic into `google-shared.ts` so the Gemini
and Vertex adapters share one implementation of the parts that are genuinely identical.

- `processGoogleStream(googleStream, output, stream, model)` — the whole
  `@google/genai` chunk consumer: text and thinking block open/close, thought
  signatures, `functionCall` handling including duplicate-id regeneration, the
  `finishReason` → `stopReason` mapping with the tool-use override, and usage plus
  `calculateCost`. It deliberately does not push `start`/`done`/`error` and does not
  inspect the abort signal, so each adapter keeps ownership of the stream lifecycle and
  can attach its own request metadata to failures.
- `buildGoogleParams(model, context, options, thinkingConfigBuilder)` — request
  assembly, with the one real difference (the shape of `thinkingConfig`) supplied by
  the caller through a two-function builder (`enabled` / `disabled`).
- The `isGemma4Model` / `isGemini3ProModel` / `isGemini3FlashModel` predicates now take
  a model id string, which removes the `model as unknown as Model<"google-generative-ai">`
  casts the Vertex adapter needed.

What is left in each adapter is only what actually differs: client construction and
auth (API key vs. ADC project/location, base-url and api-version handling), and the
thinking-config shape — Gemini passes the level through as a string, Vertex maps it
through `THINKING_LEVEL_MAP` to the SDK enum.

Net effect: `google.ts` 469 → ~230 lines, `google-vertex.ts` 546 → ~290 lines, with
the duplicated state machine gone rather than copied.

## Why

Per #956, the two adapters had drifted into two copies of the same state machine, so
every change to block handling, tool-call ids, stop-reason mapping, usage accounting,
or payload construction had to be made twice and could silently diverge in one adapter
only.

## Verification

The issue asks for "one provider-neutral fixture corpus" exercised through both
adapters, so that is implemented as an executable test rather than a manual check:
`packages/ai/test/google-shared-stream-parity.test.ts` runs 10 fixtures (text only,
thinking with a signature on the first delta only, a tool call closing an open text
block, duplicate tool-call ids, a tool call carrying a thought signature, `MAX_TOKENS`,
`SAFETY`, `MALFORMED_FUNCTION_CALL`, an empty stream, and an unterminated text block)
through both adapters and asserts the normalized event streams are equal, plus usage/cost
equality and two abort cases (aborted after the request starts, and an already-aborted
signal). The normalizer drops only what is legitimately adapter-specific:
`api`/`provider`/`model`, timestamps, the generated portion of a tool-call id, and
diagnostic stack strings that name the throwing adapter's own file.

Results:

- `packages/ai/test/google-shared-stream-parity.test.ts` — 13/13 pass.
- Existing google tests — 6 files, 28 tests, all pass.
- Mutation check, to prove the parity test is not vacuous: injecting
  `output.usage.output += 1;` after `processGoogleStream` in the Vertex adapter fails
  11 of the 13 tests; restoring the file returns it to 13/13.
- `npx tsgo --noEmit` — clean. `npx biome check --write --error-on-warnings .` — 901
  files checked, no fixes applied. `npm run check:browser-smoke` — passes.
- Full `packages/ai` suite: 48 test files pass, 1 fails — the 3 failures are all in
  `test/lazy-module-load.test.ts` with `ERR_UNSUPPORTED_ESM_URL_SCHEME ... Received
  protocol 'c:'`. That is a pre-existing Windows-only path issue: I reproduced the same
  3 failures on unmodified `main` with my changes stashed.
- `npm run check:installer` also fails locally, and likewise fails identically on
  unmodified `main` — it is a terminal-render harness check unrelated to this change.

This is a behaviour-preserving refactor, so there is no bug for a negative control to
catch; the mutation check above stands in for it.

fixes #956

---

Disclosure: I used agentic AI assistance in preparing this change. The test results and
the mutation/pre-existing-failure checks above were actually run, not assumed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share stream consumer and request builder across Google Gemini and Vertex adapters
> - Extracts `processGoogleStream` and `buildGoogleParams` into [google-shared.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1044/files#diff-b08913b9ac25a43585c80ef2d0fbd2dfd99de1f59459a69973b05bb6ed70c60d), replacing duplicated state machines and payload assembly in [google.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1044/files#diff-81d1fd5c26dd36daf50b3b8d184c76644ef8e1b62b0f8e96fe63250063ac2406) and [google-vertex.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1044/files#diff-685f96626c72e2484d8d09c0f2ffc686b130a1cdc2f8bcbffb3317193d0cc634).
> - Tool call IDs are now generated from a single module-level counter shared by both adapters, preventing duplicate IDs when Gemini and Vertex streams run concurrently.
> - Adds shared model-family helpers (`isGemma4Model`, `isGemini3ProModel`, `isGemini3FlashModel`) and a unified `GoogleThinkingOptions` interface used by both adapters.
> - Adds a parity test suite in [google-shared-stream-parity.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1044/files#diff-f0cec07eece52e7116eddf83e9efc3818f8ada25dfc4de1d45842fd73ef46f0b) that asserts identical normalized stream events, usage/cost reporting, and abort behavior across both adapters.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 519851b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->