### PR TITLE
docs: add Simplified Chinese translations for core documentation

### DIFF
--- a/AGENTS.zh-CN.md
+++ b/AGENTS.zh-CN.md
@@ -1,0 +1,261 @@
+# 开发规则（中文翻译）
+
+> 本文件是 [AGENTS.md](AGENTS.md) 的中文翻译。如有不一致之处，以英文原文为准。
+
+## 对话风格
+
+- 不写废话或欢快的填充文本
+- 回答简短精炼
+- 提交信息、Issue、PR 评论和代码中不使用表情符号
+- 仅使用技术性语言，友善但直接（例如用 "Thanks @user" 而非 "Thanks so much @user!"）
+
+## 代码质量
+
+- 在进行大范围修改前、编辑尚未完整检查的文件前，以及用户要求调查或审计时，务必完整阅读文件。不要仅依赖搜索片段进行大范围修改。
+- 代码注释不要过于冗长。仅在存在严重歧义时才写注释。
+- 除非绝对必要，不使用 `any` 类型。
+- 查看 `node_modules` 中的外部 API 类型定义，而不是猜测。
+- **绝不使用内联导入** - 不用 `await import("./foo.js")`，不用 `import("pkg").Type` 作为类型，不用动态导入类型。始终使用标准的顶层导入。
+- 绝不为了修复过时依赖导致的类型错误而删除或降级代码；应升级依赖。
+- 在删除看似有意的函数功能或代码前，务必先询问。
+- 除非用户明确要求，不保留向后兼容性。
+- 绝不硬编码按键检查，例如 `matchesKey(keyData, "ctrl+x")`。所有快捷键必须可配置。将默认值添加到匹配对象中（`DEFAULT_EDITOR_KEYBINDINGS` 或 `DEFAULT_APP_KEYBINDINGS`）。
+- 绝不直接修改 `packages/ai/src/models.generated.ts`。应更新 `packages/ai/scripts/generate-models.ts`。
+
+## 命令
+
+- 代码变更后（非文档变更）：运行 `npm run check`（获取完整输出，不截断）。提交前修复所有错误、警告和信息提示。
+- 注意：`npm run check` 不运行测试。
+- 绝不运行：`npm run dev`、`npm run build`、`npm test`。
+- 仅在用户指示时运行特定测试：`npx tsx ../../node_modules/vitest/dist/cli.js --run test/specific.test.ts`。
+- 从包根目录运行测试，而非仓库根目录。
+- 如果创建或修改了测试文件，必须运行该测试文件并迭代直到通过。
+- 编写测试时，运行它们，识别测试或实现中的问题，并迭代修复。
+- 对于 `packages/coding-agent/test/suite/`，使用 `test/suite/harness.ts` 和模拟提供商。不要使用真实提供商 API、真实 API 密钥或付费 Token。
+- 将特定 Issue 的回归测试放在 `packages/coding-agent/test/suite/regressions/` 下，命名为 `<issue-number>-<short-slug>.test.ts`。
+
+## 守护进程协议变更
+
+- 将每个守护进程命令、事件和响应结构的变更分类为向后兼容、能力门控或不兼容。
+- 在协商的服务器能力后面添加可选功能。客户端必须在发送命令或依赖事件之前检查该能力。
+- 对于不兼容变更或启动开始需要旧守护进程无法提供的行为时，提升 `DAEMON_PROTOCOL_VERSION`。
+- 对每次线路变更更新 `DAEMON_SCHEMA_REVISION`、命令/事件兼容性映射，以及新客户端/旧守护进程和旧客户端/新守护进程测试。
+- 可选的守护进程元数据和 UI 功能必须在本地优雅降级。它们不得阻止智能体、会话挂载或交互式启动。
+- 绝不在没有协议或能力门控的情况下将新的守护进程命令作为启动的一部分。
+
+## 依赖
+
+- 所有依赖更新适用 7 天最低发布期限：`.npmrc` 设置 `min-release-age=7`，`.github/dependabot.yml` 使用匹配的 `cooldown`。常规更新绝不绕过此规则。
+- 强制执行需要 npm >= 11.10；旧版 npm 会静默忽略该设置，因此更新依赖时请使用当前版本的 npm。
+- 对于 7 天内的紧急安全补丁，显式覆盖：`npm install --min-release-age=0 <pkg>`。
+
+## GitHub 工作流
+
+创建 Issue 时：
+
+- 添加 `pkg:*` 标签以指示受影响的包。
+  - 可用标签：`pkg:agent`、`pkg:ai`、`pkg:coding-agent`、`pkg:tui`
+- 如果 Issue 跨多个包，添加所有相关标签。
+
+发布 Issue/PR 评论时：
+
+- 将完整评论写入临时文件，使用 `gh issue comment --body-file` 或 `gh pr comment --body-file`。
+- 绝不在 Shell 命令中通过 `--body` 直接传递多行 Markdown。
+- 发布前预览确切的评论文本。
+- 除非用户明确要求多条评论，否则仅发布一条最终评论。
+- 如果评论格式错误，立即删除，然后发布一条修正后的评论。
+- 保持评论简洁、技术化，使用用户的语气。
+
+通过提交关闭 Issue 时：
+
+- 在提交信息中包含 `fixes #<number>` 或 `closes #<number>`。
+- 这会在提交合并时自动关闭 Issue。
+
+## PR 工作流
+
+- 先分析 PR，不要先拉取到本地。
+- 如果用户批准：创建功能分支，拉取 PR，在 main 上变基，应用调整，提交，合并到 main，推送，关闭 PR，并以用户的语气留下评论。
+- 我们在功能分支上工作，直到一切符合用户要求。绝不自行合并 PR。
+
+## 在 tmux 中测试 TUI
+
+要在受控终端环境中测试 Prime Agent 的 TUI：
+
+```bash
+# 创建具有特定尺寸的 tmux 会话
+tmux new-session -d -s prime-agent-test -x 80 -y 24
+
+# 从源码启动 Prime Agent
+tmux send-keys -t prime-agent-test "cd /Users/kevin/pi/prime-agent && ./prime-agent.sh" Enter
+
+# 等待启动，然后捕获输出
+sleep 3 && tmux capture-pane -t prime-agent-test -p
+
+# 发送输入
+tmux send-keys -t prime-agent-test "your prompt here" Enter
+
+# 发送特殊按键
+tmux send-keys -t prime-agent-test Escape
+tmux send-keys -t prime-agent-test C-o  # ctrl+o
+
+# 清理
+tmux kill-session -t prime-agent-test
+```
+
+你自己通常也运行在 tmux 会话中，因此杀死 tmux 会话时要小心。许多其他进程可能运行在不同的 tmux 会话中。
+
+## 变更日志
+
+位置：`packages/*/CHANGELOG.md`（每个包有自己的变更日志）
+
+### 格式
+
+`## [Unreleased]` 下的扁平纯文本列表。不使用 `### Added` / `### Changed` / `### Fixed` / `### Removed` 子部分 - 每个变更仅一条，以过去式动词开头的短句（Added、Changed、Fixed、Removed）。每条保持一行；描述用户可见的变更，而非实现细节。
+
+格式正确的 `[Unreleased]` 示例：
+
+```markdown
+## [Unreleased]
+
+- Added `/effort` to set the reasoning level, with autocomplete for the levels the current model supports.
+- Changed `prime-agent` to open a new chat by default instead of resuming the previous session.
+- Fixed onboarding showing no models after entering a provider key.
+- Removed the interactive `!` / `!!` bash shortcuts; use IPython instead.
+```
+
+### 规则
+
+- 先阅读完整的 `[Unreleased]` 部分，以免重复已有条目。
+- 新条目始终放在 `## [Unreleased]` 下。
+- 绝不修改已发布的版本部分（例如 `## [0.2.1]`）- 每个部分一旦发布即不可变。
+
+### 归属
+
+- **内部变更（来自 Issue）**：`Fixed foo bar ([#123](https://github.com/PrimeIntellect-ai/prime-agent/issues/123))`
+- **外部贡献**：`Added feature X ([#456](https://github.com/PrimeIntellect-ai/prime-agent/pull/456) by [@username](https://github.com/username))`
+
+## 添加新的 LLM 提供商（packages/ai）
+
+添加新提供商需要跨多个文件进行修改：
+
+### 1. 核心类型（`packages/ai/src/types.ts`）
+
+- 将 API 标识符添加到 `Api` 类型联合中（例如 `"bedrock-converse-stream"`）。
+- 创建扩展 `StreamOptions` 的选项接口。
+- 添加到 `ApiOptionsMap` 的映射。
+- 将提供商名称添加到 `KnownProvider` 类型联合中。
+
+### 2. 提供商实现（`packages/ai/src/providers/`）
+
+创建提供商文件，导出：
+
+- `stream<Provider>()` 函数，返回 `AssistantMessageEventStream`
+- `streamSimple<Provider>()` 用于 `SimpleStreamOptions` 映射
+- 提供商特定的选项接口
+- 消息/工具转换函数
+- 响应解析，发出标准化事件（`text`、`tool_call`、`thinking`、`usage`、`stop`）
+
+### 3. 提供商导出和惰性注册
+
+- 在 `packages/ai/package.json` 中添加包子路径导出，指向 `./dist/providers/<provider>.js`。
+- 在 `packages/ai/src/index.ts` 中添加 `export type` 重导出，用于应从根入口保持可用的提供商选项类型。
+- 在 `packages/ai/src/providers/register-builtins.ts` 中通过惰性加载器包装注册提供商，不要在那里静态导入提供商实现模块。
+- 在 `packages/ai/src/env-api-keys.ts` 中添加凭据检测。
+
+### 4. 模型生成（`packages/ai/scripts/generate-models.ts`）
+
+- 添加从提供商源获取/解析模型的逻辑。
+- 映射到标准化的 `Model` 接口。
+
+### 5. 测试（`packages/ai/test/`）
+
+- 始终将提供商添加到 `stream.test.ts` 中，至少包含一个代表性模型，即使它复用现有的 API 实现（例如 `openai-completions`）。
+- 在适用的更广泛提供商矩阵中添加该提供商：`tokens.test.ts`、`abort.test.ts`、`empty.test.ts`、`context-overflow.test.ts`、`image-limits.test.ts`、`unicode-surrogate.test.ts`、`tool-call-without-result.test.ts`、`image-tool-result.test.ts`、`total-tokens.test.ts`、`cross-provider-handoff.test.ts`。
+- 对于 `cross-provider-handoff.test.ts`，至少添加一个提供商/模型对。如果提供商暴露多个模型系列（例如 GPT 和 Claude），每个系列至少添加一对。
+- 对于非标准认证，创建工具（例如 `bedrock-utils.ts`）进行凭据检测。
+
+### 6. 编码智能体（`packages/coding-agent/`）
+
+- `src/core/model-resolver.ts`：将默认模型 ID 添加到 `defaultModelPerProvider`。
+- `src/core/provider-display-names.ts`：添加 API 密钥登录显示名称，以便 `/login` 和相关 UI 为内置 API 密钥认证显示该提供商。
+- `src/cli/args.ts`：添加环境变量文档。
+- `README.md`：添加提供商设置说明。
+- `docs/providers.md`：添加设置说明、环境变量和 `auth.json` 键。
+
+### 7. 文档
+
+- `packages/ai/README.md`：添加到提供商表，记录选项/认证，添加环境变量。
+- `packages/ai/CHANGELOG.md`：在 `## [Unreleased]` 下添加条目。
+
+## 发布
+
+**锁步版本控制**：所有包始终共享相同的版本号。每次发布都同时更新所有包。
+
+**版本语义**（无大版本发布）：
+
+- `patch`：Bug 修复和新功能。
+- `minor`：API 破坏性变更。
+
+### 步骤
+
+1. **更新变更日志**：确保自上次发布以来的所有变更都已记录在每个受影响包的 CHANGELOG.md 的 `[Unreleased]` 部分中。
+
+2. **运行发布脚本**：
+   ```bash
+   npm run release:patch    # 修复和新增
+   npm run release:minor    # API 破坏性变更
+   ```
+
+脚本处理：版本号提升、变更日志定稿、提交、打标签、发布，以及添加新的 `[Unreleased]` 部分。
+
+## **关键** 并行智能体的 Git 规则 **关键**
+
+多个智能体可能同时在同一工作树中操作不同的文件。你必须遵循以下规则：
+
+### 提交
+
+- **仅提交你在本次会话中修改的文件**。
+- 当有相关 Issue 或 PR 时，始终在提交信息中包含 `fixes #<number>` 或 `closes #<number>`。
+- 绝不使用 `git add -A` 或 `git add .` - 这些会扫入其他智能体的更改。
+- 始终使用 `git add <specific-file-paths>`，仅列出你修改的文件。
+- 提交前运行 `git status` 并验证你仅暂存了你的文件。
+- 跟踪你在会话期间创建/修改/删除了哪些文件。
+- 将 `packages/ai/src/models.generated.ts` 包含在提交中始终是可以的，只要与你想提交的实际文件一起即可。
+
+### 禁止的 Git 操作
+
+这些命令可能破坏其他智能体的工作：
+
+- `git reset --hard` - 销毁未提交的更改
+- `git checkout .` - 销毁未提交的更改
+- `git clean -fd` - 删除未跟踪的文件
+- `git stash` - 暂存所有更改，包括其他智能体的工作
+- `git add -A` / `git add .` - 暂存其他智能体未提交的工作
+- `git commit --no-verify` - 绕过必需的检查，绝不允许
+
+### 安全工作流
+
+```bash
+# 1. 先检查状态
+git status
+
+# 2. 仅添加你的特定文件
+git add packages/ai/src/providers/transform-messages.ts
+git add packages/ai/CHANGELOG.md
+
+# 3. 提交
+git commit -m "fix(ai): description"
+
+# 4. 推送（如有需要 pull --rebase，但绝不 reset/checkout）
+git pull --rebase && git push
+```
+
+### 如果发生变基冲突
+
+- 仅在你的文件中解决冲突。
+- 如果冲突在你未修改的文件中，中止并询问用户。
+- 绝不强制推送。
+
+### 用户覆盖
+
+如果用户指令与此处设定的规则冲突，请确认他们是否要覆盖规则。只有在确认后才执行其指令。

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Prime Agent: A Self-Improving RLM Agent
 
 <p align="center">
   <a href="packages/coding-agent/docs/index.md">Documentation</a> &bull;
