### PR TITLE
feat: add `tui.input.lineSubmit` keybinding to submit single-line inputs and slash commands with a different key than regular input

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Added `tui.input.slashSubmit` keybinding to submit slash commands with a different key than regular input.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
-- Added `tui.input.slashSubmit` keybinding to submit slash commands with a different key than regular input.
+- Added `tui.input.lineSubmit` keybinding to submit slash commands in the chat input and single-line inputs with a different key than regular input.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -56,6 +56,7 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 |--------|---------|-------------|
 | `tui.input.newLine` | `shift+enter` | Insert new line |
 | `tui.input.submit` | `enter` | Submit input |
+| `tui.input.slashSubmit` | *(none)* | Submit slash command |
 | `tui.input.tab` | `tab` | Tab / autocomplete |
 
 ### TUI Kill Ring

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -56,7 +56,7 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 |--------|---------|-------------|
 | `tui.input.newLine` | `shift+enter` | Insert new line |
 | `tui.input.submit` | `enter` | Submit input |
-| `tui.input.slashSubmit` | *(none)* | Submit slash command |
+| `tui.input.lineSubmit` | *(none)* | Submit single-line inputs and slash commands in the chat input |
 | `tui.input.tab` | `tab` | Tab / autocomplete |
 
 ### TUI Kill Ring

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -9475,6 +9475,7 @@ ${shortcutsKey ? `\`${shortcutsKey}\` quick shortcuts · ` : ""}\`/hotkeys\` ful
 		const pageUp = this.getEditorKeyDisplay("tui.editor.pageUp");
 		const pageDown = this.getEditorKeyDisplay("tui.editor.pageDown");
 		const submit = this.getEditorKeyDisplay("tui.input.submit");
+		const slashSubmit = this.getEditorKeyDisplay("tui.input.slashSubmit");
 		const newLine = this.getEditorKeyDisplay("tui.input.newLine");
 		const deleteWordBackward = this.getEditorKeyDisplay("tui.editor.deleteWordBackward");
 		const deleteWordForward = this.getEditorKeyDisplay("tui.editor.deleteWordForward");
@@ -9520,7 +9521,7 @@ ${shortcutsKey ? `\`${shortcutsKey}\` quick shortcuts · ` : ""}\`/hotkeys\` ful
 | Key | Action |
 |-----|--------|
 | \`${submit}\` | Send message |
-| \`${newLine}\` | New line${process.platform === "win32" ? " (Ctrl+Enter on Windows Terminal)" : ""} |
+${slashSubmit ? `| \`${slashSubmit}\` | Send slash command |\n` : ""}| \`${newLine}\` | New line${process.platform === "win32" ? " (Ctrl+Enter on Windows Terminal)" : ""} |
 | \`${deleteWordBackward}\` | Delete word backwards |
 | \`${deleteWordForward}\` | Delete word forwards |
 | \`${deleteToLineStart}\` | Delete to start of line |

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1086,6 +1086,7 @@ export class InteractiveMode {
 		this.defaultEditor = new CustomEditor(this.ui, getEditorTheme(), this.keybindings, {
 			paddingX: editorPaddingX,
 			autocompleteMaxVisible,
+			enableLineSubmit: true,
 			isArgumentCommand: builtinSlashCommandTakesArgument,
 			placeholder: this.startHint,
 			placeholderColor: (text) => theme.fg("dim", text),
@@ -9475,7 +9476,7 @@ ${shortcutsKey ? `\`${shortcutsKey}\` quick shortcuts · ` : ""}\`/hotkeys\` ful
 		const pageUp = this.getEditorKeyDisplay("tui.editor.pageUp");
 		const pageDown = this.getEditorKeyDisplay("tui.editor.pageDown");
 		const submit = this.getEditorKeyDisplay("tui.input.submit");
-		const slashSubmit = this.getEditorKeyDisplay("tui.input.slashSubmit");
+		const lineSubmit = this.getEditorKeyDisplay("tui.input.lineSubmit");
 		const newLine = this.getEditorKeyDisplay("tui.input.newLine");
 		const deleteWordBackward = this.getEditorKeyDisplay("tui.editor.deleteWordBackward");
 		const deleteWordForward = this.getEditorKeyDisplay("tui.editor.deleteWordForward");
@@ -9521,7 +9522,7 @@ ${shortcutsKey ? `\`${shortcutsKey}\` quick shortcuts · ` : ""}\`/hotkeys\` ful
 | Key | Action |
 |-----|--------|
 | \`${submit}\` | Send message |
-${slashSubmit ? `| \`${slashSubmit}\` | Send slash command |\n` : ""}| \`${newLine}\` | New line${process.platform === "win32" ? " (Ctrl+Enter on Windows Terminal)" : ""} |
+${lineSubmit ? `| \`${lineSubmit}\` | Send slash command |\n` : ""}| \`${newLine}\` | New line${process.platform === "win32" ? " (Ctrl+Enter on Windows Terminal)" : ""} |
 | \`${deleteWordBackward}\` | Delete word backwards |
 | \`${deleteWordForward}\` | Delete word forwards |
 | \`${deleteToLineStart}\` | Delete to start of line |

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added `tui.input.slashSubmit` keybinding for submitting slash commands with a dedicated key.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added `tui.input.slashSubmit` keybinding for submitting slash commands with a dedicated key.
+- Added `tui.input.lineSubmit` keybinding for submitting single-line inputs and slash commands in the chat input with a dedicated key.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -899,6 +899,13 @@ export class Editor implements Component, Focusable {
 			return;
 		}
 
+		// Slash command submit (when input starts with /)
+		if (this.getCurrentSlashCommandContext() !== null && kb.matches(data, "tui.input.slashSubmit")) {
+			if (this.disableSubmit) return;
+			this.submitValue();
+			return;
+		}
+
 		// New line
 		if (
 			kb.matches(data, "tui.input.newLine") ||

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -240,6 +240,13 @@ export interface EditorOptions {
 	paddingX?: number;
 	autocompleteMaxVisible?: number;
 	promptPrefix?: string;
+	/**
+	 * Enable the `tui.input.lineSubmit` keybinding in this editor, which
+	 * submits slash commands (input starting with `/`) at the prompt start.
+	 * Only the main chat input enables this; modals and single-line editors
+	 * keep the binding inert.
+	 */
+	enableLineSubmit?: boolean;
 }
 
 const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
@@ -341,6 +348,11 @@ export class Editor implements Component, Focusable {
 	public onChange?: (text: string) => void;
 	public disableSubmit: boolean = false;
 
+	// When true, the `tui.input.lineSubmit` keybinding submits slash commands
+	// (input starting with `/`). Only the main chat input enables this; modals
+	// and single-line editors keep the binding inert.
+	private lineSubmitEnabled: boolean = false;
+
 	constructor(tui: TUI, theme: EditorTheme, options: EditorOptions = {}) {
 		this.tui = tui;
 		this.theme = theme;
@@ -348,6 +360,7 @@ export class Editor implements Component, Focusable {
 		this.backgroundColor = theme.backgroundColor;
 		this.autocompleteBackgroundColor = theme.autocompleteBackgroundColor;
 		this.commandColor = theme.commandColor;
+		this.lineSubmitEnabled = options.enableLineSubmit ?? false;
 		const paddingX = options.paddingX ?? 0;
 		this.paddingX = Number.isFinite(paddingX) ? Math.max(0, Math.floor(paddingX)) : 0;
 		this.promptPrefix = options.promptPrefix ?? "";
@@ -899,8 +912,12 @@ export class Editor implements Component, Focusable {
 			return;
 		}
 
-		// Slash command submit (when input starts with /)
-		if (this.getCurrentSlashCommandContext() !== null && kb.matches(data, "tui.input.slashSubmit")) {
+		// Slash command submit via the lineSubmit key (chat input only, when input starts with /)
+		if (
+			this.lineSubmitEnabled &&
+			kb.matches(data, "tui.input.lineSubmit") &&
+			this.getCurrentSlashCommandContext()?.isAtPromptStart
+		) {
 			if (this.disableSubmit) return;
 			this.submitValue();
 			return;

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -100,8 +100,9 @@ export class Input implements Component, Focusable {
 			return;
 		}
 
-		// Submit
-		if (kb.matches(data, "tui.input.submit") || data === "\n") {
+		// Submit (single-line inputs submit on the lineSubmit key too, so a
+		// binding like Enter keeps working when the regular submit key is remapped)
+		if (kb.matches(data, "tui.input.submit") || kb.matches(data, "tui.input.lineSubmit") || data === "\n") {
 			if (this.onSubmit) this.onSubmit(this.value);
 			return;
 		}

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -30,6 +30,7 @@ export interface Keybindings {
 	// Generic input actions
 	"tui.input.newLine": true;
 	"tui.input.submit": true;
+	"tui.input.slashSubmit": true;
 	"tui.input.tab": true;
 	"tui.input.copy": true;
 	// Fullscreen transcript viewport
@@ -122,6 +123,7 @@ export const TUI_KEYBINDINGS = {
 	"tui.editor.undo": { defaultKeys: "ctrl+-", description: "Undo" },
 	"tui.input.newLine": { defaultKeys: "shift+enter", description: "Insert newline" },
 	"tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
+	"tui.input.slashSubmit": { defaultKeys: [], description: "Submit slash command" },
 	"tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },
 	"tui.input.copy": { defaultKeys: "ctrl+c", description: "Copy selection" },
 	"tui.viewport.pageUp": {

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -30,7 +30,7 @@ export interface Keybindings {
 	// Generic input actions
 	"tui.input.newLine": true;
 	"tui.input.submit": true;
-	"tui.input.slashSubmit": true;
+	"tui.input.lineSubmit": true;
 	"tui.input.tab": true;
 	"tui.input.copy": true;
 	// Fullscreen transcript viewport
@@ -123,7 +123,7 @@ export const TUI_KEYBINDINGS = {
 	"tui.editor.undo": { defaultKeys: "ctrl+-", description: "Undo" },
 	"tui.input.newLine": { defaultKeys: "shift+enter", description: "Insert newline" },
 	"tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
-	"tui.input.slashSubmit": { defaultKeys: [], description: "Submit slash command" },
+	"tui.input.lineSubmit": { defaultKeys: [], description: "Submit single-line input or slash command" },
 	"tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },
 	"tui.input.copy": { defaultKeys: "ctrl+c", description: "Copy selection" },
 	"tui.viewport.pageUp": {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { stripVTControlCharacters } from "node:util";
 import { type AutocompleteProvider, CombinedAutocompleteProvider } from "../src/autocomplete.js";
 import { Editor, wordWrapLine } from "../src/components/editor.js";
+import { getKeybindings, KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings.js";
 import { TUI } from "../src/tui.js";
 import { visibleWidth } from "../src/utils.js";
 import { defaultEditorTheme } from "./test-themes.js";
@@ -363,6 +364,68 @@ describe("Editor component", () => {
 			editor.handleInput("\r");
 			// Only the last backslash is removed, newline inserted
 			assert.strictEqual(editor.getText(), "\\\\\n");
+		});
+	});
+
+	describe("Line submit keybinding", () => {
+		// Mirrors a user config where Enter submits slash commands, Ctrl+Enter
+		// submits regular input, and Enter inserts newlines elsewhere.
+		function withLineSubmitBindings(run: () => void): void {
+			const previous = getKeybindings();
+			setKeybindings(
+				new KeybindingsManager(TUI_KEYBINDINGS, {
+					"tui.input.newLine": ["shift+enter", "enter"],
+					"tui.input.submit": ["ctrl+enter"],
+					"tui.input.lineSubmit": ["enter"],
+				}),
+			);
+			try {
+				run();
+			} finally {
+				setKeybindings(previous);
+			}
+		}
+
+		it("submits a slash command with Enter when slash submit is enabled", () => {
+			withLineSubmitBindings(() => {
+				const submitted: string[] = [];
+				const editor = new Editor(createTestTUI(), defaultEditorTheme, { enableLineSubmit: true });
+				editor.onSubmit = (text) => submitted.push(text);
+
+				for (const char of "/help") editor.handleInput(char);
+				editor.handleInput("\r"); // Enter - slash submit
+
+				assert.deepStrictEqual(submitted, ["/help"]);
+				assert.strictEqual(editor.getText(), "");
+			});
+		});
+
+		it("keeps line submit inert in editors that do not enable it", () => {
+			withLineSubmitBindings(() => {
+				const submitted: string[] = [];
+				const editor = new Editor(createTestTUI(), defaultEditorTheme); // enableLineSubmit defaults to false
+				editor.onSubmit = (text) => submitted.push(text);
+
+				for (const char of "/help") editor.handleInput(char);
+				editor.handleInput("\r"); // Enter - newline, not submit
+
+				assert.deepStrictEqual(submitted, []);
+				assert.strictEqual(editor.getText(), "/help\n");
+			});
+		});
+
+		it("does not submit on mid-line slash tokens even when line submit is enabled", () => {
+			withLineSubmitBindings(() => {
+				const submitted: string[] = [];
+				const editor = new Editor(createTestTUI(), defaultEditorTheme, { enableLineSubmit: true });
+				editor.onSubmit = (text) => submitted.push(text);
+
+				for (const char of "see /tmp") editor.handleInput(char);
+				editor.handleInput("\r"); // Enter - newline, not submit
+
+				assert.deepStrictEqual(submitted, []);
+				assert.strictEqual(editor.getText(), "see /tmp\n");
+			});
 		});
 	});
 

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { Input } from "../src/components/input.js";
+import { getKeybindings, KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings.js";
 import { visibleWidth } from "../src/utils.js";
 
 describe("Input component", () => {
@@ -23,6 +24,33 @@ describe("Input component", () => {
 
 		// Input is single-line, no backslash+Enter workaround
 		assert.strictEqual(submitted, "hello\\");
+	});
+
+	it("submits on the lineSubmit key even when the regular submit key is remapped", () => {
+		// Mirrors a user config where Enter (lineSubmit) submits single-line
+		// inputs while the regular submit key is remapped to Ctrl+Enter.
+		const previous = getKeybindings();
+		setKeybindings(
+			new KeybindingsManager(TUI_KEYBINDINGS, {
+				"tui.input.newLine": ["shift+enter", "enter"],
+				"tui.input.submit": ["ctrl+enter"],
+				"tui.input.lineSubmit": ["enter"],
+			}),
+		);
+		try {
+			const input = new Input();
+			let submitted: string | undefined;
+			input.onSubmit = (value) => {
+				submitted = value;
+			};
+
+			for (const char of "not a slash") input.handleInput(char);
+			input.handleInput("\r"); // Enter - lineSubmit
+
+			assert.strictEqual(submitted, "not a slash");
+		} finally {
+			setKeybindings(previous);
+		}
 	});
 
 	it("inserts backslash as regular character", () => {


### PR DESCRIPTION
In all harnesses, I prefer rebinding the `enter` key to `newline` and then something like `ctrl+enter` to submit. (Without it I frequently send half written prompts accidentally). Anyway, I was able to do that with prime agent just fine, but then it also applied to submitting slash commands, which I prefer the simple `enter` to `submit`.

Update: same issue applied to single-line inputs (e.g. text entry fields in modals), so generalized to handle those as well.

So this adds a new ~~`tui.input.slashSubmit`~~ `tui.input.lineSubmit` keybinding to optionally override the behavior in case. For context, my `keybindings.json` looks like this:
```
{
  "tui.input.newLine": ["shift+enter", "enter"],
  "tui.input.submit": ["ctrl+enter"],
  "tui.input.lineSubmit": ["enter"]
}
```

Anyway, I thought I'd see if it's something you'd considering including in upstream. If so, let me know if you'd like any changes (e.g. the conditional line in `interactive-mode.ts` is a bit wonky in my opinion, but a better approach hasn't come to mind yet).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `tui.input.slashSubmit` keybinding to submit slash commands independently of the regular submit key
> - Adds a new `tui.input.lineSubmit` keybinding (no default) to [keybindings.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1109/files#diff-37682caae521449d71ec7baf447af9ef6725c48fba2e43a93fbd9661814884be) that submits single-line inputs and slash commands without affecting multi-line editor submit behavior.
> - In [editor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1109/files#diff-7b6fb102370899178db8d26e334f97123c72bc2127ed9a8d7b4952049b423d42), when `enableLineSubmit` is set, pressing the bound key triggers `submitValue()` only if the cursor is at the prompt start and the input begins with `/`.
> - In [input.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1109/files#diff-dfda471cea94b64bead7017600a83152e765ea07ec2def06b4a25db87c286724), single-line inputs also submit on `tui.input.lineSubmit` alongside the existing `tui.input.submit` and raw newline.
> - Interactive mode passes `enableLineSubmit: true` to the chat editor and shows the bound key in the shortcut guide when configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f79f2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->