### PR TITLE
draft: C04 bounded child results and authenticated recovery

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1076,34 +1076,31 @@ export function rlmChildLabel(prompt: string): string {
 	return prompt.replace(/\s+/g, " ").trim() || "child agent";
 }
 
-/** C04 terminal output is externalized as bounded byte chunks; do not join, read,
- * or truncate the child reply before persistence. */
-async function* streamAssistantTerminalOutput(session: AgentSession): AsyncGenerator<Uint8Array> {
+/** C04 receives producer-time terminal blocks only. Do not scan a session
+ * transcript or encode a whole block: both make a terminal's memory use depend
+ * on historical conversation size. */
+async function* streamAssistantTerminalOutput(message: AssistantMessage | undefined): AsyncGenerator<Uint8Array> {
+	if (!message) return;
 	const encoder = new TextEncoder();
-	for (const message of session.messages) {
-		if (message.role !== "assistant") continue;
-		for (const block of (message as AssistantMessage).content) {
-			if (block.type !== "text") continue;
-			const bytes = encoder.encode(block.text);
-			for (let offset = 0; offset < bytes.length; offset += 64 * 1024)
-				yield bytes.subarray(offset, offset + 64 * 1024);
+	for (const block of message.content) {
+		if (block.type !== "text") continue;
+		// Keep each UTF-8 conversion comfortably below C04's 64 KiB chunk limit.
+		for (let offset = 0; offset < block.text.length; offset += 8_192) {
+			const text = block.text.slice(offset, offset + 8_192);
+			const bytes = encoder.encode(text);
+			for (let byteOffset = 0; byteOffset < bytes.length; byteOffset += 64 * 1024)
+				yield bytes.subarray(byteOffset, byteOffset + 64 * 1024);
 		}
 	}
 }
-/** A bounded structured presentation is independent of the raw artifact. */
+/** A bounded sanitized presentation is maintained while the child produces it. */
 function safeAssistantPreview(message: AssistantMessage): string | undefined {
 	for (const block of message.content) {
 		if (block.type !== "text" || !block.text) continue;
-		return compactRlmText(block.text, 160);
+		const bounded = block.text.slice(0, 512);
+		return compactRlmText(bounded, 160).replace(/[\u0000-\u001f\u007f]/g, " ");
 	}
 	return undefined;
-}
-
-function readAssistantText(message: AssistantMessage): string {
-	return message.content
-		.filter((block) => block.type === "text")
-		.map((block) => block.text)
-		.join("");
 }
 
 function waitForPromiseOrAbort<T>(
@@ -10073,6 +10070,7 @@ export class AgentSession {
 		const parentAssistantForUsage = this._findLastAssistantMessage();
 		const label = rlmChildLabel(prompt);
 		let answerPreview: string | undefined;
+		let terminalAssistantOutput: AssistantMessage | undefined;
 		let durationMs: number | undefined;
 		let toolUseCount = 0;
 		let runningToolCount = 0;
@@ -10211,7 +10209,7 @@ export class AgentSession {
 										{
 											kind: "terminal_output" as const,
 											contentType: "text/plain" as const,
-											data: streamAssistantTerminalOutput(childSession),
+											data: streamAssistantTerminalOutput(terminalAssistantOutput),
 										},
 									],
 								}
@@ -10397,6 +10395,7 @@ export class AgentSession {
 								}
 							}
 						}
+						terminalAssistantOutput = assistant;
 						const text = safeAssistantPreview(assistant);
 						if (text) answerPreview = text;
 						void flushAgentTraceUpload(child.sessionManager).catch(() => undefined);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -215,15 +215,16 @@ import {
 import { resolveConfigValue } from "./resolve-config-value.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import {
+	type C04ChildResultStatus,
+	canonicalChildResultBytes,
+	createOrGetTerminalChildResult,
+	terminalStorageFailedProjection,
+} from "./rlm-child-results.js";
+import {
 	createRlmSafeTerminalResultTerminalMessage,
 	materializedTerminalMessageId,
 	type RlmTerminalMessage,
 } from "./rlm-durable-operations.js";
-import {
-	canonicalChildResultBytes,
-	createOrGetTerminalChildResult,
-	type C04ChildResultStatus,
-} from "./rlm-child-results.js";
 import {
 	type CreateRlmSubagentRuntimeOptions,
 	createDefaultRlmSubagentSessionName,
@@ -1073,6 +1074,29 @@ export function compactRlmText(text: string, maxLength = 160): string {
 // would only hide the divergence between near-identical sibling prompts.
 export function rlmChildLabel(prompt: string): string {
 	return prompt.replace(/\s+/g, " ").trim() || "child agent";
+}
+
+/** C04 terminal output is externalized as bounded byte chunks; do not join, read,
+ * or truncate the child reply before persistence. */
+async function* streamAssistantTerminalOutput(session: AgentSession): AsyncGenerator<Uint8Array> {
+	const encoder = new TextEncoder();
+	for (const message of session.messages) {
+		if (message.role !== "assistant") continue;
+		for (const block of (message as AssistantMessage).content) {
+			if (block.type !== "text") continue;
+			const bytes = encoder.encode(block.text);
+			for (let offset = 0; offset < bytes.length; offset += 64 * 1024)
+				yield bytes.subarray(offset, offset + 64 * 1024);
+		}
+	}
+}
+/** A bounded structured presentation is independent of the raw artifact. */
+function safeAssistantPreview(message: AssistantMessage): string | undefined {
+	for (const block of message.content) {
+		if (block.type !== "text" || !block.text) continue;
+		return compactRlmText(block.text, 160);
+	}
+	return undefined;
 }
 
 function readAssistantText(message: AssistantMessage): string {
@@ -10176,11 +10200,22 @@ export class AgentSession {
 						operationId: run.operationId,
 						deliveryId: run.deliveryId,
 					},
-					childArtifactRoot: dirname(childArtifactDir),
+					childArtifactRoot: childArtifactDir,
 					candidate: {
 						status,
 						summary: status === "completed" ? "Child completed." : "Child terminal result is unavailable.",
 						preview: answerPreview || "No bounded terminal preview is available.",
+						...(status === "completed"
+							? {
+									artifacts: [
+										{
+											kind: "terminal_output" as const,
+											contentType: "text/plain" as const,
+											data: streamAssistantTerminalOutput(childSession),
+										},
+									],
+								}
+							: {}),
 						...(status === "completed"
 							? {}
 							: {
@@ -10206,9 +10241,20 @@ export class AgentSession {
 						: "Child ended; bounded result available.";
 				return createRlmSafeTerminalResultTerminalMessage(content, projection, Date.now());
 			} catch {
-				// No raw exception fallback and no second terminal path. A storage failure is
-				// intentionally left for C03 recovery/normal failure handling.
-				return undefined;
+				// Storage failure is itself a normal, bounded C04 projection. It always
+				// enters C03 through the same safe-terminal envelope, never as undefined.
+				const fallback = terminalStorageFailedProjection({
+					status: status === "completed" ? "failed" : status,
+					model: {
+						initialResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
+						terminalResolvedSelector: `${terminalModel.provider}/${terminalModel.id}`,
+					},
+				});
+				return createRlmSafeTerminalResultTerminalMessage(
+					"Child ended; bounded terminal result unavailable.",
+					Buffer.from(canonicalChildResultBytes(fallback)).toString("utf8"),
+					Date.now(),
+				);
 			}
 		};
 
@@ -10351,13 +10397,13 @@ export class AgentSession {
 								}
 							}
 						}
-						const text = compactRlmText(readAssistantText(assistant));
+						const text = safeAssistantPreview(assistant);
 						if (text) answerPreview = text;
 						void flushAgentTraceUpload(child.sessionManager).catch(() => undefined);
 						emitChildUpdate();
 					} else if (event.type === "message_start" || event.type === "message_update") {
 						if (event.message.role === "assistant") {
-							const text = compactRlmText(readAssistantText(event.message as AssistantMessage));
+							const text = safeAssistantPreview(event.message as AssistantMessage);
 							if (text) answerPreview = text;
 							activity = { kind: "writing" };
 							emitChildUpdate();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -215,7 +215,6 @@ import {
 import { resolveConfigValue } from "./resolve-config-value.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import {
-	type C04ChildResultReference,
 	type C04ChildResultStatus,
 	canonicalChildResultBytes,
 	createOrGetTerminalChildResult,
@@ -10105,7 +10104,6 @@ export class AgentSession {
 		// before a child can stream. Its key bytes never leave SessionManager.
 		const parentRecoveryAuthority = this.sessionManager.getC04ParentRecoveryAuthority();
 		let terminalOutputSink: C04ProducerSink | undefined;
-		let terminalOutputCommit: Promise<C04ChildResultReference> | undefined;
 		let durationMs: number | undefined;
 		let toolUseCount = 0;
 		let runningToolCount = 0;
@@ -10235,61 +10233,59 @@ export class AgentSession {
 				run.status === "done" ? "completed" : run.status === "cancelled" ? "cancelled" : "failed";
 			const terminalModel = childSession.model ?? modelSelection.model;
 			try {
-				const reference = terminalOutputCommit
-					? await terminalOutputCommit
-					: await createOrGetTerminalChildResult({
-							owner: {
-								parentSessionId: this.sessionId,
-								childSessionId: childSession.sessionId,
-								childSessionFile: childFile,
-								assignmentId: run.assignmentId,
-								operationId: run.operationId,
-								deliveryId: run.deliveryId,
-							},
-							childArtifactRoot: childArtifactDir,
-							parentRecoveryAuthority,
-							isCurrent,
-							candidate: {
-								status,
-								summary: status === "completed" ? "Child completed." : "Child terminal result is unavailable.",
-								preview: answerPreview || "No bounded terminal preview is available.",
-								...(status === "completed"
-									? {
-											artifacts: [
-												{
-													kind: "terminal_output" as const,
-													contentType: "text/plain" as const,
-													data: (() => {
-														// A producer opened by a text delta remains live until the child has
-														// actually finished.  Empty and tool-only completions have no such
-														// producer, so their fallback must already be closed: otherwise C04
-														// correctly waits forever for bytes that can never arrive.
-														if (terminalOutputSink) return terminalOutputSink;
-														const emptyTerminalOutput = new C04ProducerSink();
-														emptyTerminalOutput.close();
-														return emptyTerminalOutput;
-													})(),
-												},
-											],
-										}
-									: {}),
-								...(status === "completed"
-									? {}
-									: {
-											error: {
-												code: status === "cancelled" ? "cancelled" : "terminal_storage_failed",
-												message:
-													status === "cancelled"
-														? "Child was cancelled."
-														: "Child failed without a publishable diagnostic.",
-											},
-										}),
-								model: {
-									initialResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
-									terminalResolvedSelector: `${terminalModel.provider}/${terminalModel.id}`,
-								},
-							},
-						});
+				const reference = await createOrGetTerminalChildResult({
+					owner: {
+						parentSessionId: this.sessionId,
+						childSessionId: childSession.sessionId,
+						childSessionFile: childFile,
+						assignmentId: run.assignmentId,
+						operationId: run.operationId,
+						deliveryId: run.deliveryId,
+					},
+					childArtifactRoot: childArtifactDir,
+					parentRecoveryAuthority,
+					isCurrent,
+					candidate: {
+						status,
+						summary: status === "completed" ? "Child completed." : "Child terminal result is unavailable.",
+						preview: answerPreview || "No bounded terminal preview is available.",
+						...(status === "completed"
+							? {
+									artifacts: [
+										{
+											kind: "terminal_output" as const,
+											contentType: "text/plain" as const,
+											data: (() => {
+												// A producer opened by a text delta remains live until the child has
+												// actually finished.  Empty and tool-only completions have no such
+												// producer, so their fallback must already be closed: otherwise C04
+												// correctly waits forever for bytes that can never arrive.
+												if (terminalOutputSink) return terminalOutputSink;
+												const emptyTerminalOutput = new C04ProducerSink();
+												emptyTerminalOutput.close();
+												return emptyTerminalOutput;
+											})(),
+										},
+									],
+								}
+							: {}),
+						...(status === "completed"
+							? {}
+							: {
+									error: {
+										code: status === "cancelled" ? "cancelled" : "terminal_storage_failed",
+										message:
+											status === "cancelled"
+												? "Child was cancelled."
+												: "Child failed without a publishable diagnostic.",
+									},
+								}),
+						model: {
+							initialResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
+							terminalResolvedSelector: `${terminalModel.provider}/${terminalModel.id}`,
+						},
+					},
+				});
 				if (!isCurrent()) return undefined;
 				// C03 treats this as opaque bytes. C04 is the only parser/codec authority.
 				const projection = Buffer.from(canonicalChildResultBytes(reference)).toString("utf8");
@@ -10462,49 +10458,7 @@ export class AgentSession {
 					} else if (event.type === "message_start" || event.type === "message_update") {
 						if (event.message.role === "assistant") {
 							if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
-								if (!terminalOutputSink) {
-									terminalOutputSink = new C04ProducerSink();
-									const childFile = child.sessionManager.getSessionFile?.();
-									const childArtifactDir = child.sessionManager.getSessionArtifactDir?.();
-									if (
-										this._subagentRuntimeHost?.assignmentIdentityFenced &&
-										parentRecoveryAuthority &&
-										childFile &&
-										childArtifactDir
-									) {
-										const sink = terminalOutputSink;
-										terminalOutputCommit = createOrGetTerminalChildResult({
-											owner: {
-												parentSessionId: this.sessionId,
-												childSessionId: child.sessionId,
-												childSessionFile: childFile,
-												assignmentId: run.assignmentId,
-												operationId: run.operationId,
-												deliveryId: run.deliveryId,
-											},
-											childArtifactRoot: childArtifactDir,
-											parentRecoveryAuthority,
-											isCurrent: () =>
-												this._activeRlmChildRuns.get(run.id) === run &&
-												this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
-												this._activeRlmChildRuns.get(run.id)?.operationId === run.operationId &&
-												child.sessionManager.getSessionFile?.() === childFile &&
-												child.sessionManager.getSessionArtifactDir?.() === childArtifactDir,
-											candidate: {
-												status: "completed",
-												summary: "Child completed.",
-												preview: "Child output is streaming.",
-												artifacts: [{ kind: "terminal_output", contentType: "text/plain", data: sink }],
-												model: {
-													initialResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
-													terminalResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
-												},
-											},
-										}).catch((error) => {
-											throw error;
-										});
-									}
-								}
+								if (!terminalOutputSink) terminalOutputSink = new C04ProducerSink();
 								terminalOutputSink.push(event.assistantMessageEvent.delta);
 							}
 							const text = safeAssistantPreview(event.message as AssistantMessage);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -214,7 +214,16 @@ import {
 } from "./refinement/index.js";
 import { resolveConfigValue } from "./resolve-config-value.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
-import { materializedTerminalMessageId, type RlmTerminalMessage } from "./rlm-durable-operations.js";
+import {
+	createRlmSafeTerminalResultTerminalMessage,
+	materializedTerminalMessageId,
+	type RlmTerminalMessage,
+} from "./rlm-durable-operations.js";
+import {
+	canonicalChildResultBytes,
+	createOrGetTerminalChildResult,
+	type C04ChildResultStatus,
+} from "./rlm-child-results.js";
 import {
 	type CreateRlmSubagentRuntimeOptions,
 	createDefaultRlmSubagentSessionName,
@@ -10148,7 +10157,62 @@ export class AgentSession {
 			onSessionPublished: publishChildSession,
 		};
 
-		const deliverTerminalMessageToParent = async (message: CustomMessage): Promise<void> => {
+		/** C04 commits a bounded projection before daemon C03 sees any terminal envelope. */
+		const createDaemonTerminalResultMessage = async (): Promise<RlmTerminalMessage | undefined> => {
+			if (!this._subagentRuntimeHost?.assignmentIdentityFenced || !childSession) return undefined;
+			const childFile = childSession.sessionManager.getSessionFile?.();
+			const childArtifactDir = childSession.sessionManager.getSessionArtifactDir?.();
+			if (!childFile || !childArtifactDir) return undefined;
+			const status: C04ChildResultStatus =
+				run.status === "done" ? "completed" : run.status === "cancelled" ? "cancelled" : "failed";
+			const terminalModel = childSession.model ?? modelSelection.model;
+			try {
+				const reference = await createOrGetTerminalChildResult({
+					owner: {
+						parentSessionId: this.sessionId,
+						childSessionId: childSession.sessionId,
+						childSessionFile: childFile,
+						assignmentId: run.assignmentId,
+						operationId: run.operationId,
+						deliveryId: run.deliveryId,
+					},
+					childArtifactRoot: dirname(childArtifactDir),
+					candidate: {
+						status,
+						summary: status === "completed" ? "Child completed." : "Child terminal result is unavailable.",
+						preview: answerPreview || "No bounded terminal preview is available.",
+						...(status === "completed"
+							? {}
+							: {
+									error: {
+										code: status === "cancelled" ? "cancelled" : "terminal_storage_failed",
+										message:
+											status === "cancelled"
+												? "Child was cancelled."
+												: "Child failed without a publishable diagnostic.",
+									},
+								}),
+						model: {
+							initialResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
+							terminalResolvedSelector: `${terminalModel.provider}/${terminalModel.id}`,
+						},
+					},
+				});
+				// C03 treats this as opaque bytes. C04 is the only parser/codec authority.
+				const projection = Buffer.from(canonicalChildResultBytes(reference)).toString("utf8");
+				const content =
+					status === "completed"
+						? "Child completed; bounded result available."
+						: "Child ended; bounded result available.";
+				return createRlmSafeTerminalResultTerminalMessage(content, projection, Date.now());
+			} catch {
+				// No raw exception fallback and no second terminal path. A storage failure is
+				// intentionally left for C03 recovery/normal failure handling.
+				return undefined;
+			}
+		};
+
+		const deliverTerminalMessageToParent = async (message: RlmTerminalMessage | CustomMessage): Promise<void> => {
 			const activeOwner =
 				this._activeRlmChildRuns.get(run.id) === run &&
 				this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
@@ -10346,14 +10410,16 @@ export class AgentSession {
 				durationMs = Date.now() - startedAt;
 				activity = undefined;
 				emitChildUpdate();
-				if (!run.detachedDeletion && child._parentReplyCount === parentReplyCountBeforeRun) {
-					const lastAssistantText = child.getLastAssistantText();
+				if (!run.detachedDeletion && this._subagentRuntimeHost?.assignmentIdentityFenced) {
+					const terminal = await createDaemonTerminalResultMessage();
+					if (terminal) await deliverTerminalMessageToParent(terminal);
+				} else if (!run.detachedDeletion && child._parentReplyCount === parentReplyCountBeforeRun) {
 					await deliverTerminalMessageToParent(
 						createRlmChildTerminalNoticeMessage({
 							kind: "completed_without_reply",
 							childId: run.id,
 							sessionName,
-							lastAssistantTextPreview: lastAssistantText ? compactRlmText(lastAssistantText) : undefined,
+							lastAssistantTextPreview: answerPreview || undefined,
 						}),
 					);
 				}
@@ -10385,9 +10451,12 @@ export class AgentSession {
 				// the daemon's durable delete intent turns it into deleted/discarded.
 				// Do not suppress this merely because UI cleanup is detached.
 				if (
-					run.status === "cancelled" &&
-					(!run.detachedDeletion || this._subagentRuntimeHost?.assignmentIdentityFenced)
+					this._subagentRuntimeHost?.assignmentIdentityFenced &&
+					(!run.detachedDeletion || run.status === "cancelled")
 				) {
+					const terminal = await createDaemonTerminalResultMessage();
+					if (terminal) await deliverTerminalMessageToParent(terminal);
+				} else if (run.status === "cancelled" && !run.detachedDeletion) {
 					await deliverTerminalMessageToParent(
 						createRlmChildTerminalNoticeMessage({
 							kind: "cancelled",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1080,7 +1080,7 @@ export function rlmChildLabel(prompt: string): string {
 /** C04 terminal bytes are accepted exactly at the producer event boundary. This
  * queue never consults a completed AssistantMessage, transcript, or prompt
  * result; backpressure is the C04 artifact writer's bounded chunk contract. */
-class C04ProducerSink implements AsyncIterable<Uint8Array> {
+export class C04ProducerSink implements AsyncIterable<Uint8Array> {
 	private static readonly MAX_BUFFERED_BYTES = 2 * 64 * 1024;
 	private readonly chunks: Uint8Array[] = [];
 	private readonly waiters: Array<() => void> = [];
@@ -10101,6 +10101,9 @@ export class AgentSession {
 		const parentAssistantForUsage = this._findLastAssistantMessage();
 		const label = rlmChildLabel(prompt);
 		let answerPreview: string | undefined;
+		// This atomically materializes the parent-bound C04 recovery authority
+		// before a child can stream. Its key bytes never leave SessionManager.
+		const parentRecoveryAuthority = this.sessionManager.getC04ParentRecoveryAuthority();
 		let terminalOutputSink: C04ProducerSink | undefined;
 		let terminalOutputCommit: Promise<C04ChildResultReference> | undefined;
 		let durationMs: number | undefined;
@@ -10218,7 +10221,13 @@ export class AgentSession {
 				this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
 				this._activeRlmChildRuns.get(run.id)?.operationId === run.operationId &&
 				childSession?.sessionManager.getSessionFile?.() !== undefined;
-			if (!this._subagentRuntimeHost?.assignmentIdentityFenced || !childSession || !isCurrent()) return undefined;
+			if (
+				!this._subagentRuntimeHost?.assignmentIdentityFenced ||
+				!parentRecoveryAuthority ||
+				!childSession ||
+				!isCurrent()
+			)
+				return undefined;
 			const childFile = childSession.sessionManager.getSessionFile?.();
 			const childArtifactDir = childSession.sessionManager.getSessionArtifactDir?.();
 			if (!childFile || !childArtifactDir) return undefined;
@@ -10238,6 +10247,7 @@ export class AgentSession {
 								deliveryId: run.deliveryId,
 							},
 							childArtifactRoot: childArtifactDir,
+							parentRecoveryAuthority,
 							isCurrent,
 							candidate: {
 								status,
@@ -10447,7 +10457,12 @@ export class AgentSession {
 									terminalOutputSink = new C04ProducerSink();
 									const childFile = child.sessionManager.getSessionFile?.();
 									const childArtifactDir = child.sessionManager.getSessionArtifactDir?.();
-									if (this._subagentRuntimeHost?.assignmentIdentityFenced && childFile && childArtifactDir) {
+									if (
+										this._subagentRuntimeHost?.assignmentIdentityFenced &&
+										parentRecoveryAuthority &&
+										childFile &&
+										childArtifactDir
+									) {
 										const sink = terminalOutputSink;
 										terminalOutputCommit = createOrGetTerminalChildResult({
 											owner: {
@@ -10459,6 +10474,7 @@ export class AgentSession {
 												deliveryId: run.deliveryId,
 											},
 											childArtifactRoot: childArtifactDir,
+											parentRecoveryAuthority,
 											isCurrent: () =>
 												this._activeRlmChildRuns.get(run.id) === run &&
 												this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -215,6 +215,7 @@ import {
 import { resolveConfigValue } from "./resolve-config-value.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import {
+	type C04ChildResultReference,
 	type C04ChildResultStatus,
 	canonicalChildResultBytes,
 	createOrGetTerminalChildResult,
@@ -1076,21 +1077,51 @@ export function rlmChildLabel(prompt: string): string {
 	return prompt.replace(/\s+/g, " ").trim() || "child agent";
 }
 
-/** C04 receives producer-time terminal blocks only. Do not scan a session
- * transcript or encode a whole block: both make a terminal's memory use depend
- * on historical conversation size. */
-async function* streamAssistantTerminalOutput(message: AssistantMessage | undefined): AsyncGenerator<Uint8Array> {
-	if (!message) return;
-	const encoder = new TextEncoder();
-	for (const block of message.content) {
-		if (block.type !== "text") continue;
-		// Keep each UTF-8 conversion comfortably below C04's 64 KiB chunk limit.
-		for (let offset = 0; offset < block.text.length; offset += 8_192) {
-			const text = block.text.slice(offset, offset + 8_192);
-			const bytes = encoder.encode(text);
-			for (let byteOffset = 0; byteOffset < bytes.length; byteOffset += 64 * 1024)
-				yield bytes.subarray(byteOffset, byteOffset + 64 * 1024);
+/** C04 terminal bytes are accepted exactly at the producer event boundary. This
+ * queue never consults a completed AssistantMessage, transcript, or prompt
+ * result; backpressure is the C04 artifact writer's bounded chunk contract. */
+class C04ProducerSink implements AsyncIterable<Uint8Array> {
+	private static readonly MAX_BUFFERED_BYTES = 2 * 64 * 1024;
+	private readonly chunks: Uint8Array[] = [];
+	private readonly waiters: Array<() => void> = [];
+	private bufferedBytes = 0;
+	private failure: Error | undefined;
+	private closed = false;
+	push(text: string): void {
+		if (this.closed || !text) return;
+		const bytes = new TextEncoder().encode(text);
+		if (this.bufferedBytes + bytes.length > C04ProducerSink.MAX_BUFFERED_BYTES) {
+			this.failure = new Error("C04 producer sink exceeded its bounded buffer");
+			this.closed = true;
+			this.wake();
+			return;
 		}
+		for (let offset = 0; offset < bytes.length; offset += 64 * 1024) {
+			const chunk = bytes.slice(offset, offset + 64 * 1024);
+			this.chunks.push(chunk);
+			this.bufferedBytes += chunk.length;
+		}
+		this.wake();
+	}
+	close(): void {
+		this.closed = true;
+		this.wake();
+	}
+	private wake(): void {
+		for (const waiter of this.waiters.splice(0)) waiter();
+	}
+	async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+		while (!this.closed || this.chunks.length > 0) {
+			const chunk = this.chunks.shift();
+			if (chunk) {
+				this.bufferedBytes -= chunk.length;
+				yield chunk;
+				continue;
+			}
+			if (this.failure) throw this.failure;
+			await new Promise<void>((resolve) => this.waiters.push(resolve));
+		}
+		if (this.failure) throw this.failure;
 	}
 }
 /** A bounded sanitized presentation is maintained while the child produces it. */
@@ -10070,7 +10101,8 @@ export class AgentSession {
 		const parentAssistantForUsage = this._findLastAssistantMessage();
 		const label = rlmChildLabel(prompt);
 		let answerPreview: string | undefined;
-		let terminalAssistantOutput: AssistantMessage | undefined;
+		let terminalOutputSink: C04ProducerSink | undefined;
+		let terminalOutputCommit: Promise<C04ChildResultReference> | undefined;
 		let durationMs: number | undefined;
 		let toolUseCount = 0;
 		let runningToolCount = 0;
@@ -10181,7 +10213,12 @@ export class AgentSession {
 
 		/** C04 commits a bounded projection before daemon C03 sees any terminal envelope. */
 		const createDaemonTerminalResultMessage = async (): Promise<RlmTerminalMessage | undefined> => {
-			if (!this._subagentRuntimeHost?.assignmentIdentityFenced || !childSession) return undefined;
+			const isCurrent = () =>
+				this._activeRlmChildRuns.get(run.id) === run &&
+				this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
+				this._activeRlmChildRuns.get(run.id)?.operationId === run.operationId &&
+				childSession?.sessionManager.getSessionFile?.() !== undefined;
+			if (!this._subagentRuntimeHost?.assignmentIdentityFenced || !childSession || !isCurrent()) return undefined;
 			const childFile = childSession.sessionManager.getSessionFile?.();
 			const childArtifactDir = childSession.sessionManager.getSessionArtifactDir?.();
 			if (!childFile || !childArtifactDir) return undefined;
@@ -10189,48 +10226,52 @@ export class AgentSession {
 				run.status === "done" ? "completed" : run.status === "cancelled" ? "cancelled" : "failed";
 			const terminalModel = childSession.model ?? modelSelection.model;
 			try {
-				const reference = await createOrGetTerminalChildResult({
-					owner: {
-						parentSessionId: this.sessionId,
-						childSessionId: childSession.sessionId,
-						childSessionFile: childFile,
-						assignmentId: run.assignmentId,
-						operationId: run.operationId,
-						deliveryId: run.deliveryId,
-					},
-					childArtifactRoot: childArtifactDir,
-					candidate: {
-						status,
-						summary: status === "completed" ? "Child completed." : "Child terminal result is unavailable.",
-						preview: answerPreview || "No bounded terminal preview is available.",
-						...(status === "completed"
-							? {
-									artifacts: [
-										{
-											kind: "terminal_output" as const,
-											contentType: "text/plain" as const,
-											data: streamAssistantTerminalOutput(terminalAssistantOutput),
-										},
-									],
-								}
-							: {}),
-						...(status === "completed"
-							? {}
-							: {
-									error: {
-										code: status === "cancelled" ? "cancelled" : "terminal_storage_failed",
-										message:
-											status === "cancelled"
-												? "Child was cancelled."
-												: "Child failed without a publishable diagnostic.",
-									},
-								}),
-						model: {
-							initialResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
-							terminalResolvedSelector: `${terminalModel.provider}/${terminalModel.id}`,
-						},
-					},
-				});
+				const reference = terminalOutputCommit
+					? await terminalOutputCommit
+					: await createOrGetTerminalChildResult({
+							owner: {
+								parentSessionId: this.sessionId,
+								childSessionId: childSession.sessionId,
+								childSessionFile: childFile,
+								assignmentId: run.assignmentId,
+								operationId: run.operationId,
+								deliveryId: run.deliveryId,
+							},
+							childArtifactRoot: childArtifactDir,
+							isCurrent,
+							candidate: {
+								status,
+								summary: status === "completed" ? "Child completed." : "Child terminal result is unavailable.",
+								preview: answerPreview || "No bounded terminal preview is available.",
+								...(status === "completed"
+									? {
+											artifacts: [
+												{
+													kind: "terminal_output" as const,
+													contentType: "text/plain" as const,
+													data: terminalOutputSink ?? new C04ProducerSink(),
+												},
+											],
+										}
+									: {}),
+								...(status === "completed"
+									? {}
+									: {
+											error: {
+												code: status === "cancelled" ? "cancelled" : "terminal_storage_failed",
+												message:
+													status === "cancelled"
+														? "Child was cancelled."
+														: "Child failed without a publishable diagnostic.",
+											},
+										}),
+								model: {
+									initialResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
+									terminalResolvedSelector: `${terminalModel.provider}/${terminalModel.id}`,
+								},
+							},
+						});
+				if (!isCurrent()) return undefined;
 				// C03 treats this as opaque bytes. C04 is the only parser/codec authority.
 				const projection = Buffer.from(canonicalChildResultBytes(reference)).toString("utf8");
 				const content =
@@ -10395,13 +10436,52 @@ export class AgentSession {
 								}
 							}
 						}
-						terminalAssistantOutput = assistant;
 						const text = safeAssistantPreview(assistant);
 						if (text) answerPreview = text;
 						void flushAgentTraceUpload(child.sessionManager).catch(() => undefined);
 						emitChildUpdate();
 					} else if (event.type === "message_start" || event.type === "message_update") {
 						if (event.message.role === "assistant") {
+							if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+								if (!terminalOutputSink) {
+									terminalOutputSink = new C04ProducerSink();
+									const childFile = child.sessionManager.getSessionFile?.();
+									const childArtifactDir = child.sessionManager.getSessionArtifactDir?.();
+									if (this._subagentRuntimeHost?.assignmentIdentityFenced && childFile && childArtifactDir) {
+										const sink = terminalOutputSink;
+										terminalOutputCommit = createOrGetTerminalChildResult({
+											owner: {
+												parentSessionId: this.sessionId,
+												childSessionId: child.sessionId,
+												childSessionFile: childFile,
+												assignmentId: run.assignmentId,
+												operationId: run.operationId,
+												deliveryId: run.deliveryId,
+											},
+											childArtifactRoot: childArtifactDir,
+											isCurrent: () =>
+												this._activeRlmChildRuns.get(run.id) === run &&
+												this._activeRlmChildRuns.get(run.id)?.assignmentId === run.assignmentId &&
+												this._activeRlmChildRuns.get(run.id)?.operationId === run.operationId &&
+												child.sessionManager.getSessionFile?.() === childFile &&
+												child.sessionManager.getSessionArtifactDir?.() === childArtifactDir,
+											candidate: {
+												status: "completed",
+												summary: "Child completed.",
+												preview: "Child output is streaming.",
+												artifacts: [{ kind: "terminal_output", contentType: "text/plain", data: sink }],
+												model: {
+													initialResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
+													terminalResolvedSelector: `${modelSelection.model.provider}/${modelSelection.model.id}`,
+												},
+											},
+										}).catch((error) => {
+											throw error;
+										});
+									}
+								}
+								terminalOutputSink.push(event.assistantMessageEvent.delta);
+							}
 							const text = safeAssistantPreview(event.message as AssistantMessage);
 							if (text) answerPreview = text;
 							activity = { kind: "writing" };
@@ -10451,6 +10531,7 @@ export class AgentSession {
 					customMessage: spawnMessage,
 				});
 				if (run.error) throw new Error(run.error);
+				terminalOutputSink?.close();
 				run.status = "done";
 				durationMs = Date.now() - startedAt;
 				activity = undefined;
@@ -10484,6 +10565,7 @@ export class AgentSession {
 				}
 			} catch (error) {
 				const runError = error instanceof Error ? error : new Error(String(error));
+				terminalOutputSink?.close();
 				run.publication.reject(runError);
 				if (run.status !== "cancelled") {
 					run.status = "error";

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10259,7 +10259,16 @@ export class AgentSession {
 												{
 													kind: "terminal_output" as const,
 													contentType: "text/plain" as const,
-													data: terminalOutputSink ?? new C04ProducerSink(),
+													data: (() => {
+														// A producer opened by a text delta remains live until the child has
+														// actually finished.  Empty and tool-only completions have no such
+														// producer, so their fallback must already be closed: otherwise C04
+														// correctly waits forever for bytes that can never arrive.
+														if (terminalOutputSink) return terminalOutputSink;
+														const emptyTerminalOutput = new C04ProducerSink();
+														emptyTerminalOutput.close();
+														return emptyTerminalOutput;
+													})(),
 												},
 											],
 										}

--- a/packages/coding-agent/src/core/rlm-child-results.ts
+++ b/packages/coding-agent/src/core/rlm-child-results.ts
@@ -21,7 +21,7 @@ import {
 	unlinkSync,
 	writeSync,
 } from "node:fs";
-import { basename, dirname, join, parse, relative, resolve } from "node:path";
+import { basename, dirname, join, parse, relative, resolve, sep } from "node:path";
 import {
 	createRlmSafeTerminalResultTerminalMessage,
 	MAX_RLM_SAFE_TERMINAL_MESSAGE_BYTES,
@@ -990,9 +990,15 @@ function readParentRecoveryKey(
 	const parentRoot = canonicalDirectoryNoSymlinks(authority.parentArtifactRoot);
 	const expectedParentRoot = join(dirname(dirname(parentFile)), "session-artifacts", owner.parentSessionId);
 	if (parentRoot !== expectedParentRoot) throw new Error("C04 parent recovery artifact binding is invalid");
-	// Child and parent must remain within the same SessionManager state authority.
+	// A nested RLM child keeps its session and artifact root below the parent
+	// artifact directory. Both roots must be bound to the same parent state,
+	// rather than merely being siblings (which is true only for top-level
+	// SessionManager sessions).
 	const childRoot = canonicalDirectoryNoSymlinks(childArtifactRoot);
-	if (dirname(parentRoot) !== dirname(childRoot)) throw new Error("C04 parent recovery authority is foreign");
+	const childStateRoot = dirname(dirname(canonicalExistingRegularFile(owner.childSessionFile)!));
+	const topLevelSibling = dirname(parentRoot) === dirname(childRoot);
+	const nestedChild = parentRoot === childStateRoot && childRoot.startsWith(`${parentRoot}${sep}`);
+	if (!topLevelSibling && !nestedChild) throw new Error("C04 parent recovery authority is foreign");
 	let keyPath = resolve(authority.recoveryKeyPath);
 	try {
 		if (basename(keyPath) !== ".c04-recovery-key" || realpathSync(dirname(keyPath)) !== parentRoot)
@@ -1035,7 +1041,11 @@ function validateChildBinding(owner: C04ChildResultOwner, childArtifactRoot: str
 	// This is the one layout SessionManager publishes. IDs and paths are all
 	// checked together so a sibling session's root cannot be substituted.
 	const sessionDir = dirname(file);
-	if (basename(sessionDir) !== "sessions" || basename(file) !== `${sessionId}.jsonl`)
+	// RLM children use a private per-child session directory below their
+	// parent's artifact root, while top-level sessions use `sessions/`. Both
+	// are SessionManager layouts: in either case its artifact root is the
+	// sibling `session-artifacts/<sessionId>` of that exact session directory.
+	if (basename(file) !== `${sessionId}.jsonl`)
 		throw new Error("C04 child session file is not the exact SessionManager child binding");
 	const expected = join(dirname(sessionDir), "session-artifacts", sessionId);
 	if (root !== expected) throw new Error("C04 child artifact root is not the exact SessionManager child binding");
@@ -1380,7 +1390,7 @@ function assertArtifactRef(value: unknown, resultId: string): asserts value is C
 		typeof value.sha256 !== "string" ||
 		!SHA256.test(value.sha256) ||
 		!isUuid(value.creatorAssignmentId) ||
-		!isUuid(value.ownerSessionId) ||
+		!isCanonicalUuid(value.ownerSessionId) ||
 		!retentionStates.has(value.retentionState)
 	)
 		throw new Error("invalid C04 artifact reference");

--- a/packages/coding-agent/src/core/rlm-child-results.ts
+++ b/packages/coding-agent/src/core/rlm-child-results.ts
@@ -9,7 +9,6 @@ import {
 	constants,
 	fstatSync,
 	fsyncSync,
-	ftruncateSync,
 	lstatSync,
 	mkdirSync,
 	openSync,
@@ -18,6 +17,7 @@ import {
 	readSync,
 	realpathSync,
 	renameSync,
+	rmdirSync,
 	statSync,
 	unlinkSync,
 	writeSync,
@@ -452,7 +452,7 @@ export function recordChildResultDisposition(
 	try {
 		const verified = validateOwner(owner);
 		const root = prepareBoundRoot(verified, childArtifactRoot, false);
-		return withDispositionLock(root, input.resultId, () => {
+		return withDispositionLock(root, verified, input.resultId, () => {
 			// Re-read *under* the inter-process lock. This is a generation-CAS
 			// equivalent: no contender can base its transition on an older record.
 			const result = readStored(root, input.resultId);
@@ -486,34 +486,157 @@ export function recordChildResultDisposition(
 	}
 }
 
-/** A filesystem lock serializes retention writers across daemon processes.
- * It is intentionally result-scoped (rather than a client-wide limiter), and
- * every writer rereads the generation after acquiring it. */
-function withDispositionLock<T>(root: string, resultId: string, action: () => T): T {
+/** An authenticated result-scoped lock directory serializes retention writers.
+ * A bare O_EXCL file is unrecoverable after a crash.  The lease binds exact
+ * owner/result, random nonce, PID and PID-start identity under the parent HMAC.
+ * Live or unreadable leases fail closed. Only dead/reused identities are moved
+ * atomically to quarantine; contenders then race mkdir for the vacant name. */
+interface DispositionLeasePayload {
+	version: 1;
+	owner: C04ChildResultOwner;
+	resultId: string;
+	nonce: string;
+	pid: number;
+	processStartId: string;
+}
+interface DispositionLease extends DispositionLeasePayload {
+	mac: string;
+}
+function withDispositionLock<T>(root: string, owner: C04ChildResultOwner, resultId: string, action: () => T): T {
 	if (!isUuid(resultId)) throw new Error("invalid result ID");
-	const path = safePath(root, "operation-index", `.disposition.${resultId}.lock`);
-	let fd: number | undefined;
-	for (let attempt = 0; attempt < 400; attempt++) {
+	const recoveryKey = readDispositionRecoveryKey(root, owner);
+	const lock = safePath(root, "operation-index", `.disposition.${resultId}.lock`);
+	const identity = processIdentitySeam.captureCurrent();
+	if (!identity || !Number.isSafeInteger(identity.pid) || identity.pid < 1 || !identity.processStartId)
+		throw new Error("C04 exact process identity is unavailable");
+	const payload: DispositionLeasePayload = {
+		version: 1,
+		owner,
+		resultId,
+		nonce: randomUuid(),
+		pid: identity.pid,
+		processStartId: identity.processStartId,
+	};
+	const lease: DispositionLease = { ...payload, mac: dispositionLeaseMac(recoveryKey, payload) };
+	const token = canonicalJson(lease);
+	let acquired = false;
+	for (let attempt = 0; attempt < 32 && !acquired; attempt++) {
 		try {
-			fd = openSyncNoFollow(path, "wx", 0o600);
-			writeAll(fd, Buffer.from(`${process.pid}\n`));
-			fsyncSync(fd);
-			break;
+			mkdirSync(lock, { mode: 0o700 });
+			const leasePath = join(lock, "lease.json");
+			let fd: number | undefined;
+			try {
+				fd = openSyncNoFollow(leasePath, "wx", 0o600);
+				writeAll(fd, Buffer.from(token));
+				fsyncSync(fd);
+			} finally {
+				if (fd !== undefined) closeSync(fd);
+			}
+			fsyncDirectory(lock);
+			fsyncDirectory(dirname(lock));
+			acquired = true;
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-			// Synchronous public APIs cannot await; Atomics.wait yields the worker
-			// without spinning and allows a competing process to release promptly.
-			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+			let previous: DispositionLease;
+			try {
+				previous = readDispositionLease(lock, recoveryKey);
+				if (!sameOwner(previous.owner, owner) || previous.resultId !== resultId) throw new Error("foreign");
+			} catch (readError) {
+				// The stale directory may have been renamed by another contender
+				// after our mkdir lost. Race mkdir again; all other unreadable
+				// lease states fail closed.
+				if ((readError as NodeJS.ErrnoException).code === "ENOENT") continue;
+				throw new Error("C04 disposition lock is uncertain");
+			}
+			const state = processIdentitySeam.observe(previous);
+			if (state === "live" || state === "unreadable") throw new Error("C04 disposition lock is uncertain");
+			// Atomic rename is the stale-owner CAS. Keep quarantine as evidence;
+			// never unlink, steal, or clean a foreign/live lease.
+			const quarantine = safePath(
+				root,
+				"operation-index",
+				`.disposition.${resultId}.dead.${previous.nonce}.${randomUuid()}.lock`,
+			);
+			try {
+				renameSync(lock, quarantine);
+				fsyncDirectory(dirname(lock));
+			} catch (renameError) {
+				if ((renameError as NodeJS.ErrnoException).code !== "ENOENT") throw renameError;
+			}
 		}
 	}
-	if (fd === undefined) throw new Error("C04 disposition lock unavailable");
+	if (!acquired) throw new Error("C04 disposition lock unavailable");
 	try {
 		return action();
 	} finally {
-		closeSync(fd);
-		safeUnlink(path);
-		fsyncDirectory(dirname(path));
+		// Cleanup is bound to this exact nonce/token, never a replacement lease.
+		try {
+			const leasePath = join(lock, "lease.json");
+			if (readFileSync(leasePath, "utf8") === token) {
+				unlinkSync(leasePath);
+				rmdirSync(lock);
+				fsyncDirectory(dirname(lock));
+			}
+		} catch {
+			/* failed cleanup remains an authenticated recoverable lease */
+		}
 	}
+}
+function dispositionLeaseMac(key: Buffer, payload: DispositionLeasePayload): string {
+	return createHmac("sha256", key).update(canonicalJson(payload)).digest("hex");
+}
+function readDispositionLease(lock: string, key: Buffer): DispositionLease {
+	const leasePath = join(lock, "lease.json");
+	const stat = lstatSync(leasePath);
+	if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 8192) throw new Error("invalid disposition lease");
+	const value: unknown = JSON.parse(readFileSync(leasePath, "utf8"));
+	if (
+		!isObject(value) ||
+		!exactKeys(value, ["version", "owner", "resultId", "nonce", "pid", "processStartId", "mac"]) ||
+		value.version !== 1 ||
+		!isUuid(value.resultId) ||
+		!isUuid(value.nonce) ||
+		!Number.isSafeInteger(value.pid) ||
+		value.pid < 1 ||
+		typeof value.processStartId !== "string" ||
+		!value.processStartId ||
+		typeof value.mac !== "string" ||
+		!SHA256.test(value.mac)
+	)
+		throw new Error("invalid disposition lease");
+	const payload: DispositionLeasePayload = {
+		version: 1,
+		owner: validateOwner(value.owner as C04ChildResultOwner),
+		resultId: value.resultId,
+		nonce: value.nonce,
+		pid: value.pid,
+		processStartId: value.processStartId,
+	};
+	const expected = Buffer.from(dispositionLeaseMac(key, payload), "hex");
+	const actual = Buffer.from(value.mac, "hex");
+	if (expected.length !== actual.length || !timingSafeEqual(expected, actual))
+		throw new Error("invalid disposition lease");
+	return { ...payload, mac: value.mac };
+}
+function readDispositionRecoveryKey(root: string, owner: C04ChildResultOwner): Buffer {
+	const childRoot = dirname(root);
+	let state = dirname(dirname(childRoot));
+	for (;;) {
+		const parentArtifactRoot = join(state, "session-artifacts", owner.parentSessionId);
+		try {
+			return readParentRecoveryKey(owner, childRoot, {
+				parentSessionFile: join(state, "sessions", `${owner.parentSessionId}.jsonl`),
+				parentArtifactRoot,
+				recoveryKeyPath: join(parentArtifactRoot, ".c04-recovery-key"),
+			});
+		} catch {
+			/* candidate parent must pass exact binding */
+		}
+		const next = dirname(state);
+		if (next === state) break;
+		state = next;
+	}
+	throw new Error("C04 disposition recovery authority is unavailable");
 }
 
 export function canonicalChildResultBytes(value: C04ChildResultReference): Uint8Array {
@@ -850,6 +973,7 @@ function reserveOperationAndQuota(
 		throw immutableConflict(root, owner.operationId);
 	}
 	let currentToken = token;
+	let currentQuotaToken = token;
 	return {
 		resultId: journal.resultId,
 		recordHandle: (handleId: string) => {
@@ -861,21 +985,22 @@ function reserveOperationAndQuota(
 			// Reservation ownership is still protected by the O_EXCL name. Update it
 			// durably before publishing the random blob name, so crash recovery owns
 			// the same-attempt orphan even if no result record was written.
-			const update = openSyncNoFollow(reservation, "r+");
-			try {
-				ftruncateSync(update, 0);
-				writeAll(update, Buffer.from(next));
-				fsyncSync(update);
-			} finally {
-				closeSync(update);
-			}
+			// A crash observes either the old complete HMAC journal or the new
+			// complete HMAC journal, never an in-place truncated intermediate.
+			if (readFileSync(reservation, "utf8") !== currentToken) throw new Error("C04 reservation ownership changed");
+			if (readFileSync(quotaReservation, "utf8") !== currentQuotaToken)
+				throw new Error("C04 quota reservation ownership changed");
+			atomicJson(reservation, journal);
+			// A cut between these two replacements leaves two independently valid
+			// journals for the same nonce/result; recovery accepts either version.
+			atomicJson(quotaReservation, journal);
 			currentToken = next;
+			currentQuotaToken = next;
 		},
 		release: () => {
 			operationReservations.delete(key);
 			unlinkReservationIfOwned(reservation, currentToken);
-			// quota is only an admission mutex, so its original authenticated body is sufficient.
-			unlinkReservationIfOwned(quotaReservation, token);
+			unlinkReservationIfOwned(quotaReservation, currentQuotaToken);
 			fsyncDirectory(dirname(reservation));
 		},
 	};
@@ -942,7 +1067,13 @@ function reconcileAbandonedReservation(
 		appendAudit(root, "uncertain", "restart_tombstoned", journal.resultId);
 	}
 	unlinkReservationIfOwned(path, token);
-	unlinkReservationIfOwned(safePath(root, "operation-index", `.quota.${owner.childSessionId}.reserve`), token);
+	// A cut between journal replacements can leave quota at the prior complete
+	// version. Delete it only after independently authenticating the same attempt.
+	unlinkQuotaReservationForAttempt(
+		safePath(root, "operation-index", `.quota.${owner.childSessionId}.reserve`),
+		recoveryKey,
+		journal,
+	);
 	fsyncDirectory(dirname(path));
 }
 function reservationMac(key: Buffer, payload: ReservationJournalPayload): string {
@@ -1009,6 +1140,16 @@ function readHandleIndexIfMatching(
 		return value.resultId === resultId && sameOwner(value.owner, owner);
 	} catch {
 		return false;
+	}
+}
+function unlinkQuotaReservationForAttempt(path: string, key: Buffer, attempt: ReservationJournal): void {
+	try {
+		const token = readFileSync(path, "utf8");
+		const quota = parseAuthenticatedReservation(token, key);
+		if (sameOwner(quota.owner, attempt.owner) && quota.nonce === attempt.nonce && quota.resultId === attempt.resultId)
+			unlinkReservationIfOwned(path, token);
+	} catch {
+		// Never remove an unreadable, foreign, or unauthenticated quota lease.
 	}
 }
 function unlinkReservationIfOwned(path: string, token: string): void {
@@ -1238,7 +1379,7 @@ function expireIfElapsed(root: string, result: StoredChildResult, now: Date): St
 	return setExpired(root, result);
 }
 function setExpired(root: string, result: StoredChildResult): StoredChildResult {
-	return withDispositionLock(root, result.resultId, () => {
+	return withDispositionLock(root, result.owner, result.resultId, () => {
 		const current = readStored(root, result.resultId);
 		if (current.retentionState !== "retained") return current;
 		const expired = {

--- a/packages/coding-agent/src/core/rlm-child-results.ts
+++ b/packages/coding-agent/src/core/rlm-child-results.ts
@@ -9,6 +9,7 @@ import {
 	constants,
 	fstatSync,
 	fsyncSync,
+	ftruncateSync,
 	lstatSync,
 	mkdirSync,
 	openSync,
@@ -21,7 +22,7 @@ import {
 	unlinkSync,
 	writeSync,
 } from "node:fs";
-import { basename, dirname, join, parse, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
 import {
 	createRlmSafeTerminalResultTerminalMessage,
 	MAX_RLM_SAFE_TERMINAL_MESSAGE_BYTES,
@@ -226,7 +227,7 @@ export async function createOrGetTerminalChildResult(
 			...(candidate.error?.diagnostic ? [candidate.error.diagnostic] : []),
 		]) {
 			if (artifacts.length >= MAX_ARTIFACTS_PER_RESULT) throw new Error("artifact count exceeds C04 limit");
-			const written = await writeArtifact(root, owner, resultId, artifact, reservedBytes);
+			const written = await writeArtifact(root, owner, resultId, artifact, reservedBytes, reservation.recordHandle);
 			reservedBytes += written.byteLength;
 			artifacts.push(written);
 		}
@@ -451,30 +452,67 @@ export function recordChildResultDisposition(
 	try {
 		const verified = validateOwner(owner);
 		const root = prepareBoundRoot(verified, childArtifactRoot, false);
-		const result = readStored(root, input.resultId);
-		if (!sameOwner(result.owner, verified)) return false;
-		if (input.handleId && !result.artifacts.some((a) => a.handleId === input.handleId)) return false;
-		const changed = result.artifacts.map((artifact) =>
-			artifact.handleId === input.handleId || !input.handleId
-				? { ...artifact, retentionState: input.disposition }
-				: artifact,
-		);
-		if (canonicalJson(changed) !== canonicalJson(result.artifacts)) {
-			// State and audit are durable before bytes become unreachable.
+		return withDispositionLock(root, input.resultId, () => {
+			// Re-read *under* the inter-process lock. This is a generation-CAS
+			// equivalent: no contender can base its transition on an older record.
+			const result = readStored(root, input.resultId);
+			if (!sameOwner(result.owner, verified)) return false;
+			if (input.handleId && !result.artifacts.some((a) => a.handleId === input.handleId)) return false;
+			const changed = result.artifacts.map((artifact) =>
+				artifact.handleId === input.handleId || !input.handleId
+					? { ...artifact, retentionState: input.disposition }
+					: artifact,
+			);
+			const anyRetained = changed.some((artifact) => artifact.retentionState === "retained");
+			const resultState = anyRetained ? "retained" : input.disposition;
+			const stateChanged =
+				canonicalJson(changed) !== canonicalJson(result.artifacts) || result.retentionState !== resultState;
+			if (!stateChanged) return true;
+			// The replacement is durable before any corresponding blob is unlinked.
 			atomicJson(safePath(root, "results", `${result.resultId}.json`), {
 				...result,
 				artifacts: changed,
-				retentionState: input.disposition,
+				retentionState: resultState,
 				generation: result.generation + 1,
 			});
 			appendAudit(root, input.disposition, input.disposition, input.handleId ?? input.resultId);
 			for (const artifact of changed)
 				if (artifact.retentionState !== "retained")
 					safeUnlink(safePath(root, "objects", `${artifact.handleId}.blob`));
-		}
-		return true;
+			return true;
+		});
 	} catch {
 		return false;
+	}
+}
+
+/** A filesystem lock serializes retention writers across daemon processes.
+ * It is intentionally result-scoped (rather than a client-wide limiter), and
+ * every writer rereads the generation after acquiring it. */
+function withDispositionLock<T>(root: string, resultId: string, action: () => T): T {
+	if (!isUuid(resultId)) throw new Error("invalid result ID");
+	const path = safePath(root, "operation-index", `.disposition.${resultId}.lock`);
+	let fd: number | undefined;
+	for (let attempt = 0; attempt < 400; attempt++) {
+		try {
+			fd = openSyncNoFollow(path, "wx", 0o600);
+			writeAll(fd, Buffer.from(`${process.pid}\n`));
+			fsyncSync(fd);
+			break;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+			// Synchronous public APIs cannot await; Atomics.wait yields the worker
+			// without spinning and allows a competing process to release promptly.
+			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+		}
+	}
+	if (fd === undefined) throw new Error("C04 disposition lock unavailable");
+	try {
+		return action();
+	} finally {
+		closeSync(fd);
+		safeUnlink(path);
+		fsyncDirectory(dirname(path));
 	}
 }
 
@@ -519,11 +557,7 @@ function validateOwner(value: C04ChildResultOwner): C04ChildResultOwner {
 		throw new Error("invalid C04 owner");
 	for (const key of ["parentSessionId", "childSessionId", "assignmentId", "operationId", "deliveryId"] as const)
 		if (!isCanonicalUuid(value[key])) throw new Error(`invalid C04 owner ${key}`);
-	if (
-		typeof value.childSessionFile !== "string" ||
-		!value.childSessionFile ||
-		!resolve(value.childSessionFile).startsWith("/")
-	)
+	if (typeof value.childSessionFile !== "string" || !value.childSessionFile || !isAbsolute(value.childSessionFile))
 		throw new Error("invalid C04 child session file");
 	return { ...value, childSessionFile: resolve(value.childSessionFile) };
 }
@@ -588,14 +622,14 @@ function validateCandidate(
 		if (value.error.diagnostic) error.diagnostic = validateArtifact(value.error.diagnostic);
 	}
 	const model = validateModel(value.model);
-	const artifacts =
-		value.artifacts === undefined
-			? []
-			: Array.isArray(value.artifacts) && value.artifacts.length <= MAX_ARTIFACTS_PER_RESULT
-				? value.artifacts.map(validateArtifact)
-				: (() => {
-						throw new Error("invalid C04 artifacts");
-					})();
+	// A diagnostic is materialized as an artifact. Validate the complete set before
+	// consuming any producer so a 17th artifact can never fail halfway through a stream.
+	const rawArtifacts = value.artifacts === undefined ? [] : value.artifacts;
+	if (!Array.isArray(rawArtifacts) || rawArtifacts.length > MAX_ARTIFACTS_PER_RESULT)
+		throw new Error("invalid C04 artifacts");
+	if (rawArtifacts.length + (error?.diagnostic ? 1 : 0) > MAX_ARTIFACTS_PER_RESULT)
+		throw new Error("C04 artifact count reserves a diagnostic slot");
+	const artifacts = rawArtifacts.map(validateArtifact);
 	return { status, summary, preview, facts: normalizedFacts, nextActions: normalizedNext, error, model, artifacts };
 }
 function validateModel(value: unknown): C04ModelMetadata {
@@ -650,8 +684,10 @@ async function writeArtifact(
 	resultId: string,
 	artifact: C04ArtifactInput,
 	used = aggregateBytes(root, owner),
+	recordHandle?: (handleId: string) => void,
 ): Promise<C04OpaqueArtifactReference> {
 	const handleId = randomUuid();
+	recordHandle?.(handleId);
 	const finalPath = safePath(root, "objects", `${handleId}.blob`);
 	const temp = safePath(root, "objects", `.${handleId}.${randomUuid()}.tmp`);
 	let fd: number | undefined;
@@ -672,7 +708,6 @@ async function writeArtifact(
 		closeSync(fd);
 		fd = undefined;
 		publishExclusive(temp, finalPath);
-		fsyncDirectory(dirname(finalPath));
 		return {
 			version: 1,
 			handleId,
@@ -707,8 +742,7 @@ function aggregateBytes(root: string, owner: C04ChildResultOwner): number {
 			if (
 				r.owner.parentSessionId === owner.parentSessionId &&
 				r.owner.childSessionId === owner.childSessionId &&
-				r.owner.childSessionFile === owner.childSessionFile &&
-				r.owner.assignmentId === owner.assignmentId
+				r.owner.childSessionFile === owner.childSessionFile
 			)
 				total += r.artifacts.reduce((n, a) => n + (a.retentionState === "retained" ? a.byteLength : 0), 0);
 		} catch {
@@ -731,6 +765,8 @@ interface ReservationJournalPayload {
 	processStartId: string;
 	progress: "reserved" | "publishing";
 	resultId: string;
+	/** Every generated blob handle is journaled before its destination exists. */
+	handleIds?: string[];
 }
 interface ReservationJournal extends ReservationJournalPayload {
 	/** HMAC-SHA256 over the canonical payload. Never project this or the key. */
@@ -771,15 +807,11 @@ function reserveOperationAndQuota(
 	owner: C04ChildResultOwner,
 	indexPath: string,
 	recoveryKey: Buffer,
-): { release: () => void; resultId: string } {
+): { release: () => void; resultId: string; recordHandle: (handleId: string) => void } {
 	const key = `${root}:${owner.parentSessionId}:${owner.childSessionId}:${owner.assignmentId}`;
 	if (operationReservations.has(key)) throw immutableConflict(root, owner.operationId);
 	const reservation = safePath(root, "operation-index", `.${owner.operationId}.reserve`);
-	const quotaReservation = safePath(
-		root,
-		"operation-index",
-		`.quota.${owner.childSessionId}.${owner.assignmentId}.reserve`,
-	);
+	const quotaReservation = safePath(root, "operation-index", `.quota.${owner.childSessionId}.reserve`);
 	const identity = processIdentitySeam.captureCurrent();
 	if (!identity || !Number.isSafeInteger(identity.pid) || identity.pid < 1 || !identity.processStartId)
 		throw new Error("C04 exact process identity is unavailable");
@@ -792,8 +824,9 @@ function reserveOperationAndQuota(
 		processStartId: identity.processStartId,
 		progress: "reserved",
 		resultId: randomUuid(),
+		handleIds: [],
 	};
-	const journal: ReservationJournal = { ...payload, mac: reservationMac(recoveryKey, payload) };
+	let journal: ReservationJournal = { ...payload, mac: reservationMac(recoveryKey, payload) };
 	const token = canonicalJson(journal);
 	let operationFd: number | undefined;
 	let quotaFd: number | undefined;
@@ -816,11 +849,32 @@ function reserveOperationAndQuota(
 		unlinkReservationIfOwned(quotaReservation, token);
 		throw immutableConflict(root, owner.operationId);
 	}
+	let currentToken = token;
 	return {
 		resultId: journal.resultId,
+		recordHandle: (handleId: string) => {
+			if (!isUuid(handleId) || (journal.handleIds ?? []).includes(handleId))
+				throw new Error("invalid C04 journal handle");
+			journal = { ...journal, progress: "publishing", handleIds: [...(journal.handleIds ?? []), handleId] };
+			journal.mac = reservationMac(recoveryKey, journal);
+			const next = canonicalJson(journal);
+			// Reservation ownership is still protected by the O_EXCL name. Update it
+			// durably before publishing the random blob name, so crash recovery owns
+			// the same-attempt orphan even if no result record was written.
+			const update = openSyncNoFollow(reservation, "r+");
+			try {
+				ftruncateSync(update, 0);
+				writeAll(update, Buffer.from(next));
+				fsyncSync(update);
+			} finally {
+				closeSync(update);
+			}
+			currentToken = next;
+		},
 		release: () => {
 			operationReservations.delete(key);
-			unlinkReservationIfOwned(reservation, token);
+			unlinkReservationIfOwned(reservation, currentToken);
+			// quota is only an admission mutex, so its original authenticated body is sufficient.
 			unlinkReservationIfOwned(quotaReservation, token);
 			fsyncDirectory(dirname(reservation));
 		},
@@ -879,14 +933,16 @@ function reconcileAbandonedReservation(
 			});
 		appendAudit(root, "linked", "restart_reconciled", result.resultId);
 	} catch {
-		cleanUnindexedOwnedAttempt(root, owner, journal.resultId, []);
+		cleanUnindexedOwnedAttempt(
+			root,
+			owner,
+			journal.resultId,
+			(journal.handleIds ?? []).map((handleId) => ({ handleId }) as C04OpaqueArtifactReference),
+		);
 		appendAudit(root, "uncertain", "restart_tombstoned", journal.resultId);
 	}
 	unlinkReservationIfOwned(path, token);
-	unlinkReservationIfOwned(
-		safePath(root, "operation-index", `.quota.${owner.childSessionId}.${owner.assignmentId}.reserve`),
-		token,
-	);
+	unlinkReservationIfOwned(safePath(root, "operation-index", `.quota.${owner.childSessionId}.reserve`), token);
 	fsyncDirectory(dirname(path));
 }
 function reservationMac(key: Buffer, payload: ReservationJournalPayload): string {
@@ -905,16 +961,19 @@ function parseAuthenticatedReservation(token: string, key: Buffer): ReservationJ
 			"processStartId",
 			"progress",
 			"resultId",
+			...optionalKeys(value, ["handleIds"]),
 			"mac",
 		]) ||
 		value.version !== 1 ||
 		!isUuid(value.nonce) ||
 		!isUuid(value.resultId) ||
+		(value.handleIds !== undefined &&
+			(!Array.isArray(value.handleIds) || value.handleIds.some((handleId) => !isUuid(handleId)))) ||
 		!Number.isSafeInteger(value.pid) ||
 		value.pid < 1 ||
 		typeof value.processStartId !== "string" ||
 		!value.processStartId ||
-		value.progress !== "reserved" ||
+		(value.progress !== "reserved" && value.progress !== "publishing") ||
 		typeof value.mac !== "string" ||
 		!SHA256.test(value.mac)
 	)
@@ -930,6 +989,7 @@ function parseAuthenticatedReservation(token: string, key: Buffer): ReservationJ
 		processStartId: value.processStartId,
 		progress: value.progress,
 		resultId: value.resultId,
+		...(value.handleIds === undefined ? {} : { handleIds: value.handleIds as string[] }),
 	};
 	if (typeof payload.indexPath !== "string") throw new Error("invalid C04 reservation journal");
 	const expected = Buffer.from(reservationMac(key, payload), "hex");
@@ -1104,7 +1164,7 @@ function assertPrivateDirectory(path: string): string {
 function safePath(root: string, directory: string, name?: string): string {
 	if (
 		!/^[a-z-]+$/.test(directory) ||
-		(name !== undefined && (!/^[a-z0-9.-]+(?:\.(?:json|blob|tmp|reserve))?$/.test(name) || name.includes("..")))
+		(name !== undefined && (!/^[a-z0-9.-]+(?:\.(?:json|blob|tmp|reserve|lock))?$/.test(name) || name.includes("..")))
 	)
 		throw new Error("invalid C04 generated path");
 	const target = name === undefined ? join(root, directory) : join(root, directory, name);
@@ -1168,21 +1228,30 @@ function readHandleIndex(
 }
 
 function expireIfElapsed(root: string, result: StoredChildResult, now: Date): StoredChildResult {
-	if (Date.parse(result.retention.expiresAt) > now.getTime()) return result;
+	// Time is an input to a destructive retention transition. Invalid clocks and
+	// malformed timestamps fail closed: preserve bytes and authority rather than
+	// treating NaN as already expired.
+	const expiresAt = Date.parse(result.retention.expiresAt);
+	const current = now.getTime();
+	if (!Number.isFinite(expiresAt) || !Number.isFinite(current) || expiresAt > current) return result;
 	if (result.retentionState !== "retained") return result;
 	return setExpired(root, result);
 }
 function setExpired(root: string, result: StoredChildResult): StoredChildResult {
-	const expired = {
-		...result,
-		retentionState: "expired" as const,
-		artifacts: result.artifacts.map((a) => ({ ...a, retentionState: "expired" as const })),
-		generation: result.generation + 1,
-	};
-	atomicJson(safePath(root, "results", `${result.resultId}.json`), expired);
-	appendAudit(root, "expired", "retention_elapsed", result.resultId);
-	for (const a of expired.artifacts) safeUnlink(safePath(root, "objects", `${a.handleId}.blob`));
-	return expired;
+	return withDispositionLock(root, result.resultId, () => {
+		const current = readStored(root, result.resultId);
+		if (current.retentionState !== "retained") return current;
+		const expired = {
+			...current,
+			retentionState: "expired" as const,
+			artifacts: current.artifacts.map((a) => ({ ...a, retentionState: "expired" as const })),
+			generation: current.generation + 1,
+		};
+		atomicJson(safePath(root, "results", `${current.resultId}.json`), expired);
+		appendAudit(root, "expired", "retention_elapsed", current.resultId);
+		for (const a of expired.artifacts) safeUnlink(safePath(root, "objects", `${a.handleId}.blob`));
+		return expired;
+	});
 }
 function assertC03EnvelopeFits(reference: C04ChildResultReference): void {
 	const projection = Buffer.from(canonicalChildResultBytes(reference)).toString("utf8");
@@ -1212,7 +1281,11 @@ function cleanUnindexedOwnedAttempt(
 				const handle = readHandleIndex(root, artifact.handleId);
 				ours = handle.resultId === resultId && sameOwner(handle.owner, owner);
 				if (ours) safeUnlink(handlePath);
-			} catch {}
+			} catch {
+				// A handle named in the authenticated dead-attempt journal has never
+				// had a public index, and its random UUID belongs exclusively to it.
+				ours = true;
+			}
 			if (ours) safeUnlink(safePath(root, "objects", `${artifact.handleId}.blob`));
 		}
 		try {
@@ -1311,15 +1384,11 @@ function assertStored(value: unknown): asserts value is StoredChildResult {
 		!SHA256.test(value.requestDigest)
 	)
 		throw new Error("invalid C04 result record");
-	if (
-		value.retentionState === "retained" &&
-		(value.artifacts as C04OpaqueArtifactReference[]).some((a) => a.retentionState !== "retained")
-	)
-		throw new Error("C04 retention consistency mismatch");
-	if (
-		value.retentionState !== "retained" &&
-		(value.artifacts as C04OpaqueArtifactReference[]).some((a) => a.retentionState === "retained")
-	)
+	// A result remains retained while at least one artifact is retained. This
+	// permits an exact-handle disposition without falsely expiring its siblings.
+	const storedArtifacts = value.artifacts as C04OpaqueArtifactReference[];
+	const hasRetainedArtifact = storedArtifacts.some((a) => a.retentionState === "retained");
+	if ((value.retentionState === "retained") !== hasRetainedArtifact && storedArtifacts.length > 0)
 		throw new Error("C04 retention consistency mismatch");
 }
 function assertReference(value: unknown): asserts value is C04ChildResultReference {
@@ -1396,13 +1465,14 @@ function assertArtifactRef(value: unknown, resultId: string): asserts value is C
 		throw new Error("invalid C04 artifact reference");
 }
 function publishExclusive(temp: string, path: string): void {
-	// link(2) is an atomic no-replace publication. Node has no linkSync import
-	// here, so create the destination exclusively and copy from the private temp
-	// FD; a collision can never overwrite an immutable object name.
+	// Destination is opened O_EXCL. If copy/fsync fails, remove precisely that
+	// newly-created inode; an EEXIST winner is never opened or unlinked.
 	const source = openSyncNoFollow(temp, "r");
 	let destination: number | undefined;
+	let created = false;
 	try {
 		destination = openSyncNoFollow(path, "wx", 0o600);
+		created = true;
 		const buffer = Buffer.allocUnsafe(MAX_STREAM_CHUNK_BYTES);
 		for (;;) {
 			const count = readSync(source, buffer, 0, buffer.length, null);
@@ -1410,12 +1480,19 @@ function publishExclusive(temp: string, path: string): void {
 			writeAll(destination, buffer.subarray(0, count));
 		}
 		fsyncSync(destination);
+		fsyncDirectory(dirname(path));
+	} catch (error) {
+		if (destination !== undefined) closeSync(destination);
+		destination = undefined;
+		if (created) safeUnlink(path);
+		throw error;
 	} finally {
 		closeSync(source);
 		if (destination !== undefined) closeSync(destination);
 	}
 	safeUnlink(temp);
 }
+
 function atomicJson(path: string, value: unknown): void {
 	const temp = `${path}.${randomUuid()}.tmp`;
 	let fd: number | undefined;
@@ -1434,15 +1511,23 @@ function atomicJson(path: string, value: unknown): void {
 	}
 }
 function atomicExclusiveJson(path: string, value: unknown): void {
-	const fd = openSyncNoFollow(path, "wx", 0o600);
+	let fd: number | undefined;
+	let created = false;
 	try {
+		fd = openSyncNoFollow(path, "wx", 0o600);
+		created = true;
 		writeAll(fd, Buffer.from(canonicalJson(value)));
 		fsyncSync(fd);
-	} finally {
 		closeSync(fd);
+		fd = undefined;
+		fsyncDirectory(dirname(path));
+	} catch (error) {
+		if (fd !== undefined) closeSync(fd);
+		if (created) safeUnlink(path);
+		throw error;
 	}
-	fsyncDirectory(dirname(path));
 }
+
 function appendAudit(root: string, action: AuditAction, reason: string, id: string): void {
 	try {
 		const path = join(root, "audit.jsonl");
@@ -1495,13 +1580,15 @@ function openSyncNoFollow(path: string, flags: string, mode?: number): number {
 	const numeric =
 		flags === "r"
 			? constants.O_RDONLY
-			: flags === "a"
-				? constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY
-				: flags === "wx"
-					? constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY
-					: (() => {
-							throw new Error("invalid C04 open mode");
-						})();
+			: flags === "r+"
+				? constants.O_RDWR
+				: flags === "a"
+					? constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY
+					: flags === "wx"
+						? constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY
+						: (() => {
+								throw new Error("invalid C04 open mode");
+							})();
 	// O_NOFOLLOW closes the lstat/open race on platforms that support it.
 	return openSync(path, numeric | (constants.O_NOFOLLOW ?? 0), mode);
 }

--- a/packages/coding-agent/src/core/rlm-child-results.ts
+++ b/packages/coding-agent/src/core/rlm-child-results.ts
@@ -2,7 +2,7 @@
  * C04's sole authority for bounded terminal child results and opaque, owner-local
  * artifacts.  This module deliberately has no daemon/protocol dependency.
  */
-import { createHash, randomUUID } from "node:crypto";
+import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import {
 	chmodSync,
 	closeSync,
@@ -26,6 +26,7 @@ import {
 	createRlmSafeTerminalResultTerminalMessage,
 	MAX_RLM_SAFE_TERMINAL_MESSAGE_BYTES,
 } from "./rlm-durable-operations.js";
+import { getProcessStartId } from "./session-lease.js";
 
 export const CHILD_RESULT_SCHEMA_VERSION = 1 as const;
 /** C04's opaque projection must still fit C03's 64 KiB full envelope.
@@ -148,11 +149,20 @@ export interface C04ArtifactInput {
 	 * rejected so a terminal can never accidentally retain an unbounded reply. */
 	data: AsyncIterable<Uint8Array>;
 }
+/** SessionManager issues this private authority for a parent before C04 can write.
+ * It deliberately names no key bytes, so it can never enter a C04 projection. */
+export interface C04ParentRecoveryAuthority {
+	parentSessionFile: string;
+	parentArtifactRoot: string;
+	recoveryKeyPath: string;
+}
 export interface C04CreateTerminalChildResultInput {
 	owner: C04ChildResultOwner;
 	candidate: C04TerminalCandidate;
 	/** Trusted SessionManager child artifact directory; callers never pass a relative object path. */
 	childArtifactRoot: string;
+	/** SessionManager-owned, parent-bound private recovery authority. */
+	parentRecoveryAuthority: C04ParentRecoveryAuthority;
 	/** Captured runtime/assignment capability, rechecked before durable publication. */
 	isCurrent?: () => boolean;
 	now?: () => Date;
@@ -186,12 +196,13 @@ export async function createOrGetTerminalChildResult(
 	// Bind before creating C04 state: an untrusted sibling/renamed root never gets
 	// a durable directory merely because it was supplied by a caller.
 	validateChildBinding(owner, input.childArtifactRoot);
+	const recoveryKey = readParentRecoveryKey(owner, input.childArtifactRoot, input.parentRecoveryAuthority);
 	const root = prepareBoundRoot(owner, input.childArtifactRoot);
 	const now = input.now?.() ?? new Date();
 	if (!Number.isFinite(now.getTime())) throw new Error("C04 time is invalid");
 	const candidate = validateCandidate(input.candidate);
 	const indexPath = safePath(root, "operation-index", `${owner.operationId}.json`);
-	reconcileAbandonedReservation(root, owner, indexPath);
+	reconcileAbandonedReservation(root, owner, indexPath, recoveryKey);
 	const existing = readIndex(indexPath);
 	// A committed operation is immutable.  We do not touch a retry stream until its
 	// operation identity has been resolved, avoiding a concurrent writer consuming it.
@@ -203,7 +214,7 @@ export async function createOrGetTerminalChildResult(
 			throw immutableConflict(root, owner.operationId);
 		return projection(readStored(root, existing.resultId));
 	}
-	const reservation = reserveOperationAndQuota(root, owner, indexPath);
+	const reservation = reserveOperationAndQuota(root, owner, indexPath, recoveryKey);
 	const release = reservation.release;
 	const resultId = reservation.resultId;
 	const artifacts: C04OpaqueArtifactReference[] = [];
@@ -265,6 +276,10 @@ export async function createOrGetTerminalChildResult(
 		// projection. Check the actual C03 constructor before publishing any C04
 		// authority record; escaped quotes/backslashes are therefore charged.
 		assertC03EnvelopeFits(projection(stored));
+		// Fence both sides of the durable publication cuts. A stream await may have
+		// handed the assignment to a newer owner; neither an old result nor its
+		// operation index may become authoritative afterwards.
+		if (input.isCurrent && !input.isCurrent()) throw new Error("stale C04 child result capability");
 		// Initial result publication is immutable: a final name is never rename-overwritten.
 		atomicExclusiveJson(safePath(root, "results", `${resultId}.json`), stored);
 		for (const artifact of artifacts)
@@ -275,6 +290,7 @@ export async function createOrGetTerminalChildResult(
 				handleId: artifact.handleId,
 			});
 		const index = { version: 1, resultId, owner, requestDigest };
+		if (input.isCurrent && !input.isCurrent()) throw new Error("stale C04 child result capability");
 		try {
 			atomicExclusiveJson(indexPath, index);
 		} catch (error) {
@@ -705,20 +721,56 @@ const operationReservations = new Set<string>();
 /** A reservation is a durable, authenticated ownership journal. Its nonce, PID
  * and start time make restart reconciliation distinguish a live writer from a
  * dead attempt; its result ID makes every publish cut recoverable. */
-interface ReservationJournal {
+interface ReservationJournalPayload {
 	version: 1;
 	owner: C04ChildResultOwner;
 	indexPath: string;
 	nonce: string;
 	pid: number;
-	startedAt: string;
+	/** Exact PID incarnation captured at reservation creation. */
+	processStartId: string;
 	progress: "reserved" | "publishing";
 	resultId: string;
+}
+interface ReservationJournal extends ReservationJournalPayload {
+	/** HMAC-SHA256 over the canonical payload. Never project this or the key. */
+	mac: string;
+}
+export interface C04ProcessIdentitySeam {
+	captureCurrent(): { pid: number; processStartId: string } | undefined;
+	observe(identity: { pid: number; processStartId: string }): "live" | "dead" | "mismatch" | "unreadable";
+}
+const productionProcessIdentitySeam: C04ProcessIdentitySeam = {
+	captureCurrent() {
+		const processStartId = getProcessStartId(process.pid);
+		return processStartId ? { pid: process.pid, processStartId } : undefined;
+	},
+	observe(identity) {
+		try {
+			process.kill(identity.pid, 0);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ESRCH") return "dead";
+			return "unreadable";
+		}
+		const observed = getProcessStartId(identity.pid);
+		if (!observed) return "unreadable";
+		return observed === identity.processStartId ? "live" : "mismatch";
+	},
+};
+let processIdentitySeam = productionProcessIdentitySeam;
+/** Test-only identity seam. Production always captures PID plus its start token. */
+export function setC04ProcessIdentitySeamForTest(seam: C04ProcessIdentitySeam): () => void {
+	const previous = processIdentitySeam;
+	processIdentitySeam = seam;
+	return () => {
+		processIdentitySeam = previous;
+	};
 }
 function reserveOperationAndQuota(
 	root: string,
 	owner: C04ChildResultOwner,
 	indexPath: string,
+	recoveryKey: Buffer,
 ): { release: () => void; resultId: string } {
 	const key = `${root}:${owner.parentSessionId}:${owner.childSessionId}:${owner.assignmentId}`;
 	if (operationReservations.has(key)) throw immutableConflict(root, owner.operationId);
@@ -728,16 +780,20 @@ function reserveOperationAndQuota(
 		"operation-index",
 		`.quota.${owner.childSessionId}.${owner.assignmentId}.reserve`,
 	);
-	const journal: ReservationJournal = {
+	const identity = processIdentitySeam.captureCurrent();
+	if (!identity || !Number.isSafeInteger(identity.pid) || identity.pid < 1 || !identity.processStartId)
+		throw new Error("C04 exact process identity is unavailable");
+	const payload: ReservationJournalPayload = {
 		version: 1,
 		owner,
 		indexPath,
 		nonce: randomUuid(),
-		pid: process.pid,
-		startedAt: new Date().toISOString(),
+		pid: identity.pid,
+		processStartId: identity.processStartId,
 		progress: "reserved",
 		resultId: randomUuid(),
 	};
+	const journal: ReservationJournal = { ...payload, mac: reservationMac(recoveryKey, payload) };
 	const token = canonicalJson(journal);
 	let operationFd: number | undefined;
 	let quotaFd: number | undefined;
@@ -773,40 +829,35 @@ function reserveOperationAndQuota(
 /** Restart recovery never deletes a competing result. A dead attempt is either
  * completed from its exact durable cross-indexes or tombstoned after removing
  * only names authenticated by that attempt's random result/handle identities. */
-function reconcileAbandonedReservation(root: string, owner: C04ChildResultOwner, indexPath: string): void {
+function reconcileAbandonedReservation(
+	root: string,
+	owner: C04ChildResultOwner,
+	indexPath: string,
+	recoveryKey: Buffer,
+): void {
 	const path = safePath(root, "operation-index", `.${owner.operationId}.reserve`);
-	let journal: ReservationJournal | undefined;
-	let token = "";
+	let journal: ReservationJournal;
+	let token: string;
 	try {
 		const stat = lstatSync(path);
-		if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 8192) return;
+		if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 8192) throw immutableConflict(root, owner.operationId);
 		token = readFileSync(path, "utf8");
-		const value = JSON.parse(token) as ReservationJournal;
+		journal = parseAuthenticatedReservation(token, recoveryKey);
 		if (
-			value.version !== 1 ||
-			!sameOwner(validateOwner(value.owner), owner) ||
-			realpathSync(dirname(value.indexPath)) !== realpathSync(dirname(indexPath)) ||
-			basename(value.indexPath) !== basename(indexPath) ||
-			!isUuid(value.nonce) ||
-			!isUuid(value.resultId) ||
-			!Number.isSafeInteger(value.pid) ||
-			value.pid < 1 ||
-			Number.isNaN(Date.parse(value.startedAt)) ||
-			value.progress !== "reserved"
+			!sameOwner(journal.owner, owner) ||
+			realpathSync(dirname(journal.indexPath)) !== realpathSync(dirname(indexPath)) ||
+			basename(journal.indexPath) !== basename(indexPath)
 		)
-			return;
-		journal = value;
-	} catch {
-		return;
-	}
-	let live = false;
-	try {
-		process.kill(journal.pid, 0);
-		live = true;
+			throw immutableConflict(root, owner.operationId);
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw immutableConflict(root, owner.operationId);
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		if (error instanceof Error && error.message === "C04 immutable operation conflict") throw error;
+		// Missing/corrupt/foreign journals are live uncertainty, never stale cleanup.
+		throw immutableConflict(root, owner.operationId);
 	}
-	if (live) throw immutableConflict(root, owner.operationId);
+	const identity = processIdentitySeam.observe(journal);
+	if (identity === "live" || identity === "unreadable") throw immutableConflict(root, owner.operationId);
+	// Only a proven dead PID or a same-PID different-start-token can be reclaimed.
 	try {
 		const result = readStored(root, journal.resultId);
 		if (!sameOwner(result.owner, owner)) throw new Error("foreign result");
@@ -838,6 +889,55 @@ function reconcileAbandonedReservation(root: string, owner: C04ChildResultOwner,
 	);
 	fsyncDirectory(dirname(path));
 }
+function reservationMac(key: Buffer, payload: ReservationJournalPayload): string {
+	return createHmac("sha256", key).update(canonicalJson(payload)).digest("hex");
+}
+function parseAuthenticatedReservation(token: string, key: Buffer): ReservationJournal {
+	const value: unknown = JSON.parse(token);
+	if (
+		!isObject(value) ||
+		!exactKeys(value, [
+			"version",
+			"owner",
+			"indexPath",
+			"nonce",
+			"pid",
+			"processStartId",
+			"progress",
+			"resultId",
+			"mac",
+		]) ||
+		value.version !== 1 ||
+		!isUuid(value.nonce) ||
+		!isUuid(value.resultId) ||
+		!Number.isSafeInteger(value.pid) ||
+		value.pid < 1 ||
+		typeof value.processStartId !== "string" ||
+		!value.processStartId ||
+		value.progress !== "reserved" ||
+		typeof value.mac !== "string" ||
+		!SHA256.test(value.mac)
+	)
+		throw new Error("invalid C04 reservation journal");
+	// Do not validate/normalize owner, result, index, or nonce until the MAC
+	// authenticates the exact canonical disk payload.
+	const payload: ReservationJournalPayload = {
+		version: value.version,
+		owner: value.owner as C04ChildResultOwner,
+		indexPath: value.indexPath as string,
+		nonce: value.nonce,
+		pid: value.pid,
+		processStartId: value.processStartId,
+		progress: value.progress,
+		resultId: value.resultId,
+	};
+	if (typeof payload.indexPath !== "string") throw new Error("invalid C04 reservation journal");
+	const expected = Buffer.from(reservationMac(key, payload), "hex");
+	const actual = Buffer.from(value.mac, "hex");
+	if (expected.length !== actual.length || !timingSafeEqual(expected, actual))
+		throw new Error("invalid C04 reservation MAC");
+	return { ...payload, owner: validateOwner(payload.owner), mac: value.mac };
+}
 function readHandleIndexIfMatching(
 	root: string,
 	handleId: string,
@@ -861,6 +961,62 @@ function unlinkReservationIfOwned(path: string, token: string): void {
 function immutableConflict(root: string, operationId: string): Error {
 	appendAudit(root, "uncertain", "immutable_conflict", operationId);
 	return new Error("C04 immutable operation conflict");
+}
+/** Reads a SessionManager-owned recovery key only after proving it belongs to
+ * the parent whose ID is in the C04 owner. Missing, corrupt or redirected keys
+ * are fail-closed: recovery must not trust an unauthenticated journal. */
+function readParentRecoveryKey(
+	owner: C04ChildResultOwner,
+	childArtifactRoot: string,
+	authority: C04ParentRecoveryAuthority,
+): Buffer {
+	if (
+		!isObject(authority) ||
+		typeof authority.parentSessionFile !== "string" ||
+		typeof authority.parentArtifactRoot !== "string" ||
+		typeof authority.recoveryKeyPath !== "string"
+	)
+		throw new Error("invalid C04 parent recovery authority");
+	const parentFile = canonicalExistingRegularFile(authority.parentSessionFile);
+	if (!parentFile) throw new Error("C04 parent recovery authority is unavailable");
+	let header: unknown;
+	try {
+		header = JSON.parse(readFileSync(parentFile, "utf8").split(/\r?\n/, 1)[0] ?? "");
+	} catch {
+		throw new Error("C04 parent recovery authority is corrupt");
+	}
+	if (!isObject(header) || header.type !== "session" || header.id !== owner.parentSessionId)
+		throw new Error("C04 parent recovery authority does not match owner");
+	const parentRoot = canonicalDirectoryNoSymlinks(authority.parentArtifactRoot);
+	const expectedParentRoot = join(dirname(dirname(parentFile)), "session-artifacts", owner.parentSessionId);
+	if (parentRoot !== expectedParentRoot) throw new Error("C04 parent recovery artifact binding is invalid");
+	// Child and parent must remain within the same SessionManager state authority.
+	const childRoot = canonicalDirectoryNoSymlinks(childArtifactRoot);
+	if (dirname(parentRoot) !== dirname(childRoot)) throw new Error("C04 parent recovery authority is foreign");
+	let keyPath = resolve(authority.recoveryKeyPath);
+	try {
+		if (basename(keyPath) !== ".c04-recovery-key" || realpathSync(dirname(keyPath)) !== parentRoot)
+			throw new Error("C04 recovery key path is invalid");
+		keyPath = join(parentRoot, ".c04-recovery-key");
+	} catch {
+		throw new Error("C04 recovery key path is invalid");
+	}
+	let fd: number | undefined;
+	try {
+		const st = lstatSync(keyPath);
+		if (!st.isFile() || st.isSymbolicLink() || st.size !== 32 || (st.mode & 0o777) !== 0o600)
+			throw new Error("C04 recovery key is invalid");
+		fd = openSyncNoFollow(keyPath, "r");
+		const bytes = Buffer.alloc(32);
+		if (readSync(fd, bytes, 0, bytes.length, 0) !== bytes.length || readSync(fd, Buffer.alloc(1), 0, 1, 32) !== 0)
+			throw new Error("C04 recovery key is truncated");
+		const after = fstatSync(fd);
+		if (after.dev !== st.dev || after.ino !== st.ino || after.size !== 32)
+			throw new Error("C04 recovery key changed");
+		return bytes;
+	} finally {
+		if (fd !== undefined) closeSync(fd);
+	}
 }
 /** The C04 root belongs below, not beside, the validated child artifact dir. */
 function validateChildBinding(owner: C04ChildResultOwner, childArtifactRoot: string): void {

--- a/packages/coding-agent/src/core/rlm-child-results.ts
+++ b/packages/coding-agent/src/core/rlm-child-results.ts
@@ -21,6 +21,10 @@ import {
 	writeSync,
 } from "node:fs";
 import { basename, dirname, join, parse, relative, resolve } from "node:path";
+import {
+	createRlmSafeTerminalResultTerminalMessage,
+	MAX_RLM_SAFE_TERMINAL_MESSAGE_BYTES,
+} from "./rlm-durable-operations.js";
 
 export const CHILD_RESULT_SCHEMA_VERSION = 1 as const;
 /** C04's opaque projection must still fit C03's 64 KiB full envelope.
@@ -38,7 +42,10 @@ export const MAX_ARTIFACT_BYTES_PER_CHILD_SESSION = 2 * 1024 * 1024 * 1024;
 export const MAX_STREAM_CHUNK_BYTES = 64 * 1024;
 export const DEFAULT_CHILD_RESULT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+/** Result and object handles are random UUIDv4. Authority-issued session and
+ * operation identities accept the canonical UUID versions used by C01/C03. */
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const statuses = new Set(["completed", "failed", "cancelled", "timed_out", "stalled", "unknown_after_crash"]);
 const kinds = new Set(["terminal_output", "diagnostic", "trajectory", "attachment"]);
@@ -155,11 +162,13 @@ interface StoredChildResult extends C04ChildResultReference {
 	committedAt: string;
 	retention: { disposition: "retain_until"; expiresAt: string };
 	requestDigest: string;
+	/** Increments for every retention disposition and fences a resolved read. */
+	generation: number;
 }
 type AuditAction = "created" | "linked" | "read_allowed" | "read_denied" | "expired" | "deleted" | "uncertain";
 const capabilities = new WeakMap<
 	object,
-	{ root: string; owner: C04ChildResultOwner; handleId: string; resultId: string }
+	{ root: string; owner: C04ChildResultOwner; handleId: string; resultId: string; generation: number }
 >();
 
 /**
@@ -192,6 +201,7 @@ export async function createOrGetTerminalChildResult(
 	const release = reserveOperationAndQuota(root, owner, indexPath);
 	const resultId = randomUuid();
 	const artifacts: C04OpaqueArtifactReference[] = [];
+	let committed = false;
 	let reservedBytes = aggregateBytes(root, owner);
 	try {
 		for (const artifact of [
@@ -239,8 +249,13 @@ export async function createOrGetTerminalChildResult(
 				expiresAt: new Date(now.getTime() + DEFAULT_CHILD_RESULT_RETENTION_MS).toISOString(),
 			},
 			requestDigest,
+			generation: 0,
 		};
 		assertStored(stored);
+		// C03's cap applies to its stable serialized envelope, not merely this
+		// projection. Check the actual C03 constructor before publishing any C04
+		// authority record; escaped quotes/backslashes are therefore charged.
+		assertC03EnvelopeFits(projection(stored));
 		// Initial result publication is immutable: a final name is never rename-overwritten.
 		atomicExclusiveJson(safePath(root, "results", `${resultId}.json`), stored);
 		for (const artifact of artifacts)
@@ -260,10 +275,15 @@ export async function createOrGetTerminalChildResult(
 			appendAudit(root, "uncertain", "immutable_conflict", owner.operationId);
 			throw error;
 		}
+		committed = true;
 		appendAudit(root, "created", "committed", resultId);
 		appendAudit(root, "linked", "operation_indexed", resultId);
 		return projection(stored);
 	} catch (error) {
+		// Before an operation index exists these files have no public authority.
+		// They were created under this random result/handle identity only, so an
+		// unsuccessful producer may clean them without ever touching a winner.
+		if (!committed) cleanUnindexedOwnedAttempt(root, owner, resultId, artifacts);
 		if (!(error instanceof Error && error.message === "C04 immutable operation conflict"))
 			appendAudit(root, "uncertain", "storage_failed", owner.operationId);
 		throw error;
@@ -312,7 +332,13 @@ export function resolveOwnedChildResult(
 		const artifact = current.artifacts.find((value) => value.handleId === handleId);
 		if (!artifact || artifact.retentionState !== "retained") return denied(root, "unavailable");
 		const capability = Object.freeze({});
-		capabilities.set(capability, { root, owner: current.owner, handleId, resultId: current.resultId });
+		capabilities.set(capability, {
+			root,
+			owner: current.owner,
+			handleId,
+			resultId: current.resultId,
+			generation: current.generation,
+		});
 		appendAudit(root, "read_allowed", "resolved", handleId);
 		return { result: projection(current), capability };
 	} catch {
@@ -362,11 +388,23 @@ export function readOwnedArtifact(
 			const bytes = Buffer.allocUnsafe(Math.min(range.length, artifact.byteLength - range.offset));
 			const read = readSync(fd, bytes, 0, bytes.length, range.offset);
 			const final = fstatSync(fd);
+			// The disposition record is authoritative over a prior capability. Re-read
+			// it after the range read and require its generation, retained state,
+			// digest and inode to be unchanged before exposing any bytes.
+			const finalResult = readStored(grant.root, grant.resultId);
+			const finalArtifact = finalResult.artifacts.find((a) => a.handleId === grant.handleId);
 			if (
 				final.size !== artifact.byteLength ||
 				final.dev !== before.dev ||
 				final.ino !== before.ino ||
-				hashOpenFile(fd, artifact.byteLength) !== artifact.sha256
+				hashOpenFile(fd, artifact.byteLength) !== artifact.sha256 ||
+				!sameOwner(finalResult.owner, grant.owner) ||
+				finalResult.generation !== grant.generation ||
+				finalResult.retentionState !== "retained" ||
+				!finalArtifact ||
+				finalArtifact.retentionState !== "retained" ||
+				finalArtifact.sha256 !== artifact.sha256 ||
+				finalArtifact.byteLength !== artifact.byteLength
 			)
 				return denied(grant.root, "integrity");
 			appendAudit(grant.root, "read_allowed", "read", artifact.handleId);
@@ -402,6 +440,7 @@ export function recordChildResultDisposition(
 				...result,
 				artifacts: changed,
 				retentionState: input.disposition,
+				generation: result.generation + 1,
 			});
 			appendAudit(root, input.disposition, input.disposition, input.handleId ?? input.resultId);
 			for (const artifact of changed)
@@ -454,7 +493,7 @@ function validateOwner(value: C04ChildResultOwner): C04ChildResultOwner {
 	)
 		throw new Error("invalid C04 owner");
 	for (const key of ["parentSessionId", "childSessionId", "assignmentId", "operationId", "deliveryId"] as const)
-		if (!isUuid(value[key])) throw new Error(`invalid C04 owner ${key}`);
+		if (!isCanonicalUuid(value[key])) throw new Error(`invalid C04 owner ${key}`);
 	if (
 		typeof value.childSessionFile !== "string" ||
 		!value.childSessionFile ||
@@ -847,12 +886,51 @@ function setExpired(root: string, result: StoredChildResult): StoredChildResult 
 		...result,
 		retentionState: "expired" as const,
 		artifacts: result.artifacts.map((a) => ({ ...a, retentionState: "expired" as const })),
+		generation: result.generation + 1,
 	};
 	atomicJson(safePath(root, "results", `${result.resultId}.json`), expired);
 	appendAudit(root, "expired", "retention_elapsed", result.resultId);
 	for (const a of expired.artifacts) safeUnlink(safePath(root, "objects", `${a.handleId}.blob`));
 	return expired;
 }
+function assertC03EnvelopeFits(reference: C04ChildResultReference): void {
+	const projection = Buffer.from(canonicalChildResultBytes(reference)).toString("utf8");
+	// This invokes C03's own stable serializer and byte accounting. The fixed
+	// content/timestamp are deliberately the producer's canonical envelope.
+	const envelope = createRlmSafeTerminalResultTerminalMessage(
+		"Child completed; bounded result available.",
+		projection,
+		0,
+	);
+	if (Buffer.byteLength(canonicalJson(envelope), "utf8") > MAX_RLM_SAFE_TERMINAL_MESSAGE_BYTES)
+		throw new Error("C04 projection exceeds C03 safe-terminal envelope");
+}
+function cleanUnindexedOwnedAttempt(
+	root: string,
+	owner: C04ChildResultOwner,
+	resultId: string,
+	artifacts: readonly C04OpaqueArtifactReference[],
+): void {
+	try {
+		const index = readIndex(safePath(root, "operation-index", `${owner.operationId}.json`));
+		if (index) return; // A winner was published; never clean around it.
+		for (const artifact of artifacts) {
+			const handlePath = safePath(root, "handle-index", `${artifact.handleId}.json`);
+			let ours = false;
+			try {
+				const handle = readHandleIndex(root, artifact.handleId);
+				ours = handle.resultId === resultId && sameOwner(handle.owner, owner);
+				if (ours) safeUnlink(handlePath);
+			} catch {}
+			if (ours) safeUnlink(safePath(root, "objects", `${artifact.handleId}.blob`));
+		}
+		try {
+			const stored = readStored(root, resultId);
+			if (sameOwner(stored.owner, owner)) safeUnlink(safePath(root, "results", `${resultId}.json`));
+		} catch {}
+	} catch {}
+}
+
 function projection(result: StoredChildResult): C04ChildResultReference {
 	const {
 		schemaVersion: _schemaVersion,
@@ -862,6 +940,7 @@ function projection(result: StoredChildResult): C04ChildResultReference {
 		committedAt: _committedAt,
 		retention: _retention,
 		requestDigest: _requestDigest,
+		generation: _generation,
 		...reference
 	} = result;
 	assertReference(reference);
@@ -887,6 +966,7 @@ function assertStored(value: unknown): asserts value is StoredChildResult {
 			"committedAt",
 			"retention",
 			"requestDigest",
+			"generation",
 			...optionalKeys(value, ["error"]),
 		])
 	)
@@ -903,6 +983,8 @@ function assertStored(value: unknown): asserts value is StoredChildResult {
 		retentionState: value.retentionState,
 	});
 	const storedOwner = validateOwner(value.owner as C04ChildResultOwner);
+	if (!Number.isSafeInteger(value.generation) || value.generation < 0)
+		throw new Error("invalid C04 result generation");
 	for (const artifact of value.artifacts as C04OpaqueArtifactReference[]) {
 		if (
 			artifact.creatorAssignmentId !== storedOwner.assignmentId ||
@@ -1184,7 +1266,10 @@ function randomUuid(): string {
 	return randomUUID();
 }
 function isUuid(value: unknown): value is string {
-	return typeof value === "string" && UUID.test(value);
+	return typeof value === "string" && UUID_V4.test(value);
+}
+function isCanonicalUuid(value: unknown): value is string {
+	return typeof value === "string" && CANONICAL_UUID.test(value);
 }
 function isObject(value: unknown): value is Record<string, any> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/coding-agent/src/core/rlm-child-results.ts
+++ b/packages/coding-agent/src/core/rlm-child-results.ts
@@ -6,19 +6,21 @@ import { createHash, randomUUID } from "node:crypto";
 import {
 	chmodSync,
 	closeSync,
+	constants,
+	fstatSync,
 	fsyncSync,
 	lstatSync,
 	mkdirSync,
 	openSync,
+	readdirSync,
 	readFileSync,
 	readSync,
-	readdirSync,
+	realpathSync,
 	renameSync,
 	unlinkSync,
 	writeSync,
-	constants,
 } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, parse, relative, resolve } from "node:path";
 
 export const CHILD_RESULT_SCHEMA_VERSION = 1 as const;
 export const MAX_CHILD_RESULT_JSON_BYTES = 64 * 1024;
@@ -132,7 +134,9 @@ export interface C04TerminalCandidate {
 export interface C04ArtifactInput {
 	kind: C04ArtifactKind;
 	contentType: "text/plain" | "application/json" | "application/octet-stream";
-	data: Uint8Array | string | AsyncIterable<Uint8Array>;
+	/** Payloads are stream-only. Inline strings/Uint8Arrays are deliberately
+	 * rejected so a terminal can never accidentally retain an unbounded reply. */
+	data: AsyncIterable<Uint8Array>;
 }
 export interface C04CreateTerminalChildResultInput {
 	owner: C04ChildResultOwner;
@@ -164,32 +168,41 @@ export async function createOrGetTerminalChildResult(
 	input: C04CreateTerminalChildResultInput,
 ): Promise<C04ChildResultReference> {
 	const owner = validateOwner(input.owner);
+	// Bind before creating C04 state: an untrusted sibling/renamed root never gets
+	// a durable directory merely because it was supplied by a caller.
+	validateChildBinding(owner, input.childArtifactRoot);
 	const root = prepareRoot(input.childArtifactRoot);
 	const now = input.now?.() ?? new Date();
 	if (!Number.isFinite(now.getTime())) throw new Error("C04 time is invalid");
 	const candidate = validateCandidate(input.candidate);
-	const requestDigest = sha256(canonicalJson({ owner, candidate: digestableCandidate(candidate) }));
 	const indexPath = safePath(root, "operation-index", `${owner.operationId}.json`);
 	const existing = readIndex(indexPath);
+	// A committed operation is immutable.  We do not touch a retry stream until its
+	// operation identity has been resolved, avoiding a concurrent writer consuming it.
 	if (existing) {
-		if (!sameOwner(existing.owner, owner) || existing.requestDigest !== requestDigest) {
-			appendAudit(root, "uncertain", "immutable_conflict", owner.operationId);
-			throw new Error("C04 immutable operation conflict");
-		}
+		if (!sameOwner(existing.owner, owner)) throw immutableConflict(root, owner.operationId);
+		// A retry supplies a fresh stream; hash its bytes incrementally rather than
+		// collapsing all streams to a literal. Different raw output is a conflict.
+		if (existing.requestDigest !== (await digestCandidateStreams(owner, candidate)))
+			throw immutableConflict(root, owner.operationId);
 		return projection(readStored(root, existing.resultId));
 	}
-
+	const release = reserveOperationAndQuota(root, owner, indexPath);
 	const resultId = randomUuid();
 	const artifacts: C04OpaqueArtifactReference[] = [];
+	let reservedBytes = aggregateBytes(root, owner);
 	try {
 		for (const artifact of [
 			...(candidate.artifacts ?? []),
 			...(candidate.error?.diagnostic ? [candidate.error.diagnostic] : []),
 		]) {
 			if (artifacts.length >= MAX_ARTIFACTS_PER_RESULT) throw new Error("artifact count exceeds C04 limit");
-			artifacts.push(await writeArtifact(root, owner, resultId, artifact));
+			const written = await writeArtifact(root, owner, resultId, artifact, reservedBytes);
+			reservedBytes += written.byteLength;
+			artifacts.push(written);
 		}
 		const diagnostic = candidate.error?.diagnostic ? artifacts.at(-1) : undefined;
+		const requestDigest = digestableCandidateDigest(owner, candidate, artifacts);
 		const facts = candidate.facts.map((fact) => ({
 			claim: fact.claim,
 			...(fact.evidenceRef && artifacts.some((ref) => ref.handleId === fact.evidenceRef)
@@ -227,6 +240,13 @@ export async function createOrGetTerminalChildResult(
 		};
 		assertStored(stored);
 		atomicJson(safePath(root, "results", `${resultId}.json`), stored);
+		for (const artifact of artifacts)
+			atomicExclusiveJson(safePath(root, "handle-index", `${artifact.handleId}.json`), {
+				version: 1,
+				resultId,
+				owner,
+				handleId: artifact.handleId,
+			});
 		const index = { version: 1, resultId, owner, requestDigest };
 		try {
 			atomicExclusiveJson(indexPath, index);
@@ -241,11 +261,11 @@ export async function createOrGetTerminalChildResult(
 		appendAudit(root, "linked", "operation_indexed", resultId);
 		return projection(stored);
 	} catch (error) {
-		// The caller chooses C03's normal bounded failure terminal path.  Do not
-		// manufacture an optimistic reference or expose arbitrary OS error text.
 		if (!(error instanceof Error && error.message === "C04 immutable operation conflict"))
 			appendAudit(root, "uncertain", "storage_failed", owner.operationId);
 		throw error;
+	} finally {
+		release();
 	}
 }
 
@@ -306,7 +326,8 @@ export function readOwnedArtifact(
 	)
 		return undefined;
 	try {
-		const result = readStored(grant.root, grant.resultId);
+		// Retention is evaluated for every capability read, not merely resolution.
+		const result = expireIfElapsed(grant.root, readStored(grant.root, grant.resultId), new Date());
 		if (!sameOwner(result.owner, grant.owner)) return denied(grant.root, "owner_mismatch");
 		const artifact = result.artifacts.find((a) => a.handleId === grant.handleId);
 		if (!artifact || artifact.retentionState !== "retained" || range.offset > artifact.byteLength)
@@ -314,11 +335,20 @@ export function readOwnedArtifact(
 		const file = safePath(grant.root, "objects", `${artifact.handleId}.blob`);
 		const fd = openSyncNoFollow(file, "r");
 		try {
+			const before = fstatSync(fd);
+			if (!before.isFile() || before.size !== artifact.byteLength) return denied(grant.root, "integrity");
+			const hash = hashOpenFile(fd, artifact.byteLength);
+			const after = fstatSync(fd);
+			if (
+				hash !== artifact.sha256 ||
+				after.dev !== before.dev ||
+				after.ino !== before.ino ||
+				after.size !== artifact.byteLength
+			)
+				return denied(grant.root, "integrity");
 			const bytes = Buffer.allocUnsafe(Math.min(range.length, artifact.byteLength - range.offset));
 			const read = readSync(fd, bytes, 0, bytes.length, range.offset);
-			// Integrity is deliberately checked before *any* successful read. This is
-			// incremental and bounded by artifact cap, never readFile on payloads.
-			if (hashFile(file, artifact.byteLength) !== artifact.sha256) return denied(grant.root, "integrity");
+			if (fstatSync(fd).size !== artifact.byteLength) return denied(grant.root, "integrity");
 			appendAudit(grant.root, "read_allowed", "read", artifact.handleId);
 			return bytes.subarray(0, read);
 		} finally {
@@ -346,15 +376,16 @@ export function recordChildResultDisposition(
 				: artifact,
 		);
 		if (canonicalJson(changed) !== canonicalJson(result.artifacts)) {
-			for (const artifact of changed)
-				if (artifact.retentionState !== "retained")
-					safeUnlink(safePath(root, "objects", `${artifact.handleId}.blob`));
+			// State and audit are durable before bytes become unreachable.
 			atomicJson(safePath(root, "results", `${result.resultId}.json`), {
 				...result,
 				artifacts: changed,
 				retentionState: input.disposition,
 			});
 			appendAudit(root, input.disposition, input.disposition, input.handleId ?? input.resultId);
+			for (const artifact of changed)
+				if (artifact.retentionState !== "retained")
+					safeUnlink(safePath(root, "objects", `${artifact.handleId}.blob`));
 		}
 		return true;
 	} catch {
@@ -365,6 +396,27 @@ export function recordChildResultDisposition(
 export function canonicalChildResultBytes(value: C04ChildResultReference): Uint8Array {
 	assertReference(value);
 	return Buffer.from(canonicalJson(value));
+}
+
+/** A bounded C04-shaped terminal used when durable storage itself is unavailable. */
+export function terminalStorageFailedProjection(
+	input: { status?: Exclude<C04ChildResultStatus, "completed">; model?: Partial<C04ModelMetadata> } = {},
+): C04ChildResultReference {
+	const status = input.status ?? "failed";
+	const model = validateModel(input.model);
+	const result: C04ChildResultReference = {
+		version: 1,
+		resultId: randomUuid(),
+		status,
+		summary: "Child terminal storage failed.",
+		preview: "A bounded terminal result could not be persisted.",
+		error: { code: "terminal_storage_failed", message: "Terminal result storage failed." },
+		model,
+		artifacts: [],
+		retentionState: "unavailable",
+	};
+	assertReference(result);
+	return result;
 }
 
 function validateOwner(value: C04ChildResultOwner): C04ChildResultOwner {
@@ -502,9 +554,9 @@ function validateArtifact(value: unknown): C04ArtifactInput {
 		!exactKeys(value, ["kind", "contentType", "data"]) ||
 		!kinds.has(value.kind) ||
 		!contentTypes.has(value.contentType) ||
-		!(typeof value.data === "string" || value.data instanceof Uint8Array || isAsyncIterable(value.data))
+		!isAsyncIterable(value.data)
 	)
-		throw new Error("invalid C04 artifact");
+		throw new Error("invalid C04 artifact: payload must be an AsyncIterable<Uint8Array>");
 	return value as C04ArtifactInput;
 }
 async function writeArtifact(
@@ -512,8 +564,8 @@ async function writeArtifact(
 	owner: C04ChildResultOwner,
 	resultId: string,
 	artifact: C04ArtifactInput,
+	used = aggregateBytes(root, owner),
 ): Promise<C04OpaqueArtifactReference> {
-	const used = aggregateBytes(root, owner);
 	const handleId = randomUuid();
 	const finalPath = safePath(root, "objects", `${handleId}.blob`);
 	const temp = safePath(root, "objects", `.${handleId}.${randomUuid()}.tmp`);
@@ -555,22 +607,23 @@ async function writeArtifact(
 	}
 }
 async function* chunks(data: C04ArtifactInput["data"]): AsyncGenerator<Uint8Array> {
-	if (typeof data === "string") {
-		const bytes = Buffer.from(data);
-		for (let at = 0; at < bytes.length; at += MAX_STREAM_CHUNK_BYTES)
-			yield bytes.subarray(at, at + MAX_STREAM_CHUNK_BYTES);
-	} else if (data instanceof Uint8Array) {
-		for (let at = 0; at < data.length; at += MAX_STREAM_CHUNK_BYTES)
-			yield data.subarray(at, at + MAX_STREAM_CHUNK_BYTES);
-	} else for await (const chunk of data) yield chunk;
+	for await (const chunk of data) {
+		if (!(chunk instanceof Uint8Array)) throw new Error("C04 stream yielded non-bytes");
+		yield chunk;
+	}
 }
+
 function aggregateBytes(root: string, owner: C04ChildResultOwner): number {
 	let total = 0;
 	for (const name of readdirSync(safePath(root, "results"))) {
 		if (!name.endsWith(".json")) continue;
 		try {
 			const r = readStored(root, name.slice(0, -5));
-			if (sameOwner(r.owner, owner))
+			if (
+				r.owner.parentSessionId === owner.parentSessionId &&
+				r.owner.childSessionId === owner.childSessionId &&
+				r.owner.childSessionFile === owner.childSessionFile
+			)
 				total += r.artifacts.reduce((n, a) => n + (a.retentionState === "retained" ? a.byteLength : 0), 0);
 		} catch {
 			throw new Error("uncertain C04 result store");
@@ -578,17 +631,92 @@ function aggregateBytes(root: string, owner: C04ChildResultOwner): number {
 	}
 	return total;
 }
+const operationReservations = new Set<string>();
+/** Operation serialization plus a durable O_EXCL reservation prevents two live
+ * streams from being assigned the same operation or independently passing quota. */
+function reserveOperationAndQuota(root: string, owner: C04ChildResultOwner, indexPath: string): () => void {
+	const key = `${root}:${owner.parentSessionId}:${owner.childSessionId}`;
+	if (operationReservations.has(key)) throw immutableConflict(root, owner.operationId);
+	const reservation = safePath(root, "operation-index", `.${owner.operationId}.reserve`);
+	const quotaReservation = safePath(root, "operation-index", `.quota.${owner.childSessionId}.reserve`);
+	let operationFd: number | undefined;
+	let quotaFd: number | undefined;
+	try {
+		// Lock both exact operation and child-session quota before the first byte.
+		operationFd = openSyncNoFollow(reservation, "wx", 0o600);
+		quotaFd = openSyncNoFollow(quotaReservation, "wx", 0o600);
+		writeAll(operationFd, Buffer.from(canonicalJson({ version: 1, owner, indexPath })));
+		fsyncSync(operationFd);
+		fsyncSync(quotaFd);
+		closeSync(operationFd);
+		closeSync(quotaFd);
+		operationFd = quotaFd = undefined;
+		fsyncDirectory(dirname(reservation));
+		operationReservations.add(key);
+	} catch {
+		if (operationFd !== undefined) closeSync(operationFd);
+		if (quotaFd !== undefined) closeSync(quotaFd);
+		safeUnlink(reservation);
+		safeUnlink(quotaReservation);
+		throw immutableConflict(root, owner.operationId);
+	}
+	return () => {
+		operationReservations.delete(key);
+		safeUnlink(reservation);
+		safeUnlink(quotaReservation);
+		fsyncDirectory(dirname(reservation));
+	};
+}
+function immutableConflict(root: string, operationId: string): Error {
+	appendAudit(root, "uncertain", "immutable_conflict", operationId);
+	return new Error("C04 immutable operation conflict");
+}
+/** The C04 root belongs below, not beside, the validated child artifact dir. */
+function validateChildBinding(owner: C04ChildResultOwner, childArtifactRoot: string): void {
+	const file = canonicalExistingRegularFile(owner.childSessionFile);
+	if (!file) throw new Error("C04 child session file is not a stable regular file");
+	const root = canonicalDirectoryNoSymlinks(childArtifactRoot);
+	// The file must remain beneath the same trusted child session hierarchy. This
+	// rejects a swapped/renamed child root passed independently from its session.
+	if (relative(dirname(file), root).startsWith("..")) throw new Error("C04 child artifact root escapes child session");
+}
+function canonicalExistingRegularFile(path: string): string | undefined {
+	try {
+		const st = lstatSync(path);
+		return st.isFile() && !st.isSymbolicLink() ? realpathSync(path) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+function canonicalDirectoryNoSymlinks(path: string): string {
+	const requested = resolve(path);
+	const requestedStat = lstatSync(requested);
+	if (!requestedStat.isDirectory() || requestedStat.isSymbolicLink())
+		throw new Error("C04 rejects symlink/non-directory root");
+	// Normalize OS-owned aliases (/var -> /private/var on macOS), then reject every
+	// application-visible ancestor from the canonical path downward.
+	const absolute = realpathSync(requested);
+	const { root } = parse(absolute);
+	let current = root;
+	for (const part of relative(root, absolute).split(/[/\\]/).filter(Boolean)) {
+		current = join(current, part);
+		const st = lstatSync(current);
+		if (!st.isDirectory() || st.isSymbolicLink()) throw new Error("C04 rejects symlink/non-directory ancestor");
+	}
+	return absolute;
+}
 function prepareRoot(childArtifactRoot: string, create = true): string {
 	if (typeof childArtifactRoot !== "string" || !childArtifactRoot) throw new Error("invalid C04 artifact root");
-	if (create) mkdirSync(childArtifactRoot, { recursive: true, mode: 0o700 });
-	const base = assertDirectory(childArtifactRoot);
+	// The trusted child artifact directory must already exist; never recursively
+	// create through an attacker-controlled ancestor.
+	const base = canonicalDirectoryNoSymlinks(childArtifactRoot);
 	const root = join(base, "rlm-child-results");
 	if (create) mkdirSync(root, { recursive: true, mode: 0o700 });
 	assertDirectory(root);
-	for (const dir of ["operation-index", "results", "objects"]) {
+	for (const dir of ["operation-index", "results", "objects", "handle-index"]) {
 		const path = join(root, dir);
 		if (create) mkdirSync(path, { recursive: true, mode: 0o700 });
-		assertDirectory(path);
+		canonicalDirectoryNoSymlinks(path);
 	}
 	chmodSync(root, 0o700);
 	return root;
@@ -601,7 +729,7 @@ function assertDirectory(path: string): string {
 function safePath(root: string, directory: string, name?: string): string {
 	if (
 		!/^[a-z-]+$/.test(directory) ||
-		(name !== undefined && (!/^[0-9a-f.-]+(?:\.json|\.blob|\.tmp)?$/.test(name) || name.includes("..")))
+		(name !== undefined && (!/^[a-z0-9.-]+(?:\.(?:json|blob|tmp|reserve))?$/.test(name) || name.includes("..")))
 	)
 		throw new Error("invalid C04 generated path");
 	const target = name === undefined ? join(root, directory) : join(root, directory, name);
@@ -646,13 +774,22 @@ function readIndex(
 }
 function handleResult(root: string, handleId: string): string {
 	if (!isUuid(handleId)) throw new Error("invalid handle");
-	for (const name of readdirSync(safePath(root, "results"))) {
-		if (!name.endsWith(".json")) continue;
-		const result = readStored(root, name.slice(0, -5));
-		if (result.artifacts.some((a) => a.handleId === handleId)) return result.resultId;
-	}
-	throw new Error("not found");
+	const path = safePath(root, "handle-index", `${handleId}.json`);
+	const st = lstatSync(path);
+	if (!st.isFile() || st.isSymbolicLink() || st.size > 4096) throw new Error("not found");
+	const index = JSON.parse(readFileSync(path, "utf8"));
+	if (
+		!isObject(index) ||
+		!exactKeys(index, ["version", "resultId", "owner", "handleId"]) ||
+		index.version !== 1 ||
+		index.handleId !== handleId ||
+		!isUuid(index.resultId)
+	)
+		throw new Error("not found");
+	validateOwner(index.owner as C04ChildResultOwner);
+	return index.resultId;
 }
+
 function expireIfElapsed(root: string, result: StoredChildResult, now: Date): StoredChildResult {
 	if (Date.parse(result.retention.expiresAt) > now.getTime()) return result;
 	if (result.retentionState !== "retained") return result;
@@ -664,9 +801,9 @@ function setExpired(root: string, result: StoredChildResult): StoredChildResult 
 		retentionState: "expired" as const,
 		artifacts: result.artifacts.map((a) => ({ ...a, retentionState: "expired" as const })),
 	};
-	for (const a of expired.artifacts) safeUnlink(safePath(root, "objects", `${a.handleId}.blob`));
 	atomicJson(safePath(root, "results", `${result.resultId}.json`), expired);
 	appendAudit(root, "expired", "retention_elapsed", result.resultId);
+	for (const a of expired.artifacts) safeUnlink(safePath(root, "objects", `${a.handleId}.blob`));
 	return expired;
 }
 function projection(result: StoredChildResult): C04ChildResultReference {
@@ -709,7 +846,19 @@ function assertStored(value: unknown): asserts value is StoredChildResult {
 		artifacts: value.artifacts,
 		retentionState: value.retentionState,
 	});
-	validateOwner(value.owner as C04ChildResultOwner);
+	const storedOwner = validateOwner(value.owner as C04ChildResultOwner);
+	for (const artifact of value.artifacts as C04OpaqueArtifactReference[]) {
+		if (
+			artifact.creatorAssignmentId !== storedOwner.assignmentId ||
+			artifact.ownerSessionId !== storedOwner.childSessionId
+		)
+			throw new Error("C04 artifact owner cross-reference mismatch");
+	}
+	if (
+		value.error?.diagnosticRef &&
+		!(value.artifacts as C04OpaqueArtifactReference[]).some((a) => a.handleId === value.error?.diagnosticRef)
+	)
+		throw new Error("C04 diagnostic cross-reference mismatch");
 	if (
 		!Array.isArray(value.facts) ||
 		value.facts.length > MAX_FACTS ||
@@ -733,6 +882,16 @@ function assertStored(value: unknown): asserts value is StoredChildResult {
 		!SHA256.test(value.requestDigest)
 	)
 		throw new Error("invalid C04 result record");
+	if (
+		value.retentionState === "retained" &&
+		(value.artifacts as C04OpaqueArtifactReference[]).some((a) => a.retentionState !== "retained")
+	)
+		throw new Error("C04 retention consistency mismatch");
+	if (
+		value.retentionState !== "retained" &&
+		(value.artifacts as C04OpaqueArtifactReference[]).some((a) => a.retentionState === "retained")
+	)
+		throw new Error("C04 retention consistency mismatch");
 }
 function assertReference(value: unknown): asserts value is C04ChildResultReference {
 	if (
@@ -859,23 +1018,21 @@ function denied<T>(root: string, reason: string): T | undefined {
 	appendAudit(root, "read_denied", reason, reason);
 	return undefined;
 }
-function hashFile(path: string, length: number): string {
-	const fd = openSyncNoFollow(path, "r");
-	try {
-		const h = createHash("sha256");
-		const buffer = Buffer.allocUnsafe(MAX_STREAM_CHUNK_BYTES);
-		let off = 0;
-		while (off < length) {
-			const n = readSync(fd, buffer, 0, Math.min(buffer.length, length - off), off);
-			if (n <= 0) throw new Error("short object");
-			h.update(buffer.subarray(0, n));
-			off += n;
-		}
-		return h.digest("hex");
-	} finally {
-		closeSync(fd);
+function hashOpenFile(fd: number, length: number): string {
+	const h = createHash("sha256");
+	const buffer = Buffer.allocUnsafe(MAX_STREAM_CHUNK_BYTES);
+	let off = 0;
+	while (off < length) {
+		const n = readSync(fd, buffer, 0, Math.min(buffer.length, length - off), off);
+		if (n <= 0) throw new Error("short object");
+		h.update(buffer.subarray(0, n));
+		off += n;
 	}
+	// A byte after declared length detects a trailing append without a second path/FD.
+	if (readSync(fd, buffer, 0, 1, length) !== 0) throw new Error("trailing object bytes");
+	return h.digest("hex");
 }
+
 function fsyncDirectory(path: string): void {
 	const fd = openSync(path, "r");
 	try {
@@ -976,18 +1133,63 @@ function sameOwner(a: C04ChildResultOwner, b: C04ChildResultOwner): boolean {
 		a.deliveryId === b.deliveryId
 	);
 }
-function digestableCandidate(candidate: any): unknown {
-	const artifactDigest = (a: C04ArtifactInput) => ({
-		kind: a.kind,
-		contentType: a.contentType,
-		payload:
-			typeof a.data === "string"
-				? sha256(a.data)
-				: a.data instanceof Uint8Array
-					? createHash("sha256").update(a.data).digest("hex")
-					: "stream",
-	});
-	return {
+function digestableCandidateDigest(
+	owner: C04ChildResultOwner,
+	candidate: C04TerminalCandidate,
+	artifacts: readonly C04OpaqueArtifactReference[],
+): string {
+	return sha256(canonicalJson({ owner, candidate: digestableCandidate(candidate, artifacts) }));
+}
+async function digestCandidateStreams(
+	owner: C04ChildResultOwner,
+	candidate: ReturnType<typeof validateCandidate>,
+): Promise<string> {
+	const descriptors: Array<{
+		kind: C04ArtifactKind;
+		contentType: C04ArtifactInput["contentType"];
+		byteLength: number;
+		sha256: string;
+	}> = [];
+	for (const artifact of [
+		...(candidate.artifacts ?? []),
+		...(candidate.error?.diagnostic ? [candidate.error.diagnostic] : []),
+	]) {
+		const hash = createHash("sha256");
+		let count = 0;
+		for await (const chunk of chunks(artifact.data)) {
+			if (chunk.length > MAX_STREAM_CHUNK_BYTES) throw new Error("C04 stream chunk exceeds limit");
+			count += chunk.length;
+			if (count > MAX_ARTIFACT_BYTES) throw new Error("C04 artifact exceeds limit");
+			hash.update(chunk);
+		}
+		descriptors.push({
+			kind: artifact.kind,
+			contentType: artifact.contentType,
+			byteLength: count,
+			sha256: hash.digest("hex"),
+		});
+	}
+	const surrogate = descriptors.map((d) => ({
+		version: 1 as const,
+		handleId: randomUuid(),
+		resultId: randomUuid(),
+		...d,
+		creatorAssignmentId: owner.assignmentId,
+		ownerSessionId: owner.childSessionId,
+		retentionState: "retained" as const,
+	}));
+	// digestableCandidate uses only kind/type/length/hash and no generated IDs.
+	return digestableCandidateDigest(owner, candidate, surrogate);
+}
+function digestableCandidate(candidate: any, artifacts: readonly C04OpaqueArtifactReference[]): unknown {
+	let cursor = 0;
+	const artifactDigest = (a: C04ArtifactInput) => {
+		const written = artifacts[cursor++];
+		if (!written || written.kind !== a.kind || written.contentType !== a.contentType)
+			throw new Error("C04 artifact digest mismatch");
+		return { kind: a.kind, contentType: a.contentType, byteLength: written.byteLength, sha256: written.sha256 };
+	};
+	const output = {
 		...candidate,
 		artifacts: (candidate.artifacts ?? []).map(artifactDigest),
 		error: candidate.error
@@ -998,4 +1200,6 @@ function digestableCandidate(candidate: any): unknown {
 				}
 			: undefined,
 	};
+	if (cursor !== artifacts.length) throw new Error("C04 artifact digest mismatch");
+	return output;
 }

--- a/packages/coding-agent/src/core/rlm-child-results.ts
+++ b/packages/coding-agent/src/core/rlm-child-results.ts
@@ -17,6 +17,7 @@ import {
 	readSync,
 	realpathSync,
 	renameSync,
+	statSync,
 	unlinkSync,
 	writeSync,
 } from "node:fs";
@@ -152,6 +153,8 @@ export interface C04CreateTerminalChildResultInput {
 	candidate: C04TerminalCandidate;
 	/** Trusted SessionManager child artifact directory; callers never pass a relative object path. */
 	childArtifactRoot: string;
+	/** Captured runtime/assignment capability, rechecked before durable publication. */
+	isCurrent?: () => boolean;
 	now?: () => Date;
 }
 interface StoredChildResult extends C04ChildResultReference {
@@ -179,6 +182,7 @@ export async function createOrGetTerminalChildResult(
 	input: C04CreateTerminalChildResultInput,
 ): Promise<C04ChildResultReference> {
 	const owner = validateOwner(input.owner);
+	if (input.isCurrent && !input.isCurrent()) throw new Error("stale C04 child result capability");
 	// Bind before creating C04 state: an untrusted sibling/renamed root never gets
 	// a durable directory merely because it was supplied by a caller.
 	validateChildBinding(owner, input.childArtifactRoot);
@@ -187,6 +191,7 @@ export async function createOrGetTerminalChildResult(
 	if (!Number.isFinite(now.getTime())) throw new Error("C04 time is invalid");
 	const candidate = validateCandidate(input.candidate);
 	const indexPath = safePath(root, "operation-index", `${owner.operationId}.json`);
+	reconcileAbandonedReservation(root, owner, indexPath);
 	const existing = readIndex(indexPath);
 	// A committed operation is immutable.  We do not touch a retry stream until its
 	// operation identity has been resolved, avoiding a concurrent writer consuming it.
@@ -198,8 +203,9 @@ export async function createOrGetTerminalChildResult(
 			throw immutableConflict(root, owner.operationId);
 		return projection(readStored(root, existing.resultId));
 	}
-	const release = reserveOperationAndQuota(root, owner, indexPath);
-	const resultId = randomUuid();
+	const reservation = reserveOperationAndQuota(root, owner, indexPath);
+	const release = reservation.release;
+	const resultId = reservation.resultId;
 	const artifacts: C04OpaqueArtifactReference[] = [];
 	let committed = false;
 	let reservedBytes = aggregateBytes(root, owner);
@@ -213,6 +219,9 @@ export async function createOrGetTerminalChildResult(
 			reservedBytes += written.byteLength;
 			artifacts.push(written);
 		}
+		// Stream waits may have yielded while the parent/runtime was replaced. Never
+		// publish such an attempt; catch cleanup is restricted to its random names.
+		if (input.isCurrent && !input.isCurrent()) throw new Error("stale C04 child result capability");
 		const diagnostic = candidate.error?.diagnostic ? artifacts.at(-1) : undefined;
 		const requestDigest = digestableCandidateDigest(owner, candidate, artifacts);
 		const facts = candidate.facts.map((fact) => ({
@@ -693,9 +702,24 @@ function aggregateBytes(root: string, owner: C04ChildResultOwner): number {
 	return total;
 }
 const operationReservations = new Set<string>();
-/** Reservation ownership is a nonce-bound fact. A losing writer never unlinks
- * a name it did not create, including during the create-one/create-two cut. */
-function reserveOperationAndQuota(root: string, owner: C04ChildResultOwner, indexPath: string): () => void {
+/** A reservation is a durable, authenticated ownership journal. Its nonce, PID
+ * and start time make restart reconciliation distinguish a live writer from a
+ * dead attempt; its result ID makes every publish cut recoverable. */
+interface ReservationJournal {
+	version: 1;
+	owner: C04ChildResultOwner;
+	indexPath: string;
+	nonce: string;
+	pid: number;
+	startedAt: string;
+	progress: "reserved" | "publishing";
+	resultId: string;
+}
+function reserveOperationAndQuota(
+	root: string,
+	owner: C04ChildResultOwner,
+	indexPath: string,
+): { release: () => void; resultId: string } {
 	const key = `${root}:${owner.parentSessionId}:${owner.childSessionId}:${owner.assignmentId}`;
 	if (operationReservations.has(key)) throw immutableConflict(root, owner.operationId);
 	const reservation = safePath(root, "operation-index", `.${owner.operationId}.reserve`);
@@ -704,8 +728,17 @@ function reserveOperationAndQuota(root: string, owner: C04ChildResultOwner, inde
 		"operation-index",
 		`.quota.${owner.childSessionId}.${owner.assignmentId}.reserve`,
 	);
-	const nonce = randomUuid();
-	const token = canonicalJson({ version: 1, owner, indexPath, nonce });
+	const journal: ReservationJournal = {
+		version: 1,
+		owner,
+		indexPath,
+		nonce: randomUuid(),
+		pid: process.pid,
+		startedAt: new Date().toISOString(),
+		progress: "reserved",
+		resultId: randomUuid(),
+	};
+	const token = canonicalJson(journal);
 	let operationFd: number | undefined;
 	let quotaFd: number | undefined;
 	try {
@@ -727,12 +760,96 @@ function reserveOperationAndQuota(root: string, owner: C04ChildResultOwner, inde
 		unlinkReservationIfOwned(quotaReservation, token);
 		throw immutableConflict(root, owner.operationId);
 	}
-	return () => {
-		operationReservations.delete(key);
-		unlinkReservationIfOwned(reservation, token);
-		unlinkReservationIfOwned(quotaReservation, token);
-		fsyncDirectory(dirname(reservation));
+	return {
+		resultId: journal.resultId,
+		release: () => {
+			operationReservations.delete(key);
+			unlinkReservationIfOwned(reservation, token);
+			unlinkReservationIfOwned(quotaReservation, token);
+			fsyncDirectory(dirname(reservation));
+		},
 	};
+}
+/** Restart recovery never deletes a competing result. A dead attempt is either
+ * completed from its exact durable cross-indexes or tombstoned after removing
+ * only names authenticated by that attempt's random result/handle identities. */
+function reconcileAbandonedReservation(root: string, owner: C04ChildResultOwner, indexPath: string): void {
+	const path = safePath(root, "operation-index", `.${owner.operationId}.reserve`);
+	let journal: ReservationJournal | undefined;
+	let token = "";
+	try {
+		const stat = lstatSync(path);
+		if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 8192) return;
+		token = readFileSync(path, "utf8");
+		const value = JSON.parse(token) as ReservationJournal;
+		if (
+			value.version !== 1 ||
+			!sameOwner(validateOwner(value.owner), owner) ||
+			realpathSync(dirname(value.indexPath)) !== realpathSync(dirname(indexPath)) ||
+			basename(value.indexPath) !== basename(indexPath) ||
+			!isUuid(value.nonce) ||
+			!isUuid(value.resultId) ||
+			!Number.isSafeInteger(value.pid) ||
+			value.pid < 1 ||
+			Number.isNaN(Date.parse(value.startedAt)) ||
+			value.progress !== "reserved"
+		)
+			return;
+		journal = value;
+	} catch {
+		return;
+	}
+	let live = false;
+	try {
+		process.kill(journal.pid, 0);
+		live = true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw immutableConflict(root, owner.operationId);
+	}
+	if (live) throw immutableConflict(root, owner.operationId);
+	try {
+		const result = readStored(root, journal.resultId);
+		if (!sameOwner(result.owner, owner)) throw new Error("foreign result");
+		// A durable result is sufficient to reconstruct every missing cross-index.
+		for (const artifact of result.artifacts) {
+			const blob = safePath(root, "objects", `${artifact.handleId}.blob`);
+			const st = statSync(blob);
+			if (!st.isFile() || st.size !== artifact.byteLength) throw new Error("missing blob");
+			const handle = safePath(root, "handle-index", `${artifact.handleId}.json`);
+			if (!readHandleIndexIfMatching(root, artifact.handleId, result.resultId, owner))
+				atomicExclusiveJson(handle, { version: 1, resultId: result.resultId, owner, handleId: artifact.handleId });
+		}
+		if (!readIndex(indexPath))
+			atomicExclusiveJson(indexPath, {
+				version: 1,
+				resultId: result.resultId,
+				owner,
+				requestDigest: result.requestDigest,
+			});
+		appendAudit(root, "linked", "restart_reconciled", result.resultId);
+	} catch {
+		cleanUnindexedOwnedAttempt(root, owner, journal.resultId, []);
+		appendAudit(root, "uncertain", "restart_tombstoned", journal.resultId);
+	}
+	unlinkReservationIfOwned(path, token);
+	unlinkReservationIfOwned(
+		safePath(root, "operation-index", `.quota.${owner.childSessionId}.${owner.assignmentId}.reserve`),
+		token,
+	);
+	fsyncDirectory(dirname(path));
+}
+function readHandleIndexIfMatching(
+	root: string,
+	handleId: string,
+	resultId: string,
+	owner: C04ChildResultOwner,
+): boolean {
+	try {
+		const value = readHandleIndex(root, handleId);
+		return value.resultId === resultId && sameOwner(value.owner, owner);
+	} catch {
+		return false;
+	}
 }
 function unlinkReservationIfOwned(path: string, token: string): void {
 	try {
@@ -749,6 +866,14 @@ function immutableConflict(root: string, operationId: string): Error {
 function validateChildBinding(owner: C04ChildResultOwner, childArtifactRoot: string): void {
 	const file = canonicalExistingRegularFile(owner.childSessionFile);
 	if (!file) throw new Error("C04 child session file is not a stable regular file");
+	// Re-read the SessionManager-issued header, rather than trusting a pathname.
+	try {
+		const header = JSON.parse(readFileSync(file, "utf8").split(/\r?\n/, 1)[0] ?? "");
+		if (!isObject(header) || header.type !== "session" || header.id !== owner.childSessionId)
+			throw new Error("invalid session header");
+	} catch {
+		throw new Error("C04 child session header binding is invalid");
+	}
 	const root = canonicalDirectoryNoSymlinks(childArtifactRoot);
 	const sessionId = owner.childSessionId;
 	// This is the one layout SessionManager publishes. IDs and paths are all

--- a/packages/coding-agent/src/core/rlm-child-results.ts
+++ b/packages/coding-agent/src/core/rlm-child-results.ts
@@ -20,10 +20,12 @@ import {
 	unlinkSync,
 	writeSync,
 } from "node:fs";
-import { dirname, join, parse, relative, resolve } from "node:path";
+import { basename, dirname, join, parse, relative, resolve } from "node:path";
 
 export const CHILD_RESULT_SCHEMA_VERSION = 1 as const;
-export const MAX_CHILD_RESULT_JSON_BYTES = 64 * 1024;
+/** C04's opaque projection must still fit C03's 64 KiB full envelope.
+ * 60 KiB leaves 4 KiB for the fixed C03 JSON/message fields and presentation. */
+export const MAX_CHILD_RESULT_JSON_BYTES = 60 * 1024;
 export const MAX_SUMMARY_CHARS = 4_096;
 export const MAX_SUMMARY_BYTES = 16 * 1024;
 export const MAX_PREVIEW_CHARS = 2_048;
@@ -171,7 +173,7 @@ export async function createOrGetTerminalChildResult(
 	// Bind before creating C04 state: an untrusted sibling/renamed root never gets
 	// a durable directory merely because it was supplied by a caller.
 	validateChildBinding(owner, input.childArtifactRoot);
-	const root = prepareRoot(input.childArtifactRoot);
+	const root = prepareBoundRoot(owner, input.childArtifactRoot);
 	const now = input.now?.() ?? new Date();
 	if (!Number.isFinite(now.getTime())) throw new Error("C04 time is invalid");
 	const candidate = validateCandidate(input.candidate);
@@ -239,7 +241,8 @@ export async function createOrGetTerminalChildResult(
 			requestDigest,
 		};
 		assertStored(stored);
-		atomicJson(safePath(root, "results", `${resultId}.json`), stored);
+		// Initial result publication is immutable: a final name is never rename-overwritten.
+		atomicExclusiveJson(safePath(root, "results", `${resultId}.json`), stored);
 		for (const artifact of artifacts)
 			atomicExclusiveJson(safePath(root, "handle-index", `${artifact.handleId}.json`), {
 				version: 1,
@@ -276,9 +279,10 @@ export function getChildResultProjection(
 	now = new Date(),
 ): C04ChildResultReference | undefined {
 	try {
-		const root = prepareRoot(childArtifactRoot, false);
+		const verified = validateOwner(owner);
+		const root = prepareBoundRoot(verified, childArtifactRoot, false);
 		const result = readStored(root, resultId);
-		if (!sameOwner(result.owner, validateOwner(owner))) return denied(root, "owner_mismatch");
+		if (!sameOwner(result.owner, verified)) return denied(root, "owner_mismatch");
 		const reduced = expireIfElapsed(root, result, now);
 		return projection(reduced);
 	} catch {
@@ -294,9 +298,15 @@ export function resolveOwnedChildResult(
 	now = new Date(),
 ): { result: C04PublicChildResult; capability: object } | undefined {
 	try {
-		const root = prepareRoot(childArtifactRoot, false);
-		const result = readStored(root, handleResult(root, handleId));
-		if (!sameOwner(result.owner, validateOwner(owner)) || !result.artifacts.some((a) => a.handleId === handleId))
+		const verified = validateOwner(owner);
+		const root = prepareBoundRoot(verified, childArtifactRoot, false);
+		const indexed = readHandleIndex(root, handleId);
+		const result = readStored(root, indexed.resultId);
+		if (
+			!sameOwner(indexed.owner, verified) ||
+			!sameOwner(result.owner, verified) ||
+			!result.artifacts.some((a) => a.handleId === handleId)
+		)
 			return denied(root, "owner_mismatch");
 		const current = expireIfElapsed(root, result, now);
 		const artifact = current.artifacts.find((value) => value.handleId === handleId);
@@ -326,6 +336,9 @@ export function readOwnedArtifact(
 	)
 		return undefined;
 	try {
+		// Capabilities are bearer objects, not a substitute for the SessionManager
+		// binding: revalidate the parent/runtime-owned child root on every read.
+		if (prepareBoundRoot(grant.owner, dirname(grant.root), false) !== grant.root) return undefined;
 		// Retention is evaluated for every capability read, not merely resolution.
 		const result = expireIfElapsed(grant.root, readStored(grant.root, grant.resultId), new Date());
 		if (!sameOwner(result.owner, grant.owner)) return denied(grant.root, "owner_mismatch");
@@ -348,7 +361,14 @@ export function readOwnedArtifact(
 				return denied(grant.root, "integrity");
 			const bytes = Buffer.allocUnsafe(Math.min(range.length, artifact.byteLength - range.offset));
 			const read = readSync(fd, bytes, 0, bytes.length, range.offset);
-			if (fstatSync(fd).size !== artifact.byteLength) return denied(grant.root, "integrity");
+			const final = fstatSync(fd);
+			if (
+				final.size !== artifact.byteLength ||
+				final.dev !== before.dev ||
+				final.ino !== before.ino ||
+				hashOpenFile(fd, artifact.byteLength) !== artifact.sha256
+			)
+				return denied(grant.root, "integrity");
 			appendAudit(grant.root, "read_allowed", "read", artifact.handleId);
 			return bytes.subarray(0, read);
 		} finally {
@@ -366,9 +386,10 @@ export function recordChildResultDisposition(
 	childArtifactRoot: string,
 ): boolean {
 	try {
-		const root = prepareRoot(childArtifactRoot, false);
+		const verified = validateOwner(owner);
+		const root = prepareBoundRoot(verified, childArtifactRoot, false);
 		const result = readStored(root, input.resultId);
-		if (!sameOwner(result.owner, validateOwner(owner))) return false;
+		if (!sameOwner(result.owner, verified)) return false;
 		if (input.handleId && !result.artifacts.some((a) => a.handleId === input.handleId)) return false;
 		const changed = result.artifacts.map((artifact) =>
 			artifact.handleId === input.handleId || !input.handleId
@@ -586,7 +607,7 @@ async function writeArtifact(
 		fsyncSync(fd);
 		closeSync(fd);
 		fd = undefined;
-		renameSync(temp, finalPath);
+		publishExclusive(temp, finalPath);
 		fsyncDirectory(dirname(finalPath));
 		return {
 			version: 1,
@@ -622,7 +643,8 @@ function aggregateBytes(root: string, owner: C04ChildResultOwner): number {
 			if (
 				r.owner.parentSessionId === owner.parentSessionId &&
 				r.owner.childSessionId === owner.childSessionId &&
-				r.owner.childSessionFile === owner.childSessionFile
+				r.owner.childSessionFile === owner.childSessionFile &&
+				r.owner.assignmentId === owner.assignmentId
 			)
 				total += r.artifacts.reduce((n, a) => n + (a.retentionState === "retained" ? a.byteLength : 0), 0);
 		} catch {
@@ -632,21 +654,27 @@ function aggregateBytes(root: string, owner: C04ChildResultOwner): number {
 	return total;
 }
 const operationReservations = new Set<string>();
-/** Operation serialization plus a durable O_EXCL reservation prevents two live
- * streams from being assigned the same operation or independently passing quota. */
+/** Reservation ownership is a nonce-bound fact. A losing writer never unlinks
+ * a name it did not create, including during the create-one/create-two cut. */
 function reserveOperationAndQuota(root: string, owner: C04ChildResultOwner, indexPath: string): () => void {
-	const key = `${root}:${owner.parentSessionId}:${owner.childSessionId}`;
+	const key = `${root}:${owner.parentSessionId}:${owner.childSessionId}:${owner.assignmentId}`;
 	if (operationReservations.has(key)) throw immutableConflict(root, owner.operationId);
 	const reservation = safePath(root, "operation-index", `.${owner.operationId}.reserve`);
-	const quotaReservation = safePath(root, "operation-index", `.quota.${owner.childSessionId}.reserve`);
+	const quotaReservation = safePath(
+		root,
+		"operation-index",
+		`.quota.${owner.childSessionId}.${owner.assignmentId}.reserve`,
+	);
+	const nonce = randomUuid();
+	const token = canonicalJson({ version: 1, owner, indexPath, nonce });
 	let operationFd: number | undefined;
 	let quotaFd: number | undefined;
 	try {
-		// Lock both exact operation and child-session quota before the first byte.
 		operationFd = openSyncNoFollow(reservation, "wx", 0o600);
-		quotaFd = openSyncNoFollow(quotaReservation, "wx", 0o600);
-		writeAll(operationFd, Buffer.from(canonicalJson({ version: 1, owner, indexPath })));
+		writeAll(operationFd, Buffer.from(token));
 		fsyncSync(operationFd);
+		quotaFd = openSyncNoFollow(quotaReservation, "wx", 0o600);
+		writeAll(quotaFd, Buffer.from(token));
 		fsyncSync(quotaFd);
 		closeSync(operationFd);
 		closeSync(quotaFd);
@@ -656,16 +684,23 @@ function reserveOperationAndQuota(root: string, owner: C04ChildResultOwner, inde
 	} catch {
 		if (operationFd !== undefined) closeSync(operationFd);
 		if (quotaFd !== undefined) closeSync(quotaFd);
-		safeUnlink(reservation);
-		safeUnlink(quotaReservation);
+		unlinkReservationIfOwned(reservation, token);
+		unlinkReservationIfOwned(quotaReservation, token);
 		throw immutableConflict(root, owner.operationId);
 	}
 	return () => {
 		operationReservations.delete(key);
-		safeUnlink(reservation);
-		safeUnlink(quotaReservation);
+		unlinkReservationIfOwned(reservation, token);
+		unlinkReservationIfOwned(quotaReservation, token);
 		fsyncDirectory(dirname(reservation));
 	};
+}
+function unlinkReservationIfOwned(path: string, token: string): void {
+	try {
+		const stat = lstatSync(path);
+		if (stat.isFile() && !stat.isSymbolicLink() && stat.size <= 8192 && readFileSync(path, "utf8") === token)
+			unlinkSync(path);
+	} catch {}
 }
 function immutableConflict(root: string, operationId: string): Error {
 	appendAudit(root, "uncertain", "immutable_conflict", operationId);
@@ -676,9 +711,14 @@ function validateChildBinding(owner: C04ChildResultOwner, childArtifactRoot: str
 	const file = canonicalExistingRegularFile(owner.childSessionFile);
 	if (!file) throw new Error("C04 child session file is not a stable regular file");
 	const root = canonicalDirectoryNoSymlinks(childArtifactRoot);
-	// The file must remain beneath the same trusted child session hierarchy. This
-	// rejects a swapped/renamed child root passed independently from its session.
-	if (relative(dirname(file), root).startsWith("..")) throw new Error("C04 child artifact root escapes child session");
+	const sessionId = owner.childSessionId;
+	// This is the one layout SessionManager publishes. IDs and paths are all
+	// checked together so a sibling session's root cannot be substituted.
+	const sessionDir = dirname(file);
+	if (basename(sessionDir) !== "sessions" || basename(file) !== `${sessionId}.jsonl`)
+		throw new Error("C04 child session file is not the exact SessionManager child binding");
+	const expected = join(dirname(sessionDir), "session-artifacts", sessionId);
+	if (root !== expected) throw new Error("C04 child artifact root is not the exact SessionManager child binding");
 }
 function canonicalExistingRegularFile(path: string): string | undefined {
 	try {
@@ -705,26 +745,31 @@ function canonicalDirectoryNoSymlinks(path: string): string {
 	}
 	return absolute;
 }
-function prepareRoot(childArtifactRoot: string, create = true): string {
-	if (typeof childArtifactRoot !== "string" || !childArtifactRoot) throw new Error("invalid C04 artifact root");
-	// The trusted child artifact directory must already exist; never recursively
-	// create through an attacker-controlled ancestor.
-	const base = canonicalDirectoryNoSymlinks(childArtifactRoot);
+/** Re-check the SessionManager-shaped child binding before every C04 operation.
+ * SessionManager owns `<state>/sessions/<id>.jsonl` and
+ * `<state>/session-artifacts/<id>`; accepting merely a common ancestor would
+ * let a sibling child supply its artifact directory. */
+function prepareBoundRoot(owner: C04ChildResultOwner, childArtifactRoot: string, create = true): string {
+	validateChildBinding(owner, childArtifactRoot);
+	const base = assertPrivateDirectory(childArtifactRoot);
 	const root = join(base, "rlm-child-results");
 	if (create) mkdirSync(root, { recursive: true, mode: 0o700 });
-	assertDirectory(root);
+	assertPrivateDirectory(root);
 	for (const dir of ["operation-index", "results", "objects", "handle-index"]) {
 		const path = join(root, dir);
 		if (create) mkdirSync(path, { recursive: true, mode: 0o700 });
-		canonicalDirectoryNoSymlinks(path);
+		assertPrivateDirectory(path);
 	}
-	chmodSync(root, 0o700);
 	return root;
 }
-function assertDirectory(path: string): string {
-	const stat = lstatSync(path);
-	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("C04 rejects symlink/non-directory");
-	return resolve(path);
+function assertPrivateDirectory(path: string): string {
+	const canonical = canonicalDirectoryNoSymlinks(path);
+	const stat = lstatSync(canonical);
+	if ((stat.mode & 0o077) !== 0) {
+		chmodSync(canonical, 0o700);
+		if ((lstatSync(canonical).mode & 0o077) !== 0) throw new Error("C04 directory is not owner-private");
+	}
+	return canonical;
 }
 function safePath(root: string, directory: string, name?: string): string {
 	if (
@@ -772,7 +817,10 @@ function readIndex(
 		return undefined;
 	}
 }
-function handleResult(root: string, handleId: string): string {
+function readHandleIndex(
+	root: string,
+	handleId: string,
+): { resultId: string; owner: C04ChildResultOwner; handleId: string } {
 	if (!isUuid(handleId)) throw new Error("invalid handle");
 	const path = safePath(root, "handle-index", `${handleId}.json`);
 	const st = lstatSync(path);
@@ -786,8 +834,7 @@ function handleResult(root: string, handleId: string): string {
 		!isUuid(index.resultId)
 	)
 		throw new Error("not found");
-	validateOwner(index.owner as C04ChildResultOwner);
-	return index.resultId;
+	return { resultId: index.resultId, owner: validateOwner(index.owner as C04ChildResultOwner), handleId };
 }
 
 function expireIfElapsed(root: string, result: StoredChildResult, now: Date): StoredChildResult {
@@ -807,7 +854,16 @@ function setExpired(root: string, result: StoredChildResult): StoredChildResult 
 	return expired;
 }
 function projection(result: StoredChildResult): C04ChildResultReference {
-	const { schemaVersion, owner, facts, nextActions, committedAt, retention, requestDigest, ...reference } = result;
+	const {
+		schemaVersion: _schemaVersion,
+		owner: _owner,
+		facts: _facts,
+		nextActions: _nextActions,
+		committedAt: _committedAt,
+		retention: _retention,
+		requestDigest: _requestDigest,
+		...reference
+	} = result;
 	assertReference(reference);
 	return reference;
 }
@@ -965,6 +1021,27 @@ function assertArtifactRef(value: unknown, resultId: string): asserts value is C
 		!retentionStates.has(value.retentionState)
 	)
 		throw new Error("invalid C04 artifact reference");
+}
+function publishExclusive(temp: string, path: string): void {
+	// link(2) is an atomic no-replace publication. Node has no linkSync import
+	// here, so create the destination exclusively and copy from the private temp
+	// FD; a collision can never overwrite an immutable object name.
+	const source = openSyncNoFollow(temp, "r");
+	let destination: number | undefined;
+	try {
+		destination = openSyncNoFollow(path, "wx", 0o600);
+		const buffer = Buffer.allocUnsafe(MAX_STREAM_CHUNK_BYTES);
+		for (;;) {
+			const count = readSync(source, buffer, 0, buffer.length, null);
+			if (count === 0) break;
+			writeAll(destination, buffer.subarray(0, count));
+		}
+		fsyncSync(destination);
+	} finally {
+		closeSync(source);
+		if (destination !== undefined) closeSync(destination);
+	}
+	safeUnlink(temp);
 }
 function atomicJson(path: string, value: unknown): void {
 	const temp = `${path}.${randomUuid()}.tmp`;

--- a/packages/coding-agent/src/core/rlm-child-results.ts
+++ b/packages/coding-agent/src/core/rlm-child-results.ts
@@ -1,0 +1,1001 @@
+/**
+ * C04's sole authority for bounded terminal child results and opaque, owner-local
+ * artifacts.  This module deliberately has no daemon/protocol dependency.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import {
+	chmodSync,
+	closeSync,
+	fsyncSync,
+	lstatSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	readSync,
+	readdirSync,
+	renameSync,
+	unlinkSync,
+	writeSync,
+	constants,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+export const CHILD_RESULT_SCHEMA_VERSION = 1 as const;
+export const MAX_CHILD_RESULT_JSON_BYTES = 64 * 1024;
+export const MAX_SUMMARY_CHARS = 4_096;
+export const MAX_SUMMARY_BYTES = 16 * 1024;
+export const MAX_PREVIEW_CHARS = 2_048;
+export const MAX_PREVIEW_BYTES = 8 * 1024;
+export const MAX_FACTS = 32;
+export const MAX_NEXT_ACTIONS = 16;
+export const MAX_ARTIFACTS_PER_RESULT = 16;
+export const MAX_ARTIFACT_BYTES = 512 * 1024 * 1024;
+export const MAX_ARTIFACT_BYTES_PER_CHILD_SESSION = 2 * 1024 * 1024 * 1024;
+export const MAX_STREAM_CHUNK_BYTES = 64 * 1024;
+export const DEFAULT_CHILD_RESULT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const statuses = new Set(["completed", "failed", "cancelled", "timed_out", "stalled", "unknown_after_crash"]);
+const kinds = new Set(["terminal_output", "diagnostic", "trajectory", "attachment"]);
+const contentTypes = new Set(["text/plain", "application/json", "application/octet-stream"]);
+const retentionStates = new Set(["retained", "expired", "deleted", "unavailable", "uncertain"]);
+const errorCodes = new Set([
+	"invalid_result",
+	"result_too_large",
+	"artifact_too_large",
+	"artifact_quota_exceeded",
+	"artifact_unavailable",
+	"artifact_integrity_failed",
+	"artifact_expired",
+	"terminal_storage_failed",
+	"cancelled",
+	"timed_out",
+	"stalled",
+	"unknown_after_crash",
+]);
+
+export type C04ChildResultStatus =
+	| "completed"
+	| "failed"
+	| "cancelled"
+	| "timed_out"
+	| "stalled"
+	| "unknown_after_crash";
+export type C04RetentionState = "retained" | "expired" | "deleted" | "unavailable" | "uncertain";
+export type C04ArtifactKind = "terminal_output" | "diagnostic" | "trajectory" | "attachment";
+export type C04ErrorCode =
+	| "invalid_result"
+	| "result_too_large"
+	| "artifact_too_large"
+	| "artifact_quota_exceeded"
+	| "artifact_unavailable"
+	| "artifact_integrity_failed"
+	| "artifact_expired"
+	| "terminal_storage_failed"
+	| "cancelled"
+	| "timed_out"
+	| "stalled"
+	| "unknown_after_crash";
+
+/** Every component is required: matching a selector or only one ID is never authority. */
+export interface C04ChildResultOwner {
+	parentSessionId: string;
+	childSessionId: string;
+	childSessionFile: string;
+	assignmentId: string;
+	operationId: string;
+	deliveryId: string;
+}
+export interface C04OpaqueArtifactReference {
+	version: 1;
+	handleId: string;
+	resultId: string;
+	kind: C04ArtifactKind;
+	contentType: "text/plain" | "application/json" | "application/octet-stream";
+	byteLength: number;
+	sha256: string;
+	creatorAssignmentId: string;
+	ownerSessionId: string;
+	retentionState: C04RetentionState;
+}
+export interface C04ChildResultReference {
+	version: 1;
+	resultId: string;
+	status: C04ChildResultStatus;
+	summary: string;
+	preview: string;
+	error?: { code: C04ErrorCode; message: string; diagnosticRef?: string };
+	model: C04ModelMetadata;
+	artifacts: C04OpaqueArtifactReference[];
+	retentionState: C04RetentionState;
+}
+/** C05 receives only this same bounded shape, never correlation data or bytes. */
+export type C04PublicChildResult = C04ChildResultReference;
+export interface C04ModelMetadata {
+	requestedSelector?: string;
+	initialResolvedSelector: string;
+	terminalResolvedSelector: string;
+	fallbackHistory?: string[];
+}
+export interface C04TerminalCandidate {
+	status: C04ChildResultStatus;
+	summary: string;
+	preview: string;
+	facts?: Array<{ claim: string; evidenceRef?: string }>;
+	nextActions?: string[];
+	error?: { code?: string; message?: string; diagnostic?: C04ArtifactInput };
+	model?: Partial<C04ModelMetadata>;
+	/** Raw material is never returned or placed in the result record. */
+	artifacts?: C04ArtifactInput[];
+}
+export interface C04ArtifactInput {
+	kind: C04ArtifactKind;
+	contentType: "text/plain" | "application/json" | "application/octet-stream";
+	data: Uint8Array | string | AsyncIterable<Uint8Array>;
+}
+export interface C04CreateTerminalChildResultInput {
+	owner: C04ChildResultOwner;
+	candidate: C04TerminalCandidate;
+	/** Trusted SessionManager child artifact directory; callers never pass a relative object path. */
+	childArtifactRoot: string;
+	now?: () => Date;
+}
+interface StoredChildResult extends C04ChildResultReference {
+	schemaVersion: 1;
+	owner: C04ChildResultOwner;
+	facts: Array<{ claim: string; evidenceRef?: string }>;
+	nextActions: string[];
+	committedAt: string;
+	retention: { disposition: "retain_until"; expiresAt: string };
+	requestDigest: string;
+}
+type AuditAction = "created" | "linked" | "read_allowed" | "read_denied" | "expired" | "deleted" | "uncertain";
+const capabilities = new WeakMap<
+	object,
+	{ root: string; owner: C04ChildResultOwner; handleId: string; resultId: string }
+>();
+
+/**
+ * Validate, stream and commit one immutable operation result.  An exact retry
+ * returns its already committed reference; a different request is a conflict.
+ */
+export async function createOrGetTerminalChildResult(
+	input: C04CreateTerminalChildResultInput,
+): Promise<C04ChildResultReference> {
+	const owner = validateOwner(input.owner);
+	const root = prepareRoot(input.childArtifactRoot);
+	const now = input.now?.() ?? new Date();
+	if (!Number.isFinite(now.getTime())) throw new Error("C04 time is invalid");
+	const candidate = validateCandidate(input.candidate);
+	const requestDigest = sha256(canonicalJson({ owner, candidate: digestableCandidate(candidate) }));
+	const indexPath = safePath(root, "operation-index", `${owner.operationId}.json`);
+	const existing = readIndex(indexPath);
+	if (existing) {
+		if (!sameOwner(existing.owner, owner) || existing.requestDigest !== requestDigest) {
+			appendAudit(root, "uncertain", "immutable_conflict", owner.operationId);
+			throw new Error("C04 immutable operation conflict");
+		}
+		return projection(readStored(root, existing.resultId));
+	}
+
+	const resultId = randomUuid();
+	const artifacts: C04OpaqueArtifactReference[] = [];
+	try {
+		for (const artifact of [
+			...(candidate.artifacts ?? []),
+			...(candidate.error?.diagnostic ? [candidate.error.diagnostic] : []),
+		]) {
+			if (artifacts.length >= MAX_ARTIFACTS_PER_RESULT) throw new Error("artifact count exceeds C04 limit");
+			artifacts.push(await writeArtifact(root, owner, resultId, artifact));
+		}
+		const diagnostic = candidate.error?.diagnostic ? artifacts.at(-1) : undefined;
+		const facts = candidate.facts.map((fact) => ({
+			claim: fact.claim,
+			...(fact.evidenceRef && artifacts.some((ref) => ref.handleId === fact.evidenceRef)
+				? { evidenceRef: fact.evidenceRef }
+				: {}),
+		}));
+		const stored: StoredChildResult = {
+			schemaVersion: 1,
+			version: 1,
+			resultId,
+			owner,
+			status: candidate.status,
+			summary: candidate.summary,
+			preview: candidate.preview,
+			facts,
+			nextActions: candidate.nextActions,
+			...(candidate.error
+				? {
+						error: {
+							code: candidate.error.code as C04ErrorCode,
+							message: candidate.error.message as string,
+							...(diagnostic ? { diagnosticRef: diagnostic.handleId } : {}),
+						},
+					}
+				: {}),
+			model: candidate.model as C04ModelMetadata,
+			artifacts,
+			retentionState: "retained",
+			committedAt: now.toISOString(),
+			retention: {
+				disposition: "retain_until",
+				expiresAt: new Date(now.getTime() + DEFAULT_CHILD_RESULT_RETENTION_MS).toISOString(),
+			},
+			requestDigest,
+		};
+		assertStored(stored);
+		atomicJson(safePath(root, "results", `${resultId}.json`), stored);
+		const index = { version: 1, resultId, owner, requestDigest };
+		try {
+			atomicExclusiveJson(indexPath, index);
+		} catch (error) {
+			const raced = readIndex(indexPath);
+			if (raced && sameOwner(raced.owner, owner) && raced.requestDigest === requestDigest)
+				return projection(readStored(root, raced.resultId));
+			appendAudit(root, "uncertain", "immutable_conflict", owner.operationId);
+			throw error;
+		}
+		appendAudit(root, "created", "committed", resultId);
+		appendAudit(root, "linked", "operation_indexed", resultId);
+		return projection(stored);
+	} catch (error) {
+		// The caller chooses C03's normal bounded failure terminal path.  Do not
+		// manufacture an optimistic reference or expose arbitrary OS error text.
+		if (!(error instanceof Error && error.message === "C04 immutable operation conflict"))
+			appendAudit(root, "uncertain", "storage_failed", owner.operationId);
+		throw error;
+	}
+}
+
+export function getChildResultProjection(
+	owner: C04ChildResultOwner,
+	resultId: string,
+	childArtifactRoot: string,
+	now = new Date(),
+): C04ChildResultReference | undefined {
+	try {
+		const root = prepareRoot(childArtifactRoot, false);
+		const result = readStored(root, resultId);
+		if (!sameOwner(result.owner, validateOwner(owner))) return denied(root, "owner_mismatch");
+		const reduced = expireIfElapsed(root, result, now);
+		return projection(reduced);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Exact owner + opaque handle resolver.  It is deliberately not a generic get(handle). */
+export function resolveOwnedChildResult(
+	owner: C04ChildResultOwner,
+	handleId: string,
+	childArtifactRoot: string,
+	now = new Date(),
+): { result: C04PublicChildResult; capability: object } | undefined {
+	try {
+		const root = prepareRoot(childArtifactRoot, false);
+		const result = readStored(root, handleResult(root, handleId));
+		if (!sameOwner(result.owner, validateOwner(owner)) || !result.artifacts.some((a) => a.handleId === handleId))
+			return denied(root, "owner_mismatch");
+		const current = expireIfElapsed(root, result, now);
+		const artifact = current.artifacts.find((value) => value.handleId === handleId);
+		if (!artifact || artifact.retentionState !== "retained") return denied(root, "unavailable");
+		const capability = Object.freeze({});
+		capabilities.set(capability, { root, owner: current.owner, handleId, resultId: current.resultId });
+		appendAudit(root, "read_allowed", "resolved", handleId);
+		return { result: projection(current), capability };
+	} catch {
+		return undefined;
+	}
+}
+
+/** Reads at most one C04 chunk and checks owner, retention and digest before returning bytes. */
+export function readOwnedArtifact(
+	capability: object,
+	range: { offset: number; length: number },
+): Uint8Array | undefined {
+	const grant = capabilities.get(capability);
+	if (
+		!grant ||
+		!Number.isSafeInteger(range.offset) ||
+		!Number.isSafeInteger(range.length) ||
+		range.offset < 0 ||
+		range.length < 0 ||
+		range.length > MAX_STREAM_CHUNK_BYTES
+	)
+		return undefined;
+	try {
+		const result = readStored(grant.root, grant.resultId);
+		if (!sameOwner(result.owner, grant.owner)) return denied(grant.root, "owner_mismatch");
+		const artifact = result.artifacts.find((a) => a.handleId === grant.handleId);
+		if (!artifact || artifact.retentionState !== "retained" || range.offset > artifact.byteLength)
+			return denied(grant.root, "unavailable");
+		const file = safePath(grant.root, "objects", `${artifact.handleId}.blob`);
+		const fd = openSyncNoFollow(file, "r");
+		try {
+			const bytes = Buffer.allocUnsafe(Math.min(range.length, artifact.byteLength - range.offset));
+			const read = readSync(fd, bytes, 0, bytes.length, range.offset);
+			// Integrity is deliberately checked before *any* successful read. This is
+			// incremental and bounded by artifact cap, never readFile on payloads.
+			if (hashFile(file, artifact.byteLength) !== artifact.sha256) return denied(grant.root, "integrity");
+			appendAudit(grant.root, "read_allowed", "read", artifact.handleId);
+			return bytes.subarray(0, read);
+		} finally {
+			closeSync(fd);
+		}
+	} catch {
+		return undefined;
+	}
+}
+
+/** Idempotently records an explicit retention/delete disposition for an exact owner/result/handle. */
+export function recordChildResultDisposition(
+	owner: C04ChildResultOwner,
+	input: { resultId: string; handleId?: string; disposition: "expired" | "deleted" },
+	childArtifactRoot: string,
+): boolean {
+	try {
+		const root = prepareRoot(childArtifactRoot, false);
+		const result = readStored(root, input.resultId);
+		if (!sameOwner(result.owner, validateOwner(owner))) return false;
+		if (input.handleId && !result.artifacts.some((a) => a.handleId === input.handleId)) return false;
+		const changed = result.artifacts.map((artifact) =>
+			artifact.handleId === input.handleId || !input.handleId
+				? { ...artifact, retentionState: input.disposition }
+				: artifact,
+		);
+		if (canonicalJson(changed) !== canonicalJson(result.artifacts)) {
+			for (const artifact of changed)
+				if (artifact.retentionState !== "retained")
+					safeUnlink(safePath(root, "objects", `${artifact.handleId}.blob`));
+			atomicJson(safePath(root, "results", `${result.resultId}.json`), {
+				...result,
+				artifacts: changed,
+				retentionState: input.disposition,
+			});
+			appendAudit(root, input.disposition, input.disposition, input.handleId ?? input.resultId);
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function canonicalChildResultBytes(value: C04ChildResultReference): Uint8Array {
+	assertReference(value);
+	return Buffer.from(canonicalJson(value));
+}
+
+function validateOwner(value: C04ChildResultOwner): C04ChildResultOwner {
+	if (
+		!isObject(value) ||
+		!exactKeys(value as unknown as Record<string, unknown>, [
+			"parentSessionId",
+			"childSessionId",
+			"childSessionFile",
+			"assignmentId",
+			"operationId",
+			"deliveryId",
+		])
+	)
+		throw new Error("invalid C04 owner");
+	for (const key of ["parentSessionId", "childSessionId", "assignmentId", "operationId", "deliveryId"] as const)
+		if (!isUuid(value[key])) throw new Error(`invalid C04 owner ${key}`);
+	if (
+		typeof value.childSessionFile !== "string" ||
+		!value.childSessionFile ||
+		!resolve(value.childSessionFile).startsWith("/")
+	)
+		throw new Error("invalid C04 child session file");
+	return { ...value, childSessionFile: resolve(value.childSessionFile) };
+}
+function validateCandidate(
+	value: C04TerminalCandidate,
+): Required<Pick<C04TerminalCandidate, "status" | "summary" | "preview" | "facts" | "nextActions" | "model">> &
+	Pick<C04TerminalCandidate, "error" | "artifacts"> {
+	if (
+		!isObject(value) ||
+		!exactKeys(value as unknown as Record<string, unknown>, [
+			"status",
+			"summary",
+			"preview",
+			...optionalKeys(value as unknown as Record<string, unknown>, [
+				"facts",
+				"nextActions",
+				"error",
+				"model",
+				"artifacts",
+			]),
+		])
+	)
+		throw new Error("invalid C04 terminal candidate");
+	if (!statuses.has(value.status)) throw new Error("invalid C04 terminal status");
+	const status = value.status as C04ChildResultStatus;
+	const summary = safeText(value.summary, MAX_SUMMARY_CHARS, MAX_SUMMARY_BYTES, "summary");
+	const preview = safeText(value.preview, MAX_PREVIEW_CHARS, MAX_PREVIEW_BYTES, "preview");
+	const facts = Array.isArray(value.facts) ? value.facts : [];
+	if (
+		facts.length > MAX_FACTS ||
+		!facts.every((f) => isObject(f) && exactKeys(f, ["claim", ...optionalKeys(f, ["evidenceRef"])]))
+	)
+		throw new Error("invalid C04 facts");
+	const normalizedFacts = facts.map((f) => ({
+		claim: safeText(f.claim, 1024, 4096, "fact"),
+		...(typeof f.evidenceRef === "string" && isUuid(f.evidenceRef) ? { evidenceRef: f.evidenceRef } : {}),
+	}));
+	const nextActions = Array.isArray(value.nextActions) ? value.nextActions : [];
+	if (nextActions.length > MAX_NEXT_ACTIONS) throw new Error("too many next actions");
+	const normalizedNext = nextActions.map((a) => safeText(a, 512, 2048, "next action"));
+	let error: { code: C04ErrorCode; message: string; diagnostic?: C04ArtifactInput } | undefined;
+	if (status === "completed") {
+		if (value.error !== undefined) throw new Error("completed C04 result has error");
+	} else {
+		if (!isObject(value.error)) throw new Error("failed C04 result requires error");
+		const rawCode =
+			typeof value.error.code === "string" && errorCodes.has(value.error.code)
+				? (value.error.code as C04ErrorCode)
+				: status === "cancelled"
+					? "cancelled"
+					: status === "timed_out"
+						? "timed_out"
+						: status === "stalled"
+							? "stalled"
+							: status === "unknown_after_crash"
+								? "unknown_after_crash"
+								: "invalid_result";
+		error = {
+			code: rawCode,
+			message: safeText(value.error.message ?? "Terminal result unavailable", 1024, 4096, "error"),
+		};
+		if (value.error.diagnostic) error.diagnostic = validateArtifact(value.error.diagnostic);
+	}
+	const model = validateModel(value.model);
+	const artifacts =
+		value.artifacts === undefined
+			? []
+			: Array.isArray(value.artifacts) && value.artifacts.length <= MAX_ARTIFACTS_PER_RESULT
+				? value.artifacts.map(validateArtifact)
+				: (() => {
+						throw new Error("invalid C04 artifacts");
+					})();
+	return { status, summary, preview, facts: normalizedFacts, nextActions: normalizedNext, error, model, artifacts };
+}
+function validateModel(value: unknown): C04ModelMetadata {
+	const source = isObject(value) ? value : {};
+	if (
+		Object.keys(source).some(
+			(key) =>
+				!["requestedSelector", "initialResolvedSelector", "terminalResolvedSelector", "fallbackHistory"].includes(
+					key,
+				),
+		)
+	)
+		throw new Error("invalid C04 model");
+	const initialResolvedSelector = safeText(source.initialResolvedSelector ?? "unknown", 256, 1024, "model");
+	const terminalResolvedSelector = safeText(
+		source.terminalResolvedSelector ?? initialResolvedSelector,
+		256,
+		1024,
+		"model",
+	);
+	const history =
+		source.fallbackHistory === undefined
+			? undefined
+			: Array.isArray(source.fallbackHistory) && source.fallbackHistory.length <= 16
+				? source.fallbackHistory.map((v) => safeText(v, 256, 1024, "model fallback"))
+				: (() => {
+						throw new Error("invalid model fallback");
+					})();
+	return {
+		...(source.requestedSelector === undefined
+			? {}
+			: { requestedSelector: safeText(source.requestedSelector, 256, 1024, "requested model") }),
+		initialResolvedSelector,
+		terminalResolvedSelector,
+		...(history ? { fallbackHistory: history } : {}),
+	};
+}
+function validateArtifact(value: unknown): C04ArtifactInput {
+	if (
+		!isObject(value) ||
+		!exactKeys(value, ["kind", "contentType", "data"]) ||
+		!kinds.has(value.kind) ||
+		!contentTypes.has(value.contentType) ||
+		!(typeof value.data === "string" || value.data instanceof Uint8Array || isAsyncIterable(value.data))
+	)
+		throw new Error("invalid C04 artifact");
+	return value as C04ArtifactInput;
+}
+async function writeArtifact(
+	root: string,
+	owner: C04ChildResultOwner,
+	resultId: string,
+	artifact: C04ArtifactInput,
+): Promise<C04OpaqueArtifactReference> {
+	const used = aggregateBytes(root, owner);
+	const handleId = randomUuid();
+	const finalPath = safePath(root, "objects", `${handleId}.blob`);
+	const temp = safePath(root, "objects", `.${handleId}.${randomUuid()}.tmp`);
+	let fd: number | undefined;
+	const hash = createHash("sha256");
+	let count = 0;
+	try {
+		fd = openSyncNoFollow(temp, "wx", 0o600);
+		for await (const chunk of chunks(artifact.data)) {
+			if (chunk.length > MAX_STREAM_CHUNK_BYTES) throw new Error("C04 stream chunk exceeds limit");
+			count += chunk.length;
+			if (count > MAX_ARTIFACT_BYTES) throw new Error("C04 artifact exceeds limit");
+			if (used + count > MAX_ARTIFACT_BYTES_PER_CHILD_SESSION)
+				throw new Error("C04 session artifact quota exceeded");
+			hash.update(chunk);
+			writeAll(fd, chunk);
+		}
+		fsyncSync(fd);
+		closeSync(fd);
+		fd = undefined;
+		renameSync(temp, finalPath);
+		fsyncDirectory(dirname(finalPath));
+		return {
+			version: 1,
+			handleId,
+			resultId,
+			kind: artifact.kind,
+			contentType: artifact.contentType,
+			byteLength: count,
+			sha256: hash.digest("hex"),
+			creatorAssignmentId: owner.assignmentId,
+			ownerSessionId: owner.childSessionId,
+			retentionState: "retained",
+		};
+	} catch (error) {
+		if (fd !== undefined) closeSync(fd);
+		safeUnlink(temp);
+		throw error;
+	}
+}
+async function* chunks(data: C04ArtifactInput["data"]): AsyncGenerator<Uint8Array> {
+	if (typeof data === "string") {
+		const bytes = Buffer.from(data);
+		for (let at = 0; at < bytes.length; at += MAX_STREAM_CHUNK_BYTES)
+			yield bytes.subarray(at, at + MAX_STREAM_CHUNK_BYTES);
+	} else if (data instanceof Uint8Array) {
+		for (let at = 0; at < data.length; at += MAX_STREAM_CHUNK_BYTES)
+			yield data.subarray(at, at + MAX_STREAM_CHUNK_BYTES);
+	} else for await (const chunk of data) yield chunk;
+}
+function aggregateBytes(root: string, owner: C04ChildResultOwner): number {
+	let total = 0;
+	for (const name of readdirSync(safePath(root, "results"))) {
+		if (!name.endsWith(".json")) continue;
+		try {
+			const r = readStored(root, name.slice(0, -5));
+			if (sameOwner(r.owner, owner))
+				total += r.artifacts.reduce((n, a) => n + (a.retentionState === "retained" ? a.byteLength : 0), 0);
+		} catch {
+			throw new Error("uncertain C04 result store");
+		}
+	}
+	return total;
+}
+function prepareRoot(childArtifactRoot: string, create = true): string {
+	if (typeof childArtifactRoot !== "string" || !childArtifactRoot) throw new Error("invalid C04 artifact root");
+	if (create) mkdirSync(childArtifactRoot, { recursive: true, mode: 0o700 });
+	const base = assertDirectory(childArtifactRoot);
+	const root = join(base, "rlm-child-results");
+	if (create) mkdirSync(root, { recursive: true, mode: 0o700 });
+	assertDirectory(root);
+	for (const dir of ["operation-index", "results", "objects"]) {
+		const path = join(root, dir);
+		if (create) mkdirSync(path, { recursive: true, mode: 0o700 });
+		assertDirectory(path);
+	}
+	chmodSync(root, 0o700);
+	return root;
+}
+function assertDirectory(path: string): string {
+	const stat = lstatSync(path);
+	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("C04 rejects symlink/non-directory");
+	return resolve(path);
+}
+function safePath(root: string, directory: string, name?: string): string {
+	if (
+		!/^[a-z-]+$/.test(directory) ||
+		(name !== undefined && (!/^[0-9a-f.-]+(?:\.json|\.blob|\.tmp)?$/.test(name) || name.includes("..")))
+	)
+		throw new Error("invalid C04 generated path");
+	const target = name === undefined ? join(root, directory) : join(root, directory, name);
+	if (relative(root, target).startsWith("..") || resolve(target) === root)
+		throw new Error("C04 containment violation");
+	return target;
+}
+function readStored(root: string, resultId: string): StoredChildResult {
+	if (!isUuid(resultId)) throw new Error("invalid result ID");
+	const path = safePath(root, "results", `${resultId}.json`);
+	const stat = lstatSync(path);
+	if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_CHILD_RESULT_JSON_BYTES)
+		throw new Error("unavailable C04 result");
+	const parsed = JSON.parse(readFileSync(path, "utf8"));
+	assertStored(parsed);
+	return parsed;
+}
+function readIndex(
+	path: string,
+): { version: 1; resultId: string; owner: C04ChildResultOwner; requestDigest: string } | undefined {
+	try {
+		const st = lstatSync(path);
+		if (!st.isFile() || st.isSymbolicLink() || st.size > 8192) return undefined;
+		const x = JSON.parse(readFileSync(path, "utf8"));
+		if (
+			!isObject(x) ||
+			!exactKeys(x, ["version", "resultId", "owner", "requestDigest"]) ||
+			x.version !== 1 ||
+			!isUuid(x.resultId) ||
+			!SHA256.test(x.requestDigest)
+		)
+			return undefined;
+		return {
+			version: 1,
+			resultId: x.resultId,
+			owner: validateOwner(x.owner as C04ChildResultOwner),
+			requestDigest: x.requestDigest,
+		};
+	} catch {
+		return undefined;
+	}
+}
+function handleResult(root: string, handleId: string): string {
+	if (!isUuid(handleId)) throw new Error("invalid handle");
+	for (const name of readdirSync(safePath(root, "results"))) {
+		if (!name.endsWith(".json")) continue;
+		const result = readStored(root, name.slice(0, -5));
+		if (result.artifacts.some((a) => a.handleId === handleId)) return result.resultId;
+	}
+	throw new Error("not found");
+}
+function expireIfElapsed(root: string, result: StoredChildResult, now: Date): StoredChildResult {
+	if (Date.parse(result.retention.expiresAt) > now.getTime()) return result;
+	if (result.retentionState !== "retained") return result;
+	return setExpired(root, result);
+}
+function setExpired(root: string, result: StoredChildResult): StoredChildResult {
+	const expired = {
+		...result,
+		retentionState: "expired" as const,
+		artifacts: result.artifacts.map((a) => ({ ...a, retentionState: "expired" as const })),
+	};
+	for (const a of expired.artifacts) safeUnlink(safePath(root, "objects", `${a.handleId}.blob`));
+	atomicJson(safePath(root, "results", `${result.resultId}.json`), expired);
+	appendAudit(root, "expired", "retention_elapsed", result.resultId);
+	return expired;
+}
+function projection(result: StoredChildResult): C04ChildResultReference {
+	const { schemaVersion, owner, facts, nextActions, committedAt, retention, requestDigest, ...reference } = result;
+	assertReference(reference);
+	return reference;
+}
+function assertStored(value: unknown): asserts value is StoredChildResult {
+	if (
+		!isObject(value) ||
+		value.schemaVersion !== 1 ||
+		!exactKeys(value, [
+			"schemaVersion",
+			"version",
+			"resultId",
+			"owner",
+			"status",
+			"summary",
+			"preview",
+			"facts",
+			"nextActions",
+			"model",
+			"artifacts",
+			"retentionState",
+			"committedAt",
+			"retention",
+			"requestDigest",
+			...optionalKeys(value, ["error"]),
+		])
+	)
+		throw new Error("invalid C04 result record");
+	assertReference({
+		version: value.version,
+		resultId: value.resultId,
+		status: value.status,
+		summary: value.summary,
+		preview: value.preview,
+		...(value.error === undefined ? {} : { error: value.error }),
+		model: value.model,
+		artifacts: value.artifacts,
+		retentionState: value.retentionState,
+	});
+	validateOwner(value.owner as C04ChildResultOwner);
+	if (
+		!Array.isArray(value.facts) ||
+		value.facts.length > MAX_FACTS ||
+		!value.facts.every(
+			(fact) =>
+				isObject(fact) &&
+				exactKeys(fact, ["claim", ...optionalKeys(fact, ["evidenceRef"])]) &&
+				typeof fact.claim === "string" &&
+				(fact.evidenceRef === undefined || isUuid(fact.evidenceRef)),
+		) ||
+		!Array.isArray(value.nextActions) ||
+		value.nextActions.length > MAX_NEXT_ACTIONS ||
+		!value.nextActions.every((action) => typeof action === "string") ||
+		!isObject(value.retention) ||
+		value.retention.disposition !== "retain_until" ||
+		typeof value.retention.expiresAt !== "string" ||
+		Number.isNaN(Date.parse(value.retention.expiresAt)) ||
+		typeof value.committedAt !== "string" ||
+		Number.isNaN(Date.parse(value.committedAt)) ||
+		typeof value.requestDigest !== "string" ||
+		!SHA256.test(value.requestDigest)
+	)
+		throw new Error("invalid C04 result record");
+}
+function assertReference(value: unknown): asserts value is C04ChildResultReference {
+	if (
+		!isObject(value) ||
+		value.version !== 1 ||
+		!exactKeys(value, [
+			"version",
+			"resultId",
+			"status",
+			"summary",
+			"preview",
+			"model",
+			"artifacts",
+			"retentionState",
+			...optionalKeys(value, ["error"]),
+		]) ||
+		!isUuid(value.resultId) ||
+		!statuses.has(value.status) ||
+		!retentionStates.has(value.retentionState)
+	)
+		throw new Error("invalid C04 projection");
+	safeText(value.summary, MAX_SUMMARY_CHARS, MAX_SUMMARY_BYTES, "summary");
+	safeText(value.preview, MAX_PREVIEW_CHARS, MAX_PREVIEW_BYTES, "preview");
+	validateModel(value.model);
+	if (!Array.isArray(value.artifacts) || value.artifacts.length > MAX_ARTIFACTS_PER_RESULT)
+		throw new Error("invalid artifacts");
+	for (const a of value.artifacts) assertArtifactRef(a, value.resultId);
+	if (
+		value.status === "completed"
+			? value.error !== undefined
+			: !isObject(value.error) || !errorCodes.has(value.error.code) || typeof value.error.message !== "string"
+	)
+		throw new Error("invalid error");
+	if (value.error) {
+		if (!exactKeys(value.error, ["code", "message", ...optionalKeys(value.error, ["diagnosticRef"])]))
+			throw new Error("invalid error");
+		safeText(value.error.message, 1024, 4096, "error");
+		if (value.error.diagnosticRef !== undefined && !isUuid(value.error.diagnosticRef))
+			throw new Error("invalid diagnostic reference");
+	}
+	if (Buffer.byteLength(canonicalJson(value)) > MAX_CHILD_RESULT_JSON_BYTES)
+		throw new Error("C04 projection too large");
+}
+function assertArtifactRef(value: unknown, resultId: string): asserts value is C04OpaqueArtifactReference {
+	if (
+		!isObject(value) ||
+		!exactKeys(value, [
+			"version",
+			"handleId",
+			"resultId",
+			"kind",
+			"contentType",
+			"byteLength",
+			"sha256",
+			"creatorAssignmentId",
+			"ownerSessionId",
+			"retentionState",
+		]) ||
+		value.version !== 1 ||
+		!isUuid(value.handleId) ||
+		value.resultId !== resultId ||
+		!kinds.has(value.kind) ||
+		!contentTypes.has(value.contentType) ||
+		!Number.isSafeInteger(value.byteLength) ||
+		value.byteLength < 0 ||
+		value.byteLength > MAX_ARTIFACT_BYTES ||
+		typeof value.sha256 !== "string" ||
+		!SHA256.test(value.sha256) ||
+		!isUuid(value.creatorAssignmentId) ||
+		!isUuid(value.ownerSessionId) ||
+		!retentionStates.has(value.retentionState)
+	)
+		throw new Error("invalid C04 artifact reference");
+}
+function atomicJson(path: string, value: unknown): void {
+	const temp = `${path}.${randomUuid()}.tmp`;
+	let fd: number | undefined;
+	try {
+		fd = openSyncNoFollow(temp, "wx", 0o600);
+		writeAll(fd, Buffer.from(canonicalJson(value)));
+		fsyncSync(fd);
+		closeSync(fd);
+		fd = undefined;
+		renameSync(temp, path);
+		fsyncDirectory(dirname(path));
+	} catch (e) {
+		if (fd !== undefined) closeSync(fd);
+		safeUnlink(temp);
+		throw e;
+	}
+}
+function atomicExclusiveJson(path: string, value: unknown): void {
+	const fd = openSyncNoFollow(path, "wx", 0o600);
+	try {
+		writeAll(fd, Buffer.from(canonicalJson(value)));
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
+	}
+	fsyncDirectory(dirname(path));
+}
+function appendAudit(root: string, action: AuditAction, reason: string, id: string): void {
+	try {
+		const path = join(root, "audit.jsonl");
+		const fd = openSyncNoFollow(path, "a", 0o600);
+		try {
+			const rec = {
+				version: 1,
+				timestamp: new Date().toISOString(),
+				action,
+				reason: id ? reason : "unknown",
+				idFingerprint: sha256(id).slice(0, 16),
+			};
+			writeAll(fd, Buffer.from(`${canonicalJson(rec)}\n`));
+			fsyncSync(fd);
+		} finally {
+			closeSync(fd);
+		}
+	} catch {
+		/* Audit must not turn an already durable terminal fact into a raw exception path. */
+	}
+}
+function denied<T>(root: string, reason: string): T | undefined {
+	appendAudit(root, "read_denied", reason, reason);
+	return undefined;
+}
+function hashFile(path: string, length: number): string {
+	const fd = openSyncNoFollow(path, "r");
+	try {
+		const h = createHash("sha256");
+		const buffer = Buffer.allocUnsafe(MAX_STREAM_CHUNK_BYTES);
+		let off = 0;
+		while (off < length) {
+			const n = readSync(fd, buffer, 0, Math.min(buffer.length, length - off), off);
+			if (n <= 0) throw new Error("short object");
+			h.update(buffer.subarray(0, n));
+			off += n;
+		}
+		return h.digest("hex");
+	} finally {
+		closeSync(fd);
+	}
+}
+function fsyncDirectory(path: string): void {
+	const fd = openSync(path, "r");
+	try {
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
+	}
+}
+function openSyncNoFollow(path: string, flags: string, mode?: number): number {
+	const numeric =
+		flags === "r"
+			? constants.O_RDONLY
+			: flags === "a"
+				? constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY
+				: flags === "wx"
+					? constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY
+					: (() => {
+							throw new Error("invalid C04 open mode");
+						})();
+	// O_NOFOLLOW closes the lstat/open race on platforms that support it.
+	return openSync(path, numeric | (constants.O_NOFOLLOW ?? 0), mode);
+}
+function writeAll(fd: number, bytes: Uint8Array): void {
+	let at = 0;
+	while (at < bytes.length) {
+		const n = writeSync(fd, bytes, at, bytes.length - at);
+		if (n <= 0) throw new Error("short C04 write");
+		at += n;
+	}
+}
+function safeUnlink(path: string): void {
+	try {
+		const st = lstatSync(path);
+		if (st.isFile() && !st.isSymbolicLink()) unlinkSync(path);
+	} catch {}
+}
+function safeText(value: unknown, chars: number, bytes: number, label: string): string {
+	if (typeof value !== "string") throw new Error(`invalid C04 ${label}`);
+	const cleaned = value
+		.normalize("NFC")
+		.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ")
+		.replace(/(?:[A-Za-z]:\\|\/)[^\s]{2,}/g, "[redacted]")
+		.replace(/\b(?:sk-|AIza)[A-Za-z0-9_-]{12,}\b/g, "[redacted]")
+		.trim();
+	if (!cleaned || [...cleaned].length > chars || Buffer.byteLength(cleaned) > bytes || hasUnpairedSurrogate(cleaned))
+		throw new Error(`invalid C04 ${label}`);
+	return cleaned;
+}
+function hasUnpairedSurrogate(value: string): boolean {
+	for (let i = 0; i < value.length; i++) {
+		const n = value.charCodeAt(i);
+		if (n >= 0xd800 && n <= 0xdbff) {
+			if (++i >= value.length || value.charCodeAt(i) < 0xdc00 || value.charCodeAt(i) > 0xdfff) return true;
+		} else if (n >= 0xdc00 && n <= 0xdfff) return true;
+	}
+	return false;
+}
+function canonicalJson(value: unknown): string {
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+	const o = value as Record<string, unknown>;
+	return `{${Object.keys(o)
+		.sort()
+		.filter((k) => o[k] !== undefined)
+		.map((k) => `${JSON.stringify(k)}:${canonicalJson(o[k])}`)
+		.join(",")}}`;
+}
+function sha256(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+function randomUuid(): string {
+	return randomUUID();
+}
+function isUuid(value: unknown): value is string {
+	return typeof value === "string" && UUID.test(value);
+}
+function isObject(value: unknown): value is Record<string, any> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function exactKeys(value: Record<string, unknown>, keys: string[]): boolean {
+	const a = Object.keys(value).sort(),
+		b = [...keys].sort();
+	return a.length === b.length && a.every((x, i) => x === b[i]);
+}
+function optionalKeys(value: Record<string, unknown>, keys: string[]): string[] {
+	return keys.filter((k) => value[k] !== undefined);
+}
+function isAsyncIterable(value: unknown): value is AsyncIterable<Uint8Array> {
+	return !!value && typeof (value as any)[Symbol.asyncIterator] === "function";
+}
+function sameOwner(a: C04ChildResultOwner, b: C04ChildResultOwner): boolean {
+	return (
+		a.parentSessionId === b.parentSessionId &&
+		a.childSessionId === b.childSessionId &&
+		a.childSessionFile === b.childSessionFile &&
+		a.assignmentId === b.assignmentId &&
+		a.operationId === b.operationId &&
+		a.deliveryId === b.deliveryId
+	);
+}
+function digestableCandidate(candidate: any): unknown {
+	const artifactDigest = (a: C04ArtifactInput) => ({
+		kind: a.kind,
+		contentType: a.contentType,
+		payload:
+			typeof a.data === "string"
+				? sha256(a.data)
+				: a.data instanceof Uint8Array
+					? createHash("sha256").update(a.data).digest("hex")
+					: "stream",
+	});
+	return {
+		...candidate,
+		artifacts: (candidate.artifacts ?? []).map(artifactDigest),
+		error: candidate.error
+			? {
+					code: candidate.error.code,
+					message: candidate.error.message,
+					diagnostic: candidate.error.diagnostic ? artifactDigest(candidate.error.diagnostic) : undefined,
+				}
+			: undefined,
+	};
+}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, ServiceTier, TextContent, Usage } from "@earendil-works/pi-ai";
-import { randomUUID } from "crypto";
+import { randomBytes, randomUUID } from "crypto";
 import {
 	appendFileSync,
 	chmodSync,
@@ -8,6 +8,7 @@ import {
 	closeSync,
 	existsSync,
 	fsyncSync,
+	linkSync,
 	mkdirSync,
 	openSync,
 	readdirSync,
@@ -360,6 +361,14 @@ export interface SessionInfo {
 	agentStatus?: AgentStatus;
 	/** A malformed lifecycle/verdict was seen while scanning durable JSONL. */
 	hasInvalidDurableState?: boolean;
+}
+
+/** Private C04 recovery authority. The key itself remains on disk and is never
+ * returned, serialized, or included in a child-result projection. */
+export interface C04ParentRecoveryAuthority {
+	parentSessionFile: string;
+	parentArtifactRoot: string;
+	recoveryKeyPath: string;
 }
 
 export type ReadonlySessionManager = Pick<
@@ -1538,6 +1547,60 @@ export class SessionManager {
 
 	getSessionArtifactDir(): string | undefined {
 		return this.persist ? getSessionArtifactPath(this.sessionDir, this.sessionId) : undefined;
+	}
+
+	/**
+	 * Materialize C04's parent-scoped recovery key. This is deliberately a
+	 * SessionManager capability: C04 callers receive only its pathname and must
+	 * prove the session/artifact binding before reading it.
+	 */
+	getC04ParentRecoveryAuthority(): C04ParentRecoveryAuthority | undefined {
+		if (!this.persist || !this.sessionFile) return undefined;
+		const parentSessionFile = resolve(this.sessionFile);
+		const parentArtifactRoot = this.getSessionArtifactDir();
+		if (!parentArtifactRoot) return undefined;
+		mkdirSync(parentArtifactRoot, { recursive: true, mode: 0o700 });
+		const keyPath = join(parentArtifactRoot, ".c04-recovery-key");
+		const candidate = `${keyPath}.${process.pid}.${randomUUID()}.tmp`;
+		let fd: number | undefined;
+		try {
+			// fsync the random candidate before link(2)'s atomic no-replace cut.
+			// Unlike rename, link refuses to replace an authority created by another
+			// concurrent SessionManager.
+			fd = openSync(candidate, "wx", 0o600);
+			const bytes = randomBytes(32);
+			let offset = 0;
+			while (offset < bytes.length) {
+				const written = writeSync(fd, bytes, offset, bytes.length - offset);
+				if (written <= 0) throw new Error("C04 recovery key write made no progress");
+				offset += written;
+			}
+			fsyncSync(fd);
+			closeSync(fd);
+			fd = undefined;
+			try {
+				linkSync(candidate, keyPath);
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+			}
+			const dirFd = openSync(parentArtifactRoot, "r");
+			try {
+				fsyncSync(dirFd);
+			} finally {
+				closeSync(dirFd);
+			}
+		} finally {
+			if (fd !== undefined) closeSync(fd);
+			rmSync(candidate, { force: true });
+		}
+		// Normalize the authority key's exact requested mode even when this
+		// manager lost the no-replace race; both contenders are SessionManager
+		// instances for the same parent authority.
+		chmodSync(keyPath, 0o600);
+		const existing = statSync(keyPath);
+		if (!existing.isFile() || (existing.mode & 0o777) !== 0o600 || existing.size !== 32)
+			throw new Error("Invalid C04 recovery key");
+		return { parentSessionFile, parentArtifactRoot: resolve(parentArtifactRoot), recoveryKeyPath: keyPath };
 	}
 
 	/**

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -18,6 +18,7 @@ import {
 	rmSync,
 	statSync,
 	writeFileSync,
+	writeSync,
 } from "fs";
 import { readdir, readFile, stat } from "fs/promises";
 import { basename, dirname, join, resolve } from "path";

--- a/packages/coding-agent/test/c04-producer-sink.test.ts
+++ b/packages/coding-agent/test/c04-producer-sink.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { C04ProducerSink } from "../src/core/agent-session.js";
+
+describe("C04 producer sink", () => {
+	it("starts consumption before terminal generation, bounds buffering, and closes an overflow once", async () => {
+		const sink = new C04ProducerSink();
+		const iterator = sink[Symbol.asyncIterator]();
+		const waiting = iterator.next();
+		sink.push("first");
+		expect(new TextDecoder().decode((await waiting).value)).toBe("first");
+		sink.push("x".repeat(128 * 1024 + 1));
+		sink.push("ignored-after-overflow");
+		await expect(iterator.next()).rejects.toThrow("bounded buffer");
+		await expect(iterator.next()).resolves.toMatchObject({ done: true });
+	});
+
+	it("chunks at 64KiB and does not duplicate terminal bytes after close", async () => {
+		const sink = new C04ProducerSink();
+		sink.push("x".repeat(96 * 1024));
+		sink.close();
+		sink.push("late");
+		const chunks: Uint8Array[] = [];
+		for await (const chunk of sink) chunks.push(chunk);
+		expect(chunks.map((chunk) => chunk.length)).toEqual([64 * 1024, 32 * 1024]);
+		expect(Buffer.concat(chunks).byteLength).toBe(96 * 1024);
+	});
+});

--- a/packages/coding-agent/test/daemon-c03-real-production.test.ts
+++ b/packages/coding-agent/test/daemon-c03-real-production.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	type CreateAgentSessionRuntimeFactory,
@@ -10,7 +11,9 @@ import {
 	createAgentSessionServices,
 } from "../src/core/agent-session-runtime.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
+import type { ToolDefinition } from "../src/core/extensions/types.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
+import type { C04ChildResultReference } from "../src/core/rlm-child-results.js";
 import { materializedTerminalMessageId, readRlmDurableOperationRegistry } from "../src/core/rlm-durable-operations.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
@@ -71,7 +74,11 @@ function providerRegistration(models: readonly BarrierScriptedProvider["models"]
 	};
 }
 
-async function createRealDaemonFixture(root: string, scripted: BarrierScriptedProvider) {
+async function createRealDaemonFixture(
+	root: string,
+	scripted: BarrierScriptedProvider,
+	customTools: ToolDefinition[] = [],
+) {
 	const authStorage = AuthStorage.inMemory();
 	const modelRegistry = ModelRegistry.inMemory(authStorage);
 	const model = scripted.models[0]!;
@@ -102,7 +109,7 @@ async function createRealDaemonFixture(root: string, scripted: BarrierScriptedPr
 			scopedModels: runtimeOptions.sessionOptions?.scopedModels,
 			initialActiveToolNames: runtimeOptions.sessionOptions?.initialActiveToolNames,
 			allowedToolNames: runtimeOptions.sessionOptions?.allowedToolNames,
-			customTools: runtimeOptions.sessionOptions?.customTools,
+			customTools: runtimeOptions.sessionOptions?.customTools ?? customTools,
 			includeGoals: runtimeOptions.sessionOptions?.includeGoals,
 			includeCompactSkill: runtimeOptions.sessionOptions?.includeCompactSkill,
 			agentMessageController: runtimeOptions.sessionOptions?.agentMessageController,
@@ -175,10 +182,22 @@ function terminalEntries(session: { sessionManager: Pick<SessionManager, "getEnt
 		const message = candidate.message ?? candidate;
 		return (
 			(candidate.type === "message" || candidate.type === "custom_message") &&
-			(message.role === "custom" || message.customType === "rlm_child_terminal_notice") &&
+			(message.role === "custom" ||
+				message.customType === "rlm_child_terminal_notice" ||
+				message.customType === "rlm_safe_terminal_result") &&
 			message.details?.id === id
 		);
 	});
+}
+
+function terminalResultProjection(entry: unknown): C04ChildResultReference {
+	const candidate = entry as {
+		message?: { details?: { projection?: unknown } };
+		details?: { projection?: unknown };
+	};
+	const message = candidate.message ?? candidate;
+	if (typeof message.details?.projection !== "string") throw new Error("Missing C04 terminal projection");
+	return JSON.parse(message.details.projection) as C04ChildResultReference;
 }
 
 describe("C03 real daemon production recovery", () => {
@@ -516,6 +535,148 @@ describe("C03 real daemon production recovery", () => {
 				expect.objectContaining({ requestId: bRequest, signalAborted: false }),
 			]),
 		);
+		await internals.closeSession(parentState, "shutdown");
+	}, 20_000);
+
+	it.each([
+		{
+			label: "empty",
+			requestId: "request-9010",
+			scripts: [{ requestId: "request-9010", usage: usage(5, 0) }] satisfies readonly ProviderScript[],
+			expectedObservations: 1,
+		},
+		{
+			label: "tool-only",
+			requestId: "request-9011",
+			scripts: [
+				{
+					requestId: "request-9011",
+					stopReason: "toolUse",
+					usage: usage(5, 1),
+					blocks: [
+						{
+							type: "toolCall",
+							id: "finish-9011",
+							name: "finish",
+							argumentChunks: ["{}"],
+						},
+					],
+				},
+			] satisfies readonly ProviderScript[],
+			expectedObservations: 1,
+		},
+	])(
+		"commits a bounded empty C04 artifact and exactly one C03 terminal for a successful $label child",
+		async ({ label, requestId, scripts, expectedObservations }) => {
+			const root = await mkdtemp(join(tmpdir(), `prime-agent-c04-${label}-`));
+			const scripted = createBarrierScriptedProvider({
+				api: `c04-${label}-scripted`,
+				provider: `c04-${label}-scripted`,
+				barrier: { expected: [requestId], timeoutMs: 10_000 },
+				models: [{ id: `c04-${label}-model`, responseModel: `c04-${label}-model` }],
+				scripts: { [requestId]: scripts },
+			});
+			cleanups.push(() => scripted.unregister());
+			cleanups.push(() => rm(root, { recursive: true, force: true }));
+			const tools: ToolDefinition[] =
+				label === "tool-only"
+					? [
+							{
+								name: "finish",
+								label: "finish",
+								description: "Finish the test-only child task.",
+								parameters: Type.Object({}),
+								execute: async () => ({ content: [], details: {}, terminate: true }),
+							},
+						]
+					: [];
+			const fixture = await createRealDaemonFixture(root, scripted, tools);
+			const internals = fixture.daemon as unknown as DaemonInternals;
+			const parentState = await internals.createRuntime({ type: "create" });
+			const parent = parentState.runtime.session;
+			const handle = await parent.runRlmChild(`C04 ${label} ${requestId}`, {
+				name: `c04-${label}-worker`,
+				model: `c04-${label}-scripted/c04-${label}-model`,
+			});
+			await scripted.open;
+			scripted.release([requestId]);
+			const artifacts = parent.sessionManager.getSessionArtifactDir();
+			if (!artifacts) throw new Error("Missing parent C04 artifact directory");
+			await vi.waitFor(() => {
+				const operation = [...realRegistry(artifacts).operations.values()].find(
+					(candidate) => candidate.childId === handle.rlm_child_id,
+				);
+				expect(operation).toMatchObject({ lifecycle: "terminal_recorded" });
+				if (!operation) throw new Error("Missing C04 operation");
+				expect(terminalEntries(parent, operation.deliveryId)).toHaveLength(1);
+			});
+			const operation = [...realRegistry(artifacts).operations.values()].find(
+				(candidate) => candidate.childId === handle.rlm_child_id,
+			);
+			if (!operation) throw new Error("Missing C04 operation");
+			const terminal = terminalEntries(parent, operation.deliveryId)[0];
+			if (!terminal) throw new Error("Missing C03 terminal");
+			const projected = terminalResultProjection(terminal);
+			expect(projected).toMatchObject({
+				status: "completed",
+				artifacts: [expect.objectContaining({ byteLength: 0 })],
+			});
+			expect(projected.artifacts[0]?.sha256).toBe(
+				"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			);
+			await internals.getOrHydrateBoundSessionState(handle.rlm_child_id);
+			expect(terminalEntries(parent, operation.deliveryId)).toHaveLength(1);
+			expect(scripted.observations()).toHaveLength(expectedObservations);
+			await internals.closeSession(parentState, "shutdown");
+		},
+		20_000,
+	);
+
+	it("keeps a live text-delta producer open until its nonempty C04 artifact commits", async () => {
+		const root = await mkdtemp(join(tmpdir(), "prime-agent-c04-live-delta-"));
+		const requestId = "request-9012";
+		const scripted = createBarrierScriptedProvider({
+			api: "c04-live-delta-scripted",
+			provider: "c04-live-delta-scripted",
+			barrier: { expected: [requestId], timeoutMs: 10_000 },
+			models: [{ id: "c04-live-delta-model", responseModel: "c04-live-delta-model" }],
+			scripts: {
+				[requestId]: [{ requestId, usage: usage(5, 2), blocks: [{ type: "text", chunks: ["live ", "delta"] }] }],
+			},
+		});
+		cleanups.push(() => scripted.unregister());
+		cleanups.push(() => rm(root, { recursive: true, force: true }));
+		const fixture = await createRealDaemonFixture(root, scripted);
+		const internals = fixture.daemon as unknown as DaemonInternals;
+		const parentState = await internals.createRuntime({ type: "create" });
+		const parent = parentState.runtime.session;
+		const handle = await parent.runRlmChild(`C04 live delta ${requestId}`, {
+			name: "c04-live-delta-worker",
+			model: "c04-live-delta-scripted/c04-live-delta-model",
+		});
+		await scripted.open;
+		scripted.release([requestId]);
+		const artifacts = parent.sessionManager.getSessionArtifactDir();
+		if (!artifacts) throw new Error("Missing parent C04 artifact directory");
+		await vi.waitFor(() => {
+			const operation = [...realRegistry(artifacts).operations.values()].find(
+				(candidate) => candidate.childId === handle.rlm_child_id,
+			);
+			if (!operation) throw new Error("Missing C04 operation");
+			expect(terminalEntries(parent, operation.deliveryId)).toHaveLength(1);
+		});
+		const operation = [...realRegistry(artifacts).operations.values()].find(
+			(candidate) => candidate.childId === handle.rlm_child_id,
+		);
+		if (!operation) throw new Error("Missing C04 operation");
+		const terminal = terminalEntries(parent, operation.deliveryId)[0];
+		if (!terminal) throw new Error("Missing C03 terminal");
+		const projected = terminalResultProjection(terminal);
+		expect(projected.artifacts[0]).toMatchObject({
+			byteLength: 10,
+			sha256: "7050e1d30ca92a1ee1dbde7702615c72b8fa94ac9842395ec1773e2851966c26",
+		});
+		expect(scripted.observations()).toHaveLength(1);
 		await internals.closeSession(parentState, "shutdown");
 	}, 20_000);
 });

--- a/packages/coding-agent/test/rlm-child-results.test.ts
+++ b/packages/coding-agent/test/rlm-child-results.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	MAX_STREAM_CHUNK_BYTES,
+	createOrGetTerminalChildResult,
+	getChildResultProjection,
+	readOwnedArtifact,
+	resolveOwnedChildResult,
+} from "../src/core/rlm-child-results.js";
+
+const ids = [
+	"11111111-1111-4111-8111-111111111111",
+	"22222222-2222-4222-8222-222222222222",
+	"33333333-3333-4333-8333-333333333333",
+	"44444444-4444-4444-8444-444444444444",
+	"55555555-5555-4555-8555-555555555555",
+];
+function owner(file: string) {
+	return {
+		parentSessionId: ids[0],
+		childSessionId: ids[1],
+		childSessionFile: file,
+		assignmentId: ids[2],
+		operationId: ids[3],
+		deliveryId: ids[4],
+	};
+}
+
+describe("C04 bounded child results", () => {
+	it("commits an opaque streamed result idempotently and denies cross-owner bytes", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-"));
+		const file = join(root, "child.json");
+		try {
+			const input = {
+				owner: owner(file),
+				childArtifactRoot: root,
+				candidate: {
+					status: "completed" as const,
+					summary: "done",
+					preview: "safe",
+					artifacts: [
+						{
+							kind: "terminal_output" as const,
+							contentType: "text/plain" as const,
+							data: new TextEncoder().encode("private"),
+						},
+					],
+					model: { initialResolvedSelector: "test/a", terminalResolvedSelector: "test/a" },
+				},
+			};
+			const result = await createOrGetTerminalChildResult(input);
+			const again = await createOrGetTerminalChildResult(input);
+			expect(again).toEqual(result);
+			await expect(
+				createOrGetTerminalChildResult({ ...input, candidate: { ...input.candidate, preview: "different" } }),
+			).rejects.toThrow("immutable operation conflict");
+			expect(JSON.stringify(result)).not.toContain("private");
+			const grant = resolveOwnedChildResult(input.owner, result.artifacts[0].handleId, root);
+			expect(grant).toBeDefined();
+			expect(
+				new TextDecoder().decode(
+					readOwnedArtifact(grant!.capability, { offset: 0, length: MAX_STREAM_CHUNK_BYTES }),
+				),
+			).toBe("private");
+			expect(
+				resolveOwnedChildResult({ ...input.owner, assignmentId: ids[4] }, result.artifacts[0].handleId, root),
+			).toBeUndefined();
+			expect(getChildResultProjection(input.owner, result.resultId, root)).toEqual(result);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/rlm-child-results.test.ts
+++ b/packages/coding-agent/test/rlm-child-results.test.ts
@@ -1,5 +1,5 @@
 import { createHmac } from "node:crypto";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -252,6 +252,96 @@ describe("C04 bounded child results", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+	it("uses authenticated recoverable disposition leases and fails closed for live or unreadable owners", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-disposition-lease-"));
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", ids[1]);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		const file = join(sessions, `${ids[1]}.jsonl`);
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: ids[1] })}\n`);
+		const input = {
+			owner: owner(file),
+			childArtifactRoot: artifacts,
+			parentRecoveryAuthority: authority(file),
+			candidate: {
+				status: "completed" as const,
+				summary: "done",
+				preview: "safe",
+				artifacts: [
+					{
+						kind: "terminal_output" as const,
+						contentType: "text/plain" as const,
+						data: (async function* () {
+							yield new TextEncoder().encode("private");
+						})(),
+					},
+				],
+			},
+		};
+		try {
+			const result = await createOrGetTerminalChildResult(input);
+			const operationIndex = join(artifacts, "rlm-child-results", "operation-index");
+			const lock = join(operationIndex, `.disposition.${result.resultId}.lock`);
+			const installLease = () => {
+				const payload = {
+					version: 1,
+					owner: input.owner,
+					resultId: result.resultId,
+					nonce: ids[4],
+					pid: process.pid,
+					processStartId: "old-owner",
+				};
+				const mac = createHmac("sha256", readFileSync(input.parentRecoveryAuthority.recoveryKeyPath))
+					.update(canonical(payload))
+					.digest("hex");
+				mkdirSync(lock, { mode: 0o700 });
+				writeFileSync(join(lock, "lease.json"), canonical({ ...payload, mac }), { mode: 0o600 });
+			};
+			for (const state of ["live", "unreadable"] as const) {
+				installLease();
+				const restore = setC04ProcessIdentitySeamForTest({
+					captureCurrent: () => ({ pid: process.pid, processStartId: "current" }),
+					observe: () => state,
+				});
+				expect(
+					recordChildResultDisposition(
+						input.owner,
+						{ resultId: result.resultId, disposition: "deleted" },
+						artifacts,
+					),
+				).toBe(false);
+				restore();
+				expect(existsSync(lock)).toBe(true);
+				rmSync(lock, { recursive: true, force: true }); // Test cleanup, never production recovery.
+			}
+			for (const state of ["dead", "mismatch"] as const) {
+				installLease();
+				const restore = setC04ProcessIdentitySeamForTest({
+					captureCurrent: () => ({ pid: process.pid, processStartId: "current" }),
+					observe: () => state,
+				});
+				expect(
+					recordChildResultDisposition(
+						input.owner,
+						{ resultId: result.resultId, disposition: "deleted" },
+						artifacts,
+					),
+				).toBe(true);
+				restore();
+				expect(existsSync(lock)).toBe(false);
+				expect(
+					JSON.parse(
+						readFileSync(join(artifacts, "rlm-child-results", "results", `${result.resultId}.json`), "utf8"),
+					).generation,
+				).toBe(1);
+				break; // State is terminal after the first successful transition.
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("accepts authority UUIDv7 identities while preserving random v4 result/handle IDs", async () => {
 		const root = mkdtempSync(join(tmpdir(), "c04-v7-"));
 		const childV7 = "019a8f42-1234-7000-8000-123456789abc";

--- a/packages/coding-agent/test/rlm-child-results.test.ts
+++ b/packages/coding-agent/test/rlm-child-results.test.ts
@@ -1,11 +1,11 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-	MAX_STREAM_CHUNK_BYTES,
 	createOrGetTerminalChildResult,
 	getChildResultProjection,
+	MAX_STREAM_CHUNK_BYTES,
 	readOwnedArtifact,
 	resolveOwnedChildResult,
 } from "../src/core/rlm-child-results.js";
@@ -32,6 +32,7 @@ describe("C04 bounded child results", () => {
 	it("commits an opaque streamed result idempotently and denies cross-owner bytes", async () => {
 		const root = mkdtempSync(join(tmpdir(), "c04-"));
 		const file = join(root, "child.json");
+		writeFileSync(file, "{}\n");
 		try {
 			const input = {
 				owner: owner(file),
@@ -44,14 +45,29 @@ describe("C04 bounded child results", () => {
 						{
 							kind: "terminal_output" as const,
 							contentType: "text/plain" as const,
-							data: new TextEncoder().encode("private"),
+							data: (async function* () {
+								yield new TextEncoder().encode("private");
+							})(),
 						},
 					],
 					model: { initialResolvedSelector: "test/a", terminalResolvedSelector: "test/a" },
 				},
 			};
 			const result = await createOrGetTerminalChildResult(input);
-			const again = await createOrGetTerminalChildResult(input);
+			const again = await createOrGetTerminalChildResult({
+				...input,
+				candidate: {
+					...input.candidate,
+					artifacts: [
+						{
+							...input.candidate.artifacts![0]!,
+							data: (async function* () {
+								yield new TextEncoder().encode("private");
+							})(),
+						},
+					],
+				},
+			});
 			expect(again).toEqual(result);
 			await expect(
 				createOrGetTerminalChildResult({ ...input, candidate: { ...input.candidate, preview: "different" } }),
@@ -68,6 +84,46 @@ describe("C04 bounded child results", () => {
 				resolveOwnedChildResult({ ...input.owner, assignmentId: ids[4] }, result.artifacts[0].handleId, root),
 			).toBeUndefined();
 			expect(getChildResultProjection(input.owner, result.resultId, root)).toEqual(result);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+	it("rejects inline payloads and treats a different retry stream as an immutable conflict", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-stream-"));
+		const file = join(root, "child.json");
+		writeFileSync(file, "{}\n");
+		const stream = (text: string) =>
+			(async function* () {
+				yield new TextEncoder().encode(text);
+			})();
+		try {
+			const input = {
+				owner: owner(file),
+				childArtifactRoot: root,
+				candidate: {
+					status: "completed" as const,
+					summary: "done",
+					preview: "safe",
+					artifacts: [{ kind: "terminal_output" as const, contentType: "text/plain" as const, data: stream("A") }],
+				},
+			};
+			await createOrGetTerminalChildResult(input);
+			await expect(
+				createOrGetTerminalChildResult({
+					...input,
+					candidate: { ...input.candidate, artifacts: [{ ...input.candidate.artifacts[0]!, data: stream("B") }] },
+				}),
+			).rejects.toThrow("immutable operation conflict");
+			await expect(
+				createOrGetTerminalChildResult({
+					...input,
+					owner: { ...input.owner, operationId: ids[4] },
+					candidate: {
+						...input.candidate,
+						artifacts: [{ ...input.candidate.artifacts[0]!, data: "not-a-stream" as never }],
+					},
+				}),
+			).rejects.toThrow("payload must be");
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/rlm-child-results.test.ts
+++ b/packages/coding-agent/test/rlm-child-results.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	canonicalChildResultBytes,
 	createOrGetTerminalChildResult,
 	getChildResultProjection,
 	MAX_STREAM_CHUNK_BYTES,
@@ -10,6 +11,7 @@ import {
 	recordChildResultDisposition,
 	resolveOwnedChildResult,
 } from "../src/core/rlm-child-results.js";
+import { createRlmSafeTerminalResultTerminalMessage } from "../src/core/rlm-durable-operations.js";
 
 const ids = [
 	"11111111-1111-4111-8111-111111111111",
@@ -217,6 +219,62 @@ describe("C04 bounded child results", () => {
 				recordChildResultDisposition(input.owner, { resultId: result.resultId, disposition: "deleted" }, artifacts),
 			).toBe(true);
 			expect(readOwnedArtifact(grant.capability, { offset: 0, length: 7 })).toBeUndefined();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+	it("accepts authority UUIDv7 identities while preserving random v4 result/handle IDs", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-v7-"));
+		const childV7 = "019a8f42-1234-7000-8000-123456789abc";
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", childV7);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		const file = join(sessions, `${childV7}.jsonl`);
+		writeFileSync(file, "{}\n");
+		try {
+			const result = await createOrGetTerminalChildResult({
+				owner: {
+					parentSessionId: "019a8f42-1234-7000-8000-123456789abd",
+					childSessionId: childV7,
+					childSessionFile: file,
+					assignmentId: "019a8f42-1234-7000-8000-123456789abe",
+					operationId: "019a8f42-1234-7000-8000-123456789abf",
+					deliveryId: "019a8f42-1234-7000-8000-123456789ac0",
+				},
+				childArtifactRoot: artifacts,
+				candidate: { status: "completed", summary: "done", preview: "safe" },
+			});
+			expect(result.resultId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4/);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+	it("measures quote/backslash worst case through C03's stable envelope before commit", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-c03-cap-"));
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", ids[1]);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		const file = join(sessions, `${ids[1]}.jsonl`);
+		writeFileSync(file, "{}\n");
+		try {
+			const result = await createOrGetTerminalChildResult({
+				owner: owner(file),
+				childArtifactRoot: artifacts,
+				candidate: {
+					status: "completed",
+					summary: '\\"'.repeat(2_048),
+					preview: '\\"'.repeat(1_024),
+				},
+			});
+			const projection = Buffer.from(canonicalChildResultBytes(result)).toString("utf8");
+			const envelope = createRlmSafeTerminalResultTerminalMessage(
+				"Child completed; bounded result available.",
+				projection,
+				0,
+			);
+			expect(Buffer.byteLength(JSON.stringify(envelope))).toBeLessThanOrEqual(64 * 1024);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/rlm-child-results.test.ts
+++ b/packages/coding-agent/test/rlm-child-results.test.ts
@@ -12,6 +12,7 @@ import {
 	resolveOwnedChildResult,
 } from "../src/core/rlm-child-results.js";
 import { createRlmSafeTerminalResultTerminalMessage } from "../src/core/rlm-durable-operations.js";
+import { SessionManager } from "../src/core/session-manager.js";
 
 const ids = [
 	"11111111-1111-4111-8111-111111111111",
@@ -39,7 +40,7 @@ describe("C04 bounded child results", () => {
 		mkdirSync(sessions, { recursive: true });
 		mkdirSync(artifacts, { recursive: true });
 		const file = join(sessions, `${ids[1]}.jsonl`);
-		writeFileSync(file, "{}\n");
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: ids[1] })}\n`);
 		try {
 			const input = {
 				owner: owner(file),
@@ -102,7 +103,7 @@ describe("C04 bounded child results", () => {
 		mkdirSync(sessions, { recursive: true });
 		mkdirSync(artifacts, { recursive: true });
 		const file = join(sessions, `${ids[1]}.jsonl`);
-		writeFileSync(file, "{}\n");
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: ids[1] })}\n`);
 		const stream = (text: string) =>
 			(async function* () {
 				yield new TextEncoder().encode(text);
@@ -148,7 +149,7 @@ describe("C04 bounded child results", () => {
 		mkdirSync(artifacts, { recursive: true });
 		mkdirSync(sibling, { recursive: true });
 		const file = join(sessions, `${ids[1]}.jsonl`);
-		writeFileSync(file, "{}\n");
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: ids[1] })}\n`);
 		const base = {
 			owner: owner(file),
 			childArtifactRoot: artifacts,
@@ -193,7 +194,7 @@ describe("C04 bounded child results", () => {
 		mkdirSync(sessions, { recursive: true });
 		mkdirSync(artifacts, { recursive: true });
 		const file = join(sessions, `${ids[1]}.jsonl`);
-		writeFileSync(file, "{}\n");
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: ids[1] })}\n`);
 		const input = {
 			owner: owner(file),
 			childArtifactRoot: artifacts,
@@ -231,7 +232,7 @@ describe("C04 bounded child results", () => {
 		mkdirSync(sessions, { recursive: true });
 		mkdirSync(artifacts, { recursive: true });
 		const file = join(sessions, `${childV7}.jsonl`);
-		writeFileSync(file, "{}\n");
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: childV7 })}\n`);
 		try {
 			const result = await createOrGetTerminalChildResult({
 				owner: {
@@ -257,7 +258,7 @@ describe("C04 bounded child results", () => {
 		mkdirSync(sessions, { recursive: true });
 		mkdirSync(artifacts, { recursive: true });
 		const file = join(sessions, `${ids[1]}.jsonl`);
-		writeFileSync(file, "{}\n");
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: ids[1] })}\n`);
 		try {
 			const result = await createOrGetTerminalChildResult({
 				owner: owner(file),
@@ -275,6 +276,72 @@ describe("C04 bounded child results", () => {
 				0,
 			);
 			expect(Buffer.byteLength(JSON.stringify(envelope))).toBeLessThanOrEqual(64 * 1024);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("uses a real SessionManager-issued session header binding", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-real-session-manager-"));
+		const sessions = join(root, "sessions");
+		const manager = SessionManager.create(root, sessions);
+		manager.flushNow();
+		const file = manager.getSessionFile()!;
+		const artifacts = manager.getSessionArtifactDir()!;
+		mkdirSync(artifacts, { recursive: true });
+		try {
+			const result = await createOrGetTerminalChildResult({
+				owner: { ...owner(file), childSessionId: manager.getSessionId() },
+				childArtifactRoot: artifacts,
+				candidate: { status: "completed", summary: "done", preview: "safe" },
+			});
+			expect(
+				getChildResultProjection(
+					{ ...owner(file), childSessionId: manager.getSessionId() },
+					result.resultId,
+					artifacts,
+				),
+			).toEqual(result);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reconciles a dead reservation after the result and blobs were durable but indexes were not", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-reconcile-"));
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", ids[1]);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		const file = join(sessions, `${ids[1]}.jsonl`);
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: ids[1] })}\n`);
+		const base = {
+			owner: owner(file),
+			childArtifactRoot: artifacts,
+			candidate: { status: "completed" as const, summary: "done", preview: "safe" },
+		};
+		try {
+			const result = await createOrGetTerminalChildResult(base);
+			const resultRoot = join(artifacts, "rlm-child-results");
+			const index = join(resultRoot, "operation-index", `${ids[3]}.json`);
+			const reservation = join(resultRoot, "operation-index", `.${ids[3]}.reserve`);
+			const quota = join(resultRoot, "operation-index", `.quota.${ids[1]}.${ids[2]}.reserve`);
+			const journal = {
+				version: 1,
+				owner: base.owner,
+				indexPath: index,
+				nonce: ids[4],
+				pid: 999999,
+				startedAt: new Date().toISOString(),
+				progress: "reserved",
+				resultId: result.resultId,
+			};
+			writeFileSync(reservation, JSON.stringify(journal));
+			writeFileSync(quota, JSON.stringify(journal));
+			rmSync(index);
+			const again = await createOrGetTerminalChildResult({ ...base, candidate: { ...base.candidate } });
+			expect(again).toEqual(result);
+			expect(getChildResultProjection(base.owner, result.resultId, artifacts)).toEqual(result);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/rlm-child-results.test.ts
+++ b/packages/coding-agent/test/rlm-child-results.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -7,6 +7,7 @@ import {
 	getChildResultProjection,
 	MAX_STREAM_CHUNK_BYTES,
 	readOwnedArtifact,
+	recordChildResultDisposition,
 	resolveOwnedChildResult,
 } from "../src/core/rlm-child-results.js";
 
@@ -31,12 +32,16 @@ function owner(file: string) {
 describe("C04 bounded child results", () => {
 	it("commits an opaque streamed result idempotently and denies cross-owner bytes", async () => {
 		const root = mkdtempSync(join(tmpdir(), "c04-"));
-		const file = join(root, "child.json");
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", ids[1]);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		const file = join(sessions, `${ids[1]}.jsonl`);
 		writeFileSync(file, "{}\n");
 		try {
 			const input = {
 				owner: owner(file),
-				childArtifactRoot: root,
+				childArtifactRoot: artifacts,
 				candidate: {
 					status: "completed" as const,
 					summary: "done",
@@ -73,7 +78,7 @@ describe("C04 bounded child results", () => {
 				createOrGetTerminalChildResult({ ...input, candidate: { ...input.candidate, preview: "different" } }),
 			).rejects.toThrow("immutable operation conflict");
 			expect(JSON.stringify(result)).not.toContain("private");
-			const grant = resolveOwnedChildResult(input.owner, result.artifacts[0].handleId, root);
+			const grant = resolveOwnedChildResult(input.owner, result.artifacts[0].handleId, artifacts);
 			expect(grant).toBeDefined();
 			expect(
 				new TextDecoder().decode(
@@ -81,16 +86,20 @@ describe("C04 bounded child results", () => {
 				),
 			).toBe("private");
 			expect(
-				resolveOwnedChildResult({ ...input.owner, assignmentId: ids[4] }, result.artifacts[0].handleId, root),
+				resolveOwnedChildResult({ ...input.owner, assignmentId: ids[4] }, result.artifacts[0].handleId, artifacts),
 			).toBeUndefined();
-			expect(getChildResultProjection(input.owner, result.resultId, root)).toEqual(result);
+			expect(getChildResultProjection(input.owner, result.resultId, artifacts)).toEqual(result);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
 	it("rejects inline payloads and treats a different retry stream as an immutable conflict", async () => {
 		const root = mkdtempSync(join(tmpdir(), "c04-stream-"));
-		const file = join(root, "child.json");
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", ids[1]);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		const file = join(sessions, `${ids[1]}.jsonl`);
 		writeFileSync(file, "{}\n");
 		const stream = (text: string) =>
 			(async function* () {
@@ -99,7 +108,7 @@ describe("C04 bounded child results", () => {
 		try {
 			const input = {
 				owner: owner(file),
-				childArtifactRoot: root,
+				childArtifactRoot: artifacts,
 				candidate: {
 					status: "completed" as const,
 					summary: "done",
@@ -124,6 +133,90 @@ describe("C04 bounded child results", () => {
 					},
 				}),
 			).rejects.toThrow("payload must be");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+	it("requires the exact SessionManager child artifact binding and keeps a loser from removing a winner reservation", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-binding-"));
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", ids[1]);
+		const sibling = join(root, "session-artifacts", ids[4]);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		mkdirSync(sibling, { recursive: true });
+		const file = join(sessions, `${ids[1]}.jsonl`);
+		writeFileSync(file, "{}\n");
+		const base = {
+			owner: owner(file),
+			childArtifactRoot: artifacts,
+			candidate: { status: "completed" as const, summary: "done", preview: "safe" },
+		};
+		try {
+			await expect(createOrGetTerminalChildResult({ ...base, childArtifactRoot: sibling })).rejects.toThrow(
+				"exact SessionManager",
+			);
+			let release!: () => void;
+			const held = createOrGetTerminalChildResult({
+				...base,
+				candidate: {
+					...base.candidate,
+					artifacts: [
+						{
+							kind: "terminal_output" as const,
+							contentType: "text/plain" as const,
+							data: (async function* () {
+								await new Promise<void>((resolve) => {
+									release = resolve;
+								});
+								yield new TextEncoder().encode("winner");
+							})(),
+						},
+					],
+				},
+			});
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await expect(createOrGetTerminalChildResult(base)).rejects.toThrow("immutable operation conflict");
+			release();
+			const winner = await held;
+			expect(getChildResultProjection(base.owner, winner.resultId, artifacts)).toEqual(winner);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+	it("publishes disposition before removal so a resolved capability cannot return payload after delete", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-disposition-"));
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", ids[1]);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		const file = join(sessions, `${ids[1]}.jsonl`);
+		writeFileSync(file, "{}\n");
+		const input = {
+			owner: owner(file),
+			childArtifactRoot: artifacts,
+			candidate: {
+				status: "completed" as const,
+				summary: "done",
+				preview: "safe",
+				artifacts: [
+					{
+						kind: "terminal_output" as const,
+						contentType: "text/plain" as const,
+						data: (async function* () {
+							yield new TextEncoder().encode("private");
+						})(),
+					},
+				],
+			},
+		};
+		try {
+			const result = await createOrGetTerminalChildResult(input);
+			const grant = resolveOwnedChildResult(input.owner, result.artifacts[0]!.handleId, artifacts)!;
+			expect(
+				recordChildResultDisposition(input.owner, { resultId: result.resultId, disposition: "deleted" }, artifacts),
+			).toBe(true);
+			expect(readOwnedArtifact(grant.capability, { offset: 0, length: 7 })).toBeUndefined();
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/rlm-child-results.test.ts
+++ b/packages/coding-agent/test/rlm-child-results.test.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHmac } from "node:crypto";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	canonicalChildResultBytes,
@@ -10,6 +11,7 @@ import {
 	readOwnedArtifact,
 	recordChildResultDisposition,
 	resolveOwnedChildResult,
+	setC04ProcessIdentitySeamForTest,
 } from "../src/core/rlm-child-results.js";
 import { createRlmSafeTerminalResultTerminalMessage } from "../src/core/rlm-durable-operations.js";
 import { SessionManager } from "../src/core/session-manager.js";
@@ -31,6 +33,28 @@ function owner(file: string) {
 		deliveryId: ids[4],
 	};
 }
+function canonical(value: unknown): string {
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+	const object = value as Record<string, unknown>;
+	return `{${Object.keys(object)
+		.sort()
+		.filter((key) => object[key] !== undefined)
+		.map((key) => `${JSON.stringify(key)}:${canonical(object[key])}`)
+		.join(",")}}`;
+}
+
+function authority(file: string) {
+	const state = dirname(dirname(file));
+	const parentFile = join(state, "sessions", `${ids[0]}.jsonl`);
+	const parentArtifacts = join(state, "session-artifacts", ids[0]);
+	mkdirSync(parentArtifacts, { recursive: true, mode: 0o700 });
+	writeFileSync(parentFile, `${JSON.stringify({ type: "session", id: ids[0] })}\n`, { mode: 0o600 });
+	const recoveryKeyPath = join(parentArtifacts, ".c04-recovery-key");
+	writeFileSync(recoveryKeyPath, Buffer.alloc(32, 7), { mode: 0o600 });
+	chmodSync(recoveryKeyPath, 0o600);
+	return { parentSessionFile: parentFile, parentArtifactRoot: parentArtifacts, recoveryKeyPath };
+}
 
 describe("C04 bounded child results", () => {
 	it("commits an opaque streamed result idempotently and denies cross-owner bytes", async () => {
@@ -45,6 +69,7 @@ describe("C04 bounded child results", () => {
 			const input = {
 				owner: owner(file),
 				childArtifactRoot: artifacts,
+				parentRecoveryAuthority: authority(file),
 				candidate: {
 					status: "completed" as const,
 					summary: "done",
@@ -112,6 +137,7 @@ describe("C04 bounded child results", () => {
 			const input = {
 				owner: owner(file),
 				childArtifactRoot: artifacts,
+				parentRecoveryAuthority: authority(file),
 				candidate: {
 					status: "completed" as const,
 					summary: "done",
@@ -153,6 +179,7 @@ describe("C04 bounded child results", () => {
 		const base = {
 			owner: owner(file),
 			childArtifactRoot: artifacts,
+			parentRecoveryAuthority: authority(file),
 			candidate: { status: "completed" as const, summary: "done", preview: "safe" },
 		};
 		try {
@@ -198,6 +225,7 @@ describe("C04 bounded child results", () => {
 		const input = {
 			owner: owner(file),
 			childArtifactRoot: artifacts,
+			parentRecoveryAuthority: authority(file),
 			candidate: {
 				status: "completed" as const,
 				summary: "done",
@@ -234,9 +262,20 @@ describe("C04 bounded child results", () => {
 		const file = join(sessions, `${childV7}.jsonl`);
 		writeFileSync(file, `${JSON.stringify({ type: "session", id: childV7 })}\n`);
 		try {
+			const parentSessionId = "019a8f42-1234-7000-8000-123456789abd";
+			const parentArtifacts = join(root, "session-artifacts", parentSessionId);
+			mkdirSync(parentArtifacts, { recursive: true });
+			const parentFile = join(sessions, `${parentSessionId}.jsonl`);
+			writeFileSync(parentFile, `${JSON.stringify({ type: "session", id: parentSessionId })}\n`);
+			const parentRecoveryAuthority = {
+				parentSessionFile: parentFile,
+				parentArtifactRoot: parentArtifacts,
+				recoveryKeyPath: join(parentArtifacts, ".c04-recovery-key"),
+			};
+			writeFileSync(parentRecoveryAuthority.recoveryKeyPath, Buffer.alloc(32, 7), { mode: 0o600 });
 			const result = await createOrGetTerminalChildResult({
 				owner: {
-					parentSessionId: "019a8f42-1234-7000-8000-123456789abd",
+					parentSessionId,
 					childSessionId: childV7,
 					childSessionFile: file,
 					assignmentId: "019a8f42-1234-7000-8000-123456789abe",
@@ -244,6 +283,7 @@ describe("C04 bounded child results", () => {
 					deliveryId: "019a8f42-1234-7000-8000-123456789ac0",
 				},
 				childArtifactRoot: artifacts,
+				parentRecoveryAuthority,
 				candidate: { status: "completed", summary: "done", preview: "safe" },
 			});
 			expect(result.resultId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4/);
@@ -263,6 +303,7 @@ describe("C04 bounded child results", () => {
 			const result = await createOrGetTerminalChildResult({
 				owner: owner(file),
 				childArtifactRoot: artifacts,
+				parentRecoveryAuthority: authority(file),
 				candidate: {
 					status: "completed",
 					summary: '\\"'.repeat(2_048),
@@ -293,6 +334,7 @@ describe("C04 bounded child results", () => {
 			const result = await createOrGetTerminalChildResult({
 				owner: { ...owner(file), childSessionId: manager.getSessionId() },
 				childArtifactRoot: artifacts,
+				parentRecoveryAuthority: authority(file),
 				candidate: { status: "completed", summary: "done", preview: "safe" },
 			});
 			expect(
@@ -318,6 +360,7 @@ describe("C04 bounded child results", () => {
 		const base = {
 			owner: owner(file),
 			childArtifactRoot: artifacts,
+			parentRecoveryAuthority: authority(file),
 			candidate: { status: "completed" as const, summary: "done", preview: "safe" },
 		};
 		try {
@@ -326,22 +369,136 @@ describe("C04 bounded child results", () => {
 			const index = join(resultRoot, "operation-index", `${ids[3]}.json`);
 			const reservation = join(resultRoot, "operation-index", `.${ids[3]}.reserve`);
 			const quota = join(resultRoot, "operation-index", `.quota.${ids[1]}.${ids[2]}.reserve`);
-			const journal = {
+			const payload = {
 				version: 1,
 				owner: base.owner,
 				indexPath: index,
 				nonce: ids[4],
 				pid: 999999,
-				startedAt: new Date().toISOString(),
+				processStartId: "dead-start",
 				progress: "reserved",
 				resultId: result.resultId,
 			};
+			const key = readFileSync(base.parentRecoveryAuthority.recoveryKeyPath);
+			const journal = { ...payload, mac: createHmac("sha256", key).update(canonical(payload)).digest("hex") };
 			writeFileSync(reservation, JSON.stringify(journal));
 			writeFileSync(quota, JSON.stringify(journal));
 			rmSync(index);
+			const restoreIdentity = setC04ProcessIdentitySeamForTest({
+				captureCurrent: () => ({ pid: process.pid, processStartId: "current" }),
+				observe: () => "dead",
+			});
 			const again = await createOrGetTerminalChildResult({ ...base, candidate: { ...base.candidate } });
+			restoreIdentity();
 			expect(again).toEqual(result);
 			expect(getChildResultProjection(base.owner, result.resultId, artifacts)).toEqual(result);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed for live, unreadable, malformed, or MAC-tampered reservations without deleting them", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-reservation-fail-closed-"));
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", ids[1]);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		const file = join(sessions, `${ids[1]}.jsonl`);
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: ids[1] })}\n`);
+		const base = {
+			owner: owner(file),
+			childArtifactRoot: artifacts,
+			parentRecoveryAuthority: authority(file),
+			candidate: { status: "completed" as const, summary: "done", preview: "safe" },
+		};
+		try {
+			const result = await createOrGetTerminalChildResult(base);
+			const resultRoot = join(artifacts, "rlm-child-results");
+			const index = join(resultRoot, "operation-index", `${ids[3]}.json`);
+			const reservation = join(resultRoot, "operation-index", `.${ids[3]}.reserve`);
+			const quota = join(resultRoot, "operation-index", `.quota.${ids[1]}.${ids[2]}.reserve`);
+			const payload = {
+				version: 1,
+				owner: base.owner,
+				indexPath: index,
+				nonce: ids[4],
+				pid: 999999,
+				processStartId: "owner-start",
+				progress: "reserved",
+				resultId: result.resultId,
+			};
+			const key = readFileSync(base.parentRecoveryAuthority.recoveryKeyPath);
+			const valid = { ...payload, mac: createHmac("sha256", key).update(canonical(payload)).digest("hex") };
+			for (const [journal, identity] of [
+				[valid, "live"],
+				[valid, "unreadable"],
+				[{ ...valid, mac: "00".repeat(32) }, "dead"],
+				[{ nope: true }, "dead"],
+			] as const) {
+				rmSync(index, { force: true });
+				writeFileSync(reservation, JSON.stringify(journal));
+				writeFileSync(quota, JSON.stringify(journal));
+				const restore = setC04ProcessIdentitySeamForTest({
+					captureCurrent: () => ({ pid: process.pid, processStartId: "current" }),
+					observe: () => identity,
+				});
+				await expect(createOrGetTerminalChildResult({ ...base, candidate: { ...base.candidate } })).rejects.toThrow(
+					"immutable operation conflict",
+				);
+				restore();
+				expect(readFileSync(reservation, "utf8")).toBe(JSON.stringify(journal));
+				expect(getChildResultProjection(base.owner, result.resultId, artifacts)).toEqual(result);
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reclaims a PID-recycled start-token mismatch but never by wall clock", async () => {
+		const root = mkdtempSync(join(tmpdir(), "c04-reservation-recycled-"));
+		const sessions = join(root, "sessions");
+		const artifacts = join(root, "session-artifacts", ids[1]);
+		mkdirSync(sessions, { recursive: true });
+		mkdirSync(artifacts, { recursive: true });
+		const file = join(sessions, `${ids[1]}.jsonl`);
+		writeFileSync(file, `${JSON.stringify({ type: "session", id: ids[1] })}\n`);
+		const base = {
+			owner: owner(file),
+			childArtifactRoot: artifacts,
+			parentRecoveryAuthority: authority(file),
+			candidate: { status: "completed" as const, summary: "done", preview: "safe" },
+		};
+		try {
+			const result = await createOrGetTerminalChildResult(base);
+			const resultRoot = join(artifacts, "rlm-child-results");
+			const index = join(resultRoot, "operation-index", `${ids[3]}.json`);
+			const reservation = join(resultRoot, "operation-index", `.${ids[3]}.reserve`);
+			const quota = join(resultRoot, "operation-index", `.quota.${ids[1]}.${ids[2]}.reserve`);
+			const payload = {
+				version: 1,
+				owner: base.owner,
+				indexPath: index,
+				nonce: ids[4],
+				pid: process.pid,
+				processStartId: "old-incarnation",
+				progress: "reserved" as const,
+				resultId: result.resultId,
+			};
+			const mac = createHmac("sha256", readFileSync(base.parentRecoveryAuthority.recoveryKeyPath))
+				.update(canonical(payload))
+				.digest("hex");
+			writeFileSync(reservation, JSON.stringify({ ...payload, mac }));
+			writeFileSync(quota, JSON.stringify({ ...payload, mac }));
+			rmSync(index);
+			const restore = setC04ProcessIdentitySeamForTest({
+				captureCurrent: () => ({ pid: process.pid, processStartId: "current" }),
+				observe: () => "mismatch",
+			});
+			await expect(createOrGetTerminalChildResult({ ...base, candidate: { ...base.candidate } })).resolves.toEqual(
+				result,
+			);
+			restore();
+			expect(() => readFileSync(reservation)).toThrow();
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## C04 bounded child results — validation/security review draft

**Draft only:** this is not merge-ready. Validation and security review continue through the **1 / 100 / 500** gates.

### Scope
- Adds the bounded producer sink and opaque, owner-local child-result/artifact references.
- Adds authenticated, parent-bound recovery reservations with PID-incarnation checks and fail-closed recovery.
- Preserves C03 durable-terminal authority; C04 owns only its bounded result/artifact layer and does not overwrite C03.
- Current focused tests cover producer buffering/chunking, bounded artifacts, ownership fencing, authenticated recovery, tamper fail-closed behavior, and PID-recycle handling.

### Safety and rollback
- C04 remains exclusively responsible for its child-result artifact namespace and can be rolled back by reverting this PR without changing C03 durable-terminal delivery authority.
- No client-side limiter, shared semaphore, admission queue, or synthetic local rate limiting is introduced.

### Exact integration
- Base: `perf/c03-durable-terminal-delivery` at `d2776b2d62e87e2ba01675aa1d613f32f8ebd51d` (PR #1166 current head)
- Head: `perf/c04-bounded-child-results` at `02a5f939f11697de1e0163be3fda461dcf7a9392`
- Rebased exactly the seven C04-only commits from old base `42afc919f0e43ded880aa8a2d7088f31b264da95` onto the C03 head. No rebase conflicts occurred.
- The rebased range contains only C04-owned result/artifact sink changes and their focused tests; C03 durable-terminal authority and bot fixes are retained from the new base.

### Validation
- `git diff --check` passed.
- Focused Biome check passed for all six C04 source/test files.
- `npx tsgo --noEmit` passed.
- Focused Vitest passed: **18 tests** across `c04-producer-sink`, `rlm-child-results`, and `daemon-c03-real-production`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add C04 bounded child result storage with authenticated recovery and artifact streaming
> - Introduces a new `rlm-child-results` module implementing immutable, owner-bound terminal child result storage with MAC-authenticated reservation journals, artifact streaming, quota enforcement, and capability-based reads.
> - Adds `createOrGetTerminalChildResult` to atomically publish or idempotently retrieve a terminal child result, with strict ownership validation, inode/digest TOCTOU guards, and reconciliation of abandoned reservations from dead processes.
> - Adds `C04ProducerSink` in `agent-session.ts`, a bounded 128 KiB async iterable sink that captures text deltas during child agent runs and feeds the artifact writer; overflow rejects the consumer iterator.
> - Integrates the new storage into `AgentSession` subagent spawning: on completion/cancellation under a fenced assignment, the parent now receives a canonical C04 result projection instead of a plain `completed_without_reply` notice.
> - Adds `getC04ParentRecoveryAuthority` to `SessionManager` to materialize a 32-byte recovery key under the session artifact directory using atomic `link(2)` and strict 0600 permissions.
> - Risk: behavioral change — child completions under a fenced assignment now deliver a structured C04 result message to the parent rather than the previous unstructured notice; the fallback path is only used when fenced delivery is not applicable.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2482983. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
