### PR TITLE
feat(coding-agent): add keyless web search fallback to Exa and Parallel

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added keyless web search fallback (Exa and Parallel public MCP servers) to the `websearch` skill, so it works without a Serper API key; a configured Serper key still takes priority.
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/skills/websearch/SKILL.md
+++ b/packages/coding-agent/skills/websearch/SKILL.md
@@ -1,25 +1,30 @@
 ---
 name: websearch
-description: Search Google via the Serper API. Configure access via /login, then MCP Connections, then Serper (web search). Takes one query and returns titles, URLs, snippets, and knowledge-graph data.
+description: "Search the web. Backends, in priority order: Serper (web search), configured via /login → MCP Connections → Serper, adds knowledge-graph and people-also-ask data; then Exa's and Parallel's keyless MCP servers. Takes one query and returns titles, URLs, and snippets."
 ---
 
 # Web Search
 
-Search the web via the Serper Google Search API.
+Search the web. Works out of the box with no API key by falling back to
+Exa's and Parallel's public MCP servers; configuring a Serper key adds
+richer results (knowledge graph, people-also-ask).
 
 ## Setup
 
-Get a free API key at https://serper.dev, then run `/login` in Prime Agent,
-switch to **MCP Connections**, and choose **Serper (web search)** to paste it.
-The key is stored in Prime Agent and made available to this skill automatically.
+Web search works immediately with no configuration. For higher-quality
+results, get a free API key at https://serper.dev, then run `/login` in
+Prime Agent, switch to **MCP Connections**, and choose **Serper (web search)**
+to paste it. The key is stored in Prime Agent and made available to this
+skill automatically.
 
-If web search reports a missing key, walk the user through those two steps;
-don't ask them to set environment variables.
+If web search reports an error, don't ask the user to set environment variables.
 
 Optional overrides (environment variables):
 
 - `PRIME_AGENT_WEBSEARCH_TIMEOUT` - HTTP timeout in seconds (default 45).
 - `PRIME_AGENT_WEBSEARCH_NUM_RESULTS` - number of organic results to return (default 5).
+- `EXA_API_KEY` - optional Exa API key (uses `https://mcp.exa.ai/mcp?exaApiKey=...`).
+- `PARALLEL_API_KEY` - optional Parallel API key (adds an `Authorization: Bearer` header).
 
 ## Usage
 

--- a/packages/coding-agent/skills/websearch/src/websearch/websearch.py
+++ b/packages/coding-agent/skills/websearch/src/websearch/websearch.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from urllib.parse import quote
 
 import httpx
+
+MCP_EXA_URL = "https://mcp.exa.ai/mcp"
+MCP_PARALLEL_URL = "https://search.parallel.ai/mcp"
 
 
 def _env_int(name: str, default: int) -> int:
@@ -106,7 +110,104 @@ def _format_serper_results(data: dict, query: str, num_results: int = 5) -> str:
     return "\n\n---\n\n".join(sections)
 
 
