### PR TITLE
fix(coding-agent): preserve session-start notifications until UI attach

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed daemon-backed extension notifications emitted during `session_start` being lost before the first capable client attaches ([#1032](https://github.com/PrimeIntellect-ai/prime-agent/issues/1032)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/modes/daemon/active-session-state.ts
+++ b/packages/coding-agent/src/modes/daemon/active-session-state.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "node:crypto";
 import type { Socket } from "node:net";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
 import type { AgentStatus } from "../../core/session-manager.js";
-import type { DaemonClientCapability, DaemonEventSequence, DaemonExtensionUIResponse } from "./daemon-protocol.js";
+import type {
+	DaemonClientCapability,
+	DaemonEventSequence,
+	DaemonExtensionUIResponse,
+	DaemonOutbound,
+} from "./daemon-protocol.js";
 import { formatSessionDisplayId, matchesSessionIdSuffix } from "./daemon-session-id.js";
 
 export interface DaemonSocketClient {
@@ -38,6 +43,10 @@ export interface ActiveSessionState {
 	/** Attach snapshots in flight: reserved for passivation busyness, but not yet event recipients. */
 	pendingAttaches: number;
 	extensionUiRequests: Map<string, ActiveSessionExtensionUiRequest>;
+	/** Notifications emitted before the first extension-UI client attaches. */
+	pendingExtensionUiNotifications?: DaemonExtensionUiNotification[];
+	/** Prevents later no-client notifications from being replayed as startup notifications. */
+	hasAttachedExtensionUiClient?: boolean;
 	eventGeneration: string;
 	lastEventSequence: DaemonEventSequence;
 	unsubscribe?: () => void;
@@ -55,6 +64,15 @@ export interface ActiveSessionState {
 
 export interface ActiveSessionExtensionUiRequest {
 	resolve: (response: DaemonExtensionUIResponse) => void;
+}
+
+export type DaemonExtensionUiNotification = Extract<DaemonOutbound, { type: "extension_ui_request" }>;
+
+export function daemonClientSupportsExtensionUiForSession(
+	client: DaemonSocketClient,
+	activeSessionId: string,
+): boolean {
+	return client.capabilitiesByActiveSessionId?.get(activeSessionId)?.has("extension_ui") ?? client.supportsExtensionUi;
 }
 
 interface ActiveSessionIdIndex {

--- a/packages/coding-agent/src/modes/daemon/active-session-state.ts
+++ b/packages/coding-agent/src/modes/daemon/active-session-state.ts
@@ -43,10 +43,12 @@ export interface ActiveSessionState {
 	/** Attach snapshots in flight: reserved for passivation busyness, but not yet event recipients. */
 	pendingAttaches: number;
 	extensionUiRequests: Map<string, ActiveSessionExtensionUiRequest>;
-	/** Notifications emitted before the first extension-UI client attaches. */
+	/** Notifications emitted during the initial extension bind before a UI-capable client is available. */
 	pendingExtensionUiNotifications?: DaemonExtensionUiNotification[];
-	/** Prevents later no-client notifications from being replayed as startup notifications. */
-	hasAttachedExtensionUiClient?: boolean;
+	/** First UI-capable recipient selected for retained startup notifications. */
+	pendingExtensionUiNotificationRecipient?: DaemonSocketClient;
+	/** Prevents replacement/reload binds from opening another startup capture window. */
+	hasCompletedInitialExtensionBind?: boolean;
 	eventGeneration: string;
 	lastEventSequence: DaemonEventSequence;
 	unsubscribe?: () => void;

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -10,7 +10,11 @@ import type { SubagentRuntimeHost } from "../../core/rlm-runtime.js";
 import { createAgentConnectionState } from "../agent-connection/snapshot.js";
 import type { AgentConnectionState } from "../agent-connection/types.js";
 import { type Theme, theme } from "../interactive/theme/theme.js";
-import type { ActiveSessionState } from "./active-session-state.js";
+import {
+	type ActiveSessionState,
+	type DaemonExtensionUiNotification,
+	daemonClientSupportsExtensionUiForSession,
+} from "./active-session-state.js";
 import { execEnvForSession, withClientEnv } from "./daemon-client-env.js";
 import {
 	type DaemonExtensionUIResponse,
@@ -27,6 +31,9 @@ export interface ActiveSessionBindingCallbacks {
 }
 
 type BroadcastSessionEvent = Extract<DaemonOutbound, { type: "session_event" }>["event"];
+
+/** Retain the newest startup notifications without allowing an extension to grow daemon state unbounded. */
+export const MAX_PENDING_EXTENSION_UI_NOTIFICATIONS = 100;
 
 /**
  * message_update events carry the full partial assistant message twice: once
@@ -51,6 +58,9 @@ export async function bindActiveSessionState(
 	callbacks: ActiveSessionBindingCallbacks,
 ): Promise<void> {
 	const session = state.runtime.session;
+	if (state.unsubscribe) {
+		state.pendingExtensionUiNotifications = [];
+	}
 
 	session.setExecEnvProvider(() => execEnvForSession(state.clientEnv));
 	// Every runtime rebuild (new/switch/fork/import, subagent spawn) re-loads
@@ -126,16 +136,32 @@ function createExtensionUIContext(
 	state: ActiveSessionState,
 	broadcast: ActiveSessionBindingCallbacks["broadcast"],
 ): ExtensionUIContext {
+	const createUiRequest = (method: string, payload: Record<string, unknown>): DaemonExtensionUiNotification => ({
+		type: "extension_ui_request",
+		activeSessionId: state.activeSessionId,
+		id: randomUUID(),
+		method,
+		payload,
+	});
 	const emitUiRequest = (method: string, payload: Record<string, unknown>): string => {
-		const id = randomUUID();
-		broadcast(state, {
-			type: "extension_ui_request",
-			activeSessionId: state.activeSessionId,
-			id,
-			method,
-			payload,
-		});
-		return id;
+		const request = createUiRequest(method, payload);
+		broadcast(state, request);
+		return request.id;
+	};
+	const notify = (message: string, notifyType?: "info" | "warning" | "error"): string => {
+		const request = createUiRequest("notify", { message, notifyType });
+		if (hasExtensionUiClient(state)) {
+			state.hasAttachedExtensionUiClient = true;
+			broadcast(state, request);
+		} else if (state.hasAttachedExtensionUiClient !== true) {
+			state.pendingExtensionUiNotifications ??= [];
+			const pending = state.pendingExtensionUiNotifications;
+			if (pending.length >= MAX_PENDING_EXTENSION_UI_NOTIFICATIONS) {
+				pending.shift();
+			}
+			pending.push(request);
+		}
+		return request.id;
 	};
 
 	const dialogRequest = <T>(
@@ -197,7 +223,7 @@ function createExtensionUIContext(
 						? response.value
 						: undefined,
 			),
-		notify: (message, notifyType) => emitUiRequest("notify", { message, notifyType }),
+		notify,
 		onTerminalInput: () => () => {},
 		setStatus: (key, text) => emitUiRequest("setStatus", { statusKey: key, statusText: text }),
 		setWorkingMessage: (message) => emitUiRequest("setWorkingMessage", { message }),
@@ -250,5 +276,11 @@ function hasExtensionUiClientForMethod(state: ActiveSessionState, method: string
 	if (!isDaemonDialogExtensionUiRequest(method)) {
 		return state.clients.size > 0;
 	}
-	return [...state.clients].some((client) => client.supportsExtensionUi);
+	return hasExtensionUiClient(state);
+}
+
+function hasExtensionUiClient(state: ActiveSessionState): boolean {
+	return [...state.clients].some(
+		(client) => !client.socket.destroyed && daemonClientSupportsExtensionUiForSession(client, state.activeSessionId),
+	);
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -58,8 +58,10 @@ export async function bindActiveSessionState(
 	callbacks: ActiveSessionBindingCallbacks,
 ): Promise<void> {
 	const session = state.runtime.session;
-	if (state.unsubscribe) {
+	const captureStartupNotifications = state.hasCompletedInitialExtensionBind !== true;
+	if (!captureStartupNotifications) {
 		state.pendingExtensionUiNotifications = [];
+		state.pendingExtensionUiNotificationRecipient = undefined;
 	}
 
 	session.setExecEnvProvider(() => execEnvForSession(state.clientEnv));
@@ -90,20 +92,28 @@ export async function bindActiveSessionState(
 		});
 	});
 
-	await session.bindExtensions({
-		uiContext: createExtensionUIContext(state, callbacks.broadcast),
-		commandContextActions: createCommandContextActions(state),
-		shutdownHandler: callbacks.shutdown,
-		onError: (error) => {
-			callbacks.broadcast(state, {
-				type: "extension_error",
-				activeSessionId: state.activeSessionId,
-				extensionPath: error.extensionPath,
-				event: error.event,
-				error: error.error,
-			});
-		},
-	});
+	let bindingInitialExtensions = captureStartupNotifications;
+	try {
+		await session.bindExtensions({
+			uiContext: createExtensionUIContext(state, callbacks.broadcast, () => bindingInitialExtensions),
+			commandContextActions: createCommandContextActions(state),
+			shutdownHandler: callbacks.shutdown,
+			onError: (error) => {
+				callbacks.broadcast(state, {
+					type: "extension_error",
+					activeSessionId: state.activeSessionId,
+					extensionPath: error.extensionPath,
+					event: error.event,
+					error: error.error,
+				});
+			},
+		});
+	} finally {
+		bindingInitialExtensions = false;
+		if (captureStartupNotifications) {
+			state.hasCompletedInitialExtensionBind = true;
+		}
+	}
 }
 
 function createCommandContextActions(state: ActiveSessionState): ExtensionCommandContextActions {
@@ -135,6 +145,7 @@ function createCommandContextActions(state: ActiveSessionState): ExtensionComman
 function createExtensionUIContext(
 	state: ActiveSessionState,
 	broadcast: ActiveSessionBindingCallbacks["broadcast"],
+	isCapturingStartupNotifications: () => boolean,
 ): ExtensionUIContext {
 	const createUiRequest = (method: string, payload: Record<string, unknown>): DaemonExtensionUiNotification => ({
 		type: "extension_ui_request",
@@ -150,16 +161,15 @@ function createExtensionUIContext(
 	};
 	const notify = (message: string, notifyType?: "info" | "warning" | "error"): string => {
 		const request = createUiRequest("notify", { message, notifyType });
-		if (hasExtensionUiClient(state)) {
-			state.hasAttachedExtensionUiClient = true;
-			broadcast(state, request);
-		} else if (state.hasAttachedExtensionUiClient !== true) {
+		if (isCapturingStartupNotifications() && !hasExtensionUiClient(state)) {
 			state.pendingExtensionUiNotifications ??= [];
 			const pending = state.pendingExtensionUiNotifications;
 			if (pending.length >= MAX_PENDING_EXTENSION_UI_NOTIFICATIONS) {
 				pending.shift();
 			}
 			pending.push(request);
+		} else {
+			broadcast(state, request);
 		}
 		return request.id;
 	};

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1214,7 +1214,7 @@ export class AgentDaemon {
 			pendingAttaches: 0,
 			extensionUiRequests: new Map(),
 			pendingExtensionUiNotifications: [],
-			hasAttachedExtensionUiClient: false,
+			hasCompletedInitialExtensionBind: false,
 			eventGeneration: createActiveSessionId(),
 			lastEventSequence: 0,
 			clientEnv,
@@ -3068,9 +3068,14 @@ export class AgentDaemon {
 		socket.on("drain", () => {
 			client.backpressured = false;
 			if (!client.snapshotStreaming) {
-				void this.catchUpBackpressuredClient(client).catch((error) =>
-					this.log(`could not catch up snapshot client ${client.id}: ${String(error)}`),
-				);
+				void this.catchUpBackpressuredClient(client)
+					.then(() => {
+						for (const activeSessionId of client.attachedActiveSessionIds) {
+							const state = this.sessions.get(activeSessionId);
+							if (state) this.schedulePendingExtensionUiNotifications(state, client);
+						}
+					})
+					.catch((error) => this.log(`could not catch up snapshot client ${client.id}: ${String(error)}`));
 			}
 		});
 	}
@@ -3346,8 +3351,9 @@ export class AgentDaemon {
 					);
 					state.clients.add(client);
 					client.attachedActiveSessionIds.add(state.activeSessionId);
+					// Keep replay inside the supervisor's startup-routing window, which closes on this response.
+					this.replayPendingExtensionUiNotificationsToWorker(state, client);
 					this.write(client, success(command.id, "attach", summaryForActiveSession(state)));
-					this.schedulePendingExtensionUiNotifications(state, client);
 					return;
 				}
 				case "worker_unsubscribe": {
@@ -6048,6 +6054,7 @@ export class AgentDaemon {
 				persistError = error;
 			}
 		}
+		clearPendingExtensionUiNotifications(state);
 		cancelPendingExtensionUiRequests(state);
 		if (reason === "killed" || reason === "shutdown" || reason === "replaced" || reason === "update") {
 			await this.abortBashForClose(state);
@@ -6187,35 +6194,92 @@ export class AgentDaemon {
 		preferredClient: DaemonSocketClient,
 	): void {
 		if (
+			!state.pendingExtensionUiNotifications?.length ||
 			preferredClient.socket.destroyed ||
 			!daemonClientSupportsExtensionUiForSession(preferredClient, state.activeSessionId)
 		) {
 			return;
 		}
-		state.hasAttachedExtensionUiClient = true;
+		const selected = state.pendingExtensionUiNotificationRecipient;
+		if (
+			selected &&
+			(!state.clients.has(selected) ||
+				selected.socket.destroyed ||
+				!daemonClientSupportsExtensionUiForSession(selected, state.activeSessionId))
+		) {
+			state.pendingExtensionUiNotificationRecipient = undefined;
+		}
+		state.pendingExtensionUiNotificationRecipient ??= preferredClient;
+		if (state.pendingExtensionUiNotificationRecipient !== preferredClient) {
+			return;
+		}
 		const session = state.runtime.session;
-		setImmediate(() => {
-			if (this.sessions.get(state.activeSessionId) !== state || state.runtime.session !== session) {
+		setImmediate(() => this.replayPendingExtensionUiNotifications(state, preferredClient, session));
+	}
+
+	private replayPendingExtensionUiNotificationsToWorker(state: ActiveSessionState, client: DaemonSocketClient): void {
+		if (
+			!state.pendingExtensionUiNotifications?.length ||
+			client.socket.destroyed ||
+			!daemonClientSupportsExtensionUiForSession(client, state.activeSessionId)
+		) {
+			return;
+		}
+		state.pendingExtensionUiNotificationRecipient = client;
+		const pending = state.pendingExtensionUiNotifications;
+		while (pending.length > 0) {
+			if (client.socket.destroyed || state.pendingExtensionUiNotificationRecipient !== client) {
 				return;
 			}
-			const client =
-				state.clients.has(preferredClient) &&
-				!preferredClient.socket.destroyed &&
-				daemonClientSupportsExtensionUiForSession(preferredClient, state.activeSessionId)
-					? preferredClient
-					: [...state.clients].find(
-							(candidate) =>
-								!candidate.socket.destroyed &&
-								daemonClientSupportsExtensionUiForSession(candidate, state.activeSessionId),
-						);
-			if (!client) {
-				return;
+			const notification = pending[0]!;
+			this.write(client, this.addSessionEventMeta(state, notification));
+			pending.shift();
+		}
+		state.pendingExtensionUiNotificationRecipient = undefined;
+	}
+
+	private replayPendingExtensionUiNotifications(
+		state: ActiveSessionState,
+		client: DaemonSocketClient,
+		session: ActiveSessionState["runtime"]["session"],
+	): void {
+		if (this.sessions.get(state.activeSessionId) !== state || state.runtime.session !== session) {
+			return;
+		}
+		if (
+			state.pendingExtensionUiNotificationRecipient !== client ||
+			!state.clients.has(client) ||
+			client.socket.destroyed ||
+			!daemonClientSupportsExtensionUiForSession(client, state.activeSessionId)
+		) {
+			if (state.pendingExtensionUiNotificationRecipient === client) {
+				state.pendingExtensionUiNotificationRecipient = undefined;
 			}
-			const pending = state.pendingExtensionUiNotifications?.splice(0) ?? [];
-			for (const notification of pending) {
-				this.write(client, this.addSessionEventMeta(state, notification));
+			const fallback = [...state.clients].find(
+				(candidate) =>
+					!candidate.socket.destroyed &&
+					daemonClientSupportsExtensionUiForSession(candidate, state.activeSessionId),
+			);
+			if (fallback) {
+				this.schedulePendingExtensionUiNotifications(state, fallback);
 			}
-		});
+			return;
+		}
+		if (client.snapshotActiveSessionIds?.has(state.activeSessionId) || client.backpressured === true) {
+			return;
+		}
+		const pending = state.pendingExtensionUiNotifications;
+		while (pending?.length) {
+			const notification = pending[0]!;
+			const accepted = this.write(client, this.addSessionEventMeta(state, notification));
+			pending.shift();
+			if (!accepted) {
+				break;
+			}
+		}
+		if (!pending?.length) {
+			state.pendingExtensionUiNotificationRecipient = undefined;
+		}
 	}
 
 	private beginReplacementSnapshot(
@@ -6688,6 +6752,9 @@ export function detachClientFromActiveSession(client: DaemonSocketClient, state:
 	state.clients.delete(client);
 	client.attachedActiveSessionIds.delete(state.activeSessionId);
 	removeDaemonClientSessionCapabilities(client, state.activeSessionId);
+	if (state.pendingExtensionUiNotificationRecipient === client) {
+		state.pendingExtensionUiNotificationRecipient = undefined;
+	}
 	if (state.clients.size === 0) {
 		cancelPendingExtensionUiRequests(state);
 	}
@@ -6763,12 +6830,16 @@ export function finishClientSnapshotStreaming(client: DaemonSocketClient, active
 }
 
 export function cancelPendingExtensionUiRequests(state: ActiveSessionState): void {
-	state.pendingExtensionUiNotifications = [];
 	const pendingRequests = [...state.extensionUiRequests.values()];
 	state.extensionUiRequests.clear();
 	for (const pending of pendingRequests) {
 		pending.resolve({ cancelled: true });
 	}
+}
+
+function clearPendingExtensionUiNotifications(state: ActiveSessionState): void {
+	state.pendingExtensionUiNotifications = [];
+	state.pendingExtensionUiNotificationRecipient = undefined;
 }
 
 function normalizeClientCapabilities(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -133,6 +133,7 @@ import {
 	AmbiguousActiveSessionError,
 	createActiveSessionId,
 	type DaemonSocketClient,
+	daemonClientSupportsExtensionUiForSession,
 	resolveActiveSessionState,
 } from "./active-session-state.js";
 import { createCompactAssistantDelta } from "./compact-session-stream.js";
@@ -1212,6 +1213,8 @@ export class AgentDaemon {
 			clients: new Set(),
 			pendingAttaches: 0,
 			extensionUiRequests: new Map(),
+			pendingExtensionUiNotifications: [],
+			hasAttachedExtensionUiClient: false,
 			eventGeneration: createActiveSessionId(),
 			lastEventSequence: 0,
 			clientEnv,
@@ -3344,6 +3347,7 @@ export class AgentDaemon {
 					state.clients.add(client);
 					client.attachedActiveSessionIds.add(state.activeSessionId);
 					this.write(client, success(command.id, "attach", summaryForActiveSession(state)));
+					this.schedulePendingExtensionUiNotifications(state, client);
 					return;
 				}
 				case "worker_unsubscribe": {
@@ -3622,14 +3626,9 @@ export class AgentDaemon {
 						},
 					};
 					setImmediate(() => {
-						void this.streamWorkerSnapshot(
-							client,
-							streamedResult,
-							transcript,
-							"attach",
-							snapshotSignal,
-							true,
-						).catch((error) => this.log(`could not stream attach snapshot: ${String(error)}`));
+						void this.streamWorkerSnapshot(client, streamedResult, transcript, "attach", snapshotSignal, true)
+							.then(() => this.schedulePendingExtensionUiNotifications(state, client))
+							.catch((error) => this.log(`could not stream attach snapshot: ${String(error)}`));
 					});
 					return success(command.id, "attach", streamedResult);
 				}
@@ -3647,6 +3646,7 @@ export class AgentDaemon {
 						lastEventSequence: result.lastEventSequence,
 					});
 				}
+				this.schedulePendingExtensionUiNotifications(state, client);
 				return success(command.id, "attach", result);
 			}
 
@@ -6182,6 +6182,42 @@ export class AgentDaemon {
 		}
 	}
 
+	private schedulePendingExtensionUiNotifications(
+		state: ActiveSessionState,
+		preferredClient: DaemonSocketClient,
+	): void {
+		if (
+			preferredClient.socket.destroyed ||
+			!daemonClientSupportsExtensionUiForSession(preferredClient, state.activeSessionId)
+		) {
+			return;
+		}
+		state.hasAttachedExtensionUiClient = true;
+		const session = state.runtime.session;
+		setImmediate(() => {
+			if (this.sessions.get(state.activeSessionId) !== state || state.runtime.session !== session) {
+				return;
+			}
+			const client =
+				state.clients.has(preferredClient) &&
+				!preferredClient.socket.destroyed &&
+				daemonClientSupportsExtensionUiForSession(preferredClient, state.activeSessionId)
+					? preferredClient
+					: [...state.clients].find(
+							(candidate) =>
+								!candidate.socket.destroyed &&
+								daemonClientSupportsExtensionUiForSession(candidate, state.activeSessionId),
+						);
+			if (!client) {
+				return;
+			}
+			const pending = state.pendingExtensionUiNotifications?.splice(0) ?? [];
+			for (const notification of pending) {
+				this.write(client, this.addSessionEventMeta(state, notification));
+			}
+		});
+	}
+
 	private beginReplacementSnapshot(
 		client: DaemonSocketClient,
 		state: ActiveSessionState,
@@ -6683,10 +6719,6 @@ function daemonClientCapabilitiesForSession(
 	return client.capabilitiesByActiveSessionId?.get(activeSessionId) ?? client.capabilities;
 }
 
-function daemonClientSupportsExtensionUi(client: DaemonSocketClient, activeSessionId: string): boolean {
-	return client.capabilitiesByActiveSessionId?.get(activeSessionId)?.has("extension_ui") ?? client.supportsExtensionUi;
-}
-
 export function markClientSnapshotStreaming(client: DaemonSocketClient, activeSessionId: string): AbortSignal {
 	client.snapshotStreaming = true;
 	client.snapshotActiveSessionIds ??= new Set();
@@ -6731,6 +6763,7 @@ export function finishClientSnapshotStreaming(client: DaemonSocketClient, active
 }
 
 export function cancelPendingExtensionUiRequests(state: ActiveSessionState): void {
+	state.pendingExtensionUiNotifications = [];
 	const pendingRequests = [...state.extensionUiRequests.values()];
 	state.extensionUiRequests.clear();
 	for (const pending of pendingRequests) {
@@ -6783,8 +6816,8 @@ function isSequencedSessionOutbound(message: DaemonOutbound): message is Sequenc
 export function shouldSendDaemonOutboundToClient(client: DaemonSocketClient, message: DaemonOutbound): boolean {
 	return (
 		message.type !== "extension_ui_request" ||
-		!isDaemonDialogExtensionUiRequest(message.method) ||
-		daemonClientSupportsExtensionUi(client, message.activeSessionId)
+		(!isDaemonDialogExtensionUiRequest(message.method) && message.method !== "notify") ||
+		daemonClientSupportsExtensionUiForSession(client, message.activeSessionId)
 	);
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1449,24 +1449,28 @@ export class DaemonSupervisor {
 					const streamedResult = this.createStreamedAttachResult(attached.result, transcript);
 					try {
 						this.write(client, success(command.id, "attach", streamedResult));
-						void this.streamSnapshot(
+						const streaming = this.streamSnapshot(
 							client,
 							attached.worker,
 							streamedResult,
 							transcript,
 							"attach",
 							attached.releaseTranscript,
-						).catch((error) =>
-							this.log(
-								`Failed to stream attach snapshot for ${streamedResult.activeSessionId}: ${String(error)}`,
-							),
 						);
+						void streaming
+							.then(() => this.syncWorkerExtensionUi(streamedResult.activeSessionId))
+							.catch((error) =>
+								this.log(
+									`Failed to stream attach snapshot for ${streamedResult.activeSessionId}: ${String(error)}`,
+								),
+							);
 					} catch (error) {
 						attached.releaseTranscript?.();
 						throw error;
 					}
 					return undefined;
 				}
+				setImmediate(() => void this.syncWorkerExtensionUi(attached.result.activeSessionId));
 				return success(command.id, "attach", attached.result);
 			}
 			case "reattach": {
@@ -1502,14 +1506,17 @@ export class DaemonSupervisor {
 							releaseSnapshotReservation,
 						);
 						releaseTranscript = undefined;
-						void streaming.catch((error) =>
-							this.log(`Failed to stream reattach snapshot for ${targetActiveSessionId}: ${String(error)}`),
-						);
+						void streaming
+							.then(() => this.syncWorkerExtensionUi(targetActiveSessionId))
+							.catch((error) =>
+								this.log(`Failed to stream reattach snapshot for ${targetActiveSessionId}: ${String(error)}`),
+							);
 						return undefined;
 					}
 					this.write(client, success(command.id, command.type, attached.result));
 					this.detachClient(client, command.activeSessionId);
 					releaseSnapshotReservation();
+					setImmediate(() => void this.syncWorkerExtensionUi(targetActiveSessionId));
 					return undefined;
 				} catch (error) {
 					releaseTranscript?.();
@@ -2358,7 +2365,10 @@ export class DaemonSupervisor {
 			throw new Error("Session worker is not connected");
 		}
 		const supportsExtensionUi = [...this.clients].some(
-			(client) => client.attachedActiveSessionIds.has(activeSessionId) && client.supportsExtensionUi,
+			(client) =>
+				!client.socket.destroyed &&
+				client.attachedActiveSessionIds.has(activeSessionId) &&
+				client.supportsExtensionUi,
 		);
 		const response = await worker.client.requestWorker({
 			type: "worker_subscribe",
@@ -3415,7 +3425,6 @@ export class DaemonSupervisor {
 					lastEventSequence: publicResult.lastEventSequence,
 				});
 			}
-			void this.syncWorkerExtensionUi(activeSessionId);
 			return { result: publicResult, worker: match.worker, transcript, releaseTranscript };
 		} catch (error) {
 			releaseTranscript?.();
@@ -4271,6 +4280,7 @@ export class DaemonSupervisor {
 						releaseTranscript,
 					);
 					releaseTranscript = undefined;
+					await this.syncWorkerExtensionUi(activeSessionId);
 					continue;
 				}
 				const meta = createDaemonEventMeta(
@@ -4300,6 +4310,7 @@ export class DaemonSupervisor {
 					}
 					return;
 				}
+				await this.syncWorkerExtensionUi(activeSessionId);
 			} catch (error) {
 				releaseTranscript?.();
 				this.log(`Failed to catch up client ${client.id} for ${activeSessionId}: ${String(error)}`);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -140,6 +140,7 @@ const IDLE_EVICTION_MAX_SWEEP_INTERVAL_MS = 5 * 60_000;
 const IDLE_EVICTION_MIN_SWEEP_INTERVAL_MS = 60_000;
 const IDLE_EVICTION_DRAIN_TIMEOUT_MS = 5_000;
 const CHILD_PASSIVATION_PER_WORKER_CAP = 2;
+const MAX_PENDING_STARTUP_NOTIFICATION_FRAMES = 100;
 const SUPERVISOR_CONFIG_FILE_NAME = "supervisor-config";
 const WORKER_STARTUP_GATE_FD = 3;
 
@@ -590,6 +591,11 @@ export class DaemonSupervisor {
 	private updateRestartPhase?: "draining" | "fencing" | "prepared";
 	private readonly mutationDrain = new MutationDrainLatch();
 	private readonly clients = new Set<DaemonSocketClient>();
+	private startupNotificationRecipients?: Map<string, DaemonSocketClient>;
+	/** Sessions whose worker subscription is synchronously releasing retained startup notifications. */
+	private startupNotificationRoutingSessions?: Set<string>;
+	private pendingStartupNotificationFrames?: Map<string, Buffer[]>;
+	private workerExtensionUiSyncs?: Map<string, Promise<void>>;
 	private readonly protocolClientIds = new WeakMap<DaemonSocketClient, string>();
 	private readonly workers = new Map<string, ResidentWorker>();
 	private readonly openingWorkers = new Map<string, Promise<ResidentWorker>>();
@@ -1060,9 +1066,15 @@ export class DaemonSupervisor {
 		socket.on("drain", () => {
 			client.backpressured = false;
 			if (!client.snapshotStreaming) {
-				void this.catchUpClient(client).catch((error) =>
-					this.log(`Failed to catch up client ${client.id}: ${String(error)}`),
-				);
+				void this.catchUpClient(client)
+					.then(() =>
+						Promise.all(
+							[...client.attachedActiveSessionIds].map((activeSessionId) =>
+								this.syncWorkerExtensionUi(activeSessionId, client),
+							),
+						),
+					)
+					.catch((error) => this.log(`Failed to catch up client ${client.id}: ${String(error)}`));
 			}
 		});
 	}
@@ -1458,7 +1470,7 @@ export class DaemonSupervisor {
 							attached.releaseTranscript,
 						);
 						void streaming
-							.then(() => this.syncWorkerExtensionUi(streamedResult.activeSessionId))
+							.then(() => this.syncWorkerExtensionUi(streamedResult.activeSessionId, client))
 							.catch((error) =>
 								this.log(
 									`Failed to stream attach snapshot for ${streamedResult.activeSessionId}: ${String(error)}`,
@@ -1470,7 +1482,7 @@ export class DaemonSupervisor {
 					}
 					return undefined;
 				}
-				setImmediate(() => void this.syncWorkerExtensionUi(attached.result.activeSessionId));
+				setImmediate(() => void this.syncWorkerExtensionUi(attached.result.activeSessionId, client));
 				return success(command.id, "attach", attached.result);
 			}
 			case "reattach": {
@@ -1507,7 +1519,7 @@ export class DaemonSupervisor {
 						);
 						releaseTranscript = undefined;
 						void streaming
-							.then(() => this.syncWorkerExtensionUi(targetActiveSessionId))
+							.then(() => this.syncWorkerExtensionUi(targetActiveSessionId, client))
 							.catch((error) =>
 								this.log(`Failed to stream reattach snapshot for ${targetActiveSessionId}: ${String(error)}`),
 							);
@@ -1516,7 +1528,7 @@ export class DaemonSupervisor {
 					this.write(client, success(command.id, command.type, attached.result));
 					this.detachClient(client, command.activeSessionId);
 					releaseSnapshotReservation();
-					setImmediate(() => void this.syncWorkerExtensionUi(targetActiveSessionId));
+					setImmediate(() => void this.syncWorkerExtensionUi(targetActiveSessionId, client));
 					return undefined;
 				} catch (error) {
 					releaseTranscript?.();
@@ -2360,26 +2372,43 @@ export class DaemonSupervisor {
 		throw new Error(`Timed out connecting to daemon session worker: ${String(lastError)}`);
 	}
 
-	private async subscribeWorker(worker: ResidentWorker, activeSessionId: string): Promise<void> {
+	private async subscribeWorker(
+		worker: ResidentWorker,
+		activeSessionId: string,
+		preferredRecipient?: DaemonSocketClient,
+	): Promise<void> {
 		if (!worker.client) {
 			throw new Error("Session worker is not connected");
 		}
-		const supportsExtensionUi = [...this.clients].some(
-			(client) =>
-				!client.socket.destroyed &&
-				client.attachedActiveSessionIds.has(activeSessionId) &&
-				client.supportsExtensionUi,
-		);
-		const response = await worker.client.requestWorker({
-			type: "worker_subscribe",
-			activeSessionId,
-			capabilities: supportsExtensionUi
-				? ["attach_snapshot", "event_sequence", "extension_ui", "slim_attach", "chunked_snapshot"]
-				: ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"],
-			supportsExtensionUi,
-		});
-		if (!response.success) {
-			throw new Error(response.error);
+		const recipient = this.selectStartupNotificationRecipient(activeSessionId, preferredRecipient);
+		this.replayBufferedStartupNotifications(activeSessionId);
+		const pendingFrames = this.getPendingStartupNotificationFrames();
+		const routingSessions = this.getStartupNotificationRoutingSessions();
+		const hasBufferedNotifications = (pendingFrames.get(activeSessionId)?.length ?? 0) > 0;
+		const supportsExtensionUi =
+			!hasBufferedNotifications &&
+			recipient !== undefined &&
+			this.isStartupNotificationRecipientReady(recipient, activeSessionId);
+		if (supportsExtensionUi) {
+			routingSessions.add(activeSessionId);
+		}
+		try {
+			const response = await worker.client.requestWorker({
+				type: "worker_subscribe",
+				activeSessionId,
+				capabilities: supportsExtensionUi
+					? ["attach_snapshot", "event_sequence", "extension_ui", "slim_attach", "chunked_snapshot"]
+					: ["attach_snapshot", "event_sequence", "slim_attach", "chunked_snapshot"],
+				supportsExtensionUi,
+			});
+			if (!response.success) {
+				throw new Error(response.error);
+			}
+		} finally {
+			routingSessions.delete(activeSessionId);
+			if ((pendingFrames.get(activeSessionId)?.length ?? 0) === 0) {
+				this.getStartupNotificationRecipients().delete(activeSessionId);
+			}
 		}
 	}
 
@@ -3722,14 +3751,134 @@ export class DaemonSupervisor {
 		}
 	}
 
-	private async syncWorkerExtensionUi(activeSessionId: string): Promise<void> {
+	private syncWorkerExtensionUi(activeSessionId: string, preferredRecipient?: DaemonSocketClient): Promise<void> {
+		const syncs = this.getWorkerExtensionUiSyncs();
+		const previous = syncs.get(activeSessionId) ?? Promise.resolve();
+		const sync = previous
+			.catch(() => undefined)
+			.then(() => this.syncWorkerExtensionUiNow(activeSessionId, preferredRecipient));
+		syncs.set(activeSessionId, sync);
+		return sync.finally(() => {
+			if (syncs.get(activeSessionId) === sync) {
+				syncs.delete(activeSessionId);
+			}
+		});
+	}
+
+	private getStartupNotificationRecipients(): Map<string, DaemonSocketClient> {
+		this.startupNotificationRecipients ??= new Map();
+		return this.startupNotificationRecipients;
+	}
+
+	private getStartupNotificationRoutingSessions(): Set<string> {
+		this.startupNotificationRoutingSessions ??= new Set();
+		return this.startupNotificationRoutingSessions;
+	}
+
+	private getPendingStartupNotificationFrames(): Map<string, Buffer[]> {
+		this.pendingStartupNotificationFrames ??= new Map();
+		return this.pendingStartupNotificationFrames;
+	}
+
+	private getWorkerExtensionUiSyncs(): Map<string, Promise<void>> {
+		this.workerExtensionUiSyncs ??= new Map();
+		return this.workerExtensionUiSyncs;
+	}
+
+	private clearStartupNotificationState(activeSessionId: string): void {
+		this.startupNotificationRecipients?.delete(activeSessionId);
+		this.startupNotificationRoutingSessions?.delete(activeSessionId);
+		this.pendingStartupNotificationFrames?.delete(activeSessionId);
+		this.workerExtensionUiSyncs?.delete(activeSessionId);
+	}
+
+	private async syncWorkerExtensionUiNow(
+		activeSessionId: string,
+		preferredRecipient?: DaemonSocketClient,
+	): Promise<void> {
 		const match = this.matchWorkers(activeSessionId)[0];
 		if (!match?.worker.client) {
 			return;
 		}
-		await this.subscribeWorker(match.worker, match.summary.activeSessionId ?? match.summary.id).catch(
-			() => undefined,
+		const resolvedId = match.summary.activeSessionId ?? match.summary.id;
+		await this.subscribeWorker(match.worker, resolvedId, preferredRecipient).catch(() => undefined);
+	}
+
+	private selectStartupNotificationRecipient(
+		activeSessionId: string,
+		preferredRecipient?: DaemonSocketClient,
+	): DaemonSocketClient | undefined {
+		const recipients = this.getStartupNotificationRecipients();
+		const selected = recipients.get(activeSessionId);
+		if (selected && this.isStartupNotificationRecipientEligible(selected, activeSessionId)) {
+			return selected;
+		}
+		recipients.delete(activeSessionId);
+		const recipient =
+			preferredRecipient && this.isStartupNotificationRecipientEligible(preferredRecipient, activeSessionId)
+				? preferredRecipient
+				: [...this.clients].find((client) => this.isStartupNotificationRecipientEligible(client, activeSessionId));
+		if (recipient) {
+			recipients.set(activeSessionId, recipient);
+		}
+		return recipient;
+	}
+
+	private isStartupNotificationRecipientEligible(client: DaemonSocketClient, activeSessionId: string): boolean {
+		return (
+			this.clients.has(client) &&
+			!client.socket.destroyed &&
+			client.attachedActiveSessionIds.has(activeSessionId) &&
+			client.supportsExtensionUi
 		);
+	}
+
+	private isStartupNotificationRecipientReady(client: DaemonSocketClient, activeSessionId: string): boolean {
+		return (
+			this.isStartupNotificationRecipientEligible(client, activeSessionId) &&
+			!client.snapshotActiveSessionIds?.has(activeSessionId) &&
+			client.backpressured !== true
+		);
+	}
+
+	private replayBufferedStartupNotifications(activeSessionId: string): void {
+		const pendingFrames = this.getPendingStartupNotificationFrames();
+		const pending = pendingFrames.get(activeSessionId);
+		if (!pending?.length) {
+			return;
+		}
+		const recipient = this.selectStartupNotificationRecipient(activeSessionId);
+		if (!recipient || !this.isStartupNotificationRecipientReady(recipient, activeSessionId)) {
+			return;
+		}
+		while (pending.length > 0) {
+			const accepted = this.writeSerialized(recipient, pending[0]!);
+			pending.shift();
+			if (!accepted) {
+				break;
+			}
+		}
+		if (pending.length === 0) {
+			pendingFrames.delete(activeSessionId);
+		}
+	}
+
+	private routeStartupNotification(activeSessionId: string, payload: Buffer): void {
+		const pendingFrames = this.getPendingStartupNotificationFrames();
+		const recipient = this.selectStartupNotificationRecipient(activeSessionId);
+		if (recipient && this.isStartupNotificationRecipientReady(recipient, activeSessionId)) {
+			this.writeSerialized(recipient, payload);
+			return;
+		}
+		let pending = pendingFrames.get(activeSessionId);
+		if (!pending) {
+			pending = [];
+			pendingFrames.set(activeSessionId, pending);
+		}
+		if (pending.length >= MAX_PENDING_STARTUP_NOTIFICATION_FRAMES) {
+			pending.shift();
+		}
+		pending.push(Buffer.from(payload));
 	}
 
 	private handleWorkerFrame(worker: ResidentWorker, frame: PrivateFrame<DaemonWorkerFrameHeader>): void {
@@ -4092,6 +4241,7 @@ export class DaemonSupervisor {
 		} else if (
 			sessionEventType === "message_start" ||
 			sessionEventType === "message_end" ||
+			outboundType === "extension_ui_request" ||
 			outboundType === "session_replaced" ||
 			outboundType === "session_resynced" ||
 			outboundType === "session_closed"
@@ -4105,6 +4255,14 @@ export class DaemonSupervisor {
 		}
 		const replacementSnapshotFollows =
 			decodedOutbound?.type === "session_replaced" && decodedOutbound.snapshotFollows === true;
+		if (
+			decodedOutbound?.type === "extension_ui_request" &&
+			decodedOutbound.method === "notify" &&
+			this.getStartupNotificationRoutingSessions().has(activeSessionId)
+		) {
+			this.routeStartupNotification(activeSessionId, publicPayload);
+			return;
+		}
 		this.invalidateWorkerSnapshot(
 			worker,
 			activeSessionId,
@@ -4131,6 +4289,9 @@ export class DaemonSupervisor {
 				continue;
 			}
 			this.writeSerialized(client, publicPayload);
+		}
+		if (decodedOutbound?.type === "session_closed" || decodedOutbound?.type === "session_replaced") {
+			this.clearStartupNotificationState(activeSessionId);
 		}
 		if (outboundType === "session_replaced" || outboundType === "session_closed") {
 			void this.refreshWorkerSummaries(worker)
@@ -4280,7 +4441,7 @@ export class DaemonSupervisor {
 						releaseTranscript,
 					);
 					releaseTranscript = undefined;
-					await this.syncWorkerExtensionUi(activeSessionId);
+					await this.syncWorkerExtensionUi(activeSessionId, client);
 					continue;
 				}
 				const meta = createDaemonEventMeta(
@@ -4310,7 +4471,7 @@ export class DaemonSupervisor {
 					}
 					return;
 				}
-				await this.syncWorkerExtensionUi(activeSessionId);
+				await this.syncWorkerExtensionUi(activeSessionId, client);
 			} catch (error) {
 				releaseTranscript?.();
 				this.log(`Failed to catch up client ${client.id} for ${activeSessionId}: ${String(error)}`);
@@ -4611,6 +4772,10 @@ export class DaemonSupervisor {
 		}
 		this.workers.delete(worker.descriptor.workerId);
 		if (removeDescriptor) {
+			for (const summary of worker.summaries.values()) {
+				this.clearStartupNotificationState(summary.activeSessionId ?? summary.id);
+			}
+			this.clearStartupNotificationState(worker.descriptor.rootActiveSessionId);
 			this.deleteWorkerDescriptor(worker);
 		}
 		if (!this.shuttingDown) {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4054,7 +4054,7 @@ describe("daemon mode helpers", () => {
 				...dialogRequest,
 				method: "notify",
 			}),
-		).toBe(true);
+		).toBe(false);
 
 		setDaemonClientSessionCapabilities(uiClient, "active", new Set(["extension_ui"]));
 		setDaemonClientSessionCapabilities(uiClient, "other", new Set());

--- a/packages/coding-agent/test/suite/regressions/1032-session-start-notification.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1032-session-start-notification.test.ts
@@ -1,0 +1,367 @@
+import type { Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionRuntime } from "../../../src/core/agent-session-runtime.js";
+import type { ActiveSessionState, DaemonSocketClient } from "../../../src/modes/daemon/active-session-state.js";
+import {
+	bindActiveSessionState,
+	MAX_PENDING_EXTENSION_UI_NOTIFICATIONS,
+} from "../../../src/modes/daemon/daemon-extension-binding.js";
+import { AgentDaemon, cancelPendingExtensionUiRequests } from "../../../src/modes/daemon/daemon-mode.js";
+import {
+	DAEMON_PROTOCOL_INFO,
+	type DaemonAttachResult,
+	type DaemonCommand,
+	type DaemonOutbound,
+	type DaemonResponse,
+} from "../../../src/modes/daemon/daemon-protocol.js";
+import { DaemonSupervisor } from "../../../src/modes/daemon/daemon-supervisor.js";
+import type { DaemonWorkerCommand } from "../../../src/modes/daemon/daemon-worker-protocol.js";
+import { createHarness, type Harness } from "../harness.js";
+
+interface DaemonInternals {
+	sessions: Map<string, ActiveSessionState>;
+	broadcastToSession(state: ActiveSessionState, message: DaemonOutbound): void;
+	createAttachResult(
+		client: DaemonSocketClient,
+		state: ActiveSessionState,
+		command: Extract<DaemonCommand, { type: "attach" }>,
+	): Promise<DaemonAttachResult>;
+	handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<DaemonResponse | undefined>;
+	handleWorkerCommand(client: DaemonSocketClient, command: DaemonWorkerCommand): Promise<void>;
+}
+
+interface SupervisorInternals {
+	handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<DaemonResponse | undefined>;
+}
+
+const harnesses: Harness[] = [];
+
+afterEach(() => {
+	while (harnesses.length > 0) {
+		harnesses.pop()?.cleanup();
+	}
+});
+
+describe("Issue #1032 daemon session_start notifications", () => {
+	it("delivers startup notifications once to the first extension-UI client", async () => {
+		let notifyAfterAttach: (() => void) | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", async (_event, ctx) => {
+						ctx.ui.notify("startup one");
+						expect(await ctx.ui.confirm("Confirm", "Continue?")).toBe(false);
+						expect(await ctx.ui.select("Select", ["one", "two"])).toBeUndefined();
+						expect(await ctx.ui.input("Input", "value")).toBeUndefined();
+						ctx.ui.notify("startup two", "warning");
+						notifyAfterAttach = () => ctx.ui.notify("attached notification");
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const internals = daemon as unknown as DaemonInternals;
+		internals.sessions.set(state.activeSessionId, state);
+		stubAttachResult(internals, state);
+
+		await bindActiveSessionState(state, {
+			broadcast: (targetState, message) => internals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		});
+
+		const incapable = createClient("incapable");
+		await attach(internals, incapable.client, state.activeSessionId, false);
+		await waitForImmediate();
+		expect(extensionUiRequests(incapable.outbound)).toEqual([]);
+
+		const first = createClient("first");
+		await attach(internals, first.client, state.activeSessionId, true);
+		await waitForImmediate();
+
+		expect(extensionUiRequests(first.outbound)).toEqual([
+			expect.objectContaining({ method: "notify", payload: { message: "startup one" } }),
+			expect.objectContaining({
+				method: "notify",
+				payload: { message: "startup two", notifyType: "warning" },
+			}),
+		]);
+
+		const second = createClient("second");
+		await attach(internals, second.client, state.activeSessionId, true);
+		await waitForImmediate();
+		expect(extensionUiRequests(second.outbound)).toEqual([]);
+
+		notifyAfterAttach?.();
+		expect(extensionUiRequests(first.outbound).at(-1)).toMatchObject({
+			method: "notify",
+			payload: { message: "attached notification" },
+		});
+		expect(extensionUiRequests(second.outbound).at(-1)).toMatchObject({
+			method: "notify",
+			payload: { message: "attached notification" },
+		});
+		expect(extensionUiRequests(incapable.outbound)).toEqual([]);
+	});
+
+	it("drops pending notifications when the session closes", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => ctx.ui.notify("do not leak"));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const internals = daemon as unknown as DaemonInternals;
+		internals.sessions.set(state.activeSessionId, state);
+		stubAttachResult(internals, state);
+		await bindActiveSessionState(state, {
+			broadcast: (targetState, message) => internals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		});
+
+		cancelPendingExtensionUiRequests(state);
+		const client = createClient("after-close");
+		await attach(internals, client.client, state.activeSessionId, true);
+		await waitForImmediate();
+
+		expect(extensionUiRequests(client.outbound)).toEqual([]);
+	});
+
+	it("does not leak notifications across a session rebind", async () => {
+		let startCount = 0;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => {
+						startCount++;
+						ctx.ui.notify(`startup ${startCount}`);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const internals = daemon as unknown as DaemonInternals;
+		internals.sessions.set(state.activeSessionId, state);
+		stubAttachResult(internals, state);
+		const callbacks = {
+			broadcast: (targetState: ActiveSessionState, message: DaemonOutbound) =>
+				internals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		};
+
+		await bindActiveSessionState(state, callbacks);
+		await bindActiveSessionState(state, callbacks);
+		const client = createClient("after-rebind");
+		await attach(internals, client.client, state.activeSessionId, true);
+		await waitForImmediate();
+
+		expect(extensionUiRequests(client.outbound).map((message) => message.payload.message)).toEqual(["startup 2"]);
+	});
+
+	it("bounds pending startup notifications and preserves retained order", async () => {
+		const notificationCount = MAX_PENDING_EXTENSION_UI_NOTIFICATIONS + 3;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => {
+						for (let index = 0; index < notificationCount; index++) {
+							ctx.ui.notify(`startup ${index}`);
+						}
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const internals = daemon as unknown as DaemonInternals;
+		internals.sessions.set(state.activeSessionId, state);
+		stubAttachResult(internals, state);
+		await bindActiveSessionState(state, {
+			broadcast: (targetState, message) => internals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		});
+
+		const client = createClient("bounded");
+		await attach(internals, client.client, state.activeSessionId, true);
+		await waitForImmediate();
+		const messages = extensionUiRequests(client.outbound).map((message) => message.payload.message);
+
+		expect(messages).toHaveLength(MAX_PENDING_EXTENSION_UI_NOTIFICATIONS);
+		expect(messages[0]).toBe("startup 3");
+		expect(messages.at(-1)).toBe(`startup ${notificationCount - 1}`);
+	});
+
+	it("replays through worker subscription when the supervisor enables extension UI", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => ctx.ui.notify("worker startup"));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const internals = daemon as unknown as DaemonInternals;
+		internals.sessions.set(state.activeSessionId, state);
+		await bindActiveSessionState(state, {
+			broadcast: (targetState, message) => internals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		});
+		const workerClient = createClient("supervisor-worker");
+
+		await internals.handleWorkerCommand(workerClient.client, {
+			type: "worker_subscribe",
+			activeSessionId: state.activeSessionId,
+			capabilities: ["extension_ui"],
+			supportsExtensionUi: true,
+		});
+		await waitForImmediate();
+
+		expect(extensionUiRequests(workerClient.outbound)).toEqual([
+			expect.objectContaining({ method: "notify", payload: { message: "worker startup" } }),
+		]);
+	});
+
+	it("enables worker extension UI only after a chunked public snapshot completes", async () => {
+		let finishSnapshot: () => void = () => {};
+		const snapshot = new Promise<void>((resolve) => {
+			finishSnapshot = resolve;
+		});
+		const syncWorkerExtensionUi = vi.fn(async () => {});
+		const attachResult = {
+			activeSessionId: "active-1032",
+			snapshot: { messages: [] },
+		} as unknown as DaemonAttachResult;
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			attachClient: vi.fn(async () => ({
+				result: attachResult,
+				worker: {},
+				transcript: {},
+			})),
+			createStreamedAttachResult: vi.fn(() => attachResult),
+			streamSnapshot: vi.fn(() => snapshot),
+			syncWorkerExtensionUi,
+			write: vi.fn(() => true),
+			log: vi.fn(),
+		}) as unknown as SupervisorInternals;
+		const client = createClient("public-client").client;
+		client.capabilities.add("chunked_snapshot");
+
+		await supervisor.handleCommand(client, {
+			type: "attach",
+			activeSessionId: "active-1032",
+			capabilities: ["extension_ui", "chunked_snapshot"],
+			supportsExtensionUi: true,
+		});
+		expect(syncWorkerExtensionUi).not.toHaveBeenCalled();
+
+		finishSnapshot();
+		await snapshot;
+		await waitForImmediate();
+		expect(syncWorkerExtensionUi).toHaveBeenCalledOnce();
+		expect(syncWorkerExtensionUi).toHaveBeenCalledWith("active-1032");
+	});
+});
+
+function createState(harness: Harness): ActiveSessionState {
+	const runtime = {
+		session: harness.session,
+		cwd: harness.tempDir,
+		metadata: { kind: "top-level", createdAt: Date.now() },
+		diagnostics: [],
+		setRuntimeEnvScope: vi.fn(),
+		setSubagentRuntimeHost: vi.fn(),
+		setRebindSession: vi.fn(),
+	} as unknown as AgentSessionRuntime;
+	return {
+		activeSessionId: "active-1032",
+		runtime,
+		clients: new Set(),
+		pendingAttaches: 0,
+		extensionUiRequests: new Map(),
+		eventGeneration: "generation-1032",
+		lastEventSequence: 0,
+	};
+}
+
+function createDaemon(harness: Harness): AgentDaemon {
+	return new AgentDaemon(`${harness.tempDir}/daemon.sock`, {
+		defaultSessionConfig: { agentDir: harness.tempDir, cwd: harness.tempDir },
+		createRuntime: async () => {
+			throw new Error("Unexpected runtime creation");
+		},
+	});
+}
+
+function stubAttachResult(internals: DaemonInternals, state: ActiveSessionState): void {
+	internals.createAttachResult = vi.fn(async (client) => {
+		return {
+			protocol: DAEMON_PROTOCOL_INFO,
+			activeSessionId: state.activeSessionId,
+			snapshot: {},
+			replay: { status: "complete", toSequence: state.lastEventSequence },
+			lastEventSequence: state.lastEventSequence,
+			client: { id: client.id, capabilities: [...client.capabilities] },
+		} as unknown as DaemonAttachResult;
+	});
+}
+
+function createClient(id: string): { client: DaemonSocketClient; outbound: DaemonOutbound[] } {
+	const outbound: DaemonOutbound[] = [];
+	const socket = {
+		destroyed: false,
+		write(data: string | Uint8Array) {
+			outbound.push(JSON.parse(String(data)) as DaemonOutbound);
+			return true;
+		},
+	} as unknown as Socket;
+	return {
+		client: {
+			id,
+			socket,
+			attachedActiveSessionIds: new Set(),
+			detachInput: () => {},
+			supportsExtensionUi: false,
+			capabilities: new Set(),
+			transport: "jsonl",
+		},
+		outbound,
+	};
+}
+
+async function attach(
+	internals: DaemonInternals,
+	client: DaemonSocketClient,
+	activeSessionId: string,
+	supportsExtensionUi: boolean,
+): Promise<void> {
+	await internals.handleCommand(client, {
+		type: "attach",
+		activeSessionId,
+		supportsExtensionUi,
+		capabilities: supportsExtensionUi ? ["extension_ui"] : [],
+	});
+}
+
+function extensionUiRequests(
+	outbound: DaemonOutbound[],
+): Array<Extract<DaemonOutbound, { type: "extension_ui_request" }>> {
+	return outbound.filter(
+		(message): message is Extract<DaemonOutbound, { type: "extension_ui_request" }> =>
+			message.type === "extension_ui_request",
+	);
+}
+
+function waitForImmediate(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}

--- a/packages/coding-agent/test/suite/regressions/1032-session-start-notification.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1032-session-start-notification.test.ts
@@ -6,7 +6,7 @@ import {
 	bindActiveSessionState,
 	MAX_PENDING_EXTENSION_UI_NOTIFICATIONS,
 } from "../../../src/modes/daemon/daemon-extension-binding.js";
-import { AgentDaemon, cancelPendingExtensionUiRequests } from "../../../src/modes/daemon/daemon-mode.js";
+import { AgentDaemon, detachClientFromActiveSession } from "../../../src/modes/daemon/daemon-mode.js";
 import {
 	DAEMON_PROTOCOL_INFO,
 	type DaemonAttachResult,
@@ -15,7 +15,12 @@ import {
 	type DaemonResponse,
 } from "../../../src/modes/daemon/daemon-protocol.js";
 import { DaemonSupervisor } from "../../../src/modes/daemon/daemon-supervisor.js";
-import type { DaemonWorkerCommand } from "../../../src/modes/daemon/daemon-worker-protocol.js";
+import {
+	type DaemonWorkerCommand,
+	type DaemonWorkerFrameHeader,
+	isDaemonWorkerFrameHeader,
+} from "../../../src/modes/daemon/daemon-worker-protocol.js";
+import { PrivateFrameDecoder } from "../../../src/modes/session-worker/private-framing.js";
 import { createHarness, type Harness } from "../harness.js";
 
 interface DaemonInternals {
@@ -28,10 +33,13 @@ interface DaemonInternals {
 	): Promise<DaemonAttachResult>;
 	handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<DaemonResponse | undefined>;
 	handleWorkerCommand(client: DaemonSocketClient, command: DaemonWorkerCommand): Promise<void>;
+	closeSession(state: ActiveSessionState, reason: "killed"): Promise<void>;
+	schedulePendingExtensionUiNotifications(state: ActiveSessionState, client: DaemonSocketClient): void;
 }
 
 interface SupervisorInternals {
 	handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<DaemonResponse | undefined>;
+	handleWorkerFrame(worker: unknown, frame: { header: DaemonWorkerFrameHeader; payload: Buffer }): void;
 }
 
 const harnesses: Harness[] = [];
@@ -78,7 +86,9 @@ describe("Issue #1032 daemon session_start notifications", () => {
 		expect(extensionUiRequests(incapable.outbound)).toEqual([]);
 
 		const first = createClient("first");
+		const second = createClient("second");
 		await attach(internals, first.client, state.activeSessionId, true);
+		await attach(internals, second.client, state.activeSessionId, true);
 		await waitForImmediate();
 
 		expect(extensionUiRequests(first.outbound)).toEqual([
@@ -89,9 +99,6 @@ describe("Issue #1032 daemon session_start notifications", () => {
 			}),
 		]);
 
-		const second = createClient("second");
-		await attach(internals, second.client, state.activeSessionId, true);
-		await waitForImmediate();
 		expect(extensionUiRequests(second.outbound)).toEqual([]);
 
 		notifyAfterAttach?.();
@@ -104,6 +111,148 @@ describe("Issue #1032 daemon session_start notifications", () => {
 			payload: { message: "attached notification" },
 		});
 		expect(extensionUiRequests(incapable.outbound)).toEqual([]);
+	});
+
+	it("retains startup notifications across an incapable client's detach", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => ctx.ui.notify("survives detach"));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const internals = daemon as unknown as DaemonInternals;
+		internals.sessions.set(state.activeSessionId, state);
+		stubAttachResult(internals, state);
+		await bindActiveSessionState(state, {
+			broadcast: (targetState, message) => internals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		});
+
+		const incapable = createClient("incapable-detach");
+		await attach(internals, incapable.client, state.activeSessionId, false);
+		detachClientFromActiveSession(incapable.client, state);
+
+		const first = createClient("first-capable");
+		await attach(internals, first.client, state.activeSessionId, true);
+		await waitForImmediate();
+		expect(extensionUiRequests(first.outbound)).toEqual([
+			expect.objectContaining({ method: "notify", payload: { message: "survives detach" } }),
+		]);
+
+		const second = createClient("second-capable");
+		await attach(internals, second.client, state.activeSessionId, true);
+		await waitForImmediate();
+		expect(extensionUiRequests(second.outbound)).toEqual([]);
+	});
+
+	it("reselects a recipient if the first capable client disconnects before replay", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => ctx.ui.notify("recipient fallback"));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const internals = daemon as unknown as DaemonInternals;
+		internals.sessions.set(state.activeSessionId, state);
+		stubAttachResult(internals, state);
+		await bindActiveSessionState(state, {
+			broadcast: (targetState, message) => internals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		});
+
+		const disconnected = createClient("disconnected-recipient");
+		await attach(internals, disconnected.client, state.activeSessionId, true);
+		detachClientFromActiveSession(disconnected.client, state);
+		(disconnected.client.socket as unknown as { destroyed: boolean }).destroyed = true;
+
+		const fallback = createClient("fallback-recipient");
+		await attach(internals, fallback.client, state.activeSessionId, true);
+		await waitForImmediate();
+
+		expect(extensionUiRequests(disconnected.outbound)).toEqual([]);
+		expect(extensionUiRequests(fallback.outbound)).toEqual([
+			expect.objectContaining({ method: "notify", payload: { message: "recipient fallback" } }),
+		]);
+	});
+
+	it("keeps undelivered notifications while the selected client is backpressured", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => {
+						ctx.ui.notify("backpressure one");
+						ctx.ui.notify("backpressure two");
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const internals = daemon as unknown as DaemonInternals;
+		internals.sessions.set(state.activeSessionId, state);
+		stubAttachResult(internals, state);
+		await bindActiveSessionState(state, {
+			broadcast: (targetState, message) => internals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		});
+
+		const client = createClient("backpressured-recipient");
+		client.client.backpressured = true;
+		await attach(internals, client.client, state.activeSessionId, true);
+		await waitForImmediate();
+		expect(extensionUiRequests(client.outbound)).toEqual([]);
+		expect(state.pendingExtensionUiNotifications).toHaveLength(2);
+
+		client.client.backpressured = false;
+		internals.schedulePendingExtensionUiNotifications(state, client.client);
+		await waitForImmediate();
+		expect(extensionUiRequests(client.outbound).map((message) => message.payload.message)).toEqual([
+			"backpressure one",
+			"backpressure two",
+		]);
+		expect(state.pendingExtensionUiNotifications).toEqual([]);
+	});
+
+	it("does not replay notifications emitted after the initial bind", async () => {
+		let notifyLater: (() => void) | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => {
+						ctx.ui.notify("initial startup");
+						notifyLater = () => ctx.ui.notify("later background failure");
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const internals = daemon as unknown as DaemonInternals;
+		internals.sessions.set(state.activeSessionId, state);
+		stubAttachResult(internals, state);
+		await bindActiveSessionState(state, {
+			broadcast: (targetState, message) => internals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		});
+
+		notifyLater?.();
+		const client = createClient("after-background-notify");
+		await attach(internals, client.client, state.activeSessionId, true);
+		await waitForImmediate();
+
+		expect(extensionUiRequests(client.outbound).map((message) => message.payload.message)).toEqual([
+			"initial startup",
+		]);
 	});
 
 	it("drops pending notifications when the session closes", async () => {
@@ -125,12 +274,10 @@ describe("Issue #1032 daemon session_start notifications", () => {
 			shutdown: () => {},
 		});
 
-		cancelPendingExtensionUiRequests(state);
-		const client = createClient("after-close");
-		await attach(internals, client.client, state.activeSessionId, true);
-		await waitForImmediate();
+		await internals.closeSession(state, "killed");
 
-		expect(extensionUiRequests(client.outbound)).toEqual([]);
+		expect(state.pendingExtensionUiNotifications).toEqual([]);
+		expect(internals.sessions.has(state.activeSessionId)).toBe(false);
 	});
 
 	it("does not leak notifications across a session rebind", async () => {
@@ -163,7 +310,7 @@ describe("Issue #1032 daemon session_start notifications", () => {
 		await attach(internals, client.client, state.activeSessionId, true);
 		await waitForImmediate();
 
-		expect(extensionUiRequests(client.outbound).map((message) => message.payload.message)).toEqual(["startup 2"]);
+		expect(extensionUiRequests(client.outbound)).toEqual([]);
 	});
 
 	it("bounds pending startup notifications and preserves retained order", async () => {
@@ -232,44 +379,121 @@ describe("Issue #1032 daemon session_start notifications", () => {
 		]);
 	});
 
-	it("enables worker extension UI only after a chunked public snapshot completes", async () => {
+	it("routes worker startup replay once after the public chunked snapshot", async () => {
+		let notifyAfterBind: (() => void) | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => {
+						ctx.ui.notify("worker startup one");
+						ctx.ui.notify("worker startup two");
+						notifyAfterBind = () => ctx.ui.notify("worker live");
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const state = createState(harness);
+		const daemon = createDaemon(harness);
+		const workerInternals = daemon as unknown as DaemonInternals;
+		workerInternals.sessions.set(state.activeSessionId, state);
+		await bindActiveSessionState(state, {
+			broadcast: (targetState, message) => workerInternals.broadcastToSession(targetState, message),
+			shutdown: () => {},
+		});
+
 		let finishSnapshot: () => void = () => {};
 		const snapshot = new Promise<void>((resolve) => {
 			finishSnapshot = resolve;
 		});
-		const syncWorkerExtensionUi = vi.fn(async () => {});
 		const attachResult = {
 			activeSessionId: "active-1032",
 			snapshot: { messages: [] },
 		} as unknown as DaemonAttachResult;
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			attachClient: vi.fn(async () => ({
-				result: attachResult,
-				worker: {},
-				transcript: {},
-			})),
+		const first = createClient("public-first");
+		const second = createClient("public-second");
+		second.client.supportsExtensionUi = true;
+		second.client.capabilities.add("extension_ui");
+		second.client.attachedActiveSessionIds.add(state.activeSessionId);
+		const clients = new Set<DaemonSocketClient>([second.client]);
+		let supervisor!: SupervisorInternals;
+		let workerResponse: DaemonResponse | undefined;
+		const decoder = new PrivateFrameDecoder(isDaemonWorkerFrameHeader);
+		const workerClient = createClient("supervisor-worker").client;
+		workerClient.transport = "private-framed";
+		workerClient.socket = {
+			destroyed: false,
+			write(data: string | Uint8Array) {
+				for (const frame of decoder.push(typeof data === "string" ? Buffer.from(data) : data)) {
+					if (frame.header.kind === "outbound" && frame.header.outboundType === "response") {
+						workerResponse = JSON.parse(frame.payload.toString("utf8")) as DaemonResponse;
+					} else {
+						supervisor.handleWorkerFrame(worker, frame);
+					}
+				}
+				return true;
+			},
+		} as unknown as Socket;
+		const worker = {
+			client: {
+				requestWorker: vi.fn(
+					async (command: Omit<Extract<DaemonWorkerCommand, { type: "worker_subscribe" }>, "id">) => {
+						workerResponse = undefined;
+						await workerInternals.handleWorkerCommand(workerClient, { ...command, id: "worker-request" });
+						if (!workerResponse) throw new Error("Worker did not return a response");
+						return workerResponse;
+					},
+				),
+			},
+			snapshotCache: new Map(),
+		};
+		supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			clients,
+			workers: new Map(),
+			startupNotificationRecipients: new Map(),
+			startupNotificationRoutingSessions: new Set(),
+			pendingStartupNotificationFrames: new Map(),
+			workerExtensionUiSyncs: new Map(),
+			matchWorkers: vi.fn(() => [{ worker, summary: { id: state.activeSessionId } }]),
+			attachClient: vi.fn(
+				async (client: DaemonSocketClient, command: Extract<DaemonCommand, { type: "attach" }>) => {
+					client.capabilities = new Set(command.capabilities ?? []);
+					client.supportsExtensionUi = client.capabilities.has("extension_ui");
+					client.attachedActiveSessionIds.add(state.activeSessionId);
+					clients.add(client);
+					return { result: attachResult, worker, transcript: {} };
+				},
+			),
 			createStreamedAttachResult: vi.fn(() => attachResult),
 			streamSnapshot: vi.fn(() => snapshot),
-			syncWorkerExtensionUi,
-			write: vi.fn(() => true),
+			write: (client: DaemonSocketClient, message: DaemonOutbound) =>
+				client.socket.write(`${JSON.stringify(message)}\n`),
+			writeSerialized: (client: DaemonSocketClient, data: string | Uint8Array) => client.socket.write(data),
 			log: vi.fn(),
 		}) as unknown as SupervisorInternals;
-		const client = createClient("public-client").client;
-		client.capabilities.add("chunked_snapshot");
 
-		await supervisor.handleCommand(client, {
+		await supervisor.handleCommand(first.client, {
 			type: "attach",
 			activeSessionId: "active-1032",
 			capabilities: ["extension_ui", "chunked_snapshot"],
 			supportsExtensionUi: true,
 		});
-		expect(syncWorkerExtensionUi).not.toHaveBeenCalled();
+		expect(extensionUiRequests(first.outbound)).toEqual([]);
+		expect(extensionUiRequests(second.outbound)).toEqual([]);
+		expect(state.pendingExtensionUiNotifications).toHaveLength(2);
 
 		finishSnapshot();
 		await snapshot;
-		await waitForImmediate();
-		expect(syncWorkerExtensionUi).toHaveBeenCalledOnce();
-		expect(syncWorkerExtensionUi).toHaveBeenCalledWith("active-1032");
+		await vi.waitFor(() => expect(extensionUiRequests(first.outbound)).toHaveLength(2));
+		expect(extensionUiRequests(first.outbound).map((message) => message.payload.message)).toEqual([
+			"worker startup one",
+			"worker startup two",
+		]);
+		expect(extensionUiRequests(second.outbound)).toEqual([]);
+
+		notifyAfterBind?.();
+		expect(extensionUiRequests(first.outbound).at(-1)?.payload.message).toBe("worker live");
+		expect(extensionUiRequests(second.outbound).at(-1)?.payload.message).toBe("worker live");
 	});
 });
 
@@ -282,6 +506,7 @@ function createState(harness: Harness): ActiveSessionState {
 		setRuntimeEnvScope: vi.fn(),
 		setSubagentRuntimeHost: vi.fn(),
 		setRebindSession: vi.fn(),
+		dispose: vi.fn(async () => {}),
 	} as unknown as AgentSessionRuntime;
 	return {
 		activeSessionId: "active-1032",


### PR DESCRIPTION
## Summary

- Preserve extension notifications emitted during the initial `session_start` bind until the first eligible extension-UI client can receive them.
- Deliver retained startup notifications exactly once to the selected public client without changing normal live notification fanout.
- Prevent the supervisor's internal worker subscription from consuming startup notifications before the public attach response and snapshot are usable.

## Root cause

Extensions are bound before a daemon UI client is attached. A `session_start` handler that called `ctx.ui.notify()` therefore emitted an `extension_ui_request` into an empty recipient set. The initial fix retained notifications, but its capture window extended beyond the initial bind, ordinary last-client detach could clear the queue, and a supervisor subscription could release the queue before a public UI client was ready.

## Solution

- Capture `notify` requests only while the initial extension bind is running.
- Retain up to 100 startup notifications in deterministic order, dropping the oldest entry when the limit is reached.
- Keep the queue across temporary detach and clear it only when its lifecycle is invalidated, such as session close or runtime replacement.
- Select the first eligible public extension-UI client as the startup replay recipient, with fallback if that client disconnects or loses eligibility.
- Delay worker extension-UI synchronization until the public attach response is usable and any chunked snapshot has completed.
- Preserve queued frames through snapshot streaming and backpressure, while keeping ordinary post-attach notifications on the existing multi-client broadcast path.

Only fire-and-forget `notify` requests participate in startup retention. Modal requests such as `confirm`, `select`, `input`, and `editor` retain their existing response and cancellation behavior. Clients without the per-session `extension_ui` capability neither receive nor consume retained notifications.

## Compatibility

This change is backward-compatible. It only changes internal retention, ordering, and routing of the existing `extension_ui_request` notification. It adds no daemon command, event type, response field, or startup requirement, so `DAEMON_PROTOCOL_VERSION` and `DAEMON_SCHEMA_REVISION` remain unchanged.

## Validation

- Issue #1032 regression suite: 10 tests passed.
- Combined regression, extension-binding, and daemon-connection suites: 77 tests passed.
- Snapshot catch-up regression suite: 9 tests passed.
- Focused daemon-mode and supervisor/backpressure scenarios passed.
- `npm run check` passed, including formatting, linting, type checking, installer rendering, and browser smoke validation.
- `git diff --check` passed.

The complete supervisor monitor suite passed 44 tests on Windows; one unrelated Unix-socket test could not create its socket path because Windows returned `EACCES`. The affected supervisor routing and backpressure cases pass when run directly.

## Issue

Fixes #1032

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve daemon session-start extension UI notifications until a UI-capable client attaches
> - Extension UI `notify` events emitted during `session_start` were previously lost if no UI-capable client was attached yet; they are now buffered and replayed once to the first eligible client after attach and snapshot streaming complete.
> - Buffering is capped at 100 notifications per session (`MAX_PENDING_EXTENSION_UI_NOTIFICATIONS`) to bound memory use, and delivery is deferred past backpressure.
> - A single recipient is selected per session; detaching that client clears the recipient lock so another can be chosen. Subsequent extension rebinds do not re-open the capture window.
> - `shouldSendDaemonOutboundToClient` now gates `notify`-type `extension_ui_request` messages on per-session UI capability, so non-UI clients no longer receive them.
> - A regression test suite in [`1032-session-start-notification.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1146/files#diff-bd50ba2a9e232f7eb0a41c5a269f1ed63a37309a881a6afef8b85e92839081a9) covers capture, single-recipient replay, backpressure, rebind, and bounded buffering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39da919.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
