### PR TITLE
fix(coding-agent): emit the Bedrock provider into the CLI bundle

### DIFF
--- a/packages/coding-agent/scripts/bedrock-bundle-entry.js
+++ b/packages/coding-agent/scripts/bedrock-bundle-entry.js
@@ -1,0 +1,14 @@
+// Bundle entry for the Bedrock provider.
+//
+// pi-ai loads Bedrock through a variable specifier (importNodeOnlyProvider) so
+// that browser bundles don't pull in the AWS SDK. esbuild therefore cannot see
+// the import and emits no chunk for it, while the runtime import still resolves
+// relative to the emitted chunk directory. Building this file as an entry named
+// "amazon-bedrock" puts the module exactly where that runtime import looks.
+//
+// Only pi-ai's public ./bedrock-provider export is used, and the named exports
+// match what loadBedrockProviderModule() destructures.
+import { bedrockProviderModule } from "@earendil-works/pi-ai/bedrock-provider";
+
+export const streamBedrock = bedrockProviderModule.streamBedrock;
+export const streamSimpleBedrock = bedrockProviderModule.streamSimpleBedrock;

--- a/packages/coding-agent/scripts/bundle.mjs
+++ b/packages/coding-agent/scripts/bundle.mjs
@@ -11,7 +11,7 @@
  * compiled Bun binary), keyed off the __PI_BUNDLED__ define below, so extension
  * imports of pi packages share the bundle's module instances.
  */
