### PR TITLE
feat(coding-agent): clear prompt on Ctrl+C when idle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed `ctrl+c` to clear the prompt when it has content and no operation is running.
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6626,6 +6626,11 @@ export class InteractiveMode {
 			void this.shutdown();
 			return;
 		}
+		// If the editor has content and nothing is running, clear it.
+		if (this.editor.getText().length > 0 && !this.hasInterruptibleWork()) {
+			this.clearInputBar();
+			return;
+		}
 		this.handleInterruptKey();
 	}
 
@@ -9534,7 +9539,7 @@ ${shortcutsKey ? `\`${shortcutsKey}\` quick shortcuts · ` : ""}\`/hotkeys\` ful
 |-----|--------|
 | \`${tab}\` | Path completion / accept autocomplete |
 | \`${clearInput}\` | Clear input / cancel autocomplete |
-| \`${clear}\` | Interrupt current operation (first) / exit (second) |
+| \`${clear}\` | Clear prompt (if text) / interrupt / exit (twice) |
 ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shortcutsKey ? `| \`${shortcutsKey}\` | Show quick shortcuts |\n` : ""}| \`${exit}\` | Exit (when editor is empty) |
 | \`${selectModel}\` | Open model selector |
 | \`${expandTools}\` | Toggle tool output expansion |

--- a/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
+++ b/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
@@ -196,10 +196,9 @@ describe("InteractiveMode interrupt shortcuts", () => {
 	});
 
 	it("clears the exit hint after two seconds", async () => {
-		const mode = createInteractiveFake({ editorText: "draft" });
+		const mode = createInteractiveFake({});
 
 		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
-		expect(mode.editor.getText()).toBe("draft");
 		expect(Reflect.get(InteractiveMode.prototype, "getTrayOverrideLabel").call(mode)).toBe(
 			"Press Ctrl+C again to exit",
 		);
@@ -211,13 +210,33 @@ describe("InteractiveMode interrupt shortcuts", () => {
 		expect(mode.ui.requestRender).toHaveBeenCalled();
 	});
 
-	it("preserves idle draft input on first Ctrl+C", () => {
+	it("clears idle draft input on first Ctrl+C", () => {
 		const mode = createInteractiveFake({ editorText: "draft" });
 
 		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
 
-		expect(mode.editor.getText()).toBe("draft");
+		expect(mode.editor.getText()).toBe("");
 		expect(mode.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
+		expect(mode.shutdown).not.toHaveBeenCalled();
+	});
+
+	it("does not clear draft on Ctrl+C when streaming (interrupts instead)", () => {
+		const mode = createInteractiveFake({ editorText: "draft", streaming: true });
+
+		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
+
+		expect(mode.editor.getText()).toBe("draft");
+		expect(mode.restoreQueuedMessagesToEditor).toHaveBeenCalledWith({ abort: true });
+		expect(mode.shutdown).not.toHaveBeenCalled();
+	});
+
+	it("does not clear draft on Ctrl+C when bash is running (interrupts instead)", () => {
+		const mode = createInteractiveFake({ editorText: "draft", bashRunning: true });
+
+		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
+
+		expect(mode.editor.getText()).toBe("draft");
+		expect(mode.agentConnection.abortBash).toHaveBeenCalledTimes(1);
 		expect(mode.shutdown).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## Summary

- Changed `Ctrl+C` to clear the prompt when the editor has content and no operation is running.
- When an operation IS running (streaming, bash, retry, compaction), `Ctrl+C` still interrupts and preserves the draft.
- Updated the hotkey guide, shortcut hints, changelog, and test suite.

## Behavior matrix

| State | Ctrl+C action |
|---|---|
| Editor has content, idle | **Clear prompt** |
| Agent streaming / bash / retry / compaction | Interrupt operation, preserve draft |
| Editor empty, idle | Show exit hint → second Ctrl+C exits |

## Differences from closed #845

PR #845 unconditionally cleared the prompt in `handleInterruptKey()`, which meant pressing `Ctrl+C` during streaming would lose the user's draft. This PR gates the clear on `!hasInterruptibleWork()` so the draft survives interruptions.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-ctrl-c.test.ts` — 21 tests pass
- `npm run check` — clean (biome, tsgo, installer, browser-smoke)

Closes #1097


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear prompt on Ctrl+C when idle in coding agent interactive mode
> Previously, Ctrl+C always triggered an interrupt or exit in the interactive mode. Now, if the editor has text and no operation is running, Ctrl+C clears the input instead. Interrupt and exit behavior is unchanged when streaming or a bash command is active.
>
> - Updates `InteractiveMode.handleCtrlC` in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1098/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) to check for idle state and editor content before clearing
> - Updates the shortcut guide text to describe the new three-step behavior: clear prompt / interrupt / exit
> - Behavioral Change: Ctrl+C no longer shows the exit hint on first press when the editor has content and no work is running
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27cee34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->