### PR TITLE
fix(coding-agent): hide Windows console windows for spawned subprocesses

### DIFF
--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -696,6 +696,7 @@ async function runStart(parsed: ParsedDaemonClientCommand): Promise<void> {
 		detached: true,
 		env: process.env,
 		stdio: "ignore",
+		windowsHide: true,
 	});
 	child.unref();
 

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -379,6 +379,8 @@ async function ensureDaemonRunning(socketPath: string, spawnCwd?: string): Promi
 			// (EPIPE once it exits); crash details come from the daemon log,
 			// which the supervisor writes to before rethrowing startup errors.
 			stdio: "ignore",
+			// detached on Windows would otherwise give the daemon a visible console.
+			windowsHide: true,
 		},
 	);
 	let childFailure:

--- a/packages/coding-agent/src/cli/daemon-update-restart.ts
+++ b/packages/coding-agent/src/cli/daemon-update-restart.ts
@@ -552,6 +552,7 @@ export async function launchDaemonUpdateRestartCoordinator(
 		detached: true,
 		env: coordinatorEnvironment(agentDir),
 		stdio: "ignore",
+		windowsHide: true,
 	});
 	let launchError: Error | undefined;
 	let exitDescription: string | undefined;

--- a/packages/coding-agent/src/cli/owned-session-worker.ts
+++ b/packages/coding-agent/src/cli/owned-session-worker.ts
@@ -356,6 +356,8 @@ export async function runOwnedSessionWorkerFrontend(
 				[SESSION_LEASE_OWNER_ID_ENV]: `owned-${randomUUID()}`,
 			},
 			stdio,
+			// Console-less parents would otherwise flash a console window on Windows.
+			windowsHide: true,
 		});
 		currentChild = child;
 		if (!interactive) {

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -210,6 +210,7 @@ function readCommandOutput(
 		encoding: "utf-8",
 		stdio: ["ignore", "pipe", "pipe"],
 		shell: shouldUseWindowsShell(command),
+		windowsHide: true,
 	});
 	if (result.status === 0) return result.stdout.trim() || undefined;
 	if (options.requireSuccess) {

--- a/packages/coding-agent/src/core/autonomous.ts
+++ b/packages/coding-agent/src/core/autonomous.ts
@@ -496,6 +496,7 @@ function runChildProcess(
 			detached: process.platform !== "win32",
 			shell: options.shell === true,
 			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true,
 		});
 		if (child.pid) {
 			trackDetachedChildPid(child.pid);

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -10,6 +10,7 @@ function resolveBranchWithGitSync(repoDir: string): string | null {
 		cwd: repoDir,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		windowsHide: true,
 	});
 	const branch = result.status === 0 ? result.stdout.trim() : "";
 	return branch || null;
@@ -24,6 +25,7 @@ function resolveBranchWithGitAsync(repoDir: string): Promise<string | null> {
 			{
 				cwd: repoDir,
 				encoding: "utf8",
+				windowsHide: true,
 			},
 			(error: ExecFileException | null, stdout: string) => {
 				if (error) {

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -2383,6 +2383,7 @@ export class DefaultPackageManager implements PackageManager {
 			stdio: isStdoutTakenOver() ? ["ignore", 2, 2] : "inherit",
 			shell: shouldUseWindowsShell(command),
 			env: getEnv(),
+			windowsHide: true,
 		});
 	}
 
@@ -2397,6 +2398,7 @@ export class DefaultPackageManager implements PackageManager {
 			stdio: ["ignore", "pipe", "pipe"],
 			shell: shouldUseWindowsShell(command),
 			env: options?.env ? { ...baseEnv, ...options.env } : baseEnv,
+			windowsHide: true,
 		});
 	}
 
