### PR TITLE
Add user-visible Codex image workflows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added durable user-visible artifact presentation in interactive and ACP clients plus a stateful bundled Codex-native image generate/refine/approve workflow that keeps previews outside repositories until explicit approval.
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/skills/codex-image/SKILL.md
+++ b/packages/coding-agent/skills/codex-image/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: codex-image
+description: Generate and refine images with Codex native image generation, present every version in the conversation, and export only a user-approved version. Use for icons, logos, mockups, illustrations, concepts, and all other image creation requests.
+---
+
+# Codex Image
+
+Use this skill for every image-creation request. It runs the installed Codex CLI
+with native `image_generation`; it never substitutes Pillow, SVG, canvas, or any
+other procedural renderer.
+
+Every generated or refined version is stored under the current
+`RLM_SESSION_DIR` and automatically presented in the conversation with
+`rlm.host_request("artifact.present", ...)`. Do not copy a version into a
+repository until the user has seen it and explicitly approved it.
+
+## API
+
+The prepared import is `codex_image`:
+
+```python
+version = await codex_image.generate(
+    "A crisp app icon for an encrypted notes product",
+    kind="icon",
+    references=["/path/to/reference.png"],
+)
+
+refined = await codex_image.refine(
+    version["workflow_id"],
+    "Keep the keyhole but simplify the outer silhouette",
+)
+
+versions = codex_image.list_versions(version["workflow_id"])
+
+# Call only after the user explicitly approves this exact version.
+exported = codex_image.approve(
+    version["workflow_id"],
+    refined["version"],
+    "assets/app-icon.png",
+    approved=True,
+)
+```
+
+`generate` defaults to `kind="image"` and requests exactly one image. Pass
+`kind="icon"` for an icon. For a mockup, pass `kind="mockup"`; the default output is one comparison-sheet image
+containing three clearly labeled directions (A, B, and C), not three separate
+files. Use a fresh `generate` call for a new concept and `refine` to continue the
+same Codex thread.
+
+`list_versions()` lists every workflow in the current session, while
+`list_versions(workflow_id)` limits the result to one lineage. Versions, captured references, prompts, hashes, parent links, Codex thread IDs,
+and manifests are immutable.
+
+`approve` refuses to copy unless the keyword argument is exactly
+`approved=True`. Approval writes the requested target atomically and records an
+immutable approval receipt. It will not replace an existing target unless the
+caller also passes `overwrite=True`. Never infer
+approval from positive feedback, and never call it before the generated image
+has been presented to the user.
+
+By default the skill resolves `codex` from `PATH`. For tests or managed
+installations, pass `command=["/path/to/codex"]` (including any command prefix
+arguments) or set `CODEX_IMAGE_COMMAND`. Prompts always travel over stdin, and
+CLI stdout/stderr stay captured unless an error must be reported.
+
+## Failure and cleanup semantics
+
+If Codex is missing, unauthenticated, times out, exits non-zero, returns no new
+native raster path, or presentation fails, the call raises a focused exception,
+removes the incomplete workflow/version, and never creates a repository asset.
+A failed refinement leaves every completed prior version untouched. The skill
+never invokes a fallback image renderer. `approve` re-hashes the selected
+version against its presented manifest and persists the immutable approval
+receipt before mutating the target; an export failure can therefore leave a
+receipt of the approval attempt, but not an unrecorded repository mutation.
+
+Completed workflows live only under
+`$RLM_SESSION_DIR/codex-image/<workflow-id>/`. They intentionally survive for
+session replay and approval auditing; remove that workflow directory manually
+when its lineage and immutable approval receipts are no longer needed. Codex may
+also retain its own native output beneath `$CODEX_HOME/generated_images`; Codex
+owns cleanup of that cache.
+
+Reference images are validated, hashed, and captured into the workflow before
+Codex runs, so later refinement does not depend on the original reference path.
+The reusable package contains no credentials or personal paths: Codex continues
+to own authentication and configuration.

