### PR TITLE
feat(ai): support reasoning_effort for Z.AI GLM-5.2

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added `reasoning_effort` control for all Z.AI reasoning models, exposing five thinking levels (`off`, `low`, `medium`, `high`, `max`) in the `/effort` selector.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -110,6 +110,14 @@ const ZAI_THINKING_COMPAT: OpenAICompletionsCompat = {
 	thinkingFormat: "zai",
 };
 
+const ZAI_THINKING_LEVEL_MAP = {
+	minimal: null,
+	low: "high",
+	medium: "high",
+	high: "high",
+	max: "max",
+} as const;
+
 const PRIME_INFERENCE_BASE_URL = "https://api.pinference.ai/api/v1";
 const PRIME_INFERENCE_COMPAT: OpenAICompletionsCompat = {
 	supportsStore: false,
@@ -1136,6 +1144,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 				const m = model as ModelsDevModel;
 				if (m.tool_call !== true) continue;
 				const supportsImage = m.modalities?.input?.includes("image");
+				const hasReasoning = m.reasoning === true;
 
 				models.push({
 					id: modelId,
@@ -1143,8 +1152,9 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					api: "openai-completions",
 					provider: "zai",
 					baseUrl: "https://api.z.ai/api/coding/paas/v4",
-					reasoning: m.reasoning === true,
+					reasoning: hasReasoning,
 					input: supportsImage ? ["text", "image"] : ["text"],
+					...(hasReasoning ? { thinkingLevelMap: ZAI_THINKING_LEVEL_MAP } : {}),
 					cost: {
 						input: m.cost?.input || 0,
 						output: m.cost?.output || 0,
@@ -1154,6 +1164,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					compat: {
 						supportsDeveloperRole: false,
 						thinkingFormat: ZAI_THINKING_COMPAT.thinkingFormat,
+						...(hasReasoning ? { supportsReasoningEffort: true } : {}),
 						...(!ZAI_TOOL_STREAM_UNSUPPORTED_MODELS.has(modelId) ? { zaiToolStream: true } : {}),
 					},
 					contextWindow: m.limit?.context || 4096,

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -20330,8 +20330,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","supportsReasoningEffort":true,"zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"minimal":null,"low":"high","medium":"high","high":"high","max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,
@@ -20348,8 +20349,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","supportsReasoningEffort":true,"zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"minimal":null,"low":"high","medium":"high","high":"high","max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,
@@ -20366,8 +20368,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","supportsReasoningEffort":true,"zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"minimal":null,"low":"high","medium":"high","high":"high","max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,
@@ -20384,8 +20387,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","supportsReasoningEffort":true,"zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"minimal":null,"low":"high","medium":"high","high":"high","max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -562,7 +562,18 @@ function buildParams(
 	}
 
 	if (compat.thinkingFormat === "zai" && model.reasoning) {
-		(params as any).enable_thinking = !!options?.reasoningEffort;
+		const zaiParams = params as Omit<typeof params, "reasoning_effort"> & {
+			thinking?: { type: "enabled" | "disabled"; clear_thinking?: boolean };
+			reasoning_effort?: string;
+		};
+		zaiParams.thinking = options?.reasoningEffort ? { type: "enabled", clear_thinking: false } : { type: "disabled" };
+		if (options?.reasoningEffort && compat.supportsReasoningEffort) {
+			const mappedEffort = model.thinkingLevelMap?.[options.reasoningEffort];
+			const effort = mappedEffort === undefined ? options.reasoningEffort : mappedEffort;
+			if (typeof effort === "string") {
+				zaiParams.reasoning_effort = effort;
+			}
+		}
 	} else if (compat.thinkingFormat === "qwen" && model.reasoning) {
 		(params as any).enable_thinking = !!options?.reasoningEffort;
 	} else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -308,7 +308,7 @@ export interface OpenAICompletionsCompat {
 	requiresThinkingAsText?: boolean;
 	/** Whether all replayed assistant messages must include an empty reasoning_content field when reasoning is enabled. Default: auto-detected from URL. */
 	requiresReasoningContentOnAssistantMessages?: boolean;
-	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" uses thinking: { type } plus reasoning_effort, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
+	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" uses thinking: { type } plus reasoning_effort, "zai" uses thinking: { type, clear_thinking } plus optional reasoning_effort (when supported), "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
 	thinkingFormat?: "openai" | "openrouter" | "deepseek" | "zai" | "qwen" | "qwen-chat-template";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;

--- a/packages/ai/test/zai-thinking.test.ts
+++ b/packages/ai/test/zai-thinking.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { getModel, getSupportedThinkingLevels } from "../src/models.js";
+import { stream } from "../src/stream.js";
+import type { Context, Model } from "../src/types.js";
+
+function makeContext(): Context {
+	return {
+		messages: [
+			{
+				role: "user",
+				content: "Hello",
+				timestamp: Date.now(),
+			},
+		],
+	};
+}
+
+interface ZaiPayload {
+	thinking?: { type: string; clear_thinking?: boolean };
+	reasoning_effort?: string;
+	enable_thinking?: boolean;
+}
+
+async function capturePayload(
+	model: Model<"openai-completions">,
+	reasoningEffort?: "low" | "medium" | "high" | "max",
+): Promise<ZaiPayload> {
+	let captured: ZaiPayload | undefined;
+
+	const s = stream(model, makeContext(), {
+		reasoningEffort,
+		signal: AbortSignal.abort(),
+		onPayload: (payload) => {
+			captured = payload as ZaiPayload;
+			return undefined;
+		},
+	});
+
+	for await (const event of s) {
+		if (event.type === "error") break;
+	}
+
+	if (!captured) throw new Error("Expected payload to be captured");
+	return captured;
+}
+
+describe("Z.AI thinking levels", () => {
+	describe("getSupportedThinkingLevels", () => {
+		it("returns [off, low, medium, high, max] for glm-5.2", () => {
+			const model = getModel("zai", "glm-5.2");
+			expect(model).toBeDefined();
+			expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "medium", "high", "max"]);
+		});
+
+		it("returns [off, low, medium, high, max] for glm-5.2-highspeed", () => {
+			const model = getModel("zai", "glm-5.2-highspeed");
+			expect(model).toBeDefined();
+			expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "medium", "high", "max"]);
+		});
+
+		it("returns [off, low, medium, high, max] for glm-4.7", () => {
+			const model = getModel("zai", "glm-4.7");
+			expect(model).toBeDefined();
+			expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "medium", "high", "max"]);
+		});
+
+		it("returns [off, low, medium, high, max] for glm-5-turbo", () => {
+			const model = getModel("zai", "glm-5-turbo");
+			expect(model).toBeDefined();
+			expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "medium", "high", "max"]);
+		});
+	});
+
+	describe("request params for glm-5.2", () => {
+		it("sends thinking.type=enabled with clear_thinking=false and reasoning_effort when effort is high", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model, "high");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+			expect(payload.enable_thinking).toBeUndefined();
+		});
+
+		it("sends reasoning_effort=max when effort is max", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model, "max");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("max");
+		});
+
+		it("maps low effort to reasoning_effort=high (alias)", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model, "low");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+		});
+
+		it("maps medium effort to reasoning_effort=high (alias)", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model, "medium");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+		});
+
+		it("sends thinking.type=disabled when reasoning is off (no reasoningEffort)", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model);
+
+			expect(payload.thinking).toEqual({ type: "disabled" });
+			expect(payload.reasoning_effort).toBeUndefined();
+			expect(payload.enable_thinking).toBeUndefined();
+		});
+	});
+
+	describe("request params for glm-4.7", () => {
+		it("sends thinking.type=enabled with clear_thinking=false and reasoning_effort when effort is high", async () => {
+			const model = getModel("zai", "glm-4.7")!;
+			const payload = await capturePayload(model, "high");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+			expect(payload.enable_thinking).toBeUndefined();
+		});
+
+		it("sends reasoning_effort=max when effort is max", async () => {
+			const model = getModel("zai", "glm-4.7")!;
+			const payload = await capturePayload(model, "max");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("max");
+		});
+
+		it("sends thinking.type=disabled when reasoning is off", async () => {
+			const model = getModel("zai", "glm-4.7")!;
+			const payload = await capturePayload(model);
+
+			expect(payload.thinking).toEqual({ type: "disabled" });
+			expect(payload.reasoning_effort).toBeUndefined();
+		});
+	});
+
+	describe("request params for glm-5-turbo", () => {
+		it("sends thinking.type=enabled with clear_thinking=false and reasoning_effort when effort is high", async () => {
+			const model = getModel("zai", "glm-5-turbo")!;
+			const payload = await capturePayload(model, "high");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+			expect(payload.enable_thinking).toBeUndefined();
+		});
+
+		it("sends thinking.type=disabled when reasoning is off", async () => {
+			const model = getModel("zai", "glm-5-turbo")!;
+			const payload = await capturePayload(model);
+
+			expect(payload.thinking).toEqual({ type: "disabled" });
+			expect(payload.reasoning_effort).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
## Problem

Z.AI models with `thinkingFormat: "zai"` only send `enable_thinking: true/false`. They never send `reasoning_effort`, so selecting `high` vs `max` in `/effort` produces identical API requests. Additionally, no `thinkingLevelMap` is set, so all 7 thinking levels appear in the selector — most meaningless for these models.

Two root causes:
- `detectCompat` hardcodes `supportsReasoningEffort: false` for all Z.AI providers
- The `thinkingFormat: "zai"` handler only sets a boolean `enable_thinking`

## Evidence

E2E tested all four Z.AI models against the API with `thinking.type` + `reasoning_effort`:

| Model          | Effort | Reasoning (chars) | Tokens | Latency |
|----------------|--------|-------------------|--------|---------|
| glm-4.7        | off    | 0                 | 169    | 5.2s    |
| glm-4.7        | high   | 466               | 259    | 7.0s    |
| glm-4.7        | max    | 2612              | 928    | 20.6s   |
| glm-5-turbo    | off    | 0                 | 190    | 7.6s    |
| glm-5-turbo    | high   | 1077              | 474    | 5.6s    |
| glm-5-turbo    | max    | 674               | 352    | 4.4s    |
| glm-5.2        | off    | 0                 | 224    | 6.6s    |
| glm-5.2        | high   | 630               | 430    | 8.0s    |
| glm-5.2        | max    | 780               | 417    | 6.5s    |

All four models accept the new wire format and respond differently to `reasoning_effort`.

## Changes

- **`generate-models.ts`**: Added `ZAI_THINKING_LEVEL_MAP` (`minimal:null, low:"high", medium:"high", high:"high", max:"max"`) applied to all reasoning-capable Z.AI models. Set `supportsReasoningEffort: true` in compat.
- **`openai-completions.ts`**: Replaced `enable_thinking` with a typed `thinking` object (`{ type: "enabled", clear_thinking: false }`) for all zai models. Sends `reasoning_effort` (mapped through `thinkingLevelMap`) when `compat.supportsReasoningEffort` is true.
- **`types.ts`**: Updated JSDoc for `thinkingFormat` to reflect the new zai behavior.
- **`models.generated.ts`**: Regenerated (only zai models changed).
- **`zai-thinking.test.ts`**: 14 tests covering thinking levels and request params for glm-4.7, glm-5-turbo, and glm-5.2.

fixes #1074


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `reasoning_effort` support for Z.AI GLM models via `thinking` parameter
> - Z.AI reasoning models (glm-4.7, glm-5-turbo, glm-5.2, glm-5.2-highspeed) now support five `reasoning_effort` levels: `off`, `low`, `medium`, `high`, `max`.
> - Replaces the legacy top-level `enable_thinking` boolean with a `thinking: { type, clear_thinking }` object; when effort is provided, a `reasoning_effort` field is included using a `thinkingLevelMap` to translate SDK levels to provider values (`low/medium/high` → `'high'`, `max` → `'max'`).
> - The [generate-models script](https://github.com/PrimeIntellect-ai/prime-agent/pull/1075/files#diff-89e0723f62b802c23d445c0de0813e3c9a937463cdc57f1585eedd07c9a4635c) and [generated models file](https://github.com/PrimeIntellect-ai/prime-agent/pull/1075/files#diff-ff7c21ac6b779f6c8f30964fa301e7f89a29bfa77866258b05b9be7f35291fdd) are updated to advertise `compat.supportsReasoningEffort: true` and embed `thinkingLevelMap` for reasoning-capable Z.AI models.
> - Behavioral Change: requests to Z.AI reasoning models no longer send `enable_thinking`; they now send the `thinking` object format expected by the updated API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4582ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->