### PR TITLE
fix(package-manager): `~/.agents/skills` incorrectly scoped as project when CWD is under home directory

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -434,9 +434,15 @@ function collectAncestorAgentsSkillDirs(startDir: string): string[] {
 	const skillDirs: string[] = [];
 	const resolvedStartDir = resolve(startDir);
 	const gitRepoRoot = findGitRepoRoot(resolvedStartDir);
+	const homeDir = resolve(getHomeDir());
 
 	let dir = resolvedStartDir;
 	while (true) {
+		// Stop before reaching the home directory: ~/.agents/skills is user-scope,
+		// not project-scope, and is added separately by the caller.
+		if (dir === homeDir) {
+			break;
+		}
 		skillDirs.push(join(dir, ".agents", "skills"));
 		if (gitRepoRoot && dir === gitRepoRoot) {
 			break;
@@ -2179,9 +2185,7 @@ export class DefaultPackageManager implements PackageManager {
 			themes: join(projectBaseDir, "themes"),
 		};
 		const userAgentsSkillsDir = join(getHomeDir(), ".agents", "skills");
-		const projectAgentsSkillDirs = collectAncestorAgentsSkillDirs(this.cwd).filter(
-			(dir) => resolve(dir) !== resolve(userAgentsSkillsDir),
-		);
+		const projectAgentsSkillDirs = collectAncestorAgentsSkillDirs(this.cwd);
 
 		const addResources = (
 			resourceType: ResourceType,


### PR DESCRIPTION
 Problem

  When the working directory is inside `$HOME` (e.g. `~/projects/foo`) and is
  not
  inside a git repository, `collectAncestorAgentsSkillDirs` walks all the way
  up
  to the filesystem root. A post-hoc filter using exact string equality was the
  only guard preventing `~/.agents/skills` from ending up in the project-scoped
  skill list:

  ```ts
  const projectAgentsSkillDirs =
  collectAncestorAgentsSkillDirs(this.cwd).filter(
      (dir) => resolve(dir) !== resolve(userAgentsSkillsDir),
  );
  ```

  This filter is fragile: if process.env.HOME and os.homedir() resolve to
  different paths (symlinked home directory, trailing slash, etc.), the
  equality check fails silently and ~/.agents/skills gets tagged as "project"
  scope instead of "user" scope. Fixes #1051.

  **Solution**

  Stop the ancestor walk inside collectAncestorAgentsSkillDirs before it
  reaches the home directory, so ~/.agents/skills is never collected into the
  project list in the first place. The now-redundant filter is removed.
  ~/.agents/skills is already added with userMetadata (scope: "user") by the
  caller — this change does not affect that path.

  **Changes**

  - collectAncestorAgentsSkillDirs: break the walk when dir === homeDir
  - addAutoDiscoveredResources: remove the fragile post-hoc equality filter

  **Testing**

  All existing .agents/skills auto-discovery tests pass, including:
  - should keep ~/.agents/skills user-scoped when cwd is under home in a 
  non-git directory
  - should scan .agents/skills from cwd up to git repo root
  - should scan .agents/skills up to filesystem root when not in a git repo

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `collectAncestorAgentsSkillDirs` incorrectly including `~/.agents/skills` as a project directory
> When the working directory is under the home directory, `collectAncestorAgentsSkillDirs` in [package-manager.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1067/files#diff-c3cd658663a2617a59357bae55e941f8d7885378fdd6e4cd0400dfa967fbe750) was traversing up to and including `~/.agents/skills`, incorrectly treating it as a project-scoped skills directory. The fix adds a guard that breaks the traversal loop before reaching the home directory, and removes the downstream filter in `DefaultPackageManager` that was attempting to compensate for this.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aad1f1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->