### PR TITLE
fix(coding-agent): coalesce child usage attribution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed active RLM subagents flooding parent transcripts with one usage-attribution entry per tool-loop message ([#1054](https://github.com/PrimeIntellect-ai/prime-agent/issues/1054)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -246,7 +246,13 @@ import {
 	transitionSessionAction,
 	type WakePolicy,
 } from "./session-action-store.js";
-import type { BranchSummaryEntry, CompactionEntry, SessionContext, SessionMessageEntry } from "./session-manager.js";
+import type {
+	BranchSummaryEntry,
+	ChildUsageAttributionEntry,
+	CompactionEntry,
+	SessionContext,
+	SessionMessageEntry,
+} from "./session-manager.js";
 import {
 	CURRENT_SESSION_VERSION,
 	getLatestCompactionEntry,
@@ -9647,6 +9653,8 @@ export class AgentSession {
 		let runningToolCount = 0;
 		let activity: RlmChildAgentActivity | undefined;
 		let childSession: AgentSession | undefined;
+		let pendingChildUsage: Usage | undefined;
+		let pendingChildUsageOrigin: ChildUsageAttributionEntry["origin"] | undefined;
 		const run: RlmChildRun = {
 			id: childNodeId,
 			prompt,
@@ -9659,6 +9667,20 @@ export class AgentSession {
 		};
 		const throwIfCancelled = () => {
 			if (run.status === "cancelled") throw new Error(run.error ?? "RLM child cancelled");
+		};
+		const flushChildUsage = () => {
+			if (!pendingChildUsage || !parentAssistantForUsage) return;
+			const parentEntry = this._findAssistantEntryForMessage(parentAssistantForUsage);
+			if (parentEntry) {
+				this.sessionManager.appendChildUsageAttribution(
+					parentEntry.id,
+					pendingChildUsage,
+					parentAssistantForUsage.usage,
+					pendingChildUsageOrigin,
+				);
+			}
+			pendingChildUsage = undefined;
+			pendingChildUsageOrigin = undefined;
 		};
 		this._activeRlmChildRuns.set(run.id, run);
 		const emitChildUpdate = () => {
@@ -9750,6 +9772,7 @@ export class AgentSession {
 						activity = { kind: "waiting" };
 						emitChildUpdate();
 					} else if (event.type === "agent_end") {
+						flushChildUsage();
 						activity = undefined;
 						emitChildUpdate();
 					} else if (event.type === "message_end" && event.message.role === "assistant") {
@@ -9757,27 +9780,22 @@ export class AgentSession {
 						if (assistant.stopReason !== "error" && assistant.stopReason !== "aborted") {
 							attributeChildUsage(parentAssistantForUsage?.usage ?? emptyUsage(), assistant.usage);
 							if (parentAssistantForUsage) {
-								const parentEntry = this._findAssistantEntryForMessage(parentAssistantForUsage);
-								if (parentEntry) {
-									const messages = child.messages;
-									const assistantIndex = messages.lastIndexOf(assistant);
-									const precedingPrompt = messages
-										.slice(0, assistantIndex)
-										.reverse()
-										.find((message) => message.role === "user" || message.role === "custom");
-									const origin =
-										precedingPrompt?.role === "custom" && isAgentSessionMessage(precedingPrompt)
-											? precedingPrompt.details.id.startsWith("spawn:")
-												? "spawn_task"
-												: "agent_message"
-											: "direct_user";
-									this.sessionManager.appendChildUsageAttribution(
-										parentEntry.id,
-										assistant.usage,
-										parentAssistantForUsage.usage,
-										origin,
-									);
-								}
+								const messages = child.messages;
+								const assistantIndex = messages.lastIndexOf(assistant);
+								const precedingPrompt = messages
+									.slice(0, assistantIndex)
+									.reverse()
+									.find((message) => message.role === "user" || message.role === "custom");
+								const origin =
+									precedingPrompt?.role === "custom" && isAgentSessionMessage(precedingPrompt)
+										? precedingPrompt.details.id.startsWith("spawn:")
+											? "spawn_task"
+											: "agent_message"
+										: "direct_user";
+								if (pendingChildUsageOrigin && pendingChildUsageOrigin !== origin) flushChildUsage();
+								pendingChildUsage ??= emptyUsage();
+								pendingChildUsageOrigin = origin;
+								addAssistantUsage(pendingChildUsage, assistant.usage);
 							}
 						}
 						const text = compactRlmText(readAssistantText(assistant));
@@ -9915,6 +9933,7 @@ export class AgentSession {
 					}
 				}
 			} finally {
+				flushChildUsage();
 				if (run.detachedDeletion && childRuntime) {
 					try {
 						await this._deleteRlmSubagentSession(run.id, childRuntime.session);

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1798,7 +1798,7 @@ describe("AgentSession rlm recursion", () => {
 		expect(attribution.aggregateUsage.cost.total).toBe(10);
 	});
 
-	it("attributes every tool-loop turn in the admitted task to spawn usage", async () => {
+	it("coalesces tool-loop usage in the admitted task into one spawn attribution", async () => {
 		const tool = {
 			name: "echo",
 			description: "Echo a value",
@@ -1843,8 +1843,10 @@ describe("AgentSession rlm recursion", () => {
 			const attributions = root.sessionManager
 				.getEntries()
 				.filter((entry) => entry.type === "child_usage_attributed");
-			expect(attributions).toHaveLength(2);
-			expect(attributions.map((entry) => entry.origin)).toEqual(["spawn_task", "spawn_task"]);
+			expect(attributions).toHaveLength(1);
+			expect(attributions[0]?.origin).toBe("spawn_task");
+			expect(attributions[0]?.childUsage.input).toBe(3);
+			expect(attributions[0]?.childUsage.output).toBe(3);
 		});
 	});
 

--- a/packages/coding-agent/test/suite/regressions/1054-child-usage-attribution-flood.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1054-child-usage-attribution-flood.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.js";
+
+describe("#1054 child usage attribution flood", () => {
+	let parent: Harness | undefined;
+	let child: Harness | undefined;
+
+	afterEach(() => {
+		child?.cleanup();
+		parent?.cleanup();
+	});
+
+	it("persists one usage attribution for a tool-heavy child turn", async () => {
+		const echo: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo a value",
+			parameters: Type.Object({ value: Type.String() }),
+			execute: async (_toolCallId, params) => ({
+				content: [
+					{
+						type: "text",
+						text: typeof params === "object" && params !== null && "value" in params ? String(params.value) : "",
+					},
+				],
+				details: {},
+			}),
+		};
+		child = await createHarness({ tools: [echo] });
+		parent = await createHarness({
+			persistSession: true,
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child!.session }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+		parent.setResponses([fauxAssistantMessage("starting child")]);
+		await parent.session.prompt("prepare");
+		child.setResponses([
+			...Array.from({ length: 50 }, (_, index) =>
+				fauxAssistantMessage([fauxToolCall("echo", { value: String(index) })], { stopReason: "toolUse" }),
+			),
+			fauxAssistantMessage("done"),
+		]);
+
+		await parent.session.runRlmChild("run tool-heavy task");
+		await expect.poll(() => child!.session.getLastAssistantText()).toBe("done");
+		await expect
+			.poll(() => parent!.sessionManager.getEntries().filter((entry) => entry.type === "child_usage_attributed"))
+			.toHaveLength(1);
+
+		const sessionFile = parent.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("parent session file was not created");
+		expect(readFileSync(sessionFile, "utf8").match(/"type":"child_usage_attributed"/g)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Summary

- coalesce child assistant usage across a tool-heavy agent turn
- persist one `child_usage_attributed` entry at `agent_end` instead of one per assistant message
- retain exact aggregate usage and flush pending usage during cleanup
- add a 50-tool-call regression and update the existing RLM usage test

## Root cause

Every child `message_end` immediately appended a usage-attribution entry to the parent transcript. Tool-heavy RLM children therefore caused a sustained stream of transcript writes and leaf mutations on the same worker event loop that serves attach and heartbeat requests. Under load, the worker consumed several gigabytes of memory and stopped answering daemon control requests.

The in-memory parent usage total still updates for every assistant message. Only persistence is coalesced to the child turn boundary, preserving billing totals and reload behavior while removing the write flood.

## User impact

Long-running RLM sessions remain responsive while subagents execute dense tool loops, and parent transcripts no longer accumulate hundreds of bookkeeping entries for one child turn.

## Validation

- `test/suite/regressions/1054-child-usage-attribution-flood.test.ts`: 1 passed
- `test/agent-session-recursion.test.ts`: 96 passed
- `npm run check`: passed

Fixes #1054

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix child usage attribution flood by coalescing entries per child turn
> - Previously, each assistant message within a child agent's tool loop emitted a separate `child_usage_attributed` entry on the parent session, flooding the parent transcript.
> - `AgentSession.runRlmChild` now accumulates usage into a `pendingChildUsage` buffer and flushes a single aggregated entry per child turn, splitting only when the attribution origin changes mid-turn.
> - The regression test in [1054-child-usage-attribution-flood.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1061/files#diff-68da0dde62189ffecccb817d060dcd0ad8028d5b2909d3915bcc21435454aa94) verifies that 50 consecutive tool-loop messages produce exactly one `child_usage_attributed` entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2dacb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->