### PR TITLE
docs(security): add security and sandboxing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ On first launch, run `/login` to choose a subscription or API-key provider. Prim
 
 > [!WARNING]
 > Prime Agent executes model-generated Python and project commands with your user permissions. Its worker and kernel processes improve lifecycle isolation and recovery; they are **not** a security sandbox. Review changes and use trusted repositories, instructions, skills, and extensions only. Run untrusted code or instructions in an external sandbox or restricted environment.
+> See [Security and sandboxing](./packages/coding-agent/docs/security.md) for isolation recommendations and a pre-run checklist.
 
 Useful commands:
 

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -26,6 +26,7 @@ Public releases are currently installed from versioned release artifacts. The in
 - [Quickstart](quickstart.md) - install, authenticate, and run a first session.
 - [Using Prime Agent](usage.md) - interactive mode, RLM subagents, slash commands, context files, and CLI reference.
 - [Architecture overview](architecture.md) - client, daemon, worker, session, kernel, provider, and storage boundaries.
+- [Security and sandboxing](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/docs/security.md) - trust model, what isn't sandboxed, and how to reduce risk for long-running or autonomous runs.
 - [RLM programming model](rlm.md) - programmatic execution, native subagents, Python skills, and durable state.
 - [Long-running and background agents](long-running-agents.md) - daemon workers, messaging, heartbeats, goals, schedules, and autonomous mode.
 - [Providers](providers.md) - subscription and API-key setup for built-in providers.

--- a/packages/coding-agent/docs/security.md
+++ b/packages/coding-agent/docs/security.md
@@ -53,7 +53,42 @@ Two things persist across runs by default:
 - **Session history**, written as append-only JSONL under `sessionDir` (default `.prime/agent/sessions`, configurable in `settings.json`). It can contain paths, command output, and other details from the session. There's no dedicated clear command today; delete the relevant session file or directory directly to reset it.
 - **Stored credentials**, written to `~/.prime/agent/auth.json` (created with 0600 permissions) after `/login` or when an API key is configured this way. This lives outside `sessionDir`.
 
-`--no-session` skips persisting or resuming a session under `sessionDir` for that run. It is not a guarantee that nothing is written anywhere: whether logs, tool-approval state, or caches outside `sessionDir` are also skipped isn't documented at the time of writing. For a run that needs to leave no trace, pair `--no-session` with an ephemeral container filesystem (as in the Docker example above) rather than relying on the flag alone.
+### Disposable Runs with `--no-session`
+
+`--no-session` is useful for one-shot/disposable runs because it avoids starting or resuming a persisted session. It should not be assumed to make the run fully stateless unless verified for your prime-agent version.
+
+Until the exact scope is confirmed, assume that logs, tool-approval/policy caches, command history, package/download caches, temporary files, or files created by executed commands may still be written outside the target workspace.
+
+**Known gap:** the exact state skipped by `--no-session` is not currently documented. If you need strong disposable behavior, run the agent in a fresh container/VM with an ephemeral `HOME` and workspace mount.
+
+### Auditing State Between Runs
+
+Until the gap above is closed, you can check for yourself what a run actually touches. On the host, redirect `HOME` and the XDG dirs to a scratch location and diff before/after:
+
+```bash
+tmp=$(mktemp -d)
+mkdir -p "$tmp/home" "$tmp/config" "$tmp/cache" "$tmp/state"
+HOME="$tmp/home" \
+XDG_CONFIG_HOME="$tmp/config" \
+XDG_CACHE_HOME="$tmp/cache" \
+XDG_STATE_HOME="$tmp/state" \
+prime-agent --no-session ...
+find "$tmp" -type f | sort
+```
+
+That won't catch writes outside `$HOME`/XDG dirs. For a stronger check inside a container:
+
+```bash
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  --env HOME=/tmp/home \
+  -v "$PWD/scratch-repo:/workspace" \
+  -w /workspace \
+  <agent-image> \
+  sh -c 'mkdir -p "$HOME"; touch /tmp/.state-marker; prime-agent --no-session ...; find / -xdev -newer /tmp/.state-marker -type f'
+```
 
 ## Pre-Run Checklist
 

