### PR TITLE
fix(coding-agent): use installed Codex CLI version for model discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed OpenAI Codex model discovery using the Prime Agent version as `client_version`, which returned empty catalogs; now uses the installed Codex CLI version when available ([#639](https://github.com/PrimeIntellect-ai/prime-agent/issues/639)).
+
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -3,6 +3,7 @@
  */
 
 import { Buffer } from "node:buffer";
+import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	type AnthropicMessagesCompat,
@@ -27,7 +28,7 @@ import { dirname, join } from "path";
 import { type Static, type TProperties, Type } from "typebox";
 import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
-import { getAgentDir, VERSION } from "../config.js";
+import { getAgentDir } from "../config.js";
 import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import {
@@ -372,6 +373,30 @@ function readOpenAICodexAccountId(token: string): string | undefined {
 	}
 }
 
+let codexClientVersion: string | undefined;
+
+function getCodexClientVersion(): string | undefined {
+	if (codexClientVersion !== undefined) return codexClientVersion;
+	try {
+		const output = execSync("codex --version", { encoding: "utf-8", timeout: 3_000 }).trim();
+		const match = /(\d+\.\d+\.\d+)/.exec(output);
+		if (match) {
+			codexClientVersion = match[1];
+			return codexClientVersion;
+		}
+	} catch {}
+	try {
+		const output = execSync("openai-codex --version", { encoding: "utf-8", timeout: 3_000 }).trim();
+		const match = /(\d+\.\d+\.\d+)/.exec(output);
+		if (match) {
+			codexClientVersion = match[1];
+			return codexClientVersion;
+		}
+	} catch {}
+	codexClientVersion = null!;
+	return undefined;
+}
+
 function openAICodexModelsUrl(baseUrl: string): string {
 	const normalized = baseUrl.replace(/\/+$/, "");
 	let path: string;
@@ -383,7 +408,10 @@ function openAICodexModelsUrl(baseUrl: string): string {
 		path = `${normalized}/codex/models`;
 	}
 	const url = new URL(path);
-	url.searchParams.set("client_version", VERSION);
+	const clientVersion = getCodexClientVersion();
+	if (clientVersion) {
+		url.searchParams.set("client_version", clientVersion);
+	}
 	return url.toString();
 }
 

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -90,7 +90,7 @@ describe("ENG-4649 subagent model selection", () => {
 			const discovered = await harness.session.findRlmModels("", 20);
 			expect(discovered.models.map((model) => model.selector)).toEqual([`${codexProvider}/parent-model`]);
 			expect(fetchModels).toHaveBeenCalledWith(
-				expect.stringMatching(/\/codex\/models\?client_version=/),
+				expect.stringMatching(/\/codex\/models/),
 				expect.objectContaining({
 					headers: expect.objectContaining({ "chatgpt-account-id": "account-1" }),
 				}),

--- a/packages/coding-agent/test/suite/regressions/639-codex-client-version.test.ts
+++ b/packages/coding-agent/test/suite/regressions/639-codex-client-version.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, type Harness } from "../harness.js";
+
+function openAICodexToken(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+describe("issue #639 codex client version", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("does not send Prime Agent version as Codex client_version", async () => {
+		const harness = await createHarness({
+			provider: "openai-codex",
+			models: [{ id: "parent-model" }],
+		});
+		harnesses.push(harness);
+		const fetchModels = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ models: [{ slug: "parent-model" }, { slug: "gpt-5.6-luna" }] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchModels);
+		try {
+			harness.authStorage.setRuntimeApiKey("openai-codex", openAICodexToken("account-1"));
+			const discovered = await harness.session.findRlmModels("", 20);
+			expect(discovered.models.length).toBeGreaterThanOrEqual(1);
+			expect(fetchModels).toHaveBeenCalledWith(
+				expect.not.stringContaining("client_version=0.7.1"),
+				expect.any(Object),
+			);
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+
+	it("filters Codex models against the catalog response", async () => {
+		const harness = await createHarness({
+			provider: "openai-codex",
+			models: [{ id: "parent-model" }, { id: "unsupported-model" }],
+		});
+		harnesses.push(harness);
+		const fetchModels = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ models: [{ slug: "parent-model" }] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchModels);
+		try {
+			harness.authStorage.setRuntimeApiKey("openai-codex", openAICodexToken("account-1"));
+			const discovered = await harness.session.findRlmModels("", 20);
+			expect(discovered.models.map((model) => model.selector)).toEqual(["openai-codex/parent-model"]);
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+});


### PR DESCRIPTION
Closes #639

Fixes RLM (Recursive Language Model) excluding OpenAI Codex models because model discovery sent Prime Agent's version as `client_version` instead of a Codex-compatible version. The ChatGPT backend returns empty model catalogs for unrecognized version strings.

- Added `getCodexClientVersion()` that detects the installed Codex CLI version via `codex --version` or `openai-codex --version`
- Modified `openAICodexModelsUrl()` to use the detected Codex CLI version when available, and omit the `client_version` parameter otherwise
- Result is cached for the session lifetime

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex model discovery to use installed Codex CLI version in `client_version`
> - Replaces the hardcoded Prime Agent `VERSION` in the `client_version` query parameter with the version resolved from the locally installed Codex CLI (`codex --version` or `openai-codex --version`).
> - Adds `getCodexClientVersion()` in [model-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1070/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453), which runs the CLI via `execSync` with a 3-second timeout, parses the semver from stdout, and memoizes the result.
> - If neither command succeeds, `client_version` is omitted from the Codex catalog request entirely.
> - Behavioral Change: Codex catalog requests no longer include the Prime Agent version; they include the local CLI version when detected, or no `client_version` parameter otherwise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 202d478.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->