### PR TITLE
fix(coding-agent): renew imported session IDs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
-- Fixed imported JSONL transcripts retaining an existing session ID and making exact saved-session lookup ambiguous.
+- Fixed imported JSONL transcripts retaining an existing session ID and making exact saved-session lookup ambiguous ([#1087](https://github.com/PrimeIntellect-ai/prime-agent/pull/1087) by [@creatifcoding](https://github.com/creatifcoding)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed imported JSONL transcripts retaining an existing session ID and making exact saved-session lookup ambiguous.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -671,11 +671,14 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		const lease = this.acquireReplacementLease(destinationPath);
 		let sessionManager: SessionManager;
 		try {
-			if (resolve(destinationPath) !== resolvedPath) {
+			const copied = resolve(destinationPath) !== resolvedPath;
+			if (copied) {
 				copyFileSync(resolvedPath, destinationPath);
 			}
 
-			sessionManager = SessionManager.open(destinationPath, sessionDir, cwdOverride);
+			sessionManager = copied
+				? SessionManager.openImportedCopy(destinationPath, sessionDir, cwdOverride)
+				: SessionManager.open(destinationPath, sessionDir, cwdOverride);
 			assertSessionCwdExists(sessionManager, this.cwd);
 		} catch (error) {
 			this.releaseUncommittedLease(lease);

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -2183,6 +2183,18 @@ export class SessionManager {
 		return new SessionManager(cwd ?? process.cwd(), dir, path, true);
 	}
 
+	/** Open a copied transcript as a new saved session with its own identity. */
+	static openImportedCopy(path: string, sessionDir?: string, cwdOverride?: string): SessionManager {
+		const manager = SessionManager.open(path, sessionDir, cwdOverride);
+		const header = manager.getHeader();
+		manager.sessionId = createSessionId();
+		if (header) {
+			header.id = manager.sessionId;
+			manager._rewriteFile();
+		}
+		return manager;
+	}
+
 	/**
 	 * Non-blocking open() for the daemon: parses off the event loop so a large load
 	 * doesn't freeze other sessions. Falls back to open() for any non-happy path so

--- a/packages/coding-agent/src/core/session-resolver.ts
+++ b/packages/coding-agent/src/core/session-resolver.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import { matchesSavedSessionSelector, normalizeSessionId } from "./session-id.js";
 import type { SessionInfo } from "./session-manager.js";
 import { SessionManager } from "./session-manager.js";
@@ -110,10 +111,14 @@ export function findClosestSessionId(
 
 function resolveExactMatch(selector: string, sessions: readonly SessionInfo[]): SessionInfo | undefined {
 	const normalizedSelector = normalizeSessionId(selector);
-	return resolveUniqueMatch(
-		selector,
-		sessions.filter((session) => normalizeSessionId(session.id) === normalizedSelector),
-	);
+	const matches = sessions.filter((session) => normalizeSessionId(session.id) === normalizedSelector);
+	if (matches.length > 1) {
+		const canonicalMatches = matches.filter((session) => basename(session.path) === `${session.id}.jsonl`);
+		if (canonicalMatches.length === 1) {
+			return canonicalMatches[0];
+		}
+	}
+	return resolveUniqueMatch(selector, matches);
 }
 
 function resolvePartialMatch(selector: string, sessions: readonly SessionInfo[]): SessionInfo | undefined {

--- a/packages/coding-agent/test/agent-session-runtime-events.test.ts
+++ b/packages/coding-agent/test/agent-session-runtime-events.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
@@ -117,5 +117,35 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 		runtimeHost.setBeforeSessionInvalidate(undefined);
 		const leaseRoot = join(runtimeHost.services.agentDir, "session-leases");
 		expect(readdirSync(leaseRoot).filter((entry) => entry.endsWith(".lock"))).toHaveLength(1);
+	});
+
+	it("assigns a new session ID to each imported copy", async () => {
+		const { runtimeHost } = await createRuntimeHost(() => undefined);
+		const cwd = runtimeHost.session.sessionManager.getCwd();
+		const sourceId = "019fd5bd-5738-752e-95c8-fdfb3e710b31";
+		const header = JSON.stringify({
+			type: "session",
+			version: 3,
+			id: sourceId,
+			timestamp: "2026-08-01T00:00:00.000Z",
+			cwd,
+		});
+		const firstSource = join(cwd, "first-import.jsonl");
+		const secondSource = join(cwd, "second-import.jsonl");
+		writeFileSync(firstSource, `${header}\n`);
+		writeFileSync(secondSource, `${header}\n`);
+
+		await runtimeHost.importFromJsonl(firstSource);
+		const firstImportedId = runtimeHost.session.sessionId;
+		const firstImportedFile = runtimeHost.session.sessionFile!;
+		await runtimeHost.importFromJsonl(secondSource);
+		const secondImportedId = runtimeHost.session.sessionId;
+		const secondImportedFile = runtimeHost.session.sessionFile!;
+
+		expect(firstImportedId).not.toBe(sourceId);
+		expect(secondImportedId).not.toBe(sourceId);
+		expect(secondImportedId).not.toBe(firstImportedId);
+		expect(JSON.parse(readFileSync(firstImportedFile, "utf8").split("\n")[0]!).id).toBe(firstImportedId);
+		expect(JSON.parse(readFileSync(secondImportedFile, "utf8").split("\n")[0]!).id).toBe(secondImportedId);
 	});
 });

--- a/packages/coding-agent/test/daemon-session-id.test.ts
+++ b/packages/coding-agent/test/daemon-session-id.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -119,6 +119,24 @@ describe("resolveDaemonSessionPath", () => {
 			createSavedSession(cwd, sessionDir, "1abcd");
 
 			await expect(resolveDaemonSessionPath("AB-CD", cwd, sessionDir)).resolves.toBe(exactPath);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("prefers the canonical file when imported aliases share an exact session ID", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-daemon-session-id-"));
+		try {
+			const cwd = join(tempDir, "project");
+			const sessionDir = join(tempDir, "sessions");
+			const sessionId = "019fd5bd-5738-752e-95c8-fdfb3e710b31";
+			const canonicalPath = createSavedSession(cwd, sessionDir, sessionId);
+			copyFileSync(canonicalPath, join(sessionDir, "imported-copy.jsonl"));
+
+			await expect(resolveDaemonSessionPath(sessionId, cwd, sessionDir)).resolves.toBe(canonicalPath);
+			await expect(resolveDaemonSessionPath("fdfb3e710b31", cwd, sessionDir)).rejects.toThrow(
+				/Ambiguous saved session "fdfb3e710b31"/,
+			);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

- assign a fresh session ID when an external JSONL transcript is copied into saved sessions
- prefer the canonical `<session-id>.jsonl` file for exact full-ID resolution when legacy imported aliases share that embedded ID
- keep partial selectors ambiguous so aliases are not silently guessed

## Regression coverage

- repeated imports of transcripts with the same embedded UUID persist different IDs
- exact full-ID lookup resolves the canonical saved session while a shared suffix remains ambiguous

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-session-runtime-events.test.ts`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-session-id.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix imported JSONL transcripts to receive new session IDs instead of retaining the source ID
> - `SessionManager.openImportedCopy` assigns a fresh session ID via `createSessionId()`, updates the header, and rewrites the file when a JSONL transcript is imported.
> - `AgentSessionRuntime.importFromJsonl` now calls `openImportedCopy` instead of `open` when the source is copied into the session directory.
> - `resolveExactMatch` in [session-resolver.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1087/files#diff-8c160122add6a6653341840c1ab53d19a5dd6e5c6ca3a45f03b434950fd410a7) prefers the canonical `${id}.jsonl` filename when duplicate IDs exist, reducing ambiguity after import.
> - Behavioral Change: imported sessions now have distinct IDs; any code that relied on imported transcripts sharing the original session ID will see different behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 096e01c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->