### PR TITLE
feat(coding-agent): accept a per-child thinking level on rlm.run

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Restored bare `prime-agent --resume` opening the agents view and the `/resume [id|path]` slash command; bare commands open the agents view and an argument resumes that session in place.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 - Fixed ctrl+p ("Toggle agent message expansion") only toggling received agent messages; it now expands and collapses sent agent messages together with received ones.
+- Added a `thinking` argument to `rlm(...)` so a spawned child can run at its own reasoning level instead of inheriting the parent's, clamped against the child's model ([#703](https://github.com/PrimeIntellect-ai/prime-agent/issues/703)).
 
 ## [0.7.2] - 2026-08-11
 
@@ -17,7 +18,6 @@
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.
 - Added a configurable copy action to login dialogs so raw sign-in URLs can be copied without selecting wrapped text ([#643](https://github.com/PrimeIntellect-ai/prime-agent/issues/643)).
-- Added a `thinking` argument to `rlm(...)` so a spawned child can run at its own reasoning level instead of inheriting the parent's, clamped against the child's model ([#703](https://github.com/PrimeIntellect-ai/prime-agent/issues/703)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.
 - Added a configurable copy action to login dialogs so raw sign-in URLs can be copied without selecting wrapped text ([#643](https://github.com/PrimeIntellect-ai/prime-agent/issues/643)).
+- Added a `thinking` argument to `rlm(...)` so a spawned child can run at its own reasoning level instead of inheriting the parent's, clamped against the child's model ([#703](https://github.com/PrimeIntellect-ai/prime-agent/issues/703)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/docs/rlm.md
+++ b/packages/coding-agent/docs/rlm.md
@@ -61,6 +61,15 @@ print(handle.rlm_child_id, handle.name, handle.session_dir, handle.model)
 
 The call returns immediately after task admission with a child handle; it never waits for or returns the child's answer. The TypeScript host creates a normal child `AgentSession` with an independent context and session directory. The child inherits the parent model, provider configuration, skills, tools, retry policy, and resource loader unless the call requests another configured model.
 
+A child inherits the parent's reasoning level unless the spawn overrides it with `thinking`, which accepts `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. This lets a cheap scout run deliberately shallow while a critical child runs deep, without changing the parent:
+
+```python
+scout = await rlm("List the files that touch auth", name="scout", thinking="low")
+implementer = await rlm("Implement the fix", name="implementer", thinking="max")
+```
+
+The requested level is clamped against the child's model, so a model that does not offer the level degrades to its nearest supported one instead of failing the spawn.
+
 Spawn independent children in separate calls and end the turn instead of awaiting completion:
 
 ```python

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -224,6 +224,7 @@ import {
 	findRlmModelMatches,
 	normalizeRequestedRlmSubagentModel,
 	normalizeRequestedRlmSubagentSessionName,
+	normalizeRequestedRlmSubagentThinkingLevel,
 	type RlmDeleteSubagentResult,
 	type RlmFindModelsResult,
 	type RlmListSubagentsResult,
@@ -9013,6 +9014,8 @@ export class AgentSession {
 		spawnCode?: string;
 		sessionDir: string;
 		model: Model<any>;
+		/** Per-spawn reasoning override; falls back to the parent's level when absent. */
+		thinkingLevel?: ThinkingLevel;
 	}): CreateRlmSubagentRuntimeOptions {
 		return {
 			parentSession: this,
@@ -9022,7 +9025,7 @@ export class AgentSession {
 			spawnCode: options.spawnCode,
 			sessionDir: options.sessionDir,
 			model: options.model,
-			thinkingLevel: clampThinkingLevel(options.model, this.thinkingLevel) as ThinkingLevel,
+			thinkingLevel: clampThinkingLevel(options.model, options.thinkingLevel ?? this.thinkingLevel) as ThinkingLevel,
 			serviceTier:
 				this.serviceTier === "priority" && !supportsFastMode(options.model) ? "default" : this.serviceTier,
 			scopedModels: [...this._scopedModels],
@@ -9686,13 +9689,14 @@ export class AgentSession {
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
 	): Promise<RlmSpawnHandle> {
-		const { name: rawName, model: rawModel, ...unsupported } = kwargs;
+		const { name: rawName, model: rawModel, thinking: rawThinking, ...unsupported } = kwargs;
 		const unsupportedKwargs = Object.keys(unsupported);
 		if (unsupportedKwargs.length > 0) {
 			throw new Error(`Unsupported rlm.run kwargs: ${unsupportedKwargs.sort().join(", ")}`);
 		}
 		const requestedSessionName = normalizeRequestedRlmSubagentSessionName(rawName);
 		const requestedModel = normalizeRequestedRlmSubagentModel(rawModel);
+		const requestedThinkingLevel = normalizeRequestedRlmSubagentThinkingLevel(rawThinking);
 		if (requestedSessionName) assertDirectAgentMessageTarget(requestedSessionName);
 		if (this._rlmDepth >= this._rlmMaxDepth) {
 			throw new Error(
@@ -9782,6 +9786,7 @@ export class AgentSession {
 				spawnCode,
 				sessionDir: childSessionDir,
 				model: modelSelection.model,
+				thinkingLevel: requestedThinkingLevel,
 			}),
 			onSessionPublished: publishChildSession,
 		};

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -91,6 +91,26 @@ export function normalizeRequestedRlmSubagentModel(value: unknown): string | und
 	return model;
 }
 
+const RLM_SUBAGENT_THINKING_LEVELS: readonly ThinkingLevel[] = ["minimal", "low", "medium", "high", "xhigh", "max"];
+
+/**
+ * Validate a requested per-child reasoning level. The level is clamped against the child's model
+ * at spawn, so a model that cannot reach the requested level degrades instead of failing.
+ */
+export function normalizeRequestedRlmSubagentThinkingLevel(value: unknown): ThinkingLevel | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new Error("rlm.run thinking must be a string");
+	}
+	const thinking = value.trim();
+	if (!RLM_SUBAGENT_THINKING_LEVELS.includes(thinking as ThinkingLevel)) {
+		throw new Error(`rlm.run thinking must be one of: ${RLM_SUBAGENT_THINKING_LEVELS.join(", ")}`);
+	}
+	return thinking as ThinkingLevel;
+}
+
 /** Create a readable, collision-resistant default name usable as an agent-message selector. */
 export function createDefaultRlmSubagentSessionName(prompt: string, childId: string): string {
 	const promptSlug = prompt

--- a/packages/coding-agent/test/suite/regressions/703-per-child-thinking.test.ts
+++ b/packages/coding-agent/test/suite/regressions/703-per-child-thinking.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRequestedRlmSubagentThinkingLevel } from "../../../src/core/rlm-runtime.js";
+
+describe("issue #703 per-child thinking level on rlm.run", () => {
+	it.each(["minimal", "low", "medium", "high", "xhigh", "max"])("accepts %s", (level) => {
+		expect(normalizeRequestedRlmSubagentThinkingLevel(level)).toBe(level);
+	});
+
+	it("returns undefined when omitted so the child inherits the parent level", () => {
+		expect(normalizeRequestedRlmSubagentThinkingLevel(undefined)).toBeUndefined();
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(normalizeRequestedRlmSubagentThinkingLevel("  max  ")).toBe("max");
+	});
+
+	it.each([null, 3, true, {}, []])("rejects the non-string %s", (value) => {
+		expect(() => normalizeRequestedRlmSubagentThinkingLevel(value)).toThrow("thinking must be a string");
+	});
+
+	// "off" is deliberately excluded: the child runtime options type is ThinkingLevel, not
+	// ModelThinkingLevel, so accepting it here would widen the subagent contract.
+	it.each(["", "off", "highest", "MAX", "ultra"])("rejects the unsupported level %s", (value) => {
+		expect(() => normalizeRequestedRlmSubagentThinkingLevel(value)).toThrow("thinking must be one of");
+	});
+
+	it("names the supported levels in the error so the agent can correct itself", () => {
+		expect(() => normalizeRequestedRlmSubagentThinkingLevel("turbo")).toThrow(
+			"minimal, low, medium, high, xhigh, max",
+		);
+	});
+});


### PR DESCRIPTION
Addresses request 1 of #703.

## Problem

`_startRlmChildRun` accepts only `name` and `model`; every other kwarg throws `Unsupported rlm.run kwargs`. A child therefore always inherits the parent's reasoning level, so model choice is the only intelligence knob available per spawn.

As @Srcanesen describes on the issue, a role configured as `:max` silently runs at the parent's `medium`, and `thinking="max"` is rejected outright. That matters for cost routing as much as quality: a scout may want to run deliberately shallow while an implementation child needs depth, and model selection alone cannot express it.

## Change

`rlm(prompt, thinking="max")` now sets the child's reasoning level.

Most of the plumbing already existed. `CreateRlmSubagentRuntimeOptions.thinkingLevel` is an existing field, and the spawn path already clamps it against the child's model. It just had no way to receive an override, so the functional change is one expression:

```ts
thinkingLevel: clampThinkingLevel(options.model, options.thinkingLevel ?? this.thinkingLevel) as ThinkingLevel,
```

The rest is validation, tests and docs. `normalizeRequestedRlmSubagentThinkingLevel` mirrors the existing `normalizeRequestedRlmSubagentModel`, returning `undefined` when the kwarg is absent so the parent's level still applies.

No change was needed in `prime-agent-runtime`: `run(prompt, **kwargs)` already forwards everything to the host handler, so the value was arriving and being discarded.

## Two decisions worth flagging

**Clamped, not rejected.** A model that does not offer the requested level degrades to its nearest supported one rather than failing the spawn. This is what makes the role-file case work: a child asking for `max` on a model without it gets the best available instead of an error.

**`"off"` is not accepted.** `clampThinkingLevel` takes `ModelThinkingLevel`, which includes it, but `CreateRlmSubagentRuntimeOptions.thinkingLevel` is `ThinkingLevel`. Accepting `"off"` would widen the subagent contract, so it is excluded and the exclusion is commented. Happy to allow it if you would rather children could disable thinking entirely.

## Scope

This lands request 1 only, which is the part of #703 with written acceptance criteria. Requests 2 and 3 touch skill resolution and the bundled-skill settings, and request 4 overlaps #896, so they are better as separate PRs than bundled here.

Request 3 has a question worth settling before anyone implements it: several bundled skills are load-bearing, `compact` and `rlm-heartbeat` in particular, so making all thirteen individually disableable lets a user break long-running sessions. That probably wants a protected set or an explicit warning, and it seemed like your call rather than mine.

## Tests

`packages/coding-agent/test/suite/regressions/703-per-child-thinking.test.ts` covers each accepted level, the absent case falling back to the parent, whitespace trimming, non-string rejection, unsupported values including `"off"`, and that the error names the valid levels so the agent can correct itself.

Verified with `npm run check` and the new test plus `4649-subagent-model-selection` on Node 22.22.3.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-child `thinking` kwarg to `rlm.run` for overriding subagent reasoning level
> - Adds a `thinking` kwarg to `rlm.run` accepting values `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; when omitted, the child inherits the parent's reasoning level as before.
> - Introduces `normalizeRequestedRlmSubagentThinkingLevel` in [rlm-runtime.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1133/files#diff-e2f3586cb159b174f953a03ce37d872c059275b629a160203d8ef5c8db5d30e7) to validate and normalize the kwarg, throwing explicit errors for non-string or unsupported values.
> - The resolved level is clamped against the child model's capabilities in `_createRlmSubagentRuntimeOptions`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43c640e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->