### PR TITLE
feat(coding-agent): add /resume slash command for switching sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added `/resume` slash command to switch to a saved session by path or session ID from within an interactive session ([#679](https://github.com/PrimeIntellect-ai/prime-agent/issues/679)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -102,6 +102,12 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 		argumentHint: "<path.jsonl>",
 		takesArgument: true,
 	},
+	{
+		name: "resume",
+		description: "Resume a saved session by path or session ID",
+		argumentHint: "<path|id>",
+		takesArgument: true,
+	},
 	{ name: "share", description: "Share session as a secret GitHub gist" },
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4671,6 +4671,15 @@ export class InteractiveMode {
 					this.editor.setText("");
 					return;
 				}
+				if (commandName === "resume") {
+					this.editor.setText("");
+					if (!commandArgs) {
+						this.showError("Usage: /resume <path|id>");
+						return;
+					}
+					await this.handleResumeSession(commandArgs);
+					return;
+				}
 				if (commandName === "share" && !commandArgs) {
 					await this.handleShareCommand();
 					this.editor.setText("");

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -95,6 +95,15 @@ describe("built-in slash commands", () => {
 		expect(builtinSlashCommandTakesArgument("new")).toBe(true);
 		expect(builtinSlashCommandTakesArgument("clear")).toBe(false);
 	});
+
+	test("exposes /resume for switching to a saved session by path or ID", () => {
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "resume")).toMatchObject({
+			description: "Resume a saved session by path or session ID",
+			argumentHint: "<path|id>",
+			takesArgument: true,
+		});
+		expect(builtinSlashCommandTakesArgument("resume")).toBe(true);
+	});
 });
 
 describe("slash command aliases", () => {


### PR DESCRIPTION
Closes #679

Adds the `/resume` slash command to interactive mode, allowing users to switch to a saved session by path or session ID without restarting the process.

- Added `/resume` to `CANONICAL_BUILTIN_SLASH_COMMANDS` with argument hint `<path|id>`
- Added dispatch handler in interactive mode that calls the existing `handleResumeSession` method
- Added test

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/resume` slash command to switch sessions in interactive mode
> Registers `/resume <path|id>` as a built-in slash command in [slash-commands.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1069/files#diff-a899e324d78dc42caf37f385e87b29cb6499320280ddba9580bce8f830f1f145) and adds handling in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1069/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) that calls `handleResumeSession` with the provided argument. Invoking `/resume` without arguments displays a usage error instead of proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00074b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->