--- a/packages/coding-agent/docs/security.md
+++ b/packages/coding-agent/docs/security.md
@@ -1,0 +1,56 @@
+# Security and Sandboxing
+
+Prime Agent runs model-generated Python and project commands directly on your machine. This page separates what Prime Agent itself enforces from what you, as the operator, need to isolate yourself, especially for unattended or long-running sessions.
+
+## Trust Model
+
+Assume generated commands may be unsafe, or influenced by untrusted repository content, skills, or extensions. The agent should be treated as an automated shell user with whatever permissions it is given.
+
+The persistent IPython kernel that executes commands is a durable *control* environment, not a security sandbox. Worker and kernel processes give you lifecycle isolation and recovery (crash resilience, clean restarts), not a restriction on what the agent can read, write, or execute. This applies equally to direct shell commands, Python-backed skills, MCP-backed skills, and subagents spawned with `rlm(...)` (which inherit the parent's permissions).
+
+## Recommended Isolation
+
+- Run in a disposable container or VM, not directly on your host.
+- Mount only the target workspace — not `$HOME`, cloud provider config, SSH keys, or browser profiles.
+- Use a non-root user inside the container, and avoid mounting the Docker socket.
+- Keep secrets out of the environment and out of any mounted config; use short-lived, read-only credentials where the task allows it.
+
+## Workspace Boundaries
+
+- Point the agent at a scratch clone or branch, not your primary checkout.
+- Avoid running against a repo with uncommitted local changes — a clean baseline makes it easy to tell what the agent actually did.
+- Review generated diffs before merging or pushing.
+- For one-off, disposable runs where you don't need persistence, use `--no-session`.
+
+## Tool and Command Restrictions
+
+Prime Agent does not currently have a built-in mechanism for command approval, tool disabling, or path/command allowlists. If your workflow needs those guarantees, enforce them at the OS or container level (see Recommended Isolation above) rather than assuming Prime Agent will gate risky commands for you.
+
+Before loading any third-party skill, extension, or package (via `skills`, `extensions`, or `packages` in `settings.json`), read it. Once installed, it runs with the same kernel permissions as everything else. The same goes for repo-provided instructions (`AGENTS.md`, `CLAUDE.md`, etc.) and subagent output: a repo or a child agent's output can carry prompt-injected instructions or copied secrets, so treat both as untrusted input worth a look before acting on them further.
+
+## Persisted State
+
+Two things persist across runs by default:
+
+- **Session history**, written as append-only JSONL under `sessionDir` (default `.prime/agent/sessions`, configurable in `settings.json`). It can contain paths, command output, and other details from the session. There's no dedicated clear command today: to reset, delete the relevant session file or directory directly, or use `--no-session` to skip creating one in the first place.
+- **Stored credentials**, written to `~/.prime/agent/auth.json` (created with 0600 permissions) after `/login` or when an API key is configured this way. This lives outside `sessionDir` and isn't affected by `--no-session`.
+
+Treat both like any other artifact of the run, not just the obvious command output.
+
+## Pre-Run Checklist
+
+- [ ] Disposable container/VM or dedicated non-root user, not your primary host account
+- [ ] Only the target repository is writable; no `$HOME`, credentials, or SSH keys mounted
+- [ ] Secrets are not present in the environment or mounted config
+- [ ] Network access is restricted if the task doesn't need it
+- [ ] Working from a clean baseline (scratch clone/branch, no uncommitted changes)
+- [ ] Any skills, extensions, packages, or `AGENTS.md`/`CLAUDE.md` instructions have been read, not just installed
+- [ ] Generated diffs/output will be reviewed before merging, pushing, or acting on them further
+- [ ] For autonomous/long-running sessions specifically: a real, verifiable stopping condition is in place, not just a time or turn budget
+
+## See Also
+
+- [RLM Programming Model](./rlm.md) — the Trust Model section covers the kernel's permission model in more detail
+- [Long-Running and Background Agents](./long-running-agents.md) — autonomous mode, heartbeats, and schedules
+- [Settings](./settings.md) — `sessionDir` and resource-loading configuration
+- [Architecture Overview](./architecture.md) — daemon, worker, and kernel process boundaries

--- a/packages/coding-agent/docs/security.md
+++ b/packages/coding-agent/docs/security.md
@@ -6,21 +6,39 @@ Prime Agent runs model-generated Python and project commands directly on your ma
 
 Assume generated commands may be unsafe, or influenced by untrusted repository content, skills, or extensions. The agent should be treated as an automated shell user with whatever permissions it is given.
 
-The persistent IPython kernel that executes commands is a durable *control* environment, not a security sandbox. Worker and kernel processes give you lifecycle isolation and recovery (crash resilience, clean restarts), not a restriction on what the agent can read, write, or execute. This applies equally to direct shell commands, Python-backed skills, MCP-backed skills, and subagents spawned with `rlm(...)` (which inherit the parent's permissions).
+Prime Agent does not currently provide a full security sandbox. Treat commands executed by the agent as if they were executed by your own user account. Use container/VM isolation, restricted mounts, and minimal credentials for unattended runs.
+
+The persistent IPython kernel that executes commands is a durable *control* environment for lifecycle isolation and recovery (crash resilience, clean restarts), not a permission boundary. This applies equally to direct shell commands, Python-backed skills, MCP-backed skills, and subagents spawned with `rlm(...)` (which inherit the parent's permissions).
 
 ## Recommended Isolation
 
 - Run in a disposable container or VM, not directly on your host.
-- Mount only the target workspace — not `$HOME`, cloud provider config, SSH keys, or browser profiles.
+- Mount only the target workspace, not `$HOME`, cloud provider config, SSH keys, or browser profiles.
 - Use a non-root user inside the container, and avoid mounting the Docker socket.
 - Keep secrets out of the environment and out of any mounted config; use short-lived, read-only credentials where the task allows it.
+
+A minimal starting point:
+
+```bash
+docker run --rm -it \
+  --user "$(id -u):$(id -g)" \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  --network none \
+  -v "$PWD/scratch-repo:/workspace" \
+  -w /workspace \
+  <agent-image> \
+  --no-session
+```
+
+`--network none` is a safe default but will break workflows that need package installs or API calls; relax it deliberately (e.g. an allowlisted proxy) rather than dropping it by default.
 
 ## Workspace Boundaries
 
 - Point the agent at a scratch clone or branch, not your primary checkout.
-- Avoid running against a repo with uncommitted local changes — a clean baseline makes it easy to tell what the agent actually did.
+- Avoid running against a repo with uncommitted local changes; a clean baseline makes it easy to tell what the agent actually did.
+- Make sure the clone's remote doesn't carry push credentials, and don't forward your SSH agent into the run.
 - Review generated diffs before merging or pushing.
-- For one-off, disposable runs where you don't need persistence, use `--no-session`.
 
 ## Tool and Command Restrictions
 
@@ -32,18 +50,19 @@ Before loading any third-party skill, extension, or package (via `skills`, `exte
 
 Two things persist across runs by default:
 
-- **Session history**, written as append-only JSONL under `sessionDir` (default `.prime/agent/sessions`, configurable in `settings.json`). It can contain paths, command output, and other details from the session. There's no dedicated clear command today: to reset, delete the relevant session file or directory directly, or use `--no-session` to skip creating one in the first place.
-- **Stored credentials**, written to `~/.prime/agent/auth.json` (created with 0600 permissions) after `/login` or when an API key is configured this way. This lives outside `sessionDir` and isn't affected by `--no-session`.
+- **Session history**, written as append-only JSONL under `sessionDir` (default `.prime/agent/sessions`, configurable in `settings.json`). It can contain paths, command output, and other details from the session. There's no dedicated clear command today; delete the relevant session file or directory directly to reset it.
+- **Stored credentials**, written to `~/.prime/agent/auth.json` (created with 0600 permissions) after `/login` or when an API key is configured this way. This lives outside `sessionDir`.
 
-Treat both like any other artifact of the run, not just the obvious command output.
+`--no-session` skips persisting or resuming a session under `sessionDir` for that run. It is not a guarantee that nothing is written anywhere: whether logs, tool-approval state, or caches outside `sessionDir` are also skipped isn't documented at the time of writing. For a run that needs to leave no trace, pair `--no-session` with an ephemeral container filesystem (as in the Docker example above) rather than relying on the flag alone.
 
 ## Pre-Run Checklist
 
 - [ ] Disposable container/VM or dedicated non-root user, not your primary host account
 - [ ] Only the target repository is writable; no `$HOME`, credentials, or SSH keys mounted
+- [ ] No SSH agent forwarded, no Docker socket mounted
 - [ ] Secrets are not present in the environment or mounted config
 - [ ] Network access is restricted if the task doesn't need it
-- [ ] Working from a clean baseline (scratch clone/branch, no uncommitted changes)
+- [ ] Working from a clean baseline (scratch clone/branch, no uncommitted changes, no push credentials on the remote)
 - [ ] Any skills, extensions, packages, or `AGENTS.md`/`CLAUDE.md` instructions have been read, not just installed
 - [ ] Generated diffs/output will be reviewed before merging, pushing, or acting on them further
 - [ ] For autonomous/long-running sessions specifically: a real, verifiable stopping condition is in place, not just a time or turn budget


### PR DESCRIPTION
Adds a dedicated security/sandboxing page (#1120).

Used the structure @<maintainer-username> suggested in the issue: separates what Prime Agent enforces from what the operator needs to isolate, with concrete guidance (container/VM, don't mount $HOME/SSH keys/Docker socket, non-root user) and a pre-run checklist.

Two things worth flagging for review:

- No built-in command approval/allowlist mechanism exists today, so the doc says that explicitly instead of implying one.
- Found `--no-session` while checking this, useful for disposable one-shot runs, added it under Workspace Boundaries and Persisted State.

Linked from docs/index.md and the README.

Fixes #1120

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add security and sandboxing guidance to coding agent docs
> - Adds a new [security.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1126/files#diff-f020c2cd8dada8171bfc105d36814ecca23a4e822a10aa2961b27dbd3bfff57b) covering the trust model, recommended container/VM isolation, workspace boundaries, tool restrictions, persisted state locations, and a pre-run checklist.
> - Updates [packages/coding-agent/docs/index.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1126/files#diff-218d46321638f6fc86d50aefd277a2551b50e631d37a957a72e9abac03aa1d8c) to include a 'Security and sandboxing' link in the Start Here section.
> - Adds a warning link in [README.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1126/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) pointing to the new security doc for isolation recommendations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebc4405.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->