### PR TITLE
fix(runtime): preserve MCP tool inputSchema from SDK fields

### DIFF
--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -263,7 +263,10 @@ class McpIntegration:
                     t.name: {
                         "name": t.name,
                         "description": getattr(t, "description", "") or "",
-                        "inputSchema": getattr(t, "inputSchema", None) or {},
+                        # mcp.types.Tool uses snake_case attrs; inputSchema is only the JSON alias.
+                        "inputSchema": getattr(t, "input_schema", None)
+                        or getattr(t, "inputSchema", None)
+                        or {},
                     }
                     for t in resp.tools
                 }

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -32,7 +32,8 @@ class _FakeSession:
             t = Tool()
             t.name = name
             t.description = desc
-            t.inputSchema = schema
+            # Match mcp.types.Tool: field is input_schema, not inputSchema.
+            t.input_schema = schema
             return t
 
         resp = type("Resp", (), {})()
@@ -168,6 +169,23 @@ class McpIntegrationTest(unittest.TestCase):
             out = _run(integration.list_issues(team="Eng"))
         self.assertEqual(out, {"issues": [1, 2]})
         self.assertEqual(session.calls, [("list_issues", {"team": "Eng"})])
+
+    def test_list_tools_keeps_input_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {"team": {"type": "string"}},
+            "required": ["team"],
+        }
+        session = _FakeSession(
+            tools=[("list_issues", "List issues", schema)],
+            result=None,
+        )
+        self._write_auth(
+            {"type": "oauth", "access": "t", "refresh": "r", "expires": (time.time() + 3600) * 1000}
+        )
+        with self._patch_session(session):
+            tools = _run(_Integration().list_tools())
+        self.assertEqual(tools[0]["inputSchema"], schema)
 
     def test_unknown_tool_raises_with_available_list(self):
         session = _FakeSession(tools=[("list_issues", "", {})], result=None)


### PR DESCRIPTION
## Summary

`McpIntegration.list_tools()` always returned an empty `inputSchema` for MCP tools even when the server provided a schema.

The MCP SDK exposes the field as `input_schema` in Python, while `inputSchema` is the JSON alias. The existing code only checked `inputSchema`, so the lookup missed the actual SDK field and fell back to `{}`.

This change reads `input_schema` first while preserving `inputSchema` as a fallback for compatible stubs. The fake MCP tool used in tests was also updated to match the real SDK shape, and a regression test verifies that `list_tools()` preserves the schema.

Fixes #1073

## Test plan

Ran:

`PYTHONPATH=src python3 -m unittest discover -s test -p 'test_mcp_base.py' -v`

The new `test_list_tools_keeps_input_schema` case passed along with the existing MCP tool-call coverage.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `McpIntegration` tool discovery to preserve `input_schema` from MCP SDK
> The MCP SDK's `Tool` type uses the snake_case attribute `input_schema`, but the cache population code in [mcp_base.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/1101/files#diff-3e0a705745bc6d6096fecf5672e6173e25ee363911b2fc0ff065fa59f0117524) only read `inputSchema`, causing schemas to be silently dropped to `{}`. The fix reads `input_schema` first, falling back to `inputSchema`, then an empty dict, and stores the result under `inputSchema` in the internal cache.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d88631.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->