### PR TITLE
feat(rlm): expose queued children and failure details

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed `rlm.list_subagents()` to distinguish process-local queued children from running ones and include bounded failure details while the parent tracks the run.
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -184,9 +184,9 @@ End the turn instead of waiting for completion. Children send requested answers 
 
 ## Parent-Scoped Sub-Agent Registry
 
-The TypeScript parent maintains the authoritative direct-child registry. `await rlm.list_subagents()` returns stable child IDs, active-session IDs when daemon-backed, session IDs, names, directories, and running/completed status.
+The TypeScript parent maintains the authoritative direct-child registry. `await rlm.list_subagents()` returns stable child IDs, active-session IDs when daemon-backed, session IDs, names, directories, and queued/running/completed/error status. While the current parent process still tracks a run, errored entries also include a bounded error message.
 
-This registry survives kernel restart, compaction, and parent restore. Successfully completed daemon-backed children are rehydrated from the parent artifact registry. Inline children remain inspectable in the current process but have no active-session ID.
+This registry survives kernel restart, compaction, and parent restore, but queue placement and detailed startup errors are process-local. Successfully completed daemon-backed children are rehydrated from the parent artifact registry. Legacy interrupted daemon rows remain visible as errors without a detailed message. Inline children remain inspectable in the current process but have no active-session ID.
 
 The parent can continue a retained daemon child with `await agent_message.send(..., receiver_role="child", receiver_name=child.session_name)`. `rlm.delete_subagent()` accepts an exact child ID, active-session ID, session ID, or unique name. Deletion cancels or closes the runtime, writes a durable tombstone, and removes the child from messaging and observation. It does not erase the transcript or artifacts on disk.
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1019,6 +1019,10 @@ export function compactRlmText(text: string, maxLength = 160): string {
 	return `${compact.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
 }
 
+function normalizeRlmChildError(error: string): string {
+	return compactRlmText(error, 512) || "Subagent failed without an error message";
+}
+
 // Child-agent label: collapse to one line but keep the full prompt — the TUI
 // truncates to the visible width and elides shared prefixes, so capping here
 // would only hide the divergence between near-identical sibling prompts.
@@ -9113,7 +9117,15 @@ export class AgentSession {
 				session_id: daemonChild?.sessionId ?? run.session?.sessionId ?? null,
 				session_name: daemonChild?.sessionName ?? run.session?.sessionName ?? run.sessionName,
 				session_dir: run.sessionDir,
-				status: run.status === "done" ? "completed" : run.status === "error" ? "error" : "running",
+				status:
+					run.status === "queued"
+						? "queued"
+						: run.status === "done"
+							? "completed"
+							: run.status === "error"
+								? "error"
+								: "running",
+				...(run.error !== undefined ? { error: normalizeRlmChildError(run.error) } : {}),
 			});
 			recorded.add(run.id);
 		}

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -18,7 +18,7 @@ export interface RlmSpawnHandle {
 	model: string;
 }
 
-export type RlmSubagentRegistryStatus = "running" | "completed" | "error";
+export type RlmSubagentRegistryStatus = "queued" | "running" | "completed" | "error";
 
 export interface RlmSubagentRegistryEntry {
 	rlm_child_id: string;
@@ -27,6 +27,8 @@ export interface RlmSubagentRegistryEntry {
 	session_name: string;
 	session_dir: string;
 	status: RlmSubagentRegistryStatus;
+	/** Failure reason for an errored child, when the current parent still tracks it. */
+	error?: string;
 }
 
 export interface RlmListSubagentsResult {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1168,7 +1168,11 @@ describe("AgentSession rlm recursion", () => {
 		const spawned = await root.runRlmChild("start failing child", { name: "failing-worker" });
 		await vi.waitFor(async () => {
 			expect((await root.listRlmSubagents()).subagents).toContainEqual(
-				expect.objectContaining({ rlm_child_id: spawned.rlm_child_id, status: "error" }),
+				expect.objectContaining({
+					rlm_child_id: spawned.rlm_child_id,
+					status: "error",
+					error: "kernel startup failed",
+				}),
 			);
 		});
 		await vi.waitFor(() => {
@@ -1181,6 +1185,45 @@ describe("AgentSession rlm recursion", () => {
 			);
 			expect(root.messages).toContainEqual(
 				expect.objectContaining({ content: expect.stringContaining("kernel startup failed") }),
+			);
+		});
+	});
+
+	it("normalizes and bounds startup failures in the subagent registry", async () => {
+		let attempt = 0;
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error(attempt++ === 0 ? "" : "x".repeat(1_000));
+				},
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		await root.runRlmChild("start empty-error child", { name: "empty-error-worker" });
+		await root.runRlmChild("start long-error child", { name: "long-error-worker" });
+		await vi.waitFor(async () => {
+			const subagents = (await root.listRlmSubagents()).subagents;
+			expect(subagents).toContainEqual(
+				expect.objectContaining({
+					status: "error",
+					error: "Subagent failed without an error message",
+				}),
+			);
+			expect(subagents).toContainEqual(
+				expect.objectContaining({
+					session_name: "long-error-worker",
+					status: "error",
+					error: `${"x".repeat(509)}...`,
+				}),
+			);
+		});
+		await vi.waitFor(() => {
+			expect(root.messages).toContainEqual(
+				expect.objectContaining({
+					customType: "rlm_child_failure",
+					content: expect.stringContaining("x".repeat(1_000)),
+				}),
 			);
 		});
 	});
@@ -2679,7 +2722,7 @@ describe("AgentSession rlm recursion", () => {
 		await root.runRlmChild("blocked before runtime creation", { name: "queued-worker" });
 		await waitFor(() => runtimeCreationStarted);
 		const queued = (await root.listRlmSubagents()).subagents[0];
-		expect(queued).toBeDefined();
+		expect(queued).toMatchObject({ session_name: "queued-worker", status: "queued" });
 
 		await expect(root.deleteRlmSubagent("queued-worker")).resolves.toEqual({ subagent: queued });
 		expect((root as unknown as InspectableRlmSession)._activeRlmChildRuns.size).toBe(1);

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -48,6 +48,7 @@ class RLMSubagent:
     session_name: str
     session_dir: Path
     status: str
+    error: str | None = None
 
 
 def _install_control_comm_handlers() -> None:
@@ -185,6 +186,7 @@ def _subagent_from_payload(payload: Any, operation: str = "rlm.list_subagents") 
     session_name = payload.get("session_name")
     session_dir = payload.get("session_dir")
     status = payload.get("status")
+    error = payload.get("error")
     if not isinstance(child_id, str) or not child_id:
         raise RuntimeError(f"{operation} entry is missing rlm_child_id")
     if active_session_id is not None and not isinstance(active_session_id, str):
@@ -195,8 +197,10 @@ def _subagent_from_payload(payload: Any, operation: str = "rlm.list_subagents") 
         raise RuntimeError(f"{operation} entry is missing session_name")
     if not isinstance(session_dir, str) or not session_dir:
         raise RuntimeError(f"{operation} entry is missing session_dir")
-    if status not in {"running", "completed", "error"}:
+    if status not in {"queued", "running", "completed", "error"}:
         raise RuntimeError(f"{operation} entry has invalid status")
+    if error is not None and not isinstance(error, str):
+        raise RuntimeError(f"{operation} entry has invalid error")
     return RLMSubagent(
         rlm_child_id=child_id,
         active_session_id=active_session_id,
@@ -204,6 +208,7 @@ def _subagent_from_payload(payload: Any, operation: str = "rlm.list_subagents") 
         session_name=session_name,
         session_dir=Path(session_dir),
         status=status,
+        error=error,
     )
 
 

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -51,6 +51,7 @@ class RlmSubagentRegistryTest(unittest.TestCase):
                         "session_name": "failed-worker",
                         "session_dir": "/tmp/parent/sub-failed",
                         "status": "error",
+                        "error": "kernel startup failed",
                     }
                 ]
             }
@@ -60,6 +61,29 @@ class RlmSubagentRegistryTest(unittest.TestCase):
             subagents = asyncio.run(rlm_module.rlm.list_subagents())
 
         self.assertEqual(subagents[0].status, "error")
+        self.assertEqual(subagents[0].error, "kernel startup failed")
+
+    def test_lists_queued_subagents_from_host(self) -> None:
+        host_request = AsyncMock(
+            return_value={
+                "subagents": [
+                    {
+                        "rlm_child_id": "sub-queued",
+                        "active_session_id": None,
+                        "session_id": None,
+                        "session_name": "queued-worker",
+                        "session_dir": "/tmp/parent/sub-queued",
+                        "status": "queued",
+                    }
+                ]
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            subagents = asyncio.run(rlm_module.rlm.list_subagents())
+
+        self.assertEqual(subagents[0].status, "queued")
+        self.assertIsNone(subagents[0].error)
 
     def test_forwards_orchestrator_chosen_name_and_model_to_host(self) -> None:
         host_request = AsyncMock(
@@ -199,6 +223,25 @@ class RlmSubagentRegistryTest(unittest.TestCase):
 
         with patch.object(rlm_module, "host_request", host_request):
             with self.assertRaisesRegex(RuntimeError, "missing rlm_child_id"):
+                asyncio.run(rlm_module.list_subagents())
+
+        host_request = AsyncMock(
+            return_value={
+                "subagents": [
+                    {
+                        "rlm_child_id": "sub-error",
+                        "active_session_id": None,
+                        "session_id": None,
+                        "session_name": "error-worker",
+                        "session_dir": "/tmp/parent/sub-error",
+                        "status": "error",
+                        "error": 500,
+                    }
+                ]
+            }
+        )
+        with patch.object(rlm_module, "host_request", host_request):
+            with self.assertRaisesRegex(RuntimeError, "invalid error"):
                 asyncio.run(rlm_module.list_subagents())
 
     def test_requires_a_default_session_name(self) -> None:


### PR DESCRIPTION
## Summary

- preserve the process-local `queued` state in `rlm.list_subagents()` instead of reporting queued children as running
- expose bounded, non-empty startup failure details through the TypeScript registry and Python `RLMSubagent`
- validate queued/error payloads in the Python runtime and document that queue/error details are process-local

This is the observability prerequisite for a later bounded FIFO RLM admission queue.

## Validation

- `npm run check`
- `env -u RLM_MAX_DEPTH npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-session-recursion.test.ts` — 97 passed
- `.venv/bin/python -m unittest test/test_subagent_registry.py` — 11 passed
- GPT-5.6 Terra adversarial review — approved after narrowing daemon persistence out of scope and adding bounded/empty-error coverage


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose queued status and bounded error details in `rlm.list_subagents`
> - Adds `'queued'` as a valid status in `RlmSubagentRegistryEntry` so callers can distinguish queued children from running ones.
> - Adds an optional `error` field to registry entries, populated when the parent process tracks a failed child run; error strings are compacted to 512 characters with a fallback default message via `normalizeRlmChildError`.
> - Updates the Python `RLMSubagent` dataclass and `_subagent_from_payload` parser to accept `'queued'` status and surface the validated error string to Python clients.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adde4cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->