### PR TITLE
fix(coding-agent): wait for the kernel to exit in dispose

### DIFF
--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -39,6 +39,15 @@ const SNAPSHOT_MAX_OUTPUT_CHARS = 1_000_000;
 // on-disk copy is the fallback if this is exceeded.
 const SNAPSHOT_DISPOSE_TIMEOUT_MS = 5000;
 const KERNEL_ABORT_GRACE_MS = 1000;
+// An awaited dispose() must outlive the kill: the kernel is spawned with `cwd`
+// set to its temp dir, and Windows keeps that directory locked until the
+// process is really gone, so a caller deleting it after dispose() gets EPERM.
+const KERNEL_EXIT_TIMEOUT_MS = 2000;
+const KERNEL_EXIT_POLL_INTERVAL_MS = 10;
+// rmSync's own maxRetries does not cover this: the native implementation
+// surfaces the directory-level EPERM without retrying.
+const TEMP_DIR_REMOVE_ATTEMPTS = 10;
+const TEMP_DIR_REMOVE_DELAY_MS = 20;
 const KERNEL_BUSY_REUSE_WAIT_MS = 5000;
 const KERNEL_BUSY_INTERRUPT_INTERVAL_MS = 500;
 const MAX_LATE_SENT_AGENT_MESSAGE_HANDLERS = 256;
@@ -1285,7 +1294,55 @@ export class KernelManager {
 		await this.control.send(encode(msg, this.connection.key));
 	}
 
-	private cleanupResources(killSignal: NodeJS.Signals = "SIGTERM"): void {
+	/**
+	 * Resolves once the killed kernel has actually exited, or the timeout
+	 * elapses. A forked kernel is not a direct child and emits no "exit", so it
+	 * is polled the same way `forkedKernelDied` checks liveness.
+	 */
+	private static async waitForKernelExit(child: ChildProcess | undefined, pid: number | undefined): Promise<void> {
+		const deadline = Date.now() + KERNEL_EXIT_TIMEOUT_MS;
+
+		if (child && child.exitCode === null && child.signalCode === null) {
+			await new Promise<void>((resolve) => {
+				const done = () => {
+					globalThis.clearTimeout(timer);
+					child.removeListener("exit", done);
+					resolve();
+				};
+				const timer = globalThis.setTimeout(done, KERNEL_EXIT_TIMEOUT_MS);
+				if (typeof timer === "object" && "unref" in timer) timer.unref();
+				child.once("exit", done);
+			});
+			return;
+		}
+
+		if (pid === undefined) return;
+		while (Date.now() < deadline) {
+			try {
+				process.kill(pid, 0);
+			} catch (error) {
+				// ESRCH means gone. EPERM means the pid exists but is not ours to
+				// signal, which still counts as alive.
+				if (!(error instanceof Error && (error as NodeJS.ErrnoException).code === "EPERM")) return;
+			}
+			await new Promise((resolve) => globalThis.setTimeout(resolve, KERNEL_EXIT_POLL_INTERVAL_MS));
+		}
+	}
+
+	/** Removes a kernel temp dir, retrying while the OS still holds a handle. */
+	private static async removeTempDirWithRetries(dir: string): Promise<void> {
+		for (let attempt = 0; attempt < TEMP_DIR_REMOVE_ATTEMPTS; attempt++) {
+			try {
+				rmSync(dir, { recursive: true, force: true });
+				return;
+			} catch {
+				await new Promise((resolve) => globalThis.setTimeout(resolve, TEMP_DIR_REMOVE_DELAY_MS));
+			}
+		}
+		// Leave the temp dir for OS tmp cleanup.
+	}
+
+	private cleanupResources(killSignal: NodeJS.Signals = "SIGTERM", options: { removeTempDir?: boolean } = {}): void {
 		this.clearSnapshotTimer();
 		this.lateSentAgentMessageHandlers.clear();
 		if (this.forkedLivenessTimer) {
@@ -1314,14 +1371,16 @@ export class KernelManager {
 		this.kernel = undefined;
 		this.kernelPid = undefined;
 		this.connection = undefined;
-		if (this.tempDir) {
+		// dispose() defers this so it can wait for the kernel to exit first;
+		// disposeSync() has no such option and removes it best-effort here.
+		if (this.tempDir && options.removeTempDir !== false) {
 			try {
 				rmSync(this.tempDir, { recursive: true, force: true });
 			} catch {
 				// Leave the temp dir for OS tmp cleanup.
 			}
 		}
-		this.tempDir = undefined;
+		if (options.removeTempDir !== false) this.tempDir = undefined;
 		this.startPromise = undefined;
 	}
 
@@ -1510,7 +1569,15 @@ export class KernelManager {
 					await this.waitForHostRequestsToSettle(inFlightHostRequests, HOST_REQUEST_DISPOSE_TIMEOUT_MS);
 				}
 			} finally {
-				this.cleanupResources();
+				// Capture before cleanupResources clears them; the kill happens
+				// inside it and the exit has to be awaited afterwards.
+				const child = this.kernel;
+				const pid = this.kernelPid;
+				const tempDir = this.tempDir;
+				this.cleanupResources("SIGTERM", { removeTempDir: false });
+				this.tempDir = undefined;
+				await KernelManager.waitForKernelExit(child, pid);
+				if (tempDir) await KernelManager.removeTempDirWithRetries(tempDir);
 			}
 		})();
 	}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -43,6 +43,12 @@ const KERNEL_ABORT_GRACE_MS = 1000;
 // set to its temp dir, and Windows keeps that directory locked until the
 // process is really gone, so a caller deleting it after dispose() gets EPERM.
 const KERNEL_EXIT_TIMEOUT_MS = 2000;