-async def _fetch_serper(query: str, api_key: str, timeout: int = 45, num_results: int = 5) -> str:
+def _mcp_url(base: str, env_key: str) -> str:
+    """Build a keyless MCP endpoint URL, appending an optional API key query param."""
+    api_key = os.environ.get(env_key, "").strip()
+    if api_key:
+        return f"{base}?exaApiKey={quote(api_key)}"
+    return base
+
+
+def _parse_mcp_response(body: str) -> str | None:
+    """Extract the first text result from an MCP tools/call response.
+
+    Accepts both a direct JSON body and the SSE framing some servers use
+    (lines prefixed with ``data: ``). Mirrors opencode's parseResponse.
+    """
+    candidates: list[str] = [body.strip()]
+    for line in body.split("\n"):
+        if line.startswith("data: "):
+            candidates.append(line[6:].strip())
+    for candidate in candidates:
+        if not candidate or not candidate.startswith("{"):
+            continue
+        try:
+            data = json.loads(candidate)
+        except ValueError:
+            continue
+        result = data.get("result")
+        if not isinstance(result, dict):
+            continue
+        for item in result.get("content") or []:
+            if isinstance(item, dict) and item.get("text"):
+                return item["text"]
+    return None
+
+
+async def _mcp_call(
+    url: str,
+    tool: str,
+    arguments: dict,
+    timeout: int,
+    *,
+    headers: dict[str, str] | None = None,
+) -> str:
+    """Execute an MCP ``tools/call`` and return the first text result."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments},
+    }
+    request_headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    if headers:
+        request_headers.update(headers)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(url, json=payload, headers=request_headers)
+            resp.raise_for_status()
+            body = resp.text
+    except httpx.HTTPStatusError as e:
+        text = e.response.text if e.response is not None else ""
+        raise RuntimeError(f"{tool} error ({e.response.status_code}): {text}") from e
+    result = _parse_mcp_response(body)
+    if not result:
+        raise RuntimeError(f"{tool} returned no text results")
+    return result
+
+
+async def _fetch_exa(query: str, timeout: int = 45, num_results: int = 5) -> str:
+    """Search via Exa's public MCP server (keyless unless EXA_API_KEY is set)."""
+    arguments = {
+        "query": query,
+        "type": "auto",
+        "numResults": num_results,
+        "livecrawl": "fallback",
+        "contextMaxCharacters": 10000,
+    }
+    return await _mcp_call(
+        _mcp_url(MCP_EXA_URL, "EXA_API_KEY"), "web_search_exa", arguments, timeout
+    )
+
+
+async def _fetch_parallel(query: str, timeout: int = 45) -> str:
+    """Search via Parallel's public MCP server (keyless unless PARALLEL_API_KEY is set)."""
+    arguments = {"objective": query, "search_queries": [query]}
+    headers = {}
+    api_key = os.environ.get("PARALLEL_API_KEY", "").strip()
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return await _mcp_call(
+        MCP_PARALLEL_URL, "web_search", arguments, timeout, headers=headers
+    )
+
+
+async def _fetch_serper(
+    query: str, api_key: str, timeout: int = 45, num_results: int = 5
+) -> str:
     """Execute a single Serper API search."""
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -122,7 +223,9 @@ async def _fetch_serper(query: str, api_key: str, timeout: int = 45, num_results
             data = resp.json()
     except httpx.HTTPStatusError as e:
         body = e.response.text if e.response is not None else ""
-        raise RuntimeError(f"Serper search error ({e.response.status_code}): {body}") from e
+        raise RuntimeError(
+            f"Serper search error ({e.response.status_code}): {body}"
+        ) from e
 
     return _format_serper_results(data, query, num_results=num_results)
 
@@ -134,10 +237,14 @@ async def run(
     timeout: int | None = None,
     num_results: int | None = None,
 ) -> str:
-    """Run a Google search via Serper and return formatted results.
+    """Run a web search and return formatted results.
+
+    Backend priority: Serper (when an API key is configured), then Exa's
+    keyless MCP server, then Parallel's keyless MCP server. Only if every
+    backend fails is the setup-guide message returned.
 
     Args:
-        query: Google search query.
+        query: Web search query.
         max_output: Truncate output to this many chars.
         timeout: HTTP timeout in seconds.
         num_results: Organic results to return.
@@ -145,25 +252,57 @@ async def run(
     Returns:
         Formatted search results.
     """
-    api_key = _resolve_api_key()
-    if not api_key:
-        return (
-            "Web search is not set up yet: no Serper API key is configured.\n"
-            "Tell the user how to enable it:\n"
-            "  1. Get a free API key at https://serper.dev (sign up, copy the key).\n"
-            "  2. In Prime Agent, run /login, switch to MCP Connections, choose \"Serper (web search)\", and paste the key.\n"
-            "Do not ask the user to set environment variables. Once the key is saved, web search works automatically."
-        )
-
     if timeout is None:
         timeout = _env_int("PRIME_AGENT_WEBSEARCH_TIMEOUT", 45)
     if num_results is None:
         num_results = _env_int("PRIME_AGENT_WEBSEARCH_NUM_RESULTS", 5)
 
-    try:
-        result = await _fetch_serper(query, api_key, timeout=timeout, num_results=num_results)
-    except Exception as e:
-        result = f"Error searching for '{query}': {e}"
+    backend_errors: list[str] = []
+
+    api_key = _resolve_api_key()
+    if api_key:
+        try:
+            result = await _fetch_serper(
+                query, api_key, timeout=timeout, num_results=num_results
+            )
+            backend = "Serper"
+        except Exception as e:
+            backend_errors.append(f"Serper: {e}")
+            result = ""
+    else:
+        result = ""
+
+    if not result:
+        try:
+            result = await _fetch_exa(query, timeout=timeout, num_results=num_results)
+            backend = "Exa"
+        except Exception as e:
+            backend_errors.append(f"Exa: {e}")
+            result = ""
+
+    if not result:
+        try:
+            result = await _fetch_parallel(query, timeout=timeout)
+            backend = "Parallel"
+        except Exception as e:
+            backend_errors.append(f"Parallel: {e}")
+            result = ""
+
+    if not result:
+        if backend_errors:
+            failure = "; ".join(backend_errors)
+            result = f"Error searching for '{query}': {failure}"
+        else:
+            result = (
+                "Web search returned no results, and no Serper API key is configured.\n"
+                "Tell the user how to enable higher-quality results:\n"
+                "  1. Get a free API key at https://serper.dev (sign up, copy the key).\n"
+                '  2. In Prime Agent, run /login, switch to MCP Connections, choose "Serper (web search)", and paste the key.\n'
+                "Do not ask the user to set environment variables. Web search already works without it."
+            )
+    else:
+        result = f"[{backend}] {result}"
+
     output = f'Results for query "{query}":\n\n{result}'
 
     if len(output) > max_output:
@@ -171,7 +310,7 @@ async def run(
         marker = f"\n... [output truncated, {total} chars total] ...\n"
         # Reserve room for the marker so the result stays within max_output.
         half = max(0, (max_output - len(marker)) // 2)
-        output = output[:half] + marker + output[len(output) - half:]
+        output = output[:half] + marker + output[len(output) - half :]
         if len(output) > max_output:  # marker alone exceeds the budget
             output = output[:max_output]
 


### PR DESCRIPTION
## Summary

The bundled `websearch` skill required a Serper API key and, when none was configured, returned only a setup guide. Other CLI agents (e.g. opencode) provide keyless web search out of the box.

This PR makes the skill work immediately with no configuration and without degrading existing setups:

- **Serper stays the priority backend** when a key is configured (unchanged behavior, keeps knowledge-graph and people-also-ask data).
- **Keyless fallbacks** try Exa's then Parallel's public MCP servers (`https://mcp.exa.ai/mcp`, `https://search.parallel.ai/mcp`) using JSON-RPC `tools/call`, mirroring how opencode calls them.
- `EXA_API_KEY` / `PARALLEL_API_KEY` env vars are honored when set, but never required.
- Only if every backend fails is the existing setup-guide message returned.

## Files

- `packages/coding-agent/skills/websearch/src/websearch/websearch.py` — added `_mcp_url`, `_parse_mcp_response`, `_mcp_call`, `_fetch_exa`, `_fetch_parallel`; `run()` now chains Serper → Exa → Parallel.
- `packages/coding-agent/skills/websearch/SKILL.md` — documented the fallback chain; Serper is now an optional quality upgrade.
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased]` entry.

## Verification

- Keyless Exa and Parallel searches return live results (tested against real endpoints).
- All-backends-fail path returns a clear error.
- `npm run check` passes (biome, tsgo, installer, browser-smoke) — run via the pre-commit hook.
- `resource-loader` websearch tests (4/4), `skills.test.ts` + `system-prompt.test.ts` (57/57) pass.
- The 4 remaining `resource-loader` failures (extension/symlink conflict detection) are pre-existing on `main` and unrelated.

Note: the YAML description is double-quoted because the `yaml` lib rejects an unquoted description containing `: ` as a nested mapping.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keyless web search fallback to Exa and Parallel MCP servers in the `websearch` skill
> - The `websearch` skill previously required a Serper API key; it now works without any configuration by falling back to Exa then Parallel public MCP servers.
> - Backend priority order: Serper (if `SERPER_API_KEY` is configured) → Exa (`mcp.exa.ai`) → Parallel (`search.parallel.ai`). Successful results are prefixed with the serving backend label.
> - Optional `EXA_API_KEY` and `PARALLEL_API_KEY` env vars can be set for authenticated access to those backends.
> - When all backends fail, errors are aggregated per-backend and returned together; the setup guide no longer blocks on missing keys.
> - Behavioral Change: the skill entrypoint in [`websearch.py`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1096/files#diff-345ba871c0c38a3314764f17b955327ef4df51ce1cb00e73e61a68d38e3c67e3) now makes up to three sequential HTTP calls before failing, which increases worst-case latency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5ec87a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->