### PR TITLE
[stack 5/8] fix(coding-agent): repair queued and archived session lifecycle

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4497,6 +4497,7 @@ export class AgentSession {
 			await this._queuePreparedPrompt("steer", text, undefined, {
 				agentMessageId,
 				message: customMessage,
+				resumeIfIdle: true,
 			});
 			if (customMessage?.details.fromRelationship === "parent") this._repliedToParentSinceTask = false;
 			return true;
@@ -4504,6 +4505,7 @@ export class AgentSession {
 		const queued = await this._queuePreparedPrompt("followUp", text, undefined, {
 			agentMessageId,
 			message: customMessage,
+			resumeIfIdle: true,
 		});
 		if (queued && customMessage?.details.fromRelationship === "parent") this._repliedToParentSinceTask = false;
 		return queued;
@@ -5302,8 +5304,14 @@ export class AgentSession {
 		if (this._disposed || this._disposing) {
 			throw new Error("Cannot admit a session action because the session is disposing or disposed.");
 		}
+		const wakesIdleTurn =
+			!options.restore && options.wake !== false && action.payload.kind === "turn" && action.wake === "immediate";
+		if (wakesIdleTurn) this._sessionInputPumpSuspended = false;
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
 		if (coalescedOwner) {
+			// No new action will reach the normal scheduling path below, so wake
+			// the already-queued owner before this coalesced early return.
+			if (wakesIdleTurn) this._scheduleSessionInputPump();
 			if (action.agentMessageId !== coalescedOwner.agentMessageId) {
 				this._rejectAgentMessage(
 					action.agentMessageId,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1108,6 +1108,7 @@ export class AgentSession {
 	private _sessionInputArrivalEpoch = 0;
 	// Persists abort/restart suspension after the initiating call returns.
 	private _sessionInputPumpSuspended = false;
+	private _sessionInputPumpSuspensionReason: "abort" | "update_restart" | undefined;
 	// Branch mutation pause leases can overlap and must all release before dispatch resumes.
 	private readonly _queuedWorkPauses = new Set<symbol>();
 	private _sessionActionCommitTail: Promise<void> = Promise.resolve();
@@ -4525,7 +4526,7 @@ export class AgentSession {
 		message: CustomMessage,
 		options?: InternalPromptOptions & { executionPolicy?: TurnExecutionPolicy },
 	): Promise<void> {
-		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
+		if (!this.isStreaming && options?.resumeIfIdle) this._resumeSessionInputPumpFromIdleAdmission();
 		const admissionFence = await this._acquireDirectTurnAdmissionFence(options?.signal).catch((error: unknown) => {
 			throwIfPromptAdmissionCancelled(options?.signal);
 			throw error;
@@ -4594,7 +4595,10 @@ export class AgentSession {
 
 	private async _prompt(text: string, options?: InternalPromptOptions): Promise<void> {
 		if (!this.isStreaming) {
-			this._sessionInputPumpSuspended = false;
+			if (this._sessionInputPumpSuspensionReason === "update_restart") {
+				throw new Error("Cannot admit a prompt while the session is preparing for update restart.");
+			}
+			this._resumeSessionInputPumpFromIdleAdmission();
 			this._assertSessionActionAdmissionAvailable();
 		}
 		const commitFence = this.isStreaming
@@ -5288,6 +5292,12 @@ export class AgentSession {
 		}
 	}
 
+	private _resumeSessionInputPumpFromIdleAdmission(): void {
+		if (this._sessionInputPumpSuspensionReason === "update_restart") return;
+		this._sessionInputPumpSuspended = false;
+		this._sessionInputPumpSuspensionReason = undefined;
+	}
+
 	private _admitSessionInput(
 		action: QueuedSessionAction,
 		options: {
@@ -5306,7 +5316,7 @@ export class AgentSession {
 		}
 		const wakesIdleTurn =
 			!options.restore && options.wake !== false && action.payload.kind === "turn" && action.wake === "immediate";
-		if (wakesIdleTurn) this._sessionInputPumpSuspended = false;
+		if (wakesIdleTurn) this._resumeSessionInputPumpFromIdleAdmission();
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
 		if (coalescedOwner) {
 			// No new action will reach the normal scheduling path below, so wake
@@ -5343,7 +5353,9 @@ export class AgentSession {
 				action.payload.kind === "session_command" ||
 				action.wake === "immediate")
 		) {
-			if (action.payload.kind === "turn" && action.wake === "immediate") this._sessionInputPumpSuspended = false;
+			if (action.payload.kind === "turn" && action.wake === "immediate") {
+				this._resumeSessionInputPumpFromIdleAdmission();
+			}
 			this._scheduleSessionInputPump();
 		}
 		return { accepted: true, disposition, ticket: controller.ticket };
@@ -6427,6 +6439,7 @@ export class AgentSession {
 	/** Resume the scheduler after requestAbort/abortForUpdateRestart suspended it; owned pause leases are unaffected. */
 	resumeQueuedWork(): boolean {
 		this._sessionInputPumpSuspended = false;
+		this._sessionInputPumpSuspensionReason = undefined;
 		this._notifySessionInputCheckpointChange();
 		this._scheduleSessionInputPump();
 		return this._hasSelectableSessionInput();
@@ -6515,6 +6528,7 @@ export class AgentSession {
 		this._sessionInputPumpRequested = false;
 		this._sessionInputPumpEpoch++;
 		this._sessionInputPumpSuspended = true;
+		this._sessionInputPumpSuspensionReason = "abort";
 		this._cancelSessionActions(
 			(action) => action.payload.kind === "turn" && !action.payload.queueVisible,
 			new Error("Prompt aborted before delivery."),
@@ -6558,6 +6572,7 @@ export class AgentSession {
 		this._sessionInputPumpRequested = false;
 		this._sessionInputPumpEpoch++;
 		this._sessionInputPumpSuspended = true;
+		this._sessionInputPumpSuspensionReason = "update_restart";
 		this._cancelPostCompactionContinue();
 		this.abortRetry();
 		this._cancelActiveRlmChildRuns("Parent session aborted for update restart");

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9661,6 +9661,7 @@ export class AgentSession {
 		let runningToolCount = 0;
 		let activity: RlmChildAgentActivity | undefined;
 		let childSession: AgentSession | undefined;
+		let flushChildUsageAttribution = () => {};
 		const run: RlmChildRun = {
 			id: childNodeId,
 			prompt,
@@ -9764,6 +9765,23 @@ export class AgentSession {
 				throwIfCancelled();
 				run.status = "running";
 				emitChildUpdate();
+				const parentUsageEntry = parentAssistantForUsage
+					? this._findAssistantEntryForMessage(parentAssistantForUsage)
+					: undefined;
+				const pendingChildUsage = new Map<"spawn_task" | "agent_message" | "direct_user", Usage>();
+				flushChildUsageAttribution = () => {
+					if (!parentAssistantForUsage || !parentUsageEntry || pendingChildUsage.size === 0) return;
+					const batches = [...pendingChildUsage];
+					pendingChildUsage.clear();
+					for (const [origin, childUsage] of batches) {
+						this.sessionManager.appendChildUsageAttribution(
+							parentUsageEntry.id,
+							childUsage,
+							parentAssistantForUsage.usage,
+							origin,
+						);
+					}
+				};
 				const unsubscribeChildEvents = child.subscribe((event) => {
 					if (event.type === "rlm_child_update") {
 						this._emit(event);
@@ -9773,34 +9791,29 @@ export class AgentSession {
 						activity = { kind: "waiting" };
 						emitChildUpdate();
 					} else if (event.type === "agent_end") {
+						flushChildUsageAttribution();
 						activity = undefined;
 						emitChildUpdate();
 					} else if (event.type === "message_end" && event.message.role === "assistant") {
 						const assistant = event.message as AssistantMessage;
 						if (assistant.stopReason !== "error" && assistant.stopReason !== "aborted") {
 							attributeChildUsage(parentAssistantForUsage?.usage ?? emptyUsage(), assistant.usage);
-							if (parentAssistantForUsage) {
-								const parentEntry = this._findAssistantEntryForMessage(parentAssistantForUsage);
-								if (parentEntry) {
-									const messages = child.messages;
-									const assistantIndex = messages.lastIndexOf(assistant);
-									const precedingPrompt = messages
-										.slice(0, assistantIndex)
-										.reverse()
-										.find((message) => message.role === "user" || message.role === "custom");
-									const origin =
-										precedingPrompt?.role === "custom" && isAgentSessionMessage(precedingPrompt)
-											? precedingPrompt.details.id.startsWith("spawn:")
-												? "spawn_task"
-												: "agent_message"
-											: "direct_user";
-									this.sessionManager.appendChildUsageAttribution(
-										parentEntry.id,
-										assistant.usage,
-										parentAssistantForUsage.usage,
-										origin,
-									);
-								}
+							if (parentAssistantForUsage && parentUsageEntry) {
+								const messages = child.messages;
+								const assistantIndex = messages.lastIndexOf(assistant);
+								const precedingPrompt = messages
+									.slice(0, assistantIndex)
+									.reverse()
+									.find((message) => message.role === "user" || message.role === "custom");
+								const origin =
+									precedingPrompt?.role === "custom" && isAgentSessionMessage(precedingPrompt)
+										? precedingPrompt.details.id.startsWith("spawn:")
+											? "spawn_task"
+											: "agent_message"
+										: "direct_user";
+								const batch = pendingChildUsage.get(origin) ?? emptyUsage();
+								addAssistantUsage(batch, assistant.usage);
+								pendingChildUsage.set(origin, batch);
 							}
 						}
 						const text = compactRlmText(readAssistantText(assistant));
@@ -9939,6 +9952,11 @@ export class AgentSession {
 				}
 			} finally {
 				signal?.removeEventListener("abort", abortFromHost);
+				try {
+					flushChildUsageAttribution();
+				} catch {
+					// Attribution persistence must not prevent terminal child cleanup.
+				}
 				if (run.detachedDeletion && childRuntime) {
 					try {
 						await this._deleteRlmSubagentSession(run.id, childRuntime.session);

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -24,9 +24,64 @@ import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 const RLM_BOOTSTRAP_BASE_CODE = `
 import asyncio
 import os as _prime_agent_os
+import signal as _prime_agent_signal
+import IPython.core.magics.script as _prime_agent_script_magics
 
 _prime_agent_os.environ["NO_COLOR"] = "1"
 get_ipython().colors = "nocolor"
+
+# IPython signals only the script process when a %%bash/%%script cell is
+# interrupted. Non-interactive shells do not forward that signal to their
+# foreground child, so isolate each script in a process group and make the
+# existing SIGINT -> SIGTERM -> SIGKILL escalation target the whole group.
+if _prime_agent_os.name == "posix" and not getattr(
+    _prime_agent_script_magics.asyncio, "_prime_agent_process_groups", False
+):
+    _prime_agent_real_asyncio = _prime_agent_script_magics.asyncio
+
+    class _PrimeAgentProcessGroup:
+        def __init__(self, process):
+            self._process = process
+            self._loop = _prime_agent_real_asyncio.get_running_loop()
+            self._interrupt_escalation_scheduled = False
+
+        def __getattr__(self, name):
+            return getattr(self._process, name)
+
+        def _signal_group(self, sig):
+            try:
+                _prime_agent_os.killpg(self.pid, sig)
+            except ProcessLookupError:
+                pass
+
+        def send_signal(self, sig):
+            self._signal_group(sig)
+            if sig == _prime_agent_signal.SIGINT and not self._interrupt_escalation_scheduled:
+                self._interrupt_escalation_scheduled = True
+                # IPython's own wait_for may raise before it reaches its later
+                # terminate/kill calls, so keep the escalation inside the group
+                # proxy and guarantee stubborn descendants are reaped.
+                self._loop.call_later(0.05, self._signal_group, _prime_agent_signal.SIGTERM)
+                self._loop.call_later(0.10, self._signal_group, _prime_agent_signal.SIGKILL)
+
+        def terminate(self):
+            self._signal_group(_prime_agent_signal.SIGTERM)
+
+        def kill(self):
+            self._signal_group(_prime_agent_signal.SIGKILL)
+
+    class _PrimeAgentScriptAsyncio:
+        _prime_agent_process_groups = True
+
+        def __getattr__(self, name):
+            return getattr(_prime_agent_real_asyncio, name)
+
+        async def create_subprocess_exec(self, *args, **kwargs):
+            kwargs["start_new_session"] = True
+            process = await _prime_agent_real_asyncio.create_subprocess_exec(*args, **kwargs)
+            return _PrimeAgentProcessGroup(process)
+
+    _prime_agent_script_magics.asyncio = _PrimeAgentScriptAsyncio()
 
 try:
     import nest_asyncio as _prime_agent_nest_asyncio

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -61,8 +61,8 @@ if _prime_agent_os.name == "posix" and not getattr(
                 # IPython's own wait_for may raise before it reaches its later
                 # terminate/kill calls, so keep the escalation inside the group
                 # proxy and guarantee stubborn descendants are reaped.
-                self._loop.call_later(0.05, self._signal_group, _prime_agent_signal.SIGTERM)
-                self._loop.call_later(0.10, self._signal_group, _prime_agent_signal.SIGKILL)
+                self._loop.call_later(0.10, self._signal_group, _prime_agent_signal.SIGTERM)
+                self._loop.call_later(0.20, self._signal_group, _prime_agent_signal.SIGKILL)
 
         def terminate(self):
             self._signal_group(_prime_agent_signal.SIGTERM)

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -963,6 +963,7 @@ async function createDaemonClientConnection(options: {
 				supportsExtensionUi: options.supportsExtensionUi,
 				recoverDaemon: () => ensureInteractiveDaemonRunning(options.socketPath),
 				telemetryDisabled: options.config.telemetryDisabled,
+				reviveConfig: options.config,
 			});
 			return { connection, summary };
 		};

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -756,9 +756,30 @@ export class DaemonAgentConnection implements AgentConnection {
 			await this.promptOnce(sourceActiveSessionId, type, message, options);
 			return;
 		} catch (error) {
-			if (!this.canRevivePrompt(error, sourceActiveSessionId, sourceSessionFile, options?.signal)) {
-				throw error;
+			if (!this.isDefinitiveUnknownSessionError(error, sourceActiveSessionId)) throw error;
+			const concurrentRevival = this.revival;
+			if (
+				concurrentRevival?.sourceActiveSessionId === sourceActiveSessionId &&
+				concurrentRevival.sessionFile === sourceSessionFile
+			) {
+				try {
+					await concurrentRevival.promise;
+				} catch {
+					throw error;
+				}
 			}
+			if (
+				sourceSessionFile &&
+				this.activeSessionId !== sourceActiveSessionId &&
+				this.attachedSessionFile === sourceSessionFile
+			) {
+				if (options?.signal?.aborted) {
+					throw new AgentConnectionPromptAdmissionError("Prompt admission was cancelled.", "cancelled");
+				}
+				await this.promptOnce(this.activeSessionId, type, message, options);
+				return;
+			}
+			if (!this.canRevivePrompt(error, sourceActiveSessionId, sourceSessionFile, options?.signal)) throw error;
 			try {
 				await this.reviveArchivedSession(sourceActiveSessionId, sourceSessionFile!);
 			} catch {
@@ -773,6 +794,14 @@ export class DaemonAgentConnection implements AgentConnection {
 		}
 	}
 
+	private isDefinitiveUnknownSessionError(error: unknown, activeSessionId: string): error is Error {
+		return (
+			error instanceof Error &&
+			this.definitiveRequestErrors.has(error) &&
+			error.message.trim() === `Unknown active session: ${activeSessionId}`
+		);
+	}
+
 	private canRevivePrompt(
 		error: unknown,
 		sourceActiveSessionId: string,
@@ -780,9 +809,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		signal: AbortSignal | undefined,
 	): boolean {
 		return (
-			error instanceof Error &&
-			this.definitiveRequestErrors.has(error) &&
-			error.message.trim() === `Unknown active session: ${sourceActiveSessionId}` &&
+			this.isDefinitiveUnknownSessionError(error, sourceActiveSessionId) &&
 			Boolean(sourceSessionFile) &&
 			Boolean(this.options.reviveConfig) &&
 			!this.options.ownedSession &&

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -4,6 +4,7 @@ import type { ImageContent, ServiceTier, Transport } from "@earendil-works/pi-ai
 import { appendRotatingLog, getAgentLogPath, getDaemonLogPath } from "../../config.js";
 import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { AgentSessionEvent } from "../../core/agent-session.js";
+import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
@@ -169,6 +170,8 @@ export interface DaemonAgentConnectionOptions {
 	ownedSession?: boolean;
 	/** Require the target worker to have been created with telemetry disabled. */
 	telemetryDisabled?: true;
+	/** Runtime config used to recreate this saved transcript if its worker was archived. */
+	reviveConfig?: AgentSessionRuntimeConfig;
 }
 
 /**
@@ -228,6 +231,7 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly ignoredSnapshotIds = new Set<string>();
 	private reconnectPromise?: Promise<void>;
 	private readonly definitiveRequestErrors = new WeakSet<Error>();
+	private revival: { sourceActiveSessionId: string; sessionFile: string; promise: Promise<void> } | undefined;
 	private disposing = false;
 	private disposed = false;
 
@@ -744,6 +748,91 @@ export class DaemonAgentConnection implements AgentConnection {
 		message: string,
 		options?: AgentConnectionPromptOptions,
 	): Promise<void> {
+		const pendingRevival = this.revival;
+		if (pendingRevival) await pendingRevival.promise.catch(() => undefined);
+		const sourceActiveSessionId = this.activeSessionId;
+		const sourceSessionFile = this.attachedSessionFile;
+		try {
+			await this.promptOnce(sourceActiveSessionId, type, message, options);
+			return;
+		} catch (error) {
+			if (!this.canRevivePrompt(error, sourceActiveSessionId, sourceSessionFile, options?.signal)) {
+				throw error;
+			}
+			try {
+				await this.reviveArchivedSession(sourceActiveSessionId, sourceSessionFile!);
+			} catch {
+				// The unknown-session response is the actionable failure. A create or
+				// attach detail is implementation noise and a later prompt may retry.
+				throw error;
+			}
+			if (options?.signal?.aborted) {
+				throw new AgentConnectionPromptAdmissionError("Prompt admission was cancelled.", "cancelled");
+			}
+			await this.promptOnce(this.activeSessionId, type, message, options);
+		}
+	}
+
+	private canRevivePrompt(
+		error: unknown,
+		sourceActiveSessionId: string,
+		sourceSessionFile: string | undefined,
+		signal: AbortSignal | undefined,
+	): boolean {
+		return (
+			error instanceof Error &&
+			this.definitiveRequestErrors.has(error) &&
+			error.message.trim() === `Unknown active session: ${sourceActiveSessionId}` &&
+			Boolean(sourceSessionFile) &&
+			Boolean(this.options.reviveConfig) &&
+			!this.options.ownedSession &&
+			!this.disposed &&
+			!this.disposing &&
+			!signal?.aborted
+		);
+	}
+
+	private reviveArchivedSession(sourceActiveSessionId: string, sessionFile: string): Promise<void> {
+		const existing = this.revival;
+		if (
+			existing &&
+			existing.sourceActiveSessionId === sourceActiveSessionId &&
+			existing.sessionFile === sessionFile
+		) {
+			return existing.promise;
+		}
+		const promise = (async () => {
+			const summary = await this.requestData<SessionSummary>({
+				type: "create",
+				sessionPath: sessionFile,
+				config: this.options.reviveConfig,
+				lifecycle: "resident",
+				env: this.options.sendClientEnv ? collectDaemonClientEnv() : undefined,
+			});
+			if (
+				this.disposed ||
+				this.disposing ||
+				this.activeSessionId !== sourceActiveSessionId ||
+				this.attachedSessionFile !== sessionFile
+			) {
+				throw new Error("Archived-session revival was superseded");
+			}
+			const targetActiveSessionId = summary.activeSessionId ?? summary.id;
+			await this.reattachSession(sourceActiveSessionId, targetActiveSessionId);
+			this.terminalCloseEmitted = false;
+		})().finally(() => {
+			if (this.revival?.promise === promise) this.revival = undefined;
+		});
+		this.revival = { sourceActiveSessionId, sessionFile, promise };
+		return promise;
+	}
+
+	private async promptOnce(
+		targetActiveSessionId: string,
+		type: "prompt" | "prompt_and_wait",
+		message: string,
+		options?: AgentConnectionPromptOptions,
+	): Promise<void> {
 		const signal = options?.signal;
 		if (signal?.aborted) {
 			throw new AgentConnectionPromptAdmissionError("Prompt admission was cancelled.", "cancelled");
@@ -752,7 +841,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			await this.requestData<unknown>(
 				{
 					type,
-					activeSessionId: this.activeSessionId,
+					activeSessionId: targetActiveSessionId,
 					message,
 					images: options?.images,
 					streamingBehavior: options?.streamingBehavior,
@@ -777,7 +866,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		}
 		const command = {
 			type,
-			activeSessionId: this.activeSessionId,
+			activeSessionId: targetActiveSessionId,
 			message,
 			images: options.images,
 			streamingBehavior: options.streamingBehavior,
@@ -811,7 +900,7 @@ export class DaemonAgentConnection implements AgentConnection {
 			try {
 				const result = await this.requestData<{ status: "cancelled" | "owned" | "unknown" }>({
 					type: "cancel_prompt_admission",
-					activeSessionId: this.activeSessionId,
+					activeSessionId: targetActiveSessionId,
 					admissionId,
 				});
 				status = result.status;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -337,6 +337,7 @@ async function openAgentsViewSession(
 				recoverDaemon: options.recoverDaemon,
 				reconnectTimeoutMs: options.reconnectTimeoutMs,
 				telemetryDisabled: options.config.telemetryDisabled,
+				reviveConfig: options.config,
 			});
 			return { connection, summary };
 		} catch (error) {
@@ -360,6 +361,7 @@ async function openAgentsViewSession(
 			recoverDaemon: options.recoverDaemon,
 			reconnectTimeoutMs: options.reconnectTimeoutMs,
 			telemetryDisabled: options.config.telemetryDisabled,
+			reviveConfig: options.config,
 		});
 		return { connection, summary: resumed.summary, cwdFallbackNotice: resumed.cwdFallbackNotice };
 	} catch (error) {
@@ -2067,6 +2069,7 @@ export class AgentsViewMode implements Component, Focusable {
 				recoverDaemon: this.options.recoverDaemon,
 				reconnectTimeoutMs: this.options.reconnectTimeoutMs,
 				telemetryDisabled: true,
+				reviveConfig: this.options.config,
 			});
 			try {
 				await connection.prompt(message, streamingBehavior === undefined ? undefined : { streamingBehavior });

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -52,6 +52,8 @@ class FakeDaemonClient {
 	promptGate: Promise<void> | undefined;
 	promptError: Error | undefined;
 	promptResponseError: string | undefined;
+	promptResponseErrors: string[] = [];
+	createActiveSessionId = "active-revived";
 	cancelPromptAdmissionStatus: "cancelled" | "owned" | "unknown" = "owned";
 	serverCapabilities = new Set<string>();
 	updateRestartSessions: Array<Record<string, unknown>> = [];
@@ -75,22 +77,43 @@ class FakeDaemonClient {
 		this.requestTimeouts.push(timeoutMs);
 		switch (command.type) {
 			case "prompt":
+			case "prompt_and_wait": {
 				if (this.promptGate) await this.promptGate;
 				if (this.promptError) throw this.promptError;
-				if (this.promptResponseError) {
-					return { type: "response", command: command.type, success: false, error: this.promptResponseError };
+				const responseError = this.promptResponseErrors.shift() ?? this.promptResponseError;
+				if (responseError) {
+					return { type: "response", command: command.type, success: false, error: responseError };
 				}
 				return { type: "response", command: command.type, success: true };
-			case "prompt_and_wait":
-				if (this.promptGate) await this.promptGate;
-				if (this.promptError) throw this.promptError;
-				return { type: "response", command: command.type, success: true };
+			}
 			case "cancel_prompt_admission":
 				return {
 					type: "response",
 					command: command.type,
 					success: true,
 					data: { status: this.cancelPromptAdmissionStatus },
+				};
+			case "create": {
+				const state = createConnectionState(this.createActiveSessionId, "session-current");
+				return {
+					type: "response",
+					command: command.type,
+					success: true,
+					data: {
+						id: this.createActiveSessionId,
+						activeSessionId: this.createActiveSessionId,
+						sessionId: state.sessionId,
+						sessionFile: state.sessionFile,
+						cwd: state.cwd,
+					},
+				};
+			}
+			case "reattach":
+				return {
+					type: "response",
+					command: command.type,
+					success: true,
+					data: createAttachResult(command.targetActiveSessionId, command.clientId, command.capabilities, 20),
 				};
 			case "list":
 				return {
@@ -709,6 +732,75 @@ describe("DaemonAgentConnection", () => {
 			activeSessionId: "active-1",
 			telemetryDisabled: true,
 		});
+	});
+
+	it.each(["prompt", "promptAndWait"] as const)(
+		"revives an archived saved session before retrying %s",
+		async (method) => {
+			const fakeClient = new FakeDaemonClient();
+			fakeClient.promptResponseErrors.push("Unknown active session: active-1");
+			const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1", {
+				sendClientEnv: true,
+				reviveConfig: { cwd: "/tmp/project", telemetryDisabled: true },
+			});
+			const replacements: AgentConnectionEvent[] = [];
+			connection.subscribe((event) => {
+				if (event.type === "session_replaced") replacements.push(event);
+			});
+			await connection.attach();
+
+			await connection[method]("resume work");
+
+			expect(fakeClient.requests.map((request) => request.type)).toEqual([
+				"attach",
+				method === "prompt" ? "prompt" : "prompt_and_wait",
+				"create",
+				"reattach",
+				method === "prompt" ? "prompt" : "prompt_and_wait",
+			]);
+			expect(fakeClient.requests[2]).toMatchObject({
+				type: "create",
+				sessionPath: "/tmp/session-current.jsonl",
+				config: { cwd: "/tmp/project", telemetryDisabled: true },
+				lifecycle: "resident",
+			});
+			expect(fakeClient.requests.at(-1)).toMatchObject({
+				activeSessionId: "active-revived",
+				message: "resume work",
+			});
+			expect(replacements).toHaveLength(1);
+		},
+	);
+
+	it("shares one archived-session revival across concurrent prompts", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.promptResponseErrors.push("Unknown active session: active-1", "Unknown active session: active-1");
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1", {
+			reviveConfig: { cwd: "/tmp/project" },
+		});
+		await connection.attach();
+
+		await Promise.all([connection.prompt("first"), connection.prompt("second")]);
+
+		expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1);
+		expect(fakeClient.requests.filter((request) => request.type === "reattach")).toHaveLength(1);
+		const delivered = fakeClient.requests.filter(
+			(request): request is Extract<DaemonCommand, { type: "prompt" }> =>
+				request.type === "prompt" && request.activeSessionId === "active-revived",
+		);
+		expect(delivered.map((request) => request.message).sort()).toEqual(["first", "second"]);
+	});
+
+	it("does not revive for an inexact unknown-session rejection", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.promptResponseErrors.push("Unknown active session: active-10");
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1", {
+			reviveConfig: { cwd: "/tmp/project" },
+		});
+		await connection.attach();
+
+		await expect(connection.prompt("do not redirect")).rejects.toThrow("Unknown active session: active-10");
+		expect(fakeClient.requests.map((request) => request.type)).toEqual(["attach", "prompt"]);
 	});
 
 	it("forwards queueIfBusy for prompt admission", async () => {

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -50,6 +50,8 @@ class FakeDaemonClient {
 	abortAndClearQueueUnknownCommand = false;
 	cronAddGate: Promise<void> | undefined;
 	promptGate: Promise<void> | undefined;
+	promptGatesByMessage = new Map<string, Promise<void>>();
+	promptErrorsByMessage = new Map<string, string>();
 	promptError: Error | undefined;
 	promptResponseError: string | undefined;
 	promptResponseErrors: string[] = [];
@@ -79,8 +81,13 @@ class FakeDaemonClient {
 			case "prompt":
 			case "prompt_and_wait": {
 				if (this.promptGate) await this.promptGate;
+				const messageGate = this.promptGatesByMessage.get(command.message);
+				if (messageGate) await messageGate;
 				if (this.promptError) throw this.promptError;
-				const responseError = this.promptResponseErrors.shift() ?? this.promptResponseError;
+				const targetedResponseError = this.promptErrorsByMessage.get(command.message);
+				this.promptErrorsByMessage.delete(command.message);
+				const responseError =
+					targetedResponseError ?? this.promptResponseErrors.shift() ?? this.promptResponseError;
 				if (responseError) {
 					return { type: "response", command: command.type, success: false, error: responseError };
 				}
@@ -789,6 +796,36 @@ describe("DaemonAgentConnection", () => {
 				request.type === "prompt" && request.activeSessionId === "active-revived",
 		);
 		expect(delivered.map((request) => request.message).sort()).toEqual(["first", "second"]);
+	});
+
+	it("retries a late stale rejection after another prompt finishes revival", async () => {
+		const fakeClient = new FakeDaemonClient();
+		let releaseLateResponse = () => {};
+		const lateResponseGate = new Promise<void>((resolve) => {
+			releaseLateResponse = resolve;
+		});
+		fakeClient.promptGatesByMessage.set("late", lateResponseGate);
+		fakeClient.promptErrorsByMessage.set("first", "Unknown active session: active-1");
+		fakeClient.promptErrorsByMessage.set("late", "Unknown active session: active-1");
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1", {
+			reviveConfig: { cwd: "/tmp/project" },
+		});
+		await connection.attach();
+
+		const first = connection.prompt("first");
+		const late = connection.prompt("late");
+		await first;
+		expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1);
+		releaseLateResponse();
+		await late;
+
+		expect(fakeClient.requests.filter((request) => request.type === "create")).toHaveLength(1);
+		expect(fakeClient.requests.filter((request) => request.type === "reattach")).toHaveLength(1);
+		expect(fakeClient.requests.at(-1)).toMatchObject({
+			type: "prompt",
+			activeSessionId: "active-revived",
+			message: "late",
+		});
 	});
 
 	it("does not revive for an inexact unknown-session rejection", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1815,7 +1815,7 @@ describe("AgentSession rlm recursion", () => {
 		expect(attribution.aggregateUsage.cost.total).toBe(10);
 	});
 
-	it("attributes every tool-loop turn in the admitted task to spawn usage", async () => {
+	it("batches every tool-loop turn into one spawn usage attribution", async () => {
 		const tool = {
 			name: "echo",
 			description: "Echo a value",
@@ -1860,8 +1860,12 @@ describe("AgentSession rlm recursion", () => {
 			const attributions = root.sessionManager
 				.getEntries()
 				.filter((entry) => entry.type === "child_usage_attributed");
-			expect(attributions).toHaveLength(2);
-			expect(attributions.map((entry) => entry.origin)).toEqual(["spawn_task", "spawn_task"]);
+			expect(attributions).toHaveLength(1);
+			expect(attributions[0]).toMatchObject({
+				origin: "spawn_task",
+				childUsage: { input: 3, output: 3 },
+				aggregateUsage: { input: 3, output: 3 },
+			});
 		});
 	});
 

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -339,6 +339,64 @@ describe("IpythonKernelProvisioner", () => {
 		expect(existsSync(dill)).toBe(true);
 		expect(existsSync(manifest)).toBe(true);
 	});
+
+	it.runIf(process.platform !== "win32")(
+		"interrupts the full process group of a stubborn bash cell",
+		{ timeout: 180_000 },
+		async () => {
+			const provisioner = new IpythonKernelProvisioner(tempDir, {});
+			const bashPidFile = join(tempDir, "bash.pid");
+			const leafPidFile = join(tempDir, "leaf.pid");
+			const controller = new AbortController();
+			let bashPid: number | undefined;
+			let leafPid: number | undefined;
+			const isAlive = (pid: number | undefined): boolean => {
+				if (!pid) return false;
+				try {
+					process.kill(pid, 0);
+					return true;
+				} catch {
+					return false;
+				}
+			};
+			try {
+				const manager = await provisioner.ensure();
+				const execution = manager.execute(
+					`%%bash
+echo $$ > ${bashPidFile}
+bash -c 'trap "" INT TERM; echo $$ > ${leafPidFile}; while :; do sleep 1; done'`,
+					{ signal: controller.signal },
+				);
+				await vi.waitFor(
+					() => {
+						expect(existsSync(bashPidFile)).toBe(true);
+						expect(existsSync(leafPidFile)).toBe(true);
+					},
+					{ timeout: 10_000 },
+				);
+				bashPid = Number(readFileSync(bashPidFile, "utf8").trim());
+				leafPid = Number(readFileSync(leafPidFile, "utf8").trim());
+				controller.abort();
+				await expect(execution).resolves.toMatchObject({ status: "aborted" });
+				await vi.waitFor(
+					() => {
+						expect(isAlive(bashPid)).toBe(false);
+						expect(isAlive(leafPid)).toBe(false);
+					},
+					{ timeout: 5_000 },
+				);
+				await expect(manager.execute('print("next")')).resolves.toMatchObject({
+					status: "ok",
+					stdout: "next\n",
+				});
+			} finally {
+				for (const pid of [leafPid, bashPid]) {
+					if (isAlive(pid)) process.kill(pid!, "SIGKILL");
+				}
+				await provisioner.dispose();
+			}
+		},
+	);
 });
 
 describe("KernelManager session cleanup during startup", () => {

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -341,6 +341,44 @@ describe("IpythonKernelProvisioner", () => {
 	});
 
 	it.runIf(process.platform !== "win32")(
+		"allows cooperative bash cleanup before escalating the process group",
+		{ timeout: 180_000 },
+		async () => {
+			const provisioner = new IpythonKernelProvisioner(tempDir, {});
+			const bashPidFile = join(tempDir, "cooperative-bash.pid");
+			const interruptFile = join(tempDir, "interrupt-cleanup.txt");
+			const terminateFile = join(tempDir, "unexpected-term.txt");
+			const controller = new AbortController();
+			try {
+				const manager = await provisioner.ensure();
+				const execution = manager.execute(
+					`%%bash
+trap 'echo started > ${interruptFile}; sleep 0.07; echo complete >> ${interruptFile}; exit 0' INT
+trap 'echo term > ${terminateFile}; exit 1' TERM
+echo $$ > ${bashPidFile}
+while :; do sleep 1; done`,
+					{ signal: controller.signal },
+				);
+				await vi.waitFor(() => expect(existsSync(bashPidFile)).toBe(true), { timeout: 10_000 });
+				controller.abort();
+				await expect(execution).resolves.toMatchObject({ status: "aborted" });
+				expect(readFileSync(interruptFile, "utf8")).toContain("complete");
+				expect(existsSync(terminateFile)).toBe(false);
+			} finally {
+				if (existsSync(bashPidFile)) {
+					const bashPid = Number(readFileSync(bashPidFile, "utf8").trim());
+					try {
+						process.kill(-bashPid, "SIGKILL");
+					} catch {
+						// Cooperative cleanup already removed the process group.
+					}
+				}
+				await provisioner.dispose();
+			}
+		},
+	);
+
+	it.runIf(process.platform !== "win32")(
 		"interrupts the full process group of a stubborn bash cell",
 		{ timeout: 180_000 },
 		async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2644,6 +2644,37 @@ describe("AgentSession queue characterization", () => {
 		expect(getUserTexts(harness)).toEqual(["queued before abort", "wake after abort"]);
 	});
 
+	it("delivers programmatic agent mail to an idle session without a typed prompt", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("mail handled")]);
+		const prompt = agentPromptText("agentmsg_idle_delivery", "background result");
+
+		await expect(harness.session.queueAgentMessagePrompt(prompt, "followUp")).resolves.toBe(true);
+		await harness.session.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual([prompt]);
+		expect(getAssistantTexts(harness)).toEqual(["mail handled"]);
+	});
+
+	it("wakes an idle suspended pump when a resumeIfIdle follow-up coalesces", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("owner delivered")]);
+		await harness.session.followUp("queued owner", undefined, { queueKey: "scheduled:owner" });
+		harness.session.requestAbort();
+
+		await expect(
+			harness.session.followUp("coalesced re-fire", undefined, {
+				queueKey: "scheduled:owner",
+				resumeIfIdle: true,
+			}),
+		).resolves.toBe(false);
+		await harness.session.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual(["queued owner"]);
+	});
+
 	it("waitForIdle resolves when the queue is cleared while the pump is suspended", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2657,6 +2657,27 @@ describe("AgentSession queue characterization", () => {
 		expect(getAssistantTexts(harness)).toEqual(["mail handled"]);
 	});
 
+	it("preserves agent mail admitted during update-restart suspension", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("mail handled after restart")]);
+		const prompt = agentPromptText("agentmsg_update_restart", "hold for recovery");
+		harness.session.abortForUpdateRestart();
+
+		await expect(harness.session.queueAgentMessagePrompt(prompt, "followUp")).resolves.toBe(true);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		expect(getUserTexts(harness)).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual([prompt]);
+		expect(harness.session.getSessionActionRecoverySnapshot().actions).toEqual([
+			expect.objectContaining({ payload: expect.objectContaining({ text: prompt }) }),
+		]);
+
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await harness.session.waitForIdle();
+		expect(getUserTexts(harness)).toEqual([prompt]);
+	});
+
 	it("wakes an idle suspended pump when a resumeIfIdle follow-up coalesces", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);


### PR DESCRIPTION
# Stack 5/8 — fix(coding-agent): repair queued and archived session lifecycle

> **Active review snapshot — do not merge yet.** The complete stack is open for architecture/design review, while final cumulative audit, CI, Cursor Bug Bot, and Macroscope findings are being remediated. Branches will be force-updated after validation.

**Base:** `stack/external-04-daemon-foundations`  
**Review order:** merge only after the preceding stack layer is accepted. This PR is not intended to merge independently out of order.

## Stack navigation

1. [#1158](https://github.com/PrimeIntellect-ai/prime-agent/pull/1158) — ci: harden verification and release compatibility
2. [#1159](https://github.com/PrimeIntellect-ai/prime-agent/pull/1159) — fix(security): harden session and autonomous execution boundaries
3. [#1160](https://github.com/PrimeIntellect-ai/prime-agent/pull/1160) — fix(coding-agent): make persisted state crash-safe
4. [#1161](https://github.com/PrimeIntellect-ai/prime-agent/pull/1161) — fix(daemon): fence worker and supervisor lifecycle state
5. [#1162](https://github.com/PrimeIntellect-ai/prime-agent/pull/1162) — fix(coding-agent): repair queued and archived session lifecycle
6. [#1163](https://github.com/PrimeIntellect-ai/prime-agent/pull/1163) — fix(coding-agent): complete Windows kernel and daemon startup
7. [#1164](https://github.com/PrimeIntellect-ai/prime-agent/pull/1164) — fix(providers): harden MCP OAuth and Codex transports
8. [#1165](https://github.com/PrimeIntellect-ai/prime-agent/pull/1165) — fix(runtime): bound transcript and autonomous recovery

## Summary

- Wake idle programmatic prompts without puncturing update-restart suspension.
- Batch child usage attribution per turn while preserving in-memory accounting.
- Terminate POSIX bash process groups with cooperative grace.
- Revive archived sessions once and retry late concurrent prompts against the revived ID.

## Validation

- `npm run check`; final clean-environment lifecycle suites 189/189.
- Residual/non-blocking: #1072 only archived-session recovery; closing/mutation-drain leak remains; Windows process tree containment remains

## Provenance

- Authored independently from `upstream/main` using issue reports and PR descriptions/comments only.
- No external contributor branch, diff, commit, implementation code, or test code was fetched, inspected, copied, or reused.
- The implementation and regression tests in this stack are maintainer-owned.

## Linked-item disposition

### Fixed on merge

- Fixes #1000 — Programmatic prompts starve at idle sessions: input pump never resumes (agent messages queue for hours until a human types)
- Fixes #1054 — Child usage attribution flood freezes session worker: 550+ child_usage_attributed entries in 20 min with active RLM subagents; attach/heartbeats time out, session unreachable (v0.7.1)
- Fixes #849 — Esc/interrupt leaves `%%bash` subprocesses running forever: forceAbort resolves the tool call after 1s but never reaches the cell's grandchildren

### Independently superseded pull requests

- #895 (open) — fix(coding-agent): resume suspended input pump on programmatic admission — **will be closed with a pointer to this independently authored PR**
- #1061 (open) — fix(coding-agent): coalesce child usage attribution — **will be closed with a pointer to this independently authored PR**
- #1130 (open) — perf(coding-agent): coalesce child runtime updates — **will be closed with a pointer to this independently authored PR**
- #1030 (open) — fix(kernel): interrupt IPython subprocess groups — **will be closed with a pointer to this independently authored PR**
- #861 (open) — fix(ipython): terminate %%bash subprocesses on interrupt — **will be closed with a pointer to this independently authored PR**
- #1039 (open) — fix(coding-agent): revive archived sessions on prompt instead of dead-ending — **will be closed with a pointer to this independently authored PR**

### Partially addressed — remains open

- #1072 — Daemon leaves sessions stuck (idle-eviction failures, stuck-in-closing, stuck-in-executing) — v0.7.1

## Reviewer notes

- Please review this layer against its immediate stack base, not against `main`, to avoid cumulative duplicate diffs.
- No merge is requested; the complete stack is being left for human review.
