### PR TITLE
fix(coding-agent): passivate quiescent roots after restart

### DIFF
--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -934,14 +934,15 @@ async function forceStopTrackedWorkers(
 	const failures: string[] = [];
 	for (const worker of findTrackedWorkers(supervisorSocketPath)) {
 		const { descriptor } = worker;
-		let cleanupWorkerRecords = await stopTrackedProcess(descriptor.pid, descriptor.processStartId, assertAdmission);
+		const pid = descriptor.pid!;
+		let cleanupWorkerRecords = await stopTrackedProcess(pid, descriptor.processStartId, assertAdmission);
 		if (!cleanupWorkerRecords) {
-			failures.push(`could not safely stop worker ${descriptor.workerId} (pid ${descriptor.pid})`);
+			failures.push(`could not safely stop worker ${descriptor.workerId} (pid ${pid})`);
 		}
 		if (descriptor.orphanProcessJournalPath) {
 			let orphans: ReturnType<typeof readActiveOrphanProcesses> = [];
 			try {
-				orphans = readActiveOrphanProcesses(descriptor.orphanProcessJournalPath, descriptor.pid);
+				orphans = readActiveOrphanProcesses(descriptor.orphanProcessJournalPath, pid);
 			} catch (error) {
 				failures.push(`could not read child process records for worker ${descriptor.workerId}: ${String(error)}`);
 			}
@@ -1030,6 +1031,7 @@ function isTrackedWorkerDescriptor(value: unknown): value is DaemonWorkerDescrip
 	const descriptor = value as Partial<DaemonWorkerDescriptor>;
 	return (
 		descriptor.version === 1 &&
+		descriptor.lifecycle !== "passivated" &&
 		typeof descriptor.supervisorSocketPath === "string" &&
 		typeof descriptor.workerId === "string" &&
 		Number.isInteger(descriptor.pid) &&

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -263,8 +263,14 @@ export class AgentCronJobStore {
 			// Dispatches are not independently meaningful. An orphan, cross-session,
 			// or terminal-state mismatch may represent work whose result was lost. A
 			// completed one-shot dispatch is safe: its durable terminal job proves there
-			// is no schedule left to revive.
-			if (!job || job.sessionId !== sessionId || (job.status !== "active" && job.status !== "completed")) {
+			// is no schedule left to revive. A recurring job can become completed only
+			// after an interrupted state transition, so its outstanding dispatch is
+			// recoverable rather than evidence that passivation is safe.
+			if (
+				!job ||
+				job.sessionId !== sessionId ||
+				(job.status !== "active" && (job.status !== "completed" || job.schedule.kind !== "once"))
+			) {
 				return true;
 			}
 		}

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -238,7 +238,10 @@ export class AgentCronJobStore {
 			return true;
 		}
 		const file = parsed as CronJobsFile;
-		if ((file.jobs !== undefined && !Array.isArray(file.jobs)) || (file.dispatches !== undefined && !Array.isArray(file.dispatches))) {
+		if (
+			(file.jobs !== undefined && !Array.isArray(file.jobs)) ||
+			(file.dispatches !== undefined && !Array.isArray(file.dispatches))
+		) {
 			return true;
 		}
 		if ((file.jobs ?? []).some((job) => !isAgentCronJob(job))) {
@@ -247,7 +250,7 @@ export class AgentCronJobStore {
 		if ((file.dispatches ?? []).some((dispatch) => !isAgentCronDispatchRecord(dispatch))) {
 			return true;
 		}
-		return (file.jobs as AgentCronJob[] | undefined ?? []).some(
+		return ((file.jobs as AgentCronJob[] | undefined) ?? []).some(
 			(job) => job.status === "active" || (isHeartbeatCronJob(job) && job.status === "paused"),
 		);
 	}

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -264,11 +264,7 @@ export class AgentCronJobStore {
 			// or terminal-state mismatch may represent work whose result was lost. A
 			// completed one-shot dispatch is safe: its durable terminal job proves there
 			// is no schedule left to revive.
-			if (
-				!job ||
-				job.sessionId !== sessionId ||
-				(job.status !== "active" && job.status !== "completed")
-			) {
+			if (!job || job.sessionId !== sessionId || (job.status !== "active" && job.status !== "completed")) {
 				return true;
 			}
 		}

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -219,6 +219,39 @@ export class AgentCronJobStore {
 		return this.readJobs().sort((a, b) => compareOptionalIso(a.nextRunAt, b.nextRunAt));
 	}
 
+	/**
+	 * Whether a persisted session schedule prevents replacing its worker with a
+	 * processless passive descriptor. Unlike list(), this deliberately does not
+	 * discard malformed records: a supervisor cannot reconstruct a heartbeat
+	 * catalog from data it cannot validate.
+	 */
+	hasRecoverableSessionArtifactState(sessionId: string): boolean {
+		if (!this.sessionArtifactMode) {
+			throw new Error("Recoverable artifact state requires session artifact mode");
+		}
+		const path = this.sessionArtifactFiles.get(sessionId);
+		if (!path || !existsSync(path)) {
+			return false;
+		}
+		const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+		if (!parsed || typeof parsed !== "object") {
+			return true;
+		}
+		const file = parsed as CronJobsFile;
+		if ((file.jobs !== undefined && !Array.isArray(file.jobs)) || (file.dispatches !== undefined && !Array.isArray(file.dispatches))) {
+			return true;
+		}
+		if ((file.jobs ?? []).some((job) => !isAgentCronJob(job))) {
+			return true;
+		}
+		if ((file.dispatches ?? []).some((dispatch) => !isAgentCronDispatchRecord(dispatch))) {
+			return true;
+		}
+		return (file.jobs as AgentCronJob[] | undefined ?? []).some(
+			(job) => job.status === "active" || (isHeartbeatCronJob(job) && job.status === "paused"),
+		);
+	}
+
 	create(input: CreateAgentCronJobInput): AgentCronJob {
 		const now = input.now ?? new Date();
 		const prompt = input.prompt.trim();

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -234,7 +234,7 @@ export class AgentCronJobStore {
 			return false;
 		}
 		const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
-		if (!parsed || typeof parsed !== "object") {
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
 			return true;
 		}
 		const file = parsed as CronJobsFile;

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -250,9 +250,29 @@ export class AgentCronJobStore {
 		if ((file.dispatches ?? []).some((dispatch) => !isAgentCronDispatchRecord(dispatch))) {
 			return true;
 		}
-		return ((file.jobs as AgentCronJob[] | undefined) ?? []).some(
-			(job) => job.status === "active" || (isHeartbeatCronJob(job) && job.status === "paused"),
-		);
+		const jobs = (file.jobs as AgentCronJob[] | undefined) ?? [];
+		const jobsById = new Map<string, AgentCronJob>();
+		for (const job of jobs) {
+			// A duplicate ID makes a dispatch ambiguous: we cannot prove which durable
+			// schedule claimed it, so recovery is safer than passivation.
+			if (jobsById.has(job.id)) return true;
+			jobsById.set(job.id, job);
+		}
+		for (const dispatch of (file.dispatches as AgentCronDispatchRecord[] | undefined) ?? []) {
+			const job = jobsById.get(dispatch.jobId);
+			// Dispatches are not independently meaningful. An orphan, cross-session,
+			// or terminal-state mismatch may represent work whose result was lost. A
+			// completed one-shot dispatch is safe: its durable terminal job proves there
+			// is no schedule left to revive.
+			if (
+				!job ||
+				job.sessionId !== sessionId ||
+				(job.status !== "active" && job.status !== "completed")
+			) {
+				return true;
+			}
+		}
+		return jobs.some((job) => job.status === "active" || (isHeartbeatCronJob(job) && job.status === "paused"));
 	}
 
 	create(input: CreateAgentCronJobInput): AgentCronJob {

--- a/packages/coding-agent/src/core/session-action-store.ts
+++ b/packages/coding-agent/src/core/session-action-store.ts
@@ -326,7 +326,7 @@ export interface SessionPassivationSnapshot extends SessionEvictionSnapshot {
 }
 
 export interface WorkerEvictionSnapshot {
-	lifecycle: "starting" | "ready" | "recovering" | "failed";
+	lifecycle: "starting" | "ready" | "recovering" | "failed" | "passivated";
 	isConnected: boolean;
 	isStopping: boolean;
 	hasOwnerClient: boolean;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -190,7 +190,12 @@ export interface SessionInfoEntry extends SessionEntryBase {
 
 // On-disk lifecycle. "archived" replaces legacy "sleep" (normalized on read).
 // "crash" is read-only back-compat; no longer written.
-export type SessionStateStatus = "active" | "archived" | "crash";
+export const SESSION_STATE_STATUSES = ["active", "archived", "crash"] as const;
+export type SessionStateStatus = (typeof SESSION_STATE_STATUSES)[number];
+
+export function isSessionStateStatus(value: unknown): value is SessionStateStatus {
+	return typeof value === "string" && (SESSION_STATE_STATUSES as readonly string[]).includes(value);
+}
 
 export interface SessionState {
 	status: SessionStateStatus;
@@ -203,7 +208,13 @@ export interface SessionStateEntry extends SessionEntryBase {
 }
 
 /** Whether an idle agent's turn left the task complete or awaiting more input. */
-export type AgentTaskState = "needs_input" | "completed";
+export const AGENT_TASK_STATES = ["needs_input", "completed"] as const;
+export type AgentTaskState = (typeof AGENT_TASK_STATES)[number];
+
+/** Agent-status verdicts are durable input and must never be widened to string. */
+export function isAgentTaskState(value: unknown): value is AgentTaskState {
+	return typeof value === "string" && (AGENT_TASK_STATES as readonly string[]).includes(value);
+}
 
 /** Latest short status for an agent, shown in the agents view. */
 export interface AgentStatus {
@@ -305,6 +316,8 @@ export interface SessionInfo {
 	allMessagesText: string;
 	/** Latest persisted recap/verdict, so off-daemon sessions keep their status. */
 	agentStatus?: AgentStatus;
+	/** A malformed lifecycle/verdict was seen while scanning durable JSONL. */
+	hasInvalidDurableState?: boolean;
 }
 
 export type ReadonlySessionManager = Pick<
@@ -861,7 +874,7 @@ function extractTextContent(message: Message): string {
 // Legacy "hidden" and "sleep" statuses (written by older versions) both map to
 // the current "archived".
 function normalizeSessionStateStatus(value: unknown): SessionStateStatus | undefined {
-	if (value === "active" || value === "archived" || value === "crash") {
+	if (isSessionStateStatus(value)) {
 		return value;
 	}
 	if (value === "hidden" || value === "sleep") {
@@ -1027,6 +1040,7 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 		let name: string | undefined;
 		let state: SessionState | undefined;
 		let agentStatus: AgentStatus | undefined;
+		let hasInvalidDurableState = false;
 		let lastActivityTime: number | undefined;
 
 		for await (const lineBuffer of readLinesAsBuffers(filePath)) {
@@ -1067,14 +1081,25 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 			if (entry.type === "session_state") {
 				const stateEntry = entry as SessionStateEntry;
 				const status = normalizeSessionStateStatus(stateEntry.state?.status);
-				if (status) {
-					state = { status };
-				}
+				// A later corrupt lifecycle supersedes an earlier entry. Do not let an
+				// old archived state authorize passivation of an untrusted session.
+				state = status ? { status } : undefined;
+				if (!status) hasInvalidDurableState = true;
 			}
 			// Keep the latest recap/verdict so off-daemon sessions don't all show as
 			// unjudged in the agents view. Append-only, so last seen wins.
 			if (entry.type === "agent_status") {
-				agentStatus = (entry as AgentStatusEntry).status;
+				const status = (entry as AgentStatusEntry).status;
+				// Keep presentation-only statuses, but only a closed, well-formed
+				// verdict can ever be used by restart passivation.
+				const validStatus =
+					status &&
+					typeof status.summary === "string" &&
+					Number.isSafeInteger(status.basedOnMessageCount) &&
+					status.basedOnMessageCount >= 0 &&
+					(status.taskState === undefined || isAgentTaskState(status.taskState));
+				agentStatus = validStatus ? status : undefined;
+				if (!validStatus) hasInvalidDurableState = true;
 			}
 
 			if (!header) {
@@ -1122,6 +1147,7 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 			firstMessage: firstMessage || "(no messages)",
 			allMessagesText,
 			agentStatus,
+			...(hasInvalidDurableState ? { hasInvalidDurableState: true } : {}),
 		};
 	} catch {
 		return null;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1051,6 +1051,7 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 			// session-list metadata we need, and parsing them during every refresh
 			// can exhaust the daemon heap.
 			if (line.length > SESSION_LIST_PARSE_MAX_LINE_CHARS) {
+				if (!looksLikeMessageEntry(line)) hasInvalidDurableState = true;
 				if (looksLikeMessageEntry(line)) {
 					messageCount++;
 					const summary = extractOversizedMessageSummary(line);
@@ -1069,7 +1070,9 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 			try {
 				entry = JSON.parse(trimmed) as FileEntry;
 			} catch {
-				// Skip malformed lines
+				// A malformed row may supersede an earlier terminal record, so keep
+				// this session recoverable rather than passivating it.
+				hasInvalidDurableState = true;
 				continue;
 			}
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1084,10 +1084,12 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 			if (entry.type === "session_state") {
 				const stateEntry = entry as SessionStateEntry;
 				const status = normalizeSessionStateStatus(stateEntry.state?.status);
-				// A later corrupt lifecycle supersedes an earlier entry. Do not let an
-				// old archived state authorize passivation of an untrusted session.
-				state = status ? { status } : undefined;
-				if (!status) hasInvalidDurableState = true;
+				// Keep the last readable lifecycle for SessionManager compatibility, but
+				// mark an unrecognized later lifecycle as untrusted. C00 checks this
+				// marker before passivation, so the retained presentation state can never
+				// authorize recovery suppression.
+				if (status) state = { status };
+				else hasInvalidDurableState = true;
 			}
 			// Keep the latest recap/verdict so off-daemon sessions don't all show as
 			// unjudged in the agents view. Append-only, so last seen wins.

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -78,7 +78,7 @@ export interface SessionSummary {
 	/** Completion verdict for an idle session; absent while working or unjudged. */
 	taskState?: AgentTaskState;
 	/** Resident session-host process state, populated by the global supervisor. */
-	workerState?: "starting" | "ready" | "recovering" | "failed";
+	workerState?: "starting" | "ready" | "recovering" | "failed" | "passivated";
 	/** Diagnostic process identity; clients must not use this as a stable session identifier. */
 	workerPid?: number;
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -432,6 +432,16 @@ function isDaemonWorkerDescriptor(value: unknown, socketPath: string): value is 
 		Number.isInteger(descriptor.pid) &&
 		(descriptor.pid ?? 0) > 0 &&
 		(descriptor.processStartId === undefined || typeof descriptor.processStartId === "string");
+	// A processless recovering descriptor is a deliberate durable hand-off. Any
+	// process identity it retains, however, must be a complete, valid pair: a
+	// partial or object-shaped identity is untrusted input, not an invitation to
+	// probe, signal, or passivate an arbitrary process.
+	const validRecoveringProcess =
+		(descriptor.pid === undefined && descriptor.processStartId === undefined) ||
+		(Number.isInteger(descriptor.pid) &&
+			(descriptor.pid ?? 0) > 0 &&
+			typeof descriptor.processStartId === "string" &&
+			descriptor.processStartId.length > 0);
 	const knownLifecycle = isDaemonWorkerLifecycle(descriptor.lifecycle);
 	return (
 		descriptor.version === 1 &&
@@ -444,7 +454,8 @@ function isDaemonWorkerDescriptor(value: unknown, socketPath: string): value is 
 		// a valid process identity, and unknown legacy states do too until their
 		// first normalization pass, so malformed input remains fail-closed.
 		(knownLifecycle
-			? descriptor.lifecycle === "passivated" || descriptor.lifecycle === "recovering" || validLegacyProcess
+			? descriptor.lifecycle === "passivated" ||
+				(descriptor.lifecycle === "recovering" ? validRecoveringProcess : validLegacyProcess)
 			: validLegacyProcess) &&
 		(descriptor.ownerClientId === undefined || typeof descriptor.ownerClientId === "string") &&
 		typeof descriptor.socketPath === "string" &&

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { chmodSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { Writable } from "node:stream";
@@ -2907,8 +2907,12 @@ export class DaemonSupervisor {
 		) {
 			// Never infer an owner environment or relaunch an owner-owned worker from
 			// persisted state. This includes processless/passivated descriptors, whose
-			// missing PID must not bypass the owner/no-env guard.
+			// missing PID must not bypass the owner/no-env guard. A dead PID is not a
+			// processless descriptor until its identity is removed: otherwise a later
+			// recovery could probe or signal stale/recycled process metadata.
 			worker.descriptor.lifecycle = "passivated";
+			delete worker.descriptor.pid;
+			delete worker.descriptor.processStartId;
 			worker.descriptor.lastError = "Waiting for the owning client to reconnect";
 			this.persistWorker(worker);
 			return;
@@ -4856,9 +4860,12 @@ export class DaemonSupervisor {
 		if (worker.stopFinalized) {
 			if (removeDescriptor && archiveSession) {
 				// A prior non-removing stop retains a recovering descriptor for hand-off.
-				// A later explicit archive/delete stop must durably tombstone it before
-				// archiving, then remove it so restart cannot recover stale work.
-				this.persistWorkerStopTombstone(worker, true);
+				// Tombstone only that retained durable record. If a concurrent final stop
+				// already deleted it, writing here would recreate a crash-window tombstone
+				// after finalization. Archiving remains idempotent and is still attempted.
+				if (existsSync(worker.descriptorPath)) {
+					this.persistWorkerStopTombstone(worker, true);
+				}
 				await this.finalizeArchivedWorkerStopOnce(worker);
 				this.workers.delete(worker.descriptor.workerId);
 				this.deleteWorkerDescriptor(worker);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4780,7 +4780,9 @@ export class DaemonSupervisor {
 		// Do not coalesce stop calls. Their remove/force/archive/recovery/direct-child
 		// arguments are intentional and a later caller must not silently inherit the
 		// first caller's policy. The set is only a fence for a stale passive wake.
-		if (worker.stopFinalized) throw new Error(`Session worker ${worker.descriptor.workerId} was stopped`);
+		if (worker.stopFinalized && !(removeDescriptor && archiveSession && !worker.archiveFinalization)) {
+			throw new Error(`Session worker ${worker.descriptor.workerId} was stopped`);
+		}
 		// Defer entry one microtask so every stop dispatched in the same turn records
 		// its immutable request before any one can begin final deletion.
 		const stop = Promise.resolve().then(() =>
@@ -4792,21 +4794,25 @@ export class DaemonSupervisor {
 			await stop;
 		} catch (error) {
 			const failure = error instanceof Error ? error : new Error(String(error));
-			// A prior successful concurrent deletion may already have removed this
-			// object. Restore the failed-stop fence so a fresh lookup cannot wake it.
-			this.workers.set(worker.descriptor.workerId, worker);
-			worker.stopFailure = failure;
-			worker.intentionalStop = true;
-			try {
-				if (removeDescriptor) {
-					this.persistWorkerStopTombstone(worker, archiveSession);
-				} else {
-					worker.descriptor.lifecycle = "failed";
-					worker.descriptor.lastError = failure.message;
-					this.persistWorker(worker);
+			// A concurrent finalizer may have already stopped and removed this worker.
+			// Do not let a later loser resurrect its registry entry or descriptor merely
+			// to record its own cleanup failure.
+			if (!worker.stopFinalized) {
+				// Restore the failed-stop fence so a fresh lookup cannot wake it.
+				this.workers.set(worker.descriptor.workerId, worker);
+				worker.stopFailure = failure;
+				worker.intentionalStop = true;
+				try {
+					if (removeDescriptor) {
+						this.persistWorkerStopTombstone(worker, archiveSession);
+					} else {
+						worker.descriptor.lifecycle = "failed";
+						worker.descriptor.lastError = failure.message;
+						this.persistWorker(worker);
+					}
+				} catch (persistError) {
+					this.reportCleanupFailure(`worker stop failure fence ${worker.descriptor.workerId}`, persistError);
 				}
-			} catch (persistError) {
-				this.reportCleanupFailure(`worker stop failure fence ${worker.descriptor.workerId}`, persistError);
 			}
 			throw error;
 		} finally {
@@ -4825,6 +4831,17 @@ export class DaemonSupervisor {
 		recoveryCleanup = false,
 		directChild?: { child: ChildProcess; closed: Promise<void> },
 	): Promise<void> {
+		// Another independently dispatched stop may have completed between this
+		// request being recorded and its turn to run. A dead worker cannot be
+		// stopped twice, but a later archive request is still actionable from the
+		// retained descriptor context and must not be silently lost.
+		if (worker.stopFinalized) {
+			if (removeDescriptor && archiveSession && !worker.archiveFinalization) {
+				worker.archiveFinalization = this.finalizeArchivedWorkerStop(worker);
+				await worker.archiveFinalization;
+			}
+			return;
+		}
 		// A passivated descriptor is explicitly processless. Its old pid may have
 		// been recycled while the supervisor was down, so never probe or signal it.
 		const processless = worker.descriptor.lifecycle === "passivated" || worker.descriptor.pid === undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4780,7 +4780,7 @@ export class DaemonSupervisor {
 		// Do not coalesce stop calls. Their remove/force/archive/recovery/direct-child
 		// arguments are intentional and a later caller must not silently inherit the
 		// first caller's policy. The set is only a fence for a stale passive wake.
-		if (worker.stopFinalized && !(removeDescriptor && archiveSession && !worker.archiveFinalization)) {
+		if (worker.stopFinalized && !(removeDescriptor && archiveSession)) {
 			throw new Error(`Session worker ${worker.descriptor.workerId} was stopped`);
 		}
 		// Defer entry one microtask so every stop dispatched in the same turn records
@@ -4788,7 +4788,11 @@ export class DaemonSupervisor {
 		const stop = Promise.resolve().then(() =>
 			this.stopWorkerOnce(worker, removeDescriptor, force, archiveSession, recoveryCleanup, directChild),
 		);
-		const finalizations = worker.stopFinalizations ??= new Set();
+		let finalizations = worker.stopFinalizations;
+		if (!finalizations) {
+			finalizations = new Set();
+			worker.stopFinalizations = finalizations;
+		}
 		finalizations.add(stop);
 		try {
 			await stop;
@@ -4836,9 +4840,14 @@ export class DaemonSupervisor {
 		// stopped twice, but a later archive request is still actionable from the
 		// retained descriptor context and must not be silently lost.
 		if (worker.stopFinalized) {
-			if (removeDescriptor && archiveSession && !worker.archiveFinalization) {
-				worker.archiveFinalization = this.finalizeArchivedWorkerStop(worker);
-				await worker.archiveFinalization;
+			if (removeDescriptor && archiveSession) {
+				// A prior non-removing stop retains a recovering descriptor for hand-off.
+				// A later explicit archive/delete stop must durably tombstone it before
+				// archiving, then remove it so restart cannot recover stale work.
+				this.persistWorkerStopTombstone(worker, true);
+				await this.finalizeArchivedWorkerStopOnce(worker);
+				this.workers.delete(worker.descriptor.workerId);
+				this.deleteWorkerDescriptor(worker);
 			}
 			return;
 		}
@@ -4937,8 +4946,7 @@ export class DaemonSupervisor {
 			}
 			// Archive is the one destructive side effect that may be shared. This does
 			// not share stop results: every caller still performed its own policy above.
-			worker.archiveFinalization ??= this.finalizeArchivedWorkerStop(worker);
-			await worker.archiveFinalization;
+			await this.finalizeArchivedWorkerStopOnce(worker);
 		}
 		// A stopped resident is never routable again. Keep its descriptor only for a
 		// replacement supervisor/update hand-off, not as a stale in-memory route.
@@ -4950,6 +4958,24 @@ export class DaemonSupervisor {
 		if (!this.shuttingDown) {
 			void this.syncAgentPeers().catch(() => undefined);
 			this.broadcastHeartbeatsChanged();
+		}
+	}
+
+	private async finalizeArchivedWorkerStopOnce(worker: ResidentWorker): Promise<void> {
+		let archiveFinalization = worker.archiveFinalization;
+		if (!archiveFinalization) {
+			archiveFinalization = this.finalizeArchivedWorkerStop(worker);
+			worker.archiveFinalization = archiveFinalization;
+		}
+		try {
+			await archiveFinalization;
+		} catch (error) {
+			// Preserve successful finalization for concurrent callers, but let an
+			// explicit later archive stop retry a failed finalization.
+			if (worker.archiveFinalization === archiveFinalization) {
+				worker.archiveFinalization = undefined;
+			}
+			throw error;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3495,8 +3495,10 @@ export class DaemonSupervisor {
 			}
 		}
 		const match = await this.findWorkerForClient(client, command.activeSessionId);
-		await this.wakePassivatedWorker(match.worker);
+		// The descriptor retains the creation telemetry policy while passivated, so
+		// reject an incompatible attach before it can launch a worker process.
 		this.assertTelemetryAttachAllowed(match.worker, command.telemetryDisabled);
+		await this.wakePassivatedWorker(match.worker);
 		const activeSessionId = match.summary.activeSessionId ?? match.summary.id;
 		const duplicateValidation = this.currentSnapshotGeneration(match.worker, activeSessionId)?.validation;
 		if (duplicateValidation) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3384,6 +3384,7 @@ export class DaemonSupervisor {
 		switch (command.type) {
 			case "prompt":
 			case "prompt_and_wait":
+			case "cancel_prompt_admission":
 			case "steer":
 			case "follow_up":
 			case "restore_next_turn":
@@ -3420,6 +3421,9 @@ export class DaemonSupervisor {
 			case "set_auto_retry":
 			case "compact":
 			case "refine":
+			case "abort_compaction":
+			case "abort_branch_summary":
+			case "abort_retry":
 			case "reload":
 			case "new_session":
 			case "switch_session":

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -259,6 +259,10 @@ interface ResidentWorker {
 	recovery?: Promise<void>;
 	/** Coalesces concurrent explicit requests to revive a metadata-only root. */
 	wake?: Promise<void>;
+	/** A stop owns its tombstone, archive, and descriptor deletion until it settles. */
+	stop?: Promise<void>;
+	/** Prevents a stale routing reference from reviving a worker after deletion. */
+	stopFinalized?: boolean;
 	deferredRecovery?: Promise<void>;
 	intentionalStop: boolean;
 	stopRevision: number;
@@ -1623,6 +1627,8 @@ export class DaemonSupervisor {
 				);
 				const worker = direct ?? (await this.findWorkerForClient(client, command.activeSessionId)).worker;
 				this.assertWorkerAccessibleToClient(client, worker, command.activeSessionId);
+				const stopFence = this.stopFenceForWake(worker);
+				if (stopFence) await stopFence;
 				worker.intentionalStop = false;
 				worker.descriptor.stopRequestedAt = undefined;
 				worker.descriptor.archiveOnStop = undefined;
@@ -2141,8 +2147,26 @@ export class DaemonSupervisor {
 		}
 	}
 
-	/** Start a metadata-only worker once an explicit user operation targets it. */
+	/** Return the in-flight stop that owns this descriptor, or fail a stale route. */
+	private stopFenceForWake(worker: ResidentWorker): Promise<void> | undefined {
+		if (worker.stop) {
+			return worker.stop.then(() => {
+				throw new Error(`Session worker ${worker.descriptor.workerId} was stopped`);
+			});
+		}
+		if (worker.stopFinalized) {
+			throw new Error(`Session worker ${worker.descriptor.workerId} was stopped`);
+		}
+		return undefined;
+	}
+
 	private async wakePassivatedWorker(worker: ResidentWorker): Promise<void> {
+		// Do not introduce an await when no stop exists: that would leave a gap in
+		// which a concurrent stop could install its tombstone before this wake starts.
+		const stopFence = this.stopFenceForWake(worker);
+		if (stopFence) await stopFence;
+		// A stop marks its fence before its asynchronous archive/delete finalization.
+		// Never clear that tombstone or launch a replacement from a stale route.
 		// The second caller can arrive after the first has changed lifecycle to
 		// recovering but before it has connected. Join it instead of leaking an
 		// opaque "recovering" error (or starting a second worker).
@@ -4735,6 +4759,26 @@ export class DaemonSupervisor {
 		recoveryCleanup = false,
 		directChild?: { child: ChildProcess; closed: Promise<void> },
 	): Promise<void> {
+		// A single stop owns the passive tombstone through archive/delete. This is
+		// deliberately per-worker: unrelated session routing stays concurrent.
+		if (worker.stop) return worker.stop;
+		const stop = this.stopWorkerOnce(worker, removeDescriptor, force, archiveSession, recoveryCleanup, directChild);
+		worker.stop = stop;
+		try {
+			await stop;
+		} finally {
+			if (worker.stop === stop) worker.stop = undefined;
+		}
+	}
+
+	private async stopWorkerOnce(
+		worker: ResidentWorker,
+		removeDescriptor: boolean,
+		force = false,
+		archiveSession = false,
+		recoveryCleanup = false,
+		directChild?: { child: ChildProcess; closed: Promise<void> },
+	): Promise<void> {
 		// A passivated descriptor is explicitly processless. Its old pid may have
 		// been recycled while the supervisor was down, so never probe or signal it.
 		const processless = worker.descriptor.lifecycle === "passivated" || worker.descriptor.pid === undefined;
@@ -4830,6 +4874,9 @@ export class DaemonSupervisor {
 			}
 			await this.finalizeArchivedWorkerStop(worker);
 		}
+		// Leave an immutable marker for any route that captured this worker before
+		// descriptor deletion. A later create/retry must resolve a fresh route.
+		worker.stopFinalized = true;
 		this.workers.delete(worker.descriptor.workerId);
 		if (removeDescriptor) {
 			this.deleteWorkerDescriptor(worker);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -437,10 +437,15 @@ function isDaemonWorkerDescriptor(value: unknown, socketPath: string): value is 
 		descriptor.version === 1 &&
 		descriptor.supervisorSocketPath === socketPath &&
 		typeof descriptor.workerId === "string" &&
-		// Early v1 descriptors predate lifecycle. Accept those only when their
-		// process identity is valid, so the loader can recover them safely below.
-		// A missing/corrupt identity remains fail-closed and is ignored.
-		(knownLifecycle ? descriptor.lifecycle === "passivated" || validLegacyProcess : validLegacyProcess) &&
+		// A passivated descriptor is intentionally processless. `recovering` is
+		// also processless after normalizing a legacy missing/unknown lifecycle:
+		// retaining it lets the next supervisor recover the root without treating
+		// a stale PID as safe to adopt or signal. Other lifecycle states still need
+		// a valid process identity, and unknown legacy states do too until their
+		// first normalization pass, so malformed input remains fail-closed.
+		(knownLifecycle
+			? descriptor.lifecycle === "passivated" || descriptor.lifecycle === "recovering" || validLegacyProcess
+			: validLegacyProcess) &&
 		(descriptor.ownerClientId === undefined || typeof descriptor.ownerClientId === "string") &&
 		typeof descriptor.socketPath === "string" &&
 		typeof descriptor.authenticationToken === "string" &&

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -258,10 +258,14 @@ interface ResidentWorker {
 	recovery?: Promise<void>;
 	/** Coalesces concurrent explicit requests to revive a metadata-only root. */
 	wake?: Promise<void>;
-	/** A stop owns its tombstone, archive, and descriptor deletion until it settles. */
-	stop?: Promise<void>;
-	/** Prevents a stale routing reference from reviving a worker after deletion. */
+	/** Every active stop finalization. This is only a wake fence: each caller still executes its own stop request. */
+	stopFinalizations?: Set<Promise<void>>;
+	/** The one archival side effect may be shared, without sharing the callers' stop results. */
+	archiveFinalization?: Promise<void>;
+	/** Prevents a stale routing reference from reviving a worker after a completed stop. */
 	stopFinalized?: boolean;
+	/** A partial stop is a durable tombstone until an explicit retry clears it safely. */
+	stopFailure?: Error;
 	deferredRecovery?: Promise<void>;
 	intentionalStop: boolean;
 	stopRevision: number;
@@ -1624,8 +1628,18 @@ export class DaemonSupervisor {
 				);
 				const worker = direct ?? (await this.findWorkerForClient(client, command.activeSessionId)).worker;
 				this.assertWorkerAccessibleToClient(client, worker, command.activeSessionId);
-				const stopFence = this.stopFenceForWake(worker);
-				if (stopFence) await stopFence;
+				// Retry is the sole deliberate way to clear a failed stop tombstone. It
+				// must wait for every already-started finalization and never revive a
+				// worker whose process may still be alive.
+				const finalizations = this.waitForStopFinalizations(worker);
+				if (finalizations) await finalizations;
+				if (worker.stopFinalized) throw new Error(`Session worker ${worker.descriptor.workerId} was stopped`);
+				const processless = worker.descriptor.lifecycle === "passivated" || worker.descriptor.pid === undefined;
+				if (!processless && isProcessAlive(worker.descriptor.pid!)) {
+					throw new Error(`Session worker ${worker.descriptor.workerId} is still running; cannot retry its stop`);
+				}
+				worker.stopFailure = undefined;
+				worker.archiveFinalization = undefined;
 				worker.intentionalStop = false;
 				worker.descriptor.stopRequestedAt = undefined;
 				worker.descriptor.archiveOnStop = undefined;
@@ -2144,14 +2158,21 @@ export class DaemonSupervisor {
 		}
 	}
 
-	/** Return the in-flight stop that owns this descriptor, or fail a stale route. */
+	/** Wait for active stop finalizations without inheriting any caller's result. */
+	private waitForStopFinalizations(worker: ResidentWorker): Promise<void> | undefined {
+		const finalizations = [...(worker.stopFinalizations ?? [])];
+		return finalizations.length > 0 ? Promise.allSettled(finalizations).then(() => undefined) : undefined;
+	}
+
+	/** Return the wake fence for a stop, or fail a stale/failed route. */
 	private stopFenceForWake(worker: ResidentWorker): Promise<void> | undefined {
-		if (worker.stop) {
-			return worker.stop.then(() => {
+		const finalizations = this.waitForStopFinalizations(worker);
+		if (finalizations) {
+			return finalizations.then(() => {
 				throw new Error(`Session worker ${worker.descriptor.workerId} was stopped`);
 			});
 		}
-		if (worker.stopFinalized) {
+		if (worker.stopFinalized || worker.stopFailure || worker.descriptor.stopRequestedAt !== undefined) {
 			throw new Error(`Session worker ${worker.descriptor.workerId} was stopped`);
 		}
 		return undefined;
@@ -4756,15 +4777,43 @@ export class DaemonSupervisor {
 		recoveryCleanup = false,
 		directChild?: { child: ChildProcess; closed: Promise<void> },
 	): Promise<void> {
-		// A single stop owns the passive tombstone through archive/delete. This is
-		// deliberately per-worker: unrelated session routing stays concurrent.
-		if (worker.stop) return worker.stop;
-		const stop = this.stopWorkerOnce(worker, removeDescriptor, force, archiveSession, recoveryCleanup, directChild);
-		worker.stop = stop;
+		// Do not coalesce stop calls. Their remove/force/archive/recovery/direct-child
+		// arguments are intentional and a later caller must not silently inherit the
+		// first caller's policy. The set is only a fence for a stale passive wake.
+		if (worker.stopFinalized) throw new Error(`Session worker ${worker.descriptor.workerId} was stopped`);
+		// Defer entry one microtask so every stop dispatched in the same turn records
+		// its immutable request before any one can begin final deletion.
+		const stop = Promise.resolve().then(() =>
+			this.stopWorkerOnce(worker, removeDescriptor, force, archiveSession, recoveryCleanup, directChild),
+		);
+		const finalizations = worker.stopFinalizations ??= new Set();
+		finalizations.add(stop);
 		try {
 			await stop;
+		} catch (error) {
+			const failure = error instanceof Error ? error : new Error(String(error));
+			// A prior successful concurrent deletion may already have removed this
+			// object. Restore the failed-stop fence so a fresh lookup cannot wake it.
+			this.workers.set(worker.descriptor.workerId, worker);
+			worker.stopFailure = failure;
+			worker.intentionalStop = true;
+			try {
+				if (removeDescriptor) {
+					this.persistWorkerStopTombstone(worker, archiveSession);
+				} else {
+					worker.descriptor.lifecycle = "failed";
+					worker.descriptor.lastError = failure.message;
+					this.persistWorker(worker);
+				}
+			} catch (persistError) {
+				this.reportCleanupFailure(`worker stop failure fence ${worker.descriptor.workerId}`, persistError);
+			}
+			throw error;
 		} finally {
-			if (worker.stop === stop) worker.stop = undefined;
+			finalizations.delete(stop);
+			if (finalizations.size === 0 && worker.stopFinalizations === finalizations) {
+				worker.stopFinalizations = undefined;
+			}
 		}
 	}
 
@@ -4869,13 +4918,16 @@ export class DaemonSupervisor {
 			if (force) {
 				this.reclaimStoppedWorkerCronLock(worker);
 			}
-			await this.finalizeArchivedWorkerStop(worker);
+			// Archive is the one destructive side effect that may be shared. This does
+			// not share stop results: every caller still performed its own policy above.
+			worker.archiveFinalization ??= this.finalizeArchivedWorkerStop(worker);
+			await worker.archiveFinalization;
 		}
+		// A stopped resident is never routable again. Keep its descriptor only for a
+		// replacement supervisor/update hand-off, not as a stale in-memory route.
+		worker.stopFinalized = true;
+		this.workers.delete(worker.descriptor.workerId);
 		if (removeDescriptor) {
-			// Leave an immutable marker for any route that captured this worker before
-			// descriptor deletion. A later create/retry must resolve a fresh route.
-			worker.stopFinalized = true;
-			this.workers.delete(worker.descriptor.workerId);
 			this.deleteWorkerDescriptor(worker);
 		}
 		if (!this.shuttingDown) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1,6 +1,15 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { Writable } from "node:stream";

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4549,7 +4549,11 @@ export class DaemonSupervisor {
 	}
 
 	private async prepareUpdateRestartFenced(deadline: number): Promise<DaemonUpdateRestartManifest> {
-		const residents = [...this.workers.values()];
+		// Passivated records deliberately have no process or client. They are durable
+		// routing metadata, not residents in this transaction: preparing, draining, or
+		// stopping one would either fail on its absent client or spuriously wake it.
+		// Keep it in the registry so the replacement supervisor can retain its summary.
+		const residents = [...this.workers.values()].filter((worker) => worker.descriptor.lifecycle !== "passivated");
 		const unavailable = residents.find(
 			(worker) => worker.descriptor.lifecycle !== "ready" || worker.client === undefined,
 		);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -432,14 +432,15 @@ function isDaemonWorkerDescriptor(value: unknown, socketPath: string): value is 
 		Number.isInteger(descriptor.pid) &&
 		(descriptor.pid ?? 0) > 0 &&
 		(descriptor.processStartId === undefined || typeof descriptor.processStartId === "string");
+	const knownLifecycle = isDaemonWorkerLifecycle(descriptor.lifecycle);
 	return (
 		descriptor.version === 1 &&
 		descriptor.supervisorSocketPath === socketPath &&
 		typeof descriptor.workerId === "string" &&
-		isDaemonWorkerLifecycle(descriptor.lifecycle) &&
-		// A passivated v1 record may retain a legacy PID on disk. It is accepted
-		// solely so load can remove it; it is never an authority to probe/signal.
-		(descriptor.lifecycle === "passivated" || validLegacyProcess) &&
+		// Early v1 descriptors predate lifecycle. Accept those only when their
+		// process identity is valid, so the loader can recover them safely below.
+		// A missing/corrupt identity remains fail-closed and is ignored.
+		(knownLifecycle ? descriptor.lifecycle === "passivated" || validLegacyProcess : validLegacyProcess) &&
 		(descriptor.ownerClientId === undefined || typeof descriptor.ownerClientId === "string") &&
 		typeof descriptor.socketPath === "string" &&
 		typeof descriptor.authenticationToken === "string" &&
@@ -952,6 +953,16 @@ export class DaemonSupervisor {
 			try {
 				const descriptor: unknown = JSON.parse(readFileSync(path, "utf8"));
 				if (!isDaemonWorkerDescriptor(descriptor, this.socketPath)) continue;
+				const malformedLifecycle = !isDaemonWorkerLifecycle(descriptor.lifecycle);
+				if (malformedLifecycle) {
+					// A legacy v1 descriptor can omit lifecycle (or contain a value from a
+					// newer writer). It is not evidence that the root is idle or stopped.
+					// Discard even a syntactically valid legacy PID before recovery: do not
+					// adopt, passivate, or signal a process based on malformed lifecycle.
+					descriptor.lifecycle = "recovering";
+					delete descriptor.pid;
+					delete descriptor.processStartId;
+				}
 				descriptor.recoveryJournalPath ??= join(this.descriptorDir, `${descriptor.workerId}.recovery.jsonl`);
 				descriptor.orphanProcessJournalPath ??= join(this.descriptorDir, `${descriptor.workerId}.orphans.jsonl`);
 				const worker: ResidentWorker = {
@@ -965,6 +976,13 @@ export class DaemonSupervisor {
 					intentionalStop: descriptor.stopRequestedAt !== undefined,
 					stopRevision: 0,
 				};
+				if (malformedLifecycle) {
+					// The descriptor remains visible to startup recovery, but malformed
+					// lifecycle is never allowed to reach passivation classification.
+					this.persistWorker(worker);
+					this.workers.set(descriptor.workerId, worker);
+					continue;
+				}
 				// Never passivate a live process: adoption is the only safe way to
 				// reconnect work that may still be running. A legacy passivated v1
 				// descriptor is deliberately migrated by discarding its stale identity.
@@ -1765,6 +1783,11 @@ export class DaemonSupervisor {
 							}
 							if (worker.heartbeatSnapshot !== undefined && worker.heartbeatSnapshotStale !== true) {
 								return { heartbeats: worker.heartbeatSnapshot };
+							}
+							// Passivation is allowed only after active and paused heartbeats
+							// have been excluded. Snapshotless passivated roots are empty.
+							if (worker.descriptor.lifecycle === "passivated") {
+								return { heartbeats: [] };
 							}
 							const state =
 								worker.descriptor.lifecycle === "ready" ? "disconnected" : worker.descriptor.lifecycle;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -967,23 +967,35 @@ export class DaemonSupervisor {
 					delete descriptor.pid;
 					delete descriptor.processStartId;
 				}
-				// Client-owned workers require the caller's transient launch environment,
-				// which is intentionally never persisted. Keep their descriptors recoverable
-				// until the owner reconnects rather than creating an unwakeable passive root.
-				const passive =
-					descriptor.ownerClientId === undefined &&
-					!descriptor.stopRequestedAt &&
-					(alreadyPassivated || descriptor.pid === undefined || !isProcessAlive(descriptor.pid))
-						? await this.passivatedSummaryForDescriptor(descriptor)
-						: undefined;
-				if (passive) {
+				// A client-owned worker's launch environment is transient and deliberately
+				// never persisted. A processless descriptor therefore cannot be safely
+				// restarted at supervisor startup: only its owner can provide that env on a
+				// subsequent attach. Keep it processless, visible, and wakeable by that path.
+				const ownerOwnedProcessless = descriptor.ownerClientId !== undefined && descriptor.pid === undefined;
+				if (ownerOwnedProcessless && !descriptor.stopRequestedAt) {
+					// Fail closed even if the durable transcript is unreadable or has work
+					// pending. The owner attach path identifies this root from its descriptor
+					// and supplies launchEnv before it asks recovery to spawn anything.
 					descriptor.lifecycle = "passivated";
-					delete descriptor.pid;
-					delete descriptor.processStartId;
-					worker.summaries.set(descriptor.rootActiveSessionId, passive);
+					const passive = await this.passivatedSummaryForDescriptor(descriptor);
+					if (passive) worker.summaries.set(descriptor.rootActiveSessionId, passive);
 					this.persistWorker(worker);
 				} else {
-					descriptor.lifecycle = "recovering";
+					const passive =
+						descriptor.ownerClientId === undefined &&
+						!descriptor.stopRequestedAt &&
+						(alreadyPassivated || descriptor.pid === undefined || !isProcessAlive(descriptor.pid))
+							? await this.passivatedSummaryForDescriptor(descriptor)
+							: undefined;
+					if (passive) {
+						descriptor.lifecycle = "passivated";
+						delete descriptor.pid;
+						delete descriptor.processStartId;
+						worker.summaries.set(descriptor.rootActiveSessionId, passive);
+						this.persistWorker(worker);
+					} else {
+						descriptor.lifecycle = "recovering";
+					}
 				}
 				this.workers.set(descriptor.workerId, worker);
 			} catch (error) {
@@ -2891,10 +2903,12 @@ export class DaemonSupervisor {
 		if (
 			worker.descriptor.ownerClientId &&
 			!worker.launchEnv &&
-			worker.descriptor.pid !== undefined &&
-			!isProcessAlive(worker.descriptor.pid)
+			(worker.descriptor.pid === undefined || !isProcessAlive(worker.descriptor.pid))
 		) {
-			worker.descriptor.lifecycle = "failed";
+			// Never infer an owner environment or relaunch an owner-owned worker from
+			// persisted state. This includes processless/passivated descriptors, whose
+			// missing PID must not bypass the owner/no-env guard.
+			worker.descriptor.lifecycle = "passivated";
 			worker.descriptor.lastError = "Waiting for the owning client to reconnect";
 			this.persistWorker(worker);
 			return;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2124,7 +2124,7 @@ export class DaemonSupervisor {
 				const existing = activeMatches[0]!.worker;
 				// Preserve the #836 access collision behavior: do not let an
 				// unauthorized create revive a client-owned passive root.
-				this.reuseWorkerForCreate(existing, ownerClientId, command.sessionPath);
+				this.reuseWorkerForCreate(existing, ownerClientId, command.sessionPath, command.launchEnv);
 				await this.wakePassivatedWorker(existing);
 				return existing;
 			}
@@ -2138,7 +2138,7 @@ export class DaemonSupervisor {
 			createCommand = { ...createCommand, sessionPath };
 			const existing = this.findWorkerBySessionFile(sessionPath);
 			if (existing) {
-				this.reuseWorkerForCreate(existing.worker, ownerClientId, sessionPath);
+				this.reuseWorkerForCreate(existing.worker, ownerClientId, sessionPath, command.launchEnv);
 				await this.wakePassivatedWorker(existing.worker);
 				return existing.worker;
 			}
@@ -2242,11 +2242,17 @@ export class DaemonSupervisor {
 		worker: ResidentWorker,
 		ownerClientId: string | undefined,
 		sessionPath: string,
+		launchEnv: Record<string, string> | undefined,
 	): ResidentWorker {
-		if (worker.descriptor.ownerClientId === ownerClientId) {
-			return worker;
+		if (worker.descriptor.ownerClientId !== ownerClientId) {
+			throw new SessionAlreadyActiveError(sessionPath, worker.descriptor.rootActiveSessionId);
 		}
-		throw new SessionAlreadyActiveError(sessionPath, worker.descriptor.rootActiveSessionId);
+		// Only an authorized owner may supply the process environment used to wake
+		// its passive worker. Keep a previously authorized environment when absent.
+		if (ownerClientId !== undefined) {
+			worker.launchEnv = launchEnv ?? worker.launchEnv;
+		}
+		return worker;
 	}
 
 	private async promoteOwnedWorker(client: DaemonSocketClient, worker: ResidentWorker): Promise<void> {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -25,7 +25,6 @@ import { type AgentSessionRuntimeConfig, mergeAgentSessionRuntimeConfig } from "
 import {
 	type AgentCronJob,
 	AgentCronJobStore,
-	isHeartbeatCronJob,
 	migrateLegacyCronJobsToSessionArtifacts,
 	SESSION_SCHEDULED_JOBS_FILENAME,
 } from "../../core/cron-jobs.js";
@@ -1013,9 +1012,7 @@ export class DaemonSupervisor {
 			const artifactDir = join(dirname(dirname(info.path)), "session-artifacts", info.id);
 			const cronStore = AgentCronJobStore.forSessionArtifacts();
 			cronStore.registerSessionArtifact(info.id, artifactDir);
-			return cronStore
-				.list()
-				.some((job) => job.status === "active" || (!isHeartbeatCronJob(job) && job.status === "paused"));
+			return cronStore.hasRecoverableSessionArtifactState(info.id);
 		} catch {
 			// Recovery is safer than dropping an unreadable durable schedule/journal.
 			return true;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -960,7 +960,11 @@ export class DaemonSupervisor {
 					delete descriptor.pid;
 					delete descriptor.processStartId;
 				}
+				// Client-owned workers require the caller's transient launch environment,
+				// which is intentionally never persisted. Keep their descriptors recoverable
+				// until the owner reconnects rather than creating an unwakeable passive root.
 				const passive =
+					descriptor.ownerClientId === undefined &&
 					!descriptor.stopRequestedAt &&
 					(alreadyPassivated || descriptor.pid === undefined || !isProcessAlive(descriptor.pid))
 						? await this.passivatedSummaryForDescriptor(descriptor)
@@ -1000,8 +1004,8 @@ export class DaemonSupervisor {
 
 	private descriptorHasRecoverableWork(descriptor: DaemonWorkerDescriptor, info: SessionInfo): boolean {
 		try {
-			if (new WorkerRecoveryJournal(descriptor.recoveryJournalPath).getLatest().some((record) => record.busy))
-				return true;
+			const journal = new WorkerRecoveryJournal(descriptor.recoveryJournalPath);
+			if (journal.hasUnreadableRecords() || journal.getLatest().some((record) => record.busy)) return true;
 			const artifactDir = join(dirname(dirname(info.path)), "session-artifacts", info.id);
 			const cronStore = AgentCronJobStore.forSessionArtifacts();
 			cronStore.registerSessionArtifact(info.id, artifactDir);
@@ -3373,10 +3377,10 @@ export class DaemonSupervisor {
 	}
 
 	private commandExplicitlyWakesWorker(command: DaemonCommand): boolean {
-		// List/status queries deliberately remain metadata-only. Every command in
-		// this list is an explicit user operation which needs a runtime to change,
-		// resume, or export this one session. Keep destructive root kill out: its
-		// tombstone path must be able to remove a passivated descriptor directly.
+		// Metadata reads deliberately remain processless. These are the explicit
+		// operations which need a worker runtime to change, interrupt, or resume
+		// the session. Root kill is handled before forwarding so its tombstone path
+		// can remove a passivated descriptor without waking it.
 		switch (command.type) {
 			case "prompt":
 			case "prompt_and_wait":
@@ -3387,10 +3391,15 @@ export class DaemonSupervisor {
 			case "append_custom_message":
 			case "resume_queue":
 			case "send_message":
+			case "agent_messages_pause":
+			case "agent_messages_resume":
 			case "agent_messages_clear":
+			case "abort":
 			case "start_side_question":
+			case "abort_side_question":
 			case "execute_bash":
 			case "execute_bash_and_wait":
+			case "abort_bash":
 			case "clear_queue":
 			case "abort_and_clear_queue":
 			case "cron_add":

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -25,6 +25,7 @@ import { type AgentSessionRuntimeConfig, mergeAgentSessionRuntimeConfig } from "
 import {
 	type AgentCronJob,
 	AgentCronJobStore,
+	isHeartbeatCronJob,
 	migrateLegacyCronJobsToSessionArtifacts,
 	SESSION_SCHEDULED_JOBS_FILENAME,
 } from "../../core/cron-jobs.js";
@@ -255,6 +256,8 @@ interface ResidentWorker {
 	snapshotGenerations: Map<string, Map<string, SnapshotTranscriptGeneration>>;
 	snapshotLoads: Map<string, Promise<DaemonAttachResult>>;
 	recovery?: Promise<void>;
+	/** Coalesces concurrent explicit requests to revive a metadata-only root. */
+	wake?: Promise<void>;
 	deferredRecovery?: Promise<void>;
 	intentionalStop: boolean;
 	stopRevision: number;
@@ -656,8 +659,10 @@ export class DaemonSupervisor {
 			rmSync(this.snapshotCacheRoot, { recursive: true, force: true });
 			mkdirSync(this.snapshotCacheRoot, { recursive: true, mode: 0o700 });
 			this.commandJournal = new CommandRecoveryJournal(join(this.descriptorDir, "command-journal.jsonl"));
-			this.loadWorkerDescriptors();
-			const workersToAdopt = [...this.workers.values()];
+			await this.loadWorkerDescriptors();
+			const workersToAdopt = [...this.workers.values()].filter(
+				(worker) => worker.descriptor.lifecycle !== "passivated",
+			);
 
 			this.server = createServer((socket) => this.handleConnection(socket));
 			await this.listen();
@@ -912,21 +917,22 @@ export class DaemonSupervisor {
 		};
 	}
 
-	private loadWorkerDescriptors(): void {
+	/**
+	 * A descriptor normally means "recover this worker". That was too broad:
+	 * a cleanly-idle root leaves a durable JSONL and descriptor behind, so a
+	 * supervisor restart used to recreate every completed conversation merely to
+	 * discover that it was idle. Keep known-quiescent roots as routing records.
+	 */
+	private async loadWorkerDescriptors(): Promise<void> {
 		for (const name of readdirSync(this.descriptorDir)) {
-			if (name === SUPERVISOR_CONFIG_FILE_NAME || !name.endsWith(".json")) {
-				continue;
-			}
+			if (name === SUPERVISOR_CONFIG_FILE_NAME || !name.endsWith(".json")) continue;
 			const path = join(this.descriptorDir, name);
 			try {
 				const descriptor: unknown = JSON.parse(readFileSync(path, "utf8"));
-				if (!isDaemonWorkerDescriptor(descriptor, this.socketPath)) {
-					continue;
-				}
-				descriptor.lifecycle = "recovering";
+				if (!isDaemonWorkerDescriptor(descriptor, this.socketPath)) continue;
 				descriptor.recoveryJournalPath ??= join(this.descriptorDir, `${descriptor.workerId}.recovery.jsonl`);
 				descriptor.orphanProcessJournalPath ??= join(this.descriptorDir, `${descriptor.workerId}.orphans.jsonl`);
-				this.workers.set(descriptor.workerId, {
+				const worker: ResidentWorker = {
 					descriptor,
 					descriptorPath: path,
 					summaries: new Map(),
@@ -936,10 +942,54 @@ export class DaemonSupervisor {
 					snapshotLoads: new Map(),
 					intentionalStop: descriptor.stopRequestedAt !== undefined,
 					stopRevision: 0,
-				});
+				};
+				// Never passivate a live process: adoption performs generation fencing
+				// and is the only safe way to reconnect work that may still be running.
+				const passive =
+					!descriptor.stopRequestedAt && !isProcessAlive(descriptor.pid)
+						? await this.passivatedSummaryForDescriptor(descriptor)
+						: undefined;
+				if (passive) {
+					descriptor.lifecycle = "passivated";
+					worker.summaries.set(descriptor.rootActiveSessionId, passive);
+					this.persistWorker(worker);
+				} else {
+					descriptor.lifecycle = "recovering";
+				}
+				this.workers.set(descriptor.workerId, worker);
 			} catch (error) {
 				this.log(`Ignoring invalid worker descriptor ${path}: ${String(error)}`);
 			}
+		}
+	}
+
+	private async passivatedSummaryForDescriptor(
+		descriptor: DaemonWorkerDescriptor,
+	): Promise<SessionSummary | undefined> {
+		if (!descriptor.sessionFile) return undefined;
+		const info = await readSessionInfo(descriptor.sessionFile);
+		if (!info || this.descriptorHasRecoverableWork(descriptor, info)) return undefined;
+		const currentVerdict =
+			info.agentStatus?.taskState !== undefined && info.agentStatus.basedOnMessageCount === info.messageCount;
+		// Archived sessions are explicitly inactive. Active JSONLs require a current
+		// terminal/needs-input verdict; stale metadata must not suppress recovery.
+		if (info.state?.status !== "archived" && info.state?.status !== "crash" && !currentVerdict) return undefined;
+		return { ...summaryForInactiveSession(info), activeSessionId: descriptor.rootActiveSessionId };
+	}
+
+	private descriptorHasRecoverableWork(descriptor: DaemonWorkerDescriptor, info: SessionInfo): boolean {
+		try {
+			if (new WorkerRecoveryJournal(descriptor.recoveryJournalPath).getLatest().some((record) => record.busy))
+				return true;
+			const artifactDir = join(dirname(dirname(info.path)), "session-artifacts", info.id);
+			const cronStore = AgentCronJobStore.forSessionArtifacts();
+			cronStore.registerSessionArtifact(info.id, artifactDir);
+			return cronStore
+				.list()
+				.some((job) => job.status === "active" || (!isHeartbeatCronJob(job) && job.status === "paused"));
+		} catch {
+			// Recovery is safer than dropping an unreadable durable schedule/journal.
+			return true;
 		}
 	}
 
@@ -1824,6 +1874,9 @@ export class DaemonSupervisor {
 				if (!summary) throw new Error("Woken session worker has no target session");
 				target = { worker, summary };
 			}
+			// A2A delivery is an explicit target operation. The source is already
+			// resident (it is issuing this command), so revive only the target.
+			await this.wakePassivatedWorker(target.worker);
 			const targetActiveSessionId = target.summary.activeSessionId ?? target.summary.id;
 			if (source && command.agentOrigin === true) {
 				assertAgentFamilyReach(this.familyCatalogEntry(source.summary), this.familyCatalogEntry(target.summary));
@@ -1900,6 +1953,12 @@ export class DaemonSupervisor {
 					});
 				}
 				return await forward();
+			}
+			if (match.worker.descriptor.lifecycle === "passivated") {
+				// There is no process to ask to kill. Finalize the same tombstone and
+				// archive path without pointlessly reviving a completed root.
+				await this.stopWorker(match.worker, true, false, true);
+				return success(command.id, command.type);
 			}
 			this.persistWorkerStopTombstone(match.worker, true);
 			let response: DaemonResponse;
@@ -1999,7 +2058,12 @@ export class DaemonSupervisor {
 		if (command.sessionPath) {
 			const activeMatches = this.matchWorkers(command.sessionPath);
 			if (activeMatches.length === 1) {
-				return this.reuseWorkerForCreate(activeMatches[0]!.worker, ownerClientId, command.sessionPath);
+				const existing = activeMatches[0]!.worker;
+				// Preserve the #836 access collision behavior: do not let an
+				// unauthorized create revive a client-owned passive root.
+				this.reuseWorkerForCreate(existing, ownerClientId, command.sessionPath);
+				await this.wakePassivatedWorker(existing);
+				return existing;
 			}
 			if (activeMatches.length > 1) {
 				throw new Error(`Ambiguous active session "${command.sessionPath}"`);
@@ -2011,7 +2075,9 @@ export class DaemonSupervisor {
 			createCommand = { ...createCommand, sessionPath };
 			const existing = this.findWorkerBySessionFile(sessionPath);
 			if (existing) {
-				return this.reuseWorkerForCreate(existing.worker, ownerClientId, sessionPath);
+				this.reuseWorkerForCreate(existing.worker, ownerClientId, sessionPath);
+				await this.wakePassivatedWorker(existing.worker);
+				return existing.worker;
 			}
 			// A passive child from a stopped worker reopens as top-level here (pre-existing behavior);
 			// the recursive-harness residency/eviction PR will revisit it.
@@ -2048,6 +2114,40 @@ export class DaemonSupervisor {
 				this.openingWorkers.delete(key);
 			}
 		}
+	}
+
+	/** Start a metadata-only worker once an explicit user operation targets it. */
+	private async wakePassivatedWorker(worker: ResidentWorker): Promise<void> {
+		// The second caller can arrive after the first has changed lifecycle to
+		// recovering but before it has connected. Join it instead of leaking an
+		// opaque "recovering" error (or starting a second worker).
+		if (worker.wake) return worker.wake;
+		if (worker.descriptor.lifecycle !== "passivated") return;
+		const wake = (async () => {
+			worker.intentionalStop = false;
+			worker.descriptor.stopRequestedAt = undefined;
+			worker.descriptor.archiveOnStop = undefined;
+			worker.descriptor.lifecycle = "recovering";
+			worker.descriptor.consecutiveFailures = 0;
+			this.persistWorker(worker);
+			await this.recoverWorker(worker);
+			// recoverWorker mutates lifecycle through the normal launch/adoption
+			// path; read it after await rather than retaining the narrowed value.
+			const lifecycle = worker.descriptor.lifecycle as DaemonWorkerDescriptor["lifecycle"];
+			if (lifecycle !== "ready" || !worker.client) {
+				throw new Error(worker.descriptor.lastError ?? "Could not wake passivated session worker");
+			}
+		})();
+		worker.wake = wake;
+		void wake.then(
+			() => {
+				if (worker.wake === wake) worker.wake = undefined;
+			},
+			() => {
+				if (worker.wake === wake) worker.wake = undefined;
+			},
+		);
+		return wake;
 	}
 
 	private reuseWorkerForCreate(
@@ -2478,6 +2578,7 @@ export class DaemonSupervisor {
 			!this.shuttingDown &&
 			!worker.intentionalStop &&
 			worker.descriptor.stopRequestedAt === undefined &&
+			worker.descriptor.lifecycle !== "passivated" &&
 			this.workers.get(worker.descriptor.workerId) === worker &&
 			worker.client === undefined
 		);
@@ -3131,7 +3232,7 @@ export class DaemonSupervisor {
 			attachedClients: [...this.clients].filter((client) => client.attachedActiveSessionIds.has(activeSessionId))
 				.length,
 			workerState: worker.descriptor.lifecycle,
-			workerPid: worker.descriptor.pid,
+			...(worker.descriptor.lifecycle === "passivated" ? {} : { workerPid: worker.descriptor.pid }),
 		};
 	}
 
@@ -3230,11 +3331,76 @@ export class DaemonSupervisor {
 		return undefined;
 	}
 
+	private commandExplicitlyWakesWorker(command: DaemonCommand): boolean {
+		// List/status queries deliberately remain metadata-only. Every command in
+		// this list is an explicit user operation which needs a runtime to change,
+		// resume, or export this one session. Keep destructive root kill out: its
+		// tombstone path must be able to remove a passivated descriptor directly.
+		switch (command.type) {
+			case "prompt":
+			case "prompt_and_wait":
+			case "steer":
+			case "follow_up":
+			case "restore_next_turn":
+			case "restore_actions":
+			case "append_custom_message":
+			case "resume_queue":
+			case "send_message":
+			case "agent_messages_clear":
+			case "start_side_question":
+			case "execute_bash":
+			case "execute_bash_and_wait":
+			case "clear_queue":
+			case "abort_and_clear_queue":
+			case "cron_add":
+			case "cron_cancel":
+			case "heartbeat_manage":
+			case "heartbeat_set":
+			case "heartbeat_update":
+			case "set_model":
+			case "cycle_model":
+			case "set_scoped_models":
+			case "set_thinking_level":
+			case "cycle_thinking_level":
+			case "set_service_tier":
+			case "set_transport":
+			case "set_steering_mode":
+			case "set_follow_up_mode":
+			case "set_auto_compaction":
+			case "set_auto_retry":
+			case "compact":
+			case "refine":
+			case "reload":
+			case "new_session":
+			case "switch_session":
+			case "fork":
+			case "navigate_tree":
+			case "import_jsonl":
+			case "export_html":
+			case "export_jsonl":
+			case "rename":
+			case "rename_saved_session":
+			case "delete_saved_session":
+			case "set_session_name":
+			case "set_rlm_max_depth":
+			case "set_session_entry_label":
+			case "cancel_rlm_child":
+			case "delete_rlm_subagent":
+			case "extension_ui_response":
+				return true;
+			default:
+				return false;
+		}
+	}
+
 	private async forwardToWorker(
 		worker: ResidentWorker,
 		command: DaemonCommand,
 		timeoutMs = WORKER_REQUEST_TIMEOUT_MS,
 	): Promise<DaemonResponse> {
+		if (this.commandExplicitlyWakesWorker(command)) {
+			await this.wakePassivatedWorker(worker);
+		}
 		if (!worker.client || worker.descriptor.lifecycle !== "ready") {
 			throw new Error(`Session worker is ${worker.descriptor.lifecycle}`);
 		}
@@ -3279,6 +3445,7 @@ export class DaemonSupervisor {
 			}
 		}
 		const match = await this.findWorkerForClient(client, command.activeSessionId);
+		await this.wakePassivatedWorker(match.worker);
 		this.assertTelemetryAttachAllowed(match.worker, command.telemetryDisabled);
 		const activeSessionId = match.summary.activeSessionId ?? match.summary.id;
 		const duplicateValidation = this.currentSnapshotGeneration(match.worker, activeSessionId)?.validation;
@@ -4508,6 +4675,9 @@ export class DaemonSupervisor {
 		recoveryCleanup = false,
 		directChild?: { child: ChildProcess; closed: Promise<void> },
 	): Promise<void> {
+		// A passivated descriptor is explicitly processless. Its old pid may have
+		// been recycled while the supervisor was down, so never probe or signal it.
+		const processless = worker.descriptor.lifecycle === "passivated";
 		if (worker.ownerCleanupTimer) {
 			clearTimeout(worker.ownerCleanupTimer);
 			worker.ownerCleanupTimer = undefined;
@@ -4563,13 +4733,15 @@ export class DaemonSupervisor {
 			worker.client = undefined;
 		} else if (directChild) {
 			directChild.child.kill("SIGTERM");
-		} else if (isProcessAlive(worker.descriptor.pid)) {
+		} else if (!processless && isProcessAlive(worker.descriptor.pid)) {
 			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGTERM");
 		}
 		const isWorkerProcessAlive = () =>
-			directChild
-				? directChild.child.exitCode === null && directChild.child.signalCode === null
-				: isProcessAlive(worker.descriptor.pid);
+			processless
+				? false
+				: directChild
+					? directChild.child.exitCode === null && directChild.child.signalCode === null
+					: isProcessAlive(worker.descriptor.pid);
 		const gracefulDeadline = Date.now() + (force ? 500 : 2000);
 		while (isWorkerProcessAlive() && Date.now() < gracefulDeadline) {
 			await delay(25);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -42,7 +42,7 @@ import {
 	type WorkerEvictionSnapshot,
 } from "../../core/session-action-store.js";
 import { canonicalSessionPath, getProcessStartId, SessionAlreadyActiveError } from "../../core/session-lease.js";
-import { readSessionInfo, type SessionInfo } from "../../core/session-manager.js";
+import { isAgentTaskState, readSessionInfo, type SessionInfo } from "../../core/session-manager.js";
 import { SettingsManager } from "../../core/settings-manager.js";
 import { signalProcessGroupOrProcess } from "../../utils/child-process.js";
 import type { AgentConnectionHeartbeat } from "../agent-connection/types.js";
@@ -114,6 +114,7 @@ import {
 	type DaemonCreateCommand,
 	type DaemonWorkerDescriptor,
 	type DaemonWorkerFrameHeader,
+	isDaemonWorkerLifecycle,
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 } from "./daemon-worker-protocol.js";
@@ -411,13 +412,18 @@ function isDaemonWorkerDescriptor(value: unknown, socketPath: string): value is 
 		return false;
 	}
 	const descriptor = value as Partial<DaemonWorkerDescriptor>;
+	const validLegacyProcess =
+		Number.isInteger(descriptor.pid) &&
+		(descriptor.pid ?? 0) > 0 &&
+		(descriptor.processStartId === undefined || typeof descriptor.processStartId === "string");
 	return (
 		descriptor.version === 1 &&
 		descriptor.supervisorSocketPath === socketPath &&
 		typeof descriptor.workerId === "string" &&
-		Number.isInteger(descriptor.pid) &&
-		(descriptor.pid ?? 0) > 0 &&
-		(descriptor.processStartId === undefined || typeof descriptor.processStartId === "string") &&
+		isDaemonWorkerLifecycle(descriptor.lifecycle) &&
+		// A passivated v1 record may retain a legacy PID on disk. It is accepted
+		// solely so load can remove it; it is never an authority to probe/signal.
+		(descriptor.lifecycle === "passivated" || validLegacyProcess) &&
 		(descriptor.ownerClientId === undefined || typeof descriptor.ownerClientId === "string") &&
 		typeof descriptor.socketPath === "string" &&
 		typeof descriptor.authenticationToken === "string" &&
@@ -943,14 +949,26 @@ export class DaemonSupervisor {
 					intentionalStop: descriptor.stopRequestedAt !== undefined,
 					stopRevision: 0,
 				};
-				// Never passivate a live process: adoption performs generation fencing
-				// and is the only safe way to reconnect work that may still be running.
+				// Never passivate a live process: adoption is the only safe way to
+				// reconnect work that may still be running. A legacy passivated v1
+				// descriptor is deliberately migrated by discarding its stale identity.
+				const alreadyPassivated = descriptor.lifecycle === "passivated";
+				// Old C00 records could claim to be passivated while retaining a PID.
+				// Discard it before *any* recovery classification, including malformed
+				// JSONL that must recover, so no later consumer can act on it.
+				if (alreadyPassivated) {
+					delete descriptor.pid;
+					delete descriptor.processStartId;
+				}
 				const passive =
-					!descriptor.stopRequestedAt && !isProcessAlive(descriptor.pid)
+					!descriptor.stopRequestedAt &&
+					(alreadyPassivated || descriptor.pid === undefined || !isProcessAlive(descriptor.pid))
 						? await this.passivatedSummaryForDescriptor(descriptor)
 						: undefined;
 				if (passive) {
 					descriptor.lifecycle = "passivated";
+					delete descriptor.pid;
+					delete descriptor.processStartId;
 					worker.summaries.set(descriptor.rootActiveSessionId, passive);
 					this.persistWorker(worker);
 				} else {
@@ -968,9 +986,12 @@ export class DaemonSupervisor {
 	): Promise<SessionSummary | undefined> {
 		if (!descriptor.sessionFile) return undefined;
 		const info = await readSessionInfo(descriptor.sessionFile);
-		if (!info || this.descriptorHasRecoverableWork(descriptor, info)) return undefined;
+		if (!info || info.hasInvalidDurableState || this.descriptorHasRecoverableWork(descriptor, info)) return undefined;
+		const taskState = info.agentStatus?.taskState;
 		const currentVerdict =
-			info.agentStatus?.taskState !== undefined && info.agentStatus.basedOnMessageCount === info.messageCount;
+			isAgentTaskState(taskState) &&
+			Number.isSafeInteger(info.agentStatus?.basedOnMessageCount) &&
+			info.agentStatus?.basedOnMessageCount === info.messageCount;
 		// Archived sessions are explicitly inactive. Active JSONLs require a current
 		// terminal/needs-input verdict; stale metadata must not suppress recovery.
 		if (info.state?.status !== "archived" && info.state?.status !== "crash" && !currentVerdict) return undefined;
@@ -2475,11 +2496,22 @@ export class DaemonSupervisor {
 
 	private async adoptOrRecoverWorker(worker: ResidentWorker): Promise<void> {
 		await this.assertRecoveryAllowed();
+		// A processless passivated descriptor (or a corrupt record that was
+		// conservatively moved to recovery) has no PID authority. Never feed an
+		// absent or stale identity into adoption/cleanup; recovery launches anew.
+		if (worker.descriptor.pid === undefined) {
+			if (worker.descriptor.stopRequestedAt) {
+				await this.stopWorker(worker, true, true, worker.descriptor.archiveOnStop === true);
+			} else {
+				await this.recoverWorker(worker);
+			}
+			return;
+		}
 		if (worker.descriptor.stopRequestedAt) {
 			try {
 				// A tombstoned worker must not run long enough to elect another
 				// supervisor while its intentional stop is being adopted.
-				signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
+				signalProcessGroupOrProcess(worker.descriptor.pid!, "SIGKILL");
 				await this.stopWorker(worker, true, true, worker.descriptor.archiveOnStop === true);
 				this.log(`Completed intentional stop for worker ${worker.descriptor.workerId} during supervisor adoption`);
 			} catch (error) {
@@ -2491,10 +2523,10 @@ export class DaemonSupervisor {
 			return;
 		}
 		try {
-			if (!isProcessAlive(worker.descriptor.pid)) {
+			if (!isProcessAlive(worker.descriptor.pid!)) {
 				throw new Error("Session worker process is no longer running");
 			}
-			const observedProcessStartId = getProcessStartId(worker.descriptor.pid);
+			const observedProcessStartId = getProcessStartId(worker.descriptor.pid!);
 			await this.connectWorker(worker, 2000);
 			await this.subscribeWorker(worker, worker.descriptor.rootActiveSessionId);
 			await this.refreshWorkerSummaries(worker, true);
@@ -2810,7 +2842,12 @@ export class DaemonSupervisor {
 		if (this.isWorkerRecoveryCancelled(worker)) {
 			return;
 		}
-		if (worker.descriptor.ownerClientId && !worker.launchEnv && !isProcessAlive(worker.descriptor.pid)) {
+		if (
+			worker.descriptor.ownerClientId &&
+			!worker.launchEnv &&
+			worker.descriptor.pid !== undefined &&
+			!isProcessAlive(worker.descriptor.pid)
+		) {
 			worker.descriptor.lifecycle = "failed";
 			worker.descriptor.lastError = "Waiting for the owning client to reconnect";
 			this.persistWorker(worker);
@@ -2827,8 +2864,9 @@ export class DaemonSupervisor {
 				}
 				try {
 					await this.assertRecoveryAllowed();
-					const processAlive = isProcessAlive(worker.descriptor.pid);
-					const observedProcessStartId = processAlive ? getProcessStartId(worker.descriptor.pid) : undefined;
+					const pid = worker.descriptor.pid;
+					const processAlive = pid !== undefined && isProcessAlive(pid);
+					const observedProcessStartId = processAlive ? getProcessStartId(pid) : undefined;
 					const processIdentityMatches =
 						worker.descriptor.processStartId === undefined ||
 						observedProcessStartId === worker.descriptor.processStartId;
@@ -2924,12 +2962,15 @@ export class DaemonSupervisor {
 	private async recoverUncertainWorkerOperations(worker: ResidentWorker, killWorkerProcess = true): Promise<void> {
 		await this.assertRecoveryAllowed();
 		if (killWorkerProcess) {
-			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
+			signalProcessGroupOrProcess(worker.descriptor.pid!, "SIGKILL");
 		}
 		const orphanProcessJournalPath = worker.descriptor.orphanProcessJournalPath;
-		if (orphanProcessJournalPath) {
+		const pid = worker.descriptor.pid;
+		// A processless passive record intentionally has no parent identity. Do
+		// not use a legacy/stale parent PID to reap anything while waking it.
+		if (orphanProcessJournalPath && pid !== undefined) {
 			try {
-				for (const orphan of readActiveOrphanProcesses(orphanProcessJournalPath, worker.descriptor.pid)) {
+				for (const orphan of readActiveOrphanProcesses(orphanProcessJournalPath, pid)) {
 					if (!isOrphanProcessIdentityCurrent(orphan)) {
 						continue;
 					}
@@ -3232,7 +3273,7 @@ export class DaemonSupervisor {
 			attachedClients: [...this.clients].filter((client) => client.attachedActiveSessionIds.has(activeSessionId))
 				.length,
 			workerState: worker.descriptor.lifecycle,
-			...(worker.descriptor.lifecycle === "passivated" ? {} : { workerPid: worker.descriptor.pid }),
+			...(worker.descriptor.lifecycle === "passivated" ? {} : { workerPid: worker.descriptor.pid! }),
 		};
 	}
 
@@ -4677,7 +4718,7 @@ export class DaemonSupervisor {
 	): Promise<void> {
 		// A passivated descriptor is explicitly processless. Its old pid may have
 		// been recycled while the supervisor was down, so never probe or signal it.
-		const processless = worker.descriptor.lifecycle === "passivated";
+		const processless = worker.descriptor.lifecycle === "passivated" || worker.descriptor.pid === undefined;
 		if (worker.ownerCleanupTimer) {
 			clearTimeout(worker.ownerCleanupTimer);
 			worker.ownerCleanupTimer = undefined;
@@ -4733,15 +4774,15 @@ export class DaemonSupervisor {
 			worker.client = undefined;
 		} else if (directChild) {
 			directChild.child.kill("SIGTERM");
-		} else if (!processless && isProcessAlive(worker.descriptor.pid)) {
-			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGTERM");
+		} else if (!processless && isProcessAlive(worker.descriptor.pid!)) {
+			signalProcessGroupOrProcess(worker.descriptor.pid!, "SIGTERM");
 		}
 		const isWorkerProcessAlive = () =>
 			processless
 				? false
 				: directChild
 					? directChild.child.exitCode === null && directChild.child.signalCode === null
-					: isProcessAlive(worker.descriptor.pid);
+					: isProcessAlive(worker.descriptor.pid!);
 		const gracefulDeadline = Date.now() + (force ? 500 : 2000);
 		while (isWorkerProcessAlive() && Date.now() < gracefulDeadline) {
 			await delay(25);
@@ -4750,7 +4791,7 @@ export class DaemonSupervisor {
 			if (directChild) {
 				directChild.child.kill("SIGKILL");
 			} else {
-				signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
+				signalProcessGroupOrProcess(worker.descriptor.pid!, "SIGKILL");
 			}
 			const forceDeadline = Date.now() + 1000;
 			while (isWorkerProcessAlive() && Date.now() < forceDeadline) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4874,11 +4874,11 @@ export class DaemonSupervisor {
 			}
 			await this.finalizeArchivedWorkerStop(worker);
 		}
-		// Leave an immutable marker for any route that captured this worker before
-		// descriptor deletion. A later create/retry must resolve a fresh route.
-		worker.stopFinalized = true;
-		this.workers.delete(worker.descriptor.workerId);
 		if (removeDescriptor) {
+			// Leave an immutable marker for any route that captured this worker before
+			// descriptor deletion. A later create/retry must resolve a fresh route.
+			worker.stopFinalized = true;
+			this.workers.delete(worker.descriptor.workerId);
 			this.deleteWorkerDescriptor(worker);
 		}
 		if (!this.shuttingDown) {

--- a/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
@@ -21,7 +21,13 @@ export const DAEMON_WORKER_STARTUP_GATE_COMMIT = "start\n";
  * `passivated` descriptors retain a session's routing metadata without a worker
  * process. They are deliberately revived only by an explicit session operation.
  */
-export type DaemonWorkerLifecycle = "starting" | "ready" | "recovering" | "failed" | "passivated";
+export const DAEMON_WORKER_LIFECYCLES = ["starting", "ready", "recovering", "failed", "passivated"] as const;
+export type DaemonWorkerLifecycle = (typeof DAEMON_WORKER_LIFECYCLES)[number];
+
+/** Durable descriptor states are untrusted input when read from disk. */
+export function isDaemonWorkerLifecycle(value: unknown): value is DaemonWorkerLifecycle {
+	return typeof value === "string" && (DAEMON_WORKER_LIFECYCLES as readonly string[]).includes(value);
+}
 
 export type DaemonWorkerFrameHeader =
 	| {
@@ -90,7 +96,12 @@ export type DaemonWorkerCommandBody = DaemonWorkerCommand extends infer TCommand
 export interface DaemonWorkerDescriptor {
 	version: 1;
 	workerId: string;
-	pid: number;
+	/**
+	 * Process identity for resident workers. Both fields are deliberately absent
+	 * for passivated descriptors. Legacy fields are accepted only while reading
+	 * a non-passivated v1 descriptor; writers never retain them on a passivation.
+	 */
+	pid?: number;
 	processStartId?: string;
 	socketPath: string;
 	recoveryJournalPath: string;

--- a/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
@@ -17,7 +17,11 @@ export const DAEMON_WORKER_SUPERVISOR_SOCKET_ENV = "PRIME_AGENT_INTERNAL_DAEMON_
 export const DAEMON_WORKER_RECOVERY_JOURNAL_ENV = "PRIME_AGENT_INTERNAL_DAEMON_WORKER_RECOVERY_JOURNAL";
 export const DAEMON_WORKER_STARTUP_GATE_FD_ENV = "PRIME_AGENT_INTERNAL_DAEMON_WORKER_STARTUP_GATE_FD";
 export const DAEMON_WORKER_STARTUP_GATE_COMMIT = "start\n";
-export type DaemonWorkerLifecycle = "starting" | "ready" | "recovering" | "failed";
+/**
+ * `passivated` descriptors retain a session's routing metadata without a worker
+ * process. They are deliberately revived only by an explicit session operation.
+ */
+export type DaemonWorkerLifecycle = "starting" | "ready" | "recovering" | "failed" | "passivated";
 
 export type DaemonWorkerFrameHeader =
 	| {

--- a/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
@@ -98,8 +98,10 @@ export interface DaemonWorkerDescriptor {
 	workerId: string;
 	/**
 	 * Process identity for resident workers. Both fields are deliberately absent
-	 * for passivated descriptors. Legacy fields are accepted only while reading
-	 * a non-passivated v1 descriptor; writers never retain them on a passivation.
+	 * for passivated descriptors and may be absent on a recovering descriptor
+	 * normalized from legacy lifecycle data. Legacy fields are accepted only while
+	 * reading a non-passivated v1 descriptor; writers never retain them on a
+	 * passivation.
 	 */
 	pid?: number;
 	processStartId?: string;

--- a/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
@@ -21,25 +21,32 @@ export interface WorkerRecoveryRecord {
 	recordedAt: string;
 }
 
-function parseRecords(path: string): Map<string, WorkerRecoveryRecord> {
+interface ParsedRecords {
+	latest: Map<string, WorkerRecoveryRecord>;
+	hasInvalidRecords: boolean;
+}
+
+function parseRecords(path: string): ParsedRecords {
 	const latest = new Map<string, WorkerRecoveryRecord>();
 	let contents: string;
 	try {
 		contents = readFileSync(path, "utf8");
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-			return latest;
+			return { latest, hasInvalidRecords: false };
 		}
 		throw error;
 	}
+	let hasInvalidRecords = false;
 	for (const line of contents.split("\n")) {
-		if (!line) {
+		if (!line.trim()) {
 			continue;
 		}
 		let record: WorkerRecoveryRecord;
 		try {
 			record = JSON.parse(line) as WorkerRecoveryRecord;
 		} catch {
+			hasInvalidRecords = true;
 			continue;
 		}
 		if (
@@ -50,17 +57,22 @@ function parseRecords(path: string): Map<string, WorkerRecoveryRecord> {
 			typeof record.operation === "string"
 		) {
 			latest.set(record.activeSessionId, record);
+		} else {
+			hasInvalidRecords = true;
 		}
 	}
-	return latest;
+	return { latest, hasInvalidRecords };
 }
 
 export class WorkerRecoveryJournal {
 	private readonly latest: Map<string, WorkerRecoveryRecord>;
+	private readonly hasInvalidRecords: boolean;
 
 	constructor(private readonly path: string) {
 		mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-		this.latest = parseRecords(path);
+		const parsed = parseRecords(path);
+		this.latest = parsed.latest;
+		this.hasInvalidRecords = parsed.hasInvalidRecords;
 	}
 
 	record(input: Omit<WorkerRecoveryRecord, "version" | "recordedAt">): void {
@@ -88,8 +100,12 @@ export class WorkerRecoveryJournal {
 		return [...this.latest.values()];
 	}
 
+	hasUnreadableRecords(): boolean {
+		return this.hasInvalidRecords;
+	}
+
 	static readLatest(path: string): WorkerRecoveryRecord[] {
-		return [...parseRecords(path).values()];
+		return [...parseRecords(path).latest.values()];
 	}
 
 	private append(record: WorkerRecoveryRecord): void {

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -73,6 +73,33 @@ describe("daemon supervisor heartbeat aggregation", () => {
 		expect(supervisor.forwardToWorker).toHaveBeenCalledTimes(3);
 	});
 
+	it("uses a complete passive snapshot without targeting its processless worker", async () => {
+		const supervisor = createSupervisorHarness();
+		const resident = worker("ready");
+		const passive = {
+			descriptor: { lifecycle: "passivated" },
+			heartbeatSnapshot: [{ job: { id: "paused-heartbeat", status: "paused" } }],
+			heartbeatSnapshotStale: false,
+		};
+		supervisor.workers.set("resident", resident);
+		supervisor.workers.set("passive", passive);
+		supervisor.forwardToWorker = vi.fn(async (target, command) => {
+			expect(target).toBe(resident);
+			return success(command.id, command.type, { heartbeats: [{ job: { id: "resident-heartbeat" } }] });
+		});
+
+		const response = await supervisor.handleCommand({} as DaemonSocketClient, {
+			id: "list-passive",
+			type: "heartbeats_list",
+		});
+
+		expect(response).toMatchObject({
+			success: true,
+			data: { heartbeats: [{ job: { id: "resident-heartbeat" } }, { job: { id: "paused-heartbeat" } }] },
+		});
+		expect(supervisor.forwardToWorker).toHaveBeenCalledTimes(1);
+	});
+
 	it("returns a worker failure instead of a partial catalog", async () => {
 		const supervisor = createSupervisorHarness();
 		const first = worker("ready");

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -30,7 +30,7 @@ function createSupervisorHarness(): SupervisorHarness {
 	}) as unknown as SupervisorHarness;
 }
 
-function worker(lifecycle: "ready" | "recovering", connected = true) {
+function worker(lifecycle: "ready" | "recovering" | "passivated", connected = true) {
 	return {
 		descriptor: { lifecycle },
 		...(connected ? { client: {} } : {}),
@@ -71,6 +71,35 @@ describe("daemon supervisor heartbeat aggregation", () => {
 			data: { heartbeats: [{ job: { id: "heartbeat-1" } }, { job: { id: "heartbeat-2" } }] },
 		});
 		expect(supervisor.forwardToWorker).toHaveBeenCalledTimes(3);
+	});
+
+	it("treats a snapshotless passivated root as empty alongside live and snapshotted roots", async () => {
+		const supervisor = createSupervisorHarness();
+		const live = worker("ready");
+		const snapshotted = {
+			descriptor: { lifecycle: "recovering" },
+			heartbeatSnapshot: [{ job: { id: "cached-heartbeat" } }],
+			heartbeatSnapshotStale: false,
+		};
+		const emptyPassive = worker("passivated", false);
+		supervisor.workers.set("live", live);
+		supervisor.workers.set("snapshotted", snapshotted);
+		supervisor.workers.set("empty-passive", emptyPassive);
+		supervisor.forwardToWorker = vi.fn(async (target, command) => {
+			expect(target).toBe(live);
+			return success(command.id, command.type, { heartbeats: [{ job: { id: "live-heartbeat" } }] });
+		});
+
+		const response = await supervisor.handleCommand({} as DaemonSocketClient, {
+			id: "list-snapshotless-passive",
+			type: "heartbeats_list",
+		});
+
+		expect(response).toMatchObject({
+			success: true,
+			data: { heartbeats: [{ job: { id: "live-heartbeat" } }, { job: { id: "cached-heartbeat" } }] },
+		});
+		expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
 	});
 
 	it("uses a complete passive snapshot without targeting its processless worker", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -1258,7 +1258,7 @@ describe("daemon supervisor resident workers", () => {
 		let orphanPids: number[] = [];
 		const orphanDeadline = Date.now() + 5000;
 		while (orphanPids.length === 0 && Date.now() < orphanDeadline) {
-			orphanPids = readActiveOrphanProcesses(descriptor.orphanProcessJournalPath, descriptor.pid).map(
+			orphanPids = readActiveOrphanProcesses(descriptor.orphanProcessJournalPath, descriptor.pid!).map(
 				(orphan) => orphan.pid,
 			);
 			if (orphanPids.length === 0) {

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -30,7 +30,14 @@ interface SupervisorInternals {
 	loadWorkerDescriptors(): Promise<void>;
 	wakePassivatedWorker(worker: WorkerFixture): Promise<void>;
 	forwardToWorker(worker: WorkerFixture, command: object): Promise<unknown>;
-	stopWorker(worker: WorkerFixture, removeDescriptor: boolean, force?: boolean, archiveSession?: boolean): Promise<void>;
+	stopWorker(
+		worker: WorkerFixture,
+		removeDescriptor: boolean,
+		force?: boolean,
+		archiveSession?: boolean,
+		recoveryCleanup?: boolean,
+		directChild?: unknown,
+	): Promise<void>;
 	stopWorkerOnce: ReturnType<typeof vi.fn>;
 	recoverWorker: ReturnType<typeof vi.fn>;
 	catalog: { archive(sessionFile: string, sessionId: string): Promise<void> };
@@ -605,6 +612,77 @@ describe("daemon supervisor restart passivation", () => {
 		]);
 	});
 
+
+	it("honors a concurrent force/archive/remove stop while an update stop is still graceful", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: { ...descriptor(fixture, "force", session), lifecycle: "ready" as const },
+			descriptorPath: join(fixture.descriptorDir, "force.json"), summaries: new Map(),
+			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
+			intentionalStop: false, stopRevision: 0,
+		};
+		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
+		supervisor.workers.set("force", worker);
+		supervisor.catalog.archive = vi.fn(async () => undefined);
+		let signalTerm: () => void = () => undefined;
+		const termSignaled = new Promise<void>((resolve) => { signalTerm = resolve; });
+		const signals: string[] = [];
+		const child = {
+			exitCode: null as number | null,
+			signalCode: null as NodeJS.Signals | null,
+			kill(signal: NodeJS.Signals) {
+				signals.push(signal);
+				if (signal === "SIGTERM") signalTerm();
+				if (signal === "SIGKILL") this.signalCode = signal;
+				return true;
+			},
+		};
+		const directChild = { child, closed: Promise.resolve() };
+		const graceful = supervisor.stopWorker(worker, false, false, false, false, directChild);
+		await termSignaled;
+		const destructive = supervisor.stopWorker(worker, true, true, true, false, directChild);
+		await Promise.all([graceful, destructive]);
+
+		expect(signals).toContain("SIGKILL");
+		expect(supervisor.catalog.archive).toHaveBeenCalledTimes(1);
+		expect(supervisor.workers.has("force")).toBe(false);
+		expect(() => readFileSync(worker.descriptorPath)).toThrow();
+	});
+
+	it("does not let a recovery-cleanup direct child suppress a concurrent deleting archive", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: { ...descriptor(fixture, "recovery-collision", session), lifecycle: "ready" as const },
+			descriptorPath: join(fixture.descriptorDir, "recovery-collision.json"), summaries: new Map(),
+			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
+			intentionalStop: false, stopRevision: 0,
+		};
+		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
+		supervisor.workers.set("recovery-collision", worker);
+		supervisor.catalog.archive = vi.fn(async () => undefined);
+		let releaseChild: () => void = () => undefined;
+		const childClosed = new Promise<void>((resolve) => { releaseChild = resolve; });
+		const child = { exitCode: 0, signalCode: null, kill: vi.fn(() => true) };
+		const recoveryCleanup = supervisor.stopWorker(worker, false, true, false, true, { child, closed: childClosed });
+		await Promise.resolve();
+		const deletingArchive = supervisor.stopWorker(worker, true, false, true);
+		releaseChild();
+		await Promise.all([recoveryCleanup, deletingArchive]);
+
+		expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+		expect(supervisor.workers.has("recovery-collision")).toBe(false);
+		expect(() => readFileSync(worker.descriptorPath)).toThrow();
+	});
 
 	it("removes a stopped update resident while retaining its descriptor for replacement recovery", async () => {
 		const fixture = fixtureRoot();

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -80,22 +80,30 @@ function descriptor(
 }
 
 describe("daemon supervisor restart passivation", () => {
-	it("keeps completed and needs-input roots metadata-only, while preserving scheduled and unjudged recovery", async () => {
+	it("keeps 160 dead terminal roots metadata-only, while preserving scheduled and unjudged recovery", async () => {
 		const fixture = fixtureRoot();
-		const completed = persistSession(fixture.sessionDir, fixture.root, "completed");
-		const needsInput = persistSession(fixture.sessionDir, fixture.root, "needs_input");
+		const terminalRoots = (
+			[
+				["completed", "completed"],
+				["needs-input", "needs_input"],
+			] as const
+		).flatMap(([prefix, taskState]) =>
+			Array.from({ length: 80 }, (_, index) => {
+				const session = persistSession(fixture.sessionDir, fixture.root, taskState);
+				return descriptor(fixture, `${prefix}-${index}`, session);
+			}),
+		);
 		const scheduled = persistSession(fixture.sessionDir, fixture.root, "completed");
-		const active = SessionManager.create(fixture.root, fixture.sessionDir);
-		active.appendMessage({ role: "user", content: "in progress", timestamp: 1 });
-		active.flushNow();
-		const activeFile = active.getSessionFile();
-		if (!activeFile) throw new Error("fixture did not persist active session");
-		const entries = [
-			descriptor(fixture, "completed", completed),
-			descriptor(fixture, "needs-input", needsInput),
-			descriptor(fixture, "scheduled", scheduled),
-			descriptor(fixture, "active", { id: active.getSessionId(), sessionFile: activeFile }),
-		];
+		const unjudged = SessionManager.create(fixture.root, fixture.sessionDir);
+		unjudged.appendMessage({ role: "user", content: "in progress", timestamp: 1 });
+		unjudged.flushNow();
+		const unjudgedFile = unjudged.getSessionFile();
+		if (!unjudgedFile) throw new Error("fixture did not persist unjudged session");
+		const scheduledEntry = descriptor(fixture, "scheduled", scheduled);
+		const unjudgedEntry = descriptor(fixture, "unjudged", {
+			id: unjudged.getSessionId(),
+			sessionFile: unjudgedFile,
+		});
 		const scheduledArtifact = join(fixture.agentDir, "session-artifacts", scheduled.id);
 		mkdirSync(scheduledArtifact, { recursive: true });
 		writeFileSync(
@@ -121,6 +129,7 @@ describe("daemon supervisor restart passivation", () => {
 				dispatches: [],
 			}),
 		);
+		const entries = [...terminalRoots, scheduledEntry, unjudgedEntry];
 		for (const entry of entries)
 			writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
 
@@ -128,21 +137,27 @@ describe("daemon supervisor restart passivation", () => {
 			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
 			descriptorDir: fixture.descriptorDir,
 		}) as unknown as SupervisorInternals;
+		supervisor.recoverWorker = vi.fn();
 		await supervisor.loadWorkerDescriptors();
 
-		expect(
-			[...supervisor.workers.values()].filter((worker) => worker.descriptor.lifecycle === "passivated"),
-		).toHaveLength(2);
-		expect(supervisor.workers.get("completed")?.summaries.size).toBe(1);
-		expect(supervisor.workers.get("needs-input")?.summaries.size).toBe(1);
-		for (const workerId of ["completed", "needs-input"]) {
-			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
+		const passivated = [...supervisor.workers.values()].filter(
+			(worker) => worker.descriptor.lifecycle === "passivated",
+		);
+		expect(passivated).toHaveLength(160);
+		expect(supervisor.workers).toHaveLength(162);
+		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+		for (const entry of terminalRoots) {
+			const worker = supervisor.workers.get(entry.workerId);
+			expect(worker?.descriptor.lifecycle).toBe("passivated");
+			expect(worker?.client).toBeUndefined();
+			expect(worker?.summaries.size).toBe(1);
+			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), "utf8"));
 			expect(persisted.lifecycle).toBe("passivated");
 			expect(persisted).not.toHaveProperty("pid");
 			expect(persisted).not.toHaveProperty("processStartId");
 		}
 		expect(supervisor.workers.get("scheduled")?.descriptor.lifecycle).toBe("recovering");
-		expect(supervisor.workers.get("active")?.descriptor.lifecycle).toBe("recovering");
+		expect(supervisor.workers.get("unjudged")?.descriptor.lifecycle).toBe("recovering");
 	});
 
 	it("single-flights an explicit wake and does not revive passivated records by itself", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -1,0 +1,251 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../src/core/session-manager.js";
+import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+import type { DaemonWorkerDescriptor } from "../src/modes/daemon/daemon-worker-protocol.js";
+
+const directories: string[] = [];
+
+afterEach(() => {
+	for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+interface WorkerFixture {
+	descriptor: DaemonWorkerDescriptor;
+	descriptorPath: string;
+	summaries: Map<string, unknown>;
+	client?: object;
+	wake?: Promise<void>;
+}
+
+interface SupervisorInternals {
+	workers: Map<string, WorkerFixture>;
+	loadWorkerDescriptors(): Promise<void>;
+	wakePassivatedWorker(worker: WorkerFixture): Promise<void>;
+	forwardToWorker(worker: WorkerFixture, command: object): Promise<unknown>;
+	stopWorker(worker: WorkerFixture, removeDescriptor: boolean): Promise<void>;
+	recoverWorker: ReturnType<typeof vi.fn>;
+}
+
+function fixtureRoot(): {
+	root: string;
+	agentDir: string;
+	sessionDir: string;
+	descriptorDir: string;
+	socketPath: string;
+} {
+	const root = mkdtempSync(join(tmpdir(), "prime-restart-passivation-"));
+	directories.push(root);
+	const agentDir = join(root, "agent");
+	const sessionDir = join(agentDir, "sessions");
+	const descriptorDir = join(agentDir, "workers");
+	mkdirSync(descriptorDir, { recursive: true });
+	return { root, agentDir, sessionDir, descriptorDir, socketPath: join(root, "daemon.sock") };
+}
+
+function persistSession(sessionDir: string, cwd: string, taskState: "completed" | "needs_input") {
+	const manager = SessionManager.create(cwd, sessionDir);
+	manager.appendMessage({ role: "user", content: taskState, timestamp: 1 });
+	manager.appendAgentStatus({ summary: taskState, taskState, basedOnMessageCount: 1 });
+	manager.flushNow();
+	const sessionFile = manager.getSessionFile();
+	if (!sessionFile) throw new Error("fixture did not persist a session file");
+	return { id: manager.getSessionId(), sessionFile };
+}
+
+function descriptor(
+	fixture: ReturnType<typeof fixtureRoot>,
+	workerId: string,
+	session: { id: string; sessionFile: string },
+): DaemonWorkerDescriptor {
+	return {
+		version: 1,
+		workerId,
+		pid: 999_999_999,
+		socketPath: join(fixture.root, `${workerId}.sock`),
+		recoveryJournalPath: join(fixture.descriptorDir, `${workerId}.recovery.jsonl`),
+		supervisorSocketPath: fixture.socketPath,
+		authenticationToken: "test-token",
+		rootActiveSessionId: `active-${workerId}`,
+		rootSessionId: session.id,
+		sessionFile: session.sessionFile,
+		createdAt: new Date(0).toISOString(),
+		updatedAt: new Date(0).toISOString(),
+		lifecycle: "ready",
+		createCommand: { type: "create", sessionPath: session.sessionFile, config: { cwd: fixture.root } },
+		consecutiveFailures: 0,
+	};
+}
+
+describe("daemon supervisor restart passivation", () => {
+	it("keeps completed and needs-input roots metadata-only, while preserving scheduled and unjudged recovery", async () => {
+		const fixture = fixtureRoot();
+		const completed = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const needsInput = persistSession(fixture.sessionDir, fixture.root, "needs_input");
+		const scheduled = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const active = SessionManager.create(fixture.root, fixture.sessionDir);
+		active.appendMessage({ role: "user", content: "in progress", timestamp: 1 });
+		active.flushNow();
+		const activeFile = active.getSessionFile();
+		if (!activeFile) throw new Error("fixture did not persist active session");
+		const entries = [
+			descriptor(fixture, "completed", completed),
+			descriptor(fixture, "needs-input", needsInput),
+			descriptor(fixture, "scheduled", scheduled),
+			descriptor(fixture, "active", { id: active.getSessionId(), sessionFile: activeFile }),
+		];
+		const scheduledArtifact = join(fixture.agentDir, "session-artifacts", scheduled.id);
+		mkdirSync(scheduledArtifact, { recursive: true });
+		writeFileSync(
+			join(scheduledArtifact, "scheduled-jobs.json"),
+			JSON.stringify({
+				jobs: [
+					{
+						id: "job",
+						status: "active",
+						source: "cron",
+						activeSessionId: "active-scheduled",
+						sessionId: scheduled.id,
+						sessionFile: scheduled.sessionFile,
+						cwd: fixture.root,
+						prompt: "scheduled",
+						schedule: { kind: "interval", expression: "every 1m", intervalMs: 60_000 },
+						createdAt: new Date(0).toISOString(),
+						updatedAt: new Date(0).toISOString(),
+						nextRunAt: new Date(Date.now() + 60_000).toISOString(),
+						runCount: 0,
+					},
+				],
+				dispatches: [],
+			}),
+		);
+		for (const entry of entries)
+			writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
+
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		await supervisor.loadWorkerDescriptors();
+
+		expect(
+			[...supervisor.workers.values()].filter((worker) => worker.descriptor.lifecycle === "passivated"),
+		).toHaveLength(2);
+		expect(supervisor.workers.get("completed")?.summaries.size).toBe(1);
+		expect(supervisor.workers.get("needs-input")?.summaries.size).toBe(1);
+		expect(supervisor.workers.get("scheduled")?.descriptor.lifecycle).toBe("recovering");
+		expect(supervisor.workers.get("active")?.descriptor.lifecycle).toBe("recovering");
+	});
+
+	it("single-flights an explicit wake and does not revive passivated records by itself", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker: WorkerFixture = {
+			descriptor: { ...descriptor(fixture, "wake", session), lifecycle: "passivated" },
+			descriptorPath: join(fixture.descriptorDir, "wake.json"),
+			summaries: new Map(),
+		};
+		supervisor.workers.set("wake", worker);
+		supervisor.recoverWorker = vi.fn(async () => {
+			await Promise.resolve();
+			worker.descriptor.lifecycle = "ready";
+			worker.client = {};
+		});
+
+		await Promise.all([supervisor.wakePassivatedWorker(worker), supervisor.wakePassivatedWorker(worker)]);
+		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
+		expect(worker.descriptor.lifecycle).toBe("ready");
+	});
+
+	it("does not revive a passivated root for metadata reads, but wakes it for one explicit operation", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker: WorkerFixture = {
+			descriptor: { ...descriptor(fixture, "read", session), lifecycle: "passivated" },
+			descriptorPath: join(fixture.descriptorDir, "read.json"),
+			summaries: new Map(),
+		};
+		supervisor.recoverWorker = vi.fn(async () => {
+			worker.descriptor.lifecycle = "ready";
+			worker.client = { request: vi.fn() };
+		});
+
+		await expect(
+			supervisor.forwardToWorker(worker, { type: "get_state", activeSessionId: "active-read" }),
+		).rejects.toThrow("passivated");
+		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+
+		await supervisor.forwardToWorker(worker, {
+			type: "prompt",
+			activeSessionId: "active-read",
+			message: "resume",
+		});
+		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not passivate a dead completed root with recoverable work", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const entry = descriptor(fixture, "busy", session);
+		writeFileSync(
+			entry.recoveryJournalPath,
+			`${JSON.stringify({
+				version: 1,
+				activeSessionId: entry.rootActiveSessionId,
+				sessionId: session.id,
+				sessionFile: session.sessionFile,
+				busy: true,
+				operation: "prompt",
+				recordedAt: new Date().toISOString(),
+			})}\n`,
+		);
+		writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
+
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		await supervisor.loadWorkerDescriptors();
+		expect(supervisor.workers.get("busy")?.descriptor.lifecycle).toBe("recovering");
+	});
+
+	it("stops a passivated descriptor without probing or signaling its stale pid", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: { ...descriptor(fixture, "stop", session), pid: process.pid, lifecycle: "passivated" as const },
+			descriptorPath: join(fixture.descriptorDir, "stop.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopRevision: 0,
+		};
+		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
+		supervisor.workers.set("stop", worker);
+		const kill = vi.spyOn(process, "kill");
+		try {
+			await supervisor.stopWorker(worker, true);
+			expect(kill).not.toHaveBeenCalled();
+			expect(supervisor.workers.has("stop")).toBe(false);
+		} finally {
+			kill.mockRestore();
+		}
+	});
+});

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -19,8 +19,10 @@ interface WorkerFixture {
 	summaries: Map<string, unknown>;
 	client?: object;
 	wake?: Promise<void>;
-	stop?: Promise<void>;
+	stopFinalizations?: Set<Promise<void>>;
+	archiveFinalization?: Promise<void>;
 	stopFinalized?: boolean;
+	stopFailure?: Error;
 }
 
 interface SupervisorInternals {
@@ -29,6 +31,7 @@ interface SupervisorInternals {
 	wakePassivatedWorker(worker: WorkerFixture): Promise<void>;
 	forwardToWorker(worker: WorkerFixture, command: object): Promise<unknown>;
 	stopWorker(worker: WorkerFixture, removeDescriptor: boolean, force?: boolean, archiveSession?: boolean): Promise<void>;
+	stopWorkerOnce: ReturnType<typeof vi.fn>;
 	recoverWorker: ReturnType<typeof vi.fn>;
 	catalog: { archive(sessionFile: string, sessionId: string): Promise<void> };
 }
@@ -572,6 +575,87 @@ describe("daemon supervisor restart passivation", () => {
 		expect(() => readFileSync(worker.descriptorPath)).toThrow();
 	});
 
+
+	it("keeps concurrent stop options independent while sharing only archive finalization", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: { ...descriptor(fixture, "options", session), lifecycle: "passivated" as const },
+			descriptorPath: join(fixture.descriptorDir, "options.json"), summaries: new Map(),
+			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
+			intentionalStop: false, stopRevision: 0,
+		};
+		supervisor.workers.set("options", worker);
+		const calls: unknown[][] = [];
+		supervisor.stopWorkerOnce = vi.fn(async (...args: unknown[]) => { calls.push(args); });
+
+		await Promise.all([
+			supervisor.stopWorker(worker, false, false, false),
+			supervisor.stopWorker(worker, true, true, true),
+		]);
+
+		expect(calls).toHaveLength(2);
+		expect(calls.map((args) => args.slice(1, 4))).toEqual([
+			[false, false, false],
+			[true, true, true],
+		]);
+	});
+
+
+	it("removes a stopped update resident while retaining its descriptor for replacement recovery", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: (() => { const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "update-stop", session); return { ...passive, lifecycle: "passivated" as const }; })(),
+			descriptorPath: join(fixture.descriptorDir, "update-stop.json"), summaries: new Map(),
+			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
+			intentionalStop: false, stopRevision: 0,
+		};
+		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
+		supervisor.workers.set("update-stop", worker);
+
+		await supervisor.stopWorker(worker, false);
+		expect(supervisor.workers.has("update-stop")).toBe(false);
+		expect(JSON.parse(readFileSync(worker.descriptorPath, "utf8"))).toMatchObject({ lifecycle: "recovering" });
+	});
+
+	it("blocks ordinary wake after a failed stop until explicit retry resets its tombstone", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: (() => { const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "failed-stop", session); return { ...passive, lifecycle: "passivated" as const }; })(),
+			descriptorPath: join(fixture.descriptorDir, "failed-stop.json"), summaries: new Map(),
+			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
+			intentionalStop: false, stopRevision: 0,
+		};
+		supervisor.workers.set("failed-stop", worker);
+		supervisor.recoverWorker = vi.fn();
+		supervisor.catalog.archive = vi.fn(async () => { throw new Error("archive failed"); });
+		await expect(supervisor.stopWorker(worker, true, false, true)).rejects.toThrow("archive failed");
+		await expect(supervisor.wakePassivatedWorker(worker)).rejects.toThrow("was stopped");
+		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+		// Direct retry is the explicit reset route; its recovery is mocked only to
+		// prove it is admitted after the persisted failure fence.
+		supervisor.recoverWorker = vi.fn(async () => { worker.descriptor.lifecycle = "ready"; worker.client = {}; });
+		const retried = (supervisor as unknown as { handleCommand(client: object, command: object): Promise<unknown> }).handleCommand(
+			{ id: "client" }, { id: "retry", type: "retry_worker", activeSessionId: worker.descriptor.rootActiveSessionId },
+		);
+		await expect(retried).resolves.toBeDefined();
+		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
+	});
+
 	it("recovers rather than passivating malformed or stale durable task verdicts", async () => {
 		const fixture = fixtureRoot();
 		const malformed = persistSession(fixture.sessionDir, fixture.root, "completed");
@@ -579,6 +663,9 @@ describe("daemon supervisor restart passivation", () => {
 		const invalidLifecycle = persistSession(fixture.sessionDir, fixture.root, "completed");
 		const truncatedLifecycle = persistSession(fixture.sessionDir, fixture.root, "completed");
 		const oversizedVerdict = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const corruptArrayArtifact = persistSession(fixture.sessionDir, fixture.root, "completed");
+		mkdirSync(join(fixture.agentDir, "session-artifacts", corruptArrayArtifact.id), { recursive: true });
+		writeFileSync(join(fixture.agentDir, "session-artifacts", corruptArrayArtifact.id, "scheduled-jobs.json"), "[]");
 		for (const [workerId, session, status] of [
 			["malformed", malformed, { summary: "bad", taskState: "arbitrary_untrusted_value", basedOnMessageCount: 1 }],
 			["stale", stale, { summary: "stale", taskState: "completed", basedOnMessageCount: 0 }],
@@ -625,6 +712,7 @@ describe("daemon supervisor restart passivation", () => {
 		for (const [workerId, session] of [
 			["truncated-lifecycle", truncatedLifecycle],
 			["oversized-verdict", oversizedVerdict],
+			["corrupt-array-artifact", corruptArrayArtifact],
 		] as const) {
 			writeFileSync(
 				join(fixture.descriptorDir, `${workerId}.json`),
@@ -641,7 +729,10 @@ describe("daemon supervisor restart passivation", () => {
 		expect(supervisor.workers.get("invalid-lifecycle")?.descriptor.lifecycle).toBe("recovering");
 		expect(supervisor.workers.get("truncated-lifecycle")?.descriptor.lifecycle).toBe("recovering");
 		expect(supervisor.workers.get("oversized-verdict")?.descriptor.lifecycle).toBe("recovering");
-		for (const workerId of ["malformed", "stale", "invalid-lifecycle", "truncated-lifecycle", "oversized-verdict"]) {
+		// A top-level array is corrupt artifact state, so fail closed rather than
+		// passivating a root whose scheduled work cannot be reconstructed.
+		expect(supervisor.workers.get("corrupt-array-artifact")?.descriptor.lifecycle).toBe("recovering");
+		for (const workerId of ["malformed", "stale", "invalid-lifecycle", "truncated-lifecycle", "oversized-verdict", "corrupt-array-artifact"]) {
 			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
 			expect(persisted.pid).toBe(999_999_999);
 		}

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -1173,6 +1173,36 @@ describe("daemon supervisor restart passivation", () => {
 		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
 	});
 
+	it("recovers v1 descriptors with missing or unknown lifecycle instead of hiding their roots", async () => {
+		const fixture = fixtureRoot();
+		const missing = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const unknown = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const missingDescriptor = descriptor(fixture, "missing-lifecycle", missing);
+		const unknownDescriptor = { ...descriptor(fixture, "unknown-lifecycle", unknown), lifecycle: "future_state" };
+		delete (missingDescriptor as Partial<DaemonWorkerDescriptor>).lifecycle;
+		writeFileSync(join(fixture.descriptorDir, "missing-lifecycle.json"), JSON.stringify(missingDescriptor));
+		writeFileSync(join(fixture.descriptorDir, "unknown-lifecycle.json"), JSON.stringify(unknownDescriptor));
+
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		await supervisor.loadWorkerDescriptors();
+
+		// Both roots remain reachable by the restart path, but their malformed
+		// lifecycle cannot authorize adoption, passivation, or process signalling.
+		expect(supervisor.workers).toHaveLength(2);
+		for (const workerId of ["missing-lifecycle", "unknown-lifecycle"]) {
+			const worker = supervisor.workers.get(workerId);
+			expect(worker?.descriptor.lifecycle).toBe("recovering");
+			expect(worker?.descriptor.pid).toBeUndefined();
+			expect(worker?.descriptor.processStartId).toBeUndefined();
+			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
+			expect(persisted.lifecycle).toBe("recovering");
+			expect(persisted.pid).toBeUndefined();
+		}
+	});
+
 	it("recovers rather than passivating malformed or stale durable task verdicts", async () => {
 		const fixture = fixtureRoot();
 		const malformed = persistSession(fixture.sessionDir, fixture.root, "completed");

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -164,6 +164,82 @@ describe("daemon supervisor restart passivation", () => {
 		expect(supervisor.workers.get("unjudged")?.descriptor.lifecycle).toBe("recovering");
 	});
 
+	it("recovers terminal roots with paused or unreadable heartbeat artifacts", async () => {
+		const fixture = fixtureRoot();
+		const paused = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const unreadable = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const pausedCron = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const pausedEntry = descriptor(fixture, "paused-heartbeat", paused);
+		const unreadableEntry = descriptor(fixture, "unreadable-heartbeat", unreadable);
+		const pausedCronEntry = descriptor(fixture, "paused-cron", pausedCron);
+		const pausedArtifact = join(fixture.agentDir, "session-artifacts", paused.id);
+		const unreadableArtifact = join(fixture.agentDir, "session-artifacts", unreadable.id);
+		const pausedCronArtifact = join(fixture.agentDir, "session-artifacts", pausedCron.id);
+		mkdirSync(pausedArtifact, { recursive: true });
+		mkdirSync(unreadableArtifact, { recursive: true });
+		writeFileSync(
+			join(pausedArtifact, "scheduled-jobs.json"),
+			JSON.stringify({
+				jobs: [
+					{
+						id: "paused-heartbeat",
+						status: "paused",
+						source: "heartbeat",
+						activeSessionId: pausedEntry.rootActiveSessionId,
+						sessionId: paused.id,
+						sessionFile: paused.sessionFile,
+						cwd: fixture.root,
+						prompt: "wait for an explicit resume",
+						schedule: { kind: "interval", expression: "every 1m", intervalMs: 60_000 },
+						createdAt: new Date(0).toISOString(),
+						updatedAt: new Date(0).toISOString(),
+						runCount: 0,
+					},
+				],
+				dispatches: [],
+			}),
+		);
+		// A malformed artifact is not a proof of an empty heartbeat catalog.
+		writeFileSync(join(unreadableArtifact, "scheduled-jobs.json"), "{");
+		mkdirSync(pausedCronArtifact, { recursive: true });
+		writeFileSync(
+			join(pausedCronArtifact, "scheduled-jobs.json"),
+			JSON.stringify({
+				jobs: [
+					{
+						id: "paused-cron",
+						status: "paused",
+						source: "cron",
+						activeSessionId: pausedCronEntry.rootActiveSessionId,
+						sessionId: pausedCron.id,
+						sessionFile: pausedCron.sessionFile,
+						cwd: fixture.root,
+						prompt: "preserve passive scheduled behavior",
+						schedule: { kind: "interval", expression: "every 1m", intervalMs: 60_000 },
+						createdAt: new Date(0).toISOString(),
+						updatedAt: new Date(0).toISOString(),
+						runCount: 0,
+					},
+				],
+				dispatches: [],
+			}),
+		);
+		for (const entry of [pausedEntry, unreadableEntry, pausedCronEntry]) {
+			writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
+		}
+
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		await supervisor.loadWorkerDescriptors();
+
+		expect(supervisor.workers.get(pausedEntry.workerId)?.descriptor.lifecycle).toBe("recovering");
+		expect(supervisor.workers.get(unreadableEntry.workerId)?.descriptor.lifecycle).toBe("recovering");
+		// A paused non-heartbeat schedule has never required a runtime snapshot.
+		expect(supervisor.workers.get(pausedCronEntry.workerId)?.descriptor.lifecycle).toBe("passivated");
+	});
+
 	it("prepares only ready residents and retains processless roots for the replacement supervisor", async () => {
 		const fixture = fixtureRoot();
 		const passiveSession = persistSession(fixture.sessionDir, fixture.root, "completed");

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -67,6 +67,7 @@ interface SupervisorInternals {
 	): Promise<void>;
 	stopWorkerOnce: ReturnType<typeof vi.fn>;
 	recoverWorker: ReturnType<typeof vi.fn>;
+	passivatedSummaryForDescriptor(descriptor: DaemonWorkerDescriptor): Promise<unknown>;
 	catalog: { archive(sessionFile: string, sessionId: string): Promise<void> };
 }
 
@@ -1228,6 +1229,82 @@ describe("daemon supervisor restart passivation", () => {
 			expect(second.recoverWorker).not.toHaveBeenCalled();
 			expect(workerSpawn).not.toHaveBeenCalled();
 			expect(kill).not.toHaveBeenCalled();
+		} finally {
+			kill.mockRestore();
+		}
+	});
+
+	it("ignores malformed recovering process identities without probing, waking, or passivating them", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const malformed = [
+			["pid-only", { pid: 999_999_999 }],
+			["start-only", { processStartId: "start-only" }],
+			["object-pid", { pid: { value: 999_999_999 }, processStartId: "object-pid" }],
+			["object-start", { pid: 999_999_999, processStartId: { value: "object-start" } }],
+			["empty-start", { pid: 999_999_999, processStartId: "" }],
+		] as const;
+		for (const [workerId, processIdentity] of malformed) {
+			const entry = {
+				...descriptor(fixture, workerId, session),
+				pid: undefined,
+				processStartId: undefined,
+				...processIdentity,
+				lifecycle: "recovering",
+			};
+			writeFileSync(join(fixture.descriptorDir, `${workerId}.json`), JSON.stringify(entry));
+		}
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		supervisor.recoverWorker = vi.fn();
+		const passivatedSummary = vi.spyOn(supervisor, "passivatedSummaryForDescriptor");
+		workerSpawn.mockClear();
+		const kill = vi.spyOn(process, "kill");
+		try {
+			await supervisor.loadWorkerDescriptors();
+			expect(supervisor.workers).toHaveLength(0);
+			expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+			expect(workerSpawn).not.toHaveBeenCalled();
+			expect(kill).not.toHaveBeenCalled();
+			expect(passivatedSummary).not.toHaveBeenCalled();
+			for (const [workerId] of malformed) {
+				const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
+				expect(persisted.lifecycle).toBe("recovering");
+			}
+		} finally {
+			kill.mockRestore();
+			passivatedSummary.mockRestore();
+		}
+	});
+
+	it("normalizes a legacy passivated descriptor before process inspection", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const entry = {
+			...descriptor(fixture, "legacy-passivated", session),
+			lifecycle: "passivated",
+			pid: { stale: 999_999_999 },
+			processStartId: { stale: "legacy" },
+		};
+		writeFileSync(join(fixture.descriptorDir, "legacy-passivated.json"), JSON.stringify(entry));
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const kill = vi.spyOn(process, "kill");
+		try {
+			await supervisor.loadWorkerDescriptors();
+			const worker = supervisor.workers.get("legacy-passivated");
+			expect(worker?.descriptor.lifecycle).toBe("passivated");
+			expect(worker?.descriptor).not.toHaveProperty("pid");
+			expect(worker?.descriptor).not.toHaveProperty("processStartId");
+			expect(worker?.summaries.has(worker?.descriptor.rootActiveSessionId ?? "")).toBe(true);
+			expect(kill).not.toHaveBeenCalled();
+			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, "legacy-passivated.json"), "utf8"));
+			expect(persisted).not.toHaveProperty("pid");
+			expect(persisted).not.toHaveProperty("processStartId");
 		} finally {
 			kill.mockRestore();
 		}

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -537,7 +537,11 @@ describe("daemon supervisor restart passivation", () => {
 		}) as unknown as SupervisorInternals;
 		const worker = {
 			descriptor: (() => {
-				const { pid: _pid, processStartId: _processStartId, ...passivated } = descriptor(fixture, "stop-wake-race", session);
+				const {
+					pid: _pid,
+					processStartId: _processStartId,
+					...passivated
+				} = descriptor(fixture, "stop-wake-race", session);
 				return { ...passivated, lifecycle: "passivated" as const };
 			})(),
 			descriptorPath: join(fixture.descriptorDir, "stop-wake-race.json"),
@@ -582,7 +586,6 @@ describe("daemon supervisor restart passivation", () => {
 		expect(() => readFileSync(worker.descriptorPath)).toThrow();
 	});
 
-
 	it("keeps concurrent stop options independent while sharing only archive finalization", async () => {
 		const fixture = fixtureRoot();
 		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
@@ -592,13 +595,20 @@ describe("daemon supervisor restart passivation", () => {
 		}) as unknown as SupervisorInternals;
 		const worker = {
 			descriptor: { ...descriptor(fixture, "options", session), lifecycle: "passivated" as const },
-			descriptorPath: join(fixture.descriptorDir, "options.json"), summaries: new Map(),
-			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
-			intentionalStop: false, stopRevision: 0,
+			descriptorPath: join(fixture.descriptorDir, "options.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopRevision: 0,
 		};
 		supervisor.workers.set("options", worker);
 		const calls: unknown[][] = [];
-		supervisor.stopWorkerOnce = vi.fn(async (...args: unknown[]) => { calls.push(args); });
+		supervisor.stopWorkerOnce = vi.fn(async (...args: unknown[]) => {
+			calls.push(args);
+		});
 
 		await Promise.all([
 			supervisor.stopWorker(worker, false, false, false),
@@ -612,7 +622,6 @@ describe("daemon supervisor restart passivation", () => {
 		]);
 	});
 
-
 	it("honors a concurrent force/archive/remove stop while an update stop is still graceful", async () => {
 		const fixture = fixtureRoot();
 		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
@@ -622,15 +631,22 @@ describe("daemon supervisor restart passivation", () => {
 		}) as unknown as SupervisorInternals;
 		const worker = {
 			descriptor: { ...descriptor(fixture, "force", session), lifecycle: "ready" as const },
-			descriptorPath: join(fixture.descriptorDir, "force.json"), summaries: new Map(),
-			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
-			intentionalStop: false, stopRevision: 0,
+			descriptorPath: join(fixture.descriptorDir, "force.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopRevision: 0,
 		};
 		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
 		supervisor.workers.set("force", worker);
 		supervisor.catalog.archive = vi.fn(async () => undefined);
 		let signalTerm: () => void = () => undefined;
-		const termSignaled = new Promise<void>((resolve) => { signalTerm = resolve; });
+		const termSignaled = new Promise<void>((resolve) => {
+			signalTerm = resolve;
+		});
 		const signals: string[] = [];
 		const child = {
 			exitCode: null as number | null,
@@ -663,15 +679,22 @@ describe("daemon supervisor restart passivation", () => {
 		}) as unknown as SupervisorInternals;
 		const worker = {
 			descriptor: { ...descriptor(fixture, "recovery-collision", session), lifecycle: "ready" as const },
-			descriptorPath: join(fixture.descriptorDir, "recovery-collision.json"), summaries: new Map(),
-			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
-			intentionalStop: false, stopRevision: 0,
+			descriptorPath: join(fixture.descriptorDir, "recovery-collision.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopRevision: 0,
 		};
 		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
 		supervisor.workers.set("recovery-collision", worker);
 		supervisor.catalog.archive = vi.fn(async () => undefined);
 		let releaseChild: () => void = () => undefined;
-		const childClosed = new Promise<void>((resolve) => { releaseChild = resolve; });
+		const childClosed = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
 		const child = { exitCode: 0, signalCode: null, kill: vi.fn(() => true) };
 		const recoveryCleanup = supervisor.stopWorker(worker, false, true, false, true, { child, closed: childClosed });
 		await Promise.resolve();
@@ -692,10 +715,18 @@ describe("daemon supervisor restart passivation", () => {
 			descriptorDir: fixture.descriptorDir,
 		}) as unknown as SupervisorInternals;
 		const worker = {
-			descriptor: (() => { const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "update-stop", session); return { ...passive, lifecycle: "passivated" as const }; })(),
-			descriptorPath: join(fixture.descriptorDir, "update-stop.json"), summaries: new Map(),
-			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
-			intentionalStop: false, stopRevision: 0,
+			descriptor: (() => {
+				const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "update-stop", session);
+				return { ...passive, lifecycle: "passivated" as const };
+			})(),
+			descriptorPath: join(fixture.descriptorDir, "update-stop.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopRevision: 0,
 		};
 		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
 		supervisor.workers.set("update-stop", worker);
@@ -703,6 +734,95 @@ describe("daemon supervisor restart passivation", () => {
 		await supervisor.stopWorker(worker, false);
 		expect(supervisor.workers.has("update-stop")).toBe(false);
 		expect(JSON.parse(readFileSync(worker.descriptorPath, "utf8"))).toMatchObject({ lifecycle: "recovering" });
+	});
+
+	it("late archive deletion removes a retained recovering descriptor before restart", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: (() => {
+				const {
+					pid: _pid,
+					processStartId: _processStartId,
+					...passivated
+				} = descriptor(fixture, "late-archive-delete", session);
+				return { ...passivated, lifecycle: "passivated" as const };
+			})(),
+			descriptorPath: join(fixture.descriptorDir, "late-archive-delete.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopFinalized: false,
+			stopRevision: 0,
+		};
+		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
+		supervisor.workers.set("late-archive-delete", worker);
+		supervisor.catalog.archive = vi.fn(async () => undefined);
+
+		await supervisor.stopWorker(worker, false);
+		expect(JSON.parse(readFileSync(worker.descriptorPath, "utf8"))).toMatchObject({ lifecycle: "recovering" });
+		await supervisor.stopWorker(worker, true, false, true);
+
+		expect(supervisor.catalog.archive).toHaveBeenCalledTimes(1);
+		expect(worker.stopFinalized).toBe(true);
+		expect(supervisor.workers.has("late-archive-delete")).toBe(false);
+		expect(() => readFileSync(worker.descriptorPath)).toThrow();
+
+		const restarted = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		await restarted.loadWorkerDescriptors();
+		expect(restarted.workers.has("late-archive-delete")).toBe(false);
+	});
+
+	it("retries a rejected archive finalization on a later explicit archive stop", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: (() => {
+				const {
+					pid: _pid,
+					processStartId: _processStartId,
+					...passivated
+				} = descriptor(fixture, "archive-retry", session);
+				return { ...passivated, lifecycle: "passivated" as const };
+			})(),
+			descriptorPath: join(fixture.descriptorDir, "archive-retry.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopFinalized: false,
+			stopRevision: 0,
+		};
+		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
+		supervisor.workers.set("archive-retry", worker);
+		supervisor.catalog.archive = vi
+			.fn<SupervisorInternals["catalog"]["archive"]>()
+			.mockRejectedValueOnce(new Error("archive failed"))
+			.mockResolvedValueOnce(undefined);
+
+		await expect(supervisor.stopWorker(worker, true, false, true)).rejects.toThrow("archive failed");
+		await expect(supervisor.stopWorker(worker, true, false, true)).resolves.toBeUndefined();
+
+		expect(supervisor.catalog.archive).toHaveBeenCalledTimes(2);
+		expect(worker.stopFinalized).toBe(true);
+		expect(supervisor.workers.has("archive-retry")).toBe(false);
+		expect(() => readFileSync(worker.descriptorPath)).toThrow();
 	});
 
 	it("blocks ordinary wake after a failed stop until explicit retry resets its tombstone", async () => {
@@ -713,22 +833,38 @@ describe("daemon supervisor restart passivation", () => {
 			descriptorDir: fixture.descriptorDir,
 		}) as unknown as SupervisorInternals;
 		const worker = {
-			descriptor: (() => { const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "failed-stop", session); return { ...passive, lifecycle: "passivated" as const }; })(),
-			descriptorPath: join(fixture.descriptorDir, "failed-stop.json"), summaries: new Map(),
-			snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(),
-			intentionalStop: false, stopRevision: 0,
+			descriptor: (() => {
+				const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "failed-stop", session);
+				return { ...passive, lifecycle: "passivated" as const };
+			})(),
+			descriptorPath: join(fixture.descriptorDir, "failed-stop.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopRevision: 0,
 		};
 		supervisor.workers.set("failed-stop", worker);
 		supervisor.recoverWorker = vi.fn();
-		supervisor.catalog.archive = vi.fn(async () => { throw new Error("archive failed"); });
+		supervisor.catalog.archive = vi.fn(async () => {
+			throw new Error("archive failed");
+		});
 		await expect(supervisor.stopWorker(worker, true, false, true)).rejects.toThrow("archive failed");
 		await expect(supervisor.wakePassivatedWorker(worker)).rejects.toThrow("was stopped");
 		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
 		// Direct retry is the explicit reset route; its recovery is mocked only to
 		// prove it is admitted after the persisted failure fence.
-		supervisor.recoverWorker = vi.fn(async () => { worker.descriptor.lifecycle = "ready"; worker.client = {}; });
-		const retried = (supervisor as unknown as { handleCommand(client: object, command: object): Promise<unknown> }).handleCommand(
-			{ id: "client" }, { id: "retry", type: "retry_worker", activeSessionId: worker.descriptor.rootActiveSessionId },
+		supervisor.recoverWorker = vi.fn(async () => {
+			worker.descriptor.lifecycle = "ready";
+			worker.client = {};
+		});
+		const retried = (
+			supervisor as unknown as { handleCommand(client: object, command: object): Promise<unknown> }
+		).handleCommand(
+			{ id: "client" },
+			{ id: "retry", type: "retry_worker", activeSessionId: worker.descriptor.rootActiveSessionId },
 		);
 		await expect(retried).resolves.toBeDefined();
 		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
@@ -810,7 +946,14 @@ describe("daemon supervisor restart passivation", () => {
 		// A top-level array is corrupt artifact state, so fail closed rather than
 		// passivating a root whose scheduled work cannot be reconstructed.
 		expect(supervisor.workers.get("corrupt-array-artifact")?.descriptor.lifecycle).toBe("recovering");
-		for (const workerId of ["malformed", "stale", "invalid-lifecycle", "truncated-lifecycle", "oversized-verdict", "corrupt-array-artifact"]) {
+		for (const workerId of [
+			"malformed",
+			"stale",
+			"invalid-lifecycle",
+			"truncated-lifecycle",
+			"oversized-verdict",
+			"corrupt-array-artifact",
+		]) {
 			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
 			expect(persisted.pid).toBe(999_999_999);
 		}

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -135,6 +135,12 @@ describe("daemon supervisor restart passivation", () => {
 		).toHaveLength(2);
 		expect(supervisor.workers.get("completed")?.summaries.size).toBe(1);
 		expect(supervisor.workers.get("needs-input")?.summaries.size).toBe(1);
+		for (const workerId of ["completed", "needs-input"]) {
+			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
+			expect(persisted.lifecycle).toBe("passivated");
+			expect(persisted).not.toHaveProperty("pid");
+			expect(persisted).not.toHaveProperty("processStartId");
+		}
 		expect(supervisor.workers.get("scheduled")?.descriptor.lifecycle).toBe("recovering");
 		expect(supervisor.workers.get("active")?.descriptor.lifecycle).toBe("recovering");
 	});
@@ -227,7 +233,10 @@ describe("daemon supervisor restart passivation", () => {
 			descriptorDir: fixture.descriptorDir,
 		}) as unknown as SupervisorInternals;
 		const worker = {
-			descriptor: { ...descriptor(fixture, "stop", session), pid: process.pid, lifecycle: "passivated" as const },
+			descriptor: (() => {
+				const { pid: _pid, processStartId: _processStartId, ...passivated } = descriptor(fixture, "stop", session);
+				return { ...passivated, lifecycle: "passivated" as const };
+			})(),
 			descriptorPath: join(fixture.descriptorDir, "stop.json"),
 			summaries: new Map(),
 			snapshotCache: new Map(),
@@ -246,6 +255,59 @@ describe("daemon supervisor restart passivation", () => {
 			expect(supervisor.workers.has("stop")).toBe(false);
 		} finally {
 			kill.mockRestore();
+		}
+	});
+	it("recovers rather than passivating malformed or stale durable task verdicts", async () => {
+		const fixture = fixtureRoot();
+		const malformed = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const stale = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const invalidLifecycle = persistSession(fixture.sessionDir, fixture.root, "completed");
+		for (const [workerId, session, status] of [
+			["malformed", malformed, { summary: "bad", taskState: "arbitrary_untrusted_value", basedOnMessageCount: 1 }],
+			["stale", stale, { summary: "stale", taskState: "completed", basedOnMessageCount: 0 }],
+		] as const) {
+			writeFileSync(
+				session.sessionFile,
+				`${JSON.stringify({
+					type: "agent_status",
+					id: `${workerId}-status`,
+					parentId: "root",
+					timestamp: new Date().toISOString(),
+					status,
+				})}\n`,
+				{ flag: "a" },
+			);
+			writeFileSync(
+				join(fixture.descriptorDir, `${workerId}.json`),
+				JSON.stringify(descriptor(fixture, workerId, session)),
+			);
+		}
+		writeFileSync(
+			invalidLifecycle.sessionFile,
+			`${JSON.stringify({
+				type: "session_state",
+				id: "invalid-lifecycle",
+				parentId: "root",
+				timestamp: new Date().toISOString(),
+				state: { status: "untrusted_lifecycle" },
+			})}\n`,
+			{ flag: "a" },
+		);
+		writeFileSync(
+			join(fixture.descriptorDir, "invalid-lifecycle.json"),
+			JSON.stringify(descriptor(fixture, "invalid-lifecycle", invalidLifecycle)),
+		);
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		await supervisor.loadWorkerDescriptors();
+		expect(supervisor.workers.get("malformed")?.descriptor.lifecycle).toBe("recovering");
+		expect(supervisor.workers.get("stale")?.descriptor.lifecycle).toBe("recovering");
+		expect(supervisor.workers.get("invalid-lifecycle")?.descriptor.lifecycle).toBe("recovering");
+		for (const workerId of ["malformed", "stale", "invalid-lifecycle"]) {
+			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
+			expect(persisted.pid).toBe(999_999_999);
 		}
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -517,14 +517,53 @@ describe("daemon supervisor restart passivation", () => {
 		mkdirSync(artifact(completed), { recursive: true });
 		writeFileSync(
 			join(artifact(orphan), "scheduled-jobs.json"),
-			JSON.stringify({ jobs: [], dispatches: [{ id: "orphan", jobId: "missing", claimedAt: new Date(0).toISOString(), scheduledFor: new Date(0).toISOString() }] }),
+			JSON.stringify({
+				jobs: [],
+				dispatches: [
+					{
+						id: "orphan",
+						jobId: "missing",
+						claimedAt: new Date(0).toISOString(),
+						scheduledFor: new Date(0).toISOString(),
+					},
+				],
+			}),
 		);
 		writeFileSync(
 			join(artifact(completed), "scheduled-jobs.json"),
-			JSON.stringify({ jobs: [{ id: "done", status: "completed", source: "cron", activeSessionId: completedEntry.rootActiveSessionId, sessionId: completed.id, sessionFile: completed.sessionFile, cwd: fixture.root, prompt: "done", schedule: { kind: "once", expression: "once" }, createdAt: new Date(0).toISOString(), updatedAt: new Date(0).toISOString(), runCount: 1 }], dispatches: [{ id: "matched", jobId: "done", claimedAt: new Date(0).toISOString(), scheduledFor: new Date(0).toISOString() }] }),
+			JSON.stringify({
+				jobs: [
+					{
+						id: "done",
+						status: "completed",
+						source: "cron",
+						activeSessionId: completedEntry.rootActiveSessionId,
+						sessionId: completed.id,
+						sessionFile: completed.sessionFile,
+						cwd: fixture.root,
+						prompt: "done",
+						schedule: { kind: "once", expression: "once" },
+						createdAt: new Date(0).toISOString(),
+						updatedAt: new Date(0).toISOString(),
+						runCount: 1,
+					},
+				],
+				dispatches: [
+					{
+						id: "matched",
+						jobId: "done",
+						claimedAt: new Date(0).toISOString(),
+						scheduledFor: new Date(0).toISOString(),
+					},
+				],
+			}),
 		);
-		for (const entry of [orphanEntry, completedEntry]) writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
-		const supervisor = new DaemonSupervisor(fixture.socketPath, { defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir }, descriptorDir: fixture.descriptorDir }) as unknown as SupervisorInternals;
+		for (const entry of [orphanEntry, completedEntry])
+			writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
 		await supervisor.loadWorkerDescriptors();
 		expect(supervisor.workers.get(orphanEntry.workerId)?.descriptor.lifecycle).toBe("recovering");
 		expect(supervisor.workers.get(completedEntry.workerId)?.descriptor.lifecycle).toBe("passivated");
@@ -592,9 +631,26 @@ describe("daemon supervisor restart passivation", () => {
 	it("clears stale process identity before persisting an owner-owned no-env passive worker", async () => {
 		const fixture = fixtureRoot();
 		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
-		const entry = { ...descriptor(fixture, "owner-no-env", session), ownerClientId: "owner-client", lifecycle: "ready" as const };
-		const supervisor = new DaemonSupervisor(fixture.socketPath, { defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir }, descriptorDir: fixture.descriptorDir }) as unknown as SupervisorInternals;
-		const worker = { descriptor: entry, descriptorPath: join(fixture.descriptorDir, "owner-no-env.json"), summaries: new Map(), snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(), intentionalStop: false, stopRevision: 0 };
+		const entry = {
+			...descriptor(fixture, "owner-no-env", session),
+			ownerClientId: "owner-client",
+			lifecycle: "ready" as const,
+		};
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: entry,
+			descriptorPath: join(fixture.descriptorDir, "owner-no-env.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopRevision: 0,
+		};
 		writeFileSync(worker.descriptorPath, JSON.stringify(entry));
 		supervisor.workers.set(entry.workerId, worker);
 		await (
@@ -898,8 +954,25 @@ describe("daemon supervisor restart passivation", () => {
 	it("does not recreate a deleted descriptor when a later stop requests archive", async () => {
 		const fixture = fixtureRoot();
 		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
-		const supervisor = new DaemonSupervisor(fixture.socketPath, { defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir }, descriptorDir: fixture.descriptorDir }) as unknown as SupervisorInternals;
-		const worker = { descriptor: (() => { const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "already-deleted", session); return { ...passive, lifecycle: "passivated" as const }; })(), descriptorPath: join(fixture.descriptorDir, "already-deleted.json"), summaries: new Map(), snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(), intentionalStop: false, stopFinalized: false, stopRevision: 0 };
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: (() => {
+				const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "already-deleted", session);
+				return { ...passive, lifecycle: "passivated" as const };
+			})(),
+			descriptorPath: join(fixture.descriptorDir, "already-deleted.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopFinalized: false,
+			stopRevision: 0,
+		};
 		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
 		supervisor.workers.set(worker.descriptor.workerId, worker);
 		await supervisor.stopWorker(worker, true);

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -15,6 +15,7 @@ vi.mock("node:child_process", async (importOriginal) => ({
 }));
 
 import { SessionManager } from "../src/core/session-manager.js";
+import type { DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import { DAEMON_UPDATE_RESTART_FORMAT_VERSION } from "../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import type { DaemonWorkerDescriptor } from "../src/modes/daemon/daemon-worker-protocol.js";
@@ -24,6 +25,11 @@ const directories: string[] = [];
 afterEach(() => {
 	for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
+
+type AttachClientFixture = Pick<
+	DaemonSocketClient,
+	"id" | "attachedActiveSessionIds" | "capabilities" | "supportsExtensionUi"
+>;
 
 interface WorkerFixture {
 	descriptor: DaemonWorkerDescriptor;
@@ -35,6 +41,15 @@ interface WorkerFixture {
 	archiveFinalization?: Promise<void>;
 	stopFinalized?: boolean;
 	stopFailure?: Error;
+}
+
+interface PassivatedWorkerFixture extends WorkerFixture {
+	snapshotCache: Map<string, unknown>;
+	transcriptCaches: Map<string, unknown>;
+	snapshotGenerations: Map<string, Map<string, unknown>>;
+	snapshotLoads: Map<string, Promise<unknown>>;
+	intentionalStop: boolean;
+	stopRevision: number;
 }
 
 interface SupervisorInternals {
@@ -507,7 +522,7 @@ describe("daemon supervisor restart passivation", () => {
 			descriptorDir: fixture.descriptorDir,
 		}) as unknown as SupervisorInternals & {
 			attachClient(
-				client: { id: string },
+				client: AttachClientFixture,
 				command: { type: "attach"; activeSessionId: string; launchEnv?: Record<string, string> },
 			): Promise<unknown>;
 		};
@@ -886,7 +901,7 @@ describe("daemon supervisor restart passivation", () => {
 			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
 			descriptorDir: fixture.descriptorDir,
 		}) as unknown as SupervisorInternals;
-		const worker = {
+		const worker: PassivatedWorkerFixture = {
 			descriptor: (() => {
 				const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "failed-stop", session);
 				return { ...passive, lifecycle: "passivated" as const };

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -201,9 +201,13 @@ describe("daemon supervisor restart passivation", () => {
 			worker.client = { request: vi.fn() };
 		});
 
-		await expect(
-			supervisor.forwardToWorker(worker, { type: "get_state", activeSessionId: "active-read" }),
-		).rejects.toThrow("passivated");
+		for (const command of [
+			{ type: "get_state", activeSessionId: "active-read" },
+			{ type: "get_messages", activeSessionId: "active-read" },
+			{ type: "get_session_context", activeSessionId: "active-read" },
+		] as const) {
+			await expect(supervisor.forwardToWorker(worker, command)).rejects.toThrow("passivated");
+		}
 		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
 
 		await supervisor.forwardToWorker(worker, {
@@ -211,6 +215,31 @@ describe("daemon supervisor restart passivation", () => {
 			activeSessionId: "active-read",
 			message: "resume",
 		});
+		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		{ type: "abort", activeSessionId: "active-read" },
+		{ type: "agent_messages_pause", activeSessionId: "active-read" },
+		{ type: "agent_messages_resume", activeSessionId: "active-read" },
+	])("wakes a passivated root for state-changing $type commands", async (command) => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker: WorkerFixture = {
+			descriptor: { ...descriptor(fixture, "wake-command", session), lifecycle: "passivated" },
+			descriptorPath: join(fixture.descriptorDir, "wake-command.json"),
+			summaries: new Map(),
+		};
+		supervisor.recoverWorker = vi.fn(async () => {
+			worker.descriptor.lifecycle = "ready";
+			worker.client = { request: vi.fn() };
+		});
+
+		await supervisor.forwardToWorker(worker, command);
 		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
 	});
 
@@ -238,6 +267,23 @@ describe("daemon supervisor restart passivation", () => {
 		}) as unknown as SupervisorInternals;
 		await supervisor.loadWorkerDescriptors();
 		expect(supervisor.workers.get("busy")?.descriptor.lifecycle).toBe("recovering");
+	});
+
+	it("keeps a dead client-owned root recoverable without persisting its launch environment", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const entry = { ...descriptor(fixture, "client-owned", session), ownerClientId: "owner-client" };
+		writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
+
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		await supervisor.loadWorkerDescriptors();
+
+		expect(supervisor.workers.get(entry.workerId)?.descriptor.lifecycle).toBe("recovering");
+		const persisted = readFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), "utf8");
+		expect(persisted).not.toContain("launchEnv");
 	});
 
 	it("stops a passivated descriptor without probing or signaling its stale pid", async () => {
@@ -277,6 +323,8 @@ describe("daemon supervisor restart passivation", () => {
 		const malformed = persistSession(fixture.sessionDir, fixture.root, "completed");
 		const stale = persistSession(fixture.sessionDir, fixture.root, "completed");
 		const invalidLifecycle = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const truncatedLifecycle = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const oversizedVerdict = persistSession(fixture.sessionDir, fixture.root, "completed");
 		for (const [workerId, session, status] of [
 			["malformed", malformed, { summary: "bad", taskState: "arbitrary_untrusted_value", basedOnMessageCount: 1 }],
 			["stale", stale, { summary: "stale", taskState: "completed", basedOnMessageCount: 0 }],
@@ -312,6 +360,23 @@ describe("daemon supervisor restart passivation", () => {
 			join(fixture.descriptorDir, "invalid-lifecycle.json"),
 			JSON.stringify(descriptor(fixture, "invalid-lifecycle", invalidLifecycle)),
 		);
+		writeFileSync(truncatedLifecycle.sessionFile, '{"type":"session_state"', { flag: "a" });
+		writeFileSync(
+			oversizedVerdict.sessionFile,
+			`\n{"type":"agent_status","padding":"${"x".repeat(2 * 1024 * 1024)}"}\n`,
+			{
+				flag: "a",
+			},
+		);
+		for (const [workerId, session] of [
+			["truncated-lifecycle", truncatedLifecycle],
+			["oversized-verdict", oversizedVerdict],
+		] as const) {
+			writeFileSync(
+				join(fixture.descriptorDir, `${workerId}.json`),
+				JSON.stringify(descriptor(fixture, workerId, session)),
+			);
+		}
 		const supervisor = new DaemonSupervisor(fixture.socketPath, {
 			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
 			descriptorDir: fixture.descriptorDir,
@@ -320,7 +385,9 @@ describe("daemon supervisor restart passivation", () => {
 		expect(supervisor.workers.get("malformed")?.descriptor.lifecycle).toBe("recovering");
 		expect(supervisor.workers.get("stale")?.descriptor.lifecycle).toBe("recovering");
 		expect(supervisor.workers.get("invalid-lifecycle")?.descriptor.lifecycle).toBe("recovering");
-		for (const workerId of ["malformed", "stale", "invalid-lifecycle"]) {
+		expect(supervisor.workers.get("truncated-lifecycle")?.descriptor.lifecycle).toBe("recovering");
+		expect(supervisor.workers.get("oversized-verdict")?.descriptor.lifecycle).toBe("recovering");
+		for (const workerId of ["malformed", "stale", "invalid-lifecycle", "truncated-lifecycle", "oversized-verdict"]) {
 			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
 			expect(persisted.pid).toBe(999_999_999);
 		}

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../src/core/session-manager.js";
+import { DAEMON_UPDATE_RESTART_FORMAT_VERSION } from "../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import type { DaemonWorkerDescriptor } from "../src/modes/daemon/daemon-worker-protocol.js";
 
@@ -158,6 +159,83 @@ describe("daemon supervisor restart passivation", () => {
 		}
 		expect(supervisor.workers.get("scheduled")?.descriptor.lifecycle).toBe("recovering");
 		expect(supervisor.workers.get("unjudged")?.descriptor.lifecycle).toBe("recovering");
+	});
+
+	it("prepares only ready residents and retains processless roots for the replacement supervisor", async () => {
+		const fixture = fixtureRoot();
+		const passiveSession = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const passiveDescriptor = { ...descriptor(fixture, "passive", passiveSession), lifecycle: "passivated" as const };
+		delete passiveDescriptor.pid;
+		delete passiveDescriptor.processStartId;
+		writeFileSync(join(fixture.descriptorDir, "passive.json"), JSON.stringify(passiveDescriptor));
+
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals & {
+			prepareUpdateRestartFenced(deadline: number): Promise<{ sessions: Array<{ activeSessionId: string }> }>;
+			validateAndPersistUpdateManifest: ReturnType<typeof vi.fn>;
+			stopWorker: ReturnType<typeof vi.fn>;
+		};
+		supervisor.recoverWorker = vi.fn();
+		await supervisor.loadWorkerDescriptors();
+		const passive = supervisor.workers.get("passive");
+		if (!passive) throw new Error("passive fixture was not loaded");
+		const passiveSummary = passive.summaries.get(passiveDescriptor.rootActiveSessionId);
+		const readySession = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const readyClient = {
+			requestWorker: vi.fn(async ({ type }: { type: string }) =>
+				type === "worker_prepare_update"
+					? {
+							success: true,
+							data: {
+								formatVersion: DAEMON_UPDATE_RESTART_FORMAT_VERSION,
+								createdAt: "now",
+								sessions: [{ activeSessionId: "active-ready", sessionFile: readySession.sessionFile }],
+							},
+						}
+					: { success: true },
+			),
+		};
+		const ready = {
+			descriptor: { ...descriptor(fixture, "ready", readySession), rootActiveSessionId: "active-ready" },
+			descriptorPath: join(fixture.descriptorDir, "ready.json"),
+			client: readyClient,
+			summaries: new Map(),
+		};
+		supervisor.workers.set("ready", ready);
+		supervisor.validateAndPersistUpdateManifest = vi.fn();
+		supervisor.stopWorker = vi.fn(async () => undefined);
+
+		await expect(supervisor.prepareUpdateRestartFenced(Date.now() + 10_000)).resolves.toMatchObject({
+			sessions: [{ activeSessionId: "active-ready" }],
+		});
+		expect(readyClient.requestWorker).toHaveBeenCalledTimes(2);
+		expect(readyClient.requestWorker).toHaveBeenNthCalledWith(
+			1,
+			{ type: "worker_prepare_update" },
+			expect.any(Number),
+		);
+		expect(supervisor.stopWorker).toHaveBeenCalledTimes(1);
+		expect(supervisor.stopWorker).toHaveBeenCalledWith(ready, false);
+		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+		expect(passive.descriptor).toMatchObject({ lifecycle: "passivated" });
+		expect(passive.descriptor).not.toHaveProperty("pid");
+		expect(passive.client).toBeUndefined();
+		expect(passive.summaries.get(passiveDescriptor.rootActiveSessionId)).toEqual(passiveSummary);
+
+		const replacement = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		replacement.recoverWorker = vi.fn();
+		await replacement.loadWorkerDescriptors();
+		const reloadedPassive = replacement.workers.get("passive");
+		expect(reloadedPassive?.descriptor.lifecycle).toBe("passivated");
+		expect(reloadedPassive?.descriptor).not.toHaveProperty("pid");
+		expect(reloadedPassive?.client).toBeUndefined();
+		expect(reloadedPassive?.summaries.get(passiveDescriptor.rootActiveSessionId)).toEqual(passiveSummary);
+		expect(replacement.recoverWorker).not.toHaveBeenCalled();
 	});
 
 	it("single-flights an explicit wake and does not revive passivated records by itself", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -506,15 +506,18 @@ describe("daemon supervisor restart passivation", () => {
 		expect(supervisor.workers.get("busy")?.descriptor.lifecycle).toBe("recovering");
 	});
 
-	it("recovers an orphan cron dispatch but passivates a matched completed dispatch", async () => {
+	it("recovers orphan and completed-recurring cron dispatches but passivates a matched completed one-shot", async () => {
 		const fixture = fixtureRoot();
 		const orphan = persistSession(fixture.sessionDir, fixture.root, "completed");
 		const completed = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const completedRecurring = persistSession(fixture.sessionDir, fixture.root, "completed");
 		const orphanEntry = descriptor(fixture, "orphan-dispatch", orphan);
 		const completedEntry = descriptor(fixture, "completed-dispatch", completed);
+		const completedRecurringEntry = descriptor(fixture, "completed-recurring-dispatch", completedRecurring);
 		const artifact = (session: { id: string }) => join(fixture.agentDir, "session-artifacts", session.id);
 		mkdirSync(artifact(orphan), { recursive: true });
 		mkdirSync(artifact(completed), { recursive: true });
+		mkdirSync(artifact(completedRecurring), { recursive: true });
 		writeFileSync(
 			join(artifact(orphan), "scheduled-jobs.json"),
 			JSON.stringify({
@@ -558,7 +561,36 @@ describe("daemon supervisor restart passivation", () => {
 				],
 			}),
 		);
-		for (const entry of [orphanEntry, completedEntry])
+		writeFileSync(
+			join(artifact(completedRecurring), "scheduled-jobs.json"),
+			JSON.stringify({
+				jobs: [
+					{
+						id: "completed-recurring",
+						status: "completed",
+						source: "cron",
+						activeSessionId: completedRecurringEntry.rootActiveSessionId,
+						sessionId: completedRecurring.id,
+						sessionFile: completedRecurring.sessionFile,
+						cwd: fixture.root,
+						prompt: "interrupted recurring schedule",
+						schedule: { kind: "interval", expression: "every 1m", intervalMs: 60_000 },
+						createdAt: new Date(0).toISOString(),
+						updatedAt: new Date(0).toISOString(),
+						runCount: 1,
+					},
+				],
+				dispatches: [
+					{
+						id: "completed-recurring-dispatch",
+						jobId: "completed-recurring",
+						claimedAt: new Date(0).toISOString(),
+						scheduledFor: new Date(0).toISOString(),
+					},
+				],
+			}),
+		);
+		for (const entry of [orphanEntry, completedEntry, completedRecurringEntry])
 			writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
 		const supervisor = new DaemonSupervisor(fixture.socketPath, {
 			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
@@ -567,6 +599,7 @@ describe("daemon supervisor restart passivation", () => {
 		await supervisor.loadWorkerDescriptors();
 		expect(supervisor.workers.get(orphanEntry.workerId)?.descriptor.lifecycle).toBe("recovering");
 		expect(supervisor.workers.get(completedEntry.workerId)?.descriptor.lifecycle).toBe("passivated");
+		expect(supervisor.workers.get(completedRecurringEntry.workerId)?.descriptor.lifecycle).toBe("recovering");
 	});
 
 	it("does not recover a saved processless client-owned passive root until its owner attaches with env", async () => {
@@ -625,6 +658,72 @@ describe("daemon supervisor restart passivation", () => {
 			},
 			{ type: "attach", activeSessionId: entry.rootActiveSessionId, launchEnv: { HERDR_PANE_ID: "pane" } },
 		);
+		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
+	});
+
+	it("lets only the owner replace launch env before reusing a passive client-owned root", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const entry = {
+			...descriptor(fixture, "client-owned-reuse", session),
+			ownerClientId: "owner-client",
+			lifecycle: "passivated" as const,
+		};
+		delete entry.pid;
+		writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
+
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals & {
+			createOrReuseWorker(
+				clientId: string,
+				command: {
+					type: "create";
+					sessionPath: string;
+					lifecycle?: "client_owned";
+					launchEnv?: Record<string, string>;
+				},
+			): Promise<WorkerFixture & { launchEnv?: Record<string, string> }>;
+		};
+		await supervisor.loadWorkerDescriptors();
+		const passive = supervisor.workers.get(entry.workerId);
+		if (!passive) throw new Error("passive owner worker was not loaded");
+		supervisor.recoverWorker = vi.fn(async () => {
+			passive.descriptor.lifecycle = "ready";
+			passive.client = {};
+		});
+
+		await expect(
+			supervisor.createOrReuseWorker("other-client", {
+				type: "create",
+				sessionPath: session.sessionFile,
+				lifecycle: "client_owned",
+				launchEnv: { HERDR_PANE_ID: "injected" },
+			}),
+		).rejects.toThrow("already active");
+		expect((passive as { launchEnv?: Record<string, string> }).launchEnv).toBeUndefined();
+		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+
+		const reused = await supervisor.createOrReuseWorker("owner-client", {
+			type: "create",
+			sessionPath: session.sessionFile,
+			lifecycle: "client_owned",
+			launchEnv: { HERDR_PANE_ID: "owner-pane" },
+		});
+		expect(reused).toBe(passive);
+		expect(reused.launchEnv).toEqual({ HERDR_PANE_ID: "owner-pane" });
+		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
+
+		// Reuse by the active-session selector takes the other matching path and
+		// must update the authorized owner's environment without another wake.
+		await supervisor.createOrReuseWorker("owner-client", {
+			type: "create",
+			sessionPath: entry.rootActiveSessionId,
+			lifecycle: "client_owned",
+			launchEnv: { HERDR_PANE_ID: "owner-pane-after-restart" },
+		});
+		expect(reused.launchEnv).toEqual({ HERDR_PANE_ID: "owner-pane-after-restart" });
 		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -184,6 +184,45 @@ describe("daemon supervisor restart passivation", () => {
 		expect(worker.descriptor.lifecycle).toBe("ready");
 	});
 
+	it("rejects an incompatible telemetry attach before waking a passivated root", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals & {
+			attachClient(
+				client: object,
+				command: { type: "attach"; activeSessionId: string; telemetryDisabled: true },
+			): Promise<unknown>;
+		};
+		const worker: WorkerFixture = {
+			descriptor: { ...descriptor(fixture, "telemetry", session), lifecycle: "passivated" },
+			descriptorPath: join(fixture.descriptorDir, "telemetry.json"),
+			summaries: new Map([
+				[
+					"active-telemetry",
+					{ id: "active-telemetry", activeSessionId: "active-telemetry", sessionId: session.id },
+				],
+			]),
+		};
+		supervisor.workers.set("telemetry", worker);
+		supervisor.recoverWorker = vi.fn();
+
+		await expect(
+			supervisor.attachClient(
+				{ id: "attach-client" },
+				{
+					type: "attach",
+					activeSessionId: "active-telemetry",
+					telemetryDisabled: true,
+				},
+			),
+		).rejects.toThrow("Cannot attach to this active agent while telemetry is disabled");
+		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+		expect(worker.descriptor.lifecycle).toBe("passivated");
+	});
+
 	it("does not revive a passivated root for metadata reads, but wakes it for one explicit operation", async () => {
 		const fixture = fixtureRoot();
 		const session = persistSession(fixture.sessionDir, fixture.root, "completed");

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -506,6 +506,30 @@ describe("daemon supervisor restart passivation", () => {
 		expect(supervisor.workers.get("busy")?.descriptor.lifecycle).toBe("recovering");
 	});
 
+	it("recovers an orphan cron dispatch but passivates a matched completed dispatch", async () => {
+		const fixture = fixtureRoot();
+		const orphan = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const completed = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const orphanEntry = descriptor(fixture, "orphan-dispatch", orphan);
+		const completedEntry = descriptor(fixture, "completed-dispatch", completed);
+		const artifact = (session: { id: string }) => join(fixture.agentDir, "session-artifacts", session.id);
+		mkdirSync(artifact(orphan), { recursive: true });
+		mkdirSync(artifact(completed), { recursive: true });
+		writeFileSync(
+			join(artifact(orphan), "scheduled-jobs.json"),
+			JSON.stringify({ jobs: [], dispatches: [{ id: "orphan", jobId: "missing", claimedAt: new Date(0).toISOString(), scheduledFor: new Date(0).toISOString() }] }),
+		);
+		writeFileSync(
+			join(artifact(completed), "scheduled-jobs.json"),
+			JSON.stringify({ jobs: [{ id: "done", status: "completed", source: "cron", activeSessionId: completedEntry.rootActiveSessionId, sessionId: completed.id, sessionFile: completed.sessionFile, cwd: fixture.root, prompt: "done", schedule: { kind: "once", expression: "once" }, createdAt: new Date(0).toISOString(), updatedAt: new Date(0).toISOString(), runCount: 1 }], dispatches: [{ id: "matched", jobId: "done", claimedAt: new Date(0).toISOString(), scheduledFor: new Date(0).toISOString() }] }),
+		);
+		for (const entry of [orphanEntry, completedEntry]) writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
+		const supervisor = new DaemonSupervisor(fixture.socketPath, { defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir }, descriptorDir: fixture.descriptorDir }) as unknown as SupervisorInternals;
+		await supervisor.loadWorkerDescriptors();
+		expect(supervisor.workers.get(orphanEntry.workerId)?.descriptor.lifecycle).toBe("recovering");
+		expect(supervisor.workers.get(completedEntry.workerId)?.descriptor.lifecycle).toBe("passivated");
+	});
+
 	it("does not recover a saved processless client-owned passive root until its owner attaches with env", async () => {
 		const fixture = fixtureRoot();
 		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
@@ -563,6 +587,25 @@ describe("daemon supervisor restart passivation", () => {
 			{ type: "attach", activeSessionId: entry.rootActiveSessionId, launchEnv: { HERDR_PANE_ID: "pane" } },
 		);
 		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears stale process identity before persisting an owner-owned no-env passive worker", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const entry = { ...descriptor(fixture, "owner-no-env", session), ownerClientId: "owner-client", lifecycle: "ready" as const };
+		const supervisor = new DaemonSupervisor(fixture.socketPath, { defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir }, descriptorDir: fixture.descriptorDir }) as unknown as SupervisorInternals;
+		const worker = { descriptor: entry, descriptorPath: join(fixture.descriptorDir, "owner-no-env.json"), summaries: new Map(), snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(), intentionalStop: false, stopRevision: 0 };
+		writeFileSync(worker.descriptorPath, JSON.stringify(entry));
+		supervisor.workers.set(entry.workerId, worker);
+		await (
+			supervisor as unknown as { recoverWorker(worker: { descriptor: DaemonWorkerDescriptor }): Promise<void> }
+		).recoverWorker(worker);
+		expect(worker.descriptor).toMatchObject({ lifecycle: "passivated", ownerClientId: "owner-client" });
+		expect(worker.descriptor).not.toHaveProperty("pid");
+		expect(worker.descriptor).not.toHaveProperty("processStartId");
+		const persisted = JSON.parse(readFileSync(worker.descriptorPath, "utf8"));
+		expect(persisted).not.toHaveProperty("pid");
+		expect(persisted).not.toHaveProperty("processStartId");
 	});
 
 	it("stops a passivated descriptor without probing or signaling its stale pid", async () => {
@@ -850,6 +893,25 @@ describe("daemon supervisor restart passivation", () => {
 		}) as unknown as SupervisorInternals;
 		await restarted.loadWorkerDescriptors();
 		expect(restarted.workers.has("late-archive-delete")).toBe(false);
+	});
+
+	it("does not recreate a deleted descriptor when a later stop requests archive", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, { defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir }, descriptorDir: fixture.descriptorDir }) as unknown as SupervisorInternals;
+		const worker = { descriptor: (() => { const { pid: _pid, processStartId: _start, ...passive } = descriptor(fixture, "already-deleted", session); return { ...passive, lifecycle: "passivated" as const }; })(), descriptorPath: join(fixture.descriptorDir, "already-deleted.json"), summaries: new Map(), snapshotCache: new Map(), transcriptCaches: new Map(), snapshotGenerations: new Map(), snapshotLoads: new Map(), intentionalStop: false, stopFinalized: false, stopRevision: 0 };
+		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
+		supervisor.workers.set(worker.descriptor.workerId, worker);
+		await supervisor.stopWorker(worker, true);
+		expect(() => readFileSync(worker.descriptorPath)).toThrow();
+		supervisor.catalog.archive = vi.fn(async () => {
+			// This is the crash-window boundary: an old implementation persisted a
+			// fresh tombstone immediately before this archive call.
+			expect(() => readFileSync(worker.descriptorPath)).toThrow();
+		});
+		await supervisor.stopWorker(worker, true, false, true);
+		expect(supervisor.catalog.archive).toHaveBeenCalledOnce();
+		expect(() => readFileSync(worker.descriptorPath)).toThrow();
 	});
 
 	it("retries a rejected archive finalization on a later explicit archive stop", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -19,6 +19,8 @@ interface WorkerFixture {
 	summaries: Map<string, unknown>;
 	client?: object;
 	wake?: Promise<void>;
+	stop?: Promise<void>;
+	stopFinalized?: boolean;
 }
 
 interface SupervisorInternals {
@@ -26,8 +28,9 @@ interface SupervisorInternals {
 	loadWorkerDescriptors(): Promise<void>;
 	wakePassivatedWorker(worker: WorkerFixture): Promise<void>;
 	forwardToWorker(worker: WorkerFixture, command: object): Promise<unknown>;
-	stopWorker(worker: WorkerFixture, removeDescriptor: boolean): Promise<void>;
+	stopWorker(worker: WorkerFixture, removeDescriptor: boolean, force?: boolean, archiveSession?: boolean): Promise<void>;
 	recoverWorker: ReturnType<typeof vi.fn>;
+	catalog: { archive(sessionFile: string, sessionId: string): Promise<void> };
 }
 
 function fixtureRoot(): {
@@ -439,6 +442,60 @@ describe("daemon supervisor restart passivation", () => {
 			kill.mockRestore();
 		}
 	});
+	it("fences a concurrent explicit wake until passive stop archive/delete finalizes", async () => {
+		const fixture = fixtureRoot();
+		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
+		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+			descriptorDir: fixture.descriptorDir,
+		}) as unknown as SupervisorInternals;
+		const worker = {
+			descriptor: (() => {
+				const { pid: _pid, processStartId: _processStartId, ...passivated } = descriptor(fixture, "stop-wake-race", session);
+				return { ...passivated, lifecycle: "passivated" as const };
+			})(),
+			descriptorPath: join(fixture.descriptorDir, "stop-wake-race.json"),
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopRevision: 0,
+		};
+		writeFileSync(worker.descriptorPath, JSON.stringify(worker.descriptor));
+		supervisor.workers.set("stop-wake-race", worker);
+		let finishArchive: () => void = () => undefined;
+		const archiveStarted = new Promise<void>((resolve) => {
+			supervisor.catalog.archive = vi.fn(async () => {
+				resolve();
+				await new Promise<void>((finish) => {
+					finishArchive = finish;
+				});
+			});
+		});
+		supervisor.recoverWorker = vi.fn();
+
+		const stopping = supervisor.stopWorker(worker, true, false, true);
+		await archiveStarted;
+		const concurrentStop = supervisor.stopWorker(worker, true, false, true);
+		let wakeSettled = false;
+		const waking = supervisor.wakePassivatedWorker(worker).finally(() => {
+			wakeSettled = true;
+		});
+		await Promise.resolve();
+		expect(wakeSettled).toBe(false);
+		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+		expect(supervisor.catalog.archive).toHaveBeenCalledTimes(1);
+
+		finishArchive();
+		await Promise.all([stopping, concurrentStop]);
+		await expect(waking).rejects.toThrow("was stopped");
+		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+		expect(supervisor.workers.has("stop-wake-race")).toBe(false);
+		expect(() => readFileSync(worker.descriptorPath)).toThrow();
+	});
+
 	it("recovers rather than passivating malformed or stale durable task verdicts", async () => {
 		const fixture = fixtureRoot();
 		const malformed = persistSession(fixture.sessionDir, fixture.root, "completed");

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -1173,7 +1173,7 @@ describe("daemon supervisor restart passivation", () => {
 		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
 	});
 
-	it("recovers v1 descriptors with missing or unknown lifecycle instead of hiding their roots", async () => {
+	it("keeps normalized v1 lifecycle roots visible and passive across successive reloads", async () => {
 		const fixture = fixtureRoot();
 		const missing = persistSession(fixture.sessionDir, fixture.root, "completed");
 		const unknown = persistSession(fixture.sessionDir, fixture.root, "completed");
@@ -1183,23 +1183,53 @@ describe("daemon supervisor restart passivation", () => {
 		writeFileSync(join(fixture.descriptorDir, "missing-lifecycle.json"), JSON.stringify(missingDescriptor));
 		writeFileSync(join(fixture.descriptorDir, "unknown-lifecycle.json"), JSON.stringify(unknownDescriptor));
 
-		const supervisor = new DaemonSupervisor(fixture.socketPath, {
+		// The first reload normalizes untrusted lifecycle values. The next one must
+		// accept those durable, processless `recovering` descriptors rather than
+		// dropping their roots before it can classify them as passive.
+		const first = new DaemonSupervisor(fixture.socketPath, {
 			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
 			descriptorDir: fixture.descriptorDir,
 		}) as unknown as SupervisorInternals;
-		await supervisor.loadWorkerDescriptors();
+		first.recoverWorker = vi.fn();
+		workerSpawn.mockClear();
+		const kill = vi.spyOn(process, "kill");
+		try {
+			await first.loadWorkerDescriptors();
+			expect(first.workers).toHaveLength(2);
+			for (const workerId of ["missing-lifecycle", "unknown-lifecycle"]) {
+				const worker = first.workers.get(workerId);
+				expect(worker?.descriptor.lifecycle).toBe("recovering");
+				expect(worker?.descriptor.pid).toBeUndefined();
+				expect(worker?.descriptor.processStartId).toBeUndefined();
+				const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
+				expect(persisted.lifecycle).toBe("recovering");
+				expect(persisted.pid).toBeUndefined();
+			}
 
-		// Both roots remain reachable by the restart path, but their malformed
-		// lifecycle cannot authorize adoption, passivation, or process signalling.
-		expect(supervisor.workers).toHaveLength(2);
-		for (const workerId of ["missing-lifecycle", "unknown-lifecycle"]) {
-			const worker = supervisor.workers.get(workerId);
-			expect(worker?.descriptor.lifecycle).toBe("recovering");
-			expect(worker?.descriptor.pid).toBeUndefined();
-			expect(worker?.descriptor.processStartId).toBeUndefined();
-			const persisted = JSON.parse(readFileSync(join(fixture.descriptorDir, `${workerId}.json`), "utf8"));
-			expect(persisted.lifecycle).toBe("recovering");
-			expect(persisted.pid).toBeUndefined();
+			const second = new DaemonSupervisor(fixture.socketPath, {
+				defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
+				descriptorDir: fixture.descriptorDir,
+			}) as unknown as SupervisorInternals;
+			second.recoverWorker = vi.fn();
+			await second.loadWorkerDescriptors();
+
+			// Completed roots become metadata-only on the second reload, retaining
+			// their summaries for explicit wake without an automatic wake or signal.
+			expect(second.workers).toHaveLength(2);
+			for (const workerId of ["missing-lifecycle", "unknown-lifecycle"]) {
+				const worker = second.workers.get(workerId);
+				expect(worker?.descriptor.lifecycle).toBe("passivated");
+				expect(worker?.descriptor.pid).toBeUndefined();
+				expect(worker?.descriptor.processStartId).toBeUndefined();
+				expect(worker?.client).toBeUndefined();
+				expect(worker?.summaries.has(worker?.descriptor.rootActiveSessionId ?? "")).toBe(true);
+			}
+			expect(first.recoverWorker).not.toHaveBeenCalled();
+			expect(second.recoverWorker).not.toHaveBeenCalled();
+			expect(workerSpawn).not.toHaveBeenCalled();
+			expect(kill).not.toHaveBeenCalled();
+		} finally {
+			kill.mockRestore();
 		}
 	});
 

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -259,6 +259,10 @@ describe("daemon supervisor restart passivation", () => {
 
 	it.each([
 		{ type: "abort", activeSessionId: "active-read" },
+		{ type: "cancel_prompt_admission", activeSessionId: "active-read", admissionId: "admission-id" },
+		{ type: "abort_compaction", activeSessionId: "active-read" },
+		{ type: "abort_branch_summary", activeSessionId: "active-read" },
+		{ type: "abort_retry", activeSessionId: "active-read" },
 		{ type: "agent_messages_pause", activeSessionId: "active-read" },
 		{ type: "agent_messages_resume", activeSessionId: "active-read" },
 	])("wakes a passivated root for state-changing $type commands", async (command) => {

--- a/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-restart-passivation.test.ts
@@ -2,6 +2,18 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const workerSpawn = vi.hoisted(() =>
+	vi.fn(() => {
+		throw new Error("unexpected worker spawn");
+	}),
+);
+
+vi.mock("node:child_process", async (importOriginal) => ({
+	...(await importOriginal()),
+	spawn: workerSpawn,
+}));
+
 import { SessionManager } from "../src/core/session-manager.js";
 import { DAEMON_UPDATE_RESTART_FORMAT_VERSION } from "../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
@@ -479,21 +491,63 @@ describe("daemon supervisor restart passivation", () => {
 		expect(supervisor.workers.get("busy")?.descriptor.lifecycle).toBe("recovering");
 	});
 
-	it("keeps a dead client-owned root recoverable without persisting its launch environment", async () => {
+	it("does not recover a saved processless client-owned passive root until its owner attaches with env", async () => {
 		const fixture = fixtureRoot();
 		const session = persistSession(fixture.sessionDir, fixture.root, "completed");
-		const entry = { ...descriptor(fixture, "client-owned", session), ownerClientId: "owner-client" };
+		const entry = {
+			...descriptor(fixture, "client-owned", session),
+			ownerClientId: "owner-client",
+			lifecycle: "passivated" as const,
+		};
+		delete entry.pid;
 		writeFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), JSON.stringify(entry));
 
 		const supervisor = new DaemonSupervisor(fixture.socketPath, {
 			defaultSessionConfig: { agentDir: fixture.agentDir, cwd: fixture.root, sessionDir: fixture.sessionDir },
 			descriptorDir: fixture.descriptorDir,
-		}) as unknown as SupervisorInternals;
+		}) as unknown as SupervisorInternals & {
+			attachClient(
+				client: { id: string },
+				command: { type: "attach"; activeSessionId: string; launchEnv?: Record<string, string> },
+			): Promise<unknown>;
+		};
+		supervisor.recoverWorker = vi.fn(async () => {
+			const worker = supervisor.workers.get(entry.workerId);
+			if (!worker) throw new Error("missing worker");
+			worker.descriptor.lifecycle = "ready";
+			worker.client = {
+				request: vi.fn(async () => ({
+					success: true,
+					data: {
+						activeSessionId: entry.rootActiveSessionId,
+						snapshot: { summary: {}, messages: [] },
+						client: {},
+					},
+				})),
+			};
+		});
+		workerSpawn.mockClear();
 		await supervisor.loadWorkerDescriptors();
 
-		expect(supervisor.workers.get(entry.workerId)?.descriptor.lifecycle).toBe("recovering");
+		const passive = supervisor.workers.get(entry.workerId);
+		expect(passive?.descriptor.lifecycle).toBe("passivated");
+		expect(passive?.client).toBeUndefined();
+		expect(supervisor.recoverWorker).not.toHaveBeenCalled();
+		expect(workerSpawn).not.toHaveBeenCalled();
 		const persisted = readFileSync(join(fixture.descriptorDir, `${entry.workerId}.json`), "utf8");
+		expect(JSON.parse(persisted)).toMatchObject({ lifecycle: "passivated", ownerClientId: "owner-client" });
 		expect(persisted).not.toContain("launchEnv");
+
+		await supervisor.attachClient(
+			{
+				id: "owner-client",
+				attachedActiveSessionIds: new Set(),
+				capabilities: new Set(),
+				supportsExtensionUi: false,
+			},
+			{ type: "attach", activeSessionId: entry.rootActiveSessionId, launchEnv: { HERDR_PANE_ID: "pane" } },
+		);
+		expect(supervisor.recoverWorker).toHaveBeenCalledTimes(1);
 	});
 
 	it("stops a passivated descriptor without probing or signaling its stale pid", async () => {

--- a/packages/coding-agent/test/session-manager/session-state.test.ts
+++ b/packages/coding-agent/test/session-manager/session-state.test.ts
@@ -186,7 +186,11 @@ describe("SessionManager session state", () => {
 			expect(SessionManager.open(sessionFile!, sessionDir).getSessionState()).toEqual({ status: "active" });
 
 			const sessions = await SessionManager.list(cwd, sessionDir);
-			expect(sessions[0]).toMatchObject({ id: session.getSessionId(), state: { status: "active" } });
+			expect(sessions[0]).toMatchObject({
+				id: session.getSessionId(),
+				state: { status: "active" },
+				hasInvalidDurableState: true,
+			});
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
@@ -786,9 +786,9 @@ describe("ENG-4603 worker recovery convergence", () => {
 			await delay(25);
 		}
 		if (!replacement) throw new Error("Current supervisor did not publish a replacement worker");
-		expect(getProcessStartId(replacement.pid)).toBe(replacement.processStartId);
+		expect(getProcessStartId(replacement.pid!)).toBe(replacement.processStartId);
 		await delay(750);
-		expect(exactProcessIsAlive(replacement.pid, replacement.processStartId)).toBe(true);
+		expect(exactProcessIsAlive(replacement.pid!, replacement.processStartId)).toBe(true);
 		expect(readdirSync(paths.descriptorDir).filter((name) => name.endsWith(".json"))).toHaveLength(1);
 		const listed = await successorClient.request({ type: "list" });
 		if (!listed.success) throw new Error(listed.error);
@@ -813,7 +813,7 @@ describe("ENG-4603 worker recovery convergence", () => {
 		successorClient.close();
 		predecessorClient.close();
 		await waitForExit(successor);
-		await waitForExactProcessExit(replacement.pid, replacement.processStartId);
+		await waitForExactProcessExit(replacement.pid!, replacement.processStartId);
 		await terminateTrackedFixtureProcess(predecessor);
 	}, 120_000);
 

--- a/packages/coding-agent/test/suite/regressions/4677-snapshot-catchup-replacement.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4677-snapshot-catchup-replacement.test.ts
@@ -306,7 +306,10 @@ describe("ENG-4677 snapshot catch-up replacement", () => {
 			activeSessionId,
 			capabilities: ["chunked_snapshot"],
 		});
-		await Promise.resolve();
+		// C00 permits this attach to take the passivated-wake branch before issuing
+		// the request. Wait for the controllable request boundary rather than relying
+		// on a particular number of promise turns.
+		await vi.waitFor(() => expect(worker.client?.request).toHaveBeenCalledOnce());
 
 		for (const result of [firstResult, streamedResult(replacementSnapshotId, 1, 2)]) {
 			const { messages: _messages, ...snapshot } = result.snapshot;

--- a/packages/coding-agent/test/worker-recovery-journal.test.ts
+++ b/packages/coding-agent/test/worker-recovery-journal.test.ts
@@ -44,7 +44,7 @@ describe("WorkerRecoveryJournal", () => {
 		);
 	});
 
-	it("compacts stable checkpoints and ignores a truncated final record", () => {
+	it("compacts stable checkpoints while preserving a truncated final record as recoverable", () => {
 		const path = createPath();
 		const journal = new WorkerRecoveryJournal(path);
 		journal.record({
@@ -64,5 +64,6 @@ describe("WorkerRecoveryJournal", () => {
 		expect(WorkerRecoveryJournal.readLatest(path)).toEqual([
 			expect.objectContaining({ activeSessionId: "active-1", busy: false, operation: "bash_end" }),
 		]);
+		expect(new WorkerRecoveryJournal(path).hasUnreadableRecords()).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

C00 passivates quiescent root sessions during daemon restart instead of eagerly rehydrating workers. The retained regression demonstrates that **160 saved roots** (80 `completed`, 80 `needs_input`) remain metadata-only after restart: each has a genuinely processless durable passive descriptor (no `pid` or `processStartId`) and no resident client/recovery call. Scheduled and unjudged controls remain recoverable.

Read-only list/status paths do not wake a passive root. Explicit access operations wake only the selected root, and concurrent wake requests are single-flight. Corrupt or ambiguous durable state fails closed to normal recovery: malformed task verdicts/lifecycle values, stale verdict counts, unreadable/uncertain state, busy recovery journals, schedules, and tombstones do not authorize passivation.

## Scope and compatibility

- This is a restart/passivation foundation. It **does not claim C01's full launch-generation or process-identity fencing**.
- No public daemon wire command, schema, or protocol-version change: `passivated` is additive internal worker/session-summary lifecycle state.
- Legacy passive records are normalized by removing stale process identity before persistence. `daemon-ps` excludes passivated records from PID cleanup.
- Existing persisted-session/tree, eviction, monitor, scheduling, and #836 retry/tombstone behavior remain covered by focused regression suites.

## Validation

### Local independent review

**141/141 passing** focused tests:

| Suite | Tests |
| --- | ---: |
| `daemon-supervisor-restart-passivation.test.ts` | 6 |
| `daemon-protocol.test.ts` | 14 |
| `daemon-session-list.test.ts` | 29 |
| `session-action-store.test.ts` | 34 |
| `daemon-supervisor-eviction.test.ts` | 13 |
| `daemon-supervisor-monitor.test.ts` | 45 |

The local final review also passed changed-file Biome (9 files), `tsgo --noEmit`, and `git diff --check` at exact head `3340956d33157823c5d02e7100ad72dab977e7fe`.

### Remote final validation

[`REMOTE_C00_FINAL_VALIDATION.md`](https://github.com/PrimeIntellect-ai/prime-agent/compare/main...perf/c00-session-lifecycle) records isolated, exact-SHA remote validation, including locked `npm ci --ignore-scripts`, root build, changed-file Biome, `tsgo --noEmit`, focused 141/141 tests, and five fresh retained-160-root repetitions.

The remote runner retained raw cgroup-v2 evidence for all five repetitions: 187 samples at 100 ms across whole container process trees, mean peak memory 648.7 MiB, maximum 690.9 MiB, maximum 50 PIDs, and zero owned cgroup memory/PIDs after each container exit. Raw artifacts and checksums are recorded in `/Users/milkkarten/Research/prime-agent-performance-implementation/coordination/REMOTE_C00_FINAL_VALIDATION.md` (archive SHA-256 `02e7211b411918ab3e1f3de0adb7ba7a71ebcfb9d64ece528ee189a82cd2bbb8`). This demonstrates no 160-worker eager-rehydration fanout during validation; it is not a substitute for B00B production provider/process-tree baseline comparison.

## Current stacked exact head

Current head `bd22fc3ce0306212047d1d0a5c50d1153ff7907b` includes the hosted-review fix that retains normalized processless `recovering` v1 descriptors across the next restart. A two-reload regression proves they remain visible/processless and become passive metadata without wake, spawn, or signal.

Pinned isolated validation: cumulative Biome, root typecheck, full build, **149/149 focused tests**, and process-stress **6/6 runnable** (8 tag-skipped). Exact bundle SHA-256 `baf3b79025d0f2fa2a001db7655d1a7fa13aa8e8c0be46c435b6bcaa264bc741`; evidence archive SHA-256 `657b3b0e73a6af83d883e1bee993931064a7acfdcae612e8695e978a8e4b2d6b`. All review threads are resolved.

## Rollback

The change is isolated to the three commits on this branch and can be rolled back by reverting this PR, restoring the previous restart recovery behavior. Passive durable descriptors are compatible with the existing v1 reader; legacy passive v1 records are conservatively normalized, while any uncertain record recovers rather than being passivated.

Do not merge automatically; this PR is submitted for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large supervisor lifecycle changes affect restart recovery, worker stop/wake races, cron passivation gates, and process identity handling—incorrect classification could skip recovery or signal wrong PIDs.
> 
> **Overview**
> Adds a **`passivated`** worker lifecycle so completed or idle roots can stay as **processless routing metadata** after supervisor restart instead of always spawning recovery workers.
> 
> **On startup**, `loadWorkerDescriptors` classifies descriptors using durable session JSONL (`hasInvalidDurableState`), recovery journals (`hasUnreadableRecords`), and cron artifacts (`hasRecoverableSessionArtifactState`). Eligible quiescent roots are persisted as passivated (PID stripped); ambiguous or pending work still goes to **`recovering`**. Legacy malformed lifecycle and stale PIDs are normalized fail-closed.
> 
> **At runtime**, metadata reads do not wake passivated workers; **explicit** commands (prompt, attach, A2A, etc.) call **`wakePassivatedWorker`** (single-flight). Stop/wake/retry use fences (`stopFinalizations`, `archiveFinalization`, `stopFinalized`) so concurrent operations cannot revive tombstoned routes. Processless stops never signal recycled PIDs; `daemon-ps` skips passivated descriptors.
> 
> Passivated workers are excluded from update-restart drain; heartbeats treat them as empty; public summaries omit `workerPid`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd22fc3ce0306212047d1d0a5c50d1153ff7907b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Passivate quiescent daemon worker roots after restart instead of recovering them
> - Introduces a `passivated` lifecycle state for daemon workers: processless sessions with no pending work are classified as `passivated` at startup rather than immediately recovered, avoiding unnecessary process launches.
> - Adds `DaemonSupervisor.loadWorkerDescriptors` logic to inspect recovery journals and cron job state to determine whether a worker requires recovery or can be safely passivated.
> - Passivated workers are woken on-demand when mutating commands arrive or when an authorized owner re-creates the session; wake attempts are coalesced and fenced against concurrent stops.
> - Adds `AgentCronJobStore.hasRecoverableSessionArtifactState` and `WorkerRecoveryJournal.hasUnreadableRecords` to detect pending/uncertain work that must block passivation.
> - Stop semantics are rewritten to be idempotent and fenced: concurrent stops do not conflict, failures leave a tombstone that blocks wake until an explicit retry, and processless descriptors are never signaled.
> - `scanSessionInfo` now sets `hasInvalidDurableState` on malformed or oversized durable JSONL lines, and omits `agentStatus` when its structure is invalid.
> - Risk: passivated workers are no longer adopted or auto-recovered at startup; clients that relied on workers being in `recovering` after a restart will need to trigger an explicit action to wake them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd22fc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

