### PR TITLE
fix(coding-agent): recover supervisor ownership when its registry entry is pruned

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 - Fixed the agents view collapsing expanded subagent lists when returning from an opened agent ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
 - Kept the subagent summary row visible and selectable while its list is expanded in the agents view, so pressing enter on it collapses the list again ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
+- Fixed a long-running daemon rejecting every command with `supervisor_generation_stale` after the OS pruned its registry entry from the temp directory ([#1148](https://github.com/PrimeIntellect-ai/prime-agent/issues/1148)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -22,6 +22,10 @@ const REGISTRY_LOCK_UPDATE_MS = 1000;
 const REGISTRY_LOCK_RETRIES = 500;
 const REGISTRY_LOCK_RETRY_MS = 10;
 const STARTUP_FENCE_POLL_MS = 250;
+// The registry lives under the OS temp directory, which macOS prunes of entries that
+// have not been touched for ~3 days. Rewrite our own entry well inside that window so
+// a long-lived supervisor never ages out of its own registry.
+const OWNER_RECORD_REFRESH_MS = 60 * 60 * 1000;
 const SHUTDOWN_ADMISSION_FILE_NAME = "shutdown-admission.json";
 const SHUTDOWN_ADMISSION_LEASE_MS = 5000;
 const SHUTDOWN_ADMISSION_REFRESH_MS = 1000;
@@ -120,21 +124,66 @@ class DaemonShutdownAdmissionError extends Error {
 
 class DaemonSupervisorOwnership {
 	private released = false;
+	private refreshPromise?: Promise<void>;
+	private readonly refreshTimer: ReturnType<typeof setInterval>;
 
 	constructor(
 		readonly record: DaemonSupervisorOwnerRecord,
 		private readonly registryDir: string,
 		private readonly ownerDirectory: string,
-	) {}
+	) {
+		this.refreshTimer = setInterval(() => {
+			this.refreshPromise ??= this.reassertOwnerRecord()
+				.catch(() => undefined)
+				.finally(() => {
+					this.refreshPromise = undefined;
+				});
+		}, OWNER_RECORD_REFRESH_MS);
+		this.refreshTimer.unref();
+	}
 
 	async assertCurrent(): Promise<void> {
 		if (this.released) {
 			throw new DaemonSupervisorOwnershipLostError(this.record.generation);
 		}
 		const current = readOwnerRecord(this.ownerDirectory);
-		if (!current || !sameOwnerRecord(current, this.record)) {
+		if (current && sameOwnerRecord(current, this.record)) {
+			return;
+		}
+		// A record that belongs to someone else means we genuinely lost ownership, but a
+		// *missing* record does not: the registry lives under the OS temp directory, so an
+		// external pruner can delete a live supervisor's entry. Recover it under the guard
+		// instead of failing every subsequent command for the rest of the process lifetime.
+		await this.reassertOwnerRecord();
+	}
+
+	private async reassertOwnerRecord(): Promise<void> {
+		if (this.released) {
 			throw new DaemonSupervisorOwnershipLostError(this.record.generation);
 		}
+		await withDaemonSupervisorRegistryGuard(this.registryDir, () => {
+			const current = readOwnerRecord(this.ownerDirectory);
+			if (current && !sameOwnerRecord(current, this.record)) {
+				throw new DaemonSupervisorOwnershipLostError(this.record.generation);
+			}
+			if (!current) {
+				// Only restore the entry if no live supervisor claimed our socket or
+				// descriptor directory in the meantime; if one did, ownership is really gone.
+				for (const directory of listOwnerDirectories(this.registryDir)) {
+					if (directory === this.ownerDirectory) {
+						continue;
+					}
+					const other = readOwnerRecord(directory);
+					if (other && ownerConflicts(other, this.record) && isProcessIdentityAlive(other)) {
+						throw new DaemonSupervisorOwnershipLostError(this.record.generation);
+					}
+				}
+			}
+			this.record.updatedAt = new Date().toISOString();
+			mkdirSync(this.ownerDirectory, { recursive: true, mode: 0o700 });
+			writeOwnerScope(this.ownerDirectory, this.record);
+			writeOwnerRecord(this.ownerDirectory, this.record);
+		});
 	}
 
 	async updatePhase(phase: DaemonSupervisorOwnerPhase): Promise<void> {
@@ -160,6 +209,8 @@ class DaemonSupervisorOwnership {
 		if (this.released) {
 			return;
 		}
+		clearInterval(this.refreshTimer);
+		await this.refreshPromise;
 		let releasedDirectory: string | undefined;
 		try {
 			await withDaemonSupervisorRegistryGuard(this.registryDir, () => {

--- a/packages/coding-agent/test/suite/regressions/1148-supervisor-registry-entry-pruned.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1148-supervisor-registry-entry-pruned.test.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { acquireDaemonSupervisorOwnership } from "../../../src/modes/daemon/daemon-supervisor-ownership.js";
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+	// Ownership must be released (and its registry lock dropped) before the registry
+	// directory is removed, otherwise the removal races the lockfile and throws ENOTEMPTY.
+	while (cleanups.length > 0) {
+		await cleanups.pop()?.();
+	}
+});
+
+function registryDir(): string {
+	const directory = mkdtempSync(join(tmpdir(), "prime-agent-ownership-test-"));
+	cleanups.push(() => rmSync(directory, { recursive: true, force: true }));
+	return directory;
+}
+
+async function acquire(registry: string, generation: string, socketName = "daemon.sock") {
+	const ownership = await acquireDaemonSupervisorOwnership({
+		socketPath: join(registry, socketName),
+		descriptorDir: join(registry, `descriptors-${generation}`),
+		agentDir: join(registry, "agent"),
+		generation,
+		appVersion: "0.0.0-test",
+		registryDir: registry,
+	});
+	cleanups.push(() => ownership.release().catch(() => undefined));
+	return ownership;
+}
+
+function ownerDirectory(registry: string, generation: string): string {
+	return resolve(registry, `${generation}.owner`);
+}
+
+describe("daemon supervisor ownership", () => {
+	it("recovers when an external pruner deletes owner.json underneath a live supervisor", async () => {
+		const registry = registryDir();
+		const ownership = await acquire(registry, "gen-reaped");
+
+		// macOS prunes /var/folders entries untouched for ~3 days, which deletes the record
+		// of a healthy long-lived supervisor and leaves the owner directory behind empty.
+		rmSync(resolve(ownerDirectory(registry, "gen-reaped"), "owner.json"), { force: true });
+		rmSync(resolve(ownerDirectory(registry, "gen-reaped"), "scope.json"), { force: true });
+
+		await expect(ownership.assertCurrent()).resolves.toBeUndefined();
+		// The restored entry keeps working for every later command, not just the first.
+		await expect(ownership.assertCurrent()).resolves.toBeUndefined();
+	});
+
+	it("recovers when the whole owner directory is pruned", async () => {
+		const registry = registryDir();
+		const ownership = await acquire(registry, "gen-dir-gone");
+
+		rmSync(ownerDirectory(registry, "gen-dir-gone"), { recursive: true, force: true });
+
+		await expect(ownership.assertCurrent()).resolves.toBeUndefined();
+	});
+
+	it("still reports lost ownership when another record replaced ours", async () => {
+		const registry = registryDir();
+		const ownership = await acquire(registry, "gen-replaced");
+
+		writeFileSync(
+			resolve(ownerDirectory(registry, "gen-replaced"), "owner.json"),
+			JSON.stringify({ ...ownership.record, token: "a-different-token" }),
+		);
+
+		await expect(ownership.assertCurrent()).rejects.toMatchObject({
+			code: "supervisor_generation_stale",
+		});
+	});
+
+	it("still reports lost ownership when a live supervisor claimed our socket", async () => {
+		const registry = registryDir();
+		const ownership = await acquire(registry, "gen-superseded");
+		rmSync(ownerDirectory(registry, "gen-superseded"), { recursive: true, force: true });
+
+		// A different generation holding the same socket, whose pid is alive.
+		const usurperDirectory = ownerDirectory(registry, "gen-usurper");
+		mkdirSync(usurperDirectory, { recursive: true, mode: 0o700 });
+		const { processStartId: _ignored, ...identity } = ownership.record;
+		writeFileSync(
+			resolve(usurperDirectory, "owner.json"),
+			JSON.stringify({
+				...identity,
+				token: "usurper-token",
+				generation: "gen-usurper",
+				pid: process.pid,
+			}),
+		);
+
+		await expect(ownership.assertCurrent()).rejects.toMatchObject({
+			code: "supervisor_generation_stale",
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1148.

The supervisor registry lives under `os.tmpdir()`, and `owner.json` was only written on acquire and on a phase change. macOS prunes `/var/folders` entries untouched for about three days, so a healthy long-lived supervisor loses its own registry entry. `assertCurrent` treated that missing record exactly like a takeover, so every journaled command failed with `supervisor_generation_stale` for the rest of the process lifetime. Nothing could repair it from outside either, because `sameOwnerRecord` compares a token that existed only in the deleted file and in the supervisor's memory.

## Changes

- `assertCurrent` now distinguishes a vanished record from a stolen one. A record belonging to another generation is still fatal. A missing record is restored under `withDaemonSupervisorRegistryGuard`, re-reading inside the lock, and only after scanning for a live supervisor that has claimed the same socket or descriptor directory. If one exists, ownership really is gone and the error is still raised, so two supervisors can never both consider themselves the owner.
- Added an hourly `unref`'d refresh that rewrites the record, keeping its mtime well inside the pruning window so the entry does not age out to begin with. Cleared on `release()`.

Both halves matter: without the recovery path an already-broken daemon stays broken, and without the refresh a healthy daemon still stalls once every three days before healing itself.

`0.4.0` fixed the startup side of this through `readOwnerRecordForScope`, but that self-heal only runs when a new supervisor acquires ownership, never for the live process.

## Testing

`packages/coding-agent/test/suite/regressions/1148-supervisor-registry-entry-pruned.test.ts` covers four cases: recovery when `owner.json` is deleted, recovery when the whole owner directory is removed, and the two paths that must still fail, namely a foreign record in our slot and a live supervisor holding our socket.

Reverting only the source change fails exactly the two recovery cases and leaves the two ownership-lost cases passing, so the test pins the bug without loosening the fatal path.

`npm run check` is clean. The new test passes, as do `4600-supervisor-singleton`, `daemon-supervisor-admission`, and `daemon-supervisor-monitor` (70 tests). I did not run `daemon-supervisor-process`, which is excluded from `test:ci`.

## Note

`assertDaemonSupervisorOwnerCurrent` has the same missing-record-is-fatal logic on the worker validation path. It recovers indirectly once the supervisor rewrites the record, so I left it alone to keep this diff focused. Happy to include it if you would prefer.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix supervisor ownership recovery when OS prunes its registry entry from temp directory
> - `assertCurrent()` in [`DaemonSupervisorOwnership`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1149/files#diff-6f9ef6ce6a9d2bc51c61fe94d59310efffd26d8f7b3966f5355606b2847d06a5) now treats a missing owner record as recoverable: if the current token matches, it rewrites the scope and owner records instead of throwing `supervisor_generation_stale`.
> - A periodic refresh (every ~1 hour) rewrites the owner record proactively to reduce the chance of OS temp pruning causing issues for long-running daemons.
> - `release()` cancels and awaits any in-flight refresh before performing the cleanup rename-and-delete sequence.
> - Adds a [regression test suite](https://github.com/PrimeIntellect-ai/prime-agent/pull/1149/files#diff-f766d4a6ec5b2be9bbd21bbde7c44774729b7a25a1fe40a4c12cf3b8af009079) covering recovery from deleted files, deleted directories, token conflicts, and competing live supervisors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecde15f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->