### PR TITLE
feat(rlm): support per-subagent thinking levels

### DIFF
--- a/packages/coding-agent/docs/rlm.md
+++ b/packages/coding-agent/docs/rlm.md
@@ -56,10 +56,19 @@ The callable `rlm` object is preloaded in the kernel. Spawn a child with a direc
 
 ```python
 handle = await rlm("Review the authentication flow for security issues", name="auth-reviewer")
-print(handle.rlm_child_id, handle.name, handle.session_dir, handle.model)
+print(handle.rlm_child_id, handle.name, handle.session_dir, handle.model, handle.thinking_level)
 ```
 
 The call returns immediately after task admission with a child handle; it never waits for or returns the child's answer. The TypeScript host creates a normal child `AgentSession` with an independent context and session directory. The child inherits the parent model, provider configuration, skills, tools, retry policy, and resource loader unless the call requests another configured model.
+
+A child also inherits its parent's thinking level by default. Pass `thinking=` to request a child-specific level:
+
+```python
+handle = await rlm("Investigate the concurrency design", thinking="high")
+print(handle.thinking_level)
+```
+
+The accepted canonical values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. Prime validates and trims the requested string before admitting the child, then clamps either an explicit level or the inherited parent level to the selected model's supported reasoning levels. `handle.thinking_level` reports the effective level used for the child's initial request. It is `None` only when a newer Python runtime communicates with an older host that does not provide this field.
 
 Spawn independent children in separate calls and end the turn instead of awaiting completion:
 
