### PR TITLE
fix(ai): abort degenerate generation instead of streaming it to the cap

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -34,7 +34,9 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { describeRepetition, isRepetitionGuardDisabled, RepetitionGuard } from "../utils/repetition-guard.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { recordStreamFailure, StreamFailureError } from "../utils/stream-failure.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { buildBaseOptions } from "./simple-options.js";
@@ -174,6 +176,10 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
 			const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
 			const blocks = output.content as StreamingBlock[];
+			// Reasoning only. The text channel is left unguarded on purpose: a
+			// long legitimate answer can contain generated tables or code that
+			// look repetitive, and a false abort there destroys real work.
+			const reasoningGuard = isRepetitionGuardDisabled() ? undefined : new RepetitionGuard();
 			const getContentIndex = (block: StreamingBlock) => blocks.indexOf(block);
 			const finishBlock = (block: StreamingBlock) => {
 				const contentIndex = getContentIndex(block);
@@ -338,6 +344,16 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 								delta,
 								partial: output,
 							});
+							// A degenerate thinking loop burns the whole output budget
+							// and never emits a tool call, so nothing downstream ever
+							// sees it as a failure. Abort here instead. See #1029.
+							const finding = reasoningGuard?.push(delta);
+							if (finding) {
+								throw new StreamFailureError(
+									`Model stopped making progress and repeated itself: ${describeRepetition(finding)}`,
+									{ kind: "degenerate_output", providerErrorType: `repetition:${finding.kind}` },
+								);
+							}
 						}
 					}
 
@@ -411,6 +427,10 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			// Some providers via OpenRouter give additional information in this field.
 			const rawMetadata = (error as any)?.error?.metadata?.raw;
 			if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;