+// After SIGTERM expires the kernel is killed outright. Without this the wait is
+// best-effort in exactly the case the timeout exists for -- a kernel blocked in
+// a long-running native call, or a forked one where signal delivery is less
+// certain, is still alive when dispose() resolves, and the temp-dir removal
+// below then exhausts its retries against a directory the OS still holds.
+const KERNEL_SIGKILL_TIMEOUT_MS = 1000;
 const KERNEL_EXIT_POLL_INTERVAL_MS = 10;
 // rmSync's own maxRetries does not cover this: the native implementation
 // surfaces the directory-level EPERM without retrying.
@@ -1295,51 +1301,86 @@ export class KernelManager {
 	}
 
 	/**
-	 * Resolves once the killed kernel has actually exited, or the timeout
-	 * elapses. A forked kernel is not a direct child and emits no "exit", so it
-	 * is polled the same way `forkedKernelDied` checks liveness.
+	 * True while the pid exists. EPERM means it exists but is not ours to
+	 * signal, which still counts as alive -- same convention as
+	 * `isProcessAlive` in session-lease.ts.
 	 */
-	private static async waitForKernelExit(child: ChildProcess | undefined, pid: number | undefined): Promise<void> {
-		const deadline = Date.now() + KERNEL_EXIT_TIMEOUT_MS;
-
-		if (child && child.exitCode === null && child.signalCode === null) {
-			await new Promise<void>((resolve) => {
-				const done = () => {
-					globalThis.clearTimeout(timer);
-					child.removeListener("exit", done);
-					resolve();
-				};
-				const timer = globalThis.setTimeout(done, KERNEL_EXIT_TIMEOUT_MS);
-				if (typeof timer === "object" && "unref" in timer) timer.unref();
-				child.once("exit", done);
-			});
-			return;
-		}
-
-		if (pid === undefined) return;
-		while (Date.now() < deadline) {
-			try {
-				process.kill(pid, 0);
-			} catch (error) {
-				// ESRCH means gone. EPERM means the pid exists but is not ours to
-				// signal, which still counts as alive.
-				if (!(error instanceof Error && (error as NodeJS.ErrnoException).code === "EPERM")) return;
-			}
-			await new Promise((resolve) => globalThis.setTimeout(resolve, KERNEL_EXIT_POLL_INTERVAL_MS));
+	private static isPidAlive(pid: number): boolean {
+		try {
+			process.kill(pid, 0);
+			return true;
+		} catch (error) {
+			return (error as NodeJS.ErrnoException).code === "EPERM";
 		}
 	}
 
-	/** Removes a kernel temp dir, retrying while the OS still holds a handle. */
-	private static async removeTempDirWithRetries(dir: string): Promise<void> {
+	/**
+	 * Resolves once the killed kernel has actually exited, or the timeout
+	 * elapses. Returns whether it exited. A forked kernel is not a direct child
+	 * and emits no "exit", so it is polled instead.
+	 */
+	private static async waitForKernelExit(
+		child: ChildProcess | undefined,
+		pid: number | undefined,
+		timeoutMs: number,
+	): Promise<boolean> {
+		if (child && child.exitCode === null && child.signalCode === null) {
+			return await new Promise<boolean>((resolve) => {
+				const finish = (exited: boolean) => {
+					globalThis.clearTimeout(timer);
+					child.removeListener("exit", onExit);
+					resolve(exited);
+				};
+				const onExit = () => finish(true);
+				const timer = globalThis.setTimeout(() => finish(false), timeoutMs);
+				if (typeof timer === "object" && "unref" in timer) timer.unref();
+				child.once("exit", onExit);
+			});
+		}
+
+		if (pid === undefined) return true;
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			if (!KernelManager.isPidAlive(pid)) return true;
+			await new Promise((resolve) => globalThis.setTimeout(resolve, KERNEL_EXIT_POLL_INTERVAL_MS));
+		}
+		return !KernelManager.isPidAlive(pid);
+	}
+
+	/**
+	 * Waits for the kernel to exit, escalating to SIGKILL if SIGTERM is not
+	 * honoured in time, so that "once dispose() resolves, the pid is gone" is
+	 * true rather than usually true. Returns whether it is actually gone.
+	 */
+	private static async ensureKernelExited(child: ChildProcess | undefined, pid: number | undefined): Promise<boolean> {
+		if (await KernelManager.waitForKernelExit(child, pid, KERNEL_EXIT_TIMEOUT_MS)) return true;
+
+		try {
+			if (child) child.kill("SIGKILL");
+			else if (pid !== undefined && KernelManager.isPidAlive(pid)) process.kill(pid, "SIGKILL");
+		} catch {
+			// Raced with the kernel exiting on its own.
+		}
+		return await KernelManager.waitForKernelExit(child, pid, KERNEL_SIGKILL_TIMEOUT_MS);
+	}
+
+	/**
+	 * Removes a kernel temp dir, retrying while the OS still holds a handle.
+	 * Returns the last error if every attempt failed, so a genuine EACCES or a
+	 * bad path is visible rather than silently leaving the directory behind.
+	 */
+	private static async removeTempDirWithRetries(dir: string): Promise<unknown> {
+		let lastError: unknown;
 		for (let attempt = 0; attempt < TEMP_DIR_REMOVE_ATTEMPTS; attempt++) {
 			try {
 				rmSync(dir, { recursive: true, force: true });
-				return;
-			} catch {
+				return undefined;
+			} catch (error) {
+				lastError = error;
 				await new Promise((resolve) => globalThis.setTimeout(resolve, TEMP_DIR_REMOVE_DELAY_MS));
 			}
 		}
-		// Leave the temp dir for OS tmp cleanup.
+		return lastError;
 	}
 
 	private cleanupResources(killSignal: NodeJS.Signals = "SIGTERM", options: { removeTempDir?: boolean } = {}): void {
@@ -1576,8 +1617,18 @@ export class KernelManager {
 				const tempDir = this.tempDir;
 				this.cleanupResources("SIGTERM", { removeTempDir: false });
 				this.tempDir = undefined;
-				await KernelManager.waitForKernelExit(child, pid);
-				if (tempDir) await KernelManager.removeTempDirWithRetries(tempDir);
+				const exited = await KernelManager.ensureKernelExited(child, pid);
+				if (!exited) {
+					this.appendKernelDiagnostic("kernel did not exit after SIGTERM and SIGKILL during dispose");
+				}
+				if (tempDir) {
+					const removalError = await KernelManager.removeTempDirWithRetries(tempDir);
+					if (removalError) {
+						this.appendKernelDiagnostic(
+							`failed to remove kernel temp dir ${tempDir}: ${errorMessage(removalError)}`,
+						);
+					}
+				}
 			}
 		})();
 	}

