### PR TITLE
fix(ai): update stale Gemini test model

### DIFF
--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -205,8 +205,8 @@ describe("Context overflow error handling", () => {
 	// =============================================================================
 
 	describe.skipIf(!process.env.GEMINI_API_KEY)("Google", () => {
-		it("gemini-2.0-flash - should detect overflow via isContextOverflow", async () => {
-			const model = getModel("google", "gemini-2.0-flash");
+		it("gemini-2.5-flash - should detect overflow via isContextOverflow", async () => {
+			const model = getModel("google", "gemini-2.5-flash");
 			const result = await testContextOverflow(model, process.env.GEMINI_API_KEY!);
 			logResult(result);
 

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -221,10 +221,10 @@ describe("totalTokens field", () => {
 
 	describe.skipIf(!process.env.GEMINI_API_KEY)("Google", () => {
 		it(
-			"gemini-2.0-flash - should return totalTokens equal to sum of components",
+			"gemini-2.5-flash - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("google", "gemini-2.0-flash");
+				const llm = getModel("google", "gemini-2.5-flash");
 
 				console.log(`\nGoogle / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm);


### PR DESCRIPTION
## Summary

- update the Google context-overflow test to use `gemini-2.5-flash`
- update the Google total-token test to use `gemini-2.5-flash`

## Root cause

The CI build regenerates `packages/ai/src/models.generated.ts` from the live models.dev catalog before running `npm run check`. `gemini-2.0-flash` is no longer present in that catalog, but two live-provider tests still referenced it, causing TypeScript errors after regeneration. This was observed on #647 but is unrelated to that PR's login-dialog changes.

## Impact

The build/check job can type-check against the current generated Google catalog again.

## Validation

- `PI_NO_LOCAL_LLM=1 npx tsx ../../node_modules/vitest/dist/cli.js --run test/context-overflow.test.ts test/total-tokens.test.ts` (both files loaded; 61 credential-gated tests skipped)
- `npm run check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update stale Gemini test model from `gemini-2.0-flash` to `gemini-2.5-flash`
> Updates the model ID in two AI test files — [context-overflow.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1132/files#diff-989840d02091d7ed00ea48d54a8b4b7c5584bf865a9c1f2ccd6fc143d213bd38) and [total-tokens.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1132/files#diff-9300104eb2972544fa9f1810f19f4c40ecc6c39afbff7d62c8d13a01a3bed67d) — to target `gemini-2.5-flash` instead of the stale `gemini-2.0-flash`. Both the test titles and `getModel` calls are updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5fc41e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only model ID updates with no production or runtime logic changes.
> 
> **Overview**
> Swaps the **Google** live-integration tests from `gemini-2.0-flash` to **`gemini-2.5-flash`** so they match the regenerated `models.generated.ts` catalog (where `2.0-flash` is no longer listed for the `google` provider).
> 
> The change is limited to test titles and `getModel("google", …)` calls in **`context-overflow.test.ts`** and **`total-tokens.test.ts`**; assertions and test behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5fc41e40abecd07018f83da52191b85c34951ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->