+			// Every other provider records a structured failure here; this one
+			// did not, so openai-completions failures reached the session with
+			// no classification at all.
+			recordStreamFailure(model, output, error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/utils/repetition-guard.ts
+++ b/packages/ai/src/utils/repetition-guard.ts
@@ -1,0 +1,250 @@
+/**
+ * Detects degenerate, non-progressing generation while a stream is still
+ * running, so the request can be aborted instead of burning the whole output
+ * budget.
+ *
+ * The failure this exists for (#1029): a thinking stream settled into emitting
+ * `"The the the the the the the "` back to back 2,366 times — 79,222 characters
+ * — and only stopped when the user aborted by hand. Provider streamers are
+ * faithful assemblers and never inspect content, request construction attaches
+ * no repetition penalties, and the agent loop treats a completed stream as
+ * progress, so nothing owned this.
+ *
+ * Two shapes are detected, because a loop rarely stays verbatim for long:
+ *
+ * 1. **Periodic tail.** The tail of the stream is one short unit repeated many
+ *    times. Found with the KMP failure function, which yields the smallest
+ *    period of a string in O(n) — no scanning of candidate period lengths.
+ * 2. **Novelty stall.** The tail keeps restating the same content with drift, so
+ *    verbatim periodicity misses it. Measured as distinct word trigrams over
+ *    total word trigrams: a loop reuses the same trigrams, legitimate output
+ *    does not.
+ *
+ * The novelty threshold is calibrated, not guessed. Measured over the corpus in
+ * `test/repetition-guard.test.ts`:
+ *
+ *     loops   verbatim 0.001   drifting 0.136
+ *     legit   enumerated analysis 0.286   markdown table 0.485   JSON 0.513
+ *             source code 0.611   numbered list 0.671   prose 1.000
+ *
+ * 0.20 sits in the gap with margin on both sides. Word-trigram Jaccard between
+ * paragraphs was tried first and rejected: drifting loops scored 0.38-0.58
+ * while structurally similar legitimate paragraphs scored in the same band, so
+ * it could not separate them at any threshold.
+ *
+ * False positives are the real risk: legitimate reasoning repeats phrases, and
+ * code, tables and lists are structurally repetitive. Every threshold below is
+ * deliberately conservative, and the guard only looks at a bounded tail, never
+ * the whole transcript.
+ */
+
+/** Why the guard fired. */
+export type RepetitionKind = "periodic_tail" | "novelty_stall";
+
+export interface RepetitionFinding {
+	kind: RepetitionKind;
+	/** Characters inspected when the guard fired. */
+	inspectedChars: number;
+	/** Total characters seen on this channel. */
+	totalChars: number;
+	/** For `periodic_tail`: length of the repeating unit. */
+	periodChars?: number;
+	/** For `periodic_tail`: how many times it repeated. */
+	repeats?: number;
+	/** For `novelty_stall`: distinct trigrams over total, 0..1. */
+	novelty?: number;
+	/** Short, redacted sample of the repeating unit, for diagnostics. */
+	sample: string;
+}
+
+export interface RepetitionGuardOptions {
+	/** Tail kept for periodicity analysis. Default 4096. */
+	windowChars?: number;
+	/**
+	 * Do not consider a periodic tail degenerate below this many repeats.
+	 * Default 16 — high enough that a table of 12 similar rows cannot trip it.
+	 */
+	minRepeats?: number;
+	/**
+	 * Longest repeating unit treated as degenerate. Default 512. Above this a
+	 * "repeat" is more plausibly a legitimately re-emitted structure.
+	 */
+	maxPeriodChars?: number;
+	/**
+	 * Skip detection until this much text has arrived. Default 2048 — short
+	 * bursts of repetition are normal at the start of a thought.
+	 */
+	minCharsBeforeCheck?: number;
+	/** Run detection at most once per this many new characters. Default 256. */
+	checkEveryChars?: number;
+	/**
+	 * Distinct-trigram ratio at or below which the tail counts as stalled.
+	 * Default 0.2; see the calibration table above.
+	 */
+	noveltyFloor?: number;
+	/**
+	 * Minimum trigrams before the novelty ratio means anything. Default 200 —
+	 * a short window is trivially low-novelty.
+	 */
+	minTrigramsForNovelty?: number;
+}
+
+const DEFAULTS = {
+	windowChars: 4096,
+	minRepeats: 16,
+	maxPeriodChars: 512,
+	minCharsBeforeCheck: 2048,
+	checkEveryChars: 256,
+	noveltyFloor: 0.2,
+	minTrigramsForNovelty: 200,
+} as const satisfies Required<RepetitionGuardOptions>;
+
+const SAMPLE_CHARS = 80;
+
+/** Kill switch, matching the convention used for other guards. */
+export const REPETITION_GUARD_DISABLED_ENV = "PRIME_AGENT_NO_REPETITION_GUARD";
+
+export function isRepetitionGuardDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	const value = env[REPETITION_GUARD_DISABLED_ENV];
+	return value !== undefined && value !== "" && value !== "0" && value.toLowerCase() !== "false";
+}
+
+/**
+ * Smallest period of `text` via the KMP failure function.
+ *
+ * `len - failure[len - 1]` is the shortest string whose repetition produces
+ * `text`, when it divides `len` evenly. When it does not, `text` is not fully
+ * periodic and the value is meaningless, so callers must check divisibility.
+ */
+function smallestPeriod(text: string): number {
+	const len = text.length;
+	if (len === 0) return 0;
+	const failure = new Int32Array(len);
+	let k = 0;
+	for (let i = 1; i < len; i++) {
+		while (k > 0 && text[i] !== text[k]) k = failure[k - 1];
+		if (text[i] === text[k]) k++;
+		failure[i] = k;
+	}
+	return len - failure[len - 1];
+}
+
+/** Collapse runs of whitespace so drifting indentation is not mistaken for novelty. */
+function normalizeForCompare(text: string): string {
+	return text.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+/**
+ * Distinct word trigrams over total, 0..1. A loop reuses the same trigrams and
+ * scores near zero; varied prose approaches 1. Returns `undefined` when there
+ * is not enough text for the ratio to mean anything.
+ */
+export function trigramNovelty(text: string, minTrigrams: number): number | undefined {
+	const words = normalizeForCompare(text).split(" ").filter(Boolean);
+	if (words.length < 3) return undefined;
+	const total = words.length - 2;
+	if (total < minTrigrams) return undefined;
+	const seen = new Set<string>();
+	for (let i = 0; i + 2 < words.length; i++) {
+		seen.add(`${words[i]} ${words[i + 1]} ${words[i + 2]}`);
+	}
+	return seen.size / total;
+}
+
+function sampleOf(text: string): string {
+	const normalized = text.replace(/\s+/g, " ").trim();
+	return normalized.length > SAMPLE_CHARS ? `${normalized.slice(0, SAMPLE_CHARS)}…` : normalized;
+}
+
+/**
+ * Incremental detector for one channel of one stream. Feed it deltas; it
+ * returns a finding the first time the accumulated output looks degenerate.
+ *
+ * Not reusable across streams — construct one per channel per request.
+ */
+export class RepetitionGuard {
+	private readonly options: Required<RepetitionGuardOptions>;
+	private window = "";
+	private totalChars = 0;
+	private charsSinceCheck = 0;
+	private fired = false;
+
+	constructor(options: RepetitionGuardOptions = {}) {
+		this.options = { ...DEFAULTS, ...options };
+	}
+
+	/**
+	 * Feed one delta. Returns a finding the first time the stream looks
+	 * degenerate, and `undefined` on every call after that — the caller aborts
+	 * on the first hit, so repeat reporting would be noise.
+	 */
+	push(delta: string): RepetitionFinding | undefined {
+		if (this.fired || delta.length === 0) return undefined;
+
+		this.totalChars += delta.length;
+		this.charsSinceCheck += delta.length;
+		this.window = (this.window + delta).slice(-this.options.windowChars);
+
+		if (this.totalChars < this.options.minCharsBeforeCheck) return undefined;
+		if (this.charsSinceCheck < this.options.checkEveryChars) return undefined;
+		this.charsSinceCheck = 0;
+
+		const finding = this.detectPeriodicTail() ?? this.detectNoveltyStall();
+		if (finding) this.fired = true;
+		return finding;
+	}
+
+	/** Characters seen so far on this channel. */
+	get seenChars(): number {
+		return this.totalChars;
+	}
+
+	private detectPeriodicTail(): RepetitionFinding | undefined {
+		const window = this.window;
+		if (window.length < this.options.minCharsBeforeCheck) return undefined;
+
+		const period = smallestPeriod(window);
+		// Not evenly periodic across the whole window: try the largest suffix
+		// that is. A loop that started mid-window is the common case.
+		const candidates = window.length % period === 0 ? [window] : [window.slice(window.length % period)];
+		for (const candidate of candidates) {
+			const candidatePeriod = smallestPeriod(candidate);
+			if (candidatePeriod === 0 || candidate.length % candidatePeriod !== 0) continue;
+			if (candidatePeriod > this.options.maxPeriodChars) continue;
+			const repeats = candidate.length / candidatePeriod;
+			if (repeats < this.options.minRepeats) continue;
+			// A period that is entirely whitespace is padding, not a loop.
+			if (candidate.slice(0, candidatePeriod).trim().length === 0) continue;
+			return {
+				kind: "periodic_tail",
+				inspectedChars: candidate.length,
+				totalChars: this.totalChars,
+				periodChars: candidatePeriod,
+				repeats,
+				sample: sampleOf(candidate.slice(0, candidatePeriod)),
+			};
+		}
+		return undefined;
+	}
+
+	private detectNoveltyStall(): RepetitionFinding | undefined {
+		const novelty = trigramNovelty(this.window, this.options.minTrigramsForNovelty);
+		if (novelty === undefined || novelty > this.options.noveltyFloor) return undefined;
+		return {
+			kind: "novelty_stall",
+			inspectedChars: this.window.length,
+			totalChars: this.totalChars,
+			novelty,
+			sample: sampleOf(this.window.slice(-SAMPLE_CHARS * 2)),
+		};
+	}
+}
+
+/** One-line description for logs and the user-facing error. */
+export function describeRepetition(finding: RepetitionFinding): string {
+	if (finding.kind === "periodic_tail") {
+		return `repeated a ${finding.periodChars}-character sequence ${finding.repeats} times (${finding.totalChars} chars generated): "${finding.sample}"`;
+	}
+	const novelty = finding.novelty === undefined ? "?" : finding.novelty.toFixed(3);
+	return `stopped producing novel text (distinct-trigram ratio ${novelty} over ${finding.inspectedChars} chars, ${finding.totalChars} chars generated): "${finding.sample}"`;
+}

--- a/packages/ai/src/utils/stream-failure.ts
+++ b/packages/ai/src/utils/stream-failure.ts
@@ -17,6 +17,7 @@ export type StreamFailureKind =
 	| "auth"
 	| "invalid_request"
 	| "malformed_response"
+	| "degenerate_output"
 	| "unknown";
 
 export interface StreamFailureInfo {
@@ -48,6 +49,7 @@ const KIND_MESSAGES: Record<StreamFailureKind, string> = {
 	auth: "Provider authentication failed",
 	invalid_request: "Provider rejected the request",
 	malformed_response: "Provider returned a malformed response",
+	degenerate_output: "Model stopped making progress and repeated itself",
 	unknown: "Provider stream failed",
 };
 

--- a/packages/ai/test/openai-completions-repetition-guard.test.ts
+++ b/packages/ai/test/openai-completions-repetition-guard.test.ts
@@ -1,0 +1,197 @@
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { streamOpenAICompletions } from "../src/providers/openai-completions.js";
+import type { AssistantMessageEvent, Context, Model, OpenAICompletionsCompat } from "../src/types.js";
+import { REPETITION_GUARD_DISABLED_ENV } from "../src/utils/repetition-guard.js";
+import type { StreamFailureInfo } from "../src/utils/stream-failure.js";
+
+/**
+ * End-to-end cover for #1029 against the real streamer: a provider that emits
+ * `reasoning_content` deltas of a degenerate loop must be cut off rather than
+ * streamed to completion.
+ *
+ * The unit tests in `repetition-guard.test.ts` cover detection itself. This
+ * asserts the wiring: the stream terminates, it terminates as an error rather
+ * than a clean `done`, and it stops well short of what the provider offered.
+ */
+
+const compat = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresReasoningContentOnAssistantMessages: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	zaiToolStream: false,
+	supportsStrictMode: true,
+	cacheControlFormat: undefined,
+	sendSessionAffinityHeaders: false,
+	supportsLongCacheRetention: true,
+} satisfies Required<Omit<OpenAICompletionsCompat, "cacheControlFormat">> & {
+	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+};
+
+function buildModel(baseUrl: string): Model<"openai-completions"> {
+	return {
+		id: "repro-model",
+		name: "Repro Model",
+		api: "openai-completions",
+		provider: "repro-provider",
+		baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+		compat,
+	};
+}
+
+function buildContext(): Context {
+	return {
+		messages: [{ role: "user", content: [{ type: "text", text: "think about this" }] }],
+	} as Context;
+}
+
+/** The exact unit from the incident transcript. */
+const LOOP_UNIT = "The the the the the the the ";
+
+/**
+ * SSE endpoint that streams `chunks` reasoning deltas of the loop unit, then
+ * finishes. Records how many it actually managed to write, so the test can
+ * assert the guard cut the stream short.
+ */
+function startLoopingServer(chunks: number): { server: http.Server; sent: () => number } {
+	let sent = 0;
+	const server = http.createServer(async (req, res) => {
+		if (req.method !== "POST" || !req.url?.endsWith("/chat/completions")) {
+			res.writeHead(404).end();
+			return;
+		}
+		for await (const _chunk of req) {
+			// drain
+		}
+		res.writeHead(200, {
+			"content-type": "text/event-stream",
+			"cache-control": "no-cache",
+			connection: "keep-alive",
+		});
+		for (let i = 0; i < chunks; i++) {
+			const ok = res.write(
+				`data: ${JSON.stringify({
+					id: "chatcmpl-loop",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: "repro-model",
+					choices: [{ index: 0, delta: { reasoning_content: LOOP_UNIT }, finish_reason: null }],
+				})}\n\n`,
+			);
+			sent++;
+			// `ok === false` is only backpressure, not a hangup: wait for drain
+			// rather than truncating the response ourselves.
+			if (res.writableEnded || res.destroyed) break;
+			if (!ok) await once(res, "drain").catch(() => undefined);
+		}
+		if (!res.writableEnded) {
+			res.write(
+				`data: ${JSON.stringify({
+					id: "chatcmpl-loop",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: "repro-model",
+					choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+					usage: { prompt_tokens: 1, completion_tokens: 1 },
+				})}\n\n`,
+			);
+			res.write("data: [DONE]\n\n");
+			res.end();
+		}
+	});
+	return { server, sent: () => sent };
+}
+
+async function collect(stream: AsyncIterable<AssistantMessageEvent>): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+	return events;
+}
+
+async function runAgainstLoopingProvider(chunks: number): Promise<AssistantMessageEvent[]> {
+	const { server } = startLoopingServer(chunks);
+	server.listen(0, "127.0.0.1");
+	await once(server, "listening");
+	try {
+		const { port } = server.address() as AddressInfo;
+		return await collect(
+			streamOpenAICompletions(buildModel(`http://127.0.0.1:${port}`), buildContext(), { apiKey: "test-key" }),
+		);
+	} finally {
+		server.close();
+	}
+}
+
+describe("openai-completions repetition guard (#1029)", () => {
+	const original = process.env[REPETITION_GUARD_DISABLED_ENV];
+
+	afterEach(() => {
+		if (original === undefined) delete process.env[REPETITION_GUARD_DISABLED_ENV];
+		else process.env[REPETITION_GUARD_DISABLED_ENV] = original;
+	});
+
+	it("aborts a degenerate reasoning stream instead of consuming it", async () => {
+		// 2,366 repeats is what the reported incident produced before the user
+		// gave up and aborted by hand.
+		const events = await runAgainstLoopingProvider(2366);
+
+		const terminal = events.at(-1);
+		expect(terminal?.type).toBe("error");
+		if (terminal?.type !== "error") return;
+		expect(terminal.error.stopReason).toBe("error");
+		expect(terminal.error.errorMessage).toContain("repeated");
+	});
+
+	it("stops far short of the whole degenerate response", async () => {
+		const events = await runAgainstLoopingProvider(2366);
+
+		const thinkingDeltas = events.filter((event) => event.type === "thinking_delta");
+		const chars = thinkingDeltas.length * LOOP_UNIT.length;
+		// The incident persisted 79,222 characters.
+		expect(chars).toBeGreaterThan(0);
+		expect(chars).toBeLessThan(20000);
+	});
+
+	it("classifies the failure as degenerate_output so it is not mistaken for a provider fault", async () => {
+		const events = await runAgainstLoopingProvider(2366);
+
+		const terminal = events.at(-1);
+		expect(terminal?.type).toBe("error");
+		if (terminal?.type !== "error") return;
+		const diagnostics = terminal.error.diagnostics ?? [];
+		const failure = diagnostics.find((entry) => entry.type === "provider_stream_failure");
+		const details = failure?.details as StreamFailureInfo | undefined;
+		expect(details?.kind).toBe("degenerate_output");
+		expect(details?.providerErrorType).toMatch(/^repetition:/);
+	});
+
+	it("streams the whole response when the guard is disabled", async () => {
+		process.env[REPETITION_GUARD_DISABLED_ENV] = "1";
+		// Short enough to keep the test fast, long enough that the guard would
+		// otherwise have fired well before the end.
+		const events = await runAgainstLoopingProvider(600);
+
+		const terminal = events.at(-1);
+		expect(terminal?.type).toBe("done");
+		const thinkingDeltas = events.filter((event) => event.type === "thinking_delta");
+		expect(thinkingDeltas.length).toBe(600);
+	});
+});

