### PR TITLE
fix(security): validate session IDs and enforce private file modes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed API-key auth writes to use secure atomic writes with exclusive creation, symlink rejection, and private file modes ([#1105](https://github.com/PrimeIntellect-ai/prime-agent/pull/1105) by [@avion23](https://github.com/avion23))
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -1,7 +1,19 @@
 #!/usr/bin/env node
 
+import { randomUUID } from "node:crypto";
+import {
+	closeSync,
+	constants,
+	existsSync,
+	fchmodSync,
+	lstatSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeSync,
+} from "node:fs";
 import { createInterface } from "node:readline";
-import { existsSync, readFileSync, writeFileSync } from "fs";
 import { getOAuthProvider, getOAuthProviders } from "./utils/oauth/index.js";
 import type { OAuthCredentials, OAuthProviderId } from "./utils/oauth/types.js";
 
@@ -22,7 +34,28 @@ function loadAuth(): Record<string, { type: "oauth" } & OAuthCredentials> {
 }
 
 function saveAuth(auth: Record<string, { type: "oauth" } & OAuthCredentials>): void {
-	writeFileSync(AUTH_FILE, JSON.stringify(auth, null, 2), "utf-8");
+	try {
+		if (lstatSync(AUTH_FILE).isSymbolicLink()) throw new Error(`${AUTH_FILE} must not be a symlink`);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	const tempPath = `${AUTH_FILE}.${process.pid}.${randomUUID()}.tmp`;
+	let fd: number | undefined;
+	try {
+		fd = openSync(tempPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600);
+		fchmodSync(fd, 0o600);
+		writeSync(fd, JSON.stringify(auth, null, 2), undefined, "utf-8");
+		closeSync(fd);
+		fd = undefined;
+		renameSync(tempPath, AUTH_FILE);
+	} finally {
+		if (fd !== undefined) closeSync(fd);
+		try {
+			unlinkSync(tempPath);
+		} catch {
+			/* renamed or never created */
+		}
+	}
 }
 
 async function login(providerId: OAuthProviderId): Promise<void> {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 
+- Fixed crafted session IDs allowing path traversal outside the session directory during resume; session IDs are now validated, artifact paths contained, and symlinks rejected ([#1105](https://github.com/PrimeIntellect-ai/prime-agent/pull/1105) by [@avion23](https://github.com/avion23))
+- Enforced private file modes on session artifacts, snapshots, exports, and debug logs ([#1105](https://github.com/PrimeIntellect-ai/prime-agent/pull/1105) by [@avion23](https://github.com/avion23))
+
 ## [0.7.1] - 2026-08-07
 
 - Fixed the bundled `websearch` skill description and missing-key guidance omitting the `/login` → **MCP Connections** step required to configure Serper.

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -1,5 +1,15 @@
-import { copyFileSync, existsSync, mkdirSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import {
+	chmodSync,
+	closeSync,
+	constants,
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	renameSync,
+	rmSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import type { AgentSession } from "./agent-session.js";
 import type { AgentSessionRuntimeConfig } from "./agent-session-config.js";
 import type {
@@ -657,9 +667,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		}
 
 		const sessionDir = this.session.sessionManager.getSessionDir();
-		if (!existsSync(sessionDir)) {
-			mkdirSync(sessionDir, { recursive: true });
-		}
+		if (!existsSync(sessionDir)) mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+		chmodSync(sessionDir, 0o700);
 
 		const destinationPath = join(sessionDir, basename(resolvedPath));
 		const beforeResult = await this.emitBeforeSwitch("resume", destinationPath);
@@ -672,7 +681,25 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		let sessionManager: SessionManager;
 		try {
 			if (resolve(destinationPath) !== resolvedPath) {
-				copyFileSync(resolvedPath, destinationPath);
+				const tempPath = join(
+					dirname(destinationPath),
+					`.${basename(destinationPath)}.${process.pid}.${Date.now()}.tmp`,
+				);
+				try {
+					const tempFd = openSync(
+						tempPath,
+						constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+						0o600,
+					);
+					closeSync(tempFd);
+					copyFileSync(resolvedPath, tempPath);
+					chmodSync(tempPath, 0o600);
+					renameSync(tempPath, destinationPath);
+				} finally {
+					rmSync(tempPath, { force: true });
+				}
+			} else {
+				chmodSync(destinationPath, 0o600);
 			}
 
 			sessionManager = SessionManager.open(destinationPath, sessionDir, cwdOverride);

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -15,7 +15,7 @@ import {
 	type OAuthProviderId,
 } from "@earendil-works/pi-ai";
 import { getOAuthApiKey, getOAuthProvider, getOAuthProviders } from "@earendil-works/pi-ai/oauth";
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { getAgentDir } from "../config.js";
@@ -115,11 +115,25 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
 		}
 	}
 
-	private ensureFileExists(): void {
-		if (!existsSync(this.authPath)) {
-			writeFileSync(this.authPath, "{}", "utf-8");
-			chmodSync(this.authPath, 0o600);
+	private ensureFileSecure(): void {
+		let stat: ReturnType<typeof lstatSync>;
+		try {
+			stat = lstatSync(this.authPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			throw error;
 		}
+		if (!stat.isFile() || stat.isSymbolicLink())
+			throw new Error(`Auth storage must be a regular file: ${this.authPath}`);
+		if (typeof process.getuid === "function" && stat.uid !== process.getuid())
+			throw new Error(`Auth storage is not owned by the current user: ${this.authPath}`);
+		chmodSync(this.authPath, 0o600);
+	}
+
+	private ensureFileExists(): void {
+		if (!existsSync(this.authPath))
+			writeFileSync(this.authPath, "{}", { encoding: "utf-8", mode: 0o600, flag: "wx" });
+		this.ensureFileSecure();
 	}
 
 	private acquireLockSyncWithRetry(path: string): () => void {
@@ -156,10 +170,11 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
 		let release: (() => void) | undefined;
 		try {
 			release = this.acquireLockSyncWithRetry(this.authPath);
+			this.ensureFileSecure();
 			const current = existsSync(this.authPath) ? readFileSync(this.authPath, "utf-8") : undefined;
 			const { result, next } = fn(current);
 			if (next !== undefined) {
-				writeFileSync(this.authPath, next, "utf-8");
+				writeFileSync(this.authPath, next, { encoding: "utf-8", mode: 0o600 });
 				chmodSync(this.authPath, 0o600);
 			}
 			return result;
@@ -200,11 +215,12 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
 			});
 
 			throwIfCompromised();
+			this.ensureFileSecure();
 			const current = existsSync(this.authPath) ? readFileSync(this.authPath, "utf-8") : undefined;
 			const { result, next } = await fn(current);
 			throwIfCompromised();
 			if (next !== undefined) {
-				writeFileSync(this.authPath, next, "utf-8");
+				writeFileSync(this.authPath, next, { encoding: "utf-8", mode: 0o600 });
 				chmodSync(this.authPath, 0o600);
 			}
 			throwIfCompromised();

--- a/packages/coding-agent/src/core/export-html/index.ts
+++ b/packages/coding-agent/src/core/export-html/index.ts
@@ -1,11 +1,25 @@
+import { closeSync, constants, existsSync, fchmodSync, openSync, readFileSync, writeSync } from "node:fs";
+import { basename, join } from "node:path";
 import type { AgentState } from "@earendil-works/pi-agent-core";
-import { existsSync, readFileSync, writeFileSync } from "fs";
-import { basename, join } from "path";
 import { APP_NAME, getExportTemplateDir } from "../../config.js";
 import { getResolvedThemeColors, getThemeExportColors } from "../../modes/interactive/theme/theme.js";
 import type { ToolDefinition } from "../extensions/types.js";
 import type { SessionEntry } from "../session-manager.js";
 import { SessionManager } from "../session-manager.js";
+
+function writeExclusiveHtml(outputPath: string, html: string): void {
+	const fd = openSync(
+		outputPath,
+		constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+		0o600,
+	);
+	try {
+		fchmodSync(fd, 0o600);
+		writeSync(fd, html, undefined, "utf8");
+	} finally {
+		closeSync(fd);
+	}
+}
 
 /**
  * Interface for rendering custom tools to HTML.
@@ -276,7 +290,7 @@ export async function exportSessionToHtml(
 		outputPath = `${APP_NAME}-session-${sessionBasename}.html`;
 	}
 
-	writeFileSync(outputPath, html, "utf8");
+	writeExclusiveHtml(outputPath, html);
 	return outputPath;
 }
 
@@ -309,6 +323,6 @@ export async function exportFromFile(inputPath: string, options?: ExportOptions 
 		outputPath = `${APP_NAME}-session-${inputBasename}.html`;
 	}
 
-	writeFileSync(outputPath, html, "utf8");
+	writeExclusiveHtml(outputPath, html);
 	return outputPath;
 }

--- a/packages/coding-agent/src/core/kernel/state-snapshot.ts
+++ b/packages/coding-agent/src/core/kernel/state-snapshot.ts
@@ -99,11 +99,21 @@ def _prime_agent_snapshot_state():
         payload[name] = blob
         total += _b.len(blob)
 
-    os.makedirs(os.path.dirname(${pyStr(outPath)}), exist_ok=True)
-    tmp = ${pyStr(outPath)} + ".tmp"
+    artifact_dir = os.path.dirname(${pyStr(outPath)})
+    os.makedirs(artifact_dir, exist_ok=True, mode=0o700)
+    os.chmod(artifact_dir, 0o700)
+    tmp = ${pyStr(outPath)} + "." + str(os.getpid()) + ".tmp"
     try:
-        with _b.open(tmp, "wb") as fh:
-            dill.dump(payload, fh)
+        _fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+        try:
+            with os.fdopen(_fd, "wb") as fh:
+                _fd = None
+                dill.dump(payload, fh)
+                fh.flush()
+                os.fchmod(fh.fileno(), 0o600)
+        finally:
+            if _fd is not None:
+                os.close(_fd)
         os.replace(tmp, ${pyStr(outPath)})
     except _b.Exception as _err:
         try:
@@ -123,11 +133,24 @@ def _prime_agent_snapshot_state():
         "pythonVersion": sys.version.split()[0],
         "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
+    manifest_tmp = ${pyStr(manifestPath)} + "." + str(os.getpid()) + ".tmp"
     try:
-        with _b.open(${pyStr(manifestPath)}, "w") as fh:
-            json.dump(manifest, fh)
+        _manifest_fd = os.open(manifest_tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+        try:
+            with os.fdopen(_manifest_fd, "w") as fh:
+                _manifest_fd = None
+                json.dump(manifest, fh)
+                fh.flush()
+                os.fchmod(fh.fileno(), 0o600)
+        finally:
+            if _manifest_fd is not None:
+                os.close(_manifest_fd)
+        os.replace(manifest_tmp, ${pyStr(manifestPath)})
     except _b.Exception:
-        pass
+        try:
+            os.remove(manifest_tmp)
+        except _b.Exception:
+            pass
     _b.print(${pyStr(RESULT_MARKER)} + json.dumps({"saved": saved, "skipped": skipped, "bytes": bytes_written}))
 
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -6,6 +6,7 @@ import {
 	chmodSync,
 	chownSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
@@ -16,7 +17,7 @@ import {
 	writeFileSync,
 } from "fs";
 import { readdir, readFile, stat } from "fs/promises";
-import { basename, dirname, join, resolve } from "path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "path";
 import { v7 as uuidv7 } from "uuid";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
 import { readFirstLineSync, readLinesAsBuffers } from "../utils/file-lines.js";
@@ -36,6 +37,8 @@ const SESSION_LIST_PARSE_MAX_LINE_CHARS = 1024 * 1024;
 const SESSION_LIST_LARGE_MESSAGE_PREVIEW_MAX_CHARS = 256;
 const SESSION_STREAMING_LOAD_THRESHOLD_BYTES = 128 * 1024 * 1024;
 const SESSION_ASYNC_PARSE_YIELD_BYTES = 4 * 1024 * 1024;
+// IDs are generated UUIDs. Keep the legacy slug characters, but never path syntax.
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 
 // Entry types that can represent user intent (vs. daemon bookkeeping like
 // session_state/agent_status/git_state/child_usage_attributed). Used by
@@ -328,8 +331,35 @@ function createSessionId(): string {
 	return uuidv7();
 }
 
+function isValidSessionId(sessionId: unknown): sessionId is string {
+	return typeof sessionId === "string" && SESSION_ID_PATTERN.test(sessionId);
+}
+
 function getSessionFilePath(sessionDir: string, sessionId: string): string {
+	if (!isValidSessionId(sessionId)) throw new Error(`Invalid session id: ${String(sessionId)}`);
 	return join(sessionDir, `${sessionId}.jsonl`);
+}
+
+function rejectSymlinkIfPresent(path: string): void {
+	try {
+		if (lstatSync(path).isSymbolicLink())
+			throw new Error(`Session artifact path must not contain a symlink: ${path}`);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+}
+
+function isPathWithinRoot(rootPath: string, candidatePath: string): boolean {
+	const candidate = relative(rootPath, candidatePath);
+	return candidate === "" || (candidate !== ".." && !candidate.startsWith(`..${sep}`) && !isAbsolute(candidate));
+}
+
+function canonicalizePath(path: string): string {
+	const resolved = realpathIfPresent(path);
+	if (resolved !== path || existsSync(path)) return resolved;
+	const parent = dirname(path);
+	if (parent === path) return path;
+	return join(canonicalizePath(parent), basename(path));
 }
 
 function createUniqueSessionFileTarget(sessionDir: string): { sessionId: string; sessionFile: string } {
@@ -344,7 +374,19 @@ function createUniqueSessionFileTarget(sessionDir: string): { sessionId: string;
 }
 
 function getSessionArtifactPath(sessionDir: string, sessionId: string): string {
-	return join(dirname(sessionDir), "session-artifacts", sessionId);
+	if (!isValidSessionId(sessionId)) throw new Error(`Invalid session id: ${String(sessionId)}`);
+	const artifactRoot = resolve(dirname(resolve(sessionDir)), "session-artifacts");
+	rejectSymlinkIfPresent(dirname(artifactRoot));
+	rejectSymlinkIfPresent(artifactRoot);
+	const canonicalRoot = canonicalizePath(artifactRoot);
+	const artifactPath = resolve(artifactRoot, sessionId);
+	rejectSymlinkIfPresent(artifactPath);
+	if (!isPathWithinRoot(artifactRoot, artifactPath))
+		throw new Error(`Session artifact path escapes root: ${sessionId}`);
+	const realArtifactPath = canonicalizePath(artifactPath);
+	if (!isPathWithinRoot(canonicalRoot, realArtifactPath))
+		throw new Error(`Session artifact path escapes root: ${sessionId}`);
+	return artifactPath;
 }
 
 /** Generate a unique short ID (8 hex chars, collision-checked) */
@@ -603,7 +645,7 @@ export function buildSessionContext(
 export function getDefaultSessionDir(_cwd: string, agentDir: string = getDefaultAgentDir()): string {
 	const sessionDir = getSessionsDir(agentDir);
 	if (!existsSync(sessionDir)) {
-		mkdirSync(sessionDir, { recursive: true });
+		mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
 	}
 	return sessionDir;
 }
@@ -652,9 +694,8 @@ async function parseEntriesFromBufferAsync(buffer: Buffer): Promise<FileEntry[]>
 function finalizeLoadedEntries(entries: FileEntry[]): FileEntry[] {
 	if (entries.length === 0) return entries;
 	const header = entries[0];
-	if (header.type !== "session" || typeof (header as any).id !== "string") {
-		return [];
-	}
+	if (header.type !== "session") return [];
+	if (!isValidSessionId((header as any).id)) throw new Error("Invalid session header id");
 	applyChildUsageAttributions(entries);
 	return entries;
 }
@@ -1213,8 +1254,9 @@ export class SessionManager {
 		this.sessionDir = sessionDir;
 		this.persist = persist;
 		if (persist && sessionDir && !existsSync(sessionDir)) {
-			mkdirSync(sessionDir, { recursive: true });
+			mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
 		}
+		if (persist && sessionDir) chmodSync(sessionDir, 0o700);
 
 		if (sessionFile) {
 			this.setSessionFile(sessionFile, preloadedEntries);
@@ -1245,7 +1287,8 @@ export class SessionManager {
 			}
 
 			const header = this.fileEntries.find((e) => e.type === "session") as SessionHeader | undefined;
-			this.sessionId = header?.id ?? createSessionId();
+			if (!header || !isValidSessionId(header.id)) throw new Error("Invalid session header id");
+			this.sessionId = header.id;
 
 			let shouldRewrite = migrateToCurrentVersion(this.fileEntries);
 			if (header?.parentSession && !isValidRlmDepth(header.rlmDepth)) {
@@ -1267,6 +1310,7 @@ export class SessionManager {
 
 	newSession(options?: NewSessionOptions): string | undefined {
 		let sessionId = options?.id ?? createSessionId();
+		if (!isValidSessionId(sessionId)) throw new Error(`Invalid session id: ${sessionId}`);
 		let sessionFile: string | undefined;
 		const hasExplicitRlmDepth = options !== undefined && Object.hasOwn(options, "rlmDepth");
 		let parentHeader: Partial<SessionHeader> | undefined;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1391,11 +1391,11 @@ export class SessionManager {
 		const content = `${this.fileEntries.map((e) => JSON.stringify(e)).join("\n")}\n`;
 		const targetPath = realpathIfPresent(this.sessionFile);
 		const directory = dirname(targetPath);
-		mkdirSync(directory, { recursive: true });
+		mkdirSync(directory, { recursive: true, mode: 0o700 });
 		const tempPath = join(directory, `.${basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`);
 		try {
 			const metadata = statMetadataIfPresent(targetPath);
-			writeFileSync(tempPath, content, metadata === undefined ? undefined : { mode: metadata.mode });
+			writeFileSync(tempPath, content, { mode: metadata?.mode ?? 0o600 });
 			if (metadata !== undefined) {
 				chownSync(tempPath, metadata.uid, metadata.gid);
 				chmodSync(tempPath, metadata.mode);
@@ -1453,7 +1453,7 @@ export class SessionManager {
 		}
 		const dir = sessionDir ?? (this.sessionDir || getDefaultSessionDir(this.cwd));
 		if (!existsSync(dir)) {
-			mkdirSync(dir, { recursive: true });
+			mkdirSync(dir, { recursive: true, mode: 0o700 });
 		}
 		const previousHeader = this.getHeader();
 		const target = createUniqueSessionFileTarget(dir);
@@ -1512,8 +1512,8 @@ export class SessionManager {
 			this._rewriteFile();
 			this.flushed = true;
 		} else {
-			mkdirSync(dirname(this.sessionFile), { recursive: true });
-			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+			mkdirSync(dirname(this.sessionFile), { recursive: true, mode: 0o700 });
+			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`, { encoding: "utf8", mode: 0o600 });
 			this._notifyPersistListeners();
 		}
 	}
@@ -2286,7 +2286,7 @@ export class SessionManager {
 
 		const dir = sessionDir ?? getDefaultSessionDir(targetCwd);
 		if (!existsSync(dir)) {
-			mkdirSync(dir, { recursive: true });
+			mkdirSync(dir, { recursive: true, mode: 0o700 });
 		}
 
 		// Create new session file with new ID but forked content
@@ -2306,7 +2306,7 @@ export class SessionManager {
 			rlmDepth: resolveSessionRlmDepth(sourceHeader, sourcePath),
 			git: captureGitContext(targetCwd) ?? undefined,
 		};
-		appendFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`);
+		appendFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`, { encoding: "utf8", mode: 0o600 });
 
 		// Drop the source's git_state entries (re-linking children): they describe the source repo,
 		// so the fork would otherwise report the source's git instead of its own target context.
@@ -2323,7 +2323,7 @@ export class SessionManager {
 			if (entry.type === "session" || entry.type === "git_state") continue;
 			const parentId = liveParent(entry.parentId);
 			const out = parentId === entry.parentId ? entry : { ...entry, parentId };
-			appendFileSync(newSessionFile, `${JSON.stringify(out)}\n`);
+			appendFileSync(newSessionFile, `${JSON.stringify(out)}\n`, { encoding: "utf8", mode: 0o600 });
 		}
 
 		return new SessionManager(targetCwd, dir, newSessionFile, true);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7037,7 +7037,7 @@ export class InteractiveMode {
 
 		try {
 			// Write current content to temp file
-			fs.writeFileSync(tmpFile, currentText, "utf-8");
+			fs.writeFileSync(tmpFile, currentText, { encoding: "utf-8", mode: 0o600 });
 
 			// Stop TUI to release terminal
 			this.ui.stop();
@@ -8713,83 +8713,106 @@ export class InteractiveMode {
 			return;
 		}
 
-		// Export to a temp file
-		const tmpFile = path.join(os.tmpdir(), "session.html");
-		try {
-			await this.agentConnection.exportToHtml(tmpFile);
-		} catch (error: unknown) {
-			this.showError(`Failed to export session: ${error instanceof Error ? error.message : "Unknown error"}`);
-			return;
-		}
-
-		// Show cancellable loader, replacing the editor
-		const loader = new BorderedLoader(this.ui, theme, "Creating gist...");
-		this.editorContainer.clear();
-		this.editorContainer.addChild(loader);
-		this.ui.setFocus(loader);
-		this.ui.requestRender();
-
-		const restoreEditor = () => {
-			loader.dispose();
-			this.editorContainer.clear();
-			this.editorContainer.addChild(this.editor);
-			this.ui.setFocus(this.editor);
+		// Export to a private temporary directory and never reuse a fixed path.
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "prime-agent-share-"));
+		fs.chmodSync(tmpDir, 0o700);
+		const tmpFile = path.join(tmpDir, "session.html");
+		let tmpDirCleaned = false;
+		const cleanupTmpDir = () => {
+			if (tmpDirCleaned) return;
+			tmpDirCleaned = true;
 			try {
-				fs.unlinkSync(tmpFile);
+				fs.rmSync(tmpDir, { recursive: true, force: true });
 			} catch {
 				// Ignore cleanup errors
 			}
 		};
-
-		// Create a secret gist asynchronously
-		let proc: ReturnType<typeof spawn> | null = null;
-
-		loader.onAbort = () => {
-			proc?.kill();
-			restoreEditor();
-			this.showStatus("Share cancelled");
+		let loader: BorderedLoader | undefined;
+		let editorReplaced = false;
+		let editorRestored = false;
+		const restoreEditor = () => {
+			if (editorRestored) return;
+			editorRestored = true;
+			if (!editorReplaced) return;
+			loader?.dispose();
+			this.editorContainer.clear();
+			this.editorContainer.addChild(this.editor);
+			this.ui.setFocus(this.editor);
+			this.ui.requestRender();
 		};
 
 		try {
-			const result = await new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve) => {
-				proc = spawn("gh", ["gist", "create", "--public=false", tmpFile]);
-				let stdout = "";
-				let stderr = "";
-				proc.stdout?.on("data", (data) => {
-					stdout += data.toString();
-				});
-				proc.stderr?.on("data", (data) => {
-					stderr += data.toString();
-				});
-				proc.on("close", (code) => resolve({ stdout, stderr, code }));
-			});
-
-			if (loader.signal.aborted) return;
-
-			restoreEditor();
-
-			if (result.code !== 0) {
-				const errorMsg = result.stderr?.trim() || "Unknown error";
-				this.showError(`Failed to create gist: ${errorMsg}`);
+			try {
+				await this.agentConnection.exportToHtml(tmpFile);
+			} catch (error: unknown) {
+				this.showError(`Failed to export session: ${error instanceof Error ? error.message : "Unknown error"}`);
 				return;
 			}
 
-			// Extract gist ID from the URL returned by gh
-			// gh returns something like: https://gist.github.com/username/GIST_ID
-			const gistUrl = result.stdout?.trim();
-			const gistId = gistUrl?.split("/").pop();
-			if (!gistId) {
-				this.showError("Failed to parse gist ID from gh output");
-				return;
-			}
+			// Show cancellable loader, replacing the editor
+			loader = new BorderedLoader(this.ui, theme, "Creating gist...");
+			editorReplaced = true;
+			this.editorContainer.clear();
+			this.editorContainer.addChild(loader);
+			this.ui.setFocus(loader);
+			this.ui.requestRender();
 
-			// Create the preview URL
-			const previewUrl = getShareViewerUrl(gistId);
-			this.showStatus(`Share URL: ${previewUrl}\nGist: ${gistUrl}`);
-		} catch (error: unknown) {
-			if (!loader.signal.aborted) {
+			// Create a secret gist asynchronously
+			let proc: ReturnType<typeof spawn> | null = null;
+
+			loader.onAbort = () => {
+				proc?.kill();
 				restoreEditor();
-				this.showError(`Failed to create gist: ${error instanceof Error ? error.message : "Unknown error"}`);
+				this.showStatus("Share cancelled");
+			};
+
+			try {
+				const result = await new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve) => {
+					proc = spawn("gh", ["gist", "create", "--public=false", tmpFile]);
+					let stdout = "";
+					let stderr = "";
+					proc.stdout?.on("data", (data) => {
+						stdout += data.toString();
+					});
+					proc.stderr?.on("data", (data) => {
+						stderr += data.toString();
+					});
+					proc.on("close", (code) => resolve({ stdout, stderr, code }));
+				});
+
+				if (loader?.signal.aborted) return;
+
+				restoreEditor();
+
+				if (result.code !== 0) {
+					const errorMsg = result.stderr?.trim() || "Unknown error";
+					this.showError(`Failed to create gist: ${errorMsg}`);
+					return;
+				}
+
+				// Extract gist ID from the URL returned by gh
+				// gh returns something like: https://gist.github.com/username/GIST_ID
+				const gistUrl = result.stdout?.trim();
+				const gistId = gistUrl?.split("/").pop();
+				if (!gistId) {
+					this.showError("Failed to parse gist ID from gh output");
+					return;
+				}
+
+				// Create the preview URL
+				const previewUrl = getShareViewerUrl(gistId);
+				this.showStatus(`Share URL: ${previewUrl}\nGist: ${gistUrl}`);
+			} catch (error: unknown) {
+				if (!loader?.signal.aborted) {
+					restoreEditor();
+					this.showError(`Failed to create gist: ${error instanceof Error ? error.message : "Unknown error"}`);
+				}
+			}
+		} finally {
+			try {
+				restoreEditor();
+			} finally {
+				cleanupTmpDir();
 			}
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -9685,8 +9685,8 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 				"",
 			].join("\n");
 
-			fs.mkdirSync(path.dirname(debugLogPath), { recursive: true });
-			fs.writeFileSync(debugLogPath, debugData);
+			fs.mkdirSync(path.dirname(debugLogPath), { recursive: true, mode: 0o700 });
+			fs.writeFileSync(debugLogPath, debugData, { mode: 0o600 });
 
 			this.chatContainer.addChild(new Spacer(1));
 			this.chatContainer.addChild(

--- a/packages/coding-agent/test/kernel-state-snapshot.test.ts
+++ b/packages/coding-agent/test/kernel-state-snapshot.test.ts
@@ -1,3 +1,6 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -92,9 +95,35 @@ describe("buildSnapshotCode", () => {
 		expect(code).toContain(String(DEFAULT_SNAPSHOT_MAX_BYTES));
 	});
 
+	it("executes the generated writer and keeps snapshot files private", () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "kernel-state-snapshot-"));
+		const artifactDir = join(tempRoot, "artifacts", "session");
+		try {
+			const payloadPath = snapshotPathIn(artifactDir);
+			const manifestPath = manifestPathIn(artifactDir);
+			const runSnapshot = (source: string) =>
+				execFileSync(
+					"python3",
+					["-c", `${source}\n${buildSnapshotCode(payloadPath, manifestPath, DEFAULT_SNAPSHOT_MAX_BYTES)}`],
+					{ encoding: "utf8" },
+				);
+			runSnapshot(`value = "first"`);
+			expect(statSync(artifactDir).mode & 0o777).toBe(0o700);
+			expect(statSync(payloadPath).mode & 0o777).toBe(0o600);
+			expect(statSync(manifestPath).mode & 0o777).toBe(0o600);
+			expect(JSON.parse(readFileSync(manifestPath, "utf8")).savedNames).toContain("value");
+			runSnapshot(`value = "second"\nsecondOnly = 1`);
+			expect(JSON.parse(readFileSync(manifestPath, "utf8")).savedNames).toContain("secondOnly");
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+
 	it("uses dill, an atomic write, and skips internal handles", () => {
 		expect(code).toContain("import dill");
 		expect(code).toContain("os.replace");
+		expect(code).toContain("os.fdopen");
+		expect(code).toContain("os.O_EXCL");
 		// rlm and the IPython display names must never be serialized.
 		expect(code).toContain('"rlm"');
 		expect(code).toContain(`print(${JSON.stringify(MARKER)}`);

--- a/packages/coding-agent/test/session-manager/session-security.test.ts
+++ b/packages/coding-agent/test/session-manager/session-security.test.ts
@@ -1,10 +1,26 @@
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { SessionManager } from "../../src/core/session-manager.js";
 
 describe("SessionManager artifact security", () => {
+	it("creates session directories and JSONL files with private permissions under umask 022", () => {
+		const root = mkdtempSync(join(tmpdir(), "session-security-modes-"));
+		const previousUmask = process.umask(0o022);
+		try {
+			const sessionDir = join(root, "sessions");
+			const session = SessionManager.create(root, sessionDir);
+			session.flushNow();
+			const sessionFile = session.getSessionFile();
+			expect(sessionFile).toBeDefined();
+			expect(statSync(sessionDir).mode & 0o777).toBe(0o700);
+			expect(statSync(sessionFile!).mode & 0o777).toBe(0o600);
+		} finally {
+			process.umask(previousUmask);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 	it("rejects traversal IDs in session headers", () => {
 		const root = mkdtempSync(join(tmpdir(), "session-security-"));
 		try {

--- a/packages/coding-agent/test/session-manager/session-security.test.ts
+++ b/packages/coding-agent/test/session-manager/session-security.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.js";
+
+describe("SessionManager artifact security", () => {
+	it("rejects traversal IDs in session headers", () => {
+		const root = mkdtempSync(join(tmpdir(), "session-security-"));
+		try {
+			const sessionDir = join(root, "sessions");
+			mkdirSync(sessionDir);
+			const sessionFile = join(sessionDir, "attacker.jsonl");
+			writeFileSync(
+				sessionFile,
+				`${JSON.stringify({
+					type: "session",
+					id: "../../../../tmp/attacker-controlled",
+					timestamp: new Date().toISOString(),
+					cwd: root,
+				})}\n`,
+			);
+			expect(() => SessionManager.open(sessionFile, sessionDir)).toThrow("Invalid session header id");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects artifact directories that resolve outside the artifact root", () => {
+		const root = mkdtempSync(join(tmpdir(), "session-artifact-security-"));
+		try {
+			const sessionDir = join(root, "sessions");
+			const artifactRoot = join(root, "session-artifacts");
+			const outside = join(root, "outside");
+			mkdirSync(sessionDir);
+			mkdirSync(artifactRoot);
+			mkdirSync(outside);
+			const session = SessionManager.create(root, sessionDir);
+			const artifact = join(artifactRoot, session.getSessionId());
+			symlinkSync(outside, artifact);
+			expect(() => session.getSessionArtifactDir()).toThrow(/escapes root|must not contain a symlink/);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed TUI logs being written with world-readable permissions; logging now uses private file modes ([#1105](https://github.com/PrimeIntellect-ai/prime-agent/pull/1105) by [@avion23](https://github.com/avion23))
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
+
 import { setKittyProtocolActive } from "./keys.js";
 import { StdinBuffer } from "./stdin-buffer.js";
 import {
@@ -10,6 +11,20 @@ import {
 	type Rgb,
 	setDefaultTerminalColors,
 } from "./terminal-colors.js";
+
+function appendPrivateFile(filePath: string, data: string): void {
+	const fd = fs.openSync(
+		filePath,
+		fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_APPEND | fs.constants.O_NOFOLLOW,
+		0o600,
+	);
+	try {
+		fs.fchmodSync(fd, 0o600);
+		fs.writeSync(fd, data, undefined, "utf8");
+	} finally {
+		fs.closeSync(fd);
+	}
+}
 
 const cjsRequire = createRequire(import.meta.url);
 
@@ -492,7 +507,7 @@ export class ProcessTerminal implements Terminal {
 		process.stdout.write(data);
 		if (this.writeLogPath) {
 			try {
-				fs.appendFileSync(this.writeLogPath, data, { encoding: "utf8" });
+				appendPrivateFile(this.writeLogPath, data);
 			} catch {
 				// Ignore logging errors
 			}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -24,6 +24,42 @@ import {
 	visibleWidth,
 } from "./utils.js";
 
+function privateDebugDirectory(): string {
+	const uid = typeof process.getuid === "function" ? String(process.getuid()) : process.env.USER || "user";
+	const dir = path.join(os.tmpdir(), `prime-agent-tui-${uid}`);
+	fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+	fs.chmodSync(dir, 0o700);
+	return dir;
+}
+
+function appendPrivateLog(filePath: string, data: string): void {
+	const fd = fs.openSync(
+		filePath,
+		fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_APPEND | fs.constants.O_NOFOLLOW,
+		0o600,
+	);
+	try {
+		fs.fchmodSync(fd, 0o600);
+		fs.writeSync(fd, data, undefined, "utf8");
+	} finally {
+		fs.closeSync(fd);
+	}
+}
+
+function writePrivateLog(filePath: string, data: string): void {
+	const fd = fs.openSync(
+		filePath,
+		fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW,
+		0o600,
+	);
+	try {
+		fs.fchmodSync(fd, 0o600);
+		fs.writeSync(fd, data, undefined, "utf8");
+	} finally {
+		fs.closeSync(fd);
+	}
+}
+
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
 
 function extractKittyImageIds(line: string): number[] {
@@ -1611,9 +1647,12 @@ export class TUI extends Container {
 		const debugRedraw = process.env.PI_DEBUG_REDRAW === "1";
 		const logRedraw = (reason: string): void => {
 			if (!debugRedraw) return;
-			const logPath = path.join(os.homedir(), ".prime", "agent", "pi-debug.log");
+			const logDir = path.join(os.homedir(), ".prime", "agent");
+			fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
+			fs.chmodSync(logDir, 0o700);
+			const logPath = path.join(logDir, "pi-debug.log");
 			const msg = `[${new Date().toISOString()}] fullRender: ${reason} (prev=${this.previousLines.length}, new=${newLines.length}, height=${height})\n`;
-			fs.appendFileSync(logPath, msg);
+			appendPrivateLog(logPath, msg);
 		};
 
 		// First render - just output everything without clearing (assumes clean screen)
@@ -1803,8 +1842,10 @@ export class TUI extends Container {
 					...newLines.map((l, idx) => `[${idx}] (w=${visibleWidth(l)}) ${l}`),
 					"",
 				].join("\n");
-				fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
-				fs.writeFileSync(crashLogPath, crashData);
+				const crashDir = path.dirname(crashLogPath);
+				fs.mkdirSync(crashDir, { recursive: true, mode: 0o700 });
+				fs.chmodSync(crashDir, 0o700);
+				appendPrivateLog(crashLogPath, crashData);
 
 				// Clean up terminal state before throwing
 				this.stop();
@@ -1844,8 +1885,7 @@ export class TUI extends Container {
 		buffer += "\x1b[?2026l"; // End synchronized output
 
 		if (process.env.PI_TUI_DEBUG === "1") {
-			const debugDir = "/tmp/tui";
-			fs.mkdirSync(debugDir, { recursive: true });
+			const debugDir = privateDebugDirectory();
 			const debugPath = path.join(debugDir, `render-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);
 			const debugData = [
 				`firstChanged: ${firstChanged}`,
@@ -1869,7 +1909,7 @@ export class TUI extends Container {
 				"=== buffer ===",
 				JSON.stringify(buffer),
 			].join("\n");
-			fs.writeFileSync(debugPath, debugData);
+			writePrivateLog(debugPath, debugData);
 		}
 
 		// Write entire buffer at once

--- a/prime-agent-runtime/src/rlm/harness.py
+++ b/prime-agent-runtime/src/rlm/harness.py
@@ -285,7 +285,11 @@ class HarnessState:
         if self.file_path is None:
             # in_memory fallback: nothing to persist.
             return self
-        self.file_path.parent.mkdir(parents=True, exist_ok=True)
+        self.file_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            os.chmod(self.file_path.parent, 0o700)
+        except OSError:
+            pass
         data = {
             "schema": 1,
             "entries": {
@@ -294,8 +298,25 @@ class HarnessState:
             },
             "refinements": [asdict(event) for event in self.refinements],
         }
-        with self.file_path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
+        temp_path = self.file_path.with_name(f".{self.file_path.name}.{os.getpid()}.{id(self)}.tmp")
+        fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                fd = -1
+                json.dump(data, f, indent=2, ensure_ascii=False)
+                f.flush()
+                os.fchmod(f.fileno(), 0o600)
+                os.fsync(f.fileno())
+            if self.file_path.exists() and self.file_path.stat().st_uid == os.getuid():
+                os.chmod(self.file_path, 0o600)
+            os.replace(temp_path, self.file_path)
+        finally:
+            if fd != -1:
+                os.close(fd)
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
         self._loaded_mtime = self._disk_mtime()
         return self
 

--- a/prime-agent-runtime/test/test_harness.py
+++ b/prime-agent-runtime/test/test_harness.py
@@ -20,6 +20,19 @@ PYTHON_REFERENCE = {
 }
 
 
+class HarnessStateSecurityTest(unittest.TestCase):
+    def test_state_uses_private_directory_and_file_modes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = os.umask(0o022)
+            try:
+                state = HarnessState(Path(temp_dir) / "nested" / "harness_state.json")
+                state.upsert("memory", "private", "secret")
+            finally:
+                os.umask(previous)
+            self.assertEqual((Path(temp_dir) / "nested").stat().st_mode & 0o777, 0o700)
+            self.assertEqual(state.file_path.stat().st_mode & 0o777, 0o600)
+
+
 class HarnessStateTest(unittest.TestCase):
     def test_crud_for_all_entry_kinds(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- Validated session header IDs and enforced canonical artifact-root containment, rejecting symlinked artifact directories. This closes the critical path traversal: a `../../..` session ID could escape `session-artifacts`, and agent-session prewarm could `dill.load()` attacker-controlled content for arbitrary code execution.
- Hardened private data writes: harness state, OAuth auth, HTML exports, kernel snapshots, imported sessions, TUI logs/debug output, and editor/share temporary files now use private directories, `0600` files, exclusive no-follow temporary files, and atomic replacement where applicable.
- Hardened auth storage reads by requiring a regular file and repairing its mode to `0600`.

## Evidence

Before the fix, the upstream implementation failed the new security probe:

```text
npx tsx ../../node_modules/vitest/dist/cli.js --run test/session-manager/session-security.test.ts
# exit 1: 2 tests failed (traversal header accepted; symlinked artifact directory accepted)
```

After the fix:

```text
npx tsx ../../node_modules/vitest/dist/cli.js --run test/session-manager/ test/kernel-state-snapshot.test.ts test/auth-storage.test.ts
# exit 0: 14 files, 196 tests passed
PYTHONPATH=prime-agent-runtime/src python3 -m pytest prime-agent-runtime/test/
# exit 0: 65 passed
npm run check
# exit 0
```

## Related fork commits

- [b6e4dc53](https://github.com/avion23/prime-agent/commit/b6e4dc53d5d62826f6f7a5d8e0cdfdf209ac52a8)
- [5095cd8b](https://github.com/avion23/prime-agent/commit/5095cd8becf8e20405e0df425c8d4829c4ac1b80)
- [a5ec2444](https://github.com/avion23/prime-agent/commit/a5ec24448b5d982dba993e2505bd2f4df98d3e66)
- [2a19dd15](https://github.com/avion23/prime-agent/commit/2a19dd152b6d08dbc8c785620d8aa76922684dab)
- [246ec844](https://github.com/avion23/prime-agent/commit/246ec84480fb998837b8d15bd5315a10a46f850d)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate session IDs and enforce private file modes across auth, session, and log paths
> - Introduces `SESSION_ID_PATTERN` validation in `session-manager.ts` to reject path-traversal and malformed session IDs at all entry points (`getSessionFilePath`, `newSession`, `setSessionFile`, `finalizeLoadedEntries`).
> - Adds symlink rejection and path-containment checks in `getSessionArtifactPath` to prevent artifact directory escapes.
> - Rewrites auth file persistence in `cli.ts` and `auth-storage.ts` to use atomic writes (`O_CREAT|O_EXCL|O_NOFOLLOW`) with 0600 file modes and symlink rejection.
> - Enforces 0700 on all session and debug directories and 0600 on all written files (JSONL, HTML exports, snapshots, debug/crash logs, TUI logs, harness state) across TypeScript and generated Python code.
> - Risk: Sessions or auth files with previously permissive modes or symlinked paths will now raise errors rather than silently proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a923f00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->