-import { chmodSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,7 +32,15 @@ try {
 rmSync(outdir, { recursive: true, force: true });
 
 await build({
-	entryPoints: [join(packageDir, "dist", "cli.js")],
+	entryPoints: [
+		{ in: join(packageDir, "dist", "cli.js"), out: "cli" },
+		// pi-ai imports the Bedrock provider through a variable specifier to keep
+		// the AWS SDK out of browser bundles, so esbuild cannot discover it and
+		// emits no chunk -- leaving the runtime import pointing at a file that was
+		// never written. Declaring it as an entry emits it under the exact name the
+		// runtime looks for, while splitting keeps it a lazily loaded chunk.
+		{ in: join(packageDir, "scripts", "bedrock-bundle-entry.js"), out: "amazon-bedrock" },
+	],
 	outdir,
 	bundle: true,
 	splitting: true,
@@ -49,4 +57,14 @@ await build({
 });
 
 chmodSync(join(outdir, "cli.js"), 0o755);
+
+// esbuild cannot see the Bedrock provider import (variable specifier), so it
+// cannot warn when the chunk is absent. Without this guard a bundle whose
+// runtime import resolves to a missing file ships silently, and every Bedrock
+// model fails with "module.streamSimple is not a function".
+const bedrockOutput = join(outdir, "amazon-bedrock.js");
+if (!existsSync(bedrockOutput)) {
+	throw new Error(`bundle is missing ${bedrockOutput}; Bedrock models would fail at runtime`);
+}
+
 console.log("bundled dist/cli.js -> dist/bundle/");

--- a/packages/coding-agent/test/bundle-bedrock-entry.test.ts
+++ b/packages/coding-agent/test/bundle-bedrock-entry.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+/**
+ * pi-ai loads the Bedrock provider through a variable specifier
+ * (`importNodeOnlyProvider("./amazon-bedrock.js")`) so browser bundles do not
+ * pull in the AWS SDK. esbuild cannot resolve a variable specifier, so it emits
+ * no chunk for it and reports no warning, yet the runtime import still resolves
+ * relative to the emitted chunk directory. scripts/bundle.mjs therefore declares
+ * the provider as an explicit entry point named after that specifier.
+ *
+ * Nothing in the type system or the bundler couples those two files, so this
+ * asserts the coupling directly. When it broke, the unbundled dist/ build kept
+ * working and only the published `bin` failed, with
+ * "module.streamSimple is not a function" on first use of any Bedrock model.
+ */
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const bundleScript = join(packageDir, "scripts", "bundle.mjs");
+const registerBuiltins = join(packageDir, "..", "ai", "src", "providers", "register-builtins.ts");
+
+function runtimeSpecifiers(): string[] {
+	const source = readFileSync(registerBuiltins, "utf-8");
+	return [...source.matchAll(/importNodeOnlyProvider\("\.\/([^"]+)\.js"\)/g)].map((match) => match[1]);
+}
+
+function declaredEntryNames(): string[] {
+	const source = readFileSync(bundleScript, "utf-8");
+	return [...source.matchAll(/out:\s*"([^"]+)"/g)].map((match) => match[1]);
+}
+
+describe("bundled Bedrock provider", () => {
+	it("declares a bundle entry for every provider the bundler cannot discover", () => {
+		const specifiers = runtimeSpecifiers();
+		// Guard the guard: if pi-ai stops using the indirection this test is moot.
+		expect(specifiers.length).toBeGreaterThan(0);
+		const entries = declaredEntryNames();
+		const missing = specifiers.filter((specifier) => !entries.includes(specifier));
+		expect(missing).toEqual([]);
+	});
+
+	it("bundles the entry into a module shaped like a provider", async () => {
+		const result = await build({
+			entryPoints: [join(packageDir, "scripts", "bedrock-bundle-entry.js")],
+			bundle: true,
+			format: "esm",
+			platform: "node",
+			packages: "external",
+			write: false,
+			logLevel: "silent",
+		});
+		const code = result.outputFiles[0].text;
+		// loadBedrockProviderModule() destructures exactly these two names.
+		expect(code).toMatch(/streamBedrock/);
+		expect(code).toMatch(/streamSimpleBedrock/);
+	});
+});


### PR DESCRIPTION
# Bedrock provider is missing from the CLI bundle

## Summary

The published `bin` (`dist/bundle/cli.js`) cannot use any Bedrock model. The first
request fails with:

```
module.streamSimple is not a function
```

`dist/` built unbundled works fine, and the compiled Bun binary works, so this only
affects npm/node installs -- which is every `npm i -g prime-agent` user.

## Root cause

`packages/ai/src/providers/register-builtins.ts` loads nine providers lazily. Eight use
a literal specifier that esbuild resolves and emits as a chunk:

```ts
import("./anthropic.js")
import("./openai-completions.js")
```

Bedrock deliberately goes through a variable specifier so browser bundles do not pull
in the AWS SDK:

```ts
const importNodeOnlyProvider = (specifier: string): Promise<unknown> => import(specifier);
...
importNodeOnlyProvider("./amazon-bedrock.js")
```

esbuild cannot resolve a variable specifier, so it emits no chunk and no warning. At
runtime the import still resolves relative to the emitted chunk directory, to a file
that was never written.

Confirmed by building at `a18809e0`: chunks appear for all eight literal-specifier
providers and `dist/bundle/amazon-bedrock.js` is absent.

The indirection itself is correct and load-bearing -- removing it (making the specifier
literal) makes `npm run check` fail, because the AWS SDK then enters the browser smoke
build and `@smithy/node-http-handler` cannot resolve `node:http`. So the provider must
stay invisible to static analysis, and the bundler has to be told about it explicitly.

## Fix

Declare the provider as a second bundle entry named after the specifier the runtime
uses, so the file lands exactly where the import looks. `splitting: true` keeps it a
lazily loaded chunk, so the AWS SDK is still only read when a Bedrock model is used.

The entry imports only pi-ai's public `./bedrock-provider` export and re-exports the two
names `loadBedrockProviderModule()` destructures. `packages/ai` is untouched.

Because esbuild cannot verify this emission, `scripts/bundle.mjs` now asserts the
artifact exists and fails the build otherwise -- the original failure mode was a silent
omission that only surfaced at runtime for one provider.

## Verification

- `dist/bundle/amazon-bedrock.js` emitted (679 KB) and exports `streamBedrock` and
  `streamSimpleBedrock` as functions.
- Still lazy: the AWS SDK appears only in that chunk, which is not in the static import
  closure of `cli.js` (2 files, 4 KB eager).
- `cli.js` unchanged in name, size and `0755` mode.
- `npm run check` passes, including the browser smoke build.
- Removing the entry point reproduces the bug: the build throws
  `bundle is missing .../amazon-bedrock.js`, and the new test fails.

## Tests

`packages/coding-agent/test/bundle-bedrock-entry.test.ts` asserts the coupling between
the runtime specifier in `register-builtins.ts` and the entry names in `bundle.mjs`,
and that the entry bundles to a provider-shaped module. Nothing in the type system
relates those two files, which is why this broke silently.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit the Bedrock provider as a separate chunk in the CLI bundle
> - Adds [bedrock-bundle-entry.js](https://github.com/PrimeIntellect-ai/prime-agent/pull/1085/files#diff-510c77121e475fa6dab6c0a262ee12bc64963dcd4474c32dbd5b50efcc33b2c5) as an explicit entry point that re-exports `streamBedrock` and `streamSimpleBedrock`, allowing the bundler to emit an `amazon-bedrock.js` chunk resolvable by the runtime dynamic import.
> - Updates [bundle.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/1085/files#diff-8606e8936a1a9a467bc717dab8da4d6bafd17f129a8e044e3054e4567b18803d) to declare two named entries (`cli` and `amazon-bedrock`) and adds a post-build guard that throws if `dist/bundle/amazon-bedrock.js` was not emitted.
> - Adds tests in [bundle-bedrock-entry.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1085/files#diff-d4242b5cc302b2a83dd0751f84a8c23cf0c11f017e2f8c9cc9f1560a113f9f0c) that verify every runtime provider specifier has a matching bundle entry and that the emitted chunk exports the expected symbols.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68e1ed1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->