### PR TITLE
[stack 7/8] fix(providers): harden MCP OAuth and Codex transports

### DIFF
--- a/packages/ai/src/mcp/index.ts
+++ b/packages/ai/src/mcp/index.ts
@@ -1,4 +1,8 @@
 export type { McpCatalogEntry } from "./catalog.js";
 export { BUILTIN_MCP_CATALOG, getCatalogEntry, registerBuiltinMcpOAuthProviders } from "./catalog.js";
-export type { McpOAuthConfig } from "./oauth.js";
-export { createMcpOAuthProvider } from "./oauth.js";
+export type { McpOAuthChallenge, McpOAuthConfig } from "./oauth.js";
+export {
+	createMcpOAuthProvider,
+	parseMcpOAuthChallenge,
+	parseMcpOAuthResourceMetadataChallenge,
+} from "./oauth.js";

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -28,6 +28,7 @@ interface AuthServerMetadata {
 
 /** OAuth protected-resource metadata (RFC 9728). */
 interface ProtectedResourceMetadata {
+	resource: string;
 	authorization_servers?: string[];
 }
 
@@ -75,10 +76,28 @@ function randomState(): string {
 		.replace(/=/g, "");
 }
 
-function wellKnownCandidates(url: string, document: string): string[] {
-	const parsed = new URL(url);
+function protectedResourceCandidates(url: URL): string[] {
+	const path = url.pathname === "/" ? "" : url.pathname;
+	return [
+		...new Set([
+			`${url.origin}/.well-known/oauth-protected-resource${path}${url.search}`,
+			`${url.origin}/.well-known/oauth-protected-resource`,
+		]),
+	];
+}
+
+function authorizationServerCandidates(issuer: string): string[] {
+	const parsed = new URL(issuer);
+	if (parsed.search || parsed.hash) throw new Error(`OAuth issuer must not contain a query or fragment: ${issuer}`);
 	const path = parsed.pathname === "/" ? "" : parsed.pathname;
-	return [...new Set([`${parsed.origin}/.well-known/${document}${path}`, `${parsed.origin}/.well-known/${document}`])];
+	const candidates = [
+		`${parsed.origin}/.well-known/oauth-authorization-server${path}`,
+		`${parsed.origin}/.well-known/openid-configuration${path}`,
+	];
+	if (path) {
+		candidates.push(`${issuer.replace(/\/+$/, "")}/.well-known/openid-configuration`);
+	}
+	return [...new Set(candidates)];
 }
 
 function isAuthServerMetadata(value: unknown): value is AuthServerMetadata {
@@ -92,16 +111,21 @@ async function discoverAuthorizationServer(
 	attempts: string[],
 	errors: string[],
 ): Promise<AuthServerMetadata | undefined> {
-	for (const document of ["oauth-authorization-server", "openid-configuration"]) {
-		for (const candidate of wellKnownCandidates(issuer, document)) {
-			attempts.push(candidate);
-			try {
-				const metadata = await fetchJson(candidate);
-				if (isAuthServerMetadata(metadata)) return metadata;
+	for (const candidate of authorizationServerCandidates(issuer)) {
+		attempts.push(candidate);
+		try {
+			const metadata = await fetchJson(candidate);
+			if (!isAuthServerMetadata(metadata)) {
 				errors.push(`${candidate}: missing authorization_endpoint or token_endpoint`);
-			} catch (error) {
-				errors.push(String(error));
+				continue;
 			}
+			if (metadata.issuer !== issuer) {
+				errors.push(`${candidate}: issuer mismatch (expected ${issuer}, received ${String(metadata.issuer)})`);
+				continue;
+			}
+			return metadata;
+		} catch (error) {
+			errors.push(String(error));
 		}
 	}
 	return undefined;
@@ -110,15 +134,27 @@ async function discoverAuthorizationServer(
 /** Follow RFC 9728 resource metadata, then fall back to co-located AS discovery. */
 async function discover(url: string): Promise<AuthServerMetadata> {
 	const resourceUrl = new URL(url);
+	resourceUrl.hash = "";
+	const resourceIdentifier = resourceUrl.toString();
 	const attempts: string[] = [];
 	const errors: string[] = [];
 
-	for (const candidate of wellKnownCandidates(url, "oauth-protected-resource")) {
+	for (const candidate of protectedResourceCandidates(resourceUrl)) {
 		attempts.push(candidate);
 		try {
 			const resource = (await fetchJson(candidate)) as ProtectedResourceMetadata;
-			const issuers = Array.isArray(resource?.authorization_servers)
-				? resource.authorization_servers.filter((issuer): issuer is string => typeof issuer === "string")
+			if (resource?.resource !== resourceIdentifier) {
+				errors.push(
+					`${candidate}: resource mismatch (expected ${resourceIdentifier}, received ${String(resource?.resource)})`,
+				);
+				continue;
+			}
+			const issuers = Array.isArray(resource.authorization_servers)
+				? [
+						...new Set(
+							resource.authorization_servers.filter((issuer): issuer is string => typeof issuer === "string"),
+						),
+					].slice(0, 10)
 				: [];
 			if (issuers.length === 0) {
 				errors.push(`${candidate}: missing authorization_servers`);

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -5,7 +5,13 @@ import type { Server } from "node:http";
 import { oauthErrorHtml, oauthSuccessHtml } from "../utils/oauth/oauth-page.js";
 import { generatePKCE } from "../utils/oauth/pkce.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "../utils/oauth/types.js";
-import { createOAuthFetchPolicy, type OAuthFetchPolicy, safeFetchJson, validateOAuthNetworkUrl } from "./safe-fetch.js";
+import {
+	createOAuthFetchPolicy,
+	type OAuthFetchPolicy,
+	probeMcpOAuthChallenge,
+	safeFetchJson,
+	validateOAuthNetworkUrl,
+} from "./safe-fetch.js";
 
 const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 // A range (not one port) so a leaked/concurrent login can't wedge all logins with EADDRINUSE.
@@ -283,13 +289,32 @@ async function discover(
 	const attempts: string[] = [];
 	const errors: string[] = [];
 	let sawAdvertisedIssuers = false;
-	const challenge = authorizationChallenge ? parseMcpOAuthChallenge(authorizationChallenge) : undefined;
-	const resourceCandidates = [
-		...new Set([
-			...(challenge?.resourceMetadataUrl ? [challenge.resourceMetadataUrl] : []),
-			...protectedResourceCandidates(resourceUrl),
-		]),
-	];
+	let challenge = authorizationChallenge ? parseMcpOAuthChallenge(authorizationChallenge) : undefined;
+	if (!challenge) {
+		try {
+			const probe = await probeMcpOAuthChallenge(resourceIdentifier, resourcePolicy);
+			if (probe.challenged) {
+				if (!probe.header) throw new Error("MCP OAuth challenge omitted WWW-Authenticate");
+				try {
+					challenge = parseMcpOAuthChallenge(probe.header);
+				} catch (cause) {
+					throw new Error("MCP OAuth challenge was invalid", { cause });
+				}
+				if (!challenge?.resourceMetadataUrl) {
+					throw new Error("MCP OAuth 401 did not advertise Bearer resource_metadata");
+				}
+			}
+		} catch (error) {
+			// A syntactically valid 401 is authoritative; transport failures and
+			// non-MCP endpoints may still use RFC 9728 well-known discovery.
+			if (error instanceof Error && /MCP OAuth (challenge|401)/.test(error.message)) throw error;
+		}
+	}
+	// An actual RFC 9728 challenge is authoritative. Never downgrade to a
+	// synthesized well-known location if its supplied metadata URL fails.
+	const resourceCandidates = challenge?.resourceMetadataUrl
+		? [challenge.resourceMetadataUrl]
+		: protectedResourceCandidates(resourceUrl);
 
 	for (const candidate of resourceCandidates) {
 		attempts.push(displayOAuthUrl(candidate));
@@ -297,6 +322,9 @@ async function discover(
 		try {
 			resource = (await safeFetchJson(candidate, undefined, resourcePolicy)) as ProtectedResourceMetadata;
 		} catch (error) {
+			if (challenge?.resourceMetadataUrl) {
+				throw new Error("Challenged OAuth resource metadata could not be fetched or validated", { cause: error });
+			}
 			errors.push(String(error));
 			continue;
 		}
@@ -307,6 +335,9 @@ async function discover(
 		}
 		const issuers = optionalStringArray(resource.authorization_servers, "authorization_servers")?.slice(0, 10) ?? [];
 		if (issuers.length === 0) {
+			if (challenge?.resourceMetadataUrl) {
+				throw new Error("Challenged OAuth resource metadata omitted authorization_servers");
+			}
 			errors.push(`${displayOAuthUrl(candidate)}: missing authorization_servers`);
 			continue;
 		}

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -65,6 +65,8 @@ export interface McpOAuthConfig {
 	 * integrations that have the 401 response can pass it through this field.
 	 */
 	authorizationChallenge?: string;
+	/** Optional operator-provided RFC 6052 NAT64 prefixes for this network context. */
+	nat64Prefixes?: string[];
 }
 
 /** Extra fields we persist alongside the standard credential triple. */
@@ -289,8 +291,19 @@ async function discover(
 	const attempts: string[] = [];
 	const errors: string[] = [];
 	let sawAdvertisedIssuers = false;
-	let challenge = authorizationChallenge ? parseMcpOAuthChallenge(authorizationChallenge) : undefined;
-	if (!challenge) {
+	let challenge: McpOAuthChallenge | undefined;
+	if (authorizationChallenge !== undefined) {
+		try {
+			challenge = parseMcpOAuthChallenge(authorizationChallenge);
+			if (challenge?.resourceMetadataUrl) new URL(challenge.resourceMetadataUrl);
+		} catch (cause) {
+			throw new Error("Supplied MCP OAuth authorization challenge was invalid", { cause });
+		}
+		if (!challenge?.resourceMetadataUrl) {
+			throw new Error("Supplied MCP OAuth authorization challenge omitted Bearer resource_metadata");
+		}
+	}
+	if (authorizationChallenge === undefined) {
 		try {
 			const probe = await probeMcpOAuthChallenge(resourceIdentifier, resourcePolicy);
 			if (probe.challenged) {
@@ -565,8 +578,10 @@ function toCredentials(
 /** Build a provider for one MCP server. Register it with registerOAuthProvider(). */
 export function createMcpOAuthProvider(config: McpOAuthConfig): OAuthProviderInterface {
 	const label = config.label ?? config.server;
-	const resourcePolicy = createOAuthFetchPolicy(config.url);
-	const oauthPolicy: OAuthFetchPolicy = {};
+	const nat64Prefixes = config.nat64Prefixes ? [...config.nat64Prefixes] : undefined;
+	const nat64CacheKey = {};
+	const resourcePolicy: OAuthFetchPolicy = { ...createOAuthFetchPolicy(config.url), nat64Prefixes, nat64CacheKey };
+	const oauthPolicy: OAuthFetchPolicy = { nat64Prefixes, nat64CacheKey };
 
 	async function login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
 		const discovery = await discover(config.url, resourcePolicy, oauthPolicy, config.authorizationChallenge);

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -26,6 +26,11 @@ interface AuthServerMetadata {
 	scopes_supported?: string[];
 }
 
+/** OAuth protected-resource metadata (RFC 9728). */
+interface ProtectedResourceMetadata {
+	authorization_servers?: string[];
+}
+
 export interface McpOAuthConfig {
 	/** MCP server name; provider id becomes `mcp:<server>`. */
 	server: string;
@@ -46,11 +51,18 @@ interface McpCredentials extends OAuthCredentials {
 }
 
 async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
+	const method = init?.method ?? "GET";
 	const res = await fetch(url, init);
+	const text = await res.text();
 	if (!res.ok) {
-		throw new Error(`${init?.method ?? "GET"} ${url} failed: ${res.status} ${await res.text()}`);
+		throw new Error(`${method} ${url} failed: ${res.status} ${text}`);
 	}
-	return res.json();
+	try {
+		return JSON.parse(text);
+	} catch (cause) {
+		const contentType = res.headers.get("content-type") ?? "unknown content type";
+		throw new Error(`${method} ${url} returned non-JSON (${contentType})`, { cause });
+	}
 }
 
 /** Random, URL-safe CSRF `state` value, independent of the PKCE verifier. */
@@ -63,27 +75,74 @@ function randomState(): string {
 		.replace(/=/g, "");
 }
 
-/** Try the protected-resource and auth-server well-known docs at the URL's origin. */
-async function discover(url: string): Promise<AuthServerMetadata> {
-	const origin = new URL(url).origin;
-	const candidates = [
-		`${origin}/.well-known/oauth-authorization-server`,
-		`${origin}/.well-known/openid-configuration`,
-	];
-	let lastError: unknown;
-	for (const candidate of candidates) {
-		try {
-			const meta = (await fetchJson(candidate)) as AuthServerMetadata;
-			if (meta.authorization_endpoint && meta.token_endpoint) {
-				return meta;
+function wellKnownCandidates(url: string, document: string): string[] {
+	const parsed = new URL(url);
+	const path = parsed.pathname === "/" ? "" : parsed.pathname;
+	return [...new Set([`${parsed.origin}/.well-known/${document}${path}`, `${parsed.origin}/.well-known/${document}`])];
+}
+
+function isAuthServerMetadata(value: unknown): value is AuthServerMetadata {
+	if (!value || typeof value !== "object") return false;
+	const metadata = value as Partial<AuthServerMetadata>;
+	return typeof metadata.authorization_endpoint === "string" && typeof metadata.token_endpoint === "string";
+}
+
+async function discoverAuthorizationServer(
+	issuer: string,
+	attempts: string[],
+	errors: string[],
+): Promise<AuthServerMetadata | undefined> {
+	for (const document of ["oauth-authorization-server", "openid-configuration"]) {
+		for (const candidate of wellKnownCandidates(issuer, document)) {
+			attempts.push(candidate);
+			try {
+				const metadata = await fetchJson(candidate);
+				if (isAuthServerMetadata(metadata)) return metadata;
+				errors.push(`${candidate}: missing authorization_endpoint or token_endpoint`);
+			} catch (error) {
+				errors.push(String(error));
 			}
-		} catch (error) {
-			lastError = error;
 		}
 	}
+	return undefined;
+}
+
+/** Follow RFC 9728 resource metadata, then fall back to co-located AS discovery. */
+async function discover(url: string): Promise<AuthServerMetadata> {
+	const resourceUrl = new URL(url);
+	const attempts: string[] = [];
+	const errors: string[] = [];
+
+	for (const candidate of wellKnownCandidates(url, "oauth-protected-resource")) {
+		attempts.push(candidate);
+		try {
+			const resource = (await fetchJson(candidate)) as ProtectedResourceMetadata;
+			const issuers = Array.isArray(resource?.authorization_servers)
+				? resource.authorization_servers.filter((issuer): issuer is string => typeof issuer === "string")
+				: [];
+			if (issuers.length === 0) {
+				errors.push(`${candidate}: missing authorization_servers`);
+				continue;
+			}
+			for (const issuer of issuers) {
+				try {
+					const metadata = await discoverAuthorizationServer(issuer, attempts, errors);
+					if (metadata) return metadata;
+				} catch (error) {
+					errors.push(`${issuer}: ${String(error)}`);
+				}
+			}
+		} catch (error) {
+			errors.push(String(error));
+		}
+	}
+
+	const colocated = await discoverAuthorizationServer(resourceUrl.origin, attempts, errors);
+	if (colocated) return colocated;
+
 	throw new Error(
-		`Could not discover OAuth metadata for ${origin}. ` +
-			`Tried ${candidates.join(", ")}. Last error: ${String(lastError)}`,
+		`Could not discover OAuth metadata for ${resourceUrl.origin}. ` +
+			`Tried ${attempts.join(", ")}. Errors: ${errors.join("; ")}`,
 	);
 }
 

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -5,6 +5,7 @@ import type { Server } from "node:http";
 import { oauthErrorHtml, oauthSuccessHtml } from "../utils/oauth/oauth-page.js";
 import { generatePKCE } from "../utils/oauth/pkce.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "../utils/oauth/types.js";
+import { createOAuthFetchPolicy, type OAuthFetchPolicy, safeFetchJson, validateOAuthNetworkUrl } from "./safe-fetch.js";
 
 const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 // A range (not one port) so a leaked/concurrent login can't wedge all logins with EADDRINUSE.
@@ -24,12 +25,21 @@ interface AuthServerMetadata {
 	token_endpoint: string;
 	registration_endpoint?: string;
 	scopes_supported?: string[];
+	code_challenge_methods_supported?: string[];
 }
 
 /** OAuth protected-resource metadata (RFC 9728). */
 interface ProtectedResourceMetadata {
 	resource: string;
 	authorization_servers?: string[];
+	scopes_supported?: string[];
+}
+
+interface OAuthDiscovery {
+	metadata: AuthServerMetadata;
+	resource: string;
+	resourceScopes?: string[];
+	challengedScope?: string;
 }
 
 export interface McpOAuthConfig {
@@ -41,29 +51,22 @@ export interface McpOAuthConfig {
 	url: string;
 	/** Pre-registered client id (servers without DCR, e.g. Slack). */
 	clientId?: string;
-	/** Explicit scopes; falls back to the server's advertised scopes. */
+	/** Explicit scopes; otherwise resource scopes are preferred over AS-wide scopes. */
 	scopes?: string;
+	/**
+	 * Optional raw WWW-Authenticate challenge obtained from this MCP resource.
+	 * The current login command does not yet surface challenges automatically;
+	 * integrations that have the 401 response can pass it through this field.
+	 */
+	authorizationChallenge?: string;
 }
 
 /** Extra fields we persist alongside the standard credential triple. */
 interface McpCredentials extends OAuthCredentials {
 	tokenEndpoint?: string;
 	clientId?: string;
-}
-
-async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
-	const method = init?.method ?? "GET";
-	const res = await fetch(url, init);
-	const text = await res.text();
-	if (!res.ok) {
-		throw new Error(`${method} ${url} failed: ${res.status} ${text}`);
-	}
-	try {
-		return JSON.parse(text);
-	} catch (cause) {
-		const contentType = res.headers.get("content-type") ?? "unknown content type";
-		throw new Error(`${method} ${url} returned non-JSON (${contentType})`, { cause });
-	}
+	issuer?: string;
+	resource?: string;
 }
 
 /** Random, URL-safe CSRF `state` value, independent of the PKCE verifier. */
@@ -74,6 +77,105 @@ function randomState(): string {
 		.replace(/\+/g, "-")
 		.replace(/\//g, "_")
 		.replace(/=/g, "");
+}
+
+function splitAuthenticateHeader(header: string): string[] {
+	const parts: string[] = [];
+	let start = 0;
+	let quoted = false;
+	let escaped = false;
+	for (let index = 0; index < header.length; index++) {
+		const char = header[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (quoted && char === "\\") {
+			escaped = true;
+			continue;
+		}
+		if (char === '"') quoted = !quoted;
+		else if (char === "," && !quoted) {
+			parts.push(header.slice(start, index).trim());
+			start = index + 1;
+		}
+	}
+	if (quoted || escaped) throw new Error("Malformed WWW-Authenticate header");
+	parts.push(header.slice(start).trim());
+	return parts.filter(Boolean);
+}
+
+function decodeAuthParameter(value: string): string {
+	if (!value.startsWith('"')) return value.trim();
+	if (!value.endsWith('"')) throw new Error("Malformed WWW-Authenticate parameter");
+	let decoded = "";
+	for (let index = 1; index < value.length - 1; index++) {
+		const char = value[index];
+		if (char === "\\") {
+			index++;
+			if (index >= value.length - 1) throw new Error("Malformed WWW-Authenticate escape");
+			decoded += value[index];
+		} else {
+			decoded += char;
+		}
+	}
+	if (/[\u0000-\u001f\u007f]/.test(decoded)) throw new Error("Invalid WWW-Authenticate parameter");
+	return decoded;
+}
+
+export interface McpOAuthChallenge {
+	resourceMetadataUrl?: string;
+	scope?: string;
+}
+
+/** Parse Bearer auth-params from an MCP 401 WWW-Authenticate value. */
+export function parseMcpOAuthChallenge(header: string): McpOAuthChallenge | undefined {
+	if (header.length > 8192 || /[\r\n]/.test(header)) throw new Error("Invalid WWW-Authenticate header");
+	let scheme: string | undefined;
+	const result: McpOAuthChallenge = {};
+	const parts = splitAuthenticateHeader(header);
+	if (parts.length > 64) throw new Error("WWW-Authenticate contains too many parameters");
+	for (const part of parts) {
+		const challenge = part.match(/^([A-Za-z][A-Za-z0-9!#$%&'*+.^_`|~-]*)\s+(.+)$/);
+		let parameter = part;
+		if (challenge && !challenge[2].trimStart().startsWith("=")) {
+			scheme = challenge[1].toLowerCase();
+			parameter = challenge[2];
+		}
+		if (scheme !== "bearer") continue;
+		const equals = parameter.indexOf("=");
+		if (equals < 1) continue;
+		const name = parameter.slice(0, equals).trim().toLowerCase();
+		if (name !== "resource_metadata" && name !== "scope") continue;
+		const value = decodeAuthParameter(parameter.slice(equals + 1).trim());
+		if (!value) throw new Error(`Bearer ${name} is empty`);
+		if (value.length > 4096) throw new Error(`Bearer ${name} is too long`);
+		if (
+			name === "scope" &&
+			(value.split(/\s+/).length > 128 || value.split(/\s+/).some((scope) => scope.length > 256))
+		) {
+			throw new Error("Bearer scope is invalid");
+		}
+		const key = name === "resource_metadata" ? "resourceMetadataUrl" : "scope";
+		const previous = result[key];
+		if (previous && previous !== value) throw new Error(`Conflicting Bearer ${name} values`);
+		result[key] = value;
+	}
+	return result.resourceMetadataUrl || result.scope ? result : undefined;
+}
+
+/** Extract only the RFC 9728 resource_metadata URL for compatibility callers. */
+export function parseMcpOAuthResourceMetadataChallenge(header: string): string | undefined {
+	return parseMcpOAuthChallenge(header)?.resourceMetadataUrl;
+}
+
+function displayOAuthUrl(rawUrl: string): string {
+	try {
+		const url = new URL(rawUrl);
+		return `${url.origin}${url.pathname}`;
+	} catch {
+		return "(invalid OAuth URL)";
+	}
 }
 
 function protectedResourceCandidates(url: URL): string[] {
@@ -106,23 +208,60 @@ function isAuthServerMetadata(value: unknown): value is AuthServerMetadata {
 	return typeof metadata.authorization_endpoint === "string" && typeof metadata.token_endpoint === "string";
 }
 
+function optionalStringArray(value: unknown, field: string): string[] | undefined {
+	if (value === undefined) return undefined;
+	if (
+		!Array.isArray(value) ||
+		value.length > 128 ||
+		value.some((item) => typeof item !== "string" || item.length === 0 || item.length > 2048)
+	) {
+		throw new Error(`Invalid OAuth metadata ${field}`);
+	}
+	return value.length > 0 ? [...new Set(value)] : undefined;
+}
+
+async function validateAuthorizationServerMetadata(
+	metadata: AuthServerMetadata,
+	issuer: string,
+	policy: OAuthFetchPolicy,
+): Promise<void> {
+	if (metadata.issuer !== issuer) {
+		throw new Error(`OAuth metadata issuer mismatch (expected ${issuer}, received ${String(metadata.issuer)})`);
+	}
+	const methods = metadata.code_challenge_methods_supported;
+	if (!Array.isArray(methods) || !methods.includes("S256")) {
+		throw new Error("OAuth authorization server does not advertise required PKCE S256 support");
+	}
+	const issuerOrigin = new URL(issuer).origin;
+	const endpoints = [metadata.authorization_endpoint, metadata.token_endpoint];
+	if (metadata.registration_endpoint !== undefined) {
+		if (typeof metadata.registration_endpoint !== "string") throw new Error("Invalid OAuth registration_endpoint");
+		endpoints.push(metadata.registration_endpoint);
+	}
+	for (const endpoint of endpoints) {
+		const validated = await validateOAuthNetworkUrl(endpoint, policy);
+		if (validated.origin !== issuerOrigin) {
+			throw new Error("OAuth endpoints must share the validated issuer origin");
+		}
+	}
+}
+
 async function discoverAuthorizationServer(
 	issuer: string,
 	attempts: string[],
 	errors: string[],
+	policy: OAuthFetchPolicy,
 ): Promise<AuthServerMetadata | undefined> {
+	await validateOAuthNetworkUrl(issuer, policy);
 	for (const candidate of authorizationServerCandidates(issuer)) {
-		attempts.push(candidate);
+		attempts.push(displayOAuthUrl(candidate));
 		try {
-			const metadata = await fetchJson(candidate);
+			const metadata = await safeFetchJson(candidate, undefined, policy);
 			if (!isAuthServerMetadata(metadata)) {
-				errors.push(`${candidate}: missing authorization_endpoint or token_endpoint`);
+				errors.push(`${displayOAuthUrl(candidate)}: missing authorization_endpoint or token_endpoint`);
 				continue;
 			}
-			if (metadata.issuer !== issuer) {
-				errors.push(`${candidate}: issuer mismatch (expected ${issuer}, received ${String(metadata.issuer)})`);
-				continue;
-			}
+			await validateAuthorizationServerMetadata(metadata, issuer, policy);
 			return metadata;
 		} catch (error) {
 			errors.push(String(error));
@@ -132,49 +271,73 @@ async function discoverAuthorizationServer(
 }
 
 /** Follow RFC 9728 resource metadata, then fall back to co-located AS discovery. */
-async function discover(url: string): Promise<AuthServerMetadata> {
+async function discover(
+	url: string,
+	resourcePolicy: OAuthFetchPolicy,
+	oauthPolicy: OAuthFetchPolicy,
+	authorizationChallenge?: string,
+): Promise<OAuthDiscovery> {
 	const resourceUrl = new URL(url);
 	resourceUrl.hash = "";
 	const resourceIdentifier = resourceUrl.toString();
 	const attempts: string[] = [];
 	const errors: string[] = [];
+	let sawAdvertisedIssuers = false;
+	const challenge = authorizationChallenge ? parseMcpOAuthChallenge(authorizationChallenge) : undefined;
+	const resourceCandidates = [
+		...new Set([
+			...(challenge?.resourceMetadataUrl ? [challenge.resourceMetadataUrl] : []),
+			...protectedResourceCandidates(resourceUrl),
+		]),
+	];
 
-	for (const candidate of protectedResourceCandidates(resourceUrl)) {
-		attempts.push(candidate);
+	for (const candidate of resourceCandidates) {
+		attempts.push(displayOAuthUrl(candidate));
+		let resource: ProtectedResourceMetadata;
 		try {
-			const resource = (await fetchJson(candidate)) as ProtectedResourceMetadata;
-			if (resource?.resource !== resourceIdentifier) {
-				errors.push(
-					`${candidate}: resource mismatch (expected ${resourceIdentifier}, received ${String(resource?.resource)})`,
-				);
-				continue;
-			}
-			const issuers = Array.isArray(resource.authorization_servers)
-				? [
-						...new Set(
-							resource.authorization_servers.filter((issuer): issuer is string => typeof issuer === "string"),
-						),
-					].slice(0, 10)
-				: [];
-			if (issuers.length === 0) {
-				errors.push(`${candidate}: missing authorization_servers`);
-				continue;
-			}
-			for (const issuer of issuers) {
-				try {
-					const metadata = await discoverAuthorizationServer(issuer, attempts, errors);
-					if (metadata) return metadata;
-				} catch (error) {
-					errors.push(`${issuer}: ${String(error)}`);
-				}
-			}
+			resource = (await safeFetchJson(candidate, undefined, resourcePolicy)) as ProtectedResourceMetadata;
 		} catch (error) {
 			errors.push(String(error));
+			continue;
+		}
+		if (resource?.resource !== resourceIdentifier) {
+			throw new Error(
+				`${displayOAuthUrl(candidate)}: resource mismatch (expected ${resourceIdentifier}, received ${String(resource?.resource)})`,
+			);
+		}
+		const issuers = optionalStringArray(resource.authorization_servers, "authorization_servers")?.slice(0, 10) ?? [];
+		if (issuers.length === 0) {
+			errors.push(`${displayOAuthUrl(candidate)}: missing authorization_servers`);
+			continue;
+		}
+		sawAdvertisedIssuers = true;
+		const resourceScopes = optionalStringArray(resource.scopes_supported, "scopes_supported");
+		for (const issuer of [...new Set(issuers)]) {
+			try {
+				const metadata = await discoverAuthorizationServer(issuer, attempts, errors, oauthPolicy);
+				if (metadata) {
+					return {
+						metadata,
+						resource: resourceIdentifier,
+						resourceScopes,
+						challengedScope: challenge?.scope,
+					};
+				}
+			} catch (error) {
+				errors.push(`${displayOAuthUrl(issuer)}: ${String(error)}`);
+			}
 		}
 	}
 
-	const colocated = await discoverAuthorizationServer(resourceUrl.origin, attempts, errors);
-	if (colocated) return colocated;
+	if (sawAdvertisedIssuers) {
+		throw new Error(
+			`Could not discover OAuth metadata for ${resourceUrl.origin}. ` +
+				`Tried ${attempts.join(", ")}. Errors: ${errors.join("; ")}`,
+		);
+	}
+
+	const colocated = await discoverAuthorizationServer(resourceUrl.origin, attempts, errors, oauthPolicy);
+	if (colocated) return { metadata: colocated, resource: resourceIdentifier };
 
 	throw new Error(
 		`Could not discover OAuth metadata for ${resourceUrl.origin}. ` +
@@ -183,7 +346,7 @@ async function discover(url: string): Promise<AuthServerMetadata> {
 }
 
 /** Dynamic client registration (RFC 7591). Returns the issued client_id. */
-async function registerClient(registrationEndpoint: string, label: string): Promise<string> {
+async function registerClient(registrationEndpoint: string, label: string, policy: OAuthFetchPolicy): Promise<string> {
 	const body = {
 		client_name: label,
 		redirect_uris: ALL_REDIRECT_URIS,
@@ -191,13 +354,19 @@ async function registerClient(registrationEndpoint: string, label: string): Prom
 		response_types: ["code"],
 		token_endpoint_auth_method: "none",
 	};
-	const data = (await fetchJson(registrationEndpoint, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(body),
-	})) as { client_id?: string };
-	if (!data.client_id) {
-		throw new Error(`Dynamic client registration at ${registrationEndpoint} returned no client_id`);
+	const data = (await safeFetchJson(
+		registrationEndpoint,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		},
+		policy,
+	)) as { client_id?: string };
+	if (typeof data.client_id !== "string" || data.client_id.length === 0 || data.client_id.length > 4096) {
+		throw new Error(
+			`Dynamic client registration at ${displayOAuthUrl(registrationEndpoint)} returned no valid client_id`,
+		);
 	}
 	return data.client_id;
 }
@@ -307,26 +476,45 @@ function parseRedirectInput(input: string, expectedState: string): { code: strin
 	return { code, state: state ?? expectedState };
 }
 
+interface TokenResponse {
+	access_token: string;
+	refresh_token?: string;
+	expires_in?: number;
+}
+
 async function exchangeToken(
 	tokenEndpoint: string,
 	params: Record<string, string>,
-): Promise<{ access_token: string; refresh_token?: string; expires_in?: number }> {
-	const res = await fetch(tokenEndpoint, {
-		method: "POST",
-		headers: { "Content-Type": "application/x-www-form-urlencoded" },
-		body: new URLSearchParams(params).toString(),
-	});
-	const text = await res.text();
-	if (!res.ok) {
-		throw new Error(`Token request to ${tokenEndpoint} failed: ${res.status} ${text}`);
+	policy: OAuthFetchPolicy,
+): Promise<TokenResponse> {
+	const data = await safeFetchJson(
+		tokenEndpoint,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams(params).toString(),
+		},
+		policy,
+	);
+	if (!data || typeof data !== "object" || typeof (data as Partial<TokenResponse>).access_token !== "string") {
+		throw new Error("OAuth token endpoint returned an invalid token response");
 	}
-	return JSON.parse(text);
+	const token = data as TokenResponse;
+	if (token.refresh_token !== undefined && typeof token.refresh_token !== "string") {
+		throw new Error("OAuth token endpoint returned an invalid refresh_token");
+	}
+	if (token.expires_in !== undefined && (!Number.isFinite(token.expires_in) || token.expires_in <= 0)) {
+		throw new Error("OAuth token endpoint returned an invalid expires_in");
+	}
+	return token;
 }
 
 function toCredentials(
-	token: { access_token: string; refresh_token?: string; expires_in?: number },
+	token: TokenResponse,
 	tokenEndpoint: string,
 	clientId: string,
+	issuer: string,
+	resource: string,
 	previousRefresh?: string,
 ): McpCredentials {
 	return {
@@ -338,15 +526,20 @@ function toCredentials(
 			: Date.now() + 3600 * 1000 - TOKEN_EXPIRY_BUFFER_MS,
 		tokenEndpoint,
 		clientId,
+		issuer,
+		resource,
 	};
 }
 
 /** Build a provider for one MCP server. Register it with registerOAuthProvider(). */
 export function createMcpOAuthProvider(config: McpOAuthConfig): OAuthProviderInterface {
 	const label = config.label ?? config.server;
+	const resourcePolicy = createOAuthFetchPolicy(config.url);
+	const oauthPolicy: OAuthFetchPolicy = {};
 
 	async function login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-		const meta = await discover(config.url);
+		const discovery = await discover(config.url, resourcePolicy, oauthPolicy, config.authorizationChallenge);
+		const meta = discovery.metadata;
 		callbacks.onProgress?.(`Discovered ${meta.issuer ?? new URL(config.url).origin}`);
 
 		let clientId = config.clientId;
@@ -358,28 +551,32 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): OAuthProviderInt
 				);
 			}
 			callbacks.onProgress?.("Registering OAuth client…");
-			clientId = await registerClient(meta.registration_endpoint, `Prime Agent (${label})`);
+			clientId = await registerClient(meta.registration_endpoint, `Prime Agent (${label})`, oauthPolicy);
 		}
 
 		const { verifier, challenge } = await generatePKCE();
 		// `state` must be independent of the PKCE verifier — the verifier is the
 		// secret used at token exchange, while `state` is echoed on the redirect URL.
 		const state = randomState();
-		const scope = config.scopes ?? meta.scopes_supported?.join(" ");
+		const scope = discovery.challengedScope ?? config.scopes ?? discovery.resourceScopes?.join(" ");
 		const cb = await startCallbackServer(label);
 		try {
-			const authParams = new URLSearchParams({
+			const authorizationUrl = new URL(meta.authorization_endpoint);
+			for (const [name, value] of Object.entries({
 				client_id: clientId,
 				response_type: "code",
 				redirect_uri: cb.redirectUri,
 				code_challenge: challenge,
 				code_challenge_method: "S256",
 				state,
-			});
-			if (scope) authParams.set("scope", scope);
+				resource: discovery.resource,
+			})) {
+				authorizationUrl.searchParams.set(name, value);
+			}
+			if (scope) authorizationUrl.searchParams.set("scope", scope);
 
 			callbacks.onAuth({
-				url: `${meta.authorization_endpoint}?${authParams.toString()}`,
+				url: authorizationUrl.toString(),
 				instructions:
 					"Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.",
 			});
@@ -436,14 +633,19 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): OAuthProviderInt
 			}
 
 			callbacks.onProgress?.("Exchanging authorization code for tokens…");
-			const token = await exchangeToken(meta.token_endpoint, {
-				grant_type: "authorization_code",
-				code: result.code,
-				redirect_uri: cb.redirectUri,
-				client_id: clientId,
-				code_verifier: verifier,
-			});
-			return toCredentials(token, meta.token_endpoint, clientId);
+			const token = await exchangeToken(
+				meta.token_endpoint,
+				{
+					grant_type: "authorization_code",
+					code: result.code,
+					redirect_uri: cb.redirectUri,
+					client_id: clientId,
+					code_verifier: verifier,
+					resource: discovery.resource,
+				},
+				oauthPolicy,
+			);
+			return toCredentials(token, meta.token_endpoint, clientId, meta.issuer!, discovery.resource);
 		} finally {
 			cb.server.close();
 		}
@@ -451,17 +653,35 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): OAuthProviderInt
 
 	async function refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
 		const creds = credentials as McpCredentials;
-		const tokenEndpoint = creds.tokenEndpoint ?? (await discover(config.url)).token_endpoint;
-		const clientId = creds.clientId ?? config.clientId;
 		if (!creds.refresh) {
 			throw new Error(`No refresh token stored for ${label}; re-run /mcp login ${config.server}`);
 		}
-		const token = await exchangeToken(tokenEndpoint, {
-			grant_type: "refresh_token",
-			refresh_token: creds.refresh,
-			...(clientId ? { client_id: clientId } : {}),
-		});
-		return toCredentials(token, tokenEndpoint, clientId ?? "", creds.refresh);
+		if (!creds.resource || !creds.issuer || !creds.tokenEndpoint) {
+			throw new Error(`OAuth credential binding is missing for ${label}; re-run /mcp login ${config.server}`);
+		}
+		const discovery = await discover(config.url, resourcePolicy, oauthPolicy, config.authorizationChallenge);
+		const meta = discovery.metadata;
+		if (creds.resource && creds.resource !== discovery.resource) {
+			throw new Error(`OAuth resource changed for ${label}; re-run /mcp login ${config.server}`);
+		}
+		if (creds.issuer && creds.issuer !== meta.issuer) {
+			throw new Error(`OAuth issuer changed for ${label}; re-run /mcp login ${config.server}`);
+		}
+		if (creds.tokenEndpoint && creds.tokenEndpoint !== meta.token_endpoint) {
+			throw new Error(`OAuth token endpoint changed for ${label}; re-run /mcp login ${config.server}`);
+		}
+		const clientId = creds.clientId ?? config.clientId;
+		const token = await exchangeToken(
+			meta.token_endpoint,
+			{
+				grant_type: "refresh_token",
+				refresh_token: creds.refresh,
+				resource: discovery.resource,
+				...(clientId ? { client_id: clientId } : {}),
+			},
+			oauthPolicy,
+		);
+		return toCredentials(token, meta.token_endpoint, clientId ?? "", meta.issuer!, discovery.resource, creds.refresh);
 	}
 
 	return {

--- a/packages/ai/src/mcp/safe-fetch.ts
+++ b/packages/ai/src/mcp/safe-fetch.ts
@@ -1,0 +1,303 @@
+// Node-only SSRF-safe fetch primitives for MCP OAuth metadata and token flows.
+
+const DEFAULT_MAX_REDIRECTS = 3;
+const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_REQUEST_BODY_BYTES = 64 * 1024;
+
+export interface OAuthFetchPolicy {
+	/** The one explicitly configured HTTP origin allowed when it resolves only to loopback. */
+	allowedHttpOrigin?: string;
+	maxRedirects?: number;
+	maxBodyBytes?: number;
+	timeoutMs?: number;
+}
+
+interface ResolvedTarget {
+	url: URL;
+	address: string;
+	family: 4 | 6;
+}
+
+function canonicalHostname(hostname: string): string {
+	return hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+}
+
+function parseIpv4(address: string): number[] | undefined {
+	const parts = address.split(".");
+	if (parts.length !== 4) return undefined;
+	const bytes = parts.map((part) => (/^\d{1,3}$/.test(part) ? Number(part) : Number.NaN));
+	return bytes.every((byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255) ? bytes : undefined;
+}
+
+function ipv4Kind(address: string): "public" | "loopback" | "blocked" {
+	const bytes = parseIpv4(address);
+	if (!bytes) return "blocked";
+	const [a, b, c] = bytes;
+	if (a === 127) return "loopback";
+	if (
+		a === 0 ||
+		a === 10 ||
+		(a === 100 && b >= 64 && b <= 127) ||
+		(a === 169 && b === 254) ||
+		(a === 172 && b >= 16 && b <= 31) ||
+		(a === 192 && b === 168) ||
+		(a === 192 && b === 0 && c === 0) ||
+		(a === 192 && b === 0 && c === 2) ||
+		(a === 192 && b === 88 && c === 99) ||
+		(a === 198 && (b === 18 || b === 19)) ||
+		(a === 198 && b === 51 && c === 100) ||
+		(a === 203 && b === 0 && c === 113) ||
+		a >= 224
+	) {
+		return "blocked";
+	}
+	return "public";
+}
+
+function ipv6Bytes(address: string): number[] | undefined {
+	const withoutZone = address.split("%", 1)[0]?.toLowerCase();
+	if (!withoutZone || address.includes("%")) return undefined;
+	let input = withoutZone;
+	if (input.includes(".")) {
+		const lastColon = input.lastIndexOf(":");
+		const ipv4 = parseIpv4(input.slice(lastColon + 1));
+		if (lastColon < 0 || !ipv4) return undefined;
+		input = `${input.slice(0, lastColon)}:${((ipv4[0] << 8) | ipv4[1]).toString(16)}:${((ipv4[2] << 8) | ipv4[3]).toString(16)}`;
+	}
+	if ((input.match(/::/g) ?? []).length > 1) return undefined;
+	const [leftRaw, rightRaw] = input.split("::");
+	const left = leftRaw ? leftRaw.split(":") : [];
+	const right = rightRaw ? rightRaw.split(":") : [];
+	const missing = 8 - left.length - right.length;
+	if ((input.includes("::") && missing < 1) || (!input.includes("::") && missing !== 0)) return undefined;
+	const groups = [...left, ...Array.from({ length: Math.max(0, missing) }, () => "0"), ...right];
+	if (groups.length !== 8 || groups.some((group) => !/^[0-9a-f]{1,4}$/.test(group))) return undefined;
+	return groups.flatMap((group) => {
+		const value = Number.parseInt(group, 16);
+		return [value >> 8, value & 0xff];
+	});
+}
+
+function ipv6Kind(address: string): "public" | "loopback" | "blocked" {
+	const bytes = ipv6Bytes(address);
+	if (!bytes) return "blocked";
+	if (bytes.slice(0, 15).every((byte) => byte === 0) && bytes[15] === 1) return "loopback";
+	if (bytes.every((byte) => byte === 0)) return "blocked";
+	if (bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff) {
+		return ipv4Kind(bytes.slice(12).join("."));
+	}
+	const first = bytes[0];
+	const second = bytes[1];
+	const firstGroup = (first << 8) | second;
+	const secondGroup = (bytes[2] << 8) | bytes[3];
+	if (
+		(first & 0xfe) === 0xfc ||
+		(first === 0xfe && (second & 0xc0) === 0x80) ||
+		first === 0xff ||
+		(firstGroup === 0x64 && secondGroup === 0xff9b) ||
+		(firstGroup === 0x100 && bytes.slice(2, 8).every((byte) => byte === 0)) ||
+		(firstGroup === 0x2001 && (bytes[2] <= 1 || secondGroup === 0x0db8)) ||
+		firstGroup === 0x2002 ||
+		(firstGroup === 0x3fff && (secondGroup & 0xf000) === 0) ||
+		firstGroup === 0x5f00
+	) {
+		return "blocked";
+	}
+	return "public";
+}
+
+function addressKind(address: string, family: number): "public" | "loopback" | "blocked" {
+	return family === 4 ? ipv4Kind(address) : family === 6 ? ipv6Kind(address) : "blocked";
+}
+
+export function createOAuthFetchPolicy(resourceUrl: string): OAuthFetchPolicy {
+	const parsed = new URL(resourceUrl);
+	if (parsed.username || parsed.password || parsed.hash) {
+		throw new Error("MCP OAuth resource URL must not contain credentials or a fragment");
+	}
+	if (parsed.protocol === "https:") return {};
+	if (parsed.protocol === "http:") {
+		const hostname = canonicalHostname(parsed.hostname);
+		const literalKind = ipv4Kind(hostname) === "loopback" || ipv6Kind(hostname) === "loopback";
+		if (hostname.toLowerCase() !== "localhost" && !literalKind) {
+			throw new Error("HTTP MCP OAuth resources must use an explicit loopback host");
+		}
+		return { allowedHttpOrigin: parsed.origin };
+	}
+	throw new Error("MCP OAuth resource URL must use HTTPS");
+}
+
+function redactedUrl(url: URL): string {
+	return `${url.origin}${url.pathname}`;
+}
+
+async function resolveTarget(rawUrl: string | URL, policy: OAuthFetchPolicy): Promise<ResolvedTarget> {
+	if (String(rawUrl).length > 4096) throw new Error("OAuth URL is too long");
+	const url = new URL(rawUrl);
+	if (url.username || url.password || url.hash)
+		throw new Error("OAuth URL must not contain credentials or a fragment");
+	const isHttpException = url.protocol === "http:" && url.origin === policy.allowedHttpOrigin;
+	if (url.protocol !== "https:" && !isHttpException) throw new Error("OAuth network requests must use HTTPS");
+
+	const hostname = canonicalHostname(url.hostname);
+	const { isIP } = await import("node:net");
+	const literalFamily = isIP(hostname);
+	let addresses: Array<{ address: string; family: number }>;
+	if (literalFamily) {
+		addresses = [{ address: hostname, family: literalFamily }];
+	} else {
+		if (hostname.toLowerCase() === "localhost" || hostname.toLowerCase().endsWith(".localhost")) {
+			addresses = [{ address: "127.0.0.1", family: 4 }];
+		} else {
+			let dnsTimeout: ReturnType<typeof setTimeout> | undefined;
+			try {
+				const { lookup } = await import("node:dns/promises");
+				addresses = await Promise.race([
+					lookup(hostname, { all: true, verbatim: true }),
+					new Promise<never>((_, reject) => {
+						dnsTimeout = setTimeout(
+							() => reject(new Error("OAuth DNS lookup timed out")),
+							policy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+						);
+					}),
+				]);
+			} catch (cause) {
+				throw new Error(`OAuth hostname could not be resolved: ${hostname}`, { cause });
+			} finally {
+				if (dnsTimeout) clearTimeout(dnsTimeout);
+			}
+		}
+	}
+	if (addresses.length === 0) throw new Error(`OAuth hostname resolved to no addresses: ${hostname}`);
+	const kinds = addresses.map(({ address, family }) => addressKind(address, family));
+	if (isHttpException) {
+		if (kinds.some((kind) => kind !== "loopback")) {
+			throw new Error("The configured HTTP MCP resource must resolve only to loopback addresses");
+		}
+	} else if (kinds.some((kind) => kind !== "public")) {
+		throw new Error(`OAuth hostname resolves to a non-public address: ${hostname}`);
+	}
+	const selected = addresses[0];
+	return { url, address: selected.address, family: selected.family as 4 | 6 };
+}
+
+export async function validateOAuthNetworkUrl(rawUrl: string, policy: OAuthFetchPolicy): Promise<URL> {
+	return (await resolveTarget(rawUrl, policy)).url;
+}
+
+async function readBoundedBody(response: Response, maxBytes: number): Promise<string> {
+	if (!response.body) return "";
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let total = 0;
+	let text = "";
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			total += value.byteLength;
+			if (total > maxBytes) throw new Error(`OAuth response exceeded ${maxBytes} bytes`);
+			text += decoder.decode(value, { stream: true });
+		}
+		return text + decoder.decode();
+	} finally {
+		try {
+			await reader.cancel();
+		} catch {
+			// Already closed.
+		}
+		rendererRelease(reader);
+	}
+}
+
+function rendererRelease(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+	try {
+		reader.releaseLock();
+	} catch {
+		// Lock already released.
+	}
+}
+
+export async function safeFetchJson(
+	rawUrl: string,
+	init: RequestInit | undefined,
+	policy: OAuthFetchPolicy,
+): Promise<unknown> {
+	const method = (init?.method ?? "GET").toUpperCase();
+	const requestBodyBytes =
+		typeof init?.body === "string"
+			? new TextEncoder().encode(init.body).byteLength
+			: init?.body instanceof Uint8Array
+				? init.body.byteLength
+				: 0;
+	if (requestBodyBytes > MAX_REQUEST_BODY_BYTES) throw new Error("OAuth request body is too large");
+	const maxRedirects = policy.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+	const maxBodyBytes = policy.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+	let current = rawUrl;
+
+	for (let redirects = 0; ; redirects++) {
+		const target = await resolveTarget(current, policy);
+		const { Agent } = await import("undici");
+		const pinnedLookup = ((_hostname: string, options: { all?: boolean }, callback: (...args: unknown[]) => void) => {
+			if (options?.all) callback(null, [{ address: target.address, family: target.family }]);
+			else callback(null, target.address, target.family);
+		}) as unknown as import("node:net").LookupFunction;
+		const dispatcher = new Agent({
+			headersTimeout: policy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+			bodyTimeout: policy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+			maxResponseSize: maxBodyBytes,
+			connect: {
+				timeout: Math.min(5_000, policy.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+				lookup: pinnedLookup,
+			},
+		});
+		const controller = new AbortController();
+		const onAbort = () => controller.abort(init?.signal?.reason);
+		if (init?.signal?.aborted) controller.abort(init.signal.reason);
+		else init?.signal?.addEventListener("abort", onAbort, { once: true });
+		const timeout = setTimeout(
+			() => controller.abort(new Error("OAuth request timed out")),
+			policy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+		);
+		try {
+			const requestInit = {
+				...init,
+				redirect: "manual",
+				signal: controller.signal,
+				dispatcher,
+			} as unknown as RequestInit;
+			const response = await fetch(target.url, requestInit);
+
+			if (response.status >= 300 && response.status < 400) {
+				try {
+					await response.body?.cancel();
+				} catch {
+					// Ignore redirect response teardown errors.
+				}
+				if (method !== "GET" && method !== "HEAD") throw new Error("OAuth POST redirects are not allowed");
+				if (redirects >= maxRedirects) throw new Error(`OAuth redirect limit exceeded (${maxRedirects})`);
+				const location = response.headers.get("location");
+				if (!location) throw new Error("OAuth redirect response omitted Location");
+				const next = new URL(location, target.url);
+				if (next.origin !== target.url.origin)
+					throw new Error("Cross-origin OAuth metadata redirects are not allowed");
+				current = next.toString();
+				continue;
+			}
+
+			const body = await readBoundedBody(response, maxBodyBytes);
+			if (!response.ok) throw new Error(`${method} ${redactedUrl(target.url)} failed with HTTP ${response.status}`);
+			try {
+				return JSON.parse(body);
+			} catch (cause) {
+				const contentType = response.headers.get("content-type") ?? "unknown content type";
+				throw new Error(`${method} ${redactedUrl(target.url)} returned non-JSON (${contentType})`, { cause });
+			}
+		} finally {
+			clearTimeout(timeout);
+			init?.signal?.removeEventListener("abort", onAbort);
+			await dispatcher.close();
+		}
+	}
+}

--- a/packages/ai/src/mcp/safe-fetch.ts
+++ b/packages/ai/src/mcp/safe-fetch.ts
@@ -11,6 +11,10 @@ export interface OAuthFetchPolicy {
 	maxRedirects?: number;
 	maxBodyBytes?: number;
 	timeoutMs?: number;
+	/** Optional RFC 6052 NAT64 prefixes (length /32, /40, /48, /56, /64, or /96). */
+	nat64Prefixes?: string[];
+	/** @internal Shares one RFC 7050 discovery result across related endpoint policies. */
+	nat64CacheKey?: object;
 }
 
 interface ResolvedTarget {
@@ -89,6 +93,121 @@ function inCidr(bytes: number[], network: number[], prefixBits: number): boolean
 	if (remainder === 0) return true;
 	const mask = (0xff << (8 - remainder)) & 0xff;
 	return (bytes[wholeBytes] & mask) === (network[wholeBytes] & mask);
+}
+
+const RFC6052_PREFIX_LENGTHS = new Set([32, 40, 48, 56, 64, 96]);
+const IPV4ONLY_DISCOVERY_ADDRESSES = new Set(["192.0.0.170", "192.0.0.171"]);
+interface Nat64Prefix {
+	bytes: number[];
+	length: number;
+}
+const NAT64_DISCOVERY_CACHE_MS = 30_000;
+interface Nat64CacheEntry {
+	expiresAt: number;
+	promise: Promise<Nat64Prefix[]>;
+}
+const nat64PrefixCache = new WeakMap<object, Nat64CacheEntry>();
+
+function parseNat64Prefix(cidr: string): Nat64Prefix {
+	const slash = cidr.lastIndexOf("/");
+	const length = Number(cidr.slice(slash + 1));
+	const bytes = ipv6Bytes(cidr.slice(0, slash));
+	if (slash <= 0 || !bytes || !RFC6052_PREFIX_LENGTHS.has(length)) {
+		throw new Error("OAuth NAT64 prefix must be valid IPv6 with RFC 6052 length /32, /40, /48, /56, /64, or /96");
+	}
+	const network = bytes.map((byte, index) => (index < length / 8 ? byte : 0));
+	if (!bytes.every((byte, index) => byte === network[index])) {
+		throw new Error("OAuth NAT64 prefix contains non-zero host bits");
+	}
+	if (length === 96 && bytes[8] !== 0) {
+		throw new Error("OAuth NAT64 /96 prefix must keep the RFC 6052 u octet zero");
+	}
+	return { bytes: network, length };
+}
+
+function decodeRfc6052(address: number[], prefix: Nat64Prefix): number[] | undefined {
+	if (!inCidr(address, prefix.bytes, prefix.length)) return undefined;
+	const n = prefix.length / 8;
+	if (prefix.length === 96) return address.slice(12, 16);
+	const beforeU = 8 - n;
+	if (address[8] !== 0) return undefined;
+	const embedded = [...address.slice(n, n + beforeU), ...address.slice(9, 9 + (4 - beforeU))];
+	return embedded.length === 4 ? embedded : undefined;
+}
+
+function deriveRfc7050Prefix(address: string): Nat64Prefix | undefined {
+	const bytes = ipv6Bytes(address);
+	if (!bytes) return undefined;
+	for (const length of RFC6052_PREFIX_LENGTHS) {
+		const prefix: Nat64Prefix = {
+			bytes: bytes.map((byte, index) => (index < length / 8 ? byte : 0)),
+			length,
+		};
+		if (length === 96 && prefix.bytes[8] !== 0) continue;
+		const embedded = decodeRfc6052(bytes, prefix);
+		if (embedded && IPV4ONLY_DISCOVERY_ADDRESSES.has(embedded.join("."))) return prefix;
+	}
+	return undefined;
+}
+
+async function resolveNat64Prefixes(policy: OAuthFetchPolicy): Promise<Nat64Prefix[]> {
+	const cacheKey = policy.nat64CacheKey ?? policy;
+	const existing = nat64PrefixCache.get(cacheKey);
+	if (existing && Date.now() < existing.expiresAt) return existing.promise;
+	const promise = (async () => {
+		if ((policy.nat64Prefixes?.length ?? 0) > 16) throw new Error("OAuth NAT64 prefix limit exceeded (16)");
+		const configured = policy.nat64Prefixes?.map(parseNat64Prefix);
+		if (configured) return [parseNat64Prefix("64:ff9b::/96"), ...configured];
+		try {
+			const { lookup } = await import("node:dns/promises");
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			try {
+				const answers = await Promise.race([
+					lookup("ipv4only.arpa", { all: true, verbatim: true }),
+					new Promise<never>((_, reject) => {
+						timer = setTimeout(
+							() => reject(new Error("RFC 7050 discovery timed out")),
+							policy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+						);
+					}),
+				]);
+				const discovered = answers
+					.slice(0, 64)
+					.filter(({ family }) => family === 6)
+					.map(({ address }) => deriveRfc7050Prefix(address))
+					.filter((prefix): prefix is Nat64Prefix => prefix !== undefined);
+				const unique = new Map(discovered.map((prefix) => [`${prefix.bytes.join(":")}/${prefix.length}`, prefix]));
+				return [parseNat64Prefix("64:ff9b::/96"), ...unique.values()];
+			} finally {
+				if (timer) clearTimeout(timer);
+			}
+		} catch {
+			return [parseNat64Prefix("64:ff9b::/96")];
+		}
+	})();
+	nat64PrefixCache.set(cacheKey, {
+		expiresAt: policy.nat64Prefixes === undefined ? Date.now() + NAT64_DISCOVERY_CACHE_MS : Number.POSITIVE_INFINITY,
+		promise,
+	});
+	return promise;
+}
+
+async function addressKindWithPolicy(
+	address: string,
+	family: number,
+	policy: OAuthFetchPolicy,
+): Promise<"public" | "loopback" | "blocked"> {
+	if (family !== 6) return addressKind(address, family);
+	const bytes = ipv6Bytes(address);
+	if (!bytes) return "blocked";
+	for (const prefix of await resolveNat64Prefixes(policy)) {
+		if (!inCidr(bytes, prefix.bytes, prefix.length)) continue;
+		const embedded = decodeRfc6052(bytes, prefix);
+		if (!embedded || ipv4Kind(embedded.join(".")) !== "public") return "blocked";
+	}
+	// A public embedded IPv4 never upgrades an otherwise non-global IPv6
+	// locator; discovered/configured prefixes are monotonic deny-only.
+	return ipv6Kind(address);
 }
 
 function ipv6Kind(address: string): "public" | "loopback" | "blocked" {
@@ -203,7 +322,9 @@ async function resolveTarget(rawUrl: string | URL, policy: OAuthFetchPolicy): Pr
 		}
 	}
 	if (addresses.length === 0) throw new Error(`OAuth hostname resolved to no addresses: ${hostname}`);
-	const kinds = addresses.map(({ address, family }) => addressKind(address, family));
+	const kinds = await Promise.all(
+		addresses.map(({ address, family }) => addressKindWithPolicy(address, family, policy)),
+	);
 	if (isHttpException) {
 		if (kinds.some((kind) => kind !== "loopback")) {
 			throw new Error("The configured HTTP MCP resource must resolve only to loopback addresses");

--- a/packages/ai/src/mcp/safe-fetch.ts
+++ b/packages/ai/src/mcp/safe-fetch.ts
@@ -35,6 +35,7 @@ function ipv4Kind(address: string): "public" | "loopback" | "blocked" {
 	if (!bytes) return "blocked";
 	const [a, b, c] = bytes;
 	if (a === 127) return "loopback";
+	if (a === 192 && b === 0 && c === 0 && (bytes[3] === 9 || bytes[3] === 10)) return "public";
 	if (
 		a === 0 ||
 		a === 10 ||
@@ -79,32 +80,64 @@ function ipv6Bytes(address: string): number[] | undefined {
 	});
 }
 
+function inCidr(bytes: number[], network: number[], prefixBits: number): boolean {
+	const wholeBytes = Math.floor(prefixBits / 8);
+	const remainder = prefixBits % 8;
+	for (let index = 0; index < wholeBytes; index++) {
+		if (bytes[index] !== network[index]) return false;
+	}
+	if (remainder === 0) return true;
+	const mask = (0xff << (8 - remainder)) & 0xff;
+	return (bytes[wholeBytes] & mask) === (network[wholeBytes] & mask);
+}
+
 function ipv6Kind(address: string): "public" | "loopback" | "blocked" {
 	const bytes = ipv6Bytes(address);
 	if (!bytes) return "blocked";
 	if (bytes.slice(0, 15).every((byte) => byte === 0) && bytes[15] === 1) return "loopback";
 	if (bytes.every((byte) => byte === 0)) return "blocked";
-	if (bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff) {
+
+	// Normalize the operational IPv4-mapped socket alias before classification.
+	if (inCidr(bytes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff], 96)) {
 		return ipv4Kind(bytes.slice(12).join("."));
 	}
-	const first = bytes[0];
-	const second = bytes[1];
-	const firstGroup = (first << 8) | second;
-	const secondGroup = (bytes[2] << 8) | bytes[3];
+	// Deprecated IPv4-compatible and RFC 2765 translated forms are not global
+	// IPv6 locators, even when their embedded IPv4 value is public.
 	if (
-		(first & 0xfe) === 0xfc ||
-		(first === 0xfe && (second & 0xc0) === 0x80) ||
-		first === 0xff ||
-		(firstGroup === 0x64 && secondGroup === 0xff9b) ||
-		(firstGroup === 0x100 && bytes.slice(2, 8).every((byte) => byte === 0)) ||
-		(firstGroup === 0x2001 && (bytes[2] <= 1 || secondGroup === 0x0db8)) ||
-		firstGroup === 0x2002 ||
-		(firstGroup === 0x3fff && (secondGroup & 0xf000) === 0) ||
-		firstGroup === 0x5f00
+		inCidr(bytes, new Array<number>(12).fill(0), 96) ||
+		inCidr(bytes, [0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0], 96)
 	) {
 		return "blocked";
 	}
-	return "public";
+	// RFC 6052's well-known NAT64 prefix is globally reachable only when its
+	// embedded destination is itself public; local-use translation prefixes
+	// remain excluded by the positive global-unicast gate below.
+	if (inCidr(bytes, [0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0], 96)) {
+		return ipv4Kind(bytes.slice(12).join(".")) === "public" ? "public" : "blocked";
+	}
+
+	// Positive policy from the IANA IPv6 Special-Purpose Address Registry:
+	// currently allocated general global-unicast locators are in 2000::/3.
+	// This denies site/link-local, ULA, multicast, discard, translation,
+	// benchmarking and unallocated space by default.
+	if (!inCidr(bytes, [0x20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 3)) return "blocked";
+
+	// Globally reachable locator exceptions inside the otherwise special
+	// 2001::/23 IETF assignments block. ORCHIDv2 and DET identity prefixes
+	// are deliberately not treated as SSRF-safe network destinations even
+	// though the IANA registry marks them globally reachable.
+	const globalIetfException =
+		[1, 2, 3].some((last) => inCidr(bytes, [0x20, 0x01, 0, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, last], 128)) ||
+		inCidr(bytes, [0x20, 0x01, 0, 0x03, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 32) ||
+		inCidr(bytes, [0x20, 0x01, 0, 0x04, 0x01, 0x12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 48);
+	if (globalIetfException) return "public";
+
+	const nonGlobalSpecial =
+		inCidr(bytes, [0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 23) ||
+		inCidr(bytes, [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 32) ||
+		inCidr(bytes, [0x20, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 16) ||
+		inCidr(bytes, [0x3f, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 20);
+	return nonGlobalSpecial ? "blocked" : "public";
 }
 
 function addressKind(address: string, family: number): "public" | "loopback" | "blocked" {
@@ -219,11 +252,19 @@ function rendererRelease(reader: ReadableStreamDefaultReader<Uint8Array>): void 
 	}
 }
 
-export async function safeFetchJson(
+interface BoundedFetchResult {
+	status: number;
+	headers: Headers;
+	body: string;
+	url: URL;
+}
+
+async function safeFetchBounded(
 	rawUrl: string,
 	init: RequestInit | undefined,
 	policy: OAuthFetchPolicy,
-): Promise<unknown> {
+	discardBody = false,
+): Promise<BoundedFetchResult> {
 	const method = (init?.method ?? "GET").toUpperCase();
 	const requestBodyBytes =
 		typeof init?.body === "string"
@@ -286,18 +327,73 @@ export async function safeFetchJson(
 				continue;
 			}
 
-			const body = await readBoundedBody(response, maxBodyBytes);
-			if (!response.ok) throw new Error(`${method} ${redactedUrl(target.url)} failed with HTTP ${response.status}`);
-			try {
-				return JSON.parse(body);
-			} catch (cause) {
-				const contentType = response.headers.get("content-type") ?? "unknown content type";
-				throw new Error(`${method} ${redactedUrl(target.url)} returned non-JSON (${contentType})`, { cause });
+			let body = "";
+			if (discardBody) {
+				try {
+					await response.body?.cancel();
+				} catch {
+					// Headers are already bounded by Undici; teardown errors do not
+					// invalidate an authoritative authentication challenge.
+				}
+			} else {
+				body = await readBoundedBody(response, maxBodyBytes);
 			}
+			return { status: response.status, headers: new Headers(response.headers), body, url: target.url };
 		} finally {
 			clearTimeout(timeout);
 			init?.signal?.removeEventListener("abort", onAbort);
 			await dispatcher.close();
 		}
 	}
+}
+
+export async function safeFetchJson(
+	rawUrl: string,
+	init: RequestInit | undefined,
+	policy: OAuthFetchPolicy,
+): Promise<unknown> {
+	const method = (init?.method ?? "GET").toUpperCase();
+	const result = await safeFetchBounded(rawUrl, init, policy);
+	if (result.status < 200 || result.status >= 300) {
+		throw new Error(`${method} ${redactedUrl(result.url)} failed with HTTP ${result.status}`);
+	}
+	try {
+		return JSON.parse(result.body);
+	} catch (cause) {
+		const contentType = result.headers.get("content-type") ?? "unknown content type";
+		throw new Error(`${method} ${redactedUrl(result.url)} returned non-JSON (${contentType})`, { cause });
+	}
+}
+
+/** Perform a bounded unauthenticated MCP initialize probe and return only a 401 challenge. */
+export async function probeMcpOAuthChallenge(
+	rawUrl: string,
+	policy: OAuthFetchPolicy,
+): Promise<{ challenged: boolean; header?: string }> {
+	const body = JSON.stringify({
+		jsonrpc: "2.0",
+		id: 1,
+		method: "initialize",
+		params: {
+			protocolVersion: "2025-06-18",
+			capabilities: {},
+			clientInfo: { name: "prime-agent-oauth-discovery", version: "1" },
+		},
+	});
+	const result = await safeFetchBounded(
+		rawUrl,
+		{
+			method: "POST",
+			headers: {
+				Accept: "application/json, text/event-stream",
+				"Content-Type": "application/json",
+			},
+			body,
+		},
+		policy,
+		true,
+	);
+	return result.status === 401
+		? { challenged: true, header: result.headers.get("www-authenticate") ?? undefined }
+		: { challenged: false };
 }

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -147,7 +147,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 	options?: OpenAICodexResponsesOptions,
 ): AssistantMessageEventStream => {
 	const stream = new AssistantMessageEventStream();
-	const activeRequest = registerActiveWebSocketRequest(options?.sessionId);
+	const activeRequest = registerActiveCodexRequest(options?.sessionId, (options?.transport ?? "auto") !== "sse");
 	const effectiveSignal = options?.signal
 		? AbortSignal.any([options.signal, activeRequest.controller.signal])
 		: activeRequest.controller.signal;
@@ -699,41 +699,50 @@ export interface OpenAICodexWebSocketDebugStats {
 const websocketSessionCache = new Map<string, CachedWebSocketConnection>();
 const websocketDebugStats = new Map<string, OpenAICodexWebSocketDebugStats>();
 const websocketSseFallbackSessions = new Set<string>();
-const activeWebSocketRequests = new Map<string | undefined, Set<AbortController>>();
-
-function registerActiveWebSocketRequest(sessionId: string | undefined): {
+interface ActiveCodexRequest {
 	controller: AbortController;
-	unregister: () => void;
-} {
-	const controller = new AbortController();
-	let requests = activeWebSocketRequests.get(sessionId);
+	websocketEligible: boolean;
+}
+
+const activeCodexRequests = new Map<string | undefined, Set<ActiveCodexRequest>>();
+
+function registerActiveCodexRequest(
+	sessionId: string | undefined,
+	websocketEligible: boolean,
+): { controller: AbortController; unregister: () => void } {
+	const request: ActiveCodexRequest = { controller: new AbortController(), websocketEligible };
+	let requests = activeCodexRequests.get(sessionId);
 	if (!requests) {
 		requests = new Set();
-		activeWebSocketRequests.set(sessionId, requests);
+		activeCodexRequests.set(sessionId, requests);
 	}
-	requests.add(controller);
+	requests.add(request);
 	return {
-		controller,
+		controller: request.controller,
 		unregister: () => {
-			requests.delete(controller);
-			if (requests.size === 0 && activeWebSocketRequests.get(sessionId) === requests) {
-				activeWebSocketRequests.delete(sessionId);
+			requests.delete(request);
+			if (requests.size === 0 && activeCodexRequests.get(sessionId) === requests) {
+				activeCodexRequests.delete(sessionId);
 			}
 		},
 	};
 }
 
-function abortActiveWebSocketRequests(sessionId?: string): void {
-	const abortRequests = (requests: Set<AbortController> | undefined) => {
-		for (const controller of requests ?? []) controller.abort(createAbortError());
+function abortActiveCodexRequests(sessionId: string | undefined, includePureSse: boolean): void {
+	const abortRequests = (key: string | undefined, requests: Set<ActiveCodexRequest> | undefined) => {
+		if (!requests) return;
+		for (const request of [...requests]) {
+			if (!includePureSse && !request.websocketEligible) continue;
+			requests.delete(request);
+			request.controller.abort(createAbortError());
+		}
+		if (requests.size === 0 && activeCodexRequests.get(key) === requests) activeCodexRequests.delete(key);
 	};
 	if (sessionId !== undefined) {
-		abortRequests(activeWebSocketRequests.get(sessionId));
-		activeWebSocketRequests.delete(sessionId);
+		abortRequests(sessionId, activeCodexRequests.get(sessionId));
 		return;
 	}
-	for (const requests of activeWebSocketRequests.values()) abortRequests(requests);
-	activeWebSocketRequests.clear();
+	for (const [key, requests] of [...activeCodexRequests]) abortRequests(key, requests);
 }
 
 function getOrCreateWebSocketDebugStats(sessionId: string): OpenAICodexWebSocketDebugStats {
@@ -770,7 +779,7 @@ export function resetOpenAICodexWebSocketDebugStats(sessionId?: string): void {
 }
 
 export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
-	abortActiveWebSocketRequests(sessionId);
+	abortActiveCodexRequests(sessionId, false);
 	const closeEntry = (entry: CachedWebSocketConnection) => {
 		if (entry.idleTimer) clearTimeout(entry.idleTimer);
 		closeWebSocketSilently(entry.socket, 1000, "debug_close");
@@ -791,7 +800,12 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 	websocketSseFallbackSessions.clear();
 }
 
-registerSessionResourceCleanup(closeOpenAICodexWebSocketSessions);
+registerSessionResourceCleanup((sessionId) => {
+	// Internal session teardown owns all Codex transports, while the public
+	// WebSocket-only closer must not interrupt explicit SSE requests.
+	abortActiveCodexRequests(sessionId, true);
+	closeOpenAICodexWebSocketSessions(sessionId);
+});
 
 function isWebSocketSseFallbackActive(sessionId: string | undefined): boolean {
 	return sessionId ? websocketSseFallbackSessions.has(sessionId) : false;

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -737,12 +737,16 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 		const entry = websocketSessionCache.get(sessionId);
 		if (entry) closeEntry(entry);
 		websocketSessionCache.delete(sessionId);
+		websocketDebugStats.delete(sessionId);
+		websocketSseFallbackSessions.delete(sessionId);
 		return;
 	}
 	for (const entry of websocketSessionCache.values()) {
 		closeEntry(entry);
 	}
 	websocketSessionCache.clear();
+	websocketDebugStats.clear();
+	websocketSseFallbackSessions.clear();
 }
 
 registerSessionResourceCleanup(closeOpenAICodexWebSocketSessions);

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -721,11 +721,9 @@ export function getOpenAICodexWebSocketDebugStats(sessionId: string): OpenAICode
 export function resetOpenAICodexWebSocketDebugStats(sessionId?: string): void {
 	if (sessionId) {
 		websocketDebugStats.delete(sessionId);
-		websocketSseFallbackSessions.delete(sessionId);
 		return;
 	}
 	websocketDebugStats.clear();
-	websocketSseFallbackSessions.clear();
 }
 
 export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -147,6 +147,11 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 	options?: OpenAICodexResponsesOptions,
 ): AssistantMessageEventStream => {
 	const stream = new AssistantMessageEventStream();
+	const activeRequest = registerActiveWebSocketRequest(options?.sessionId);
+	const effectiveSignal = options?.signal
+		? AbortSignal.any([options.signal, activeRequest.controller.signal])
+		: activeRequest.controller.signal;
+	options = { ...options, signal: effectiveSignal };
 
 	(async () => {
 		const output: AssistantMessage = {
@@ -322,6 +327,8 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 					: String(error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
+		} finally {
+			activeRequest.unregister();
 		}
 	})();
 
@@ -692,6 +699,42 @@ export interface OpenAICodexWebSocketDebugStats {
 const websocketSessionCache = new Map<string, CachedWebSocketConnection>();
 const websocketDebugStats = new Map<string, OpenAICodexWebSocketDebugStats>();
 const websocketSseFallbackSessions = new Set<string>();
+const activeWebSocketRequests = new Map<string | undefined, Set<AbortController>>();
+
+function registerActiveWebSocketRequest(sessionId: string | undefined): {
+	controller: AbortController;
+	unregister: () => void;
+} {
+	const controller = new AbortController();
+	let requests = activeWebSocketRequests.get(sessionId);
+	if (!requests) {
+		requests = new Set();
+		activeWebSocketRequests.set(sessionId, requests);
+	}
+	requests.add(controller);
+	return {
+		controller,
+		unregister: () => {
+			requests.delete(controller);
+			if (requests.size === 0 && activeWebSocketRequests.get(sessionId) === requests) {
+				activeWebSocketRequests.delete(sessionId);
+			}
+		},
+	};
+}
+
+function abortActiveWebSocketRequests(sessionId?: string): void {
+	const abortRequests = (requests: Set<AbortController> | undefined) => {
+		for (const controller of requests ?? []) controller.abort(createAbortError());
+	};
+	if (sessionId !== undefined) {
+		abortRequests(activeWebSocketRequests.get(sessionId));
+		activeWebSocketRequests.delete(sessionId);
+		return;
+	}
+	for (const requests of activeWebSocketRequests.values()) abortRequests(requests);
+	activeWebSocketRequests.clear();
+}
 
 function getOrCreateWebSocketDebugStats(sessionId: string): OpenAICodexWebSocketDebugStats {
 	let stats = websocketDebugStats.get(sessionId);
@@ -727,6 +770,7 @@ export function resetOpenAICodexWebSocketDebugStats(sessionId?: string): void {
 }
 
 export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
+	abortActiveWebSocketRequests(sessionId);
 	const closeEntry = (entry: CachedWebSocketConnection) => {
 		if (entry.idleTimer) clearTimeout(entry.idleTimer);
 		closeWebSocketSilently(entry.socket, 1000, "debug_close");
@@ -1257,36 +1301,40 @@ async function processWebSocketStream(
 	onStart: () => void,
 	options?: OpenAICodexResponsesOptions,
 ): Promise<void> {
-	const { socket, entry, reused, release } = await acquireWebSocket(url, headers, options?.sessionId, options?.signal);
+	const signal = options?.signal;
+	const { socket, entry, reused, release } = await acquireWebSocket(url, headers, options?.sessionId, signal);
 	let keepConnection = false;
-	const useCachedContext = options?.transport === "websocket-cached" || options?.transport === "auto";
-	// ChatGPT Codex Responses rejects `store: true` ("Store must be set to false").
-	// WebSocket continuation still works via connection-scoped previous_response_id state.
-	const fullBody = body;
-	const requestBody = useCachedContext && entry ? buildCachedWebSocketRequestBody(entry, fullBody) : fullBody;
-	const stats = options?.sessionId ? getOrCreateWebSocketDebugStats(options.sessionId) : undefined;
-	if (stats) {
-		stats.requests++;
-		if (reused) stats.connectionsReused++;
-		else stats.connectionsCreated++;
-		if (useCachedContext) stats.cachedContextRequests++;
-		if (requestBody.store === true) stats.storeTrueRequests++;
-		stats.lastInputItems = requestBody.input?.length ?? 0;
-		if (requestBody.previous_response_id) {
-			stats.deltaRequests++;
-			stats.lastDeltaInputItems = requestBody.input?.length ?? 0;
-			stats.lastPreviousResponseId = requestBody.previous_response_id;
-		} else {
-			stats.fullContextRequests++;
-			stats.lastDeltaInputItems = undefined;
-			stats.lastPreviousResponseId = undefined;
-		}
-	}
 	let websocketStream: ReturnType<typeof createWebSocketEventStream> | undefined;
 	try {
-		throwIfAborted(options?.signal);
-		websocketStream = createWebSocketEventStream(socket, options?.signal);
-		throwIfAborted(options?.signal);
+		// acquireWebSocket always crosses an await boundary. Cleanup may have
+		// invalidated this request before this continuation resumes, so check
+		// before stats, cache continuation state, listeners, or send side effects.
+		throwIfAborted(signal);
+		const useCachedContext = options?.transport === "websocket-cached" || options?.transport === "auto";
+		// ChatGPT Codex Responses rejects `store: true` ("Store must be set to false").
+		// WebSocket continuation still works via connection-scoped previous_response_id state.
+		const fullBody = body;
+		const requestBody = useCachedContext && entry ? buildCachedWebSocketRequestBody(entry, fullBody) : fullBody;
+		const stats = options?.sessionId ? getOrCreateWebSocketDebugStats(options.sessionId) : undefined;
+		if (stats) {
+			stats.requests++;
+			if (reused) stats.connectionsReused++;
+			else stats.connectionsCreated++;
+			if (useCachedContext) stats.cachedContextRequests++;
+			if (requestBody.store === true) stats.storeTrueRequests++;
+			stats.lastInputItems = requestBody.input?.length ?? 0;
+			if (requestBody.previous_response_id) {
+				stats.deltaRequests++;
+				stats.lastDeltaInputItems = requestBody.input?.length ?? 0;
+				stats.lastPreviousResponseId = requestBody.previous_response_id;
+			} else {
+				stats.fullContextRequests++;
+				stats.lastDeltaInputItems = undefined;
+				stats.lastPreviousResponseId = undefined;
+			}
+		}
+		websocketStream = createWebSocketEventStream(socket, signal);
+		throwIfAborted(signal);
 		socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
 		await processResponsesStream(
 			startWebSocketOutputOnFirstEvent(mapCodexEvents(websocketStream.events), output, stream, onStart),
@@ -1299,7 +1347,7 @@ async function processWebSocketStream(
 				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
 			},
 		);
-		throwIfAborted(options?.signal);
+		throwIfAborted(signal);
 		if (useCachedContext && entry && output.responseId) {
 			const responseItems = convertResponsesMessages(model, { messages: [output] }, CODEX_TOOL_CALL_PROVIDERS, {
 				includeSystemPrompt: false,

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -106,17 +106,34 @@ function isRetryableError(status: number, errorText: string): boolean {
 	return /rate.?limit|overloaded|service.?unavailable|upstream.?connect|connection.?refused/i.test(errorText);
 }
 
+function createAbortError(): Error {
+	const error = new Error("Request was aborted");
+	error.name = "AbortError";
+	return error;
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && (error.name === "AbortError" || error.message === "Request was aborted");
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+	if (signal?.aborted) throw createAbortError();
+}
+
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 	return new Promise((resolve, reject) => {
-		if (signal?.aborted) {
-			reject(new Error("Request was aborted"));
-			return;
-		}
-		const timeout = setTimeout(resolve, ms);
-		signal?.addEventListener("abort", () => {
+		throwIfAborted(signal);
+		const cleanup = () => signal?.removeEventListener("abort", onAbort);
+		const timeout = setTimeout(() => {
+			cleanup();
+			resolve();
+		}, ms);
+		const onAbort = () => {
 			clearTimeout(timeout);
-			reject(new Error("Request was aborted"));
-		});
+			cleanup();
+			reject(createAbortError());
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
 	});
 }
 
@@ -151,6 +168,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 		};
 
 		try {
+			throwIfAborted(options?.signal);
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			if (!apiKey) {
 				throw new Error(`No API key for provider: ${model.provider}`);
@@ -194,9 +212,6 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						options,
 					);
 
-					if (options?.signal?.aborted) {
-						throw new Error("Request was aborted");
-					}
 					stream.push({
 						type: "done",
 						reason: output.stopReason as "stop" | "length" | "toolUse",
@@ -205,8 +220,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 					stream.end();
 					return;
 				} catch (error) {
-					const aborted = options?.signal?.aborted;
-					if (aborted || isCodexNonTransportError(error)) {
+					if (isAbortError(error) || options?.signal?.aborted || isCodexNonTransportError(error)) {
 						throw error;
 					}
 					appendAssistantMessageDiagnostic(
@@ -232,9 +246,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			let lastError: Error | undefined;
 
 			for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-				if (options?.signal?.aborted) {
-					throw new Error("Request was aborted");
-				}
+				throwIfAborted(options?.signal);
 
 				try {
 					response = await fetch(resolveCodexUrl(model.baseUrl), {
@@ -267,10 +279,8 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 					const info = await parseErrorResponse(fakeResponse);
 					throw new Error(info.friendlyMessage || info.message);
 				} catch (error) {
-					if (error instanceof Error) {
-						if (error.name === "AbortError" || error.message === "Request was aborted") {
-							throw new Error("Request was aborted");
-						}
+					if (isAbortError(error) || options?.signal?.aborted) {
+						throw createAbortError();
 					}
 					lastError = error instanceof Error ? error : new Error(String(error));
 					// Network errors are retryable
@@ -294,9 +304,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			stream.push({ type: "start", partial: output });
 			await processStream(response, output, stream, model, options);
 
-			if (options?.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
+			throwIfAborted(options?.signal);
 
 			stream.push({ type: "done", reason: output.stopReason as "stop" | "length" | "toolUse", message: output });
 			stream.end();
@@ -305,8 +313,13 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				// partialJson is only a streaming scratch buffer; never persist it.
 				delete (block as { partialJson?: string }).partialJson;
 			}
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : String(error);
+			const aborted = isAbortError(error) || options?.signal?.aborted;
+			output.stopReason = aborted ? "aborted" : "error";
+			output.errorMessage = aborted
+				? createAbortError().message
+				: error instanceof Error
+					? error.message
+					: String(error);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}
@@ -454,7 +467,7 @@ async function processStream(
 	model: Model<"openai-codex-responses">,
 	options?: OpenAICodexResponsesOptions,
 ): Promise<void> {
-	await processResponsesStream(mapCodexEvents(parseSSE(response)), output, stream, model, {
+	await processResponsesStream(mapCodexEvents(parseSSE(response, options?.signal)), output, stream, model, {
 		serviceTier: options?.serviceTier,
 		resolveServiceTier: resolveCodexServiceTier,
 		applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
@@ -532,45 +545,89 @@ function normalizeCodexStatus(status: unknown): CodexResponseStatus | undefined 
 // SSE Parsing
 // ============================================================================
 
-async function* parseSSE(response: Response): AsyncGenerator<Record<string, unknown>> {
+class CodexSSEDecoder {
+	private readonly decoder = new TextDecoder();
+	private buffer = "";
+	private dataLines: string[] = [];
+
+	push(value?: Uint8Array, final = false): string[] {
+		if (value) this.buffer += this.decoder.decode(value, { stream: !final });
+		if (final) this.buffer += this.decoder.decode();
+
+		const events: string[] = [];
+		while (true) {
+			const newline = this.buffer.search(/[\r\n]/);
+			if (newline < 0) break;
+
+			const delimiter = this.buffer[newline];
+			if (delimiter === "\r" && newline === this.buffer.length - 1 && !final) break;
+			const width = delimiter === "\r" && this.buffer[newline + 1] === "\n" ? 2 : 1;
+			const line = this.buffer.slice(0, newline);
+			this.buffer = this.buffer.slice(newline + width);
+			this.processLine(line, events);
+		}
+
+		if (final) {
+			if (this.buffer.length > 0) this.processLine(this.buffer, events);
+			this.buffer = "";
+			this.dispatch(events);
+		}
+		return events;
+	}
+
+	private processLine(line: string, events: string[]): void {
+		if (line.length === 0) {
+			this.dispatch(events);
+			return;
+		}
+		if (line.startsWith(":")) return;
+
+		const colon = line.indexOf(":");
+		const field = colon < 0 ? line : line.slice(0, colon);
+		let value = colon < 0 ? "" : line.slice(colon + 1);
+		if (value.startsWith(" ")) value = value.slice(1);
+		if (field === "data") this.dataLines.push(value);
+	}
+
+	private dispatch(events: string[]): void {
+		if (this.dataLines.length === 0) return;
+		events.push(this.dataLines.join("\n"));
+		this.dataLines = [];
+	}
+}
+
+async function* parseSSE(response: Response, signal?: AbortSignal): AsyncGenerator<Record<string, unknown>> {
 	if (!response.body) return;
+	throwIfAborted(signal);
 
 	const reader = response.body.getReader();
-	const decoder = new TextDecoder();
-	let buffer = "";
+	const decoder = new CodexSSEDecoder();
+	const onAbort = () => {
+		void reader.cancel(createAbortError()).catch(() => {});
+	};
+	signal?.addEventListener("abort", onAbort, { once: true });
 
 	try {
 		while (true) {
+			throwIfAborted(signal);
 			const { done, value } = await reader.read();
-			if (done) break;
-			buffer += decoder.decode(value, { stream: true });
-
-			let idx = buffer.indexOf("\n\n");
-			while (idx !== -1) {
-				const chunk = buffer.slice(0, idx);
-				buffer = buffer.slice(idx + 2);
-
-				const dataLines = chunk
-					.split("\n")
-					.filter((l) => l.startsWith("data:"))
-					.map((l) => l.slice(5).trim());
-				if (dataLines.length > 0) {
-					const data = dataLines.join("\n").trim();
-					if (data && data !== "[DONE]") {
-						try {
-							yield JSON.parse(data) as Record<string, unknown>;
-						} catch (cause) {
-							throw new CodexProtocolError(`Invalid Codex SSE JSON: ${formatThrownValue(cause)}`, {
-								cause,
-								payload: data,
-							});
-						}
-					}
+			throwIfAborted(signal);
+			for (const data of decoder.push(value, done)) {
+				const payload = data.trim();
+				if (!payload || payload === "[DONE]") continue;
+				try {
+					yield JSON.parse(payload) as Record<string, unknown>;
+				} catch (cause) {
+					throw new CodexProtocolError(`Invalid Codex SSE JSON: ${formatThrownValue(cause)}`, {
+						cause,
+						payload: data,
+					});
 				}
-				idx = buffer.indexOf("\n\n");
 			}
+			if (done) break;
 		}
 	} finally {
+		signal?.removeEventListener("abort", onAbort);
 		// Best-effort stream teardown: the reader may already be closed or errored.
 		try {
 			await reader.cancel();
@@ -760,13 +817,14 @@ function scheduleSessionWebSocketExpiry(sessionId: string, entry: CachedWebSocke
 		clearTimeout(entry.idleTimer);
 	}
 	entry.idleTimer = setTimeout(() => {
-		if (entry.busy) return;
+		if (entry.busy || websocketSessionCache.get(sessionId) !== entry) return;
 		closeWebSocketSilently(entry.socket, 1000, "idle_timeout");
 		websocketSessionCache.delete(sessionId);
 	}, SESSION_WEBSOCKET_CACHE_TTL_MS);
 }
 
 async function connectWebSocket(url: string, headers: Headers, signal?: AbortSignal): Promise<WebSocketLike> {
+	throwIfAborted(signal);
 	const WebSocketCtor = getWebSocketConstructor();
 	if (!WebSocketCtor) {
 		throw new Error("WebSocket transport is not available in this runtime");
@@ -797,6 +855,7 @@ async function connectWebSocket(url: string, headers: Headers, signal?: AbortSig
 			if (settled) return;
 			settled = true;
 			cleanup();
+			closeWebSocketSilently(socket, 1000, "connection_error");
 			reject(error);
 		};
 		const onClose: WebSocketListener = (event) => {
@@ -810,8 +869,8 @@ async function connectWebSocket(url: string, headers: Headers, signal?: AbortSig
 			if (settled) return;
 			settled = true;
 			cleanup();
-			socket.close(1000, "aborted");
-			reject(new Error("Request was aborted"));
+			closeWebSocketSilently(socket, 1000, "aborted");
+			reject(createAbortError());
 		};
 
 		const cleanup = () => {
@@ -824,8 +883,15 @@ async function connectWebSocket(url: string, headers: Headers, signal?: AbortSig
 		socket.addEventListener("open", onOpen);
 		socket.addEventListener("error", onError);
 		socket.addEventListener("close", onClose);
-		signal?.addEventListener("abort", onAbort);
+		signal?.addEventListener("abort", onAbort, { once: true });
+		if (signal?.aborted) onAbort();
 	});
+}
+
+function rejectAbortedConnectedSocket(socket: WebSocketLike, signal?: AbortSignal): void {
+	if (!signal?.aborted) return;
+	closeWebSocketSilently(socket, 1000, "aborted");
+	throw createAbortError();
 }
 
 async function acquireWebSocket(
@@ -839,8 +905,10 @@ async function acquireWebSocket(
 	reused: boolean;
 	release: (options?: { keep?: boolean }) => void;
 }> {
+	throwIfAborted(signal);
 	if (!sessionId) {
 		const socket = await connectWebSocket(url, headers, signal);
+		rejectAbortedConnectedSocket(socket, signal);
 		return {
 			socket,
 			reused: false,
@@ -867,6 +935,10 @@ async function acquireWebSocket(
 				entry: cached,
 				reused: true,
 				release: ({ keep } = {}) => {
+					if (websocketSessionCache.get(sessionId) !== cached) {
+						closeWebSocketSilently(cached.socket);
+						return;
+					}
 					if (!keep || !isWebSocketReusable(cached.socket)) {
 						closeWebSocketSilently(cached.socket);
 						websocketSessionCache.delete(sessionId);
@@ -879,6 +951,7 @@ async function acquireWebSocket(
 		}
 		if (cached.busy) {
 			const socket = await connectWebSocket(url, headers, signal);
+			rejectAbortedConnectedSocket(socket, signal);
 			return {
 				socket,
 				reused: false,
@@ -894,6 +967,7 @@ async function acquireWebSocket(
 	}
 
 	const socket = await connectWebSocket(url, headers, signal);
+	rejectAbortedConnectedSocket(socket, signal);
 	const entry: CachedWebSocketConnection = { socket, busy: true };
 	websocketSessionCache.set(sessionId, entry);
 	return {
@@ -901,6 +975,10 @@ async function acquireWebSocket(
 		entry,
 		reused: false,
 		release: ({ keep } = {}) => {
+			if (websocketSessionCache.get(sessionId) !== entry) {
+				closeWebSocketSilently(entry.socket);
+				return;
+			}
 			if (!keep || !isWebSocketReusable(entry.socket)) {
 				closeWebSocketSilently(entry.socket);
 				if (entry.idleTimer) clearTimeout(entry.idleTimer);
@@ -972,12 +1050,18 @@ async function decodeWebSocketData(data: unknown): Promise<string | null> {
 	return null;
 }
 
-async function* parseWebSocket(socket: WebSocketLike, signal?: AbortSignal): AsyncGenerator<Record<string, unknown>> {
+function createWebSocketEventStream(
+	socket: WebSocketLike,
+	signal?: AbortSignal,
+): { events: AsyncIterable<Record<string, unknown>>; dispose: () => void } {
+	throwIfAborted(signal);
 	const queue: Record<string, unknown>[] = [];
 	let pending: (() => void) | null = null;
 	let done = false;
+	let disposed = false;
 	let failed: Error | null = null;
 	let sawCompletion = false;
+	let processing = Promise.resolve();
 
 	const wake = () => {
 		if (!pending) return;
@@ -986,89 +1070,108 @@ async function* parseWebSocket(socket: WebSocketLike, signal?: AbortSignal): Asy
 		resolve();
 	};
 
+	const cleanup = () => {
+		if (disposed) return;
+		disposed = true;
+		socket.removeEventListener("message", onMessage);
+		socket.removeEventListener("error", onError);
+		socket.removeEventListener("close", onClose);
+		signal?.removeEventListener("abort", onAbort);
+	};
+
+	const finish = (error?: Error) => {
+		if (done) return;
+		if (error) failed = error;
+		done = true;
+		wake();
+	};
+
+	const enqueue = (task: () => Promise<void> | void) => {
+		processing = processing.then(task).catch((cause) => {
+			finish(cause instanceof Error ? cause : new Error(String(cause)));
+		});
+	};
+
 	const onMessage: WebSocketListener = (event) => {
-		void (async () => {
+		enqueue(async () => {
+			if (done || !event || typeof event !== "object" || !("data" in event)) return;
 			let text: string | null = null;
 			try {
-				if (!event || typeof event !== "object" || !("data" in event)) return;
 				text = await decodeWebSocketData((event as { data?: unknown }).data);
-				if (!text) return;
+				if (!text || done) return;
 				const parsed = JSON.parse(text) as Record<string, unknown>;
+				queue.push(parsed);
 				const type = typeof parsed.type === "string" ? parsed.type : "";
 				if (type === "response.completed" || type === "response.done" || type === "response.incomplete") {
 					sawCompletion = true;
-					done = true;
+					finish();
+				} else {
+					wake();
 				}
-				queue.push(parsed);
-				wake();
 			} catch (cause) {
-				failed = new CodexProtocolError(`Invalid Codex WebSocket JSON: ${formatThrownValue(cause)}`, {
-					cause,
-					payload: text,
-				});
-				done = true;
-				wake();
+				finish(
+					new CodexProtocolError(`Invalid Codex WebSocket JSON: ${formatThrownValue(cause)}`, {
+						cause,
+						payload: text,
+					}),
+				);
 			}
-		})();
+		});
 	};
 
 	const onError: WebSocketListener = (event) => {
-		failed = extractWebSocketError(event);
-		done = true;
-		wake();
+		enqueue(() => finish(extractWebSocketError(event)));
 	};
 
 	const onClose: WebSocketListener = (event) => {
-		if (sawCompletion) {
-			done = true;
-			wake();
-			return;
-		}
-		if (!failed) {
-			failed = extractWebSocketCloseError(event);
-		}
-		done = true;
-		wake();
+		enqueue(() => {
+			if (sawCompletion) finish();
+			else finish(extractWebSocketCloseError(event));
+		});
 	};
 
 	const onAbort = () => {
-		failed = new Error("Request was aborted");
-		done = true;
-		wake();
+		finish(createAbortError());
+		closeWebSocketSilently(socket, 1000, "aborted");
+		cleanup();
 	};
 
 	socket.addEventListener("message", onMessage);
 	socket.addEventListener("error", onError);
 	socket.addEventListener("close", onClose);
-	signal?.addEventListener("abort", onAbort);
+	signal?.addEventListener("abort", onAbort, { once: true });
+	if (signal?.aborted) onAbort();
 
-	try {
-		while (true) {
-			if (signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-			if (queue.length > 0) {
-				yield queue.shift()!;
-				continue;
-			}
-			if (done) break;
-			await new Promise<void>((resolve) => {
-				pending = resolve;
-			});
-		}
+	const events: AsyncIterable<Record<string, unknown>> = {
+		async *[Symbol.asyncIterator]() {
+			try {
+				while (true) {
+					throwIfAborted(signal);
+					if (queue.length > 0) {
+						yield queue.shift()!;
+						continue;
+					}
+					if (done) break;
+					await new Promise<void>((resolve) => {
+						pending = resolve;
+					});
+				}
 
-		if (failed) {
-			throw failed;
-		}
-		if (!sawCompletion) {
-			throw new Error("WebSocket stream closed before response.completed");
-		}
-	} finally {
-		socket.removeEventListener("message", onMessage);
-		socket.removeEventListener("error", onError);
-		socket.removeEventListener("close", onClose);
-		signal?.removeEventListener("abort", onAbort);
-	}
+				if (failed) throw failed;
+				if (!sawCompletion) throw new Error("WebSocket stream closed before response.completed");
+			} finally {
+				cleanup();
+			}
+		},
+	};
+
+	return {
+		events,
+		dispose: () => {
+			finish();
+			cleanup();
+		},
+	};
 }
 
 function requestBodyWithoutInput(body: RequestBody): RequestBody {
@@ -1153,7 +1256,7 @@ async function processWebSocketStream(
 	options?: OpenAICodexResponsesOptions,
 ): Promise<void> {
 	const { socket, entry, reused, release } = await acquireWebSocket(url, headers, options?.sessionId, options?.signal);
-	let keepConnection = true;
+	let keepConnection = false;
 	const useCachedContext = options?.transport === "websocket-cached" || options?.transport === "auto";
 	// ChatGPT Codex Responses rejects `store: true` ("Store must be set to false").
 	// WebSocket continuation still works via connection-scoped previous_response_id state.
@@ -1177,15 +1280,14 @@ async function processWebSocketStream(
 			stats.lastPreviousResponseId = undefined;
 		}
 	}
+	let websocketStream: ReturnType<typeof createWebSocketEventStream> | undefined;
 	try {
+		throwIfAborted(options?.signal);
+		websocketStream = createWebSocketEventStream(socket, options?.signal);
+		throwIfAborted(options?.signal);
 		socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
 		await processResponsesStream(
-			startWebSocketOutputOnFirstEvent(
-				mapCodexEvents(parseWebSocket(socket, options?.signal)),
-				output,
-				stream,
-				onStart,
-			),
+			startWebSocketOutputOnFirstEvent(mapCodexEvents(websocketStream.events), output, stream, onStart),
 			output,
 			stream,
 			model,
@@ -1195,9 +1297,8 @@ async function processWebSocketStream(
 				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
 			},
 		);
-		if (options?.signal?.aborted) {
-			keepConnection = false;
-		} else if (useCachedContext && entry && output.responseId) {
+		throwIfAborted(options?.signal);
+		if (useCachedContext && entry && output.responseId) {
 			const responseItems = convertResponsesMessages(model, { messages: [output] }, CODEX_TOOL_CALL_PROVIDERS, {
 				includeSystemPrompt: false,
 			}).filter((item) => item.type !== "function_call_output");
@@ -1207,6 +1308,7 @@ async function processWebSocketStream(
 				lastResponseItems: responseItems,
 			};
 		}
+		keepConnection = true;
 	} catch (error) {
 		if (entry) {
 			entry.continuation = undefined;
@@ -1214,6 +1316,7 @@ async function processWebSocketStream(
 		keepConnection = false;
 		throw error;
 	} finally {
+		websocketStream?.dispose();
 		release({ keep: keepConnection });
 	}
 }

--- a/packages/ai/test/mcp-oauth.test.ts
+++ b/packages/ai/test/mcp-oauth.test.ts
@@ -74,6 +74,101 @@ describe.sequential("MCP OAuth provider", () => {
 		expect(authParams.get("scope")).toBe("read write");
 	});
 
+	it("follows path-suffixed protected-resource metadata to an external issuer", async () => {
+		let authUrl = "";
+		const requested: string[] = [];
+		const externalMeta = {
+			...META,
+			issuer: "https://auth.test/tenant",
+			authorization_endpoint: "https://auth.test/authorize",
+			token_endpoint: "https://auth.test/token",
+		};
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				requested.push(url);
+				if (url === "https://resource.test/.well-known/oauth-protected-resource/mcp/v1") {
+					return jsonResponse({ authorization_servers: ["https://auth.test/tenant"] });
+				}
+				if (url === "https://auth.test/.well-known/oauth-authorization-server/tenant") {
+					return jsonResponse(externalMeta);
+				}
+				if (url === externalMeta.token_endpoint) {
+					return jsonResponse({ access_token: "external-access", expires_in: 3600 });
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+
+		const provider = createMcpOAuthProvider({
+			server: "external",
+			url: "https://resource.test/mcp/v1",
+			clientId: "configured-client",
+		});
+		const credentials = await provider.login({
+			onAuth: (info) => {
+				authUrl = info.url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const state = new URL(authUrl).searchParams.get("state") ?? "";
+				return `${REDIRECT}?code=external-code&state=${state}`;
+			},
+		});
+
+		expect(credentials.access).toBe("external-access");
+		expect(new URL(authUrl).origin).toBe("https://auth.test");
+		expect(requested.slice(0, 2)).toEqual([
+			"https://resource.test/.well-known/oauth-protected-resource/mcp/v1",
+			"https://auth.test/.well-known/oauth-authorization-server/tenant",
+		]);
+	});
+
+	it("falls back from path-suffixed to root protected-resource metadata", async () => {
+		let authUrl = "";
+		const requested: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				requested.push(url);
+				if (url.endsWith("/.well-known/oauth-protected-resource/mcp")) {
+					return new Response("not found", { status: 404 });
+				}
+				if (url.endsWith("/.well-known/oauth-protected-resource")) {
+					return jsonResponse({ authorization_servers: ["https://srv.test"] });
+				}
+				if (url === "https://srv.test/.well-known/oauth-authorization-server") return jsonResponse(META);
+				if (url === META.token_endpoint) return jsonResponse({ access_token: "root-access", expires_in: 3600 });
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+
+		const provider = createMcpOAuthProvider({
+			server: "root-resource",
+			url: "https://srv.test/mcp",
+			clientId: "configured-client",
+		});
+		const credentials = await provider.login({
+			onAuth: (info) => {
+				authUrl = info.url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const state = new URL(authUrl).searchParams.get("state") ?? "";
+				return `${REDIRECT}?code=root-code&state=${state}`;
+			},
+		});
+
+		expect(credentials.access).toBe("root-access");
+		expect(requested.slice(0, 3)).toEqual([
+			"https://srv.test/.well-known/oauth-protected-resource/mcp",
+			"https://srv.test/.well-known/oauth-protected-resource",
+			"https://srv.test/.well-known/oauth-authorization-server",
+		]);
+	});
+
 	it("falls back to the next port when the base callback port is in use", async () => {
 		const http = await import("node:http");
 		// Occupy the base callback port. If something already holds it (e.g. a stray

--- a/packages/ai/test/mcp-oauth.test.ts
+++ b/packages/ai/test/mcp-oauth.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createMcpOAuthProvider } from "../src/mcp/oauth.js";
+import { createMcpOAuthProvider, parseMcpOAuthChallenge } from "../src/mcp/oauth.js";
+
+const dnsLookup = vi.hoisted(() => vi.fn(async () => [{ address: "93.184.216.34", family: 4 as const }]));
+vi.mock("node:dns/promises", () => ({ lookup: dnsLookup }));
 
 function jsonResponse(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
@@ -18,11 +21,14 @@ const META = {
 	token_endpoint: "https://srv.test/token",
 	registration_endpoint: "https://srv.test/register",
 	scopes_supported: ["read", "write"],
+	code_challenge_methods_supported: ["S256"],
 };
 
 describe.sequential("MCP OAuth provider", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
+		dnsLookup.mockReset();
+		dnsLookup.mockImplementation(async () => [{ address: "93.184.216.34", family: 4 as const }]);
 	});
 
 	it("has a namespaced id and label", () => {
@@ -44,6 +50,7 @@ describe.sequential("MCP OAuth provider", () => {
 				expect(params.get("client_id")).toBe("client-xyz");
 				expect(params.get("code")).toBe("the-code");
 				expect(params.get("code_verifier")).toBeTruthy();
+				expect(params.get("resource")).toBe("https://srv.test/mcp");
 				return jsonResponse({ access_token: "access-1", refresh_token: "refresh-1", expires_in: 3600 });
 			}
 			throw new Error(`unexpected fetch: ${url}`);
@@ -71,7 +78,8 @@ describe.sequential("MCP OAuth provider", () => {
 		const authParams = new URL(authUrl).searchParams;
 		expect(authParams.get("client_id")).toBe("client-xyz");
 		expect(authParams.get("code_challenge")).toBeTruthy();
-		expect(authParams.get("scope")).toBe("read write");
+		expect(authParams.get("scope")).toBeNull();
+		expect(authParams.get("resource")).toBe("https://srv.test/mcp");
 	});
 
 	it("follows path-suffixed protected-resource metadata to an external issuer", async () => {
@@ -82,10 +90,11 @@ describe.sequential("MCP OAuth provider", () => {
 			issuer: "https://auth.test/tenant",
 			authorization_endpoint: "https://auth.test/authorize",
 			token_endpoint: "https://auth.test/token",
+			registration_endpoint: undefined,
 		};
 		vi.stubGlobal(
 			"fetch",
-			vi.fn(async (input: unknown): Promise<Response> => {
+			vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
 				const url = urlOf(input);
 				requested.push(url);
 				if (url === "https://resource.test/.well-known/oauth-protected-resource/mcp/v1?tenant=a") {
@@ -98,6 +107,8 @@ describe.sequential("MCP OAuth provider", () => {
 					return jsonResponse(externalMeta);
 				}
 				if (url === externalMeta.token_endpoint) {
+					const params = new URLSearchParams(String(init?.body));
+					expect(params.get("resource")).toBe("https://resource.test/mcp/v1?tenant=a");
 					return jsonResponse({ access_token: "external-access", expires_in: 3600 });
 				}
 				throw new Error(`unexpected fetch: ${url}`);
@@ -122,6 +133,7 @@ describe.sequential("MCP OAuth provider", () => {
 
 		expect(credentials.access).toBe("external-access");
 		expect(new URL(authUrl).origin).toBe("https://auth.test");
+		expect(new URL(authUrl).searchParams.get("resource")).toBe("https://resource.test/mcp/v1?tenant=a");
 		expect(requested.slice(0, 2)).toEqual([
 			"https://resource.test/.well-known/oauth-protected-resource/mcp/v1?tenant=a",
 			"https://auth.test/.well-known/oauth-authorization-server/tenant",
@@ -137,6 +149,7 @@ describe.sequential("MCP OAuth provider", () => {
 			issuer,
 			authorization_endpoint: "https://auth.test/tenant/authorize",
 			token_endpoint: "https://auth.test/tenant/token",
+			registration_endpoint: undefined,
 		};
 		vi.stubGlobal(
 			"fetch",
@@ -189,7 +202,11 @@ describe.sequential("MCP OAuth provider", () => {
 					return new Response("not found", { status: 404 });
 				}
 				if (url.endsWith("/.well-known/oauth-protected-resource")) {
-					return jsonResponse({ resource: "https://srv.test/mcp", authorization_servers: ["https://srv.test"] });
+					return jsonResponse({
+						resource: "https://srv.test/mcp",
+						authorization_servers: ["https://srv.test"],
+						scopes_supported: ["resource.read"],
+					});
 				}
 				if (url === "https://srv.test/.well-known/oauth-authorization-server") return jsonResponse(META);
 				if (url === META.token_endpoint) return jsonResponse({ access_token: "root-access", expires_in: 3600 });
@@ -214,6 +231,8 @@ describe.sequential("MCP OAuth provider", () => {
 		});
 
 		expect(credentials.access).toBe("root-access");
+		expect(new URL(authUrl).searchParams.get("scope")).toBe("resource.read");
+		expect(new URL(authUrl).searchParams.get("resource")).toBe("https://srv.test/mcp");
 		expect(requested.slice(0, 3)).toEqual([
 			"https://srv.test/.well-known/oauth-protected-resource/mcp",
 			"https://srv.test/.well-known/oauth-protected-resource",
@@ -263,13 +282,18 @@ describe.sequential("MCP OAuth provider", () => {
 		}
 	});
 
-	it("refreshes tokens, keeping the prior refresh token when omitted", async () => {
+	it("refreshes tokens, keeping the prior refresh token and resource binding", async () => {
 		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
 			const url = urlOf(input);
+			if (url.endsWith("/.well-known/oauth-protected-resource/mcp")) {
+				return jsonResponse({ resource: "https://srv.test/mcp", authorization_servers: [META.issuer] });
+			}
+			if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
 			if (url === META.token_endpoint) {
 				const params = new URLSearchParams(String(init?.body));
 				expect(params.get("grant_type")).toBe("refresh_token");
 				expect(params.get("refresh_token")).toBe("old-refresh");
+				expect(params.get("resource")).toBe("https://srv.test/mcp");
 				return jsonResponse({ access_token: "access-2", expires_in: 1800 });
 			}
 			throw new Error(`unexpected fetch: ${url}`);
@@ -283,10 +307,49 @@ describe.sequential("MCP OAuth provider", () => {
 			expires: Date.now() - 1000,
 			tokenEndpoint: META.token_endpoint,
 			clientId: "client-xyz",
+			issuer: META.issuer,
+			resource: "https://srv.test/mcp",
 		} as never);
 
 		expect(refreshed.access).toBe("access-2");
 		expect(refreshed.refresh).toBe("old-refresh");
+	});
+
+	it("fails closed before network access when refresh bindings are missing", async () => {
+		global.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
+		const provider = createMcpOAuthProvider({ server: "legacy", url: "https://srv.test/mcp" });
+		await expect(
+			provider.refreshToken({ access: "old", refresh: "legacy-secret", expires: Date.now() - 1 }),
+		).rejects.toThrow("credential binding is missing");
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it("never sends a refresh token to a changed persisted endpoint", async () => {
+		const requested: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				requested.push(url);
+				if (url.endsWith("/.well-known/oauth-protected-resource/mcp")) {
+					return jsonResponse({ resource: "https://srv.test/mcp", authorization_servers: [META.issuer] });
+				}
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const provider = createMcpOAuthProvider({ server: "demo", url: "https://srv.test/mcp" });
+		await expect(
+			provider.refreshToken({
+				access: "old",
+				refresh: "top-secret-refresh",
+				expires: Date.now() - 1,
+				tokenEndpoint: "https://evil.test/token",
+				issuer: META.issuer,
+				resource: "https://srv.test/mcp",
+			} as never),
+		).rejects.toThrow("token endpoint changed");
+		expect(requested).not.toContain("https://evil.test/token");
 	});
 
 	it("fails clearly when DCR is unavailable and no clientId is set", async () => {
@@ -303,6 +366,124 @@ describe.sequential("MCP OAuth provider", () => {
 		await expect(provider.login({ onAuth: () => {}, onPrompt: async () => "" })).rejects.toThrow(
 			"dynamic client registration",
 		);
+	});
+
+	it("parses only Bearer resource metadata and scope parameters", () => {
+		expect(
+			parseMcpOAuthChallenge(
+				'Basic realm="resource_metadata=fake", Bearer realm="files, api", resource_metadata = "https://hint.test/prm", scope = "files.read files.write"',
+			),
+		).toEqual({ resourceMetadataUrl: "https://hint.test/prm", scope: "files.read files.write" });
+		expect(parseMcpOAuthChallenge('Basic resource_metadata="https://evil.test"')).toBeUndefined();
+		expect(() =>
+			parseMcpOAuthChallenge('Bearer resource_metadata="https://a.test", resource_metadata="https://b.test"'),
+		).toThrow("Conflicting");
+		expect(() => parseMcpOAuthChallenge("Bearer realm=x\r\nInjected: yes")).toThrow("Invalid");
+	});
+
+	it("uses a surfaced challenge metadata URL and challenged scope", async () => {
+		let authUrl = "";
+		const requested: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = urlOf(input);
+				requested.push(url);
+				if (url === "https://hint.test/prm") {
+					return jsonResponse({
+						resource: "https://srv.test/mcp",
+						authorization_servers: [META.issuer],
+						scopes_supported: ["resource.scope"],
+					});
+				}
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				if (url === META.token_endpoint) {
+					const params = new URLSearchParams(String(init?.body));
+					expect(params.get("resource")).toBe("https://srv.test/mcp");
+					return jsonResponse({ access_token: "challenge-access", expires_in: 3600 });
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const provider = createMcpOAuthProvider({
+			server: "challenge",
+			url: "https://srv.test/mcp",
+			clientId: "configured-client",
+			scopes: "configured.scope",
+			authorizationChallenge: 'Bearer resource_metadata="https://hint.test/prm", scope="challenge.scope"',
+		});
+		await provider.login({
+			onAuth: (info) => {
+				authUrl = info.url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const state = new URL(authUrl).searchParams.get("state") ?? "";
+				return `${REDIRECT}?code=challenge-code&state=${state}`;
+			},
+		});
+		expect(requested[0]).toBe("https://hint.test/prm");
+		expect(new URL(authUrl).searchParams.get("scope")).toBe("challenge.scope");
+	});
+
+	it("rejects mismatched protected-resource metadata without discovery downgrade", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				if (url.endsWith("/.well-known/oauth-protected-resource/mcp")) {
+					return jsonResponse({ resource: "https://other.test/mcp", authorization_servers: [META.issuer] });
+				}
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				return new Response("not found", { status: 404 });
+			}),
+		);
+		const provider = createMcpOAuthProvider({ server: "mismatch", url: "https://srv.test/mcp", clientId: "client" });
+		await expect(provider.login({ onAuth: vi.fn(), onPrompt: async () => "" })).rejects.toThrow("resource mismatch");
+	});
+
+	it("rejects authorization servers without required PKCE S256 support", async () => {
+		const onAuth = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				if (url.endsWith("/.well-known/oauth-protected-resource/mcp")) {
+					return jsonResponse({ resource: "https://srv.test/mcp", authorization_servers: [META.issuer] });
+				}
+				if (url.endsWith("/.well-known/oauth-authorization-server")) {
+					return jsonResponse({ ...META, code_challenge_methods_supported: ["plain"] });
+				}
+				return new Response("not found", { status: 404 });
+			}),
+		);
+		const provider = createMcpOAuthProvider({ server: "no-pkce", url: "https://srv.test/mcp", clientId: "client" });
+		await expect(provider.login({ onAuth, onPrompt: async () => "" })).rejects.toThrow("PKCE S256");
+		expect(onAuth).not.toHaveBeenCalled();
+	});
+
+	it("rejects cross-origin authorization-server endpoints before exposing auth UI", async () => {
+		const onAuth = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				if (url.endsWith("/.well-known/oauth-protected-resource/mcp")) {
+					return jsonResponse({ resource: "https://srv.test/mcp", authorization_servers: [META.issuer] });
+				}
+				if (url.endsWith("/.well-known/oauth-authorization-server")) {
+					return jsonResponse({ ...META, token_endpoint: "https://evil.test/token" });
+				}
+				return new Response("not found", { status: 404 });
+			}),
+		);
+		const provider = createMcpOAuthProvider({
+			server: "cross-origin",
+			url: "https://srv.test/mcp",
+			clientId: "client",
+		});
+		await expect(provider.login({ onAuth, onPrompt: async () => "" })).rejects.toThrow("issuer origin");
+		expect(onAuth).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/ai/test/mcp-oauth.test.ts
+++ b/packages/ai/test/mcp-oauth.test.ts
@@ -482,6 +482,24 @@ describe.sequential("MCP OAuth provider", () => {
 		expect(() => parseMcpOAuthChallenge("Bearer realm=x\r\nInjected: yes")).toThrow("Invalid");
 	});
 
+	it.each([
+		'Bearer scope="read"',
+		'Bearer error="invalid_token"',
+		'Basic realm="decoy"',
+		'Bearer resource_metadata="not a url"',
+	])("fails closed for supplied challenge without valid resource metadata: %s", async (authorizationChallenge) => {
+		global.fetch = vi.fn(async () => jsonResponse(META)) as typeof fetch;
+		const provider = createMcpOAuthProvider({
+			server: "bad-supplied-challenge",
+			url: "https://srv.test/mcp",
+			authorizationChallenge,
+		});
+		await expect(provider.login({ onAuth: vi.fn(), onPrompt: async () => "" })).rejects.toThrow(
+			/Supplied MCP OAuth authorization challenge/,
+		);
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
 	it("uses a surfaced challenge metadata URL and challenged scope", async () => {
 		let authUrl = "";
 		const requested: string[] = [];

--- a/packages/ai/test/mcp-oauth.test.ts
+++ b/packages/ai/test/mcp-oauth.test.ts
@@ -88,8 +88,11 @@ describe.sequential("MCP OAuth provider", () => {
 			vi.fn(async (input: unknown): Promise<Response> => {
 				const url = urlOf(input);
 				requested.push(url);
-				if (url === "https://resource.test/.well-known/oauth-protected-resource/mcp/v1") {
-					return jsonResponse({ authorization_servers: ["https://auth.test/tenant"] });
+				if (url === "https://resource.test/.well-known/oauth-protected-resource/mcp/v1?tenant=a") {
+					return jsonResponse({
+						resource: "https://resource.test/mcp/v1?tenant=a",
+						authorization_servers: ["https://auth.test/tenant"],
+					});
 				}
 				if (url === "https://auth.test/.well-known/oauth-authorization-server/tenant") {
 					return jsonResponse(externalMeta);
@@ -103,7 +106,7 @@ describe.sequential("MCP OAuth provider", () => {
 
 		const provider = createMcpOAuthProvider({
 			server: "external",
-			url: "https://resource.test/mcp/v1",
+			url: "https://resource.test/mcp/v1?tenant=a",
 			clientId: "configured-client",
 		});
 		const credentials = await provider.login({
@@ -120,8 +123,57 @@ describe.sequential("MCP OAuth provider", () => {
 		expect(credentials.access).toBe("external-access");
 		expect(new URL(authUrl).origin).toBe("https://auth.test");
 		expect(requested.slice(0, 2)).toEqual([
-			"https://resource.test/.well-known/oauth-protected-resource/mcp/v1",
+			"https://resource.test/.well-known/oauth-protected-resource/mcp/v1?tenant=a",
 			"https://auth.test/.well-known/oauth-authorization-server/tenant",
+		]);
+	});
+
+	it("uses OIDC path-append discovery for pathful issuers", async () => {
+		let authUrl = "";
+		const requested: string[] = [];
+		const issuer = "https://auth.test/tenant";
+		const oidcMeta = {
+			...META,
+			issuer,
+			authorization_endpoint: "https://auth.test/tenant/authorize",
+			token_endpoint: "https://auth.test/tenant/token",
+		};
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				requested.push(url);
+				if (url === "https://resource.test/.well-known/oauth-protected-resource/mcp") {
+					return jsonResponse({ resource: "https://resource.test/mcp", authorization_servers: [issuer] });
+				}
+				if (url === "https://auth.test/tenant/.well-known/openid-configuration") return jsonResponse(oidcMeta);
+				if (url === oidcMeta.token_endpoint) return jsonResponse({ access_token: "oidc-access", expires_in: 3600 });
+				return new Response("not found", { status: 404 });
+			}),
+		);
+
+		const provider = createMcpOAuthProvider({
+			server: "oidc-path",
+			url: "https://resource.test/mcp",
+			clientId: "configured-client",
+		});
+		const credentials = await provider.login({
+			onAuth: (info) => {
+				authUrl = info.url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const state = new URL(authUrl).searchParams.get("state") ?? "";
+				return `${REDIRECT}?code=oidc-code&state=${state}`;
+			},
+		});
+
+		expect(credentials.access).toBe("oidc-access");
+		expect(requested.slice(0, 4)).toEqual([
+			"https://resource.test/.well-known/oauth-protected-resource/mcp",
+			"https://auth.test/.well-known/oauth-authorization-server/tenant",
+			"https://auth.test/.well-known/openid-configuration/tenant",
+			"https://auth.test/tenant/.well-known/openid-configuration",
 		]);
 	});
 
@@ -137,7 +189,7 @@ describe.sequential("MCP OAuth provider", () => {
 					return new Response("not found", { status: 404 });
 				}
 				if (url.endsWith("/.well-known/oauth-protected-resource")) {
-					return jsonResponse({ authorization_servers: ["https://srv.test"] });
+					return jsonResponse({ resource: "https://srv.test/mcp", authorization_servers: ["https://srv.test"] });
 				}
 				if (url === "https://srv.test/.well-known/oauth-authorization-server") return jsonResponse(META);
 				if (url === META.token_endpoint) return jsonResponse({ access_token: "root-access", expires_in: 3600 });

--- a/packages/ai/test/mcp-oauth.test.ts
+++ b/packages/ai/test/mcp-oauth.test.ts
@@ -82,6 +82,104 @@ describe.sequential("MCP OAuth provider", () => {
 		expect(authParams.get("resource")).toBe("https://srv.test/mcp");
 	});
 
+	it("does not downgrade a native 401 that omits its OAuth challenge", async () => {
+		const requested: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				requested.push(urlOf(input));
+				if (urlOf(input) === "https://srv.test/mcp") return new Response(null, { status: 401 });
+				return jsonResponse(META);
+			}),
+		);
+		const provider = createMcpOAuthProvider({ server: "missing-challenge", url: "https://srv.test/mcp" });
+		await expect(provider.login({ onAuth: vi.fn(), onPrompt: async () => "" })).rejects.toThrow(
+			"omitted WWW-Authenticate",
+		);
+		expect(requested).toEqual(["https://srv.test/mcp"]);
+	});
+
+	it("uses the native initialize challenge for login and refresh discovery", async () => {
+		let authUrl = "";
+		let probes = 0;
+		const metadataUrl = "https://metadata.test/prm";
+		const externalMeta = {
+			...META,
+			issuer: "https://auth.test",
+			authorization_endpoint: "https://auth.test/authorize",
+			token_endpoint: "https://auth.test/token",
+			registration_endpoint: undefined,
+		};
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = urlOf(input);
+				if (url === "https://resource.test/mcp" && init?.method === "POST") {
+					probes++;
+					expect(new Headers(init.headers).get("authorization")).toBeNull();
+					expect(new Headers(init.headers).get("accept")).toBe("application/json, text/event-stream");
+					expect(JSON.parse(String(init.body))).toMatchObject({
+						jsonrpc: "2.0",
+						method: "initialize",
+						params: { capabilities: {}, clientInfo: { name: "prime-agent-oauth-discovery" } },
+					});
+					return new Response("ignored".repeat(200_000), {
+						status: 401,
+						headers: {
+							"WWW-Authenticate": `Basic realm="decoy", Bearer resource_metadata="${metadataUrl}", scope="challenge.read"`,
+						},
+					});
+				}
+				if (url === metadataUrl) {
+					return jsonResponse({
+						resource: "https://resource.test/mcp",
+						authorization_servers: [externalMeta.issuer],
+					});
+				}
+				if (url === "https://auth.test/.well-known/oauth-authorization-server") return jsonResponse(externalMeta);
+				if (url === externalMeta.token_endpoint) {
+					const params = new URLSearchParams(String(init?.body));
+					expect(params.get("resource")).toBe("https://resource.test/mcp");
+					if (params.get("grant_type") === "refresh_token") {
+						expect(params.get("refresh_token")).toBe("refresh-native");
+						return jsonResponse({
+							access_token: "refreshed-native",
+							refresh_token: "refresh-native",
+							expires_in: 3600,
+						});
+					}
+					return jsonResponse({
+						access_token: "access-native",
+						refresh_token: "refresh-native",
+						expires_in: 3600,
+					});
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const provider = createMcpOAuthProvider({
+			server: "challenge-native",
+			url: "https://resource.test/mcp",
+			clientId: "configured-client",
+			scopes: "configured.scope",
+		});
+		const credentials = await provider.login({
+			onAuth: (info) => {
+				authUrl = info.url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const state = new URL(authUrl).searchParams.get("state") ?? "";
+				return `${REDIRECT}?code=native-code&state=${state}`;
+			},
+		});
+		expect(new URL(authUrl).searchParams.get("scope")).toBe("challenge.read");
+		expect(credentials.access).toBe("access-native");
+		const refreshed = await provider.refreshToken(credentials);
+		expect(refreshed.access).toBe("refreshed-native");
+		expect(probes).toBe(2);
+	});
+
 	it("follows path-suffixed protected-resource metadata to an external issuer", async () => {
 		let authUrl = "";
 		const requested: string[] = [];
@@ -134,7 +232,8 @@ describe.sequential("MCP OAuth provider", () => {
 		expect(credentials.access).toBe("external-access");
 		expect(new URL(authUrl).origin).toBe("https://auth.test");
 		expect(new URL(authUrl).searchParams.get("resource")).toBe("https://resource.test/mcp/v1?tenant=a");
-		expect(requested.slice(0, 2)).toEqual([
+		expect(requested.slice(0, 3)).toEqual([
+			"https://resource.test/mcp/v1?tenant=a",
 			"https://resource.test/.well-known/oauth-protected-resource/mcp/v1?tenant=a",
 			"https://auth.test/.well-known/oauth-authorization-server/tenant",
 		]);
@@ -182,7 +281,8 @@ describe.sequential("MCP OAuth provider", () => {
 		});
 
 		expect(credentials.access).toBe("oidc-access");
-		expect(requested.slice(0, 4)).toEqual([
+		expect(requested.slice(0, 5)).toEqual([
+			"https://resource.test/mcp",
 			"https://resource.test/.well-known/oauth-protected-resource/mcp",
 			"https://auth.test/.well-known/oauth-authorization-server/tenant",
 			"https://auth.test/.well-known/openid-configuration/tenant",
@@ -233,7 +333,8 @@ describe.sequential("MCP OAuth provider", () => {
 		expect(credentials.access).toBe("root-access");
 		expect(new URL(authUrl).searchParams.get("scope")).toBe("resource.read");
 		expect(new URL(authUrl).searchParams.get("resource")).toBe("https://srv.test/mcp");
-		expect(requested.slice(0, 3)).toEqual([
+		expect(requested.slice(0, 4)).toEqual([
+			"https://srv.test/mcp",
 			"https://srv.test/.well-known/oauth-protected-resource/mcp",
 			"https://srv.test/.well-known/oauth-protected-resource",
 			"https://srv.test/.well-known/oauth-authorization-server",
@@ -424,6 +525,57 @@ describe.sequential("MCP OAuth provider", () => {
 		});
 		expect(requested[0]).toBe("https://hint.test/prm");
 		expect(new URL(authUrl).searchParams.get("scope")).toBe("challenge.scope");
+	});
+
+	it("fails closed when authoritative challenged resource metadata is unavailable", async () => {
+		const requested: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				requested.push(url);
+				if (url === "https://hint.test/missing") return new Response("not found", { status: 404 });
+				if (url.endsWith("/.well-known/oauth-protected-resource/mcp")) {
+					return jsonResponse({ resource: "https://srv.test/mcp", authorization_servers: [META.issuer] });
+				}
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const provider = createMcpOAuthProvider({
+			server: "challenge-fail-closed",
+			url: "https://srv.test/mcp",
+			clientId: "client",
+			authorizationChallenge: 'Bearer resource_metadata="https://hint.test/missing"',
+		});
+		await expect(provider.login({ onAuth: vi.fn(), onPrompt: async () => "" })).rejects.toThrow(
+			"Challenged OAuth resource metadata",
+		);
+		expect(requested).toEqual(["https://hint.test/missing"]);
+	});
+
+	it("rejects authoritative challenged metadata without authorization servers", async () => {
+		const requested: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = urlOf(input);
+				requested.push(url);
+				if (url === "https://hint.test/no-issuer") return jsonResponse({ resource: "https://srv.test/mcp" });
+				if (url.endsWith("/.well-known/oauth-authorization-server")) return jsonResponse(META);
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const provider = createMcpOAuthProvider({
+			server: "challenge-no-issuer",
+			url: "https://srv.test/mcp",
+			clientId: "client",
+			authorizationChallenge: 'Bearer resource_metadata="https://hint.test/no-issuer"',
+		});
+		await expect(provider.login({ onAuth: vi.fn(), onPrompt: async () => "" })).rejects.toThrow(
+			"omitted authorization_servers",
+		);
+		expect(requested).toEqual(["https://hint.test/no-issuer"]);
 	});
 
 	it("rejects mismatched protected-resource metadata without discovery downgrade", async () => {

--- a/packages/ai/test/mcp-safe-fetch.test.ts
+++ b/packages/ai/test/mcp-safe-fetch.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOAuthFetchPolicy, safeFetchJson } from "../src/mcp/safe-fetch.js";
+
+const dnsLookup = vi.hoisted(() => vi.fn(async () => [{ address: "93.184.216.34", family: 4 as const }]));
+vi.mock("node:dns/promises", () => ({ lookup: dnsLookup }));
+
+const originalFetch = global.fetch;
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+	return new Response(JSON.stringify(body), {
+		...init,
+		headers: { "content-type": "application/json", ...init?.headers },
+	});
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	global.fetch = originalFetch;
+	dnsLookup.mockReset();
+	dnsLookup.mockImplementation(async () => [{ address: "93.184.216.34", family: 4 as const }]);
+	vi.restoreAllMocks();
+});
+
+describe("MCP OAuth safe fetch", () => {
+	it.each([
+		"https://127.0.0.1/metadata",
+		"https://10.1.2.3/metadata",
+		"https://169.254.169.254/latest/meta-data",
+		"https://224.0.0.1/metadata",
+		"https://[::1]/metadata",
+		"https://[::ffff:127.0.0.1]/metadata",
+		"https://[fe80::1]/metadata",
+		"https://[ff02::1]/metadata",
+		"https://[3fff::1]/metadata",
+		"https://[5f00::1]/metadata",
+	])("rejects non-public IP literal %s before fetch", async (url) => {
+		global.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
+		await expect(safeFetchJson(url, undefined, {})).rejects.toThrow(/non-public/);
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it("rejects a hostname when any DNS answer is private", async () => {
+		dnsLookup.mockResolvedValueOnce([
+			{ address: "93.184.216.34", family: 4 as const },
+			{ address: "10.0.0.5", family: 4 as const },
+		]);
+		global.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
+		await expect(safeFetchJson("https://public.test/metadata", undefined, {})).rejects.toThrow(/non-public/);
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it("bounds DNS resolution time", async () => {
+		vi.useFakeTimers();
+		dnsLookup.mockImplementationOnce(() => new Promise(() => {}));
+		global.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
+		const pending = safeFetchJson("https://slow.test/metadata", undefined, { timeoutMs: 5 });
+		const rejected = expect(pending).rejects.toThrow("could not be resolved");
+		await vi.advanceTimersByTimeAsync(6);
+		await rejected;
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it("validates every redirect hop and blocks a private pivot", async () => {
+		global.fetch = vi.fn(
+			async () => new Response(null, { status: 302, headers: { location: "https://127.0.0.1/secret" } }),
+		) as typeof fetch;
+		await expect(safeFetchJson("https://public.test/metadata", undefined, {})).rejects.toThrow(
+			/Cross-origin|non-public/,
+		);
+		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+
+	it("revalidates same-origin DNS on every redirect hop", async () => {
+		dnsLookup
+			.mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 as const }])
+			.mockResolvedValueOnce([{ address: "10.0.0.8", family: 4 as const }]);
+		global.fetch = vi.fn(
+			async () => new Response(null, { status: 302, headers: { location: "/next" } }),
+		) as typeof fetch;
+		await expect(safeFetchJson("https://public.test/metadata", undefined, {})).rejects.toThrow("non-public");
+		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+
+	it("never follows POST redirects containing OAuth secrets", async () => {
+		global.fetch = vi.fn(
+			async () => new Response(null, { status: 307, headers: { location: "https://public.test/other" } }),
+		) as typeof fetch;
+		await expect(
+			safeFetchJson("https://public.test/token", { method: "POST", body: "refresh_token=top-secret" }, {}),
+		).rejects.toThrow("POST redirects are not allowed");
+		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+
+	it("bounds response bodies without reflecting their contents", async () => {
+		const secret = "do-not-reflect";
+		global.fetch = vi.fn(async () => new Response(secret.repeat(100))) as typeof fetch;
+		let error: Error | undefined;
+		try {
+			await safeFetchJson("https://public.test/metadata", undefined, { maxBodyBytes: 32 });
+		} catch (value) {
+			error = value as Error;
+		}
+		expect(error?.message).toContain("exceeded 32 bytes");
+		expect(error?.message).not.toContain(secret);
+	});
+
+	it("allows HTTP only for an explicitly configured loopback resource origin", async () => {
+		const policy = createOAuthFetchPolicy("http://localhost:8080/mcp");
+		global.fetch = vi.fn(async () => jsonResponse({ ok: true })) as typeof fetch;
+		await expect(safeFetchJson("http://localhost:8080/metadata", undefined, policy)).resolves.toEqual({ ok: true });
+		await expect(safeFetchJson("http://localhost:9090/metadata", undefined, policy)).rejects.toThrow("HTTPS");
+		expect(() => createOAuthFetchPolicy("http://public.test/mcp")).toThrow("explicit loopback");
+	});
+});

--- a/packages/ai/test/mcp-safe-fetch.test.ts
+++ b/packages/ai/test/mcp-safe-fetch.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createOAuthFetchPolicy, safeFetchJson } from "../src/mcp/safe-fetch.js";
 
-const dnsLookup = vi.hoisted(() => vi.fn(async () => [{ address: "93.184.216.34", family: 4 as const }]));
+const dnsLookup = vi.hoisted(() => vi.fn(async () => [{ address: "93.184.216.34", family: 4 as 4 | 6 }]));
 vi.mock("node:dns/promises", () => ({ lookup: dnsLookup }));
 
 const originalFetch = global.fetch;
@@ -17,7 +17,7 @@ afterEach(() => {
 	vi.useRealTimers();
 	global.fetch = originalFetch;
 	dnsLookup.mockReset();
-	dnsLookup.mockImplementation(async () => [{ address: "93.184.216.34", family: 4 as const }]);
+	dnsLookup.mockImplementation(async () => [{ address: "93.184.216.34", family: 4 as 4 | 6 }]);
 	vi.restoreAllMocks();
 });
 
@@ -30,6 +30,19 @@ describe("MCP OAuth safe fetch", () => {
 		"https://[::1]/metadata",
 		"https://[::ffff:127.0.0.1]/metadata",
 		"https://[fe80::1]/metadata",
+		"https://[fec0::1]/metadata",
+		"https://[::192.168.1.1]/metadata",
+		"https://[::ffff:0:8.8.8.8]/metadata",
+		"https://[64:ff9b::127.0.0.1]/metadata",
+		"https://[64:ff9b:1::808:808]/metadata",
+		"https://[100::1]/metadata",
+		"https://[2001:2::1]/metadata",
+		"https://[2001:10::1]/metadata",
+		"https://[2001:20::1]/metadata",
+		"https://[2001:30::1]/metadata",
+		"https://[2001:db8::1]/metadata",
+		"https://[2002:a00:1::1]/metadata",
+		"https://[4000::1]/metadata",
 		"https://[ff02::1]/metadata",
 		"https://[3fff::1]/metadata",
 		"https://[5f00::1]/metadata",
@@ -39,14 +52,47 @@ describe("MCP OAuth safe fetch", () => {
 		expect(global.fetch).not.toHaveBeenCalled();
 	});
 
+	it.each([
+		"https://192.0.0.9/metadata",
+		"https://192.0.0.10/metadata",
+		"https://[::ffff:8.8.8.8]/metadata",
+		"https://[64:ff9b::808:808]/metadata",
+		"https://[2001:1::1]/metadata",
+		"https://[2001:1::2]/metadata",
+		"https://[2001:1::3]/metadata",
+		"https://[2001:3::1]/metadata",
+		"https://[2001:4:112::1]/metadata",
+		"https://[2606:4700:4700::1111]/metadata",
+	])("accepts globally reachable literal %s", async (url) => {
+		global.fetch = vi.fn(async () => jsonResponse({ ok: true })) as typeof fetch;
+		await expect(safeFetchJson(url, undefined, {})).resolves.toEqual({ ok: true });
+		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+
 	it("rejects a hostname when any DNS answer is private", async () => {
 		dnsLookup.mockResolvedValueOnce([
-			{ address: "93.184.216.34", family: 4 as const },
-			{ address: "10.0.0.5", family: 4 as const },
+			{ address: "93.184.216.34", family: 4 as 4 | 6 },
+			{ address: "10.0.0.5", family: 4 as 4 | 6 },
 		]);
 		global.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
 		await expect(safeFetchJson("https://public.test/metadata", undefined, {})).rejects.toThrow(/non-public/);
 		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it.each(["fec0::1", "::192.168.1.1", "::ffff:192.168.1.1", "::ffff:0:8.8.8.8"])(
+		"rejects non-global IPv6 DNS answer %s",
+		async (address) => {
+			dnsLookup.mockResolvedValueOnce([{ address, family: 6 as const }]);
+			global.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
+			await expect(safeFetchJson("https://answer.test/metadata", undefined, {})).rejects.toThrow(/non-public/);
+			expect(global.fetch).not.toHaveBeenCalled();
+		},
+	);
+
+	it("accepts a representative public IPv6 DNS answer", async () => {
+		dnsLookup.mockResolvedValueOnce([{ address: "2606:4700:4700::1111", family: 6 as const }]);
+		global.fetch = vi.fn(async () => jsonResponse({ ok: true })) as typeof fetch;
+		await expect(safeFetchJson("https://answer.test/metadata", undefined, {})).resolves.toEqual({ ok: true });
 	});
 
 	it("bounds DNS resolution time", async () => {
@@ -72,8 +118,8 @@ describe("MCP OAuth safe fetch", () => {
 
 	it("revalidates same-origin DNS on every redirect hop", async () => {
 		dnsLookup
-			.mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 as const }])
-			.mockResolvedValueOnce([{ address: "10.0.0.8", family: 4 as const }]);
+			.mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 as 4 | 6 }])
+			.mockResolvedValueOnce([{ address: "10.0.0.8", family: 4 as 4 | 6 }]);
 		global.fetch = vi.fn(
 			async () => new Response(null, { status: 302, headers: { location: "/next" } }),
 		) as typeof fetch;

--- a/packages/ai/test/mcp-safe-fetch.test.ts
+++ b/packages/ai/test/mcp-safe-fetch.test.ts
@@ -69,6 +69,107 @@ describe("MCP OAuth safe fetch", () => {
 		expect(global.fetch).toHaveBeenCalledOnce();
 	});
 
+	it.each([
+		{ prefix: "2a00::/32", publicAddress: "2a00:0:808:808::", privateAddress: "2a00:0:a00:1::" },
+		{ prefix: "2a00:1200::/40", publicAddress: "2a00:1200:8:808:8::", privateAddress: "2a00:1200:a:0:1::" },
+		{
+			prefix: "2a00:1234:5600::/48",
+			publicAddress: "2a00:1234:5600:808:8:800::",
+			privateAddress: "2a00:1234:5600:a00:0:100::",
+		},
+		{
+			prefix: "2a00:1234:5678::/56",
+			publicAddress: "2a00:1234:5678:8:8:808::",
+			privateAddress: "2a00:1234:5678:a:0:1::",
+		},
+		{
+			prefix: "2a00:1234:5678:9abc::/64",
+			publicAddress: "2a00:1234:5678:9abc:8:808:800:0",
+			privateAddress: "2a00:1234:5678:9abc:a:0:100:0",
+		},
+		{ prefix: "2a00:1098:2c::/96", publicAddress: "2a00:1098:2c::808:808", privateAddress: "2a00:1098:2c::a00:1" },
+	])("decodes configured RFC 6052 $prefix destinations", async ({ prefix, publicAddress, privateAddress }) => {
+		global.fetch = vi.fn(async () => jsonResponse({ ok: true })) as typeof fetch;
+		const policy = { nat64Prefixes: [prefix] };
+		await expect(safeFetchJson(`https://[${publicAddress}]/metadata`, undefined, policy)).resolves.toEqual({
+			ok: true,
+		});
+		await expect(safeFetchJson(`https://[${privateAddress}]/metadata`, undefined, policy)).rejects.toThrow(
+			/non-public/,
+		);
+	});
+
+	it("blocks private embeddings with non-zero suffix and invalid u octets", async () => {
+		global.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
+		const policy = { nat64Prefixes: ["2a00::/32"] };
+		await expect(safeFetchJson("https://[2a00:0:a00:1:0:0:0:1]/metadata", undefined, policy)).rejects.toThrow(
+			/non-public/,
+		);
+		await expect(safeFetchJson("https://[2a00:0:808:808:100::]/metadata", undefined, policy)).rejects.toThrow(
+			/non-public/,
+		);
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it.each(["2a00:1098:2c::7f00:1", "2a00:1098:2c::a00:1"])(
+		"rejects private IPv4 embedded under an RFC 7050-discovered prefix: %s",
+		async (address) => {
+			dnsLookup.mockResolvedValueOnce([
+				{ address: "2a00:1098:2c::c000:aa", family: 6 as const },
+				{ address: "2a00:1098:2c::c000:ab", family: 6 as const },
+			]);
+			global.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
+			await expect(safeFetchJson(`https://[${address}]/metadata`, undefined, {})).rejects.toThrow(/non-public/);
+			expect(global.fetch).not.toHaveBeenCalled();
+		},
+	);
+
+	it("allows and caches public RFC 7050-discovered NAT64 destinations", async () => {
+		dnsLookup.mockResolvedValueOnce([
+			{ address: "2a00:1098:2c::c000:aa", family: 6 as const },
+			{ address: "2a00:1098:2c::c000:ab", family: 6 as const },
+		]);
+		global.fetch = vi.fn(async () => jsonResponse({ ok: true })) as typeof fetch;
+		const policy = {};
+		await expect(safeFetchJson("https://[2a00:1098:2c::808:808]/metadata", undefined, policy)).resolves.toEqual({
+			ok: true,
+		});
+		await expect(safeFetchJson("https://[2a00:1098:2c::101:101]/metadata", undefined, policy)).resolves.toEqual({
+			ok: true,
+		});
+		expect(dnsLookup).toHaveBeenCalledOnce();
+	});
+
+	it("refreshes cached RFC 7050 discovery so network-prefix changes fail closed", async () => {
+		vi.useFakeTimers();
+		dnsLookup
+			.mockResolvedValueOnce([{ address: "2a00:1098:2c::c000:aa", family: 6 as const }])
+			.mockResolvedValueOnce([{ address: "2a01:1098:2c::c000:aa", family: 6 as const }]);
+		global.fetch = vi.fn(async () => jsonResponse({ ok: true })) as typeof fetch;
+		const policy = {};
+		await expect(safeFetchJson("https://[2a00:1098:2c::808:808]/metadata", undefined, policy)).resolves.toEqual({
+			ok: true,
+		});
+		await vi.advanceTimersByTimeAsync(30_001);
+		await expect(safeFetchJson("https://[2a01:1098:2c::a00:1]/metadata", undefined, policy)).rejects.toThrow(
+			/non-public/,
+		);
+		expect(dnsLookup).toHaveBeenCalledTimes(2);
+		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+
+	it.each([
+		["2a00::1/32", /non-zero host bits/],
+		["2a00::/72", /RFC 6052 length/],
+		["2a00:1098:2c:0:100::/96", /u octet zero/],
+	] as const)("rejects malformed configured NAT64 prefix %s", async (prefix, message) => {
+		global.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
+		await expect(
+			safeFetchJson("https://[2a00:1098:2c::808:808]/metadata", undefined, { nat64Prefixes: [prefix] }),
+		).rejects.toThrow(message);
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
 	it("rejects a hostname when any DNS answer is private", async () => {
 		dnsLookup.mockResolvedValueOnce([
 			{ address: "93.184.216.34", family: 4 as 4 | 6 },

--- a/packages/ai/test/openai-codex-transport-regressions.test.ts
+++ b/packages/ai/test/openai-codex-transport-regressions.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	closeOpenAICodexWebSocketSessions,
 	getOpenAICodexWebSocketDebugStats,
+	resetOpenAICodexWebSocketDebugStats,
 	streamOpenAICodexResponses,
 } from "../src/providers/openai-codex-responses.js";
+import { cleanupSessionResources } from "../src/session-resources.js";
 import type { Context, Model } from "../src/types.js";
 
 const originalFetch = global.fetch;
@@ -321,11 +323,37 @@ describe("Codex WebSocket cancellation regressions", () => {
 		expect(constructed).toBe(1);
 		expect(getOpenAICodexWebSocketDebugStats(sessionId)?.websocketFallbackActive).toBe(true);
 
-		closeOpenAICodexWebSocketSessions(sessionId);
+		cleanupSessionResources(sessionId);
 		expect(getOpenAICodexWebSocketDebugStats(sessionId)).toBeUndefined();
 
 		await streamOpenAICodexResponses(model, context, { apiKey: token, transport: "auto", sessionId }).result();
 		expect(constructed).toBe(2);
+	});
+
+	it("keeps sticky SSE fallback state when only debug stats are reset", async () => {
+		let constructed = 0;
+		class MockWebSocket extends MockSocketBase {
+			constructor() {
+				super();
+				constructed++;
+				queueMicrotask(() => this.dispatch("open", {}));
+			}
+			send(): void {
+				this.dispatch("error", { message: "transport unavailable" });
+			}
+		}
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		global.fetch = vi.fn(async () => completeSSE("fallback")) as typeof fetch;
+		const sessionId = "debug-reset-fallback";
+
+		await streamOpenAICodexResponses(model, context, { apiKey: token, transport: "auto", sessionId }).result();
+		expect(constructed).toBe(1);
+		resetOpenAICodexWebSocketDebugStats(sessionId);
+		expect(getOpenAICodexWebSocketDebugStats(sessionId)).toBeUndefined();
+
+		await streamOpenAICodexResponses(model, context, { apiKey: token, transport: "auto", sessionId }).result();
+		expect(constructed).toBe(1);
+		expect(global.fetch).toHaveBeenCalledTimes(2);
 	});
 
 	it("evicts an active aborted cached socket", async () => {

--- a/packages/ai/test/openai-codex-transport-regressions.test.ts
+++ b/packages/ai/test/openai-codex-transport-regressions.test.ts
@@ -330,6 +330,73 @@ describe("Codex WebSocket cancellation regressions", () => {
 		expect(constructed).toBe(2);
 	});
 
+	it("does not abort a pending pure SSE request through the public websocket closer", async () => {
+		let responseController: ReadableStreamDefaultController<Uint8Array> | undefined;
+		let requestSignal: AbortSignal | null | undefined;
+		global.fetch = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			requestSignal = init?.signal;
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						responseController = controller;
+					},
+				}),
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+		}) as typeof fetch;
+		const sessionId = "pending-pure-sse";
+		const pending = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "sse",
+			sessionId,
+		}).result();
+		await vi.waitFor(() => expect(responseController).toBeDefined());
+
+		closeOpenAICodexWebSocketSessions(sessionId);
+		expect(requestSignal?.aborted).toBe(false);
+		const payload = `${responseEvents("still-running")
+			.map((event) => `data: ${event}`)
+			.join("\n\n")}\n\n`;
+		responseController?.enqueue(new TextEncoder().encode(payload));
+		responseController?.close();
+		const result = await pending;
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "still-running" })]);
+	});
+
+	it("aborts a pending pure SSE request through internal session cleanup", async () => {
+		let started: (() => void) | undefined;
+		const didStart = new Promise<void>((resolve) => {
+			started = resolve;
+		});
+		global.fetch = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						started?.();
+						init?.signal?.addEventListener(
+							"abort",
+							() => controller.error(new DOMException("Request was aborted", "AbortError")),
+							{ once: true },
+						);
+					},
+				}),
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+		}) as typeof fetch;
+		const sessionId = "cleanup-pure-sse";
+		const pending = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "sse",
+			sessionId,
+		}).result();
+		await didStart;
+		cleanupSessionResources(sessionId);
+		const result = await pending;
+		expect(result.stopReason).toBe("aborted");
+		expect(result.errorMessage).toBe("Request was aborted");
+	});
+
 	it("aborts a request cleaned up while its websocket is still connecting", async () => {
 		let socket: MockWebSocket | undefined;
 		let constructed: (() => void) | undefined;

--- a/packages/ai/test/openai-codex-transport-regressions.test.ts
+++ b/packages/ai/test/openai-codex-transport-regressions.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	closeOpenAICodexWebSocketSessions,
+	streamOpenAICodexResponses,
+} from "../src/providers/openai-codex-responses.js";
+import type { Context, Model } from "../src/types.js";
+
+const originalFetch = global.fetch;
+const originalWebSocket = globalThis.WebSocket;
+
+const token = (() => {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
+		"utf8",
+	).toString("base64");
+	return `aaa.${payload}.bbb`;
+})();
+
+const model: Model<"openai-codex-responses"> = {
+	id: "gpt-5.6-sol",
+	name: "GPT-5.6 Sol",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400000,
+	maxTokens: 128000,
+};
+
+const context: Context = {
+	systemPrompt: "Be helpful.",
+	messages: [{ role: "user", content: "hello", timestamp: 1 }],
+};
+
+function responseEvents(text = "café 🧠"): string[] {
+	return [
+		JSON.stringify({
+			type: "response.output_item.added",
+			item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+		}),
+		JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } }),
+		JSON.stringify({ type: "response.output_text.delta", delta: text }),
+		JSON.stringify({
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				id: "msg_1",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text }],
+			},
+		}),
+		JSON.stringify({
+			type: "response.completed",
+			response: {
+				status: "completed",
+				usage: {
+					input_tokens: 1,
+					output_tokens: 1,
+					total_tokens: 2,
+					input_tokens_details: { cached_tokens: 0 },
+				},
+			},
+		}),
+	];
+}
+
+function sseBytes(payload: string, cuts: number[] = []): Uint8Array[] {
+	const bytes = new TextEncoder().encode(payload);
+	const boundaries = [0, ...cuts.filter((cut) => cut > 0 && cut < bytes.length), bytes.length];
+	return boundaries.slice(0, -1).map((start, index) => bytes.slice(start, boundaries[index + 1]));
+}
+
+function streamResponse(chunks: Uint8Array[]): Response {
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		}),
+		{ status: 200, headers: { "content-type": "text/event-stream" } },
+	);
+}
+
+async function runSSE(chunks: Uint8Array[]) {
+	global.fetch = vi.fn(async () => streamResponse(chunks)) as typeof fetch;
+	return streamOpenAICodexResponses(model, context, { apiKey: token, transport: "sse" }).result();
+}
+
+function completeSSE(text = "fallback"): Response {
+	const payload = `${responseEvents(text)
+		.map((event) => `data: ${event}`)
+		.join("\n\n")}\n\n`;
+	return streamResponse(sseBytes(payload));
+}
+
+afterEach(() => {
+	closeOpenAICodexWebSocketSessions();
+	global.fetch = originalFetch;
+	globalThis.WebSocket = originalWebSocket;
+	vi.restoreAllMocks();
+});
+
+describe("Codex SSE framing regressions", () => {
+	it.each([
+		["LF", "\n\n"],
+		["CRLF", "\r\n\r\n"],
+		["CR", "\r\r"],
+	] as const)("decodes %s-framed events", async (_name, separator) => {
+		const payload = `${responseEvents()
+			.map((event) => `data: ${event}`)
+			.join(separator)}${separator}`;
+		const result = await runSSE(sseBytes(payload));
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find((block) => block.type === "text")?.text).toBe("café 🧠");
+	});
+
+	it("handles mixed and split line endings", async () => {
+		const separators = ["\n\r", "\r\n\r\n", "\r\r", "\n\n", "\r\n\n"];
+		const events = responseEvents();
+		const payload = events.map((event, index) => `data: ${event}${separators[index]}`).join("");
+		const bytes = new TextEncoder().encode(payload);
+		const cuts: number[] = [];
+		for (let index = 1; index < bytes.length; index++) {
+			if (bytes[index - 1] === 13 && bytes[index] === 10) cuts.push(index);
+		}
+		const result = await runSSE(sseBytes(payload, cuts));
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find((block) => block.type === "text")?.text).toBe("café 🧠");
+	});
+
+	it("preserves UTF-8 characters split across byte chunks", async () => {
+		const payload = `${responseEvents()
+			.map((event) => `data: ${event}`)
+			.join("\n\n")}\n\n`;
+		const bytes = new TextEncoder().encode(payload);
+		const brain = new TextEncoder().encode("🧠");
+		const start = bytes.findIndex((_value, index) => brain.every((part, offset) => bytes[index + offset] === part));
+		expect(start).toBeGreaterThan(0);
+		const result = await runSSE(sseBytes(payload, [start + 1, start + 2, start + 3]));
+		expect(result.content.find((block) => block.type === "text")?.text).toBe("café 🧠");
+	});
+
+	it("ignores comments, joins multiline data, and dispatches the terminal event at EOF", async () => {
+		const payload = [
+			": keepalive",
+			"event: response",
+			'data: {"type":',
+			'data: "response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}}',
+		].join("\r\n");
+		const result = await runSSE(sseBytes(payload));
+		expect(result.stopReason).toBe("length");
+	});
+
+	it("cancels a pending SSE read and reports a normalized abort", async () => {
+		let cancelled = false;
+		global.fetch = vi.fn(
+			async () =>
+				new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(new TextEncoder().encode(": waiting\n"));
+						},
+						cancel() {
+							cancelled = true;
+						},
+					}),
+					{ status: 200 },
+				),
+		) as typeof fetch;
+		const controller = new AbortController();
+		const pending = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "sse",
+			signal: controller.signal,
+		}).result();
+		setTimeout(() => controller.abort(), 0);
+		const result = await Promise.race([
+			pending,
+			new Promise<never>((_, reject) => setTimeout(() => reject(new Error("abort timed out")), 500)),
+		]);
+		expect(cancelled).toBe(true);
+		expect(result.stopReason).toBe("aborted");
+		expect(result.errorMessage).toBe("Request was aborted");
+	});
+});
+
+type Listener = (event: unknown) => void;
+
+class MockSocketBase {
+	readyState = 1;
+	readonly listeners = new Map<string, Set<Listener>>();
+	readonly closes: Array<{ code?: number; reason?: string }> = [];
+
+	addEventListener(type: string, listener: Listener): void {
+		let listeners = this.listeners.get(type);
+		if (!listeners) {
+			listeners = new Set();
+			this.listeners.set(type, listeners);
+		}
+		listeners.add(listener);
+	}
+
+	removeEventListener(type: string, listener: Listener): void {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	close(code?: number, reason?: string): void {
+		this.readyState = 3;
+		this.closes.push({ code, reason });
+	}
+
+	dispatch(type: string, event: unknown): void {
+		for (const listener of [...(this.listeners.get(type) ?? [])]) listener(event);
+	}
+
+	listenerCount(): number {
+		return [...this.listeners.values()].reduce((total, listeners) => total + listeners.size, 0);
+	}
+}
+
+describe("Codex WebSocket cancellation regressions", () => {
+	it("rejects pre-aborted requests before constructing or sending", async () => {
+		let constructed = 0;
+		class MockWebSocket extends MockSocketBase {
+			constructor() {
+				super();
+				constructed++;
+			}
+			send(): void {
+				throw new Error("must not send");
+			}
+		}
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		global.fetch = vi.fn(async () => completeSSE()) as typeof fetch;
+		const controller = new AbortController();
+		controller.abort();
+
+		const result = await streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "websocket",
+			signal: controller.signal,
+		}).result();
+
+		expect(constructed).toBe(0);
+		expect(global.fetch).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("aborted");
+		expect(result.errorMessage).toBe("Request was aborted");
+	});
+
+	it("closes and cleans up when aborted during connection", async () => {
+		let socket: MockWebSocket | undefined;
+		class MockWebSocket extends MockSocketBase {
+			constructor() {
+				super();
+				socket = this;
+			}
+			send(): void {}
+		}
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		const controller = new AbortController();
+		const pending = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "websocket",
+			signal: controller.signal,
+		}).result();
+		await Promise.resolve();
+		controller.abort();
+		const result = await pending;
+
+		expect(result.stopReason).toBe("aborted");
+		expect(socket?.closes).toContainEqual({ code: 1000, reason: "aborted" });
+		expect(socket?.listenerCount()).toBe(0);
+	});
+
+	it("observes a synchronous WebSocket error and falls back to SSE", async () => {
+		let socket: MockWebSocket | undefined;
+		class MockWebSocket extends MockSocketBase {
+			constructor() {
+				super();
+				socket = this;
+				queueMicrotask(() => this.dispatch("open", {}));
+			}
+			send(): void {
+				this.dispatch("error", { message: "sync failure" });
+			}
+		}
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		global.fetch = vi.fn(async () => completeSSE("fallback")) as typeof fetch;
+
+		const result = await streamOpenAICodexResponses(model, context, { apiKey: token, transport: "auto" }).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find((block) => block.type === "text")?.text).toBe("fallback");
+		expect(socket?.closes.length).toBeGreaterThan(0);
+		expect(socket?.listenerCount()).toBe(0);
+		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+
+	it("evicts an active aborted cached socket", async () => {
+		const sockets: MockWebSocket[] = [];
+		let secondSend: (() => void) | undefined;
+		const secondSent = new Promise<void>((resolve) => {
+			secondSend = resolve;
+		});
+		class MockWebSocket extends MockSocketBase {
+			private sends = 0;
+			constructor() {
+				super();
+				sockets.push(this);
+				queueMicrotask(() => this.dispatch("open", {}));
+			}
+			send(): void {
+				this.sends++;
+				if (this === sockets[0] && this.sends === 2) {
+					secondSend?.();
+					return;
+				}
+				for (const event of responseEvents("ok")) this.dispatch("message", { data: event });
+			}
+		}
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		const sessionId = "abort-cache";
+		const first = await streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "websocket-cached",
+			sessionId,
+		}).result();
+		expect(first.stopReason).toBe("stop");
+
+		const controller = new AbortController();
+		const secondPending = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "websocket-cached",
+			sessionId,
+			signal: controller.signal,
+		}).result();
+		await secondSent;
+		controller.abort();
+		const second = await secondPending;
+		expect(second.stopReason).toBe("aborted");
+
+		const third = await streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "websocket-cached",
+			sessionId,
+		}).result();
+		expect(third.stopReason).toBe("stop");
+		expect(sockets).toHaveLength(2);
+		expect(sockets[0].closes.some((close) => close.reason === "aborted")).toBe(true);
+	});
+});

--- a/packages/ai/test/openai-codex-transport-regressions.test.ts
+++ b/packages/ai/test/openai-codex-transport-regressions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	closeOpenAICodexWebSocketSessions,
+	getOpenAICodexWebSocketDebugStats,
 	streamOpenAICodexResponses,
 } from "../src/providers/openai-codex-responses.js";
 import type { Context, Model } from "../src/types.js";
@@ -298,6 +299,33 @@ describe("Codex WebSocket cancellation regressions", () => {
 		expect(socket?.closes.length).toBeGreaterThan(0);
 		expect(socket?.listenerCount()).toBe(0);
 		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+
+	it("clears debug stats and sticky SSE fallback state during session cleanup", async () => {
+		let constructed = 0;
+		class MockWebSocket extends MockSocketBase {
+			constructor() {
+				super();
+				constructed++;
+				queueMicrotask(() => this.dispatch("open", {}));
+			}
+			send(): void {
+				this.dispatch("error", { message: "transport unavailable" });
+			}
+		}
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		global.fetch = vi.fn(async () => completeSSE("fallback")) as typeof fetch;
+		const sessionId = "cleanup-fallback";
+
+		await streamOpenAICodexResponses(model, context, { apiKey: token, transport: "auto", sessionId }).result();
+		expect(constructed).toBe(1);
+		expect(getOpenAICodexWebSocketDebugStats(sessionId)?.websocketFallbackActive).toBe(true);
+
+		closeOpenAICodexWebSocketSessions(sessionId);
+		expect(getOpenAICodexWebSocketDebugStats(sessionId)).toBeUndefined();
+
+		await streamOpenAICodexResponses(model, context, { apiKey: token, transport: "auto", sessionId }).result();
+		expect(constructed).toBe(2);
 	});
 
 	it("evicts an active aborted cached socket", async () => {

--- a/packages/ai/test/openai-codex-transport-regressions.test.ts
+++ b/packages/ai/test/openai-codex-transport-regressions.test.ts
@@ -330,6 +330,81 @@ describe("Codex WebSocket cancellation regressions", () => {
 		expect(constructed).toBe(2);
 	});
 
+	it("aborts a request cleaned up while its websocket is still connecting", async () => {
+		let socket: MockWebSocket | undefined;
+		let constructed: (() => void) | undefined;
+		const didConstruct = new Promise<void>((resolve) => {
+			constructed = resolve;
+		});
+		class MockWebSocket extends MockSocketBase {
+			constructor() {
+				super();
+				socket = this;
+				constructed?.();
+			}
+			send(): void {
+				throw new Error("cleaned-up socket must not send");
+			}
+		}
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		global.fetch = vi.fn(async () => completeSSE("must-not-fallback")) as typeof fetch;
+		const sessionId = "cleanup-connecting";
+		const pending = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "auto",
+			sessionId,
+		}).result();
+		await didConstruct;
+
+		cleanupSessionResources(sessionId);
+		socket?.dispatch("open", {});
+		const result = await Promise.race([
+			pending,
+			new Promise<never>((_, reject) => setTimeout(() => reject(new Error("cleanup timed out")), 500)),
+		]);
+		expect(result.stopReason).toBe("aborted");
+		expect(socket?.closes.some(({ reason }) => reason === "aborted")).toBe(true);
+		expect(global.fetch).not.toHaveBeenCalled();
+		expect(getOpenAICodexWebSocketDebugStats(sessionId)).toBeUndefined();
+	});
+
+	it("aborts an open pending request during session cleanup without recreating fallback state", async () => {
+		let sent: (() => void) | undefined;
+		const didSend = new Promise<void>((resolve) => {
+			sent = resolve;
+		});
+		class MockWebSocket extends MockSocketBase {
+			constructor() {
+				super();
+				queueMicrotask(() => this.dispatch("open", {}));
+			}
+			send(): void {
+				sent?.();
+			}
+		}
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		global.fetch = vi.fn(async () => completeSSE("must-not-fallback")) as typeof fetch;
+		const sessionId = "cleanup-active";
+		const pending = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "auto",
+			sessionId,
+		}).result();
+		await didSend;
+
+		cleanupSessionResources(sessionId);
+		const result = await Promise.race([
+			pending,
+			new Promise<never>((_, reject) => setTimeout(() => reject(new Error("cleanup timed out")), 500)),
+		]);
+		expect(result.stopReason).toBe("aborted");
+		expect(result.errorMessage).toBe("Request was aborted");
+		expect(global.fetch).not.toHaveBeenCalled();
+		expect(getOpenAICodexWebSocketDebugStats(sessionId)).toBeUndefined();
+		await Promise.resolve();
+		expect(getOpenAICodexWebSocketDebugStats(sessionId)).toBeUndefined();
+	});
+
 	it("keeps sticky SSE fallback state when only debug stats are reset", async () => {
 		let constructed = 0;
 		class MockWebSocket extends MockSocketBase {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added a configurable copy action to login dialogs so raw sign-in URLs can be copied without selecting wrapped text ([#643](https://github.com/PrimeIntellect-ai/prime-agent/issues/643)).
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
+- Fixed RLM rejecting authenticated Codex child models when discovery returned an empty catalog ([#1011](https://github.com/PrimeIntellect-ai/prime-agent/issues/1011)).
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 - Fixed the agents view collapsing expanded subagent lists when returning from an opened agent ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
 - Kept the subagent summary row visible and selectable while its list is expanded in the agents view, so pressing enter on it collapses the list again ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).

--- a/packages/coding-agent/docs/mcp-integrations.md
+++ b/packages/coding-agent/docs/mcp-integrations.md
@@ -177,12 +177,13 @@ is a few lines — the package above is the whole integration.
   `bearer_token_env = "ACME_TOKEN"` on the subclass.
 
 OAuth discovery checks RFC 9728 well-known protected-resource metadata directly.
-The AI package also exports `parseMcpOAuthChallenge()` and accepts its raw challenge
-through programmatic `McpOAuthConfig.authorizationChallenge` when an integration has
-captured the MCP resource's actual 401 response. The current `/mcp login` call site
-does **not** perform an unauthenticated MCP initialize request or surface
-`WWW-Authenticate`, so servers that publish metadata only through a
-`resource_metadata` challenge still require that integration-level handoff.
+The AI package also exports `parseMcpOAuthChallenge()` and accepts a raw challenge
+through programmatic `McpOAuthConfig.authorizationChallenge`. Native `/mcp login`
+and refresh discovery perform a bounded, unauthenticated MCP initialize probe at the
+configured resource URL. A 401 `WWW-Authenticate` Bearer `resource_metadata` hint is
+treated as authoritative and fetched through the same SSRF-safe policy; it is never
+persisted in credentials. This supports catalog and user-declared servers that publish
+protected-resource metadata only through the MCP authorization challenge.
 
 ## The `McpIntegration` API
 

--- a/packages/coding-agent/docs/mcp-integrations.md
+++ b/packages/coding-agent/docs/mcp-integrations.md
@@ -176,6 +176,14 @@ is a few lines — the package above is the whole integration.
   the integration is "connected" whenever that env var is set. Set the matching
   `bearer_token_env = "ACME_TOKEN"` on the subclass.
 
+OAuth discovery checks RFC 9728 well-known protected-resource metadata directly.
+The AI package also exports `parseMcpOAuthChallenge()` and accepts its raw challenge
+through programmatic `McpOAuthConfig.authorizationChallenge` when an integration has
+captured the MCP resource's actual 401 response. The current `/mcp login` call site
+does **not** perform an unauthenticated MCP initialize request or surface
+`WWW-Authenticate`, so servers that publish metadata only through a
+`resource_metadata` challenge still require that integration-level handoff.
+
 ## The `McpIntegration` API
 
 Imported from `rlm` (`from rlm import McpIntegration`).

--- a/packages/coding-agent/docs/mcp-integrations.md
+++ b/packages/coding-agent/docs/mcp-integrations.md
@@ -185,6 +185,13 @@ treated as authoritative and fetched through the same SSRF-safe policy; it is ne
 persisted in credentials. This supports catalog and user-declared servers that publish
 protected-resource metadata only through the MCP authorization challenge.
 
+The safe network policy performs RFC 7050 `ipv4only.arpa` discovery and decodes every
+RFC 6052 prefix layout before classifying an embedded IPv4 destination. Programmatic
+providers can set `McpOAuthConfig.nat64Prefixes` when the network's translator prefix
+cannot be discovered. To preserve ordinary IPv6 compatibility, an unmatched global
+IPv6 address remains subject to the global-locator policy rather than being guessed as
+NAT64; operators using a non-discoverable translator should configure its prefixes.
+
 ## The `McpIntegration` API
 
 Imported from `rlm` (`from rlm import McpIntegration`).

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -27,7 +27,7 @@ import { dirname, join } from "path";
 import { type Static, type TProperties, Type } from "typebox";
 import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
-import { getAgentDir, VERSION } from "../config.js";
+import { getAgentDir } from "../config.js";
 import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import {
@@ -372,6 +372,10 @@ function readOpenAICodexAccountId(token: string): string | undefined {
 	}
 }
 
+// ChatGPT gates Codex model catalogs by Codex CLI compatibility, not by the
+// unrelated Prime Agent package version. This floor includes the gpt-5.6 family.
+const OPENAI_CODEX_MODELS_CLIENT_VERSION = "0.144.0";
+
 function openAICodexModelsUrl(baseUrl: string): string {
 	const normalized = baseUrl.replace(/\/+$/, "");
 	let path: string;
@@ -383,7 +387,7 @@ function openAICodexModelsUrl(baseUrl: string): string {
 		path = `${normalized}/codex/models`;
 	}
 	const url = new URL(path);
-	url.searchParams.set("client_version", VERSION);
+	url.searchParams.set("client_version", OPENAI_CODEX_MODELS_CLIENT_VERSION);
 	return url.toString();
 }
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -405,6 +405,11 @@ function readOpenAICodexModelIds(value: unknown): Set<string> {
 	);
 }
 
+function applyOpenAICodexCatalog(models: Model<Api>[], modelIds: Set<string>): Model<Api>[] {
+	if (modelIds.size === 0) return models;
+	return models.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
+}
+
 const PRIVATE_PRIME_AUTHORIZATION_CACHE_FILE = "prime-inference-private-models.json";
 const PRIVATE_PRIME_AUTHORIZATION_CACHE_TTL_MS = 5 * 60_000;
 const PRIVATE_PRIME_BACKGROUND_REFRESH_TIMEOUT_MS = 3_000;
@@ -984,7 +989,7 @@ export class ModelRegistry {
 		const authFingerprint = createHash("sha256").update(auth.apiKey).digest("hex");
 		const cached = this.openAICodexModelsCache;
 		if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-			return availableModels.filter((model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id));
+			return applyOpenAICodexCatalog(availableModels, cached.modelIds);
 		}
 
 		const accountId = readOpenAICodexAccountId(auth.apiKey);
@@ -1006,12 +1011,10 @@ export class ModelRegistry {
 			}
 			const modelIds = readOpenAICodexModelIds(await response.json());
 			this.openAICodexModelsCache = { authFingerprint, modelIds, refreshedAt: Date.now() };
-			return availableModels.filter((model) => model.provider !== "openai-codex" || modelIds.has(model.id));
+			return applyOpenAICodexCatalog(availableModels, modelIds);
 		} catch {
 			if (cached?.authFingerprint === authFingerprint && Date.now() - cached.refreshedAt < 300_000) {
-				return availableModels.filter(
-					(model) => model.provider !== "openai-codex" || cached.modelIds.has(model.id),
-				);
+				return applyOpenAICodexCatalog(availableModels, cached.modelIds);
 			}
 			return availableModels.filter((model) => model.provider !== "openai-codex");
 		}

--- a/packages/coding-agent/test/mcp-manager.test.ts
+++ b/packages/coding-agent/test/mcp-manager.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getOAuthProvider, resetOAuthProviders } from "@earendil-works/pi-ai/oauth";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { McpManager } from "../src/core/mcp/mcp-manager.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
@@ -19,6 +19,7 @@ describe("McpManager", () => {
 	});
 
 	afterEach(() => {
+		vi.unstubAllGlobals();
 		resetOAuthProviders();
 		rmSync(tempDir, { recursive: true, force: true });
 	});
@@ -70,6 +71,64 @@ describe("McpManager", () => {
 		expect(getOAuthProvider("mcp:acme")).toBeDefined();
 		registry.refresh(); // resets registry; hook must re-add the custom provider
 		expect(getOAuthProvider("mcp:acme")).toBeDefined();
+	});
+
+	it("logs a user-declared server in through its native MCP 401 challenge", async () => {
+		const resource = "https://93.184.216.34/mcp";
+		const metadataUrl = "https://93.184.216.34/protected-resource";
+		const issuer = "https://93.184.216.34";
+		let authUrl = "";
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+				if (url === resource && init?.method === "POST") {
+					return new Response(null, {
+						status: 401,
+						headers: { "WWW-Authenticate": `Bearer resource_metadata="${metadataUrl}"` },
+					});
+				}
+				if (url === metadataUrl) {
+					return Response.json({ resource, authorization_servers: [issuer] });
+				}
+				if (url === `${issuer}/.well-known/oauth-authorization-server`) {
+					return Response.json({
+						issuer,
+						authorization_endpoint: `${issuer}/authorize`,
+						token_endpoint: `${issuer}/token`,
+						registration_endpoint: `${issuer}/register`,
+						code_challenge_methods_supported: ["S256"],
+					});
+				}
+				if (url === `${issuer}/register`) return Response.json({ client_id: "manager-client" });
+				if (url === `${issuer}/token`) {
+					return Response.json({
+						access_token: "manager-access",
+						refresh_token: "manager-refresh",
+						expires_in: 3600,
+					});
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const manager = new McpManager({
+			authStorage,
+			getUserServers: () => ({
+				"challenge-only": { type: "http", url: resource, oauth: true },
+			}),
+		});
+		await authStorage.login("mcp:challenge-only", {
+			onAuth: (info) => {
+				authUrl = info.url;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => {
+				const state = new URL(authUrl).searchParams.get("state") ?? "";
+				return `http://localhost:1455/auth/callback?code=manager-code&state=${state}`;
+			},
+		});
+		expect(authStorage.get("mcp:challenge-only")).toMatchObject({ access: "manager-access" });
+		expect(manager.listStatus().find((status) => status.server === "challenge-only")?.enabled).toBe(true);
 	});
 
 	it("exposes only mcp.refresh when no interactive login is wired", async () => {

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -113,6 +113,43 @@ describe("ENG-4649 subagent model selection", () => {
 		}
 	});
 
+	it("keeps a Luna child selectable when ChatGPT discovery returns an empty catalog", async () => {
+		const codexProvider = "openai-codex";
+		const harness = await createHarness({
+			provider: codexProvider,
+			models: [{ id: "gpt-5.6-sol" }, { id: "gpt-5.6-luna" }],
+		});
+		const fetchModels = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ models: [] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchModels);
+		try {
+			harness.authStorage.setRuntimeApiKey(codexProvider, openAICodexToken("account-empty-catalog"));
+			const lunaSelector = `${codexProvider}/gpt-5.6-luna`;
+			await expect(harness.session.findRlmModels("luna", 8)).resolves.toMatchObject({
+				models: [{ selector: lunaSelector }],
+			});
+			await harness.session.findRlmModels("luna", 8);
+
+			harness.setResponses([fauxAssistantMessage("Luna child completed")]);
+			await expect(harness.session.runRlmChild("run on Luna", { model: lunaSelector })).resolves.toMatchObject({
+				model: lunaSelector,
+			});
+			await vi.waitFor(async () => {
+				const child = (await harness.session.listRlmSubagents()).subagents[0];
+				expect(harness.session.getRlmChildSession(child!.rlm_child_id)?.model?.id).toBe("gpt-5.6-luna");
+			});
+			expect(fetchModels).toHaveBeenCalledOnce();
+		} finally {
+			vi.unstubAllGlobals();
+			harness.cleanup();
+		}
+	});
+
 	it("includes private Prime models authorized for the selected team", async () => {
 		const harness = await createHarness({ provider, models: [{ id: "parent-model" }] });
 		const fetchModels = vi.fn(

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -75,11 +75,11 @@ describe("ENG-4649 subagent model selection", () => {
 		const codexProvider = "openai-codex";
 		const harness = await createHarness({
 			provider: codexProvider,
-			models: [{ id: "parent-model" }, { id: "unsupported-model" }],
+			models: [{ id: "gpt-5.6-sol" }, { id: "unsupported-model" }],
 		});
 		const fetchModels = vi.fn(
-			async () =>
-				new Response(JSON.stringify({ models: [{ slug: "parent-model" }] }), {
+			async (_input?: string | URL, _init?: RequestInit) =>
+				new Response(JSON.stringify({ models: [{ slug: "gpt-5.6-sol" }] }), {
 					status: 200,
 					headers: { "content-type": "application/json" },
 				}),
@@ -88,13 +88,16 @@ describe("ENG-4649 subagent model selection", () => {
 		try {
 			harness.authStorage.setRuntimeApiKey(codexProvider, openAICodexToken("account-1"));
 			const discovered = await harness.session.findRlmModels("", 20);
-			expect(discovered.models.map((model) => model.selector)).toEqual([`${codexProvider}/parent-model`]);
+			expect(discovered.models.map((model) => model.selector)).toEqual([`${codexProvider}/gpt-5.6-sol`]);
 			expect(fetchModels).toHaveBeenCalledWith(
 				expect.stringMatching(/\/codex\/models\?client_version=/),
 				expect.objectContaining({
 					headers: expect.objectContaining({ "chatgpt-account-id": "account-1" }),
 				}),
 			);
+
+			const [catalogUrl] = fetchModels.mock.calls[0] ?? [];
+			expect(new URL(String(catalogUrl)).searchParams.get("client_version")).toBe("0.144.0");
 
 			await expect(
 				harness.session.runRlmChild("reject unsupported account model", {

--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -263,7 +263,11 @@ class McpIntegration:
                     t.name: {
                         "name": t.name,
                         "description": getattr(t, "description", "") or "",
-                        "inputSchema": getattr(t, "inputSchema", None) or {},
+                        # mcp.types.Tool exposes the Python attribute as
+                        # input_schema; inputSchema is only its wire alias.
+                        "inputSchema": getattr(t, "input_schema", None)
+                        or getattr(t, "inputSchema", None)
+                        or {},
                     }
                     for t in resp.tools
                 }

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -32,7 +32,9 @@ class _FakeSession:
             t = Tool()
             t.name = name
             t.description = desc
-            t.inputSchema = schema
+            # Match mcp.types.Tool: inputSchema is a validation/serialization
+            # alias, while Python code reads the snake_case field.
+            t.input_schema = schema
             return t
 
         resp = type("Resp", (), {})()
@@ -168,6 +170,17 @@ class McpIntegrationTest(unittest.TestCase):
             out = _run(integration.list_issues(team="Eng"))
         self.assertEqual(out, {"issues": [1, 2]})
         self.assertEqual(session.calls, [("list_issues", {"team": "Eng"})])
+
+    def test_list_tools_preserves_sdk_input_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        }
+        session = _FakeSession(tools=[("search", "Search", schema)], result=None)
+        with self._patch_session(session):
+            tools = _run(_Integration().list_tools())
+        self.assertEqual(tools, [{"name": "search", "description": "Search", "inputSchema": schema}])
 
     def test_unknown_tool_raises_with_available_list(self):
         session = _FakeSession(tools=[("list_issues", "", {})], result=None)


### PR DESCRIPTION
# Stack 7/8 — fix(providers): harden MCP OAuth and Codex transports

> **Active review snapshot — do not merge yet.** The complete stack is open for architecture/design review, while final cumulative audit, CI, Cursor Bug Bot, and Macroscope findings are being remediated. Branches will be force-updated after validation.

**Base:** `stack/external-06-windows`  
**Review order:** merge only after the preceding stack layer is accepted. This PR is not intended to merge independently out of order.

## Stack navigation

1. [#1158](https://github.com/PrimeIntellect-ai/prime-agent/pull/1158) — ci: harden verification and release compatibility
2. [#1159](https://github.com/PrimeIntellect-ai/prime-agent/pull/1159) — fix(security): harden session and autonomous execution boundaries
3. [#1160](https://github.com/PrimeIntellect-ai/prime-agent/pull/1160) — fix(coding-agent): make persisted state crash-safe
4. [#1161](https://github.com/PrimeIntellect-ai/prime-agent/pull/1161) — fix(daemon): fence worker and supervisor lifecycle state
5. [#1162](https://github.com/PrimeIntellect-ai/prime-agent/pull/1162) — fix(coding-agent): repair queued and archived session lifecycle
6. [#1163](https://github.com/PrimeIntellect-ai/prime-agent/pull/1163) — fix(coding-agent): complete Windows kernel and daemon startup
7. [#1164](https://github.com/PrimeIntellect-ai/prime-agent/pull/1164) — fix(providers): harden MCP OAuth and Codex transports
8. [#1165](https://github.com/PrimeIntellect-ai/prime-agent/pull/1165) — fix(runtime): bound transcript and autonomous recovery

## Summary

- Preserve MCP tool schemas and use the correct Codex discovery client version.
- Harden Codex SSE/WebSocket framing, cancellation, cleanup, and fallback state.
- Implement SSRF-safe RFC 9728/8414/8707 OAuth discovery, native MCP challenges, refresh binding, and RFC 6052 NAT64 policy.

## Validation

- `npm run check`; targeted AI provider suites 99/99; MCP manager 14/14.
- Residual/non-blocking: WWW-Authenticate-only OAuth challenge discovery remains follow-up; provider stack must include independent #1153 empty-catalog commit

## Provenance

- Authored independently from `upstream/main` using issue reports and PR descriptions/comments only.
- No external contributor branch, diff, commit, implementation code, or test code was fetched, inspected, copied, or reused.
- The implementation and regression tests in this stack are maintainer-owned.

## Linked-item disposition

### Fixed on merge

- Fixes #1073 — McpIntegration.list_tools() always returns an empty inputSchema (camelCase getattr vs snake_case SDK field)
- Fixes #766 — [coding-agent] MCP OAuth discovery ignores RFC 9728 protected-resource metadata; 17 of 36 hosted servers cannot be logged into
- Fixes #639 — RLM excludes OpenAI Codex models because discovery sends Prime Agent version as client_version

### Independently superseded pull requests

- #1015 (open) — fix(ai): harden Codex streaming transport — **will be closed with a pointer to this independently authored PR**
- #1101 (open) — fix(runtime): preserve MCP tool inputSchema from SDK fields — **will be closed with a pointer to this independently authored PR**
- #1084 (open) — fix(runtime): preserve MCP tool inputSchema from SDK snake_case fields — **will be closed with a pointer to this independently authored PR**
- #837 (open) — fix(ai): follow RFC 9728 protected-resource metadata in MCP OAuth discovery — **will be closed with a pointer to this independently authored PR**
- #831 (open) — fix(coding-agent): send a supported codex client_version in model discovery — **will be closed with a pointer to this independently authored PR**
- #717 (closed) — fix: keep codex models executable when discovery returns an empty catalog — **already closed; retain cross-reference**
- #718 (open) — Fix OpenAI Codex model discovery for RLM subagents — **will be closed with a pointer to this independently authored PR**
- #731 (open) — fix: codex model discovery sends prime-agent version as client_version — **will be closed with a pointer to this independently authored PR**
- #1153 (open) — fix(coding-agent): handle empty Codex discovery catalogs — **will be closed with a pointer to this independently authored PR**
- #1012 (closed) — fix(coding-agent): allow Luna children on empty Codex catalogs — **already closed; retain cross-reference**

## Reviewer notes

- Please review this layer against its immediate stack base, not against `main`, to avoid cumulative duplicate diffs.
- No merge is requested; the complete stack is being left for human review.
