### PR TITLE
fix(coding-agent): preserve saved cwd on daemon resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed resumed sessions using the daemon launch directory instead of their recorded working directory ([#1124](https://github.com/PrimeIntellect-ai/prime-agent/issues/1124)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -389,6 +389,24 @@ function withoutSupervisorCreateFields(command: DaemonCreateCommand): DaemonCrea
 	return workerCommand;
 }
 
+function prepareWorkerLaunch(
+	defaultSessionConfig: AgentSessionRuntimeConfig,
+	command: DaemonCreateCommand,
+): { createCommand: DaemonCreateCommand; processCwd: string | undefined } {
+	const config = mergeAgentSessionRuntimeConfig(defaultSessionConfig, command.config);
+	const processCwd = config.cwd;
+	if (command.sessionPath && command.config?.cwd === undefined) {
+		delete config.cwd;
+	}
+	return {
+		createCommand: {
+			...withoutSupervisorCreateFields(command),
+			config,
+		},
+		processCwd,
+	};
+}
+
 function responseWithId(response: DaemonResponse, id: string | undefined): DaemonResponse {
 	return { ...response, id };
 }
@@ -2098,10 +2116,7 @@ export class DaemonSupervisor {
 		const recoveryStopRevision = existing?.stopRevision;
 		const launchEnv =
 			ownerClientId || existing?.descriptor.ownerClientId ? (command.launchEnv ?? existing?.launchEnv) : undefined;
-		const createCommand: DaemonCreateCommand = {
-			...withoutSupervisorCreateFields(command),
-			config: mergeAgentSessionRuntimeConfig(this.defaultSessionConfig, command.config),
-		};
+		const { createCommand, processCwd } = prepareWorkerLaunch(this.defaultSessionConfig, command);
 		const workerId = existing?.descriptor.workerId ?? createActiveSessionId();
 		const rootActiveSessionId = existing?.descriptor.rootActiveSessionId ?? createActiveSessionId();
 		const socketPath = existing?.descriptor.socketPath ?? workerSocketPath(this.socketPath, workerId);
@@ -2115,7 +2130,7 @@ export class DaemonSupervisor {
 		const launch = createCliSubprocessLaunchSpec(["--mode", "daemon", "--daemon-socket", socketPath]);
 		await this.assertRecoveryAllowed();
 		const child: ChildProcess = spawn(launch.command, launch.args, {
-			cwd: createCommand.config?.cwd ?? process.cwd(),
+			cwd: processCwd ?? process.cwd(),
 			detached: true,
 			env: createCliSubprocessEnv({
 				...process.env,

--- a/packages/coding-agent/test/suite/regressions/1124-resume-recorded-cwd.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1124-resume-recorded-cwd.test.ts
@@ -1,0 +1,119 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../../../src/config.js";
+import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
+import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-list.js";
+import { createHarness, type Harness } from "../harness.js";
+
+const cliPath = resolve(__dirname, "../../../src/cli.ts");
+const tsxPath = resolve(__dirname, "../../../../../node_modules/tsx/dist/cli.mjs");
+
+describe("#1124 resumed session cwd", () => {
+	let harness: Harness | undefined;
+	let supervisor: ChildProcess | undefined;
+	let client: DaemonClient | undefined;
+	let supervisorStderr = "";
+
+	afterEach(async () => {
+		if (client) {
+			try {
+				await client.request({ type: "shutdown" }, 2000);
+			} catch {
+				// The supervisor may already be gone after a failed assertion.
+			}
+			client.close();
+			client = undefined;
+		}
+		if (supervisor && supervisor.exitCode === null && supervisor.signalCode === null) {
+			supervisor.kill("SIGTERM");
+			await waitForExit(supervisor);
+		}
+		supervisor = undefined;
+		harness?.cleanup();
+		harness = undefined;
+		supervisorStderr = "";
+	});
+
+	it("uses the saved cwd when the daemon was launched elsewhere", async () => {
+		harness = await createHarness({ persistSession: true });
+		harness.sessionManager.flushNow();
+		const sessionPath = harness.sessionManager.materializeSessionFile();
+		const savedCwd = harness.tempDir;
+		const daemonCwd = join(harness.tempDir, "daemon-launch");
+		const agentDir = join(harness.tempDir, "agent");
+		const socketPath = join(tmpdir(), `prime-1124-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		mkdirSync(daemonCwd, { recursive: true });
+
+		supervisor = spawn(
+			process.execPath,
+			[tsxPath, cliPath, "--mode", "daemon", "--daemon-socket", socketPath, "--offline"],
+			{
+				cwd: daemonCwd,
+				env: {
+					...process.env,
+					[ENV_AGENT_DIR]: agentDir,
+					PI_OFFLINE: "1",
+					TSX_TSCONFIG_PATH: resolve(__dirname, "../../../../../tsconfig.json"),
+				},
+				stdio: ["ignore", "ignore", "pipe"],
+			},
+		);
+		supervisor.stderr?.on("data", (chunk: Buffer) => {
+			supervisorStderr += chunk.toString("utf8");
+		});
+
+		client = await connectEventually(socketPath, supervisor);
+		const created = await client.request({
+			type: "create",
+			sessionPath,
+			config: { agentDir, noTools: true, noExtensions: true },
+		});
+		if (!created.success) {
+			throw new Error(created.error);
+		}
+
+		const summary = created.data as SessionSummary;
+		expect(summary.cwd).toBe(savedCwd);
+		expect(summary.cwd).not.toBe(daemonCwd);
+	}, 30_000);
+
+	async function connectEventually(socketPath: string, child: ChildProcess): Promise<DaemonClient> {
+		const deadline = Date.now() + 15_000;
+		let lastError: unknown;
+		while (Date.now() < deadline) {
+			if (child.exitCode !== null || child.signalCode !== null) {
+				throw new Error(
+					`Supervisor exited before becoming ready (code ${child.exitCode}, signal ${child.signalCode})\n${supervisorStderr}`,
+				);
+			}
+			const candidate = new DaemonClient(socketPath);
+			try {
+				await candidate.connect(250);
+				await candidate.waitForHello(1000);
+				return candidate;
+			} catch (error) {
+				lastError = error;
+				candidate.close();
+				await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+			}
+		}
+		throw new Error(`Timed out waiting for supervisor: ${String(lastError)}\n${supervisorStderr}`);
+	}
+
+	async function waitForExit(child: ChildProcess): Promise<void> {
+		if (child.exitCode !== null || child.signalCode !== null) {
+			return;
+		}
+		await new Promise<void>((resolveExit) => {
+			const timeout = setTimeout(resolveExit, 5000);
+			child.once("exit", () => {
+				clearTimeout(timeout);
+				resolveExit();
+			});
+		});
+	}
+});


### PR DESCRIPTION
## Summary

- Preserve an omitted `cwd` when the supervisor forwards a saved-session create to its worker, so `SessionManager.openAsync` uses the cwd recorded in the session header.
- Keep the merged cwd separately for the worker process launch, preserving existing spawn behavior without turning it into a session override.
- Add a process-level A/B regression that starts the daemon in project A, resumes a persisted session from project B, and asserts the worker reports B.

This is a backward-compatible behavior fix; the daemon wire shape and schema are unchanged.

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/1124-resume-recorded-cwd.test.ts`
- `npm run check`

Fixes #1124


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix resumed daemon sessions to use saved working directory instead of daemon launch directory
> When resuming a session from a `sessionPath`, the spawned worker process was starting in the daemon's launch directory instead of the session's recorded `cwd`. The fix introduces `prepareWorkerLaunch` in [`daemon-supervisor.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1128/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8), which strips `cwd` from the config for resumed sessions and passes it directly to the spawn options instead. A regression test in [`1124-resume-recorded-cwd.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1128/files#diff-5ba33e711e86b9739b321b1d66439f7d386372e6bcf01ddc1ab07b00a8924022) verifies the correct directory is used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88eb3be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->