### PR TITLE
feat(ai): add xAI subscription OAuth via device flow

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added xAI subscription login (SuperGrok/X Premium) via the RFC 8628 device flow, serving xAI models over the Responses API while OAuth credentials are active.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added xAI subscription login (SuperGrok/X Premium) via the RFC 8628 device flow, serving xAI models over the Responses API while OAuth credentials are active.
+- Added xAI subscription login (SuperGrok/X Premium) via the RFC 8628 device flow, serving xAI models over the Responses API while OAuth credentials are active ([#678](https://github.com/PrimeIntellect-ai/prime-agent/issues/678)).
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -75,7 +75,7 @@ Unified LLM API with automatic model discovery, provider configuration, token an
 - **Cerebras**
 - **Cloudflare AI Gateway**
 - **Cloudflare Workers AI**
-- **xAI**
+- **xAI** (API key, or SuperGrok/X Premium OAuth, see below)
 - **OpenRouter**
 - **Vercel AI Gateway**
 - **MiniMax**
@@ -1101,6 +1101,7 @@ Several providers require OAuth authentication instead of static API keys:
 - **Anthropic** (Claude Pro/Max subscription)
 - **OpenAI Codex** (ChatGPT Plus/Pro subscription, access to GPT-5.x Codex models)
 - **GitHub Copilot** (Copilot subscription)
+- **xAI** (SuperGrok/X Premium subscription, device flow; served over the Responses API)
 
 For paid Cloud Code Assist subscriptions, set `GOOGLE_CLOUD_PROJECT` or `GOOGLE_CLOUD_PROJECT_ID` to your project ID.
 
@@ -1168,6 +1169,7 @@ import {
   loginOpenAICodex,
   loginGitHubCopilot,
   loginGeminiCli,
+  loginXai,
 
   // Token management
   refreshOAuthToken,   // (provider, credentials) => new credentials
@@ -1237,6 +1239,8 @@ const response = await complete(model, {
 **Azure OpenAI (Responses)**: Uses the Responses API only. Set `AZURE_OPENAI_API_KEY` and either `AZURE_OPENAI_BASE_URL` or `AZURE_OPENAI_RESOURCE_NAME`. `AZURE_OPENAI_BASE_URL` supports both `https://<resource>.openai.azure.com` and `https://<resource>.cognitiveservices.azure.com`; root endpoints are normalized to `.../openai/v1` automatically. Use `AZURE_OPENAI_API_VERSION` (defaults to `v1`) to override the API version if needed. Deployment names are treated as model IDs by default, override with `azureDeploymentName` or `AZURE_OPENAI_DEPLOYMENT_NAME_MAP` using comma-separated `model-id=deployment` pairs (for example `gpt-4o-mini=my-deployment,gpt-4o=prod`). Legacy deployment-based URLs are intentionally unsupported.
 
 **GitHub Copilot**: If you get "The requested model is not supported" error, enable the model manually in VS Code: open Copilot Chat, click the model selector, select the model (warning icon), and click "Enable".
+
+**xAI**: `loginXai` uses the RFC 8628 device flow against `https://auth.x.ai`, so it needs no local callback server and works over SSH. Subscription tokens authorize the Responses API rail used by xAI's Grok CLI; while OAuth credentials are active the provider's `modifyModels` hook serves xAI models over `https://api.x.ai/v1/responses`. API-key (`XAI_API_KEY`) usage keeps the Chat Completions models unchanged.
 
 ## Development
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -267,6 +267,11 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 				effort: (model.thinkingLevelMap?.off ?? "none") as NonNullable<typeof params.reasoning>["effort"],
 			};
 		}
+		// Grok always reasons; without encrypted content the reasoning items
+		// cannot be replayed on the next turn.
+		if (model.provider === "xai" && !params.include) {
+			params.include = ["reasoning.encrypted_content"];
+		}
 	}
 
 	return params;

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -5,6 +5,7 @@
  * for OAuth-based providers:
  * - Anthropic (Claude Pro/Max)
  * - GitHub Copilot
+ * - xAI (SuperGrok/X Premium)
  */
 
 // Anthropic
@@ -19,8 +20,9 @@ export {
 } from "./github-copilot.js";
 // OpenAI Codex (ChatGPT OAuth)
 export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.js";
-
 export * from "./types.js";
+// xAI (SuperGrok/X Premium)
+export { applyXaiOAuthModels, loginXai, refreshXaiToken, xaiOAuthProvider } from "./xai.js";
 
 // ============================================================================
 // Provider Registry
@@ -30,11 +32,13 @@ import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
+import { xaiOAuthProvider } from "./xai.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	anthropicOAuthProvider,
 	githubCopilotOAuthProvider,
 	openaiCodexOAuthProvider,
+	xaiOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -146,8 +146,9 @@ export async function getOAuthApiKey(
 	if (Date.now() >= creds.expires) {
 		try {
 			creds = await provider.refreshToken(creds);
-		} catch (_error) {
-			throw new Error(`Failed to refresh OAuth token for ${providerId}`);
+		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error);
+			throw new Error(`Failed to refresh OAuth token for ${providerId}: ${detail}`);
 		}
 	}
 

--- a/packages/ai/src/utils/oauth/xai.ts
+++ b/packages/ai/src/utils/oauth/xai.ts
@@ -1,0 +1,262 @@
+/**
+ * xAI OAuth flow (SuperGrok / X Premium subscriptions)
+ *
+ * RFC 8628 device authorization grant against the xAI OIDC issuer, using the
+ * public client that xAI ships in its own Grok CLI. The device flow needs no
+ * loopback callback server, so it works over SSH and in containers.
+ *
+ * Subscription access tokens authorize the Responses API rail the Grok CLI
+ * itself uses, so `modifyModels` moves xAI models there while OAuth
+ * credentials are active. API-key users keep the untouched Chat Completions
+ * models.
+ */
+
+import type { Api, Model } from "../../types.js";
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+
+const CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const DEVICE_CODE_URL = "https://auth.x.ai/oauth2/device/code";
+const TOKEN_URL = "https://auth.x.ai/oauth2/token";
+const DEFAULT_POLL_INTERVAL_SECONDS = 5;
+const DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;
+/** Refresh five minutes before the token actually expires. */
+const EXPIRY_SKEW_MS = 5 * 60 * 1000;
+const RELOGIN_HINT = "Run /login and sign in to xAI again.";
+
+type JsonObject = Record<string, unknown>;
+
+type TokenEndpointResponse = {
+	ok: boolean;
+	status: number;
+	body: JsonObject;
+};
+
+type DeviceAuthorization = {
+	deviceCode: string;
+	userCode: string;
+	verificationUri: string;
+	verificationUriComplete?: string;
+	intervalSeconds: number;
+	expiresInSeconds: number;
+};
+
+function requiredString(body: JsonObject, field: string): string {
+	const value = body[field];
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`xAI OAuth response is missing ${field}`);
+	}
+	return value;
+}
+
+function optionalPositiveNumber(body: JsonObject, field: string): number | undefined {
+	const value = body[field];
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function httpsUrl(raw: string, field: string): string {
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		throw new Error(`xAI OAuth response has an invalid ${field}: ${raw}`);
+	}
+	if (url.protocol !== "https:") {
+		throw new Error(`xAI OAuth response has a non-HTTPS ${field}: ${raw}`);
+	}
+	return url.href;
+}
+
+async function postForm(
+	fields: Record<string, string>,
+	url: string,
+	signal?: AbortSignal,
+): Promise<TokenEndpointResponse> {
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "POST",
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			body: new URLSearchParams(fields),
+			signal,
+		});
+	} catch (error) {
+		if (signal?.aborted) throw new Error("Login cancelled");
+		throw error;
+	}
+
+	let body: JsonObject = {};
+	try {
+		const parsed = (await response.json()) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			body = parsed as JsonObject;
+		}
+	} catch {
+		throw new Error(`xAI OAuth endpoint returned invalid JSON (HTTP ${response.status})`);
+	}
+	return { ok: response.ok, status: response.status, body };
+}
+
+function oauthError(action: string, response: TokenEndpointResponse, hint?: string): Error {
+	const code = typeof response.body.error === "string" ? response.body.error : undefined;
+	const description =
+		typeof response.body.error_description === "string" ? response.body.error_description : undefined;
+	const detail = [code, description].filter(Boolean).join(": ");
+	return new Error(
+		`xAI OAuth ${action} failed (HTTP ${response.status})${detail ? `: ${detail}` : ""}${hint ? `. ${hint}` : ""}`,
+	);
+}
+
+function credentialsFromTokenResponse(body: JsonObject, previousRefreshToken?: string): OAuthCredentials {
+	const rotatedRefresh = typeof body.refresh_token === "string" && body.refresh_token.length > 0;
+	if (!rotatedRefresh && !previousRefreshToken) {
+		throw new Error("xAI OAuth response is missing refresh_token");
+	}
+	const expiresInSeconds = optionalPositiveNumber(body, "expires_in") ?? DEFAULT_TOKEN_LIFETIME_SECONDS;
+	return {
+		access: requiredString(body, "access_token"),
+		refresh: rotatedRefresh ? (body.refresh_token as string) : (previousRefreshToken as string),
+		expires: Date.now() + expiresInSeconds * 1000 - EXPIRY_SKEW_MS,
+	};
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Login cancelled"));
+			return;
+		}
+		const onAbort = () => {
+			clearTimeout(timeout);
+			reject(new Error("Login cancelled"));
+		};
+		const timeout = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+async function requestDeviceAuthorization(signal?: AbortSignal): Promise<DeviceAuthorization> {
+	const response = await postForm({ client_id: CLIENT_ID, scope: SCOPE }, DEVICE_CODE_URL, signal);
+	if (!response.ok) throw oauthError("device authorization", response);
+
+	const body = response.body;
+	const verificationUriComplete =
+		typeof body.verification_uri_complete === "string" && body.verification_uri_complete.length > 0
+			? httpsUrl(body.verification_uri_complete, "verification_uri_complete")
+			: undefined;
+	return {
+		deviceCode: requiredString(body, "device_code"),
+		userCode: requiredString(body, "user_code"),
+		verificationUri: httpsUrl(requiredString(body, "verification_uri"), "verification_uri"),
+		verificationUriComplete,
+		intervalSeconds: optionalPositiveNumber(body, "interval") ?? DEFAULT_POLL_INTERVAL_SECONDS,
+		expiresInSeconds: optionalPositiveNumber(body, "expires_in") ?? 900,
+	};
+}
+
+async function pollForTokens(device: DeviceAuthorization, signal?: AbortSignal): Promise<OAuthCredentials> {
+	const deadline = Date.now() + device.expiresInSeconds * 1000;
+	let intervalSeconds = device.intervalSeconds;
+
+	while (true) {
+		const remainingMs = deadline - Date.now();
+		if (remainingMs <= 0) break;
+		await abortableSleep(Math.min(intervalSeconds * 1000, remainingMs), signal);
+		if (Date.now() >= deadline) break;
+
+		const response = await postForm(
+			{
+				grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+				client_id: CLIENT_ID,
+				device_code: device.deviceCode,
+			},
+			TOKEN_URL,
+			signal,
+		);
+		if (response.ok) return credentialsFromTokenResponse(response.body);
+
+		const error = response.body.error;
+		if (error === "authorization_pending") continue;
+		if (error === "slow_down") {
+			// RFC 8628 section 3.5: increase the interval by at least 5 seconds,
+			// honoring a larger server-provided interval when present.
+			const serverInterval = optionalPositiveNumber(response.body, "interval");
+			intervalSeconds = Math.max(serverInterval ?? 0, intervalSeconds + 5);
+			continue;
+		}
+		if (error === "access_denied") throw new Error("xAI device authorization was denied");
+		if (error === "expired_token") break;
+		throw oauthError("device token polling", response);
+	}
+	throw new Error("xAI device code expired before the login was approved. Run /login to try again.");
+}
+
+/**
+ * Login with the xAI device authorization flow (RFC 8628).
+ */
+export async function loginXai(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+	const device = await requestDeviceAuthorization(callbacks.signal);
+	callbacks.onAuth({
+		url: device.verificationUriComplete ?? device.verificationUri,
+		instructions: `Confirm code ${device.userCode} in your browser and approve the login.`,
+	});
+	callbacks.onProgress?.("Waiting for approval...");
+	return pollForTokens(device, callbacks.signal);
+}
+
+/**
+ * Refresh an xAI OAuth access token.
+ */
+export async function refreshXaiToken(refreshToken: string): Promise<OAuthCredentials> {
+	const response = await postForm(
+		{
+			grant_type: "refresh_token",
+			client_id: CLIENT_ID,
+			refresh_token: refreshToken,
+		},
+		TOKEN_URL,
+	);
+	if (!response.ok) {
+		const code = typeof response.body.error === "string" ? response.body.error : undefined;
+		const revoked =
+			code === "invalid_grant" || code === "invalid_token" || response.status === 401 || response.status === 403;
+		throw oauthError("token refresh", response, revoked ? RELOGIN_HINT : undefined);
+	}
+	return credentialsFromTokenResponse(response.body, refreshToken);
+}
+
+/**
+ * Move xAI models to the Responses API rail used by subscription tokens.
+ * Exported for the provider's `modifyModels` hook and tests.
+ */
+export function applyXaiOAuthModels(models: Model<Api>[]): Model<Api>[] {
+	return models.map((model) => {
+		if (model.provider !== "xai" || model.api !== "openai-completions") return model;
+		const { compat: _compat, ...rest } = model as Model<"openai-completions">;
+		const responsesModel: Model<"openai-responses"> = {
+			...rest,
+			api: "openai-responses",
+			compat: { supportsLongCacheRetention: false },
+		};
+		if (model.reasoning) {
+			// Subscription Grok reasoning models always think; efforts are low/medium/high.
+			responsesModel.thinkingLevelMap = { ...model.thinkingLevelMap, off: null, minimal: null };
+		}
+		return responsesModel;
+	});
+}
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+	id: "xai",
+	name: "xAI (SuperGrok/X Premium)",
+	login: loginXai,
+	refreshToken: (credentials) => refreshXaiToken(credentials.refresh),
+	getApiKey: (credentials) => credentials.access,
+	modifyModels: (models) => applyXaiOAuthModels(models),
+};

