### PR TITLE
Add current working directory to editor status line

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added the current working directory to the editor status line.
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5965,9 +5965,10 @@ export class InteractiveMode {
 		const modelLabel = this.getModelTrayLabel();
 		const hasChildren = this.options.sessionHasChildren === true || (this.subagentSnapshots?.size ?? 0) > 0;
 		const depthLabel = formatAgentDepthLabel(this.options.sessionDepth, hasChildren);
+		const cwdLabel = truncatePathMiddle(formatSplashCwd(this.getCurrentCwd()), 30);
 		const shortcutsHint = this.getShortcutsTrayHint();
 		const agentsHint = this.getAgentsViewTrayHint();
-		return [agentsHint, depthLabel, modelLabel, shortcutsHint]
+		return [agentsHint, depthLabel, modelLabel, cwdLabel, shortcutsHint]
 			.filter((label): label is string => label !== undefined)
 			.join("  ");
 	}


### PR DESCRIPTION
## Summary

Adds the current working directory to the editor status line (tray) so it is always visible during active use.

**Before:** `agents/resume  GLM-5.2 • max`
**After:** `agents/resume  GLM-5.2 • max  ~/pets/prime-agent`

The cwd is shown as a separate segment (double-space separated, same as other segments), formatted home-relative via the existing `formatSplashCwd()` helper, and truncated to 30 characters via `truncatePathMiddle()` for long paths.

Closes #1090

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add current working directory to the editor status line
> Adds a `cwdLabel` to the tray/status line in [`interactive-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1092/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) via `InteractiveMode.getTrayLocationLabel`. The CWD is formatted with `formatSplashCwd` and truncated to 30 characters using `truncatePathMiddle`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92ade39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->