--- a/packages/coding-agent/test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts
@@ -118,6 +118,32 @@ describe("kernel dispose waits for the child to exit (#1049)", () => {
 		await started;
 	}, 30000);
 
+	it("leaves the caller's cwd removable even when the kernel ignores SIGTERM", async () => {
+		// The issue's literal repro: the caller deletes the directory it passed
+		// as cwd immediately after an awaited dispose(). That directory is the
+		// one Windows holds open -- not KernelManager's own connection-file
+		// temp dir -- so only the wait plus escalation makes this safe.
+		const pidFile = join(tempDir, "kernel.pid");
+		const python = join(tempDir, "python");
+		writeExecutable(
+			python,
+			["#!/bin/sh", `echo $$ > "${pidFile}"`, "trap '' TERM", "while true; do sleep 0.05; done", ""].join("\n"),
+		);
+
+		const manager = new KernelManager({ python, cwd: tempDir });
+		const started = manager.execute("print(1)").catch(() => undefined);
+		await waitFor(() => existsSync(pidFile), 5000);
+		const pid = Number.parseInt(readFileSync(pidFile, "utf8").trim(), 10);
+
+		await manager.dispose();
+
+		expect(isAlive(pid), "kernel still holding cwd open").toBe(false);
+		expect(() => rmSync(tempDir, { recursive: true, force: true })).not.toThrow();
+		tempDir = "";
+
+		await started;
+	}, 30000);
+
 	it("removes the kernel temp directory once dispose resolves", async () => {
 		const pidFile = join(tempDir, "kernel.pid");
 		const python = join(tempDir, "python");

--- a/packages/coding-agent/test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts
@@ -1,0 +1,119 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { KernelManager } from "../../../src/core/kernel/index.js";
+
+// Regression for #1049. dispose() killed the kernel and removed its temp
+// directory in the same synchronous pass, so the promise resolved while the
+// child was still exiting. The kernel is spawned with cwd set to that
+// directory, and Windows holds it open until the process is really gone, so a
+// caller deleting it after an awaited dispose() got EPERM.
+//
+// The defect is not Windows-specific — nothing ever waited for "exit" — so it
+// is asserted here on the process itself rather than on a filesystem error:
+// once dispose() resolves, the kernel pid must be gone.
+
+let tempDir = "";
+
+function writeExecutable(filePath: string, content: string): void {
+	writeFileSync(filePath, content);
+	chmodSync(filePath, 0o755);
+}
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		// EPERM means the pid exists but is not ours to signal: still alive.
+		return error instanceof Error && (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return true;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	return predicate();
+}
+
+describe("kernel dispose waits for the child to exit (#1049)", () => {
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "prime-agent-1049-"));
+	});
+
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("does not resolve until the kernel process is gone", async () => {
+		const pidFile = join(tempDir, "kernel.pid");
+		const python = join(tempDir, "python");
+		// Records its pid, then delays exit on SIGTERM the way a real kernel
+		// does while it tears down. Without the fix dispose() returns during
+		// this window.
+		writeExecutable(
+			python,
+			[
+				"#!/bin/sh",
+				`echo $$ > "${pidFile}"`,
+				"trap 'sleep 0.3; exit 0' TERM",
+				"while true; do sleep 0.05; done",
+				"",
+			].join("\n"),
+		);
+
+		const manager = new KernelManager({ python, cwd: tempDir });
+		// The fake never binds ports, so this rejects; it is only here to make
+		// the manager spawn the child.
+		const started = manager.execute("print(1)").catch(() => undefined);
+
+		const spawned = await waitFor(() => existsSync(pidFile), 5000);
+		expect(spawned, "fake kernel never started").toBe(true);
+		const pid = Number.parseInt(readFileSync(pidFile, "utf8").trim(), 10);
+		expect(Number.isFinite(pid)).toBe(true);
+		expect(isAlive(pid), "fake kernel should be running before dispose").toBe(true);
+
+		await manager.dispose();
+
+		// The assertion that fails on unpatched code: dispose() resolved while
+		// the child was still shutting down.
+		expect(isAlive(pid), "dispose() resolved before the kernel exited").toBe(false);
+
+		await started;
+	}, 20000);
+
+	it("removes the kernel temp directory once dispose resolves", async () => {
+		const pidFile = join(tempDir, "kernel.pid");
+		const python = join(tempDir, "python");
+		writeExecutable(
+			python,
+			[
+				"#!/bin/sh",
+				`echo $$ > "${pidFile}"`,
+				"trap 'sleep 0.3; exit 0' TERM",
+				"while true; do sleep 0.05; done",
+				"",
+			].join("\n"),
+		);
+
+		const manager = new KernelManager({ python, cwd: tempDir });
+		const started = manager.execute("print(1)").catch(() => undefined);
+		await waitFor(() => existsSync(pidFile), 5000);
+
+		await manager.dispose();
+
+		// The connection temp dir is the manager's own, not `cwd`; deleting the
+		// caller-owned directory must succeed immediately after dispose().
+		expect(() => rmSync(tempDir, { recursive: true, force: true })).not.toThrow();
+		tempDir = "";
+
+		await started;
+	}, 20000);
+});

