### PR TITLE
docs(coding-agent): document steer-only agent messages

### DIFF
--- a/packages/coding-agent/docs/long-running-agents.md
+++ b/packages/coding-agent/docs/long-running-agents.md
@@ -84,7 +84,6 @@ receipt = await agent_message.send(
     "Recheck the endpoint after the latest edit",
     receiver_role="sibling",
     receiver_name="api-reviewer",
-    mode="auto",
 )
 print(receipt["deliveryStatus"])
 ```
@@ -101,13 +100,13 @@ await agent_message.send(
 )
 ```
 
-Delivery modes are:
-
-- `auto`: steer a busy target and deliver immediately to an idle target;
-- `steer`: intentionally inject the message into active work; and
-- `follow_up`: wait until the target's current work finishes.
-
-A receipt is `delivered` when it reached an idle target's context or `queued` when accepted for later delivery. `agent_message.send("all", message)` broadcasts only within the family roster. The daemon derives sender identity and enforces message-size, rate, and pending-queue limits.
+Agent messages always use steering delivery. An idle target receives the
+message immediately; a busy target accepts it for delivery at the next steering
+boundary. A receipt is `delivered` when the message reaches an idle target's
+context, or `queued` when it is accepted for later delivery. `send` does not
+wait for a queued message to run. `agent_message.send("all", message)`
+broadcasts only within the family roster. The daemon derives sender identity
+and enforces message-size, rate, and pending-queue limits.
 
 ## Heartbeats and Scheduled Prompts
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -222,7 +222,7 @@ RPC clients can use the same daemon-owned coordination features as the interacti
 
 | Command | Fields | Successful response data |
 |---------|--------|--------------------------|
-| `send_message` | `targetActiveSessionId`, `message`, optional `deliveryMode` (`auto`, `steer`, `follow_up`) | Agent-message delivery receipt |
+| `send_message` | `targetActiveSessionId`, `message` | Agent-message delivery receipt; messages always use steering delivery |
 | `agent_messages_status` | none | Messaging safety status |
 | `agent_messages_pause` | none | Updated messaging safety status |
 | `agent_messages_resume` | none | Updated messaging safety status |


### PR DESCRIPTION
## Summary

- remove the obsolete `mode="auto"` argument from the `agent_message.send` example
- document that Agent messages always use steering delivery
- align the RPC `send_message` fields with the current public API

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/kernel-agent-message-skill.test.ts`
- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document steer-only delivery for coding agent messages
> Updates docs to reflect that agent messages always use steering delivery, removing the `mode` parameter and `deliveryMode` field from examples.
>
> - [long-running-agents.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1091/files#diff-9e53b518ab81ad5c6d3096b998bb610e513acb3409edac64c558769067e5fc3a): removes `mode="auto"` from `agent_message.send(...)` and replaces the delivery modes section with a description of steering-only behavior (idle targets receive immediately, busy targets queue until next steering boundary).
> - [rpc.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1091/files#diff-9cdce3c0b76820edb3a48842524d4add29e3355a12afc8a7fe292492ee408182): removes the optional `deliveryMode` field from the `send_message` command; fields are now `targetActiveSessionId` and `message` only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb18903.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->