### PR TITLE
fix(ai): emit Bedrock cache points for Claude 5 models

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -580,8 +580,23 @@ function isAnthropicClaudeModel(model: Model<"bedrock-converse-stream">): boolea
 }
 
 /**
+ * Major version of a Claude model reference.
+ *
+ * Handles both naming conventions: family-first ("claude-opus-5",
+ * "claude-haiku-4-5-20251001-v1:0") and version-first ("claude-3-7-sonnet").
+ * Returns 0 when no version token is present.
+ */
+function claudeMajorVersion(candidate: string): number {
+	for (const pattern of [/claude-[a-z]+-(\d+)/, /claude-(\d+)-/]) {
+		const match = pattern.exec(candidate);
+		if (match) return Number(match[1]);
+	}
+	return 0;
+}
+
+/**
  * Check if the model supports prompt caching.
- * Supported: Claude 3.5 Haiku, Claude 3.7 Sonnet, Claude 4.x models
+ * Supported: Claude 3.5 Haiku, Claude 3.7 Sonnet, and Claude 4 or newer.
  *
  * For base models and system-defined inference profiles the model ID / ARN
  * contains the model name, so we can decide locally.
@@ -601,8 +616,10 @@ function supportsPromptCaching(model: Model<"bedrock-converse-stream">): boolean
 		if (typeof process !== "undefined" && process.env.AWS_BEDROCK_FORCE_CACHE === "1") return true;
 		return false;
 	}
-	// Claude 4.x models (opus-4, sonnet-4, haiku-4)
-	if (candidates.some((s) => s.includes("-4-"))) return true;
+	// Claude 4 and newer. Comparing the version token rather than matching fixed
+	// substrings keeps caching enabled for future releases; a missed match is
+	// silent and bills the entire context as uncached input on every request.
+	if (candidates.some((s) => claudeMajorVersion(s) >= 4)) return true;
 	// Claude 3.7 Sonnet
 	if (candidates.some((s) => s.includes("claude-3-7-sonnet"))) return true;
 	// Claude 3.5 Haiku

--- a/packages/ai/test/bedrock-prompt-caching.test.ts
+++ b/packages/ai/test/bedrock-prompt-caching.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { MODELS } from "../src/models.generated.js";
+import { getModel } from "../src/models.js";
+import { type BedrockOptions, streamBedrock } from "../src/providers/amazon-bedrock.js";
+import type { CacheRetention, Context, Model } from "../src/types.js";
+
+type BedrockModelId = keyof (typeof MODELS)["amazon-bedrock"];
+
+interface BedrockCachePayload {
+	system?: Array<{ text?: string; cachePoint?: { type: string; ttl?: string } }>;
+	messages?: Array<{
+		role: string;
+		content?: Array<{ text?: string; cachePoint?: { type: string; ttl?: string } }>;
+	}>;
+}
+
+function makeContext(): Context {
+	return {
+		systemPrompt: "You are a helpful assistant.",
+		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+	};
+}
+
+async function capturePayload(
+	model: Model<"bedrock-converse-stream">,
+	options?: BedrockOptions,
+): Promise<BedrockCachePayload> {
+	let capturedPayload: BedrockCachePayload | undefined;
+	const s = streamBedrock(model, makeContext(), {
+		...options,
+		signal: AbortSignal.abort(),
+		onPayload: (payload) => {
+			capturedPayload = payload as BedrockCachePayload;
+			return payload;
+		},
+	});
+
+	for await (const event of s) {
+		if (event.type === "error") {
+			break;
+		}
+	}
+
+	if (!capturedPayload) {
+		throw new Error("Expected Bedrock payload to be captured before request abort");
+	}
+
+	return capturedPayload;
+}
+
+function systemCachePoints(payload: BedrockCachePayload): number {
+	return (payload.system ?? []).filter((block) => block.cachePoint !== undefined).length;
+}
+
+function lastMessageCachePoints(payload: BedrockCachePayload): number {
+	const messages = payload.messages ?? [];
+	const last = messages[messages.length - 1];
+	return (last?.content ?? []).filter((block) => block.cachePoint !== undefined).length;
+}
+
+async function cachePointsFor(
+	modelId: BedrockModelId,
+	cacheRetention?: CacheRetention,
+): Promise<{ system: number; lastMessage: number }> {
+	const model = getModel("amazon-bedrock", modelId);
+	const payload = await capturePayload(model, cacheRetention ? { cacheRetention } : undefined);
+	return { system: systemCachePoints(payload), lastMessage: lastMessageCachePoints(payload) };
+}
+
+describe("Bedrock prompt caching", () => {
+	// A model missing from the version gate is billed at full input price on every
+	// request with no error, so each supported family is asserted explicitly.
+	const cachingModels: BedrockModelId[] = [
+		"us.anthropic.claude-opus-5",
+		"global.anthropic.claude-opus-5",
+		"global.anthropic.claude-sonnet-5",
+		"global.anthropic.claude-fable-5",
+		"global.anthropic.claude-opus-4-8",
+		"global.anthropic.claude-opus-4-6-v1",
+		"us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+		"us.anthropic.claude-haiku-4-5-20251001-v1:0",
+	];
+
+	it.each(cachingModels)("emits cache points for %s", async (modelId) => {
+		const points = await cachePointsFor(modelId);
+		expect(points.system).toBe(1);
+		expect(points.lastMessage).toBe(1);
+	});
+
+	it("omits cache points for models without prompt cache support", async () => {
+		const points = await cachePointsFor("amazon.nova-pro-v1:0");
+		expect(points.system).toBe(0);
+		expect(points.lastMessage).toBe(0);
+	});
+
+	it("omits cache points when caching is disabled", async () => {
+		const points = await cachePointsFor("us.anthropic.claude-opus-5", "none");
+		expect(points.system).toBe(0);
+		expect(points.lastMessage).toBe(0);
+	});
+
+	it("requests a one hour ttl for long retention", async () => {
+		const model = getModel("amazon-bedrock", "us.anthropic.claude-opus-5");
+		const payload = await capturePayload(model, { cacheRetention: "long" });
+		const cachePoint = (payload.system ?? []).find((block) => block.cachePoint !== undefined);
+		expect(cachePoint?.cachePoint?.ttl).toBe("1h");
+	});
+});


### PR DESCRIPTION
# Bedrock prompt caching is silently disabled for Claude 5 models

## Summary

`supportsPromptCaching()` in `packages/ai/src/providers/amazon-bedrock.ts` gates Converse
`cachePoint` emission on a substring allowlist that predates Claude 5. Any
`claude-*-5` model matches none of the branches, so no cache point is ever sent and
every request re-bills the full context as fresh input.

Affected (all regional prefixes): `anthropic.claude-opus-5`, `anthropic.claude-sonnet-5`,
`anthropic.claude-fable-5`.

There is no error and no warning. The only visible symptom is
`cacheReadInputTokens: 0` / `cacheWriteInputTokens: 0` on every response, which is
easy to mistake for normal behaviour.

## Impact

Measured on one workstation across 1,727 Bedrock Claude Opus 5 calls: 445M input
tokens billed at the full rate with a 0.0% cache hit rate. After patching, the same
kind of session shows a 100% hit rate and steady-state cost per call falls from
$0.617 to $0.097 (6.3x) at ~120K context.

Before (fresh input on every turn):

```
timestamp                  fresh_in   cacheRead   cacheWr      cost
16:07:39Z                   120,305           0         0    $0.6369
```

After:

```
16:09:22Z                         2           0   122,402    $0.7991   <- writes cache
16:09:42Z                         2     122,402     3,361    $0.1152
16:10:03Z                         2     125,763     2,142    $0.1136
```

## Root cause

```ts
// Claude 4.x models (opus-4, sonnet-4, haiku-4)
if (candidates.some((s) => s.includes("-4-"))) return true;
// Claude 3.7 Sonnet
if (candidates.some((s) => s.includes("claude-3-7-sonnet"))) return true;
// Claude 3.5 Haiku
if (candidates.some((s) => s.includes("claude-3-5-haiku"))) return true;
return false;
```

`us.anthropic.claude-opus-5` contains `"claude"`, so `hasClaudeRef` is true, but it does
not contain `"-4-"` and matches neither explicit branch, so the function returns false.

Note that `AWS_BEDROCK_FORCE_CACHE=1` is not a workaround: it is only consulted inside
the `!hasClaudeRef` branch, which Claude 5 model IDs never reach. `PI_CACHE_RETENTION`
only selects the TTL after the gate has already passed.

## Reproduction

```ts
const model = getModel("amazon-bedrock", "us.anthropic.claude-opus-5");
// capture the Converse payload via options.onPayload
// -> payload.system contains no { cachePoint } block
// -> the last user message contains no { cachePoint } block
```

## Fix

Compare the version token instead of matching fixed substrings, so a new Claude major
release does not silently lose caching:

```ts
function claudeMajorVersion(candidate: string): number {
	for (const pattern of [/claude-[a-z]+-(\d+)/, /claude-(\d+)-/]) {
		const match = pattern.exec(candidate);
		if (match) return Number(match[1]);
	}
	return 0;
}

if (candidates.some((s) => claudeMajorVersion(s) >= 4)) return true;
```

The second pattern preserves the version-first Claude 3 naming, so `claude-3-7-sonnet`
and `claude-3-5-haiku` still fall through to their explicit branches while
`claude-3-sonnet` correctly stays uncached.

## Tests

`packages/ai/test/bedrock-prompt-caching.test.ts` asserts cache points for each
supported family, absence for non-caching models, absence under
`cacheRetention: "none"`, and the 1h TTL under `cacheRetention: "long"`.

Verified red before the fix / green after: without the change, exactly the Claude 5
cases fail (5 failures) and all 4.x cases still pass.

Repo gate: `tsgo --noEmit` clean, `biome check` clean, `packages/ai` suite 374 passed
with 2 pre-existing failures unrelated to this change (they require live OpenAI and
Mistral credentials).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Bedrock prompt caching to emit cache points for Claude 4 and 5 models
> - Adds a `claudeMajorVersion` helper in [amazon-bedrock.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1082/files#diff-3f2d56a0422dc4ee7e752f4025cae682faf57ec5e2f958e69a3d04c6ffa3de69) that parses major version numbers from both `family-first` (e.g. `claude-opus-5`) and `version-first` (e.g. `claude-3-7-sonnet`) naming conventions.
> - Updates `supportsPromptCaching` to use `claudeMajorVersion(candidate) >= 4` instead of a fixed `-4-` substring check, so Claude 5.x models now correctly receive cache points.
> - Adds a Vitest suite in [bedrock-prompt-caching.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1082/files#diff-45c15897ed00e014d0f29dc1a6b54c7777e6d4a7b4dbde995bff3aa6e3d2ae3b) covering cache point emission, omission for unsupported models, `cacheRetention: 'none'`, and 1h TTL for `'long'` retention.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b09246e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->