--- a/packages/coding-agent/test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts
@@ -1,7 +1,7 @@
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { KernelManager } from "../../../src/core/kernel/index.js";
 
 // Regression for #1049. dispose() killed the kernel and removed its temp
@@ -13,6 +13,19 @@ import { KernelManager } from "../../../src/core/kernel/index.js";
 // The defect is not Windows-specific — nothing ever waited for "exit" — so it
 // is asserted here on the process itself rather than on a filesystem error:
 // once dispose() resolves, the kernel pid must be gone.
+
+// The forkserver is default-on for Linux, and these tests pass a stub as
+// `python`. It would be started as the forkserver template rather than a
+// managed kernel, so dispose() would have no kernelPid to kill. Same reason
+// ipython-provisioner.test.ts pins direct-spawn.
+const savedForkFlag = process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+beforeAll(() => {
+	process.env.PRIME_AGENT_KERNEL_FORKSERVER = "0";
+});
+afterAll(() => {
+	if (savedForkFlag === undefined) delete process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+	else process.env.PRIME_AGENT_KERNEL_FORKSERVER = savedForkFlag;
+});
 
 let tempDir = "";
 

--- a/packages/coding-agent/test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts
@@ -89,6 +89,35 @@ describe("kernel dispose waits for the child to exit (#1049)", () => {
 		await started;
 	}, 20000);
 