--- a/packages/ai/test/repetition-guard.test.ts
+++ b/packages/ai/test/repetition-guard.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import {
+	describeRepetition,
+	isRepetitionGuardDisabled,
+	REPETITION_GUARD_DISABLED_ENV,
+	type RepetitionFinding,
+	RepetitionGuard,
+} from "../src/utils/repetition-guard.js";
+
+/**
+ * Detection tests are cheap; the false-positive tests below are the ones that
+ * matter. A guard that aborts legitimate reasoning is worse than the loop it
+ * prevents, so every realistic repetitive shape a model actually emits — code,
+ * tables, lists, JSON, enumerated analysis — is asserted NOT to fire.
+ */
+
+/** Feed text in small chunks, the way deltas actually arrive. */
+function stream(guard: RepetitionGuard, text: string, chunkChars = 24): RepetitionFinding | undefined {
+	let firstFinding: RepetitionFinding | undefined;
+	for (let i = 0; i < text.length; i += chunkChars) {
+		const finding = guard.push(text.slice(i, i + chunkChars));
+		if (finding && !firstFinding) firstFinding = finding;
+	}
+	return firstFinding;
+}
+
+describe("RepetitionGuard — the reported failure", () => {
+	it("catches the #1029 loop", () => {
+		// The exact shape from the issue: "The the the the the the the " repeated
+		// until the user aborted, 79,222 chars in the wild.
+		const unit = "The the the the the the the ";
+		const finding = stream(new RepetitionGuard(), unit.repeat(400));
+
+		expect(finding).toBeDefined();
+		expect(finding?.kind).toBe("periodic_tail");
+		expect(finding?.repeats).toBeGreaterThanOrEqual(16);
+		expect(finding?.sample).toContain("The the");
+	});
+
+	it("fires far below the 32k-token output cap", () => {
+		const guard = new RepetitionGuard();
+		const unit = "The the the the the the the ";
+		let charsWhenFired = 0;
+		let emitted = 0;
+		for (let i = 0; i < 4000 && charsWhenFired === 0; i++) {
+			emitted += unit.length;
+			if (guard.push(unit)) charsWhenFired = emitted;
+		}
+		expect(charsWhenFired).toBeGreaterThan(0);
+		// The incident persisted 79,222 characters. Anything in the low
+		// thousands is a decisive improvement; assert well inside that.
+		expect(charsWhenFired).toBeLessThan(8000);
+	});
+
+	it("reports only once so the caller is not spammed", () => {
+		const guard = new RepetitionGuard();
+		const unit = "The the the the the the the ";
+		let findings = 0;
+		for (let i = 0; i < 400; i++) {
+			if (guard.push(unit)) findings++;
+		}
+		expect(findings).toBe(1);
+	});
+
+	it("catches a single-word loop with no spaces", () => {
+		const finding = stream(new RepetitionGuard(), "loop".repeat(2000));
+		expect(finding?.kind).toBe("periodic_tail");
+	});
+
+	it("catches a loop that only starts after legitimate reasoning", () => {
+		const preamble =
+			"I need to weigh the tradeoffs between the two designs before writing any code. " +
+			"The first keeps the parser simple but pushes complexity into the caller. ".repeat(6);
+		const finding = stream(new RepetitionGuard(), preamble + "wait wait wait wait ".repeat(500));
+		// Either detector is a correct answer here; the point is that it stops.
+		expect(finding).toBeDefined();
+	});
+
+	it("catches a drifting loop that verbatim periodicity cannot see", () => {
+		// Same thought re-emitted with small wording changes: verbatim
+		// periodicity cannot see this.
+		const variants = [
+			"Let me reconsider the approach here, because the previous attempt did not account for the retry path.",
+			"Let me reconsider the approach here since the previous attempt did not account for the retry path.",
+			"Let me reconsider this approach, because that previous attempt did not account for the retry path.",
+		];
+		let text = "";
+		for (let i = 0; i < 40; i++) text += `${variants[i % variants.length]}\n\n`;
+
+		const finding = stream(new RepetitionGuard(), text);
+		expect(finding).toBeDefined();
+		expect(finding?.kind).toBe("novelty_stall");
+		expect(finding?.novelty).toBeLessThanOrEqual(0.2);
+	});
+});
+
+describe("RepetitionGuard — must not fire on legitimate output", () => {
+	const cases: [string, string][] = [
+		[
+			"prose reasoning",
+			"I will start by reading the provider streamer to understand how deltas are assembled. " +
+				"The reasoning field is chosen from a list of candidates, which means a provider that returns " +
+				"two of them could duplicate content. After that I want to check whether the agent loop has any " +
+				"notion of progress, because if it does the guard belongs there instead of in the provider. " +
+				"Finally I will look at how errors are classified so a synthetic failure is retryable rather " +
+				"than terminal, and confirm the session actually re-samples on that path instead of surfacing it.",
+		],
+		[
+			"a markdown table",
+			`| field | type | required | description |\n|---|---|---|---|\n${Array.from(
+				{ length: 40 },
+				(_, i) => `| field_${i} | string | yes | describes the ${i}th configured property |`,
+			).join("\n")}`,
+		],
+		[
+			"a numbered list",
+			Array.from({ length: 60 }, (_, i) => `${i + 1}. Check that handler ${i} forwards its abort signal.`).join(
+				"\n",
+			),
+		],
+		[
+			"repetitive source code",
+			Array.from(
+				{ length: 40 },
+				(_, i) => `export function handler${i}(input: string): string {\n\treturn transform(input, ${i});\n}\n`,
+			).join("\n"),
+		],
+		[
+			"a JSON payload",
+			`[\n${Array.from(
+				{ length: 60 },
+				(_, i) => `  { "id": ${i}, "name": "item-${i}", "enabled": true, "weight": 0.5 }`,
+			).join(",\n")}\n]`,
+		],
+		[
+			"enumerated analysis paragraphs",
+			Array.from(
+				{ length: 12 },
+				(_, i) =>
+					`Step ${i + 1}: inspect subsystem ${i} and record whether it owns the abort signal, ` +
+					`what it does on a partial write, and which failure kind it maps to.\n\n`,
+			).join(""),
+		],
+	];
+
+	for (const [name, text] of cases) {
+		it(`does not fire on ${name}`, () => {
+			expect(stream(new RepetitionGuard(), text)).toBeUndefined();
+		});
+	}
+
+	it("does not fire on repetition that stops before the threshold", () => {
+		// Eight repeats is well under minRepeats; a model recovering from a
+		// short stutter must not be aborted. The recovery text has to be
+		// genuinely varied — repeating one sentence 40 times is itself
+		// degenerate, and an earlier version of this test wrongly asserted
+		// that shape was legitimate.
+		const recovery = Array.from(
+			{ length: 60 },
+			(_, i) =>
+				`Back to the real problem: step ${i} needs to confirm that the ${i % 2 === 0 ? "reader" : "writer"} ` +
+				`releases its handle before subsystem ${i + 3} tears the socket down, otherwise the retry path ` +
+				`observes a half-open connection and reports success incorrectly.`,
+		).join(" ");
+		expect(stream(new RepetitionGuard(), `${"The the the the ".repeat(8)}${recovery}`)).toBeUndefined();
+	});
+
+	it("does not fire below the minimum inspection length", () => {
+		const guard = new RepetitionGuard();
+		// Loop shape, but only ~1 KB — under minCharsBeforeCheck.
+		expect(stream(guard, "ab".repeat(500))).toBeUndefined();
+		expect(guard.seenChars).toBe(1000);
+	});
+
+	it("does not fire on whitespace padding", () => {
+		expect(stream(new RepetitionGuard(), " ".repeat(6000))).toBeUndefined();
+	});
+});
+
+describe("RepetitionGuard — configuration", () => {
+	it("honours a lowered repeat threshold", () => {
+		const guard = new RepetitionGuard({ minRepeats: 4, minCharsBeforeCheck: 64, checkEveryChars: 16 });
+		expect(stream(guard, "spin ".repeat(40))).toBeDefined();
+	});
+
+	it("ignores a period longer than maxPeriodChars", () => {
+		const unit = `${"x".repeat(600)}\n`;
+		expect(stream(new RepetitionGuard({ maxPeriodChars: 64 }), unit.repeat(30))).toBeUndefined();
+	});
+
+	it("respects the kill switch env var", () => {
+		expect(isRepetitionGuardDisabled({})).toBe(false);
+		expect(isRepetitionGuardDisabled({ [REPETITION_GUARD_DISABLED_ENV]: "" })).toBe(false);
+		expect(isRepetitionGuardDisabled({ [REPETITION_GUARD_DISABLED_ENV]: "0" })).toBe(false);
+		expect(isRepetitionGuardDisabled({ [REPETITION_GUARD_DISABLED_ENV]: "false" })).toBe(false);
+		expect(isRepetitionGuardDisabled({ [REPETITION_GUARD_DISABLED_ENV]: "1" })).toBe(true);
+		expect(isRepetitionGuardDisabled({ [REPETITION_GUARD_DISABLED_ENV]: "true" })).toBe(true);
+	});
+
+	it("is unaffected by how deltas are chunked", () => {
+		const unit = "The the the the the the the ";
+		const text = unit.repeat(400);
+		for (const chunk of [1, 7, 64, 1024]) {
+			expect(stream(new RepetitionGuard(), text, chunk)?.kind, `chunk size ${chunk}`).toBe("periodic_tail");
+		}
+	});
+});
+
+describe("describeRepetition", () => {
+	it("describes a periodic tail", () => {
+		const finding = stream(new RepetitionGuard(), "The the the the the the the ".repeat(400));
+		expect(finding).toBeDefined();
+		if (!finding) return;
+		const text = describeRepetition(finding);
+		expect(text).toMatch(/repeated a \d+-character sequence \d+ times/);
+	});
+
+	it("describes a novelty stall", () => {
+		const finding: RepetitionFinding = {
+			kind: "novelty_stall",
+			inspectedChars: 4096,
+			totalChars: 12000,
+			novelty: 0.081,
+			sample: "Let me reconsider the approach here",
+		};
+		const text = describeRepetition(finding);
+		expect(text).toContain("stopped producing novel text");
+		expect(text).toContain("0.081");
+	});
+});


