### PR TITLE
fix(coding-agent): handle empty Codex discovery catalogs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a configurable copy action to login dialogs so raw sign-in URLs can be copied without selecting wrapped text ([#643](https://github.com/PrimeIntellect-ai/prime-agent/issues/643)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
+- Fixed RLM rejecting authenticated Codex child models when discovery returned an empty catalog ([#1011](https://github.com/PrimeIntellect-ai/prime-agent/issues/1011)).
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 - Fixed the agents view collapsing expanded subagent lists when returning from an opened agent ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
 - Kept the subagent summary row visible and selectable while its list is expanded in the agents view, so pressing enter on it collapses the list again ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -401,6 +401,11 @@ function readOpenAICodexModelIds(value: unknown): Set<string> {
 	);
 }
 
+function applyOpenAICodexCatalog(models: Model<Api>[], modelIds: Set<string>): Model<Api>[] {
+	if (modelIds.size === 0) return models;
+	return models.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
+}
+
 const PRIVATE_PRIME_AUTHORIZATION_CACHE_FILE = "prime-inference-private-models.json";
 const PRIVATE_PRIME_AUTHORIZATION_CACHE_TTL_MS = 5 * 60_000;
 const PRIVATE_PRIME_BACKGROUND_REFRESH_TIMEOUT_MS = 3_000;
@@ -980,7 +985,7 @@ export class ModelRegistry {
 		const authFingerprint = createHash("sha256").update(auth.apiKey).digest("hex");
 		const cached = this.openAICodexModelsCache;
 		if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-			return availableModels.filter((model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id));
+			return applyOpenAICodexCatalog(availableModels, cached.modelIds);
 		}
 
 		const accountId = readOpenAICodexAccountId(auth.apiKey);
@@ -1002,12 +1007,10 @@ export class ModelRegistry {
 			}
 			const modelIds = readOpenAICodexModelIds(await response.json());
 			this.openAICodexModelsCache = { authFingerprint, modelIds, refreshedAt: Date.now() };
-			return availableModels.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
+			return applyOpenAICodexCatalog(availableModels, modelIds);
 		} catch {
 			if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-				return availableModels.filter(
-					(model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id),
-				);
+				return applyOpenAICodexCatalog(availableModels, cached.modelIds);
 			}
 			return availableModels.filter((model) => model.provider !== "openai-codex");
 		}

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -110,6 +110,43 @@ describe("ENG-4649 subagent model selection", () => {
 		}
 	});
 
+	it("keeps a Luna child selectable when ChatGPT discovery returns an empty catalog", async () => {
+		const codexProvider = "openai-codex";
+		const harness = await createHarness({
+			provider: codexProvider,
+			models: [{ id: "gpt-5.6-sol" }, { id: "gpt-5.6-luna" }],
+		});
+		const fetchModels = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ models: [] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchModels);
+		try {
+			harness.authStorage.setRuntimeApiKey(codexProvider, openAICodexToken("account-empty-catalog"));
+			const lunaSelector = `${codexProvider}/gpt-5.6-luna`;
+			await expect(harness.session.findRlmModels("luna", 8)).resolves.toMatchObject({
+				models: [{ selector: lunaSelector }],
+			});
+			await harness.session.findRlmModels("luna", 8);
+
+			harness.setResponses([fauxAssistantMessage("Luna child completed")]);
+			await expect(harness.session.runRlmChild("run on Luna", { model: lunaSelector })).resolves.toMatchObject({
+				model: lunaSelector,
+			});
+			await vi.waitFor(async () => {
+				const child = (await harness.session.listRlmSubagents()).subagents[0];
+				expect(harness.session.getRlmChildSession(child!.rlm_child_id)?.model?.id).toBe("gpt-5.6-luna");
+			});
+			expect(fetchModels).toHaveBeenCalledOnce();
+		} finally {
+			vi.unstubAllGlobals();
+			harness.cleanup();
+		}
+	});
+
 	it("includes private Prime models authorized for the selected team", async () => {
 		const harness = await createHarness({ provider, models: [{ id: "parent-model" }] });
 		const fetchModels = vi.fn(


### PR DESCRIPTION
## Summary

- Keep locally known authenticated OpenAI Codex models selectable when a successful discovery response contains no model IDs.
- Preserve non-empty account catalogs as authoritative model allowlists.
- Extend the existing subagent model-selection regression suite to cover cached empty discovery and explicit Sol-to-Luna child admission.
- Add a coding-agent changelog entry.

Fixes #1011.
Addresses the executable-model behavior in #696; warning and error-message improvements remain separate follow-up work.

## Independent implementation

This branch was implemented from `upstream/main` without importing commits, source code, or test files from external PRs #717 or #1012. It uses a new module-level catalog application function and adds coverage to the repository's existing ENG-4649 regression suite.

It supersedes our earlier aggregation PR #1152, which will be closed.

## Behavior

An empty successful discovery result is inconclusive because the same authenticated account can still serve direct model requests. Actual inference remains authoritative in that case. Authentication, account-ID, and discovery failure paths remain fail-closed.

A non-empty discovery result still filters Codex models to the exact IDs returned by the account catalog.

## Verification

- `env -u GEMINI_API_KEY npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/4649-subagent-model-selection.test.ts`
  - 13 tests passed.
- `npm run check`
  - formatting, linting, type checking, installer rendering, and browser smoke checks passed.

## Related

- #639
- #702
- #740

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Codex catalog filtering with preserved fail-closed paths for auth and discovery failures; regression test covers the empty-catalog case.
> 
> **Overview**
> Fixes **RLM rejecting authenticated OpenAI Codex child models** when ChatGPT model discovery succeeds but returns **no model slugs** (e.g. Luna variants).
> 
> **`getExecutableModels`** now routes Codex filtering through **`applyOpenAICodexCatalog`**: if the discovered ID set is **empty**, locally known authenticated **`openai-codex`** models are **left in place** instead of being filtered out. When discovery returns **one or more IDs**, behavior is unchanged—Codex models are limited to that account allowlist. Auth failures, missing account ID, and discovery errors remain **fail-closed** (Codex models dropped unless a valid stale cache applies).
> 
> Adds a regression test that **`findRlmModels`** and **`runRlmChild`** still admit **`gpt-5.6-luna`** when discovery returns `{ models: [] }`, plus an unreleased changelog entry for #1011.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8443818335ee46f5e8d5fcd2bcf035df64c2ef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model registry to retain Codex models when discovery returns an empty catalog
> Previously, when OpenAI Codex discovery returned an empty catalog (or the cache held an empty set), all Codex models were filtered out and rejected by RLM. The fix extracts the filtering logic into a new `applyOpenAICodexCatalog` helper in [`model-registry.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1153/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453) that skips filtering when the model ID set is empty, leaving Codex models available. A regression test covering an empty-catalog discovery response is added in [`4649-subagent-model-selection.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1153/files#diff-c8140144b2be9fb03036909d9c590ea967f1e95ed2d9fd659456dd56fa63e1f7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f844381.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->