+	it("escalates to SIGKILL when the kernel ignores SIGTERM", async () => {
+		const pidFile = join(tempDir, "kernel.pid");
+		const python = join(tempDir, "python");
+		// Ignores SIGTERM outright, standing in for a kernel blocked in a
+		// long-running native call. Waiting on SIGTERM alone would time out and
+		// leave this process alive, which is the case the escalation exists for.
+		writeExecutable(
+			python,
+			["#!/bin/sh", `echo $$ > "${pidFile}"`, "trap '' TERM", "while true; do sleep 0.05; done", ""].join("\n"),
+		);
+
+		const manager = new KernelManager({ python, cwd: tempDir });
+		const started = manager.execute("print(1)").catch(() => undefined);
+
+		const spawned = await waitFor(() => existsSync(pidFile), 5000);
+		expect(spawned, "fake kernel never started").toBe(true);
+		const pid = Number.parseInt(readFileSync(pidFile, "utf8").trim(), 10);
+		expect(isAlive(pid)).toBe(true);
+
+		await manager.dispose();
+
+		// Without escalation dispose() returns after the SIGTERM deadline with
+		// the kernel still running, and the temp-dir removal then races a
+		// directory the OS still holds open.
+		expect(isAlive(pid), "dispose() resolved with a SIGTERM-ignoring kernel still alive").toBe(false);
+
+		await started;
+	}, 30000);
+
 	it("removes the kernel temp directory once dispose resolves", async () => {
 		const pidFile = join(tempDir, "kernel.pid");
 		const python = join(tempDir, "python");


### PR DESCRIPTION
`cleanupResources` killed the kernel and removed its temp directory in the same
synchronous pass, so `dispose()` resolved while the child was still exiting. The
kernel is spawned with `cwd` set to that directory; Windows keeps it locked
until the process is really gone, so a caller deleting it after an awaited
`dispose()` got `EPERM`.

fixes #1049

## The defect is not Windows-specific

Nothing ever waited for `"exit"`, so the promise resolved early on every
platform. Unix only hides it by unlinking files that are still open.

That is worth stating because it changes how it is tested. Rather than assert a
Windows filesystem error, the regression asserts the actual contract on the
process itself: once `dispose()` resolves, the kernel pid must be gone. That
reproduces deterministically on macOS and Linux.

Against unpatched `main`:

```
FAIL  test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts
  → dispose() resolved before the kernel exited
  - false
  + true
Tests  1 failed | 1 passed (2)
```

With the fix, both pass.

## Change

`dispose()` defers temp-dir removal, waits for the process to actually exit,
then removes the directory.

- Direct children are awaited on their `"exit"` event.
- A forked kernel is not a direct child and emits no `"exit"`, so its pid is
  polled the same way `forkedKernelDied` already checks liveness — including
  treating `EPERM` as alive rather than gone.
- Both paths are bounded by `KERNEL_EXIT_TIMEOUT_MS` (2s) so a wedged kernel
  cannot hang disposal.
- Removal retries explicitly. As the issue notes, `rmSync`'s own `maxRetries`
  does not cover this: the native implementation surfaces the directory-level
  `EPERM` without retrying.

`disposeSync()` is deliberately unchanged. It runs from `process.on("exit")`
where nothing async can be awaited, so it keeps the previous best-effort
synchronous removal. `cleanupResources` gained an option rather than becoming
async, so that path is untouched.

## Verification

macOS arm64, Node v25.6.1.

```
test/suite/regressions/1049-kernel-dispose-waits-for-exit.test.ts   2 passed
test/kernel-startup.test.ts
test/kernel-state-snapshot.test.ts
test/kernel-fork-server.test.ts                                    18 passed
```

`npm run check` exits 0 (biome, tsgo --noEmit, installer render, browser smoke).
The pre-commit hook ran it again independently and passed.

The fake kernel in the test is a `/bin/sh` script that records its pid and
delays exit on SIGTERM, matching the style of `test/kernel-startup.test.ts`. No
provider, no API keys, no real IPython.

## Note on placement

AGENTS.md says issue regressions go under
`packages/coding-agent/test/suite/regressions/<issue-number>-<short-slug>.test.ts`,
so that is where it is. It does not use `test/suite/harness.ts` or the faux
provider, since it exercises `KernelManager` process lifecycle directly and
never starts an agent session. Happy to move it next to the other
`test/kernel-*.test.ts` files if you would rather keep the harness invariant
strict for that directory.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `KernelManager.dispose` to wait for kernel process exit before removing temp directory
> - `dispose()` now captures the child process and PID before cleanup, sends SIGTERM via `cleanupResources`, then awaits the new `ensureKernelExited` helper before removing the temp directory.
> - `ensureKernelExited` waits up to `KERNEL_EXIT_TIMEOUT_MS` for a graceful exit, then escalates to SIGKILL and waits a further `KERNEL_SIGKILL_TIMEOUT_MS` if the process is still alive.
> - Temp directory removal is deferred until after exit and retried on transient failures via `removeTempDirWithRetries`; diagnostics are appended if the process or removal fails.
> - Adds a regression test suite covering: exit waiting, SIGKILL escalation, and caller/temp-dir removability after `dispose()` resolves.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e27c00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->