@@ -2464,6 +2466,7 @@ export class DefaultPackageManager implements PackageManager {
 			encoding: "utf-8",
 			shell: shouldUseWindowsShell(command),
 			env: getEnv(),
+			windowsHide: true,
 		});
 		if (result.error || result.status !== 0) {
 			throw new Error(

--- a/packages/coding-agent/src/core/resolve-config-value.ts
+++ b/packages/coding-agent/src/core/resolve-config-value.ts
@@ -58,6 +58,7 @@ function executeWithDefaultShell(command: string): string | undefined {
 			encoding: "utf-8",
 			timeout: 10000,
 			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
 		});
 		return output.trim() || undefined;
 	} catch {

--- a/packages/coding-agent/src/core/session-file-actions.ts
+++ b/packages/coding-agent/src/core/session-file-actions.ts
@@ -25,7 +25,7 @@ async function deleteSessionArtifacts(sessionPath: string): Promise<void> {
 /** Remove the session `.jsonl`, trying the `trash` CLI first, then falling back to unlink. */
 async function removeSessionFile(sessionPath: string): Promise<DeleteSessionFileResult> {
 	const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
-	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
+	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8", windowsHide: true });
 
 	const getTrashErrorHint = (): string | null => {
 		const parts: string[] = [];

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -77,6 +77,9 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 					detached: process.platform !== "win32",
 					env: env ?? getShellEnv(),
 					stdio: ["ignore", "pipe", "pipe"],
+					// Console-less parents (daemon/workers) would otherwise flash a
+					// console window per bash call on Windows.
+					windowsHide: true,
 				});
 				if (child.pid) trackDetachedChildPid(child.pid);
 				let timedOut = false;

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -396,6 +396,8 @@ export class DaemonCatalogClient {
 			cwd: process.cwd(),
 			env: createCliSubprocessEnv({ ...process.env, [DAEMON_CATALOG_ROLE_ENV]: "1" }),
 			stdio: ["ignore", "ignore", "ignore", "ipc"],
+			// The daemon has no console; without this Windows pops one for the child.
+			windowsHide: true,
 		});
 		this.child = child;
 		child.on("message", (value: unknown) => this.handleMessage(value));

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -820,6 +820,7 @@ export class AgentDaemon {
 				detached: true,
 				env: environment,
 				stdio: "ignore",
+				windowsHide: true,
 			});
 			child.unref();
 			const deadline = Date.now() + 10_000;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2131,6 +2131,9 @@ export class DaemonSupervisor {
 				[SESSION_LEASE_OWNER_ID_ENV]: rootActiveSessionId,
 			}),
 			stdio: ["ignore", "ignore", "pipe", "pipe"],