--- a/packages/ai/test/xai-oauth.test.ts
+++ b/packages/ai/test/xai-oauth.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Api, Model } from "../src/types.js";
+import { applyXaiOAuthModels, loginXai, refreshXaiToken, xaiOAuthProvider } from "../src/utils/oauth/xai.js";
+
+const DEVICE_CODE_URL = "https://auth.x.ai/oauth2/device/code";
+const TOKEN_URL = "https://auth.x.ai/oauth2/token";
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function getUrl(input: unknown): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	if (input instanceof Request) return input.url;
+	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+function deviceCodeResponse(overrides: Record<string, unknown> = {}): Response {
+	return jsonResponse({
+		device_code: "device-code",
+		user_code: "ZZFP-2324",
+		verification_uri: "https://accounts.x.ai/oauth2/device",
+		verification_uri_complete: "https://accounts.x.ai/oauth2/device?user_code=ZZFP-2324",
+		expires_in: 1800,
+		interval: 5,
+		...overrides,
+	});
+}
+
+function tokenResponse(overrides: Record<string, unknown> = {}): Response {
+	return jsonResponse({
+		access_token: "access-token",
+		refresh_token: "refresh-token",
+		expires_in: 3600,
+		token_type: "Bearer",
+		...overrides,
+	});
+}
+
+function stubFetchRouter(tokenResponses: Response[], deviceResponse: Response = deviceCodeResponse()) {
+	const tokenPollTimes: number[] = [];
+	const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+		const url = getUrl(input);
+		if (url === DEVICE_CODE_URL) {
+			expect(init?.method).toBe("POST");
+			expect(String(init?.body)).toContain("client_id=");
+			expect(String(init?.body)).toContain("scope=");
+			return deviceResponse;
+		}
+		if (url === TOKEN_URL) {
+			tokenPollTimes.push(Date.now());
+			expect(String(init?.body)).toContain("device_code=device-code");
+			expect(String(init?.body)).toContain("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code");
+			const response = tokenResponses.shift();
+			if (!response) throw new Error("Unexpected extra token poll");
+			return response;
+		}
+		throw new Error(`Unexpected fetch URL: ${url}`);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return { fetchMock, tokenPollTimes };
+}
+
+describe("xAI OAuth device flow", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it("completes the device flow and surfaces the prefilled verification URL", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-03-09T00:00:00Z"));
+		stubFetchRouter([tokenResponse()]);
+
+		const authInfos: { url: string; instructions?: string }[] = [];
+		const loginPromise = loginXai({
+			onAuth: (info) => authInfos.push(info),
+			onPrompt: async () => "",
+		});
+
+		await vi.advanceTimersByTimeAsync(5000);
+		const credentials = await loginPromise;
+
+		expect(authInfos).toHaveLength(1);
+		expect(authInfos[0].url).toBe("https://accounts.x.ai/oauth2/device?user_code=ZZFP-2324");
+		expect(authInfos[0].instructions).toContain("ZZFP-2324");
+		expect(credentials.access).toBe("access-token");
+		expect(credentials.refresh).toBe("refresh-token");
+		expect(credentials.expires).toBe(Date.now() + 3600 * 1000 - 5 * 60 * 1000);
+	});
+
+	it("falls back to the plain verification URL when the prefilled one is missing", async () => {
+		vi.useFakeTimers();
+		stubFetchRouter([tokenResponse()], deviceCodeResponse({ verification_uri_complete: undefined }));
+
+		const authInfos: { url: string }[] = [];
+		const loginPromise = loginXai({
+			onAuth: (info) => authInfos.push(info),
+			onPrompt: async () => "",
+		});
+		await vi.advanceTimersByTimeAsync(5000);
+		await loginPromise;
+
+		expect(authInfos[0].url).toBe("https://accounts.x.ai/oauth2/device");
+	});
+
+	it("waits before the first poll, keeps polling through authorization_pending, and bumps the interval on slow_down", async () => {
+		vi.useFakeTimers();
+		const startTime = new Date("2026-03-09T00:00:00Z");
+		vi.setSystemTime(startTime);
+		const { tokenPollTimes } = stubFetchRouter([
+			jsonResponse({ error: "authorization_pending" }, 400),
+			jsonResponse({ error: "slow_down", interval: 10 }, 400),
+			jsonResponse({ error: "authorization_pending" }, 400),
+			tokenResponse(),
+		]);
+
+		const loginPromise = loginXai({ onAuth: () => {}, onPrompt: async () => "" });
+
+		await vi.advanceTimersByTimeAsync(4999);
+		expect(tokenPollTimes).toHaveLength(0);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(tokenPollTimes).toHaveLength(1);
+
+		// pending: keep the 5s cadence
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(tokenPollTimes).toHaveLength(2);
+
+		// slow_down with interval=10: next wait is max(10, 5 + 5) = 10s
+		await vi.advanceTimersByTimeAsync(9999);
+		expect(tokenPollTimes).toHaveLength(2);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(tokenPollTimes).toHaveLength(3);
+
+		await vi.advanceTimersByTimeAsync(10000);
+		await loginPromise;
+
+		expect(tokenPollTimes).toEqual([
+			startTime.getTime() + 5000,
+			startTime.getTime() + 10000,
+			startTime.getTime() + 20000,
+			startTime.getTime() + 30000,
+		]);
+	});
+
+	it("increases the interval by at least five seconds when slow_down has no interval", async () => {
+		vi.useFakeTimers();
+		const startTime = new Date("2026-03-09T00:00:00Z");
+		vi.setSystemTime(startTime);
+		const { tokenPollTimes } = stubFetchRouter([jsonResponse({ error: "slow_down" }, 400), tokenResponse()]);
+
+		const loginPromise = loginXai({ onAuth: () => {}, onPrompt: async () => "" });
+
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(tokenPollTimes).toHaveLength(1);
+		await vi.advanceTimersByTimeAsync(9999);
+		expect(tokenPollTimes).toHaveLength(1);
+		await vi.advanceTimersByTimeAsync(1);
+		await loginPromise;
+
+		expect(tokenPollTimes).toEqual([startTime.getTime() + 5000, startTime.getTime() + 15000]);
+	});
+
+	it("fails when the user denies the authorization", async () => {
+		vi.useFakeTimers();
+		stubFetchRouter([jsonResponse({ error: "access_denied" }, 400)]);
+
+		const loginPromise = loginXai({ onAuth: () => {}, onPrompt: async () => "" });
+		const assertion = expect(loginPromise).rejects.toThrow("xAI device authorization was denied");
+		await vi.advanceTimersByTimeAsync(5000);
+		await assertion;
+	});
+
+	it("fails when the device code expires", async () => {
+		vi.useFakeTimers();
+		stubFetchRouter([jsonResponse({ error: "expired_token" }, 400)]);
+
+		const loginPromise = loginXai({ onAuth: () => {}, onPrompt: async () => "" });
+		const assertion = expect(loginPromise).rejects.toThrow("xAI device code expired");
+		await vi.advanceTimersByTimeAsync(5000);
+		await assertion;
+	});
+
+	it("stops polling at the device code deadline", async () => {
+		vi.useFakeTimers();
+		const { tokenPollTimes } = stubFetchRouter(
+			[jsonResponse({ error: "authorization_pending" }, 400)],
+			deviceCodeResponse({ expires_in: 8 }),
+		);
+
+		const loginPromise = loginXai({ onAuth: () => {}, onPrompt: async () => "" });
+		const assertion = expect(loginPromise).rejects.toThrow("xAI device code expired");
+		await vi.advanceTimersByTimeAsync(8000);
+		await assertion;
+		expect(tokenPollTimes).toHaveLength(1);
+	});
+
+	it("cancels polling when the abort signal fires", async () => {
+		vi.useFakeTimers();
+		stubFetchRouter([]);
+		const controller = new AbortController();
+
+		const loginPromise = loginXai({ onAuth: () => {}, onPrompt: async () => "", signal: controller.signal });
+		const assertion = expect(loginPromise).rejects.toThrow("Login cancelled");
+		await vi.advanceTimersByTimeAsync(1000);
+		controller.abort();
+		await assertion;
+	});
+
+	it("surfaces device authorization errors", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({ error: "invalid_client", error_description: "unknown client" }, 401)),
+		);
+
+		await expect(loginXai({ onAuth: () => {}, onPrompt: async () => "" })).rejects.toThrow(
+			"xAI OAuth device authorization failed (HTTP 401): invalid_client: unknown client",
+		);
+	});
+
+	it("rejects non-HTTPS verification URLs", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				jsonResponse({
+					device_code: "device-code",
+					user_code: "ZZFP-2324",
+					verification_uri: "http://accounts.x.ai/oauth2/device",
+					expires_in: 1800,
+					interval: 5,
+				}),
+			),
+		);
+
+		await expect(loginXai({ onAuth: () => {}, onPrompt: async () => "" })).rejects.toThrow(
+			"non-HTTPS verification_uri",
+		);
+	});
+});
+
+describe("xAI OAuth token refresh", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it("refreshes and keeps a rotated refresh token", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-03-09T00:00:00Z"));
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			expect(getUrl(input)).toBe(TOKEN_URL);
+			expect(String(init?.body)).toContain("grant_type=refresh_token");
+			expect(String(init?.body)).toContain("refresh_token=old-refresh");
+			return tokenResponse({ access_token: "new-access", refresh_token: "new-refresh" });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await refreshXaiToken("old-refresh");
+		expect(credentials.access).toBe("new-access");
+		expect(credentials.refresh).toBe("new-refresh");
+		expect(credentials.expires).toBe(Date.now() + 3600 * 1000 - 5 * 60 * 1000);
+	});
+
+	it("keeps the previous refresh token when the response does not rotate it", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => tokenResponse({ access_token: "new-access", refresh_token: undefined })),
+		);
+
+		const credentials = await refreshXaiToken("old-refresh");
+		expect(credentials.refresh).toBe("old-refresh");
+	});
+
+	it("tells the user to log in again when the refresh token is revoked", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({ error: "invalid_grant", error_description: "revoked" }, 400)),
+		);
+
+		await expect(refreshXaiToken("revoked-refresh")).rejects.toThrow(
+			"xAI OAuth token refresh failed (HTTP 400): invalid_grant: revoked. Run /login and sign in to xAI again.",
+		);
+	});
+
+	it("keeps upstream details for other refresh failures", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({ error: "server_error" }, 500)),
+		);
+
+		await expect(refreshXaiToken("refresh")).rejects.toThrow(
+			"xAI OAuth token refresh failed (HTTP 500): server_error",
+		);
+	});
+});
+
+describe("xAI OAuth model modification", () => {
+	function xaiModel(overrides: Partial<Model<"openai-completions">> = {}): Model<Api> {
+		return {
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			api: "openai-completions",
+			provider: "xai",
+			baseUrl: "https://api.x.ai/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 2, output: 6, cacheRead: 0.3, cacheWrite: 0 },
+			contextWindow: 500000,
+			maxTokens: 500000,
+			...overrides,
+		} as Model<Api>;
+	}
+
+	it("moves xAI chat-completions models to the Responses API", () => {
+		const [model] = applyXaiOAuthModels([xaiModel()]);
+		expect(model.api).toBe("openai-responses");
+		expect(model.provider).toBe("xai");
+		expect(model.baseUrl).toBe("https://api.x.ai/v1");
+		expect(model.compat).toEqual({ supportsLongCacheRetention: false });
+	});
+
+	it("disables the off and minimal thinking levels for reasoning models", () => {
+		const [model] = applyXaiOAuthModels([xaiModel()]);
+		expect(model.thinkingLevelMap).toEqual({ off: null, minimal: null });
+	});
+
+	it("leaves non-reasoning models without a thinking level map", () => {
+		const [model] = applyXaiOAuthModels([xaiModel({ id: "grok-code-fast-1", reasoning: false })]);
+		expect(model.api).toBe("openai-responses");
+		expect(model.thinkingLevelMap).toBeUndefined();
+	});
+
+	it("does not touch other providers or non-completions models", () => {
+		const other: Model<Api> = xaiModel({ provider: "openai" } as Partial<Model<"openai-completions">>);
+		const custom: Model<Api> = { ...xaiModel(), api: "openai-responses" } as Model<Api>;
+		const [unchangedOther, unchangedCustom] = applyXaiOAuthModels([other, custom]);
+		expect(unchangedOther).toBe(other);
+		expect(unchangedCustom).toBe(custom);
+	});
+
+	it("registers the provider with the shared xai id and access-token API key", () => {
+		expect(xaiOAuthProvider.id).toBe("xai");
+		expect(xaiOAuthProvider.getApiKey({ access: "token", refresh: "r", expires: 0 })).toBe("token");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.
 - Added xAI (SuperGrok/X Premium) to `/login` so Grok models can be used on a subscription without an `XAI_API_KEY` ([#678](https://github.com/PrimeIntellect-ai/prime-agent/issues/678)).
+- Fixed OAuth refresh failures surfacing generic missing-key guidance instead of the provider's actionable error message.
+- Fixed model shapes not following the active auth source: a runtime `--api-key` or an environment fallback after a stale credential now outranks a stored OAuth credential's model modifications, and live sessions rebind their selected and scoped models when `/login`, `/logout`, auth staleness, or model cycling reshapes the catalog.
 - Added a configurable copy action to login dialogs so raw sign-in URLs can be copied without selecting wrapped text ([#643](https://github.com/PrimeIntellect-ai/prime-agent/issues/643)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,8 +9,8 @@
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.
 - Added xAI (SuperGrok/X Premium) to `/login` so Grok models can be used on a subscription without an `XAI_API_KEY` ([#678](https://github.com/PrimeIntellect-ai/prime-agent/issues/678)).
-- Fixed OAuth refresh failures surfacing generic missing-key guidance instead of the provider's actionable error message.
-- Fixed model shapes not following the active auth source: a runtime `--api-key` or an environment fallback after a stale credential now outranks a stored OAuth credential's model modifications, and live sessions rebind their selected and scoped models when `/login`, `/logout`, auth staleness, or model cycling reshapes the catalog.
+- Fixed OAuth refresh failures surfacing generic missing-key guidance instead of the provider's actionable error message ([#678](https://github.com/PrimeIntellect-ai/prime-agent/issues/678)).
+- Fixed model shapes not following the active auth source: a runtime `--api-key` or an environment fallback after a stale credential now outranks a stored OAuth credential's model modifications, and live sessions rebind their selected and scoped models when `/login`, `/logout`, auth staleness, or model cycling reshapes the catalog ([#678](https://github.com/PrimeIntellect-ai/prime-agent/issues/678)).
 - Added a configurable copy action to login dialogs so raw sign-in URLs can be copied without selecting wrapped text ([#643](https://github.com/PrimeIntellect-ai/prime-agent/issues/643)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added `app.messages.expand` (`ctrl+p`) to collapse or expand agent-to-agent messages separately from `ctrl+o` tool output.
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.
-- Added xAI (SuperGrok/X Premium) to `/login` so Grok models can be used on a subscription without an `XAI_API_KEY`.
+- Added xAI (SuperGrok/X Premium) to `/login` so Grok models can be used on a subscription without an `XAI_API_KEY` ([#678](https://github.com/PrimeIntellect-ai/prime-agent/issues/678)).
 - Added a configurable copy action to login dialogs so raw sign-in URLs can be copied without selecting wrapped text ([#643](https://github.com/PrimeIntellect-ai/prime-agent/issues/643)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `app.messages.expand` (`ctrl+p`) to collapse or expand agent-to-agent messages separately from `ctrl+o` tool output.
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.
+- Added xAI (SuperGrok/X Premium) to `/login` so Grok models can be used on a subscription without an `XAI_API_KEY`.
 - Added a configurable copy action to login dialogs so raw sign-in URLs can be copied without selecting wrapped text ([#643](https://github.com/PrimeIntellect-ai/prime-agent/issues/643)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -18,6 +18,7 @@ Use `/login` in interactive mode, then select a provider:
 - ChatGPT Plus/Pro (Codex)
 - Claude Pro/Max
 - GitHub Copilot
+- xAI (SuperGrok/X Premium)
 
 Use `/logout` to clear credentials. Tokens are stored in `~/.prime/agent/auth.json` and auto-refresh when expired.
 
@@ -34,6 +35,12 @@ Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party h
 
 - Press Enter for github.com, or enter your GitHub Enterprise Server domain
 - If you get "model not supported", enable it in VS Code: Copilot Chat → model selector → select model → "Enable"
+
+### xAI (SuperGrok/X Premium)
+
+- Requires a SuperGrok or X Premium subscription
+- Open the sign-in link, confirm the code shown in the terminal, and approve the login; no callback server is used, so this also works over SSH
+- While subscription credentials are active, xAI models are served over the Responses API (`https://api.x.ai/v1/responses`), the same rail xAI's Grok CLI uses; with an `XAI_API_KEY` they keep using Chat Completions
 
 ## API Keys
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -638,7 +638,7 @@ export interface TurnExecutionPolicy {
  * headers). Used to decide if a live session model must be rebound after the
  * registry catalog is rebuilt.
  */
-function modelRequestShapeChanged(a: Model<any>, b: Model<any>): boolean {
+function modelRequestShapeChanged(a: Model<Api>, b: Model<Api>): boolean {
 	return (
 		a.api !== b.api ||
 		a.baseUrl !== b.baseUrl ||

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -632,6 +632,22 @@ export interface TurnExecutionPolicy {
 	completionIncludesRetryChain: boolean;
 }
 
+/**
+ * Whether two catalog entries for the same logical model differ in the fields
+ * that shape provider requests (API rail, endpoint, compat, thinking levels,
+ * headers). Used to decide if a live session model must be rebound after the
+ * registry catalog is rebuilt.
+ */
+function modelRequestShapeChanged(a: Model<any>, b: Model<any>): boolean {
+	return (
+		a.api !== b.api ||
+		a.baseUrl !== b.baseUrl ||
+		JSON.stringify(a.compat ?? null) !== JSON.stringify(b.compat ?? null) ||
+		JSON.stringify(a.thinkingLevelMap ?? null) !== JSON.stringify(b.thinkingLevelMap ?? null) ||
+		JSON.stringify(a.headers ?? null) !== JSON.stringify(b.headers ?? null)
+	);
+}
+
 function turnExecutionPoliciesEqual(left: TurnExecutionPolicy, right: TurnExecutionPolicy): boolean {
 	return (
 		left.preparation.initialRefineBarrier === right.preparation.initialRefineBarrier &&
@@ -4250,11 +4266,13 @@ export class AgentSession {
 	 * logout switching a provider between API rails). Keeps the same logical
 	 * model selection, so no session history or settings are touched beyond
 	 * re-clamping the thinking level for the rebound model's capabilities.
+	 * Models are only swapped when their request shape actually changed, so
+	 * routine catalog refreshes stay side-effect free.
 	 */
 	rebindModelsFromRegistry(): void {
 		this._scopedModels = this._scopedModels.map((scoped) => {
 			const rebound = this._modelRegistry.find(scoped.model.provider, scoped.model.id);
-			return rebound && rebound !== scoped.model ? { ...scoped, model: rebound } : scoped;
+			return rebound && modelRequestShapeChanged(scoped.model, rebound) ? { ...scoped, model: rebound } : scoped;
 		});
 
 		const current = this.agent.state.model;
@@ -4262,7 +4280,7 @@ export class AgentSession {
 			return;
 		}
 		const rebound = this._modelRegistry.find(current.provider, current.id);
-		if (!rebound || rebound === current) {
+		if (!rebound || !modelRequestShapeChanged(current, rebound)) {
 			return;
 		}
 		this.agent.state.model = rebound;
@@ -10192,6 +10210,7 @@ export class AgentSession {
 				marked = this._modelRegistry.markProviderAuthSourceStale(token) || marked;
 			}
 			if (marked) {
+				this._refreshCatalogAfterAuthStale();
 				this._emit({
 					type: "auth_stale",
 					provider: message.provider,
@@ -10202,9 +10221,21 @@ export class AgentSession {
 		}
 		const marked = this._modelRegistry.markProviderAuthStale(message.provider);
 		if (marked) {
+			this._refreshCatalogAfterAuthStale();
 			this._emit({ type: "auth_stale", provider: message.provider });
 		}
 		return marked;
+	}
+
+	/**
+	 * A stale credential can change the active auth source (e.g. stored OAuth
+	 * falling back to an environment API key), which can reshape provider
+	 * models. Rebuild the catalog and rebind the live models so the next
+	 * request uses the shapes that match the auth source it will resolve.
+	 */
+	private _refreshCatalogAfterAuthStale(): void {
+		this._modelRegistry.refresh();
+		this.rebindModelsFromRegistry();
 	}
 
 	private _markProviderAuthStaleForRetryFailure(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6801,6 +6801,9 @@ export class AgentSession {
 		options: ModelSelectOptions,
 	): Promise<ModelCycleResult | undefined> {
 		const availableModels = await this._modelRegistry.refreshAvailableModels();
+		// The refresh may have reshaped provider models (e.g. an auth change
+		// switching API rails), so re-resolve the scoped objects before cycling.
+		this.rebindModelsFromRegistry();
 		const scopedModels = this._scopedModels.filter((scoped) =>
 			availableModels.some((model) => modelsAreEqual(model, scoped.model)),
 		);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4244,6 +4244,31 @@ export class AgentSession {
 		this._scopedModels = scopedModels;
 	}
 
+	/**
+	 * Re-resolve the live and scoped model objects from the current registry
+	 * catalog after a credential change reshaped it (e.g. an OAuth login or
+	 * logout switching a provider between API rails). Keeps the same logical
+	 * model selection, so no session history or settings are touched beyond
+	 * re-clamping the thinking level for the rebound model's capabilities.
+	 */
+	rebindModelsFromRegistry(): void {
+		this._scopedModels = this._scopedModels.map((scoped) => {
+			const rebound = this._modelRegistry.find(scoped.model.provider, scoped.model.id);
+			return rebound && rebound !== scoped.model ? { ...scoped, model: rebound } : scoped;
+		});
+
+		const current = this.agent.state.model;
+		if (!current) {
+			return;
+		}
+		const rebound = this._modelRegistry.find(current.provider, current.id);
+		if (!rebound || rebound === current) {
+			return;
+		}
+		this.agent.state.model = rebound;
+		this.setThinkingLevel(this.thinkingLevel);
+	}
+
 	/** File-based prompt templates */
 	get promptTemplates(): ReadonlyArray<PromptTemplate> {
 		return this._resourceLoader.getPrompts().prompts;

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -98,6 +98,8 @@ type AuthSourceCandidate = {
 type AuthApiKeyResult = {
 	apiKey?: string;
 	sourceToken?: AuthSourceToken;
+	/** Auth was found but could not produce a key (e.g. OAuth refresh failed). */
+	error?: string;
 };
 
 export interface AuthStorageBackend {
@@ -920,9 +922,11 @@ export class AuthStorage {
 							};
 						}
 
-						// Refresh truly failed - return undefined so model discovery skips this provider
+						// Refresh truly failed - return no key so model discovery skips
+						// this provider, but carry the provider's own error message so
+						// request-time callers can surface actionable guidance.
 						// User can /login to re-authenticate (credentials preserved for retry)
-						return {};
+						return { error: error instanceof Error ? error.message : String(error) };
 					}
 				} else {
 					// Token not expired, use current access token

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -527,9 +527,10 @@ export class ModelRegistry {
 		for (const oauthProvider of this.authStorage.getOAuthProviders()) {
 			const cred = this.authStorage.get(oauthProvider.id);
 			if (cred?.type === "oauth" && oauthProvider.modifyModels) {
-				// A runtime --api-key override outranks stored OAuth credentials,
-				// so keep the API-key model shapes while one is active.
-				if (this.authStorage.getAuthStatus(oauthProvider.id).source === "runtime") {
+				// Only reshape models while the stored OAuth credential is the
+				// active auth source; a runtime --api-key override or an
+				// environment fallback after a stale credential outranks it.
+				if (this.authStorage.getAuthStatus(oauthProvider.id).source !== "stored") {
 					continue;
 				}
 				combined = oauthProvider.modifyModels(combined, cred);

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -527,6 +527,11 @@ export class ModelRegistry {
 		for (const oauthProvider of this.authStorage.getOAuthProviders()) {
 			const cred = this.authStorage.get(oauthProvider.id);
 			if (cred?.type === "oauth" && oauthProvider.modifyModels) {
+				// A runtime --api-key override outranks stored OAuth credentials,
+				// so keep the API-key model shapes while one is active.
+				if (this.authStorage.getAuthStatus(oauthProvider.id).source === "runtime") {
+					continue;
+				}
 				combined = oauthProvider.modifyModels(combined, cred);
 			}
 		}

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -1325,6 +1325,10 @@ export class ModelRegistry {
 			}
 			this.setLastProviderAuthSourceToken(model.provider, apiKey === undefined ? undefined : authSourceToken);
 
+			if (apiKey === undefined && authStorageAuth.error) {
+				return { ok: false, error: authStorageAuth.error };
+			}
+
 			const providerHeaders = resolveHeadersOrThrow(providerConfig?.headers, `provider "${model.provider}"`);
 			const authStorageHeaders = this.authStorage.getProviderHeaders(model.provider);
 			const modelHeaders = resolveHeadersOrThrow(

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -795,6 +795,12 @@ async function prepareRuntimeServices(options: {
 				modelRegistry.refresh();
 				if (modelPatterns && modelPatterns.length > 0) {
 					scopedModels = await resolveModelScope(modelPatterns, modelRegistry);
+					if (scopedModels.length > 0) {
+						sessionOptions.scopedModels = scopedModels.map((sm) => ({
+							model: sm.model,
+							thinkingLevel: sm.thinkingLevel,
+						}));
+					}
 				}
 				if (!options.sessionOptionsOverride?.model && sessionOptions.model) {
 					const rebuilt = modelRegistry.find(sessionOptions.model.provider, sessionOptions.model.id);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -764,7 +764,7 @@ async function prepareRuntimeServices(options: {
 	];
 
 	const modelPatterns = config.models ?? settingsManager.getEnabledModels();
-	const scopedModels =
+	let scopedModels =
 		modelPatterns && modelPatterns.length > 0 ? await resolveModelScope(modelPatterns, modelRegistry) : [];
 	const {
 		options: sessionOptions,
@@ -788,6 +788,21 @@ async function prepareRuntimeServices(options: {
 			});
 		} else {
 			authStorage.setRuntimeApiKey(effectiveSessionModel.provider, config.apiKey);
+			// The runtime key outranks a stored OAuth credential for the same
+			// provider, so rebuild the catalog without that credential's model
+			// modifications and re-resolve the already-selected models.
+			if (authStorage.get(effectiveSessionModel.provider)?.type === "oauth") {
+				modelRegistry.refresh();
+				if (modelPatterns && modelPatterns.length > 0) {
+					scopedModels = await resolveModelScope(modelPatterns, modelRegistry);
+				}
+				if (!options.sessionOptionsOverride?.model && sessionOptions.model) {
+					const rebuilt = modelRegistry.find(sessionOptions.model.provider, sessionOptions.model.id);
+					if (rebuilt) {
+						sessionOptions.model = rebuilt;
+					}
+				}
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -145,11 +145,15 @@ export class InProcessAgentConnection implements AgentConnection {
 	}
 
 	async getAvailableModels(): Promise<AgentConnectionModel[]> {
-		return this.session.modelRegistry.refreshAvailableModels();
+		const models = await this.session.modelRegistry.refreshAvailableModels();
+		this.session.rebindModelsFromRegistry();
+		return models;
 	}
 
 	async getModelCatalog(): Promise<AgentConnectionModelCatalog> {
-		return this.session.modelRegistry.refreshModelCatalog();
+		const catalog = await this.session.modelRegistry.refreshModelCatalog();
+		this.session.rebindModelsFromRegistry();
+		return catalog;
 	}
 
 	async getSessionStats(): Promise<SessionStats> {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -4160,18 +4160,16 @@ export class AgentDaemon {
 
 			case "get_available_models": {
 				const state = this.getSessionState(command.activeSessionId);
-				return success(command.id, "get_available_models", {
-					models: await state.runtime.session.modelRegistry.refreshAvailableModels(),
-				});
+				const models = await state.runtime.session.modelRegistry.refreshAvailableModels();
+				state.runtime.session.rebindModelsFromRegistry();
+				return success(command.id, "get_available_models", { models });
 			}
 
 			case "get_model_catalog": {
 				const state = this.getSessionState(command.activeSessionId);
-				return success(
-					command.id,
-					"get_model_catalog",
-					await state.runtime.session.modelRegistry.refreshModelCatalog(),
-				);
+				const catalog = await state.runtime.session.modelRegistry.refreshModelCatalog();
+				state.runtime.session.rebindModelsFromRegistry();
+				return success(command.id, "get_model_catalog", catalog);
 			}
 
 			case "get_queue": {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2723,6 +2723,9 @@ export class InteractiveMode {
 		if (!marked) {
 			this.modelRegistry.markProviderAuthStale(event.provider);
 		}
+		// The auth source change can reshape provider models, so refetch the
+		// catalog (the session rebinds its live models during that refresh).
+		void this.refreshConnectionModelsAfterAuthChange();
 		this.footer.invalidate();
 		this.updateEditorBorderColor();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2541,12 +2541,15 @@ export class InteractiveMode {
 
 	private async refreshConnectionCatalog(): Promise<void> {
 		this.invalidateConnectionModelRefresh();
-		const [state, commands, modelCatalog, resources] = await Promise.all([
-			this.agentConnection.getState(),
+		// Fetch the catalog before the state: serving the catalog can rebind the
+		// session's live models (e.g. auth.json changed while detached), and the
+		// state snapshot must reflect the rebound models.
+		const [commands, modelCatalog, resources] = await Promise.all([
 			this.agentConnection.getCommands().catch(() => []),
 			this.agentConnection.getModelCatalog(),
 			this.agentConnection.getResourceSnapshot(),
 		]);
+		const state = await this.agentConnection.getState();
 		this.applyConnectionStateSnapshot(state);
 		this.connectionCommands = commands;
 		this.applyConnectionModelCatalog(modelCatalog);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7760,12 +7760,28 @@ export class InteractiveMode {
 		}
 
 		const version = this.connectionModelsRefreshVersion;
-		const promise = this.agentConnection.getModelCatalog().then((catalog) => {
+		const promise = this.agentConnection.getModelCatalog().then(async (catalog) => {
 			if (version !== this.connectionModelsRefreshVersion) {
 				return [...this.connectionModels];
 			}
 			this.applyConnectionModelCatalog(catalog);
 			this.connectionModelsFetchedAt = Date.now();
+			// The catalog refresh may have rebound the session's live and scoped
+			// models (e.g. an auth change switching API rails), so pull the
+			// fields that mirror them into the connection snapshot. This sync is
+			// best-effort: the models were already fetched, and the next state
+			// event refreshes the snapshot anyway.
+			try {
+				const state = await this.agentConnection.getState();
+				if (version === this.connectionModelsRefreshVersion) {
+					this.patchConnectionState({
+						model: state.model,
+						scopedModels: state.scopedModels,
+						availableThinkingLevels: state.availableThinkingLevels,
+						thinkingLevel: state.thinkingLevel,
+					});
+				}
+			} catch {}
 			return [...this.connectionModels];
 		});
 		this.connectionModelsRefreshInFlight = { version, promise };
@@ -7826,16 +7842,6 @@ export class InteractiveMode {
 	private async refreshConnectionModelsAfterAuthChange(): Promise<void> {
 		this.invalidateConnectionModels();
 		await this.getConnectionAvailableModels();
-		// The catalog refresh may have rebound the session's live and scoped
-		// models (e.g. an auth change switching API rails), so pull the fields
-		// that mirror them into the connection snapshot.
-		const state = await this.agentConnection.getState();
-		this.patchConnectionState({
-			model: state.model,
-			scopedModels: state.scopedModels,
-			availableThinkingLevels: state.availableThinkingLevels,
-			thinkingLevel: state.thinkingLevel,
-		});
 	}
 
 	private async getModelCandidates(): Promise<AgentConnectionModel[]> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2725,7 +2725,9 @@ export class InteractiveMode {
 		}
 		// The auth source change can reshape provider models, so refetch the
 		// catalog (the session rebinds its live models during that refresh).
-		void this.refreshConnectionModelsAfterAuthChange();
+		void this.refreshConnectionModelsAfterAuthChange().catch((error) => {
+			this.showError(error instanceof Error ? error.message : String(error));
+		});
 		this.footer.invalidate();
 		this.updateEditorBorderColor();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7826,6 +7826,16 @@ export class InteractiveMode {
 	private async refreshConnectionModelsAfterAuthChange(): Promise<void> {
 		this.invalidateConnectionModels();
 		await this.getConnectionAvailableModels();
+		// The catalog refresh may have rebound the session's live and scoped
+		// models (e.g. an auth change switching API rails), so pull the fields
+		// that mirror them into the connection snapshot.
+		const state = await this.agentConnection.getState();
+		this.patchConnectionState({
+			model: state.model,
+			scopedModels: state.scopedModels,
+			availableThinkingLevels: state.availableThinkingLevels,
+			thinkingLevel: state.thinkingLevel,
+		});
 	}
 
 	private async getModelCandidates(): Promise<AgentConnectionModel[]> {

--- a/packages/coding-agent/test/agent-connection-in-process.test.ts
+++ b/packages/coding-agent/test/agent-connection-in-process.test.ts
@@ -104,6 +104,7 @@ function createFakeSession(id: string, messages: AgentMessage[]): FakeSessionCon
 		modelRegistry: {
 			refreshModelCatalog: async () => ({ models: model ? [model] : [], configuredProviders: ["openai"] }),
 		},
+		rebindModelsFromRegistry: () => {},
 		scopedModels: [],
 		getActiveToolNames: () => ["ipython"],
 		getContextUsage: () => undefined,

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -2784,6 +2784,7 @@ function createFakeConnectionSession(commandName: string): AgentSessionRuntime["
 			getAgentsFiles: () => ({ agentsFiles: [] }),
 		},
 		modelRegistry: { refreshModelCatalog: async () => ({ models: [], configuredProviders: [] }) },
+		rebindModelsFromRegistry: () => {},
 		sessionManager: {
 			getCwd: () => "/tmp/project",
 			getSessionDir: () => "/tmp/sessions",

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1733,6 +1733,54 @@ describe("ModelRegistry", () => {
 			}
 		});
 
+		test("surfaces the revoked-refresh-token guidance through request auth", async () => {
+			const providerId = `test-oauth-revoked-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			registerOAuthProvider({
+				id: providerId,
+				name: "Test OAuth Revoked",
+				async login() {
+					throw new Error("Not used in this test");
+				},
+				async refreshToken() {
+					throw new Error(
+						"xAI OAuth token refresh failed (HTTP 400): invalid_grant. Run /login and sign in to xAI again.",
+					);
+				},
+				getApiKey(credentials) {
+					return credentials.access;
+				},
+			});
+			authStorage.set(providerId, {
+				type: "oauth",
+				refresh: "revoked-refresh-token",
+				access: "expired-access-token",
+				expires: Date.now() - 10_000,
+			});
+			writeRawModelsJson({
+				[providerId]: { baseUrl: "https://api.example.com/v1", api: "openai-completions", models: [] },
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const model: Model<Api> = {
+				id: "test-model",
+				name: "Test Model",
+				api: "openai-completions",
+				provider: providerId,
+				baseUrl: "https://api.example.com/v1",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 100000,
+				maxTokens: 8000,
+			};
+
+			const auth = await registry.getApiKeyAndHeaders(model);
+			expect(auth.ok).toBe(false);
+			if (!auth.ok) {
+				expect(auth.error).toContain("Run /login and sign in to xAI again.");
+			}
+		});
+
 		test("keeps xAI models on Chat Completions while a runtime API key outranks the OAuth credential", () => {
 			authStorage.set("xai", {
 				type: "oauth",

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1710,5 +1710,26 @@ describe("ModelRegistry", () => {
 				expect(model.api).toBe("openai-completions");
 			}
 		});
+
+		test("keeps xAI models on Chat Completions while a runtime API key outranks the OAuth credential", () => {
+			authStorage.set("xai", {
+				type: "oauth",
+				refresh: "refresh",
+				access: "access",
+				expires: Date.now() + 3600_000,
+			});
+			authStorage.setRuntimeApiKey("xai", "xai-runtime-key");
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			for (const model of getModelsForProvider(registry, "xai")) {
+				expect(model.api).toBe("openai-completions");
+			}
+
+			authStorage.removeRuntimeApiKey("xai");
+			registry.refresh();
+			for (const model of getModelsForProvider(registry, "xai")) {
+				expect(model.api).toBe("openai-responses");
+			}
+		});
 	});
 });

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1711,6 +1711,28 @@ describe("ModelRegistry", () => {
 			}
 		});
 
+		test("keeps xAI models on Chat Completions when a stale OAuth credential falls back to the environment key", async () => {
+			authStorage.set("xai", {
+				type: "oauth",
+				refresh: "refresh",
+				access: "access",
+				expires: Date.now() + 3600_000,
+			});
+			await authStorage.getApiKey("xai");
+			expect(authStorage.markAuthStale("xai")).toBe(true);
+			process.env.XAI_API_KEY = "env-key";
+			try {
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+				const xaiModels = getModelsForProvider(registry, "xai");
+				expect(xaiModels.length).toBeGreaterThan(0);
+				for (const model of xaiModels) {
+					expect(model.api).toBe("openai-completions");
+				}
+			} finally {
+				delete process.env.XAI_API_KEY;
+			}
+		});
+
 		test("keeps xAI models on Chat Completions while a runtime API key outranks the OAuth credential", () => {
 			authStorage.set("xai", {
 				type: "oauth",

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1684,4 +1684,31 @@ describe("ModelRegistry", () => {
 			});
 		});
 	});
+
+	describe("xAI OAuth models", () => {
+		test("serves xAI models over the Responses API while OAuth credentials are stored", () => {
+			authStorage.set("xai", {
+				type: "oauth",
+				refresh: "refresh",
+				access: "access",
+				expires: Date.now() + 3600_000,
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const xaiModels = getModelsForProvider(registry, "xai");
+			expect(xaiModels.length).toBeGreaterThan(0);
+			for (const model of xaiModels) {
+				expect(model.api).toBe("openai-responses");
+			}
+		});
+
+		test("keeps xAI models on Chat Completions without OAuth credentials", () => {
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const xaiModels = getModelsForProvider(registry, "xai");
+			expect(xaiModels.length).toBeGreaterThan(0);
+			for (const model of xaiModels) {
+				expect(model.api).toBe("openai-completions");
+			}
+		});
+	});
 });

--- a/packages/coding-agent/test/suite/agent-session-model-rebind.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-rebind.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { createHarness } from "./harness.js";
+
+describe("agent session model rebinding", () => {
+	it("rebinds the live and scoped model objects from the refreshed registry", async () => {
+		const harness = await createHarness();
+		try {
+			const { session, faux } = harness;
+			const original = session.model;
+			expect(original).toBeDefined();
+			session.setScopedModels([{ model: original! }]);
+
+			// Simulate a credential change reshaping the catalog (e.g. an OAuth
+			// login switching a provider between API rails).
+			session.modelRegistry.registerProvider(original!.provider, {
+				baseUrl: "https://rebound.example/v1",
+				apiKey: "faux-key",
+				api: faux.api,
+				models: faux.models.map((registeredModel) => ({
+					id: registeredModel.id,
+					name: registeredModel.name,
+					api: registeredModel.api,
+					reasoning: registeredModel.reasoning,
+					input: registeredModel.input,
+					cost: registeredModel.cost,
+					contextWindow: registeredModel.contextWindow,
+					maxTokens: registeredModel.maxTokens,
+					baseUrl: "https://rebound.example/v1",
+				})),
+			});
+
+			const historyLengthBefore = session.messages.length;
+			session.rebindModelsFromRegistry();
+
+			expect(session.model).not.toBe(original);
+			expect(session.model?.provider).toBe(original!.provider);
+			expect(session.model?.id).toBe(original!.id);
+			expect(session.model?.baseUrl).toBe("https://rebound.example/v1");
+			expect(session.scopedModels[0]?.model.baseUrl).toBe("https://rebound.example/v1");
+			// Rebinding keeps the same logical selection: no session history entries.
+			expect(session.messages.length).toBe(historyLengthBefore);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("keeps the same logical selection when the catalog is unchanged", async () => {
+		const harness = await createHarness();
+		try {
+			const { session } = harness;
+			const original = session.model;
+			session.rebindModelsFromRegistry();
+			expect(session.model?.provider).toBe(original!.provider);
+			expect(session.model?.id).toBe(original!.id);
+			expect(session.model?.baseUrl).toBe(original!.baseUrl);
+			expect(session.model?.api).toBe(original!.api);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-model-rebind.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-rebind.test.ts
@@ -44,16 +44,13 @@ describe("agent session model rebinding", () => {
 		}
 	});
 
-	it("keeps the same logical selection when the catalog is unchanged", async () => {
+	it("keeps the same model object when the catalog shape is unchanged", async () => {
 		const harness = await createHarness();
 		try {
 			const { session } = harness;
 			const original = session.model;
 			session.rebindModelsFromRegistry();
-			expect(session.model?.provider).toBe(original!.provider);
-			expect(session.model?.id).toBe(original!.id);
-			expect(session.model?.baseUrl).toBe(original!.baseUrl);
-			expect(session.model?.api).toBe(original!.api);
+			expect(session.model).toBe(original);
 		} finally {
 			harness.cleanup();
 		}

--- a/packages/coding-agent/test/suite/regressions/678-agent-session-model-rebind.test.ts
+++ b/packages/coding-agent/test/suite/regressions/678-agent-session-model-rebind.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createHarness } from "./harness.js";
+import { createHarness } from "../harness.js";
 
 describe("agent session model rebinding", () => {
 	it("rebinds the live and scoped model objects from the refreshed registry", async () => {


### PR DESCRIPTION
## Summary

Closes #678.

Adds xAI (SuperGrok/X Premium) as a built-in OAuth provider so subscribers can sign in from `/login` and use Grok models without an `XAI_API_KEY`. Uses the RFC 8628 device authorization grant against `https://auth.x.ai` with the public client id xAI ships in its own Grok CLI, so there is no loopback callback server, no fixed-port conflicts, and login works over SSH and in containers.

## Design

The provider registers under the existing `xai` id, like the Anthropic provider does for its subscription and API-key rails. Two consequences keep the diff small and the blast radius zero:

- **No new provider id, no catalog duplication.** `types.ts`, `env-api-keys.ts`, `generate-models.ts`, and `models.generated.ts` are untouched.
- **API-key users see no behavior change.** Subscription tokens authorize the Responses API rail that the Grok CLI itself uses (`api_backend: "responses"` in [grok-build's default_models.json](https://github.com/xai-org/grok-build), external API keys route to `api.x.ai`). Instead of flipping the shared catalog, the provider uses the existing `modifyModels` OAuth hook — the mechanism GitHub Copilot already uses for baseUrl rewrites — to serve xAI models over `openai-responses` only while OAuth credentials are stored. Reasoning models get `thinkingLevelMap: { off: null, minimal: null }`, matching the low/medium/high efforts Grok exposes.

Because auth.json credentials win over environment variables, an OAuth login cleanly takes over from `XAI_API_KEY` and `/logout` cleanly hands back.

One provider tweak: xAI Responses requests from reasoning models always include `reasoning.encrypted_content`, since Grok always reasons and the items cannot be replayed on the next turn without it.

Revoked or expired refresh tokens surface an actionable error ("Run /login and sign in to xAI again.") instead of a raw HTTP failure, per the feedback on #754.

## Validation

Live end-to-end on a real SuperGrok subscription, running this branch:

- `/login` shows "xAI (SuperGrok/X Premium)"; the dialog displays the prefilled `verification_uri_complete` link plus the user code and polls until approval.
- After approving in the browser, `prime-agent --model xai/grok-4.5` runs Grok 4.5 through the OAuth credentials: single-turn, multi-turn (encrypted reasoning replay), and tool-calling turns all completed over `https://api.x.ai/v1/responses` with reasoning summaries and usage accounting.
- Token refresh against the live endpoint returns HTTP 200 and rotates the refresh token, which the provider persists.
- `reasoning.effort: "none"` is rejected by the live API (`HTTP 400 invalid-argument`), confirming the `off: null` thinking-level mapping is required, and `include: ["reasoning.encrypted_content"]` returns encrypted reasoning items as expected.
- Endpoint semantics without credentials also match the test fixtures exactly: device-code issuance (`interval: 5`, `expires_in: 1800`), `authorization_pending` polling, and `invalid_grant` for revoked refresh tokens.

For completeness: subscription tokens are accepted on both `/v1/responses` and `/v1/chat/completions` (consistent with the independent two-rail verification posted on #678). The Responses rail is used because it is what the Grok CLI itself ships, and it supports reasoning effort control and encrypted reasoning replay, neither of which Grok exposes over Chat Completions (the completions compat path disables `reasoning_effort` for xAI).

Tests and checks:

- `packages/ai`: `test/xai-oauth.test.ts`, 19/19 passed (device flow with fake-timer poll cadence, slow_down interval bumps per RFC 8628 section 3.5, denial/expiry/deadline, abort, refresh rotation and non-rotation, revoked-token hint, `modifyModels` behavior).
- `packages/coding-agent`: `test/model-registry.test.ts`, 74/74 passed, including two new tests that built-in xAI models serve over `openai-responses` with stored OAuth credentials and stay on `openai-completions` without them.
- `packages/coding-agent`: `test/oauth-selector.test.ts`, 21/21 passed.
- `npm run check` passes.

## Relation to existing PRs

#652, #752, #754, and #880 also add xAI OAuth. This PR differs by pairing the device flow with the `modifyModels` hook: the whole change is one new OAuth module plus registry/docs/tests — no generated-catalog edits, no new `KnownProvider`, no API switch for metered users, and all xAI models ride the live-verified subscription rail rather than only `grok-4.5`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add xAI OAuth login via RFC 8628 device flow with live session model rebinding
> - Adds `loginXai` and `refreshXaiToken` in [xai.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1154/files#diff-a09114a3bec83ce83a7c3dfcaaf770c8e5e78ece71fae3b8e6de5109a64df65b) implementing RFC 8628 device authorization against xAI's OIDC issuer, returning OAuth credentials without a local callback server.
> - When xAI OAuth is active, `applyXaiOAuthModels` remaps xAI models from the Chat Completions rail to the Responses API and adjusts thinking level options for reasoning models; API key or env fallbacks bypass this reshaping.
> - `AgentSession.rebindModelsFromRegistry` is introduced to swap live model objects when catalog shape changes (e.g., after auth source changes), called from model/catalog fetch paths and on auth-stale events.
> - Error messages from failed OAuth token refreshes now propagate to callers in both `getOAuthApiKey` and `AuthStorage.getApiKey` instead of returning generic failures.
> - Behavioral Change: runtime `--api-key` for an xAI session now triggers a catalog refresh to remove OAuth-based model reshaping, so model API rail follows the active auth source.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b8fb64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->