### PR DESCRIPTION
A thinking stream settled into emitting `"The the the the the the the "` back to
back 2,366 times — 79,222 characters — and stopped only when the user aborted by
hand. No layer owned this: provider streamers are faithful assemblers and never
inspect content, request construction attaches no repetition penalties, and the
agent loop treats a completed stream as progress. A runaway response could burn
the whole 32k output cap.

fixes #1029

## Detection

A stream-level guard on the reasoning channel of `openai-completions`, with two
detectors:

- **Periodic tail** — the tail is one short unit repeated many times. Found with
  the KMP failure function, which yields the smallest period of a string in
  O(n), so there is no scan over candidate period lengths.
- **Novelty stall** — distinct word trigrams over total, for loops that drift
  enough that verbatim periodicity misses them.

## The novelty floor is calibrated, not guessed

I first implemented near-duplicate paragraph clustering by word-trigram Jaccard,
following the prior art named in the issue. **Measured, it does not work here**:
drifting loops scored 0.38–0.58, and structurally similar legitimate paragraphs
scored in the same band. No threshold separates them, so I removed it.

Distinct-trigram novelty does separate. Measured over the corpus in the tests:

| | novelty |
|---|---|
| loop, verbatim | **0.001** |
| loop, drifting | **0.136** |
| enumerated analysis | 0.286 |
| markdown table | 0.485 |
| JSON payload | 0.513 |
| source code | 0.611 |
| numbered list | 0.671 |
| prose reasoning | 1.000 |

