### PR TITLE
C03: durable terminal delivery

### DIFF
--- a/C04_WIRE_SEAM_REPORT.md
+++ b/C04_WIRE_SEAM_REPORT.md
@@ -1,0 +1,17 @@
+# C04 wire seam report — C03 integration
+
+**Order / dependency.** This narrowly completes the C03-to-C04 terminal wire seam on top of C03 `d9b58451e012774f5d4e5b708668cd3e413994f1`. It is intentionally earlier than, and does not substitute for, the C04 artifact store/resolver described in `terra-c04-contract.md`; C03 remains the sole ledger/outbox/inbox/consumed transport authority. There are no provider, stream, queue, daemon protocol, or limiter changes.
+
+## Contract delivered
+
+- Added the closed `RlmTerminalMessage` `rlm_child_result_reference` variant, with `details.kind: "child_result_v1"` and a `RlmChildResultReferenceV1` projection only.
+- `assertChildResultReference` is recursive and fail-closed: exact keys at every object level, canonical UUIDv4 result/handle IDs, lower-case 64-hex SHA-256, safe artifact byte integers through 512 MiB, at most 16 unique handles bound to the outer `resultId`, closed status/kind/content-type/error/retention sets, required summary/preview, and scalar-value plus UTF-8 byte limits.
+- The projection is capped at 64 KiB. Legacy terminal messages retain their pre-existing 16,384-character / 24-KiB envelope cap. The result-reference branch validates its projection cap instead and never loosens legacy acceptance.
+- `formatRlmChildResultReference` and `createRlmChildResultReferenceTerminalMessage` make `content` exactly the canonical projection. Validation rejects arbitrary or mismatching content. A completed result rejects `error`; every non-completed result requires a closed `{ code, message }` safe error.
+- No owner/correlation ID, filesystem path, payload/body, or unknown nested field can enter this C03 public projection.
+
+## Focused proof
+
+`rlm-c04-wire-seam.test.ts` adds five deterministic tests for exact acceptance/formatting, legacy-cap isolation, outbox/terminal/inbox/restart/materialization and digest idempotence, malicious nested fields/malformed recovery, and character/byte/64-KiB boundaries. It uses only temporary local artifacts.
+
+The source is a C03 adapter seam, not C04 artifact creation or authorization. The full C04 implementation must use the contract-owned `rlm-child-results.ts` authority and then hand only this validated projection to C03.

--- a/C04_WIRE_SEAM_REPORT.md
+++ b/C04_WIRE_SEAM_REPORT.md
@@ -1,17 +1,13 @@
-# C04 wire seam report — C03 integration
-
-**Order / dependency.** This narrowly completes the C03-to-C04 terminal wire seam on top of C03 `d9b58451e012774f5d4e5b708668cd3e413994f1`. It is intentionally earlier than, and does not substitute for, the C04 artifact store/resolver described in `terra-c04-contract.md`; C03 remains the sole ledger/outbox/inbox/consumed transport authority. There are no provider, stream, queue, daemon protocol, or limiter changes.
+# C03 generic safe-terminal envelope report
 
 ## Contract delivered
 
-- Added the closed `RlmTerminalMessage` `rlm_child_result_reference` variant, with `details.kind: "child_result_v1"` and a `RlmChildResultReferenceV1` projection only.
-- `assertChildResultReference` is recursive and fail-closed: exact keys at every object level, canonical UUIDv4 result/handle IDs, lower-case 64-hex SHA-256, safe artifact byte integers through 512 MiB, at most 16 unique handles bound to the outer `resultId`, closed status/kind/content-type/error/retention sets, required summary/preview, and scalar-value plus UTF-8 byte limits.
-- The projection is capped at 64 KiB. Legacy terminal messages retain their pre-existing 16,384-character / 24-KiB envelope cap. The result-reference branch validates its projection cap instead and never loosens legacy acceptance.
-- `formatRlmChildResultReference` and `createRlmChildResultReferenceTerminalMessage` make `content` exactly the canonical projection. Validation rejects arbitrary or mismatching content. A completed result rejects `error`; every non-completed result requires a closed `{ code, message }` safe error.
-- No owner/correlation ID, filesystem path, payload/body, or unknown nested field can enter this C03 public projection.
+C03 now owns one durable terminal-envelope variant only: `rlm_safe_terminal_result` with the exact `details` shape `{ kind: "safe_terminal_result_v1", projection: string }`. The `projection` is an opaque caller-produced safe JSON string. C03 checks its JavaScript string type and UTF-8 byte size only as part of the full stable terminal-message 64 KiB cap. It never parses, validates, sanitizes, or reserializes the projection's JSON.
+
+`content` is separately supplied bounded human presentation (16,384 characters). It is intentionally not compared with or derived from `projection`. The exported `createRlmSafeTerminalResultTerminalMessage(content, projection, timestamp)` constructor accepts these already-sanitized caller inputs and creates the exact envelope.
+
+The generic envelope is accepted by the existing durable ledger/outbox/inbox/consumed transport. Stable-message digest identity and restart recovery therefore retain the exact message once. Legacy terminal variants retain their established 16,384-character and 24 KiB envelope bounds.
 
 ## Focused proof
 
-`rlm-c04-wire-seam.test.ts` adds five deterministic tests for exact acceptance/formatting, legacy-cap isolation, outbox/terminal/inbox/restart/materialization and digest idempotence, malicious nested fields/malformed recovery, and character/byte/64-KiB boundaries. It uses only temporary local artifacts.
-
-The source is a C03 adapter seam, not C04 artifact creation or authorization. The full C04 implementation must use the contract-owned `rlm-child-results.ts` authority and then hand only this validated projection to C03.
+The focused seam test proves exact keys, verbatim opaque projection retention, arbitrary mismatched human presentation, full-envelope near-cap rejection, legacy-cap isolation, deterministic digest/idempotence, outbox/inbox round-trip, restart/materialization, and malformed JSONL recovery. It uses only temporary local artifacts; no provider or queue is involved.

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -128,6 +128,19 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		return this._session;
 	}
 
+	/** Preserve C03 identity when this daemon runtime is used as a release callback handle. */
+	get assignmentId(): string | undefined {
+		return this._metadata.assignmentId;
+	}
+
+	get operationId(): string | undefined {
+		return this._metadata.operationId;
+	}
+
+	get deliveryId(): string | undefined {
+		return this._metadata.deliveryId;
+	}
+
 	get cwd(): string {
 		return this._services.cwd;
 	}

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -61,6 +61,9 @@ export interface AgentSessionRuntimeMetadata {
 	generation?: string;
 	/** Required for C01-created subagent runtimes; internal only. */
 	assignmentId?: string;
+	/** C03 internal durable identities. */
+	operationId?: string;
+	deliveryId?: string;
 	rlmParentNodeId?: string;
 	/** Runtime restored from an already-persisted completed registry entry. */
 	rehydratedCompleted?: boolean;
@@ -379,6 +382,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 					parentSessionFile: options.parentSession.sessionFile,
 					rlmChildId: options.id,
 					assignmentId: assignmentId,
+					operationId: options.operationId,
+					deliveryId: options.deliveryId,
 					rlmParentNodeId: options.rlmParentNodeId,
 					prompt: options.prompt,
 					spawnCode: options.spawnCode,
@@ -411,15 +416,29 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			await runtime.dispose();
 			throw error;
 		}
-		return runtime;
+		return {
+			session: runtime.session,
+			assignmentId,
+			operationId: options.operationId,
+			deliveryId: options.deliveryId,
+		};
 	}
 
-	async deleteRlmSubagentRuntime(childId: string, childSession?: AgentSession, assignmentId?: string): Promise<void> {
+	async deleteRlmSubagentRuntime(
+		childId: string,
+		childSession?: AgentSession,
+		assignmentId?: string,
+		operationId?: string,
+	): Promise<void> {
 		const runtime = this.subagentRuntimes.get(childId);
 		const currentAssignment = this.subagentRuntimeAssignments.get(childId);
 		// Inline runtimes have no durable daemon registry. Preserve direct delete
 		// compatibility, but a named C01 assignment fences stale callbacks.
-		if (!runtime || (assignmentId !== undefined && currentAssignment !== assignmentId)) {
+		if (
+			!runtime ||
+			(assignmentId !== undefined && currentAssignment !== assignmentId) ||
+			(operationId !== undefined && runtime.metadata.operationId !== operationId)
+		) {
 			await childSession?.disposeAsync();
 			return;
 		}

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -467,7 +467,11 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		if (
 			!runtime ||
 			(assignmentId !== undefined && currentAssignment !== assignmentId) ||
-			((operationId !== undefined || currentOperation !== undefined) && currentOperation !== operationId)
+			(operationId !== undefined && currentOperation !== operationId) ||
+			(operationId === undefined &&
+				currentOperation !== undefined &&
+				childSession !== undefined &&
+				runtime.session !== childSession)
 		) {
 			await childSession?.disposeAsync();
 			return;

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -100,6 +100,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	private subagentRuntimes = new Map<string, AgentSessionRuntime>();
 	/** Assignment currently owning each compatibility child-id map entry. */
 	private subagentRuntimeAssignments = new Map<string, string>();
+	/** C03 operation companion for each compatibility child-id map entry. */
+	private subagentRuntimeOperations = new Map<string, string | undefined>();
 	private disposePromise?: Promise<void>;
 
 	constructor(
@@ -309,6 +311,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		const runtimes = [...this.subagentRuntimes.values()];
 		this.subagentRuntimes.clear();
 		this.subagentRuntimeAssignments.clear();
+		this.subagentRuntimeOperations.clear();
 		let disposeError: unknown;
 		for (const runtime of runtimes) {
 			try {
@@ -341,6 +344,19 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 
 	listSubagentRuntimes(): readonly AgentSessionRuntime[] {
 		return [...this.subagentRuntimes.values()];
+	}
+
+	private ownsSubagentRuntime(
+		childId: string,
+		runtime: AgentSessionRuntime,
+		assignmentId: string,
+		operationId: string | undefined,
+	): boolean {
+		return (
+			this.subagentRuntimes.get(childId) === runtime &&
+			this.subagentRuntimeAssignments.get(childId) === assignmentId &&
+			this.subagentRuntimeOperations.get(childId) === operationId
+		);
 	}
 
 	async createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime> {
@@ -393,10 +409,11 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		);
 		this.subagentRuntimes.set(options.id, runtime);
 		this.subagentRuntimeAssignments.set(options.id, assignmentId);
+		this.subagentRuntimeOperations.set(options.id, options.operationId);
 		try {
 			await runtime.session.bindExtensions({});
 			if (
-				this.subagentRuntimeAssignments.get(options.id) !== assignmentId ||
+				!this.ownsSubagentRuntime(options.id, runtime, assignmentId, options.operationId) ||
 				options.parentSession.getRlmChildRunStatus(options.id) === "cancelled"
 			) {
 				throw new Error("RLM subagent startup was cancelled");
@@ -406,12 +423,10 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			}
 			options.onSessionPublished?.(runtime.session);
 		} catch (error) {
-			if (
-				this.subagentRuntimes.get(options.id) === runtime &&
-				this.subagentRuntimeAssignments.get(options.id) === assignmentId
-			) {
+			if (this.ownsSubagentRuntime(options.id, runtime, assignmentId, options.operationId)) {
 				this.subagentRuntimes.delete(options.id);
 				this.subagentRuntimeAssignments.delete(options.id);
+				this.subagentRuntimeOperations.delete(options.id);
 			}
 			await runtime.dispose();
 			throw error;
@@ -432,18 +447,21 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	): Promise<void> {
 		const runtime = this.subagentRuntimes.get(childId);
 		const currentAssignment = this.subagentRuntimeAssignments.get(childId);
+		const currentOperation = this.subagentRuntimeOperations.get(childId);
 		// Inline runtimes have no durable daemon registry. Preserve direct delete
-		// compatibility, but a named C01 assignment fences stale callbacks.
+		// compatibility only when both sides lack C03 operation identity; otherwise
+		// a named C01 assignment and C03 operation fence stale callbacks.
 		if (
 			!runtime ||
 			(assignmentId !== undefined && currentAssignment !== assignmentId) ||
-			(operationId !== undefined && runtime.metadata.operationId !== operationId)
+			((operationId !== undefined || currentOperation !== undefined) && currentOperation !== operationId)
 		) {
 			await childSession?.disposeAsync();
 			return;
 		}
 		this.subagentRuntimes.delete(childId);
 		this.subagentRuntimeAssignments.delete(childId);
+		this.subagentRuntimeOperations.delete(childId);
 		const shouldDisposeStaleSession = !!childSession && runtime.session !== childSession;
 		try {
 			await runtime.dispose();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9908,7 +9908,11 @@ export class AgentSession {
 		}
 		const localConflict =
 			[...this._activeRlmChildRuns.values()].some(
-				(run) => run.session?.sessionName === name || (!run.session && run.sessionName === name),
+				// A detached deletion keeps only its immutable tuple; it no longer owns
+				// this public selector while its terminal hand-off finishes.
+				(run) =>
+					!(run.detachedDeletion && this._subagentRuntimeHost?.assignmentIdentityFenced) &&
+					(run.session?.sessionName === name || (!run.session && run.sessionName === name)),
 			) ||
 			[...this._rlmChildSessions.values()].some((session) => session.sessionName === name) ||
 			[...this._rlmChildCleanupFailures.values()].some((entry) => entry.session_name === name);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1257,6 +1257,8 @@ export class AgentSession {
 	// the daemon does the same by leaving the child session resident in its registry.
 	private _rlmChildSessions = new Map<string, AgentSession>();
 	private _rlmChildSessionAssignments = new Map<string, string>();
+	/** C03 operation companion for every retained C03 child; absent only for legacy rows. */
+	private _rlmChildSessionOperations = new Map<string, string>();
 	// Tombstones are attempt-scoped: a late A deletion must never hide B.
 	private _deletedRlmChildIds = new Set<string>();
 	// Failed explicit deletes stay hidden from listings but retain their original
@@ -1274,6 +1276,7 @@ export class AgentSession {
 	// still forward to root; torn down when the retained child is disposed.
 	private _rlmChildUnsubscribes = new Map<string, () => void>();
 	private _rlmChildUnsubscribeAssignments = new Map<string, string>();
+	private _rlmChildUnsubscribeOperations = new Map<string, string>();
 	/** Latest recap for this session, written by the daemon summarizer; read by a parent to label its child snapshots. */
 	private _currentRecap?: string;
 
@@ -4061,10 +4064,13 @@ export class AgentSession {
 			unsubscribe();
 		}
 		this._rlmChildUnsubscribes.clear();
+		this._rlmChildUnsubscribeOperations.clear();
 		for (const session of this._rlmChildSessions.values()) {
 			await session.disposeAsync().catch(() => undefined);
 		}
 		this._rlmChildSessions.clear();
+		this._rlmChildSessionAssignments.clear();
+		this._rlmChildSessionOperations.clear();
 		this._rlmChildCleanupFailures.clear();
 		this._deletedRlmChildIds.clear();
 		try {
@@ -9465,13 +9471,20 @@ export class AgentSession {
 		}
 	}
 
-	private _deleteRlmSubagentSession(childId: string, assignmentId?: string, session?: AgentSession): Promise<void> {
+	private _deleteRlmSubagentSession(
+		childId: string,
+		assignmentId?: string,
+		session?: AgentSession,
+		operationId?: string,
+	): Promise<void> {
 		if (this._subagentRuntimeHost) {
 			// Preserve the established assignment-aware host ABI. A daemon host treats
 			// assignment-less deletes as explicit durable migration, never as callback authority.
-			return this._subagentRuntimeHost.assignmentIdentityFenced
+			if (!this._subagentRuntimeHost.assignmentIdentityFenced)
+				return this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
+			return operationId === undefined
 				? this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session, assignmentId)
-				: this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
+				: this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session, assignmentId, operationId);
 		}
 		return session?.disposeAsync() ?? Promise.resolve();
 	}
@@ -9490,18 +9503,27 @@ export class AgentSession {
 
 	private _removeRlmSubagentTracking(childId: string, run?: RlmChildRun, expectedAssignmentId?: string): void {
 		const assignmentId = expectedAssignmentId ?? run?.assignmentId ?? this._rlmChildSessionAssignments.get(childId);
+		const operationId = run?.operationId ?? this._rlmChildSessionOperations.get(childId);
 		// A callback which cannot name its assignment is a legacy/display path and has
 		// no authority to mutate a C01 child incarnation.
 		if (!assignmentId) return;
 		if (run && run.assignmentId !== assignmentId) return;
-		if (this._rlmChildUnsubscribeAssignments.get(childId) === assignmentId) {
+		if (
+			this._rlmChildUnsubscribeAssignments.get(childId) === assignmentId &&
+			this._rlmChildUnsubscribeOperations.get(childId) === operationId
+		) {
 			this._rlmChildUnsubscribes.get(childId)?.();
 			this._rlmChildUnsubscribes.delete(childId);
 			this._rlmChildUnsubscribeAssignments.delete(childId);
+			this._rlmChildUnsubscribeOperations.delete(childId);
 		}
-		if (this._rlmChildSessionAssignments.get(childId) === assignmentId) {
+		if (
+			this._rlmChildSessionAssignments.get(childId) === assignmentId &&
+			this._rlmChildSessionOperations.get(childId) === operationId
+		) {
 			this._rlmChildSessions.delete(childId);
 			this._rlmChildSessionAssignments.delete(childId);
+			this._rlmChildSessionOperations.delete(childId);
 			this._rlmChildCleanupFailures.delete(childId);
 		}
 		if (this._activeRlmChildRuns.get(childId)?.assignmentId === assignmentId) {
@@ -9558,10 +9580,12 @@ export class AgentSession {
 					if (this._activeRlmChildRuns.get(childId) === run) {
 						this._rlmChildSessions.set(childId, liveSession);
 						this._rlmChildSessionAssignments.set(childId, run.assignmentId);
+						this._rlmChildSessionOperations.set(childId, run.operationId);
 						this._rlmChildCleanupFailures.set(childId, subagent);
 						if (run.unsubscribe) {
 							this._rlmChildUnsubscribes.set(childId, run.unsubscribe);
 							this._rlmChildUnsubscribeAssignments.set(childId, run.assignmentId);
+							this._rlmChildUnsubscribeOperations.set(childId, run.operationId);
 						}
 						this._activeRlmChildRuns.delete(childId);
 					}
@@ -9593,8 +9617,9 @@ export class AgentSession {
 		// a compatibility map, but it must not make this explicit deletion forget
 		// the incarnation it admitted.
 		const retainedAssignmentId = this._rlmChildSessionAssignments.get(childId);
+		const retainedOperationId = this._rlmChildSessionOperations.get(childId);
 		try {
-			await this._deleteRlmSubagentSession(childId, retainedAssignmentId, retained);
+			await this._deleteRlmSubagentSession(childId, retainedAssignmentId, retained, retainedOperationId);
 		} catch (error) {
 			if (this._disposed || this._disposing) {
 				this._removeRlmSubagentTracking(childId, undefined, this._rlmChildSessionAssignments.get(childId));
@@ -9627,21 +9652,25 @@ export class AgentSession {
 		session: AgentSession,
 		unsubscribe?: () => void,
 		assignmentId?: string,
+		operationId?: string,
 	): boolean {
 		const run = this._activeRlmChildRuns.get(childId);
 		// Older in-process hosts may register a freshly restored child directly.
 		// Mint an internal assignment for that synchronous compatibility path; all
 		// asynchronous C01 callbacks supply their captured assignment explicitly.
 		const expectedAssignmentId = assignmentId ?? run?.assignmentId ?? randomUUID();
+		const expectedOperationId = operationId ?? run?.operationId;
 		const retainedAssignmentId = this._rlmChildSessionAssignments.get(childId);
+		const retainedOperationId = this._rlmChildSessionOperations.get(childId);
 		// A live run must name its immutable assignment. Hydration has no live run,
 		// but it has already persisted a fresh assignment; it may bind only an empty
 		// slot (or its own prior binding), never a selector reused by another child.
 		if (
 			!expectedAssignmentId ||
 			(run
-				? run.assignmentId !== expectedAssignmentId
-				: retainedAssignmentId !== undefined && retainedAssignmentId !== expectedAssignmentId)
+				? run.assignmentId !== expectedAssignmentId || run.operationId !== expectedOperationId
+				: (retainedAssignmentId !== undefined && retainedAssignmentId !== expectedAssignmentId) ||
+					(retainedOperationId !== undefined && retainedOperationId !== expectedOperationId))
 		)
 			return false;
 		// A child can finish concurrently while the parent is (or has) torn down; don't
@@ -9657,7 +9686,7 @@ export class AgentSession {
 		// compatibility shims; daemon-owned hosts always receive and verify assignmentId.
 		const completionResult = completeRuntime
 			? this._subagentRuntimeHost?.assignmentIdentityFenced
-				? completeRuntime(childId, session, expectedAssignmentId, run?.operationId)
+				? completeRuntime(childId, session, expectedAssignmentId, expectedOperationId)
 				: completeRuntime(childId, session)
 			: undefined;
 		if (completionResult === false) {
@@ -9669,9 +9698,11 @@ export class AgentSession {
 		}
 		this._rlmChildSessions.set(childId, session);
 		this._rlmChildSessionAssignments.set(childId, expectedAssignmentId);
+		if (expectedOperationId) this._rlmChildSessionOperations.set(childId, expectedOperationId);
 		if (unsubscribe) {
 			this._rlmChildUnsubscribes.set(childId, unsubscribe);
 			this._rlmChildUnsubscribeAssignments.set(childId, expectedAssignmentId);
+			if (expectedOperationId) this._rlmChildUnsubscribeOperations.set(childId, expectedOperationId);
 		}
 		return true;
 	}
@@ -9681,24 +9712,46 @@ export class AgentSession {
 	 * altering the historical register callback arity.  The session identity guard
 	 * prevents an A hydration continuation from rebinding a replacement B.
 	 */
-	rebindRlmChildSessionAssignment(childId: string, session: AgentSession, assignmentId: string): boolean {
+	rebindRlmChildSessionAssignment(
+		childId: string,
+		session: AgentSession,
+		assignmentId: string,
+		operationId?: string,
+	): boolean {
 		if (this._rlmChildSessions.get(childId) !== session) return false;
 		// Hydration can resume after a selector has been rebound. The same session
 		// object is not sufficient authority: only the assignment which installed it
 		// may refresh its binding.
 		const currentAssignmentId = this._rlmChildSessionAssignments.get(childId);
+		const currentOperationId = this._rlmChildSessionOperations.get(childId);
 		if (currentAssignmentId !== undefined && currentAssignmentId !== assignmentId) return false;
+		if (currentOperationId !== undefined && currentOperationId !== operationId) return false;
 		this._rlmChildSessionAssignments.set(childId, assignmentId);
-		if (this._rlmChildUnsubscribes.has(childId)) this._rlmChildUnsubscribeAssignments.set(childId, assignmentId);
+		if (operationId) this._rlmChildSessionOperations.set(childId, operationId);
+		if (this._rlmChildUnsubscribes.has(childId)) {
+			this._rlmChildUnsubscribeAssignments.set(childId, assignmentId);
+			if (operationId) this._rlmChildUnsubscribeOperations.set(childId, operationId);
+		}
 		return true;
 	}
 
 	/** Stop retaining an idle daemon child without deleting its durable registry row. */
-	releaseRlmChildSession(childId: string, session: AgentSession, assignmentId?: string): (() => void) | false {
+	releaseRlmChildSession(
+		childId: string,
+		session: AgentSession,
+		assignmentId?: string,
+		operationId?: string,
+	): (() => void) | false {
 		const run = this._activeRlmChildRuns.get(childId);
 		const expectedAssignmentId = assignmentId ?? run?.assignmentId ?? this._rlmChildSessionAssignments.get(childId);
+		const expectedOperationId = operationId ?? run?.operationId ?? this._rlmChildSessionOperations.get(childId);
 		if (!expectedAssignmentId) return false;
-		if (run?.session === session && run.status === "done" && run.assignmentId === expectedAssignmentId) {
+		if (
+			run?.session === session &&
+			run.status === "done" &&
+			run.assignmentId === expectedAssignmentId &&
+			run.operationId === expectedOperationId
+		) {
 			const unsubscribe = run.unsubscribe ?? noopRlmChildEventUnsubscribe;
 			run.unsubscribe = undefined;
 			if (this._activeRlmChildRuns.get(childId)?.assignmentId === expectedAssignmentId)
@@ -9707,16 +9760,22 @@ export class AgentSession {
 		}
 		if (
 			this._rlmChildSessions.get(childId) !== session ||
-			this._rlmChildSessionAssignments.get(childId) !== expectedAssignmentId
+			this._rlmChildSessionAssignments.get(childId) !== expectedAssignmentId ||
+			this._rlmChildSessionOperations.get(childId) !== expectedOperationId
 		)
 			return false;
 		const unsubscribe = this._rlmChildUnsubscribes.get(childId) ?? noopRlmChildEventUnsubscribe;
-		if (this._rlmChildUnsubscribeAssignments.get(childId) === expectedAssignmentId) {
+		if (
+			this._rlmChildUnsubscribeAssignments.get(childId) === expectedAssignmentId &&
+			this._rlmChildUnsubscribeOperations.get(childId) === expectedOperationId
+		) {
 			this._rlmChildUnsubscribes.delete(childId);
 			this._rlmChildUnsubscribeAssignments.delete(childId);
+			this._rlmChildUnsubscribeOperations.delete(childId);
 		}
 		this._rlmChildSessions.delete(childId);
 		this._rlmChildSessionAssignments.delete(childId);
+		this._rlmChildSessionOperations.delete(childId);
 		return unsubscribe;
 	}
 
@@ -10202,7 +10261,7 @@ export class AgentSession {
 						}),
 					);
 				}
-				if (!this.registerRlmChildSession(run.id, child, undefined, run.assignmentId)) {
+				if (!this.registerRlmChildSession(run.id, child, undefined, run.assignmentId, run.operationId)) {
 					if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 						await this._subagentRuntimeHost
 							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
@@ -10288,7 +10347,7 @@ export class AgentSession {
 			} finally {
 				if (run.detachedDeletion && childRuntime) {
 					try {
-						await this._deleteRlmSubagentSession(run.id, run.assignmentId, childRuntime.session);
+						await this._deleteRlmSubagentSession(run.id, run.assignmentId, childRuntime.session, run.operationId);
 						// A retry can complete after its first failed delete retained the
 						// child. Remove only that captured session/assignment, never B.
 						if (
@@ -10302,6 +10361,7 @@ export class AgentSession {
 						if (!this._disposed && !this._disposing && this._activeRlmChildRuns.get(run.id) === run) {
 							this._rlmChildSessions.set(run.id, childRuntime.session);
 							this._rlmChildSessionAssignments.set(run.id, run.assignmentId);
+							this._rlmChildSessionOperations.set(run.id, run.operationId);
 							this._rlmChildCleanupFailures.set(run.id, run.detachedDeletion);
 						}
 					}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10354,7 +10354,12 @@ export class AgentSession {
 					if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 						await this._subagentRuntimeHost
 							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
-							.catch(() => void child.disposeAsync().catch(() => undefined));
+							.catch((error) => {
+								// The fenced daemon owns C03 release authority. It must not
+								// be bypassed by this legacy best-effort local fallback.
+								if (this._subagentRuntimeHost?.assignmentIdentityFenced) throw error;
+								return child.disposeAsync().catch(() => undefined);
+							});
 					} else {
 						await child.disposeAsync().catch(() => undefined);
 					}
@@ -10417,7 +10422,11 @@ export class AgentSession {
 								this._removeRlmSubagentTracking(run.id, run, run.assignmentId);
 							}
 						}
-					} catch {
+					} catch (error) {
+						// A fenced C03 release failed before its authoritative deletion.
+						// Preserve the session for the daemon-owned retry rather than
+						// silently disposing it through the generic legacy fallback.
+						if (this._subagentRuntimeHost?.assignmentIdentityFenced) throw error;
 						await childSession?.disposeAsync().catch(() => undefined);
 					}
 				} else if (!run.detachedDeletion) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9501,13 +9501,18 @@ export class AgentSession {
 		return this._deletingRlmChildren.has(this._rlmAssignmentKey(childId, assignmentId));
 	}
 
-	private _removeRlmSubagentTracking(childId: string, run?: RlmChildRun, expectedAssignmentId?: string): void {
+	private _removeRlmSubagentTracking(
+		childId: string,
+		run?: RlmChildRun,
+		expectedAssignmentId?: string,
+		expectedOperationId?: string,
+	): void {
 		const assignmentId = expectedAssignmentId ?? run?.assignmentId ?? this._rlmChildSessionAssignments.get(childId);
-		const operationId = run?.operationId ?? this._rlmChildSessionOperations.get(childId);
+		const operationId = expectedOperationId ?? run?.operationId ?? this._rlmChildSessionOperations.get(childId);
 		// A callback which cannot name its assignment is a legacy/display path and has
 		// no authority to mutate a C01 child incarnation.
 		if (!assignmentId) return;
-		if (run && run.assignmentId !== assignmentId) return;
+		if (run && (run.assignmentId !== assignmentId || run.operationId !== operationId)) return;
 		if (
 			this._rlmChildUnsubscribeAssignments.get(childId) === assignmentId &&
 			this._rlmChildUnsubscribeOperations.get(childId) === operationId
@@ -9526,7 +9531,10 @@ export class AgentSession {
 			this._rlmChildSessionOperations.delete(childId);
 			this._rlmChildCleanupFailures.delete(childId);
 		}
-		if (this._activeRlmChildRuns.get(childId)?.assignmentId === assignmentId) {
+		if (
+			this._activeRlmChildRuns.get(childId)?.assignmentId === assignmentId &&
+			this._activeRlmChildRuns.get(childId)?.operationId === operationId
+		) {
 			this._activeRlmChildRuns.delete(childId);
 		}
 		if (run) {
@@ -9568,7 +9576,7 @@ export class AgentSession {
 			}
 			if (liveSession) {
 				try {
-					await this._deleteRlmSubagentSession(childId, run.assignmentId, liveSession);
+					await this._deleteRlmSubagentSession(childId, run.assignmentId, liveSession, run.operationId);
 				} catch (error) {
 					if (this._disposed || this._disposing) {
 						this._removeRlmSubagentTracking(childId, run, run.assignmentId);
@@ -9622,7 +9630,7 @@ export class AgentSession {
 			await this._deleteRlmSubagentSession(childId, retainedAssignmentId, retained, retainedOperationId);
 		} catch (error) {
 			if (this._disposed || this._disposing) {
-				this._removeRlmSubagentTracking(childId, undefined, this._rlmChildSessionAssignments.get(childId));
+				this._removeRlmSubagentTracking(childId, undefined, retainedAssignmentId, retainedOperationId);
 				void retained?.disposeAsync().catch(() => undefined);
 			} else {
 				this._rlmChildCleanupFailures.set(childId, subagent);
@@ -9631,7 +9639,7 @@ export class AgentSession {
 		}
 		if (retainedAssignmentId) {
 			this._deletedRlmChildIds.add(this._rlmAssignmentKey(childId, retainedAssignmentId));
-			this._removeRlmSubagentTracking(childId, undefined, retainedAssignmentId);
+			this._removeRlmSubagentTracking(childId, undefined, retainedAssignmentId, retainedOperationId);
 		} else {
 			// Display-only legacy hosts never expose an assignment. This explicit
 			// user deletion still hides their public row, but it grants no authority
@@ -10008,10 +10016,12 @@ export class AgentSession {
 			const isCurrent = () => {
 				const activeOwner =
 					this._activeRlmChildRuns.get(run.id) === run &&
-					this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId;
+					this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
+					this._activeRlmChildRuns.get(run.id)?.operationId === run.operationId;
 				const retainedOwner =
 					this._rlmChildSessions.get(run.id) === childSession &&
-					this._rlmChildSessionAssignments.get(run.id) === run.assignmentId;
+					this._rlmChildSessionAssignments.get(run.id) === run.assignmentId &&
+					this._rlmChildSessionOperations.get(run.id) === run.operationId;
 				return activeOwner || retainedOwner;
 			};
 			if (!isCurrent()) return;
@@ -10049,7 +10059,8 @@ export class AgentSession {
 			childSession = child;
 			if (
 				this._activeRlmChildRuns.get(run.id) !== run ||
-				this._activeRlmChildRuns.get(run.id)?.assignmentId !== run.assignmentId
+				this._activeRlmChildRuns.get(run.id)?.assignmentId !== run.assignmentId ||
+				this._activeRlmChildRuns.get(run.id)?.operationId !== run.operationId
 			)
 				return;
 			run.session = child;
@@ -10074,7 +10085,8 @@ export class AgentSession {
 		const deliverTerminalMessageToParent = async (message: CustomMessage): Promise<void> => {
 			if (
 				this._activeRlmChildRuns.get(run.id) !== run ||
-				this._activeRlmChildRuns.get(run.id)?.assignmentId !== run.assignmentId
+				this._activeRlmChildRuns.get(run.id)?.assignmentId !== run.assignmentId ||
+				this._activeRlmChildRuns.get(run.id)?.operationId !== run.operationId
 			)
 				return;
 			// A daemon-owned host has the only durable terminal authority. In particular,
@@ -10148,10 +10160,13 @@ export class AgentSession {
 					// projecting this exact child session, but never let A's subscription
 					// observe a replacement B that reused the selector.
 					const activeOwner =
-						this._activeRlmChildRuns.get(run.id) === run && run.assignmentId === subagentOptions.assignmentId;
+						this._activeRlmChildRuns.get(run.id) === run &&
+						run.assignmentId === subagentOptions.assignmentId &&
+						run.operationId === subagentOptions.operationId;
 					const retainedOwner =
 						this._rlmChildSessions.get(run.id) === child &&
-						this._rlmChildSessionAssignments.get(run.id) === run.assignmentId;
+						this._rlmChildSessionAssignments.get(run.id) === run.assignmentId &&
+						this._rlmChildSessionOperations.get(run.id) === run.operationId;
 					if (!activeOwner && !retainedOwner) return;
 					if (event.type === "rlm_child_update") {
 						this._emit(event);
@@ -10331,13 +10346,22 @@ export class AgentSession {
 							await childSession.disposeAsync();
 						}
 						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
-							const activeOwner = this._activeRlmChildRuns.get(run.id) === run;
+							const activeOwner =
+								this._activeRlmChildRuns.get(run.id) === run &&
+								this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
+								this._activeRlmChildRuns.get(run.id)?.operationId === run.operationId;
 							const retainedOwner =
 								this._rlmChildSessions.get(run.id) === childRuntime?.session &&
-								this._rlmChildSessionAssignments.get(run.id) === run.assignmentId;
+								this._rlmChildSessionAssignments.get(run.id) === run.assignmentId &&
+								this._rlmChildSessionOperations.get(run.id) === run.operationId;
 							if (activeOwner || retainedOwner) {
 								this._deletedRlmChildIds.add(this._rlmAssignmentKey(run.id, run.assignmentId));
-								this._removeRlmSubagentTracking(run.id, activeOwner ? run : undefined, run.assignmentId);
+								this._removeRlmSubagentTracking(
+									run.id,
+									activeOwner ? run : undefined,
+									run.assignmentId,
+									run.operationId,
+								);
 							}
 						}
 					} catch {
@@ -10352,10 +10376,11 @@ export class AgentSession {
 						// child. Remove only that captured session/assignment, never B.
 						if (
 							this._rlmChildSessions.get(run.id) === childRuntime.session &&
-							this._rlmChildSessionAssignments.get(run.id) === run.assignmentId
+							this._rlmChildSessionAssignments.get(run.id) === run.assignmentId &&
+							this._rlmChildSessionOperations.get(run.id) === run.operationId
 						) {
 							this._deletedRlmChildIds.add(this._rlmAssignmentKey(run.id, run.assignmentId));
-							this._removeRlmSubagentTracking(run.id, undefined, run.assignmentId);
+							this._removeRlmSubagentTracking(run.id, undefined, run.assignmentId, run.operationId);
 						}
 					} catch {
 						if (!this._disposed && !this._disposing && this._activeRlmChildRuns.get(run.id) === run) {
@@ -10366,13 +10391,21 @@ export class AgentSession {
 						}
 					}
 				}
-				if (this._activeRlmChildRuns.get(run.id) === run) {
+				if (
+					this._activeRlmChildRuns.get(run.id) === run &&
+					this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
+					this._activeRlmChildRuns.get(run.id)?.operationId === run.operationId
+				) {
 					if (this._rlmChildSessions.has(run.id)) {
-						if (this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId)
+						if (
+							this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
+							this._activeRlmChildRuns.get(run.id)?.operationId === run.operationId
+						)
 							this._activeRlmChildRuns.delete(run.id);
 						if (run.unsubscribe) {
 							this._rlmChildUnsubscribes.set(run.id, run.unsubscribe);
 							this._rlmChildUnsubscribeAssignments.set(run.id, run.assignmentId);
+							this._rlmChildUnsubscribeOperations.set(run.id, run.operationId);
 						}
 						run.abort = noopRlmChildAbort;
 						run.unsubscribe = undefined;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -976,8 +976,14 @@ interface RlmChildRun {
 	session?: AgentSession;
 	/** True once the detached run task has finished its catch and cleanup paths. */
 	settled: boolean;
-	/** Selector snapshot for a delete admitted while runtime startup was still pending. */
+	/**
+	 * Exact selector snapshot for a delete admitted for this run. It is a
+	 * run-local capability, never a selector lookup: it lets only the captured A
+	 * cancellation terminal finish its durable delete chain after B reuses A's ID.
+	 */
 	detachedDeletion?: RlmSubagentRegistryEntry;
+	/** Resolves once the daemon has durably admitted the captured delete intent. */
+	deleteIntentReady?: Promise<void>;
 	/** Re-emits the run's rlm_child_update snapshot with its current status. */
 	emitUpdate?: () => void;
 	/** Idempotent child-event forwarder cleanup, once the child runtime exists. */
@@ -4630,8 +4636,9 @@ export class AgentSession {
 		deliveryId: string,
 		current: () => boolean = () => true,
 	): Promise<boolean> {
-		// The daemon supplies the complete parent/child incarnation fence. Check at
-		// the immediate mutation seam rather than only before awaiting this method.
+		// This intentionally does not use sendCustomMessage: its streaming branch
+		// creates a steer prompt. C03 must be an immediate ordinary transcript append,
+		// never provider/queue work, even while the parent is streaming.
 		if (!current()) return false;
 		const id = materializedTerminalMessageId(deliveryId);
 		const hasId = (candidate: unknown): boolean =>
@@ -4639,19 +4646,41 @@ export class AgentSession {
 			candidate !== null &&
 			(candidate as { role?: unknown }).role === "custom" &&
 			(candidate as { details?: { id?: unknown } }).details?.id === id;
-		if (
-			this.agent.state.messages.some(hasId) ||
-			this.sessionManager.getEntries().some((entry) => entry.type === "message" && hasId(entry.message))
-		)
-			return false;
-		// sendCustomMessage's no-turn branch is the normal transcript append seam.
-		// It writes an ordinary custom message, emits normal events, and cannot prompt.
-		await this.sendCustomMessage({ ...message, details: { ...message.details, id } }, { triggerTurn: false });
-		// A terminal notice is deliberately a no-turn custom message, so it may be
-		// the first transcript content and bypass SessionManager's assistant-driven
-		// persistence heuristic. Its durable-delivery acknowledgement must not outrun
-		// the actual parent transcript across a daemon restart.
-		this.sessionManager.flushNow();
+		// This manager is the sole C03 transcript writer. A matching tree entry is
+		// therefore a prior durable append (including a reopened session), whereas a
+		// queued streaming prompt never reaches this tree.
+		const persistedDuplicate = this.sessionManager
+			.getEntries()
+			.some(
+				(entry) =>
+					(entry.type === "message" && hasId(entry.message)) ||
+					(entry.type === "custom_message" && (entry.details as { id?: unknown } | undefined)?.id === id),
+			);
+		if (persistedDuplicate) return true;
+		if (!current()) return false;
+		const appMessage = {
+			role: "custom" as const,
+			customType: message.customType,
+			content: message.content,
+			display: message.display,
+			details: { ...message.details, id },
+			timestamp: Date.now(),
+		};
+		// Persist first. The manager's internal append performs write-all + file fsync
+		// (or write-all + temp fsync + rename + directory fsync) and rolls its tree
+		// back on failure. State/events therefore happen exactly once only after bytes
+		// are durable, and no flush shortcut can acknowledge a queued message.
+		if (!current()) return false;
+		const appended = this.sessionManager.appendDurableCustomMessageEntry(
+			appMessage.customType,
+			appMessage.content,
+			appMessage.display,
+			appMessage.details,
+		);
+		if (!appended) return false;
+		this.agent.state.messages.push(appMessage);
+		this._emit({ type: "message_start", message: appMessage });
+		this._emit({ type: "message_end", message: appMessage });
 		return true;
 	}
 
@@ -9577,6 +9606,9 @@ export class AgentSession {
 		const childId = subagent.rlm_child_id;
 		const run = this._activeRlmChildRuns.get(childId);
 		if (run) {
+			// Capture this incarnation before cancellation/host awaits. The terminal
+			// closure may run after B installs under the same public selector.
+			run.detachedDeletion ??= subagent;
 			if (!this._cancelRlmChildRun(run, "Deleted by parent orchestrator")) {
 				this._emitRlmSubagentRemoval(subagent);
 			}
@@ -9588,7 +9620,12 @@ export class AgentSession {
 			}
 			if (liveSession) {
 				try {
-					await this._deleteRlmSubagentSession(childId, run.assignmentId, liveSession, run.operationId);
+					const deletion = this._deleteRlmSubagentSession(childId, run.assignmentId, liveSession, run.operationId);
+					run.deleteIntentReady = deletion.then(
+						() => undefined,
+						() => undefined,
+					);
+					await deletion;
 				} catch (error) {
 					if (this._disposed || this._disposing) {
 						this._removeRlmSubagentTracking(childId, run, run.assignmentId);
@@ -10095,12 +10132,27 @@ export class AgentSession {
 		};
 
 		const deliverTerminalMessageToParent = async (message: CustomMessage): Promise<void> => {
-			if (
-				this._activeRlmChildRuns.get(run.id) !== run ||
-				this._activeRlmChildRuns.get(run.id)?.assignmentId !== run.assignmentId ||
-				this._activeRlmChildRuns.get(run.id)?.operationId !== run.operationId
-			)
-				return;
+			const activeOwner =
+				this._activeRlmChildRuns.get(run.id) === run &&
+				this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
+				this._activeRlmChildRuns.get(run.id)?.operationId === run.operationId;
+			const detachedDeleteOwner =
+				run.detachedDeletion !== undefined &&
+				run.status === "cancelled" &&
+				this._subagentRuntimeHost?.assignmentIdentityFenced === true;
+			// A live delete records intent before its cancellation can hand off a
+			// terminal. For a delete admitted while startup was still pending, this is
+			// the first point at which the captured child session exists, so make the
+			// same exact delete request before handing off its known cancellation.
+			if (detachedDeleteOwner && !run.deleteIntentReady && childSession) {
+				const deletion = this._deleteRlmSubagentSession(run.id, run.assignmentId, childSession, run.operationId);
+				run.deleteIntentReady = deletion.then(
+					() => undefined,
+					() => undefined,
+				);
+			}
+			if (detachedDeleteOwner) await run.deleteIntentReady;
+			if (!activeOwner && !detachedDeleteOwner) return;
 			// A daemon-owned host has the only durable terminal authority. In particular,
 			// startup failure before a stable child materialization must not fall through
 			// to the old agent-message/prompt path and invent an undurable completion.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4640,6 +4640,11 @@ export class AgentSession {
 		// sendCustomMessage's no-turn branch is the normal transcript append seam.
 		// It writes an ordinary custom message, emits normal events, and cannot prompt.
 		await this.sendCustomMessage({ ...message, details: { ...message.details, id } }, { triggerTurn: false });
+		// A terminal notice is deliberately a no-turn custom message, so it may be
+		// the first transcript content and bypass SessionManager's assistant-driven
+		// persistence heuristic. Its durable-delivery acknowledgement must not outrun
+		// the actual parent transcript across a daemon restart.
+		this.sessionManager.flushNow();
 		return true;
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4625,7 +4625,14 @@ export class AgentSession {
 	 * C03's no-prompt persistence seam. It deliberately appends an ordinary custom
 	 * session message and emits ordinary message events; it never schedules a turn.
 	 */
-	async appendDurableRlmTerminalMessage(message: RlmTerminalMessage, deliveryId: string): Promise<boolean> {
+	async appendDurableRlmTerminalMessage(
+		message: RlmTerminalMessage,
+		deliveryId: string,
+		current: () => boolean = () => true,
+	): Promise<boolean> {
+		// The daemon supplies the complete parent/child incarnation fence. Check at
+		// the immediate mutation seam rather than only before awaiting this method.
+		if (!current()) return false;
 		const id = materializedTerminalMessageId(deliveryId);
 		const hasId = (candidate: unknown): boolean =>
 			typeof candidate === "object" &&
@@ -10300,7 +10307,22 @@ export class AgentSession {
 				durationMs = Date.now() - startedAt;
 				activity = undefined;
 				emitChildUpdate();
-				if (!run.detachedDeletion) {
+				// A live explicit deletion still needs its exact cancellation hand-off:
+				// the daemon's durable delete intent turns it into deleted/discarded.
+				// Do not suppress this merely because UI cleanup is detached.
+				if (
+					run.status === "cancelled" &&
+					(!run.detachedDeletion || this._subagentRuntimeHost?.assignmentIdentityFenced)
+				) {
+					await deliverTerminalMessageToParent(
+						createRlmChildTerminalNoticeMessage({
+							kind: "cancelled",
+							childId: run.id,
+							sessionName,
+							reason: run.error,
+						}),
+					);
+				} else if (!run.detachedDeletion) {
 					if (run.status === "error") {
 						await deliverTerminalMessageToParent(
 							createRlmChildFailureMessage({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9349,6 +9349,11 @@ export class AgentSession {
 				recorded.has(childId) ||
 				this._isRlmChildDeleting(childId, this._rlmChildSessionAssignments.get(childId)) ||
 				this._deletedRlmChildIds.has(this._rlmAssignmentKey(childId, this._currentRlmAssignment(childId))) ||
+				// A daemon catalog summary does not expose C03's assignment. Once the
+				// parent has removed A's local tracking during an explicit delete, retain
+				// its exact child-id tombstone rather than looking it up as legacy; B has
+				// a new child id even when it reuses A's public session name.
+				[...this._deletedRlmChildIds].some((key) => key.startsWith(`${childId}\u0000`)) ||
 				this._rlmChildCleanupFailures.has(childId) ||
 				!daemonChild.sessionDir
 			) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9345,15 +9345,16 @@ export class AgentSession {
 			recorded.add(childId);
 		}
 		for (const [childId, daemonChild] of daemonChildren) {
+			// Daemon-mode catalog rows are already filtered against the durable C03
+			// (assignmentId, operationId) registry. This public summary deliberately
+			// carries no private incarnation identity, so a local A tombstone must not
+			// be guessed from childId: it could otherwise hide B (or a legacy row) that
+			// reused A's childId. Local runs/retained sessions above retain their own
+			// exact deletion fences; this fallback trusts the daemon's exact catalog.
 			if (
 				recorded.has(childId) ||
 				this._isRlmChildDeleting(childId, this._rlmChildSessionAssignments.get(childId)) ||
 				this._deletedRlmChildIds.has(this._rlmAssignmentKey(childId, this._currentRlmAssignment(childId))) ||
-				// A daemon catalog summary does not expose C03's assignment. Once the
-				// parent has removed A's local tracking during an explicit delete, retain
-				// its exact child-id tombstone rather than looking it up as legacy; B has
-				// a new child id even when it reuses A's public session name.
-				[...this._deletedRlmChildIds].some((key) => key.startsWith(`${childId}\u0000`)) ||
 				this._rlmChildCleanupFailures.has(childId) ||
 				!daemonChild.sessionDir
 			) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9258,9 +9258,16 @@ export class AgentSession {
 		return true;
 	}
 
-	/** Status of a direct RLM child run, while the run is still tracked. */
-	getRlmChildRunStatus(childId: string): RlmChildAgentStatus | undefined {
-		return this._activeRlmChildRuns.get(childId)?.status;
+	/** Status of a direct RLM child run, optionally fenced to its exact durable incarnation. */
+	getRlmChildRunStatus(childId: string, assignmentId?: string, operationId?: string): RlmChildAgentStatus | undefined {
+		const run = this._activeRlmChildRuns.get(childId);
+		if (
+			!run ||
+			(assignmentId !== undefined && run.assignmentId !== assignmentId) ||
+			(operationId !== undefined && run.operationId !== operationId)
+		)
+			return undefined;
+		return run.status;
 	}
 
 	private async _currentActiveSessionId(): Promise<string | undefined> {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -214,6 +214,7 @@ import {
 } from "./refinement/index.js";
 import { resolveConfigValue } from "./resolve-config-value.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
+import { materializedTerminalMessageId, type RlmTerminalMessage } from "./rlm-durable-operations.js";
 import {
 	type CreateRlmSubagentRuntimeOptions,
 	createDefaultRlmSubagentSessionName,
@@ -962,6 +963,8 @@ interface RlmChildRun {
 	id: string;
 	/** UUID attempt fence, minted before this run is visible to any host. */
 	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
 	prompt: string;
 	sessionName: string;
 	sessionDir: string;
@@ -4610,6 +4613,28 @@ export class AgentSession {
 			customMessage,
 		});
 		if (customMessage?.details.fromRelationship === "parent") this._repliedToParentSinceTask = false;
+	}
+
+	/**
+	 * C03's no-prompt persistence seam. It deliberately appends an ordinary custom
+	 * session message and emits ordinary message events; it never schedules a turn.
+	 */
+	async appendDurableRlmTerminalMessage(message: RlmTerminalMessage, deliveryId: string): Promise<boolean> {
+		const id = materializedTerminalMessageId(deliveryId);
+		const hasId = (candidate: unknown): boolean =>
+			typeof candidate === "object" &&
+			candidate !== null &&
+			(candidate as { role?: unknown }).role === "custom" &&
+			(candidate as { details?: { id?: unknown } }).details?.id === id;
+		if (
+			this.agent.state.messages.some(hasId) ||
+			this.sessionManager.getEntries().some((entry) => entry.type === "message" && hasId(entry.message))
+		)
+			return false;
+		// sendCustomMessage's no-turn branch is the normal transcript append seam.
+		// It writes an ordinary custom message, emits normal events, and cannot prompt.
+		await this.sendCustomMessage({ ...message, details: { ...message.details, id } }, { triggerTurn: false });
+		return true;
 	}
 
 	async queueAgentMessagePrompt(
@@ -9054,6 +9079,8 @@ export class AgentSession {
 	private _createRlmSubagentRuntimeOptions(options: {
 		id: string;
 		assignmentId: string;
+		operationId: string;
+		deliveryId: string;
 		prompt: string;
 		sessionName: string;
 		spawnCode?: string;
@@ -9064,6 +9091,8 @@ export class AgentSession {
 			parentSession: this,
 			id: options.id,
 			assignmentId: options.assignmentId,
+			operationId: options.operationId,
+			deliveryId: options.deliveryId,
 			prompt: options.prompt,
 			sessionName: options.sessionName,
 			spawnCode: options.spawnCode,
@@ -9628,7 +9657,7 @@ export class AgentSession {
 		// compatibility shims; daemon-owned hosts always receive and verify assignmentId.
 		const completionResult = completeRuntime
 			? this._subagentRuntimeHost?.assignmentIdentityFenced
-				? completeRuntime(childId, session, expectedAssignmentId)
+				? completeRuntime(childId, session, expectedAssignmentId, run?.operationId)
 				: completeRuntime(childId, session)
 			: undefined;
 		if (completionResult === false) {
@@ -9886,6 +9915,8 @@ export class AgentSession {
 		const run: RlmChildRun = {
 			id: childNodeId,
 			assignmentId: randomUUID(),
+			operationId: randomUUID(),
+			deliveryId: randomUUID(),
 			prompt,
 			sessionName,
 			sessionDir: childSessionDir,
@@ -9897,6 +9928,21 @@ export class AgentSession {
 		const throwIfCancelled = () => {
 			if (run.status === "cancelled") throw new Error(run.error ?? "RLM child cancelled");
 		};
+		// A daemon host fsyncs admission before this run becomes visible or any
+		// detached construction/provider work can begin.
+		this._subagentRuntimeHost?.admitRlmSubagentOperation?.({
+			...this._createRlmSubagentRuntimeOptions({
+				id: childNodeId,
+				assignmentId: run.assignmentId,
+				operationId: run.operationId,
+				deliveryId: run.deliveryId,
+				prompt,
+				sessionName,
+				spawnCode,
+				sessionDir: childSessionDir,
+				model: modelSelection.model,
+			}),
+		});
 		this._activeRlmChildRuns.set(run.id, run);
 		let runningPublished = false;
 		const emitChildUpdate = (structural = false) => {
@@ -9955,6 +10001,8 @@ export class AgentSession {
 			...this._createRlmSubagentRuntimeOptions({
 				id: childNodeId,
 				assignmentId: run.assignmentId,
+				operationId: run.operationId,
+				deliveryId: run.deliveryId,
 				prompt,
 				sessionName,
 				spawnCode,
@@ -9970,6 +10018,34 @@ export class AgentSession {
 				this._activeRlmChildRuns.get(run.id)?.assignmentId !== run.assignmentId
 			)
 				return;
+			// A daemon-owned host has the only durable terminal authority. In particular,
+			// startup failure before a stable child materialization must not fall through
+			// to the old agent-message/prompt path and invent an undurable completion.
+			if (this._subagentRuntimeHost?.deliverRlmSubagentTerminal) {
+				if (childSession) {
+					const runtime = {
+						session: childSession,
+						assignmentId: run.assignmentId,
+						operationId: run.operationId,
+						deliveryId: run.deliveryId,
+					};
+					await this._subagentRuntimeHost.deliverRlmSubagentTerminal(
+						runtime,
+						subagentOptions,
+						run.status === "cancelled" ? "cancelled" : run.status === "error" ? "error" : "done",
+						message as RlmTerminalMessage,
+					);
+				}
+				return;
+			}
+			const terminalId = materializedTerminalMessageId(run.deliveryId);
+			if (
+				this.agent.state.messages.some(
+					(entry) =>
+						entry.role === "custom" && (entry as { details?: { id?: string } }).details?.id === terminalId,
+				)
+			)
+				return;
 			const childController = childSession?._agentMessageController;
 			if (childController) {
 				try {
@@ -9982,12 +10058,16 @@ export class AgentSession {
 					// An unattributed notice beats silence, so fall through to the injected path.
 				}
 			}
-			await this._promptInjectedMessage(message.content as string, message, {
-				streamingBehavior: "followUp",
-				queueIfBusy: true,
-				returnAfterAccepted: true,
-				suppressAutonomousContinuation: true,
-			}).catch(() => undefined);
+			await this._promptInjectedMessage(
+				message.content as string,
+				{ ...message, details: { ...(message.details as object), id: terminalId } } as CustomMessage,
+				{
+					streamingBehavior: "followUp",
+					queueIfBusy: true,
+					returnAfterAccepted: true,
+					suppressAutonomousContinuation: true,
+				},
+			).catch(() => undefined);
 		};
 
 		// Runtime startup and the task run are deliberately detached. The public
@@ -10185,6 +10265,7 @@ export class AgentSession {
 										run.id,
 										childRuntime.session,
 										run.assignmentId,
+										run.operationId,
 									)
 								: this._subagentRuntimeHost.deleteRlmSubagentRuntime(run.id, childRuntime.session));
 						} else if (childSession) {

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -22,14 +22,30 @@ import { dirname, isAbsolute, relative } from "node:path";
 export type RlmChildTerminalStatus = "done" | "error" | "cancelled";
 export const RLM_DURABLE_VERSION = 1 as const;
 
-export interface RlmTerminalMessage {
-	role: "custom";
-	customType: "rlm_child_failure" | "rlm_child_terminal_notice" | "agent_message";
-	content: string;
-	display: boolean;
-	details: Record<string, unknown>;
-	timestamp: number;
-}
+export type RlmTerminalMessage =
+	| {
+			role: "custom";
+			customType: "rlm_child_failure";
+			content: string;
+			display: true;
+			details: { childId: string; sessionName: string; error: string };
+			timestamp: number;
+	  }
+	| {
+			role: "custom";
+			customType: "rlm_child_terminal_notice";
+			content: string;
+			display: true;
+			details:
+				| { kind: "cancelled"; childId: string; sessionName: string; reason?: string }
+				| {
+						kind: "completed_without_reply";
+						childId: string;
+						sessionName: string;
+						lastAssistantTextPreview?: string;
+				  };
+			timestamp: number;
+	  };
 
 export interface RlmOperationAdmittedRecord {
 	version: 1;
@@ -54,7 +70,10 @@ export interface RlmOperationMaterializedRecord {
 	operationId: string;
 	childSessionId: string;
 	childSessionFile: string;
+	/** Immutable roots captured from the trusted materialization call. */
+	childSessionRoot: string;
 	childArtifactDir: string;
+	childArtifactRoot: string;
 	recordedAt: string;
 }
 export interface RlmOperationTerminalRecordedRecord {
@@ -183,7 +202,10 @@ export interface RlmDurableOperation {
 	rlmMaxDepth: number;
 	childSessionId?: string;
 	childSessionFile?: string;
+	/** These are immutable, trusted roots captured at materialization. */
+	childSessionRoot?: string;
 	childArtifactDir?: string;
+	childArtifactRoot?: string;
 	terminal?: RlmChildTerminalStatus;
 	lifecycle: "admitted" | "materialized" | "terminal_recorded" | "released" | "deleted";
 	uncertain: boolean;
@@ -229,9 +251,22 @@ export interface RlmDurableIo {
 	realpathSync: typeof realpathSync;
 	renameSync: typeof renameSync;
 }
+export interface RlmTrustedChildRecoveryRoots {
+	childSessionRoot: string;
+	childArtifactRoot: string;
+}
+/**
+ * Recovery roots come from the owning session manager, never from JSONL. A
+ * passive read without this authority deliberately leaves child outboxes
+ * unopened and their operations uncertain.
+ */
+export type RlmChildRecoveryTrust = (
+	operation: Readonly<RlmDurableOperation>,
+) => RlmTrustedChildRecoveryRoots | undefined;
 export interface RlmDurableOperationStoreOptions {
 	io?: RlmDurableIo;
 	now?: () => string;
+	trustedChildRecoveryRoots?: RlmChildRecoveryTrust;
 }
 
 const defaultIo: RlmDurableIo = {
@@ -269,18 +304,24 @@ export function openRlmDurableOperationStore(
 }
 
 /** Passive: this does not create, chmod, repair, or write an artifact/cache. */
-export function readRlmDurableOperationRegistry(parentArtifactDir: string): RlmDurableOperationRegistry {
-	return reduceArtifact(parentArtifactDir, defaultIo, false);
+export function readRlmDurableOperationRegistry(
+	parentArtifactDir: string,
+	trustedChildRecoveryRoots?: RlmChildRecoveryTrust,
+): RlmDurableOperationRegistry {
+	return reduceArtifact(parentArtifactDir, defaultIo, trustedChildRecoveryRoots);
 }
 
 class Store implements RlmDurableOperationStore {
 	private readonly io: RlmDurableIo;
 	private readonly now: () => string;
 	private readonly parentArtifactDir: string;
+	private readonly trustedChildRecoveryRoots?: RlmChildRecoveryTrust;
+	private readonly inProcessChildRoots = new Map<string, RlmTrustedChildRecoveryRoots>();
 
 	constructor(parentArtifactDir: string, options: RlmDurableOperationStoreOptions) {
 		this.io = options.io ?? defaultIo;
 		this.now = options.now ?? (() => new Date().toISOString());
+		this.trustedChildRecoveryRoots = options.trustedChildRecoveryRoots;
 		this.io.mkdirSync(parentArtifactDir, { recursive: true, mode: 0o700 });
 		this.io.chmodSync(parentArtifactDir, 0o700);
 		this.parentArtifactDir = this.io.realpathSync(parentArtifactDir);
@@ -322,8 +363,7 @@ class Store implements RlmDurableOperationStore {
 		const operation = registry.operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
-		if (!operation || operation.uncertain || operation.lifecycle === "released" || operation.lifecycle === "deleted")
-			return false;
+		if (!operation || operation.uncertain || operation.lifecycle !== "admitted") return false;
 		const childFile = canonicalExistingFile(input.childSessionFile, input.childSessionRoot, this.io);
 		try {
 			assertSessionIdentity(input.childSessionId, childFile, this.io);
@@ -339,17 +379,26 @@ class Store implements RlmDurableOperationStore {
 			operationId: input.operationId,
 			childSessionId: input.childSessionId,
 			childSessionFile: childFile,
+			childSessionRoot: canonicalDirectory(input.childSessionRoot, input.childSessionRoot, this.io),
 			childArtifactDir: assertContainedDirectory(input.childArtifactDir, input.childArtifactRoot, this.io, true),
+			childArtifactRoot: canonicalDirectory(input.childArtifactRoot, input.childArtifactRoot, this.io),
 			recordedAt: this.now(),
 		};
 		if (operation.childSessionFile) {
 			if (
 				operation.childSessionId === record.childSessionId &&
-				operation.childSessionFile === record.childSessionFile
+				operation.childSessionFile === record.childSessionFile &&
+				operation.childSessionRoot === record.childSessionRoot &&
+				operation.childArtifactDir === record.childArtifactDir &&
+				operation.childArtifactRoot === record.childArtifactRoot
 			)
 				return true;
 			return false;
 		}
+		this.inProcessChildRoots.set(operation.key, {
+			childSessionRoot: record.childSessionRoot,
+			childArtifactRoot: record.childArtifactRoot,
+		});
 		this.append(this.path(LEDGER), record);
 		this.afterAppend();
 		return true;
@@ -363,7 +412,13 @@ class Store implements RlmDurableOperationStore {
 		const operation = registry.operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
-		if (!operation || operation.uncertain || !operation.childSessionFile || operation.deliveryId !== input.deliveryId)
+		if (
+			!operation ||
+			operation.uncertain ||
+			operation.lifecycle !== "materialized" ||
+			!operation.childSessionFile ||
+			operation.deliveryId !== input.deliveryId
+		)
 			return false;
 		if (operation.terminal) return operation.terminal === input.terminal;
 		const delivery = registry.deliveries.get(deliveryKey(operation.key, input.deliveryId));
@@ -378,11 +433,10 @@ class Store implements RlmDurableOperationStore {
 		const registry = this.reduce();
 		const prior = registry.deliveries.get(deliveryKey(operation.key, record.deliveryId));
 		if (prior?.outboxed) {
-			const priorDigest = (prior as RlmDurableDelivery & { _digest?: string })._digest;
 			if (
 				prior.uncertain ||
 				prior.terminal !== record.terminal ||
-				(priorDigest !== undefined && priorDigest !== digestMessage(record.message))
+				deliveryDigest(prior as DeliveryFact, record) !== digestMessage(record.message)
 			) {
 				throw new Error("Conflicting durable outbox record");
 			}
@@ -397,11 +451,17 @@ class Store implements RlmDurableOperationStore {
 		const { operation, record } = this.validateOutboxInput(input, true);
 		const registry = this.reduce();
 		const delivery = registry.deliveries.get(deliveryKey(operation.key, record.deliveryId));
-		if (!delivery?.outboxed || delivery.uncertain || operation.terminal !== record.terminal) {
+		if (
+			!delivery?.outboxed ||
+			delivery.uncertain ||
+			operation.terminal !== record.terminal ||
+			outboxDigest(delivery) !== digestOutbox(record)
+		) {
 			throw new Error("Outbox is not a durable terminal hand-off");
 		}
 		if (delivery.received) return "already_received";
-		const inbox: RlmTerminalInboxRecord = { ...record, type: "received", receivedAt: this.now() };
+		const { recordedAt: _recordedAt, ...outboxFact } = record;
+		const inbox: RlmTerminalInboxRecord = { ...outboxFact, type: "received", receivedAt: this.now() };
 		this.append(this.path(INBOX), inbox);
 		this.afterAppend();
 		return "new";
@@ -468,8 +528,7 @@ class Store implements RlmDurableOperationStore {
 		const operation = this.reduce().operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
-		if (!operation || operation.uncertain || operation.lifecycle === "released" || operation.lifecycle === "deleted")
-			return false;
+		if (!operation || operation.uncertain || operation.lifecycle !== "terminal_recorded") return false;
 		this.append(this.path(LEDGER), { version: 1, type, ...input, recordedAt: this.now() });
 		this.afterAppend();
 		return true;
@@ -543,7 +602,11 @@ class Store implements RlmDurableOperationStore {
 		canonicalDirectory(input.childSessionDir, input.childSessionDir, this.io);
 	}
 	private reduce(): RlmDurableOperationRegistry {
-		return reduceArtifact(this.parentArtifactDir, this.io, false);
+		return reduceArtifact(
+			this.parentArtifactDir,
+			this.io,
+			(operation) => this.inProcessChildRoots.get(operation.key) ?? this.trustedChildRecoveryRoots?.(operation),
+		);
 	}
 	private afterAppend(): RlmDurableOperationRegistry {
 		const registry = this.reduce();
@@ -569,7 +632,7 @@ class Store implements RlmDurableOperationStore {
 function reduceArtifact(
 	parentArtifactDir: string,
 	io: RlmDurableIo,
-	_writeCache: boolean,
+	trustedChildRecoveryRoots?: RlmChildRecoveryTrust,
 ): RlmDurableOperationRegistry {
 	const registry: RlmDurableOperationRegistry = {
 		operations: new Map(),
@@ -586,14 +649,35 @@ function reduceArtifact(
 	}
 	for (const parsed of readJsonl(joinArtifact(canonicalParent, LEDGER, io), io, registry, "ledger"))
 		reduceLedger(parsed, registry);
-	// A child outbox becomes discoverable only from a materialized, admitted operation.
+	// Child paths in JSONL are data, not authority. Only a live session-manager
+	// trust resolver can authorize opening a child artifact.
 	for (const operation of registry.operations.values()) {
-		if (!operation.childSessionFile || !operation.childArtifactDir || operation.uncertain) continue;
+		if (
+			!operation.childSessionId ||
+			!operation.childSessionFile ||
+			!operation.childArtifactDir ||
+			operation.uncertain
+		)
+			continue;
+		const roots = trustedChildRecoveryRoots?.(operation);
+		if (!roots) {
+			markOperationUncertain(operation, registry, "child recovery roots unavailable");
+			continue;
+		}
 		try {
-			for (const parsed of readJsonl(joinArtifact(operation.childArtifactDir, OUTBOX, io), io, registry, "outbox"))
+			const trustedSessionRoot = canonicalDirectory(roots.childSessionRoot, roots.childSessionRoot, io);
+			const trustedArtifactRoot = canonicalDirectory(roots.childArtifactRoot, roots.childArtifactRoot, io);
+			if (operation.childSessionRoot !== trustedSessionRoot || operation.childArtifactRoot !== trustedArtifactRoot)
+				throw new Error("persisted roots do not match session-manager authority");
+			const childFile = canonicalExistingFile(operation.childSessionFile, trustedSessionRoot, io);
+			assertSessionIdentity(operation.childSessionId, childFile, io);
+			if (childFile !== operation.childSessionFile) throw new Error("child session file changed");
+			const artifact = assertContainedDirectory(operation.childArtifactDir, trustedArtifactRoot, io, false);
+			if (artifact !== operation.childArtifactDir) throw new Error("child artifact path changed");
+			for (const parsed of readJsonl(joinArtifact(artifact, OUTBOX, io), io, registry, "outbox"))
 				reduceOutbox(parsed, registry);
 		} catch {
-			markOperationUncertain(operation, registry, "outbox path cannot be read");
+			markOperationUncertain(operation, registry, "untrusted or unreadable child recovery binding");
 		}
 	}
 	for (const parsed of readJsonl(joinArtifact(canonicalParent, INBOX, io), io, registry, "inbox"))
@@ -684,37 +768,48 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 		if (!operation.childSessionFile) {
 			operation.childSessionId = raw.childSessionId;
 			operation.childSessionFile = raw.childSessionFile;
+			operation.childSessionRoot = raw.childSessionRoot;
 			operation.childArtifactDir = raw.childArtifactDir;
+			operation.childArtifactRoot = raw.childArtifactRoot;
 			operation.lifecycle = "materialized";
 		} else if (
 			operation.childSessionId !== raw.childSessionId ||
 			operation.childSessionFile !== raw.childSessionFile ||
-			operation.childArtifactDir !== raw.childArtifactDir
+			operation.childSessionRoot !== raw.childSessionRoot ||
+			operation.childArtifactDir !== raw.childArtifactDir ||
+			operation.childArtifactRoot !== raw.childArtifactRoot
 		)
 			markOperationUncertain(operation, registry, "conflicting materialization");
 		return;
 	}
 	if (raw.type === "terminal_recorded") {
-		if (!validTerminalRecorded(raw) || !operation.childSessionFile || raw.deliveryId !== operation.deliveryId) {
+		if (
+			!validTerminalRecorded(raw) ||
+			operation.lifecycle !== "materialized" ||
+			!operation.childSessionFile ||
+			raw.deliveryId !== operation.deliveryId
+		) {
 			markOperationUncertain(operation, registry, "invalid terminal");
 			return;
 		}
 		if (!operation.terminal) {
 			operation.terminal = raw.terminal as RlmChildTerminalStatus;
-			if (operation.lifecycle !== "deleted") operation.lifecycle = "terminal_recorded";
+			operation.lifecycle = "terminal_recorded";
 		} else if (operation.terminal !== raw.terminal)
 			markOperationUncertain(operation, registry, "conflicting terminal");
 		return;
 	}
 	if (raw.type === "released" || raw.type === "deleted") {
-		if (!validStamped(raw)) {
+		if (!validReleased(raw)) {
 			markOperationUncertain(operation, registry, "invalid release");
 			return;
 		}
-		if (operation.lifecycle === "released" || operation.lifecycle === "deleted") {
-			if (operation.lifecycle !== raw.type)
-				markOperationUncertain(operation, registry, "conflicting release/deletion");
-		} else operation.lifecycle = raw.type;
+		if (operation.lifecycle === raw.type) return;
+		if (operation.lifecycle !== "terminal_recorded") {
+			markOperationUncertain(operation, registry, "release/deletion before terminal");
+			return;
+		}
+		operation.lifecycle = raw.type;
 		return;
 	}
 	markOperationUncertain(operation, registry, "unknown ledger event");
@@ -776,7 +871,8 @@ function reduceInbox(raw: unknown, registry: RlmDurableOperationRegistry): void 
 		delivery.uncertain ||
 		!operation.terminal ||
 		operation.terminal !== record.terminal ||
-		delivery.terminal !== record.terminal
+		delivery.terminal !== record.terminal ||
+		outboxDigest(delivery) !== digestOutbox(record)
 	) {
 		markDeliveryUncertain(delivery, operation, registry, "inbox without matching outbox/terminal");
 		return;
@@ -806,6 +902,10 @@ function reduceConsumed(raw: unknown, registry: RlmDurableOperationRegistry): vo
 		markDeliveryUncertain(delivery, operation, registry, "consumed before inbox");
 		return;
 	}
+	if (record.type === "materialized" && record.sessionMessageId !== materializedTerminalMessageId(record.deliveryId)) {
+		markDeliveryUncertain(delivery, operation, registry, "forged materialized message id");
+		return;
+	}
 	if (record.type === "discarded" && operation.lifecycle !== "deleted") {
 		markDeliveryUncertain(delivery, operation, registry, "discard without deletion");
 		return;
@@ -828,17 +928,37 @@ function deliveryFor(
 	}
 	return delivery;
 }
-function defineDeliveryDigest(
-	delivery: RlmDurableDelivery & { _digest?: string },
-	record: { message: RlmTerminalMessage },
-): void {
-	delivery._digest = digestMessage(record.message);
+type DeliveryFact = RlmDurableDelivery & { _messageDigest?: string; _outboxDigest?: string };
+function defineDeliveryDigest(delivery: DeliveryFact, record: RlmTerminalOutboxRecord | RlmTerminalInboxRecord): void {
+	delivery._messageDigest = digestMessage(record.message);
+	if (record.type === "terminal") delivery._outboxDigest = digestOutbox(record);
 }
-function deliveryDigest(
-	delivery: RlmDurableDelivery & { _digest?: string },
-	record: { message: RlmTerminalMessage },
-): string {
-	return delivery._digest ?? digestMessage(record.message);
+function deliveryDigest(delivery: DeliveryFact, record: { message: RlmTerminalMessage }): string {
+	return delivery._messageDigest ?? digestMessage(record.message);
+}
+function outboxDigest(delivery: DeliveryFact): string | undefined {
+	return delivery._outboxDigest;
+}
+/** Immutable parent/child identity and bounded body are a single hand-off fact. */
+function digestOutbox(record: RlmTerminalOutboxRecord | RlmTerminalInboxRecord): string {
+	return createHash("sha256")
+		.update(
+			stableJson({
+				version: 1,
+				type: "terminal",
+				parentSessionId: record.parentSessionId,
+				parentSessionFile: record.parentSessionFile,
+				childSessionId: record.childSessionId,
+				childSessionFile: record.childSessionFile,
+				childId: record.childId,
+				assignmentId: record.assignmentId,
+				operationId: record.operationId,
+				deliveryId: record.deliveryId,
+				terminal: record.terminal,
+				message: record.message,
+			}),
+		)
+		.digest("hex");
 }
 function markOperationUncertain(
 	operation: RlmDurableOperation,
@@ -991,37 +1111,55 @@ function assertOperationInput(value: { parentSessionId: string; assignmentId: st
 function assertTerminalMessage(value: unknown): asserts value is RlmTerminalMessage {
 	if (
 		!isObject(value) ||
+		!exactKeys(value, ["role", "customType", "content", "display", "details", "timestamp"]) ||
 		value.role !== "custom" ||
-		(value.customType !== "rlm_child_failure" &&
-			value.customType !== "rlm_child_terminal_notice" &&
-			value.customType !== "agent_message") ||
-		typeof value.content !== "string" ||
-		value.content.length > MAX_MESSAGE_CHARS ||
-		typeof value.display !== "boolean" ||
-		!Number.isFinite(value.timestamp) ||
-		!isSafeDetails(value.details, 0)
+		value.display !== true ||
+		!isBoundedText(value.content, MAX_MESSAGE_CHARS) ||
+		!Number.isFinite(value.timestamp)
 	)
 		throw new Error("Terminal message is not a bounded approved custom projection");
-	if (Buffer.byteLength(stableJson(value)) > MAX_MESSAGE_BYTES) throw new Error("Terminal message is too large");
-}
-function isSafeDetails(value: unknown, depth: number): boolean {
-	if (depth > 4) return false;
-	if (value === null || typeof value === "boolean" || typeof value === "number") return true;
-	if (typeof value === "string") return value.length <= 4096;
-	if (Array.isArray(value)) return value.length <= 32 && value.every((item) => isSafeDetails(item, depth + 1));
-	if (!isObject(value)) return false;
-	const entries = Object.entries(value);
-	return (
-		entries.length <= 32 &&
-		entries.every(
-			([key, item]) =>
-				key.length <= 64 &&
-				key !== "__proto__" &&
-				key !== "constructor" &&
-				key !== "prototype" &&
-				isSafeDetails(item, depth + 1),
+	if (value.customType === "rlm_child_failure") {
+		if (
+			!isObject(value.details) ||
+			!exactKeys(value.details, ["childId", "sessionName", "error"]) ||
+			!isBoundedText(value.details.childId, 256) ||
+			!isBoundedText(value.details.sessionName, 256) ||
+			!isBoundedText(value.details.error, 4096)
 		)
-	);
+			throw new Error("Failure message details are not approved");
+	} else if (value.customType === "rlm_child_terminal_notice") {
+		if (
+			!isObject(value.details) ||
+			!isBoundedText(value.details.childId, 256) ||
+			!isBoundedText(value.details.sessionName, 256)
+		)
+			throw new Error("Terminal notice details are not approved");
+		if (value.details.kind === "cancelled") {
+			if (
+				!exactKeys(
+					value.details,
+					value.details.reason === undefined
+						? ["kind", "childId", "sessionName"]
+						: ["kind", "childId", "sessionName", "reason"],
+				) ||
+				(value.details.reason !== undefined && !isBoundedText(value.details.reason, 4096))
+			)
+				throw new Error("Cancelled notice details are not approved");
+		} else if (value.details.kind === "completed_without_reply") {
+			if (
+				!exactKeys(
+					value.details,
+					value.details.lastAssistantTextPreview === undefined
+						? ["kind", "childId", "sessionName"]
+						: ["kind", "childId", "sessionName", "lastAssistantTextPreview"],
+				) ||
+				(value.details.lastAssistantTextPreview !== undefined &&
+					!isBoundedText(value.details.lastAssistantTextPreview, 4096))
+			)
+				throw new Error("Completed notice details are not approved");
+		} else throw new Error("Unknown terminal notice kind");
+	} else throw new Error("Terminal message custom type is not approved");
+	if (Buffer.byteLength(stableJson(value)) > MAX_MESSAGE_BYTES) throw new Error("Terminal message is too large");
 }
 function digestMessage(message: RlmTerminalMessage): string {
 	return createHash("sha256").update(stableJson(message)).digest("hex");
@@ -1048,41 +1186,94 @@ function hasOperationIdentity(value: Record<string, unknown>): value is Record<s
 		UUID.test(value.operationId)
 	);
 }
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+	const actual = Object.keys(value).sort();
+	const expected = [...keys].sort();
+	return actual.length === expected.length && actual.every((key, i) => key === expected[i]);
+}
 function validStamped(value: Record<string, unknown>): boolean {
-	return typeof value.recordedAt === "string" && !Number.isNaN(Date.parse(value.recordedAt));
+	return (
+		typeof value.recordedAt === "string" &&
+		value.recordedAt.length <= 64 &&
+		!Number.isNaN(Date.parse(value.recordedAt))
+	);
 }
 function validAdmitted(value: Record<string, unknown>): boolean {
 	return (
+		exactKeys(value, [
+			"version",
+			"type",
+			"parentSessionId",
+			"parentSessionFile",
+			"childId",
+			"assignmentId",
+			"operationId",
+			"deliveryId",
+			"childSessionDir",
+			"requestedModel",
+			"rlmDepth",
+			"rlmMaxDepth",
+			"recordedAt",
+		]) &&
 		hasOperationIdentity(value) &&
 		typeof value.deliveryId === "string" &&
 		UUID.test(value.deliveryId) &&
 		typeof value.parentSessionFile === "string" &&
 		isAbsolute(value.parentSessionFile) &&
-		typeof value.childId === "string" &&
+		isBoundedText(value.childId, 256) &&
 		typeof value.childSessionDir === "string" &&
 		isAbsolute(value.childSessionDir) &&
-		isObject(value.requestedModel) &&
-		typeof value.requestedModel.provider === "string" &&
-		typeof value.requestedModel.modelId === "string" &&
-		Number.isInteger(value.rlmDepth) &&
-		Number.isInteger(value.rlmMaxDepth) &&
+		isValidModel(value.requestedModel) &&
+		isBoundedInteger(value.rlmDepth) &&
+		isBoundedInteger(value.rlmMaxDepth) &&
+		value.rlmDepth <= value.rlmMaxDepth &&
 		validStamped(value)
 	);
 }
 function validMaterialized(value: Record<string, unknown>): value is Record<string, string> {
 	return (
+		exactKeys(value, [
+			"version",
+			"type",
+			"parentSessionId",
+			"assignmentId",
+			"operationId",
+			"childSessionId",
+			"childSessionFile",
+			"childSessionRoot",
+			"childArtifactDir",
+			"childArtifactRoot",
+			"recordedAt",
+		]) &&
 		hasOperationIdentity(value) &&
 		typeof value.childSessionId === "string" &&
 		UUID.test(value.childSessionId) &&
-		typeof value.childSessionFile === "string" &&
-		isAbsolute(value.childSessionFile) &&
-		typeof value.childArtifactDir === "string" &&
-		isAbsolute(value.childArtifactDir) &&
+		["childSessionFile", "childSessionRoot", "childArtifactDir", "childArtifactRoot"].every(
+			(key) => typeof value[key] === "string" && isAbsolute(value[key] as string),
+		) &&
+		validStamped(value)
+	);
+}
+function validReleased(value: Record<string, unknown>): boolean {
+	return (
+		exactKeys(value, ["version", "type", "parentSessionId", "assignmentId", "operationId", "recordedAt"]) &&
+		hasOperationIdentity(value) &&
+		(value.type === "released" || value.type === "deleted") &&
 		validStamped(value)
 	);
 }
 function validTerminalRecorded(value: Record<string, unknown>): value is Record<string, string> {
 	return (
+		exactKeys(value, [
+			"version",
+			"type",
+			"parentSessionId",
+			"assignmentId",
+			"operationId",
+			"deliveryId",
+			"terminal",
+			"recordedAt",
+		]) &&
 		hasOperationIdentity(value) &&
 		typeof value.deliveryId === "string" &&
 		UUID.test(value.deliveryId) &&
@@ -1096,6 +1287,40 @@ function validOutbox(value: unknown, type: "terminal" | "received"): boolean {
 		!isObject(value) ||
 		value.version !== 1 ||
 		value.type !== type ||
+		!exactKeys(
+			value,
+			type === "terminal"
+				? [
+						"version",
+						"type",
+						"parentSessionId",
+						"parentSessionFile",
+						"childSessionId",
+						"childSessionFile",
+						"childId",
+						"assignmentId",
+						"operationId",
+						"deliveryId",
+						"terminal",
+						"message",
+						"recordedAt",
+					]
+				: [
+						"version",
+						"type",
+						"parentSessionId",
+						"parentSessionFile",
+						"childSessionId",
+						"childSessionFile",
+						"childId",
+						"assignmentId",
+						"operationId",
+						"deliveryId",
+						"terminal",
+						"message",
+						"receivedAt",
+					],
+		) ||
 		!hasOperationIdentity(value) ||
 		typeof value.deliveryId !== "string" ||
 		!UUID.test(value.deliveryId) ||
@@ -1105,7 +1330,7 @@ function validOutbox(value: unknown, type: "terminal" | "received"): boolean {
 		!UUID.test(value.childSessionId) ||
 		typeof value.childSessionFile !== "string" ||
 		!isAbsolute(value.childSessionFile) ||
-		typeof value.childId !== "string" ||
+		!isBoundedText(value.childId, 256) ||
 		typeof value.terminal !== "string" ||
 		!TERMINALS.has(value.terminal as RlmChildTerminalStatus)
 	)
@@ -1117,22 +1342,62 @@ function validOutbox(value: unknown, type: "terminal" | "received"): boolean {
 	}
 	return type === "terminal"
 		? validStamped(value)
-		: typeof value.receivedAt === "string" && !Number.isNaN(Date.parse(value.receivedAt));
+		: typeof value.receivedAt === "string" &&
+				value.receivedAt.length <= 64 &&
+				!Number.isNaN(Date.parse(value.receivedAt));
 }
 function validConsumed(value: unknown): boolean {
+	if (
+		!isObject(value) ||
+		value.version !== 1 ||
+		!hasOperationIdentity(value) ||
+		typeof value.deliveryId !== "string" ||
+		!UUID.test(value.deliveryId) ||
+		!validStamped(value)
+	)
+		return false;
+	if (value.type === "materialized")
+		return (
+			exactKeys(value, [
+				"version",
+				"type",
+				"parentSessionId",
+				"assignmentId",
+				"operationId",
+				"deliveryId",
+				"sessionMessageId",
+				"recordedAt",
+			]) &&
+			typeof value.sessionMessageId === "string" &&
+			value.sessionMessageId === `rlm-terminal-${value.deliveryId}`
+		);
+	return (
+		value.type === "discarded" &&
+		exactKeys(value, [
+			"version",
+			"type",
+			"parentSessionId",
+			"assignmentId",
+			"operationId",
+			"deliveryId",
+			"reason",
+			"recordedAt",
+		]) &&
+		(value.reason === "parent_mismatch" || value.reason === "superseded_assignment" || value.reason === "deleted")
+	);
+}
+function isBoundedText(value: unknown, maximum: number): value is string {
+	return typeof value === "string" && !!value.trim() && value.length <= maximum;
+}
+function isBoundedInteger(value: unknown): value is number {
+	return Number.isInteger(value) && (value as number) >= 0 && (value as number) <= 1024;
+}
+function isValidModel(value: unknown): boolean {
 	return (
 		isObject(value) &&
-		value.version === 1 &&
-		(value.type === "materialized" || value.type === "discarded") &&
-		hasOperationIdentity(value) &&
-		typeof value.deliveryId === "string" &&
-		UUID.test(value.deliveryId) &&
-		validStamped(value) &&
-		(value.type !== "materialized" || typeof value.sessionMessageId === "string") &&
-		(value.type !== "discarded" ||
-			value.reason === "parent_mismatch" ||
-			value.reason === "superseded_assignment" ||
-			value.reason === "deleted")
+		exactKeys(value, ["provider", "modelId"]) &&
+		isBoundedText(value.provider, 256) &&
+		isBoundedText(value.modelId, 256)
 	);
 }
 function sameAdmitted(operation: RlmDurableOperation, record: RlmOperationAdmittedRecord): boolean {

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -1108,15 +1108,33 @@ function atomicCache(path: string, body: string, io: RlmDurableIo): void {
 	}
 }
 
+/**
+ * Replaceable operator cache, deliberately narrower than the JSONL authority.
+ * Never spread reducer records here: deliveries retain outbox/inbox records for
+ * authenticated recovery, and those records contain terminal message bodies.
+ */
 function bodylessIndex(registry: RlmDurableOperationRegistry): unknown {
 	return {
 		version: 1,
-		operations: [...registry.operations.values()].map(({ parentSessionFile, childSessionFile, ...operation }) => ({
-			...operation,
-			parentSessionFile,
-			childSessionFile,
+		operations: [...registry.operations.values()].map((operation) => ({
+			parentSessionId: operation.parentSessionId,
+			childId: operation.childId,
+			assignmentId: operation.assignmentId,
+			operationId: operation.operationId,
+			deliveryId: operation.deliveryId,
+			lifecycle: operation.lifecycle,
+			terminal: operation.terminal,
+			uncertain: operation.uncertain,
 		})),
-		deliveries: [...registry.deliveries.values()].map((delivery) => ({ ...delivery })),
+		deliveries: [...registry.deliveries.values()].map((delivery) => ({
+			operationKey: delivery.operationKey,
+			deliveryId: delivery.deliveryId,
+			terminal: delivery.terminal,
+			outboxed: delivery.outboxed,
+			received: delivery.received,
+			consumed: delivery.consumed,
+			uncertain: delivery.uncertain,
+		})),
 		uncertain: registry.hasUncertainRecords,
 	};
 }

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -22,6 +22,76 @@ import { dirname, isAbsolute, relative } from "node:path";
 export type RlmChildTerminalStatus = "done" | "error" | "cancelled";
 export const RLM_DURABLE_VERSION = 1 as const;
 
+/**
+ * The deliberately small, C03-owned view of C04's terminal result reference.
+ * It has no C01/C03 owner tuple: those IDs remain only in the surrounding
+ * durable record and are never copied into a parent transcript message.
+ */
+/** C04's C05-facing opaque-reference spelling for this C03 wire view. */
+export type C04OpaqueArtifactReference = RlmChildResultArtifactReference;
+
+export interface RlmChildResultArtifactReference {
+	version: 1;
+	handleId: string;
+	resultId: string;
+	kind: "terminal_output" | "diagnostic" | "trajectory" | "attachment";
+	contentType: "text/plain" | "application/json" | "application/octet-stream";
+	byteLength: number;
+	sha256: string;
+	retentionState: "retained" | "expired" | "deleted" | "unavailable" | "uncertain";
+}
+
+export interface RlmChildResultModelReference {
+	requestedSelector?: string;
+	initialResolvedSelector: string;
+	terminalResolvedSelector: string;
+	fallbackHistory?: readonly string[];
+}
+
+export type RlmChildResultErrorCode =
+	| "invalid_result"
+	| "result_too_large"
+	| "artifact_too_large"
+	| "artifact_quota_exceeded"
+	| "artifact_unavailable"
+	| "artifact_integrity_failed"
+	| "artifact_expired"
+	| "terminal_storage_failed"
+	| "cancelled"
+	| "timed_out"
+	| "stalled"
+	| "unknown_after_crash";
+
+export interface RlmChildResultErrorReference {
+	/** A closed C04 code, never a provider error or a thrown error name. */
+	code: RlmChildResultErrorCode;
+	/** A pre-sanitized, bounded safe explanation. */
+	message: string;
+}
+
+/**
+ * C04's v1 bounded terminal projection as carried by C03. C03 validates,
+ * persists, imports, and materializes this value, but does not construct it.
+ * In particular it is not an artifact-read capability and contains neither
+ * owner identities nor payload/path/body data.
+ */
+export interface RlmChildResultReferenceV1 {
+	version: 1;
+	resultId: string;
+	status: "completed" | "failed" | "cancelled" | "timed_out" | "stalled" | "unknown_after_crash";
+	summary: string;
+	/** C04 requires a deliberately prepared safe preview for every terminal result. */
+	preview: string;
+	error?: RlmChildResultErrorReference;
+	model?: RlmChildResultModelReference;
+	artifacts: readonly RlmChildResultArtifactReference[];
+	retentionState: "retained" | "expired" | "deleted" | "unavailable" | "uncertain";
+}
+
+/** C04's stable bounded public projection spelling. */
+export type C04ChildResultReference = RlmChildResultReferenceV1;
+export type C04PublicChildResult = RlmChildResultReferenceV1;
+
 export type RlmTerminalMessage =
 	| {
 			role: "custom";
@@ -44,6 +114,14 @@ export type RlmTerminalMessage =
 						sessionName: string;
 						lastAssistantTextPreview?: string;
 				  };
+			timestamp: number;
+	  }
+	| {
+			role: "custom";
+			customType: "rlm_child_result_reference";
+			content: string;
+			display: true;
+			details: { kind: "child_result_v1"; result: RlmChildResultReferenceV1 };
 			timestamp: number;
 	  };
 
@@ -308,6 +386,64 @@ const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-
 const TERMINALS = new Set<RlmChildTerminalStatus>(["done", "error", "cancelled"]);
 const MAX_MESSAGE_CHARS = 16_384;
 const MAX_MESSAGE_BYTES = 24 * 1024;
+/** C04 v1 wire bounds. These are fixed C03 acceptance bounds, not knobs. */
+export const RLM_CHILD_RESULT_REFERENCE_VERSION = 1 as const;
+export const MAX_RLM_CHILD_RESULT_REFERENCE_BYTES = 64 * 1024;
+export const MAX_RLM_CHILD_RESULT_SUMMARY_CHARS = 4_096;
+export const MAX_RLM_CHILD_RESULT_SUMMARY_BYTES = 16 * 1024;
+export const MAX_RLM_CHILD_RESULT_PREVIEW_CHARS = 2_048;
+export const MAX_RLM_CHILD_RESULT_PREVIEW_BYTES = 8 * 1024;
+export const MAX_RLM_CHILD_RESULT_ERROR_CODE_CHARS = 96;
+export const MAX_RLM_CHILD_RESULT_ERROR_MESSAGE_CHARS = 1_024;
+export const MAX_RLM_CHILD_RESULT_ERROR_MESSAGE_BYTES = 4 * 1024;
+export const MAX_RLM_CHILD_RESULT_ARTIFACTS = 16;
+const MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS = 512;
+const MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES = 2 * 1024;
+const MAX_RLM_CHILD_RESULT_MODEL_FALLBACKS = 16;
+export const MAX_RLM_CHILD_RESULT_ARTIFACT_BYTES = 512 * 1024 * 1024;
+const MAX_RLM_CHILD_RESULT_ERROR_CODE_BYTES = 384;
+const SHA256 = /^[0-9a-f]{64}$/;
+const RLM_CHILD_RESULT_STATUSES = new Set<RlmChildResultReferenceV1["status"]>([
+	"completed",
+	"failed",
+	"cancelled",
+	"timed_out",
+	"stalled",
+	"unknown_after_crash",
+]);
+const RLM_CHILD_RESULT_RETENTION_STATES = new Set<RlmChildResultReferenceV1["retentionState"]>([
+	"retained",
+	"expired",
+	"deleted",
+	"unavailable",
+	"uncertain",
+]);
+const RLM_CHILD_RESULT_ARTIFACT_KINDS = new Set<RlmChildResultArtifactReference["kind"]>([
+	"terminal_output",
+	"diagnostic",
+	"trajectory",
+	"attachment",
+]);
+const RLM_CHILD_RESULT_CONTENT_TYPES = new Set<RlmChildResultArtifactReference["contentType"]>([
+	"text/plain",
+	"application/json",
+	"application/octet-stream",
+]);
+const RLM_CHILD_RESULT_ERROR_CODES = new Set<RlmChildResultErrorCode>([
+	"invalid_result",
+	"result_too_large",
+	"artifact_too_large",
+	"artifact_quota_exceeded",
+	"artifact_unavailable",
+	"artifact_integrity_failed",
+	"artifact_expired",
+	"terminal_storage_failed",
+	"cancelled",
+	"timed_out",
+	"stalled",
+	"unknown_after_crash",
+]);
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const LEDGER = "rlm-operation-ledger.jsonl";
 const INBOX = "rlm-terminal-inbox.jsonl";
 const CONSUMED = "rlm-terminal-consumed.jsonl";
@@ -1263,7 +1399,7 @@ function assertTerminalMessage(value: unknown): asserts value is RlmTerminalMess
 		!exactKeys(value, ["role", "customType", "content", "display", "details", "timestamp"]) ||
 		value.role !== "custom" ||
 		value.display !== true ||
-		!isBoundedText(value.content, MAX_MESSAGE_CHARS) ||
+		typeof value.content !== "string" ||
 		!Number.isFinite(value.timestamp)
 	)
 		throw new Error("Terminal message is not a bounded approved custom projection");
@@ -1307,9 +1443,245 @@ function assertTerminalMessage(value: unknown): asserts value is RlmTerminalMess
 			)
 				throw new Error("Completed notice details are not approved");
 		} else throw new Error("Unknown terminal notice kind");
+	} else if (value.customType === "rlm_child_result_reference") {
+		if (
+			!isObject(value.details) ||
+			!exactKeys(value.details, ["kind", "result"]) ||
+			value.details.kind !== "child_result_v1"
+		)
+			throw new Error("Child-result reference details are not approved");
+		assertChildResultReference(value.details.result);
+		if (value.content !== formatRlmChildResultReference(value.details.result))
+			throw new Error("Child-result reference content must be its deterministic projection");
+		// The C04 projection itself has the 64-KiB cap.  Do not apply C03's
+		// legacy 24-KiB envelope cap here: that would silently narrow C04.
 	} else throw new Error("Terminal message custom type is not approved");
-	if (Buffer.byteLength(stableJson(value)) > MAX_MESSAGE_BYTES) throw new Error("Terminal message is too large");
+	if (value.customType !== "rlm_child_result_reference") {
+		if (!isBoundedText(value.content, MAX_MESSAGE_CHARS) || Buffer.byteLength(stableJson(value)) > MAX_MESSAGE_BYTES)
+			throw new Error("Terminal message is too large");
+	}
 }
+
+/**
+ * Stable C03 transcript/outbox representation of C04's public projection.
+ * It deliberately contains only the projection and has no owner/path/body
+ * interpolation or provider/queue side effect.
+ */
+export function formatRlmChildResultReference(result: RlmChildResultReferenceV1): string {
+	assertChildResultReference(result);
+	return stableJson(result);
+}
+
+/** Creates the only accepted C04 terminal-message form. */
+export function createRlmChildResultReferenceTerminalMessage(
+	result: RlmChildResultReferenceV1,
+	timestamp: number,
+): Extract<RlmTerminalMessage, { customType: "rlm_child_result_reference" }> {
+	if (!Number.isFinite(timestamp)) throw new Error("Terminal timestamp must be finite");
+	const content = formatRlmChildResultReference(result);
+	return {
+		role: "custom",
+		customType: "rlm_child_result_reference",
+		content,
+		display: true,
+		details: { kind: "child_result_v1", result },
+		timestamp,
+	};
+}
+
+/**
+ * Exact, recursive C04 wire validator.  This validates the public C03
+ * projection, rather than C04's owner-bearing on-disk ChildResult.  Thus a
+ * successful value cannot smuggle a capability, a path, a body, or C01/C03
+ * correlation fields through an unknown nested property.
+ */
+export function assertChildResultReference(value: unknown): asserts value is RlmChildResultReferenceV1 {
+	if (!isObject(value)) throw new Error("Child-result reference has unknown or missing fields");
+	const hasError = value.error !== undefined;
+	const hasModel = value.model !== undefined;
+	if (
+		!exactKeys(value, [
+			"version",
+			"resultId",
+			"status",
+			"summary",
+			"preview",
+			"artifacts",
+			"retentionState",
+			...(hasError ? ["error"] : []),
+			...(hasModel ? ["model"] : []),
+		])
+	)
+		throw new Error("Child-result reference has unknown or missing fields");
+	if (value.version !== RLM_CHILD_RESULT_REFERENCE_VERSION)
+		throw new Error("Child-result reference version is unsupported");
+	assertUuidV4(value.resultId, "resultId");
+	if (
+		typeof value.status !== "string" ||
+		!RLM_CHILD_RESULT_STATUSES.has(value.status as RlmChildResultReferenceV1["status"])
+	)
+		throw new Error("Child-result status is not approved");
+	assertResultText(value.summary, "summary", MAX_RLM_CHILD_RESULT_SUMMARY_CHARS, MAX_RLM_CHILD_RESULT_SUMMARY_BYTES);
+	assertResultText(value.preview, "preview", MAX_RLM_CHILD_RESULT_PREVIEW_CHARS, MAX_RLM_CHILD_RESULT_PREVIEW_BYTES);
+	if (
+		typeof value.retentionState !== "string" ||
+		!RLM_CHILD_RESULT_RETENTION_STATES.has(value.retentionState as RlmChildResultReferenceV1["retentionState"])
+	)
+		throw new Error("Child-result retention state is not approved");
+	if (hasModel) assertChildResultModel(value.model);
+	if (!Array.isArray(value.artifacts) || value.artifacts.length > MAX_RLM_CHILD_RESULT_ARTIFACTS)
+		throw new Error("Child-result artifacts are too numerous or invalid");
+	const handles = new Set<string>();
+	for (const artifact of value.artifacts) {
+		assertChildResultArtifact(artifact, value.resultId);
+		if (handles.has(artifact.handleId)) throw new Error("Child-result artifact handles must be unique");
+		handles.add(artifact.handleId);
+	}
+	if (value.status === "completed") {
+		if (value.error !== undefined) throw new Error("Completed child result cannot carry an error");
+	} else {
+		assertChildResultError(value.error);
+	}
+	if (Buffer.byteLength(stableJson(value), "utf8") > MAX_RLM_CHILD_RESULT_REFERENCE_BYTES)
+		throw new Error("Child-result reference is too large");
+}
+
+/** Boolean form for reducers which must fail closed without throwing. */
+export function isRlmChildResultReference(value: unknown): value is RlmChildResultReferenceV1 {
+	try {
+		assertChildResultReference(value);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function assertChildResultArtifact(value: unknown, resultId: string): asserts value is RlmChildResultArtifactReference {
+	if (
+		!isObject(value) ||
+		!exactKeys(value, [
+			"version",
+			"handleId",
+			"resultId",
+			"kind",
+			"contentType",
+			"byteLength",
+			"sha256",
+			"retentionState",
+		])
+	)
+		throw new Error("Child-result artifact has unknown or missing fields");
+	if (value.version !== RLM_CHILD_RESULT_REFERENCE_VERSION)
+		throw new Error("Child-result artifact version is unsupported");
+	assertUuidV4(value.handleId, "handleId");
+	if (value.resultId !== resultId) throw new Error("Child-result artifact resultId does not match");
+	if (
+		typeof value.kind !== "string" ||
+		!RLM_CHILD_RESULT_ARTIFACT_KINDS.has(value.kind as RlmChildResultArtifactReference["kind"])
+	)
+		throw new Error("Child-result artifact kind is not approved");
+	if (
+		typeof value.contentType !== "string" ||
+		!RLM_CHILD_RESULT_CONTENT_TYPES.has(value.contentType as RlmChildResultArtifactReference["contentType"])
+	)
+		throw new Error("Child-result artifact content type is not approved");
+	if (
+		typeof value.byteLength !== "number" ||
+		!Number.isSafeInteger(value.byteLength) ||
+		value.byteLength < 0 ||
+		value.byteLength > MAX_RLM_CHILD_RESULT_ARTIFACT_BYTES
+	)
+		throw new Error("Child-result artifact byte length is invalid");
+	if (typeof value.sha256 !== "string" || !SHA256.test(value.sha256))
+		throw new Error("Child-result artifact sha256 is invalid");
+	if (
+		typeof value.retentionState !== "string" ||
+		!RLM_CHILD_RESULT_RETENTION_STATES.has(value.retentionState as RlmChildResultReferenceV1["retentionState"])
+	)
+		throw new Error("Child-result artifact retention state is not approved");
+}
+
+function assertChildResultModel(value: unknown): asserts value is RlmChildResultModelReference {
+	if (!isObject(value)) throw new Error("Child-result model is invalid");
+	const hasRequested = value.requestedSelector !== undefined;
+	const hasHistory = value.fallbackHistory !== undefined;
+	if (
+		!exactKeys(value, [
+			"initialResolvedSelector",
+			"terminalResolvedSelector",
+			...(hasRequested ? ["requestedSelector"] : []),
+			...(hasHistory ? ["fallbackHistory"] : []),
+		])
+	)
+		throw new Error("Child-result model has unknown or missing fields");
+	if (hasRequested)
+		assertResultText(
+			value.requestedSelector,
+			"requestedSelector",
+			MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS,
+			MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES,
+		);
+	assertResultText(
+		value.initialResolvedSelector,
+		"initialResolvedSelector",
+		MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS,
+		MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES,
+	);
+	assertResultText(
+		value.terminalResolvedSelector,
+		"terminalResolvedSelector",
+		MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS,
+		MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES,
+	);
+	if (hasHistory) {
+		if (!Array.isArray(value.fallbackHistory) || value.fallbackHistory.length > MAX_RLM_CHILD_RESULT_MODEL_FALLBACKS)
+			throw new Error("Child-result model fallback history is invalid");
+		for (const selector of value.fallbackHistory)
+			assertResultText(
+				selector,
+				"fallback selector",
+				MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS,
+				MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES,
+			);
+	}
+}
+
+function assertChildResultError(value: unknown): asserts value is RlmChildResultErrorReference {
+	if (
+		!isObject(value) ||
+		!exactKeys(value, ["code", "message"]) ||
+		typeof value.code !== "string" ||
+		!RLM_CHILD_RESULT_ERROR_CODES.has(value.code as RlmChildResultErrorCode)
+	)
+		throw new Error("Child-result error is not a closed safe error");
+	assertResultText(
+		value.code,
+		"error code",
+		MAX_RLM_CHILD_RESULT_ERROR_CODE_CHARS,
+		MAX_RLM_CHILD_RESULT_ERROR_CODE_BYTES,
+	);
+	assertResultText(
+		value.message,
+		"error message",
+		MAX_RLM_CHILD_RESULT_ERROR_MESSAGE_CHARS,
+		MAX_RLM_CHILD_RESULT_ERROR_MESSAGE_BYTES,
+	);
+}
+
+function assertUuidV4(value: unknown, name: string): asserts value is string {
+	if (typeof value !== "string" || !UUID_V4.test(value)) throw new Error(`${name} must be a canonical UUIDv4`);
+}
+
+function assertResultText(value: unknown, name: string, charLimit: number, byteLimit: number): asserts value is string {
+	if (
+		typeof value !== "string" ||
+		!value.trim() ||
+		Array.from(value).length > charLimit ||
+		Buffer.byteLength(value, "utf8") > byteLimit
+	)
+		throw new Error(`${name} is invalid or too large`);
+}
+
 function digestMessage(message: RlmTerminalMessage): string {
 	return createHash("sha256").update(stableJson(message)).digest("hex");
 }

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -251,18 +251,26 @@ export interface RlmDurableIo {
 	realpathSync: typeof realpathSync;
 	renameSync: typeof renameSync;
 }
-export interface RlmTrustedChildRecoveryRoots {
+/**
+ * An owner/session-manager binding for one exact child assignment. Every
+ * value here is authority supplied by the manager, never an identity inferred
+ * from the materialized ledger record being checked.
+ */
+export interface RlmTrustedChildRecoveryBinding {
+	childSessionId: string;
+	childSessionFile: string;
 	childSessionRoot: string;
+	childArtifactDir: string;
 	childArtifactRoot: string;
 }
 /**
- * Recovery roots come from the owning session manager, never from JSONL. A
- * passive read without this authority deliberately leaves child outboxes
+ * Recovery bindings come from the owning session manager, never from JSONL.
+ * A passive read without an exact binding deliberately leaves child outboxes
  * unopened and their operations uncertain.
  */
 export type RlmChildRecoveryTrust = (
 	operation: Readonly<RlmDurableOperation>,
-) => RlmTrustedChildRecoveryRoots | undefined;
+) => RlmTrustedChildRecoveryBinding | undefined;
 export interface RlmDurableOperationStoreOptions {
 	io?: RlmDurableIo;
 	now?: () => string;
@@ -316,7 +324,7 @@ class Store implements RlmDurableOperationStore {
 	private readonly now: () => string;
 	private readonly parentArtifactDir: string;
 	private readonly trustedChildRecoveryRoots?: RlmChildRecoveryTrust;
-	private readonly inProcessChildRoots = new Map<string, RlmTrustedChildRecoveryRoots>();
+	private readonly inProcessChildBindings = new Map<string, RlmTrustedChildRecoveryBinding>();
 
 	constructor(parentArtifactDir: string, options: RlmDurableOperationStoreOptions) {
 		this.io = options.io ?? defaultIo;
@@ -395,8 +403,11 @@ class Store implements RlmDurableOperationStore {
 				return true;
 			return false;
 		}
-		this.inProcessChildRoots.set(operation.key, {
+		this.inProcessChildBindings.set(operation.key, {
+			childSessionId: record.childSessionId,
+			childSessionFile: record.childSessionFile,
 			childSessionRoot: record.childSessionRoot,
+			childArtifactDir: record.childArtifactDir,
 			childArtifactRoot: record.childArtifactRoot,
 		});
 		this.append(this.path(LEDGER), record);
@@ -442,7 +453,7 @@ class Store implements RlmDurableOperationStore {
 			}
 			return "already_recorded";
 		}
-		this.append(joinArtifact(input.childArtifactDir, OUTBOX, this.io), record);
+		this.append(joinArtifact(operation.childArtifactDir!, OUTBOX, this.io), record);
 		this.afterAppend();
 		return "new";
 	}
@@ -558,15 +569,20 @@ class Store implements RlmDurableOperationStore {
 		if (requireTerminal && operation.terminal !== input.terminal)
 			throw new Error("Outbox terminal is not ledger-recorded");
 		const parentFile = canonicalExistingFile(input.parentSessionFile, input.parentSessionRoot, this.io);
-		const childFile = canonicalExistingFile(input.childSessionFile, input.childSessionRoot, this.io);
+		const childSessionRoot = canonicalDirectory(input.childSessionRoot, input.childSessionRoot, this.io);
+		const childFile = canonicalExistingFile(input.childSessionFile, childSessionRoot, this.io);
+		const childArtifactRoot = canonicalDirectory(input.childArtifactRoot, input.childArtifactRoot, this.io);
+		const childArtifactDir = assertContainedDirectory(input.childArtifactDir, childArtifactRoot, this.io, false);
 		assertSessionIdentity(input.parentSessionId, parentFile, this.io);
 		assertSessionIdentity(input.childSessionId, childFile, this.io);
 		assertContainedDirectory(this.parentArtifactDir, input.parentArtifactRoot, this.io, false);
-		assertContainedDirectory(input.childArtifactDir, input.childArtifactRoot, this.io, true);
 		if (
 			operation.parentSessionFile !== parentFile ||
 			operation.childSessionFile !== childFile ||
 			operation.childSessionId !== input.childSessionId ||
+			operation.childSessionRoot !== childSessionRoot ||
+			operation.childArtifactDir !== childArtifactDir ||
+			operation.childArtifactRoot !== childArtifactRoot ||
 			operation.childId !== input.childId
 		) {
 			throw new Error("Outbox session identity/path conflicts with admission");
@@ -605,7 +621,7 @@ class Store implements RlmDurableOperationStore {
 		return reduceArtifact(
 			this.parentArtifactDir,
 			this.io,
-			(operation) => this.inProcessChildRoots.get(operation.key) ?? this.trustedChildRecoveryRoots?.(operation),
+			(operation) => this.inProcessChildBindings.get(operation.key) ?? this.trustedChildRecoveryRoots?.(operation),
 		);
 	}
 	private afterAppend(): RlmDurableOperationRegistry {
@@ -659,27 +675,38 @@ function reduceArtifact(
 			operation.uncertain
 		)
 			continue;
-		const roots = trustedChildRecoveryRoots?.(operation);
-		if (!roots) {
-			markOperationUncertain(operation, registry, "child recovery roots unavailable");
+		const binding = trustedChildRecoveryRoots?.(operation);
+		if (!binding) {
+			markOperationUncertain(operation, registry, "child recovery binding unavailable");
 			continue;
 		}
 		try {
-			const trustedSessionRoot = canonicalDirectory(roots.childSessionRoot, roots.childSessionRoot, io);
-			const trustedArtifactRoot = canonicalDirectory(roots.childArtifactRoot, roots.childArtifactRoot, io);
-			if (operation.childSessionRoot !== trustedSessionRoot || operation.childArtifactRoot !== trustedArtifactRoot)
-				throw new Error("persisted roots do not match session-manager authority");
-			const childFile = canonicalExistingFile(operation.childSessionFile, trustedSessionRoot, io);
-			assertSessionIdentity(operation.childSessionId, childFile, io);
-			if (childFile !== operation.childSessionFile) throw new Error("child session file changed");
-			const artifact = assertContainedDirectory(operation.childArtifactDir, trustedArtifactRoot, io, false);
-			if (artifact !== operation.childArtifactDir) throw new Error("child artifact path changed");
-			for (const parsed of readJsonl(joinArtifact(artifact, OUTBOX, io), io, registry, "outbox"))
+			// Validate manager authority first. In particular, do not use a ledger
+			// path or ID as the expected value for validating that same ledger fact.
+			const trustedSessionRoot = canonicalDirectory(binding.childSessionRoot, binding.childSessionRoot, io);
+			const trustedArtifactRoot = canonicalDirectory(binding.childArtifactRoot, binding.childArtifactRoot, io);
+			const trustedChildFile = canonicalExistingFile(binding.childSessionFile, trustedSessionRoot, io);
+			assertSessionIdentity(binding.childSessionId, trustedChildFile, io);
+			const trustedArtifact = assertContainedDirectory(binding.childArtifactDir, trustedArtifactRoot, io, false);
+			if (
+				operation.childSessionId !== binding.childSessionId ||
+				operation.childSessionFile !== trustedChildFile ||
+				operation.childSessionRoot !== trustedSessionRoot ||
+				operation.childArtifactDir !== trustedArtifact ||
+				operation.childArtifactRoot !== trustedArtifactRoot
+			)
+				throw new Error("persisted child binding does not match session-manager authority");
+			for (const parsed of readJsonl(joinArtifact(trustedArtifact, OUTBOX, io), io, registry, "outbox"))
 				reduceOutbox(parsed, registry);
 		} catch {
 			markOperationUncertain(operation, registry, "untrusted or unreadable child recovery binding");
 		}
 	}
+	// Ledger and child outbox files are independently durable, so recovery can
+	// observe a raw cut between their appends. Reconcile only after every
+	// authorized outbox has been reduced; a terminal fact without its immutable
+	// hand-off is never delivery authority.
+	reconcileTerminalOutboxes(registry);
 	for (const parsed of readJsonl(joinArtifact(canonicalParent, INBOX, io), io, registry, "inbox"))
 		reduceInbox(parsed, registry);
 	for (const parsed of readJsonl(joinArtifact(canonicalParent, CONSUMED, io), io, registry, "consumed"))
@@ -850,6 +877,22 @@ function reduceOutbox(raw: unknown, registry: RlmDurableOperationRegistry): void
 	)
 		markDeliveryUncertain(delivery, operation, registry, "conflicting outbox");
 	else defineDeliveryDigest(delivery, record);
+}
+
+function reconcileTerminalOutboxes(registry: RlmDurableOperationRegistry): void {
+	for (const operation of registry.operations.values()) {
+		if (!operation.terminal) continue;
+		const delivery = deliveryFor(operation, operation.deliveryId, registry);
+		if (
+			operation.uncertain ||
+			!delivery.outboxed ||
+			delivery.uncertain ||
+			delivery.terminal !== operation.terminal ||
+			!outboxDigest(delivery)
+		) {
+			markDeliveryUncertain(delivery, operation, registry, "terminal without matching durable outbox");
+		}
+	}
 }
 
 function reduceInbox(raw: unknown, registry: RlmDurableOperationRegistry): void {

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -237,8 +237,10 @@ export interface RlmDurableDelivery {
 export interface RlmDurableOperationRegistry {
 	operations: Map<string, RlmDurableOperation>;
 	deliveries: Map<string, RlmDurableDelivery>;
-	/** A corrupt line without a usable compound key still makes the history unsafe. */
+	/** Any reducer corruption, including exact-key corruption. */
 	hasUncertainRecords: boolean;
+	/** A complete record without an attributable operation key quarantines all operations. */
+	hasGlobalUncertainty: boolean;
 	diagnostics: readonly string[];
 }
 
@@ -369,6 +371,7 @@ class Store implements RlmDurableOperationStore {
 	admit(input: RlmOperationAdmission): RlmDurableOperation {
 		this.assertAdmission(input);
 		const registry = this.reduce();
+		assertGloballyCertain(registry);
 		const key = operationKey(input.parentSessionId, input.assignmentId, input.operationId);
 		const existing = registry.operations.get(key);
 		const record: RlmOperationAdmittedRecord = {
@@ -399,6 +402,7 @@ class Store implements RlmDurableOperationStore {
 	markMaterialized(input: RlmOperationMaterialization): boolean {
 		assertOperationInput(input);
 		const registry = this.reduce();
+		if (registry.hasGlobalUncertainty) return false;
 		const operation = registry.operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
@@ -456,6 +460,7 @@ class Store implements RlmDurableOperationStore {
 		assertUuid(input.deliveryId, "deliveryId");
 		assertTerminal(input.terminal);
 		const registry = this.reduce();
+		if (registry.hasGlobalUncertainty) return false;
 		const operation = registry.operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
@@ -524,6 +529,7 @@ class Store implements RlmDurableOperationStore {
 			throw new Error("sessionMessageId must be the deterministic durable delivery id");
 		}
 		const registry = this.reduce();
+		assertGloballyCertain(registry);
 		const delivery = registry.deliveries.get(
 			deliveryKey(operationKey(input.parentSessionId, input.assignmentId, input.operationId), input.deliveryId),
 		);
@@ -540,6 +546,7 @@ class Store implements RlmDurableOperationStore {
 		assertOperationInput(input);
 		assertUuid(input.deliveryId, "deliveryId");
 		const registry = this.reduce();
+		assertGloballyCertain(registry);
 		const operation = registry.operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
@@ -562,6 +569,7 @@ class Store implements RlmDurableOperationStore {
 
 	importPendingOutboxes(): number {
 		const registry = this.reduce();
+		if (registry.hasGlobalUncertainty) return 0;
 		let imported = 0;
 		for (const delivery of registry.deliveries.values()) {
 			const operation = registry.operations.get(delivery.operationKey);
@@ -585,21 +593,28 @@ class Store implements RlmDurableOperationStore {
 	}
 
 	pendingInbox(): readonly RlmTerminalInboxRecord[] {
-		return [...this.reduce().deliveries.values()]
+		const registry = this.reduce();
+		if (registry.hasGlobalUncertainty) return [];
+		return [...registry.deliveries.values()]
 			.filter((delivery) => delivery.received && !delivery.consumed && !delivery.uncertain && delivery.inboxRecord)
 			.map((delivery) => delivery.inboxRecord!);
 	}
 
 	rebuild(): RlmDurableOperationRegistry {
 		const registry = this.reduce();
-		this.writeIndex(registry); // cache failure cannot undo an fsynced authority append.
+		// A global quarantine is read-only, including its non-authoritative cache:
+		// recovery must not make any durable write before an operator repairs the
+		// complete corrupt record.
+		if (!registry.hasGlobalUncertainty) this.writeIndex(registry);
 		return registry;
 	}
 
 	/** Durable exact-key delete request for a live operation. It is not completion. */
 	recordDeleteIntent(input: Pick<RlmOperationTerminal, "parentSessionId" | "assignmentId" | "operationId">): boolean {
 		assertOperationInput(input);
-		const operation = this.reduce().operations.get(
+		const registry = this.reduce();
+		if (registry.hasGlobalUncertainty) return false;
+		const operation = registry.operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
 		if (!operation || operation.uncertain) return false;
@@ -622,7 +637,9 @@ class Store implements RlmDurableOperationStore {
 		type: "released" | "deleted",
 	): boolean {
 		assertOperationInput(input);
-		const operation = this.reduce().operations.get(
+		const registry = this.reduce();
+		if (registry.hasGlobalUncertainty) return false;
+		const operation = registry.operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
 		if (!operation || operation.uncertain || operation.lifecycle !== "terminal_recorded") return false;
@@ -640,6 +657,7 @@ class Store implements RlmDurableOperationStore {
 		assertTerminal(input.terminal);
 		assertTerminalMessage(input.message);
 		const registry = this.reduce();
+		assertGloballyCertain(registry);
 		const operation = registry.operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
@@ -740,6 +758,7 @@ function reduceArtifact(
 		operations: new Map(),
 		deliveries: new Map(),
 		hasUncertainRecords: false,
+		hasGlobalUncertainty: false,
 		diagnostics: [],
 	};
 	let canonicalParent: string;
@@ -816,8 +835,7 @@ function readJsonl(path: string, io: RlmDurableIo, registry: RlmDurableOperation
 	for (let i = 0; i < count; i++) {
 		const line = lines[i]!;
 		if (!line) {
-			registry.hasUncertainRecords = true;
-			registry.diagnostics = [...registry.diagnostics, `${kind}: empty complete line ${i + 1}`];
+			globalUncertain(registry, `${kind}: empty complete line ${i + 1}`);
 			continue;
 		}
 		// A final record becomes authoritative only with its newline delimiter. A
@@ -827,8 +845,7 @@ function readJsonl(path: string, io: RlmDurableIo, registry: RlmDurableOperation
 		try {
 			parsed.push(JSON.parse(line));
 		} catch {
-			registry.hasUncertainRecords = true;
-			registry.diagnostics = [...registry.diagnostics, `${kind}: malformed complete line ${i + 1}`];
+			globalUncertain(registry, `${kind}: malformed complete line ${i + 1}`);
 		}
 	}
 	return parsed;
@@ -836,12 +853,12 @@ function readJsonl(path: string, io: RlmDurableIo, registry: RlmDurableOperation
 
 function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void {
 	if (!isObject(raw) || raw.version !== 1 || typeof raw.type !== "string") {
-		globalUncertain(registry, "invalid ledger record");
+		markInvalidRecord(raw, registry, "invalid ledger record");
 		return;
 	}
 	if (raw.type === "admitted") {
 		if (!validAdmitted(raw)) {
-			globalUncertain(registry, "invalid admitted record");
+			markInvalidRecord(raw, registry, "invalid admitted record");
 			return;
 		}
 		const record = raw as unknown as RlmOperationAdmittedRecord;
@@ -862,7 +879,8 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 				rlmMaxDepth: record.rlmMaxDepth,
 				lifecycle: "admitted",
 				deleteIntent: false,
-				uncertain: false,
+				// An unattributable complete record quarantines every later reduction too.
+				uncertain: registry.hasGlobalUncertainty,
 			});
 		} else if (!sameAdmitted(existing, record)) markOperationUncertain(existing, registry, "conflicting admission");
 		return;
@@ -878,7 +896,7 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 	}
 	if (raw.type === "materialized") {
 		if (!validMaterialized(raw)) {
-			markOperationUncertain(operation, registry, "invalid materialization");
+			globalUncertain(registry, "invalid materialization");
 			return;
 		}
 		if (!operation.childSessionFile) {
@@ -899,13 +917,16 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 		return;
 	}
 	if (raw.type === "terminal_recorded") {
+		if (!validTerminalRecorded(raw)) {
+			globalUncertain(registry, "invalid terminal record");
+			return;
+		}
 		if (
-			!validTerminalRecorded(raw) ||
 			(operation.lifecycle !== "materialized" && operation.lifecycle !== "delete_intent") ||
 			!operation.childSessionFile ||
 			raw.deliveryId !== operation.deliveryId
 		) {
-			markOperationUncertain(operation, registry, "invalid terminal");
+			markOperationUncertain(operation, registry, "invalid terminal transition");
 			return;
 		}
 		if (!operation.terminal) {
@@ -917,7 +938,7 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 	}
 	if (raw.type === "delete_intent") {
 		if (!validDeleteIntent(raw)) {
-			markOperationUncertain(operation, registry, "invalid delete intent");
+			globalUncertain(registry, "invalid delete intent record");
 			return;
 		}
 		if (operation.lifecycle === "deleted") return;
@@ -936,7 +957,7 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 	}
 	if (raw.type === "released" || raw.type === "deleted") {
 		if (!validReleased(raw)) {
-			markOperationUncertain(operation, registry, "invalid release");
+			globalUncertain(registry, "invalid release record");
 			return;
 		}
 		if (operation.lifecycle === raw.type) return;
@@ -947,12 +968,12 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 		operation.lifecycle = raw.type;
 		return;
 	}
-	markOperationUncertain(operation, registry, "unknown ledger event");
+	globalUncertain(registry, "unknown ledger event");
 }
 
 function reduceOutbox(raw: unknown, registry: RlmDurableOperationRegistry): void {
 	if (!validOutbox(raw, "terminal")) {
-		globalUncertain(registry, "invalid outbox record");
+		markInvalidRecord(raw, registry, "invalid outbox record");
 		return;
 	}
 	const record = raw as RlmTerminalOutboxRecord;
@@ -1006,7 +1027,7 @@ function reconcileTerminalOutboxes(registry: RlmDurableOperationRegistry): void 
 
 function reduceInbox(raw: unknown, registry: RlmDurableOperationRegistry): void {
 	if (!validOutbox(raw, "received")) {
-		globalUncertain(registry, "invalid inbox record");
+		markInvalidRecord(raw, registry, "invalid inbox record");
 		return;
 	}
 	const record = raw as RlmTerminalInboxRecord;
@@ -1039,7 +1060,7 @@ function reduceInbox(raw: unknown, registry: RlmDurableOperationRegistry): void 
 
 function reduceConsumed(raw: unknown, registry: RlmDurableOperationRegistry): void {
 	if (!validConsumed(raw)) {
-		globalUncertain(registry, "invalid consumed record");
+		markInvalidRecord(raw, registry, "invalid consumed record");
 		return;
 	}
 	const record = raw as RlmTerminalConsumedRecord;
@@ -1076,7 +1097,14 @@ function deliveryFor(
 	const key = deliveryKey(operation.key, deliveryId);
 	let delivery = registry.deliveries.get(key);
 	if (!delivery) {
-		delivery = { key, operationKey: operation.key, deliveryId, outboxed: false, received: false, uncertain: false };
+		delivery = {
+			key,
+			operationKey: operation.key,
+			deliveryId,
+			outboxed: false,
+			received: false,
+			uncertain: registry.hasGlobalUncertainty,
+		};
 		registry.deliveries.set(key, delivery);
 	}
 	return delivery;
@@ -1113,6 +1141,18 @@ function digestOutbox(record: RlmTerminalOutboxRecord | RlmTerminalInboxRecord):
 		)
 		.digest("hex");
 }
+/**
+ * A complete malformed record has no safely attributable meaning, even if it
+ * happens to contain fields that look like an operation key.  In particular,
+ * accepting the apparent key would let an attacker or a torn serializer hide
+ * a conflicting lifecycle fact behind it.  Complete malformed records are
+ * therefore global corruption; only a torn final tail is explicitly repaired
+ * and ignored by readJsonl/appendJsonl.
+ */
+function markInvalidRecord(_raw: unknown, registry: RlmDurableOperationRegistry, message: string): void {
+	globalUncertain(registry, message);
+}
+
 function markOperationUncertain(
 	operation: RlmDurableOperation,
 	registry: RlmDurableOperationRegistry,
@@ -1131,9 +1171,20 @@ function markDeliveryUncertain(
 	delivery.uncertain = true;
 	markOperationUncertain(operation, registry, message);
 }
+/**
+ * A complete record with no trustworthy compound identity cannot be scoped to
+ * one operation. It therefore taints the entire authoritative history, rather
+ * than allowing a reducer order or a later valid record to re-enable work.
+ */
 function globalUncertain(registry: RlmDurableOperationRegistry, message: string): void {
 	registry.hasUncertainRecords = true;
+	registry.hasGlobalUncertainty = true;
+	for (const operation of registry.operations.values()) operation.uncertain = true;
+	for (const delivery of registry.deliveries.values()) delivery.uncertain = true;
 	registry.diagnostics = [...registry.diagnostics, message];
+}
+function assertGloballyCertain(registry: RlmDurableOperationRegistry): void {
+	if (registry.hasGlobalUncertainty) throw new Error("Durable history is globally uncertain");
 }
 
 function appendJsonl(path: string, record: unknown, io: RlmDurableIo): void {
@@ -1223,6 +1274,7 @@ function bodylessIndex(registry: RlmDurableOperationRegistry): unknown {
 			uncertain: delivery.uncertain,
 		})),
 		uncertain: registry.hasUncertainRecords,
+		globallyUncertain: registry.hasGlobalUncertainty,
 	};
 }
 function operationKey(parentSessionId: string, assignmentId: string, operationId: string): string {

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -1,0 +1,1152 @@
+/**
+ * Durable, owner-local facts for daemon RLM terminal delivery.
+ *
+ * The JSONL files are the authority.  The index deliberately is not read by
+ * this module when making a decision: it is merely a crash-safe, body-free
+ * summary for an operator that already has permission to inspect artifacts.
+ */
+import { createHash } from "node:crypto";
+import {
+	chmodSync,
+	closeSync,
+	fsyncSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	realpathSync,
+	renameSync,
+	writeSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative } from "node:path";
+
+export type RlmChildTerminalStatus = "done" | "error" | "cancelled";
+export const RLM_DURABLE_VERSION = 1 as const;
+
+export interface RlmTerminalMessage {
+	role: "custom";
+	customType: "rlm_child_failure" | "rlm_child_terminal_notice" | "agent_message";
+	content: string;
+	display: boolean;
+	details: Record<string, unknown>;
+	timestamp: number;
+}
+
+export interface RlmOperationAdmittedRecord {
+	version: 1;
+	type: "admitted";
+	parentSessionId: string;
+	parentSessionFile: string;
+	childId: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+	childSessionDir: string;
+	requestedModel: { provider: string; modelId: string };
+	rlmDepth: number;
+	rlmMaxDepth: number;
+	recordedAt: string;
+}
+export interface RlmOperationMaterializedRecord {
+	version: 1;
+	type: "materialized";
+	parentSessionId: string;
+	assignmentId: string;
+	operationId: string;
+	childSessionId: string;
+	childSessionFile: string;
+	childArtifactDir: string;
+	recordedAt: string;
+}
+export interface RlmOperationTerminalRecordedRecord {
+	version: 1;
+	type: "terminal_recorded";
+	parentSessionId: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+	terminal: RlmChildTerminalStatus;
+	recordedAt: string;
+}
+export interface RlmOperationReleasedRecord {
+	version: 1;
+	type: "released" | "deleted";
+	parentSessionId: string;
+	assignmentId: string;
+	operationId: string;
+	recordedAt: string;
+}
+export type RlmOperationLedgerRecord =
+	| RlmOperationAdmittedRecord
+	| RlmOperationMaterializedRecord
+	| RlmOperationTerminalRecordedRecord
+	| RlmOperationReleasedRecord;
+
+export interface RlmTerminalOutboxRecord {
+	version: 1;
+	type: "terminal";
+	parentSessionId: string;
+	parentSessionFile: string;
+	childSessionId: string;
+	childSessionFile: string;
+	childId: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+	terminal: RlmChildTerminalStatus;
+	message: RlmTerminalMessage;
+	recordedAt: string;
+}
+export interface RlmTerminalInboxRecord extends Omit<RlmTerminalOutboxRecord, "type" | "recordedAt"> {
+	version: 1;
+	type: "received";
+	receivedAt: string;
+}
+export interface RlmTerminalConsumedRecord {
+	version: 1;
+	type: "materialized" | "discarded";
+	parentSessionId: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+	sessionMessageId?: string;
+	reason?: "parent_mismatch" | "superseded_assignment" | "deleted";
+	recordedAt: string;
+}
+
+export interface RlmOperationAdmission {
+	parentSessionId: string;
+	parentSessionFile: string;
+	/** Trusted root containing the parent session file, not its artifact dir. */
+	parentSessionRoot: string;
+	/** Trusted root containing the parent artifact dir, which may be a sibling of the session dir. */
+	parentArtifactRoot: string;
+	childId: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+	childSessionDir: string;
+	requestedModel: { provider: string; modelId: string };
+	rlmDepth: number;
+	rlmMaxDepth: number;
+}
+export interface RlmOperationMaterialization {
+	parentSessionId: string;
+	assignmentId: string;
+	operationId: string;
+	childSessionId: string;
+	childSessionFile: string;
+	childSessionRoot: string;
+	childArtifactDir: string;
+	childArtifactRoot: string;
+}
+export interface RlmOperationTerminal {
+	parentSessionId: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+	terminal: RlmChildTerminalStatus;
+}
+export interface RlmTerminalOutbox extends Omit<RlmTerminalOutboxRecord, "version" | "type" | "recordedAt"> {
+	/** Required trusted roots. They are validation inputs and are never persisted. */
+	parentSessionRoot: string;
+	parentArtifactRoot: string;
+	childSessionRoot: string;
+	childArtifactDir: string;
+	childArtifactRoot: string;
+}
+export interface RlmDeliveryMaterialization {
+	parentSessionId: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+	sessionMessageId: string;
+}
+export interface RlmDeliveryDiscard {
+	parentSessionId: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+	reason: "parent_mismatch" | "superseded_assignment" | "deleted";
+}
+
+export interface RlmDurableOperation {
+	key: string;
+	parentSessionId: string;
+	parentSessionFile: string;
+	childId: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+	childSessionDir: string;
+	requestedModel: { provider: string; modelId: string };
+	rlmDepth: number;
+	rlmMaxDepth: number;
+	childSessionId?: string;
+	childSessionFile?: string;
+	childArtifactDir?: string;
+	terminal?: RlmChildTerminalStatus;
+	lifecycle: "admitted" | "materialized" | "terminal_recorded" | "released" | "deleted";
+	uncertain: boolean;
+}
+export interface RlmDurableDelivery {
+	key: string;
+	operationKey: string;
+	deliveryId: string;
+	terminal?: RlmChildTerminalStatus;
+	outboxed: boolean;
+	received: boolean;
+	consumed?: "materialized" | "discarded";
+	uncertain: boolean;
+}
+export interface RlmDurableOperationRegistry {
+	operations: Map<string, RlmDurableOperation>;
+	deliveries: Map<string, RlmDurableDelivery>;
+	/** A corrupt line without a usable compound key still makes the history unsafe. */
+	hasUncertainRecords: boolean;
+	diagnostics: readonly string[];
+}
+
+export interface RlmDurableOperationStore {
+	admit(input: RlmOperationAdmission): RlmDurableOperation;
+	markMaterialized(input: RlmOperationMaterialization): boolean;
+	recordTerminal(input: RlmOperationTerminal): boolean;
+	appendOutbox(input: RlmTerminalOutbox): "new" | "already_recorded";
+	importOutbox(input: RlmTerminalOutbox): "new" | "already_received";
+	markMaterializedDelivery(input: RlmDeliveryMaterialization): "new" | "already_materialized";
+	markDiscardedDelivery(input: RlmDeliveryDiscard): "new" | "already_discarded";
+	rebuild(): RlmDurableOperationRegistry;
+}
+
+/** Injectable only for focused durability fault tests. */
+export interface RlmDurableIo {
+	mkdirSync: typeof mkdirSync;
+	chmodSync: typeof chmodSync;
+	openSync: typeof openSync;
+	closeSync: typeof closeSync;
+	writeSync: typeof writeSync;
+	fsyncSync: typeof fsyncSync;
+	readFileSync: typeof readFileSync;
+	realpathSync: typeof realpathSync;
+	renameSync: typeof renameSync;
+}
+export interface RlmDurableOperationStoreOptions {
+	io?: RlmDurableIo;
+	now?: () => string;
+}
+
+const defaultIo: RlmDurableIo = {
+	mkdirSync,
+	chmodSync,
+	openSync,
+	closeSync,
+	writeSync,
+	fsyncSync,
+	readFileSync,
+	realpathSync,
+	renameSync,
+};
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const TERMINALS = new Set<RlmChildTerminalStatus>(["done", "error", "cancelled"]);
+const MAX_MESSAGE_CHARS = 16_384;
+const MAX_MESSAGE_BYTES = 24 * 1024;
+const LEDGER = "rlm-operation-ledger.jsonl";
+const INBOX = "rlm-terminal-inbox.jsonl";
+const CONSUMED = "rlm-terminal-consumed.jsonl";
+const INDEX = "rlm-active-index.json";
+const OUTBOX = "rlm-terminal-outbox.jsonl";
+
+export function materializedTerminalMessageId(deliveryId: string): string {
+	assertUuid(deliveryId, "deliveryId");
+	return `rlm-terminal-${deliveryId}`;
+}
+
+/** Open is an owner action and creates its supplied artifact directory with owner-only permissions. */
+export function openRlmDurableOperationStore(
+	parentArtifactDir: string,
+	options: RlmDurableOperationStoreOptions = {},
+): RlmDurableOperationStore {
+	return new Store(parentArtifactDir, options);
+}
+
+/** Passive: this does not create, chmod, repair, or write an artifact/cache. */
+export function readRlmDurableOperationRegistry(parentArtifactDir: string): RlmDurableOperationRegistry {
+	return reduceArtifact(parentArtifactDir, defaultIo, false);
+}
+
+class Store implements RlmDurableOperationStore {
+	private readonly io: RlmDurableIo;
+	private readonly now: () => string;
+	private readonly parentArtifactDir: string;
+
+	constructor(parentArtifactDir: string, options: RlmDurableOperationStoreOptions) {
+		this.io = options.io ?? defaultIo;
+		this.now = options.now ?? (() => new Date().toISOString());
+		this.io.mkdirSync(parentArtifactDir, { recursive: true, mode: 0o700 });
+		this.io.chmodSync(parentArtifactDir, 0o700);
+		this.parentArtifactDir = this.io.realpathSync(parentArtifactDir);
+	}
+
+	admit(input: RlmOperationAdmission): RlmDurableOperation {
+		this.assertAdmission(input);
+		const registry = this.reduce();
+		const key = operationKey(input.parentSessionId, input.assignmentId, input.operationId);
+		const existing = registry.operations.get(key);
+		const record: RlmOperationAdmittedRecord = {
+			version: 1,
+			type: "admitted",
+			parentSessionId: input.parentSessionId,
+			parentSessionFile: canonicalExistingFile(input.parentSessionFile, input.parentSessionRoot, this.io),
+			childId: boundedText(input.childId, "childId", 256),
+			assignmentId: canonicalUuid(input.assignmentId, "assignmentId"),
+			operationId: canonicalUuid(input.operationId, "operationId"),
+			deliveryId: canonicalUuid(input.deliveryId, "deliveryId"),
+			childSessionDir: canonicalDirectory(input.childSessionDir, input.childSessionDir, this.io),
+			requestedModel: validateModel(input.requestedModel),
+			rlmDepth: boundedInteger(input.rlmDepth, "rlmDepth"),
+			rlmMaxDepth: boundedInteger(input.rlmMaxDepth, "rlmMaxDepth"),
+			recordedAt: this.now(),
+		};
+		if (record.rlmDepth > record.rlmMaxDepth) throw new Error("rlmDepth cannot exceed rlmMaxDepth");
+		if (existing) {
+			if (existing.uncertain || !sameAdmitted(existing, record))
+				throw new Error(`Conflicting durable admission: ${key}`);
+			return existing;
+		}
+		this.append(this.path(LEDGER), record);
+		return this.afterAppend().operations.get(key)!;
+	}
+
+	markMaterialized(input: RlmOperationMaterialization): boolean {
+		assertOperationInput(input);
+		const registry = this.reduce();
+		const operation = registry.operations.get(
+			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
+		);
+		if (!operation || operation.uncertain || operation.lifecycle === "released" || operation.lifecycle === "deleted")
+			return false;
+		const childFile = canonicalExistingFile(input.childSessionFile, input.childSessionRoot, this.io);
+		try {
+			assertSessionIdentity(input.childSessionId, childFile, this.io);
+			assertContainedDirectory(input.childArtifactDir, input.childArtifactRoot, this.io, true);
+		} catch {
+			return false;
+		}
+		const record: RlmOperationMaterializedRecord = {
+			version: 1,
+			type: "materialized",
+			parentSessionId: input.parentSessionId,
+			assignmentId: input.assignmentId,
+			operationId: input.operationId,
+			childSessionId: input.childSessionId,
+			childSessionFile: childFile,
+			childArtifactDir: assertContainedDirectory(input.childArtifactDir, input.childArtifactRoot, this.io, true),
+			recordedAt: this.now(),
+		};
+		if (operation.childSessionFile) {
+			if (
+				operation.childSessionId === record.childSessionId &&
+				operation.childSessionFile === record.childSessionFile
+			)
+				return true;
+			return false;
+		}
+		this.append(this.path(LEDGER), record);
+		this.afterAppend();
+		return true;
+	}
+
+	recordTerminal(input: RlmOperationTerminal): boolean {
+		assertOperationInput(input);
+		assertUuid(input.deliveryId, "deliveryId");
+		assertTerminal(input.terminal);
+		const registry = this.reduce();
+		const operation = registry.operations.get(
+			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
+		);
+		if (!operation || operation.uncertain || !operation.childSessionFile || operation.deliveryId !== input.deliveryId)
+			return false;
+		if (operation.terminal) return operation.terminal === input.terminal;
+		const delivery = registry.deliveries.get(deliveryKey(operation.key, input.deliveryId));
+		if (!delivery?.outboxed || delivery.terminal !== input.terminal || delivery.uncertain) return false;
+		this.append(this.path(LEDGER), { version: 1, type: "terminal_recorded", ...input, recordedAt: this.now() });
+		this.afterAppend();
+		return true;
+	}
+
+	appendOutbox(input: RlmTerminalOutbox): "new" | "already_recorded" {
+		const { operation, record } = this.validateOutboxInput(input, false);
+		const registry = this.reduce();
+		const prior = registry.deliveries.get(deliveryKey(operation.key, record.deliveryId));
+		if (prior?.outboxed) {
+			const priorDigest = (prior as RlmDurableDelivery & { _digest?: string })._digest;
+			if (
+				prior.uncertain ||
+				prior.terminal !== record.terminal ||
+				(priorDigest !== undefined && priorDigest !== digestMessage(record.message))
+			) {
+				throw new Error("Conflicting durable outbox record");
+			}
+			return "already_recorded";
+		}
+		this.append(joinArtifact(input.childArtifactDir, OUTBOX, this.io), record);
+		this.afterAppend();
+		return "new";
+	}
+
+	importOutbox(input: RlmTerminalOutbox): "new" | "already_received" {
+		const { operation, record } = this.validateOutboxInput(input, true);
+		const registry = this.reduce();
+		const delivery = registry.deliveries.get(deliveryKey(operation.key, record.deliveryId));
+		if (!delivery?.outboxed || delivery.uncertain || operation.terminal !== record.terminal) {
+			throw new Error("Outbox is not a durable terminal hand-off");
+		}
+		if (delivery.received) return "already_received";
+		const inbox: RlmTerminalInboxRecord = { ...record, type: "received", receivedAt: this.now() };
+		this.append(this.path(INBOX), inbox);
+		this.afterAppend();
+		return "new";
+	}
+
+	markMaterializedDelivery(input: RlmDeliveryMaterialization): "new" | "already_materialized" {
+		assertOperationInput(input);
+		assertUuid(input.deliveryId, "deliveryId");
+		if (
+			boundedText(input.sessionMessageId, "sessionMessageId", 128) !==
+			materializedTerminalMessageId(input.deliveryId)
+		) {
+			throw new Error("sessionMessageId must be the deterministic durable delivery id");
+		}
+		const registry = this.reduce();
+		const delivery = registry.deliveries.get(
+			deliveryKey(operationKey(input.parentSessionId, input.assignmentId, input.operationId), input.deliveryId),
+		);
+		if (!delivery || delivery.uncertain || !delivery.received)
+			throw new Error("Cannot consume a missing or uncertain inbox record");
+		if (delivery.consumed === "materialized") return "already_materialized";
+		if (delivery.consumed) throw new Error("Delivery was discarded");
+		this.append(this.path(CONSUMED), { version: 1, type: "materialized", ...input, recordedAt: this.now() });
+		this.afterAppend();
+		return "new";
+	}
+
+	markDiscardedDelivery(input: RlmDeliveryDiscard): "new" | "already_discarded" {
+		assertOperationInput(input);
+		assertUuid(input.deliveryId, "deliveryId");
+		const registry = this.reduce();
+		const operation = registry.operations.get(
+			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
+		);
+		const delivery = registry.deliveries.get(deliveryKey(operation?.key ?? "", input.deliveryId));
+		if (
+			!operation ||
+			operation.uncertain ||
+			operation.lifecycle !== "deleted" ||
+			!delivery?.received ||
+			delivery.uncertain
+		) {
+			throw new Error("Only an exact deleted operation may discard an inbox delivery");
+		}
+		if (delivery.consumed === "discarded") return "already_discarded";
+		if (delivery.consumed) throw new Error("Delivery was materialized");
+		this.append(this.path(CONSUMED), { version: 1, type: "discarded", ...input, recordedAt: this.now() });
+		this.afterAppend();
+		return "new";
+	}
+
+	rebuild(): RlmDurableOperationRegistry {
+		const registry = this.reduce();
+		this.writeIndex(registry); // cache failure cannot undo an fsynced authority append.
+		return registry;
+	}
+
+	/** Releases/deletes are deliberately internal helpers for later host integration. */
+	recordRelease(
+		input: Pick<RlmOperationTerminal, "parentSessionId" | "assignmentId" | "operationId">,
+		type: "released" | "deleted",
+	): boolean {
+		assertOperationInput(input);
+		const operation = this.reduce().operations.get(
+			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
+		);
+		if (!operation || operation.uncertain || operation.lifecycle === "released" || operation.lifecycle === "deleted")
+			return false;
+		this.append(this.path(LEDGER), { version: 1, type, ...input, recordedAt: this.now() });
+		this.afterAppend();
+		return true;
+	}
+
+	private validateOutboxInput(
+		input: RlmTerminalOutbox,
+		requireTerminal: boolean,
+	): { operation: RlmDurableOperation; record: RlmTerminalOutboxRecord } {
+		assertOperationInput(input);
+		assertUuid(input.deliveryId, "deliveryId");
+		assertTerminal(input.terminal);
+		assertTerminalMessage(input.message);
+		const registry = this.reduce();
+		const operation = registry.operations.get(
+			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
+		);
+		if (
+			!operation ||
+			operation.uncertain ||
+			!operation.childSessionFile ||
+			!operation.childSessionId ||
+			operation.deliveryId !== input.deliveryId
+		) {
+			throw new Error("Outbox does not match an exact materialized operation");
+		}
+		if (requireTerminal && operation.terminal !== input.terminal)
+			throw new Error("Outbox terminal is not ledger-recorded");
+		const parentFile = canonicalExistingFile(input.parentSessionFile, input.parentSessionRoot, this.io);
+		const childFile = canonicalExistingFile(input.childSessionFile, input.childSessionRoot, this.io);
+		assertSessionIdentity(input.parentSessionId, parentFile, this.io);
+		assertSessionIdentity(input.childSessionId, childFile, this.io);
+		assertContainedDirectory(this.parentArtifactDir, input.parentArtifactRoot, this.io, false);
+		assertContainedDirectory(input.childArtifactDir, input.childArtifactRoot, this.io, true);
+		if (
+			operation.parentSessionFile !== parentFile ||
+			operation.childSessionFile !== childFile ||
+			operation.childSessionId !== input.childSessionId ||
+			operation.childId !== input.childId
+		) {
+			throw new Error("Outbox session identity/path conflicts with admission");
+		}
+		return {
+			operation,
+			record: {
+				version: 1,
+				type: "terminal",
+				parentSessionId: input.parentSessionId,
+				parentSessionFile: parentFile,
+				childSessionId: input.childSessionId,
+				childSessionFile: childFile,
+				childId: boundedText(input.childId, "childId", 256),
+				assignmentId: input.assignmentId,
+				operationId: input.operationId,
+				deliveryId: input.deliveryId,
+				terminal: input.terminal,
+				message: input.message,
+				recordedAt: this.now(),
+			},
+		};
+	}
+
+	private assertAdmission(input: RlmOperationAdmission): void {
+		assertUuid(input.parentSessionId, "parentSessionId");
+		assertUuid(input.assignmentId, "assignmentId");
+		assertUuid(input.operationId, "operationId");
+		assertUuid(input.deliveryId, "deliveryId");
+		const parentFile = canonicalExistingFile(input.parentSessionFile, input.parentSessionRoot, this.io);
+		assertSessionIdentity(input.parentSessionId, parentFile, this.io);
+		assertContainedDirectory(this.parentArtifactDir, input.parentArtifactRoot, this.io, false);
+		canonicalDirectory(input.childSessionDir, input.childSessionDir, this.io);
+	}
+	private reduce(): RlmDurableOperationRegistry {
+		return reduceArtifact(this.parentArtifactDir, this.io, false);
+	}
+	private afterAppend(): RlmDurableOperationRegistry {
+		const registry = this.reduce();
+		this.writeIndex(registry);
+		return registry;
+	}
+	private path(name: string): string {
+		return joinArtifact(this.parentArtifactDir, name, this.io);
+	}
+	private append(path: string, record: unknown): void {
+		appendJsonl(path, record, this.io);
+	}
+	private writeIndex(registry: RlmDurableOperationRegistry): void {
+		try {
+			const body = JSON.stringify(bodylessIndex(registry));
+			atomicCache(this.path(INDEX), body, this.io);
+		} catch {
+			// Cache is deliberately non-authoritative. The next owner rebuild may retry.
+		}
+	}
+}
+
+function reduceArtifact(
+	parentArtifactDir: string,
+	io: RlmDurableIo,
+	_writeCache: boolean,
+): RlmDurableOperationRegistry {
+	const registry: RlmDurableOperationRegistry = {
+		operations: new Map(),
+		deliveries: new Map(),
+		hasUncertainRecords: false,
+		diagnostics: [],
+	};
+	let canonicalParent: string;
+	try {
+		canonicalParent = io.realpathSync(parentArtifactDir);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return registry;
+		throw error;
+	}
+	for (const parsed of readJsonl(joinArtifact(canonicalParent, LEDGER, io), io, registry, "ledger"))
+		reduceLedger(parsed, registry);
+	// A child outbox becomes discoverable only from a materialized, admitted operation.
+	for (const operation of registry.operations.values()) {
+		if (!operation.childSessionFile || !operation.childArtifactDir || operation.uncertain) continue;
+		try {
+			for (const parsed of readJsonl(joinArtifact(operation.childArtifactDir, OUTBOX, io), io, registry, "outbox"))
+				reduceOutbox(parsed, registry);
+		} catch {
+			markOperationUncertain(operation, registry, "outbox path cannot be read");
+		}
+	}
+	for (const parsed of readJsonl(joinArtifact(canonicalParent, INBOX, io), io, registry, "inbox"))
+		reduceInbox(parsed, registry);
+	for (const parsed of readJsonl(joinArtifact(canonicalParent, CONSUMED, io), io, registry, "consumed"))
+		reduceConsumed(parsed, registry);
+	return registry;
+}
+
+function readJsonl(path: string, io: RlmDurableIo, registry: RlmDurableOperationRegistry, kind: string): unknown[] {
+	let source: string;
+	try {
+		source = io.readFileSync(path, "utf8") as string;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+	if (!source) return [];
+	const lines = source.split("\n");
+	const hasFinalNewline = source.endsWith("\n");
+	const count = hasFinalNewline ? lines.length - 1 : lines.length;
+	const parsed: unknown[] = [];
+	for (let i = 0; i < count; i++) {
+		const line = lines[i]!;
+		if (!line) {
+			registry.hasUncertainRecords = true;
+			registry.diagnostics = [...registry.diagnostics, `${kind}: empty complete line ${i + 1}`];
+			continue;
+		}
+		try {
+			parsed.push(JSON.parse(line));
+		} catch {
+			// Only an invalid physical final tail without a newline is crash-tolerated.
+			if (!hasFinalNewline && i === count - 1) continue;
+			registry.hasUncertainRecords = true;
+			registry.diagnostics = [...registry.diagnostics, `${kind}: malformed complete line ${i + 1}`];
+		}
+	}
+	return parsed;
+}
+
+function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void {
+	if (!isObject(raw) || raw.version !== 1 || typeof raw.type !== "string") {
+		globalUncertain(registry, "invalid ledger record");
+		return;
+	}
+	if (raw.type === "admitted") {
+		if (!validAdmitted(raw)) {
+			globalUncertain(registry, "invalid admitted record");
+			return;
+		}
+		const record = raw as unknown as RlmOperationAdmittedRecord;
+		const key = operationKey(record.parentSessionId, record.assignmentId, record.operationId);
+		const existing = registry.operations.get(key);
+		if (!existing) {
+			registry.operations.set(key, {
+				key,
+				parentSessionId: record.parentSessionId,
+				parentSessionFile: record.parentSessionFile,
+				childId: record.childId,
+				assignmentId: record.assignmentId,
+				operationId: record.operationId,
+				deliveryId: record.deliveryId,
+				childSessionDir: record.childSessionDir,
+				requestedModel: record.requestedModel,
+				rlmDepth: record.rlmDepth,
+				rlmMaxDepth: record.rlmMaxDepth,
+				lifecycle: "admitted",
+				uncertain: false,
+			});
+		} else if (!sameAdmitted(existing, record)) markOperationUncertain(existing, registry, "conflicting admission");
+		return;
+	}
+	if (!hasOperationIdentity(raw)) {
+		globalUncertain(registry, "invalid ledger identity");
+		return;
+	}
+	const operation = registry.operations.get(operationKey(raw.parentSessionId, raw.assignmentId, raw.operationId));
+	if (!operation) {
+		globalUncertain(registry, "ledger event without admission");
+		return;
+	}
+	if (raw.type === "materialized") {
+		if (!validMaterialized(raw)) {
+			markOperationUncertain(operation, registry, "invalid materialization");
+			return;
+		}
+		if (!operation.childSessionFile) {
+			operation.childSessionId = raw.childSessionId;
+			operation.childSessionFile = raw.childSessionFile;
+			operation.childArtifactDir = raw.childArtifactDir;
+			operation.lifecycle = "materialized";
+		} else if (
+			operation.childSessionId !== raw.childSessionId ||
+			operation.childSessionFile !== raw.childSessionFile ||
+			operation.childArtifactDir !== raw.childArtifactDir
+		)
+			markOperationUncertain(operation, registry, "conflicting materialization");
+		return;
+	}
+	if (raw.type === "terminal_recorded") {
+		if (!validTerminalRecorded(raw) || !operation.childSessionFile || raw.deliveryId !== operation.deliveryId) {
+			markOperationUncertain(operation, registry, "invalid terminal");
+			return;
+		}
+		if (!operation.terminal) {
+			operation.terminal = raw.terminal as RlmChildTerminalStatus;
+			if (operation.lifecycle !== "deleted") operation.lifecycle = "terminal_recorded";
+		} else if (operation.terminal !== raw.terminal)
+			markOperationUncertain(operation, registry, "conflicting terminal");
+		return;
+	}
+	if (raw.type === "released" || raw.type === "deleted") {
+		if (!validStamped(raw)) {
+			markOperationUncertain(operation, registry, "invalid release");
+			return;
+		}
+		if (operation.lifecycle === "released" || operation.lifecycle === "deleted") {
+			if (operation.lifecycle !== raw.type)
+				markOperationUncertain(operation, registry, "conflicting release/deletion");
+		} else operation.lifecycle = raw.type;
+		return;
+	}
+	markOperationUncertain(operation, registry, "unknown ledger event");
+}
+
+function reduceOutbox(raw: unknown, registry: RlmDurableOperationRegistry): void {
+	if (!validOutbox(raw, "terminal")) {
+		globalUncertain(registry, "invalid outbox record");
+		return;
+	}
+	const record = raw as RlmTerminalOutboxRecord;
+	const operation = registry.operations.get(
+		operationKey(record.parentSessionId, record.assignmentId, record.operationId),
+	);
+	if (!operation) {
+		globalUncertain(registry, "outbox without operation");
+		return;
+	}
+	const delivery = deliveryFor(operation, record.deliveryId, registry);
+	if (
+		operation.uncertain ||
+		record.deliveryId !== operation.deliveryId ||
+		operation.parentSessionFile !== record.parentSessionFile ||
+		operation.childSessionId !== record.childSessionId ||
+		operation.childSessionFile !== record.childSessionFile ||
+		operation.childId !== record.childId
+	) {
+		markDeliveryUncertain(delivery, operation, registry, "outbox identity mismatch");
+		return;
+	}
+	if (!delivery.outboxed) {
+		delivery.outboxed = true;
+		delivery.terminal = record.terminal;
+		defineDeliveryDigest(delivery, record);
+	} else if (
+		delivery.terminal !== record.terminal ||
+		deliveryDigest(delivery, record) !== digestMessage(record.message)
+	)
+		markDeliveryUncertain(delivery, operation, registry, "conflicting outbox");
+	else defineDeliveryDigest(delivery, record);
+}
+
+function reduceInbox(raw: unknown, registry: RlmDurableOperationRegistry): void {
+	if (!validOutbox(raw, "received")) {
+		globalUncertain(registry, "invalid inbox record");
+		return;
+	}
+	const record = raw as RlmTerminalInboxRecord;
+	const operation = registry.operations.get(
+		operationKey(record.parentSessionId, record.assignmentId, record.operationId),
+	);
+	if (!operation) {
+		globalUncertain(registry, "inbox without operation");
+		return;
+	}
+	const delivery = deliveryFor(operation, record.deliveryId, registry);
+	if (
+		!delivery.outboxed ||
+		delivery.uncertain ||
+		!operation.terminal ||
+		operation.terminal !== record.terminal ||
+		delivery.terminal !== record.terminal
+	) {
+		markDeliveryUncertain(delivery, operation, registry, "inbox without matching outbox/terminal");
+		return;
+	}
+	if (!delivery.received) {
+		delivery.received = true;
+		defineDeliveryDigest(delivery, record);
+	} else if (deliveryDigest(delivery, record) !== digestMessage(record.message))
+		markDeliveryUncertain(delivery, operation, registry, "conflicting inbox");
+}
+
+function reduceConsumed(raw: unknown, registry: RlmDurableOperationRegistry): void {
+	if (!validConsumed(raw)) {
+		globalUncertain(registry, "invalid consumed record");
+		return;
+	}
+	const record = raw as RlmTerminalConsumedRecord;
+	const operation = registry.operations.get(
+		operationKey(record.parentSessionId, record.assignmentId, record.operationId),
+	);
+	if (!operation) {
+		globalUncertain(registry, "consumed without operation");
+		return;
+	}
+	const delivery = deliveryFor(operation, record.deliveryId, registry);
+	if (!delivery.received || delivery.uncertain) {
+		markDeliveryUncertain(delivery, operation, registry, "consumed before inbox");
+		return;
+	}
+	if (record.type === "discarded" && operation.lifecycle !== "deleted") {
+		markDeliveryUncertain(delivery, operation, registry, "discard without deletion");
+		return;
+	}
+	if (!delivery.consumed) delivery.consumed = record.type;
+	else if (delivery.consumed !== record.type)
+		markDeliveryUncertain(delivery, operation, registry, "conflicting consumption");
+}
+
+function deliveryFor(
+	operation: RlmDurableOperation,
+	deliveryId: string,
+	registry: RlmDurableOperationRegistry,
+): RlmDurableDelivery {
+	const key = deliveryKey(operation.key, deliveryId);
+	let delivery = registry.deliveries.get(key);
+	if (!delivery) {
+		delivery = { key, operationKey: operation.key, deliveryId, outboxed: false, received: false, uncertain: false };
+		registry.deliveries.set(key, delivery);
+	}
+	return delivery;
+}
+function defineDeliveryDigest(
+	delivery: RlmDurableDelivery & { _digest?: string },
+	record: { message: RlmTerminalMessage },
+): void {
+	delivery._digest = digestMessage(record.message);
+}
+function deliveryDigest(
+	delivery: RlmDurableDelivery & { _digest?: string },
+	record: { message: RlmTerminalMessage },
+): string {
+	return delivery._digest ?? digestMessage(record.message);
+}
+function markOperationUncertain(
+	operation: RlmDurableOperation,
+	registry: RlmDurableOperationRegistry,
+	message: string,
+): void {
+	operation.uncertain = true;
+	registry.hasUncertainRecords = true;
+	registry.diagnostics = [...registry.diagnostics, `${operation.key}: ${message}`];
+}
+function markDeliveryUncertain(
+	delivery: RlmDurableDelivery,
+	operation: RlmDurableOperation,
+	registry: RlmDurableOperationRegistry,
+	message: string,
+): void {
+	delivery.uncertain = true;
+	markOperationUncertain(operation, registry, message);
+}
+function globalUncertain(registry: RlmDurableOperationRegistry, message: string): void {
+	registry.hasUncertainRecords = true;
+	registry.diagnostics = [...registry.diagnostics, message];
+}
+
+function appendJsonl(path: string, record: unknown, io: RlmDurableIo): void {
+	const fd = io.openSync(path, "a", 0o600);
+	try {
+		writeAll(fd, Buffer.from(`${JSON.stringify(record)}\n`), io);
+		io.fsyncSync(fd);
+	} finally {
+		io.closeSync(fd);
+	}
+	io.chmodSync(path, 0o600);
+}
+function writeAll(fd: number, data: Buffer, io: RlmDurableIo): void {
+	let offset = 0;
+	while (offset < data.length) {
+		const written = io.writeSync(fd, data, offset, data.length - offset);
+		if (!Number.isSafeInteger(written) || written <= 0 || written > data.length - offset)
+			throw new Error("Durable write made no forward progress");
+		offset += written;
+	}
+}
+function atomicCache(path: string, body: string, io: RlmDurableIo): void {
+	const temp = `${path}.${process.pid}.${Date.now()}.tmp`;
+	const fd = io.openSync(temp, "wx", 0o600);
+	try {
+		writeAll(fd, Buffer.from(body), io);
+		io.fsyncSync(fd);
+	} finally {
+		io.closeSync(fd);
+	}
+	io.chmodSync(temp, 0o600);
+	io.renameSync(temp, path);
+	const directory = io.openSync(dirname(path), "r");
+	try {
+		io.fsyncSync(directory);
+	} finally {
+		io.closeSync(directory);
+	}
+}
+
+function bodylessIndex(registry: RlmDurableOperationRegistry): unknown {
+	return {
+		version: 1,
+		operations: [...registry.operations.values()].map(({ parentSessionFile, childSessionFile, ...operation }) => ({
+			...operation,
+			parentSessionFile,
+			childSessionFile,
+		})),
+		deliveries: [...registry.deliveries.values()].map((delivery) => ({ ...delivery })),
+		uncertain: registry.hasUncertainRecords,
+	};
+}
+function operationKey(parentSessionId: string, assignmentId: string, operationId: string): string {
+	return JSON.stringify([parentSessionId, assignmentId, operationId]);
+}
+function deliveryKey(operation: string, deliveryId: string): string {
+	return JSON.stringify([operation, deliveryId]);
+}
+function joinArtifact(directory: string, file: string, io: RlmDurableIo): string {
+	return `${canonicalDirectory(directory, directory, io)}/${file}`;
+}
+function canonicalDirectory(path: string, root: string, io: RlmDurableIo): string {
+	return assertContainedDirectory(path, root, io, false);
+}
+function canonicalExistingFile(path: string, root: string, io: RlmDurableIo): string {
+	const canonicalRoot = io.realpathSync(root);
+	const file = io.realpathSync(path);
+	if (!inside(canonicalRoot, file)) throw new Error("Path escapes trusted session root");
+	return file;
+}
+function assertContainedDirectory(path: string, root: string, io: RlmDurableIo, create: boolean): string {
+	if (create) {
+		io.mkdirSync(path, { recursive: true, mode: 0o700 });
+		io.chmodSync(path, 0o700);
+	}
+	const canonicalRoot = io.realpathSync(root);
+	const target = io.realpathSync(path);
+	if (!inside(canonicalRoot, target)) throw new Error("Path escapes trusted artifact root");
+	return target;
+}
+function inside(root: string, candidate: string): boolean {
+	const rel = relative(root, candidate);
+	return rel === "" || (!rel.startsWith("../") && !rel.startsWith("..\\") && rel !== ".." && !isAbsolute(rel));
+}
+function assertSessionIdentity(id: string, file: string, io: RlmDurableIo): void {
+	assertUuid(id, "sessionId");
+	const first = (io.readFileSync(file, "utf8") as string).split("\n", 1)[0];
+	try {
+		const header = JSON.parse(first) as unknown;
+		if (!isObject(header) || header.type !== "session" || header.id !== id) throw new Error();
+	} catch {
+		throw new Error("Session file does not match claimed session id");
+	}
+}
+function assertUuid(value: unknown, name: string): asserts value is string {
+	if (typeof value !== "string" || !UUID.test(value)) throw new Error(`${name} must be a canonical UUID`);
+}
+function canonicalUuid(value: string, name: string): string {
+	assertUuid(value, name);
+	return value;
+}
+function boundedText(value: unknown, name: string, maximum: number): string {
+	if (typeof value !== "string" || !value.trim() || value.length > maximum)
+		throw new Error(`${name} is invalid or too large`);
+	return value;
+}
+function boundedInteger(value: unknown, name: string): number {
+	if (!Number.isInteger(value) || (value as number) < 0 || (value as number) > 1024)
+		throw new Error(`${name} is not a bounded integer`);
+	return value as number;
+}
+function assertTerminal(value: unknown): asserts value is RlmChildTerminalStatus {
+	if (typeof value !== "string" || !TERMINALS.has(value as RlmChildTerminalStatus))
+		throw new Error("Unknown terminal projection");
+}
+function validateModel(value: unknown): { provider: string; modelId: string } {
+	if (!isObject(value)) throw new Error("requestedModel is invalid");
+	return {
+		provider: boundedText(value.provider, "provider", 256),
+		modelId: boundedText(value.modelId, "modelId", 256),
+	};
+}
+function assertOperationInput(value: { parentSessionId: string; assignmentId: string; operationId: string }): void {
+	assertUuid(value.parentSessionId, "parentSessionId");
+	assertUuid(value.assignmentId, "assignmentId");
+	assertUuid(value.operationId, "operationId");
+}
+function assertTerminalMessage(value: unknown): asserts value is RlmTerminalMessage {
+	if (
+		!isObject(value) ||
+		value.role !== "custom" ||
+		(value.customType !== "rlm_child_failure" &&
+			value.customType !== "rlm_child_terminal_notice" &&
+			value.customType !== "agent_message") ||
+		typeof value.content !== "string" ||
+		value.content.length > MAX_MESSAGE_CHARS ||
+		typeof value.display !== "boolean" ||
+		!Number.isFinite(value.timestamp) ||
+		!isSafeDetails(value.details, 0)
+	)
+		throw new Error("Terminal message is not a bounded approved custom projection");
+	if (Buffer.byteLength(stableJson(value)) > MAX_MESSAGE_BYTES) throw new Error("Terminal message is too large");
+}
+function isSafeDetails(value: unknown, depth: number): boolean {
+	if (depth > 4) return false;
+	if (value === null || typeof value === "boolean" || typeof value === "number") return true;
+	if (typeof value === "string") return value.length <= 4096;
+	if (Array.isArray(value)) return value.length <= 32 && value.every((item) => isSafeDetails(item, depth + 1));
+	if (!isObject(value)) return false;
+	const entries = Object.entries(value);
+	return (
+		entries.length <= 32 &&
+		entries.every(
+			([key, item]) =>
+				key.length <= 64 &&
+				key !== "__proto__" &&
+				key !== "constructor" &&
+				key !== "prototype" &&
+				isSafeDetails(item, depth + 1),
+		)
+	);
+}
+function digestMessage(message: RlmTerminalMessage): string {
+	return createHash("sha256").update(stableJson(message)).digest("hex");
+}
+function stableJson(value: unknown): string {
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+	const object = value as Record<string, unknown>;
+	return `{${Object.keys(object)
+		.sort()
+		.map((key) => `${JSON.stringify(key)}:${stableJson(object[key])}`)
+		.join(",")}}`;
+}
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function hasOperationIdentity(value: Record<string, unknown>): value is Record<string, string> {
+	return (
+		typeof value.parentSessionId === "string" &&
+		typeof value.assignmentId === "string" &&
+		typeof value.operationId === "string" &&
+		UUID.test(value.parentSessionId) &&
+		UUID.test(value.assignmentId) &&
+		UUID.test(value.operationId)
+	);
+}
+function validStamped(value: Record<string, unknown>): boolean {
+	return typeof value.recordedAt === "string" && !Number.isNaN(Date.parse(value.recordedAt));
+}
+function validAdmitted(value: Record<string, unknown>): boolean {
+	return (
+		hasOperationIdentity(value) &&
+		typeof value.deliveryId === "string" &&
+		UUID.test(value.deliveryId) &&
+		typeof value.parentSessionFile === "string" &&
+		isAbsolute(value.parentSessionFile) &&
+		typeof value.childId === "string" &&
+		typeof value.childSessionDir === "string" &&
+		isAbsolute(value.childSessionDir) &&
+		isObject(value.requestedModel) &&
+		typeof value.requestedModel.provider === "string" &&
+		typeof value.requestedModel.modelId === "string" &&
+		Number.isInteger(value.rlmDepth) &&
+		Number.isInteger(value.rlmMaxDepth) &&
+		validStamped(value)
+	);
+}
+function validMaterialized(value: Record<string, unknown>): value is Record<string, string> {
+	return (
+		hasOperationIdentity(value) &&
+		typeof value.childSessionId === "string" &&
+		UUID.test(value.childSessionId) &&
+		typeof value.childSessionFile === "string" &&
+		isAbsolute(value.childSessionFile) &&
+		typeof value.childArtifactDir === "string" &&
+		isAbsolute(value.childArtifactDir) &&
+		validStamped(value)
+	);
+}
+function validTerminalRecorded(value: Record<string, unknown>): value is Record<string, string> {
+	return (
+		hasOperationIdentity(value) &&
+		typeof value.deliveryId === "string" &&
+		UUID.test(value.deliveryId) &&
+		typeof value.terminal === "string" &&
+		TERMINALS.has(value.terminal as RlmChildTerminalStatus) &&
+		validStamped(value)
+	);
+}
+function validOutbox(value: unknown, type: "terminal" | "received"): boolean {
+	if (
+		!isObject(value) ||
+		value.version !== 1 ||
+		value.type !== type ||
+		!hasOperationIdentity(value) ||
+		typeof value.deliveryId !== "string" ||
+		!UUID.test(value.deliveryId) ||
+		typeof value.parentSessionFile !== "string" ||
+		!isAbsolute(value.parentSessionFile) ||
+		typeof value.childSessionId !== "string" ||
+		!UUID.test(value.childSessionId) ||
+		typeof value.childSessionFile !== "string" ||
+		!isAbsolute(value.childSessionFile) ||
+		typeof value.childId !== "string" ||
+		typeof value.terminal !== "string" ||
+		!TERMINALS.has(value.terminal as RlmChildTerminalStatus)
+	)
+		return false;
+	try {
+		assertTerminalMessage(value.message);
+	} catch {
+		return false;
+	}
+	return type === "terminal"
+		? validStamped(value)
+		: typeof value.receivedAt === "string" && !Number.isNaN(Date.parse(value.receivedAt));
+}
+function validConsumed(value: unknown): boolean {
+	return (
+		isObject(value) &&
+		value.version === 1 &&
+		(value.type === "materialized" || value.type === "discarded") &&
+		hasOperationIdentity(value) &&
+		typeof value.deliveryId === "string" &&
+		UUID.test(value.deliveryId) &&
+		validStamped(value) &&
+		(value.type !== "materialized" || typeof value.sessionMessageId === "string") &&
+		(value.type !== "discarded" ||
+			value.reason === "parent_mismatch" ||
+			value.reason === "superseded_assignment" ||
+			value.reason === "deleted")
+	);
+}
+function sameAdmitted(operation: RlmDurableOperation, record: RlmOperationAdmittedRecord): boolean {
+	return (
+		operation.parentSessionId === record.parentSessionId &&
+		operation.parentSessionFile === record.parentSessionFile &&
+		operation.childId === record.childId &&
+		operation.assignmentId === record.assignmentId &&
+		operation.operationId === record.operationId &&
+		operation.deliveryId === record.deliveryId &&
+		operation.childSessionDir === record.childSessionDir &&
+		operation.requestedModel.provider === record.requestedModel.provider &&
+		operation.requestedModel.modelId === record.requestedModel.modelId &&
+		operation.rlmDepth === record.rlmDepth &&
+		operation.rlmMaxDepth === record.rlmMaxDepth
+	);
+}

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -22,76 +22,6 @@ import { dirname, isAbsolute, relative } from "node:path";
 export type RlmChildTerminalStatus = "done" | "error" | "cancelled";
 export const RLM_DURABLE_VERSION = 1 as const;
 
-/**
- * The deliberately small, C03-owned view of C04's terminal result reference.
- * It has no C01/C03 owner tuple: those IDs remain only in the surrounding
- * durable record and are never copied into a parent transcript message.
- */
-/** C04's C05-facing opaque-reference spelling for this C03 wire view. */
-export type C04OpaqueArtifactReference = RlmChildResultArtifactReference;
-
-export interface RlmChildResultArtifactReference {
-	version: 1;
-	handleId: string;
-	resultId: string;
-	kind: "terminal_output" | "diagnostic" | "trajectory" | "attachment";
-	contentType: "text/plain" | "application/json" | "application/octet-stream";
-	byteLength: number;
-	sha256: string;
-	retentionState: "retained" | "expired" | "deleted" | "unavailable" | "uncertain";
-}
-
-export interface RlmChildResultModelReference {
-	requestedSelector?: string;
-	initialResolvedSelector: string;
-	terminalResolvedSelector: string;
-	fallbackHistory?: readonly string[];
-}
-
-export type RlmChildResultErrorCode =
-	| "invalid_result"
-	| "result_too_large"
-	| "artifact_too_large"
-	| "artifact_quota_exceeded"
-	| "artifact_unavailable"
-	| "artifact_integrity_failed"
-	| "artifact_expired"
-	| "terminal_storage_failed"
-	| "cancelled"
-	| "timed_out"
-	| "stalled"
-	| "unknown_after_crash";
-
-export interface RlmChildResultErrorReference {
-	/** A closed C04 code, never a provider error or a thrown error name. */
-	code: RlmChildResultErrorCode;
-	/** A pre-sanitized, bounded safe explanation. */
-	message: string;
-}
-
-/**
- * C04's v1 bounded terminal projection as carried by C03. C03 validates,
- * persists, imports, and materializes this value, but does not construct it.
- * In particular it is not an artifact-read capability and contains neither
- * owner identities nor payload/path/body data.
- */
-export interface RlmChildResultReferenceV1 {
-	version: 1;
-	resultId: string;
-	status: "completed" | "failed" | "cancelled" | "timed_out" | "stalled" | "unknown_after_crash";
-	summary: string;
-	/** C04 requires a deliberately prepared safe preview for every terminal result. */
-	preview: string;
-	error?: RlmChildResultErrorReference;
-	model?: RlmChildResultModelReference;
-	artifacts: readonly RlmChildResultArtifactReference[];
-	retentionState: "retained" | "expired" | "deleted" | "unavailable" | "uncertain";
-}
-
-/** C04's stable bounded public projection spelling. */
-export type C04ChildResultReference = RlmChildResultReferenceV1;
-export type C04PublicChildResult = RlmChildResultReferenceV1;
-
 export type RlmTerminalMessage =
 	| {
 			role: "custom";
@@ -118,10 +48,10 @@ export type RlmTerminalMessage =
 	  }
 	| {
 			role: "custom";
-			customType: "rlm_child_result_reference";
+			customType: "rlm_safe_terminal_result";
 			content: string;
 			display: true;
-			details: { kind: "child_result_v1"; result: RlmChildResultReferenceV1 };
+			details: { kind: "safe_terminal_result_v1"; projection: string };
 			timestamp: number;
 	  };
 
@@ -386,64 +316,10 @@ const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-
 const TERMINALS = new Set<RlmChildTerminalStatus>(["done", "error", "cancelled"]);
 const MAX_MESSAGE_CHARS = 16_384;
 const MAX_MESSAGE_BYTES = 24 * 1024;
-/** C04 v1 wire bounds. These are fixed C03 acceptance bounds, not knobs. */
-export const RLM_CHILD_RESULT_REFERENCE_VERSION = 1 as const;
-export const MAX_RLM_CHILD_RESULT_REFERENCE_BYTES = 64 * 1024;
-export const MAX_RLM_CHILD_RESULT_SUMMARY_CHARS = 4_096;
-export const MAX_RLM_CHILD_RESULT_SUMMARY_BYTES = 16 * 1024;
-export const MAX_RLM_CHILD_RESULT_PREVIEW_CHARS = 2_048;
-export const MAX_RLM_CHILD_RESULT_PREVIEW_BYTES = 8 * 1024;
-export const MAX_RLM_CHILD_RESULT_ERROR_CODE_CHARS = 96;
-export const MAX_RLM_CHILD_RESULT_ERROR_MESSAGE_CHARS = 1_024;
-export const MAX_RLM_CHILD_RESULT_ERROR_MESSAGE_BYTES = 4 * 1024;
-export const MAX_RLM_CHILD_RESULT_ARTIFACTS = 16;
-const MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS = 512;
-const MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES = 2 * 1024;
-const MAX_RLM_CHILD_RESULT_MODEL_FALLBACKS = 16;
-export const MAX_RLM_CHILD_RESULT_ARTIFACT_BYTES = 512 * 1024 * 1024;
-const MAX_RLM_CHILD_RESULT_ERROR_CODE_BYTES = 384;
-const SHA256 = /^[0-9a-f]{64}$/;
-const RLM_CHILD_RESULT_STATUSES = new Set<RlmChildResultReferenceV1["status"]>([
-	"completed",
-	"failed",
-	"cancelled",
-	"timed_out",
-	"stalled",
-	"unknown_after_crash",
-]);
-const RLM_CHILD_RESULT_RETENTION_STATES = new Set<RlmChildResultReferenceV1["retentionState"]>([
-	"retained",
-	"expired",
-	"deleted",
-	"unavailable",
-	"uncertain",
-]);
-const RLM_CHILD_RESULT_ARTIFACT_KINDS = new Set<RlmChildResultArtifactReference["kind"]>([
-	"terminal_output",
-	"diagnostic",
-	"trajectory",
-	"attachment",
-]);
-const RLM_CHILD_RESULT_CONTENT_TYPES = new Set<RlmChildResultArtifactReference["contentType"]>([
-	"text/plain",
-	"application/json",
-	"application/octet-stream",
-]);
-const RLM_CHILD_RESULT_ERROR_CODES = new Set<RlmChildResultErrorCode>([
-	"invalid_result",
-	"result_too_large",
-	"artifact_too_large",
-	"artifact_quota_exceeded",
-	"artifact_unavailable",
-	"artifact_integrity_failed",
-	"artifact_expired",
-	"terminal_storage_failed",
-	"cancelled",
-	"timed_out",
-	"stalled",
-	"unknown_after_crash",
-]);
-const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+/** Fixed C03 bounds for the generic public safe-terminal envelope. */
+export const MAX_RLM_SAFE_TERMINAL_MESSAGE_BYTES = 64 * 1024;
+export const MAX_RLM_SAFE_TERMINAL_CONTENT_CHARS = 16_384;
+
 const LEDGER = "rlm-operation-ledger.jsonl";
 const INBOX = "rlm-terminal-inbox.jsonl";
 const CONSUMED = "rlm-terminal-consumed.jsonl";
@@ -1443,243 +1319,60 @@ function assertTerminalMessage(value: unknown): asserts value is RlmTerminalMess
 			)
 				throw new Error("Completed notice details are not approved");
 		} else throw new Error("Unknown terminal notice kind");
-	} else if (value.customType === "rlm_child_result_reference") {
+	} else if (value.customType === "rlm_safe_terminal_result") {
 		if (
 			!isObject(value.details) ||
-			!exactKeys(value.details, ["kind", "result"]) ||
-			value.details.kind !== "child_result_v1"
+			!exactKeys(value.details, ["kind", "projection"]) ||
+			value.details.kind !== "safe_terminal_result_v1" ||
+			!isUtf8String(value.details.projection)
 		)
-			throw new Error("Child-result reference details are not approved");
-		assertChildResultReference(value.details.result);
-		if (value.content !== formatRlmChildResultReference(value.details.result))
-			throw new Error("Child-result reference content must be its deterministic projection");
-		// The C04 projection itself has the 64-KiB cap.  Do not apply C03's
-		// legacy 24-KiB envelope cap here: that would silently narrow C04.
+			throw new Error("Safe-terminal result details are not approved");
+		if (!isBoundedText(value.content, MAX_RLM_SAFE_TERMINAL_CONTENT_CHARS))
+			throw new Error("Safe-terminal human content is invalid or too large");
+		// The string is deliberately opaque; only the full envelope byte cap is checked.
+		if (Buffer.byteLength(stableJson(value), "utf8") > MAX_RLM_SAFE_TERMINAL_MESSAGE_BYTES)
+			throw new Error("Safe-terminal terminal message is too large");
 	} else throw new Error("Terminal message custom type is not approved");
-	if (value.customType !== "rlm_child_result_reference") {
+	if (value.customType !== "rlm_safe_terminal_result") {
 		if (!isBoundedText(value.content, MAX_MESSAGE_CHARS) || Buffer.byteLength(stableJson(value)) > MAX_MESSAGE_BYTES)
 			throw new Error("Terminal message is too large");
 	}
 }
 
 /**
- * Stable C03 transcript/outbox representation of C04's public projection.
- * It deliberately contains only the projection and has no owner/path/body
- * interpolation or provider/queue side effect.
+ * Creates the generic safe-terminal envelope from already-sanitized caller
+ * inputs. It deliberately makes no interpretation of `projection`.
  */
-export function formatRlmChildResultReference(result: RlmChildResultReferenceV1): string {
-	assertChildResultReference(result);
-	return stableJson(result);
-}
-
-/** Creates the only accepted C04 terminal-message form. */
-export function createRlmChildResultReferenceTerminalMessage(
-	result: RlmChildResultReferenceV1,
+export function createRlmSafeTerminalResultTerminalMessage(
+	content: string,
+	projection: string,
 	timestamp: number,
-): Extract<RlmTerminalMessage, { customType: "rlm_child_result_reference" }> {
+): Extract<RlmTerminalMessage, { customType: "rlm_safe_terminal_result" }> {
 	if (!Number.isFinite(timestamp)) throw new Error("Terminal timestamp must be finite");
-	const content = formatRlmChildResultReference(result);
-	return {
-		role: "custom",
-		customType: "rlm_child_result_reference",
+	const message = {
+		role: "custom" as const,
+		customType: "rlm_safe_terminal_result" as const,
 		content,
-		display: true,
-		details: { kind: "child_result_v1", result },
+		display: true as const,
+		details: { kind: "safe_terminal_result_v1" as const, projection },
 		timestamp,
 	};
+	assertTerminalMessage(message);
+	return message;
 }
 
-/**
- * Exact, recursive C04 wire validator.  This validates the public C03
- * projection, rather than C04's owner-bearing on-disk ChildResult.  Thus a
- * successful value cannot smuggle a capability, a path, a body, or C01/C03
- * correlation fields through an unknown nested property.
- */
-export function assertChildResultReference(value: unknown): asserts value is RlmChildResultReferenceV1 {
-	if (!isObject(value)) throw new Error("Child-result reference has unknown or missing fields");
-	const hasError = value.error !== undefined;
-	const hasModel = value.model !== undefined;
-	if (
-		!exactKeys(value, [
-			"version",
-			"resultId",
-			"status",
-			"summary",
-			"preview",
-			"artifacts",
-			"retentionState",
-			...(hasError ? ["error"] : []),
-			...(hasModel ? ["model"] : []),
-		])
-	)
-		throw new Error("Child-result reference has unknown or missing fields");
-	if (value.version !== RLM_CHILD_RESULT_REFERENCE_VERSION)
-		throw new Error("Child-result reference version is unsupported");
-	assertUuidV4(value.resultId, "resultId");
-	if (
-		typeof value.status !== "string" ||
-		!RLM_CHILD_RESULT_STATUSES.has(value.status as RlmChildResultReferenceV1["status"])
-	)
-		throw new Error("Child-result status is not approved");
-	assertResultText(value.summary, "summary", MAX_RLM_CHILD_RESULT_SUMMARY_CHARS, MAX_RLM_CHILD_RESULT_SUMMARY_BYTES);
-	assertResultText(value.preview, "preview", MAX_RLM_CHILD_RESULT_PREVIEW_CHARS, MAX_RLM_CHILD_RESULT_PREVIEW_BYTES);
-	if (
-		typeof value.retentionState !== "string" ||
-		!RLM_CHILD_RESULT_RETENTION_STATES.has(value.retentionState as RlmChildResultReferenceV1["retentionState"])
-	)
-		throw new Error("Child-result retention state is not approved");
-	if (hasModel) assertChildResultModel(value.model);
-	if (!Array.isArray(value.artifacts) || value.artifacts.length > MAX_RLM_CHILD_RESULT_ARTIFACTS)
-		throw new Error("Child-result artifacts are too numerous or invalid");
-	const handles = new Set<string>();
-	for (const artifact of value.artifacts) {
-		assertChildResultArtifact(artifact, value.resultId);
-		if (handles.has(artifact.handleId)) throw new Error("Child-result artifact handles must be unique");
-		handles.add(artifact.handleId);
+/** Verifies that the JavaScript string contains Unicode scalar values only. */
+function isUtf8String(value: unknown): value is string {
+	if (typeof value !== "string") return false;
+	for (let index = 0; index < value.length; index++) {
+		const unit = value.charCodeAt(index);
+		if (unit >= 0xd800 && unit <= 0xdbff) {
+			if (index + 1 >= value.length) return false;
+			const next = value.charCodeAt(++index);
+			if (next < 0xdc00 || next > 0xdfff) return false;
+		} else if (unit >= 0xdc00 && unit <= 0xdfff) return false;
 	}
-	if (value.status === "completed") {
-		if (value.error !== undefined) throw new Error("Completed child result cannot carry an error");
-	} else {
-		assertChildResultError(value.error);
-	}
-	if (Buffer.byteLength(stableJson(value), "utf8") > MAX_RLM_CHILD_RESULT_REFERENCE_BYTES)
-		throw new Error("Child-result reference is too large");
-}
-
-/** Boolean form for reducers which must fail closed without throwing. */
-export function isRlmChildResultReference(value: unknown): value is RlmChildResultReferenceV1 {
-	try {
-		assertChildResultReference(value);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-function assertChildResultArtifact(value: unknown, resultId: string): asserts value is RlmChildResultArtifactReference {
-	if (
-		!isObject(value) ||
-		!exactKeys(value, [
-			"version",
-			"handleId",
-			"resultId",
-			"kind",
-			"contentType",
-			"byteLength",
-			"sha256",
-			"retentionState",
-		])
-	)
-		throw new Error("Child-result artifact has unknown or missing fields");
-	if (value.version !== RLM_CHILD_RESULT_REFERENCE_VERSION)
-		throw new Error("Child-result artifact version is unsupported");
-	assertUuidV4(value.handleId, "handleId");
-	if (value.resultId !== resultId) throw new Error("Child-result artifact resultId does not match");
-	if (
-		typeof value.kind !== "string" ||
-		!RLM_CHILD_RESULT_ARTIFACT_KINDS.has(value.kind as RlmChildResultArtifactReference["kind"])
-	)
-		throw new Error("Child-result artifact kind is not approved");
-	if (
-		typeof value.contentType !== "string" ||
-		!RLM_CHILD_RESULT_CONTENT_TYPES.has(value.contentType as RlmChildResultArtifactReference["contentType"])
-	)
-		throw new Error("Child-result artifact content type is not approved");
-	if (
-		typeof value.byteLength !== "number" ||
-		!Number.isSafeInteger(value.byteLength) ||
-		value.byteLength < 0 ||
-		value.byteLength > MAX_RLM_CHILD_RESULT_ARTIFACT_BYTES
-	)
-		throw new Error("Child-result artifact byte length is invalid");
-	if (typeof value.sha256 !== "string" || !SHA256.test(value.sha256))
-		throw new Error("Child-result artifact sha256 is invalid");
-	if (
-		typeof value.retentionState !== "string" ||
-		!RLM_CHILD_RESULT_RETENTION_STATES.has(value.retentionState as RlmChildResultReferenceV1["retentionState"])
-	)
-		throw new Error("Child-result artifact retention state is not approved");
-}
-
-function assertChildResultModel(value: unknown): asserts value is RlmChildResultModelReference {
-	if (!isObject(value)) throw new Error("Child-result model is invalid");
-	const hasRequested = value.requestedSelector !== undefined;
-	const hasHistory = value.fallbackHistory !== undefined;
-	if (
-		!exactKeys(value, [
-			"initialResolvedSelector",
-			"terminalResolvedSelector",
-			...(hasRequested ? ["requestedSelector"] : []),
-			...(hasHistory ? ["fallbackHistory"] : []),
-		])
-	)
-		throw new Error("Child-result model has unknown or missing fields");
-	if (hasRequested)
-		assertResultText(
-			value.requestedSelector,
-			"requestedSelector",
-			MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS,
-			MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES,
-		);
-	assertResultText(
-		value.initialResolvedSelector,
-		"initialResolvedSelector",
-		MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS,
-		MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES,
-	);
-	assertResultText(
-		value.terminalResolvedSelector,
-		"terminalResolvedSelector",
-		MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS,
-		MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES,
-	);
-	if (hasHistory) {
-		if (!Array.isArray(value.fallbackHistory) || value.fallbackHistory.length > MAX_RLM_CHILD_RESULT_MODEL_FALLBACKS)
-			throw new Error("Child-result model fallback history is invalid");
-		for (const selector of value.fallbackHistory)
-			assertResultText(
-				selector,
-				"fallback selector",
-				MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_CHARS,
-				MAX_RLM_CHILD_RESULT_MODEL_SELECTOR_BYTES,
-			);
-	}
-}
-
-function assertChildResultError(value: unknown): asserts value is RlmChildResultErrorReference {
-	if (
-		!isObject(value) ||
-		!exactKeys(value, ["code", "message"]) ||
-		typeof value.code !== "string" ||
-		!RLM_CHILD_RESULT_ERROR_CODES.has(value.code as RlmChildResultErrorCode)
-	)
-		throw new Error("Child-result error is not a closed safe error");
-	assertResultText(
-		value.code,
-		"error code",
-		MAX_RLM_CHILD_RESULT_ERROR_CODE_CHARS,
-		MAX_RLM_CHILD_RESULT_ERROR_CODE_BYTES,
-	);
-	assertResultText(
-		value.message,
-		"error message",
-		MAX_RLM_CHILD_RESULT_ERROR_MESSAGE_CHARS,
-		MAX_RLM_CHILD_RESULT_ERROR_MESSAGE_BYTES,
-	);
-}
-
-function assertUuidV4(value: unknown, name: string): asserts value is string {
-	if (typeof value !== "string" || !UUID_V4.test(value)) throw new Error(`${name} must be a canonical UUIDv4`);
-}
-
-function assertResultText(value: unknown, name: string, charLimit: number, byteLimit: number): asserts value is string {
-	if (
-		typeof value !== "string" ||
-		!value.trim() ||
-		Array.from(value).length > charLimit ||
-		Buffer.byteLength(value, "utf8") > byteLimit
-	)
-		throw new Error(`${name} is invalid or too large`);
+	return true;
 }
 
 function digestMessage(message: RlmTerminalMessage): string {

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -399,7 +399,12 @@ class Store implements RlmDurableOperationStore {
 		const operation = registry.operations.get(
 			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
 		);
-		if (!operation || operation.uncertain || operation.lifecycle !== "admitted") return false;
+		if (
+			!operation ||
+			operation.uncertain ||
+			(operation.lifecycle !== "admitted" && operation.lifecycle !== "materialized")
+		)
+			return false;
 		const childFile = canonicalExistingFile(input.childSessionFile, input.childSessionRoot, this.io);
 		try {
 			assertSessionIdentity(input.childSessionId, childFile, this.io);

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -88,7 +88,7 @@ export interface RlmOperationTerminalRecordedRecord {
 }
 export interface RlmOperationReleasedRecord {
 	version: 1;
-	type: "released" | "deleted";
+	type: "delete_intent" | "released" | "deleted";
 	parentSessionId: string;
 	assignmentId: string;
 	operationId: string;
@@ -207,7 +207,9 @@ export interface RlmDurableOperation {
 	childArtifactDir?: string;
 	childArtifactRoot?: string;
 	terminal?: RlmChildTerminalStatus;
-	lifecycle: "admitted" | "materialized" | "terminal_recorded" | "released" | "deleted";
+	lifecycle: "admitted" | "materialized" | "delete_intent" | "terminal_recorded" | "released" | "deleted";
+	/** A live explicit deletion is durably retained until its terminal hand-off can be deleted. */
+	deleteIntent: boolean;
 	uncertain: boolean;
 }
 export interface RlmDurableDelivery {
@@ -243,6 +245,8 @@ export interface RlmDurableOperationStore {
 	importPendingOutboxes(): number;
 	/** Owner-only pending bodies, after durable inbox reduction. */
 	pendingInbox(): readonly RlmTerminalInboxRecord[];
+	/** Exact-key live-delete fence, retained through cancellation until terminal hand-off. */
+	recordDeleteIntent(input: Pick<RlmOperationTerminal, "parentSessionId" | "assignmentId" | "operationId">): boolean;
 	/** Exact-key terminal-only lifecycle transition for daemon adapters. */
 	recordRelease(
 		input: Pick<RlmOperationTerminal, "parentSessionId" | "assignmentId" | "operationId">,
@@ -438,7 +442,7 @@ class Store implements RlmDurableOperationStore {
 		if (
 			!operation ||
 			operation.uncertain ||
-			operation.lifecycle !== "materialized" ||
+			(operation.lifecycle !== "materialized" && operation.lifecycle !== "delete_intent") ||
 			!operation.childSessionFile ||
 			operation.deliveryId !== input.deliveryId
 		)
@@ -570,6 +574,26 @@ class Store implements RlmDurableOperationStore {
 		const registry = this.reduce();
 		this.writeIndex(registry); // cache failure cannot undo an fsynced authority append.
 		return registry;
+	}
+
+	/** Durable exact-key delete request for a live operation. It is not completion. */
+	recordDeleteIntent(input: Pick<RlmOperationTerminal, "parentSessionId" | "assignmentId" | "operationId">): boolean {
+		assertOperationInput(input);
+		const operation = this.reduce().operations.get(
+			operationKey(input.parentSessionId, input.assignmentId, input.operationId),
+		);
+		if (!operation || operation.uncertain) return false;
+		if (operation.lifecycle === "deleted") return true;
+		if (operation.deleteIntent) return true;
+		if (
+			operation.lifecycle !== "admitted" &&
+			operation.lifecycle !== "materialized" &&
+			operation.lifecycle !== "terminal_recorded"
+		)
+			return false;
+		this.append(this.path(LEDGER), { version: 1, type: "delete_intent", ...input, recordedAt: this.now() });
+		this.afterAppend();
+		return true;
 	}
 
 	/** Releases/deletes are deliberately internal helpers for later host integration. */
@@ -815,6 +839,7 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 				rlmDepth: record.rlmDepth,
 				rlmMaxDepth: record.rlmMaxDepth,
 				lifecycle: "admitted",
+				deleteIntent: false,
 				uncertain: false,
 			});
 		} else if (!sameAdmitted(existing, record)) markOperationUncertain(existing, registry, "conflicting admission");
@@ -854,7 +879,7 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 	if (raw.type === "terminal_recorded") {
 		if (
 			!validTerminalRecorded(raw) ||
-			operation.lifecycle !== "materialized" ||
+			(operation.lifecycle !== "materialized" && operation.lifecycle !== "delete_intent") ||
 			!operation.childSessionFile ||
 			raw.deliveryId !== operation.deliveryId
 		) {
@@ -866,6 +891,25 @@ function reduceLedger(raw: unknown, registry: RlmDurableOperationRegistry): void
 			operation.lifecycle = "terminal_recorded";
 		} else if (operation.terminal !== raw.terminal)
 			markOperationUncertain(operation, registry, "conflicting terminal");
+		return;
+	}
+	if (raw.type === "delete_intent") {
+		if (!validDeleteIntent(raw)) {
+			markOperationUncertain(operation, registry, "invalid delete intent");
+			return;
+		}
+		if (operation.lifecycle === "deleted") return;
+		if (operation.deleteIntent) return;
+		if (
+			operation.lifecycle !== "admitted" &&
+			operation.lifecycle !== "materialized" &&
+			operation.lifecycle !== "terminal_recorded"
+		) {
+			markOperationUncertain(operation, registry, "delete intent after release");
+			return;
+		}
+		operation.deleteIntent = true;
+		if (operation.lifecycle !== "terminal_recorded") operation.lifecycle = "delete_intent";
 		return;
 	}
 	if (raw.type === "released" || raw.type === "deleted") {
@@ -1356,6 +1400,14 @@ function validMaterialized(value: Record<string, unknown>): value is Record<stri
 		["childSessionFile", "childSessionRoot", "childArtifactDir", "childArtifactRoot"].every(
 			(key) => typeof value[key] === "string" && isAbsolute(value[key] as string),
 		) &&
+		validStamped(value)
+	);
+}
+function validDeleteIntent(value: Record<string, unknown>): boolean {
+	return (
+		exactKeys(value, ["version", "type", "parentSessionId", "assignmentId", "operationId", "recordedAt"]) &&
+		hasOperationIdentity(value) &&
+		value.type === "delete_intent" &&
 		validStamped(value)
 	);
 }

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -219,6 +219,9 @@ export interface RlmDurableDelivery {
 	received: boolean;
 	consumed?: "materialized" | "discarded";
 	uncertain: boolean;
+	/** Internal reducer projection; never cached or sent on a public surface. */
+	inboxRecord?: RlmTerminalInboxRecord;
+	outboxRecord?: RlmTerminalOutboxRecord;
 }
 export interface RlmDurableOperationRegistry {
 	operations: Map<string, RlmDurableOperation>;
@@ -236,6 +239,15 @@ export interface RlmDurableOperationStore {
 	importOutbox(input: RlmTerminalOutbox): "new" | "already_received";
 	markMaterializedDelivery(input: RlmDeliveryMaterialization): "new" | "already_materialized";
 	markDiscardedDelivery(input: RlmDeliveryDiscard): "new" | "already_discarded";
+	/** Owner-only recovery join: append eligible authenticated outboxes to the inbox. */
+	importPendingOutboxes(): number;
+	/** Owner-only pending bodies, after durable inbox reduction. */
+	pendingInbox(): readonly RlmTerminalInboxRecord[];
+	/** Exact-key terminal-only lifecycle transition for daemon adapters. */
+	recordRelease(
+		input: Pick<RlmOperationTerminal, "parentSessionId" | "assignmentId" | "operationId">,
+		type: "released" | "deleted",
+	): boolean;
 	rebuild(): RlmDurableOperationRegistry;
 }
 
@@ -522,6 +534,36 @@ class Store implements RlmDurableOperationStore {
 		this.append(this.path(CONSUMED), { version: 1, type: "discarded", ...input, recordedAt: this.now() });
 		this.afterAppend();
 		return "new";
+	}
+
+	importPendingOutboxes(): number {
+		const registry = this.reduce();
+		let imported = 0;
+		for (const delivery of registry.deliveries.values()) {
+			const operation = registry.operations.get(delivery.operationKey);
+			const record = delivery.outboxRecord;
+			if (
+				!operation ||
+				operation.uncertain ||
+				delivery.uncertain ||
+				delivery.received ||
+				!record ||
+				operation.terminal !== record.terminal ||
+				!delivery.outboxed
+			)
+				continue;
+			const { recordedAt: _recordedAt, ...outboxFact } = record;
+			this.append(this.path(INBOX), { ...outboxFact, type: "received", receivedAt: this.now() });
+			imported++;
+		}
+		if (imported) this.afterAppend();
+		return imported;
+	}
+
+	pendingInbox(): readonly RlmTerminalInboxRecord[] {
+		return [...this.reduce().deliveries.values()]
+			.filter((delivery) => delivery.received && !delivery.consumed && !delivery.uncertain && delivery.inboxRecord)
+			.map((delivery) => delivery.inboxRecord!);
 	}
 
 	rebuild(): RlmDurableOperationRegistry {
@@ -870,6 +912,7 @@ function reduceOutbox(raw: unknown, registry: RlmDurableOperationRegistry): void
 	if (!delivery.outboxed) {
 		delivery.outboxed = true;
 		delivery.terminal = record.terminal;
+		delivery.outboxRecord = record;
 		defineDeliveryDigest(delivery, record);
 	} else if (
 		delivery.terminal !== record.terminal ||
@@ -922,6 +965,7 @@ function reduceInbox(raw: unknown, registry: RlmDurableOperationRegistry): void 
 	}
 	if (!delivery.received) {
 		delivery.received = true;
+		delivery.inboxRecord = record;
 		defineDeliveryDigest(delivery, record);
 	} else if (deliveryDigest(delivery, record) !== digestMessage(record.message))
 		markDeliveryUncertain(delivery, operation, registry, "conflicting inbox");

--- a/packages/coding-agent/src/core/rlm-durable-operations.ts
+++ b/packages/coding-agent/src/core/rlm-durable-operations.ts
@@ -10,6 +10,7 @@ import {
 	chmodSync,
 	closeSync,
 	fsyncSync,
+	ftruncateSync,
 	mkdirSync,
 	openSync,
 	readFileSync,
@@ -271,6 +272,7 @@ export interface RlmDurableIo {
 	closeSync: typeof closeSync;
 	writeSync: typeof writeSync;
 	fsyncSync: typeof fsyncSync;
+	ftruncateSync: typeof ftruncateSync;
 	readFileSync: typeof readFileSync;
 	realpathSync: typeof realpathSync;
 	renameSync: typeof renameSync;
@@ -308,6 +310,7 @@ const defaultIo: RlmDurableIo = {
 	closeSync,
 	writeSync,
 	fsyncSync,
+	ftruncateSync,
 	readFileSync,
 	realpathSync,
 	renameSync,
@@ -817,11 +820,13 @@ function readJsonl(path: string, io: RlmDurableIo, registry: RlmDurableOperation
 			registry.diagnostics = [...registry.diagnostics, `${kind}: empty complete line ${i + 1}`];
 			continue;
 		}
+		// A final record becomes authoritative only with its newline delimiter. A
+		// crash may leave valid JSON without that delimiter; ignore the whole tail
+		// so a later append can truncate it instead of concatenating two records.
+		if (!hasFinalNewline && i === count - 1) continue;
 		try {
 			parsed.push(JSON.parse(line));
 		} catch {
-			// Only an invalid physical final tail without a newline is crash-tolerated.
-			if (!hasFinalNewline && i === count - 1) continue;
 			registry.hasUncertainRecords = true;
 			registry.diagnostics = [...registry.diagnostics, `${kind}: malformed complete line ${i + 1}`];
 		}
@@ -1132,14 +1137,35 @@ function globalUncertain(registry: RlmDurableOperationRegistry, message: string)
 }
 
 function appendJsonl(path: string, record: unknown, io: RlmDurableIo): void {
+	// Never append after a crash-torn physical record. It is not authority until
+	// its newline landed, and retaining it would merge two JSON values into one
+	// malformed line. Read before opening so ENOENT remains the normal first-write path.
+	let retainedBytes: number | undefined;
+	try {
+		const existing = io.readFileSync(path, "utf8") as string;
+		if (existing && !existing.endsWith("\n")) {
+			const newline = existing.lastIndexOf("\n");
+			retainedBytes = Buffer.byteLength(newline < 0 ? "" : existing.slice(0, newline + 1));
+		}
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
 	const fd = io.openSync(path, "a", 0o600);
 	try {
+		if (retainedBytes !== undefined) io.ftruncateSync(fd, retainedBytes);
 		writeAll(fd, Buffer.from(`${JSON.stringify(record)}\n`), io);
 		io.fsyncSync(fd);
 	} finally {
 		io.closeSync(fd);
 	}
 	io.chmodSync(path, 0o600);
+	// File fsync alone cannot persist a newly-created directory entry.
+	const directory = io.openSync(dirname(path), "r");
+	try {
+		io.fsyncSync(directory);
+	} finally {
+		io.closeSync(directory);
+	}
 }
 function writeAll(fd: number, data: Buffer, io: RlmDurableIo): void {
 	let offset = 0;

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -208,6 +208,10 @@ export interface RlmSubagentRuntime {
 	session: AgentSession;
 	/** Immutable attempt identity; never expose this in the public child catalog. */
 	assignmentId?: string;
+	/** C03 internal durable operation identity. */
+	operationId?: string;
+	/** C03 internal terminal delivery identity. */
+	deliveryId?: string;
 }
 
 export interface CreateRlmSubagentRuntimeOptions {
@@ -215,6 +219,9 @@ export interface CreateRlmSubagentRuntimeOptions {
 	id: string;
 	/** Minted by the parent before this child is published. */
 	assignmentId?: string;
+	/** Durable daemon-only identities; never projected through public handles. */
+	operationId?: string;
+	deliveryId?: string;
 	prompt: string;
 	sessionName: string;
 	sessionDir: string;
@@ -241,7 +248,12 @@ export interface SubagentRuntimeHost {
 	readonly assignmentIdentityFenced?: true;
 	createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime>;
 	/** Persist host-owned completion before the child becomes passivation-eligible. */
-	completeRlmSubagentRuntime?(childId: string, session: AgentSession, assignmentId?: string): boolean;
+	completeRlmSubagentRuntime?(
+		childId: string,
+		session: AgentSession,
+		assignmentId?: string,
+		operationId?: string,
+	): boolean;
 	/** Release a host-owned child after its detached initial task settles. */
 	releaseRlmSubagentRuntime?: (
 		runtime: RlmSubagentRuntime,
@@ -249,6 +261,19 @@ export interface SubagentRuntimeHost {
 		status: "done" | "error" | "cancelled",
 	) => Promise<void>;
 	/** Close or remove the host-owned child; session is absent when a persisted child is still passive. */
-	deleteRlmSubagentRuntime(childId: string, session?: AgentSession, assignmentId?: string): Promise<void>;
+	deleteRlmSubagentRuntime(
+		childId: string,
+		session?: AgentSession,
+		assignmentId?: string,
+		operationId?: string,
+	): Promise<void>;
+	/** Private daemon durable seams. No protocol/public-handle field may use these. */
+	admitRlmSubagentOperation?(options: CreateRlmSubagentRuntimeOptions): void;
+	deliverRlmSubagentTerminal?(
+		runtime: RlmSubagentRuntime,
+		options: CreateRlmSubagentRuntimeOptions,
+		terminal: RlmChildTerminalStatus,
+		message: import("./rlm-durable-operations.js").RlmTerminalMessage,
+	): Promise<void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;
 }

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -5,15 +5,18 @@ import {
 	appendFileSync,
 	chmodSync,
 	chownSync,
+	closeSync,
 	existsSync,
+	fsyncSync,
 	mkdirSync,
+	openSync,
 	readdirSync,
 	readFileSync,
 	realpathSync,
 	renameSync,
 	rmSync,
 	statSync,
-	writeFileSync,
+	writeSync,
 } from "fs";
 import { readdir, readFile, stat } from "fs/promises";
 import { basename, dirname, join, resolve } from "path";
@@ -69,6 +72,25 @@ function statMetadataIfPresent(path: string): { mode: number; uid: number; gid: 
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 		throw error;
+	}
+}
+
+/** Write a buffer completely: Node's synchronous write may still make short progress. */
+function writeAllSync(fd: number, bytes: Buffer): void {
+	let offset = 0;
+	while (offset < bytes.length) {
+		const written = writeSync(fd, bytes, offset, bytes.length - offset);
+		if (written <= 0) throw new Error("Session persistence made no write progress");
+		offset += written;
+	}
+}
+
+function fsyncDirectorySync(directory: string): void {
+	const fd = openSync(directory, "r");
+	try {
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
 	}
 }
 
@@ -1373,21 +1395,33 @@ export class SessionManager {
 		}
 	}
 
+	/**
+	 * Replace the transcript atomically.  This is also the durability primitive
+	 * used when C03 creates a transcript: bytes and metadata are fsynced before
+	 * rename, then the containing directory is fsynced before acknowledgement.
+	 */
 	private _rewriteFile(): void {
 		if (!this.persist || !this.sessionFile) return;
-		const content = `${this.fileEntries.map((e) => JSON.stringify(e)).join("\n")}\n`;
+		const bytes = Buffer.from(`${this.fileEntries.map((e) => JSON.stringify(e)).join("\n")}\n`);
 		const targetPath = realpathIfPresent(this.sessionFile);
 		const directory = dirname(targetPath);
 		mkdirSync(directory, { recursive: true });
 		const tempPath = join(directory, `.${basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`);
 		try {
 			const metadata = statMetadataIfPresent(targetPath);
-			writeFileSync(tempPath, content, metadata === undefined ? undefined : { mode: metadata.mode });
-			if (metadata !== undefined) {
-				chownSync(tempPath, metadata.uid, metadata.gid);
-				chmodSync(tempPath, metadata.mode);
+			const fd = openSync(tempPath, "wx", metadata?.mode ?? 0o600);
+			try {
+				writeAllSync(fd, bytes);
+				if (metadata !== undefined) {
+					chownSync(tempPath, metadata.uid, metadata.gid);
+					chmodSync(tempPath, metadata.mode);
+				}
+				fsyncSync(fd);
+			} finally {
+				closeSync(fd);
 			}
 			renameSync(tempPath, targetPath);
+			fsyncDirectorySync(directory);
 		} finally {
 			rmSync(tempPath, { force: true });
 		}
@@ -1825,6 +1859,67 @@ export class SessionManager {
 		details?: T,
 	): string {
 		return this._appendEntryWithRollback(() => this.appendCustomMessageEntry(customType, content, display, details));
+	}
+
+	/**
+	 * Internal C03 seam: append one ordinary custom transcript entry without
+	 * using the prompt/stream queue.  It mutates the in-memory tree only while
+	 * the matching bytes are durably persisted and rolls the tree back on every
+	 * write/fsync/rename failure.  Returns false for non-persisted managers.
+	 */
+	appendDurableCustomMessageEntry<T = unknown>(
+		customType: string,
+		content: string | (TextContent | ImageContent)[],
+		display: boolean,
+		details?: T,
+	): boolean {
+		if (!this.persist || !this.sessionFile) return false;
+		const entry: CustomMessageEntry<T> = {
+			type: "custom_message",
+			customType,
+			content,
+			display,
+			details,
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+		};
+		const previousLeafId = this.leafId;
+		this.fileEntries.push(entry);
+		this.byId.set(entry.id, entry);
+		this.leafId = entry.id;
+		try {
+			const file = this.sessionFile;
+			if (!this.flushed || !existsSync(file)) {
+				this._rewriteFile();
+				this.flushed = true;
+			} else {
+				const fd = openSync(file, "a");
+				try {
+					writeAllSync(fd, Buffer.from(`${JSON.stringify(entry)}\n`));
+					fsyncSync(fd);
+				} finally {
+					closeSync(fd);
+				}
+				this._notifyPersistListeners();
+			}
+			return true;
+		} catch (error) {
+			this.byId.delete(entry.id);
+			this.fileEntries.pop();
+			this.leafId = previousLeafId;
+			// A failed append can have reached the kernel before fsync reports an
+			// error. Best-effort restore the pre-append tree, never acknowledge this
+			// attempt, and force a later retry/restart to re-establish authority.
+			this.flushed = false;
+			try {
+				this._rewriteFile();
+				this.flushed = true;
+			} catch {
+				this.flushed = false;
+			}
+			throw error;
+		}
 	}
 
 	private _appendEntryWithRollback(append: () => string): string {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -16,7 +16,7 @@ import {
 	renameSync,
 	rmSync,
 	statSync,
-	writeSync,
+	writeFileSync,
 } from "fs";
 import { readdir, readFile, stat } from "fs/promises";
 import { basename, dirname, join, resolve } from "path";
@@ -90,12 +90,10 @@ type SessionDurabilityIo = {
 
 const productionSessionDurabilityIo: SessionDurabilityIo = {
 	writeAll(fd, bytes) {
-		let offset = 0;
-		while (offset < bytes.length) {
-			const written = writeSync(fd, bytes, offset, bytes.length - offset);
-			if (written <= 0) throw new Error("Session persistence made no write progress");
-			offset += written;
-		}
+		// writeFileSync(fd, ...) completes the full buffer (unlike one writeSync
+		// call) and preserves the established synchronous fs-failure contract used
+		// by flush callers. The descriptor remains open for the required fsync.
+		writeFileSync(fd, bytes);
 	},
 	fileFsync(fd) {
 		fsyncSync(fd);

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -75,24 +75,46 @@ function statMetadataIfPresent(path: string): { mode: number; uid: number; gid: 
 	}
 }
 
-/** Write a buffer completely: Node's synchronous write may still make short progress. */
-function writeAllSync(fd: number, bytes: Buffer): void {
-	let offset = 0;
-	while (offset < bytes.length) {
-		const written = writeSync(fd, bytes, offset, bytes.length - offset);
-		if (written <= 0) throw new Error("Session persistence made no write progress");
-		offset += written;
-	}
-}
+/**
+ * Private persistence cut points. They are intentionally narrower than fs: the
+ * only supported test fault injections are the five durability boundaries C03
+ * relies upon. Production always uses the synchronous Node primitives below.
+ */
+type SessionDurabilityIo = {
+	writeAll(fd: number, bytes: Buffer): void;
+	fileFsync(fd: number): void;
+	tempFsync(fd: number): void;
+	rename(tempPath: string, targetPath: string): void;
+	directoryFsync(directory: string): void;
+};
 
-function fsyncDirectorySync(directory: string): void {
-	const fd = openSync(directory, "r");
-	try {
+const productionSessionDurabilityIo: SessionDurabilityIo = {
+	writeAll(fd, bytes) {
+		let offset = 0;
+		while (offset < bytes.length) {
+			const written = writeSync(fd, bytes, offset, bytes.length - offset);
+			if (written <= 0) throw new Error("Session persistence made no write progress");
+			offset += written;
+		}
+	},
+	fileFsync(fd) {
 		fsyncSync(fd);
-	} finally {
-		closeSync(fd);
-	}
-}
+	},
+	tempFsync(fd) {
+		fsyncSync(fd);
+	},
+	rename(tempPath, targetPath) {
+		renameSync(tempPath, targetPath);
+	},
+	directoryFsync(directory) {
+		const fd = openSync(directory, "r");
+		try {
+			fsyncSync(fd);
+		} finally {
+			closeSync(fd);
+		}
+	},
+};
 
 export interface SessionHeader {
 	type: "session";
@@ -1242,6 +1264,22 @@ async function listSessionsFromDir(
  * handles compaction summaries and follows the path from root to current leaf.
  */
 export class SessionManager {
+	private static durabilityIo: SessionDurabilityIo = productionSessionDurabilityIo;
+
+	/**
+	 * Test-only, process-local C03 durability seam. This is deliberately not
+	 * exported from the package surface; callers get a restore closure so a cut
+	 * cannot leak into another test or into a later retry.
+	 */
+	// biome-ignore lint/correctness/noUnusedPrivateClassMembers: tests invoke the deliberately private seam through a narrowed cast.
+	private static _setDurabilityIoForTest(overrides: Partial<SessionDurabilityIo>): () => void {
+		const previous = SessionManager.durabilityIo;
+		SessionManager.durabilityIo = { ...previous, ...overrides };
+		return () => {
+			SessionManager.durabilityIo = previous;
+		};
+	}
+
 	private sessionId: string = "";
 	private sessionFile: string | undefined;
 	private sessionDir: string;
@@ -1411,17 +1449,17 @@ export class SessionManager {
 			const metadata = statMetadataIfPresent(targetPath);
 			const fd = openSync(tempPath, "wx", metadata?.mode ?? 0o600);
 			try {
-				writeAllSync(fd, bytes);
+				SessionManager.durabilityIo.writeAll(fd, bytes);
 				if (metadata !== undefined) {
 					chownSync(tempPath, metadata.uid, metadata.gid);
 					chmodSync(tempPath, metadata.mode);
 				}
-				fsyncSync(fd);
+				SessionManager.durabilityIo.tempFsync(fd);
 			} finally {
 				closeSync(fd);
 			}
-			renameSync(tempPath, targetPath);
-			fsyncDirectorySync(directory);
+			SessionManager.durabilityIo.rename(tempPath, targetPath);
+			SessionManager.durabilityIo.directoryFsync(directory);
 		} finally {
 			rmSync(tempPath, { force: true });
 		}
@@ -1896,8 +1934,8 @@ export class SessionManager {
 			} else {
 				const fd = openSync(file, "a");
 				try {
-					writeAllSync(fd, Buffer.from(`${JSON.stringify(entry)}\n`));
-					fsyncSync(fd);
+					SessionManager.durabilityIo.writeAll(fd, Buffer.from(`${JSON.stringify(entry)}\n`));
+					SessionManager.durabilityIo.fileFsync(fd);
 				} finally {
 					closeSync(fd);
 				}

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -6,6 +6,7 @@ import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
 import { readSessionInfo, type SessionInfo, SessionManager } from "../../core/session-manager.js";
+import { assertFreshUuid } from "./daemon-lifecycle-identity.js";
 
 export const DAEMON_CATALOG_ROLE_ENV = "PRIME_AGENT_INTERNAL_DAEMON_CATALOG";
 
@@ -74,10 +75,12 @@ function savedRlmIncarnationKey(entry: SavedRlmSubagentRegistryEntry): string | 
 	if (typeof entry.childId !== "string") return undefined;
 	if (entry.assignmentId === undefined && entry.operationId === undefined && entry.deliveryId === undefined)
 		return `${entry.childId}\0legacy`;
+	// C03 durable identities are opaque canonical UUIDs. Any partial or malformed
+	// triple is untrusted registry history, not an alternative current incarnation.
 	if (
-		typeof entry.assignmentId !== "string" ||
-		typeof entry.operationId !== "string" ||
-		typeof entry.deliveryId !== "string"
+		!assertFreshUuid(entry.assignmentId) ||
+		!assertFreshUuid(entry.operationId) ||
+		!assertFreshUuid(entry.deliveryId)
 	)
 		return undefined;
 	return `${entry.childId}\0${entry.assignmentId}\0${entry.operationId}\0${entry.deliveryId}`;

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -70,19 +70,24 @@ interface SavedRlmSubagentRegistryEntry {
 	status?: unknown;
 }
 
+function hasCanonicalC03Identity(entry: SavedRlmSubagentRegistryEntry): boolean {
+	return (
+		assertFreshUuid(entry.assignmentId) && assertFreshUuid(entry.operationId) && assertFreshUuid(entry.deliveryId)
+	);
+}
+
 /** Read-only, private registry incarnation key. Legacy rows remain display-only. */
 function savedRlmIncarnationKey(entry: SavedRlmSubagentRegistryEntry): string | undefined {
 	if (typeof entry.childId !== "string") return undefined;
 	if (entry.assignmentId === undefined && entry.operationId === undefined && entry.deliveryId === undefined)
 		return `${entry.childId}\0legacy`;
+	// Pre-C03 C01 rows have a canonical assignment but no durable operation or
+	// delivery. Keep those as display-only history with their own incarnation key.
+	if (entry.operationId === undefined && entry.deliveryId === undefined && assertFreshUuid(entry.assignmentId))
+		return `${entry.childId}\0legacy-assignment\0${entry.assignmentId}`;
 	// C03 durable identities are opaque canonical UUIDs. Any partial or malformed
 	// triple is untrusted registry history, not an alternative current incarnation.
-	if (
-		!assertFreshUuid(entry.assignmentId) ||
-		!assertFreshUuid(entry.operationId) ||
-		!assertFreshUuid(entry.deliveryId)
-	)
-		return undefined;
+	if (!hasCanonicalC03Identity(entry)) return undefined;
 	return `${entry.childId}\0${entry.assignmentId}\0${entry.operationId}\0${entry.deliveryId}`;
 }
 
@@ -117,10 +122,18 @@ export async function listSavedSessionSiblings(sessionPath: string): Promise<Ses
 			// Ignore malformed registry history just like the owning worker does.
 		}
 	}
-	const newestBySelector = new Map<string, SavedRlmSubagentRegistryEntry>();
+	const newestLegacyBySelector = new Map<string, SavedRlmSubagentRegistryEntry>();
+	const newestC03BySelector = new Map<string, SavedRlmSubagentRegistryEntry>();
 	for (const entry of latestByIncarnation.values()) {
-		if (typeof entry.childId === "string") newestBySelector.set(entry.childId, entry);
+		if (typeof entry.childId !== "string") continue;
+		// Only a canonical full triple may select a current C03 incarnation. A
+		// display-only pre-C03 row cannot displace it, even if its old lifecycle
+		// update is appended after a C03 entry.
+		if (hasCanonicalC03Identity(entry)) newestC03BySelector.set(entry.childId, entry);
+		else newestLegacyBySelector.set(entry.childId, entry);
 	}
+	const newestBySelector = new Map(newestLegacyBySelector);
+	for (const [childId, entry] of newestC03BySelector) newestBySelector.set(childId, entry);
 	const siblingPaths = new Set<string>([resolve(target.path)]);
 	for (const entry of newestBySelector.values()) {
 		if (entry.status !== "deleted" && typeof entry.sessionFile === "string")

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -6,7 +6,7 @@ import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
 import { readSessionInfo, type SessionInfo, SessionManager } from "../../core/session-manager.js";
-import { assertFreshUuid } from "./daemon-lifecycle-identity.js";
+import { classifyRlmRegistryIdentity } from "./daemon-rlm-registry-identity.js";
 
 export const DAEMON_CATALOG_ROLE_ENV = "PRIME_AGENT_INTERNAL_DAEMON_CATALOG";
 
@@ -71,24 +71,23 @@ interface SavedRlmSubagentRegistryEntry {
 }
 
 function hasCanonicalC03Identity(entry: SavedRlmSubagentRegistryEntry): boolean {
-	return (
-		assertFreshUuid(entry.assignmentId) && assertFreshUuid(entry.operationId) && assertFreshUuid(entry.deliveryId)
-	);
+	return classifyRlmRegistryIdentity(entry).kind === "c03";
 }
 
 /** Read-only, private registry incarnation key. Legacy rows remain display-only. */
 function savedRlmIncarnationKey(entry: SavedRlmSubagentRegistryEntry): string | undefined {
 	if (typeof entry.childId !== "string") return undefined;
-	if (entry.assignmentId === undefined && entry.operationId === undefined && entry.deliveryId === undefined)
-		return `${entry.childId}\0legacy`;
-	// Pre-C03 C01 rows have a canonical assignment but no durable operation or
-	// delivery. Keep those as display-only history with their own incarnation key.
-	if (entry.operationId === undefined && entry.deliveryId === undefined && assertFreshUuid(entry.assignmentId))
-		return `${entry.childId}\0legacy-assignment\0${entry.assignmentId}`;
-	// C03 durable identities are opaque canonical UUIDs. Any partial or malformed
-	// triple is untrusted registry history, not an alternative current incarnation.
-	if (!hasCanonicalC03Identity(entry)) return undefined;
-	return `${entry.childId}\0${entry.assignmentId}\0${entry.operationId}\0${entry.deliveryId}`;
+	const identity = classifyRlmRegistryIdentity(entry);
+	switch (identity.kind) {
+		case "legacy-display":
+			return `${entry.childId}\0legacy`;
+		case "assignment-display":
+			return `${entry.childId}\0legacy-assignment\0${identity.assignmentId}`;
+		case "c03":
+			return `${entry.childId}\0${identity.assignmentId}\0${identity.operationId}\0${identity.deliveryId}`;
+		case "invalid":
+			return undefined;
+	}
 }
 
 export async function listSavedSessionSiblings(sessionPath: string): Promise<SessionInfo[]> {

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -62,8 +62,25 @@ function deserializeSessionInfo(session: SessionInfoWire): SessionInfo {
 interface SavedRlmSubagentRegistryEntry {
 	type?: unknown;
 	childId?: unknown;
+	assignmentId?: unknown;
+	operationId?: unknown;
+	deliveryId?: unknown;
 	sessionFile?: unknown;
 	status?: unknown;
+}
+
+/** Read-only, private registry incarnation key. Legacy rows remain display-only. */
+function savedRlmIncarnationKey(entry: SavedRlmSubagentRegistryEntry): string | undefined {
+	if (typeof entry.childId !== "string") return undefined;
+	if (entry.assignmentId === undefined && entry.operationId === undefined && entry.deliveryId === undefined)
+		return `${entry.childId}\0legacy`;
+	if (
+		typeof entry.assignmentId !== "string" ||
+		typeof entry.operationId !== "string" ||
+		typeof entry.deliveryId !== "string"
+	)
+		return undefined;
+	return `${entry.childId}\0${entry.assignmentId}\0${entry.operationId}\0${entry.deliveryId}`;
 }
 
 export async function listSavedSessionSiblings(sessionPath: string): Promise<SessionInfo[]> {
@@ -81,18 +98,28 @@ export async function listSavedSessionSiblings(sessionPath: string): Promise<Ses
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [target];
 		throw error;
 	}
-	const latest = new Map<string, SavedRlmSubagentRegistryEntry>();
+	// Preserve the first durable incarnation position when a later lifecycle row
+	// updates A. A selector reused by B must still select B, not be overwritten by
+	// A's late completion/deletion. This parser has no authority to wake, write, or
+	// materialize C03 delivery files.
+	const latestByIncarnation = new Map<string, SavedRlmSubagentRegistryEntry>();
 	for (const line of contents.split(/\r?\n/)) {
 		if (!line.trim()) continue;
 		try {
 			const entry = JSON.parse(line) as SavedRlmSubagentRegistryEntry;
-			if (entry.type === "rlm_subagent" && typeof entry.childId === "string") latest.set(entry.childId, entry);
+			if (entry.type !== "rlm_subagent") continue;
+			const key = savedRlmIncarnationKey(entry);
+			if (key) latestByIncarnation.set(key, entry);
 		} catch {
 			// Ignore malformed registry history just like the owning worker does.
 		}
 	}
+	const newestBySelector = new Map<string, SavedRlmSubagentRegistryEntry>();
+	for (const entry of latestByIncarnation.values()) {
+		if (typeof entry.childId === "string") newestBySelector.set(entry.childId, entry);
+	}
 	const siblingPaths = new Set<string>([resolve(target.path)]);
-	for (const entry of latest.values()) {
+	for (const entry of newestBySelector.values()) {
 		if (entry.status !== "deleted" && typeof entry.sessionFile === "string")
 			siblingPaths.add(resolve(entry.sessionFile));
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2407,8 +2407,11 @@ export class AgentDaemon {
 					continue;
 				}
 				if (!current()) return;
-				await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId, current);
-				if (!current()) return;
+				const persisted = await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId, current);
+				// `persisted` is true only for the actual fsynced append or the deterministic
+				// transcript duplicate. Recheck the complete resident incarnation after the
+				// call before the consumed fact: no stale/failed append may be acknowledged.
+				if (!persisted || !current()) return;
 				store.markMaterializedDelivery({
 					parentSessionId: parent.sessionId,
 					assignmentId: identity.assignmentId,

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -117,12 +117,7 @@ import {
 } from "../../core/session-action-store.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
 import { acquireSessionLease, canonicalSessionPath, type SessionLease } from "../../core/session-lease.js";
-import {
-	readSessionInfo,
-	resolveSessionRlmDepth,
-	type SessionInfo,
-	SessionManager,
-} from "../../core/session-manager.js";
+import { readSessionInfo, type SessionInfo, SessionManager } from "../../core/session-manager.js";
 import { resolveSessionPath } from "../../core/session-resolver.js";
 import type { SessionStats } from "../../core/session-stats.js";
 import { type SideQuestionRun, startSideQuestion } from "../../core/side-question.js";
@@ -932,7 +927,8 @@ export class AgentDaemon {
 	}
 
 	private rlmSubagentRegistryPath(parentSession: AgentSession): string | undefined {
-		const artifactDir = parentSession.sessionManager.getSessionArtifactDir();
+		// Legacy/session-shaped hosts without artifact authority cannot read a durable registry.
+		const artifactDir = parentSession.sessionManager?.getSessionArtifactDir?.();
 		if (!artifactDir) {
 			return undefined;
 		}
@@ -1502,7 +1498,7 @@ export class AgentDaemon {
 				}
 				await this.assertFamilySessionNameAvailable({
 					name: normalizedName,
-					depth: passiveSubagent.info.rlmDepth ?? passiveSubagent.entry.rlmDepth ?? 1,
+					depth: this.passiveRlmSubagentOpenDepth(passiveSubagent),
 					parentSessionId: passiveSubagent.entry.parentSessionId,
 					parentSessionPath:
 						passiveSubagent.entry.parentSessionFile ??
@@ -3445,6 +3441,9 @@ export class AgentDaemon {
 		let runtime: AgentSessionRuntime | undefined;
 		let sessionLease: SessionLease | undefined;
 		try {
+			// Read this before SessionManager compatibility loading can derive and append
+			// a legacy path depth. Only the stored registry/header may establish depth.
+			const persistedDepth = this.persistedRlmSubagentOpenDepth(entry);
 			sessionLease = acquireSessionLease(entry.sessionFile, parentState.runtime.services.agentDir);
 			const sessionManager = await SessionManager.openAsync(entry.sessionFile, entry.sessionDir);
 			const modelRegistry = parentState.runtime.services.modelRegistry;
@@ -3494,14 +3493,9 @@ export class AgentDaemon {
 							},
 						},
 						rlmSessionDir: entry.sessionDir,
-						// Registry depth is authoritative (written at spawn); for legacy entries
-						// without it, the shared accessor resolves persisted header depth or the
-						// session file's sub- path before the depth-1 default.
-						rlmDepth:
-							entry.rlmDepth ??
-							(existsSync(entry.sessionFile)
-								? resolveSessionRlmDepth(sessionManager.getHeader() ?? {}, entry.sessionFile)
-								: 1),
+						// Registry depth is authoritative. If it is absent, only an explicit
+						// persisted header depth can establish nesting; path ancestry is not authority.
+						rlmDepth: persistedDepth,
 						rlmMaxDepth: entry.rlmMaxDepth,
 						rlmParentNodeId: entry.rlmParentNodeId ?? entry.childId,
 					},
@@ -5903,10 +5897,65 @@ export class AgentDaemon {
 		};
 	}
 
+	/**
+	 * A nonresident complete C03 record is a durable passive lifecycle fact, not a
+	 * live family member. It remains in the explicit list/observe projections, but
+	 * cannot reserve a public family name, appear in the active roster, or be woken
+	 * through an agent-family operation. Match the exact catalog row by its durable
+	 * session path plus child identity so legacy rows and resident C03 runtimes keep
+	 * their established behavior.
+	 */
+	private isNonresidentAuthoritativeC03Passive(passive: PassiveRlmSubagent): boolean {
+		return (
+			this.isAuthoritativeC03RegistryEntry(passive.entry) &&
+			this.findSessionBySessionFile(passive.entry.sessionFile) === undefined
+		);
+	}
+
+	private isNonresidentAuthoritativeC03PassiveFamilyEntry(
+		agent: AgentSessionMessageAgentSummary,
+		passiveByPath: ReadonlyMap<string, PassiveRlmSubagent>,
+	): boolean {
+		if (!agent.sessionPath || !agent.rlmChildId) return false;
+		const passive = passiveByPath.get(canonicalSessionPath(agent.sessionPath));
+		return (
+			passive !== undefined &&
+			passive.info.id === agent.sessionId &&
+			passive.entry.childId === agent.rlmChildId &&
+			this.isNonresidentAuthoritativeC03Passive(passive)
+		);
+	}
+
+	/** Use only explicit depth facts when a passive C03 child is about to be re-opened. */
+	private persistedRlmSubagentOpenDepth(entry: PersistedRlmSubagentRegistryEntry): number {
+		if (entry.rlmDepth !== undefined) return entry.rlmDepth;
+		try {
+			const header = JSON.parse(readFileSync(entry.sessionFile, "utf8").split(/\r?\n/, 1)[0] ?? "{}") as {
+				rlmDepth?: unknown;
+			};
+			if (typeof header.rlmDepth === "number" && Number.isSafeInteger(header.rlmDepth) && header.rlmDepth >= 0) {
+				return header.rlmDepth;
+			}
+		} catch {
+			// The subsequent hydration reports file failures; this preflight has no depth authority.
+		}
+		return 1;
+	}
+
+	private passiveRlmSubagentOpenDepth(passive: PassiveRlmSubagent): number {
+		return this.persistedRlmSubagentOpenDepth(passive.entry);
+	}
+
 	private async createAgentFamilyCatalog(currentState?: ActiveSessionState): Promise<AgentFamilyCatalogEntry[]> {
 		const current =
 			currentState ?? [...this.sessions.values()].find((state) => !this.bindingSessions.has(state.activeSessionId));
 		const listed = current ? await this.createAgentMessageListResult(current) : { agents: [] };
+		const passiveByPath = new Map(
+			(await this.listPassiveRlmSubagents()).map((passive) => [
+				canonicalSessionPath(passive.entry.sessionFile),
+				passive,
+			]),
+		);
 		const remotePeers = new Set(this.remoteAgentPeers.values());
 		// A live C03 deletion immediately closes its public registry row but retains
 		// the cancelled runtime until its exact terminal hand-off is durable. Exclude
@@ -5920,7 +5969,9 @@ export class AgentDaemon {
 				: [],
 		);
 		const visibleLocalAgents = listed.agents.filter((agent) => {
-			if (remotePeers.has(agent)) return false;
+			if (remotePeers.has(agent) || this.isNonresidentAuthoritativeC03PassiveFamilyEntry(agent, passiveByPath)) {
+				return false;
+			}
 			const state = this.sessions.get(agent.activeSessionId);
 			const metadata = state?.runtime.metadata;
 			return !(
@@ -5980,7 +6031,7 @@ export class AgentDaemon {
 			if (entry && state.runtime.session.sessionFile)
 				entry.sessionPath = canonicalSessionPath(state.runtime.session.sessionFile);
 		}
-		for (const passive of await this.listPassiveRlmSubagents()) {
+		for (const passive of passiveByPath.values()) {
 			const entry = byId.get(passive.info.id);
 			if (entry) entry.sessionPath = canonicalSessionPath(passive.entry.sessionFile);
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -425,7 +425,7 @@ class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
 
 /** A C03 lifecycle boundary cannot proceed without its parent-owned registry. */
-class RlmRegistryAuthorityError extends Error {}
+export class RlmRegistryAuthorityError extends Error {}
 
 export async function runDaemonMode(options: DaemonModeOptions): Promise<never> {
 	const socketPath = options.socketPath ?? defaultDaemonSocketPath();
@@ -2704,17 +2704,15 @@ export class AgentDaemon {
 						);
 					}
 				}
-				// Persist the deletion boundary first, but never let a registry failure
-				// strand the cancelled child as a stale resident session.
-				let deletionError: unknown;
+				// A C03 cancellation may close only after its exact registry tombstone is
+				// durable.  In particular, do not turn an authority/write failure into a
+				// local cleanup success: the child must remain wholly untouched for a retry.
+				// Awaiting this can interleave a replacement, but a deletion failure still
+				// wins over that later stale observation.
 				if (status === "cancelled") {
-					try {
-						if (operationId)
-							await this.recordRlmSubagentDeletion(parentState, options.id, assignmentId, operationId);
-						else await this.recordRlmSubagentDeletion(parentState, options.id, assignmentId);
-					} catch (error) {
-						deletionError = error;
-					}
+					if (operationId)
+						await this.recordRlmSubagentDeletion(parentState, options.id, assignmentId, operationId);
+					else await this.recordRlmSubagentDeletion(parentState, options.id, assignmentId);
 				}
 				const state = [...this.sessions.values()].find(
 					(candidate) =>
@@ -2733,7 +2731,6 @@ export class AgentDaemon {
 				} else {
 					await runtime.session.disposeAsync();
 				}
-				if (deletionError !== undefined) throw deletionError;
 			},
 			deleteRlmSubagentRuntime: async (childId, childSession, requestedAssignmentId, requestedOperationId) => {
 				// An operation-bearing request is C03 authority. Never convert a missing

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -178,6 +178,7 @@ import {
 	success,
 	UPDATE_RESTART_DRAIN_COMMANDS,
 } from "./daemon-protocol.js";
+import { assertRlmRegistryWriteIdentity, classifyRlmRegistryIdentity } from "./daemon-rlm-registry-identity.js";
 import { getDaemonRuntimeIdentity } from "./daemon-runtime-identity.js";
 import {
 	buildRlmChildSnapshots,
@@ -938,34 +939,40 @@ export class AgentDaemon {
 		return join(artifactDir, RLM_SUBAGENT_REGISTRY_FILE);
 	}
 
-	private rlmAssignmentKey(entry: Pick<PersistedRlmSubagentRegistryEntry, "childId" | "assignmentId">): string {
-		// Missing assignment is a legacy display identity and is deliberately never
-		// equal to a C01 UUID callback identity.
-		return `${entry.childId}\u0000${entry.assignmentId ?? "legacy"}`;
+	private rlmRegistryIncarnationKey(entry: PersistedRlmSubagentRegistryEntry): string | undefined {
+		const identity = classifyRlmRegistryIdentity(entry);
+		switch (identity.kind) {
+			case "legacy-display":
+				return `${entry.childId}\u0000legacy`;
+			case "assignment-display":
+				return `${entry.childId}\u0000assignment-display\u0000${identity.assignmentId}`;
+			case "c03":
+				return `${entry.childId}\u0000${identity.assignmentId}\u0000${identity.operationId}\u0000${identity.deliveryId}`;
+			case "invalid":
+				return undefined;
+		}
 	}
 
-	/**
-	 * Registry entries retain one terminal state per durable assignment, ordered
-	 * by the assignment's first durable publication. A later terminal update for
-	 * old A must not make A the public incarnation after B reuses its childId.
-	 */
+	/** Only a complete C03 tuple is daemon authority, including passive hydrate/delete selection. */
+	private isAuthoritativeC03RegistryEntry(entry: PersistedRlmSubagentRegistryEntry): boolean {
+		return classifyRlmRegistryIdentity(entry).kind === "c03";
+	}
+
 	private currentRlmSubagentRegistryEntry(
 		entries: readonly PersistedRlmSubagentRegistryEntry[],
 		childId: string,
 	): PersistedRlmSubagentRegistryEntry | undefined {
-		for (let index = entries.length - 1; index >= 0; index--) {
-			const entry = entries[index];
-			if (entry?.childId === childId) return entry;
-		}
-		return undefined;
+		return this.currentLiveRlmSubagentRegistryEntries(entries).find((entry) => entry.childId === childId);
 	}
 
-	/** The sole public/passive row for each reused child selector. */
+	/** The sole authoritative C03 row for each reused child selector. */
 	private currentLiveRlmSubagentRegistryEntries(
 		entries: readonly PersistedRlmSubagentRegistryEntry[],
 	): PersistedRlmSubagentRegistryEntry[] {
 		const currentByChildId = new Map<string, PersistedRlmSubagentRegistryEntry>();
-		for (const entry of entries) currentByChildId.set(entry.childId, entry);
+		for (const entry of entries) {
+			if (this.isAuthoritativeC03RegistryEntry(entry)) currentByChildId.set(entry.childId, entry);
+		}
 		return [...currentByChildId.values()].filter((entry) => entry.status !== "deleted");
 	}
 
@@ -973,6 +980,7 @@ export class AgentDaemon {
 		parentState: ActiveSessionState,
 		entry: PersistedRlmSubagentRegistryEntry,
 	): boolean {
+		assertRlmRegistryWriteIdentity(entry);
 		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
 		if (!path) {
 			return true;
@@ -1017,6 +1025,7 @@ export class AgentDaemon {
 			createdAt?: number;
 		},
 	): boolean {
+		assertRlmRegistryWriteIdentity(input);
 		const parentSession = parentState.runtime.session;
 		return this.appendRlmSubagentRegistryEntry(parentState, {
 			type: "rlm_subagent",
@@ -1113,39 +1122,22 @@ export class AgentDaemon {
 					typeof entry.sessionFile !== "string" ||
 					(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted") ||
 					(entry.rlmDepth !== undefined && (!Number.isSafeInteger(entry.rlmDepth) || entry.rlmDepth < 0)) ||
-					(entry.rlmMaxDepth !== undefined &&
-						(!Number.isSafeInteger(entry.rlmMaxDepth) || entry.rlmMaxDepth < 0)) ||
-					(entry.assignmentId !== undefined &&
-						(typeof entry.assignmentId !== "string" ||
-							!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-								entry.assignmentId,
-							))) ||
-					(entry.operationId !== undefined &&
-						(typeof entry.operationId !== "string" || !assertFreshUuid(entry.operationId))) ||
-					(entry.deliveryId !== undefined &&
-						(typeof entry.deliveryId !== "string" || !assertFreshUuid(entry.deliveryId)))
+					(entry.rlmMaxDepth !== undefined && (!Number.isSafeInteger(entry.rlmMaxDepth) || entry.rlmMaxDepth < 0))
 				) {
 					continue;
 				}
-				latest.set(
-					this.rlmAssignmentKey(entry as PersistedRlmSubagentRegistryEntry),
-					entry as PersistedRlmSubagentRegistryEntry,
-				);
+				const authoritative = entry as PersistedRlmSubagentRegistryEntry;
+				const key = this.rlmRegistryIncarnationKey(authoritative);
+				// Partial/malformed identities never enter reduction, so a late corrupt
+				// row cannot overwrite a complete C03 incarnation.
+				if (key) latest.set(key, authoritative);
 			} catch (error) {
 				this.log(
 					`ignored malformed RLM subagent registry entry: ${error instanceof Error ? error.message : String(error)}`,
 				);
 			}
 		}
-		const entries = [...latest.values()];
-		// Once an explicit hydrate has durably rebound an old display-only row,
-		// suppress that legacy duplicate from catalog traversal. Its late callbacks
-		// still cannot match the assigned row because callback matching is exact.
-		return entries.filter(
-			(entry) =>
-				entry.assignmentId !== undefined ||
-				!entries.some((candidate) => candidate.childId === entry.childId && candidate.assignmentId !== undefined),
-		);
+		return [...latest.values()];
 	}
 
 	/** Read only selectable catalog incarnations; exact lifecycle operations use the full reader above. */
@@ -2372,8 +2364,19 @@ export class AgentDaemon {
 			parentState.eventGeneration === generation &&
 			!this.closingSessions.has(parentState.activeSessionId) &&
 			parentState.runtime.session === parent &&
-			child.session.sessionId !== "";
+			child.session.sessionId !== "" &&
+			[...this.sessions.values()].some(
+				(state) =>
+					state.runtime.metadata.kind === "subagent" &&
+					state.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
+					state.runtime.metadata.rlmChildId === identity.childId &&
+					state.runtime.metadata.assignmentId === identity.assignmentId &&
+					state.runtime.metadata.operationId === identity.operationId &&
+					state.runtime.metadata.deliveryId === identity.deliveryId &&
+					state.runtime.session === child.session,
+			);
 		const work = (async () => {
+			// Every mutation is preceded by the complete parent + resident child fence.
 			if (!current()) return;
 			store.importPendingOutboxes();
 			if (!current()) return;
@@ -2393,6 +2396,7 @@ export class AgentDaemon {
 				// Only the exact deleted durable incarnation is discardable. A replacement
 				// selector assignment remains unrelated and cannot suppress this record.
 				if (operation?.lifecycle === "deleted") {
+					if (!current()) return;
 					store.markDiscardedDelivery({
 						parentSessionId: parent.sessionId,
 						assignmentId: identity.assignmentId,
@@ -2403,7 +2407,7 @@ export class AgentDaemon {
 					continue;
 				}
 				if (!current()) return;
-				await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId);
+				await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId, current);
 				if (!current()) return;
 				store.markMaterializedDelivery({
 					parentSessionId: parent.sessionId,
@@ -2511,7 +2515,6 @@ export class AgentDaemon {
 			},
 			deliverRlmSubagentTerminal: async (runtime, options, terminal, message) => {
 				if (
-					!current(options, runtime) ||
 					!parentFile ||
 					!parentArtifactDir ||
 					!options.assignmentId ||
@@ -2519,6 +2522,15 @@ export class AgentDaemon {
 					!options.deliveryId
 				)
 					return;
+				const store = durableStore();
+				const durableOperation = () =>
+					store
+						.rebuild()
+						.operations.get(JSON.stringify([parent.sessionId, options.assignmentId!, options.operationId!]));
+				// A live explicit delete closes C01 before its cancelled task unwinds. Its
+				// exact intent can finish only A's outbox/terminal/deleted/discarded chain.
+				const deleteIntent = () => durableOperation()?.deleteIntent === true;
+				if (!current(options, runtime) && !deleteIntent()) return;
 				const child = runtime.session;
 				const childFile = child.sessionManager.getSessionFile?.();
 				const childArtifactDir = child.sessionManager.getSessionArtifactDir?.();
@@ -2540,7 +2552,6 @@ export class AgentDaemon {
 					terminal,
 					message,
 				};
-				const store = durableStore();
 				store.appendOutbox(outbox); // child outbox fsync happens before parent ledger.
 				if (
 					!store.recordTerminal({
@@ -2552,6 +2563,37 @@ export class AgentDaemon {
 					})
 				)
 					return;
+				// An explicit live delete is a durable intent, not an early deleted
+				// transition. Once its terminal hand-off is fsynced, make deleted legal
+				// before the importer can materialize this exact delivery.
+				const operation = durableOperation();
+				if (operation?.deleteIntent) {
+					if (
+						!store.recordRelease(
+							{
+								parentSessionId: parent.sessionId,
+								assignmentId: options.assignmentId,
+								operationId: options.operationId,
+							},
+							"deleted",
+						)
+					) {
+						// Keep the exact outbox/terminal/intent pending for recovery rather than
+						// falsely materializing a delete whose terminal transition is uncertain.
+						return;
+					}
+					// Do not require A to remain resident after live close: deleted delivery
+					// has no parent transcript mutation and is consumed exactly once.
+					store.importPendingOutboxes();
+					store.markDiscardedDelivery({
+						parentSessionId: parent.sessionId,
+						assignmentId: options.assignmentId,
+						operationId: options.operationId,
+						deliveryId: options.deliveryId,
+						reason: "deleted",
+					});
+					return;
+				}
 				if (!current(options, runtime)) return;
 				// The owner-local join imports the fsynced outbox, then performs the
 				// normal no-turn transcript append before the consumed fsync.
@@ -2756,14 +2798,27 @@ export class AgentDaemon {
 				if (assignmentId && operationId) {
 					const artifactDir = parent.sessionManager.getSessionArtifactDir?.();
 					if (!artifactDir) throw new Error("Durable RLM deletion requires parent artifact");
-					// The exact C03 lifecycle transition precedes the C01 deletion and close.
+					// A materialized live child cannot yet be `deleted`: retain an exact
+					// intent through cancellation. The terminal owner converts it to deleted
+					// before any inbox import, while C01 deletion/close proceeds normally.
+					const store = durableStore();
+					const operation = store
+						.rebuild()
+						.operations.get(JSON.stringify([parent.sessionId, assignmentId, operationId]));
+					// A full registry tuple without a durable ledger operation is passive
+					// historical display only: it has no live cancellation hand-off to
+					// complete. Preserve its ordinary C01 tombstone behavior. A real
+					// durable operation must retain its exact intent or remain live.
 					if (
-						!openRlmDurableOperationStore(artifactDir).recordRelease(
-							{ parentSessionId: parent.sessionId, assignmentId, operationId },
-							"deleted",
-						)
-					)
-						throw new Error(`Failed to persist durable deletion for RLM subagent ${childId}`);
+						operation &&
+						!store.recordDeleteIntent({ parentSessionId: parent.sessionId, assignmentId, operationId })
+					) {
+						const refreshed = store
+							.rebuild()
+							.operations.get(JSON.stringify([parent.sessionId, assignmentId, operationId]));
+						if (!refreshed?.deleteIntent && refreshed?.lifecycle !== "deleted")
+							throw new Error(`Failed to retain durable deletion intent for RLM subagent ${childId}`);
+					}
 				}
 				if (assignmentId) await this.recordRlmSubagentDeletion(parentState, childId, assignmentId, operationId);
 				// C01 append awaited above; reject a late A before it can close B.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1045,9 +1045,13 @@ export class AgentDaemon {
 		parentState: ActiveSessionState,
 		childId: string,
 		assignmentId: string,
+		operationId?: string,
 	): Promise<void> {
 		const latest = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
-			(entry) => entry.childId === childId && entry.assignmentId === assignmentId,
+			(entry) =>
+				entry.childId === childId &&
+				entry.assignmentId === assignmentId &&
+				(operationId === undefined ? entry.operationId === undefined : entry.operationId === operationId),
 		);
 		if (!latest || latest.status === "deleted") {
 			return;
@@ -2637,7 +2641,9 @@ export class AgentDaemon {
 				let deletionError: unknown;
 				if (status === "cancelled") {
 					try {
-						await this.recordRlmSubagentDeletion(parentState, options.id, assignmentId);
+						if (operationId)
+							await this.recordRlmSubagentDeletion(parentState, options.id, assignmentId, operationId);
+						else await this.recordRlmSubagentDeletion(parentState, options.id, assignmentId);
 					} catch (error) {
 						deletionError = error;
 					}
@@ -2737,7 +2743,11 @@ export class AgentDaemon {
 				if (
 					(this.sessions.get(parentState.activeSessionId) !== undefined &&
 						this.sessions.get(parentState.activeSessionId) !== parentState) ||
-					(state && this.sessions.get(state.activeSessionId) !== state)
+					(operationId !== undefined && parentState.eventGeneration !== parentGeneration) ||
+					(state &&
+						(this.sessions.get(state.activeSessionId) !== state ||
+							state.runtime.metadata.assignmentId !== assignmentId ||
+							state.runtime.metadata.operationId !== operationId))
 				) {
 					await childSession?.disposeAsync();
 					return;
@@ -2755,13 +2765,14 @@ export class AgentDaemon {
 					)
 						throw new Error(`Failed to persist durable deletion for RLM subagent ${childId}`);
 				}
-				if (assignmentId) await this.recordRlmSubagentDeletion(parentState, childId, assignmentId);
+				if (assignmentId) await this.recordRlmSubagentDeletion(parentState, childId, assignmentId, operationId);
 				// C01 append awaited above; reject a late A before it can close B.
 				if (
-					state &&
-					(this.sessions.get(state.activeSessionId) !== state ||
-						state.runtime.metadata.assignmentId !== assignmentId ||
-						state.runtime.metadata.operationId !== operationId)
+					parentState.eventGeneration !== parentGeneration ||
+					(state &&
+						(this.sessions.get(state.activeSessionId) !== state ||
+							state.runtime.metadata.assignmentId !== assignmentId ||
+							state.runtime.metadata.operationId !== operationId))
 				)
 					return;
 				const staleSession =
@@ -3008,6 +3019,7 @@ export class AgentDaemon {
 		const parentActiveSessionId = metadata.parentActiveSessionId;
 		const childId = metadata.rlmChildId;
 		const assignmentId = metadata.assignmentId;
+		const operationId = metadata.operationId;
 		// Legacy resident children remain readable but cannot let an asynchronous
 		// passivation callback unbind a newer same-selector assignment.
 		if (!assignmentId) return false;
@@ -3034,6 +3046,9 @@ export class AgentDaemon {
 				this.shuttingDown ||
 				this.updateRestart !== undefined ||
 				this.sessions.get(state.activeSessionId) !== state ||
+				state.eventGeneration !== passivationOperation.generation ||
+				state.runtime.metadata.assignmentId !== assignmentId ||
+				state.runtime.metadata.operationId !== operationId ||
 				!canPassivateSession(await this.sessionPassivationSnapshot(state), idleEvictionMinutes, now)
 			) {
 				return;
@@ -3043,11 +3058,14 @@ export class AgentDaemon {
 			const idleMinutes = Math.floor((now - snapshot.lastActivityAt) / 60_000);
 			// Detach parent tracking before the standard graceful runtime disposal. The
 			// registry/catalog rows remain the sole passive representation after close.
-			const unsubscribeChild = parentState.runtime.session.releaseRlmChildSession(
-				childId,
-				state.runtime.session,
-				assignmentId,
-			);
+			const unsubscribeChild = operationId
+				? parentState.runtime.session.releaseRlmChildSession(
+						childId,
+						state.runtime.session,
+						assignmentId,
+						operationId,
+					)
+				: parentState.runtime.session.releaseRlmChildSession(childId, state.runtime.session, assignmentId);
 			if (!unsubscribeChild) {
 				return;
 			}
@@ -3058,22 +3076,41 @@ export class AgentDaemon {
 				// parent's ownership map or disconnect its event forwarder.
 				if (
 					this.sessions.get(state.activeSessionId) === state &&
+					state.eventGeneration === passivationOperation.generation &&
+					state.runtime.metadata.assignmentId === assignmentId &&
+					state.runtime.metadata.operationId === operationId &&
 					this.sessions.get(parentActiveSessionId) === parentState &&
-					parentState.runtime.session.registerRlmChildSession(
-						childId,
-						state.runtime.session,
-						unsubscribeChild,
-						assignmentId,
-					)
+					(operationId
+						? parentState.runtime.session.registerRlmChildSession(
+								childId,
+								state.runtime.session,
+								unsubscribeChild,
+								assignmentId,
+								operationId,
+							)
+						: parentState.runtime.session.registerRlmChildSession(
+								childId,
+								state.runtime.session,
+								unsubscribeChild,
+								assignmentId,
+							))
 				) {
 					// The adapter is deliberately optional so old embedded/test hosts observe
 					// the historical register arity. Real AgentSession instances bind the
 					// durable assignment immediately after that compatibility call.
-					parentState.runtime.session.rebindRlmChildSessionAssignment?.(
-						childId,
-						state.runtime.session,
-						assignmentId,
-					);
+					if (operationId)
+						parentState.runtime.session.rebindRlmChildSessionAssignment?.(
+							childId,
+							state.runtime.session,
+							assignmentId,
+							operationId,
+						);
+					else
+						parentState.runtime.session.rebindRlmChildSessionAssignment?.(
+							childId,
+							state.runtime.session,
+							assignmentId,
+						);
 					throw error;
 				}
 				unsubscribeChild();
@@ -3478,12 +3515,14 @@ export class AgentDaemon {
 				this.sessions.get(parentState.activeSessionId) !== parentState ||
 				this.closingSessions.has(parentState.activeSessionId)
 			) {
-				const unsubscribeChild = parentState.runtime.session.releaseRlmChildSession(
-					entry.childId,
-					runtime.session,
-					entry.assignmentId,
-					entry.operationId,
-				);
+				const unsubscribeChild = entry.operationId
+					? parentState.runtime.session.releaseRlmChildSession(
+							entry.childId,
+							runtime.session,
+							entry.assignmentId,
+							entry.operationId,
+						)
+					: parentState.runtime.session.releaseRlmChildSession(entry.childId, runtime.session, entry.assignmentId);
 				try {
 					await this.closeSession(state, "replaced");
 				} finally {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2403,7 +2403,9 @@ export class AgentDaemon {
 			// Every mutation is preceded by the complete parent + resident child fence.
 			if (!current()) return;
 			store.importPendingOutboxes();
-			if (!current()) return;
+			// A complete unkeyed record globally quarantines the recovery projection.
+			// Do not wake a provider-facing parent or materialize any transcript body.
+			if (store.rebuild().hasGlobalUncertainty || !current()) return;
 			for (const inbox of store.pendingInbox()) {
 				if (
 					inbox.parentSessionId !== parent.sessionId ||
@@ -2966,6 +2968,11 @@ export class AgentDaemon {
 			if (!parentArtifactDir) throw new Error("Durable RLM requires a persisted parent artifact");
 			return openRlmDurableOperationStore(parentArtifactDir);
 		};
+		// Admission may have preceded a later complete corrupt append.  Check again
+		// before creating a child session: global uncertainty must not launch or
+		// materialize a provider-facing operation.
+		if (options.operationId && durableStore().rebuild().hasGlobalUncertainty)
+			throw new Error("Durable RLM history is globally uncertain");
 		const sessionManager = SessionManager.create(options.parentSession.sessionManager.getCwd(), options.sessionDir);
 		sessionManager.newSession({
 			parentSession: options.parentSession.sessionFile,
@@ -3486,6 +3493,14 @@ export class AgentDaemon {
 		clientEnv?: Record<string, string>,
 	): Promise<ActiveSessionState> {
 		const hydrationEnv = parentState.clientEnv ?? clientEnv;
+		// Recovery must not wake a durable child after a complete unkeyed/malformed
+		// record quarantines the parent's history.  This read is intentionally before
+		// acquiring the child lease or opening its session manager.
+		if (entry.operationId && entry.assignmentId && entry.deliveryId) {
+			const parentArtifactDir = parentState.runtime.session.sessionManager.getSessionArtifactDir?.();
+			if (parentArtifactDir && openRlmDurableOperationStore(parentArtifactDir).rebuild().hasGlobalUncertainty)
+				throw new Error("Durable RLM history is globally uncertain");
+		}
 		let stateRef: ActiveSessionState | undefined;
 		let runtime: AgentSessionRuntime | undefined;
 		let sessionLease: SessionLease | undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2648,8 +2648,12 @@ export class AgentDaemon {
 						candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
 						candidate.runtime.metadata.rlmChildId === options.id &&
 						candidate.runtime.metadata.assignmentId === assignmentId &&
+						candidate.runtime.metadata.operationId === operationId &&
 						candidate.runtime.session === runtime.session,
 				);
+				// Awaited registry I/O may have allowed a reused selector to replace this
+				// operation. Recheck the full compound identity before close/dispose.
+				if (operationId && !current(options, runtime)) return;
 				if (state && this.sessions.get(state.activeSessionId) === state) {
 					await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
 				} else {
@@ -2702,6 +2706,9 @@ export class AgentDaemon {
 						persisted = { ...persisted, assignmentId };
 					} else assignmentId = persisted.assignmentId;
 				}
+				// A retained C03 child passes its operation; an explicit selector delete
+				// resolves the newest durable C03 incarnation, while legacy stays undefined.
+				const operationId = requestedOperationId ?? persisted?.operationId;
 				// Callback cleanup carries an operation; it is never a selector or
 				// assignment-only capability.  A legacy explicit delete has no operation
 				// and intentionally retains its historical catalog behavior.
@@ -2718,7 +2725,8 @@ export class AgentDaemon {
 						candidate.runtime.metadata.kind === "subagent" &&
 						candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
 						candidate.runtime.metadata.rlmChildId === childId &&
-						(assignmentId === undefined || candidate.runtime.metadata.assignmentId === assignmentId),
+						(assignmentId === undefined || candidate.runtime.metadata.assignmentId === assignmentId) &&
+						(operationId === undefined || candidate.runtime.metadata.operationId === operationId),
 				);
 				if (!assignmentId && !state) {
 					await childSession?.disposeAsync();
@@ -2734,7 +2742,28 @@ export class AgentDaemon {
 					await childSession?.disposeAsync();
 					return;
 				}
+				if (operationId && (!assignmentId || persisted?.operationId !== operationId)) return;
+				if (assignmentId && operationId) {
+					const artifactDir = parent.sessionManager.getSessionArtifactDir?.();
+					if (!artifactDir) throw new Error("Durable RLM deletion requires parent artifact");
+					// The exact C03 lifecycle transition precedes the C01 deletion and close.
+					if (
+						!openRlmDurableOperationStore(artifactDir).recordRelease(
+							{ parentSessionId: parent.sessionId, assignmentId, operationId },
+							"deleted",
+						)
+					)
+						throw new Error(`Failed to persist durable deletion for RLM subagent ${childId}`);
+				}
 				if (assignmentId) await this.recordRlmSubagentDeletion(parentState, childId, assignmentId);
+				// C01 append awaited above; reject a late A before it can close B.
+				if (
+					state &&
+					(this.sessions.get(state.activeSessionId) !== state ||
+						state.runtime.metadata.assignmentId !== assignmentId ||
+						state.runtime.metadata.operationId !== operationId)
+				)
+					return;
 				const staleSession =
 					state && childSession && state.runtime.session !== childSession ? childSession : undefined;
 				try {
@@ -2888,26 +2917,33 @@ export class AgentDaemon {
 						)
 							throw new Error("Failed durable RLM child materialization");
 					}
-					this.recordRlmSubagentRegistryEntry(parentState, {
-						childId: options.id,
-						assignmentId,
-						operationId: options.operationId,
-						deliveryId: options.deliveryId,
-						sessionName: options.sessionName,
-						sessionDir: options.sessionDir,
-						sessionFile: runtime.session.sessionFile,
-						rlmDepth: options.rlmDepth,
-						rlmMaxDepth: options.rlmMaxDepth,
-						rlmParentNodeId: options.rlmParentNodeId,
-						prompt: options.prompt.length <= 4096 ? options.prompt : undefined,
-						spawnCode: options.spawnCode,
-						model: {
-							provider: options.model.provider,
-							modelId: options.model.id,
-						},
-						status: "running",
-						createdAt: runtime.metadata.createdAt,
-					});
+					if (
+						!this.recordRlmSubagentRegistryEntry(parentState, {
+							childId: options.id,
+							assignmentId,
+							operationId: options.operationId,
+							deliveryId: options.deliveryId,
+							sessionName: options.sessionName,
+							sessionDir: options.sessionDir,
+							sessionFile: runtime.session.sessionFile,
+							rlmDepth: options.rlmDepth,
+							rlmMaxDepth: options.rlmMaxDepth,
+							rlmParentNodeId: options.rlmParentNodeId,
+							prompt: options.prompt.length <= 4096 ? options.prompt : undefined,
+							spawnCode: options.spawnCode,
+							model: {
+								provider: options.model.provider,
+								modelId: options.model.id,
+							},
+							status: "running",
+							createdAt: runtime.metadata.createdAt,
+						})
+					) {
+						// C01 publication is a second durable boundary.  The C03 materialized
+						// fact remains recoverably pending, but this unpublished runtime must
+						// never become addressable or start prompt work.
+						throw new Error("Failed to persist running RLM subagent registry entry");
+					}
 				}
 				options.onSessionPublished?.(runtime.session);
 			},
@@ -3362,21 +3398,36 @@ export class AgentDaemon {
 			);
 			// The session transcript is authoritative for mutable metadata such as a
 			// later user-assigned name; the registry value is only the spawn snapshot.
-			const registered = parentState.runtime.session.registerRlmChildSession(
-				entry.childId,
-				runtime.session,
-				undefined,
-				entry.assignmentId,
-			);
+			const registered = entry.operationId
+				? parentState.runtime.session.registerRlmChildSession(
+						entry.childId,
+						runtime.session,
+						undefined,
+						entry.assignmentId,
+						entry.operationId,
+					)
+				: parentState.runtime.session.registerRlmChildSession(
+						entry.childId,
+						runtime.session,
+						undefined,
+						entry.assignmentId,
+					);
 			// The explicit assignment is the authority boundary for lazy hydration.
 			// Keep the historical rebinding adapter only for an old session host that
 			// does not accept the fourth argument.
 			const assignmentBound = entry.assignmentId
-				? parentState.runtime.session.rebindRlmChildSessionAssignment?.(
-						entry.childId,
-						runtime.session,
-						entry.assignmentId,
-					)
+				? entry.operationId
+					? parentState.runtime.session.rebindRlmChildSessionAssignment?.(
+							entry.childId,
+							runtime.session,
+							entry.assignmentId,
+							entry.operationId,
+						)
+					: parentState.runtime.session.rebindRlmChildSessionAssignment?.(
+							entry.childId,
+							runtime.session,
+							entry.assignmentId,
+						)
 				: undefined;
 			if (!registered || assignmentBound === false) {
 				await this.closeSession(state, "replaced");
@@ -3431,6 +3482,7 @@ export class AgentDaemon {
 					entry.childId,
 					runtime.session,
 					entry.assignmentId,
+					entry.operationId,
 				);
 				try {
 					await this.closeSession(state, "replaced");

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -5840,9 +5840,26 @@ export class AgentDaemon {
 	}
 
 	private async createAgentMessageListResult(current: ActiveSessionState): Promise<AgentSessionMessageListResult> {
-		const localAgents = this.listTargetableSessionStates(current).map((state) =>
-			this.createAgentMessageAgentSummary(state),
+		// Keep C03 deletion identity private to daemon mode. The model-facing
+		// AgentSessionMessageAgentSummary ABI intentionally has no assignment or
+		// operation fields, but this internal seam can exactly suppress only A while
+		// retaining a later same-childId B or an identity-less legacy catalog row.
+		const deletedC03Operations = new Set(
+			(await this.readLatestRlmSubagentRegistry(current))
+				.filter((entry) => this.isAuthoritativeC03RegistryEntry(entry) && entry.status === "deleted")
+				.map((entry) => `${entry.assignmentId}\u0000${entry.operationId}`),
 		);
+		const localAgents = this.listTargetableSessionStates(current)
+			.filter((state) => {
+				const metadata = state.runtime.metadata;
+				return !(
+					metadata.kind === "subagent" &&
+					metadata.assignmentId !== undefined &&
+					metadata.operationId !== undefined &&
+					deletedC03Operations.has(`${metadata.assignmentId}\u0000${metadata.operationId}`)
+				);
+			})
+			.map((state) => this.createAgentMessageAgentSummary(state));
 		for (const passive of await this.listPassiveRlmSubagents()) {
 			const { entry, info } = passive;
 			localAgents.push({

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2673,12 +2673,14 @@ export class AgentDaemon {
 				// Lifecycle facts are exact operation keyed. A stale A cannot release B.
 				if (operationId && options.deliveryId && current(options, runtime)) {
 					const parentArtifactDir = parent.sessionManager.getSessionArtifactDir?.();
-					if (parentArtifactDir) {
-						const store = durableStore();
-						if (status === "cancelled")
-							store.recordRelease({ parentSessionId: parent.sessionId, assignmentId, operationId }, "deleted");
-						else
-							store.recordRelease({ parentSessionId: parent.sessionId, assignmentId, operationId }, "released");
+					if (parentArtifactDir && status !== "cancelled") {
+						// A cancellation's durable terminal owner alone may turn a live intent
+						// into deleted.  Releasing it here races the actual child terminal and
+						// can incorrectly make terminal-before-deleted unobservable.
+						durableStore().recordRelease(
+							{ parentSessionId: parent.sessionId, assignmentId, operationId },
+							"released",
+						);
 					}
 				}
 				// Persist the deletion boundary first, but never let a registry failure
@@ -2857,6 +2859,16 @@ export class AgentDaemon {
 					}
 				}
 				if (assignmentId) await this.recordRlmSubagentDeletion(parentState, childId, assignmentId, operationId);
+				// A live C03 deletion has already durably hidden the public row and retained
+				// its exact delete intent. Keep only the active cancelled run alive long
+				// enough for its abort to write the owner-local terminal hand-off. Passive
+				// and passivating instances have no such owner and must close normally.
+				if (assignmentId && operationId && parent.getRlmChildRunStatus(childId) === "cancelled") {
+					const pendingDelete = durableStore()
+						.rebuild()
+						.operations.get(JSON.stringify([parent.sessionId, assignmentId, operationId]));
+					if (pendingDelete?.deleteIntent && pendingDelete.lifecycle !== "deleted") return;
+				}
 				// C01 append awaited above; reject a late A before it can close B.
 				if (
 					parentState.eventGeneration !== parentGeneration ||

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -100,7 +100,16 @@ import {
 } from "../../core/cron-jobs.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js";
 import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
-import type { CreateRlmSubagentRuntimeOptions, SubagentRuntimeHost } from "../../core/rlm-runtime.js";
+import {
+	materializedTerminalMessageId,
+	openRlmDurableOperationStore,
+	type RlmTerminalOutbox,
+} from "../../core/rlm-durable-operations.js";
+import type {
+	CreateRlmSubagentRuntimeOptions,
+	RlmSubagentRuntime,
+	SubagentRuntimeHost,
+} from "../../core/rlm-runtime.js";
 import {
 	canPassivateSession,
 	type IdleEvictionMinutes,
@@ -381,6 +390,9 @@ interface PersistedRlmSubagentRegistryEntry {
 	childId: string;
 	/** Undefined only for legacy display rows; C01 callbacks must never bind one. */
 	assignmentId?: string;
+	/** C03 private recovery binding facts; never sent through catalog/wire output. */
+	operationId?: string;
+	deliveryId?: string;
 	sessionName: string;
 	sessionDir: string;
 	sessionFile: string;
@@ -458,6 +470,8 @@ export class AgentDaemon {
 	/** Covers path resolution through publication in openingSessions, before the runtime promise exists. */
 	private readonly reservingSessionOpens = new Map<string, Promise<void>>();
 	private readonly bindingCompletions = new Map<string, Promise<void>>();
+	/** Parent-object/generation-local delivery joins; never a global delivery queue. */
+	private readonly rlmTerminalImportJoins = new WeakMap<ActiveSessionState, Map<string, Promise<void>>>();
 	/**
 	 * Resolved-session-file keyed passivations let wake paths join after closeSessionOnce
 	 * removes the live session. This intentionally complements closingSessions: that map
@@ -988,6 +1002,8 @@ export class AgentDaemon {
 		input: {
 			childId: string;
 			assignmentId: string;
+			operationId?: string;
+			deliveryId?: string;
 			sessionName: string;
 			sessionDir: string;
 			sessionFile: string;
@@ -1006,6 +1022,8 @@ export class AgentDaemon {
 			type: "rlm_subagent",
 			childId: input.childId,
 			assignmentId: input.assignmentId,
+			operationId: input.operationId,
+			deliveryId: input.deliveryId,
 			sessionName: input.sessionName,
 			sessionDir: input.sessionDir,
 			sessionFile: input.sessionFile,
@@ -1097,7 +1115,11 @@ export class AgentDaemon {
 						(typeof entry.assignmentId !== "string" ||
 							!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
 								entry.assignmentId,
-							)))
+							))) ||
+					(entry.operationId !== undefined &&
+						(typeof entry.operationId !== "string" || !assertFreshUuid(entry.operationId))) ||
+					(entry.deliveryId !== undefined &&
+						(typeof entry.deliveryId !== "string" || !assertFreshUuid(entry.deliveryId)))
 				) {
 					continue;
 				}
@@ -2325,11 +2347,225 @@ export class AgentDaemon {
 		return passive ? this.hydratePassiveRlmSubagent(passive) : this.getOrHydrateBoundSessionState(selector);
 	}
 
+	private importBoundRlmTerminalInbox(
+		parentState: ActiveSessionState,
+		child: RlmSubagentRuntime,
+		identity: { childId: string; assignmentId: string; operationId: string; deliveryId: string },
+		store: ReturnType<typeof openRlmDurableOperationStore>,
+	): Promise<void> {
+		const parent = parentState.runtime.session;
+		const generation = parentState.eventGeneration;
+		const key = `${identity.assignmentId}\u0000${identity.operationId}\u0000${identity.deliveryId}`;
+		let joins = this.rlmTerminalImportJoins.get(parentState);
+		if (!joins) {
+			joins = new Map();
+			this.rlmTerminalImportJoins.set(parentState, joins);
+		}
+		const existing = joins.get(key);
+		if (existing) return existing;
+		const current = () =>
+			this.sessions.get(parentState.activeSessionId) === parentState &&
+			parentState.eventGeneration === generation &&
+			!this.closingSessions.has(parentState.activeSessionId) &&
+			parentState.runtime.session === parent &&
+			child.session.sessionId !== "";
+		const work = (async () => {
+			if (!current()) return;
+			store.importPendingOutboxes();
+			if (!current()) return;
+			for (const inbox of store.pendingInbox()) {
+				if (
+					inbox.parentSessionId !== parent.sessionId ||
+					inbox.childId !== identity.childId ||
+					inbox.assignmentId !== identity.assignmentId ||
+					inbox.operationId !== identity.operationId ||
+					inbox.deliveryId !== identity.deliveryId
+				)
+					continue;
+				if (!current()) return;
+				const operation = store
+					.rebuild()
+					.operations.get(JSON.stringify([parent.sessionId, identity.assignmentId, identity.operationId]));
+				// Only the exact deleted durable incarnation is discardable. A replacement
+				// selector assignment remains unrelated and cannot suppress this record.
+				if (operation?.lifecycle === "deleted") {
+					store.markDiscardedDelivery({
+						parentSessionId: parent.sessionId,
+						assignmentId: identity.assignmentId,
+						operationId: identity.operationId,
+						deliveryId: identity.deliveryId,
+						reason: "deleted",
+					});
+					continue;
+				}
+				if (!current()) return;
+				await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId);
+				if (!current()) return;
+				store.markMaterializedDelivery({
+					parentSessionId: parent.sessionId,
+					assignmentId: identity.assignmentId,
+					operationId: identity.operationId,
+					deliveryId: identity.deliveryId,
+					sessionMessageId: materializedTerminalMessageId(identity.deliveryId),
+				});
+			}
+		})();
+		joins.set(key, work);
+		void work.catch(() => undefined);
+		void work
+			.finally(() => {
+				if (joins?.get(key) === work) joins.delete(key);
+			})
+			.catch(() => undefined);
+		return work;
+	}
+
 	private createSubagentRuntimeHost(parentState: ActiveSessionState): SubagentRuntimeHost {
+		// Some legacy host-only tests construct no real parent session. Such a host
+		// remains C03-incapable; every durable seam below rejects before mutation.
+		const parent = parentState.runtime.session;
+		// C03 must remain ABI-compatible with legacy host-only embeddings whose
+		// session manager exposes neither persisted-artifact accessor. Feature-test
+		// the methods themselves before a durable seam can use their result.
+		const parentFile = parent?.sessionManager?.getSessionFile?.();
+		const parentArtifactDir = parent?.sessionManager?.getSessionArtifactDir?.();
+		const parentGeneration = parentState.eventGeneration;
+		let parentStore: ReturnType<typeof openRlmDurableOperationStore> | undefined;
+		const durableStore = () => {
+			if (!parentFile || !parentArtifactDir)
+				throw new Error("Durable RLM requires a persisted parent session/artifact");
+			// A parent host owns one store instance. Its in-process materialization
+			// bindings are manager-originated and survive all terminal/import calls;
+			// do not reopen a ledger and use its own child paths as authority.
+			if (parentStore) return parentStore;
+			parentStore = openRlmDurableOperationStore(parentArtifactDir, {
+				trustedChildRecoveryRoots: (operation) => {
+					const state = [...this.sessions.values()].find(
+						(candidate) =>
+							candidate.runtime.metadata.kind === "subagent" &&
+							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
+							candidate.runtime.metadata.assignmentId === operation.assignmentId &&
+							candidate.runtime.metadata.operationId === operation.operationId,
+					);
+					if (!state) return undefined;
+					const child = state.runtime.session;
+					const childFile = child.sessionManager.getSessionFile?.();
+					const childArtifactDir = child.sessionManager.getSessionArtifactDir?.();
+					if (!childFile || !childArtifactDir) return undefined;
+					return {
+						childSessionId: child.sessionId,
+						childSessionFile: childFile,
+						childSessionRoot: dirname(childFile),
+						childArtifactDir,
+						childArtifactRoot: dirname(childArtifactDir),
+					};
+				},
+			});
+			return parentStore;
+		};
+		const current = (options: CreateRlmSubagentRuntimeOptions, runtime?: RlmSubagentRuntime) =>
+			this.sessions.get(parentState.activeSessionId) === parentState &&
+			parentState.eventGeneration === parentGeneration &&
+			options.parentSession === parent &&
+			!!options.assignmentId &&
+			!!options.operationId &&
+			!!options.deliveryId &&
+			(!runtime ||
+				(runtime.assignmentId === options.assignmentId &&
+					runtime.operationId === options.operationId &&
+					runtime.deliveryId === options.deliveryId &&
+					[...this.sessions.values()].some(
+						(state) =>
+							state.runtime.metadata.kind === "subagent" &&
+							state.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
+							state.runtime.metadata.rlmChildId === options.id &&
+							state.runtime.metadata.assignmentId === options.assignmentId &&
+							state.runtime.metadata.operationId === options.operationId &&
+							state.runtime.metadata.deliveryId === options.deliveryId &&
+							state.runtime.session === runtime.session,
+					)));
+
 		return {
 			assignmentIdentityFenced: true,
+			admitRlmSubagentOperation: (options) => {
+				if (!current(options) || !parentFile || !parentArtifactDir)
+					throw new Error("Stale or unpersisted durable RLM admission");
+				durableStore().admit({
+					parentSessionId: parent.sessionId,
+					parentSessionFile: parentFile,
+					parentSessionRoot: dirname(parentFile),
+					parentArtifactRoot: dirname(parentArtifactDir),
+					childId: options.id,
+					assignmentId: options.assignmentId!,
+					operationId: options.operationId!,
+					deliveryId: options.deliveryId!,
+					childSessionDir: options.sessionDir,
+					requestedModel: { provider: options.model.provider, modelId: options.model.id },
+					rlmDepth: options.rlmDepth,
+					rlmMaxDepth: options.rlmMaxDepth,
+				});
+			},
+			deliverRlmSubagentTerminal: async (runtime, options, terminal, message) => {
+				if (
+					!current(options, runtime) ||
+					!parentFile ||
+					!parentArtifactDir ||
+					!options.assignmentId ||
+					!options.operationId ||
+					!options.deliveryId
+				)
+					return;
+				const child = runtime.session;
+				const childFile = child.sessionManager.getSessionFile?.();
+				const childArtifactDir = child.sessionManager.getSessionArtifactDir?.();
+				if (!childFile || !childArtifactDir) return;
+				const outbox: RlmTerminalOutbox = {
+					parentSessionId: parent.sessionId,
+					parentSessionFile: parentFile,
+					parentSessionRoot: dirname(parentFile),
+					parentArtifactRoot: dirname(parentArtifactDir),
+					childSessionId: child.sessionId,
+					childSessionFile: childFile,
+					childSessionRoot: dirname(childFile),
+					childArtifactDir,
+					childArtifactRoot: dirname(childArtifactDir),
+					childId: options.id,
+					assignmentId: options.assignmentId,
+					operationId: options.operationId,
+					deliveryId: options.deliveryId,
+					terminal,
+					message,
+				};
+				const store = durableStore();
+				store.appendOutbox(outbox); // child outbox fsync happens before parent ledger.
+				if (
+					!store.recordTerminal({
+						parentSessionId: parent.sessionId,
+						assignmentId: options.assignmentId,
+						operationId: options.operationId,
+						deliveryId: options.deliveryId,
+						terminal,
+					})
+				)
+					return;
+				if (!current(options, runtime)) return;
+				// The owner-local join imports the fsynced outbox, then performs the
+				// normal no-turn transcript append before the consumed fsync.
+				await this.importBoundRlmTerminalInbox(
+					parentState,
+					runtime,
+					{
+						childId: options.id,
+						assignmentId: options.assignmentId,
+						operationId: options.operationId,
+						deliveryId: options.deliveryId,
+					},
+					store,
+				);
+				if (!current(options, runtime)) return;
+			},
 			createRlmSubagentRuntime: async (options) => this.createRlmSubagentRuntime(parentState, options),
-			completeRlmSubagentRuntime: (childId, childSession, assignmentId) => {
+			completeRlmSubagentRuntime: (childId, childSession, assignmentId, operationId) => {
 				if (!assignmentId || !childSession) return false;
 				const state = [...this.sessions.values()].find(
 					(candidate) =>
@@ -2337,6 +2573,12 @@ export class AgentDaemon {
 						candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
 						candidate.runtime.metadata.rlmChildId === childId &&
 						candidate.runtime.metadata.assignmentId === assignmentId &&
+						// Fresh C03 runtimes must carry the exact durable operation. Only a
+						// genuinely pre-C03 metadata record (no operation at all) may use
+						// the C01 assignment fence for host ABI compatibility.
+						(operationId !== undefined
+							? candidate.runtime.metadata.operationId === operationId
+							: candidate.runtime.metadata.operationId === undefined) &&
 						candidate.runtime.session === childSession,
 				);
 				if (!state?.runtime.session.sessionFile || this.sessions.get(parentState.activeSessionId) !== parentState)
@@ -2347,6 +2589,8 @@ export class AgentDaemon {
 				return this.recordRlmSubagentRegistryEntry(parentState, {
 					childId,
 					assignmentId,
+					operationId,
+					deliveryId: metadata.deliveryId,
 					sessionName: childSession.sessionName ?? childId,
 					sessionDir: metadata.sessionDir ?? dirname(state.runtime.session.sessionFile),
 					sessionFile: state.runtime.session.sessionFile,
@@ -2362,11 +2606,31 @@ export class AgentDaemon {
 			},
 			releaseRlmSubagentRuntime: async (runtime, options, status) => {
 				const assignmentId = runtime.assignmentId ?? options.assignmentId;
+				const operationId = runtime.operationId ?? options.operationId;
 				// A callback without an assignment is a legacy display path and may only
-				// dispose its own unpublished runtime, never mutate daemon state.
-				if (!assignmentId || this.sessions.get(parentState.activeSessionId) !== parentState) {
-					await runtime.session.disposeAsync();
+				// dispose its own unpublished runtime, never mutate daemon state.  Both
+				// durable identifiers must agree: a held A continuation must never acquire
+				// B merely because the public selector was reused.
+				const identityMismatch =
+					(runtime.assignmentId !== undefined && runtime.assignmentId !== options.assignmentId) ||
+					(runtime.operationId !== undefined && runtime.operationId !== options.operationId);
+				if (!assignmentId || identityMismatch || this.sessions.get(parentState.activeSessionId) !== parentState) {
+					const resident = [...this.sessions.values()].some((state) => state.runtime.session === runtime.session);
+					// A failed/unpublished A still owns its local runtime and can clean it up;
+					// never dispose a resident B supplied by a stale/malformed continuation.
+					if (!resident) await runtime.session.disposeAsync();
 					return;
+				}
+				// Lifecycle facts are exact operation keyed. A stale A cannot release B.
+				if (operationId && options.deliveryId && current(options, runtime)) {
+					const parentArtifactDir = parent.sessionManager.getSessionArtifactDir?.();
+					if (parentArtifactDir) {
+						const store = durableStore();
+						if (status === "cancelled")
+							store.recordRelease({ parentSessionId: parent.sessionId, assignmentId, operationId }, "deleted");
+						else
+							store.recordRelease({ parentSessionId: parent.sessionId, assignmentId, operationId }, "released");
+					}
 				}
 				// Persist the deletion boundary first, but never let a registry failure
 				// strand the cancelled child as a stale resident session.
@@ -2393,7 +2657,7 @@ export class AgentDaemon {
 				}
 				if (deletionError !== undefined) throw deletionError;
 			},
-			deleteRlmSubagentRuntime: async (childId, childSession, requestedAssignmentId) => {
+			deleteRlmSubagentRuntime: async (childId, childSession, requestedAssignmentId, requestedOperationId) => {
 				// Public catalog entries intentionally hide assignment IDs. An explicit
 				// delete is therefore the one legacy operation permitted to resolve its
 				// durable row internally. A missing legacy ID is rebound *before* delete;
@@ -2437,6 +2701,14 @@ export class AgentDaemon {
 							throw new Error(`Failed to bind legacy RLM subagent ${childId} for deletion`);
 						persisted = { ...persisted, assignmentId };
 					} else assignmentId = persisted.assignmentId;
+				}
+				// Callback cleanup carries an operation; it is never a selector or
+				// assignment-only capability.  A legacy explicit delete has no operation
+				// and intentionally retains its historical catalog behavior.
+				if (requestedOperationId && persisted?.operationId !== requestedOperationId) {
+					const resident = [...this.sessions.values()].some((state) => state.runtime.session === childSession);
+					if (!resident) await childSession?.disposeAsync();
+					return;
 				}
 				// Assignment-less resident children are old host data. They remain
 				// deletable only by this explicit (not callback) path; do not invent a
@@ -2487,12 +2759,27 @@ export class AgentDaemon {
 		parentState: ActiveSessionState,
 		options: CreateRlmSubagentRuntimeOptions,
 	): Promise<AgentSessionRuntime> {
-		// Assignment is mandatory authority for every daemon-hosted incarnation.
-		// Legacy callers that omit it are adapted by minting here; untrusted values
-		// are never written because readers correctly reject them.
+		// C03 creation is all-or-nothing: the parent mints all opaque identities
+		// before admission. The old assignment-only compatibility path has no C03
+		// authority and never acquires an operation/delivery here.
+		const hasDurableIdentity = options.operationId !== undefined || options.deliveryId !== undefined;
+		if (
+			hasDurableIdentity &&
+			(!assertFreshUuid(options.assignmentId) ||
+				!assertFreshUuid(options.operationId) ||
+				!assertFreshUuid(options.deliveryId))
+		) {
+			throw new Error("Daemon C03 child creation requires parent-minted durable identities");
+		}
 		const assignmentId = assertFreshUuid(options.assignmentId) ? options.assignmentId : randomUUID();
 		const assignedOptions = assignmentId === options.assignmentId ? options : { ...options, assignmentId };
 		options = assignedOptions;
+		const parent = parentState.runtime.session;
+		const parentArtifactDir = options.operationId ? parent.sessionManager.getSessionArtifactDir?.() : undefined;
+		const durableStore = () => {
+			if (!parentArtifactDir) throw new Error("Durable RLM requires a persisted parent artifact");
+			return openRlmDurableOperationStore(parentArtifactDir);
+		};
 		const sessionManager = SessionManager.create(options.parentSession.sessionManager.getCwd(), options.sessionDir);
 		sessionManager.newSession({
 			parentSession: options.parentSession.sessionFile,
@@ -2559,6 +2846,8 @@ export class AgentDaemon {
 					parentSessionFile: options.parentSession.sessionFile,
 					rlmChildId: options.id,
 					assignmentId: options.assignmentId,
+					operationId: options.operationId,
+					deliveryId: options.deliveryId,
 					rlmParentNodeId: options.rlmParentNodeId,
 					prompt: options.prompt,
 					spawnCode: options.spawnCode,
@@ -2579,9 +2868,31 @@ export class AgentDaemon {
 					runtime.session.setSessionName(options.sessionName);
 				}
 				if (runtime.session.sessionFile) {
+					// Only C03-admitted children carry the opaque operation. Legacy rows stay
+					// display-compatible and deliberately acquire no durable delivery authority.
+					if (options.operationId) {
+						const artifactDir = runtime.session.sessionManager.getSessionArtifactDir();
+						if (!artifactDir || !options.assignmentId || !parentArtifactDir)
+							throw new Error("RLM child lacks durable artifact identity");
+						if (
+							!durableStore().markMaterialized({
+								parentSessionId: parent.sessionId,
+								assignmentId: options.assignmentId,
+								operationId: options.operationId,
+								childSessionId: runtime.session.sessionId,
+								childSessionFile: runtime.session.sessionFile,
+								childSessionRoot: dirname(runtime.session.sessionFile),
+								childArtifactDir: artifactDir,
+								childArtifactRoot: dirname(artifactDir),
+							})
+						)
+							throw new Error("Failed durable RLM child materialization");
+					}
 					this.recordRlmSubagentRegistryEntry(parentState, {
 						childId: options.id,
 						assignmentId,
+						operationId: options.operationId,
+						deliveryId: options.deliveryId,
 						sessionName: options.sessionName,
 						sessionDir: options.sessionDir,
 						sessionFile: runtime.session.sessionFile,
@@ -3028,6 +3339,8 @@ export class AgentDaemon {
 							: {}),
 						rlmChildId: entry.childId,
 						assignmentId: entry.assignmentId,
+						operationId: entry.operationId,
+						deliveryId: entry.deliveryId,
 						rlmParentNodeId: entry.rlmParentNodeId ?? entry.childId,
 						rehydratedCompleted: true,
 						...(entry.prompt ? { prompt: entry.prompt } : {}),
@@ -3068,6 +3381,47 @@ export class AgentDaemon {
 			if (!registered || assignmentBound === false) {
 				await this.closeSession(state, "replaced");
 				throw new RuntimeOpenCancelledError();
+			}
+			// Hydration is the sole restart join. It binds the exact registry incarnation
+			// before reading a child outbox and never starts prompt/task work.
+			if (entry.operationId && entry.deliveryId && entry.assignmentId) {
+				const parent = parentState.runtime.session;
+				const parentArtifactDir = parent.sessionManager.getSessionArtifactDir();
+				const parentFile = parent.sessionManager.getSessionFile();
+				const childFile = runtime.session.sessionManager.getSessionFile();
+				const childArtifactDir = runtime.session.sessionManager.getSessionArtifactDir();
+				if (parentArtifactDir && parentFile && childFile && childArtifactDir) {
+					const store = openRlmDurableOperationStore(parentArtifactDir, {
+						trustedChildRecoveryRoots: (operation) =>
+							operation.parentSessionId === parent.sessionId &&
+							operation.assignmentId === entry.assignmentId &&
+							operation.operationId === entry.operationId
+								? {
+										childSessionId: runtime!.session.sessionId,
+										childSessionFile: childFile,
+										childSessionRoot: dirname(childFile),
+										childArtifactDir,
+										childArtifactRoot: dirname(childArtifactDir),
+									}
+								: undefined,
+					});
+					await this.importBoundRlmTerminalInbox(
+						parentState,
+						{
+							session: runtime.session,
+							assignmentId: entry.assignmentId,
+							operationId: entry.operationId,
+							deliveryId: entry.deliveryId,
+						},
+						{
+							childId: entry.childId,
+							assignmentId: entry.assignmentId,
+							operationId: entry.operationId,
+							deliveryId: entry.deliveryId,
+						},
+						store,
+					);
+				}
 			}
 			if (
 				this.sessions.get(parentState.activeSessionId) !== parentState ||

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -5891,9 +5891,31 @@ export class AgentDaemon {
 			currentState ?? [...this.sessions.values()].find((state) => !this.bindingSessions.has(state.activeSessionId));
 		const listed = current ? await this.createAgentMessageListResult(current) : { agents: [] };
 		const remotePeers = new Set(this.remoteAgentPeers.values());
+		// A live C03 deletion immediately closes its public registry row but retains
+		// the cancelled runtime until its exact terminal hand-off is durable. Exclude
+		// only that deleted durable incarnation from family-name authority, allowing B
+		// to reuse A's public selector while A completes its private discard path.
+		const deletedC03Operations = new Set(
+			current
+				? (await this.readLatestRlmSubagentRegistry(current))
+						.filter((entry) => this.isAuthoritativeC03RegistryEntry(entry) && entry.status === "deleted")
+						.map((entry) => `${entry.assignmentId}\u0000${entry.operationId}`)
+				: [],
+		);
+		const visibleLocalAgents = listed.agents.filter((agent) => {
+			if (remotePeers.has(agent)) return false;
+			const state = this.sessions.get(agent.activeSessionId);
+			const metadata = state?.runtime.metadata;
+			return !(
+				metadata?.kind === "subagent" &&
+				metadata.assignmentId !== undefined &&
+				metadata.operationId !== undefined &&
+				deletedC03Operations.has(`${metadata.assignmentId}\u0000${metadata.operationId}`)
+			);
+		});
 		const localAgents = current
-			? [this.createAgentMessageAgentSummary(current), ...listed.agents.filter((agent) => !remotePeers.has(agent))]
-			: listed.agents.filter((agent) => !remotePeers.has(agent));
+			? [this.createAgentMessageAgentSummary(current), ...visibleLocalAgents]
+			: visibleLocalAgents;
 		const activePaths = new Set(
 			localAgents.flatMap((agent) => (agent.sessionPath ? [canonicalSessionPath(agent.sessionPath)] : [])),
 		);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2804,7 +2804,40 @@ export class AgentDaemon {
 					// A materialized live child cannot yet be `deleted`: retain an exact
 					// intent through cancellation. The terminal owner converts it to deleted
 					// before any inbox import, while C01 deletion/close proceeds normally.
-					const store = durableStore();
+					// A passive C03 incarnation has no resident runtime, so bind its exact
+					// already-selected registry tuple through SessionManager before reading
+					// its private outbox.  This is a manager-owned materialization check,
+					// never an assignment-only/ledger-path fallback.
+					const store = persisted
+						? openRlmDurableOperationStore(artifactDir, {
+								trustedChildRecoveryRoots: (candidate) => {
+									if (
+										candidate.parentSessionId !== parent.sessionId ||
+										candidate.assignmentId !== assignmentId ||
+										candidate.operationId !== operationId ||
+										persisted.assignmentId !== assignmentId ||
+										persisted.operationId !== operationId ||
+										persisted.deliveryId !== candidate.deliveryId
+									)
+										return undefined;
+									try {
+										const manager = SessionManager.open(persisted.sessionFile);
+										const childFile = manager.getSessionFile();
+										const childArtifactDir = manager.getSessionArtifactDir();
+										if (!childFile || !childArtifactDir) return undefined;
+										return {
+											childSessionId: manager.getSessionId(),
+											childSessionFile: childFile,
+											childSessionRoot: dirname(childFile),
+											childArtifactDir,
+											childArtifactRoot: dirname(childArtifactDir),
+										};
+									} catch {
+										return undefined;
+									}
+								},
+							})
+						: durableStore();
 					const operation = store
 						.rebuild()
 						.operations.get(JSON.stringify([parent.sessionId, assignmentId, operationId]));

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -424,6 +424,9 @@ interface RecoveryOperationToken {
 class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
 
+/** A C03 lifecycle boundary cannot proceed without its parent-owned registry. */
+class RlmRegistryAuthorityError extends Error {}
+
 export async function runDaemonMode(options: DaemonModeOptions): Promise<never> {
 	const socketPath = options.socketPath ?? defaultDaemonSocketPath();
 	const daemon = new AgentDaemon(socketPath, options);
@@ -972,6 +975,14 @@ export class AgentDaemon {
 		return [...currentByChildId.values()].filter((entry) => entry.status !== "deleted");
 	}
 
+	private requireRlmSubagentRegistryPath(parentState: ActiveSessionState): string {
+		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
+		if (!path) {
+			throw new RlmRegistryAuthorityError("Durable RLM requires a parent registry artifact");
+		}
+		return path;
+	}
+
 	private appendRlmSubagentRegistryEntry(
 		parentState: ActiveSessionState,
 		entry: PersistedRlmSubagentRegistryEntry,
@@ -979,7 +990,8 @@ export class AgentDaemon {
 		assertRlmRegistryWriteIdentity(entry);
 		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
 		if (!path) {
-			return true;
+			this.log("failed to persist RLM subagent registry entry: parent registry artifact is unavailable");
+			return false;
 		}
 		try {
 			mkdirSync(dirname(path), { recursive: true });
@@ -1052,6 +1064,10 @@ export class AgentDaemon {
 		assignmentId: string,
 		operationId?: string,
 	): Promise<void> {
+		// A C03 deletion is an authoritative lifecycle acknowledgement and must
+		// not degrade into an in-memory success. Assignment-only legacy cleanup
+		// retains its compatibility behavior when no registry exists.
+		if (operationId) this.requireRlmSubagentRegistryPath(parentState);
 		const latest = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 			(entry) =>
 				entry.childId === childId &&
@@ -2495,8 +2511,13 @@ export class AgentDaemon {
 		return {
 			assignmentIdentityFenced: true,
 			admitRlmSubagentOperation: (options) => {
-				if (!current(options) || !parentFile || !parentArtifactDir)
-					throw new Error("Stale or unpersisted durable RLM admission");
+				if (!current(options)) throw new RlmRegistryAuthorityError("Stale durable RLM admission");
+				// Admission is the first C03 mutation. Require the companion registry
+				// before ledger/factory work, so an unpublishable operation never reaches a
+				// provider or public child state.
+				this.requireRlmSubagentRegistryPath(parentState);
+				if (!parentFile || !parentArtifactDir)
+					throw new RlmRegistryAuthorityError("Unpersisted durable RLM admission");
 				durableStore().admit({
 					parentSessionId: parent.sessionId,
 					parentSessionFile: parentFile,
@@ -2520,7 +2541,8 @@ export class AgentDaemon {
 					!options.operationId ||
 					!options.deliveryId
 				)
-					return;
+					throw new RlmRegistryAuthorityError("Durable RLM terminal requires a parent registry artifact");
+				this.requireRlmSubagentRegistryPath(parentState);
 				const store = durableStore();
 				const durableOperation = () =>
 					store
@@ -2629,6 +2651,9 @@ export class AgentDaemon {
 				if (!state?.runtime.session.sessionFile || this.sessions.get(parentState.activeSessionId) !== parentState)
 					return false;
 				if (state.runtime.metadata.rehydratedCompleted) return true;
+				// A registry-less assignment-only embedded runtime is display-compatible,
+				// not a C03 completion boundary. Do not claim that an append occurred.
+				if (operationId === undefined && !this.rlmSubagentRegistryPath(parentState.runtime.session)) return true;
 				const metadata = state.runtime.metadata;
 				const model = childSession.model;
 				return this.recordRlmSubagentRegistryEntry(parentState, {
@@ -2711,6 +2736,9 @@ export class AgentDaemon {
 				if (deletionError !== undefined) throw deletionError;
 			},
 			deleteRlmSubagentRuntime: async (childId, childSession, requestedAssignmentId, requestedOperationId) => {
+				// An operation-bearing request is C03 authority. Never convert a missing
+				// registry into an in-memory close or a successful deletion acknowledgement.
+				if (requestedOperationId) this.requireRlmSubagentRegistryPath(parentState);
 				// Public catalog entries intentionally hide assignment IDs. An explicit
 				// delete is therefore the one legacy operation permitted to resolve its
 				// durable row internally. A missing legacy ID is rebound *before* delete;
@@ -2758,6 +2786,9 @@ export class AgentDaemon {
 				// A retained C03 child passes its operation; an explicit selector delete
 				// resolves the newest durable C03 incarnation, while legacy stays undefined.
 				const operationId = requestedOperationId ?? persisted?.operationId;
+				// A selector may resolve a C03 row only after proving it can persist the
+				// corresponding tombstone. Do this before durable intent or runtime close.
+				if (operationId) this.requireRlmSubagentRegistryPath(parentState);
 				// Callback cleanup carries an operation; it is never a selector or
 				// assignment-only capability.  A legacy explicit delete has no operation
 				// and intentionally retains its historical catalog behavior.
@@ -2914,6 +2945,9 @@ export class AgentDaemon {
 		const assignedOptions = assignmentId === options.assignmentId ? options : { ...options, assignmentId };
 		options = assignedOptions;
 		const parent = parentState.runtime.session;
+		// Direct daemon callers share the host admission invariant: a C03 child
+		// cannot construct a runtime before the parent registry is writable.
+		if (options.operationId) this.requireRlmSubagentRegistryPath(parentState);
 		const parentArtifactDir = options.operationId ? parent.sessionManager.getSessionArtifactDir?.() : undefined;
 		const durableStore = () => {
 			if (!parentArtifactDir) throw new Error("Durable RLM requires a persisted parent artifact");
@@ -3027,7 +3061,9 @@ export class AgentDaemon {
 						)
 							throw new Error("Failed durable RLM child materialization");
 					}
+					const hasRegistryAuthority = this.rlmSubagentRegistryPath(parent) !== undefined;
 					if (
+						(options.operationId || hasRegistryAuthority) &&
 						!this.recordRlmSubagentRegistryEntry(parentState, {
 							childId: options.id,
 							assignmentId,
@@ -3049,7 +3085,7 @@ export class AgentDaemon {
 							createdAt: runtime.metadata.createdAt,
 						})
 					) {
-						// C01 publication is a second durable boundary.  The C03 materialized
+						// C01 publication is a second durable boundary. The C03 materialized
 						// fact remains recoverably pending, but this unpublished runtime must
 						// never become addressable or start prompt work.
 						throw new Error("Failed to persist running RLM subagent registry entry");

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -968,11 +968,23 @@ export class AgentDaemon {
 	private currentLiveRlmSubagentRegistryEntries(
 		entries: readonly PersistedRlmSubagentRegistryEntry[],
 	): PersistedRlmSubagentRegistryEntry[] {
-		const currentByChildId = new Map<string, PersistedRlmSubagentRegistryEntry>();
+		const c03ByChildId = new Map<string, PersistedRlmSubagentRegistryEntry>();
+		const displayByChildId = new Map<string, PersistedRlmSubagentRegistryEntry>();
 		for (const entry of entries) {
-			if (this.isAuthoritativeC03RegistryEntry(entry)) currentByChildId.set(entry.childId, entry);
+			if (this.isAuthoritativeC03RegistryEntry(entry)) {
+				c03ByChildId.set(entry.childId, entry);
+			} else {
+				// Pre-C03 rows remain selectable for display/compatibility, but never
+				// outrank an authoritative C03 lifecycle incarnation of the selector.
+				displayByChildId.set(entry.childId, entry);
+			}
 		}
-		return [...currentByChildId.values()].filter((entry) => entry.status !== "deleted");
+		return [
+			...[...c03ByChildId.values()].filter((entry) => entry.status !== "deleted"),
+			...[...displayByChildId.values()].filter(
+				(entry) => !c03ByChildId.has(entry.childId) && entry.status !== "deleted",
+			),
+		];
 	}
 
 	private requireRlmSubagentRegistryPath(parentState: ActiveSessionState): string {
@@ -2887,7 +2899,11 @@ export class AgentDaemon {
 				// its exact delete intent. Keep only the active cancelled run alive long
 				// enough for its abort to write the owner-local terminal hand-off. Passive
 				// and passivating instances have no such owner and must close normally.
-				if (assignmentId && operationId && parent.getRlmChildRunStatus(childId) === "cancelled") {
+				if (
+					assignmentId &&
+					operationId &&
+					parent.getRlmChildRunStatus(childId, assignmentId, operationId) === "cancelled"
+				) {
 					const pendingDelete = durableStore()
 						.rebuild()
 						.operations.get(JSON.stringify([parent.sessionId, assignmentId, operationId]));
@@ -3664,6 +3680,19 @@ export class AgentDaemon {
 			}
 			return state;
 		} catch (error) {
+			// Registration happens before inbox import. If a later hydration step fails,
+			// detach this exact incarnation so a retry is not blocked by the closed child.
+			if (runtime && entry.assignmentId) {
+				const unsubscribe = entry.operationId
+					? parentState.runtime.session.releaseRlmChildSession(
+							entry.childId,
+							runtime.session,
+							entry.assignmentId,
+							entry.operationId,
+						)
+					: parentState.runtime.session.releaseRlmChildSession(entry.childId, runtime.session, entry.assignmentId);
+				if (unsubscribe) unsubscribe();
+			}
 			if (stateRef && this.sessions.get(stateRef.activeSessionId) === stateRef) {
 				await this.closeSession(stateRef, "completed").catch(() => undefined);
 			} else {
@@ -5871,8 +5900,12 @@ export class AgentDaemon {
 		// AgentSessionMessageAgentSummary ABI intentionally has no assignment or
 		// operation fields, but this internal seam can exactly suppress only A while
 		// retaining a later same-childId B or an identity-less legacy catalog row.
+		// Each child is tombstoned in its direct parent's registry. The result can
+		// include descendants and siblings, so inspect every resident owner rather
+		// than only `current`'s direct registry.
 		const deletedC03Operations = new Set(
-			(await this.readLatestRlmSubagentRegistry(current))
+			(await Promise.all([...this.sessions.values()].map((state) => this.readLatestRlmSubagentRegistry(state))))
+				.flat()
 				.filter((entry) => this.isAuthoritativeC03RegistryEntry(entry) && entry.status === "deleted")
 				.map((entry) => `${entry.assignmentId}\u0000${entry.operationId}`),
 		);
@@ -5941,6 +5974,7 @@ export class AgentDaemon {
 	private isNonresidentAuthoritativeC03Passive(passive: PassiveRlmSubagent): boolean {
 		return (
 			this.isAuthoritativeC03RegistryEntry(passive.entry) &&
+			(passive.entry.status === "completed" || passive.entry.status === "deleted") &&
 			this.findSessionBySessionFile(passive.entry.sessionFile) === undefined
 		);
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-rlm-registry-identity.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-rlm-registry-identity.ts
@@ -1,0 +1,39 @@
+import { assertFreshUuid } from "./daemon-lifecycle-identity.js";
+
+/**
+ * The registry is a compatibility journal, but only a complete C03 tuple is
+ * authority.  Keep this classifier shared by its owning daemon and the
+ * read-only catalog so partial disk history cannot acquire a second meaning.
+ */
+export type RlmRegistryIdentity =
+	| { kind: "legacy-display" }
+	| { kind: "assignment-display"; assignmentId: string }
+	| { kind: "c03"; assignmentId: string; operationId: string; deliveryId: string }
+	| { kind: "invalid" };
+
+export interface RlmRegistryIdentityFields {
+	assignmentId?: unknown;
+	operationId?: unknown;
+	deliveryId?: unknown;
+}
+
+export function classifyRlmRegistryIdentity(entry: RlmRegistryIdentityFields): RlmRegistryIdentity {
+	const { assignmentId, operationId, deliveryId } = entry;
+	if (assignmentId === undefined && operationId === undefined && deliveryId === undefined) {
+		return { kind: "legacy-display" };
+	}
+	if (operationId === undefined && deliveryId === undefined && assertFreshUuid(assignmentId)) {
+		return { kind: "assignment-display", assignmentId };
+	}
+	if (assertFreshUuid(assignmentId) && assertFreshUuid(operationId) && assertFreshUuid(deliveryId)) {
+		return { kind: "c03", assignmentId, operationId, deliveryId };
+	}
+	return { kind: "invalid" };
+}
+
+/** Fail closed at every C03 registry writer before a partial row reaches disk. */
+export function assertRlmRegistryWriteIdentity(entry: RlmRegistryIdentityFields): void {
+	if (classifyRlmRegistryIdentity(entry).kind === "invalid") {
+		throw new Error("RLM registry identity must be all-absent, assignment-only, or a complete C03 triple");
+	}
+}

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -647,6 +647,50 @@ describe("AgentSession rlm recursion", () => {
 		expect(internals._deletedRlmChildIds.has(`${childId}\0${assignmentA}`)).toBe(true);
 	});
 
+	it("does not let an exact A tombstone hide a daemon B or legacy row with the same child id", async () => {
+		const childId = "reused-daemon-child";
+		const assignmentA = "deleted-assignment-A";
+		const daemonRow = (sessionName: string) => ({
+			activeSessionId: `${sessionName}-active`,
+			sessionId: `${sessionName}-session`,
+			sessionName,
+			runtimeKind: "subagent" as const,
+			cwd: tempDir,
+			isStreaming: false,
+			unfinishedActionCount: 0,
+			parentActiveSessionId: "parent-active",
+			rlmChildId: childId,
+			sessionDir: join(tempDir, sessionName),
+		});
+		const listWith = (row: ReturnType<typeof daemonRow>) =>
+			createSession({
+				agentMessageController: {
+					listAgents: () => ({
+						current: { activeSessionId: "parent-active", sessionId: "parent-session" },
+						agents: [row],
+					}),
+					sendAgentMessage: vi.fn(),
+				},
+			});
+
+		// The daemon owns exact C03 (assignmentId, operationId) filtering. Its public
+		// list seam intentionally exposes neither identity, so an old local A key
+		// cannot be used as a child-id-wide fallback predicate.
+		const b = listWith(daemonRow("later-B"));
+		(b as unknown as InspectableRlmSession)._deletedRlmChildIds.add(`${childId}\0${assignmentA}`);
+		expect(await b.listRlmSubagents()).toMatchObject({
+			subagents: [expect.objectContaining({ rlm_child_id: childId, session_name: "later-B" })],
+		});
+
+		// The same guarantee applies to an identity-less legacy daemon row: it is not
+		// silently treated as A merely because it shares A's public child id.
+		const legacy = listWith(daemonRow("legacy-child"));
+		(legacy as unknown as InspectableRlmSession)._deletedRlmChildIds.add(`${childId}\0${assignmentA}`);
+		expect(await legacy.listRlmSubagents()).toMatchObject({
+			subagents: [expect.objectContaining({ rlm_child_id: childId, session_name: "legacy-child" })],
+		});
+	});
+
 	it("retries and releases failed retained child cleanup on the next compaction", async () => {
 		const childId = "retained-retry-child";
 		const childDir = join(tempDir, childId);

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1206,6 +1206,52 @@ describe("AgentSession rlm recursion", () => {
 		expect(resumed.repliedToParentSinceTask).toBeUndefined();
 	});
 
+	it("fails a real public spawn before child construction when daemon durable admission cannot fsync", async () => {
+		const root = createSession();
+		const parentArtifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!parentArtifactDir) throw new Error("Missing persisted parent artifact dir");
+		let childFactoryCalls = 0;
+		const daemon = new AgentDaemon(join(tempDir, "admission-failure.sock"), {
+			defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: join(tempDir, "daemon-sessions") },
+			createRuntime: async () => {
+				childFactoryCalls += 1;
+				throw new Error("child factory must not run before durable admission");
+			},
+		});
+		const parentState = {
+			activeSessionId: "real-parent",
+			eventGeneration: "admission-failure-generation",
+			runtime: {
+				session: root,
+				services: { agentDir: tempDir },
+				metadata: { kind: "top-level", createdAt: 0 },
+			},
+		} as unknown as ActiveSessionState;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+		};
+		internals.sessions.set(parentState.activeSessionId, parentState);
+		root.setSubagentRuntimeHost(internals.createSubagentRuntimeHost(parentState));
+
+		// A non-directory artifact path is a deterministic durable append/fsync failure.
+		// The normal public runRlmChild boundary must reject before it publishes a run
+		// or asks the daemon to construct a child runtime/provider task.
+		rmSync(parentArtifactDir, { recursive: true, force: true });
+		writeFileSync(parentArtifactDir, "injected admission append failure");
+		await expect(root.runRlmChild("must not start", { name: "durable-failure-worker" })).rejects.toThrow();
+
+		expect(childFactoryCalls).toBe(0);
+		expect((root as unknown as InspectableRlmSession)._activeRlmChildRuns).toHaveLength(0);
+		expect(root.getRlmChildSession("durable-failure-worker")).toBeUndefined();
+		expect(root.messages).not.toContainEqual(
+			expect.objectContaining({
+				customType: "rlm_child_failure",
+				content: expect.stringContaining("must not start"),
+			}),
+		);
+	});
+
 	it("surfaces post-admission startup failure in the parent transcript and subagent registry", async () => {
 		const root = createSession({
 			subagentRuntimeHost: {

--- a/packages/coding-agent/test/daemon-c03-real-production.test.ts
+++ b/packages/coding-agent/test/daemon-c03-real-production.test.ts
@@ -108,8 +108,10 @@ async function createRealDaemonFixture(root: string, scripted: BarrierScriptedPr
 			agentMessageController: runtimeOptions.sessionOptions?.agentMessageController,
 			agentObserveController: runtimeOptions.sessionOptions?.agentObserveController,
 			rlmHeartbeatController: runtimeOptions.sessionOptions?.rlmHeartbeatController,
-			rlmDepth: runtimeOptions.sessionOptions?.rlmDepth,
-			rlmMaxDepth: runtimeOptions.sessionOptions?.rlmMaxDepth,
+			// Test process environment may itself be a maximum-depth RLM child; a
+			// daemon-created top-level parent is nevertheless depth zero.
+			rlmDepth: runtimeOptions.sessionOptions?.rlmDepth ?? 0,
+			rlmMaxDepth: runtimeOptions.sessionOptions?.rlmMaxDepth ?? 1,
 			rlmSessionDir: runtimeOptions.sessionOptions?.rlmSessionDir,
 			rlmParentNodeId: runtimeOptions.sessionOptions?.rlmParentNodeId,
 			rlmParentAgent: runtimeOptions.sessionOptions?.rlmParentAgent,
@@ -309,5 +311,171 @@ describe("C03 real daemon production recovery", () => {
 		expect(promptAndWait).toHaveBeenCalledTimes(1);
 		expect([...realRegistry(artifacts).deliveries.values()]).toHaveLength(1);
 		await cInternals.closeSession(parentC, "shutdown");
+	}, 20_000);
+
+	it("uses the public daemon delete path to retain a live intent until its real cancelled terminal is deleted and discarded", async () => {
+		const root = await mkdtemp(join(tmpdir(), "prime-agent-c03-real-delete-"));
+		const requestId = "request-9002";
+		const scripted = createBarrierScriptedProvider({
+			api: "c03-real-delete-scripted",
+			provider: "c03-real-delete-scripted",
+			barrier: { expected: [requestId], timeoutMs: 10_000 },
+			models: [{ id: "c03-real-delete-model", responseModel: "c03-real-delete-model" }],
+			scripts: {
+				[requestId]: [
+					{
+						requestId,
+						blocks: [{ type: "text", chunks: ["must never reach parent"] }],
+						usage: usage(11, 7),
+						responseModel: "c03-real-delete-model",
+						waitForRelease: true,
+					},
+				],
+			},
+		});
+		cleanups.push(() => scripted.unregister());
+		cleanups.push(() => rm(root, { recursive: true, force: true }));
+		const fixture = await createRealDaemonFixture(root, scripted);
+		const internals = fixture.daemon as unknown as DaemonInternals;
+		const parentState = await internals.createRuntime({ type: "create" });
+		const parent = parentState.runtime.session;
+		const handle = await parent.runRlmChild(`C03 actual cancel ${requestId}`, {
+			name: "c03-live-delete-worker",
+			model: "c03-real-delete-scripted/c03-real-delete-model",
+		});
+		await scripted.open;
+		const artifacts = parent.sessionManager.getSessionArtifactDir();
+		if (!artifacts) throw new Error("Missing persisted real parent artifact");
+		const admitted = realRegistry(artifacts);
+		const operation = [...admitted.operations.values()].find(
+			(candidate) => candidate.childId === handle.rlm_child_id,
+		);
+		if (!operation) throw new Error("Missing admitted real C03 deletion operation");
+
+		// This is the public session API, which delegates to the real daemon host.
+		await parent.deleteRlmSubagent(handle.rlm_child_id);
+		expect(terminalEntries(parent, operation.deliveryId)).toHaveLength(0);
+		await vi.waitFor(() => {
+			const after = realRegistry(artifacts);
+			expect(after.operations.get(operation.key)).toMatchObject({ lifecycle: "deleted", deleteIntent: true });
+			expect(
+				[...after.deliveries.values()].find((delivery) => delivery.deliveryId === operation.deliveryId),
+			).toMatchObject({
+				consumed: "discarded",
+			});
+		});
+		expect(terminalEntries(parent, operation.deliveryId)).toHaveLength(0);
+		expect(parent.messages.filter((message) => message.role === "custom")).toHaveLength(0);
+		expect(scripted.observations()).toEqual([
+			expect.objectContaining({ requestId, terminal: "aborted", signalAborted: true }),
+		]);
+		await vi.waitFor(async () => expect((await parent.listRlmSubagents()).subagents).toHaveLength(0));
+		await internals.closeSession(parentState, "shutdown");
+	}, 20_000);
+
+	it("keeps deleted A durable facts separate when B reuses the same public selector", async () => {
+		const root = await mkdtemp(join(tmpdir(), "prime-agent-c03-real-reuse-"));
+		const aRequest = "request-9002";
+		const bRequest = "request-9003";
+		const scripted = createBarrierScriptedProvider({
+			api: "c03-real-reuse-scripted",
+			provider: "c03-real-reuse-scripted",
+			barrier: { expected: [aRequest, bRequest], timeoutMs: 10_000 },
+			models: [{ id: "c03-real-reuse-model", responseModel: "c03-real-reuse-model" }],
+			scripts: {
+				[aRequest]: [
+					{
+						requestId: aRequest,
+						blocks: [{ type: "text", chunks: ["A must be discarded"] }],
+						usage: usage(11, 7),
+						responseModel: "c03-real-reuse-model",
+						waitForRelease: true,
+					},
+				],
+				[bRequest]: [
+					{
+						requestId: bRequest,
+						blocks: [{ type: "text", chunks: ["B completed"] }],
+						usage: usage(13, 9),
+						responseModel: "c03-real-reuse-model",
+						waitForRelease: true,
+					},
+				],
+			},
+		});
+		cleanups.push(() => scripted.unregister());
+		cleanups.push(() => rm(root, { recursive: true, force: true }));
+		const fixture = await createRealDaemonFixture(root, scripted);
+		const internals = fixture.daemon as unknown as DaemonInternals;
+		const parentState = await internals.createRuntime({ type: "create" });
+		const parent = parentState.runtime.session;
+		const name = "c03-reused-public-selector";
+		const a = await parent.runRlmChild(`C03 stale A ${aRequest}`, {
+			name,
+			model: "c03-real-reuse-scripted/c03-real-reuse-model",
+		});
+		// A's provider entry is sufficient to make cancellation real, but B must not be
+		// admitted until the public delete has hidden the exact A incarnation.
+		await vi.waitFor(() => expect(scripted.observations()).toHaveLength(1));
+		const artifacts = parent.sessionManager.getSessionArtifactDir();
+		const parentFile = parent.sessionFile;
+		if (!artifacts || !parentFile) throw new Error("Missing persisted real parent paths");
+		const aOperation = [...realRegistry(artifacts).operations.values()].find(
+			(candidate) => candidate.childId === a.rlm_child_id,
+		);
+		if (!aOperation) throw new Error("Missing real A operation");
+		await parent.deleteRlmSubagent(name);
+		await vi.waitFor(async () => expect((await parent.listRlmSubagents()).subagents).toHaveLength(0));
+		const b = await parent.runRlmChild(`C03 replacement B ${bRequest}`, {
+			name,
+			model: "c03-real-reuse-scripted/c03-real-reuse-model",
+		});
+		expect(b.rlm_child_id).not.toBe(a.rlm_child_id);
+		await scripted.open;
+		scripted.release([bRequest]);
+		await vi.waitFor(() => {
+			const registry = realRegistry(artifacts);
+			const candidate = [...registry.operations.values()].find((operation) => operation.childId === b.rlm_child_id);
+			expect(candidate).toMatchObject({ lifecycle: "terminal_recorded" });
+			expect(candidate && terminalEntries(parent, candidate.deliveryId)).toHaveLength(1);
+		});
+		const beforeACompletes = realRegistry(artifacts);
+		const bOperation = [...beforeACompletes.operations.values()].find(
+			(candidate) => candidate.childId === b.rlm_child_id,
+		);
+		if (!bOperation) throw new Error("Missing B operation");
+		const bDelivery = [...beforeACompletes.deliveries.values()].find(
+			(candidate) => candidate.deliveryId === bOperation.deliveryId,
+		);
+		const bState = await internals.getOrHydrateBoundSessionState(b.rlm_child_id);
+		const bFile = bState.runtime.session.sessionFile;
+		if (!bFile) throw new Error("Missing B session file");
+		const bSessionBefore = await readFile(bFile, "utf8");
+		const parentTranscriptBefore = await readFile(parentFile, "utf8");
+
+		// A's exact durable deletion is independent of B's reused public selector.
+		await vi.waitFor(() => {
+			const registry = realRegistry(artifacts);
+			expect(registry.operations.get(aOperation.key)).toMatchObject({ lifecycle: "deleted", deleteIntent: true });
+			expect(
+				[...registry.deliveries.values()].find((delivery) => delivery.deliveryId === aOperation.deliveryId),
+			).toMatchObject({
+				consumed: "discarded",
+			});
+		});
+		const afterACompletes = realRegistry(artifacts);
+		expect(afterACompletes.operations.get(bOperation.key)).toEqual(beforeACompletes.operations.get(bOperation.key));
+		expect(
+			[...afterACompletes.deliveries.values()].find((delivery) => delivery.deliveryId === bOperation.deliveryId),
+		).toEqual(bDelivery);
+		expect(await readFile(bFile, "utf8")).toBe(bSessionBefore);
+		expect(await readFile(parentFile, "utf8")).toBe(parentTranscriptBefore);
+		expect(terminalEntries(parent, aOperation.deliveryId)).toHaveLength(0);
+		expect(terminalEntries(parent, bOperation.deliveryId)).toHaveLength(1);
+		expect(afterACompletes.operations.get(aOperation.key)).not.toMatchObject({ lifecycle: "delete_intent" });
+		expect(await parent.listRlmSubagents()).toMatchObject({
+			subagents: [expect.objectContaining({ rlm_child_id: b.rlm_child_id, session_name: name })],
+		});
+		await internals.closeSession(parentState, "shutdown");
 	}, 20_000);
 });

--- a/packages/coding-agent/test/daemon-c03-real-production.test.ts
+++ b/packages/coding-agent/test/daemon-c03-real-production.test.ts
@@ -1,0 +1,313 @@
+/** Real daemon C03 terminal recovery: no hand-written lifecycle facts or fake runtimes. */
+import { randomUUID } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	type CreateAgentSessionRuntimeFactory,
+	createAgentSessionFromServices,
+	createAgentSessionServices,
+} from "../src/core/agent-session-runtime.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { materializedTerminalMessageId, readRlmDurableOperationRegistry } from "../src/core/rlm-durable-operations.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import type { ActiveSessionState } from "../src/modes/daemon/active-session-state.js";
+import { AgentDaemon } from "../src/modes/daemon/daemon-mode.js";
+import type { DaemonCommand } from "../src/modes/daemon/daemon-protocol.js";
+import {
+	type BarrierScriptedProvider,
+	createBarrierScriptedProvider,
+	type ProviderScript,
+} from "./swarm/production-scripted-provider.js";
+
+const cleanups: Array<() => Promise<void> | void> = [];
+afterEach(async () => {
+	vi.restoreAllMocks();
+	while (cleanups.length) await cleanups.pop()?.();
+});
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T | PromiseLike<T>): void } {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+const usage = (input: number, output: number) => ({
+	input,
+	output,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: input + output,
+	cost: {
+		input: input * 0.000001,
+		output: output * 0.000002,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: input * 0.000001 + output * 0.000002,
+	},
+});
+
+function providerRegistration(models: readonly BarrierScriptedProvider["models"][number][]) {
+	return {
+		baseUrl: models[0]!.baseUrl,
+		apiKey: "fixture-key",
+		api: models[0]!.api,
+		models: models.map((model) => ({
+			id: model.id,
+			name: model.name,
+			api: model.api,
+			reasoning: model.reasoning,
+			input: model.input,
+			cost: model.cost,
+			contextWindow: model.contextWindow,
+			maxTokens: model.maxTokens,
+			baseUrl: model.baseUrl,
+		})),
+	};
+}
+
+async function createRealDaemonFixture(root: string, scripted: BarrierScriptedProvider) {
+	const authStorage = AuthStorage.inMemory();
+	const modelRegistry = ModelRegistry.inMemory(authStorage);
+	const model = scripted.models[0]!;
+	authStorage.setRuntimeApiKey(model.provider, "fixture-key");
+	modelRegistry.registerProvider(model.provider, providerRegistration(scripted.models));
+	const createRuntime: CreateAgentSessionRuntimeFactory = async (runtimeOptions) => {
+		const services = await createAgentSessionServices({
+			cwd: runtimeOptions.cwd,
+			agentDir: root,
+			authStorage,
+			modelRegistry,
+			settingsManager: SettingsManager.inMemory({ retry: { enabled: false } }),
+			telemetryDisabled: true,
+			resourceLoaderOptions: {
+				noExtensions: true,
+				noSkills: true,
+				noPromptTemplates: true,
+				noThemes: true,
+			},
+		});
+		const result = await createAgentSessionFromServices({
+			services,
+			sessionManager: runtimeOptions.sessionManager,
+			sessionStartEvent: runtimeOptions.sessionStartEvent,
+			model: runtimeOptions.sessionOptions?.model ?? model,
+			thinkingLevel: runtimeOptions.sessionOptions?.thinkingLevel ?? "off",
+			serviceTier: runtimeOptions.sessionOptions?.serviceTier,
+			scopedModels: runtimeOptions.sessionOptions?.scopedModels,
+			initialActiveToolNames: runtimeOptions.sessionOptions?.initialActiveToolNames,
+			allowedToolNames: runtimeOptions.sessionOptions?.allowedToolNames,
+			customTools: runtimeOptions.sessionOptions?.customTools,
+			includeGoals: runtimeOptions.sessionOptions?.includeGoals,
+			includeCompactSkill: runtimeOptions.sessionOptions?.includeCompactSkill,
+			agentMessageController: runtimeOptions.sessionOptions?.agentMessageController,
+			agentObserveController: runtimeOptions.sessionOptions?.agentObserveController,
+			rlmHeartbeatController: runtimeOptions.sessionOptions?.rlmHeartbeatController,
+			rlmDepth: runtimeOptions.sessionOptions?.rlmDepth,
+			rlmMaxDepth: runtimeOptions.sessionOptions?.rlmMaxDepth,
+			rlmSessionDir: runtimeOptions.sessionOptions?.rlmSessionDir,
+			rlmParentNodeId: runtimeOptions.sessionOptions?.rlmParentNodeId,
+			rlmParentAgent: runtimeOptions.sessionOptions?.rlmParentAgent,
+		});
+		return { ...result, services, diagnostics: services.diagnostics };
+	};
+	const sessionDir = join(root, "sessions");
+	const daemon = new AgentDaemon(join(root, `daemon-${randomUUID()}.sock`), {
+		defaultSessionConfig: {
+			agentDir: root,
+			cwd: root,
+			sessionDir,
+			noExtensions: true,
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+			telemetryDisabled: true,
+		},
+		createRuntime,
+	});
+	return { daemon, sessionDir };
+}
+
+type DaemonInternals = {
+	createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+	getOrHydrateBoundSessionState(selector: string): Promise<ActiveSessionState>;
+	closeSession(state: ActiveSessionState, reason: "shutdown"): Promise<void>;
+	sessions: Map<string, ActiveSessionState>;
+};
+
+function realRegistry(parentArtifactDir: string) {
+	return readRlmDurableOperationRegistry(parentArtifactDir, (operation) => {
+		if (
+			!operation.childSessionId ||
+			!operation.childSessionFile ||
+			!operation.childSessionRoot ||
+			!operation.childArtifactDir ||
+			!operation.childArtifactRoot
+		)
+			return undefined;
+		return {
+			childSessionId: operation.childSessionId,
+			childSessionFile: operation.childSessionFile,
+			childSessionRoot: operation.childSessionRoot,
+			childArtifactDir: operation.childArtifactDir,
+			childArtifactRoot: operation.childArtifactRoot,
+		};
+	});
+}
+
+function terminalEntries(session: { sessionManager: Pick<SessionManager, "getEntries"> }, deliveryId: string) {
+	const id = materializedTerminalMessageId(deliveryId);
+	return session.sessionManager.getEntries().filter((entry) => {
+		const candidate = entry as {
+			type?: string;
+			role?: string;
+			customType?: string;
+			details?: { id?: string };
+			message?: { role?: string; customType?: string; details?: { id?: string } };
+		};
+		const message = candidate.message ?? candidate;
+		return (
+			(candidate.type === "message" || candidate.type === "custom_message") &&
+			(message.role === "custom" || message.customType === "rlm_child_terminal_notice") &&
+			message.details?.id === id
+		);
+	});
+}
+
+describe("C03 real daemon production recovery", () => {
+	it("recovers one real daemon-hosted child terminal after a deferred parent append without provider or prompt replay", async () => {
+		const root = await mkdtemp(join(tmpdir(), "prime-agent-c03-real-production-"));
+		const requestId = "request-9001";
+		const script: ProviderScript = {
+			requestId,
+			blocks: [{ type: "text", chunks: ["real child completed"] }],
+			usage: usage(11, 7),
+			responseModel: "c03-real-model",
+			waitForRelease: true,
+		};
+		const scripted = createBarrierScriptedProvider({
+			api: "c03-real-scripted",
+			provider: "c03-real-scripted",
+			barrier: { expected: [requestId], timeoutMs: 10_000 },
+			models: [{ id: "c03-real-model", responseModel: "c03-real-model" }],
+			scripts: { [requestId]: [script] },
+		});
+		cleanups.push(() => scripted.unregister());
+		cleanups.push(() => rm(root, { recursive: true, force: true }));
+
+		const promptAndWait = vi.spyOn(
+			(await import("../src/core/agent-session.js")).AgentSession.prototype,
+			"promptAndWait",
+		);
+		const a = await createRealDaemonFixture(root, scripted);
+		const aInternals = a.daemon as unknown as DaemonInternals;
+		const parentA = await aInternals.createRuntime({ type: "create" });
+		const parent = parentA.runtime.session;
+		const appendEntered = deferred<void>();
+		const releaseStaleAppend = deferred<void>();
+		vi.spyOn(parent, "appendDurableRlmTerminalMessage").mockImplementationOnce(async () => {
+			appendEntered.resolve();
+			await releaseStaleAppend.promise;
+			// This is the sole cut: do not materialize a transcript message from A.
+			return false;
+		});
+
+		const handle = await parent.runRlmChild(`C03 real production child ${requestId}`, {
+			name: "c03-real-worker",
+			model: "c03-real-scripted/c03-real-model",
+		});
+		await scripted.open;
+		scripted.release([requestId]);
+		await appendEntered.promise;
+
+		const parentFile = parent.sessionFile;
+		const artifacts = parent.sessionManager.getSessionArtifactDir();
+		if (!parentFile || !artifacts) throw new Error("Missing persisted real parent paths");
+		const beforeCut = realRegistry(artifacts);
+		const operation = [...beforeCut.operations.values()].find(
+			(candidate) => candidate.childId === handle.rlm_child_id,
+		);
+		if (!operation) throw new Error("Missing real C03 operation");
+		const delivery = [...beforeCut.deliveries.values()].find(
+			(candidate) => candidate.deliveryId === operation.deliveryId,
+		);
+		if (!delivery) throw new Error("Missing real C03 delivery");
+		expect(operation).toMatchObject({ lifecycle: "terminal_recorded" });
+		expect(delivery.outboxed).toBe(true);
+		expect(delivery.received).toBe(true);
+		expect(delivery.consumed).toBeUndefined();
+		const c01 = (await readFile(join(artifacts, "rlm-subagents.jsonl"), "utf8"))
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as Record<string, unknown>);
+		expect(c01).toContainEqual(
+			expect.objectContaining({
+				childId: handle.rlm_child_id,
+				assignmentId: operation.assignmentId,
+				operationId: operation.operationId,
+				deliveryId: operation.deliveryId,
+			}),
+		);
+		expect(terminalEntries(parent, operation.deliveryId)).toHaveLength(0);
+		expect(scripted.observations()).toHaveLength(1);
+		expect(promptAndWait).toHaveBeenCalledTimes(1);
+
+		// Manager-owned close removes A before its deferred importer can resume.
+		await aInternals.closeSession(parentA, "shutdown");
+		expect(aInternals.sessions.has(parentA.activeSessionId)).toBe(false);
+		const passiveParent = SessionManager.open(parentFile, a.sessionDir);
+		expect(passiveParent.getSessionId()).toBe(parent.sessionId);
+		expect(terminalEntries({ sessionManager: passiveParent }, operation.deliveryId)).toHaveLength(0);
+
+		const b = await createRealDaemonFixture(root, scripted);
+		const bInternals = b.daemon as unknown as DaemonInternals;
+		const parentB = await bInternals.createRuntime({ type: "create", sessionPath: parentFile });
+		expect(parentB.eventGeneration).not.toBe(parentA.eventGeneration);
+		expect(scripted.observations()).toHaveLength(1);
+		expect(promptAndWait).toHaveBeenCalledTimes(1);
+		expect(terminalEntries(parentB.runtime.session, operation.deliveryId)).toHaveLength(0);
+
+		const [firstWake, secondWake] = await Promise.all([
+			bInternals.getOrHydrateBoundSessionState(handle.rlm_child_id),
+			bInternals.getOrHydrateBoundSessionState(handle.rlm_child_id),
+		]);
+		expect(firstWake).toBe(secondWake);
+		expect(terminalEntries(parentB.runtime.session, operation.deliveryId)).toHaveLength(1);
+		expect(scripted.observations()).toHaveLength(1);
+		expect(promptAndWait).toHaveBeenCalledTimes(1);
+		const afterB = realRegistry(artifacts);
+		expect(
+			[...afterB.deliveries.values()].find((candidate) => candidate.deliveryId === operation.deliveryId),
+		).toMatchObject({
+			consumed: "materialized",
+		});
+		await bInternals.getOrHydrateBoundSessionState(handle.rlm_child_id);
+		expect(terminalEntries(parentB.runtime.session, operation.deliveryId)).toHaveLength(1);
+		expect(promptAndWait).toHaveBeenCalledTimes(1);
+
+		// Releasing the stale A callback after B consumed cannot append or consume.
+		releaseStaleAppend.resolve();
+		await vi.waitFor(() => expect(terminalEntries(parentB.runtime.session, operation.deliveryId)).toHaveLength(1));
+		expect(realRegistry(artifacts).deliveries.get(delivery.key)).toMatchObject({
+			consumed: "materialized",
+		});
+
+		await bInternals.closeSession(parentB, "shutdown");
+		const c = await createRealDaemonFixture(root, scripted);
+		const cInternals = c.daemon as unknown as DaemonInternals;
+		const parentC = await cInternals.createRuntime({ type: "create", sessionPath: parentFile });
+		await cInternals.getOrHydrateBoundSessionState(handle.rlm_child_id);
+		expect(
+			terminalEntries({ sessionManager: SessionManager.open(parentFile, a.sessionDir) }, operation.deliveryId),
+		).toHaveLength(1);
+		expect(scripted.observations()).toHaveLength(1);
+		expect(promptAndWait).toHaveBeenCalledTimes(1);
+		expect([...realRegistry(artifacts).deliveries.values()]).toHaveLength(1);
+		await cInternals.closeSession(parentC, "shutdown");
+	}, 20_000);
+});

--- a/packages/coding-agent/test/daemon-c03-real-production.test.ts
+++ b/packages/coding-agent/test/daemon-c03-real-production.test.ts
@@ -373,7 +373,7 @@ describe("C03 real daemon production recovery", () => {
 		await internals.closeSession(parentState, "shutdown");
 	}, 20_000);
 
-	it("keeps deleted A durable facts separate when B reuses the same public selector", async () => {
+	it("keeps a real cancelled A fenced while B reuses its public selector", async () => {
 		const root = await mkdtemp(join(tmpdir(), "prime-agent-c03-real-reuse-"));
 		const aRequest = "request-9002";
 		const bRequest = "request-9003";
@@ -395,7 +395,7 @@ describe("C03 real daemon production recovery", () => {
 				[bRequest]: [
 					{
 						requestId: bRequest,
-						blocks: [{ type: "text", chunks: ["B completed"] }],
+						blocks: [{ type: "text", chunks: ["B remains running"] }],
 						usage: usage(13, 9),
 						responseModel: "c03-real-reuse-model",
 						waitForRelease: true,
@@ -414,8 +414,6 @@ describe("C03 real daemon production recovery", () => {
 			name,
 			model: "c03-real-reuse-scripted/c03-real-reuse-model",
 		});
-		// A's provider entry is sufficient to make cancellation real, but B must not be
-		// admitted until the public delete has hidden the exact A incarnation.
 		await vi.waitFor(() => expect(scripted.observations()).toHaveLength(1));
 		const artifacts = parent.sessionManager.getSessionArtifactDir();
 		const parentFile = parent.sessionFile;
@@ -424,58 +422,100 @@ describe("C03 real daemon production recovery", () => {
 			(candidate) => candidate.childId === a.rlm_child_id,
 		);
 		if (!aOperation) throw new Error("Missing real A operation");
-		await parent.deleteRlmSubagent(name);
-		await vi.waitFor(async () => expect((await parent.listRlmSubagents()).subagents).toHaveLength(0));
+
+		// This wraps the actual daemon host, after the public delete has fsynced its
+		// intent and closed A's registry row, but before its terminal hand-off.
+		const daemonHost = (
+			parent as unknown as { _subagentRuntimeHost?: import("../src/core/rlm-runtime.js").SubagentRuntimeHost }
+		)._subagentRuntimeHost;
+		const realDeliver = daemonHost?.deliverRlmSubagentTerminal;
+		if (!daemonHost || !realDeliver) throw new Error("Missing real daemon terminal host");
+		const aTerminalEntered = deferred<void>();
+		const releaseATerminal = deferred<void>();
+		daemonHost.deliverRlmSubagentTerminal = async (runtime, options, terminal, message) => {
+			if (terminal === "cancelled" && options.operationId === aOperation.operationId) {
+				aTerminalEntered.resolve();
+				await releaseATerminal.promise;
+			}
+			return await realDeliver.call(daemonHost, runtime, options, terminal, message);
+		};
+		cleanups.push(() => {
+			daemonHost.deliverRlmSubagentTerminal = realDeliver;
+		});
+
+		const deleteA = parent.deleteRlmSubagent(name);
+		await aTerminalEntered.promise;
+		const whileAHeld = realRegistry(artifacts);
+		expect(whileAHeld.operations.get(aOperation.key)).toMatchObject({
+			lifecycle: "delete_intent",
+			deleteIntent: true,
+		});
+		expect(
+			[...whileAHeld.deliveries.values()].find((delivery) => delivery.deliveryId === aOperation.deliveryId),
+		).toBeUndefined();
+		const aRegistryRows = (await readFile(join(artifacts, "rlm-subagents.jsonl"), "utf8"))
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as Record<string, unknown>);
+		expect(aRegistryRows.at(-1)).toMatchObject({
+			childId: a.rlm_child_id,
+			assignmentId: aOperation.assignmentId,
+			operationId: aOperation.operationId,
+			status: "deleted",
+		});
 		const b = await parent.runRlmChild(`C03 replacement B ${bRequest}`, {
 			name,
 			model: "c03-real-reuse-scripted/c03-real-reuse-model",
 		});
 		expect(b.rlm_child_id).not.toBe(a.rlm_child_id);
 		await scripted.open;
-		scripted.release([bRequest]);
-		await vi.waitFor(() => {
-			const registry = realRegistry(artifacts);
-			const candidate = [...registry.operations.values()].find((operation) => operation.childId === b.rlm_child_id);
-			expect(candidate).toMatchObject({ lifecycle: "terminal_recorded" });
-			expect(candidate && terminalEntries(parent, candidate.deliveryId)).toHaveLength(1);
-		});
-		const beforeACompletes = realRegistry(artifacts);
-		const bOperation = [...beforeACompletes.operations.values()].find(
-			(candidate) => candidate.childId === b.rlm_child_id,
-		);
-		if (!bOperation) throw new Error("Missing B operation");
-		const bDelivery = [...beforeACompletes.deliveries.values()].find(
-			(candidate) => candidate.deliveryId === bOperation.deliveryId,
-		);
 		const bState = await internals.getOrHydrateBoundSessionState(b.rlm_child_id);
 		const bFile = bState.runtime.session.sessionFile;
 		if (!bFile) throw new Error("Missing B session file");
+		const bRegistryBefore = realRegistry(artifacts);
+		const bOperation = [...bRegistryBefore.operations.values()].find(
+			(operation) => operation.childId === b.rlm_child_id,
+		);
+		if (!bOperation) throw new Error("Missing real B operation");
+		const bDeliveryBefore = [...bRegistryBefore.deliveries.values()].find(
+			(delivery) => delivery.deliveryId === bOperation.deliveryId,
+		);
+		expect(bDeliveryBefore).toBeUndefined();
 		const bSessionBefore = await readFile(bFile, "utf8");
+		const bRegistryFileBefore = await readFile(join(artifacts, "rlm-subagents.jsonl"), "utf8");
 		const parentTranscriptBefore = await readFile(parentFile, "utf8");
-
-		// A's exact durable deletion is independent of B's reused public selector.
-		await vi.waitFor(() => {
-			const registry = realRegistry(artifacts);
-			expect(registry.operations.get(aOperation.key)).toMatchObject({ lifecycle: "deleted", deleteIntent: true });
-			expect(
-				[...registry.deliveries.values()].find((delivery) => delivery.deliveryId === aOperation.deliveryId),
-			).toMatchObject({
-				consumed: "discarded",
-			});
+		expect(await parent.listRlmSubagents()).toMatchObject({
+			subagents: [expect.objectContaining({ rlm_child_id: b.rlm_child_id, session_name: name, status: "running" })],
 		});
-		const afterACompletes = realRegistry(artifacts);
-		expect(afterACompletes.operations.get(bOperation.key)).toEqual(beforeACompletes.operations.get(bOperation.key));
-		expect(
-			[...afterACompletes.deliveries.values()].find((delivery) => delivery.deliveryId === bOperation.deliveryId),
-		).toEqual(bDelivery);
+
+		releaseATerminal.resolve();
+		await deleteA;
+		await vi.waitFor(() => {
+			const after = realRegistry(artifacts);
+			expect(after.operations.get(aOperation.key)).toMatchObject({ lifecycle: "deleted", deleteIntent: true });
+			expect(
+				[...after.deliveries.values()].find((delivery) => delivery.deliveryId === aOperation.deliveryId),
+			).toMatchObject({ consumed: "discarded" });
+		});
+		const afterA = realRegistry(artifacts);
+		expect(afterA.operations.get(bOperation.key)).toEqual(bRegistryBefore.operations.get(bOperation.key));
+		expect([...afterA.deliveries.values()].find((delivery) => delivery.deliveryId === bOperation.deliveryId)).toEqual(
+			bDeliveryBefore,
+		);
 		expect(await readFile(bFile, "utf8")).toBe(bSessionBefore);
+		expect(await readFile(join(artifacts, "rlm-subagents.jsonl"), "utf8")).toBe(bRegistryFileBefore);
 		expect(await readFile(parentFile, "utf8")).toBe(parentTranscriptBefore);
 		expect(terminalEntries(parent, aOperation.deliveryId)).toHaveLength(0);
-		expect(terminalEntries(parent, bOperation.deliveryId)).toHaveLength(1);
-		expect(afterACompletes.operations.get(aOperation.key)).not.toMatchObject({ lifecycle: "delete_intent" });
+		expect(parent.messages.filter((message) => message.role === "custom")).toHaveLength(0);
 		expect(await parent.listRlmSubagents()).toMatchObject({
-			subagents: [expect.objectContaining({ rlm_child_id: b.rlm_child_id, session_name: name })],
+			subagents: [expect.objectContaining({ rlm_child_id: b.rlm_child_id, session_name: name, status: "running" })],
 		});
+		expect(scripted.observations()).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ requestId: aRequest, terminal: "aborted", signalAborted: true }),
+				expect.objectContaining({ requestId: bRequest, signalAborted: false }),
+			]),
+		);
 		await internals.closeSession(parentState, "shutdown");
 	}, 20_000);
 });

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -21,7 +21,7 @@ function session(id: string, name: string | undefined, path: string): SessionInf
 }
 
 describe("daemon catalog selector resolution", () => {
-	it("reads only a saved child's persisted sibling set", async () => {
+	it("keeps canonical C01 assignment-only and assignment-less legacy rows displayable", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-siblings-"));
 		const sessionDir = join(root, "sessions");
 		const parent = SessionManager.create(root, sessionDir);
@@ -38,7 +38,13 @@ describe("daemon catalog selector resolution", () => {
 		writeFileSync(
 			registry,
 			[
-				{ type: "rlm_subagent", childId: "first", sessionFile: first.getSessionFile(), status: "completed" },
+				{
+					type: "rlm_subagent",
+					childId: "first",
+					assignmentId: "11111111-1111-4111-8111-111111111111",
+					sessionFile: first.getSessionFile(),
+					status: "completed",
+				},
 				{ type: "rlm_subagent", childId: "second", sessionFile: second.getSessionFile(), status: "completed" },
 			]
 				.map((entry) => JSON.stringify(entry))
@@ -100,6 +106,50 @@ describe("daemon catalog selector resolution", () => {
 		]);
 	});
 
+	it("does not let late display-only legacy history displace a canonical C03 incarnation", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-c03-over-legacy-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession();
+		parent.appendSessionInfo("parent");
+		const first = SessionManager.create(root, join(root, "first"));
+		first.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		first.appendSessionInfo("first");
+		const second = SessionManager.create(root, join(root, "second"));
+		second.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		second.appendSessionInfo("second");
+		const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
+		mkdirSync(dirname(registry), { recursive: true });
+		writeFileSync(
+			registry,
+			[
+				{
+					type: "rlm_subagent",
+					childId: "reused",
+					assignmentId: "11111111-1111-4111-8111-111111111111",
+					operationId: "22222222-2222-4222-8222-222222222222",
+					deliveryId: "33333333-3333-4333-8333-333333333333",
+					sessionFile: second.getSessionFile(),
+					status: "completed",
+				},
+				{
+					type: "rlm_subagent",
+					childId: "reused",
+					assignmentId: "44444444-4444-4444-8444-444444444444",
+					sessionFile: first.getSessionFile(),
+					status: "completed",
+				},
+			]
+				.map((entry) => JSON.stringify(entry))
+				.join("\n"),
+		);
+
+		await expect(listSavedSessionSiblings(first.getSessionFile()!)).resolves.toEqual([
+			expect.objectContaining({ id: first.getSessionId(), name: "first" }),
+			expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+		]);
+	});
+
 	it("resolves relative parent headers from each child session directory", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-relative-siblings-"));
 		const sessionDir = join(root, "sessions");
@@ -120,7 +170,13 @@ describe("daemon catalog selector resolution", () => {
 		writeFileSync(
 			registry,
 			[
-				{ type: "rlm_subagent", childId: "first", sessionFile: first.getSessionFile(), status: "completed" },
+				{
+					type: "rlm_subagent",
+					childId: "first",
+					assignmentId: "11111111-1111-4111-8111-111111111111",
+					sessionFile: first.getSessionFile(),
+					status: "completed",
+				},
 				{ type: "rlm_subagent", childId: "second", sessionFile: second.getSessionFile(), status: "completed" },
 			]
 				.map((entry) => JSON.stringify(entry))

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -51,6 +51,55 @@ describe("daemon catalog selector resolution", () => {
 		]);
 	});
 
+	it("selects the newest valid C03 incarnation while ignoring partial and malformed triples", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-c03-incarnations-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession();
+		parent.appendSessionInfo("parent");
+		const first = SessionManager.create(root, join(root, "first"));
+		first.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		first.appendSessionInfo("first");
+		const second = SessionManager.create(root, join(root, "second"));
+		second.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		second.appendSessionInfo("second");
+		const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
+		mkdirSync(dirname(registry), { recursive: true });
+		const validA = {
+			type: "rlm_subagent",
+			childId: "reused",
+			assignmentId: "11111111-1111-4111-8111-111111111111",
+			operationId: "22222222-2222-4222-8222-222222222222",
+			deliveryId: "33333333-3333-4333-8333-333333333333",
+			sessionFile: first.getSessionFile(),
+			status: "completed",
+		};
+		const validB = {
+			...validA,
+			assignmentId: "44444444-4444-4444-8444-444444444444",
+			operationId: "55555555-5555-4555-8555-555555555555",
+			deliveryId: "66666666-6666-4666-8666-666666666666",
+			sessionFile: second.getSessionFile(),
+		};
+		writeFileSync(
+			registry,
+			[
+				validA,
+				validB,
+				{ ...validA, status: "deleted" }, // Late A must not displace B.
+				{ ...validB, assignmentId: "not-a-uuid" },
+				{ ...validB, operationId: undefined },
+			]
+				.map((entry) => JSON.stringify(entry))
+				.join("\n"),
+		);
+
+		await expect(listSavedSessionSiblings(first.getSessionFile()!)).resolves.toEqual([
+			expect.objectContaining({ id: first.getSessionId(), name: "first" }),
+			expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+		]);
+	});
+
 	it("resolves relative parent headers from each child session directory", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-relative-siblings-"));
 		const sessionDir = join(root, "sessions");

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1441,7 +1441,7 @@ describe("daemon mode helpers", () => {
 		expect(internals.sessions.get(childB.activeSessionId)).toBe(childB);
 	});
 
-	it("keeps an assignment-only passive delete display-only without minting authority", async () => {
+	it("deletes an assignment-only passive row without minting C03 authority", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-legacy-delete-assignment-"));
 		try {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
@@ -1463,8 +1463,11 @@ describe("daemon mode helpers", () => {
 					(line) =>
 						JSON.parse(line) as { childId: string; assignmentId?: string; operationId?: string; status: string },
 				);
-			expect(rows).toEqual([expect.objectContaining({ childId: fixture.childId, status: "completed" })]);
-			expect(rows[0]?.operationId).toBeUndefined();
+			expect(rows).toEqual([
+				expect.objectContaining({ childId: fixture.childId, status: "completed" }),
+				expect.objectContaining({ childId: fixture.childId, status: "deleted" }),
+			]);
+			expect(rows.every((row) => row.operationId === undefined)).toBe(true);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -6614,7 +6617,7 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("does not match a renamed passive child by its stale registry name", async () => {
+	it("matches a legacy passive child by its persisted session name rather than another row's stale name", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-lazy-rlm-renamed-"));
 		try {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
@@ -6627,9 +6630,13 @@ describe("daemon mode helpers", () => {
 			const siblingSessionFile = siblingManager.getSessionFile();
 			if (!siblingSessionFile) throw new Error("Missing sibling session file");
 			const parentRegistry = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const legacyPrimary = JSON.parse(readFileSync(parentRegistry, "utf8")) as Record<string, unknown>;
+			delete legacyPrimary.assignmentId;
+			delete legacyPrimary.operationId;
+			delete legacyPrimary.deliveryId;
 			writeFileSync(
 				parentRegistry,
-				`${readFileSync(parentRegistry, "utf8")}${JSON.stringify({
+				`${JSON.stringify(legacyPrimary)}\n${JSON.stringify({
 					type: "rlm_subagent",
 					childId: siblingId,
 					sessionName: "spawn-worker",
@@ -6657,8 +6664,10 @@ describe("daemon mode helpers", () => {
 				internals
 					.createAgentMessageController(() => parentState)
 					.sendAgentMessage({ target: "spawn-worker", message: "report progress" }),
-			).rejects.toThrow("Unknown active session");
-			expect(fixture.createRuntime).toHaveBeenCalledOnce();
+			).resolves.toMatchObject({ target: { sessionName: "spawn-worker" } });
+			// The C03 row has been renamed in its session transcript; lookup must wake
+			// the distinct legacy child whose current persisted name still matches.
+			expect(fixture.createRuntime).toHaveBeenCalledTimes(2);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11017,6 +11017,124 @@ function makeClient(id: string, activeSessionId: string, supportsExtensionUi = f
 }
 
 describe("C03 durable daemon publication", () => {
+	it("fails closed without parent registry authority while read-only family metadata remains safe", async () => {
+		const createRuntime = vi.fn();
+		const daemon = new AgentDaemon("/tmp/prime-agent-c03-no-registry.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime,
+		});
+		const parent = makeState("c03-parent");
+		const parentSession = {
+			sessionId: "c03-parent-session",
+			sessionName: "read-only-parent",
+			sessionManager: { getCwd: () => "/tmp" },
+			rlmDepth: 0,
+			rlmMaxDepth: 4,
+		} as ActiveSessionState["runtime"]["session"];
+		parent.runtime = {
+			...parent.runtime,
+			metadata: { kind: "top-level", createdAt: 1 },
+			session: parentSession,
+		} as ActiveSessionState["runtime"];
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			appendRlmSubagentRegistryEntry(parent: ActiveSessionState, entry: Record<string, unknown>): boolean;
+			recordRlmSubagentRegistryEntry(parent: ActiveSessionState, input: Record<string, unknown>): boolean;
+			recordRlmSubagentDeletion(
+				parent: ActiveSessionState,
+				childId: string,
+				assignmentId: string,
+				operationId: string,
+			): Promise<void>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+			createRlmSubagentRuntime(
+				parent: ActiveSessionState,
+				options: CreateRlmSubagentRuntimeOptions,
+			): Promise<ActiveSessionState["runtime"]>;
+		};
+		internals.sessions.set(parent.activeSessionId, parent);
+		const options: CreateRlmSubagentRuntimeOptions = {
+			parentSession,
+			id: "no-registry-child",
+			assignmentId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+			operationId: "aaaaaaaa-aaaa-4aaa-8aaa-000000000010",
+			deliveryId: "aaaaaaaa-aaaa-4aaa-8aaa-000000000020",
+			prompt: "must not reach child factory",
+			sessionName: "no-registry-child",
+			sessionDir: "/tmp/no-registry-child",
+			model: {} as Model<Api>,
+			thinkingLevel: "off",
+			serviceTier: null,
+			scopedModels: [],
+			activeToolNames: [],
+			customTools: [],
+			includeGoals: false,
+			includeCompactSkill: false,
+			rlmDepth: 1,
+			rlmMaxDepth: 4,
+			rlmParentNodeId: "no-registry-child",
+		};
+		const registryRow = {
+			type: "rlm_subagent",
+			childId: options.id,
+			assignmentId: options.assignmentId,
+			operationId: options.operationId,
+			deliveryId: options.deliveryId,
+			sessionName: options.sessionName,
+			sessionDir: options.sessionDir,
+			sessionFile: "/tmp/no-registry-child/session.jsonl",
+			parentSessionId: parentSession.sessionId,
+			rlmDepth: 1,
+			rlmMaxDepth: 4,
+			status: "running",
+			createdAt: 1,
+			updatedAt: new Date(0).toISOString(),
+		};
+
+		const host = internals.createSubagentRuntimeHost(parent);
+		expect(() => host.admitRlmSubagentOperation?.(options)).toThrow("parent registry artifact");
+		await expect(internals.createRlmSubagentRuntime(parent, options)).rejects.toThrow("parent registry artifact");
+		expect(createRuntime).not.toHaveBeenCalled();
+		expect(internals.appendRlmSubagentRegistryEntry(parent, registryRow)).toBe(false);
+		expect(internals.recordRlmSubagentRegistryEntry(parent, registryRow)).toBe(false);
+		await expect(
+			internals.recordRlmSubagentDeletion(parent, options.id, options.assignmentId!, options.operationId!),
+		).rejects.toThrow("parent registry artifact");
+		const child = { disposeAsync: vi.fn(async () => {}) } as unknown as ActiveSessionState["runtime"]["session"];
+		await expect(
+			host.deleteRlmSubagentRuntime(options.id, child, options.assignmentId, options.operationId),
+		).rejects.toThrow("parent registry artifact");
+		expect(child.disposeAsync).not.toHaveBeenCalled();
+		await expect(
+			host.deliverRlmSubagentTerminal?.(
+				{
+					session: child,
+					assignmentId: options.assignmentId,
+					operationId: options.operationId,
+					deliveryId: options.deliveryId,
+				},
+				options,
+				"done",
+				{
+					role: "custom",
+					customType: "rlm_child_terminal_notice",
+					content: "must remain unacknowledged",
+					display: true,
+					details: { kind: "completed_without_reply", childId: options.id, sessionName: options.sessionName },
+					timestamp: 1,
+				},
+			),
+		).rejects.toThrow("parent registry artifact");
+
+		// Metadata-only legacy/mocked sessions remain readable by family discovery.
+		const roster = daemon as unknown as {
+			createAgentFamilyRoster(state: ActiveSessionState): Promise<{ current: { id: string } }>;
+		};
+		await expect(roster.createAgentFamilyRoster(parent)).resolves.toMatchObject({
+			current: { id: parentSession.sessionId },
+		});
+	});
+
 	it("fsyncs admission before factory work, materializes before registry/publication, and leaves a failed child pending", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-c03-durable-publication-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -10918,7 +10918,7 @@ describe("C03 durable daemon publication", () => {
 			let publicationSawMaterialized = false;
 			const runtimeA = await internals.createRlmSubagentRuntime(
 				parent,
-				makeOptions(a.assignmentId, a.operationId, a.deliveryId, a.sessionDir, () => {
+				makeOptions(a.assignmentId!, a.operationId!, a.deliveryId!, a.sessionDir, () => {
 					const row = readRlmDurableOperationRegistry(fixture.parentArtifactDir).operations.get(
 						JSON.stringify([fixture.parentSessionId, a.assignmentId, a.operationId]),
 					);
@@ -10945,6 +10945,34 @@ describe("C03 durable daemon publication", () => {
 				throw new Error("injected child factory failure");
 			});
 			await expect(internals.createRlmSubagentRuntime(parent, b)).rejects.toThrow("injected child factory failure");
+			// A materialized child whose C01 running registry append fails remains an
+			// unpublished pending C03 fact: no callback can make it addressable.
+			const cDir = join(fixture.parentArtifactDir, "c03-C-registry-failed");
+			mkdirSync(cDir, { recursive: true });
+			const c = makeOptions(
+				"cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+				"cccccccc-cccc-4ccc-8ccc-000000000010",
+				"cccccccc-cccc-4ccc-8ccc-000000000020",
+				cDir,
+			);
+			host.admitRlmSubagentOperation?.(c);
+			const publication = vi.fn();
+			const append = vi
+				.spyOn(
+					fixture.daemon as unknown as { recordRlmSubagentRegistryEntry: () => boolean },
+					"recordRlmSubagentRegistryEntry",
+				)
+				.mockReturnValueOnce(false);
+			await expect(
+				internals.createRlmSubagentRuntime(parent, { ...c, onSessionPublished: publication as never }),
+			).rejects.toThrow("Failed to persist running RLM subagent registry entry");
+			append.mockRestore();
+			expect(publication).not.toHaveBeenCalled();
+			expect(
+				readRlmDurableOperationRegistry(fixture.parentArtifactDir).operations.get(
+					JSON.stringify([fixture.parentSessionId, c.assignmentId, c.operationId]),
+				)?.lifecycle,
+			).toBe("materialized");
 			ledger = readRlmDurableOperationRegistry(fixture.parentArtifactDir);
 			const admittedB = ledger.operations.get(
 				JSON.stringify([fixture.parentSessionId, b.assignmentId, b.operationId]),

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -35,6 +35,7 @@ import {
 	finishClientSnapshotStreaming,
 	getChildActiveSessionStates,
 	markClientSnapshotStreaming,
+	RlmRegistryAuthorityError,
 	setDaemonClientSessionCapabilities,
 	shouldSendDaemonOutboundToClient,
 } from "../src/modes/daemon/daemon-mode.js";
@@ -1341,7 +1342,8 @@ describe("daemon mode helpers", () => {
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
-		// A registry failure must not strand the cancelled child as a stale resident session.
+		// An authoritative deletion failure leaves the child intact for retry; it
+		// must not be converted into an in-memory cancellation cleanup.
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.recordRlmSubagentDeletion = vi.fn(async () => {
 			throw new Error("registry write failed");
@@ -1356,7 +1358,7 @@ describe("daemon mode helpers", () => {
 				),
 		).rejects.toThrow("registry write failed");
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
-		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
+		expect(internals.sessions.has(childState.activeSessionId)).toBe(true);
 	});
 
 	it("fences stale assignment completion and deletion when a child selector is reused", async () => {
@@ -11133,6 +11135,128 @@ describe("C03 durable daemon publication", () => {
 		await expect(roster.createAgentFamilyRoster(parent)).resolves.toMatchObject({
 			current: { id: parentSession.sessionId },
 		});
+	});
+
+	it("never locally cleans an exact release when its registry deletion fails across a replacement interleave", async () => {
+		const assignmentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+		const operationId = "aaaaaaaa-aaaa-4aaa-8aaa-000000000010";
+		const deliveryId = "aaaaaaaa-aaaa-4aaa-8aaa-000000000020";
+		const daemon = new AgentDaemon("/tmp/prime-agent-c03-release-authority.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parent = makeState("release-parent");
+		const parentSession = {
+			sessionId: "release-parent-session",
+			sessionName: "release-parent",
+			sessionManager: { getCwd: () => "/tmp" },
+			rlmDepth: 0,
+			rlmMaxDepth: 4,
+		} as ActiveSessionState["runtime"]["session"];
+		parent.runtime = {
+			...parent.runtime,
+			metadata: { kind: "top-level", createdAt: 1 },
+			session: parentSession,
+		} as ActiveSessionState["runtime"];
+		const childSession = {
+			disposeAsync: vi.fn(async () => {}),
+		} as unknown as ActiveSessionState["runtime"]["session"];
+		const child = makeState("release-child", parent.activeSessionId);
+		child.runtime = {
+			...child.runtime,
+			metadata: {
+				kind: "subagent",
+				createdAt: 1,
+				parentActiveSessionId: parent.activeSessionId,
+				rlmChildId: "release-child",
+				assignmentId,
+				operationId,
+				deliveryId,
+			},
+			session: childSession,
+		} as ActiveSessionState["runtime"];
+		const options = {
+			parentSession,
+			id: "release-child",
+			assignmentId,
+			operationId,
+			deliveryId,
+		} as CreateRlmSubagentRuntimeOptions;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closeSession: ReturnType<typeof vi.fn>;
+			recordRlmSubagentDeletion: ReturnType<typeof vi.fn>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+		};
+		const closeSession = vi.fn(async (state: ActiveSessionState) => {
+			internals.sessions.delete(state.activeSessionId);
+		});
+		internals.closeSession = closeSession;
+		internals.sessions.set(parent.activeSessionId, parent);
+		internals.sessions.set(child.activeSessionId, child);
+
+		// No artifact is an authority failure even when this exact child remains current.
+		const currentHost = internals.createSubagentRuntimeHost(parent);
+		await expect(
+			currentHost.releaseRlmSubagentRuntime?.(
+				{ session: childSession, assignmentId, operationId, deliveryId },
+				options,
+				"cancelled",
+			),
+		).rejects.toBeInstanceOf(RlmRegistryAuthorityError);
+		expect(closeSession).not.toHaveBeenCalled();
+		expect(childSession.disposeAsync).not.toHaveBeenCalled();
+		expect(internals.sessions.get(child.activeSessionId)).toBe(child);
+
+		// Force the await boundary to supersede A with B before A's deletion rejects.
+		// The deletion error must win instead of the stale-current early return.
+		const replacement = makeState("release-child-b", parent.activeSessionId);
+		const replacementSession = {
+			disposeAsync: vi.fn(async () => {}),
+		} as unknown as ActiveSessionState["runtime"]["session"];
+		replacement.runtime = {
+			...replacement.runtime,
+			metadata: {
+				kind: "subagent",
+				createdAt: 2,
+				parentActiveSessionId: parent.activeSessionId,
+				rlmChildId: "release-child",
+				assignmentId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+				operationId: "bbbbbbbb-bbbb-4bbb-8bbb-000000000010",
+				deliveryId: "bbbbbbbb-bbbb-4bbb-8bbb-000000000020",
+			},
+			session: replacementSession,
+		} as ActiveSessionState["runtime"];
+		internals.recordRlmSubagentDeletion = vi.fn(async () => {
+			internals.sessions.delete(child.activeSessionId);
+			internals.sessions.set(replacement.activeSessionId, replacement);
+			throw new RlmRegistryAuthorityError("missing registry during exact deletion");
+		});
+		const staleHost = internals.createSubagentRuntimeHost(parent);
+		await expect(
+			staleHost.releaseRlmSubagentRuntime?.(
+				{ session: childSession, assignmentId, operationId, deliveryId },
+				options,
+				"cancelled",
+			),
+		).rejects.toBeInstanceOf(RlmRegistryAuthorityError);
+		expect(closeSession).not.toHaveBeenCalled();
+		expect(childSession.disposeAsync).not.toHaveBeenCalled();
+		expect(replacementSession.disposeAsync).not.toHaveBeenCalled();
+		expect(internals.sessions.get(replacement.activeSessionId)).toBe(replacement);
+
+		// Once the exact deletion succeeds, its own current resident closes normally.
+		internals.sessions.delete(replacement.activeSessionId);
+		internals.sessions.set(child.activeSessionId, child);
+		internals.recordRlmSubagentDeletion = vi.fn(async () => {});
+		await internals
+			.createSubagentRuntimeHost(parent)
+			.releaseRlmSubagentRuntime?.(
+				{ session: childSession, assignmentId, operationId, deliveryId },
+				options,
+				"cancelled",
+			);
+		expect(closeSession).toHaveBeenCalledWith(child, "killed");
 	});
 
 	it("fsyncs admission before factory work, materializes before registry/publication, and leaves a failed child pending", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1775,9 +1775,9 @@ describe("daemon mode helpers", () => {
 			expect((await internals.listPassiveRlmSubagents()).map(({ entry }) => entry.childId)).toContain("child-1");
 			expect((await internals.findPassiveRlmSubagent("real-worker"))?.entry.childId).toBe("child-1");
 			const roster = await internals.createAgentMessageController(() => parentState).roster?.();
-			const passiveRosterEntry = roster?.entries.find((entry) => entry.name === "real-worker");
-			expect(passiveRosterEntry).toMatchObject({ relationship: "child", status: "inactive" });
-			expect(passiveRosterEntry).not.toHaveProperty("repliedSinceTask");
+			// A nonresident authoritative C03 record stays in explicit list metadata,
+			// but is deliberately absent from the active family roster.
+			expect(roster?.entries.find((entry) => entry.name === "real-worker")).toBeUndefined();
 			const listed = await internals.buildSessionListWithPassiveRlmSubagents(
 				[parentState],
 				await SessionManager.listAll(undefined, sessionDir),
@@ -6495,10 +6495,21 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("validates a requested passive child name before hydration", async () => {
+	it("defaults a requested passive child name to depth 1 without persisted depth authority", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-name-preflight-"));
 		try {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			// Neither registry nor header supplies depth. Do not fabricate nested authority
+			// from the artifact path: passive compatibility uses the depth-1 default.
+			const childLines = readFileSync(fixture.childSessionFile, "utf8").split("\n");
+			const childHeader = JSON.parse(childLines[0] ?? "{}") as Record<string, unknown>;
+			delete childHeader.rlmDepth;
+			childLines[0] = JSON.stringify(childHeader);
+			writeFileSync(fixture.childSessionFile, childLines.join("\n"));
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const registryEntry = JSON.parse(readFileSync(registryPath, "utf8").trim()) as Record<string, unknown>;
+			delete registryEntry.rlmDepth;
+			writeFileSync(registryPath, `${JSON.stringify(registryEntry)}\n`);
 			const internals = fixture.daemon as unknown as {
 				sessions: Map<string, ActiveSessionState>;
 				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
@@ -6524,7 +6535,7 @@ describe("daemon mode helpers", () => {
 			).rejects.toBe(nameError);
 			expect(internals.assertFamilySessionNameAvailable).toHaveBeenCalledWith({
 				name: "sibling",
-				depth: 2,
+				depth: 1,
 				parentSessionId: parentState.runtime.session.sessionId,
 				parentSessionPath: fixture.parentSessionFile,
 				ignoreSessionId: expect.any(String),
@@ -6575,7 +6586,7 @@ describe("daemon mode helpers", () => {
 	});
 
 	it("rehydrates a legacy child with depth inferred from its session file path", async () => {
-		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-legacy-rlm-depth-"));
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-c03-no-depth-"));
 		try {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
 			const lines = readFileSync(fixture.childSessionFile, "utf8").split("\n");
@@ -6680,7 +6691,7 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("rehydrates a C03 passive subagent at its persisted depth", async () => {
+	it("defaults a C03 passive subagent to depth 1 without persisted depth authority", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-legacy-rlm-depth-"));
 		try {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
@@ -6710,7 +6721,9 @@ describe("daemon mode helpers", () => {
 				.createAgentMessageController(() => parentState)
 				.sendAgentMessage({ target: "renamed-worker", message: "report progress" });
 
-			expect(fixture.createRuntime.mock.calls[1]?.[0].sessionOptions?.rlmDepth).toBe(2);
+			// Both sources deliberately omitted depth, so C03 does not invent depth 2
+			// from its parent/path relationship; compatibility falls back to depth 1.
+			expect(fixture.createRuntime.mock.calls[1]?.[0].sessionOptions?.rlmDepth).toBe(1);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -15,6 +15,7 @@ import type { AgentObserveController } from "../src/core/agent-observe.js";
 import type { SessionActionRecoverySnapshot } from "../src/core/agent-session.js";
 import type { CreateAgentSessionRuntimeFactory } from "../src/core/agent-session-runtime.js";
 import type { AgentCronJob, AgentCronJobStore } from "../src/core/cron-jobs.js";
+import { readRlmDurableOperationRegistry } from "../src/core/rlm-durable-operations.js";
 import {
 	type CreateRlmSubagentRuntimeOptions,
 	createDefaultRlmSubagentSessionName,
@@ -1698,6 +1699,17 @@ describe("daemon mode helpers", () => {
 			);
 			if (!childState?.runtime.session.sessionFile) throw new Error("Missing child state");
 			const host = internals.createSubagentRuntimeHost(parentState);
+			// This direct legacy host call predates C03 and has a C01 assignment but
+			// no operation metadata. It stays compatible only on the exact legacy
+			// shape: naming a fabricated C03 operation must not complete it.
+			expect(
+				host.completeRlmSubagentRuntime?.(
+					"child-1",
+					childRuntime.session,
+					childRuntime.metadata.assignmentId!,
+					"00000000-0000-4000-8000-000000000099",
+				),
+			).toBe(false);
 			expect(
 				host.completeRlmSubagentRuntime?.("child-1", childRuntime.session, childRuntime.metadata.assignmentId!),
 			).toBe(true);
@@ -10841,3 +10853,109 @@ function makeClient(id: string, activeSessionId: string, supportsExtensionUi = f
 		capabilities: new Set(supportsExtensionUi ? ["extension_ui"] : []),
 	};
 }
+
+describe("C03 durable daemon publication", () => {
+	it("fsyncs admission before factory work, materializes before registry/publication, and leaves a failed child pending", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-c03-durable-publication-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				createRlmSubagentRuntime(
+					parent: ActiveSessionState,
+					options: CreateRlmSubagentRuntimeOptions,
+				): Promise<ActiveSessionState["runtime"]>;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const host = internals.createSubagentRuntimeHost(parent);
+			const model = { provider: "test", id: "durable-model" } as Model<Api>;
+			const makeOptions = (
+				assignmentId: string,
+				operationId: string,
+				deliveryId: string,
+				sessionDir: string,
+				onSessionPublished?: (session: never) => void,
+			): CreateRlmSubagentRuntimeOptions => ({
+				parentSession: parent.runtime.session,
+				id: "c03-reused-selector",
+				assignmentId,
+				operationId,
+				deliveryId,
+				prompt: `durable ${operationId}`,
+				sessionName: "c03-reused-selector",
+				sessionDir,
+				model,
+				thinkingLevel: "off",
+				serviceTier: null,
+				scopedModels: [],
+				activeToolNames: [],
+				customTools: [],
+				includeGoals: false,
+				includeCompactSkill: false,
+				rlmDepth: 1,
+				rlmMaxDepth: 4,
+				rlmParentNodeId: "c03-reused-selector",
+				...(onSessionPublished ? { onSessionPublished: onSessionPublished as never } : {}),
+			});
+			const aDir = join(fixture.parentArtifactDir, "c03-A");
+			mkdirSync(aDir, { recursive: true });
+			const a = makeOptions(
+				"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+				"aaaaaaaa-aaaa-4aaa-8aaa-000000000010",
+				"aaaaaaaa-aaaa-4aaa-8aaa-000000000020",
+				aDir,
+			);
+			// The durable fact exists before the daemon calls its runtime factory.
+			host.admitRlmSubagentOperation?.(a);
+			let ledger = readRlmDurableOperationRegistry(fixture.parentArtifactDir);
+			const admittedA = ledger.operations.get(
+				JSON.stringify([fixture.parentSessionId, a.assignmentId, a.operationId]),
+			);
+			expect(admittedA).toMatchObject({ lifecycle: "admitted" });
+			expect(admittedA?.childSessionFile).toBeUndefined();
+
+			let publicationSawMaterialized = false;
+			const runtimeA = await internals.createRlmSubagentRuntime(
+				parent,
+				makeOptions(a.assignmentId, a.operationId, a.deliveryId, a.sessionDir, () => {
+					const row = readRlmDurableOperationRegistry(fixture.parentArtifactDir).operations.get(
+						JSON.stringify([fixture.parentSessionId, a.assignmentId, a.operationId]),
+					);
+					publicationSawMaterialized = row?.lifecycle === "materialized";
+				}),
+			);
+			expect(runtimeA.metadata.operationId).toBe(a.operationId);
+			expect(publicationSawMaterialized).toBe(true);
+			const registryRows = readFileSync(join(fixture.parentArtifactDir, "rlm-subagents.jsonl"), "utf8");
+			expect(registryRows).toContain(a.operationId);
+
+			// A second admission is durable even when construction fails. It has neither
+			// a materialized child nor a fake running/completed registry row.
+			const bDir = join(fixture.parentArtifactDir, "c03-B-failed");
+			mkdirSync(bDir, { recursive: true });
+			const b = makeOptions(
+				"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+				"bbbbbbbb-bbbb-4bbb-8bbb-000000000010",
+				"bbbbbbbb-bbbb-4bbb-8bbb-000000000020",
+				bDir,
+			);
+			host.admitRlmSubagentOperation?.(b);
+			fixture.createRuntime.mockImplementationOnce(async () => {
+				throw new Error("injected child factory failure");
+			});
+			await expect(internals.createRlmSubagentRuntime(parent, b)).rejects.toThrow("injected child factory failure");
+			ledger = readRlmDurableOperationRegistry(fixture.parentArtifactDir);
+			const admittedB = ledger.operations.get(
+				JSON.stringify([fixture.parentSessionId, b.assignmentId, b.operationId]),
+			);
+			expect(admittedB).toMatchObject({ lifecycle: "admitted" });
+			expect(admittedB?.childSessionFile).toBeUndefined();
+			expect(readFileSync(join(fixture.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")).not.toContain(
+				b.operationId,
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1522,11 +1522,15 @@ describe("daemon mode helpers", () => {
 			const childBSessionFile = childBManager.getSessionFile();
 			if (!childBSessionFile) throw new Error("Missing B session file");
 			const assignmentB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+			const operationB = "bbbbbbbb-bbbb-4bbb-8bbb-000000000010";
+			const deliveryB = "bbbbbbbb-bbbb-4bbb-8bbb-000000000020";
 			writeFileSync(
 				registryPath,
 				`${JSON.stringify(a)}\n${JSON.stringify({
 					...a,
 					assignmentId: assignmentB,
+					operationId: operationB,
+					deliveryId: deliveryB,
 					sessionName: "reused-B",
 					sessionDir: childBSessionDir,
 					sessionFile: childBSessionFile,
@@ -1534,6 +1538,19 @@ describe("daemon mode helpers", () => {
 					status: "completed",
 					createdAt: 3,
 					updatedAt: "2026-01-01T00:00:03.000Z",
+				})}\n${JSON.stringify({
+					...a,
+					assignmentId: assignmentB,
+					operationId: operationB,
+					// A corrupt late partial must never replace B for hydrate/delete.
+					deliveryId: undefined,
+					sessionName: "partial-late-A",
+					sessionDir: childBSessionDir,
+					sessionFile: childBSessionFile,
+					parentSessionId: childBManager.getSessionId(),
+					status: "completed",
+					createdAt: 4,
+					updatedAt: "2026-01-01T00:00:04.000Z",
 				})}\n`,
 			);
 			const internals = fixture.daemon as unknown as {
@@ -11123,7 +11140,7 @@ describe("C03 durable daemon publication", () => {
 			expect(fixture.createRuntime).toHaveBeenCalledTimes(factoryCallsBeforeWake + 1);
 			const append = restartedParent.runtime.session.appendDurableRlmTerminalMessage as ReturnType<typeof vi.fn>;
 			expect(append).toHaveBeenCalledTimes(1);
-			expect(append).toHaveBeenCalledWith(message, deliveryId);
+			expect(append).toHaveBeenCalledWith(message, deliveryId, expect.any(Function));
 			expect(
 				store
 					.rebuild()

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11268,6 +11268,59 @@ describe("C03 durable daemon publication", () => {
 		expect(closeSession).toHaveBeenCalledWith(child, "killed");
 	});
 
+	it("does not launch or materialize an admitted child after global durable uncertainty", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-c03-global-uncertainty-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				createRlmSubagentRuntime(
+					parent: ActiveSessionState,
+					options: CreateRlmSubagentRuntimeOptions,
+				): Promise<ActiveSessionState["runtime"]>;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const childDir = join(fixture.parentArtifactDir, "global-uncertainty-child");
+			mkdirSync(childDir, { recursive: true });
+			const options: CreateRlmSubagentRuntimeOptions = {
+				parentSession: parent.runtime.session,
+				id: "globally-quarantined-child",
+				assignmentId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+				operationId: "aaaaaaaa-aaaa-4aaa-8aaa-000000000010",
+				deliveryId: "aaaaaaaa-aaaa-4aaa-8aaa-000000000020",
+				prompt: "must never start",
+				sessionName: "globally-quarantined-child",
+				sessionDir: childDir,
+				model: { provider: "test", id: "durable-model" } as Model<Api>,
+				thinkingLevel: "off",
+				serviceTier: null,
+				scopedModels: [],
+				activeToolNames: [],
+				customTools: [],
+				includeGoals: false,
+				includeCompactSkill: false,
+				rlmDepth: 1,
+				rlmMaxDepth: 4,
+				rlmParentNodeId: "globally-quarantined-child",
+			};
+			internals.createSubagentRuntimeHost(parent).admitRlmSubagentOperation?.(options);
+			writeFileSync(
+				join(fixture.parentArtifactDir, "rlm-operation-ledger.jsonl"),
+				"{complete malformed unkeyed durable record}\n",
+				{ flag: "a" },
+			);
+			const runtimeCallsBefore = fixture.createRuntime.mock.calls.length;
+			await expect(internals.createRlmSubagentRuntime(parent, options)).rejects.toThrow("globally uncertain");
+			expect(fixture.createRuntime).toHaveBeenCalledTimes(runtimeCallsBefore);
+			expect(readRlmDurableOperationRegistry(fixture.parentArtifactDir)).toMatchObject({
+				hasGlobalUncertainty: true,
+			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("fsyncs admission before factory work, materializes before registry/publication, and leaves a failed child pending", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-c03-durable-publication-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1439,13 +1439,14 @@ describe("daemon mode helpers", () => {
 		expect(internals.sessions.get(childB.activeSessionId)).toBe(childB);
 	});
 
-	it("binds a legacy passive delete to a fresh assignment before persisting its exact tombstone", async () => {
+	it("keeps an assignment-only passive delete display-only without minting authority", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-legacy-delete-assignment-"));
 		try {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
 			const legacy = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
-			delete legacy.assignmentId;
+			delete legacy.operationId;
+			delete legacy.deliveryId;
 			writeFileSync(registryPath, `${JSON.stringify(legacy)}\n`);
 			const internals = fixture.daemon as unknown as {
 				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
@@ -1456,16 +1457,12 @@ describe("daemon mode helpers", () => {
 			const rows = readFileSync(registryPath, "utf8")
 				.trim()
 				.split(/\r?\n/)
-				.map((line) => JSON.parse(line) as { childId: string; assignmentId?: string; status: string });
-			const bound = rows.at(-2);
-			const deleted = rows.at(-1);
-			expect(bound).toMatchObject({ childId: fixture.childId, status: "completed" });
-			expect(bound?.assignmentId).toMatch(/^[0-9a-f-]{36}$/i);
-			expect(deleted).toMatchObject({
-				childId: fixture.childId,
-				assignmentId: bound?.assignmentId,
-				status: "deleted",
-			});
+				.map(
+					(line) =>
+						JSON.parse(line) as { childId: string; assignmentId?: string; operationId?: string; status: string },
+				);
+			expect(rows).toEqual([expect.objectContaining({ childId: fixture.childId, status: "completed" })]);
+			expect(rows[0]?.operationId).toBeUndefined();
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -1520,10 +1517,36 @@ describe("daemon mode helpers", () => {
 			childBManager.appendMessage({ role: "user", content: "B's distinct session file", timestamp: 3 });
 			childBManager.flushNow();
 			const childBSessionFile = childBManager.getSessionFile();
-			if (!childBSessionFile) throw new Error("Missing B session file");
+			const childBArtifactDir = childBManager.getSessionArtifactDir();
+			if (!childBSessionFile || !childBArtifactDir) throw new Error("Missing B session paths");
 			const assignmentB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 			const operationB = "bbbbbbbb-bbbb-4bbb-8bbb-000000000010";
 			const deliveryB = "bbbbbbbb-bbbb-4bbb-8bbb-000000000020";
+			const storeB = openRlmDurableOperationStore(fixture.parentArtifactDir);
+			storeB.admit({
+				parentSessionId: fixture.parentSessionId,
+				parentSessionFile: fixture.parentSessionFile,
+				parentSessionRoot: dirname(fixture.parentSessionFile),
+				parentArtifactRoot: dirname(fixture.parentArtifactDir),
+				childId: fixture.childId,
+				assignmentId: assignmentB,
+				operationId: operationB,
+				deliveryId: deliveryB,
+				childSessionDir: childBSessionDir,
+				requestedModel: { provider: "test", modelId: "fixture" },
+				rlmDepth: 1,
+				rlmMaxDepth: 4,
+			});
+			storeB.markMaterialized({
+				parentSessionId: fixture.parentSessionId,
+				assignmentId: assignmentB,
+				operationId: operationB,
+				childSessionId: childBManager.getSessionId(),
+				childSessionFile: childBSessionFile,
+				childSessionRoot: dirname(childBSessionFile),
+				childArtifactDir: childBArtifactDir,
+				childArtifactRoot: dirname(childBArtifactDir),
+			});
 			writeFileSync(
 				registryPath,
 				`${JSON.stringify(a)}\n${JSON.stringify({
@@ -1534,7 +1557,7 @@ describe("daemon mode helpers", () => {
 					sessionName: "reused-B",
 					sessionDir: childBSessionDir,
 					sessionFile: childBSessionFile,
-					parentSessionId: childBManager.getSessionId(),
+					parentSessionId: fixture.parentSessionId,
 					status: "completed",
 					createdAt: 3,
 					updatedAt: "2026-01-01T00:00:03.000Z",
@@ -1547,7 +1570,7 @@ describe("daemon mode helpers", () => {
 					sessionName: "partial-late-A",
 					sessionDir: childBSessionDir,
 					sessionFile: childBSessionFile,
-					parentSessionId: childBManager.getSessionId(),
+					parentSessionId: fixture.parentSessionId,
 					status: "completed",
 					createdAt: 4,
 					updatedAt: "2026-01-01T00:00:04.000Z",
@@ -1697,9 +1720,12 @@ describe("daemon mode helpers", () => {
 				hasRunningRlmChildren: () => false,
 				getSessionActionSnapshot: () => ({ queuedCount: 0, steering: [], followUps: [] }),
 			});
-			const childRuntime = await internals.createRlmSubagentRuntime(parentState, {
+			const durableOptions: CreateRlmSubagentRuntimeOptions = {
 				parentSession: parentState.runtime.session,
 				id: "child-1",
+				assignmentId: "33333333-3333-4333-8333-333333333333",
+				operationId: "33333333-3333-4333-8333-333333333334",
+				deliveryId: "33333333-3333-4333-8333-333333333335",
 				prompt: "complete and persist",
 				sessionName: "real-worker",
 				sessionDir: childSessionDir,
@@ -1714,12 +1740,15 @@ describe("daemon mode helpers", () => {
 				rlmDepth: 1,
 				rlmMaxDepth: 4,
 				rlmParentNodeId: "child-1",
-			});
+			};
+			mkdirSync(childSessionDir, { recursive: true });
+			const host = internals.createSubagentRuntimeHost(parentState);
+			host.admitRlmSubagentOperation?.(durableOptions);
+			const childRuntime = await internals.createRlmSubagentRuntime(parentState, durableOptions);
 			const childState = [...internals.sessions.values()].find(
 				(state) => state.runtime.session === childRuntime.session,
 			);
 			if (!childState?.runtime.session.sessionFile) throw new Error("Missing child state");
-			const host = internals.createSubagentRuntimeHost(parentState);
 			// This direct legacy host call predates C03 and has a C01 assignment but
 			// no operation metadata. It stays compatible only on the exact legacy
 			// shape: naming a fabricated C03 operation must not complete it.
@@ -1732,7 +1761,12 @@ describe("daemon mode helpers", () => {
 				),
 			).toBe(false);
 			expect(
-				host.completeRlmSubagentRuntime?.("child-1", childRuntime.session, childRuntime.metadata.assignmentId!),
+				host.completeRlmSubagentRuntime?.(
+					"child-1",
+					childRuntime.session,
+					childRuntime.metadata.assignmentId!,
+					durableOptions.operationId,
+				),
 			).toBe(true);
 			await (
 				daemon as unknown as { closeSession(state: ActiveSessionState, reason: "shutdown"): Promise<void> }
@@ -1778,7 +1812,7 @@ describe("daemon mode helpers", () => {
 				fixture.childId,
 			);
 			await expect(internals.createAgentMessageController(() => parentState).roster?.()).resolves.toMatchObject({
-				entries: [expect.objectContaining({ relationship: "child", name: "renamed-worker" })],
+				entries: [],
 			});
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
@@ -5764,14 +5798,46 @@ describe("daemon mode helpers", () => {
 			childManager.newSession({ parentSession: parentSessionFile });
 			childManager.appendSessionInfo("heartbeat-child");
 			const childSessionFile = childManager.getSessionFile();
-			if (!childSessionFile) {
-				throw new Error("Missing child session file");
+			const childArtifactDir = childManager.getSessionArtifactDir();
+			if (!childSessionFile || !childArtifactDir) {
+				throw new Error("Missing child session paths");
 			}
+			const assignmentId = "44444444-4444-4444-8444-444444444444";
+			const operationId = "44444444-4444-4444-8444-444444444445";
+			const deliveryId = "44444444-4444-4444-8444-444444444446";
+			const store = openRlmDurableOperationStore(parentArtifactDir);
+			store.admit({
+				parentSessionId: parentManager.getSessionId(),
+				parentSessionFile,
+				parentSessionRoot: dirname(parentSessionFile),
+				parentArtifactRoot: dirname(parentArtifactDir),
+				childId,
+				assignmentId,
+				operationId,
+				deliveryId,
+				childSessionDir,
+				requestedModel: { provider: "test", modelId: "fixture" },
+				rlmDepth: 1,
+				rlmMaxDepth: 4,
+			});
+			store.markMaterialized({
+				parentSessionId: parentManager.getSessionId(),
+				assignmentId,
+				operationId,
+				childSessionId: childManager.getSessionId(),
+				childSessionFile,
+				childSessionRoot: dirname(childSessionFile),
+				childArtifactDir,
+				childArtifactRoot: dirname(childArtifactDir),
+			});
 			writeFileSync(
 				join(parentArtifactDir, "rlm-subagents.jsonl"),
 				`${JSON.stringify({
 					type: "rlm_subagent",
 					childId,
+					assignmentId,
+					operationId,
+					deliveryId,
 					sessionName: "heartbeat-child",
 					sessionDir: childSessionDir,
 					sessionFile: childSessionFile,
@@ -6170,9 +6236,7 @@ describe("daemon mode helpers", () => {
 			const messageController = internals.createAgentMessageController(() => parentState);
 			await expect(messageController.roster?.()).resolves.toMatchObject({
 				current: { id: parentState.runtime.session.sessionId, depth: 0 },
-				entries: [
-					expect.objectContaining({ relationship: "child", name: "renamed-worker", depth: 1, status: "inactive" }),
-				],
+				entries: [],
 			});
 			await expect(
 				messageController.assertSessionNameAvailable?.({
@@ -6181,7 +6245,7 @@ describe("daemon mode helpers", () => {
 					parentSessionId: parentState.runtime.session.sessionId,
 					parentSessionPath: fixture.parentSessionFile,
 				}),
-			).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
+			).resolves.toBeUndefined();
 			const listResponse = (await internals.handleCommand(makeClient("client-1", parentState.activeSessionId), {
 				type: "list",
 				all: true,
@@ -6460,7 +6524,7 @@ describe("daemon mode helpers", () => {
 			).rejects.toBe(nameError);
 			expect(internals.assertFamilySessionNameAvailable).toHaveBeenCalledWith({
 				name: "sibling",
-				depth: 1,
+				depth: 2,
 				parentSessionId: parentState.runtime.session.sessionId,
 				parentSessionPath: fixture.parentSessionFile,
 				ignoreSessionId: expect.any(String),
@@ -6580,12 +6644,8 @@ describe("daemon mode helpers", () => {
 				internals
 					.createAgentMessageController(() => parentState)
 					.sendAgentMessage({ target: "spawn-worker", message: "report progress" }),
-			).resolves.toMatchObject({
-				deliveryStatus: "delivered",
-				target: { runtimeKind: "subagent", sessionName: "spawn-worker" },
-			});
-			expect(fixture.createRuntime).toHaveBeenCalledTimes(2);
-			expect(fixture.createRuntime.mock.calls[1]?.[0].sessionManager.getSessionFile()).toBe(siblingSessionFile);
+			).rejects.toThrow("Unknown active session");
+			expect(fixture.createRuntime).toHaveBeenCalledOnce();
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -6620,7 +6680,7 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("rehydrates a legacy passive subagent at depth one", async () => {
+	it("rehydrates a C03 passive subagent at its persisted depth", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-legacy-rlm-depth-"));
 		try {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
@@ -6650,7 +6710,7 @@ describe("daemon mode helpers", () => {
 				.createAgentMessageController(() => parentState)
 				.sendAgentMessage({ target: "renamed-worker", message: "report progress" });
 
-			expect(fixture.createRuntime.mock.calls[1]?.[0].sessionOptions?.rlmDepth).toBe(1);
+			expect(fixture.createRuntime.mock.calls[1]?.[0].sessionOptions?.rlmDepth).toBe(2);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -7063,6 +7123,7 @@ describe("daemon mode helpers", () => {
 				fixture.childId,
 				childState!.runtime.session,
 				"11111111-1111-4111-8111-111111111111",
+				"11111111-1111-4111-8111-111111111112",
 			);
 		} finally {
 			releaseHydration();
@@ -7146,6 +7207,7 @@ describe("daemon mode helpers", () => {
 				attachedState.runtime.session,
 				undefined,
 				"11111111-1111-4111-8111-111111111111",
+				"11111111-1111-4111-8111-111111111112",
 			);
 
 			await expect(
@@ -7321,6 +7383,7 @@ describe("daemon mode helpers", () => {
 				grandchildState.runtime.session,
 				undefined,
 				"22222222-2222-4222-8222-222222222222",
+				"22222222-2222-4222-8222-222222222223",
 			);
 		} finally {
 			releaseHydration();
@@ -7749,6 +7812,7 @@ describe("daemon mode helpers", () => {
 				childState.runtime.session,
 				unsubscribeForwarder,
 				"11111111-1111-4111-8111-111111111111",
+				"11111111-1111-4111-8111-111111111112",
 			);
 			expect(unsubscribeForwarder).not.toHaveBeenCalled();
 			emitChildUpdate("recap after failed close");
@@ -7841,6 +7905,7 @@ describe("daemon mode helpers", () => {
 				fixture.childId,
 				firstChild.runtime.session,
 				"11111111-1111-4111-8111-111111111111",
+				"11111111-1111-4111-8111-111111111112",
 			);
 			expect(fixture.runtimeSessions[1]?.disposeAsync).toHaveBeenCalledOnce();
 
@@ -10639,6 +10704,12 @@ function makePersistedRlmDaemonFixture(
 		throw new Error("Missing child session paths");
 	}
 	const grandchildId = "grandchild-1";
+	const childAssignmentId = "11111111-1111-4111-8111-111111111111";
+	const childOperationId = "11111111-1111-4111-8111-111111111112";
+	const childDeliveryId = "11111111-1111-4111-8111-111111111113";
+	const grandchildAssignmentId = "22222222-2222-4222-8222-222222222222";
+	const grandchildOperationId = "22222222-2222-4222-8222-222222222223";
+	const grandchildDeliveryId = "22222222-2222-4222-8222-222222222224";
 	mkdirSync(childArtifactDir, { recursive: true });
 	const grandchildSessionDir = join(childSessionDir, "sub-deadbeef");
 	const grandchildManager = SessionManager.create(tempDir, grandchildSessionDir);
@@ -10647,13 +10718,70 @@ function makePersistedRlmDaemonFixture(
 	grandchildManager.appendMessage({ role: "user", content: "complete the nested task", timestamp: 2 });
 	grandchildManager.flushNow();
 	const grandchildSessionFile = grandchildManager.getSessionFile();
-	if (!grandchildSessionFile) throw new Error("Missing grandchild session file");
+	const grandchildArtifactDir = grandchildManager.getSessionArtifactDir();
+	if (!grandchildSessionFile || !grandchildArtifactDir) throw new Error("Missing grandchild session paths");
+
+	// The shared passive fixture is an actual C03 incarnation, not an
+	// assignment-shaped C01 row.  Its ledger materialization is what permits
+	// selector hydration; legacy tests below explicitly remove this tuple.
+	const parentStore = openRlmDurableOperationStore(parentArtifactDir);
+	parentStore.admit({
+		parentSessionId: parentManager.getSessionId(),
+		parentSessionFile,
+		parentSessionRoot: dirname(parentSessionFile),
+		parentArtifactRoot: dirname(parentArtifactDir),
+		childId,
+		assignmentId: childAssignmentId,
+		operationId: childOperationId,
+		deliveryId: childDeliveryId,
+		childSessionDir,
+		requestedModel: { provider: "test", modelId: "fixture" },
+		rlmDepth: 1,
+		rlmMaxDepth: 4,
+	});
+	parentStore.markMaterialized({
+		parentSessionId: parentManager.getSessionId(),
+		assignmentId: childAssignmentId,
+		operationId: childOperationId,
+		childSessionId: childManager.getSessionId(),
+		childSessionFile,
+		childSessionRoot: dirname(childSessionFile),
+		childArtifactDir,
+		childArtifactRoot: dirname(childArtifactDir),
+	});
+	const childStore = openRlmDurableOperationStore(childArtifactDir);
+	childStore.admit({
+		parentSessionId: childManager.getSessionId(),
+		parentSessionFile: childSessionFile,
+		parentSessionRoot: dirname(childSessionFile),
+		parentArtifactRoot: dirname(childArtifactDir),
+		childId: grandchildId,
+		assignmentId: grandchildAssignmentId,
+		operationId: grandchildOperationId,
+		deliveryId: grandchildDeliveryId,
+		childSessionDir: grandchildSessionDir,
+		requestedModel: { provider: "test", modelId: "fixture" },
+		rlmDepth: 2,
+		rlmMaxDepth: 4,
+	});
+	childStore.markMaterialized({
+		parentSessionId: childManager.getSessionId(),
+		assignmentId: grandchildAssignmentId,
+		operationId: grandchildOperationId,
+		childSessionId: grandchildManager.getSessionId(),
+		childSessionFile: grandchildSessionFile,
+		childSessionRoot: dirname(grandchildSessionFile),
+		childArtifactDir: grandchildArtifactDir,
+		childArtifactRoot: dirname(grandchildArtifactDir),
+	});
 	writeFileSync(
 		join(childArtifactDir, "rlm-subagents.jsonl"),
 		`${JSON.stringify({
 			type: "rlm_subagent",
 			childId: grandchildId,
-			assignmentId: "22222222-2222-4222-8222-222222222222",
+			assignmentId: grandchildAssignmentId,
+			operationId: grandchildOperationId,
+			deliveryId: grandchildDeliveryId,
 			sessionName: "nested-worker",
 			sessionDir: grandchildSessionDir,
 			sessionFile: grandchildSessionFile,
@@ -10665,15 +10793,16 @@ function makePersistedRlmDaemonFixture(
 			status: "completed",
 			createdAt: 2,
 			updatedAt: "2026-01-01T00:00:01.000Z",
-		})}
-`,
+		})}\n`,
 	);
 	writeFileSync(
 		join(parentArtifactDir, "rlm-subagents.jsonl"),
 		`${JSON.stringify({
 			type: "rlm_subagent",
 			childId,
-			assignmentId: "11111111-1111-4111-8111-111111111111",
+			assignmentId: childAssignmentId,
+			operationId: childOperationId,
+			deliveryId: childDeliveryId,
 			sessionName: "spawn-worker",
 			sessionDir: childSessionDir,
 			sessionFile: childSessionFile,
@@ -10685,10 +10814,8 @@ function makePersistedRlmDaemonFixture(
 			status: "completed",
 			createdAt: 1,
 			updatedAt: "2026-01-01T00:00:00.000Z",
-		})}
-`,
+		})}\n`,
 	);
-
 	const acceptAgentMessagePrompt = vi.fn(
 		async (_message: string, promptOptions?: { preflightResult?: (didSucceed: boolean) => void }) => {
 			if (options.childAdmissionGate) {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -15,7 +15,11 @@ import type { AgentObserveController } from "../src/core/agent-observe.js";
 import type { SessionActionRecoverySnapshot } from "../src/core/agent-session.js";
 import type { CreateAgentSessionRuntimeFactory } from "../src/core/agent-session-runtime.js";
 import type { AgentCronJob, AgentCronJobStore } from "../src/core/cron-jobs.js";
-import { readRlmDurableOperationRegistry } from "../src/core/rlm-durable-operations.js";
+import {
+	openRlmDurableOperationStore,
+	type RlmTerminalMessage,
+	readRlmDurableOperationRegistry,
+} from "../src/core/rlm-durable-operations.js";
 import {
 	type CreateRlmSubagentRuntimeOptions,
 	createDefaultRlmSubagentSessionName,
@@ -10762,6 +10766,7 @@ function makeRuntimeSession(
 			return sessionManager.getSessionName();
 		},
 		setSubagentRuntimeHost: vi.fn(),
+		appendDurableRlmTerminalMessage: vi.fn(async () => true),
 		getRlmChildRunStatus: vi.fn(() => "running"),
 		registerRlmChildSession: vi.fn(() => true),
 		releaseRlmChildSession: vi.fn(() => vi.fn()),
@@ -10982,6 +10987,171 @@ describe("C03 durable daemon publication", () => {
 			expect(readFileSync(join(fixture.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")).not.toContain(
 				b.operationId,
 			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rehydrates one pending normal durable terminal through manager-owned passive wake without replay", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-c03-restart-import-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				createRlmSubagentRuntime(
+					parent: ActiveSessionState,
+					options: CreateRlmSubagentRuntimeOptions,
+				): Promise<ActiveSessionState["runtime"]>;
+				closeSession(state: ActiveSessionState, reason: "shutdown"): Promise<void>;
+				sessions: Map<string, ActiveSessionState>;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const host = internals.createSubagentRuntimeHost(parent);
+			const assignmentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+			const operationId = "aaaaaaaa-aaaa-4aaa-8aaa-000000000010";
+			const deliveryId = "aaaaaaaa-aaaa-4aaa-8aaa-000000000020";
+			const childDir = join(fixture.parentArtifactDir, "c03-restart-child");
+			mkdirSync(childDir, { recursive: true });
+			const options: CreateRlmSubagentRuntimeOptions = {
+				parentSession: parent.runtime.session,
+				id: "restart-worker",
+				assignmentId,
+				operationId,
+				deliveryId,
+				prompt: "normal production seam task",
+				sessionName: "restart-worker",
+				sessionDir: childDir,
+				model: { provider: "test", id: "durable-model" } as Model<Api>,
+				thinkingLevel: "off",
+				serviceTier: null,
+				scopedModels: [],
+				activeToolNames: [],
+				customTools: [],
+				includeGoals: false,
+				includeCompactSkill: false,
+				rlmDepth: 1,
+				rlmMaxDepth: 4,
+				rlmParentNodeId: "restart-worker",
+			};
+			host.admitRlmSubagentOperation?.(options);
+			const runtime = await internals.createRlmSubagentRuntime(parent, options);
+			expect(host.completeRlmSubagentRuntime?.("restart-worker", runtime.session, assignmentId, operationId)).toBe(
+				true,
+			);
+
+			// This is the real durable terminal path up to the crash boundary: the
+			// manager-created child is materialized and registered, then its fsynced
+			// outbox and parent terminal fact exist while no importer is running.
+			const parentFile = parent.runtime.session.sessionManager.getSessionFile();
+			const childFile = runtime.session.sessionManager.getSessionFile();
+			const childArtifacts = runtime.session.sessionManager.getSessionArtifactDir();
+			if (!parentFile || !childFile || !childArtifacts) throw new Error("Missing materialized C03 paths");
+			const store = openRlmDurableOperationStore(fixture.parentArtifactDir, {
+				trustedChildRecoveryRoots: (operation) =>
+					operation.assignmentId === assignmentId && operation.operationId === operationId
+						? {
+								childSessionId: runtime.session.sessionId,
+								childSessionFile: childFile,
+								childSessionRoot: dirname(childFile),
+								childArtifactDir: childArtifacts,
+								childArtifactRoot: dirname(childArtifacts),
+							}
+						: undefined,
+			});
+			const message: RlmTerminalMessage = {
+				role: "custom",
+				customType: "rlm_child_terminal_notice",
+				content: "restart-worker completed without sending a reply",
+				display: true,
+				details: { kind: "completed_without_reply", childId: "restart-worker", sessionName: "restart-worker" },
+				timestamp: 1,
+			};
+			store.appendOutbox({
+				parentSessionId: parent.runtime.session.sessionId,
+				parentSessionFile: parentFile,
+				parentSessionRoot: dirname(parentFile),
+				parentArtifactRoot: dirname(fixture.parentArtifactDir),
+				childSessionId: runtime.session.sessionId,
+				childSessionFile: childFile,
+				childSessionRoot: dirname(childFile),
+				childArtifactDir: childArtifacts,
+				childArtifactRoot: dirname(childArtifacts),
+				childId: "restart-worker",
+				assignmentId,
+				operationId,
+				deliveryId,
+				terminal: "done",
+				message,
+			});
+			expect(
+				store.recordTerminal({
+					parentSessionId: parent.runtime.session.sessionId,
+					assignmentId,
+					operationId,
+					deliveryId,
+					terminal: "done",
+				}),
+			).toBe(true);
+			const childState = [...internals.sessions.values()].find((state) => state.runtime.session === runtime.session);
+			if (!childState) throw new Error("Missing running materialized child");
+			await internals.closeSession(childState, "shutdown");
+			await internals.closeSession(parent, "shutdown");
+
+			// A new daemon has only saved session managers and the durable registry.
+			// Concurrent legitimate selector wakes join that normal hydration path.
+			const restarted = new AgentDaemon(join(tempDir, "restarted.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: join(tempDir, "sessions") },
+				createRuntime: fixture.createRuntime,
+			});
+			const restartedInternals = restarted as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				getOrHydrateBoundSessionState(selector: string): Promise<ActiveSessionState>;
+				sessions: Map<string, ActiveSessionState>;
+				closeSession(state: ActiveSessionState, reason: "shutdown"): Promise<void>;
+			};
+			const restartedParent = await restartedInternals.createRuntime({
+				type: "create",
+				sessionPath: fixture.parentSessionFile,
+			});
+			const factoryCallsBeforeWake = fixture.createRuntime.mock.calls.length;
+			const [firstWake, secondWake] = await Promise.all([
+				restartedInternals.getOrHydrateBoundSessionState("restart-worker"),
+				restartedInternals.getOrHydrateBoundSessionState("restart-worker"),
+			]);
+			expect(firstWake).toBe(secondWake);
+			expect(fixture.createRuntime).toHaveBeenCalledTimes(factoryCallsBeforeWake + 1);
+			const append = restartedParent.runtime.session.appendDurableRlmTerminalMessage as ReturnType<typeof vi.fn>;
+			expect(append).toHaveBeenCalledTimes(1);
+			expect(append).toHaveBeenCalledWith(message, deliveryId);
+			expect(
+				store
+					.rebuild()
+					.deliveries.get(
+						JSON.stringify([
+							JSON.stringify([restartedParent.runtime.session.sessionId, assignmentId, operationId]),
+							deliveryId,
+						]),
+					)?.consumed,
+			).toBe("materialized");
+
+			// A later daemon restart sees consumed durable state: importing it creates
+			// neither a second normal transcript append nor child prompt/provider work.
+			await restartedInternals.closeSession(restartedParent, "shutdown");
+			const secondRestart = new AgentDaemon(join(tempDir, "second-restarted.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: join(tempDir, "sessions") },
+				createRuntime: fixture.createRuntime,
+			});
+			const secondInternals = secondRestart as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				getOrHydrateBoundSessionState(selector: string): Promise<ActiveSessionState>;
+			};
+			const secondParent = await secondInternals.createRuntime({
+				type: "create",
+				sessionPath: fixture.parentSessionFile,
+			});
+			await secondInternals.getOrHydrateBoundSessionState("restart-worker");
+			expect(secondParent.runtime.session.appendDurableRlmTerminalMessage).not.toHaveBeenCalled();
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/daemon-rlm-durable-operations.test.ts
@@ -1,0 +1,155 @@
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { openRlmDurableOperationStore, readRlmDurableOperationRegistry } from "../src/core/rlm-durable-operations.js";
+
+const uuid = (tail: number) => `00000000-0000-4000-8000-${String(tail).padStart(12, "0")}`;
+const roots: string[] = [];
+afterEach(() =>
+	roots.splice(0).forEach((root) => {
+		rmSync(root, { recursive: true, force: true });
+	}),
+);
+
+function createOperation(tail: number) {
+	const root = mkdtempSync(join(tmpdir(), "daemon-rlm-durable-"));
+	roots.push(root);
+	const artifacts = join(root, "artifacts");
+	const parent = join(root, "parent.jsonl");
+	mkdirSync(artifacts);
+	const parentId = uuid(1);
+	writeFileSync(parent, `${JSON.stringify({ type: "session", id: parentId })}\n`);
+	const store = openRlmDurableOperationStore(artifacts);
+	const assignmentId = uuid(tail);
+	const operationId = uuid(tail + 10);
+	const deliveryId = uuid(tail + 20);
+	store.admit({
+		parentSessionId: parentId,
+		parentSessionFile: parent,
+		parentSessionRoot: root,
+		parentArtifactRoot: root,
+		childId: "reused-selector",
+		assignmentId,
+		operationId,
+		deliveryId,
+		childSessionDir: root,
+		requestedModel: { provider: "test", modelId: "test" },
+		rlmDepth: 1,
+		rlmMaxDepth: 2,
+	});
+	return { root, artifacts, store, parentId, assignmentId, operationId, deliveryId };
+}
+
+describe("daemon RLM durable operation identity fences", () => {
+	it("admission is authoritative before work and passive reads neither wake nor write", () => {
+		const f = createOperation(2);
+		const before = readRlmDurableOperationRegistry(f.artifacts);
+		expect(before.operations).toHaveLength(1);
+		expect(before.operations.get(JSON.stringify([f.parentId, f.assignmentId, f.operationId]))?.lifecycle).toBe(
+			"admitted",
+		);
+		// A passive catalog/list projection is reducer-only: no child session, outbox,
+		// inbox, transcript, or prompt task is manufactured merely by inspection.
+		expect(before.deliveries).toHaveLength(0);
+		expect(readRlmDurableOperationRegistry(f.artifacts).operations).toHaveLength(1);
+	});
+
+	it("separates reused-selector A/B operations so stale A cannot release or delete B", () => {
+		const f = createOperation(2);
+		const assignmentB = uuid(3);
+		const operationB = uuid(13);
+		const deliveryB = uuid(23);
+		f.store.admit({
+			parentSessionId: f.parentId,
+			parentSessionFile: join(f.root, "parent.jsonl"),
+			parentSessionRoot: f.root,
+			parentArtifactRoot: f.root,
+			childId: "reused-selector",
+			assignmentId: assignmentB,
+			operationId: operationB,
+			deliveryId: deliveryB,
+			childSessionDir: f.root,
+			requestedModel: { provider: "test", modelId: "test" },
+			rlmDepth: 1,
+			rlmMaxDepth: 2,
+		});
+		// Neither A nor B can transition without its own materialized terminal; in
+		// particular a stale A callback has no selector-only capability over B.
+		expect(
+			f.store.recordRelease(
+				{ parentSessionId: f.parentId, assignmentId: f.assignmentId, operationId: f.operationId },
+				"deleted",
+			),
+		).toBe(false);
+		expect(
+			f.store.recordRelease(
+				{ parentSessionId: f.parentId, assignmentId: assignmentB, operationId: operationB },
+				"deleted",
+			),
+		).toBe(false);
+		const registry = f.store.rebuild();
+		expect(registry.operations.get(JSON.stringify([f.parentId, assignmentB, operationB]))?.lifecycle).toBe(
+			"admitted",
+		);
+	});
+
+	it("keeps late A terminal/release/delete facts disjoint from a reused B operation and parent generation", () => {
+		const f = createOperation(2);
+		const assignmentB = uuid(3);
+		const operationB = uuid(13);
+		const deliveryB = uuid(23);
+		f.store.admit({
+			parentSessionId: f.parentId,
+			parentSessionFile: join(f.root, "parent.jsonl"),
+			parentSessionRoot: f.root,
+			parentArtifactRoot: f.root,
+			childId: "reused-selector",
+			assignmentId: assignmentB,
+			operationId: operationB,
+			deliveryId: deliveryB,
+			childSessionDir: f.root,
+			requestedModel: { provider: "test", modelId: "B-different-operation" },
+			rlmDepth: 1,
+			rlmMaxDepth: 2,
+		});
+		// A's held callback has no B operation capability, even after the daemon
+		// parent incarnation is replaced: no B terminal/outbox/inbox/registry fact.
+		expect(
+			f.store.recordTerminal({
+				parentSessionId: f.parentId,
+				assignmentId: f.assignmentId,
+				operationId: operationB,
+				deliveryId: deliveryB,
+				terminal: "done",
+			}),
+		).toBe(false);
+		expect(
+			f.store.recordRelease(
+				{ parentSessionId: f.parentId, assignmentId: f.assignmentId, operationId: operationB },
+				"deleted",
+			),
+		).toBe(false);
+		const rebuilt = f.store.rebuild();
+		expect(rebuilt.operations.get(JSON.stringify([f.parentId, assignmentB, operationB]))).toMatchObject({
+			lifecycle: "admitted",
+			deliveryId: deliveryB,
+		});
+		expect(rebuilt.deliveries).toHaveLength(0);
+	});
+
+	it("makes passive catalog reduction read-only with pending disk facts", () => {
+		const f = createOperation(2);
+		const before = readdirSync(f.artifacts).sort();
+		const ledgerPath = join(f.artifacts, "rlm-operation-ledger.jsonl");
+		const size = statSync(ledgerPath).size;
+		// This is the same reducer used by list/catalog discovery: it neither opens
+		// child runtime directories nor manufactures indexes, outboxes, inboxes, or
+		// transcript work merely because a durable admission is visible on disk.
+		const passive = readRlmDurableOperationRegistry(f.artifacts);
+		expect(passive.operations).toHaveLength(1);
+		expect(readdirSync(f.artifacts).sort()).toEqual(before);
+		expect(statSync(ledgerPath).size).toBe(size);
+		expect(f.store.pendingInbox()).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/rlm-c04-wire-seam.test.ts
+++ b/packages/coding-agent/test/rlm-c04-wire-seam.test.ts
@@ -1,0 +1,226 @@
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	assertChildResultReference,
+	createRlmChildResultReferenceTerminalMessage,
+	formatRlmChildResultReference,
+	MAX_RLM_CHILD_RESULT_REFERENCE_BYTES,
+	materializedTerminalMessageId,
+	openRlmDurableOperationStore,
+	type RlmChildResultReferenceV1,
+	readRlmDurableOperationRegistry,
+} from "../src/core/rlm-durable-operations.js";
+
+const uuid = (tail: number) => `00000000-0000-4000-8000-${String(tail).padStart(12, "0")}`;
+const parentId = uuid(1);
+const assignmentId = uuid(2);
+const operationId = uuid(3);
+const deliveryId = uuid(4);
+const childSessionId = uuid(5);
+const resultId = uuid(6);
+const handleId = uuid(7);
+const roots: string[] = [];
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function reference(overrides: Partial<RlmChildResultReferenceV1> = {}): RlmChildResultReferenceV1 {
+	return {
+		version: 1,
+		resultId,
+		status: "completed",
+		summary: "completed safely",
+		preview: "safe preview",
+		model: {
+			initialResolvedSelector: "test/initial",
+			terminalResolvedSelector: "test/final",
+			fallbackHistory: ["test/initial"],
+		},
+		artifacts: [
+			{
+				version: 1,
+				handleId,
+				resultId,
+				kind: "terminal_output",
+				contentType: "text/plain",
+				byteLength: 512 * 1024 * 1024,
+				sha256: "a".repeat(64),
+				retentionState: "retained",
+			},
+		],
+		retentionState: "retained",
+		...overrides,
+	};
+}
+
+function fixture() {
+	const root = mkdtempSync(join(tmpdir(), "rlm-c04-wire-"));
+	roots.push(root);
+	const parentArtifacts = join(root, "parent-artifacts");
+	const childArtifacts = join(root, "child-artifacts");
+	mkdirSync(parentArtifacts);
+	mkdirSync(childArtifacts);
+	const parentFile = join(root, "parent.jsonl");
+	const childFile = join(root, "child.jsonl");
+	writeFileSync(parentFile, `${JSON.stringify({ type: "session", id: parentId })}\n`);
+	writeFileSync(childFile, `${JSON.stringify({ type: "session", id: childSessionId })}\n`);
+	const store = openRlmDurableOperationStore(parentArtifacts);
+	store.admit({
+		parentSessionId: parentId,
+		parentSessionFile: parentFile,
+		parentSessionRoot: root,
+		parentArtifactRoot: root,
+		childId: "child",
+		assignmentId,
+		operationId,
+		deliveryId,
+		childSessionDir: root,
+		requestedModel: { provider: "test", modelId: "test" },
+		rlmDepth: 1,
+		rlmMaxDepth: 2,
+	});
+	expect(
+		store.markMaterialized({
+			parentSessionId: parentId,
+			assignmentId,
+			operationId,
+			childSessionId,
+			childSessionFile: childFile,
+			childSessionRoot: root,
+			childArtifactDir: childArtifacts,
+			childArtifactRoot: root,
+		}),
+	).toBe(true);
+	const outbox = (message: ReturnType<typeof createRlmChildResultReferenceTerminalMessage>) => ({
+		parentSessionId: parentId,
+		parentSessionFile: parentFile,
+		parentSessionRoot: root,
+		parentArtifactRoot: root,
+		childSessionId,
+		childSessionFile: childFile,
+		childSessionRoot: root,
+		childArtifactDir: childArtifacts,
+		childArtifactRoot: root,
+		childId: "child",
+		assignmentId,
+		operationId,
+		deliveryId,
+		terminal: "done" as const,
+		message,
+	});
+	return { root, parentArtifacts, childArtifacts, parentFile, childFile, store, outbox };
+}
+
+describe("C03 C04 bounded child-result wire seam", () => {
+	it("accepts an exact C04 projection and deterministically derives the only content", () => {
+		const result = reference();
+		assertChildResultReference(result);
+		const message = createRlmChildResultReferenceTerminalMessage(result, 1);
+		expect(message.content).toBe(formatRlmChildResultReference(result));
+		expect(Buffer.byteLength(message.content)).toBeLessThanOrEqual(MAX_RLM_CHILD_RESULT_REFERENCE_BYTES);
+	});
+
+	it("rejects arbitrary/mismatched content while leaving legacy 24KiB messages unchanged", () => {
+		const result = reference();
+		const message = createRlmChildResultReferenceTerminalMessage(result, 1);
+		const f = fixture();
+		expect(() => f.store.appendOutbox(f.outbox({ ...message, content: "arbitrary" }))).toThrow(/deterministic/);
+		const legacy = {
+			role: "custom" as const,
+			customType: "rlm_child_terminal_notice" as const,
+			content: "x".repeat(24 * 1024),
+			display: true as const,
+			details: { kind: "cancelled" as const, childId: "child", sessionName: "child" },
+			timestamp: 1,
+		};
+		expect(() => f.store.appendOutbox(f.outbox(legacy as never))).toThrow(/too large/);
+	});
+
+	it("round-trips reference-only delivery through outbox, terminal, inbox, restart and materialization", () => {
+		const f = fixture();
+		const message = createRlmChildResultReferenceTerminalMessage(reference(), 1);
+		expect(f.store.appendOutbox(f.outbox(message))).toBe("new");
+		// Store identity compares the canonical message digest, so the exact
+		// projection is idempotent without a second hand-off body.
+		expect(f.store.appendOutbox(f.outbox(createRlmChildResultReferenceTerminalMessage(reference(), 1)))).toBe(
+			"already_recorded",
+		);
+		expect(
+			f.store.recordTerminal({ parentSessionId: parentId, assignmentId, operationId, deliveryId, terminal: "done" }),
+		).toBe(true);
+		expect(f.store.importOutbox(f.outbox(message))).toBe("new");
+		const inbox = f.store.pendingInbox();
+		expect(inbox).toHaveLength(1);
+		expect(inbox[0]!.message).toEqual(message);
+		expect(readFileSync(join(f.childArtifacts, "rlm-terminal-outbox.jsonl"), "utf8")).not.toContain("owner");
+		expect(
+			f.store.markMaterializedDelivery({
+				parentSessionId: parentId,
+				assignmentId,
+				operationId,
+				deliveryId,
+				sessionMessageId: materializedTerminalMessageId(deliveryId),
+			}),
+		).toBe("new");
+		const restarted = openRlmDurableOperationStore(f.parentArtifacts, {
+			trustedChildRecoveryRoots: () => ({
+				childSessionId,
+				childSessionFile: f.childFile,
+				childSessionRoot: f.root,
+				childArtifactDir: f.childArtifacts,
+				childArtifactRoot: f.root,
+			}),
+		});
+		expect(restarted.pendingInbox()).toEqual([]);
+		expect(
+			readRlmDurableOperationRegistry(f.parentArtifacts, () => ({
+				childSessionId,
+				childSessionFile: f.childFile,
+				childSessionRoot: f.root,
+				childArtifactDir: f.childArtifacts,
+				childArtifactRoot: f.root,
+			})).deliveries.size,
+		).toBe(1);
+	});
+
+	it("fails closed for unknown/nested owner/path/body, bad UUID/digest, duplicate handles, mismatch and malformed JSONL", () => {
+		const bads: unknown[] = [
+			{ ...reference(), owner: {} },
+			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, owner: { parentSessionId: parentId } }] },
+			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, path: "/private/secret" }] },
+			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, body: "secret" }] },
+			{ ...reference(), resultId: "not-a-v4" },
+			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, sha256: "A".repeat(64) }] },
+			{ ...reference(), artifacts: [reference().artifacts[0]!, reference().artifacts[0]!] },
+			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, resultId: uuid(8) }] },
+			{ ...reference(), status: "completed", error: { code: "invalid_result", message: "no" } },
+			{ ...reference(), status: "failed", error: undefined },
+		];
+		for (const candidate of bads) expect(() => assertChildResultReference(candidate)).toThrow();
+		const f = fixture();
+		appendFileSync(join(f.parentArtifacts, "rlm-terminal-inbox.jsonl"), "{bad}\n");
+		expect(readRlmDurableOperationRegistry(f.parentArtifacts).hasUncertainRecords).toBe(true);
+	});
+
+	it("enforces Unicode scalar and UTF-8 byte bounds and the 64KiB projection cap", () => {
+		expect(() => assertChildResultReference(reference({ summary: "😀".repeat(4097) }))).toThrow();
+		expect(() => assertChildResultReference(reference({ preview: "😀".repeat(2049) }))).toThrow();
+		expect(() => assertChildResultReference(reference({ summary: "𐀀".repeat(4097) }))).toThrow();
+		const huge = reference({
+			artifacts: Array.from({ length: 16 }, (_, index) => ({
+				...reference().artifacts[0]!,
+				handleId: uuid(index + 20),
+			})),
+		});
+		huge.summary = "𐀀".repeat(4096);
+		huge.preview = "𐀀".repeat(2048);
+		huge.model = {
+			initialResolvedSelector: "𐀀".repeat(512),
+			terminalResolvedSelector: "𐀀".repeat(512),
+			fallbackHistory: Array.from({ length: 16 }, () => "𐀀".repeat(512)),
+		};
+		expect(() => assertChildResultReference(huge)).toThrow(/too large/);
+	});
+});

--- a/packages/coding-agent/test/rlm-c04-wire-seam.test.ts
+++ b/packages/coding-agent/test/rlm-c04-wire-seam.test.ts
@@ -3,13 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	assertChildResultReference,
-	createRlmChildResultReferenceTerminalMessage,
-	formatRlmChildResultReference,
-	MAX_RLM_CHILD_RESULT_REFERENCE_BYTES,
+	createRlmSafeTerminalResultTerminalMessage,
+	MAX_RLM_SAFE_TERMINAL_MESSAGE_BYTES,
 	materializedTerminalMessageId,
 	openRlmDurableOperationStore,
-	type RlmChildResultReferenceV1,
 	readRlmDurableOperationRegistry,
 } from "../src/core/rlm-durable-operations.js";
 
@@ -19,44 +16,13 @@ const assignmentId = uuid(2);
 const operationId = uuid(3);
 const deliveryId = uuid(4);
 const childSessionId = uuid(5);
-const resultId = uuid(6);
-const handleId = uuid(7);
 const roots: string[] = [];
 afterEach(() => {
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-function reference(overrides: Partial<RlmChildResultReferenceV1> = {}): RlmChildResultReferenceV1 {
-	return {
-		version: 1,
-		resultId,
-		status: "completed",
-		summary: "completed safely",
-		preview: "safe preview",
-		model: {
-			initialResolvedSelector: "test/initial",
-			terminalResolvedSelector: "test/final",
-			fallbackHistory: ["test/initial"],
-		},
-		artifacts: [
-			{
-				version: 1,
-				handleId,
-				resultId,
-				kind: "terminal_output",
-				contentType: "text/plain",
-				byteLength: 512 * 1024 * 1024,
-				sha256: "a".repeat(64),
-				retentionState: "retained",
-			},
-		],
-		retentionState: "retained",
-		...overrides,
-	};
-}
-
 function fixture() {
-	const root = mkdtempSync(join(tmpdir(), "rlm-c04-wire-"));
+	const root = mkdtempSync(join(tmpdir(), "rlm-safe-terminal-"));
 	roots.push(root);
 	const parentArtifacts = join(root, "parent-artifacts");
 	const childArtifacts = join(root, "child-artifacts");
@@ -93,7 +59,7 @@ function fixture() {
 			childArtifactRoot: root,
 		}),
 	).toBe(true);
-	const outbox = (message: ReturnType<typeof createRlmChildResultReferenceTerminalMessage>) => ({
+	const outbox = (message: ReturnType<typeof createRlmSafeTerminalResultTerminalMessage>) => ({
 		parentSessionId: parentId,
 		parentSessionFile: parentFile,
 		parentSessionRoot: root,
@@ -110,23 +76,45 @@ function fixture() {
 		terminal: "done" as const,
 		message,
 	});
-	return { root, parentArtifacts, childArtifacts, parentFile, childFile, store, outbox };
+	return { root, parentArtifacts, childArtifacts, childFile, store, outbox };
 }
 
-describe("C03 C04 bounded child-result wire seam", () => {
-	it("accepts an exact C04 projection and deterministically derives the only content", () => {
-		const result = reference();
-		assertChildResultReference(result);
-		const message = createRlmChildResultReferenceTerminalMessage(result, 1);
-		expect(message.content).toBe(formatRlmChildResultReference(result));
-		expect(Buffer.byteLength(message.content)).toBeLessThanOrEqual(MAX_RLM_CHILD_RESULT_REFERENCE_BYTES);
+describe("C03 generic safe-terminal envelope", () => {
+	it("uses only the exact generic keys and retains the opaque projection verbatim", () => {
+		const projection = '{"unrelated":true,"nested":{"anything":"caller-owned"}}';
+		const message = createRlmSafeTerminalResultTerminalMessage("human presentation", projection, 1);
+		expect(message).toEqual({
+			role: "custom",
+			customType: "rlm_safe_terminal_result",
+			content: "human presentation",
+			display: true,
+			details: { kind: "safe_terminal_result_v1", projection },
+			timestamp: 1,
+		});
+		expect(Object.keys(message.details).sort()).toEqual(["kind", "projection"]);
 	});
 
-	it("rejects arbitrary/mismatched content while leaving legacy 24KiB messages unchanged", () => {
-		const result = reference();
-		const message = createRlmChildResultReferenceTerminalMessage(result, 1);
+	it("permits caller-owned mismatched presentation without interpreting projection", () => {
 		const f = fixture();
-		expect(() => f.store.appendOutbox(f.outbox({ ...message, content: "arbitrary" }))).toThrow(/deterministic/);
+		const message = createRlmSafeTerminalResultTerminalMessage("status unavailable", '{"status":"completed"}', 1);
+		expect(() => f.store.appendOutbox(f.outbox(message))).not.toThrow();
+	});
+
+	it("rejects unknown envelope keys and the full near-cap overflow while legacy remains 24KiB", () => {
+		const f = fixture();
+		const valid = createRlmSafeTerminalResultTerminalMessage("presentation", "{}", 1);
+		expect(() =>
+			f.store.appendOutbox(f.outbox({ ...valid, details: { ...valid.details, extra: true } } as never)),
+		).toThrow(/details/);
+		const base = createRlmSafeTerminalResultTerminalMessage("presentation", "", 1);
+		const overhead = Buffer.byteLength(JSON.stringify(base));
+		expect(() =>
+			createRlmSafeTerminalResultTerminalMessage(
+				"presentation",
+				"x".repeat(MAX_RLM_SAFE_TERMINAL_MESSAGE_BYTES - overhead + 32),
+				1,
+			),
+		).toThrow(/too large/);
 		const legacy = {
 			role: "custom" as const,
 			customType: "rlm_child_terminal_notice" as const,
@@ -138,23 +126,24 @@ describe("C03 C04 bounded child-result wire seam", () => {
 		expect(() => f.store.appendOutbox(f.outbox(legacy as never))).toThrow(/too large/);
 	});
 
-	it("round-trips reference-only delivery through outbox, terminal, inbox, restart and materialization", () => {
+	it("stores the exact message once with deterministic digest, import, restart, and materialization", () => {
 		const f = fixture();
-		const message = createRlmChildResultReferenceTerminalMessage(reference(), 1);
+		const message = createRlmSafeTerminalResultTerminalMessage("arbitrary presentation", '{"safe":"opaque"}', 1);
 		expect(f.store.appendOutbox(f.outbox(message))).toBe("new");
-		// Store identity compares the canonical message digest, so the exact
-		// projection is idempotent without a second hand-off body.
-		expect(f.store.appendOutbox(f.outbox(createRlmChildResultReferenceTerminalMessage(reference(), 1)))).toBe(
-			"already_recorded",
-		);
+		expect(
+			f.store.appendOutbox(
+				f.outbox(createRlmSafeTerminalResultTerminalMessage("arbitrary presentation", '{"safe":"opaque"}', 1)),
+			),
+		).toBe("already_recorded");
 		expect(
 			f.store.recordTerminal({ parentSessionId: parentId, assignmentId, operationId, deliveryId, terminal: "done" }),
 		).toBe(true);
 		expect(f.store.importOutbox(f.outbox(message))).toBe("new");
-		const inbox = f.store.pendingInbox();
-		expect(inbox).toHaveLength(1);
-		expect(inbox[0]!.message).toEqual(message);
-		expect(readFileSync(join(f.childArtifacts, "rlm-terminal-outbox.jsonl"), "utf8")).not.toContain("owner");
+		expect(f.store.pendingInbox()).toHaveLength(1);
+		expect(f.store.pendingInbox()[0]!.message).toEqual(message);
+		expect(readFileSync(join(f.childArtifacts, "rlm-terminal-outbox.jsonl"), "utf8")).toContain(
+			JSON.stringify(message.details.projection),
+		);
 		expect(
 			f.store.markMaterializedDelivery({
 				parentSessionId: parentId,
@@ -185,42 +174,9 @@ describe("C03 C04 bounded child-result wire seam", () => {
 		).toBe(1);
 	});
 
-	it("fails closed for unknown/nested owner/path/body, bad UUID/digest, duplicate handles, mismatch and malformed JSONL", () => {
-		const bads: unknown[] = [
-			{ ...reference(), owner: {} },
-			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, owner: { parentSessionId: parentId } }] },
-			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, path: "/private/secret" }] },
-			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, body: "secret" }] },
-			{ ...reference(), resultId: "not-a-v4" },
-			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, sha256: "A".repeat(64) }] },
-			{ ...reference(), artifacts: [reference().artifacts[0]!, reference().artifacts[0]!] },
-			{ ...reference(), artifacts: [{ ...reference().artifacts[0]!, resultId: uuid(8) }] },
-			{ ...reference(), status: "completed", error: { code: "invalid_result", message: "no" } },
-			{ ...reference(), status: "failed", error: undefined },
-		];
-		for (const candidate of bads) expect(() => assertChildResultReference(candidate)).toThrow();
+	it("retains malformed JSONL recovery without introducing a provider or queue path", () => {
 		const f = fixture();
 		appendFileSync(join(f.parentArtifacts, "rlm-terminal-inbox.jsonl"), "{bad}\n");
 		expect(readRlmDurableOperationRegistry(f.parentArtifacts).hasUncertainRecords).toBe(true);
-	});
-
-	it("enforces Unicode scalar and UTF-8 byte bounds and the 64KiB projection cap", () => {
-		expect(() => assertChildResultReference(reference({ summary: "😀".repeat(4097) }))).toThrow();
-		expect(() => assertChildResultReference(reference({ preview: "😀".repeat(2049) }))).toThrow();
-		expect(() => assertChildResultReference(reference({ summary: "𐀀".repeat(4097) }))).toThrow();
-		const huge = reference({
-			artifacts: Array.from({ length: 16 }, (_, index) => ({
-				...reference().artifacts[0]!,
-				handleId: uuid(index + 20),
-			})),
-		});
-		huge.summary = "𐀀".repeat(4096);
-		huge.preview = "𐀀".repeat(2048);
-		huge.model = {
-			initialResolvedSelector: "𐀀".repeat(512),
-			terminalResolvedSelector: "𐀀".repeat(512),
-			fallbackHistory: Array.from({ length: 16 }, () => "𐀀".repeat(512)),
-		};
-		expect(() => assertChildResultReference(huge)).toThrow(/too large/);
 	});
 });

--- a/packages/coding-agent/test/rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/rlm-durable-operations.test.ts
@@ -284,7 +284,7 @@ describe("RLM durable operation store", () => {
 		).toBe("already_materialized");
 	});
 
-	it("only ignores a malformed non-newline final tail; malformed interior becomes uncertainty", () => {
+	it("ignores and repairs every non-newline final tail before a subsequent append", () => {
 		const f = fixture();
 		const store = openRlmDurableOperationStore(f.parentArtifacts);
 		store.admit(f.admission);
@@ -293,6 +293,17 @@ describe("RLM durable operation store", () => {
 		expect(readRlmDurableOperationRegistry(f.parentArtifacts).hasUncertainRecords).toBe(false);
 		appendFileSync(ledger, "\n");
 		expect(readRlmDurableOperationRegistry(f.parentArtifacts).hasUncertainRecords).toBe(true);
+
+		const g = fixture();
+		const torn = openRlmDurableOperationStore(g.parentArtifacts);
+		torn.admit(g.admission);
+		const tornLedger = join(g.parentArtifacts, "rlm-operation-ledger.jsonl");
+		const complete = readFileSync(tornLedger, "utf8").trimEnd();
+		writeFileSync(tornLedger, complete);
+		expect(readRlmDurableOperationRegistry(g.parentArtifacts).operations.size).toBe(0);
+		torn.admit(g.admission);
+		expect(readRlmDurableOperationRegistry(g.parentArtifacts).operations.size).toBe(1);
+		expect(readFileSync(tornLedger, "utf8")).toMatch(/\n$/);
 	});
 
 	it("rejects UUID, terminal projection, traversal, symlink escape, and forged session identity", () => {

--- a/packages/coding-agent/test/rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/rlm-durable-operations.test.ts
@@ -128,7 +128,13 @@ function outboxRecord(input: ReturnType<typeof outbox>): Record<string, unknown>
 }
 
 function trustedRoots(f: Fixture) {
-	return () => ({ childSessionRoot: f.root, childArtifactRoot: f.root });
+	return () => ({
+		childSessionId,
+		childSessionFile: f.childFile,
+		childSessionRoot: f.root,
+		childArtifactDir: f.childArtifacts,
+		childArtifactRoot: f.root,
+	});
 }
 function appendRecord(path: string, record: Record<string, unknown>): void {
 	appendFileSync(path, `${JSON.stringify(record)}\n`);
@@ -368,12 +374,35 @@ describe("RLM durable operation store", () => {
 			}),
 		).toBe("already_discarded");
 	});
-	it("never opens a persisted child artifact without matching session-manager roots and identity", () => {
+	it("refuses alternate contained artifacts for both outbox append and import", () => {
 		const f = fixture();
+		const alternate = join(f.root, "alternate-child-artifacts");
+		mkdirSync(alternate);
 		const store = openRlmDurableOperationStore(f.parentArtifacts);
 		store.admit(f.admission);
-		const foreign = join(f.root, "foreign-artifacts");
-		mkdirSync(foreign);
+		materialize(store, f);
+		const stranded = { ...outbox(f), childArtifactDir: alternate };
+		expect(() => store.appendOutbox(stranded)).toThrow(/conflicts/);
+		store.appendOutbox(outbox(f));
+		store.recordTerminal({
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			deliveryId: delivery,
+			terminal: "done",
+		});
+		expect(() => store.importOutbox(stranded)).toThrow(/conflicts/);
+		expect(() => readFileSync(join(alternate, "rlm-terminal-outbox.jsonl"), "utf8")).toThrow();
+	});
+
+	it("does not authorize a raw outbox stranded in an alternate contained artifact", () => {
+		const f = fixture();
+		const alternate = join(f.root, "raw-alternate-child-artifacts");
+		mkdirSync(alternate);
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		// Simulate an old/wrong writer by placing otherwise valid production facts
+		// directly in JSONL, with the outbox under a contained but non-materialized dir.
 		appendRecord(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), {
 			version: 1,
 			type: "materialized",
@@ -383,14 +412,136 @@ describe("RLM durable operation store", () => {
 			childSessionId,
 			childSessionFile: f.childFile,
 			childSessionRoot: f.root,
-			childArtifactDir: foreign,
-			childArtifactRoot: foreign,
+			childArtifactDir: f.childArtifacts,
+			childArtifactRoot: f.root,
 			recordedAt: new Date().toISOString(),
 		});
-		appendRecord(join(foreign, "rlm-terminal-outbox.jsonl"), outboxRecord(outbox(f)));
+		appendRecord(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), {
+			version: 1,
+			type: "terminal_recorded",
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			deliveryId: delivery,
+			terminal: "done",
+			recordedAt: new Date().toISOString(),
+		});
+		appendRecord(
+			join(alternate, "rlm-terminal-outbox.jsonl"),
+			outboxRecord({ ...outbox(f), childArtifactDir: alternate }),
+		);
+		const rebuilt = readRlmDurableOperationRegistry(f.parentArtifacts, trustedRoots(f));
+		const key = JSON.stringify([parentId, assignment, operation]);
+		const rawDelivery = rebuilt.deliveries.get(JSON.stringify([key, delivery]));
+		expect(rebuilt.operations.get(key)?.uncertain).toBe(true);
+		expect(rawDelivery?.outboxed).toBe(false);
+		expect(rawDelivery?.uncertain).toBe(true);
+	});
+
+	it("does not authorize a raw sibling-session/artifact substitution under trusted broad roots", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		const siblingSessionId = uuid(7);
+		const siblingFile = join(f.childSessions, "sibling.jsonl");
+		const siblingArtifacts = join(f.root, "sibling-artifacts");
+		session(siblingFile, siblingSessionId);
+		mkdirSync(siblingArtifacts);
+		// These are raw production JSONL facts, not calls to materialization helpers.
+		appendRecord(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), {
+			version: 1,
+			type: "materialized",
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			childSessionId: siblingSessionId,
+			childSessionFile: siblingFile,
+			childSessionRoot: f.root,
+			childArtifactDir: siblingArtifacts,
+			childArtifactRoot: f.root,
+			recordedAt: new Date().toISOString(),
+		});
+		appendRecord(
+			join(siblingArtifacts, "rlm-terminal-outbox.jsonl"),
+			outboxRecord({ ...outbox(f), childSessionId: siblingSessionId, childSessionFile: siblingFile }),
+		);
 		const rebuilt = readRlmDurableOperationRegistry(f.parentArtifacts, trustedRoots(f));
 		expect(rebuilt.operations.get(JSON.stringify([parentId, assignment, operation]))?.uncertain).toBe(true);
 		expect(rebuilt.deliveries.size).toBe(0);
+	});
+
+	it("marks a raw terminal ledger fact without its durable outbox uncertain after restart", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		appendRecord(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), {
+			version: 1,
+			type: "materialized",
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			childSessionId,
+			childSessionFile: f.childFile,
+			childSessionRoot: f.root,
+			childArtifactDir: f.childArtifacts,
+			childArtifactRoot: f.root,
+			recordedAt: new Date().toISOString(),
+		});
+		appendRecord(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), {
+			version: 1,
+			type: "terminal_recorded",
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			deliveryId: delivery,
+			terminal: "done",
+			recordedAt: new Date().toISOString(),
+		});
+		const restarted = openRlmDurableOperationStore(f.parentArtifacts, { trustedChildRecoveryRoots: trustedRoots(f) });
+		const rebuilt = restarted.rebuild();
+		const key = JSON.stringify([parentId, assignment, operation]);
+		const deliveryKey = JSON.stringify([key, delivery]);
+		expect(rebuilt.operations.get(key)?.uncertain).toBe(true);
+		expect(rebuilt.deliveries.get(deliveryKey)?.outboxed).toBe(false);
+		expect(rebuilt.deliveries.get(deliveryKey)?.uncertain).toBe(true);
+		expect(() => restarted.importOutbox(outbox(f))).toThrow(/exact materialized/);
+	});
+
+	it("fails closed on raw deleted-then-terminal ledger ordering", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		appendRecord(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), {
+			version: 1,
+			type: "materialized",
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			childSessionId,
+			childSessionFile: f.childFile,
+			childSessionRoot: f.root,
+			childArtifactDir: f.childArtifacts,
+			childArtifactRoot: f.root,
+			recordedAt: new Date().toISOString(),
+		});
+		for (const type of ["deleted", "terminal_recorded"] as const) {
+			appendRecord(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), {
+				version: 1,
+				type,
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				...(type === "terminal_recorded" ? { deliveryId: delivery, terminal: "done" } : {}),
+				recordedAt: new Date().toISOString(),
+			});
+		}
+		const rebuilt = readRlmDurableOperationRegistry(f.parentArtifacts, trustedRoots(f));
+		const key = JSON.stringify([parentId, assignment, operation]);
+		const rawDelivery = rebuilt.deliveries.get(JSON.stringify([key, delivery]));
+		expect(rebuilt.operations.get(key)?.uncertain).toBe(true);
+		expect(rebuilt.hasUncertainRecords).toBe(true);
+		expect(rawDelivery?.outboxed).toBe(false);
+		expect(rawDelivery?.uncertain).toBe(true);
 	});
 
 	it("cryptographically binds inbox immutable facts and body to the durable outbox", () => {

--- a/packages/coding-agent/test/rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/rlm-durable-operations.test.ts
@@ -92,7 +92,7 @@ function message(content = "terminal"): RlmTerminalMessage {
 		customType: "rlm_child_terminal_notice",
 		content,
 		display: true,
-		details: { kind: "cancelled" },
+		details: { kind: "cancelled", childId, sessionName: "child" },
 		timestamp: 1,
 	};
 }
@@ -115,6 +115,25 @@ function outbox(f: Fixture, terminal: "done" | "error" | "cancelled" = "done", c
 		message: message(content),
 	};
 }
+function outboxRecord(input: ReturnType<typeof outbox>): Record<string, unknown> {
+	const {
+		parentSessionRoot: _parentSessionRoot,
+		parentArtifactRoot: _parentArtifactRoot,
+		childSessionRoot: _childSessionRoot,
+		childArtifactDir: _childArtifactDir,
+		childArtifactRoot: _childArtifactRoot,
+		...record
+	} = input;
+	return { version: 1, type: "terminal", ...record, recordedAt: new Date().toISOString() };
+}
+
+function trustedRoots(f: Fixture) {
+	return () => ({ childSessionRoot: f.root, childArtifactRoot: f.root });
+}
+function appendRecord(path: string, record: Record<string, unknown>): void {
+	appendFileSync(path, `${JSON.stringify(record)}\n`);
+}
+
 function materialize(store: ReturnType<typeof openRlmDurableOperationStore>, f: Fixture): void {
 	expect(
 		store.markMaterialized({
@@ -187,7 +206,7 @@ describe("RLM durable operation store", () => {
 		// A physically injected second body is never last-write-wins.
 		appendFileSync(
 			join(f.childArtifacts, "rlm-terminal-outbox.jsonl"),
-			`${JSON.stringify({ version: 1, type: "terminal", ...outbox(f, "done", "different"), recordedAt: new Date().toISOString() })}\n`,
+			`${JSON.stringify(outboxRecord(outbox(f, "done", "different")))}\n`,
 		);
 		const rebuilt = readRlmDurableOperationRegistry(f.parentArtifacts);
 		expect(rebuilt.operations.get(JSON.stringify([parentId, assignment, operation]))?.uncertain).toBe(true);
@@ -348,5 +367,138 @@ describe("RLM durable operation store", () => {
 				reason: "deleted",
 			}),
 		).toBe("already_discarded");
+	});
+	it("never opens a persisted child artifact without matching session-manager roots and identity", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		const foreign = join(f.root, "foreign-artifacts");
+		mkdirSync(foreign);
+		appendRecord(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), {
+			version: 1,
+			type: "materialized",
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			childSessionId,
+			childSessionFile: f.childFile,
+			childSessionRoot: f.root,
+			childArtifactDir: foreign,
+			childArtifactRoot: foreign,
+			recordedAt: new Date().toISOString(),
+		});
+		appendRecord(join(foreign, "rlm-terminal-outbox.jsonl"), outboxRecord(outbox(f)));
+		const rebuilt = readRlmDurableOperationRegistry(f.parentArtifacts, trustedRoots(f));
+		expect(rebuilt.operations.get(JSON.stringify([parentId, assignment, operation]))?.uncertain).toBe(true);
+		expect(rebuilt.deliveries.size).toBe(0);
+	});
+
+	it("cryptographically binds inbox immutable facts and body to the durable outbox", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		materialize(store, f);
+		store.appendOutbox(outbox(f));
+		store.recordTerminal({
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			deliveryId: delivery,
+			terminal: "done",
+		});
+		const { recordedAt: _recordedAt, ...fact } = outboxRecord(outbox(f)) as Record<string, unknown>;
+		appendRecord(join(f.parentArtifacts, "rlm-terminal-inbox.jsonl"), {
+			...fact,
+			type: "received",
+			parentSessionFile: f.childFile,
+			receivedAt: new Date().toISOString(),
+		});
+		const rebuilt = readRlmDurableOperationRegistry(f.parentArtifacts, trustedRoots(f));
+		const key = JSON.stringify([JSON.stringify([parentId, assignment, operation]), delivery]);
+		expect(rebuilt.deliveries.get(key)?.uncertain).toBe(true);
+		expect(rebuilt.deliveries.get(key)?.received).toBe(false);
+	});
+
+	it("rejects unknown record/message fields and forged consumed ids during reduction", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		appendRecord(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), {
+			...f.admission,
+			version: 1,
+			type: "admitted",
+			recordedAt: new Date().toISOString(),
+			surprise: "provider body",
+		});
+		expect(readRlmDurableOperationRegistry(f.parentArtifacts).hasUncertainRecords).toBe(true);
+		const unsafe = { ...message(), customType: "agent_message", details: { stack: "secret" } };
+		expect(() => store.appendOutbox({ ...outbox(f), message: unsafe as never })).toThrow(/approved/);
+	});
+
+	it("enforces terminal-before-release and rejects terminal resurrection after an exact deletion", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts) as ReturnType<
+			typeof openRlmDurableOperationStore
+		> & {
+			recordRelease: (
+				input: { parentSessionId: string; assignmentId: string; operationId: string },
+				type: "released" | "deleted",
+			) => boolean;
+		};
+		store.admit(f.admission);
+		expect(
+			store.recordRelease(
+				{ parentSessionId: parentId, assignmentId: assignment, operationId: operation },
+				"deleted",
+			),
+		).toBe(false);
+		materialize(store, f);
+		store.appendOutbox(outbox(f));
+		expect(
+			store.recordTerminal({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				terminal: "done",
+			}),
+		).toBe(true);
+		expect(
+			store.recordRelease(
+				{ parentSessionId: parentId, assignmentId: assignment, operationId: operation },
+				"deleted",
+			),
+		).toBe(true);
+		expect(
+			store.recordTerminal({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				terminal: "done",
+			}),
+		).toBe(false);
+	});
+
+	it("does not advance terminal/import authority across outbox or inbox fsync cuts", () => {
+		const f = fixture();
+		let cutNow = false;
+		const cut = {
+			...fs,
+			fsyncSync: (fd: number) => {
+				if (cutNow) throw new Error("outbox fsync cut");
+				return fs.fsyncSync(fd);
+			},
+		} as unknown as RlmDurableIo;
+		const store = openRlmDurableOperationStore(f.parentArtifacts, { io: cut });
+		store.admit(f.admission);
+		materialize(store, f);
+		cutNow = true;
+		expect(() => store.appendOutbox(outbox(f))).toThrow(/fsync cut/);
+		// The append was never reported as durable; callers must not advance to
+		// the terminal/inbox steps on an I/O cut.
+		expect(readFileSync(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"), "utf8")).not.toContain(
+			"terminal_recorded",
+		);
 	});
 });

--- a/packages/coding-agent/test/rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/rlm-durable-operations.test.ts
@@ -675,4 +675,84 @@ describe("RLM durable operation store", () => {
 			"terminal_recorded",
 		);
 	});
+
+	it("retains inbox and consumed facts across independent fsync cuts, then retries one delivery", () => {
+		const f = fixture();
+		const fdPaths = new Map<number, string>();
+		let failInbox = false;
+		let failConsumed = false;
+		const io = {
+			...fs,
+			openSync: ((path: fs.PathLike, flags: string | number, mode?: fs.Mode) => {
+				const fd = fs.openSync(path, flags, mode);
+				fdPaths.set(fd, String(path));
+				return fd;
+			}) as typeof fs.openSync,
+			closeSync: ((fd: number) => {
+				fdPaths.delete(fd);
+				return fs.closeSync(fd);
+			}) as typeof fs.closeSync,
+			fsyncSync: ((fd: number) => {
+				const path = fdPaths.get(fd) ?? "";
+				if (failInbox && path.endsWith("rlm-terminal-inbox.jsonl")) throw new Error("inbox fsync cut");
+				if (failConsumed && path.endsWith("rlm-terminal-consumed.jsonl")) throw new Error("consumed fsync cut");
+				return fs.fsyncSync(fd);
+			}) as typeof fs.fsyncSync,
+		} as unknown as RlmDurableIo;
+		const store = openRlmDurableOperationStore(f.parentArtifacts, { io, trustedChildRecoveryRoots: trustedRoots(f) });
+		store.admit(f.admission);
+		materialize(store, f);
+		store.appendOutbox(outbox(f));
+		store.recordTerminal({
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			deliveryId: delivery,
+			terminal: "done",
+		});
+
+		failInbox = true;
+		expect(() => store.importOutbox(outbox(f))).toThrow("inbox fsync cut");
+		// The receiver cannot advance to consumed after the failed acknowledgement.
+		expect(
+			openRlmDurableOperationStore(f.parentArtifacts, { trustedChildRecoveryRoots: trustedRoots(f) }).pendingInbox(),
+		).toHaveLength(1);
+		failInbox = false;
+		const afterInboxRestart = openRlmDurableOperationStore(f.parentArtifacts, {
+			io,
+			trustedChildRecoveryRoots: trustedRoots(f),
+		});
+		expect(afterInboxRestart.importOutbox(outbox(f))).toBe("already_received");
+		expect(afterInboxRestart.pendingInbox()).toHaveLength(1);
+
+		// Model the real transcript's deterministic id. A consumed fsync cut leaves
+		// this transcript fact and the durable inbox visible to the next importer.
+		const transcriptIds = new Set<string>();
+		transcriptIds.add(materializedTerminalMessageId(delivery));
+		failConsumed = true;
+		expect(() =>
+			afterInboxRestart.markMaterializedDelivery({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				sessionMessageId: materializedTerminalMessageId(delivery),
+			}),
+		).toThrow("consumed fsync cut");
+		const afterConsumedRestart = openRlmDurableOperationStore(f.parentArtifacts, {
+			trustedChildRecoveryRoots: trustedRoots(f),
+		});
+		expect(afterConsumedRestart.pendingInbox()).toHaveLength(0);
+		expect(transcriptIds).toEqual(new Set([materializedTerminalMessageId(delivery)]));
+		failConsumed = false;
+		expect(
+			afterConsumedRestart.markMaterializedDelivery({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				sessionMessageId: materializedTerminalMessageId(delivery),
+			}),
+		).toBe("already_materialized");
+	});
 });

--- a/packages/coding-agent/test/rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/rlm-durable-operations.test.ts
@@ -1,0 +1,352 @@
+import * as fs from "node:fs";
+import {
+	appendFileSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	materializedTerminalMessageId,
+	openRlmDurableOperationStore,
+	type RlmDurableIo,
+	type RlmTerminalMessage,
+	readRlmDurableOperationRegistry,
+} from "../src/core/rlm-durable-operations.js";
+
+const uuid = (tail: number) => `00000000-0000-4000-8000-${String(tail).padStart(12, "0")}`;
+const parentId = uuid(1);
+const assignment = uuid(2);
+const operation = uuid(3);
+const delivery = uuid(4);
+const childId = uuid(5);
+const childSessionId = uuid(6);
+
+interface Fixture {
+	root: string;
+	parentFile: string;
+	childFile: string;
+	parentArtifacts: string;
+	childArtifacts: string;
+	childSessions: string;
+	admission: ReturnType<typeof admission>;
+}
+const roots: string[] = [];
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function session(path: string, id: string): void {
+	writeFileSync(path, `${JSON.stringify({ type: "session", id, version: 3 })}\n`);
+}
+function fixture(): Fixture {
+	const root = mkdtempSync(join(tmpdir(), "rlm-durable-"));
+	roots.push(root);
+	const parentSessions = join(root, "parent-sessions");
+	const childSessions = join(root, "child-sessions");
+	const parentArtifacts = join(root, "parent-artifacts");
+	const childArtifacts = join(root, "child-artifacts");
+	mkdirSync(parentSessions);
+	mkdirSync(childSessions);
+	mkdirSync(parentArtifacts);
+	mkdirSync(childArtifacts);
+	const parentFile = join(parentSessions, "parent.jsonl");
+	const childFile = join(childSessions, "child.jsonl");
+	session(parentFile, parentId);
+	session(childFile, childSessionId);
+	return {
+		root,
+		parentFile,
+		childFile,
+		parentArtifacts,
+		childArtifacts,
+		childSessions,
+		admission: admission(parentFile, root, parentArtifacts, childSessions),
+	};
+}
+function admission(parentFile: string, root: string, _parentArtifacts: string, childSessions: string) {
+	return {
+		parentSessionId: parentId,
+		parentSessionFile: parentFile,
+		parentSessionRoot: root,
+		parentArtifactRoot: root,
+		childId,
+		assignmentId: assignment,
+		operationId: operation,
+		deliveryId: delivery,
+		childSessionDir: childSessions,
+		requestedModel: { provider: "test", modelId: "model" },
+		rlmDepth: 1,
+		rlmMaxDepth: 2,
+	};
+}
+function message(content = "terminal"): RlmTerminalMessage {
+	return {
+		role: "custom",
+		customType: "rlm_child_terminal_notice",
+		content,
+		display: true,
+		details: { kind: "cancelled" },
+		timestamp: 1,
+	};
+}
+function outbox(f: Fixture, terminal: "done" | "error" | "cancelled" = "done", content = "terminal") {
+	return {
+		parentSessionId: parentId,
+		parentSessionFile: f.parentFile,
+		parentSessionRoot: f.root,
+		parentArtifactRoot: f.root,
+		childSessionId,
+		childSessionFile: f.childFile,
+		childSessionRoot: f.root,
+		childArtifactDir: f.childArtifacts,
+		childArtifactRoot: f.root,
+		childId,
+		assignmentId: assignment,
+		operationId: operation,
+		deliveryId: delivery,
+		terminal,
+		message: message(content),
+	};
+}
+function materialize(store: ReturnType<typeof openRlmDurableOperationStore>, f: Fixture): void {
+	expect(
+		store.markMaterialized({
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			childSessionId,
+			childSessionFile: f.childFile,
+			childSessionRoot: f.root,
+			childArtifactDir: f.childArtifacts,
+			childArtifactRoot: f.root,
+		}),
+	).toBe(true);
+}
+
+function mode(path: string): number {
+	return lstatSync(path).mode & 0o777;
+}
+
+describe("RLM durable operation store", () => {
+	it("records sibling session/artifact layout with owner-only durable files and deterministic ids", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		const admitted = store.admit(f.admission);
+		expect(admitted.lifecycle).toBe("admitted");
+		expect(mode(f.parentArtifacts)).toBe(0o700);
+		expect(mode(join(f.parentArtifacts, "rlm-operation-ledger.jsonl"))).toBe(0o600);
+		expect(materializedTerminalMessageId(delivery)).toBe(`rlm-terminal-${delivery}`);
+		materialize(store, f);
+		expect(store.appendOutbox(outbox(f))).toBe("new");
+		expect(mode(join(f.childArtifacts, "rlm-terminal-outbox.jsonl"))).toBe(0o600);
+		expect(
+			store.recordTerminal({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				terminal: "done",
+			}),
+		).toBe(true);
+		expect(store.importOutbox(outbox(f))).toBe("new");
+		expect(
+			store.markMaterializedDelivery({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				sessionMessageId: materializedTerminalMessageId(delivery),
+			}),
+		).toBe("new");
+		expect(mode(join(f.parentArtifacts, "rlm-terminal-consumed.jsonl"))).toBe(0o600);
+	});
+
+	it("makes exact duplicates idempotent and conflicting terminal body uncertain/fail-closed", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		expect(store.admit(f.admission).key).toContain(operation);
+		materialize(store, f);
+		expect(store.appendOutbox(outbox(f))).toBe("new");
+		expect(store.appendOutbox(outbox(f))).toBe("already_recorded");
+		expect(() => store.appendOutbox(outbox(f, "done", "different"))).toThrow(/Conflicting/);
+		store.recordTerminal({
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			deliveryId: delivery,
+			terminal: "done",
+		});
+		// A physically injected second body is never last-write-wins.
+		appendFileSync(
+			join(f.childArtifacts, "rlm-terminal-outbox.jsonl"),
+			`${JSON.stringify({ version: 1, type: "terminal", ...outbox(f, "done", "different"), recordedAt: new Date().toISOString() })}\n`,
+		);
+		const rebuilt = readRlmDurableOperationRegistry(f.parentArtifacts);
+		expect(rebuilt.operations.get(JSON.stringify([parentId, assignment, operation]))?.uncertain).toBe(true);
+		expect(rebuilt.hasUncertainRecords).toBe(true);
+	});
+
+	it("requires outbox then ledger then inbox then transcript-consumption", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		materialize(store, f);
+		expect(
+			store.recordTerminal({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				terminal: "done",
+			}),
+		).toBe(false);
+		expect(() => store.importOutbox(outbox(f))).toThrow(/ledger-recorded/);
+		store.appendOutbox(outbox(f));
+		expect(
+			store.recordTerminal({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				terminal: "done",
+			}),
+		).toBe(true);
+		store.importOutbox(outbox(f));
+		expect(
+			store.markMaterializedDelivery({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				sessionMessageId: materializedTerminalMessageId(delivery),
+			}),
+		).toBe("new");
+		expect(
+			store.markMaterializedDelivery({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				sessionMessageId: materializedTerminalMessageId(delivery),
+			}),
+		).toBe("already_materialized");
+	});
+
+	it("only ignores a malformed non-newline final tail; malformed interior becomes uncertainty", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		const ledger = join(f.parentArtifacts, "rlm-operation-ledger.jsonl");
+		appendFileSync(ledger, '{"version":1,"type":"admitted"');
+		expect(readRlmDurableOperationRegistry(f.parentArtifacts).hasUncertainRecords).toBe(false);
+		appendFileSync(ledger, "\n");
+		expect(readRlmDurableOperationRegistry(f.parentArtifacts).hasUncertainRecords).toBe(true);
+	});
+
+	it("rejects UUID, terminal projection, traversal, symlink escape, and forged session identity", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		expect(() => store.admit({ ...f.admission, operationId: "not-a-uuid" })).toThrow(/canonical UUID/);
+		expect(() => store.admit({ ...f.admission, parentSessionFile: f.childFile })).toThrow(/does not match/);
+		const outside = join(f.root, "outside");
+		mkdirSync(outside);
+		symlinkSync(outside, join(f.root, "escape"));
+		expect(() => store.admit({ ...f.admission, parentArtifactRoot: join(f.root, "escape") })).toThrow(/escapes/);
+		store.admit(f.admission);
+		materialize(store, f);
+		expect(() => store.appendOutbox({ ...outbox(f), terminal: "completed" as never })).toThrow(/Unknown terminal/);
+	});
+
+	it("uses a write-all loop, fails zero-progress writes before fsync, and leaves no claimed admission", () => {
+		const f = fixture();
+		let writes = 0;
+		let syncs = 0;
+		const partial = {
+			...fs,
+			writeSync: (fd: number, data: Buffer, offset: number, length: number) => {
+				writes++;
+				return fs.writeSync(fd, data, offset, Math.max(1, Math.min(length, 3)));
+			},
+			fsyncSync: (fd: number) => {
+				syncs++;
+				return fs.fsyncSync(fd);
+			},
+		} as unknown as RlmDurableIo;
+		const store = openRlmDurableOperationStore(f.parentArtifacts, { io: partial });
+		store.admit(f.admission);
+		expect(writes).toBeGreaterThan(1);
+		expect(syncs).toBeGreaterThan(0);
+		const zero = { ...fs, writeSync: () => 0 } as unknown as RlmDurableIo;
+		const g = fixture();
+		const broken = openRlmDurableOperationStore(g.parentArtifacts, { io: zero });
+		expect(() => broken.admit(g.admission)).toThrow(/no forward progress/);
+		expect(readRlmDurableOperationRegistry(g.parentArtifacts).operations.size).toBe(0);
+	});
+
+	it("does not make a cache cut authoritative and passive reads do not repair it", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		store.rebuild();
+		const index = join(f.parentArtifacts, "rlm-active-index.json");
+		writeFileSync(index, "torn");
+		const before = readFileSync(index, "utf8");
+		const passive = readRlmDurableOperationRegistry(f.parentArtifacts);
+		expect(passive.operations.size).toBe(1);
+		expect(readFileSync(index, "utf8")).toBe(before);
+		const renameCut = {
+			...fs,
+			renameSync: () => {
+				throw new Error("cut before rename");
+			},
+		} as unknown as RlmDurableIo;
+		expect(openRlmDurableOperationStore(f.parentArtifacts, { io: renameCut }).rebuild().operations.size).toBe(1);
+		expect(readRlmDurableOperationRegistry(f.parentArtifacts).operations.size).toBe(1);
+	});
+
+	it("allows one exact deleted-assignment discard, never a materialized delivery", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		materialize(store, f);
+		store.appendOutbox(outbox(f));
+		store.recordTerminal({
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			deliveryId: delivery,
+			terminal: "done",
+		});
+		store.importOutbox(outbox(f));
+		appendFileSync(
+			join(f.parentArtifacts, "rlm-operation-ledger.jsonl"),
+			`${JSON.stringify({ version: 1, type: "deleted", parentSessionId: parentId, assignmentId: assignment, operationId: operation, recordedAt: new Date().toISOString() })}\n`,
+		);
+		expect(
+			store.markDiscardedDelivery({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				reason: "deleted",
+			}),
+		).toBe("new");
+		expect(
+			store.markDiscardedDelivery({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				reason: "deleted",
+			}),
+		).toBe("already_discarded");
+	});
+});

--- a/packages/coding-agent/test/rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/rlm-durable-operations.test.ts
@@ -337,6 +337,29 @@ describe("RLM durable operation store", () => {
 		expect(readRlmDurableOperationRegistry(f.parentArtifacts).operations.size).toBe(1);
 	});
 
+	it("projects a body-free cache after terminal delivery", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		const secret = "terminal body must never reach index";
+		store.admit(f.admission);
+		materialize(store, f);
+		store.appendOutbox(outbox(f, "done", secret));
+		store.recordTerminal({
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			deliveryId: delivery,
+			terminal: "done",
+		});
+		store.importOutbox(outbox(f, "done", secret));
+		store.rebuild();
+		const index = JSON.parse(readFileSync(join(f.parentArtifacts, "rlm-active-index.json"), "utf8"));
+		expect(JSON.stringify(index)).not.toContain(secret);
+		expect(index.deliveries[0]).not.toHaveProperty("outboxRecord");
+		expect(index.deliveries[0]).not.toHaveProperty("inboxRecord");
+		expect(index.deliveries[0]).not.toHaveProperty("message");
+	});
+
 	it("allows one exact deleted-assignment discard, never a materialized delivery", () => {
 		const f = fixture();
 		const store = openRlmDurableOperationStore(f.parentArtifacts);

--- a/packages/coding-agent/test/rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/rlm-durable-operations.test.ts
@@ -284,6 +284,127 @@ describe("RLM durable operation store", () => {
 		).toBe("already_materialized");
 	});
 
+	it("globally quarantines prior and later operations after an unkeyed complete corrupt record", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		materialize(store, f);
+		expect(store.appendOutbox(outbox(f))).toBe("new");
+		expect(
+			store.recordTerminal({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				terminal: "done",
+			}),
+		).toBe(true);
+		expect(store.importOutbox(outbox(f))).toBe("new");
+
+		const ledger = join(f.parentArtifacts, "rlm-operation-ledger.jsonl");
+		appendFileSync(ledger, "{this is a complete but unkeyed corrupt record}\n");
+		const later = JSON.parse(readFileSync(ledger, "utf8").split("\n")[0]!) as Record<string, unknown>;
+		const laterAssignment = uuid(10);
+		const laterOperation = uuid(11);
+		const laterDelivery = uuid(12);
+		appendRecord(ledger, {
+			...later,
+			childId: uuid(13),
+			assignmentId: laterAssignment,
+			operationId: laterOperation,
+			deliveryId: laterDelivery,
+		});
+
+		const rebuilt = store.rebuild();
+		const aKey = JSON.stringify([parentId, assignment, operation]);
+		const bKey = JSON.stringify([parentId, laterAssignment, laterOperation]);
+		expect(rebuilt.hasUncertainRecords).toBe(true);
+		expect(rebuilt.operations.get(aKey)?.uncertain).toBe(true);
+		expect(rebuilt.deliveries.get(JSON.stringify([aKey, delivery]))?.uncertain).toBe(true);
+		expect(rebuilt.operations.get(bKey)?.uncertain).toBe(true);
+		expect(store.pendingInbox()).toEqual([]);
+		expect(store.importPendingOutboxes()).toBe(0);
+		expect(() =>
+			store.admit({ ...f.admission, assignmentId: uuid(14), operationId: uuid(15), deliveryId: uuid(16) }),
+		).toThrow(/globally uncertain/);
+		expect(
+			store.markMaterialized({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				childSessionId,
+				childSessionFile: f.childFile,
+				childSessionRoot: f.root,
+				childArtifactDir: f.childArtifacts,
+				childArtifactRoot: f.root,
+			}),
+		).toBe(false);
+		expect(
+			store.recordTerminal({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				terminal: "done",
+			}),
+		).toBe(false);
+		expect(() => store.appendOutbox(outbox(f))).toThrow(/globally uncertain/);
+		expect(() => store.importOutbox(outbox(f))).toThrow(/globally uncertain/);
+		expect(() =>
+			store.markMaterializedDelivery({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				sessionMessageId: materializedTerminalMessageId(delivery),
+			}),
+		).toThrow(/globally uncertain/);
+		expect(
+			store.recordDeleteIntent({ parentSessionId: parentId, assignmentId: assignment, operationId: operation }),
+		).toBe(false);
+		expect(
+			store.recordRelease(
+				{ parentSessionId: parentId, assignmentId: assignment, operationId: operation },
+				"released",
+			),
+		).toBe(false);
+		// Quarantine has no recovery/mutation writes; only the intentionally injected
+		// corrupt record and the later valid admission are present after the original facts.
+		expect(readFileSync(ledger, "utf8").split("\n")).toHaveLength(6);
+	});
+
+	it("globally quarantines a complete malformed record even when it carries a valid-looking key", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		const ledger = join(f.parentArtifacts, "rlm-operation-ledger.jsonl");
+		appendRecord(ledger, {
+			version: 1,
+			type: "materialized",
+			parentSessionId: parentId,
+			assignmentId: assignment,
+			operationId: operation,
+			childSessionId: "not-a-uuid",
+			childSessionFile: f.childFile,
+			childSessionRoot: f.root,
+			childArtifactDir: f.childArtifacts,
+			childArtifactRoot: f.root,
+			recordedAt: new Date().toISOString(),
+		});
+		const rebuilt = store.rebuild();
+		expect(rebuilt).toMatchObject({ hasUncertainRecords: true, hasGlobalUncertainty: true });
+		expect(rebuilt.operations.get(JSON.stringify([parentId, assignment, operation]))?.uncertain).toBe(true);
+		expect(() =>
+			store.admit({
+				...f.admission,
+				childId: uuid(20),
+				assignmentId: uuid(21),
+				operationId: uuid(22),
+				deliveryId: uuid(23),
+			}),
+		).toThrow(/globally uncertain/);
+	});
+
 	it("ignores and repairs every non-newline final tail before a subsequent append", () => {
 		const f = fixture();
 		const store = openRlmDurableOperationStore(f.parentArtifacts);

--- a/packages/coding-agent/test/rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/rlm-durable-operations.test.ts
@@ -193,6 +193,25 @@ describe("RLM durable operation store", () => {
 		expect(mode(join(f.parentArtifacts, "rlm-terminal-consumed.jsonl"))).toBe(0o600);
 	});
 
+	it("makes exact materialization retries idempotent after the lifecycle advances", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts);
+		store.admit(f.admission);
+		materialize(store, f);
+		expect(
+			store.markMaterialized({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				childSessionId,
+				childSessionFile: f.childFile,
+				childSessionRoot: f.root,
+				childArtifactDir: f.childArtifacts,
+				childArtifactRoot: f.root,
+			}),
+		).toBe(true);
+	});
+
 	it("makes exact duplicates idempotent and conflicting terminal body uncertain/fail-closed", () => {
 		const f = fixture();
 		const store = openRlmDurableOperationStore(f.parentArtifacts);

--- a/packages/coding-agent/test/rlm-durable-operations.test.ts
+++ b/packages/coding-agent/test/rlm-durable-operations.test.ts
@@ -755,4 +755,56 @@ describe("RLM durable operation store", () => {
 			}),
 		).toBe("already_materialized");
 	});
+	it("retains a live exact delete intent until terminal, then deletes and discards without materialization", () => {
+		const f = fixture();
+		const store = openRlmDurableOperationStore(f.parentArtifacts, { trustedChildRecoveryRoots: trustedRoots(f) });
+		store.admit(f.admission);
+		materialize(store, f);
+		expect(
+			store.recordDeleteIntent({ parentSessionId: parentId, assignmentId: assignment, operationId: operation }),
+		).toBe(true);
+		expect(
+			store.recordRelease(
+				{ parentSessionId: parentId, assignmentId: assignment, operationId: operation },
+				"deleted",
+			),
+		).toBe(false);
+		store.appendOutbox(outbox(f, "cancelled"));
+		expect(
+			store.recordTerminal({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				terminal: "cancelled",
+			}),
+		).toBe(true);
+		expect(
+			store.recordRelease(
+				{ parentSessionId: parentId, assignmentId: assignment, operationId: operation },
+				"deleted",
+			),
+		).toBe(true);
+		expect(store.importPendingOutboxes()).toBe(1);
+		expect(store.pendingInbox()).toHaveLength(1);
+		expect(
+			store.markDiscardedDelivery({
+				parentSessionId: parentId,
+				assignmentId: assignment,
+				operationId: operation,
+				deliveryId: delivery,
+				reason: "deleted",
+			}),
+		).toBe("new");
+		const registry = store.rebuild();
+		expect(registry.operations.get(JSON.stringify([parentId, assignment, operation]))).toMatchObject({
+			lifecycle: "deleted",
+			deleteIntent: true,
+		});
+		expect(
+			registry.deliveries.get(JSON.stringify([JSON.stringify([parentId, assignment, operation]), delivery])),
+		).toMatchObject({
+			consumed: "discarded",
+		});
+	});
 });

--- a/packages/coding-agent/test/rlm-terminal-delivery.test.ts
+++ b/packages/coding-agent/test/rlm-terminal-delivery.test.ts
@@ -1,0 +1,224 @@
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { getModel } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import {
+	materializedTerminalMessageId,
+	openRlmDurableOperationStore,
+	type RlmTerminalMessage,
+} from "../src/core/rlm-durable-operations.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { createTestResourceLoader } from "./utilities.js";
+
+const id = (tail: number) => `00000000-0000-4000-8000-${String(tail).padStart(12, "0")}`;
+const parentId = id(1);
+const assignmentId = id(2);
+const operationId = id(3);
+const deliveryId = id(4);
+const childSessionId = id(5);
+const roots: string[] = [];
+afterEach(() =>
+	roots.splice(0).forEach((root) => {
+		rmSync(root, { recursive: true, force: true });
+	}),
+);
+
+function fixture() {
+	const root = mkdtempSync(join(tmpdir(), "rlm-terminal-delivery-"));
+	roots.push(root);
+	const artifacts = join(root, "parent-artifacts");
+	const childArtifacts = join(root, "child-artifacts");
+	mkdirSync(artifacts);
+	mkdirSync(childArtifacts);
+	const parentFile = join(root, "parent.jsonl");
+	const childFile = join(root, "child.jsonl");
+	writeFileSync(parentFile, `${JSON.stringify({ type: "session", id: parentId })}\n`);
+	writeFileSync(childFile, `${JSON.stringify({ type: "session", id: childSessionId })}\n`);
+	const store = openRlmDurableOperationStore(artifacts);
+	store.admit({
+		parentSessionId: parentId,
+		parentSessionFile: parentFile,
+		parentSessionRoot: root,
+		parentArtifactRoot: root,
+		childId: "child",
+		assignmentId,
+		operationId,
+		deliveryId,
+		childSessionDir: root,
+		requestedModel: { provider: "test", modelId: "test" },
+		rlmDepth: 1,
+		rlmMaxDepth: 2,
+	});
+	expect(
+		store.markMaterialized({
+			parentSessionId: parentId,
+			assignmentId,
+			operationId,
+			childSessionId,
+			childSessionFile: childFile,
+			childSessionRoot: root,
+			childArtifactDir: childArtifacts,
+			childArtifactRoot: root,
+		}),
+	).toBe(true);
+	const message: RlmTerminalMessage = {
+		role: "custom",
+		customType: "rlm_child_terminal_notice",
+		content: "child completed",
+		display: true,
+		details: { kind: "completed_without_reply", childId: "child", sessionName: "child" },
+		timestamp: 1,
+	};
+	const outbox = {
+		parentSessionId: parentId,
+		parentSessionFile: parentFile,
+		parentSessionRoot: root,
+		parentArtifactRoot: root,
+		childSessionId,
+		childSessionFile: childFile,
+		childSessionRoot: root,
+		childArtifactDir: childArtifacts,
+		childArtifactRoot: root,
+		childId: "child",
+		assignmentId,
+		operationId,
+		deliveryId,
+		terminal: "done" as const,
+		message,
+	};
+	store.appendOutbox(outbox);
+	expect(
+		store.recordTerminal({ parentSessionId: parentId, assignmentId, operationId, deliveryId, terminal: "done" }),
+	).toBe(true);
+	return { root, artifacts, store, outbox, message };
+}
+
+function consumeIfTranscriptHasId(store: ReturnType<typeof openRlmDurableOperationStore>, transcriptIds: Set<string>) {
+	for (const inbox of store.pendingInbox()) {
+		const messageId = materializedTerminalMessageId(inbox.deliveryId);
+		if (!transcriptIds.has(messageId)) transcriptIds.add(messageId);
+		store.markMaterializedDelivery({
+			parentSessionId: inbox.parentSessionId,
+			assignmentId: inbox.assignmentId,
+			operationId: inbox.operationId,
+			deliveryId: inbox.deliveryId,
+			sessionMessageId: messageId,
+		});
+	}
+}
+
+describe("RLM terminal durable delivery", () => {
+	it("keeps inbox-before-transcript pending, then appends exactly one deterministic normal message", () => {
+		const f = fixture();
+		expect(f.store.importOutbox(f.outbox)).toBe("new");
+		expect(f.store.pendingInbox()).toHaveLength(1);
+		const transcriptIds = new Set<string>();
+		// A failed/no-op transcript attempt cannot consume an inbox record.
+		expect(f.store.pendingInbox()[0]?.message.content).toBe("child completed");
+		expect(transcriptIds).toEqual(new Set());
+		consumeIfTranscriptHasId(f.store, transcriptIds);
+		expect(transcriptIds).toEqual(new Set([materializedTerminalMessageId(deliveryId)]));
+		expect(f.store.pendingInbox()).toHaveLength(0);
+		consumeIfTranscriptHasId(f.store, transcriptIds);
+		expect(transcriptIds).toHaveLength(1);
+	});
+
+	it("re-scans transcript-before-consumed and never duplicates a delivery after retry/restart", () => {
+		const f = fixture();
+		f.store.importOutbox(f.outbox);
+		const transcriptIds = new Set([materializedTerminalMessageId(deliveryId)]);
+		consumeIfTranscriptHasId(f.store, transcriptIds);
+		expect(transcriptIds).toHaveLength(1);
+		expect(f.store.pendingInbox()).toHaveLength(0);
+		// A fresh owner sees the authoritative consumed fact, not a prompt replay.
+		const restarted = openRlmDurableOperationStore(f.artifacts, {
+			trustedChildRecoveryRoots: () => ({
+				childSessionId,
+				childSessionFile: f.outbox.childSessionFile,
+				childSessionRoot: f.root,
+				childArtifactDir: f.outbox.childArtifactDir,
+				childArtifactRoot: f.root,
+			}),
+		});
+		expect(restarted.pendingInbox()).toHaveLength(0);
+	});
+
+	it("allows one exact deleted-A discard without fabricating a transcript fact", () => {
+		const f = fixture();
+		f.store.importOutbox(f.outbox);
+		appendFileSync(
+			join(f.artifacts, "rlm-operation-ledger.jsonl"),
+			`${JSON.stringify({ version: 1, type: "deleted", parentSessionId: parentId, assignmentId, operationId, recordedAt: new Date().toISOString() })}\n`,
+		);
+		expect(
+			f.store.markDiscardedDelivery({
+				parentSessionId: parentId,
+				assignmentId,
+				operationId,
+				deliveryId,
+				reason: "deleted",
+			}),
+		).toBe("new");
+		expect(f.store.pendingInbox()).toHaveLength(0);
+	});
+});
+
+function liveParent(root: string, file: string) {
+	const sessionManager = SessionManager.open(file, join(root, "sessions"));
+	const auth = AuthStorage.create(join(root, "auth.json"));
+	auth.setRuntimeApiKey("anthropic", "test-key");
+	const model = getModel("anthropic", "claude-sonnet-4-5")!;
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: "", tools: [], thinkingLevel: "off" },
+		streamFn: vi.fn(() => {
+			throw new Error("terminal transcript append must never call a provider");
+		}),
+	});
+	return new AgentSession({
+		agent,
+		sessionManager,
+		settingsManager: SettingsManager.create(root, root),
+		cwd: root,
+		modelRegistry: ModelRegistry.create(auth, join(root, "models.json")),
+		resourceLoader: createTestResourceLoader(),
+	});
+}
+
+describe("C03 real normal transcript materialization", () => {
+	it("retries an inbox-before-transcript cut and appends one normal custom message without prompt/provider replay", async () => {
+		const f = fixture();
+		f.store.importOutbox(f.outbox);
+		const parent = liveParent(f.root, f.outbox.parentSessionFile);
+		const append = vi.spyOn(parent, "appendDurableRlmTerminalMessage");
+		// The inbox is authoritative before a transcript attempt. A retry uses the
+		// same deterministic id and only consumes after the real normal append.
+		expect(f.store.pendingInbox()).toHaveLength(1);
+		const inbox = f.store.pendingInbox()[0]!;
+		expect(await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId)).toBe(true);
+		expect(await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId)).toBe(false);
+		expect(append).toHaveBeenCalledTimes(2);
+		f.store.markMaterializedDelivery({
+			parentSessionId: inbox.parentSessionId,
+			assignmentId: inbox.assignmentId,
+			operationId: inbox.operationId,
+			deliveryId: inbox.deliveryId,
+			sessionMessageId: materializedTerminalMessageId(inbox.deliveryId),
+		});
+		expect(f.store.pendingInbox()).toEqual([]);
+		const messages = parent.messages.filter((message) => message.role === "custom");
+		expect(messages).toHaveLength(1);
+		expect(messages[0]).toMatchObject({
+			customType: "rlm_child_terminal_notice",
+			details: { id: materializedTerminalMessageId(deliveryId) },
+		});
+		expect(parent.isStreaming).toBe(false);
+		parent.dispose();
+	});
+});

--- a/packages/coding-agent/test/rlm-terminal-delivery.test.ts
+++ b/packages/coding-agent/test/rlm-terminal-delivery.test.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Agent } from "@earendil-works/pi-agent-core";
@@ -192,6 +192,36 @@ function liveParent(root: string, file: string) {
 }
 
 describe("C03 real normal transcript materialization", () => {
+	it("persists immediately while parent streaming without a prompt, queue, or provider turn", async () => {
+		const f = fixture();
+		f.store.importOutbox(f.outbox);
+		const parent = liveParent(f.root, f.outbox.parentSessionFile);
+		const queue = vi.fn(async () => undefined);
+		Object.defineProperty(parent.agent.state, "isStreaming", { configurable: true, get: () => true });
+		vi.spyOn(parent, "sendCustomMessage");
+		vi.spyOn(
+			parent as unknown as { _queuePreparedPrompt: (...args: unknown[]) => Promise<void> },
+			"_queuePreparedPrompt",
+		).mockImplementation(queue);
+		const inbox = f.store.pendingInbox()[0]!;
+		expect(await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId)).toBe(true);
+		expect(parent.sendCustomMessage).not.toHaveBeenCalled();
+		expect(queue).not.toHaveBeenCalled();
+		const id = materializedTerminalMessageId(inbox.deliveryId);
+		expect(readFileSync(f.outbox.parentSessionFile, "utf8")).toContain(id);
+		// The caller may now acknowledge only after it observed this durable entry.
+		f.store.markMaterializedDelivery({
+			parentSessionId: inbox.parentSessionId,
+			assignmentId: inbox.assignmentId,
+			operationId: inbox.operationId,
+			deliveryId: inbox.deliveryId,
+			sessionMessageId: id,
+		});
+		expect(f.store.pendingInbox()).toEqual([]);
+		expect(parent.messages.filter((message) => message.role === "custom")).toHaveLength(1);
+		parent.dispose();
+	});
+
 	it("retries an inbox-before-transcript cut and appends one normal custom message without prompt/provider replay", async () => {
 		const f = fixture();
 		f.store.importOutbox(f.outbox);
@@ -202,7 +232,9 @@ describe("C03 real normal transcript materialization", () => {
 		expect(f.store.pendingInbox()).toHaveLength(1);
 		const inbox = f.store.pendingInbox()[0]!;
 		expect(await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId)).toBe(true);
-		expect(await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId)).toBe(false);
+		// A deterministic transcript duplicate is an idempotent durable success,
+		// not a second append.
+		expect(await parent.appendDurableRlmTerminalMessage(inbox.message, inbox.deliveryId)).toBe(true);
 		expect(append).toHaveBeenCalledTimes(2);
 		f.store.markMaterializedDelivery({
 			parentSessionId: inbox.parentSessionId,

--- a/packages/coding-agent/test/session-manager-flush.test.ts
+++ b/packages/coding-agent/test/session-manager-flush.test.ts
@@ -437,3 +437,105 @@ describe("SessionManager.appendCustomMessageEntryWithRollback", () => {
 		expect(readFileSync(file)).toEqual(before);
 	});
 });
+
+type SessionDurabilityTestSeam = {
+	_setDurabilityIoForTest(overrides: {
+		writeAll?: (fd: number, bytes: Buffer) => void;
+		fileFsync?: (fd: number) => void;
+		tempFsync?: (fd: number) => void;
+		rename?: (tempPath: string, targetPath: string) => void;
+		directoryFsync?: (directory: string) => void;
+	}): () => void;
+};
+
+function c03DurabilityManager(): { mgr: SessionManager; file: string; before: Buffer } {
+	const dir = createTempDir();
+	const mgr = SessionManager.create(dir, join(dir, "sessions"));
+	mgr.appendMessage({ role: "user", content: "durable baseline", timestamp: 1 });
+	mgr.appendMessage({
+		role: "assistant",
+		content: [{ type: "text", text: "ready" }],
+		api: "openai-completions",
+		provider: "test",
+		model: "test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 2,
+	});
+	const file = mgr.getSessionFile()!;
+	return { mgr, file, before: readFileSync(file) };
+}
+
+describe("SessionManager C03 durability cut seam", () => {
+	const seam = SessionManager as unknown as SessionDurabilityTestSeam;
+	const cuts: Array<
+		[
+			"writeAll" | "fileFsync" | "tempFsync" | "rename" | "directoryFsync",
+			// append is already flushed for the first two cuts; replacements exercise
+			// the remaining three pre-/post-rename boundaries.
+			"append" | "rewrite",
+		]
+	> = [
+		["writeAll", "append"],
+		["fileFsync", "append"],
+		["tempFsync", "rewrite"],
+		["rename", "rewrite"],
+		["directoryFsync", "rewrite"],
+	];
+
+	it.each(cuts)("does not acknowledge or duplicate a C03 entry across a %s %s cut", (cut, path) => {
+		const { mgr, file, before } = c03DurabilityManager();
+		if (path === "rewrite") {
+			// A failed append repair and a first durable materialization both use
+			// the same replacement primitive. Force that path without changing the
+			// already-authoritative transcript bytes.
+			(mgr as unknown as { flushed: boolean }).flushed = false;
+		}
+		const authorityBefore = readFileSync(file);
+		const restore = seam._setDurabilityIoForTest({
+			[cut]: () => {
+				throw new Error(`injected ${cut} cut`);
+			},
+		});
+		try {
+			expect(() =>
+				mgr.appendDurableCustomMessageEntry("rlm_child_terminal_notice", "one terminal", true, { id: "c03-cut" }),
+			).toThrow(`injected ${cut} cut`);
+		} finally {
+			restore();
+		}
+		// No failed attempt remains in the manager tree. A cut after kernel write
+		// or rename can leave ambiguous bytes, so the manager remains unflushed;
+		// its first post-fault flush deterministically restores prior authority.
+		expect(mgr.getEntries().filter((entry) => entry.type === "custom_message")).toHaveLength(0);
+		mgr.flushNow();
+		expect(readFileSync(file)).toEqual(authorityBefore);
+		expect(
+			SessionManager.open(file)
+				.getEntries()
+				.filter((entry) => entry.type === "custom_message"),
+		).toHaveLength(0);
+		expect(before.length).toBeGreaterThan(0);
+
+		// The same delivery retry has one deterministic transcript fact, not a
+		// provider/prompt replay or a second entry.
+		expect(
+			mgr.appendDurableCustomMessageEntry("rlm_child_terminal_notice", "one terminal", true, { id: "c03-cut" }),
+		).toBe(true);
+		const reopened = SessionManager.open(file);
+		const terminals = reopened
+			.getEntries()
+			.filter(
+				(entry) =>
+					entry.type === "custom_message" && (entry.details as { id?: string } | undefined)?.id === "c03-cut",
+			);
+		expect(terminals).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -24,6 +24,10 @@ import type {
 	SessionShutdownEvent,
 	SessionStartEvent,
 } from "../../src/index.js";
+import { initTheme } from "../../src/modes/interactive/theme/theme.js";
+
+// The runtime characterization exercises an error renderer; initialize its test-only theme dependency.
+initTheme("dark");
 
 type RecordedSessionEvent =
 	| SessionBeforeSwitchEvent

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -492,12 +492,10 @@ describe("AgentSessionRuntime characterization", () => {
 		await runtime.deleteRlmSubagentRuntime("reused-child", childSessions[0], baseOptions.assignmentId);
 		expect(maps.subagentRuntimes.get("reused-child")?.session).toBe(b.session);
 		expect(childDisposals[1]).not.toHaveBeenCalled();
-		await runtime.deleteRlmSubagentRuntime(
-			"reused-child",
-			b.session,
-			baseOptions.assignmentId,
-			"bbbbbbbb-bbbb-4bbb-8bbb-000000000001",
-		);
+		// The normal inline owner does not carry C03 operation IDs through this
+		// delete call. Its matching session is still sufficient authority to clean up.
+		await runtime.deleteRlmSubagentRuntime("reused-child", b.session, baseOptions.assignmentId);
+		expect(maps.subagentRuntimes.has("reused-child")).toBe(false);
 	});
 
 	it("releases a failed child run from the inline runtime host", async () => {

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
@@ -14,7 +14,7 @@ import {
 	createAgentSessionServices,
 } from "../../src/core/agent-session-runtime.js";
 import { AuthStorage } from "../../src/core/auth-storage.js";
-import type { SubagentRuntimeHost } from "../../src/core/rlm-runtime.js";
+import type { CreateRlmSubagentRuntimeOptions, SubagentRuntimeHost } from "../../src/core/rlm-runtime.js";
 import { SessionManager } from "../../src/core/session-manager.js";
 import type {
 	ExtensionAPI,
@@ -33,6 +33,8 @@ type RecordedSessionEvent =
 
 type RuntimeSubagentMapAccess = {
 	subagentRuntimes: Map<string, AgentSessionRuntime>;
+	subagentRuntimeAssignments: Map<string, string>;
+	subagentRuntimeOperations: Map<string, string | undefined>;
 };
 
 describe("AgentSessionRuntime characterization", () => {
@@ -373,6 +375,125 @@ describe("AgentSessionRuntime characterization", () => {
 			}),
 		).rejects.toThrow("startup was cancelled");
 		expect((runtime as unknown as RuntimeSubagentMapAccess).subagentRuntimes.has("cancelled-child")).toBe(false);
+	});
+
+	it("fences deferred inline C03 binding by operation when a selector and assignment are reused", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-inline-c03-operation-"));
+		cleanups.push(() => rmSync(tempDir, { recursive: true, force: true }));
+		const parentManager = SessionManager.inMemory(tempDir);
+		const parentSession = {
+			sessionManager: parentManager,
+			getRlmChildRunStatus: vi.fn(() => "running"),
+			setSubagentRuntimeHost: vi.fn(),
+		} as unknown as AgentSession;
+		let markBindAStarted!: () => void;
+		const bindAStarted = new Promise<void>((resolve) => {
+			markBindAStarted = resolve;
+		});
+		let releaseBindA!: () => void;
+		const bindAGate = new Promise<void>((resolve) => {
+			releaseBindA = resolve;
+		});
+		const childSessions: AgentSession[] = [];
+		const childDisposals: Array<ReturnType<typeof vi.fn>> = [];
+		const createRuntime: CreateAgentSessionRuntimeFactory = async ({ sessionManager }) => {
+			const childIndex = childSessions.length;
+			let sessionName = "pending";
+			const disposeAsync = vi.fn(async () => {});
+			const session = {
+				sessionManager,
+				extensionRunner: { hasHandlers: () => false },
+				get sessionName() {
+					return sessionName;
+				},
+				setSessionName: vi.fn((name: string) => {
+					sessionName = name;
+				}),
+				setSubagentRuntimeHost: vi.fn(),
+				bindExtensions: vi.fn(async () => {
+					if (childIndex === 0) {
+						markBindAStarted();
+						await bindAGate;
+					}
+				}),
+				disposeAsync,
+			} as unknown as AgentSession;
+			childSessions.push(session);
+			childDisposals.push(disposeAsync);
+			return {
+				session,
+				services: { cwd: tempDir, agentDir: tempDir } as AgentSessionServices,
+				diagnostics: [],
+				extensionsResult: { extensions: [], errors: [], runtime: {} },
+			} as unknown as Awaited<ReturnType<CreateAgentSessionRuntimeFactory>>;
+		};
+		const runtime = new AgentSessionRuntime(
+			parentSession,
+			{ cwd: tempDir, agentDir: tempDir } as AgentSessionServices,
+			createRuntime,
+		);
+		const baseOptions: Omit<CreateRlmSubagentRuntimeOptions, "operationId" | "sessionDir"> = {
+			parentSession,
+			id: "reused-child",
+			assignmentId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+			deliveryId: "delivery-is-not-used-inline",
+			prompt: "run",
+			sessionName: "reused-child",
+			model: {} as never,
+			thinkingLevel: "off",
+			serviceTier: null,
+			scopedModels: [],
+			activeToolNames: [],
+			customTools: [],
+			includeGoals: false,
+			includeCompactSkill: false,
+			rlmDepth: 1,
+			rlmMaxDepth: 2,
+			rlmParentNodeId: "reused-child",
+		};
+		const publishedA = vi.fn();
+		const a = runtime.createRlmSubagentRuntime({
+			...baseOptions,
+			operationId: "aaaaaaaa-aaaa-4aaa-8aaa-000000000001",
+			sessionDir: join(tempDir, "inline-c03-a"),
+			onSessionPublished: publishedA,
+		});
+		await bindAStarted;
+		const publishedB = vi.fn();
+		const b = await runtime.createRlmSubagentRuntime({
+			...baseOptions,
+			operationId: "bbbbbbbb-bbbb-4bbb-8bbb-000000000001",
+			sessionDir: join(tempDir, "inline-c03-b"),
+			onSessionPublished: publishedB,
+		});
+		releaseBindA();
+		await expect(a).rejects.toThrow("startup was cancelled");
+
+		const maps = runtime as unknown as RuntimeSubagentMapAccess;
+		expect(publishedA).not.toHaveBeenCalled();
+		expect(publishedB).toHaveBeenCalledOnce();
+		expect(maps.subagentRuntimes.get("reused-child")?.session).toBe(b.session);
+		expect(maps.subagentRuntimeAssignments.get("reused-child")).toBe(baseOptions.assignmentId);
+		expect(maps.subagentRuntimeOperations.get("reused-child")).toBe("bbbbbbbb-bbbb-4bbb-8bbb-000000000001");
+		expect(childDisposals[1]).not.toHaveBeenCalled();
+
+		await runtime.deleteRlmSubagentRuntime(
+			"reused-child",
+			childSessions[0],
+			baseOptions.assignmentId,
+			"aaaaaaaa-aaaa-4aaa-8aaa-000000000001",
+		);
+		expect(maps.subagentRuntimes.get("reused-child")?.session).toBe(b.session);
+		expect(childDisposals[1]).not.toHaveBeenCalled();
+		await runtime.deleteRlmSubagentRuntime("reused-child", childSessions[0], baseOptions.assignmentId);
+		expect(maps.subagentRuntimes.get("reused-child")?.session).toBe(b.session);
+		expect(childDisposals[1]).not.toHaveBeenCalled();
+		await runtime.deleteRlmSubagentRuntime(
+			"reused-child",
+			b.session,
+			baseOptions.assignmentId,
+			"bbbbbbbb-bbbb-4bbb-8bbb-000000000001",
+		);
 	});
 
 	it("releases a failed child run from the inline runtime host", async () => {


### PR DESCRIPTION
## C03: durable terminal delivery

Implements durable at-least-once terminal delivery and the generic safe terminal envelope, with manager bindings and exact fencing across passivation, deletion, restart, and transcript flush.

**Scope limits:** this is not exactly-once delivery; it adds no provider prompt or queue and no limiter. C04 ownership is excluded.

**Pinned remote PASS:** exact head `42afc919f0e43ded880aa8a2d7088f31b264da95` on C02 `d2223258fa362e8fed5c5209cabf59d0eacc6e98`. Final remote counts: C03 named 161/161; flush 18/18; passive/release 33/33; full daemon 211/211; C02 exact 177/177; process stress 6/6 runnable (8 tag-skipped); B00B 70/70; RSS 20/20 measured cells. Bundle SHA-256: `b167d36f98c484a32feb38139b9b8e6954bbabdf254e34f57dda1cc3d5f67e6a`; evidence manifest SHA-256: `73498cfdb83d87db47bfcb07a07513ac24162c267f3c36423603c1db31ca1e5c`. Prior invalid manifest attempts are retained alongside the final manifest.

**Rollback / flags / dependency:** rollback the C03 branch/PR as a unit to C02; C03 intentionally has no feature flag because bypassing the durable terminal hand-off would restore loss/duplication behavior. Depends on C02 PR #1130 / exact SHA above.

No merge or human-review action is requested yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to RLM subagent spawn/delete/cancel/restart and transcript durability; incorrect fencing or ledger reduction could lose terminals, duplicate messages, or strand children after ID reuse.
> 
> **Overview**
> Adds **d-least-once terminal delivery** for daemon-hosted RLM subagents via a new JSONL-backed store (`ledger` / child `outbox` / parent `inbox` / `consumed`) and a canonical **`(assignmentId, operationId, deliveryId)`** incarnation key threaded through registry rows, runtime metadata, and host callbacks.
> 
> **Lifecycle:** parent admits an operation before child work is visible; the daemon materializes the child, appends a terminal to the child outbox, records terminal state on the ledger, imports into the parent inbox, and **`appendDurableRlmTerminalMessage`** fsyncs a deterministic transcript id (`rlm-terminal-{deliveryId}`) without scheduling a turn. Live deletes retain **`delete_intent`** until the exact cancellation terminal is discarded rather than materialized.
> 
> **Envelope:** introduces **`rlm_safe_terminal_result`** with opaque `projection` plus separate bounded `content`, validated only for size/type—not parsed JSON.
> 
> **Fencing & registry:** assignment-only legacy paths remain display-compatible; complete C03 triples are authoritative in registry reduction and catalog parsing. Stale incarnations after childId reuse are blocked via **`operationId`** checks on register/delete/release/terminal delivery; missing parent registry/artifact authority fails closed (`RlmRegistryAuthorityError`).
> 
> **Persistence:** `SessionManager` gains **`appendDurableCustomMessageEntry`** and stricter rewrite/append fsync semantics (incl. test-injectable durability IO).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5cc5d0042b26191b127e19869f540c20ce8dff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add durable exactly-once terminal delivery for RLM subagent operations
> - Introduces a new durable operation ledger ([rlm-durable-operations.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1166/files#diff-717e994ed943cbcbc595a5b81eb564f12ad55c41cd94f91d82129c8d3efbc3e0)) with admit/materialize/deliver/consume lifecycle stages, keyed by a per-spawn `(assignmentId, operationId, deliveryId)` triple minted by the parent daemon.
> - `AgentSession` now mints `operationId`/`deliveryId` at child spawn time, calls `admitRlmSubagentOperation` before any provider work, and delegates terminal delivery to `deliverRlmSubagentTerminal` on the daemon host; all child lifecycle maps are fenced by both `assignmentId` and `operationId` to prevent cross-incarnation interference.
> - `SessionManager.appendDurableCustomMessageEntry` provides an fsync-backed, exactly-once append path for terminal messages without engaging the prompt queue; failures roll back in-memory state and force a later rewrite.
> - `AgentDaemon` enforces parent-owned registry/artifact authority for all C03 paths; hydration aborts when durable history is globally uncertain; registry selection now prefers authoritative C03 rows over legacy display-only rows.
> - `daemon-catalog-process` groups registry entries by incarnation key and prevents a late legacy-only row from displacing an existing C03 incarnation for the same child selector.
> - Risk: registry writes now return `false`/throw when no parent registry artifact is available instead of silently succeeding; depth derivation no longer falls back to path inference and defaults to `1` when no persisted authority exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5cc5d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->