### PR TITLE
fix(coding-agent): retain required goal skill with --no-skills

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -33,7 +33,14 @@ import {
 	SessionSelectorError,
 	SessionSelectorNotFoundError,
 } from "./cli/session-resolver.js";
-import { APP_NAME, expandTildePath, getAgentDir, getSessionDirEnvOverride, VERSION } from "./config.js";
+import {
+	APP_NAME,
+	expandTildePath,
+	getAgentDir,
+	getBundledSkillsDir,
+	getSessionDirEnvOverride,
+	VERSION,
+} from "./config.js";
 import {
 	type AgentExecutionMode,
 	type AgentSessionRuntimeConfig,
@@ -684,6 +691,21 @@ export function daemonServerDefaultSessionConfig(config: AgentSessionRuntimeConf
 	return { ...config, initialGoal: undefined };
 }
 
+/**
+ * Keep the goal runtime available when automatic skill discovery is disabled.
+ * `--goal` tells the model to call the bundled Python `goal` module, so omitting
+ * that one required skill leaves autonomous runs unable to complete.
+ */
+export function resolveRuntimeSkillPaths(config: AgentSessionRuntimeConfig, rlmDepth = 0): string[] | undefined {
+	const configuredSkills = config.skills ?? [];
+	if (!config.noSkills || !config.initialGoal || rlmDepth > 0) {
+		return config.skills;
+	}
+
+	const goalSkillPath = join(getBundledSkillsDir(), "goal");
+	return configuredSkills.includes(goalSkillPath) ? configuredSkills : [...configuredSkills, goalSkillPath];
+}
+
 export function resolveRuntimeSessionOptions(
 	sessionOptions: CreateAgentSessionOptions,
 	runtimeSessionOptions?: CreateAgentSessionOptions,
@@ -740,7 +762,7 @@ async function prepareRuntimeServices(options: {
 		telemetryDisabled: config.telemetryDisabled,
 		resourceLoaderOptions: {
 			additionalExtensionPaths: config.extensions,
-			additionalSkillPaths: config.skills,
+			additionalSkillPaths: resolveRuntimeSkillPaths(config, options.sessionOptionsOverride?.rlmDepth),
 			additionalPromptTemplatePaths: config.promptTemplates,
 			additionalThemePaths: config.themes,
 			noExtensions: config.noExtensions,

--- a/packages/coding-agent/test/builtin-skills.test.ts
+++ b/packages/coding-agent/test/builtin-skills.test.ts
@@ -207,6 +207,21 @@ describe("builtin skills", () => {
 			expect(loader.getSkills().skills).toEqual([]);
 		});
 
+		it("loads an explicitly required bundled skill with --no-skills", async () => {
+			writeSkill(bundledDir, "goal");
+
+			const loader = new DefaultResourceLoader({
+				cwd,
+				agentDir,
+				bundledSkillsDir: bundledDir,
+				noSkills: true,
+				additionalSkillPaths: [join(bundledDir, "goal")],
+			});
+			await loader.reload();
+
+			expect(loader.getSkills().skills.map((skill) => skill.name)).toEqual(["goal"]);
+		});
+
 		it("surfaces a skill diagnostic when the bundled skills dir is missing", async () => {
 			const missingDir = join(tempDir, "does-not-exist");
 			const loader = new DefaultResourceLoader({ cwd, agentDir, bundledSkillsDir: missingDir });

--- a/packages/coding-agent/test/main-interactive-routing.test.ts
+++ b/packages/coding-agent/test/main-interactive-routing.test.ts
@@ -13,6 +13,7 @@ import {
 	type InteractiveDaemonStartupDecision,
 	parseAgentsViewCommand,
 	resolveRuntimeSessionOptions,
+	resolveRuntimeSkillPaths,
 	shouldEnsureDaemonBeforeActiveSessionLookup,
 	shouldEnsureInteractiveDaemonForStartup,
 	shouldOpenAgentsViewForDaemonInteractive,
@@ -350,6 +351,39 @@ describe("agents view command parsing", () => {
 });
 
 describe("runtime session option resolution", () => {
+	test("keeps only the required bundled goal skill with --goal --no-skills", () => {
+		const paths = resolveRuntimeSkillPaths({
+			noSkills: true,
+			initialGoal: { objective: "finish the task" },
+		});
+
+		expect(paths).toHaveLength(1);
+		expect(paths?.[0]).toMatch(/[/\\]skills[/\\]goal$/);
+	});
+
+	test("does not inject the goal skill into RLM subagents", () => {
+		expect(
+			resolveRuntimeSkillPaths(
+				{
+					noSkills: true,
+					initialGoal: { objective: "finish the task" },
+				},
+				1,
+			),
+		).toBeUndefined();
+	});
+
+	test("preserves explicitly configured skills while adding the required goal skill", () => {
+		const paths = resolveRuntimeSkillPaths({
+			noSkills: true,
+			skills: ["/tmp/custom-skill"],
+			initialGoal: { objective: "finish the task" },
+		});
+
+		expect(paths?.[0]).toBe("/tmp/custom-skill");
+		expect(paths?.[1]).toMatch(/[/\\]skills[/\\]goal$/);
+	});
+
 	test("keeps verifier goals per session instead of in the daemon fallback", () => {
 		const headlessCreateConfig = {
 			cwd: "/repo",


### PR DESCRIPTION
# fix(coding-agent): retain required goal skill with `--no-skills`

Closes #1111.

## Summary

- load the bundled `goal` Python skill when a top-level session explicitly seeds `initialGoal` while automatic skill discovery is disabled
- preserve explicitly configured skill paths
- avoid injecting the goal skill into RLM subagents, where the initial goal is not seeded
- add focused runtime-routing and resource-loader regression coverage

## Problem

`--goal --no-skills` currently creates an inconsistent runtime. The goal state and model context are present, and the context instructs the model to call `await goal.complete()`, but `--no-skills` removes the Python module that implements that call. The result is:

```text
NameError: name 'goal' is not defined
```

Because the goal never transitions out of `active`, autonomous mode may keep scheduling continuations after the requested work has already been completed.

## Implementation

The new `resolveRuntimeSkillPaths()` helper treats the goal skill as a required runtime dependency only when all of the following are true:

1. automatic skill discovery is disabled;
2. the top-level runtime has an `initialGoal`;
3. the runtime is not an RLM descendant.

All other `--no-skills` behavior remains unchanged. Explicit skill paths are retained, and the required goal path is de-duplicated.

## Tests

```text
npx vitest --run test/main-interactive-routing.test.ts test/builtin-skills.test.ts

Test Files  2 passed (2)
Tests      76 passed (76)
```

Additional checks:

```text
npx biome check packages/coding-agent/src/main.ts \
  packages/coding-agent/test/main-interactive-routing.test.ts \
  packages/coding-agent/test/builtin-skills.test.ts

npx tsgo -p packages/coding-agent/tsconfig.build.json --noEmit
```

Both pass after building the workspace packages.

## Scope

This change does not alter normal skill discovery, goal state semantics, autonomous limits, or subagent goal seeding. It only makes an explicitly requested top-level goal completable under `--no-skills`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `--no-skills` flag to retain the bundled `goal` skill for top-level autonomous runs
> When `--goal` and `--no-skills` are both set, the coding agent failed to include the bundled `goal` skill needed to execute the run. A new `resolveRuntimeSkillPaths` utility in [main.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1112/files#diff-4baeaa77e0a68df3cb411f5b9f216f6a26a7a23495a61b955b1d46482f76d586) detects this case (top-level run with `rlmDepth === 0`) and injects the bundled `goal` skill path unless it is already present. Subagent runs (`rlmDepth > 0`) are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73148b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->