### PR TITLE
feat(coding-agent): add provider and model allowlist

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added an optional `modelAllowlist` setting to restrict provider and model discovery and prevent unlisted environment-backed providers from being used.
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -114,6 +114,23 @@ See [docs/providers.md](docs/providers.md) for detailed setup instructions.
 
 **Custom providers & models:** Add providers via `~/.prime/agent/models.json` if they speak a supported API (OpenAI, Anthropic, Google). For custom APIs or OAuth, use extensions. See [docs/models.md](docs/models.md) and [docs/custom-provider.md](docs/custom-provider.md).
 
+**Explicit provider/model control:** Environment-backed providers are discovered automatically by default. To opt in
+to only the providers or models you want to use, set `modelAllowlist` in `~/.prime/agent/settings.json` or the
+project settings file:
+
+```json
+{
+  "modelAllowlist": [
+    "anthropic/claude-sonnet-4-5",
+    "prime-inference"
+  ]
+}
+```
+
+Entries can be provider names, model IDs, or `provider/model` glob patterns. Models outside the list are hidden and
+cannot be selected or used, even when their API keys are present. An empty list disables all providers. See
+[docs/models.md](docs/models.md#restricting-providers-and-models) for details.
+
 ## Interactive Mode
 
 <p align="center"><img src="docs/images/interactive-mode.png" alt="Interactive Mode" width="600"></p>

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -91,6 +91,24 @@ Override defaults when you need specific values:
 
 The file reloads each time you open `/model`. Edit during session; no restart needed.
 
+## Restricting Providers and Models
+
+Environment variables are available by default so existing setups continue to work. To opt in to an explicit
+provider/model allowlist, add `modelAllowlist` to `~/.prime/agent/settings.json` (or the project settings file):
+
+```json
+{
+  "modelAllowlist": [
+    "anthropic/claude-sonnet-4-5",
+    "prime-inference"
+  ]
+}
+```
+
+Entries match a provider, a model ID, or a `provider/model` glob. When this setting is present, models outside the
+list are hidden from discovery and cannot be selected or used, including when their API keys are present in the
+environment. An empty list disables all providers. Omit the setting to retain automatic provider discovery.
+
 ## Google AI Studio Example
 
 Use `google-generative-ai` with a `baseUrl` to add models from Google AI Studio, including custom Gemma 4 entries:

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -181,7 +181,9 @@ export async function createAgentSessionServices(
 	const agentDir = options.agentDir ?? getAgentDir();
 	const authStorage = options.authStorage ?? AuthStorage.create(join(agentDir, "auth.json"));
 	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
-	const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, join(agentDir, "models.json"));
+	const modelRegistry =
+		options.modelRegistry ??
+		ModelRegistry.create(authStorage, join(agentDir, "models.json"), settingsManager.getModelAllowlist());
 
 	// MCP integrations: registers OAuth providers and gates the built-in
 	// integration skills by whether the user is logged in (enable-by-login).

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -23,6 +23,7 @@ import {
 import { registerBuiltinMcpOAuthProviders } from "@earendil-works/pi-ai/mcp";
 import { registerOAuthProvider, resetOAuthProviders } from "@earendil-works/pi-ai/oauth";
 import { existsSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { minimatch } from "minimatch";
 import { dirname, join } from "path";
 import { type Static, type TProperties, Type } from "typebox";
 import type { Validator } from "typebox/compile";
@@ -444,6 +445,7 @@ export class ModelRegistry {
 	private constructor(
 		readonly authStorage: AuthStorage,
 		private modelsJsonPath: string | undefined,
+		private modelAllowlist: readonly string[] | undefined,
 	) {
 		this.loadModels();
 	}
@@ -452,12 +454,16 @@ export class ModelRegistry {
 		this.onOAuthProvidersReset = hook;
 	}
 
-	static create(authStorage: AuthStorage, modelsJsonPath: string = join(getAgentDir(), "models.json")): ModelRegistry {
-		return new ModelRegistry(authStorage, modelsJsonPath);
+	static create(
+		authStorage: AuthStorage,
+		modelsJsonPath: string = join(getAgentDir(), "models.json"),
+		modelAllowlist?: readonly string[],
+	): ModelRegistry {
+		return new ModelRegistry(authStorage, modelsJsonPath, modelAllowlist);
 	}
 
 	static inMemory(authStorage: AuthStorage): ModelRegistry {
-		return new ModelRegistry(authStorage, undefined);
+		return new ModelRegistry(authStorage, undefined, undefined);
 	}
 
 	/**
@@ -758,7 +764,7 @@ export class ModelRegistry {
 	 * If models.json had errors, returns only built-in models.
 	 */
 	getAll(): Model<Api>[] {
-		return this.models;
+		return this.models.filter((model) => this.isModelAllowed(model));
 	}
 
 	/**
@@ -766,7 +772,7 @@ export class ModelRegistry {
 	 * This is a fast check that doesn't refresh OAuth tokens.
 	 */
 	getAvailable(): Model<Api>[] {
-		return this.models.filter((model) => {
+		return this.getAll().filter((model) => {
 			if (
 				isPrivatePrimeInferenceModel(model) &&
 				!this.explicitPrivatePrimeInferenceModelIds.has(model.id) &&
@@ -945,7 +951,7 @@ export class ModelRegistry {
 			availableModels.filter(isPrivatePrimeInferenceModel).map((model) => `${model.provider}/${model.id}`),
 		);
 		return {
-			models: this.models.filter(
+			models: this.getAll().filter(
 				(model) =>
 					!isPrivatePrimeInferenceModel(model) || availablePrivateModels.has(`${model.provider}/${model.id}`),
 			),
@@ -1017,14 +1023,33 @@ export class ModelRegistry {
 	 * Find a model by provider and ID.
 	 */
 	find(provider: string, modelId: string): Model<Api> | undefined {
-		return this.models.find((m) => m.provider === provider && m.id === modelId);
+		return this.getAll().find((m) => m.provider === provider && m.id === modelId);
 	}
 
 	/**
 	 * Get API key for a model.
 	 */
 	hasConfiguredAuth(model: Model<Api>): boolean {
-		return this.authStorage.hasAuth(model.provider) || this.hasConfiguredProviderRequestAuth(model.provider);
+		return (
+			this.isModelAllowed(model) &&
+			(this.authStorage.hasAuth(model.provider) || this.hasConfiguredProviderRequestAuth(model.provider))
+		);
+	}
+
+	private isModelAllowed(model: Model<Api>): boolean {
+		if (this.modelAllowlist === undefined) return true;
+		const provider = model.provider.toLowerCase();
+		const modelId = model.id.toLowerCase();
+		const fullId = `${provider}/${modelId}`;
+		return this.modelAllowlist.some((pattern) => {
+			const normalized = pattern.trim().toLowerCase();
+			return (
+				normalized === provider ||
+				minimatch(provider, normalized, { nocase: true }) ||
+				minimatch(modelId, normalized, { nocase: true }) ||
+				minimatch(fullId, normalized, { nocase: true })
+			);
+		});
 	}
 
 	private fingerprintProviderRequestAuthSource(source: ProviderRequestAuthSource["source"], material: string): string {
@@ -1295,6 +1320,9 @@ export class ModelRegistry {
 	 * Get API key and request headers for a model.
 	 */
 	async getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth> {
+		if (!this.isModelAllowed(model)) {
+			return { ok: false, error: `Model "${model.provider}/${model.id}" is not enabled by modelAllowlist` };
+		}
 		try {
 			const providerConfig = this.providerRequestConfigs.get(model.provider);
 			const authStorageAuth = await this.authStorage.getApiKeyWithSourceToken(model.provider, {

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -161,9 +161,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const authPath = options.agentDir ? join(agentDir, "auth.json") : undefined;
 	const modelsPath = options.agentDir ? join(agentDir, "models.json") : undefined;
 	const authStorage = options.authStorage ?? AuthStorage.create(authPath);
-	const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, modelsPath);
-
 	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
+	const modelRegistry =
+		options.modelRegistry ?? ModelRegistry.create(authStorage, modelsPath, settingsManager.getModelAllowlist());
 	const sessionManager = options.sessionManager ?? SessionManager.create(cwd, getDefaultSessionDir(cwd, agentDir));
 
 	// Ensure MCP providers are registered and built-in MCP skills are gated by

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -156,6 +156,7 @@ export interface Settings {
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
+	modelAllowlist?: string[]; // Provider/model patterns allowed for discovery and execution; unset allows all
 	treeFilterMode?: "default" | "no-tools" | "user-only" | "labeled-only" | "all"; // Default: "user-only"
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
@@ -1207,6 +1208,10 @@ export class SettingsManager {
 
 	getEnabledModels(): string[] | undefined {
 		return this.settings.enabledModels;
+	}
+
+	getModelAllowlist(): string[] | undefined {
+		return this.settings.modelAllowlist;
 	}
 
 	getMcpServers(): Record<string, McpServerConfig> | undefined {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -61,6 +61,48 @@ describe("ModelRegistry", () => {
 		return value.replace(/\\/g, "/").replace(/"/g, '\\"');
 	}
 
+	describe("model allowlist", () => {
+		test("omitting the allowlist preserves the full built-in catalog", () => {
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+			expect(registry.getAll().length).toBeGreaterThan(1);
+			expect(registry.find("openai", "gpt-5.1")).toBeDefined();
+		});
+
+		test("filters providers and models from discovery", () => {
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath, ["anthropic/claude-sonnet-4-5"]);
+
+			expect(
+				registry.getAll().every((model) => model.provider === "anthropic" && model.id === "claude-sonnet-4-5"),
+			).toBe(true);
+			expect(registry.find("openai", "gpt-5.1")).toBeUndefined();
+		});
+
+		test("supports provider and glob patterns", () => {
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath, ["openai"]);
+			const openAiModels = registry.getAll().filter((model) => model.provider === "openai");
+
+			expect(openAiModels.length).toBeGreaterThan(0);
+		});
+
+		test("blocks direct requests for disallowed models", async () => {
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath, ["anthropic/*"]);
+			const model = registry.find("openai", "gpt-5.1");
+			const allModelsModel = registry.getAll().find((candidate) => candidate.provider === "anthropic");
+
+			expect(model).toBeUndefined();
+			expect(allModelsModel).toBeDefined();
+			if (!allModelsModel) throw new Error("Expected an allowed model");
+			const disallowedModel = {
+				...allModelsModel,
+				provider: "openai",
+			};
+			const result = await registry.getApiKeyAndHeaders(disallowedModel);
+
+			expect(result.ok).toBe(false);
+		});
+	});
+
 	/** Create a baseUrl-only override (no custom models) */
 	function overrideConfig(baseUrl: string, headers?: Record<string, string>) {
 		return { baseUrl, ...(headers && { headers }) };


### PR DESCRIPTION
## Summary

Fixes #1064

- Add an optional `modelAllowlist` setting for provider/model opt-in control.
- Filter discovery, lookup, availability, catalogs, and direct request authorization.
- Preserve existing automatic provider discovery when the setting is omitted.
- Document provider names, model IDs, and `provider/model` glob patterns.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/model-registry.test.ts` from `packages/coding-agent` (76 passed)
- `npx tsgo --noEmit` (passed)
- Focused Biome check on changed TypeScript files (passed)
- Manual CLI verification confirmed that an allowlisted Anthropic model remains visible while a configured OpenRouter key is excluded.

The full repository check reached the existing installer-render harness, which fails in this environment before exercising this change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `modelAllowlist` setting to restrict provider and model discovery in coding agent
> - Adds an optional `modelAllowlist` field to [Settings](https://github.com/PrimeIntellect-ai/prime-agent/pull/1068/files#diff-6e8b43ea9be5845c1f130f3a12344386eb8e1e03ca381c3577a40713e6a3d8ab) accepting a list of provider, model, or `provider/model` glob patterns.
> - `ModelRegistry` filters `getAll`, `find`, `getAvailable`, and `refreshModelCatalog` to only include models matching the allowlist; `getApiKeyAndHeaders` returns an error for disallowed models.
> - When `modelAllowlist` is unset, all discovered models are available as before.
> - Behavioral Change: sessions created via `createAgentSession` and `createAgentSessionServices` now pass the allowlist to `ModelRegistry`, so disallowed models are completely hidden from discovery and unusable at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4f603e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->