`0.20` sits in the gap with margin on both sides. The table is reproduced in the
module docstring so the number is not mistaken for a magic constant.

## False positives are the real risk

A wrong abort destroys real work, which is worse than the loop it prevents. The
tests assert the guard does **not** fire on source code, markdown tables,
numbered lists, JSON, prose, enumerated analysis, whitespace padding, short
sub-threshold stutters, or anything under the minimum inspection length.

One of those tests caught a mistake of mine: my first "recovery text" repeated a
single sentence 40 times and the guard fired. It was right to — that shape is
degenerate. The test corpus was wrong, not the detector, and the comment now
says so.

The **text channel is deliberately left unguarded**. A long legitimate answer can
contain generated tables or code, and the cost asymmetry there is the wrong way
round. This is one of the two deviations the issue flagged as needing sign-off —
the other, default-on for all models, is how this ships. Kill switch:
`PRIME_AGENT_NO_REPETITION_GUARD=1`.

## A second gap found on the way

`openai-completions.ts` was the only major provider that never called
`recordStreamFailure` — anthropic, google, google-vertex, amazon-bedrock,
mistral, openai-responses and azure-openai-responses all do. So failures on the
most widely used path (OpenRouter, llama.cpp, any OpenAI-compatible endpoint)
reached the session with **no classification at all**.