--- a/packages/coding-agent/skills/codex-image/pyproject.toml
+++ b/packages/coding-agent/skills/codex-image/pyproject.toml
@@ -1,0 +1,15 @@
+# Kernel-side package for the bundled Codex image skill. It uses only the
+# standard library plus the Prime Agent host bridge.
+[project]
+name = "prime-agent-skill-codex-image"
+version = "0.1.0"
+description = "Stateful Codex-native image generation with presentation and approval-gated export"
+requires-python = ">=3.10"
+dependencies = ["prime-agent-runtime"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/codex_image"]

--- a/packages/coding-agent/skills/codex-image/src/codex_image/__init__.py
+++ b/packages/coding-agent/skills/codex-image/src/codex_image/__init__.py
@@ -1,0 +1,5 @@
+"""Stateful Codex-native image generation for Prime Agent sessions."""
+
+from .workflow import approve, generate, list_versions, refine
+
+__all__ = ["approve", "generate", "list_versions", "refine"]

--- a/packages/coding-agent/skills/codex-image/src/codex_image/workflow.py
+++ b/packages/coding-agent/skills/codex-image/src/codex_image/workflow.py
@@ -1,0 +1,1176 @@
+"""Stateful Codex-native image generation workflow."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import stat as stat_module
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+from urllib.parse import unquote, urlparse
+
+from rlm import host_request
+
+_SCHEMA_VERSION = 1
+_STORAGE_DIRECTORY = "codex-image"
+_MAX_BRIEF_CHARS = 20_000
+_MAX_IMAGE_BYTES = 20 * 1024 * 1024
+_MAX_IMAGE_PIXELS = 100_000_000
+_MAX_VERSIONS_PER_WORKFLOW = 100
+_MAX_REFERENCES = 10
+_MAX_TIMEOUT_SECONDS = 1_800.0
+_DEFAULT_TIMEOUT_SECONDS = 600.0
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+_WORKFLOW_ID_PATTERN = re.compile(r"^img-[0-9a-f]{32}$")
+_VERSION_DIRECTORY_PATTERN = re.compile(r"^v([0-9]{4})$")
+_QUOTED_IMAGE_PATH_PATTERN = re.compile(
+    r"""["'`](.+?\.(?:png|jpe?g|gif|webp))["'`]""", re.IGNORECASE
+)
+_MARKDOWN_IMAGE_PATH_PATTERN = re.compile(
+    r"!?\[[^\]]*\]\((.+?\.(?:png|jpe?g|gif|webp))\)", re.IGNORECASE
+)
+
+CodexCommand = str | Sequence[str] | None
+
+
+def _session_directory() -> Path:
+    raw = os.environ.get("RLM_SESSION_DIR")
+    if raw is None or not raw.strip():
+        raise RuntimeError(
+            "codex_image requires RLM_SESSION_DIR; start it from a persisted Prime Agent session."
+        )
+    session_directory = Path(raw).expanduser().resolve()
+    if not session_directory.is_dir():
+        raise RuntimeError(
+            f"RLM_SESSION_DIR is not an existing directory: {session_directory}"
+        )
+    return session_directory
+
+
+def _storage_root(*, create: bool) -> Path:
+    session_directory = _session_directory()
+    root = session_directory / _STORAGE_DIRECTORY
+    if create:
+        root.mkdir(mode=0o700, parents=False, exist_ok=True)
+    if root.exists():
+        resolved_root = root.resolve()
+        try:
+            resolved_root.relative_to(session_directory)
+        except ValueError as error:
+            raise RuntimeError("codex_image storage escapes RLM_SESSION_DIR") from error
+        if not resolved_root.is_dir():
+            raise RuntimeError(f"codex_image storage is not a directory: {resolved_root}")
+        return resolved_root
+    return root
+
+
+def _validate_workflow_id(workflow_id: str) -> str:
+    if not isinstance(workflow_id, str):
+        raise TypeError(
+            f"workflow_id must be str, got {type(workflow_id).__name__}"
+        )
+    if not _WORKFLOW_ID_PATTERN.fullmatch(workflow_id):
+        raise ValueError("workflow_id is not a codex_image workflow ID")
+    return workflow_id
+
+
+def _workflow_directory(workflow_id: str, *, must_exist: bool) -> Path:
+    validated_id = _validate_workflow_id(workflow_id)
+    root = _storage_root(create=False)
+    candidate = root / validated_id
+    if must_exist and not candidate.is_dir():
+        raise FileNotFoundError(f"codex_image workflow not found: {validated_id}")
+    if candidate.exists():
+        resolved = candidate.resolve()
+        try:
+            resolved.relative_to(root.resolve())
+        except ValueError as error:
+            raise RuntimeError("codex_image workflow escapes session storage") from error
+        if not resolved.is_dir():
+            raise RuntimeError(f"codex_image workflow is not a directory: {validated_id}")
+        return resolved
+    return candidate
+
+
+def _validate_brief(brief: str) -> str:
+    if not isinstance(brief, str):
+        raise TypeError(f"brief must be str, got {type(brief).__name__}")
+    normalized = brief.strip()
+    if not normalized:
+        raise ValueError("brief must not be empty")
+    if len(normalized) > _MAX_BRIEF_CHARS:
+        raise ValueError(f"brief must be at most {_MAX_BRIEF_CHARS} characters")
+    return normalized
+
+
+def _validate_kind(kind: str) -> str:
+    if not isinstance(kind, str):
+        raise TypeError(f"kind must be str, got {type(kind).__name__}")
+    if kind not in {"image", "icon", "mockup"}:
+        raise ValueError('kind must be "image", "icon", or "mockup"')
+    return kind
+
+
+def _validate_label(label: str | None) -> str | None:
+    if label is None:
+        return None
+    if not isinstance(label, str):
+        raise TypeError(f"label must be str or None, got {type(label).__name__}")
+    normalized = label.strip()
+    if not normalized:
+        raise ValueError("label must not be empty")
+    if len(normalized) > 200:
+        raise ValueError("label must be at most 200 characters")
+    return normalized
+
+
+def _validate_timeout(timeout_seconds: float) -> float:
+    if isinstance(timeout_seconds, bool) or not isinstance(
+        timeout_seconds, (int, float)
+    ):
+        raise TypeError(
+            "timeout_seconds must be a positive number, got "
+            f"{type(timeout_seconds).__name__}"
+        )
+    normalized = float(timeout_seconds)
+    if normalized <= 0 or normalized > _MAX_TIMEOUT_SECONDS:
+        raise ValueError(
+            f"timeout_seconds must be greater than 0 and at most {_MAX_TIMEOUT_SECONDS:g}"
+        )
+    return normalized
+
+
+def _resolve_command(command: CodexCommand) -> list[str]:
+    configured: str | Sequence[str]
+    if command is None:
+        configured = os.environ.get("CODEX_IMAGE_COMMAND", "codex")
+    else:
+        configured = command
+
+    if isinstance(configured, str):
+        arguments = shlex.split(configured, posix=os.name != "nt")
+        if os.name == "nt":
+            arguments = [
+                argument[1:-1]
+                if len(argument) >= 2 and argument[0] == argument[-1] and argument[0] in {'"', "'"}
+                else argument
+                for argument in arguments
+            ]
+    elif isinstance(configured, Sequence):
+        arguments = list(configured)
+    else:
+        raise TypeError(
+            f"command must be str, a sequence of str, or None; got {type(configured).__name__}"
+        )
+
+    if not arguments or any(
+        not isinstance(argument, str) or not argument for argument in arguments
+    ):
+        raise ValueError("Codex command must contain one or more non-empty strings")
+
+    executable = shutil.which(arguments[0])
+    if executable is None:
+        raise RuntimeError(
+            f"Codex CLI not found: {arguments[0]!r}. Install Codex, add it to PATH, "
+            "or configure CODEX_IMAGE_COMMAND."
+        )
+    arguments[0] = executable
+    return arguments
+
+
+def _initial_prompt(
+    brief: str, kind: str, output_directory: Path, reference_count: int
+) -> str:
+    if kind != "mockup":
+        composition = (
+            f"Create exactly one final {kind} image. Do not make a grid, contact sheet, "
+            "or alternate directions."
+        )
+    else:
+        composition = (
+            "Create exactly one final mockup comparison-sheet image containing three "
+            "visually distinct directions, clearly labeled A, B, and C. Do not create "
+            "three separate image files."
+        )
+    reference_instruction = (
+        f"Use the {reference_count} attached reference image(s) as visual context."
+        if reference_count
+        else "No external reference image is attached."
+    )
+    return f"""Use Codex's native image generation tool (imagegen) for this task.
+Do not draw the requested asset with code, SVG, HTML, canvas, Pillow, or any procedural fallback.
+{composition}
+{reference_instruction}
+Prefer the session staging directory below when choosing an output location. The native
+image tool may instead save under Codex's generated_images directory; do not recreate the
+image with code just to relocate it. Always emit/report the exact native raster output path
+in the JSON event stream.
+Staging directory (JSON): {json.dumps(str(output_directory))}
+
+Original brief:
+{brief}
+"""
+
+
+def _refinement_prompt(
+    brief: str,
+    kind: str,
+    previous_image: Path,
+    output_directory: Path,
+) -> str:
+    if kind != "mockup":
+        composition = (
+            f"Return exactly one refined {kind} image, not a grid or a set of alternatives."
+        )
+    else:
+        composition = (
+            "Return exactly one refined comparison-sheet image with three clearly "
+            "labeled directions A, B, and C, not three separate files."
+        )
+    return f"""Continue this same image-generation thread and use Codex's native image generation tool (imagegen).
+Refine the preceding version using the attached previous image as the visual source.
+Do not draw the asset with code, SVG, HTML, canvas, Pillow, or any procedural fallback.
+{composition}
+Previous version (read-only): {previous_image}
+Do not overwrite the previous image. Prefer the session staging directory below when
+choosing an output location. The native image tool may instead save under Codex's
+generated_images directory; do not recreate the image with code just to relocate it.
+Always emit/report the exact native raster output path in the JSON event stream.
+Staging directory (JSON): {json.dumps(str(output_directory))}
+
+Requested refinement:
+{brief}
+"""
+
+
+def _json_event_error(events: Sequence[dict[str, Any]]) -> str | None:
+    for event in events:
+        event_type = event.get("type")
+        if event_type not in {"error", "turn.failed", "item.failed"}:
+            continue
+        message = event.get("message") or event.get("error") or event
+        if isinstance(message, str):
+            return message
+        return json.dumps(message, sort_keys=True)
+    return None
+
+
+def _format_cli_failure(details: str) -> RuntimeError:
+    normalized = details.strip()
+    lowered = normalized.lower()
+    if any(
+        marker in lowered
+        for marker in (
+            "not authenticated",
+            "authentication",
+            "unauthorized",
+            "log in",
+            "login required",
+            "api key",
+        )
+    ):
+        return RuntimeError(
+            "Codex authentication failed. Run `codex login` or configure Codex "
+            f"credentials, then retry. {normalized[-1000:]}"
+        )
+    if not normalized:
+        normalized = "Codex exited without an error message"
+    return RuntimeError(f"Codex image generation failed: {normalized[-2000:]}")
+
+
+async def _run_codex(
+    arguments: Sequence[str],
+    prompt: str,
+    cwd: Path,
+    timeout_seconds: float,
+) -> list[dict[str, Any]]:
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *arguments,
+            cwd=str(cwd),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as error:
+        raise RuntimeError(f"Codex CLI not found: {arguments[0]!r}") from error
+    except OSError as error:
+        raise RuntimeError(f"Could not start Codex CLI: {error}") from error
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            process.communicate(prompt.encode("utf-8")), timeout=timeout_seconds
+        )
+    except asyncio.TimeoutError as error:
+        process.kill()
+        await process.communicate()
+        raise TimeoutError(
+            f"Codex image generation timed out after {timeout_seconds:g} seconds"
+        ) from error
+    except BaseException:
+        if process.returncode is None:
+            process.kill()
+            await process.communicate()
+        raise
+
+    stdout = stdout_bytes.decode("utf-8", errors="replace")
+    stderr = stderr_bytes.decode("utf-8", errors="replace")
+    events: list[dict[str, Any]] = []
+    invalid_lines: list[str] = []
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            value = json.loads(stripped)
+        except json.JSONDecodeError:
+            invalid_lines.append(stripped)
+            continue
+        if isinstance(value, dict):
+            events.append(value)
+
+    if process.returncode != 0:
+        details = stderr or "\n".join(invalid_lines) or stdout
+        raise _format_cli_failure(
+            f"exit code {process.returncode}: {details}".strip()
+        )
+
+    event_error = _json_event_error(events)
+    if event_error is not None:
+        raise _format_cli_failure(event_error)
+    return events
+
+
+def _walk_json_strings(value: Any, key: str = ""):
+    if isinstance(value, dict):
+        for child_key, child_value in value.items():
+            yield from _walk_json_strings(child_value, str(child_key))
+    elif isinstance(value, list):
+        for child_value in value:
+            yield from _walk_json_strings(child_value, key)
+    elif isinstance(value, str):
+        yield key, value
+
+
+def _extract_thread_id(events: Sequence[dict[str, Any]]) -> str | None:
+    thread_ids: list[str] = []
+    for event in events:
+        for key, value in _walk_json_strings(event):
+            if key.lower() not in {"thread_id", "threadid"}:
+                continue
+            normalized = value.strip()
+            if normalized and normalized not in thread_ids:
+                thread_ids.append(normalized)
+    return thread_ids[-1] if thread_ids else None
+
+
+def _codex_generated_images_root() -> Path:
+    codex_home = Path(os.environ.get("CODEX_HOME", "~/.codex")).expanduser()
+    return (codex_home / "generated_images").resolve()
+
+
+def _possible_path_strings(value: str, allowed_roots: Sequence[Path]) -> list[str]:
+    candidates = [value.strip()]
+    candidates.extend(match.group(1).strip() for match in _QUOTED_IMAGE_PATH_PATTERN.finditer(value))
+    candidates.extend(match.group(1).strip() for match in _MARKDOWN_IMAGE_PATH_PATTERN.finditer(value))
+    for allowed_root in allowed_roots:
+        path_start = value.find(str(allowed_root))
+        if path_start < 0:
+            continue
+        path_text = value[path_start:]
+        image_suffix = re.search(r"\.(?:png|jpe?g|gif|webp)", path_text, re.IGNORECASE)
+        if image_suffix is not None:
+            candidates.append(path_text[: image_suffix.end()])
+    result: list[str] = []
+    for candidate in candidates:
+        candidate = candidate.strip().strip("\"'`")
+        if candidate.startswith("file://"):
+            parsed = urlparse(candidate)
+            candidate = unquote(parsed.path)
+            if parsed.netloc and os.name == "nt":
+                candidate = f"//{parsed.netloc}{candidate}"
+            elif os.name == "nt" and re.match(r"^/[A-Za-z]:/", candidate):
+                candidate = candidate[1:]
+        if candidate and candidate not in result:
+            result.append(candidate)
+    return result
+
+
+def _candidate_path(
+    raw_path: str,
+    run_directory: Path,
+    process_directory: Path,
+    allowed_roots: Sequence[Path],
+    started_at_ns: int,
+) -> Path | None:
+    raw_candidate = Path(raw_path).expanduser()
+    candidates = (
+        [raw_candidate]
+        if raw_candidate.is_absolute()
+        else [process_directory / raw_candidate, run_directory / raw_candidate]
+    )
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+            if not any(
+                resolved.is_relative_to(allowed_root)
+                for allowed_root in allowed_roots
+            ):
+                continue
+            image_stat = resolved.stat()
+        except (OSError, ValueError):
+            continue
+        if resolved.suffix.lower() not in _IMAGE_EXTENSIONS or not resolved.is_file():
+            continue
+        # Files explicitly reported by this invocation must not predate it. Keep
+        # a small tolerance for filesystems with coarse timestamp resolution.
+        if image_stat.st_mtime_ns + 2_000_000_000 < started_at_ns:
+            continue
+        return resolved
+    return None
+
+
+def _extract_output_path(
+    events: Sequence[dict[str, Any]],
+    run_directory: Path,
+    process_directory: Path,
+    started_at_ns: int,
+) -> Path:
+    allowed_roots = [process_directory.resolve(), _codex_generated_images_root()]
+    candidates: list[Path] = []
+    for event in events:
+        for key, value in _walk_json_strings(event):
+            key_lower = key.lower()
+            if not any(
+                marker in key_lower
+                for marker in ("path", "output", "image", "result", "message", "text")
+            ):
+                continue
+            for raw_path in _possible_path_strings(value, allowed_roots):
+                candidate = _candidate_path(
+                    raw_path,
+                    run_directory,
+                    process_directory,
+                    allowed_roots,
+                    started_at_ns,
+                )
+                if candidate is not None and candidate not in candidates:
+                    candidates.append(candidate)
+    if not candidates:
+        raise RuntimeError(
+            "Codex completed without reporting a generated image path created by this "
+            "invocation in the session staging directory or Codex generated-images store"
+        )
+    return candidates[-1]
+
+
+def _jpeg_dimensions(data: bytes) -> tuple[int, int] | None:
+    offset = 2
+    while offset + 9 < len(data):
+        if data[offset] != 0xFF:
+            offset += 1
+            continue
+        marker = data[offset + 1]
+        offset += 2
+        if marker in {0xD8, 0xD9}:
+            continue
+        if offset + 2 > len(data):
+            break
+        segment_length = int.from_bytes(data[offset : offset + 2], "big")
+        if segment_length < 2 or offset + segment_length > len(data):
+            break
+        if marker in {
+            0xC0,
+            0xC1,
+            0xC2,
+            0xC3,
+            0xC5,
+            0xC6,
+            0xC7,
+            0xC9,
+            0xCA,
+            0xCB,
+            0xCD,
+            0xCE,
+            0xCF,
+        }:
+            height = int.from_bytes(data[offset + 3 : offset + 5], "big")
+            width = int.from_bytes(data[offset + 5 : offset + 7], "big")
+            return width, height
+        offset += segment_length
+    return None
+
+
+def _raster_properties(
+    data: bytes, mime_type: str
+) -> tuple[int | None, int | None, bool | None]:
+    if mime_type == "image/png" and len(data) >= 26:
+        width = int.from_bytes(data[16:20], "big")
+        height = int.from_bytes(data[20:24], "big")
+        color_type = data[25]
+        return width, height, color_type in {4, 6} or b"tRNS" in data
+    if mime_type == "image/gif" and len(data) >= 10:
+        width = int.from_bytes(data[6:8], "little")
+        height = int.from_bytes(data[8:10], "little")
+        transparency = any(
+            data[index + 3] & 1
+            for index in range(len(data) - 7)
+            if data[index : index + 3] == b"\x21\xf9\x04"
+        )
+        return width, height, transparency
+    if mime_type == "image/jpeg":
+        dimensions = _jpeg_dimensions(data)
+        return (*dimensions, False) if dimensions else (None, None, False)
+    if mime_type == "image/webp":
+        if data[12:16] == b"VP8X" and len(data) >= 30:
+            width = int.from_bytes(data[24:27], "little") + 1
+            height = int.from_bytes(data[27:30], "little") + 1
+            return width, height, bool(data[20] & 0x10)
+        if data[12:16] == b"VP8L" and len(data) >= 25 and data[20] == 0x2F:
+            bits = int.from_bytes(data[21:25], "little")
+            return (bits & 0x3FFF) + 1, ((bits >> 14) & 0x3FFF) + 1, bool(bits & (1 << 28))
+        frame_header = data.find(b"\x9d\x01\x2a")
+        if frame_header >= 0 and frame_header + 7 <= len(data):
+            width = int.from_bytes(data[frame_header + 3 : frame_header + 5], "little") & 0x3FFF
+            height = int.from_bytes(data[frame_header + 5 : frame_header + 7], "little") & 0x3FFF
+            return width, height, b"ALPH" in data
+    return None, None, None
+
+
+def _detect_image(
+    path: Path,
+) -> tuple[str, str, int, str, int | None, int | None, bool | None]:
+    data = path.read_bytes()
+    size = len(data)
+    if size <= 0:
+        raise RuntimeError(f"Codex generated an empty image: {path}")
+    if size > _MAX_IMAGE_BYTES:
+        raise RuntimeError(
+            f"Codex generated a {size}-byte image; the limit is {_MAX_IMAGE_BYTES} bytes"
+        )
+    header = data[:16]
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        mime_type, extension = "image/png", ".png"
+    elif header.startswith(b"\xff\xd8\xff"):
+        mime_type, extension = "image/jpeg", ".jpg"
+    elif header.startswith((b"GIF87a", b"GIF89a")):
+        mime_type, extension = "image/gif", ".gif"
+    elif header[:4] == b"RIFF" and header[8:12] == b"WEBP":
+        mime_type, extension = "image/webp", ".webp"
+    else:
+        raise RuntimeError(
+            f"Codex reported an unsupported or invalid raster image: {path}"
+        )
+    width, height, has_alpha = _raster_properties(data, mime_type)
+    if width is not None and height is not None:
+        if width <= 0 or height <= 0 or width * height > _MAX_IMAGE_PIXELS:
+            raise RuntimeError(
+                f"Codex generated invalid or oversized dimensions {width}x{height}: {path}"
+            )
+    digest = hashlib.sha256(data).hexdigest()
+    return mime_type, extension, size, digest, width, height, has_alpha
+
+
+def _reserve_version_directory(workflow_directory: Path) -> tuple[int, Path]:
+    versions_directory = workflow_directory / "versions"
+    versions_directory.mkdir(mode=0o700, exist_ok=True)
+    existing_numbers = []
+    for child in versions_directory.iterdir():
+        match = _VERSION_DIRECTORY_PATTERN.fullmatch(child.name)
+        if match:
+            existing_numbers.append(int(match.group(1)))
+    next_number = max(existing_numbers, default=0) + 1
+    while next_number <= _MAX_VERSIONS_PER_WORKFLOW:
+        version_directory = versions_directory / f"v{next_number:04d}"
+        try:
+            version_directory.mkdir(mode=0o700)
+            return next_number, version_directory
+        except FileExistsError:
+            next_number += 1
+    raise RuntimeError(
+        f"codex_image workflows are limited to {_MAX_VERSIONS_PER_WORKFLOW} versions"
+    )
+
+
+def _remove_tree(path: Path) -> None:
+    def handle_readonly(function, failing_path, _error_info):
+        os.chmod(failing_path, stat_module.S_IWRITE | stat_module.S_IREAD)
+        function(failing_path)
+
+    try:
+        shutil.rmtree(path, onerror=handle_readonly)
+    except OSError:
+        # Cleanup is best effort and must not replace the operation's real error.
+        pass
+
+
+def _atomic_copy_new(source: Path, destination: Path) -> None:
+    temporary = destination.parent / f".{destination.name}.{uuid.uuid4().hex}.tmp"
+    try:
+        with source.open("rb") as source_file, temporary.open("xb") as target_file:
+            shutil.copyfileobj(source_file, target_file, length=1024 * 1024)
+            target_file.flush()
+            os.fsync(target_file.fileno())
+        if destination.exists():
+            raise FileExistsError(f"immutable destination already exists: {destination}")
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _copy_references(
+    workflow_directory: Path,
+    references: Sequence[str | os.PathLike[str]],
+) -> list[dict[str, Any]]:
+    if isinstance(references, (str, bytes, os.PathLike)):
+        raise TypeError("references must be a sequence of paths, not a single path")
+    if not isinstance(references, Sequence):
+        raise TypeError(
+            f"references must be a sequence of paths, got {type(references).__name__}"
+        )
+    if len(references) > _MAX_REFERENCES:
+        raise ValueError(f"references supports at most {_MAX_REFERENCES} images")
+
+    references_directory = workflow_directory / "references"
+    records: list[dict[str, Any]] = []
+    for index, raw_reference in enumerate(references, start=1):
+        if not isinstance(raw_reference, (str, os.PathLike)):
+            raise TypeError(
+                "each reference must be str or path-like, got "
+                f"{type(raw_reference).__name__}"
+            )
+        source = Path(raw_reference).expanduser().resolve()
+        if not source.is_file():
+            raise FileNotFoundError(f"reference is not an existing regular file: {source}")
+        mime_type, extension, size, sha256, width, height, has_alpha = _detect_image(source)
+        references_directory.mkdir(mode=0o700, exist_ok=True)
+        destination = references_directory / f"reference-{index:02d}{extension}"
+        _atomic_copy_new(source, destination)
+        copied_mime_type, _, copied_size, copied_sha256, copied_width, copied_height, copied_has_alpha = _detect_image(
+            destination
+        )
+        if (
+            copied_size,
+            copied_sha256,
+            copied_width,
+            copied_height,
+            copied_has_alpha,
+        ) != (size, sha256, width, height, has_alpha):
+            raise RuntimeError(f"reference changed while it was being captured: {source}")
+        os.chmod(destination, 0o444)
+        records.append(
+            {
+                "file": str(destination.relative_to(workflow_directory)),
+                "original_name": source.name,
+                "mime_type": copied_mime_type,
+                "bytes": copied_size,
+                "sha256": copied_sha256,
+                "width": copied_width,
+                "height": copied_height,
+                "has_alpha": copied_has_alpha,
+            }
+        )
+    return records
+
+
+def _reference_paths(
+    workflow_directory: Path, references: Sequence[dict[str, Any]]
+) -> list[Path]:
+    paths: list[Path] = []
+    for reference in references:
+        raw_file = reference.get("file")
+        if not isinstance(raw_file, str):
+            raise RuntimeError("Invalid codex_image reference manifest")
+        path = (workflow_directory / raw_file).resolve()
+        try:
+            path.relative_to(workflow_directory.resolve())
+        except ValueError as error:
+            raise RuntimeError("codex_image reference escapes workflow storage") from error
+        if not path.is_file():
+            raise RuntimeError(f"codex_image reference is missing: {path}")
+        paths.append(path)
+    return paths
+
+
+def _write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    temporary = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
+    try:
+        with temporary.open("x", encoding="utf-8") as manifest_file:
+            json.dump(manifest, manifest_file, indent=2, sort_keys=True)
+            manifest_file.write("\n")
+            manifest_file.flush()
+            os.fsync(manifest_file.fileno())
+        if path.exists():
+            raise FileExistsError(f"immutable manifest already exists: {path}")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _read_manifest(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"Could not read codex_image manifest {path}: {error}") from error
+    if not isinstance(value, dict) or value.get("schema") != _SCHEMA_VERSION:
+        raise RuntimeError(f"Invalid codex_image manifest: {path}")
+    image = value.get("image")
+    if not isinstance(image, dict) or not isinstance(image.get("file"), str):
+        raise RuntimeError(f"Invalid codex_image image manifest: {path}")
+    return value
+
+
+def _public_manifest(manifest: dict[str, Any], manifest_path: Path) -> dict[str, Any]:
+    public = dict(manifest)
+    image = dict(manifest["image"])
+    image_path = (manifest_path.parent / image["file"]).resolve()
+    try:
+        image_path.relative_to(manifest_path.parent.resolve())
+    except ValueError as error:
+        raise RuntimeError(f"Manifest image escapes its immutable version: {manifest_path}") from error
+    if not image_path.is_file():
+        raise RuntimeError(f"Manifest image is missing: {image_path}")
+    image["path"] = str(image_path)
+    public["image"] = image
+    public["path"] = str(image_path)
+    workflow_directory = manifest_path.parent.parent.parent.resolve()
+    public_references: list[dict[str, Any]] = []
+    raw_references = manifest.get("references", [])
+    if not isinstance(raw_references, list):
+        raise RuntimeError(f"Invalid codex_image references manifest: {manifest_path}")
+    for reference in raw_references:
+        if not isinstance(reference, dict) or not isinstance(reference.get("file"), str):
+            raise RuntimeError(f"Invalid codex_image reference manifest: {manifest_path}")
+        reference_path = (workflow_directory / reference["file"]).resolve()
+        try:
+            reference_path.relative_to(workflow_directory)
+        except ValueError as error:
+            raise RuntimeError(
+                f"Manifest reference escapes its workflow: {manifest_path}"
+            ) from error
+        if not reference_path.is_file():
+            raise RuntimeError(f"Manifest reference is missing: {reference_path}")
+        public_references.append({**reference, "path": str(reference_path)})
+    public["references"] = public_references
+    public["manifest_path"] = str(manifest_path.resolve())
+    return public
+
+
+def list_versions(workflow_id: str | None = None) -> list[dict[str, Any]]:
+    """List immutable generated versions in the current Prime Agent session."""
+    root = _storage_root(create=False)
+    if not root.exists():
+        return []
+    if workflow_id is None:
+        workflow_directories = sorted(
+            child
+            for child in root.iterdir()
+            if child.is_dir() and _WORKFLOW_ID_PATTERN.fullmatch(child.name)
+        )
+    else:
+        workflow_directories = [
+            _workflow_directory(_validate_workflow_id(workflow_id), must_exist=True)
+        ]
+
+    versions: list[dict[str, Any]] = []
+    for workflow_directory in workflow_directories:
+        versions_directory = workflow_directory / "versions"
+        if not versions_directory.is_dir():
+            continue
+        for version_directory in sorted(versions_directory.iterdir()):
+            if not _VERSION_DIRECTORY_PATTERN.fullmatch(version_directory.name):
+                continue
+            manifest_path = version_directory / "manifest.json"
+            if not manifest_path.is_file():
+                continue
+            versions.append(
+                _public_manifest(_read_manifest(manifest_path), manifest_path)
+            )
+    versions.sort(key=lambda item: (str(item["workflow_id"]), int(item["version"])))
+    return versions
+
+
+def _load_version(workflow_id: str, version: int) -> dict[str, Any]:
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise TypeError(f"version must be int, got {type(version).__name__}")
+    if version <= 0 or version > _MAX_VERSIONS_PER_WORKFLOW:
+        raise ValueError(
+            f"version must be between 1 and {_MAX_VERSIONS_PER_WORKFLOW}"
+        )
+    workflow_directory = _workflow_directory(workflow_id, must_exist=True)
+    manifest_path = workflow_directory / "versions" / f"v{version:04d}" / "manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(
+            f"codex_image version not found: {workflow_id} v{version:04d}"
+        )
+    return _public_manifest(_read_manifest(manifest_path), manifest_path)
+
+
+async def _create_version(
+    *,
+    workflow_id: str,
+    brief: str,
+    original_brief: str,
+    kind: str,
+    references: list[dict[str, Any]],
+    label: str | None,
+    command: CodexCommand,
+    timeout_seconds: float,
+    parent: dict[str, Any] | None,
+) -> dict[str, Any]:
+    workflow_directory = _workflow_directory(workflow_id, must_exist=True)
+    version, version_directory = _reserve_version_directory(workflow_directory)
+    run_directory = workflow_directory / f".run-{uuid.uuid4().hex}"
+    run_directory.mkdir(mode=0o700)
+    try:
+        command_prefix = _resolve_command(command)
+        if parent is None:
+            prompt = _initial_prompt(brief, kind, run_directory, len(references))
+            reference_arguments = [
+                argument
+                for reference_path in _reference_paths(
+                    workflow_directory, references
+                )
+                for argument in ("-i", str(reference_path))
+            ]
+            arguments = [
+                *command_prefix,
+                "exec",
+                "--json",
+                "--enable",
+                "image_generation",
+                *reference_arguments,
+                # This option terminates the variadic --image values before the
+                # positional stdin marker.
+                "--sandbox",
+                "workspace-write",
+                "--skip-git-repo-check",
+                "-C",
+                str(workflow_directory),
+                "-",
+            ]
+            expected_thread_id = None
+        else:
+            previous_path = Path(str(parent["path"])).resolve()
+            expected_thread_id = str(parent["thread_id"])
+            prompt = _refinement_prompt(
+                brief, kind, previous_path, run_directory
+            )
+            arguments = [
+                *command_prefix,
+                "exec",
+                "resume",
+                "--json",
+                "--enable",
+                "image_generation",
+                "--skip-git-repo-check",
+                "-i",
+                str(previous_path),
+                expected_thread_id,
+                "-",
+            ]
+
+        started_at_ns = time.time_ns()
+        events = await _run_codex(
+            arguments, prompt, workflow_directory, timeout_seconds
+        )
+        emitted_thread_id = _extract_thread_id(events)
+        if expected_thread_id is None:
+            if emitted_thread_id is None:
+                raise RuntimeError(
+                    "Codex completed without reporting a thread ID; refinement cannot resume safely"
+                )
+            thread_id = emitted_thread_id
+        else:
+            if emitted_thread_id is not None and emitted_thread_id != expected_thread_id:
+                raise RuntimeError(
+                    "Codex resumed a different thread than the requested image workflow"
+                )
+            thread_id = expected_thread_id
+
+        generated_path = _extract_output_path(
+            events, run_directory, workflow_directory, started_at_ns
+        )
+        mime_type, extension, size, sha256, width, height, has_alpha = _detect_image(
+            generated_path
+        )
+        image_path = version_directory / f"image{extension}"
+        _atomic_copy_new(generated_path, image_path)
+        (
+            copied_mime_type,
+            copied_extension,
+            copied_size,
+            copied_sha256,
+            copied_width,
+            copied_height,
+            copied_has_alpha,
+        ) = _detect_image(image_path)
+        if (
+            copied_mime_type,
+            copied_extension,
+            copied_size,
+            copied_sha256,
+            copied_width,
+            copied_height,
+            copied_has_alpha,
+        ) != (mime_type, extension, size, sha256, width, height, has_alpha):
+            raise RuntimeError("Codex output changed while it was being captured")
+        os.chmod(image_path, 0o444)
+
+        version_label = label or f"Codex {kind} — {workflow_id} v{version:04d}"
+        presentation = await host_request(
+            "artifact.present", {"path": str(image_path.resolve()), "label": version_label}
+        )
+        if not isinstance(presentation, dict):
+            raise RuntimeError("artifact.present returned an invalid presentation receipt")
+
+        manifest: dict[str, Any] = {
+            "schema": _SCHEMA_VERSION,
+            "workflow_id": workflow_id,
+            "version": version,
+            "version_id": f"v{version:04d}",
+            "parent_version": None if parent is None else int(parent["version"]),
+            "thread_id": thread_id,
+            "kind": kind,
+            "brief": brief,
+            "original_brief": original_brief,
+            "references": references,
+            "label": version_label,
+            "presented": True,
+            "presentation": {
+                key: presentation[key]
+                for key in (
+                    "artifactId",
+                    "presentationId",
+                    "mimeType",
+                    "width",
+                    "height",
+                    "originalWidth",
+                    "originalHeight",
+                )
+                if key in presentation
+            },
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "image": {
+                "file": image_path.name,
+                "mime_type": mime_type,
+                "bytes": size,
+                "sha256": sha256,
+                "width": width,
+                "height": height,
+                "has_alpha": has_alpha,
+            },
+        }
+        manifest_path = version_directory / "manifest.json"
+        _write_manifest(manifest_path, manifest)
+        os.chmod(manifest_path, 0o444)
+        return _public_manifest(manifest, manifest_path)
+    except BaseException:
+        _remove_tree(version_directory)
+        raise
+    finally:
+        _remove_tree(run_directory)
+
+
+async def generate(
+    brief: str,
+    *,
+    kind: str = "image",
+    references: Sequence[str | os.PathLike[str]] = (),
+    label: str | None = None,
+    command: CodexCommand = None,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Generate and present the first immutable version of a Codex image workflow."""
+    normalized_brief = _validate_brief(brief)
+    normalized_kind = _validate_kind(kind)
+    normalized_label = _validate_label(label)
+    normalized_timeout = _validate_timeout(timeout_seconds)
+    root = _storage_root(create=True)
+    workflow_id = f"img-{uuid.uuid4().hex}"
+    workflow_directory = root / workflow_id
+    workflow_directory.mkdir(mode=0o700)
+    try:
+        captured_references = _copy_references(workflow_directory, references)
+        return await _create_version(
+            workflow_id=workflow_id,
+            brief=normalized_brief,
+            original_brief=normalized_brief,
+            kind=normalized_kind,
+            references=captured_references,
+            label=normalized_label,
+            command=command,
+            timeout_seconds=normalized_timeout,
+            parent=None,
+        )
+    except BaseException:
+        _remove_tree(workflow_directory)
+        raise
+
+
+async def refine(
+    workflow_id: str,
+    brief: str,
+    *,
+    label: str | None = None,
+    command: CodexCommand = None,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Refine the latest version by resuming its exact Codex thread, then present it."""
+    validated_id = _validate_workflow_id(workflow_id)
+    normalized_brief = _validate_brief(brief)
+    normalized_label = _validate_label(label)
+    normalized_timeout = _validate_timeout(timeout_seconds)
+    versions = list_versions(validated_id)
+    if not versions:
+        raise RuntimeError(f"codex_image workflow has no completed versions: {validated_id}")
+    parent = versions[-1]
+    return await _create_version(
+        workflow_id=validated_id,
+        brief=normalized_brief,
+        original_brief=str(parent["original_brief"]),
+        kind=str(parent["kind"]),
+        references=[
+            {
+                key: reference[key]
+                for key in (
+                    "file",
+                    "original_name",
+                    "mime_type",
+                    "bytes",
+                    "sha256",
+                    "width",
+                    "height",
+                    "has_alpha",
+                )
+            }
+            for reference in parent.get("references", [])
+        ],
+        label=normalized_label,
+        command=command,
+        timeout_seconds=normalized_timeout,
+        parent=parent,
+    )
+
+
+def approve(
+    workflow_id: str,
+    version: int,
+    target: str | os.PathLike[str],
+    *,
+    approved: bool = False,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Atomically export one immutable version after explicit user approval."""
+    if approved is not True:
+        raise PermissionError(
+            "codex_image.approve requires explicit approved=True after the user approves this version"
+        )
+    if not isinstance(overwrite, bool):
+        raise TypeError(f"overwrite must be bool, got {type(overwrite).__name__}")
+    if not isinstance(target, (str, os.PathLike)):
+        raise TypeError(
+            f"target must be str or path-like, got {type(target).__name__}"
+        )
+    validated_id = _validate_workflow_id(workflow_id)
+    source = _load_version(validated_id, version)
+    if source.get("presented") is not True:
+        raise PermissionError("codex_image cannot approve a version that was not presented")
+    source_path = Path(str(source["path"]))
+    source_image = source["image"]
+    (
+        actual_mime_type,
+        _actual_extension,
+        actual_size,
+        actual_sha256,
+        actual_width,
+        actual_height,
+        actual_has_alpha,
+    ) = _detect_image(source_path)
+    expected_integrity = (
+        source_image.get("mime_type"),
+        source_image.get("bytes"),
+        source_image.get("sha256"),
+        source_image.get("width"),
+        source_image.get("height"),
+        source_image.get("has_alpha"),
+    )
+    actual_integrity = (
+        actual_mime_type,
+        actual_size,
+        actual_sha256,
+        actual_width,
+        actual_height,
+        actual_has_alpha,
+    )
+    if actual_integrity != expected_integrity:
+        raise RuntimeError(
+            "codex_image version bytes no longer match the presented immutable manifest"
+        )
+
+    target_path = Path(target).expanduser().resolve()
+    if target_path.exists() and target_path.is_dir():
+        raise IsADirectoryError(f"approval target is a directory: {target_path}")
+    if target_path.exists() and not overwrite:
+        raise FileExistsError(
+            f"approval target already exists; pass overwrite=True to replace it: {target_path}"
+        )
+    if not target_path.parent.is_dir():
+        raise FileNotFoundError(
+            f"approval target parent does not exist: {target_path.parent}"
+        )
+
+    # Persist the user's approval before mutating the external destination. If
+    # export later fails, the immutable receipt still records what was approved
+    # and no successful repository mutation can exist without that record.
+    approval = {
+        "schema": _SCHEMA_VERSION,
+        "status": "approved_for_export",
+        "approved": True,
+        "approved_at": datetime.now(timezone.utc).isoformat(),
+        "workflow_id": validated_id,
+        "version": version,
+        "source": str(source_path),
+        "target": str(target_path),
+        "sha256": actual_sha256,
+        "overwrite": overwrite,
+    }
+    workflow_directory = _workflow_directory(validated_id, must_exist=True)
+    approvals_directory = workflow_directory / "approvals"
+    approvals_directory.mkdir(mode=0o700, exist_ok=True)
+    approval_path = approvals_directory / f"approval-{uuid.uuid4().hex}.json"
+    _write_manifest(approval_path, approval)
+    os.chmod(approval_path, 0o444)
+
+    temporary = target_path.parent / f".{target_path.name}.codex-image-{uuid.uuid4().hex}.tmp"
+    try:
+        with source_path.open("rb") as source_file, temporary.open("xb") as target_file:
+            shutil.copyfileobj(source_file, target_file, length=1024 * 1024)
+            target_file.flush()
+            os.fsync(target_file.fileno())
+        os.chmod(temporary, 0o644)
+        if overwrite:
+            os.replace(temporary, target_path)
+        elif os.name == "nt":
+            # Windows rename is atomic and refuses an existing destination.
+            os.rename(temporary, target_path)
+        else:
+            # Hard-link publication is atomic and refuses to clobber a target
+            # that appeared after the preflight check.
+            os.link(temporary, target_path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    return {
+        **approval,
+        "exported": True,
+        "approval_path": str(approval_path.resolve()),
+    }

--- a/packages/coding-agent/skills/present-artifact/SKILL.md
+++ b/packages/coding-agent/skills/present-artifact/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: present-artifact
+description: Present a generated image or other supported on-disk artifact to the user without attaching it to the model context. Use when the user should see an artifact before it is exported or committed.
+---
+
+# Present Artifact
+
+Present an on-disk artifact in the current Prime Agent conversation:
+
+```python
+await present_artifact("/path/to/generated.png")
+await present_artifact("/path/to/generated.png", label="Direction A")
+```
+
+This is a display-only action for the user. It does not load the artifact into
+the model context, upload it, copy it into a repository, or imply approval.
+The host validates and captures the artifact so the source file may be removed
+after the call succeeds.
+
+
+The host rejects missing/directories and files larger than 20 MiB. Supported
+raster images are decoded and size-bounded for an inline preview; other files
+are captured with durable metadata and a local path fallback. Presentation
+failures raise an exception and do not imply approval.
+
+
+Inline raster previews travel with the conversation and render in image-capable
+interactive or ACP clients. Generic files currently expose captured metadata
+and a host-local path only; this is not a remote file-download channel.

--- a/packages/coding-agent/skills/present-artifact/pyproject.toml
+++ b/packages/coding-agent/skills/present-artifact/pyproject.toml
@@ -1,0 +1,18 @@
+# Kernel-side package for the bundled present-artifact skill. The runtime is
+# installed in the kernel environment before bundled skills.
+[project]
+name = "present-artifact"
+version = "0.1.0"
+description = "Present on-disk artifacts to Prime Agent users over the host bridge"
+requires-python = ">=3.10"
+dependencies = ["prime-agent-runtime"]
+
+[project.scripts]
+present_artifact = "rlm.skill:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/present_artifact"]

--- a/packages/coding-agent/skills/present-artifact/src/present_artifact/__init__.py
+++ b/packages/coding-agent/skills/present-artifact/src/present_artifact/__init__.py
@@ -1,0 +1,5 @@
+"""Present on-disk artifacts to the user through the Prime Agent host."""
+
+from .present_artifact import run
+
+__all__ = ["run"]

--- a/packages/coding-agent/skills/present-artifact/src/present_artifact/present_artifact.py
+++ b/packages/coding-agent/skills/present-artifact/src/present_artifact/present_artifact.py
@@ -1,0 +1,37 @@
+"""Thin kernel adapter for user-visible artifact presentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from rlm import host_request
+
+
+async def run(path: str, label: str | None = None) -> dict[str, Any]:
+    """Present an on-disk artifact to the user without attaching it to the model.
+
+    The Prime Agent host owns artifact inspection, capture, and rendering. This
+    adapter only resolves an existing regular file and forwards its path and an
+    optional display label.
+
+    Args:
+        path: Path to an existing regular file.
+        label: Optional user-visible label.
+
+    Returns:
+        The host's compact presentation receipt.
+    """
+    if not isinstance(path, str):
+        raise TypeError(f"path must be str, got {type(path).__name__}")
+    if label is not None and not isinstance(label, str):
+        raise TypeError(f"label must be str or None, got {type(label).__name__}")
+
+    filepath = Path(path).expanduser().resolve()
+    if not filepath.is_file():
+        raise FileNotFoundError(f"{path} is not an existing regular file")
+
+    payload: dict[str, Any] = {"path": str(filepath)}
+    if label is not None:
+        payload["label"] = label
+    return await host_request("artifact.present", payload)

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -189,6 +189,12 @@ import {
 	isSessionSlashCommandMessage,
 } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
+import {
+	capturePresentedArtifact,
+	normalizePresentedArtifactHostPayload,
+	type PresentedArtifactHostPayload,
+	type PresentedArtifactReceipt,
+} from "./presented-artifacts.js";
 import { throwIfPromptAdmissionCancelled } from "./prompt-admission.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import {
@@ -5891,6 +5897,29 @@ export class AgentSession {
 		}
 	}
 
+	/** Capture and display an artifact without adding it to model context or steering an active turn. */
+	async presentArtifact(payload: PresentedArtifactHostPayload): Promise<PresentedArtifactReceipt> {
+		const artifactDir = this._ensureRlmSessionDir() ?? this._createEphemeralRlmSessionDir();
+		const captured = await capturePresentedArtifact(payload, {
+			cwd: this.sessionManager.getCwd(),
+			artifactDir,
+			sessionId: this.sessionManager.getSessionId(),
+		});
+		const message = captured.message;
+		// Persist and flush before touching live state so a failed write cannot
+		// display an artifact that will disappear on replay.
+		this.sessionManager.appendCustomMessageEntryWithRollback(
+			message.customType,
+			message.content,
+			message.display,
+			message.details,
+		);
+		this.agent.state.messages.push(message);
+		this._emit({ type: "message_start", message });
+		this._emit({ type: "message_end", message });
+		return captured.receipt;
+	}
+
 	/**
 	 * Send a custom message to the session. Creates a CustomMessageEntry.
 	 *
@@ -8690,6 +8719,9 @@ export class AgentSession {
 				id: this.model?.id ?? null,
 				provider: this.model?.provider ?? null,
 				input: this.model?.input ?? [],
+			}),
+			"artifact.present": async (payload) => ({
+				...(await this.presentArtifact(normalizePresentedArtifactHostPayload(payload))),
 			}),
 		};
 		if (this._includeGoals) {

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -33,6 +33,7 @@ export const SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE = "session_slash_command_r
 export const COMPACTION_OUTCOME_CUSTOM_TYPE = "compaction_outcome";
 export const RLM_CHILD_FAILURE_CUSTOM_TYPE = "rlm_child_failure";
 export const RLM_CHILD_TERMINAL_NOTICE_CUSTOM_TYPE = "rlm_child_terminal_notice";
+export const PRESENTED_ARTIFACT_CUSTOM_TYPE = "prime-agent.presented-artifact";
 
 export interface SessionSlashCommandDetails {
 	command: SessionSlashCommand;
@@ -445,7 +446,8 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 					if (
 						m.customType === SESSION_SLASH_COMMAND_CUSTOM_TYPE ||
 						m.customType === SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE ||
-						m.customType === COMPACTION_OUTCOME_CUSTOM_TYPE
+						m.customType === COMPACTION_OUTCOME_CUSTOM_TYPE ||
+						m.customType === PRESENTED_ARTIFACT_CUSTOM_TYPE
 					) {
 						return undefined;
 					}

--- a/packages/coding-agent/src/core/presented-artifacts.ts
+++ b/packages/coding-agent/src/core/presented-artifacts.ts
@@ -1,0 +1,201 @@
+import { createHash, randomUUID } from "node:crypto";
+import { link, mkdir, readFile, stat, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
+import { fileTypeFromBuffer } from "file-type";
+import { resizeImage } from "../utils/image-resize.js";
+import { IMAGE_MIME_TYPES } from "../utils/mime.js";
+import { type CustomMessage, createCustomMessage, PRESENTED_ARTIFACT_CUSTOM_TYPE } from "./messages.js";
+
+export { PRESENTED_ARTIFACT_CUSTOM_TYPE };
+const MAX_SOURCE_BYTES = 20 * 1024 * 1024;
+const MAX_PREVIEW_BASE64_BYTES = 350_000;
+const MAX_LABEL_LENGTH = 500;
+
+export interface PresentedArtifactHostPayload {
+	path: string;
+	label?: string;
+}
+
+export interface PresentedArtifactDetails {
+	artifactId: string;
+	presentationId: string;
+	sessionId: string;
+	kind: "image" | "file";
+	name: string;
+	label?: string;
+	mimeType: string;
+	byteSize: number;
+	path: string;
+	width?: number;
+	height?: number;
+	originalWidth?: number;
+	originalHeight?: number;
+}
+
+export interface PresentedArtifactReceipt {
+	artifactId: string;
+	presentationId: string;
+	kind: "image" | "file";
+	name: string;
+	mimeType: string;
+	byteSize: number;
+	path: string;
+	width?: number;
+	height?: number;
+	originalWidth?: number;
+	originalHeight?: number;
+}
+
+export interface CapturedPresentedArtifact {
+	message: CustomMessage<PresentedArtifactDetails>;
+	receipt: PresentedArtifactReceipt;
+}
+
+export interface CapturePresentedArtifactOptions {
+	cwd: string;
+	artifactDir: string;
+	sessionId: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function normalizePresentedArtifactHostPayload(payload: unknown): PresentedArtifactHostPayload {
+	if (!isRecord(payload) || typeof payload.path !== "string" || payload.path.trim().length === 0) {
+		throw new Error("artifact.present requires a non-empty path");
+	}
+	if (payload.label !== undefined && typeof payload.label !== "string") {
+		throw new Error("artifact.present label must be a string");
+	}
+	const label = typeof payload.label === "string" ? payload.label.trim() : undefined;
+	if (label && label.length > MAX_LABEL_LENGTH) {
+		throw new Error(`artifact.present label must be at most ${MAX_LABEL_LENGTH} characters`);
+	}
+	return { path: payload.path, ...(label ? { label } : {}) };
+}
+
+function safeArtifactName(input: string): string {
+	const cleaned = input.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+	return cleaned || "artifact";
+}
+
+function fallbackMimeType(fileName: string): string {
+	switch (extname(fileName).toLowerCase()) {
+		case ".txt":
+		case ".md":
+		case ".csv":
+			return "text/plain";
+		case ".json":
+			return "application/json";
+		default:
+			return "application/octet-stream";
+	}
+}
+
+async function captureFile(bytes: Buffer, destinationPath: string): Promise<void> {
+	await mkdir(dirname(destinationPath), { recursive: true });
+	const temporaryPath = `${destinationPath}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+	await writeFile(temporaryPath, bytes, { flag: "wx" });
+	try {
+		await link(temporaryPath, destinationPath);
+	} catch (error) {
+		const existing = await readFile(destinationPath).catch(() => undefined);
+		if (!existing?.equals(bytes)) throw error;
+	} finally {
+		await unlink(temporaryPath).catch(() => undefined);
+	}
+}
+
+export async function capturePresentedArtifact(
+	rawPayload: unknown,
+	options: CapturePresentedArtifactOptions,
+): Promise<CapturedPresentedArtifact> {
+	const payload = normalizePresentedArtifactHostPayload(rawPayload);
+	const sourcePath = isAbsolute(payload.path) ? resolve(payload.path) : resolve(options.cwd, payload.path);
+	const sourceStat = await stat(sourcePath).catch((error: NodeJS.ErrnoException) => {
+		if (error.code === "ENOENT") throw new Error(`Artifact does not exist: ${payload.path}`);
+		throw error;
+	});
+	if (!sourceStat.isFile()) throw new Error(`Artifact path must be a regular file: ${payload.path}`);
+	if (sourceStat.size > MAX_SOURCE_BYTES) {
+		throw new Error(`Artifact exceeds the 20 MiB presentation limit: ${payload.path}`);
+	}
+
+	const bytes = await readFile(sourcePath);
+	if (bytes.byteLength > MAX_SOURCE_BYTES) {
+		throw new Error(`Artifact exceeds the 20 MiB presentation limit: ${payload.path}`);
+	}
+	const digest = createHash("sha256").update(bytes).digest("hex");
+	const artifactId = digest.slice(0, 16);
+	const presentationId = randomUUID();
+	const name = basename(sourcePath);
+	const destinationDir = join(options.artifactDir, "presented-artifacts");
+	const destinationPath = join(destinationDir, `${artifactId}-${safeArtifactName(name)}`);
+	const detectedFileType = await fileTypeFromBuffer(bytes);
+	const detectedImageMime =
+		detectedFileType && IMAGE_MIME_TYPES.has(detectedFileType.mime) ? detectedFileType.mime : null;
+	let mimeType = detectedImageMime;
+	let kind: "image" | "file" = "file";
+	const content: (TextContent | ImageContent)[] = [{ type: "text", text: payload.label ?? `Artifact: ${name}` }];
+	let dimensions: Pick<PresentedArtifactDetails, "width" | "height" | "originalWidth" | "originalHeight"> = {};
+
+	if (detectedImageMime) {
+		const preview = await resizeImage(
+			{ type: "image", data: bytes.toString("base64"), mimeType: detectedImageMime },
+			{ maxWidth: 1600, maxHeight: 1600, maxBytes: MAX_PREVIEW_BASE64_BYTES },
+		);
+		if (!preview) throw new Error(`Artifact is not a readable supported image: ${payload.path}`);
+		kind = "image";
+		mimeType = preview.mimeType;
+		dimensions = {
+			width: preview.width,
+			height: preview.height,
+			originalWidth: preview.originalWidth,
+			originalHeight: preview.originalHeight,
+		};
+		content.push({ type: "image", data: preview.data, mimeType: preview.mimeType });
+	} else {
+		mimeType = detectedFileType?.mime ?? fallbackMimeType(name);
+		content.push({ type: "text", text: destinationPath });
+	}
+	await captureFile(bytes, destinationPath);
+
+	const details: PresentedArtifactDetails = {
+		artifactId,
+		presentationId,
+		sessionId: options.sessionId,
+		kind,
+		name,
+		...(payload.label ? { label: payload.label } : {}),
+		mimeType,
+		byteSize: bytes.byteLength,
+		path: destinationPath,
+		...dimensions,
+	};
+	return {
+		message: createCustomMessage(
+			PRESENTED_ARTIFACT_CUSTOM_TYPE,
+			content,
+			true,
+			details,
+			new Date().toISOString(),
+		) as CustomMessage<PresentedArtifactDetails>,
+		receipt: {
+			artifactId,
+			presentationId,
+			kind,
+			name,
+			mimeType,
+			byteSize: bytes.byteLength,
+			path: destinationPath,
+			...dimensions,
+		},
+	};
+}
+
+export function isPresentedArtifactMessage(message: AgentMessage): message is CustomMessage<PresentedArtifactDetails> {
+	return message.role === "custom" && message.customType === PRESENTED_ARTIFACT_CUSTOM_TYPE;
+}

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -137,7 +137,7 @@ export {
 } from "./core/extensions/index.js";
 // Footer data provider (git branch + extension statuses - data not otherwise available to extensions)
 export type { ReadonlyFooterDataProvider } from "./core/footer-data-provider.js";
-export { convertToLlm } from "./core/messages.js";
+export { convertToLlm, PRESENTED_ARTIFACT_CUSTOM_TYPE } from "./core/messages.js";
 export { ModelRegistry } from "./core/model-registry.js";
 export type {
 	PackageManager,
@@ -148,6 +148,12 @@ export type {
 	ResolvedResource,
 } from "./core/package-manager.js";
 export { DefaultPackageManager } from "./core/package-manager.js";
+export {
+	isPresentedArtifactMessage,
+	type PresentedArtifactDetails,
+	type PresentedArtifactHostPayload,
+	type PresentedArtifactReceipt,
+} from "./core/presented-artifacts.js";
 export type { ResourceCollision, ResourceDiagnostic, ResourceLoader } from "./core/resource-loader.js";
 export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.js";
 // SDK for programmatic usage
@@ -361,6 +367,7 @@ export {
 	LoginDialogComponent,
 	ModelSelectorComponent,
 	OAuthSelectorComponent,
+	PresentedArtifactMessageComponent,
 	type RenderDiffOptions,
 	rawKeyHint,
 	renderDiff,

--- a/packages/coding-agent/src/modes/acp/acp-events.ts
+++ b/packages/coding-agent/src/modes/acp/acp-events.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessageEvent } from "@earendil-works/pi-ai";
+import { isPresentedArtifactMessage } from "../../core/presented-artifacts.js";
 import type { AgentConnectionSessionEvent } from "../agent-connection/types.js";
 import type { PrimeAgentIpythonMeta, PrimeAgentSessionMeta } from "./acp-meta.js";
 import { primeAgentMeta } from "./acp-meta.js";
@@ -137,6 +138,20 @@ export function acpUpdatesForSessionEvent(
 	state: AcpEventMappingState = {},
 ): AcpSessionUpdate[] {
 	switch (event.type) {
+		case "message_end": {
+			const message = event.message;
+			if (!isPresentedArtifactMessage(message)) return [];
+			const content =
+				typeof message.content === "string"
+					? [{ type: "text" as const, text: message.content }]
+					: message.content.filter((block) => block.type === "text" || block.type === "image");
+			return content.map((block) => ({
+				sessionUpdate: "agent_message_chunk",
+				content: block,
+				messageId: message.details?.presentationId,
+			}));
+		}
+
 		case "message_update":
 			if (event.message.role !== "assistant") return [];
 			return assistantDeltaUpdates(event.assistantMessageEvent);

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -9,6 +9,7 @@ import {
 	SESSION_SLASH_COMMAND_CUSTOM_TYPE,
 	SESSION_SLASH_COMMAND_RESULT_CUSTOM_TYPE,
 } from "../../../core/messages.js";
+import { isPresentedArtifactMessage } from "../../../core/presented-artifacts.js";
 import { AgentMessageComponent } from "./agent-message.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
 import { BashExecutionComponent } from "./bash-execution.js";
@@ -18,6 +19,7 @@ import {
 } from "./compaction-outcome-message.js";
 import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./injected-prompt-message.js";
 import { IPythonCellComponent } from "./ipython-cell.js";
+import { PresentedArtifactMessageComponent } from "./presented-artifact-message.js";
 import { SlashCommandMessageComponent } from "./slash-command-message.js";
 import { SlashCommandResultMessageComponent } from "./slash-command-result-message.js";
 import {
@@ -129,6 +131,9 @@ export function buildConversationComponents(
 			} else {
 				components.push(new UserMessageComponent("[Malformed session command message]", options.markdownTheme));
 			}
+		} else if (message.role === "custom" && isPresentedArtifactMessage(message)) {
+			if (!message.display) continue;
+			components.push(new PresentedArtifactMessageComponent(message, options.toolOptions.showImages));
 		} else if (message.role === "custom" && message.customType === COMPACTION_OUTCOME_CUSTOM_TYPE) {
 			if (!message.display) continue;
 			components.push(

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -35,6 +35,7 @@ export { keyHint, keyText, rawKeyHint } from "./keybinding-hints.js";
 export { LoginDialogComponent } from "./login-dialog.js";
 export { ModelSelectorComponent } from "./model-selector.js";
 export { OAuthSelectorComponent } from "./oauth-selector.js";
+export { PresentedArtifactMessageComponent } from "./presented-artifact-message.js";
 export { PrimeOnboardingSplashComponent } from "./prime-onboarding-splash.js";
 export { type ModelsCallbacks, type ModelsConfig, ScopedModelsSelectorComponent } from "./scoped-models-selector.js";
 export { type SettingsCallbacks, type SettingsConfig, SettingsSelectorComponent } from "./settings-selector.js";

--- a/packages/coding-agent/src/modes/interactive/components/presented-artifact-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/presented-artifact-message.ts
@@ -1,0 +1,48 @@
+import { Container, Image, Text } from "@earendil-works/pi-tui";
+import type { CustomMessage } from "../../../core/messages.js";
+import type { PresentedArtifactDetails } from "../../../core/presented-artifacts.js";
+import { theme } from "../theme/theme.js";
+
+function isImageContent(value: unknown): value is { type: "image"; data: string; mimeType: string } {
+	if (typeof value !== "object" || value === null) return false;
+	const content = value as Record<string, unknown>;
+	return content.type === "image" && typeof content.data === "string" && typeof content.mimeType === "string";
+}
+
+function textContent(message: CustomMessage): string | undefined {
+	if (typeof message.content === "string") return message.content;
+	return message.content.find((item) => item.type === "text")?.text;
+}
+
+/** Durable, display-only artifact message with actual terminal image rendering. */
+export class PresentedArtifactMessageComponent extends Container {
+	setExpanded(_expanded: boolean): void {}
+
+	constructor(message: CustomMessage<PresentedArtifactDetails>, showImages = true) {
+		super();
+		const details = message.details;
+		const label =
+			textContent(message) ?? details?.label ?? (details?.name ? `Artifact: ${details.name}` : "Artifact");
+		this.addChild(new Text(theme.fg("muted", label), 0, 0));
+
+		if (details?.kind === "image" && Array.isArray(message.content)) {
+			const image = message.content.find(isImageContent);
+			if (image) {
+				this.addChild(
+					new Image(
+						image.data,
+						image.mimeType,
+						{ fallbackColor: (value) => theme.fg("muted", value) },
+						{ filename: details.name, fallbackOnly: !showImages },
+						details.width && details.height ? { widthPx: details.width, heightPx: details.height } : undefined,
+					),
+				);
+				return;
+			}
+		}
+
+		if (details?.path) {
+			this.addChild(new Text(theme.fg("dim", details.path), 0, 0));
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -111,6 +111,7 @@ import {
 } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScopeFromModels } from "../../core/model-resolver.js";
 import { parseNewSessionCommand } from "../../core/new-session-command.js";
+import { isPresentedArtifactMessage } from "../../core/presented-artifacts.js";
 import { resolvePrimeAgentTracesBaseUrl } from "../../core/prime-inference-auth.js";
 import { resolvePrimeInferencePostLoginModelAction } from "../../core/prime-inference-model-selection.js";
 import { parseCommandArgs } from "../../core/prompt-templates.js";
@@ -202,6 +203,7 @@ import { HeartbeatManagerComponent } from "./components/heartbeat-manager.js";
 import { InjectedPromptMessageComponent, isInjectedPromptMessage } from "./components/injected-prompt-message.js";
 import { formatKeyText, keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.js";
 import type { AuthSelectorProvider } from "./components/oauth-selector.js";
+import { PresentedArtifactMessageComponent } from "./components/presented-artifact-message.js";
 import { PrimeOnboardingSplashComponent } from "./components/prime-onboarding-splash.js";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.js";
 import { SettingsSelectorComponent } from "./components/settings-selector.js";
@@ -6226,27 +6228,32 @@ export class InteractiveMode {
 										"[Malformed session command message]",
 										this.getMarkdownThemeWithSettings(),
 									)
-								: isCompactionOutcomeMessage(message)
-									? new CompactionOutcomeMessageComponent(message)
-									: message.customType === COMPACTION_OUTCOME_CUSTOM_TYPE
-										? new MalformedCompactionOutcomeMessageComponent()
-										: isAgentSessionMessage(message)
-											? new AgentMessageComponent(message, this.getMarkdownThemeWithSettings(), {
-													suppressLeadingSpace: isCompactAgentMessageNeighbor(
-														this.chatContainer.children.at(-1),
-													),
-												})
-											: isInjectedPromptMessage(message)
-												? new InjectedPromptMessageComponent(message, this.getMarkdownThemeWithSettings())
-												: new CustomMessageComponent(
-														message,
-														this.bindLocalSessionExtensions
-															? this.getLocalSessionHost()
-																	.getExtensionRunner()
-																	.getMessageRenderer(message.customType)
-															: undefined,
-														this.getMarkdownThemeWithSettings(),
-													);
+								: isPresentedArtifactMessage(message)
+									? new PresentedArtifactMessageComponent(message, this.settingsManager.getShowImages())
+									: isCompactionOutcomeMessage(message)
+										? new CompactionOutcomeMessageComponent(message)
+										: message.customType === COMPACTION_OUTCOME_CUSTOM_TYPE
+											? new MalformedCompactionOutcomeMessageComponent()
+											: isAgentSessionMessage(message)
+												? new AgentMessageComponent(message, this.getMarkdownThemeWithSettings(), {
+														suppressLeadingSpace: isCompactAgentMessageNeighbor(
+															this.chatContainer.children.at(-1),
+														),
+													})
+												: isInjectedPromptMessage(message)
+													? new InjectedPromptMessageComponent(
+															message,
+															this.getMarkdownThemeWithSettings(),
+														)
+													: new CustomMessageComponent(
+															message,
+															this.bindLocalSessionExtensions
+																? this.getLocalSessionHost()
+																		.getExtensionRunner()
+																		.getMessageRenderer(message.customType)
+																: undefined,
+															this.getMarkdownThemeWithSettings(),
+														);
 					if (!(component instanceof UserMessageComponent)) {
 						component.setExpanded(this.toolOutputExpanded);
 					}

--- a/packages/coding-agent/test/acp-events.test.ts
+++ b/packages/coding-agent/test/acp-events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { PRESENTED_ARTIFACT_CUSTOM_TYPE } from "../src/core/messages.js";
 import {
 	type AcpEventMappingState,
 	acpToolKind,
@@ -281,5 +282,33 @@ describe("ACP session event mapping", () => {
 		expect(acpUpdatesForSessionEvent({ type: "recap_update", recap: "x" } as AgentConnectionSessionEvent)).toEqual(
 			[],
 		);
+	});
+	it("delivers presented artifacts as standard ACP text and image chunks", () => {
+		const updates = acpUpdatesForSessionEvent({
+			type: "message_end",
+			message: {
+				role: "custom",
+				customType: PRESENTED_ARTIFACT_CUSTOM_TYPE,
+				content: [
+					{ type: "text", text: "Generated preview" },
+					{ type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+				],
+				display: true,
+				details: { artifactId: "artifact-1", presentationId: "presentation-1" },
+				timestamp: 0,
+			},
+		} as AgentConnectionSessionEvent);
+		expect(updates).toEqual([
+			{
+				sessionUpdate: "agent_message_chunk",
+				content: { type: "text", text: "Generated preview" },
+				messageId: "presentation-1",
+			},
+			{
+				sessionUpdate: "agent_message_chunk",
+				content: { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+				messageId: "presentation-1",
+			},
+		]);
 	});
 });

--- a/packages/coding-agent/test/builtin-skills.test.ts
+++ b/packages/coding-agent/test/builtin-skills.test.ts
@@ -254,6 +254,15 @@ describe("builtin skills", () => {
 			expect(rlmHeartbeat?.kind === "python" && rlmHeartbeat.python.importName).toBe("rlm_heartbeat");
 		});
 
+		it("ships user-facing artifact and Codex image workflows as python skills", () => {
+			const { skills } = loadSkillsFromDir({ dir: getBundledSkillsDir(), source: "builtin" });
+			const imports = new Map(
+				skills.filter((skill) => skill.kind === "python").map((skill) => [skill.name, skill.python.importName]),
+			);
+			expect(imports.get("present-artifact")).toBe("present_artifact");
+			expect(imports.get("codex-image")).toBe("codex_image");
+		});
+
 		it("does not ship orchestration heartbeat as a built-in skill", () => {
 			const { skills } = loadSkillsFromDir({ dir: getBundledSkillsDir(), source: "builtin" });
 

--- a/packages/coding-agent/test/kernel-codex-image-skill.test.ts
+++ b/packages/coding-agent/test/kernel-codex-image-skill.test.ts
@@ -1,0 +1,390 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBundledSkillsDir } from "../src/config.js";
+import { PRESENTED_ARTIFACT_CUSTOM_TYPE } from "../src/core/messages.js";
+import { capturePresentedArtifact } from "../src/core/presented-artifacts.js";
+import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
+import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+
+interface ImageInfo {
+	bytes: number;
+	has_alpha: boolean;
+	height: number;
+	file: string;
+	mime_type: string;
+	path: string;
+	sha256: string;
+	width: number;
+}
+
+interface ImageVersion {
+	brief: string;
+	original_brief: string;
+	references: Array<{ file: string; original_name: string; path: string; sha256: string }>;
+	image: ImageInfo;
+	kind: "icon" | "mockup";
+	manifest_path: string;
+	parent_version: number | null;
+	path: string;
+	presentation: { artifactId: string; presentationId: string };
+	presented: boolean;
+	thread_id: string;
+	version: number;
+	version_id: string;
+	workflow_id: string;
+}
+
+interface FakeCodexCall {
+	args: string[];
+	prompt: string;
+}
+
+interface WorkflowOutput {
+	allVersions: ImageVersion[];
+	approved: {
+		approval_path: string;
+		approved: boolean;
+		exported: boolean;
+		status: string;
+		source: string;
+		target: string;
+		version: number;
+		workflow_id: string;
+	};
+	failures: Record<string, string>;
+	first: ImageVersion;
+	mockup: ImageVersion;
+	refined: ImageVersion;
+	targetExistedBeforeApproval: boolean;
+	versions: ImageVersion[];
+}
+
+function bundledCodexImageSkill(): PythonSkillRuntimeInfo {
+	const packagePath = join(getBundledSkillsDir(), "codex-image");
+	return {
+		name: "codex-image",
+		importName: "codex_image",
+		packagePath,
+		pyprojectPath: join(packagePath, "pyproject.toml"),
+	};
+}
+
+const FAKE_CODEX = String.raw`import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { relative } from "node:path";
+
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const prompt = Buffer.concat(chunks).toString("utf8");
+const args = process.argv.slice(2);
+appendFileSync(process.env.FAKE_CODEX_LOG, JSON.stringify({ args, prompt }) + "\n");
+process.stderr.write("captured fake Codex diagnostic\n");
+
+if (prompt.includes("AUTH_FAIL")) {
+	process.stderr.write("not authenticated; run codex login\n");
+	process.exitCode = 1;
+} else if (prompt.includes("TIMEOUT")) {
+	await new Promise((resolve) => setTimeout(resolve, 10_000));
+} else {
+	console.log(JSON.stringify({ type: "thread.started", thread_id: "thread-fake-imagegen" }));
+	if (!prompt.includes("NO_OUTPUT")) {
+		const outputLine = prompt.match(/^Staging directory \(JSON\): (.+)$/m);
+		if (!outputLine) throw new Error("missing staging directory instruction");
+		const stagingDirectory = JSON.parse(outputLine[1]);
+		const countPath = process.env.FAKE_CODEX_COUNT;
+		const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) + 1 : 1;
+		writeFileSync(countPath, String(count));
+		const outputDirectory =
+			count === 1 ? process.env.CODEX_HOME + "/generated_images/thread-fake-imagegen" : stagingDirectory;
+		mkdirSync(outputDirectory, { recursive: true });
+		const imagePath = outputDirectory + "/generated-" + count + ".png";
+		const png = Buffer.from(
+			"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+			"base64",
+		);
+		writeFileSync(imagePath, Buffer.concat([png, Buffer.from([count])]));
+		console.log(
+			JSON.stringify({
+				type: "item.completed",
+				item:
+					count === 2
+						? { type: "image_generation", saved_path: relative(process.cwd(), imagePath) }
+						: { type: "image_generation", output_path: imagePath },
+			}),
+		);
+	}
+}
+`;
+
+describe("codex-image skill over a live kernel", { tags: ["kernel-heavy"] }, () => {
+	let tempDir: string;
+	let sessionDir: string;
+	let fakeCodexPath: string;
+	let fakeCodexLog: string;
+	let fakeCodexCount: string;
+	let referencePath: string;
+	let provisioner: IpythonKernelProvisioner | undefined;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-codex-image-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		sessionDir = join(tempDir, "session-artifacts");
+		fakeCodexPath = join(tempDir, "fake-codex.mjs");
+		fakeCodexLog = join(tempDir, "fake-codex.jsonl");
+		fakeCodexCount = join(tempDir, "fake-codex-count");
+		referencePath = join(tempDir, "reference.png");
+		mkdirSync(sessionDir, { recursive: true });
+		writeFileSync(fakeCodexPath, FAKE_CODEX);
+		writeFileSync(
+			referencePath,
+			Buffer.from(
+				"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+				"base64",
+			),
+		);
+	});
+
+	afterEach(async () => {
+		await provisioner?.dispose();
+		provisioner = undefined;
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("generates, resumes, presents, records immutable lineage, and gates atomic approval", async () => {
+		const presentations: Array<{ label: string; path: string }> = [];
+		const presentationMessages: unknown[] = [];
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			env: {
+				RLM_SESSION_DIR: sessionDir,
+				FAKE_CODEX_LOG: fakeCodexLog,
+				FAKE_CODEX_COUNT: fakeCodexCount,
+				CODEX_HOME: join(tempDir, "codex-home"),
+			},
+			pythonSkills: [bundledCodexImageSkill()],
+			hostHandlers: {
+				"artifact.present": async (payload) => {
+					if (typeof payload.path !== "string" || typeof payload.label !== "string") {
+						throw new Error("invalid artifact.present payload");
+					}
+					const captured = await capturePresentedArtifact(payload, {
+						cwd: tempDir,
+						artifactDir: sessionDir,
+						sessionId: "codex-image-test",
+					});
+					presentations.push({ path: payload.path, label: payload.label });
+					presentationMessages.push(captured.message);
+					return { ...captured.receipt };
+				},
+			},
+		});
+
+		const manager = await provisioner.ensure();
+		const targetPath = join(tempDir, "approved-icon.png");
+		const command = [process.execPath, fakeCodexPath];
+		const result = await manager.execute(`
+import json
+import os
+from pathlib import Path
+
+_command = ${JSON.stringify(command)}
+_first = await codex_image.generate(
+    "A focused compass icon for a hiking app",
+    kind="icon",
+    references=[${JSON.stringify(referencePath)}],
+    label="Compass icon v1",
+    command=_command,
+)
+Path(${JSON.stringify(referencePath)}).unlink()
+_refined = await codex_image.refine(
+    _first["workflow_id"],
+    "Make the needle broader and remove the outer tick marks",
+    command=_command,
+)
+_mockup = await codex_image.generate(
+    "A desktop settings screen for the hiking app",
+    kind="mockup",
+    command=_command,
+)
+_versions = codex_image.list_versions(_first["workflow_id"])
+_all_versions = codex_image.list_versions()
+_target = Path(${JSON.stringify(targetPath)})
+_failures = {}
+_tampered_target = Path(${JSON.stringify(join(tempDir, "tampered-mockup.png"))})
+_tampered_path = Path(_mockup["path"])
+_tampered_path.chmod(0o644)
+_tampered_path.write_bytes(_tampered_path.read_bytes() + b"tampered")
+try:
+    codex_image.approve(
+        _mockup["workflow_id"], _mockup["version"], _tampered_target, approved=True
+    )
+except RuntimeError as error:
+    _failures["tamper"] = str(error)
+try:
+    codex_image.approve(
+        _first["workflow_id"], _refined["version"], _target, approved=False
+    )
+except PermissionError as error:
+    _failures["approval"] = str(error)
+_target_existed_before_approval = _target.exists()
+_approved = codex_image.approve(
+    _first["workflow_id"], _refined["version"], _target, approved=True
+)
+try:
+    codex_image.approve(
+        _first["workflow_id"], _refined["version"], _target, approved=True
+    )
+except FileExistsError as error:
+    _failures["collision"] = str(error)
+
+_saved_session_dir = os.environ.pop("RLM_SESSION_DIR")
+try:
+    await codex_image.generate("missing session", command=_command)
+except RuntimeError as error:
+    _failures["session"] = str(error)
+finally:
+    os.environ["RLM_SESSION_DIR"] = _saved_session_dir
+
+try:
+    await codex_image.generate("missing command", command=["codex-that-does-not-exist"])
+except RuntimeError as error:
+    _failures["cli"] = str(error)
+try:
+    await codex_image.generate("AUTH_FAIL", command=_command)
+except RuntimeError as error:
+    _failures["auth"] = str(error)
+try:
+    await codex_image.generate("NO_OUTPUT", command=_command)
+except RuntimeError as error:
+    _failures["output"] = str(error)
+try:
+    await codex_image.generate("TIMEOUT", command=_command, timeout_seconds=0.05)
+except TimeoutError as error:
+    _failures["timeout"] = str(error)
+
+print(json.dumps({
+    "first": _first,
+    "refined": _refined,
+    "mockup": _mockup,
+    "versions": _versions,
+    "allVersions": _all_versions,
+    "targetExistedBeforeApproval": _target_existed_before_approval,
+    "approved": _approved,
+    "failures": _failures,
+}, sort_keys=True))
+`);
+
+		expect(result.status).toBe("ok");
+		expect(result.stderr).not.toContain("captured fake Codex diagnostic");
+		const output = JSON.parse(result.stdout.trim()) as WorkflowOutput;
+
+		expect(output.first.kind).toBe("icon");
+		expect(output.first.version).toBe(1);
+		expect(output.first.parent_version).toBeNull();
+		expect(output.first.presented).toBe(true);
+		expect(output.first.presentation.artifactId).toMatch(/^[a-f0-9]{16}$/);
+		expect(output.first.presentation.presentationId).toBeTruthy();
+		expect(output.first.image).toMatchObject({ width: 1, height: 1, has_alpha: true });
+		expect(output.first.original_brief).toBe(output.first.brief);
+		expect(output.first.references).toHaveLength(1);
+		expect(output.first.references[0].original_name).toBe("reference.png");
+		expect(output.first.references[0].path.startsWith(join(sessionDir, "codex-image"))).toBe(true);
+		expect(output.refined.version).toBe(2);
+		expect(output.refined.parent_version).toBe(1);
+		expect(output.refined.thread_id).toBe(output.first.thread_id);
+		expect(output.refined.workflow_id).toBe(output.first.workflow_id);
+		expect(output.mockup.kind).toBe("mockup");
+		expect(output.versions.map((version) => version.version)).toEqual([1, 2]);
+		expect(output.allVersions).toHaveLength(3);
+		expect(output.first.path).not.toBe(output.refined.path);
+		expect(output.first.path.startsWith(join(sessionDir, "codex-image"))).toBe(true);
+		expect(output.refined.path.startsWith(join(sessionDir, "codex-image"))).toBe(true);
+
+		expect(presentations).toEqual([
+			{ path: output.first.path, label: "Compass icon v1" },
+			{
+				path: output.refined.path,
+				label: `Codex icon — ${output.first.workflow_id} v0002`,
+			},
+			{
+				path: output.mockup.path,
+				label: `Codex mockup — ${output.mockup.workflow_id} v0001`,
+			},
+		]);
+
+		const firstManifestBefore = readFileSync(output.first.manifest_path, "utf8");
+		const firstManifest = JSON.parse(firstManifestBefore) as ImageVersion;
+		const refinedManifest = JSON.parse(readFileSync(output.refined.manifest_path, "utf8")) as ImageVersion;
+		expect(firstManifest.thread_id).toBe("thread-fake-imagegen");
+		expect(firstManifest.parent_version).toBeNull();
+		expect(refinedManifest.thread_id).toBe(firstManifest.thread_id);
+		expect(refinedManifest.parent_version).toBe(1);
+		expect(readFileSync(output.first.manifest_path, "utf8")).toBe(firstManifestBefore);
+		expect(statSync(output.first.manifest_path).mode & 0o222).toBe(0);
+		expect(statSync(output.first.path).mode & 0o222).toBe(0);
+
+		expect(output.targetExistedBeforeApproval).toBe(false);
+		expect(output.failures.approval).toContain("explicit approved=True");
+		expect(output.failures.tamper).toContain("no longer match");
+		expect(existsSync(join(tempDir, "tampered-mockup.png"))).toBe(false);
+		expect(output.failures.collision).toContain("overwrite=True");
+		expect(output.approved).toMatchObject({
+			approved: true,
+			exported: true,
+			status: "approved_for_export",
+			source: output.refined.path,
+			target: targetPath,
+			version: 2,
+			workflow_id: output.first.workflow_id,
+		});
+		expect(readFileSync(targetPath)).toEqual(readFileSync(output.refined.path));
+		expect(existsSync(output.approved.approval_path)).toBe(true);
+		expect(JSON.parse(readFileSync(output.approved.approval_path, "utf8"))).toMatchObject({
+			status: "approved_for_export",
+			sha256: output.refined.image.sha256,
+		});
+		expect(readdirSync(tempDir).some((name) => name.includes(".codex-image-") && name.endsWith(".tmp"))).toBe(false);
+
+		expect(output.failures.session).toContain("requires RLM_SESSION_DIR");
+		expect(output.failures.cli).toContain("Codex CLI not found");
+		expect(output.failures.auth).toContain("Codex authentication failed");
+		expect(output.failures.output).toContain("without reporting a generated image path");
+		expect(output.failures.timeout).toContain("timed out after 0.05 seconds");
+		expect(presentations).toHaveLength(3);
+		expect(presentationMessages).toHaveLength(3);
+		expect(presentationMessages[0]).toMatchObject({
+			customType: PRESENTED_ARTIFACT_CUSTOM_TYPE,
+			display: true,
+			details: { kind: "image", originalWidth: 1, originalHeight: 1 },
+		});
+		expect(codexImageWorkflowDirectories(sessionDir)).toHaveLength(2);
+
+		const calls = readFileSync(fakeCodexLog, "utf8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as FakeCodexCall);
+		const initialCall = calls[0];
+		const refinementCall = calls[1];
+		const mockupCall = calls[2];
+		expect(initialCall.args.slice(0, 2)).toEqual(["exec", "--json"]);
+		expect(initialCall.args).toContain("image_generation");
+		expect(initialCall.args).toContain("-i");
+		expect(initialCall.args).not.toContain(referencePath);
+		expect(initialCall.args[initialCall.args.indexOf("-i") + 1]).toContain(join(sessionDir, "codex-image"));
+		expect(initialCall.args.at(-1)).toBe("-");
+		expect(initialCall.prompt).toContain("native image generation tool (imagegen)");
+		expect(initialCall.prompt).toContain("exactly one final icon image");
+		expect(initialCall.prompt).not.toContain("comparison-sheet");
+		expect(refinementCall.args.slice(0, 3)).toEqual(["exec", "resume", "--json"]);
+		expect(refinementCall.args).toContain("thread-fake-imagegen");
+		expect(refinementCall.args).toContain("-i");
+		expect(refinementCall.args.at(-1)).toBe("-");
+		expect(refinementCall.prompt).toContain("Requested refinement:");
+		expect(mockupCall.prompt).toContain("exactly one final mockup comparison-sheet image");
+		expect(mockupCall.prompt).toContain("clearly labeled A, B, and C");
+	});
+});
+
+function codexImageWorkflowDirectories(sessionDir: string): string[] {
+	const storageDir = join(sessionDir, "codex-image");
+	return readdirSync(storageDir).filter((name) => name.startsWith("img-"));
+}

--- a/packages/coding-agent/test/kernel-present-artifact-skill.test.ts
+++ b/packages/coding-agent/test/kernel-present-artifact-skill.test.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBundledSkillsDir } from "../src/config.js";
+import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
+import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+
+function bundledPresentArtifactSkill(): PythonSkillRuntimeInfo {
+	const packagePath = join(getBundledSkillsDir(), "present-artifact");
+	return {
+		name: "present-artifact",
+		importName: "present_artifact",
+		packagePath,
+		pyprojectPath: join(packagePath, "pyproject.toml"),
+	};
+}
+
+describe("present-artifact skill over the kernel host bridge", () => {
+	let tempDir: string;
+	let provisioner: IpythonKernelProvisioner | undefined;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-present-artifact-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		writeFileSync(join(tempDir, "sample.png"), "host-owned test fixture");
+	});
+
+	afterEach(async () => {
+		await provisioner?.dispose();
+		provisioner = undefined;
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("forwards resolved paths and optional labels without creating model attachments", async () => {
+		const requests: Array<Record<string, unknown>> = [];
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			pythonSkills: [bundledPresentArtifactSkill()],
+			hostHandlers: {
+				"artifact.present": async (payload) => {
+					requests.push(payload);
+					return {
+						artifactId: `artifact-${requests.length}`,
+						kind: "image",
+						name: "sample.png",
+						mimeType: "image/png",
+						byteSize: 24,
+						path: "/captured/sample.png",
+					};
+				},
+			},
+		});
+
+		const manager = await provisioner.ensure();
+		const result = await manager.execute(`
+import json
+without_label = await present_artifact("sample.png")
+with_label = await present_artifact("sample.png", label="Direction A")
+print(json.dumps([without_label, with_label], sort_keys=True))
+`);
+
+		expect(result.status).toBe("ok");
+		expect(JSON.parse(result.stdout.trim())).toEqual([
+			{
+				artifactId: "artifact-1",
+				byteSize: 24,
+				kind: "image",
+				mimeType: "image/png",
+				name: "sample.png",
+				path: "/captured/sample.png",
+			},
+			{
+				artifactId: "artifact-2",
+				byteSize: 24,
+				kind: "image",
+				mimeType: "image/png",
+				name: "sample.png",
+				path: "/captured/sample.png",
+			},
+		]);
+		expect(requests).toMatchObject([
+			{ type: "artifact.present", path: join(tempDir, "sample.png") },
+			{ type: "artifact.present", path: join(tempDir, "sample.png"), label: "Direction A" },
+		]);
+		expect(result.attachments).toBeUndefined();
+	});
+
+	it("surfaces host errors as Python exceptions", async () => {
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			pythonSkills: [bundledPresentArtifactSkill()],
+			hostHandlers: {
+				"artifact.present": async () => {
+					throw new Error("artifact capture failed");
+				},
+			},
+		});
+
+		const manager = await provisioner.ensure();
+		const result = await manager.execute(`
+try:
+    await present_artifact("sample.png")
+except RuntimeError as error:
+    print(f"RuntimeError: {error}")
+`);
+
+		expect(result.status).toBe("ok");
+		expect(result.stdout.trim()).toBe("RuntimeError: artifact capture failed");
+		expect(result.attachments).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/presented-artifact-message.test.ts
+++ b/packages/coding-agent/test/presented-artifact-message.test.ts
@@ -1,0 +1,82 @@
+import { Container, resetCapabilitiesCache, setCapabilities } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { type CustomMessage, PRESENTED_ARTIFACT_CUSTOM_TYPE } from "../src/core/messages.js";
+import type { PresentedArtifactDetails } from "../src/core/presented-artifacts.js";
+import { PresentedArtifactMessageComponent } from "../src/modes/interactive/components/presented-artifact-message.js";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+
+function message(kind: "image" | "file" = "image"): CustomMessage<PresentedArtifactDetails> {
+	const details: PresentedArtifactDetails = {
+		artifactId: "0123456789abcdef",
+		presentationId: "presentation-1",
+		sessionId: "session-1",
+		kind,
+		name: kind === "image" ? "preview.png" : "report.pdf",
+		label: kind === "image" ? "Generated preview" : undefined,
+		mimeType: kind === "image" ? "image/png" : "application/pdf",
+		byteSize: 68,
+		path: `/tmp/${kind === "image" ? "preview.png" : "report.pdf"}`,
+		width: kind === "image" ? 1 : undefined,
+		height: kind === "image" ? 1 : undefined,
+	};
+	return {
+		role: "custom",
+		customType: PRESENTED_ARTIFACT_CUSTOM_TYPE,
+		content:
+			kind === "image"
+				? [
+						{ type: "text", text: "Generated preview" },
+						{ type: "image", data: PNG_BASE64, mimeType: "image/png" },
+					]
+				: [{ type: "text", text: "Artifact: report.pdf" }],
+		display: true,
+		details,
+		timestamp: 0,
+	};
+}
+
+describe("PresentedArtifactMessageComponent", () => {
+	beforeAll(() => initTheme("dark"));
+	afterEach(() => resetCapabilitiesCache());
+
+	it("renders actual terminal graphics for presented images", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		const output = new PresentedArtifactMessageComponent(message()).render(80).join("\n");
+		expect(output).toContain("Generated preview");
+		expect(output).toContain("\x1b_G");
+	});
+
+	it("provides filename, MIME, and dimensions when graphics are unavailable or hidden", () => {
+		setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+		const visible = new PresentedArtifactMessageComponent(message()).render(80).join("\n");
+		expect(visible).toContain("preview.png");
+		expect(visible).toContain("image/png");
+		expect(visible).toContain("1x1");
+		const hidden = new PresentedArtifactMessageComponent(message(), false).render(80).join("\n");
+		expect(hidden).toContain("preview.png · image/png · 1×1");
+	});
+
+	it("renders durable generic artifact metadata without throwing", () => {
+		const output = new PresentedArtifactMessageComponent(message("file")).render(100).join("\n");
+		expect(output).toContain("Artifact: report.pdf");
+		expect(output).toContain("/tmp/report.pdf");
+	});
+	it("routes live and replayed custom messages to the artifact renderer", () => {
+		const chatContainer = new Container();
+		const harness = {
+			chatContainer,
+			settingsManager: { getShowImages: () => true },
+			toolOutputExpanded: false,
+		};
+		const addMessageToChat = (
+			InteractiveMode.prototype as unknown as {
+				addMessageToChat(this: typeof harness, value: CustomMessage<PresentedArtifactDetails>): void;
+			}
+		).addMessageToChat;
+		addMessageToChat.call(harness, message());
+		expect(chatContainer.children[0]).toBeInstanceOf(PresentedArtifactMessageComponent);
+	});
+});

--- a/packages/coding-agent/test/presented-artifacts.test.ts
+++ b/packages/coding-agent/test/presented-artifacts.test.ts
@@ -1,0 +1,151 @@
+import { mkdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { convertToLlm } from "../src/core/messages.js";
+import {
+	capturePresentedArtifact,
+	normalizePresentedArtifactHostPayload,
+	PRESENTED_ARTIFACT_CUSTOM_TYPE,
+} from "../src/core/presented-artifacts.js";
+
+const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+
+describe("presented artifacts", () => {
+	let root: string;
+	let sourceDir: string;
+	let artifactDir: string;
+
+	beforeEach(() => {
+		root = join(tmpdir(), `prime-present-artifact-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		sourceDir = join(root, "source");
+		artifactDir = join(root, "session-artifacts");
+		mkdirSync(sourceDir, { recursive: true });
+	});
+
+	afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+	it("captures a durable bounded image preview and excludes it from LLM context", async () => {
+		const source = join(sourceDir, "sample.png");
+		writeFileSync(source, Buffer.from(PNG_BASE64, "base64"));
+
+		const result = await capturePresentedArtifact(
+			{ path: source, label: "Generated icon" },
+			{ cwd: sourceDir, artifactDir, sessionId: "session-1" },
+		);
+		unlinkSync(source);
+
+		expect(result.receipt).toMatchObject({
+			artifactId: expect.stringMatching(/^[a-f0-9]{16}$/),
+			name: "sample.png",
+			mimeType: "image/png",
+			kind: "image",
+		});
+		expect(result.message).toMatchObject({
+			role: "custom",
+			customType: PRESENTED_ARTIFACT_CUSTOM_TYPE,
+			display: true,
+			details: {
+				kind: "image",
+				name: "sample.png",
+				label: "Generated icon",
+				path: expect.stringContaining("presented-artifacts"),
+			},
+		});
+		const content = result.message.content;
+		expect(Array.isArray(content) && content[0]).toEqual({ type: "text", text: "Generated icon" });
+		expect(Array.isArray(content) && content[1]).toMatchObject({ type: "image", mimeType: "image/png" });
+		expect(JSON.stringify(result.message)).not.toContain(source);
+		expect(convertToLlm([result.message])).toEqual([]);
+	});
+
+	it("captures generic files without embedding their bytes in the message", async () => {
+		const source = join(sourceDir, "notes.txt");
+		writeFileSync(source, "portable handoff");
+
+		const result = await capturePresentedArtifact(
+			{ path: "notes.txt" },
+			{ cwd: sourceDir, artifactDir, sessionId: "session-1" },
+		);
+		expect(result.receipt.kind).toBe("file");
+		expect(result.message.content).toEqual([
+			{ type: "text", text: "Artifact: notes.txt" },
+			{ type: "text", text: result.receipt.path },
+		]);
+		expect(JSON.stringify(result.message)).not.toContain(Buffer.from("portable handoff").toString("base64"));
+	});
+
+	it("rejects invalid payloads, missing files, directories, and oversized files", async () => {
+		expect(() => normalizePresentedArtifactHostPayload({ path: "", label: 2 })).toThrow("non-empty path");
+		expect(() => normalizePresentedArtifactHostPayload({ path: "a", label: "x".repeat(501) })).toThrow("at most 500");
+		await expect(
+			capturePresentedArtifact(
+				{ path: join(sourceDir, "missing.png") },
+				{ cwd: sourceDir, artifactDir, sessionId: "session-1" },
+			),
+		).rejects.toThrow("does not exist");
+		await expect(
+			capturePresentedArtifact({ path: sourceDir }, { cwd: sourceDir, artifactDir, sessionId: "session-1" }),
+		).rejects.toThrow("regular file");
+
+		const large = join(sourceDir, "large.bin");
+		writeFileSync(large, Buffer.alloc(20 * 1024 * 1024 + 1));
+		await expect(
+			capturePresentedArtifact({ path: large }, { cwd: sourceDir, artifactDir, sessionId: "session-1" }),
+		).rejects.toThrow("20 MiB");
+	});
+	it("appends and emits a display-only session message even during an active turn", async () => {
+		const source = join(sourceDir, "streamed.png");
+		writeFileSync(source, Buffer.from(PNG_BASE64, "base64"));
+		const messages: unknown[] = [];
+		const appendCustomMessageEntryWithRollback = vi.fn();
+		const emit = vi.fn();
+		const harness = {
+			_ensureRlmSessionDir: () => artifactDir,
+			_createEphemeralRlmSessionDir: () => artifactDir,
+			agent: { state: { messages } },
+			sessionManager: {
+				getCwd: () => sourceDir,
+				getSessionId: () => "session-live",
+				appendCustomMessageEntryWithRollback,
+			},
+			_emit: emit,
+			isStreaming: true,
+		};
+
+		const receipt = await AgentSession.prototype.presentArtifact.call(harness as never, {
+			path: source,
+			label: "Live preview",
+		});
+		expect(receipt.kind).toBe("image");
+		expect(messages).toHaveLength(1);
+		expect(appendCustomMessageEntryWithRollback).toHaveBeenCalledTimes(1);
+		expect(emit.mock.calls.map(([event]) => event.type)).toEqual(["message_start", "message_end"]);
+	});
+	it("does not display or retain an artifact when durable persistence fails", async () => {
+		const source = join(sourceDir, "persistence-failure.png");
+		writeFileSync(source, Buffer.from(PNG_BASE64, "base64"));
+		const messages: unknown[] = [];
+		const emit = vi.fn();
+		const harness = {
+			_ensureRlmSessionDir: () => artifactDir,
+			_createEphemeralRlmSessionDir: () => artifactDir,
+			agent: { state: { messages } },
+			sessionManager: {
+				getCwd: () => sourceDir,
+				getSessionId: () => "session-failing",
+				appendCustomMessageEntryWithRollback: () => {
+					throw new Error("disk full");
+				},
+			},
+			_emit: emit,
+		};
+
+		await expect(AgentSession.prototype.presentArtifact.call(harness as never, { path: source })).rejects.toThrow(
+			"disk full",
+		);
+		expect(messages).toEqual([]);
+		expect(emit).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- add a durable `present_artifact(path, label=None)` Python skill backed by a session-scoped, display-only custom message
- render bounded inline image previews in the interactive client and deliver standard ACP text/image chunks without adding previews to model context
- add a stateful `codex_image` skill for native Codex generation, same-thread refinement, immutable prompt/reference/version lineage, and approval-gated atomic export
- capture outputs outside repositories, preserve prior versions, re-verify the presented manifest before approval, and persist the approval receipt before target mutation

## Design notes

- `attach_image` remains model-facing; `present_artifact` is user-facing.
- Presentation reuses the existing `CustomMessage` / `session_event` wire shape, so this is backward-compatible and does not require a daemon protocol or schema bump. Older clients retain the text fallback.
- Raster previews are capped and embedded for replay. Generic files retain durable metadata and a host-local path; this does not introduce a remote download protocol.
- Codex prompts are passed on stdin and subprocess output stays captured. The bridge accepts Codex 0.147 native generated-image paths and workflow-relative `saved_path` events; it has no procedural fallback.
- Generation/refinement cannot write to the requested repository target. `approve(..., approved=True)` is the only export operation.

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/presented-artifacts.test.ts test/presented-artifact-message.test.ts test/acp-events.test.ts test/builtin-skills.test.ts test/tool-execution-component.test.ts`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run --no-file-parallelism test/kernel-present-artifact-skill.test.ts test/kernel-attach-image-skill.test.ts`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run --tagsFilter kernel-heavy test/kernel-codex-image-skill.test.ts`
- manually checked the command/feature surface against Codex CLI 0.147.0 (`codex exec --help`, `codex exec resume --help`, `codex features list`)

The Codex integration test uses a deterministic fake CLI; it performs no network request or paid generation.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add user-visible artifact presentation and Codex image generation workflows
> - Adds a `present-artifact` Python skill that presents on-disk files to users via the `artifact.present` host bridge without attaching file bytes to model context.
> - Adds a `codex-image` Python skill implementing a stateful, versioned image-generation workflow: `generate`, `refine`, `list_versions`, and `approve` (atomic export with integrity verification).
> - Adds `capturePresentedArtifact` in [`presented-artifacts.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1062/files#diff-faae9ed71942b7fb5c2929dce2a92261cef6e19155c7e6088458befb2bab6801) which validates, stores, and optionally generates a resized base64 preview (≤350 kB, 1600×1600) for images, returning a durable custom message excluded from LLM context.
> - Renders presented artifact messages in the interactive TUI via a new `PresentedArtifactMessageComponent` (inline terminal images or path fallback) and emits `agent_message_chunk` ACP events tied to `presentationId`.
> - The codex-image workflow uses immutable versioned directories, per-version manifests with sha256 integrity checks, and atomic filesystem operations throughout; approval requires a prior `artifact.present` call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1cd5f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->