### PR TITLE
fix(coding-agent): keep shutdown admission through delays

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed long or concurrent daemon shutdown checks aborting cleanup when their lease refresh was delayed or self-contended.
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -182,7 +182,7 @@ class DaemonSupervisorOwnership {
 class DaemonShutdownAdmission {
 	private released = false;
 	private lost = false;
-	private refreshPromise?: Promise<void>;
+	private renewalPromise?: Promise<void>;
 	private readonly refreshTimer: ReturnType<typeof setInterval>;
 
 	constructor(
@@ -190,11 +190,7 @@ class DaemonShutdownAdmission {
 		private readonly registryDir: string,
 	) {
 		this.refreshTimer = setInterval(() => {
-			this.refreshPromise ??= this.assertOrRenew()
-				.catch(() => undefined)
-				.finally(() => {
-					this.refreshPromise = undefined;
-				});
+			void this.assertOrRenew().catch(() => undefined);
 		}, SHUTDOWN_ADMISSION_REFRESH_MS);
 		this.refreshTimer.unref();
 	}
@@ -203,6 +199,37 @@ class DaemonShutdownAdmission {
 		if (this.released || this.lost) {
 			throw new DaemonShutdownAdmissionError("Daemon shutdown admission was lost");
 		}
+		if (this.renewalPromise) {
+			return this.renewalPromise;
+		}
+		const renewal = this.renewOnce();
+		this.renewalPromise = renewal;
+		const clearRenewal = (): void => {
+			if (this.renewalPromise === renewal) {
+				this.renewalPromise = undefined;
+			}
+		};
+		void renewal.then(clearRenewal, clearRenewal);
+		return renewal;
+	}
+
+	async release(): Promise<void> {
+		if (this.released) {
+			return;
+		}
+		this.released = true;
+		clearInterval(this.refreshTimer);
+		await this.renewalPromise?.catch(() => undefined);
+		await withDaemonSupervisorRegistryGuard(this.registryDir, () => {
+			const path = shutdownAdmissionPath(this.registryDir);
+			const current = readShutdownAdmission(path);
+			if (current?.token === this.record.token) {
+				rmSync(path, { force: true });
+			}
+		});
+	}
+
+	private async renewOnce(): Promise<void> {
 		try {
 			await withDaemonSupervisorRegistryGuard(this.registryDir, () => {
 				const path = shutdownAdmissionPath(this.registryDir);
@@ -212,7 +239,6 @@ class DaemonShutdownAdmission {
 					current.token !== this.record.token ||
 					current.pid !== this.record.pid ||
 					current.processStartId !== this.record.processStartId ||
-					Date.parse(current.expiresAt) <= Date.now() ||
 					!matchesExactProcessIdentity(this.record)
 				) {
 					throw new DaemonShutdownAdmissionError("Daemon shutdown admission was lost");
@@ -227,22 +253,6 @@ class DaemonShutdownAdmission {
 			clearInterval(this.refreshTimer);
 			throw error;
 		}
-	}
-
-	async release(): Promise<void> {
-		if (this.released) {
-			return;
-		}
-		this.released = true;
-		clearInterval(this.refreshTimer);
-		await this.refreshPromise;
-		await withDaemonSupervisorRegistryGuard(this.registryDir, () => {
-			const path = shutdownAdmissionPath(this.registryDir);
-			const current = readShutdownAdmission(path);
-			if (current?.token === this.record.token) {
-				rmSync(path, { force: true });
-			}
-		});
 	}
 }
 

--- a/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
@@ -8,11 +8,13 @@ import {
 	readFileSync,
 	renameSync,
 	rmSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { createConnection, type Socket } from "node:net";
 import { join, resolve } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import lockfile from "proper-lockfile";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { APP_NAME, ENV_AGENT_DIR } from "../../../src/config.js";
 import { getProcessStartId } from "../../../src/core/session-lease.js";
 import { DaemonAgentConnection } from "../../../src/modes/agent-connection/daemon-agent-connection.js";
@@ -126,7 +128,12 @@ async function createPaths(): Promise<TestPaths> {
 	const harness = await createHarness();
 	harnesses.push(harness);
 	const executablePath = join(harness.tempDir, APP_NAME);
-	linkSync(process.execPath, executablePath);
+	if (process.platform === "win32") {
+		linkSync(process.execPath, executablePath);
+	} else {
+		// Homebrew Node resolves libnode relative to its installed executable path.
+		symlinkSync(process.execPath, executablePath);
+	}
 	const socketTmpDir = `/tmp/eng-4603-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	mkdirSync(socketTmpDir, { recursive: true, mode: 0o700 });
 	socketTempDirs.add(socketTmpDir);
@@ -986,6 +993,90 @@ describe("ENG-4603 worker recovery convergence", () => {
 		}
 	}, 15_000);
 
+	it("renews an expired shutdown admission when no successor claimed it", async () => {
+		const paths = await createPaths();
+		const previousRegistryDir = process.env[supervisorRegistryDirEnv];
+		process.env[supervisorRegistryDirEnv] = paths.registryDir;
+		try {
+			const admission = await acquireDaemonShutdownAdmission();
+			try {
+				const refreshTimer = Reflect.get(admission, "refreshTimer") as NodeJS.Timeout | undefined;
+				if (!refreshTimer) throw new Error("Shutdown admission did not start its lease refresh");
+				clearInterval(refreshTimer);
+				const admissionPath = join(paths.registryDir, "shutdown-admission.json");
+				const record = JSON.parse(readFileSync(admissionPath, "utf8")) as { expiresAt: string };
+				record.expiresAt = new Date(Date.now() - 1_000).toISOString();
+				writeFileSync(admissionPath, `${JSON.stringify(record, null, 2)}\n`);
+
+				await expect(admission.assertOrRenew()).resolves.toBeUndefined();
+				const renewed = JSON.parse(readFileSync(admissionPath, "utf8")) as { expiresAt: string };
+				expect(Date.parse(renewed.expiresAt)).toBeGreaterThan(Date.now());
+			} finally {
+				await admission.release();
+			}
+		} finally {
+			if (previousRegistryDir === undefined) {
+				delete process.env[supervisorRegistryDirEnv];
+			} else {
+				process.env[supervisorRegistryDirEnv] = previousRegistryDir;
+			}
+		}
+	});
+
+	it("coalesces concurrent shutdown admission renewals", async () => {
+		const paths = await createPaths();
+		const previousRegistryDir = process.env[supervisorRegistryDirEnv];
+		process.env[supervisorRegistryDirEnv] = paths.registryDir;
+		try {
+			const admission = await acquireDaemonShutdownAdmission();
+			const renewals: Promise<void>[] = [];
+			let releaseBlockedLocks: () => void = () => undefined;
+			try {
+				const refreshTimer = Reflect.get(admission, "refreshTimer") as NodeJS.Timeout | undefined;
+				if (!refreshTimer) throw new Error("Shutdown admission did not start its lease refresh");
+				clearInterval(refreshTimer);
+
+				const originalLock = lockfile.lock.bind(lockfile);
+				const blockedLocks = new Promise<void>((resolveBlockedLocks) => {
+					releaseBlockedLocks = resolveBlockedLocks;
+				});
+				let signalLockEntered: () => void = () => undefined;
+				const lockEntered = new Promise<void>((resolveLockEntered) => {
+					signalLockEntered = resolveLockEntered;
+				});
+				let lockCalls = 0;
+				const lockSpy = vi.spyOn(lockfile, "lock").mockImplementation(async (...args) => {
+					lockCalls++;
+					signalLockEntered();
+					await blockedLocks;
+					return originalLock(...args);
+				});
+				try {
+					renewals.push(...Array.from({ length: 8 }, () => admission.assertOrRenew()));
+					await lockEntered;
+					expect(lockCalls).toBe(1);
+					releaseBlockedLocks();
+					await Promise.all(renewals);
+					await admission.assertOrRenew();
+					expect(lockCalls).toBe(2);
+				} finally {
+					releaseBlockedLocks();
+					await Promise.allSettled(renewals);
+					lockSpy.mockRestore();
+				}
+			} finally {
+				releaseBlockedLocks();
+				await admission.release();
+			}
+		} finally {
+			if (previousRegistryDir === undefined) {
+				delete process.env[supervisorRegistryDirEnv];
+			} else {
+				process.env[supervisorRegistryDirEnv] = previousRegistryDir;
+			}
+		}
+	});
+
 	it("shutdown --force removes hidden supervisors and workers through the public CLI", async () => {
 		if (process.platform === "win32") return;
 		const paths = await createPaths();
@@ -1027,7 +1118,9 @@ describe("ENG-4603 worker recovery convergence", () => {
 		expect(listenersBeforeShutdown).toContain(`p${successor.child.pid}`);
 
 		const shutdown = await runCli(paths, ["shutdown", "--force", "--json"], 60_000, lsofEnvironment);
-		expect(shutdown.code).toBe(0);
+		if (shutdown.code !== 0) {
+			throw new Error(`shutdown --force failed (${shutdown.code}): ${shutdown.stderr || shutdown.stdout}`);
+		}
 		const shutdownResult = JSON.parse(shutdown.stdout) as { stopped: unknown[]; failed: unknown[] };
 		const survivingIdentities = [
 			{ pid: predecessor.child.pid!, processStartId: predecessorStartId },


### PR DESCRIPTION
## Summary

- coalesce concurrent shutdown-admission renewals so the timer and explicit checks cannot contend with each other
- allow the same live, token-matching owner to renew after expiry when no successor claimed the lease
- make the ENG-4603 macOS fixture use a symlink so Homebrew Node keeps its `@rpath/libnode` resolution

## Root cause

`shutdown --force` can spend longer than the 5-second lease inside synchronous daemon discovery before the event loop gets its first refresh. In the reproduced failure, the lease was created at `16:10:19.904`, expired at `16:10:24.904`, and first renewed at `16:10:29.401`; the token, PID, process start ID, and live process identity were still unchanged. The old code permanently fenced out its own shutdown. Concurrent explicit checks could also bypass the timer's in-flight promise and create avoidable registry-lock contention.

Renewal still runs under the supervisor registry guard. If a successor claims an expired lease first, it removes/replaces the record, and the predecessor fails the token fence. The existing successor-reclaim regression continues to cover that case.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/4603-worker-recovery.test.ts -t "renews an expired shutdown admission"`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/4603-worker-recovery.test.ts -t "coalesces concurrent shutdown admission renewals"`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/4603-worker-recovery.test.ts -t "shutdown --force removes hidden supervisors"`
- `npm run check`
- `npm run build` in `packages/coding-agent`

The full ENG-4603 file also ran all six test bodies; under sustained local load its final shutdown case intermittently timed out in the test harness's post-test `waitForExit` cleanup after the isolated end-to-end case passed. No residual Prime Agent process remained.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix daemon shutdown admission loss during delayed or concurrent lease refresh
> - Expired but otherwise valid shutdown admissions are now renewed instead of treated as lost; the `expiresAt` check is removed from the loss condition in `renewOnce()`.
> - Concurrent calls to `assertOrRenew()` in [`daemon-supervisor-ownership.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1081/files#diff-6f9ef6ce6a9d2bc51c61fe94d59310efffd26d8f7b3966f5355606b2847d06a5) now coalesce into a single in-flight renewal promise instead of racing.
> - `release()` now awaits any in-flight renewal with errors ignored, so cleanup is not blocked or aborted by a renewing promise.
> - New regression tests cover expired admission renewal and concurrent renewal coalescing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3392ae9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->