### PR TITLE
feat(coding-agent): expose pi.kernel.execute for extension kernel access

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Added `pi.kernel.execute()` so TypeScript extensions can run code in the session's IPython kernel, sharing state with the built-in `ipython` tool.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -12,6 +12,7 @@ Extensions are TypeScript modules that extend Prime Agent's behavior. They can s
 - **User interaction** - Prompt users via `ctx.ui` (select, confirm, input, notify)
 - **Custom UI components** - Full TUI components with keyboard input via `ctx.ui.custom()` for complex interactions
 - **Custom commands** - Register commands like `/mycommand` via `pi.registerCommand()`
+- **Kernel access** - Execute code in the session IPython kernel via `pi.kernel.execute()`
 - **Session persistence** - Store state that survives restarts via `pi.appendEntry()`
 - **Custom rendering** - Control how tool calls/results and messages appear in TUI
 
@@ -1480,6 +1481,30 @@ Execute a shell command.
 const result = await pi.exec("git", ["status"], { signal, timeout: 5000 });
 // result.stdout, result.stderr, result.code, result.killed
 ```
+
+### pi.kernel.execute(code, options?)
+
+Execute a Python code cell in the session's persistent IPython kernel — the same kernel the built-in `ipython` tool uses. Variables, imports, and running tasks persist across calls and are visible to both the extension and the agent's `ipython` tool. The kernel starts lazily on first use.
+
+```typescript
+const result = await pi.kernel.execute("print(2 + 2)");
+// result.stdout === "4\n"
+// result.status === "ok" | "error" | "aborted"
+// result.error?.ename / result.error?.evalue on failure
+
+// Keep state for later calls (and for the agent's ipython tool)
+await pi.kernel.execute("answer = 6 * 7");
+const next = await pi.kernel.execute("print(answer)");
+```
+
+**Options:**
+- `signal` - `AbortSignal`; aborting interrupts the kernel via the control channel.
+- `onStream(chunk, name)` - Receive raw stdout/stderr chunks as the cell runs.
+- `maxOutputChars` - Cap stdout / stderr / result characters (default 65536).
+
+Calls are serialized against the kernel's execution queue, so an extension call waits for any agent `ipython` cell that is still running (and vice versa). A cell that keeps running after an interrupt rejects with `KernelBusyAfterInterruptError`; the caller decides whether to wait and retry.
+
+Useful for extensions that need shared Python state with the agent (scratch buffers, data loaders, long-running task orchestration) without going through the LLM.
 
 ### pi.getActiveTools() / pi.getAllTools() / pi.setActiveTools(names)
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -44,7 +44,7 @@
 		"postinstall": "node postinstall.cjs",
 		"prepublishOnly": "npm run clean && npm run build",
 		"bundle": "node scripts/bundle.mjs",
-		"test:kernel": "vitest --run --no-file-parallelism --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts test/kernel-goal-skill.test.ts test/kernel-state-roundtrip.test.ts"
+		"test:kernel": "vitest --run --no-file-parallelism --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts test/kernel-goal-skill.test.ts test/kernel-state-roundtrip.test.ts test/suite/agent-session-kernel-extension.test.ts"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -8388,6 +8388,14 @@ export class AgentSession {
 						});
 					});
 				},
+				executeKernel: async (code, options) => {
+					const provisioner = this._ipythonKernelProvisioner;
+					if (!provisioner) {
+						throw new Error("IPython kernel is not available in this session (no ipython tool configured)");
+					}
+					const manager = await provisioner.ensure(undefined, options?.signal);
+					return manager.execute(code, options);
+				},
 				appendEntry: (customType, data) => {
 					this.sessionManager.appendCustomEntry(customType, data);
 				},

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -88,6 +88,10 @@ export type {
 	InputSource,
 	IpythonToolCallEvent,
 	IpythonToolResultEvent,
+	// Kernel access
+	KernelAPI,
+	KernelExecuteHandler,
+	KernelExecuteOptions,
 	KeybindingsManager,
 	LoadExtensionsResult,
 	// Events - Message

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -126,6 +126,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 	const runtime: ExtensionRuntime = {
 		sendMessage: notInitialized,
 		sendUserMessage: notInitialized,
+		executeKernel: notInitialized,
 		appendEntry: notInitialized,
 		setSessionName: notInitialized,
 		getSessionName: notInitialized,
@@ -241,6 +242,13 @@ function createExtensionAPI(
 		sendUserMessage(content, options): void {
 			runtime.assertActive();
 			runtime.sendUserMessage(content, options);
+		},
+
+		kernel: {
+			execute(code, options) {
+				runtime.assertActive();
+				return runtime.executeKernel(code, options);
+			},
 		},
 
 		appendEntry(customType: string, data?: unknown): void {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -272,6 +272,7 @@ export class ExtensionRunner {
 		// Copy actions into the shared runtime (all extension APIs reference this)
 		this.runtime.sendMessage = actions.sendMessage;
 		this.runtime.sendUserMessage = actions.sendUserMessage;
+		this.runtime.executeKernel = actions.executeKernel;
 		this.runtime.appendEntry = actions.appendEntry;
 		this.runtime.setSessionName = actions.setSessionName;
 		this.runtime.getSessionName = actions.getSessionName;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -46,6 +46,7 @@ import type { CompactionPreparation, CompactionResult } from "../compaction/inde
 import type { EventBus } from "../event-bus.js";
 import type { ExecOptions, ExecResult } from "../exec.js";
 import type { ReadonlyFooterDataProvider } from "../footer-data-provider.js";
+import type { ExecuteResult } from "../kernel/index.js";
 import type { KeybindingsManager } from "../keybindings.js";
 import type { CustomMessage } from "../messages.js";
 import type { ModelRegistry } from "../model-registry.js";
@@ -1156,6 +1157,21 @@ export interface ExtensionAPI {
 	/** Execute a shell command. */
 	exec(command: string, args: string[], options?: ExecOptions): Promise<ExecResult>;
 
+	/**
+	 * Execute code in the session's persistent IPython kernel.
+	 *
+	 * Shares the kernel with the built-in `ipython` tool: variables, imports,
+	 * and running tasks persist across calls and are visible to both. Calls are
+	 * serialized against the kernel's execution queue, so a cell running from
+	 * the agent blocks an extension call (and vice versa) until it finishes.
+	 * The kernel starts lazily on first use.
+	 *
+	 * @example
+	 * const result = await pi.kernel.execute("print(2 + 2)");
+	 * // result.stdout === "4\n", result.status === "ok"
+	 */
+	kernel: KernelAPI;
+
 	/** Get the list of currently active tool names. */
 	getActiveTools(): string[];
 
@@ -1422,12 +1438,42 @@ export interface ExtensionRuntimeState {
 }
 
 /**
+ * Options for `pi.kernel.execute()`. A subset of the kernel's native execute
+ * options; extensions cannot mark a cell as internal.
+ */
+export interface KernelExecuteOptions {
+	/** Abort the execution: interrupts the kernel via the control channel. */
+	signal?: AbortSignal;
+	/** Receive raw stdout/stderr chunks as the cell runs. */
+	onStream?: (chunk: string, name: "stdout" | "stderr") => void;
+	/** Cap stdout / stderr / result at this many characters. Default 65536. */
+	maxOutputChars?: number;
+}
+
+/** Execute a code cell in the session's IPython kernel. */
+export type KernelExecuteHandler = (code: string, options?: KernelExecuteOptions) => Promise<ExecuteResult>;
+
+/**
+ * Kernel access for extensions.
+ *
+ * Executions share the session's persistent IPython kernel with the built-in
+ * `ipython` tool and are serialized against it, so kernel state (variables,
+ * imports, running tasks) is visible to both. The kernel starts lazily on the
+ * first call.
+ */
+export interface KernelAPI {
+	/** Execute a code cell in the session's IPython kernel. */
+	execute: KernelExecuteHandler;
+}
+
+/**
  * Action implementations for pi.* API methods.
  * Provided to runner.initialize(), copied into the shared runtime.
  */
 export interface ExtensionActions {
 	sendMessage: SendMessageHandler;
 	sendUserMessage: SendUserMessageHandler;
+	executeKernel: KernelExecuteHandler;
 	appendEntry: AppendEntryHandler;
 	setSessionName: SetSessionNameHandler;
 	getSessionName: GetSessionNameHandler;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -87,6 +87,9 @@ export type {
 	InputEventResult,
 	InputSource,
 	IpythonToolCallEvent,
+	KernelAPI,
+	KernelExecuteHandler,
+	KernelExecuteOptions,
 	KeybindingsManager,
 	LoadExtensionsResult,
 	MessageRenderer,
@@ -137,6 +140,13 @@ export {
 } from "./core/extensions/index.js";
 // Footer data provider (git branch + extension statuses - data not otherwise available to extensions)
 export type { ReadonlyFooterDataProvider } from "./core/footer-data-provider.js";
+// Kernel
+export type {
+	ExecuteResult,
+	KernelAttachment,
+	KernelDiffDisplay,
+	KernelSentAgentMessage,
+} from "./core/kernel/index.js";
 export { convertToLlm } from "./core/messages.js";
 export { ModelRegistry } from "./core/model-registry.js";
 export type {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -9,7 +9,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { createExtensionRuntime, discoverAndLoadExtensions } from "../src/core/extensions/loader.js";
 import { ExtensionRunner } from "../src/core/extensions/runner.js";
-import type { ExtensionActions, ExtensionContextActions, ProviderConfig } from "../src/core/extensions/types.js";
+import type {
+	ExtensionActions,
+	ExtensionContextActions,
+	KernelExecuteOptions,
+	ProviderConfig,
+} from "../src/core/extensions/types.js";
 import { KeybindingsManager, type KeyId } from "../src/core/keybindings.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import { SessionManager } from "../src/core/session-manager.js";
@@ -54,6 +59,7 @@ describe("ExtensionRunner", () => {
 	const extensionActions: ExtensionActions = {
 		sendMessage: () => {},
 		sendUserMessage: () => {},
+		executeKernel: async () => ({ stdout: "", stderr: "", status: "ok", durationMs: 0 }),
 		appendEntry: () => {},
 		setSessionName: () => {},
 		getSessionName: () => undefined,
@@ -709,6 +715,60 @@ describe("ExtensionRunner", () => {
 			);
 
 			await expect(runtime.setSessionName("duplicate")).rejects.toBe(failure);
+		});
+
+		it("routes pi.kernel.execute through the bound kernel action", async () => {
+			const executeKernel = vi.fn(async (code: string, _options?: KernelExecuteOptions) => ({
+				stdout: `ran: ${code}`,
+				stderr: "",
+				result: "7",
+				status: "ok" as const,
+				durationMs: 1,
+			}));
+			const extCode = `
+				export default function(pi) {
+					pi.registerCommand("run-kernel", {
+						description: "Run code in the IPython kernel",
+						handler: async (args, ctx) => {
+							const result = await pi.kernel.execute(args, { maxOutputChars: 123 });
+							ctx.ui.notify(result.stdout + " " + result.status, "info");
+						},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "kernel-access.ts"), extCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			runner.bindCore({ ...extensionActions, executeKernel }, extensionContextActions);
+
+			const command = runner.getCommand("run-kernel")!;
+			const ctx = runner.createCommandContext();
+			await command.handler("print(3 + 4)", ctx);
+
+			expect(executeKernel).toHaveBeenCalledWith("print(3 + 4)", { maxOutputChars: 123 });
+		});
+
+		it("throws when pi.kernel.execute is called before bindCore", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.registerCommand("run-kernel", {
+						description: "Run code in the IPython kernel",
+						handler: async (args) => {
+							return await pi.kernel.execute(args);
+						},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "kernel-unbound.ts"), extCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			const command = runner.getCommand("run-kernel")!;
+			await expect(command.handler("print(1)", runner.createCommandContext())).rejects.toThrow(
+				"Extension runtime not initialized",
+			);
 		});
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-kernel-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-kernel-extension.test.ts
@@ -1,0 +1,190 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { ExecuteResult } from "../../src/core/kernel/index.js";
+import type { ExtensionAPI } from "../../src/index.js";
+import { createHarness, getMessageText, type Harness } from "./harness.js";
+
+/** Find a python that can launch an ipykernel with the rlm runtime, or null to skip. */
+function resolveKernelPython(): string | null {
+	const candidates = [
+		process.env.PRIME_AGENT_KERNEL_PYTHON,
+		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python"),
+	].filter((p): p is string => Boolean(p));
+	for (const python of candidates) {
+		if (!existsSync(python)) continue;
+		const check = spawnSync(python, ["-c", "import ipykernel, rlm"], { encoding: "utf8" });
+		if (check.status === 0) return python;
+	}
+	return null;
+}
+
+const python = resolveKernelPython();
+const describeIfKernel = python ? describe : describe.skip;
+
+/**
+ * Extension access to the session IPython kernel via `pi.kernel.execute()`.
+ *
+ * Exercises the real kernel (same one the built-in ipython tool uses), so the
+ * suite requires a bootstrapped kernel venv and skips otherwise.
+ */
+describeIfKernel("pi.kernel extension API (real kernel)", { tags: ["kernel-heavy"] }, () => {
+	const harnesses: Harness[] = [];
+	let originalKernelPython: string | undefined;
+
+	beforeAll(() => {
+		originalKernelPython = process.env.PRIME_AGENT_KERNEL_PYTHON;
+		process.env.PRIME_AGENT_KERNEL_PYTHON = python as string;
+	});
+
+	afterAll(() => {
+		if (originalKernelPython === undefined) {
+			delete process.env.PRIME_AGENT_KERNEL_PYTHON;
+		} else {
+			process.env.PRIME_AGENT_KERNEL_PYTHON = originalKernelPython;
+		}
+	});
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	function captureKernelCalls(): {
+		results: ExecuteResult[];
+		errors: unknown[];
+		factory: (pi: ExtensionAPI) => void;
+	} {
+		const results: ExecuteResult[] = [];
+		const errors: unknown[] = [];
+		return {
+			results,
+			errors,
+			factory: (pi) => {
+				pi.on("session_start", async () => {
+					try {
+						results.push(await pi.kernel.execute("print(2 + 2)"));
+					} catch (error) {
+						errors.push(error);
+					}
+				});
+			},
+		};
+	}
+
+	it("executes code in the session kernel from an extension", async () => {
+		const { results, errors, factory } = captureKernelCalls();
+		const harness = await createHarness({ extensionFactories: [factory] });
+		harnesses.push(harness);
+
+		await harness.session.bindExtensions({});
+
+		expect(errors).toEqual([]);
+		expect(results).toHaveLength(1);
+		expect(results[0].status).toBe("ok");
+		expect(results[0].stdout).toContain("4");
+	});
+
+	it("keeps kernel state across extension calls", async () => {
+		const results: ExecuteResult[] = [];
+		const errors: unknown[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", async () => {
+						try {
+							results.push(await pi.kernel.execute("answer = 6 * 7"));
+							results.push(await pi.kernel.execute("print(answer)"));
+						} catch (error) {
+							errors.push(error);
+						}
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.bindExtensions({});
+
+		expect(errors).toEqual([]);
+		expect(results.map((result) => result.status)).toEqual(["ok", "ok"]);
+		expect(results[1].stdout).toContain("42");
+	});
+
+	it("shares kernel state with the built-in ipython tool", async () => {
+		const errors: unknown[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", async () => {
+						try {
+							await pi.kernel.execute("answer = 42");
+						} catch (error) {
+							errors.push(error);
+						}
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.bindExtensions({});
+		expect(errors).toEqual([]);
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("ipython", { code: "print(answer)" })], { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+		await harness.session.prompt("print answer in python");
+
+		const toolResult = harness.session.messages.find(
+			(message) => message.role === "toolResult" && message.toolName === "ipython",
+		);
+		expect(toolResult).toBeDefined();
+		expect(getMessageText(toolResult)).toContain("42");
+	});
+
+	it("reports kernel errors in the result instead of rejecting host-side", async () => {
+		let result: ExecuteResult | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", async () => {
+						result = await pi.kernel.execute('raise ValueError("boom")');
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.bindExtensions({});
+
+		expect(result?.status).toBe("error");
+		expect(result?.error?.ename).toBe("ValueError");
+		expect(result?.error?.evalue).toContain("boom");
+	});
+
+	it("honors maxOutputChars truncation", async () => {
+		let result: ExecuteResult | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", async () => {
+						result = await pi.kernel.execute('print("x" * 10000)', { maxOutputChars: 100 });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.bindExtensions({});
+
+		expect(result?.status).toBe("ok");
+		expect(result?.stdout.length).toBeLessThanOrEqual(200);
+		expect(result?.stdout).toContain("output truncated");
+	});
+});


### PR DESCRIPTION
This adds a `pi.kernel.execute(...)` method to the Typescript harness extension interface, enabling extensions to execute arbitrary code on the Python kernel directly.

For example, a general `/kernel <python code>` command:
```
// ~/.prime/agent/extensions/kernel.ts
import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";

export default function (pi: ExtensionAPI) {
  pi.registerCommand("kernel", {
      description: "Run Python in the session IPython kernel",
    handler: async (args, ctx) => {
      try {
        const result = await pi.kernel.execute(args);
        const text = [
          result.stdout, result.stderr, result.result,
          result.error?.traceback?.join("\n")
        ].filter(Boolean).join("\n");
        ctx.ui.notify(
          text.trim() || "(no output)",
          result.status === "error" ? "error" : "info"
        );
      } catch (e) {
        ctx.ui.notify(e.message, "error")
      }
    },
  });
}
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `pi.kernel.execute` for TypeScript extensions to run code in the shared IPython kernel
> - Adds a `pi.kernel.execute(code, options)` method to the extension API, allowing extensions to execute code in the session's shared IPython kernel with options for `signal`, `onStream`, and `maxOutputChars`.
> - Wires the implementation through `ExtensionActions.executeKernel` in [`agent-session.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1114/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae), which validates that an IPython kernel provisioner is configured before delegating to the kernel manager.
> - Exposes new types `KernelAPI`, `KernelExecuteHandler`, `KernelExecuteOptions`, `ExecuteResult`, and related kernel types from the public package index.
> - Risk: calling `pi.kernel.execute` when no ipython tool is configured throws an error at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6923005.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->