@@ -87,7 +96,7 @@ await agent_message.send(
 
 #### Child handles and lifecycle
 
-An admission handle contains `rlm_child_id`, `name`, `session_dir`, and `model`. Child usage is attributed to the parent session while remaining distinguishable in context-tree reporting.
+An admission handle contains `rlm_child_id`, `name`, `session_dir`, `model`, and `thinking_level`. Child usage is attributed to the parent session while remaining distinguishable in context-tree reporting.
 
 The parent-scoped child registry survives compaction, kernel restart, and parent restoration:
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -224,6 +224,7 @@ import {
 	findRlmModelMatches,
 	normalizeRequestedRlmSubagentModel,
 	normalizeRequestedRlmSubagentSessionName,
+	normalizeRequestedRlmSubagentThinkingLevel,
 	type RlmDeleteSubagentResult,
 	type RlmFindModelsResult,
 	type RlmListSubagentsResult,
@@ -8933,6 +8934,7 @@ export class AgentSession {
 		spawnCode?: string;
 		sessionDir: string;
 		model: Model<any>;
+		thinkingLevel: ThinkingLevel;
 	}): CreateRlmSubagentRuntimeOptions {
 		return {
 			parentSession: this,
@@ -8942,7 +8944,7 @@ export class AgentSession {
 			spawnCode: options.spawnCode,
 			sessionDir: options.sessionDir,
 			model: options.model,
-			thinkingLevel: clampThinkingLevel(options.model, this.thinkingLevel) as ThinkingLevel,
+			thinkingLevel: options.thinkingLevel,
 			serviceTier:
 				this.serviceTier === "priority" && !supportsFastMode(options.model) ? "default" : this.serviceTier,
 			scopedModels: [...this._scopedModels],
@@ -9606,13 +9608,14 @@ export class AgentSession {
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
 	): Promise<RlmSpawnHandle> {
-		const { name: rawName, model: rawModel, ...unsupported } = kwargs;
+		const { name: rawName, model: rawModel, thinking: rawThinkingLevel, ...unsupported } = kwargs;
 		const unsupportedKwargs = Object.keys(unsupported);
 		if (unsupportedKwargs.length > 0) {
 			throw new Error(`Unsupported rlm.run kwargs: ${unsupportedKwargs.sort().join(", ")}`);
 		}
 		const requestedSessionName = normalizeRequestedRlmSubagentSessionName(rawName);
 		const requestedModel = normalizeRequestedRlmSubagentModel(rawModel);
+		const requestedThinkingLevel = normalizeRequestedRlmSubagentThinkingLevel(rawThinkingLevel);
 		if (requestedSessionName) assertDirectAgentMessageTarget(requestedSessionName);
 		if (this._rlmDepth >= this._rlmMaxDepth) {
 			throw new Error(
@@ -9633,6 +9636,10 @@ export class AgentSession {
 			if (requestedSessionName) this._pendingRlmSubagentSessionNames.delete(requestedSessionName);
 		}
 		if (this._disposed || this._disposing) throw new Error("Cannot spawn a subagent after its parent was disposed");
+		const thinkingLevel = clampThinkingLevel(
+			modelSelection.model,
+			requestedThinkingLevel ?? this.thinkingLevel,
+		) as ThinkingLevel;
 
 		const childSessionDir = this._createChildRlmSessionDir();
 		const childNodeId = basename(childSessionDir);
@@ -9702,6 +9709,7 @@ export class AgentSession {
 				spawnCode,
 				sessionDir: childSessionDir,
 				model: modelSelection.model,
+				thinkingLevel,
 			}),
 			onSessionPublished: publishChildSession,
 		};
@@ -9949,6 +9957,7 @@ export class AgentSession {
 			name: sessionName,
 			session_dir: childSessionDir,
 			model: `${modelSelection.model.provider}/${modelSelection.model.id}`,
+			thinking_level: thinkingLevel,
 		};
 	}
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -126,9 +126,10 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 	if (allowRecursion && hasIpython) {
 		parts.push(
 			"",
-			"A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, and `model`; it never waits for or returns the child's answer.",
+			"A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, `model`, and `thinking_level`; it never waits for or returns the child's answer.",
 			"Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.",
 			"A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`.",
+			"Set a child reasoning level with `await rlm('sub-task', thinking='high')`. Accepted values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. If omitted, the child inherits your thinking level; either inherited or requested levels are clamped to the selected model, and the effective result is returned as `handle.thinking_level`.",
 		);
 		if (hasAgentMessage) {
 			parts.push(

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -16,6 +16,7 @@ export interface RlmSpawnHandle {
 	name: string;
 	session_dir: string;
 	model: string;
+	thinking_level: ThinkingLevel;
 }
 
 export type RlmSubagentRegistryStatus = "running" | "completed" | "error";
@@ -57,6 +58,15 @@ export type RlmFindModelsHandler = (query: string, limit: number) => RlmFindMode
 const RLM_SUBAGENT_SESSION_NAME_MAX_LENGTH = 64;
 export const DEFAULT_RLM_MODEL_SEARCH_LIMIT = 8;
 export const MAX_RLM_MODEL_SEARCH_LIMIT = 20;
+export const RLM_THINKING_LEVELS = [
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const satisfies readonly ThinkingLevel[];
 
 /** Validate and normalize an orchestrator-supplied subagent session name. */
 export function normalizeRequestedRlmSubagentSessionName(value: unknown): string | undefined {
@@ -89,6 +99,24 @@ export function normalizeRequestedRlmSubagentModel(value: unknown): string | und
 		throw new Error("rlm.run model must not be empty");
 	}
 	return model;
+}
+
+/** Validate and normalize an orchestrator-supplied child thinking level. */
+export function normalizeRequestedRlmSubagentThinkingLevel(value: unknown): ThinkingLevel | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new Error("rlm.run thinking must be a string");
+	}
+	const thinkingLevel = value.trim();
+	if (!thinkingLevel) {
+		throw new Error("rlm.run thinking must not be empty");
+	}
+	if (!(RLM_THINKING_LEVELS as readonly string[]).includes(thinkingLevel)) {
+		throw new Error(`rlm.run thinking must be one of: ${RLM_THINKING_LEVELS.join(", ")}`);
+	}
+	return thinkingLevel as ThinkingLevel;
 }
 
 /** Create a readable, collision-resistant default name usable as an agent-message selector. */

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -254,6 +254,7 @@ describe("AgentSession rlm recursion", () => {
 			agentMessageController?: AgentSessionMessageController;
 			subagentRuntimeHost?: SubagentRuntimeHost;
 			customTools?: ConstructorParameters<typeof AgentSession>[0]["customTools"];
+			runtimeApiKeys?: Record<string, string>;
 			rlmSessionDir?: string;
 			sessionManager?: SessionManager;
 			settingsManager?: SettingsManager;
@@ -262,6 +263,9 @@ describe("AgentSession rlm recursion", () => {
 	): AgentSession {
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		for (const [provider, apiKey] of Object.entries(options.runtimeApiKeys ?? {})) {
+			authStorage.setRuntimeApiKey(provider, apiKey);
+		}
 		const sessionManager = options.sessionManager ?? SessionManager.create(tempDir, join(tempDir, "sessions"));
 		const settingsManager = options.settingsManager ?? SettingsManager.create(tempDir, tempDir);
 
@@ -442,6 +446,67 @@ describe("AgentSession rlm recursion", () => {
 		await expect(root.runRlmChild("reserved name", { name: "all" })).rejects.toThrow(
 			"Broadcast agent messaging is not supported",
 		);
+	});
+
+	it("validates child thinking before runtime admission", async () => {
+		const createRlmSubagentRuntime = vi.fn(async () => {
+			throw new Error("runtime creation should not run");
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime,
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		await expect(root.runRlmChild("bad type", { thinking: 1 })).rejects.toThrow("rlm.run thinking must be a string");
+		await expect(root.runRlmChild("empty", { thinking: "   " })).rejects.toThrow(
+			"rlm.run thinking must not be empty",
+		);
+		await expect(root.runRlmChild("unknown", { thinking: "ultra" })).rejects.toThrow(
+			"rlm.run thinking must be one of: off, minimal, low, medium, high, xhigh, max",
+		);
+		expect(createRlmSubagentRuntime).not.toHaveBeenCalled();
+	});
+
+	it("uses an explicit normalized thinking level for the child initial state and spawn handle", async () => {
+		const root = createSession();
+		root.setThinkingLevel("high");
+
+		const spawned = await root.runRlmChild("review with lower reasoning", { thinking: " minimal " });
+		expect(spawned.thinking_level).toBe("minimal");
+		await waitFor(() => root.getRlmChildSession(spawned.rlm_child_id) !== undefined);
+		const child = root.getRlmChildSession(spawned.rlm_child_id);
+		expect(child?.thinkingLevel).toBe("minimal");
+		expect(child?.sessionManager.getEntries()).toContainEqual(
+			expect.objectContaining({ type: "thinking_level_change", thinkingLevel: "minimal" }),
+		);
+	});
+
+	it("inherits the parent thinking level when a child omits thinking", async () => {
+		const root = createSession();
+		root.setThinkingLevel("high");
+
+		const spawned = await root.runRlmChild("inherit reasoning");
+		expect(spawned.thinking_level).toBe("high");
+		await waitFor(() => root.getRlmChildSession(spawned.rlm_child_id) !== undefined);
+		expect(root.getRlmChildSession(spawned.rlm_child_id)?.thinkingLevel).toBe("high");
+	});
+
+	it("clamps explicit child thinking for a selected non-reasoning model", async () => {
+		const root = createSession({ runtimeApiKeys: { openai: "test-key" } });
+		root.setThinkingLevel("high");
+
+		const spawned = await root.runRlmChild("use a non-reasoning model", {
+			model: " openai/gpt-4.1 ",
+			thinking: "max",
+		});
+		expect(spawned.model).toBe("openai/gpt-4.1");
+		expect(spawned.thinking_level).toBe("off");
+		await waitFor(() => root.getRlmChildSession(spawned.rlm_child_id) !== undefined);
+		const child = root.getRlmChildSession(spawned.rlm_child_id);
+		expect(child?.model?.reasoning).toBe(false);
+		expect(child?.thinkingLevel).toBe("off");
 	});
 
 	it("falls back to listed family metadata when a controller lacks name validation", async () => {
@@ -2163,7 +2228,7 @@ describe("AgentSession rlm recursion", () => {
 	it("rejects unsupported rlm.run kwargs loudly", async () => {
 		const root = createSession();
 
-		await expect(root.runRlmChild("nested", { temperature: 0 })).rejects.toThrow(
+		await expect(root.runRlmChild("nested", { thinking: "high", temperature: 0 })).rejects.toThrow(
 			"Unsupported rlm.run kwargs: temperature",
 		);
 	});

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -30,6 +30,8 @@ class RLMSpawnHandle:
     name: str
     session_dir: Path
     model: str
+    # None preserves compatibility with a host that predates thinking_level.
+    thinking_level: str | None = None
 
 
 @dataclass(frozen=True)
@@ -71,13 +73,17 @@ def _spawn_handle_from_payload(payload: Any) -> RLMSpawnHandle:
     name = payload.get("name")
     session_dir = payload.get("session_dir")
     model = payload.get("model")
+    thinking_level = payload.get("thinking_level")
     if not all(isinstance(value, str) and value for value in (child_id, name, session_dir, model)):
+        raise RuntimeError("rlm.run returned an invalid spawn handle")
+    if thinking_level is not None and (not isinstance(thinking_level, str) or not thinking_level):
         raise RuntimeError("rlm.run returned an invalid spawn handle")
     return RLMSpawnHandle(
         rlm_child_id=child_id,
         name=name,
         session_dir=Path(session_dir),
         model=model,
+        thinking_level=thinking_level,
     )
 
 
@@ -144,6 +150,9 @@ async def run(prompt: str, **kwargs: Any) -> RLMSpawnHandle:
     """Spawn a recursive Prime Agent child and return once its task is admitted.
 
     ``model`` selects a child with an exact ``provider/model`` selector.
+    ``thinking`` accepts ``off``, ``minimal``, ``low``, ``medium``, ``high``,
+    ``xhigh``, or ``max``. When omitted, the child inherits the parent level;
+    the host clamps either choice for the selected model.
     """
     if not isinstance(prompt, str):
         raise TypeError(f"prompt must be str, got {type(prompt).__name__}")

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -93,6 +93,45 @@ class RlmSubagentRegistryTest(unittest.TestCase):
         self.assertEqual(result.rlm_child_id, "sub-a1b2c3d4")
         self.assertEqual(result.name, "api-reviewer")
         self.assertEqual(result.model, "deepseek/deepseek-v4-flash")
+        self.assertIsNone(result.thinking_level)
+
+    def test_forwards_thinking_and_parses_effective_thinking_level(self) -> None:
+        host_request = AsyncMock(
+            return_value={
+                "rlm_child_id": "sub-a1b2c3d4",
+                "name": "reasoning-reviewer",
+                "session_dir": "/tmp/parent/sub-a1b2c3d4",
+                "model": "anthropic/claude-sonnet-4-5",
+                "thinking_level": "high",
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            result = asyncio.run(rlm_module.rlm("review the design", thinking="high"))
+
+        host_request.assert_awaited_once_with(
+            "rlm.run",
+            {
+                "prompt": "review the design",
+                "kwargs": {"thinking": "high"},
+            },
+        )
+        self.assertEqual(result.thinking_level, "high")
+
+    def test_rejects_invalid_thinking_level_in_spawn_handle(self) -> None:
+        host_request = AsyncMock(
+            return_value={
+                "rlm_child_id": "sub-a1b2c3d4",
+                "name": "reasoning-reviewer",
+                "session_dir": "/tmp/parent/sub-a1b2c3d4",
+                "model": "anthropic/claude-sonnet-4-5",
+                "thinking_level": 1,
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            with self.assertRaisesRegex(RuntimeError, "invalid spawn handle"):
+                asyncio.run(rlm_module.rlm("review the design", thinking="high"))
 
     def test_finds_authenticated_models_through_host(self) -> None:
         host_request = AsyncMock(


### PR DESCRIPTION
## Summary

- add an optional `thinking=` override to native Python `rlm()` subagent spawns
- validate the canonical Prime Agent thinking levels before admission and clamp the requested level to the selected child model before runtime creation
- preserve the existing inherited-and-clamped behavior when `thinking` is omitted
- expose the effective level as `RLMSpawnHandle.thinking_level`, while accepting older host payloads that omit the field
- document the new spawn contract and add TypeScript/Python regression coverage

```python
child = await rlm(
    "Review this change",
    model="provider/model",
    thinking="high",
)
print(child.thinking_level)  # effective, model-clamped level
```

## Behavior

Accepted values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.

The effective level is resolved before child runtime creation, so it applies to the child's initial state and first provider request. The implementation reuses the existing model-aware `clampThinkingLevel` path and adds no provider-specific RLM behavior.

## Validation

- `npm run check`
- `npm --workspace @earendil-works/pi-coding-agent test -- agent-session-recursion.test.ts` — 100 passed
- focused recursion + system-prompt run — 125 passed
- `uv run --project prime-agent-runtime python -m unittest prime-agent-runtime/test/test_subagent_registry.py` — 12 passed
- `git diff --check upstream/main...HEAD`

An independent Claude Opus 5 review found 0 BLOCKER and 0 MAJOR issues and approved the change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-subagent `thinking` kwarg to RLM recursive agent spawning
> - `runRlmChild` now accepts a `thinking` kwarg that sets the thinking level for a spawned subagent independently of the parent's level.
> - Valid values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; invalid values are rejected before admission via `normalizeRequestedRlmSubagentThinkingLevel`.
> - If no explicit `thinking` kwarg is given, the parent's thinking level is inherited; in both cases the level is clamped to what the selected model supports.
> - The returned `RlmSpawnHandle` / `RLMSpawnHandle` now includes a `thinking_level` field reflecting the effective level chosen for the child.
> - Documentation and system prompt guidance in [rlm.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1108/files#diff-2ec933be9333470440c88985cbf8067597cf0d9bf4580f76e1a36781fd951527) and [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1108/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) are updated to describe the new behaviour.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbcaa0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->