+			// detached on Windows gives the worker its own visible console window
+			// (the ipython kernel then attaches to it, titled as python) — hide it.
+			windowsHide: true,
 		});
 		const detachWorkerStderr = child.stderr
 			? attachJsonlLineReader(child.stderr, (line) => this.log(`Session worker ${workerId} stderr: ${line}`), {
@@ -4864,6 +4867,7 @@ export class DaemonSupervisor {
 				detached: true,
 				env: environment,
 				stdio: "ignore",
+				windowsHide: true,
 			});
 			replacement.unref();
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -107,6 +107,7 @@ export class RpcClient {
 			cwd: this.options.cwd,
 			env: { ...process.env, ...this.options.env },
 			stdio: ["pipe", "pipe", "pipe"],
+			windowsHide: true,
 		});
 
 		// Collect stderr for debugging

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -466,6 +466,7 @@ async function runSelfUpdate(command: SelfUpdateCommand): Promise<void> {
 			const child = spawn(step.command, step.args, {
 				stdio: "inherit",
 				shell: shouldUseWindowsShell(step.command),
+				windowsHide: true,
 			});
 			child.on("error", (error) => {
 				reject(error);

--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -98,6 +98,7 @@ function runCommand(
 		timeout: timeoutMs,
 		maxBuffer: maxBufferBytes,
 		env: options?.env,
+		windowsHide: true,
 	});
 
 	if (result.error) {

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -7,6 +7,7 @@ type NativeClipboardExecOptions = {
 	input: string;
 	timeout: number;
 	stdio: ["pipe", "ignore", "ignore"];
+	windowsHide: boolean;
 };
 
 function copyToX11Clipboard(options: NativeClipboardExecOptions): void {
@@ -61,7 +62,12 @@ export async function copyToClipboard(text: string): Promise<void> {
 		return;
 	}
 
-	const options: NativeClipboardExecOptions = { input: text, timeout: 5000, stdio: ["pipe", "ignore", "ignore"] };
+	const options: NativeClipboardExecOptions = {
+		input: text,
+		timeout: 5000,
+		stdio: ["pipe", "ignore", "ignore"],
+		windowsHide: true,
+	};
 
 	if (!copied) {
 		try {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -253,6 +253,7 @@ function runGit(cwd: string, args: string[]): string | null {
 		cwd,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		windowsHide: true,
 	});
 	if (result.status !== 0 || typeof result.stdout !== "string") return null;
 	return result.stdout.trim() || null;

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -16,7 +16,7 @@ function findBashOnPath(): string | null {
 	if (process.platform === "win32") {
 		// Windows: Use 'where' and verify file exists (where can return non-existent paths)
 		try {
-			const result = spawnSync("where", ["bash.exe"], { encoding: "utf-8", timeout: 5000 });
+			const result = spawnSync("where", ["bash.exe"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
 			if (result.status === 0 && result.stdout) {
 				const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
 				if (firstMatch && existsSync(firstMatch)) {
@@ -31,7 +31,7 @@ function findBashOnPath(): string | null {
 
 	// Unix: Use 'which' and trust its output (handles Termux and special filesystems)
 	try {
-		const result = spawnSync("which", ["bash"], { encoding: "utf-8", timeout: 5000 });
+		const result = spawnSync("which", ["bash"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
 		if (result.status === 0 && result.stdout) {
 			const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
 			if (firstMatch) {
@@ -194,6 +194,7 @@ export function killProcessTree(pid: number): void {
 			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
 				detached: true,
+				windowsHide: true,
 			});
 		} catch {
 			// Ignore errors if taskkill fails

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -100,7 +100,7 @@ const TOOLS: Record<string, ToolConfig> = {
 // Check that a command both launches and reports a successful version.
 function commandWorks(cmd: string): boolean {
 	try {
-		const result = spawnSync(cmd, ["--version"], { stdio: "pipe", timeout: COMMAND_TIMEOUT_MS });
+		const result = spawnSync(cmd, ["--version"], { stdio: "pipe", timeout: COMMAND_TIMEOUT_MS, windowsHide: true });
 		return !result.error && result.status === 0;
 	} catch {
 		return false;
@@ -224,7 +224,10 @@ async function downloadTool(tool: ManagedTool): Promise<string> {
 
 	try {
 		if (assetName.endsWith(".tar.gz")) {
-			const extractResult = spawnSync("tar", ["xzf", archivePath, "-C", extractDir], { stdio: "pipe" });
+			const extractResult = spawnSync("tar", ["xzf", archivePath, "-C", extractDir], {
+				stdio: "pipe",
+				windowsHide: true,
+			});
 			if (extractResult.error || extractResult.status !== 0) {
 				const errMsg = extractResult.error?.message ?? extractResult.stderr?.toString().trim() ?? "unknown error";
 				throw new Error(`Failed to extract ${assetName}: ${errMsg}`);


### PR DESCRIPTION
## Problem

On Windows, a console-less parent process (the daemon and its session workers) spawning a console-subsystem child (node, python, git, npm via its cmd shim, taskkill, …) makes conhost pop a **visible console window** for the child; `detached: true` forces a brand-new console outright. In practice users see console windows flashing during agent activity — e.g. session-worker spawns whose console ends up titled with the ipython kernel command line, and cmd.exe flashes on `shell: true`/`execSync` paths.

An earlier pass added `windowsHide` to the kernel/bootstrap/exec/session-lease spawns; this PR sweeps all the remaining spawn sites:

- **Daemon/worker launches** (`detached: true`): session-worker spawn + replacement in the supervisor, daemon launch, background daemon start, replacement supervisor, update-restart coordinator
- **Daemon children**: catalog process, RPC client
- **High-frequency paths**: bash tool spawn, `killProcessTree`'s taskkill, autonomous runner, footer git probes
- **Infrequent paths**: package manager command steps/capture, self-update steps, `!command` config-value resolution (execSync fallback), `where bash.exe` detection, git context capture, clipboard tools (incl. the WSL powershell read), tool detection, session-file trash

## Compatibility

`windowsHide` is ignored on non-Windows platforms, so this is a no-op elsewhere. No behavior change beyond suppressing the stray console windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide Windows console windows for all spawned subprocesses in coding-agent
> Adds `windowsHide: true` to every `spawn`, `spawnSync`, `execFile`, and `execSync` call across the coding-agent package so that no console windows flash on screen when the agent spawns subprocesses on Windows. The change covers daemon lifecycle, session workers, bash tools, git helpers, clipboard utilities, package manager commands, and RPC client launches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5457e40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->