### PR TITLE
fix(runtime): preserve MCP tool inputSchema from SDK snake_case fields

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed MCP `list_tools()` returning empty `inputSchema` values by reading the SDK's snake_case `input_schema` field ([#1073](https://github.com/PrimeIntellect-ai/prime-agent/issues/1073))
 
 ## [0.7.1] - 2026-08-07
 

--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -90,6 +90,18 @@ def _resolve_config_value(value: str) -> str:
     return (os.environ.get(value) or value).strip()
 
 
+def _sdk_field(obj: Any, snake: str, camel: str, default: Any = None) -> Any:
+    """Read an MCP SDK field that is snake_case in Python and camelCase on the wire.
+
+    Pydantic models in ``mcp.types`` expose the snake_case attribute; ``camel`` is
+    only the serialization alias, so ``getattr(obj, camel)`` is always missing.
+    Prefer snake_case, then camelCase for plain test doubles / older shapes.
+    """
+    if hasattr(obj, snake):
+        return getattr(obj, snake)
+    return getattr(obj, camel, default)
+
+
 def _resolve_streamable_http():
     """Return an SDK streamable-HTTP transport callable.
 
@@ -263,7 +275,7 @@ class McpIntegration:
                     t.name: {
                         "name": t.name,
                         "description": getattr(t, "description", "") or "",
-                        "inputSchema": getattr(t, "inputSchema", None) or {},
+                        "inputSchema": _sdk_field(t, "input_schema", "inputSchema") or {},
                     }
                     for t in resp.tools
                 }
@@ -314,10 +326,10 @@ def _parse_result(result: Any) -> Any:
         text = getattr(block, "text", None)
         if text is not None:
             texts.append(text)
-    if getattr(result, "isError", False):
+    if _sdk_field(result, "is_error", "isError", False):
         raise McpToolError("\n".join(texts) or "MCP tool returned an error")
 
-    structured = getattr(result, "structuredContent", None)
+    structured = _sdk_field(result, "structured_content", "structuredContent")
     if structured is not None:  # falsy-but-valid payloads ({} / []) are real results
         return structured
     if texts:

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -29,10 +29,11 @@ class _FakeSession:
         Tool = type("Tool", (), {})
 
         def make(name, desc, schema):
+            # Mirror mcp.types.Tool: snake_case Python attrs, camelCase wire aliases.
             t = Tool()
             t.name = name
             t.description = desc
-            t.inputSchema = schema
+            t.input_schema = schema
             return t
 
         resp = type("Resp", (), {})()
@@ -145,20 +146,48 @@ class McpIntegrationTest(unittest.TestCase):
 
     def test_empty_structured_result_preserved(self):
         for payload in ({}, []):
-            result = type("R", (), {"structuredContent": payload, "content": [], "isError": False})()
+            result = type(
+                "R", (), {"structured_content": payload, "content": [], "is_error": False}
+            )()
             self.assertEqual(mcp_base._parse_result(result), payload)
 
     def test_error_result_raises(self):
         block = type("B", (), {"text": "boom"})()
-        result = type("R", (), {"isError": True, "content": [block], "structuredContent": None})()
+        result = type("R", (), {"is_error": True, "content": [block], "structured_content": None})()
         with self.assertRaises(McpToolError) as ctx:
             mcp_base._parse_result(result)
         self.assertIn("boom", str(ctx.exception))
 
+    def test_parse_result_accepts_camel_case_aliases(self):
+        # Plain dict-shaped doubles may still use wire names.
+        block = type("B", (), {"text": "boom"})()
+        err = type("R", (), {"isError": True, "content": [block], "structuredContent": None})()
+        with self.assertRaises(McpToolError):
+            mcp_base._parse_result(err)
+        ok = type("R", (), {"structuredContent": {"ok": True}, "content": [], "isError": False})()
+        self.assertEqual(mcp_base._parse_result(ok), {"ok": True})
+
+    def test_list_tools_preserves_input_schema_from_sdk_field(self):
+        schema = {
+            "type": "object",
+            "properties": {"team": {"type": "string"}},
+            "required": ["team"],
+        }
+        session = _FakeSession(
+            tools=[("list_issues", "List issues", schema)],
+            result=type("R", (), {"structured_content": None, "content": [], "is_error": False})(),
+        )
+        self._write_auth(
+            {"type": "oauth", "access": "t", "refresh": "r", "expires": (time.time() + 3600) * 1000}
+        )
+        with self._patch_session(session):
+            tools = _run(_Integration().list_tools())
+        self.assertEqual(tools, [{"name": "list_issues", "description": "List issues", "inputSchema": schema}])
+
     def test_auto_bound_tool_calls_session(self):
         session = _FakeSession(
             tools=[("list_issues", "List issues", {"type": "object"})],
-            result=type("R", (), {"structuredContent": {"issues": [1, 2]}})(),
+            result=type("R", (), {"structured_content": {"issues": [1, 2]}})(),
         )
         self._write_auth(
             {"type": "oauth", "access": "t", "refresh": "r", "expires": (time.time() + 3600) * 1000}
@@ -182,7 +211,7 @@ class McpIntegrationTest(unittest.TestCase):
 
     def test_text_result_parsing(self):
         block = type("B", (), {"text": "hello"})()
-        result = type("R", (), {"content": [block], "structuredContent": None})()
+        result = type("R", (), {"content": [block], "structured_content": None, "is_error": False})()
         self.assertEqual(mcp_base._parse_result(result), "hello")
 
     def test_requires_server_attribute(self):
@@ -211,7 +240,9 @@ class McpIntegrationTest(unittest.TestCase):
             session = mock.MagicMock()
             session.initialize = mock.AsyncMock()
             session.call_tool = mock.AsyncMock(
-                return_value=type("R", (), {"content": [], "structuredContent": None})()
+                return_value=type(
+                    "R", (), {"content": [], "structured_content": None, "is_error": False}
+                )()
             )
             session_cls.return_value.__aenter__ = mock.AsyncMock(return_value=session)
             session_cls.return_value.__aexit__ = mock.AsyncMock(return_value=False)


### PR DESCRIPTION
## Summary
- Fixed `McpIntegration.list_tools()` always returning empty `inputSchema` by reading the MCP SDK's snake_case `input_schema` attribute (camelCase is only the wire alias).
- Applied the same snake_case-first lookup for `is_error` / `structured_content` in `_parse_result`.
- Updated unit fakes and added a regression test so SDK-shaped attributes are exercised.

Fixes #1073

## Test plan
- [x] `cd prime-agent-runtime && PYTHONPATH=src uv run python -m unittest discover -s test -p 'test_mcp_base.py' -v`
- [x] Confirmed `_sdk_field` returns the schema from a real `mcp.types.Tool`



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP tool `inputSchema` population by reading SDK snake_case `input_schema` field
> The MCP Python SDK exposes fields like `input_schema`, `is_error`, and `structured_content` as snake_case attributes, but the code was reading camelCase names (`inputSchema`, `isError`, `structuredContent`), causing tool schemas and structured results to be empty or ignored.
>
> - Adds `_sdk_field()` helper in [mcp_base.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/1084/files#diff-3e0a705745bc6d6096fecf5672e6173e25ee363911b2fc0ff065fa59f0117524) that prefers the snake_case attribute and falls back to the camelCase alias, so both naming conventions are handled.
> - Updates `list_tools()` to use `_sdk_field(t, "input_schema", "inputSchema")` so tool entries include the correct schema.
> - Updates `_parse_result()` to read `is_error` and `structured_content` via the same helper.
> - New tests verify snake_case fields are read correctly and camelCase aliases still work as fallbacks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33320d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->