### PR TITLE
feat: add /exit as an alias for /quit

### DIFF
--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -202,6 +202,7 @@ const BUILTIN_SLASH_COMMAND_ALIASES: ReadonlyArray<BuiltinSlashCommandAlias> = [
 	{ name: "thinking", aliasFor: "effort" },
 	{ name: "rename", aliasFor: "name" },
 	{ name: "side", aliasFor: "btw" },
+	{ name: "exit", aliasFor: "quit" },
 ];
 
 function buildBuiltinSlashCommands(): ReadonlyArray<BuiltinSlashCommand> {

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -119,6 +119,21 @@ describe("slash command aliases", () => {
 		});
 	});
 
+	test("resolves /exit to /quit through the alias path", () => {
+		const parsed = parseSlashCommand("/exit");
+
+		expect(parsed).toEqual({ name: "exit", args: "" });
+		expect(isBuiltinSlashCommandName("exit")).toBe(true);
+		expect(resolveBuiltinSlashCommandName("exit")).toBe("quit");
+		expect(resolveSlashCommand(parsed!)).toEqual({
+			name: "quit",
+			args: "",
+			originalName: "exit",
+			isAlias: true,
+		});
+		expect(BUILTIN_SLASH_COMMANDS.some((command) => command.name === "exit")).toBe(false);
+	});
+
 	test("resolves /rename to /name through the alias path", () => {
 		const parsed = parseSlashCommand("/rename my session");
 


### PR DESCRIPTION
Users coming from other terminal coding agents type /exit, which fell through to the model as a plain prompt. The attach-mode REPL in daemon-command.ts already accepts it; this adds it to the interactive TUI through the existing alias mechanism, so /exit stays hidden from the command list the way /clear and /side do.

Closes #1093

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/exit` as an alias for the `/quit` slash command
> Adds `"exit"` to `BUILTIN_SLASH_COMMAND_ALIASES` in [slash-commands.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1142/files#diff-1c09ca743d0363fbc0f524e5ca07b9d5ac086e6907790d18a884c6a1957bd051), resolving it to the canonical `quit` command. A corresponding test in [slash-commands.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1142/files#diff-28e17ac57c278424443a39e46d6f2e7b13e433f9752470d11f79eab972d315d3) verifies the alias resolves correctly and that no standalone `exit` command exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fd85f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->