### PR TITLE
feat(coding-agent): add /exit as an alias for /quit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Added `/exit` as an alias for `/quit` ([#1093](https://github.com/PrimeIntellect-ai/prime-agent/issues/1093)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -60,7 +60,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/reload` | Reload keybindings, extensions, skills, prompts, and context files |
 | `/hotkeys` | Show all keyboard shortcuts |
 | `/changelog` | Display version history |
-| `/quit` | Quit Prime Agent |
+| `/quit`, `/exit` | Quit Prime Agent |
 
 ## Message Queue
 

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -202,6 +202,7 @@ const BUILTIN_SLASH_COMMAND_ALIASES: ReadonlyArray<BuiltinSlashCommandAlias> = [
 	{ name: "thinking", aliasFor: "effort" },
 	{ name: "rename", aliasFor: "name" },
 	{ name: "side", aliasFor: "btw" },
+	{ name: "exit", aliasFor: "quit" },
 ];
 
 function buildBuiltinSlashCommands(): ReadonlyArray<BuiltinSlashCommand> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4840,7 +4840,7 @@ export class InteractiveMode {
 					this.editor.setText("");
 					return;
 				}
-				if (text === "/quit") {
+				if (commandName === "quit") {
 					this.editor.setText("");
 					await this.shutdown();
 					return;

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -193,6 +193,23 @@ describe("slash command aliases", () => {
 			isAlias: true,
 		});
 	});
+
+	test("resolves /exit to /quit through the alias path", () => {
+		const parsed = parseSlashCommand("/exit");
+
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "quit")).toMatchObject({
+			aliases: ["exit"],
+		});
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "exit")).toBeUndefined();
+		expect(isBuiltinSlashCommandName("exit")).toBe(true);
+		expect(resolveBuiltinSlashCommandName("exit")).toBe("quit");
+		expect(resolveSlashCommand(parsed!)).toEqual({
+			name: "quit",
+			args: "",
+			originalName: "exit",
+			isAlias: true,
+		});
+	});
 });
 
 describe("session slash commands", () => {


### PR DESCRIPTION
## Summary

Adds `/exit` as an alias for `/quit` so users migrating from other terminal coding agents can quit Prime Agent as expected.

Closes #1093

## Changes

- `slash-commands.ts`: registered `/exit` in `BUILTIN_SLASH_COMMAND_ALIASES` (`exit` -> `quit`), consistent with `/clear` -> `/new` and `/side` -> `/btw`. Autocomplete, side-conversation rejection, and `isBuiltinSlashCommandName` pick it up automatically.
- `interactive-mode.ts`: changed the shutdown check from the raw-text `text === "/quit"` to the resolved `commandName === "quit"`. This was required for the alias to take effect — previously the literal comparison bypassed alias resolution.
- `slash-commands.test.ts`: added `/exit` -> `/quit` alias path test.
- `docs/usage.md` + `CHANGELOG.md`: documented the alias.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/slash-commands.test.ts` — 19/19 pass
- `npm run check` — exit 0, no warnings

There is also an unrelated local change to `packages/coding-agent/skills/websearch/...` in this worktree; it was not included.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/exit` as an alias for `/quit` in the coding agent interactive mode
> Registers `exit` in `BUILTIN_SLASH_COMMAND_ALIASES` so `/exit` resolves to the canonical `quit` command. The quit check in `InteractiveMode` is updated to match on the parsed command name rather than raw text, so both `/quit` and `/exit` trigger shutdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5cf423.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->