The new `degenerate_output` kind depends on it, but wiring it in fixes
classification for every existing failure kind on that provider too. Flagging it
because it is scope beyond the issue and easy to miss in review — happy to split
it out.

## Verification

25 tests across two files. Unit tests cover detection and the false-positive
corpus; the end-to-end test drives the real `streamOpenAICompletions` against a
local SSE server that replays the incident (2,366 reasoning deltas of the loop
unit), following the existing pattern in
`openai-completions-thinking-as-text.test.ts`.

```
test/repetition-guard.test.ts                     21 passed
test/openai-completions-repetition-guard.test.ts   4 passed
```

End to end the stream now terminates as an error, classifies as
`degenerate_output`, and stops after under 20,000 characters against the
79,222 the incident produced. With the kill switch set, all 600 deltas stream
and the turn ends `done`.

All 9 existing `openai-completions-*` test files still pass (81 tests).
`npm run check` exits 0; the pre-commit hook ran it again independently.

## Not done

No sampling penalties (`frequency_penalty` / `presence_penalty`) and no
cross-turn tool-call loop guard. Both are mentioned in the issue, both are
separate decisions, and neither is needed to stop this failure.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Abort degenerate AI reasoning streams instead of forwarding repetitive output
> - Adds a `RepetitionGuard` in [`repetition-guard.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1099/files#diff-dba06be8af57ad36471c3348d43655172067f7f940ba9936cbb487765a15d7c9) that detects two degenerate patterns in streaming text: periodic tail repetition (via KMP failure function) and novelty stall (low trigram novelty ratio).
> - Wires the guard into the OpenAI completions stream handler to monitor the `reasoning_content` channel and throw a `StreamFailureError` early when degeneracy is detected.
> - Classifies the failure as `degenerate_output` with a `repetition:...` providerErrorType and attaches structured diagnostics via `recordStreamFailure`.
> - An env-based kill switch (`REPETITION_GUARD_DISABLED_ENV`) disables the guard and restores the original pass-through behavior.
> - Behavioral Change: streams that previously completed with repetitive reasoning content now abort with an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a17252d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->