+  <a href="README.zh-CN.md">中文文档</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/verifiers">Verifiers</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a> &bull;
   <a href="https://github.com/badlogic/pi-mono">pi-mono</a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,109 @@
+<p align="center">
+  <a href="https://primeintellect.ai">
+    <picture>
+      <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/40c36e38-c5bd-4c5a-9cb3-f7b902cd155d">
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/6414bc9b-126b-41ca-9307-9e982430cde8">
+      <img alt="Prime Intellect" src="https://github.com/user-attachments/assets/6414bc9b-126b-41ca-9307-9e982430cde8" width="312" style="max-width: 100%;">
+    </picture>
+  </a>
+</p>
+
+<h3 align="center">
+Prime Agent：自改进 RLM 智能体
+</h3>
+
+<p align="center">
+  <a href="packages/coding-agent/docs/index.zh-CN.md">中文文档</a> &bull;
+  <a href="README.md">English</a> &bull;
+  <a href="https://github.com/PrimeIntellect-ai/verifiers">Verifiers</a> &bull;
+  <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a> &bull;
+  <a href="https://github.com/badlogic/pi-mono">pi-mono</a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/ci.yml">
+    <img src="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/ci.yml/badge.svg" alt="CI" />
+  </a>
+  <a href="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/build-binaries.yml">
+    <img src="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/build-binaries.yml/badge.svg" alt="Build Binaries" />
+  </a>
+</p>
+
+Prime Agent 是一个开源的编码与研究智能体，适用于通用任务和长时间运行的工作。它围绕两个核心抽象构建：
+
+- **[递归语言模型（RLM）](https://www.primeintellect.ai/blog/rlm)** 将上下文视为变量（*提示即变量*），并将递归子智能体等工具视为持久 REPL 内部的函数调用（*程序化工具/子智能体调用*）。
+- **[持续框架（Continual Harness）](https://arxiv.org/abs/2605.09998)** 将补充提示、记忆、技能描述和可复用的子智能体规范存储为持久状态，Prime Agent 可以通过基于证据的微小更新来改进这些状态，默认情况下这些更新仅在会话本地生效。
+
+Prime Agent 将持久化的 Python 控制环境与持久的框架状态相结合，使得有用的工作上下文和可复用的操作模式能够超越单个聊天窗口的生命周期。
+
+- **一切皆为程序化操作：** 持久化的 IPython 是内置的模型工具；文件操作、Shell 命令、工具使用、子智能体和上下文管理都通过代码完成。
+- **内置子智能体：** `rlm(...)` 可生成真正的子智能体用于并行或后台工作，并以程序化方式返回结果。
+- **框架可自我改进：** `/refine` 会审查当前轨迹，并可对补充框架状态应用基于证据的微小更新。它永远不会重写不可变的基础系统提示，且记录的快照支持回滚。
+- **技能可执行：** 技能是可导入的 Python 包，内置的技能创建器可将重复的工作流转化为项目技能或个人技能。
+- **会话后台运行：** 基于守护进程的智能体在终端断开连接后仍持续运行，并可在之后重新挂载。
+- **智能体直接通信：** 运行中的智能体可以相互交换消息并相互协调，无需通过用户路由所有内容。
+- **长时任务持续推进：** 自动压缩、持久化目标、心跳、调度、自主模式和保留的子智能体可跨轮次和终端会话保持进度。
+
+## 快速开始
+
+在 macOS 或 Linux 上安装最新稳定版：
+
+```bash
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
+```
+
+安装程序会下载带版本号的发布产物，验证其 SHA-256 校验和，安装 `prime-agent` 命令，并可准备智能体使用的 IPython 运行时。
+
+从你希望它工作的仓库或目录启动 Prime Agent：
+
+```bash
+cd /path/to/project
+prime-agent
+```
+
+首次启动时，运行 `/login` 选择订阅或 API 密钥提供商。Prime Agent 在当前目录中工作，可以在那里运行命令和修改文件。请使用一次性的克隆、干净的工作树或其他你可以检查和恢复的检查点。
+
+> [!WARNING]
+> Prime Agent 会以你的用户权限执行模型生成的 Python 和项目命令。其工作进程和内核进程改进了生命周期隔离和恢复能力；它们**不是**安全沙箱。请审查更改，仅使用受信任的仓库、指令、技能和扩展。在外部沙箱或受限环境中运行不受信任的代码或指令。
+
+常用命令：
+
+```bash
+prime-agent agents                   # 浏览运行中、空闲和已保存的会话
+prime-agent attach <agent>           # 重新挂载到运行中的会话
+prime-agent --resume <path|id>       # 恢复已保存的会话
+prime-agent status                   # 检查后台服务状态
+prime-agent doctor [--fix]           # 检查或修复后台服务
+prime-agent update [--force]         # 更新 Prime Agent
+prime-agent shutdown [--force]       # 停止所有智能体、工作进程和后台服务
+```
+
+## 为长时间运行的任务而构建
+Prime Agent 专为长时间运行的任务而构建，特别适用于研究中的评估。这些功能可在 TUI 中使用，也可在自主运行时使用。
+
+- **持续框架：** `/refine` 可以将聚焦的、可审查的经验教训持久化为补充提示、记忆、可复用的技能描述或子智能体规范，并记录改进历史。它不替代打包和审查新的可执行技能。
+- **智能体间直接通信：** 运行中的智能体和保留的子智能体可以相互发现、交换消息并引导正在进行的工作。
+- **守护进程支持的连续性：** 活跃会话、IPython 状态、调度和子智能体在终端断开后仍持续运行，并可在之后重新挂载。
+- **心跳和调度：** `/heartbeat`、`rlm_heartbeat` 和 `prime-agent schedule` 可以定期或在特定时间重新进入会话。
+- **持久化目标：** `/goal` 在目标完成、暂停或清除之前，保持目标及其进度跨轮次活跃。
+- **有界自主模式：** `/autonomous` 在配置的轮次、Token 和时间预算内继续运行，并可运行用户自定义的质量门控。通过的门控仅检查该门控验证的内容；达到限制并不意味着任务成功。
+
+## 文档
+
+- [快速入门](packages/coding-agent/docs/quickstart.zh-CN.md) - 安装、认证并运行第一个会话
+- [使用与 CLI 参考](packages/coding-agent/docs/usage.zh-CN.md) - 命令、会话、自主限制和输出模式
+- [长时间运行和后台智能体](packages/coding-agent/docs/long-running-agents.md) - 断开与重新挂载、目标、心跳和调度
+- [RLM 编程模型](packages/coding-agent/docs/rlm.md) - 持久化 IPython、子智能体、技能和信任模型
+- [JSON 模式](packages/coding-agent/docs/json.md) 和 [RPC 模式](packages/coding-agent/docs/rpc.md) - 无头自动化和集成
+- [技能](packages/coding-agent/docs/skills.md) - 安装和创建可复用能力
+- [提供商设置](packages/coding-agent/docs/providers.md) - 订阅和 API 密钥提供商
+- [架构概览](packages/coding-agent/docs/architecture.md) - 守护进程、工作进程、内核和持久化边界
+- [开发](packages/coding-agent/docs/development.md) - 从源码构建和运行
+
+## 致谢
+
+我们的智能体和 TUI 构建于 [`pi`](https://github.com/earendil-works/pi) 之上。我们感谢 `pi` 作者的宝贵工作。
+
+## 许可证
+
+Prime Agent 完全开源，基于 [MIT 许可证](LICENSE)发布。

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -1,5 +1,7 @@
 # Prime Agent Documentation
 
+> **中文文档**：[index.zh-CN.md](index.zh-CN.md)
+
 Prime Agent is an RLM-native coding and research harness built around a persistent IPython kernel, recursive subagents, durable sessions, and a multi-process local runtime. It began as a hard fork of pi-mono, but Prime Agent is now the product, CLI, install source, and development repository.
 
 ## Quick Start

--- a/packages/coding-agent/docs/index.zh-CN.md
+++ b/packages/coding-agent/docs/index.zh-CN.md
@@ -1,0 +1,77 @@
+# Prime Agent 文档
+
+> 本文件是 [index.md](index.md) 的中文翻译。如有不一致之处，以英文原文为准。
+
+Prime Agent 是一个 RLM 原生的编码与研究框架，围绕持久化 IPython 内核、递归子智能体、持久会话和多进程本地运行时构建。它最初是 pi-mono 的硬分叉，但 Prime Agent 现在是产品、CLI、安装源和开发仓库。
+
+## 快速开始
+
+在 Linux 或 macOS 上安装最新稳定版：
+
+```bash
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
+```
+
+然后在项目目录中运行：
+
+```bash
+cd /path/to/project
+prime-agent
+```
+
+通过 `/login` 进行订阅或存储 API 密钥提供商的认证，或在启动前设置环境变量（如 `ANTHROPIC_API_KEY`）。完整首次运行流程请参阅[快速入门](quickstart.zh-CN.md)。
+
+公开发布目前从带版本号的发布产物安装。源码树中继承的 npm 工作区名称是实现细节，不是公开安装路径。
+
+## 从这里开始
+
+- [快速入门](quickstart.zh-CN.md) - 安装、认证并运行第一个会话。
+- [使用 Prime Agent](usage.zh-CN.md) - 交互模式、RLM 子智能体、斜杠命令、上下文文件和 CLI 参考。
+- [架构概览](architecture.md) - 客户端、守护进程、工作进程、会话、内核、提供商和存储边界。
+- [RLM 编程模型](rlm.md) - 程序化执行、原生子智能体、Python 技能和持久状态。
+- [长时间运行和后台智能体](long-running-agents.md) - 守护进程工作进程、消息传递、心跳、目标、调度和自主模式。
+- [提供商](providers.md) - 内置提供商的订阅和 API 密钥设置。
+- [设置](settings.md) - 全局和项目设置。
+- [快捷键](keybindings.md) - 默认快捷键和自定义快捷键。
+- [会话](sessions.md) - 会话管理、分支和树形导航。
+- [压缩](compaction.md) - 上下文压缩和分支摘要。
+
+## 自定义
+
+- [扩展](extensions.md) - 用于工具、命令、事件和自定义 UI 的 TypeScript 模块。
+- [技能](skills.md) - Markdown 和 Python 支持的技能，包括如何让 Prime Agent 创建它们。
+- [MCP 集成](mcp-integrations.md) - 通过 Python 技能使用 MCP 服务器，无需扩大模型的工具面。
+- [提示模板](prompt-templates.md) - 从斜杠命令展开的可复用提示。
+- [主题](themes.md) - 内置和自定义终端主题。
+- [Prime Agent 包](packages.md) - 打包和共享扩展、技能、提示和主题。
+- [自定义模型](models.md) - 为支持的提供商 API 添加模型条目。
+- [自定义提供商](custom-provider.md) - 实现自定义 API 和 OAuth 流程。
+
+## 程序化使用
+
+- [SDK](sdk.md) - 在 Node.js 应用中嵌入 Prime Agent。
+- [ACP 模式](acp.md) - 从任何 Agent Client Protocol 客户端驱动 Prime Agent。
+- [RPC 模式](rpc.md) - 通过 stdin/stdout JSONL 集成。
+- [JSON 事件流模式](json.md) - 带结构化事件的打印模式。
+- [TUI 组件](tui.md) - 为扩展构建自定义终端 UI。
+
+## 参考
+
+- [会话格式](session-format.md) - JSONL 会话文件格式、条目类型和 SessionManager API。
+- [CLI 包参考](../README.md) - 完整的用户和 CLI 参考。
+
+## 平台设置
+
+- [Windows](windows.md)
+- [Android 上的 Termux](termux.md)
+- [tmux](tmux.md)
+- [终端设置](terminal-setup.md)
+- [Shell 别名](shell-aliases.md)
+
+## 开发
+
+- [开发](development.md) - 本地设置、配置、调试和验证。
+- [架构概览](architecture.md) - 系统拓扑和端到端提示流。
+- [守护进程架构](daemon.md) - 监督器、目录、工作进程、生命周期和恢复详情。
+- [智能体连接架构](agent-connection.md) - 客户端/运行时连接边界。
+- [RLM 运行时架构](rlm-runtime.md) - ZeroMQ 内核传输和递归子智能体执行。

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -1,5 +1,7 @@
 # Quickstart
 
+> **中文文档**：[quickstart.zh-CN.md](quickstart.zh-CN.md)
+
 This page gets you from install to a useful first Prime Agent session.
 
 ## Install

--- a/packages/coding-agent/docs/quickstart.zh-CN.md
+++ b/packages/coding-agent/docs/quickstart.zh-CN.md
@@ -1,0 +1,169 @@
+# 快速入门
+
+> 本文件是 [quickstart.md](quickstart.md) 的中文翻译。如有不一致之处，以英文原文为准。
+
+本页带你从安装到一个有用的 Prime Agent 首次会话。
+
+## 安装
+
+在 Linux 或 macOS 上安装最新稳定版：
+
+```bash
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
+```
+
+尝试从 `main` 构建的最新 beta 版：
+
+```bash
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh -s -- beta
+```
+
+两个命令都会获取带版本号的 Prime Agent 发布产物并安装 `prime-agent` 命令。源码树中继承的 npm 工作区标识符不是公开安装路径。
+
+然后在你想让它工作的项目目录中启动 Prime Agent：
+
+```bash
+cd /path/to/project
+prime-agent
+```
+
+要运行源码检出，请使用 Node.js 22.8.0 或更新版本：
+
+```bash
+git clone https://github.com/PrimeIntellect-ai/prime-agent
+cd prime-agent
+npm ci
+./prime-agent.sh
+```
+
+源码运行器会保留调用它的目录，因此你也可以从其他项目调用 `/path/to/prime-agent/prime-agent.sh`。
+
+## 认证
+
+Prime Agent 可以通过 `/login` 使用订阅提供商，或通过环境变量或其认证文件使用 API 密钥提供商。
+
+### 选项 1：订阅登录
+
+启动 Prime Agent 并运行：
+
+```text
+/login
+```
+
+然后选择一个提供商。内置订阅登录包括 Claude Pro/Max、ChatGPT Plus/Pro（Codex）和 GitHub Copilot。
+
+### 选项 2：API 密钥
+
+在启动 Prime Agent 之前设置 API 密钥：
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+prime-agent
+```
+
+你也可以运行 `/login` 并选择 API 密钥提供商，将密钥存储在 `~/.prime/agent/auth.json` 中。
+
+所有支持的提供商、环境变量和云提供商设置请参阅[提供商](providers.md)。
+
+## 首次会话
+
+Prime Agent 启动后，输入请求并按 Enter：
+
+```text
+Summarize this repository and tell me how to run its checks.
+```
+
+Prime Agent 为模型提供一个内置工具 `ipython`。这个长生命周期的内核是一个控制环境，用于读取和编辑文件、运行项目命令、检查数据、保留 Python 状态和调用已安装的技能。内核运行时在首次使用时自动引导启动；设置 `PRIME_AGENT_KERNEL_PYTHON` 可使用带有 `ipykernel` 的现有 Python 环境。
+
+Prime Agent 在你当前的工作目录中运行，可以在那里修改文件。如果你想轻松回滚，请使用 git 或其他检查点工作流。
+
+## 递归子智能体
+
+递归子智能体是 Prime Agent 的内置能力。模型通过 IPython 中的 `await rlm("subtask")` 生成独立工作；每次调用在准入时返回一个子句柄，永远不会返回答案。子智能体将请求的结果作为显式的 `agent_message` 回复发送给父智能体，或将结果写入文件。子智能体使用与父智能体相同的 TypeScript 智能体运行时、提供商、工具、技能和会话机制。
+
+你可以直接提示模型使用该能力：
+
+```text
+Review authentication and test coverage as independent subtasks. Run them in parallel, then synthesize the findings.
+```
+
+API 和执行模型请参阅 [RLM 运行时架构](rlm-runtime.md)。
+
+## 为 Prime Agent 提供项目指令
+
+Prime Agent 在启动时加载上下文文件。添加一个 `AGENTS.md` 文件来告诉它如何在项目中工作：
+
+```markdown
+# Project Instructions
+
+- Run `npm run check` after code changes.
+- Do not run production migrations locally.
+- Keep responses concise.
+```
+
+Prime Agent 加载：
+
+- `~/.prime/agent/AGENTS.md` 用于全局指令
+- 父目录和当前目录中的 `AGENTS.md` 或 `CLAUDE.md`
+
+更改上下文文件后，重启 Prime Agent 或运行 `/reload`。
+
+## 常见尝试
+
+### 引用文件
+
+在编辑器中输入 `@` 进行文件模糊搜索，或在命令行上传递文件：
+
+```bash
+prime-agent @README.md "Summarize this"
+prime-agent @src/app.ts @src/app.test.ts "Review these together"
+```
+
+图片可以通过 Ctrl+V（Windows 上为 Alt+V）粘贴或拖入支持的终端。
+
+### 运行 Shell 命令
+
+在交互模式下：
+
+```text
+!npm run lint
+```
+
+命令输出发送给模型。使用 `!!command` 运行命令但不将其输出添加到模型上下文。在智能体工作期间，模型通常通过 `%%bash` 单元从 IPython 控制环境运行项目命令。
+
+### 切换模型
+
+使用 `/model` 或 Ctrl+L 选择模型。使用 `/effort` 设置推理级别。使用 Ctrl+P / Shift+Ctrl+P 在范围内的模型之间循环。
+
+### 稍后继续
+
+会话自动保存在 `~/.prime/agent/sessions/` 下：
+
+```bash
+prime-agent -c                  # 继续最近的会话
+prime-agent -r [path|id]        # 浏览会话或打开特定会话
+```
+
+在 Prime Agent 内部，使用 `/resume`、`/new`、`/tree`、`/fork` 和 `/clone` 管理会话。持久会话在工作进程中运行，因此关闭 TUI 只是从智能体上断开，不一定停止它。使用 `prime-agent agents` 检查或重新挂载到活跃工作。
+
+### 非交互模式
+
+用于一次性提示：
+
+```bash
+prime-agent -p "Summarize this codebase"
+cat README.md | prime-agent -p "Summarize this text"
+prime-agent -p @screenshot.png "What's in this image?"
+```
+
+使用 `--mode json` 进行 JSON 事件输出或 `--mode rpc` 进行进程集成。
+
+## 后续步骤
+
+- [使用 Prime Agent](usage.zh-CN.md) - 交互模式、斜杠命令、会话、上下文文件和 CLI 参考。
+- [提供商](providers.md) - 认证和模型设置。
+- [设置](settings.md) - 全局和项目配置。
+- [快捷键](keybindings.md) - 快捷键和自定义。
+- [Prime Agent 包](packages.md) - 安装共享扩展、技能、提示和主题。
+
+平台说明：[Windows](windows.md)、[Termux](termux.md)、[tmux](tmux.md)、[终端设置](terminal-setup.md)、[Shell 别名](shell-aliases.md)。

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -1,5 +1,7 @@
 # Using Prime Agent
 
+> **中文文档**：[usage.zh-CN.md](usage.zh-CN.md)
+
 This page collects day-to-day usage details that do not fit on the quickstart page.
 
 Prime Agent is built around one model-facing tool: a persistent IPython kernel. The kernel retains Python state across turns and acts as a control environment for file operations, project commands, installed Python skills, MCP-backed skills, and recursive subagents. The TypeScript host remains responsible for provider calls, session state, tool execution, scheduling, and child-agent lifecycles.

--- a/packages/coding-agent/docs/usage.zh-CN.md
+++ b/packages/coding-agent/docs/usage.zh-CN.md
@@ -1,0 +1,378 @@
+# 使用 Prime Agent
+
+> 本文件是 [usage.md](usage.md) 的中文翻译。如有不一致之处，以英文原文为准。
+
+本页收集不适合放在快速入门页面上的日常使用细节。
+
+Prime Agent 围绕一个面向模型的工具构建：持久化 IPython 内核。该内核跨轮次保留 Python 状态，并充当文件操作、项目命令、已安装 Python 技能、MCP 支持的技能和递归子智能体的控制环境。TypeScript 宿主仍负责提供商调用、会话状态、工具执行、调度和子智能体生命周期。
+
+## 交互模式
+
+<p align="center"><img src="images/interactive-mode.png" alt="Interactive Mode" width="600"></p>
+
+界面有四个主要区域：
+
+- **启动头部** - 简洁的品牌和运行时摘要；`--verbose` 还会列出已加载的上下文文件、提示模板、技能和扩展。
+- **消息** - 用户消息、助手响应、工具调用、工具结果、通知、错误和扩展 UI。
+- **编辑器** - 你输入的地方。
+- **页脚** - 默认为空；使用 `/usage` 查看 Token、费用和上下文详情。
+
+编辑器可以被内置 UI（如 `/settings`）或自定义扩展 UI 临时替换。
+
+### 编辑器功能
+
+| 功能 | 操作方式 |
+|---------|-----|
+| 文件引用 | 输入 `@` 模糊搜索项目文件 |
+| 路径补全 | 按 Tab 补全路径 |
+| 多行输入 | Shift+Enter，或 Windows Terminal 上的 Ctrl+Enter |
+| 图片 | Ctrl+V 粘贴，Windows 上为 Alt+V，或拖入终端 |
+| Shell 命令 | `!command` 运行并将输出发送给模型 |
+| 隐藏 Shell 命令 | `!!command` 运行但不将输出发送给模型 |
+| 外部编辑器 | Ctrl+G 打开 `$VISUAL` 或 `$EDITOR` |
+
+所有快捷键和自定义请参阅[快捷键](keybindings.md)。
+
+## 斜杠命令
+
+在编辑器中输入 `/` 打开命令补全。扩展可以注册自定义命令，技能可通过 `/skill:name` 使用，提示模板通过 `/templatename` 展开。
+
+| 命令 | 说明 |
+|---------|-------------|
+| `/login`、`/logout` | 管理 OAuth 或 API 密钥凭据 |
+| `/model` | 切换模型 |
+| `/effort` | 设置推理/思考级别 |
+| `/scoped-models` | 启用/禁用用于 Ctrl+P 循环的模型 |
+| `/settings` | 思考级别、主题、消息传递、传输方式 |
+| `/resume` | 从之前的会话中选择 |
+| `/new` | 开始新会话 |
+| `/name <name>` | 设置会话显示名称 |
+| `/session` | 显示会话文件、ID 和消息计数 |
+| `/traces [status\|on\|off\|preview\|upload-current\|upload-all\|login]` | 预览、上传或管理可选的追踪共享 |
+| `/usage`、`/context` | 显示父智能体和子智能体的上下文、Token 和费用明细 |
+| `/tree` | 跳转到会话中的任意点并从那里继续 |
+| `/fork` | 从之前的用户消息创建新会话 |
+| `/clone` | 将当前活跃分支复制到新会话 |
+| `/compact [prompt]` | 手动压缩上下文，可带自定义指令 |
+| `/refine [instructions]` | 改进或回滚会话支持的框架状态 |
+| `/copy` | 复制最后一条助手消息到剪贴板 |
+| `/btw <question>`、`/side <question>` | 提出内联旁路问题而不将其添加到会话；回复继续旁路对话，esc 返回 |
+| `/export [file]` | 将会话导出为 HTML |
+| `/share` | 上传为私有 GitHub gist 并带可共享的 HTML 链接 |
+| `/reload` | 重新加载快捷键、扩展、技能、提示和上下文文件 |
+| `/hotkeys` | 显示所有键盘快捷键 |
+| `/changelog` | 显示版本历史 |
+| `/quit` | 退出 Prime Agent |
+
+## 消息队列
+
+你可以在智能体仍在工作时提交消息：
+
+- **Enter** 排队一条引导消息，在当前助手轮次执行完工具调用后传递。
+- **Alt+Enter** 排队一条后续消息，在智能体完成所有工作后传递。
+- **Ctrl+C** 中断当前操作并短暂显示退出提示；在提示可见时再次按下则退出。
+- **Escape** 清空输入栏而不中断智能体。
+- **Alt+Up** 将排队的消息取回编辑器。
+
+在 Windows Terminal 上，Alt+Enter 默认是全屏。如果你希望 Prime Agent 接收该快捷键，请按[终端设置](terminal-setup.md)中的说明重新映射。
+
+在[设置](settings.md)中通过 `steeringMode` 和 `followUpMode` 配置传递方式。
+
+## 会话
+
+会话自动保存为 `~/.prime/agent/sessions/` 下的扁平 JSONL 文件。每个会话头部记录其工作目录，会话选择器使用它进行项目范围视图。
+
+```bash
+prime-agent -c                  # 继续最近的会话
+prime-agent -r [path|id]        # 浏览会话或直接恢复一个
+prime-agent --no-session        # 临时模式；不保存
+prime-agent --fork <path|id>    # 将会话分叉为新会话文件
+```
+
+有用的会话命令：
+
+- `/session` 显示当前会话文件和 ID。
+- `/usage` 显示 Token、费用和上下文使用情况。
+- `/tree` 导航文件内会话树，并可摘要被放弃的分支。
+- `/fork` 从更早的用户消息创建新会话。
+- `/clone` 将当前活跃分支复制到新会话文件。
+- `/compact` 摘要旧消息以释放上下文。
+
+详情请参阅[会话](sessions.md)和[压缩](compaction.md)。
+
+## 智能体与递归子智能体
+
+正常的交互会话是由隔离工作进程支持的持久智能体。关闭 TUI 只断开客户端；使用 `prime-agent agents`、`prime-agent list` 或 `prime-agent attach <agent>` 查找并重新挂载到运行中的工作。`prime-agent stop <agent>` 停止一个根智能体，而 `prime-agent shutdown` 停止所有工作进程和本地监督器。
+
+在会话内，模型可以通过 IPython 中已有的 `rlm` 可调用对象进行委派：
+
+```python
+# 生成独立子智能体。每次调用在准入时返回子句柄，
+# 而非子智能体的答案。
+review = await rlm(
+    "Review authentication and reply to the parent with findings.",
+    name="auth-reviewer",
+)
+tests = await rlm("Find missing regression tests and reply to the parent.", name="test-reviewer")
+docs = await rlm("Find stale public documentation and reply to the parent.", name="docs-reviewer")
+
+# 子智能体从自己的会话回复：
+# await agent_message.send(message, receiver_role="parent")
+# 它们的回复作为普通智能体消息到达这里。
+
+# 恢复句柄并向保留的子智能体发送后续消息。
+children = await rlm.list_subagents()
+await agent_message.send(
+    "Also check authorization boundaries.",
+    receiver_role="child",
+    receiver_name=review.name,
+)
+```
+
+子智能体继承父模型，除非用户请求另一个模型。它们作为 TypeScript `AgentSession` 实例在同一根工作进程下运行，可以使用相同的提供商、工具、技能、会话存储和调度系统。请参阅 [RLM 运行时架构](rlm-runtime.md)。
+
+## 上下文文件
+
+Prime Agent 在启动时从以下位置加载 `AGENTS.md` 或 `CLAUDE.md`：
+
+- `~/.prime/agent/AGENTS.md` 用于全局指令
+- 父目录，从当前工作目录向上遍历
+- 当前目录
+
+使用上下文文件来定义项目约定、命令、安全规则和偏好。使用 `--no-context-files` 或 `-nc` 禁用加载。
+
+### 系统提示文件
+
+用以下文件替换默认系统提示：
+
+- `.prime/agent/SYSTEM.md` 用于项目
+- `~/.prime/agent/SYSTEM.md` 用于全局
+
+在任一位置使用 `APPEND_SYSTEM.md` 追加到默认提示而不替换它。
+
+## 导出和共享会话
+
+使用 `/export [file]` 将会话写入 HTML。
+
+使用 `/share` 上传私有 GitHub gist 并带可共享的 HTML 链接。
+
+## CLI 参考
+
+```bash
+prime-agent [options] [@files...] [messages...]
+```
+
+### Shell 命令
+
+```bash
+prime-agent agents
+prime-agent list [--all]
+prime-agent attach <agent>
+prime-agent stop <agent>
+prime-agent rename <agent> <name>
+prime-agent send <agent> <message>
+prime-agent schedule <list|add|cancel>
+prime-agent status
+prime-agent doctor [--fix]
+prime-agent shutdown [--force]
+
+prime-agent package install <source> [--local]
+prime-agent package remove <source> [--local]
+prime-agent package list
+prime-agent package update [source]
+prime-agent update [--force]
+prime-agent config
+```
+
+包源和安全说明请参阅 [Prime Agent 包](packages.md)。
+
+### 模式
+
+| 标志 | 说明 |
+|------|------|
+| 默认 | 交互模式 |
+| `-p`、`--print` | 打印响应并退出 |
+| `--mode json` | 将所有事件输出为 JSON 行；见 [JSON 模式](json.md) |
+| `--mode rpc` | 通过 stdin/stdout 的 RPC 模式；见 [RPC 模式](rpc.md) |
+
+在打印模式下，Prime Agent 还会读取管道输入的 stdin 并将其合并到初始提示中：
+
+```bash
+cat README.md | prime-agent -p "Summarize this text"
+```
+
+### 模型选项
+
+| 选项 | 说明 |
+|--------|------|
+| `--provider <name>` | 提供商，如 `anthropic`、`openai` 或 `google` |
+| `--model <pattern>` | 模型模式或 ID；支持 `provider/id` 和可选的 `:<thinking>` |
+| `--api-key <key>` | API 密钥，覆盖环境变量 |
+| `--thinking <level>` | `off`、`minimal`、`low`、`medium`、`high`、`xhigh` 或 `max` |
+| `--models <patterns>` | 逗号分隔的 Ctrl+P 循环模式 |
+
+使用 `prime-agent model list [search]` 列出可用模型。
+
+### 会话选项
+
+| 选项 | 说明 |
+|--------|------|
+| `-c`、`--continue` | 继续最近的会话 |
+| `-r`、`--resume [path\|id]` | 浏览并选择会话，或恢复特定会话文件或部分 UUID |
+| `--fork <path\|id>` | 将会话文件或部分 UUID 分叉为新会话 |
+| `--session-dir <dir>` | 自定义会话存储目录 |
+| `--no-session` | 临时模式；不保存 |
+
+使用 `prime-agent session export <file> [output]` 将会话导出为 HTML。
+
+### 工具选项
+
+| 选项 | 说明 |
+|--------|------|
+| `--tools <list>`、`-t <list>` | 允许列表特定内置、扩展和自定义工具 |
+| `--no-builtin-tools`、`-nbt` | 禁用内置工具但保持扩展/自定义工具启用 |
+| `--no-tools`、`-nt` | 禁用所有工具 |
+
+内置工具：`ipython`。
+
+### 资源选项
+
+| 选项 | 说明 |
+|--------|------|
+| `-e`、`--extension <source>` | 从路径、npm 或 git 加载扩展；可重复 |
+| `--no-extensions`、`-ne` | 禁用扩展发现 |
+| `--skill <path>` | 加载技能；可重复 |
+| `--no-skills`、`-ns` | 禁用技能发现 |
+| `--prompt-template <path>` | 加载提示模板；可重复 |
+| `--no-prompt-templates`、`-np` | 禁用提示模板发现 |
+| `--theme <path>` | 加载主题；可重复 |
+| `--no-themes` | 禁用主题发现 |
+| `--no-context-files`、`-nc` | 禁用 `AGENTS.md` 和 `CLAUDE.md` 发现 |
+
+将 `--no-*` 与显式标志结合使用，以仅加载你所需的内容，忽略设置。例如：
+
+```bash
+prime-agent --no-extensions -e ./my-extension.ts
+```
+
+### 自主选项
+
+自主模式是用于无人值守工作的宿主策略。它默认禁用。`--autonomous` 启用它，提供任何 `--autonomous-*` 子选项也会启用它。宿主以全新的延续、轮次、Token 和经过时间计数器启动每个启用的运行。
+
+| 选项 | 行为、单位和默认值 |
+|--------|------------------------------|
+| `--autonomous` | 启用自主延续。无门控时，宿主持续请求工作直到某个限制阻止下一次延续。 |
+| `--autonomous-gate <command>` | 添加必须在运行完成前通过的 Shell 命令。可重复的命令按 CLI 顺序运行；默认无门控。 |
+| `--autonomous-gate-retries <n>` | 设置每个门控的重试限制。默认：`3`。失败的门控在其记录的尝试次数不超过此值时可继续；下一次失败尝试将耗尽门控。 |
+| `--autonomous-gate-timeout-ms <n>` | 设置每个门控进程的超时时间（毫秒）。默认：`300000`（5 分钟）。超时的门控视为失败并停止其进程树。 |
+| `--autonomous-max-continuations <n>` | 设置最大宿主注入后续消息数。默认：`3`。 |
+| `--autonomous-max-turns <n>` | 设置自主模式启用时计算的最大助手响应数。默认：`12`。 |
+| `--autonomous-max-tokens <n>` | 设置最大累积 Token 数。默认：`80000`；计算包括输入、输出和缓存写入 Token，但不包括缓存读取 Token。 |
+| `--autonomous-timeout-ms <n>` | 设置最大自主经过时间（毫秒）。默认：`1800000`（30 分钟）。 |
+
+所有 `<n>` 值必须是正整数：零、负数、分数和非数值会被拒绝。接受值的自主标志需要单独的参数，而非 `--flag=value`。缺少值会被拒绝，后续的长选项不会被当作值消费。重复的数值标志使用其最后一个值；重复 `--autonomous-gate` 会追加另一个门控。
+
+每次助手响应后，配置的门控在评估普通延续限制之前运行。所有门控必须通过才能完成运行。失败的门控向下一次延续提供有界的命令输出，以便智能体修复它；Prime Agent 避免重新运行未更改的失败门控，而是推进其尝试计数。通过的門控即使在已达到延续、轮次、Token 或时间限制的情况下也允许完成。如果门控未通过或没有门控，宿主只能在所有四个限制都低于其配置值时注入另一次延续。限制按以下顺序检查：延续、轮次、Token，然后是经过时间。达到任何一个都会阻止另一次自动延续；这并不意味着任务成功。
+
+例如，以下非交互运行使用本地可用的模型配置，跳过启动网络操作，并限定每个自主预算，同时要求项目检查通过：
+
+```bash
+prime-agent -p \
+  --autonomous \
+  --autonomous-gate "npm run check" \
+  --autonomous-gate-retries 2 \
+  --autonomous-gate-timeout-ms 300000 \
+  --autonomous-max-continuations 3 \
+  --autonomous-max-turns 12 \
+  --autonomous-max-tokens 80000 \
+  --autonomous-timeout-ms 1800000 \
+  --model openai/gpt-5.1-codex \
+  --offline \
+  --thinking high \
+  "Fix the failing check and report the verified result."
+```
+
+`--offline` 禁用启动网络操作；它不提供模型凭据，也不使提供商推理离线。选择已为本地环境配置的模型。
+
+目标与自主模式分开：`--goal <objective>` 仅在没有现有目标状态的新根会话中启动持久目标，而自主模式决定宿主是否应注入另一次延续。`--goal-token-budget <n>` 是该初始目标的正整数 Token 预算，需要 `--goal`。
+
+### 其他选项
+
+| 选项 | 说明 |
+|--------|------|
+| `--cwd <dir>` | 为会话使用特定工作目录 |
+| `--system-prompt <text>` | 替换默认提示；上下文文件和技能仍会追加 |
+| `--append-system-prompt <text>` | 追加到系统提示 |
+| `--verbose` | 强制详细启动 |
+| `--offline` | 禁用启动网络操作 |
+| `-h`、`--help` | 显示帮助 |
+| `-v`、`--version` | 显示版本 |
+| `--` | 结束选项解析，将所有后续参数视为消息 |
+
+### 文件参数
+
+在文件前加 `@` 将其包含在消息中：
+
+```bash
+prime-agent @prompt.md "Answer this"
+prime-agent -p @screenshot.png "What's in this image?"
+prime-agent @code.ts @test.ts "Review these files"
+```
+
+### 示例
+
+```bash
+# 带初始提示的交互模式
+prime-agent "List all .ts files in src/"
+
+# 非交互模式
+prime-agent -p "Summarize this codebase"
+
+# 带管道 stdin 的非交互模式
+cat README.md | prime-agent -p "Summarize this text"
+
+# 不同模型
+prime-agent --provider openai --model gpt-4o "Help me refactor"
+
+# 带提供商前缀的模型
+prime-agent --model openai/gpt-4o "Help me refactor"
+
+# 带思考级别简写的模型
+prime-agent --model sonnet:high "Solve this complex problem"
+
+# 限制模型循环
+prime-agent --models "claude-*,gpt-4o"
+
+# 仅限内置 IPython 工具
+prime-agent --tools ipython -p "Review the code"
+```
+
+### 环境变量
+
+| 变量 | 说明 |
+|----------|------|
+| `PRIME_AGENT_CODING_AGENT_DIR` | 覆盖配置目录；默认为 `~/.prime/agent` |
+| `PRIME_AGENT_SESSION_DIR` | 覆盖会话存储目录；被 `--session-dir` 覆盖 |
+| `PRIME_AGENT_CODING_AGENT_SESSION_DIR` | `PRIME_AGENT_SESSION_DIR` 的旧别名 |
+| `PI_PACKAGE_DIR` | 覆盖包目录，适用于 Nix/Guix 存储路径 |
+| `PI_OFFLINE` | 禁用启动网络操作，包括更新检查和包更新检查 |
+| `PI_SKIP_VERSION_CHECK` | 跳过启动时的 Prime Agent 版本更新检查。这会阻止发布清单请求 |
+| `PRIME_AGENT_DOWNLOAD_BASE_URL` | 覆盖 Prime Agent 发布清单和 tarball 基础 URL |
+| `PI_CACHE_RETENTION` | 设置为 `long` 以在支持的提供商上使用扩展提示缓存 |
+| `PRIME_API_KEY` | Prime 推理 API 密钥；当具有 `agent_traces` 范围时也用于追踪共享 |
+| `PRIME_AGENT_TRACES_API_KEY` | 仅用于可选追踪共享的 Prime API 密钥 |
+| `PRIME_AGENT_TRACES_BASE_URL` | 覆盖 Prime Agent 追踪上传 API 基础 URL |
+| `PRIME_AGENT_KERNEL_PYTHON` | 使用带有 `ipykernel` 的现有 Python 环境，而非引导 `~/.prime/agent/kernel-venv` |
+| `VISUAL`、`EDITOR` | Ctrl+G 的外部编辑器 |
+
+其余 `PI_*` 变量是当前运行时仍读取的兼容名称。它们不会更改应用名称、命令或默认的 `~/.prime/agent` 配置路径。
+
+## 设计原则
+
+Prime Agent 保持面向模型的工具面小而精，同时使 IPython 运行时强大且可组合。内置的 `ipython` 工具提供持久状态、项目命令执行、Python 技能、MCP 支持的集成和原生 `rlm` 委派 API，而无需将每项能力作为单独的模型工具呈现。
+
+递归子智能体是核心能力，而非可选扩展。TypeScript 宿主拥有每个父智能体和子智能体循环，因此递归使用相同的提供商、会话、工具、技能、调度、使用量核算和恢复基础设施。Python `rlm` 包是通往宿主的薄桥接，而非单独的智能体实现。
+
+扩展、技能、提示模板、主题和 Prime Agent 包仍然是主要的自定义面。它们可以在内置运行时周围添加项目特定的工作流、自定义工具和 UI、权限策略、提供商集成和编排模式。
+
+Prime Agent 保留了 pi-mono 上游血统的 MIT 归属，但上游 Pi 产品声明和限制不描述当前的 Prime Agent 架构。


### PR DESCRIPTION
Add Chinese (zh-CN) translations of the five core user-facing docs:
- README.zh-CN.md
- AGENTS.zh-CN.md
- packages/coding-agent/docs/index.zh-CN.md
- packages/coding-agent/docs/quickstart.zh-CN.md
- packages/coding-agent/docs/usage.zh-CN.md

Add language switcher links to the original English docs so users can discover the Chinese versions. Uses .zh-CN.md suffix convention. Code blocks, commands, and config values are preserved as-is.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Simplified Chinese translations for core documentation
> Adds Chinese (`zh-CN`) translations for key documentation files, including [README.zh-CN.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1144/files#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987), [AGENTS.zh-CN.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1144/files#diff-98501bb8508446686a73b66e78995172cd60daa497a0bd2be319d675e6d9aaa4), and translated versions of the docs index, quickstart, and usage guide under [packages/coding-agent/docs/](https://github.com/PrimeIntellect-ai/prime-agent/pull/1144/files#diff-c7315866857c5467aec66a2670cff3e2920e3e51accce7f0d02780b82af5fd4f). Each existing English doc is updated with a link to its Chinese counterpart at the top of the file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20d8905.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->