### PR TITLE
feat(tui): word/line selection, click counting, persistent highlight

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 - Added double-click word selection, triple-click line selection, and word-granularity drag selection in the fullscreen TUI.
+- Changed click counting to use word-level proximity instead of exact column match, so slight mouse drift between clicks still registers multi-clicks.
+- Fixed selection anchor mutating during word/line drag by computing the effective range from the initial word/line boundary.
+- Changed fullscreen mouse selection to keep the highlight visible after release instead of clearing immediately.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added double-click word selection, triple-click line selection, and word-granularity drag selection in the fullscreen TUI.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -139,7 +139,22 @@ export class FullscreenViewport {
 	private orderedSelection(): { start: SelectionPoint; end: SelectionPoint } | null {
 		const a = this.selectionAnchor;
 		const b = this.selectionHead;
-		if (!a || !b || (a.line === b.line && a.col === b.col)) return null;
+		if (!a || !b) return null;
+
+		// For word/line granularity the anchor is the click position and head is the
+		// drag target; the effective range spans the initial word/line plus the head.
+		if (
+			(this.selectionGranularity === "word" || this.selectionGranularity === "line") &&
+			this.selectionInitialRange
+		) {
+			const initial = this.selectionInitialRange;
+			const start = this.compareSelectionPoints(b, initial.start) < 0 ? b : initial.start;
+			const end = this.compareSelectionPoints(b, initial.end) > 0 ? b : initial.end;
+			if (this.compareSelectionPoints(start, end) === 0) return null;
+			return { start, end };
+		}
+
+		if (a.line === b.line && a.col === b.col) return null;
 		const flipped = a.line > b.line || (a.line === b.line && a.col > b.col);
 		return flipped ? { start: b, end: a } : { start: a, end: b };
 	}
@@ -201,7 +216,7 @@ export class FullscreenViewport {
 		}
 		const text = stripAnsi(this.lastTranscript[line] ?? "");
 		const word = this.wordAtColumn(text, Math.max(0, screenCol));
-		this.selectionAnchor = { line, col: word.start };
+		this.selectionAnchor = { line, col: Math.max(0, screenCol) };
 		this.selectionHead = { line, col: word.end };
 		this.selectionInitialRange = {
 			start: { line, col: word.start },
@@ -213,7 +228,7 @@ export class FullscreenViewport {
 		return true;
 	}
 
-	beginLineSelection(screenRow: number, _screenCol: number): boolean {
+	beginLineSelection(screenRow: number, screenCol: number): boolean {
 		const line = this.transcriptLineForScreenRow(screenRow, false);
 		if (line === null) {
 			this.clearSelection();
@@ -221,7 +236,7 @@ export class FullscreenViewport {
 		}
 		const text = stripAnsi(this.lastTranscript[line] ?? "");
 		const width = visibleWidth(text);
-		this.selectionAnchor = { line, col: 0 };
+		this.selectionAnchor = { line, col: Math.max(0, screenCol) };
 		this.selectionHead = { line, col: width };
 		this.selectionInitialRange = {
 			start: { line, col: 0 },
@@ -243,6 +258,14 @@ export class FullscreenViewport {
 			start = end;
 		}
 		return { start, end: start };
+	}
+
+	/** Word segment boundaries (terminal columns) at a screen position, or null outside transcript. */
+	wordRangeAt(screenRow: number, screenCol: number): { start: number; end: number } | null {
+		const line = this.transcriptLineForScreenRow(screenRow, false);
+		if (line === null) return null;
+		const text = stripAnsi(this.lastTranscript[line] ?? "");
+		return this.wordAtColumn(text, Math.max(0, screenCol));
 	}
 
 	extendSelection(screenRow: number, screenCol: number): void {
@@ -268,29 +291,13 @@ export class FullscreenViewport {
 			const text = stripAnsi(this.lastTranscript[line] ?? "");
 			const word = this.wordAtColumn(text, clampedCol);
 			if (line < initial.start.line || (line === initial.start.line && clampedCol < initial.start.col)) {
-				// Dragging left/up: anchor at initial word end, head at dragged word start
-				this.selectionAnchor = { line: initial.end.line, col: initial.end.col };
 				this.selectionHead = { line, col: word.start };
 			} else {
-				// Dragging right/down: anchor at initial word start, head at dragged word end
-				this.selectionAnchor = { line: initial.start.line, col: initial.start.col };
 				this.selectionHead = { line, col: word.end };
 			}
 		} else {
-			// "line" granularity: select whole lines
-			const initialText = stripAnsi(this.lastTranscript[initial.start.line] ?? "");
-			const initialWidth = visibleWidth(initialText);
-			const dragText = stripAnsi(this.lastTranscript[line] ?? "");
-			if (line < initial.start.line) {
-				this.selectionAnchor = { line: initial.start.line, col: initialWidth };
-				this.selectionHead = { line, col: 0 };
-			} else if (line > initial.start.line) {
-				this.selectionAnchor = { line: initial.start.line, col: 0 };
-				this.selectionHead = { line, col: visibleWidth(dragText) };
-			} else {
-				this.selectionAnchor = { line: initial.start.line, col: 0 };
-				this.selectionHead = { line: initial.start.line, col: initialWidth };
-			}
+			const text = stripAnsi(this.lastTranscript[line] ?? "");
+			this.selectionHead = line < initial.start.line ? { line, col: 0 } : { line, col: visibleWidth(text) };
 		}
 	}
 
@@ -335,13 +342,10 @@ export class FullscreenViewport {
 			return null;
 		}
 		const sel = this.orderedSelection();
-		const text = sel
-			? this.selectionMode === "table"
-				? this.extractTableSelectionText(this.lastTranscript, sel)
-				: this.extractSelectionText(this.lastTranscript, sel)
-			: null;
-		this.clearSelection();
-		return text;
+		if (!sel) return null;
+		return this.selectionMode === "table"
+			? this.extractTableSelectionText(this.lastTranscript, sel)
+			: this.extractSelectionText(this.lastTranscript, sel);
 	}
 
 	extendActiveSelection(screenRow: number, screenCol: number): void {
@@ -421,7 +425,6 @@ export class FullscreenViewport {
 		const active = this.activeFrameSelection;
 		const sourceLines = active?.frame ?? this.lastFrame;
 		const regions = active?.regions ?? this.frameSelectionRegions;
-		this.clearSelection();
 		if (!sel) return null;
 		return this.extractFrameSelectionText(sourceLines, regions, sel);
 	}

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -7,7 +7,7 @@
 
 import type { TableCellSelectionRegion } from "./selection-metadata.js";
 import { isImageLine } from "./terminal-image.js";
-import { sliceByColumn, stripAnsi, visibleWidth } from "./utils.js";
+import { getWordSegmenter, sliceByColumn, stripAnsi, visibleWidth } from "./utils.js";
 
 export const FULLSCREEN_MIN_TRANSCRIPT_ROWS = 3;
 
@@ -71,6 +71,8 @@ interface TableSelectionRange {
 
 type SelectionMode = "transcript" | "table" | "frame";
 
+type SelectionGranularity = "character" | "word" | "line";
+
 export class FullscreenViewport {
 	private scrollTop = 0;
 	private following = true;
@@ -90,6 +92,8 @@ export class FullscreenViewport {
 	private selectionAnchor: SelectionPoint | null = null;
 	private selectionHead: SelectionPoint | null = null;
 	private selectionMode: SelectionMode | null = null;
+	private selectionGranularity: SelectionGranularity = "character";
+	private selectionInitialRange: { start: SelectionPoint; end: SelectionPoint } | null = null;
 
 	/**
 	 * Compose a frame of exactly `height` lines: scrolled transcript window on
@@ -175,6 +179,8 @@ export class FullscreenViewport {
 		const point = { line, col: Math.max(0, screenCol) };
 		this.selectionAnchor = point;
 		this.selectionHead = { ...point };
+		this.selectionGranularity = "character";
+		this.selectionInitialRange = null;
 		const table = this.tableAtPoint(point);
 		const tableCell = table ? this.closestTableCell(table, point) : null;
 		if (table && tableCell) {
@@ -187,11 +193,105 @@ export class FullscreenViewport {
 		return true;
 	}
 
+	beginWordSelection(screenRow: number, screenCol: number): boolean {
+		const line = this.transcriptLineForScreenRow(screenRow, false);
+		if (line === null) {
+			this.clearSelection();
+			return false;
+		}
+		const text = stripAnsi(this.lastTranscript[line] ?? "");
+		const word = this.wordAtColumn(text, Math.max(0, screenCol));
+		this.selectionAnchor = { line, col: word.start };
+		this.selectionHead = { line, col: word.end };
+		this.selectionInitialRange = {
+			start: { line, col: word.start },
+			end: { line, col: word.end },
+		};
+		this.selectionGranularity = "word";
+		this.selectionMode = "transcript";
+		this.activeTableSelection = null;
+		return true;
+	}
+
+	beginLineSelection(screenRow: number, _screenCol: number): boolean {
+		const line = this.transcriptLineForScreenRow(screenRow, false);
+		if (line === null) {
+			this.clearSelection();
+			return false;
+		}
+		const text = stripAnsi(this.lastTranscript[line] ?? "");
+		const width = visibleWidth(text);
+		this.selectionAnchor = { line, col: 0 };
+		this.selectionHead = { line, col: width };
+		this.selectionInitialRange = {
+			start: { line, col: 0 },
+			end: { line, col: width },
+		};
+		this.selectionGranularity = "line";
+		this.selectionMode = "transcript";
+		this.activeTableSelection = null;
+		return true;
+	}
+
+	private wordAtColumn(text: string, col: number): { start: number; end: number } {
+		const segmenter = getWordSegmenter();
+		let start = 0;
+		for (const { segment } of segmenter.segment(text)) {
+			const segWidth = visibleWidth(segment);
+			const end = start + segWidth;
+			if (col >= start && col < end) return { start, end };
+			start = end;
+		}
+		return { start, end: start };
+	}
+
 	extendSelection(screenRow: number, screenCol: number): void {
 		if (!this.selectionAnchor || (this.selectionMode !== "transcript" && this.selectionMode !== "table")) return;
 		const line = this.transcriptLineForScreenRow(screenRow, true);
 		if (line === null) return;
-		this.selectionHead = { line, col: Math.max(0, screenCol) };
+
+		if (this.selectionMode === "table") {
+			this.selectionHead = { line, col: Math.max(0, screenCol) };
+			return;
+		}
+
+		const clampedCol = Math.max(0, screenCol);
+
+		if (this.selectionGranularity === "character" || !this.selectionInitialRange) {
+			this.selectionHead = { line, col: clampedCol };
+			return;
+		}
+
+		const initial = this.selectionInitialRange;
+
+		if (this.selectionGranularity === "word") {
+			const text = stripAnsi(this.lastTranscript[line] ?? "");
+			const word = this.wordAtColumn(text, clampedCol);
+			if (line < initial.start.line || (line === initial.start.line && clampedCol < initial.start.col)) {
+				// Dragging left/up: anchor at initial word end, head at dragged word start
+				this.selectionAnchor = { line: initial.end.line, col: initial.end.col };
+				this.selectionHead = { line, col: word.start };
+			} else {
+				// Dragging right/down: anchor at initial word start, head at dragged word end
+				this.selectionAnchor = { line: initial.start.line, col: initial.start.col };
+				this.selectionHead = { line, col: word.end };
+			}
+		} else {
+			// "line" granularity: select whole lines
+			const initialText = stripAnsi(this.lastTranscript[initial.start.line] ?? "");
+			const initialWidth = visibleWidth(initialText);
+			const dragText = stripAnsi(this.lastTranscript[line] ?? "");
+			if (line < initial.start.line) {
+				this.selectionAnchor = { line: initial.start.line, col: initialWidth };
+				this.selectionHead = { line, col: 0 };
+			} else if (line > initial.start.line) {
+				this.selectionAnchor = { line: initial.start.line, col: 0 };
+				this.selectionHead = { line, col: visibleWidth(dragText) };
+			} else {
+				this.selectionAnchor = { line: initial.start.line, col: 0 };
+				this.selectionHead = { line: initial.start.line, col: initialWidth };
+			}
+		}
 	}
 
 	selectionAutoScrollDirection(screenRow: number): SelectionScrollDirection | null {
@@ -297,6 +397,8 @@ export class FullscreenViewport {
 		};
 		this.selectionAnchor = point;
 		this.selectionHead = { ...point };
+		this.selectionGranularity = "character";
+		this.selectionInitialRange = null;
 		this.selectionMode = "frame";
 		return true;
 	}
@@ -617,6 +719,8 @@ export class FullscreenViewport {
 		this.selectionAnchor = null;
 		this.selectionHead = null;
 		this.selectionMode = null;
+		this.selectionGranularity = "character";
+		this.selectionInitialRange = null;
 		this.activeFrameSelection = null;
 		this.activeTableSelection = null;
 	}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -353,7 +353,8 @@ export class TUI extends Container {
 	private static readonly DOUBLE_CLICK_MS = 500;
 	private lastClickTime = 0;
 	private lastClickRow = -1;
-	private lastClickCol = -1;
+	private lastClickWordStart = -1;
+	private lastClickWordEnd = -1;
 	private clickCount = 0;
 	private selectionAutoScrollTimer: NodeJS.Timeout | undefined;
 	private selectionAutoScrollDirection: SelectionScrollDirection | null = null;
@@ -798,20 +799,23 @@ export class TUI extends Container {
 		this.selectionAutoScrollTimer.unref();
 	}
 
-	private countClick(screenRow: number, screenCol: number): number {
+	private countClick(screenRow: number, screenCol: number, viewport: FullscreenViewport): number {
 		const now = Date.now();
-		if (
-			now - this.lastClickTime <= TUI.DOUBLE_CLICK_MS &&
+		const word = viewport.wordRangeAt(screenRow, screenCol);
+		const sameWord =
 			screenRow === this.lastClickRow &&
-			screenCol === this.lastClickCol
-		) {
+			word !== null &&
+			word.start === this.lastClickWordStart &&
+			word.end === this.lastClickWordEnd;
+		if (now - this.lastClickTime <= TUI.DOUBLE_CLICK_MS && sameWord) {
 			this.clickCount = (this.clickCount % 3) + 1;
 		} else {
 			this.clickCount = 1;
 		}
 		this.lastClickTime = now;
 		this.lastClickRow = screenRow;
-		this.lastClickCol = screenCol;
+		this.lastClickWordStart = word?.start ?? screenCol;
+		this.lastClickWordEnd = word?.end ?? screenCol;
 		return this.clickCount;
 	}
 
@@ -924,7 +928,7 @@ export class TUI extends Container {
 					this.scrollBy(TUI.WHEEL_SCROLL_LINES);
 				} else if (event.button === MOUSE_BUTTON_LEFT && event.press && !event.motion) {
 					this.stopSelectionAutoScroll();
-					const clicks = this.countClick(event.y - 1, event.x - 1);
+					const clicks = this.countClick(event.y - 1, event.x - 1, viewport);
 					let began = false;
 					if (clicks === 2) {
 						began = viewport.beginWordSelection(event.y - 1, event.x - 1);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -350,6 +350,11 @@ export class TUI extends Container {
 	private static readonly WHEEL_SCROLL_LINES = 3;
 	private static readonly SELECTION_AUTO_SCROLL_DELAY_MS = 150;
 	private static readonly SELECTION_AUTO_SCROLL_INTERVAL_MS = 50;
+	private static readonly DOUBLE_CLICK_MS = 500;
+	private lastClickTime = 0;
+	private lastClickRow = -1;
+	private lastClickCol = -1;
+	private clickCount = 0;
 	private selectionAutoScrollTimer: NodeJS.Timeout | undefined;
 	private selectionAutoScrollDirection: SelectionScrollDirection | null = null;
 	private selectionAutoScrollRow = 0;
@@ -793,6 +798,23 @@ export class TUI extends Container {
 		this.selectionAutoScrollTimer.unref();
 	}
 
+	private countClick(screenRow: number, screenCol: number): number {
+		const now = Date.now();
+		if (
+			now - this.lastClickTime <= TUI.DOUBLE_CLICK_MS &&
+			screenRow === this.lastClickRow &&
+			screenCol === this.lastClickCol
+		) {
+			this.clickCount = (this.clickCount % 3) + 1;
+		} else {
+			this.clickCount = 1;
+		}
+		this.lastClickTime = now;
+		this.lastClickRow = screenRow;
+		this.lastClickCol = screenCol;
+		return this.clickCount;
+	}
+
 	private stopSelectionAutoScroll(): void {
 		if (this.selectionAutoScrollTimer) {
 			clearTimeout(this.selectionAutoScrollTimer);
@@ -902,7 +924,16 @@ export class TUI extends Container {
 					this.scrollBy(TUI.WHEEL_SCROLL_LINES);
 				} else if (event.button === MOUSE_BUTTON_LEFT && event.press && !event.motion) {
 					this.stopSelectionAutoScroll();
-					if (!viewport.beginSelection(event.y - 1, event.x - 1)) {
+					const clicks = this.countClick(event.y - 1, event.x - 1);
+					let began = false;
+					if (clicks === 2) {
+						began = viewport.beginWordSelection(event.y - 1, event.x - 1);
+					} else if (clicks === 3) {
+						began = viewport.beginLineSelection(event.y - 1, event.x - 1);
+					} else {
+						began = viewport.beginSelection(event.y - 1, event.x - 1);
+					}
+					if (!began) {
 						viewport.beginFrameSelection(event.y - 1, event.x - 1);
 					}
 					this.requestRender();

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -3,11 +3,21 @@ import { eastAsianWidth } from "get-east-asian-width";
 // Grapheme segmenter (shared instance)
 const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
+// Word-level segmenter (shared instance) for double-click word selection
+const wordSegmenter = new Intl.Segmenter(undefined, { granularity: "word" });
+
 /**
  * Get the shared grapheme segmenter instance.
  */
 export function getSegmenter(): Intl.Segmenter {
 	return segmenter;
+}
+
+/**
+ * Get the shared word-level segmenter instance.
+ */
+export function getWordSegmenter(): Intl.Segmenter {
+	return wordSegmenter;
 }
 
 /**

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -1033,4 +1033,168 @@ describe("TUI fullscreen mode", () => {
 
 		tui.stop();
 	});
+
+	it("double-click selects a word", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Screen row 3 = transcript line 15 ("hello world foo bar")
+		// "world" is at cols 6-10 (0-based). Click at col 7 -> SGR col=8, row=4.
+		// First click (press + release)
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// Second click (press + release) -- double-click
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["world"]);
+
+		tui.stop();
+	});
+
+	it("triple-click selects a full line", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Triple-click at the same position
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		// Click 2 (double-click)
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		copies.length = 0; // double-click already copied the word
+		// Click 3 (triple-click)
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["hello world foo bar"]);
+
+		tui.stop();
+	});
+
+	it("double-click and drag extends selection by words", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Double-click on "world" then drag right into "foo" without releasing
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		// Click 2 -- double-click starts word selection
+		terminal.sendInput("\x1b[<0;8;4M");
+		// Drag to "foo" at col 13 -> SGR col=14
+		terminal.sendInput("\x1b[<32;14;4M");
+		// Release
+		terminal.sendInput("\x1b[<0;14;4m");
+		await terminal.waitForRender();
+
+		// Should select "world foo" (word boundary snapping)
+		assert.deepStrictEqual(copies, ["world foo"]);
+
+		tui.stop();
+	});
+
+	it("double-click and drag left extends backward by words", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Double-click on "world" then drag left into "hello"
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		// Click 2 -- double-click starts word selection
+		terminal.sendInput("\x1b[<0;8;4M");
+		// Drag left to "hello" at col 2 -> SGR col=3
+		terminal.sendInput("\x1b[<32;3;4M");
+		// Release
+		terminal.sendInput("\x1b[<0;3;4m");
+		await terminal.waitForRender();
+
+		// Should select "hello world" (from start of "hello" to end of "world")
+		assert.deepStrictEqual(copies, ["hello world"]);
+
+		tui.stop();
+	});
+
+	it("click count resets after the double-click interval", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// First click
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// Wait past the 500ms double-click interval
+		await new Promise((resolve) => setTimeout(resolve, 600));
+
+		// Second click -- should be treated as a new single click, not a double-click
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// No word selection -- single click copies nothing
+		assert.deepStrictEqual(copies, []);
+
+		tui.stop();
+	});
+
+	it("click count resets on a different row", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Click at row 4, col 8
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// Click at row 5, col 8 -- different row
+		terminal.sendInput("\x1b[<0;8;5M");
+		terminal.sendInput("\x1b[<0;8;5m");
+		await terminal.waitForRender();
+
+		// No word selection
+		assert.deepStrictEqual(copies, []);
+
+		tui.stop();
+	});
 });

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -1197,4 +1197,161 @@ describe("TUI fullscreen mode", () => {
 
 		tui.stop();
 	});
+
+	it("double-click and drag across lines extends by words", async () => {
+		const testLines = lines(20);
+		testLines[14] = "alpha beta gamma";
+		testLines[15] = "delta epsilon zeta";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Double-click on "beta" (line 14, col 7 → SGR col 8, row 3)
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;3M");
+		terminal.sendInput("\x1b[<0;8;3m");
+		await terminal.waitForRender();
+		// Click 2 -- double-click starts word selection on "beta"
+		terminal.sendInput("\x1b[<0;8;3M");
+		// Drag to "epsilon" (line 15, col 10 → SGR col 11, row 4)
+		terminal.sendInput("\x1b[<32;11;4M");
+		// Release
+		terminal.sendInput("\x1b[<0;11;4m");
+		await terminal.waitForRender();
+
+		// Should select from "beta" start through "epsilon" end, spanning both lines
+		assert.deepStrictEqual(copies, ["beta gamma\ndelta epsilon"]);
+
+		tui.stop();
+	});
+
+	it("triple-click and drag extends by whole lines", async () => {
+		const testLines = lines(20);
+		testLines[14] = "alpha beta gamma";
+		testLines[15] = "delta epsilon zeta";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Triple-click on line 14 (col 3, row 3 → SGR col 4, row 3)
+		// Click 1
+		terminal.sendInput("\x1b[<0;4;3M");
+		terminal.sendInput("\x1b[<0;4;3m");
+		await terminal.waitForRender();
+		// Click 2 (double-click)
+		terminal.sendInput("\x1b[<0;4;3M");
+		terminal.sendInput("\x1b[<0;4;3m");
+		await terminal.waitForRender();
+		copies.length = 0;
+		// Click 3 (triple-click -- selects full line)
+		terminal.sendInput("\x1b[<0;4;3M");
+		// Drag down to line 15 (col 5, row 4 → SGR col 6, row 4)
+		terminal.sendInput("\x1b[<32;6;4M");
+		// Release
+		terminal.sendInput("\x1b[<0;6;4m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["alpha beta gamma\ndelta epsilon zeta"]);
+
+		tui.stop();
+	});
+
+	it("double-clicking whitespace copies nothing", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Double-click on the space between "hello" and "world" (col 5 → SGR col 6, row 4)
+		// Click 1
+		terminal.sendInput("\x1b[<0;6;4M");
+		terminal.sendInput("\x1b[<0;6;4m");
+		await terminal.waitForRender();
+		// Click 2
+		terminal.sendInput("\x1b[<0;6;4M");
+		terminal.sendInput("\x1b[<0;6;4m");
+		await terminal.waitForRender();
+
+		// Whitespace selection trims to null -- nothing copied
+		assert.deepStrictEqual(copies, []);
+
+		tui.stop();
+	});
+
+	it("double-click selects CJK wide-character words", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello \u4e16\u754c bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// "世界" occupies visible cols 6-9. Click at col 7 → SGR col 8, row 4.
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		// Click 2
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["\u4e16\u754c"]);
+
+		tui.stop();
+	});
+
+	it("selection remains highlighted after mouse release", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Drag-select "hello" (cols 0-4 on line 15 = screen row 3)
+		// SGR col 1 → internal col 0, SGR col 6 → internal col 5
+		terminal.sendInput("\x1b[<0;1;4M");
+		terminal.sendInput("\x1b[<32;6;4M");
+		await terminal.waitForRender();
+
+		// Release
+		terminal.sendInput("\x1b[<0;6;4m");
+		await terminal.waitForRender();
+
+		// Text was copied
+		assert.deepStrictEqual(copies, ["hello"]);
+
+		// Selection highlight persists after release — force a full repaint
+		// and verify the highlight is re-applied
+		terminal.clearWrites();
+		terminal.resize(40, 11);
+		await terminal.waitForRender();
+		assert.ok(terminal.getWrites().includes("\x1b[7m"), "selection highlight visible after release");
+
+		// A plain click clears the persisted selection
+		terminal.clearWrites();
+		terminal.resize(40, 10);
+		await terminal.waitForRender();
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// Force repaint to check the highlight is gone
+		terminal.clearWrites();
+		terminal.resize(40, 11);
+		await terminal.waitForRender();
+		assert.ok(!terminal.getWrites().includes("\x1b[7m"), "selection cleared by plain click");
+
+		tui.stop();
+	});
 });


### PR DESCRIPTION
## Summary

Adds double-click word selection, triple-click line selection, word-granularity drag, and persistent selection highlight in the fullscreen TUI.

## Changes

**`packages/tui/src/fullscreen.ts`**
- `beginWordSelection()` / `beginLineSelection()` — select a word or full line on double/triple-click
- `wordAtColumn()` — Unicode-correct word boundary detection via `Intl.Segmenter` (handles CJK, wide chars)
- `wordRangeAt()` — public accessor for click-counting word proximity checks
- `extendSelection()` — word/line granularity snapping during drag (anchor stays stable, only head moves)
- `orderedSelection()` — computes effective selection range from `selectionInitialRange` + head for word/line modes
- `endSelection()` / `endFrameSelection()` — no longer call `clearSelection()`; highlight persists after release

**`packages/tui/src/tui.ts`**
- `countClick()` — uses word-level proximity instead of exact column match, so slight mouse drift still registers multi-clicks
- Click count fields changed from `lastClickCol` to `lastClickWordStart/End`

**`packages/tui/test/fullscreen.test.ts`**
- 5 new tests: word selection, line selection, word drag (right/left), click reset by time/position, multi-line word drag, triple-click drag, whitespace double-click, CJK wide chars, persistent highlight after release

## E2E Verified

Tested in a real terminal via tmux with `--daemon-socket` isolation:
- Double-click copies the correct word
- Triple-click copies the full line
- Word-granularity drag snaps correctly to word boundaries in both directions
- Selection highlight persists after mouse release, clears on next click

Closes #1088


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add word/line selection and persistent highlight to fullscreen TUI transcript
> - Double-click starts word-granularity selection and triple-click selects the entire line in the fullscreen transcript viewport.
> - Drag after double/triple-click snaps the selection head to word or line boundaries without mutating the anchor, using a derived `selectionInitialRange`.
> - Click counting uses word-level proximity via `Intl.Segmenter` within a 500ms window, so small mouse drift doesn't break double/triple-click recognition.
> - Selection highlight now persists after mouse release; `endSelection` and `endFrameSelection` return the copied text but no longer clear the selection state. A subsequent plain click clears it.
> - Behavioral Change: previously, releasing the mouse cleared the selection highlight immediately; it now stays visible until the next click.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 249545a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->