### PR TITLE
N01: incremental structured-output streaming parser

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -25,7 +25,13 @@ export * from "./stream.js";
 export * from "./types.js";
 export * from "./utils/diagnostics.js";
 export * from "./utils/event-stream.js";
-export * from "./utils/json-parse.js";
+export type { StreamingJsonParseState } from "./utils/json-parse.js";
+export {
+	createStreamingJsonParseState,
+	parseJsonWithRepair,
+	parseStreamingJson,
+	repairJson,
+} from "./utils/json-parse.js";
 export type {
 	OAuthAuthInfo,
 	OAuthCredentials,

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -41,7 +41,7 @@ import type {
 	ToolResultMessage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
-import { parseStreamingJson } from "../utils/json-parse.js";
+import { createStreamingJsonParseState, type StreamingJsonParseState } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { recordStreamFailure, streamFailureFromStopReason } from "../utils/stream-failure.js";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.js";
@@ -83,7 +83,10 @@ export interface BedrockOptions extends StreamOptions {
 	bearerToken?: string;
 }
 
-type Block = (TextContent | ThinkingContent | ToolCall) & { index?: number; partialJson?: string };
+type Block = (TextContent | ThinkingContent | ToolCall) & {
+	index?: number;
+	parser?: StreamingJsonParseState<Record<string, unknown>>;
+};
 
 export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> = (
 	model: Model<"bedrock-converse-stream">,
@@ -271,8 +274,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as Block).index;
-				// partialJson is only a streaming scratch buffer; never persist it.
-				delete (block as Block).partialJson;
+				delete (block as Block).parser;
 			}
 			output.stopReason = options.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatBedrockError(error);
@@ -374,7 +376,7 @@ function handleContentBlockStart(
 			id: start.toolUse.toolUseId || "",
 			name: start.toolUse.name || "",
 			arguments: {},
-			partialJson: "",
+			parser: createStreamingJsonParseState<Record<string, unknown>>(),
 			index,
 		};
 		output.content.push(block);
@@ -407,8 +409,8 @@ function handleContentBlockDelta(
 			stream.push({ type: "text_delta", contentIndex: index, delta: delta.text, partial: output });
 		}
 	} else if (delta?.toolUse && block?.type === "toolCall") {
-		block.partialJson = (block.partialJson || "") + (delta.toolUse.input || "");
-		block.arguments = parseStreamingJson(block.partialJson);
+		if (!block.parser) throw new Error("Missing Bedrock streaming JSON parser");
+		block.arguments = block.parser.append(delta.toolUse.input || "");
 		stream.push({ type: "toolcall_delta", contentIndex: index, delta: delta.toolUse.input || "", partial: output });
 	} else if (delta?.reasoningContent) {
 		let thinkingBlock = block;
@@ -474,10 +476,9 @@ function handleContentBlockStop(
 			stream.push({ type: "thinking_end", contentIndex: index, content: block.thinking, partial: output });
 			break;
 		case "toolCall":
-			block.arguments = parseStreamingJson(block.partialJson);
-			// Finalize in-place and strip the scratch buffer so replay only
-			// carries parsed arguments.
-			delete (block as Block).partialJson;
+			if (!block.parser) throw new Error("Missing Bedrock streaming JSON parser");
+			block.arguments = block.parser.finalize();
+			delete (block as Block).parser;
 			stream.push({ type: "toolcall_end", contentIndex: index, toolCall: block, partial: output });
 			break;
 	}

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -41,7 +41,11 @@ import type {
 	ToolResultMessage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
-import { createStreamingJsonParseState, type StreamingJsonParseState } from "../utils/json-parse.js";
+import {
+	createStreamingJsonParseState,
+	discardStreamingJsonParseState,
+	type StreamingJsonParseState,
+} from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { recordStreamFailure, streamFailureFromStopReason } from "../utils/stream-failure.js";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.js";
@@ -274,6 +278,8 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as Block).index;
+				const parser = (block as Block).parser;
+				if (parser) discardStreamingJsonParseState(parser);
 				delete (block as Block).parser;
 			}
 			output.stopReason = options.signal?.aborted ? "aborted" : "error";

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -32,6 +32,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import {
 	createStreamingJsonParseState,
+	discardStreamingJsonParseState,
 	parseJsonWithRepair,
 	type StreamingJsonParseState,
 } from "../utils/json-parse.js";
@@ -729,6 +730,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as { index?: number }).index;
+				const parser = (block as { parser?: StreamingJsonParseState<unknown> }).parser;
+				if (parser) discardStreamingJsonParseState(parser);
 				delete (block as { parser?: StreamingJsonParseState<Record<string, unknown>> }).parser;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -30,7 +30,11 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
-import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
+import {
+	createStreamingJsonParseState,
+	parseJsonWithRepair,
+	type StreamingJsonParseState,
+} from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
 	classifyStreamFailure,
@@ -532,7 +536,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			const requestId = response.headers.get("request-id") ?? undefined;
 			stream.push({ type: "start", partial: output });
 
-			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
+			type Block = (
+				| ThinkingContent
+				| TextContent
+				| (ToolCall & { parser: StreamingJsonParseState<Record<string, unknown>> })
+			) & { index: number };
 			const blocks = output.content as Block[];
 
 			for await (const event of iterateAnthropicEvents(response, options?.signal, requestId)) {
@@ -595,7 +603,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 								? fromClaudeCodeName(event.content_block.name, context.tools)
 								: event.content_block.name,
 							arguments: (event.content_block.input as Record<string, any>) ?? {},
-							partialJson: "",
+							parser: createStreamingJsonParseState<Record<string, unknown>>(),
 							index: event.index,
 						};
 						output.content.push(block);
@@ -630,8 +638,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 						const index = blocks.findIndex((b) => b.index === event.index);
 						const block = blocks[index];
 						if (block && block.type === "toolCall") {
-							block.partialJson += event.delta.partial_json;
-							block.arguments = parseStreamingJson(block.partialJson);
+							block.arguments = block.parser.append(event.delta.partial_json);
 							stream.push({
 								type: "toolcall_delta",
 								contentIndex: index,
@@ -667,10 +674,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 								partial: output,
 							});
 						} else if (block.type === "toolCall") {
-							block.arguments = parseStreamingJson(block.partialJson);
-							// Finalize in-place and strip the scratch buffer so replay only
-							// carries parsed arguments.
-							delete (block as { partialJson?: string }).partialJson;
+							block.arguments = block.parser.finalize();
+							delete (block as { parser?: StreamingJsonParseState<Record<string, unknown>> }).parser;
 							stream.push({
 								type: "toolcall_end",
 								contentIndex: index,
@@ -724,8 +729,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as { index?: number }).index;
-				// partialJson is only a streaming scratch buffer; never persist it.
-				delete (block as { partialJson?: string }).partialJson;
+				delete (block as { parser?: StreamingJsonParseState<Record<string, unknown>> }).parser;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatStreamFailureMessage(error);

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
+import { discardStreamingJsonParseState, type StreamingJsonParseState } from "../utils/json-parse.js";
 import {
 	formatStreamFailureMessage,
 	recordStreamFailure,
@@ -121,8 +122,9 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as { index?: number }).index;
-				// partialJson is only a streaming scratch buffer; never persist it.
-				delete (block as { partialJson?: string }).partialJson;
+				const parser = (block as { parser?: StreamingJsonParseState<unknown> }).parser;
+				if (parser) discardStreamingJsonParseState(parser);
+				delete (block as { parser?: StreamingJsonParseState<unknown> }).parser;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatStreamFailureMessage(error);

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -24,7 +24,11 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
-import { createStreamingJsonParseState, type StreamingJsonParseState } from "../utils/json-parse.js";
+import {
+	createStreamingJsonParseState,
+	discardStreamingJsonParseState,
+	type StreamingJsonParseState,
+} from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { recordStreamFailure, streamFailureFromStopReason } from "../utils/stream-failure.js";
 import { buildBaseOptions } from "./simple-options.js";
@@ -93,6 +97,8 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
 			stream.end();
 		} catch (error) {
 			for (const block of output.content) {
+				const parser = (block as { parser?: StreamingJsonParseState<unknown> }).parser;
+				if (parser) discardStreamingJsonParseState(parser);
 				delete (block as { parser?: StreamingJsonParseState<Record<string, unknown>> }).parser;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -24,7 +24,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
-import { parseStreamingJson } from "../utils/json-parse.js";
+import { createStreamingJsonParseState, type StreamingJsonParseState } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { recordStreamFailure, streamFailureFromStopReason } from "../utils/stream-failure.js";
 import { buildBaseOptions } from "./simple-options.js";
@@ -93,8 +93,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
 			stream.end();
 		} catch (error) {
 			for (const block of output.content) {
-				// partialArgs is only a streaming scratch buffer; never persist it.
-				delete (block as { partialArgs?: string }).partialArgs;
+				delete (block as { parser?: StreamingJsonParseState<Record<string, unknown>> }).parser;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatMistralError(error);
@@ -402,12 +401,12 @@ async function consumeChatStream(
 					: deriveMistralToolCallId(`toolcall:${toolCall.index ?? 0}`, 0);
 			const key = `${callId}:${toolCall.index || 0}`;
 			const existingIndex = toolBlocksByKey.get(key);
-			let block: (ToolCall & { partialArgs?: string }) | undefined;
+			let block: (ToolCall & { parser?: StreamingJsonParseState<Record<string, unknown>> }) | undefined;
 
 			if (existingIndex !== undefined) {
 				const existing = output.content[existingIndex];
 				if (existing?.type === "toolCall") {
-					block = existing as ToolCall & { partialArgs?: string };
+					block = existing as ToolCall & { parser?: StreamingJsonParseState<Record<string, unknown>> };
 				}
 			}
 
@@ -417,7 +416,7 @@ async function consumeChatStream(
 					id: callId,
 					name: toolCall.function.name,
 					arguments: {},
-					partialArgs: "",
+					parser: createStreamingJsonParseState<Record<string, unknown>>(),
 				};
 				output.content.push(block);
 				toolBlocksByKey.set(key, output.content.length - 1);
@@ -428,8 +427,8 @@ async function consumeChatStream(
 				typeof toolCall.function.arguments === "string"
 					? toolCall.function.arguments
 					: JSON.stringify(toolCall.function.arguments || {});
-			block.partialArgs = (block.partialArgs || "") + argsDelta;
-			block.arguments = parseStreamingJson<Record<string, unknown>>(block.partialArgs);
+			if (!block.parser) throw new Error("Missing Mistral streaming JSON parser");
+			block.arguments = block.parser.append(argsDelta);
 			stream.push({
 				type: "toolcall_delta",
 				contentIndex: toolBlocksByKey.get(key)!,
@@ -443,11 +442,10 @@ async function consumeChatStream(
 	for (const index of toolBlocksByKey.values()) {
 		const block = output.content[index];
 		if (block.type !== "toolCall") continue;
-		const toolBlock = block as ToolCall & { partialArgs?: string };
-		toolBlock.arguments = parseStreamingJson<Record<string, unknown>>(toolBlock.partialArgs);
-		// Finalize in-place and strip the scratch buffer so replay only
-		// carries parsed arguments.
-		delete toolBlock.partialArgs;
+		const toolBlock = block as ToolCall & { parser?: StreamingJsonParseState<Record<string, unknown>> };
+		if (!toolBlock.parser) throw new Error("Missing Mistral streaming JSON parser");
+		toolBlock.arguments = toolBlock.parser.finalize();
+		delete toolBlock.parser;
 		stream.push({
 			type: "toolcall_end",
 			contentIndex: index,

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -40,6 +40,7 @@ import {
 } from "../utils/diagnostics.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
+import { discardStreamingJsonParseState, type StreamingJsonParseState } from "../utils/json-parse.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
@@ -302,8 +303,9 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			stream.end();
 		} catch (error) {
 			for (const block of output.content) {
-				// partialJson is only a streaming scratch buffer; never persist it.
-				delete (block as { partialJson?: string }).partialJson;
+				const parser = (block as { parser?: StreamingJsonParseState<unknown> }).parser;
+				if (parser) discardStreamingJsonParseState(parser);
+				delete (block as { parser?: StreamingJsonParseState<unknown> }).parser;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -33,7 +33,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
-import { parseStreamingJson } from "../utils/json-parse.js";
+import { createStreamingJsonParseState, type StreamingJsonParseState } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
@@ -163,7 +163,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			stream.push({ type: "start", partial: output });
 
 			interface StreamingToolCallBlock extends ToolCall {
-				partialArgs?: string;
+				parser?: StreamingJsonParseState<Record<string, unknown>>;
 				streamIndex?: number;
 			}
 			type StreamingBlock = TextContent | ThinkingContent | StreamingToolCallBlock;
@@ -195,10 +195,9 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 						partial: output,
 					});
 				} else if (block.type === "toolCall") {
-					block.arguments = parseStreamingJson(block.partialArgs);
-					// Finalize in-place and strip the scratch buffers so replay only
-					// carries parsed arguments.
-					delete block.partialArgs;
+					if (!block.parser) throw new Error("Missing OpenAI streaming JSON parser");
+					block.arguments = block.parser.finalize();
+					delete block.parser;
 					delete block.streamIndex;
 					stream.push({
 						type: "toolcall_end",
@@ -240,7 +239,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 						id: toolCall.id || "",
 						name: toolCall.function?.name || "",
 						arguments: {},
-						partialArgs: "",
+						parser: createStreamingJsonParseState<Record<string, unknown>>(),
 						streamIndex,
 					};
 					if (streamIndex !== undefined) {
@@ -355,8 +354,8 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 							let delta = "";
 							if (toolCall.function?.arguments) {
 								delta = toolCall.function.arguments;
-								block.partialArgs = (block.partialArgs ?? "") + toolCall.function.arguments;
-								block.arguments = parseStreamingJson(block.partialArgs);
+								if (!block.parser) throw new Error("Missing OpenAI streaming JSON parser");
+								block.arguments = block.parser.append(toolCall.function.arguments);
 							}
 							stream.push({
 								type: "toolcall_delta",
@@ -402,8 +401,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as { index?: number }).index;
-				// Streaming scratch buffers are only used during parsing; never persist them.
-				delete (block as { partialArgs?: string }).partialArgs;
+				delete (block as { parser?: StreamingJsonParseState<Record<string, unknown>> }).parser;
 				delete (block as { streamIndex?: number }).streamIndex;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -33,7 +33,11 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
-import { createStreamingJsonParseState, type StreamingJsonParseState } from "../utils/json-parse.js";
+import {
+	createStreamingJsonParseState,
+	discardStreamingJsonParseState,
+	type StreamingJsonParseState,
+} from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
@@ -401,6 +405,8 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as { index?: number }).index;
+				const parser = (block as { parser?: StreamingJsonParseState<unknown> }).parser;
+				if (parser) discardStreamingJsonParseState(parser);
 				delete (block as { parser?: StreamingJsonParseState<Record<string, unknown>> }).parser;
 				delete (block as { streamIndex?: number }).streamIndex;
 			}

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -29,7 +29,11 @@ import type {
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
-import { parseStreamingJson } from "../utils/json-parse.js";
+import {
+	createStreamingJsonParseState,
+	getStreamingJsonRawForProviderCheck,
+	type StreamingJsonParseState,
+} from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { classifyStreamFailure, StreamFailureError } from "../utils/stream-failure.js";
 import { transformMessages } from "./transform-messages.js";
@@ -289,7 +293,11 @@ export async function processResponsesStream<TApi extends Api>(
 	options?: OpenAIResponsesStreamOptions,
 ): Promise<void> {
 	let currentItem: ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | null = null;
-	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
+	let currentBlock:
+		| ThinkingContent
+		| TextContent
+		| (ToolCall & { parser: StreamingJsonParseState<Record<string, unknown>> })
+		| null = null;
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
 
@@ -315,9 +323,10 @@ export async function processResponsesStream<TApi extends Api>(
 					id: `${item.call_id}|${item.id}`,
 					name: item.name,
 					arguments: {},
-					partialJson: item.arguments || "",
+					parser: createStreamingJsonParseState<Record<string, unknown>>(),
 				};
 				output.content.push(currentBlock);
+				if (item.arguments) currentBlock.arguments = currentBlock.parser.append(item.arguments);
 				stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
 			}
 		} else if (event.type === "response.reasoning_summary_part.added") {
@@ -409,8 +418,7 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.function_call_arguments.delta") {
 			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson += event.delta;
-				currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+				currentBlock.arguments = currentBlock.parser.append(event.delta);
 				stream.push({
 					type: "toolcall_delta",
 					contentIndex: blockIndex(),
@@ -420,20 +428,19 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.function_call_arguments.done") {
 			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				const previousPartialJson = currentBlock.partialJson;
-				currentBlock.partialJson = event.arguments;
-				currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
-
-				if (event.arguments.startsWith(previousPartialJson)) {
-					const delta = event.arguments.slice(previousPartialJson.length);
-					if (delta.length > 0) {
-						stream.push({
-							type: "toolcall_delta",
-							contentIndex: blockIndex(),
-							delta,
-							partial: output,
-						});
-					}
+				const accumulated = getStreamingJsonRawForProviderCheck(currentBlock.parser);
+				if (!event.arguments.startsWith(accumulated)) {
+					throw new Error("OpenAI Responses function-call arguments replaced a streamed prefix");
+				}
+				const delta = event.arguments.slice(accumulated.length);
+				if (delta.length > 0) {
+					currentBlock.arguments = currentBlock.parser.append(delta);
+					stream.push({
+						type: "toolcall_delta",
+						contentIndex: blockIndex(),
+						delta,
+						partial: output,
+					});
 				}
 			}
 		} else if (event.type === "response.output_item.done") {
@@ -462,24 +469,19 @@ export async function processResponsesStream<TApi extends Api>(
 				});
 				currentBlock = null;
 			} else if (item.type === "function_call") {
-				const args =
-					currentBlock?.type === "toolCall" && currentBlock.partialJson
-						? parseStreamingJson(currentBlock.partialJson)
-						: parseStreamingJson(item.arguments || "{}");
-
 				let toolCall: ToolCall;
 				if (currentBlock?.type === "toolCall") {
-					// Finalize in-place and strip the scratch buffer so replay only
-					// carries parsed arguments.
-					currentBlock.arguments = args;
-					delete (currentBlock as { partialJson?: string }).partialJson;
+					currentBlock.arguments = currentBlock.parser.finalize();
+					delete (currentBlock as { parser?: StreamingJsonParseState<Record<string, unknown>> }).parser;
 					toolCall = currentBlock;
 				} else {
+					const parser = createStreamingJsonParseState<Record<string, unknown>>();
+					parser.append(item.arguments || "{}");
 					toolCall = {
 						type: "toolCall",
 						id: `${item.call_id}|${item.id}`,
 						name: item.name,
-						arguments: args,
+						arguments: parser.finalize(),
 					};
 				}
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -471,6 +471,13 @@ export async function processResponsesStream<TApi extends Api>(
 			} else if (item.type === "function_call") {
 				let toolCall: ToolCall;
 				if (currentBlock?.type === "toolCall") {
+					const accumulated = getStreamingJsonRawForProviderCheck(currentBlock.parser);
+					if (accumulated.length === 0)
+						currentBlock.arguments = currentBlock.parser.append(item.arguments || "{}");
+					else if (!item.arguments.startsWith(accumulated))
+						throw new Error("OpenAI Responses function-call item replaced a streamed prefix");
+					else if (item.arguments.length > accumulated.length)
+						currentBlock.arguments = currentBlock.parser.append(item.arguments.slice(accumulated.length));
 					currentBlock.arguments = currentBlock.parser.finalize();
 					delete (currentBlock as { parser?: StreamingJsonParseState<Record<string, unknown>> }).parser;
 					toolCall = currentBlock;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
+import { discardStreamingJsonParseState, type StreamingJsonParseState } from "../utils/json-parse.js";
 import {
 	formatStreamFailureMessage,
 	recordStreamFailure,
@@ -132,8 +133,9 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as { index?: number }).index;
-				// partialJson is only a streaming scratch buffer; never persist it.
-				delete (block as { partialJson?: string }).partialJson;
+				const parser = (block as { parser?: StreamingJsonParseState<unknown> }).parser;
+				if (parser) discardStreamingJsonParseState(parser);
+				delete (block as { parser?: StreamingJsonParseState<unknown> }).parser;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatStreamFailureMessage(error);

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -379,8 +379,11 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 		if (char === '"') {
 			this.stringToken = undefined;
 			if (token.rawControl) {
-				this.previewInvalid = this.frames.length > 1;
-				if (!this.previewInvalid) this.replaceCurrentValue(token.repairedValue);
+				// A closed raw-control string is only repairable once the whole
+				// enclosing document closes; partial-json rejects this prefix.
+				this.previewInvalid = true;
+				if (token.location)
+					this.repairedStringsAtRootClose.push({ location: token.location, value: token.repairedValue });
 			}
 			if (token.unicode !== undefined) token.invalidUnicode = true;
 			if (token.invalidUnicode) {
@@ -410,18 +413,19 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 			return;
 		}
 		if (char === "\u2028" || char === "\u2029") {
-			// partial-json's JSON.parse probe rejects these line separators while
-			// open, leaving the preceding display value intact.
+			// partial-json only exposes these separators after the next character.
 			token.repairedValue += char;
+			token.value += char;
 			return;
 		}
 		if (char.charCodeAt(0) < 0x20) {
-			// partial-json preserves the string up to the raw control while the
-			// string remains open. repairJson can expose the complete value once
-			// a later quote closes it.
+			// partial-json retains the prefix for whitespace controls, but rejects
+			// other raw controls immediately. Any following character makes the
+			// incomplete string invalid until repair can run on a closed root.
 			token.rawControl = true;
 			token.repairedValue += char;
-			this.updateStringPreview(token);
+			if (char.charCodeAt(0) < 0x09 || char.charCodeAt(0) > 0x0d) this.previewInvalid = true;
+			else this.updateStringPreview(token);
 			return;
 		}
 		token.repairedValue += char;

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -122,3 +122,267 @@ export function parseStreamingJson<T = Record<string, unknown>>(partialJson: str
 		}
 	}
 }
+
+/**
+ * Incremental, display-only JSON parser for streamed tool arguments. Unlike
+ * `parseStreamingJson`, this never reparses the accumulated prefix. The raw
+ * document is retained solely for the one strict terminal validation.
+ */
+export interface StreamingJsonParseState<T = Record<string, unknown>> {
+	append(delta: string): T;
+	preview(): T;
+	finalize(): T;
+}
+
+type Container = Record<string, unknown> | unknown[];
+type Frame = {
+	value: Container;
+	kind: "object" | "array";
+	key?: string;
+	expecting: "key" | "colon" | "value" | "comma";
+};
+type StringToken = { target: "key" | "value"; value: string; escape: boolean; unicode: string | undefined };
+type ScalarToken = { value: string; target: "value" };
+
+/**
+ * The lexer deliberately advances UTF-16 code units: a surrogate pair split
+ * between stream chunks is therefore indistinguishable from the same input in
+ * one chunk. Preview is best effort; only finalize is authoritative.
+ */
+class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T> {
+	private readonly rawChunks: string[] = [];
+	private terminal = false;
+	private root: unknown = {};
+	private hasRoot = false;
+	private rootComplete = false;
+	private previewInvalid = false;
+	private readonly frames: Frame[] = [];
+	private stringToken: StringToken | undefined;
+	private scalarToken: ScalarToken | undefined;
+	private strictValidationCount = 0;
+
+	append(delta: string): T {
+		if (this.terminal) throw new Error("Cannot append after streaming JSON finalization");
+		if (typeof delta !== "string") throw new TypeError("Streaming JSON delta must be a string");
+		this.rawChunks.push(delta);
+		for (let index = 0; index < delta.length; index++) this.consume(delta[index]);
+		return this.preview();
+	}
+
+	preview(): T {
+		if (this.terminal) throw new Error("Cannot preview after streaming JSON finalization");
+		return (this.previewInvalid ? {} : this.hasRoot ? this.root : {}) as T;
+	}
+
+	finalize(): T {
+		if (this.terminal) throw new Error("Streaming JSON has already been finalized");
+		this.terminal = true;
+		const raw = this.rawChunks.join("");
+		this.rawChunks.length = 0;
+		this.strictValidationCount++;
+		return JSON.parse(raw) as T;
+	}
+
+	/** Test-only inspection; intentionally not part of the exported interface. */
+	getStrictValidationCountForTesting(): number {
+		return this.strictValidationCount;
+	}
+
+	getRawForProviderCheck(): string {
+		return this.rawChunks.join("");
+	}
+
+	private consume(char: string): void {
+		if (this.stringToken) {
+			this.consumeString(char);
+			return;
+		}
+		if (this.scalarToken) {
+			if (char === "," || char === "]" || char === "}" || isWhitespace(char)) {
+				this.finishScalar();
+				this.consume(char);
+			} else {
+				this.scalarToken.value += char;
+				this.updateScalarPreview();
+			}
+			return;
+		}
+		if (isWhitespace(char) || this.rootComplete) return;
+		const frame = this.frames.at(-1);
+		if (char === "{") {
+			this.beginValue({});
+			this.frames.push({ value: this.rootOrCurrentValue(), kind: "object", expecting: "key" });
+			return;
+		}
+		if (char === "[") {
+			this.beginValue([]);
+			this.frames.push({ value: this.rootOrCurrentValue(), kind: "array", expecting: "value" });
+			return;
+		}
+		if (char === '"') {
+			if (frame?.kind === "object" && frame.expecting === "key") {
+				this.stringToken = { target: "key", value: "", escape: false, unicode: undefined };
+			} else {
+				this.beginValue("");
+				this.stringToken = { target: "value", value: "", escape: false, unicode: undefined };
+			}
+			return;
+		}
+		if (char === ":") {
+			if (frame?.kind === "object") frame.expecting = "value";
+			return;
+		}
+		if (char === ",") {
+			if (frame) frame.expecting = frame.kind === "object" ? "key" : "value";
+			return;
+		}
+		if (char === "}" || char === "]") {
+			if (frame && ((char === "}" && frame.kind === "object") || (char === "]" && frame.kind === "array"))) {
+				this.frames.pop();
+				this.valueComplete();
+				if (this.frames.length === 0) this.rootComplete = true;
+			}
+			return;
+		}
+		this.scalarToken = { target: "value", value: char };
+		this.beginValue(this.previewScalar(char));
+	}
+
+	private consumeString(char: string): void {
+		const token = this.stringToken!;
+		if (token.unicode !== undefined) {
+			token.unicode += char;
+			if (token.unicode.length === 4) {
+				if (/^[0-9a-fA-F]{4}$/.test(token.unicode))
+					token.value += String.fromCharCode(Number.parseInt(token.unicode, 16));
+				token.unicode = undefined;
+				this.updateStringPreview(token);
+			}
+			return;
+		}
+		if (token.escape) {
+			token.escape = false;
+			if (char === "u") token.unicode = "";
+			else {
+				const escaped: Record<string, string> = {
+					'"': '"',
+					"\\": "\\",
+					"/": "/",
+					b: "\b",
+					f: "\f",
+					n: "\n",
+					r: "\r",
+					t: "\t",
+				};
+				if (char in escaped) token.value += escaped[char];
+				this.updateStringPreview(token);
+			}
+			return;
+		}
+		if (char === "\\") {
+			token.escape = true;
+			return;
+		}
+		if (char === '"') {
+			this.previewInvalid = false;
+			this.stringToken = undefined;
+			if (token.target === "key") {
+				const frame = this.frames.at(-1);
+				if (frame?.kind === "object") {
+					frame.key = token.value;
+					frame.expecting = "colon";
+				}
+			} else this.valueComplete();
+			return;
+		}
+		if (char.charCodeAt(0) < 0x20) this.previewInvalid = true;
+		token.value += char;
+		this.updateStringPreview(token);
+	}
+
+	private beginValue(value: unknown): void {
+		const frame = this.frames.at(-1);
+		if (!frame) {
+			this.root = value;
+			this.hasRoot = true;
+			return;
+		}
+		if (frame.kind === "array") (frame.value as unknown[]).push(value);
+		else if (frame.key !== undefined) (frame.value as Record<string, unknown>)[frame.key] = value;
+		frame.expecting = "comma";
+	}
+
+	private rootOrCurrentValue(): Container {
+		const parent = this.frames.at(-1);
+		if (!parent) return this.root as Container;
+		if (parent.kind === "array") {
+			const values = parent.value as unknown[];
+			return values[values.length - 1] as Container;
+		}
+		return (parent.value as Record<string, unknown>)[parent.key!] as Container;
+	}
+
+	private valueComplete(): void {
+		const frame = this.frames.at(-1);
+		if (frame) frame.expecting = "comma";
+	}
+
+	private updateStringPreview(token: StringToken): void {
+		if (token.target === "value") this.replaceCurrentValue(token.value);
+	}
+
+	private updateScalarPreview(): void {
+		this.replaceCurrentValue(this.previewScalar(this.scalarToken!.value));
+	}
+
+	private replaceCurrentValue(value: unknown): void {
+		const frame = this.frames.at(-1);
+		if (!frame) this.root = value;
+		else if (frame.kind === "array") {
+			const values = frame.value as unknown[];
+			values[values.length - 1] = value;
+		} else if (frame.key !== undefined) {
+			(frame.value as Record<string, unknown>)[frame.key] = value;
+		}
+	}
+
+	private finishScalar(): void {
+		if (!this.scalarToken) return;
+		this.updateScalarPreview();
+		this.scalarToken = undefined;
+		this.valueComplete();
+		if (this.frames.length === 0) this.rootComplete = true;
+	}
+
+	private previewScalar(value: string): unknown {
+		if (value === "true" || value === "t" || value === "tr" || value === "tru") return true;
+		if (value === "false" || value === "f" || value === "fa" || value === "fal" || value === "fals") return false;
+		if (value === "null" || value === "n" || value === "nu" || value === "nul") return null;
+		// This accepts only the JSON number grammar. An unfinished exponent is
+		// represented by its completed mantissa, matching the legacy preview.
+		if (/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(value)) return Number(value);
+		const exponent = value.search(/[eE]/);
+		if (exponent > 0 && /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value.slice(0, exponent))) {
+			return Number(value.slice(0, exponent));
+		}
+		return {};
+	}
+}
+
+function isWhitespace(char: string): boolean {
+	return char === " " || char === "\n" || char === "\r" || char === "\t";
+}
+
+export function createStreamingJsonParseState<T = Record<string, unknown>>(): StreamingJsonParseState<T> {
+	return new IncrementalStreamingJsonParseState<T>();
+}
+
+/** Internal test seam; production callers should use the public interface. */
+export function getStreamingJsonStrictValidationCountForTesting(state: StreamingJsonParseState<unknown>): number {
+	return (state as IncrementalStreamingJsonParseState<unknown>).getStrictValidationCountForTesting();
+}
+
+/** Internal provider seam; never serialize this raw value. */
+export function getStreamingJsonRawForProviderCheck(state: StreamingJsonParseState<unknown>): string {
+	return (state as IncrementalStreamingJsonParseState<unknown>).getRawForProviderCheck();
+}

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -2,6 +2,17 @@ import { parse as partialParse } from "partial-json";
 
 const VALID_JSON_ESCAPES = new Set(['"', "\\", "/", "b", "f", "n", "r", "t", "u"]);
 
+/** Test/benchmark accounting for actual input supplied to the legacy prefix parser. */
+let legacyStreamingJsonInputExamined = 0;
+
+export function resetStreamingJsonParseInstrumentationForTesting(): void {
+	legacyStreamingJsonInputExamined = 0;
+}
+
+export function getLegacyStreamingJsonInputExaminedForTesting(): number {
+	return legacyStreamingJsonInputExamined;
+}
+
 function isControlCharacter(char: string): boolean {
 	const codePoint = char.codePointAt(0);
 	return codePoint !== undefined && codePoint >= 0x00 && codePoint <= 0x1f;
@@ -102,6 +113,7 @@ export function parseJsonWithRepair<T>(json: string): T {
  * @returns Parsed object or empty object if parsing fails
  */
 export function parseStreamingJson<T = Record<string, unknown>>(partialJson: string | undefined): T {
+	legacyStreamingJsonInputExamined += partialJson?.length ?? 0;
 	if (!partialJson || partialJson.trim() === "") {
 		return {} as T;
 	}
@@ -141,7 +153,20 @@ type Frame = {
 	key?: string;
 	expecting: "key" | "colon" | "value" | "comma";
 };
-type StringToken = { target: "key" | "value"; value: string; escape: boolean; unicode: string | undefined };
+type StringToken = {
+	target: "key" | "value";
+	/** The value partial-json can safely expose for the original prefix. */
+	value: string;
+	/** The value visible once repair makes a closed invalid escape parseable. */
+	repairedValue: string;
+	escape: boolean;
+	unicode: string | undefined;
+	invalidEscape: boolean;
+	invalidUnicode: boolean;
+	rawControl: boolean;
+	location?: ValueLocation;
+};
+type ValueLocation = { frame?: Frame; key?: string; arrayIndex?: number; root: boolean };
 type ScalarToken = { value: string; target: "value" };
 
 /**
@@ -160,11 +185,15 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 	private stringToken: StringToken | undefined;
 	private scalarToken: ScalarToken | undefined;
 	private strictValidationCount = 0;
+	private incrementalInputExamined = 0;
+	private finalInputExamined = 0;
+	private readonly repairedStringsAtRootClose: Array<{ location: ValueLocation; value: string }> = [];
 
 	append(delta: string): T {
 		if (this.terminal) throw new Error("Cannot append after streaming JSON finalization");
 		if (typeof delta !== "string") throw new TypeError("Streaming JSON delta must be a string");
 		this.rawChunks.push(delta);
+		this.incrementalInputExamined += delta.length;
 		for (let index = 0; index < delta.length; index++) this.consume(delta[index]);
 		return this.preview();
 	}
@@ -179,6 +208,7 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 		this.terminal = true;
 		const raw = this.rawChunks.join("");
 		this.rawChunks.length = 0;
+		this.finalInputExamined += raw.length;
 		this.strictValidationCount++;
 		return JSON.parse(raw) as T;
 	}
@@ -190,6 +220,22 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 
 	getRawForProviderCheck(): string {
 		return this.rawChunks.join("");
+	}
+
+	getInputExaminedForTesting(): { incremental: number; final: number; total: number } {
+		return {
+			incremental: this.incrementalInputExamined,
+			final: this.finalInputExamined,
+			total: this.incrementalInputExamined + this.finalInputExamined,
+		};
+	}
+
+	discard(): void {
+		this.rawChunks.length = 0;
+		this.frames.length = 0;
+		this.stringToken = undefined;
+		this.scalarToken = undefined;
+		this.terminal = true;
 	}
 
 	private consume(char: string): void {
@@ -210,21 +256,43 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 		if (isWhitespace(char) || this.rootComplete) return;
 		const frame = this.frames.at(-1);
 		if (char === "{") {
-			this.beginValue({});
-			this.frames.push({ value: this.rootOrCurrentValue(), kind: "object", expecting: "key" });
+			const value: Record<string, unknown> = {};
+			this.beginValue(value);
+			this.frames.push({ value, kind: "object", expecting: "key" });
 			return;
 		}
 		if (char === "[") {
-			this.beginValue([]);
-			this.frames.push({ value: this.rootOrCurrentValue(), kind: "array", expecting: "value" });
+			const value: unknown[] = [];
+			this.beginValue(value);
+			this.frames.push({ value, kind: "array", expecting: "value" });
 			return;
 		}
 		if (char === '"') {
 			if (frame?.kind === "object" && frame.expecting === "key") {
-				this.stringToken = { target: "key", value: "", escape: false, unicode: undefined };
+				this.stringToken = {
+					target: "key",
+					value: "",
+					repairedValue: "",
+					escape: false,
+					unicode: undefined,
+					invalidEscape: false,
+					invalidUnicode: false,
+					rawControl: false,
+				};
 			} else {
+				const location = this.currentValueLocation();
 				this.beginValue("");
-				this.stringToken = { target: "value", value: "", escape: false, unicode: undefined };
+				this.stringToken = {
+					target: "value",
+					value: "",
+					repairedValue: "",
+					escape: false,
+					unicode: undefined,
+					invalidEscape: false,
+					invalidUnicode: false,
+					rawControl: false,
+					location,
+				};
 			}
 			return;
 		}
@@ -240,7 +308,11 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 			if (frame && ((char === "}" && frame.kind === "object") || (char === "]" && frame.kind === "array"))) {
 				this.frames.pop();
 				this.valueComplete();
-				if (this.frames.length === 0) this.rootComplete = true;
+				if (this.frames.length === 0) {
+					this.rootComplete = true;
+					this.previewInvalid = false;
+					for (const repaired of this.repairedStringsAtRootClose) this.setValue(repaired.location, repaired.value);
+				}
 			}
 			return;
 		}
@@ -251,10 +323,22 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 	private consumeString(char: string): void {
 		const token = this.stringToken!;
 		if (token.unicode !== undefined) {
+			if (!/[0-9a-fA-F]/.test(char)) {
+				// partial-json retains the pre-escape value while this malformed
+				// unicode sequence is still open. A closing quote makes the prefix
+				// unparseable; handle that quote as the next normal token.
+				token.invalidEscape = true;
+				token.invalidUnicode = true;
+				token.unicode = undefined;
+				if (char === '"') this.consumeString(char);
+				else token.repairedValue += char;
+				return;
+			}
 			token.unicode += char;
 			if (token.unicode.length === 4) {
-				if (/^[0-9a-fA-F]{4}$/.test(token.unicode))
-					token.value += String.fromCharCode(Number.parseInt(token.unicode, 16));
+				const value = String.fromCharCode(Number.parseInt(token.unicode, 16));
+				if (!token.invalidEscape) token.value += value;
+				token.repairedValue += value;
 				token.unicode = undefined;
 				this.updateStringPreview(token);
 			}
@@ -262,21 +346,30 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 		}
 		if (token.escape) {
 			token.escape = false;
-			if (char === "u") token.unicode = "";
-			else {
-				const escaped: Record<string, string> = {
-					'"': '"',
-					"\\": "\\",
-					"/": "/",
-					b: "\b",
-					f: "\f",
-					n: "\n",
-					r: "\r",
-					t: "\t",
-				};
-				if (char in escaped) token.value += escaped[char];
-				this.updateStringPreview(token);
+			if (char === "u") {
+				token.unicode = "";
+				return;
 			}
+			const escaped: Record<string, string> = {
+				'"': '"',
+				"\\": "\\",
+				"/": "/",
+				b: "\b",
+				f: "\f",
+				n: "\n",
+				r: "\r",
+				t: "\t",
+			};
+			if (char in escaped) {
+				if (!token.invalidEscape) token.value += escaped[char];
+				token.repairedValue += escaped[char];
+			} else {
+				// partial-json exposes the prefix before an invalid escape while it
+				// remains open. repairJson exposes a literal backslash once closed.
+				token.invalidEscape = true;
+				token.repairedValue += `\\${char}`;
+			}
+			this.updateStringPreview(token);
 			return;
 		}
 		if (char === "\\") {
@@ -284,22 +377,58 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 			return;
 		}
 		if (char === '"') {
-			this.previewInvalid = false;
 			this.stringToken = undefined;
+			if (token.rawControl) {
+				this.previewInvalid = this.frames.length > 1;
+				if (!this.previewInvalid) this.replaceCurrentValue(token.repairedValue);
+			}
+			if (token.unicode !== undefined) token.invalidUnicode = true;
+			if (token.invalidUnicode) {
+				if (token.location) this.removeValue(token.location);
+				this.previewInvalid = true;
+				return;
+			}
+			if (token.invalidEscape) {
+				// partial-json retains the already-complete surrounding structure but
+				// rejects this malformed member. At a fully closed root repairJson
+				// would expose it as a literal backslash, so defer that restoration.
+				if (token.location) {
+					this.removeValue(token.location);
+					this.repairedStringsAtRootClose.push({ location: token.location, value: token.repairedValue });
+				}
+			}
 			if (token.target === "key") {
 				const frame = this.frames.at(-1);
 				if (frame?.kind === "object") {
-					frame.key = token.value;
+					frame.key = token.invalidEscape ? token.repairedValue : token.value;
 					frame.expecting = "colon";
 				}
-			} else this.valueComplete();
+			} else {
+				this.valueComplete();
+				if (this.frames.length === 0) this.rootComplete = true;
+			}
 			return;
 		}
-		if (char.charCodeAt(0) < 0x20) this.previewInvalid = true;
-		token.value += char;
-		this.updateStringPreview(token);
+		if (char === "\u2028" || char === "\u2029") {
+			// partial-json's JSON.parse probe rejects these line separators while
+			// open, leaving the preceding display value intact.
+			token.repairedValue += char;
+			return;
+		}
+		if (char.charCodeAt(0) < 0x20) {
+			// partial-json preserves the string up to the raw control while the
+			// string remains open. repairJson can expose the complete value once
+			// a later quote closes it.
+			token.rawControl = true;
+			token.repairedValue += char;
+			this.updateStringPreview(token);
+			return;
+		}
+		token.repairedValue += char;
+		if (!token.invalidEscape) token.value += char;
+		if (token.rawControl) this.previewInvalid = true;
+		else this.updateStringPreview(token);
 	}
-
 	private beginValue(value: unknown): void {
 		const frame = this.frames.at(-1);
 		if (!frame) {
@@ -310,16 +439,6 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 		if (frame.kind === "array") (frame.value as unknown[]).push(value);
 		else if (frame.key !== undefined) (frame.value as Record<string, unknown>)[frame.key] = value;
 		frame.expecting = "comma";
-	}
-
-	private rootOrCurrentValue(): Container {
-		const parent = this.frames.at(-1);
-		if (!parent) return this.root as Container;
-		if (parent.kind === "array") {
-			const values = parent.value as unknown[];
-			return values[values.length - 1] as Container;
-		}
-		return (parent.value as Record<string, unknown>)[parent.key!] as Container;
 	}
 
 	private valueComplete(): void {
@@ -343,6 +462,32 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 			values[values.length - 1] = value;
 		} else if (frame.key !== undefined) {
 			(frame.value as Record<string, unknown>)[frame.key] = value;
+		}
+	}
+
+	private currentValueLocation(): ValueLocation {
+		const frame = this.frames.at(-1);
+		if (!frame) return { root: true };
+		if (frame.kind === "array") return { frame, arrayIndex: (frame.value as unknown[]).length, root: false };
+		return { frame, key: frame.key, root: false };
+	}
+
+	private setValue(location: ValueLocation, value: unknown): void {
+		if (location.root) this.root = value;
+		else if (location.frame?.kind === "array" && location.arrayIndex !== undefined)
+			(location.frame.value as unknown[])[location.arrayIndex] = value;
+		else if (location.frame?.kind === "object" && location.key !== undefined)
+			(location.frame.value as Record<string, unknown>)[location.key] = value;
+	}
+
+	private removeValue(location: ValueLocation): void {
+		if (location.root) this.root = {};
+		else if (location.frame?.kind === "array" && location.arrayIndex !== undefined) {
+			const values = location.frame.value as unknown[];
+			if (values.length === location.arrayIndex + 1) values.pop();
+			else values[location.arrayIndex] = undefined;
+		} else if (location.frame?.kind === "object" && location.key !== undefined) {
+			delete (location.frame.value as Record<string, unknown>)[location.key];
 		}
 	}
 
@@ -385,4 +530,18 @@ export function getStreamingJsonStrictValidationCountForTesting(state: Streaming
 /** Internal provider seam; never serialize this raw value. */
 export function getStreamingJsonRawForProviderCheck(state: StreamingJsonParseState<unknown>): string {
 	return (state as IncrementalStreamingJsonParseState<unknown>).getRawForProviderCheck();
+}
+
+/** Internal test seam for linear-work assertions. */
+export function getStreamingJsonInputExaminedForTesting(state: StreamingJsonParseState<unknown>): {
+	incremental: number;
+	final: number;
+	total: number;
+} {
+	return (state as IncrementalStreamingJsonParseState<unknown>).getInputExaminedForTesting();
+}
+
+/** Internal lifecycle seam: erase the private final buffer on every abort/error path. */
+export function discardStreamingJsonParseState(state: StreamingJsonParseState<unknown>): void {
+	(state as IncrementalStreamingJsonParseState<unknown>).discard();
 }

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -167,7 +167,7 @@ type StringToken = {
 	location?: ValueLocation;
 };
 type ValueLocation = { frame?: Frame; key?: string; arrayIndex?: number; root: boolean };
-type ScalarToken = { value: string; target: "value" };
+type ScalarToken = { value: string; target: "value"; location: ValueLocation };
 
 /**
  * The lexer deliberately advances UTF-16 code units: a surrogate pair split
@@ -316,8 +316,11 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 			}
 			return;
 		}
-		this.scalarToken = { target: "value", value: char };
-		this.beginValue(this.previewScalar(char));
+		const location = this.currentValueLocation();
+		const preview = this.previewScalar(char);
+		this.beginValue(preview === undefined ? {} : preview);
+		this.scalarToken = { target: "value", value: char, location };
+		if (preview === undefined) this.removeValue(location);
 	}
 
 	private consumeString(char: string): void {
@@ -455,7 +458,10 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 	}
 
 	private updateScalarPreview(): void {
-		this.replaceCurrentValue(this.previewScalar(this.scalarToken!.value));
+		const token = this.scalarToken!;
+		const preview = this.previewScalar(token.value);
+		if (preview === undefined) this.removeValue(token.location);
+		else this.setValue(token.location, preview);
 	}
 
 	private replaceCurrentValue(value: unknown): void {
@@ -503,7 +509,7 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 		if (this.frames.length === 0) this.rootComplete = true;
 	}
 
-	private previewScalar(value: string): unknown {
+	private previewScalar(value: string): unknown | undefined {
 		if (value === "true" || value === "t" || value === "tr" || value === "tru") return true;
 		if (value === "false" || value === "f" || value === "fa" || value === "fal" || value === "fals") return false;
 		if (value === "null" || value === "n" || value === "nu" || value === "nul") return null;
@@ -514,7 +520,7 @@ class IncrementalStreamingJsonParseState<T> implements StreamingJsonParseState<T
 		if (exponent > 0 && /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value.slice(0, exponent))) {
 			return Number(value.slice(0, exponent));
 		}
-		return {};
+		return undefined;
 	}
 }
 

--- a/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
+++ b/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
@@ -88,6 +88,7 @@ describe("openai responses partialJson cleanup", () => {
 		}
 		expect(persistedToolCall.arguments).toEqual({ path: "README.md", content: "updated" });
 		expect("partialJson" in persistedToolCall).toBe(false);
+		expect("parser" in persistedToolCall).toBe(false);
 
 		const emittedEvents = pushSpy.mock.calls.map(([event]) => event as AssistantMessageEvent);
 		const toolCallEnd = emittedEvents.find((event) => event.type === "toolcall_end");
@@ -97,5 +98,26 @@ describe("openai responses partialJson cleanup", () => {
 		}
 		expect(toolCallEnd.toolCall).toBe(persistedToolCall);
 		expect("partialJson" in toolCallEnd.toolCall).toBe(false);
+		expect("parser" in toolCallEnd.toolCall).toBe(false);
+	});
+
+	it("rejects an authoritative done replacement that is not a streamed prefix", async () => {
+		const model = {
+			id: "gpt-5-mini",
+			name: "GPT-5 Mini",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		} satisfies Model<"openai-responses">;
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+		await expect(
+			processResponsesStream(createFunctionCallEvents('{"replacement":true}'), output, stream, model),
+		).rejects.toThrow("replaced a streamed prefix");
 	});
 });

--- a/packages/ai/test/streaming-json-parse-cpu-bench.test.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.test.ts
@@ -4,6 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+	BENCHMARK_NAME,
+	estimateCorpusPlan,
+	MAX_CORPUS_BYTES,
+	MAX_REPETITIONS,
+	parseBenchmarkOptions,
+} from "./streaming-json-parse-cpu-bench.js";
 
 const tsxPath = fileURLToPath(new URL("../../../node_modules/tsx/dist/cli.mjs", import.meta.url));
 const benchmarkPath = fileURLToPath(new URL("./streaming-json-parse-cpu-bench.ts", import.meta.url));
@@ -26,7 +33,7 @@ describe("streaming JSON CPU benchmark CLI", () => {
 				tsxPath,
 				benchmarkPath,
 				"--name",
-				"N01-streaming-structured-output-parse-cpu",
+				BENCHMARK_NAME,
 				"--json",
 				output,
 				"--escaped-bytes",
@@ -57,6 +64,30 @@ describe("streaming JSON CPU benchmark CLI", () => {
 		);
 		expect(result.results.find(({ name }) => name.startsWith("unicode"))?.inputLength).toBeLessThan(4096);
 		expect(JSON.stringify(result)).not.toContain('"outer"');
+	});
+
+	it("rejects corpus and repetition limits before estimating or allocating", () => {
+		const base = ["--name", BENCHMARK_NAME, "--json", "result.json"];
+		expect(() => parseBenchmarkOptions([...base, "--escaped-bytes", String(MAX_CORPUS_BYTES + 1)])).toThrow(
+			`--escaped-bytes must be a positive safe integer no greater than ${MAX_CORPUS_BYTES}`,
+		);
+		expect(() => parseBenchmarkOptions([...base, "--unicode-bytes", String(Number.MAX_SAFE_INTEGER)])).toThrow(
+			`--unicode-bytes must be a positive safe integer no greater than ${MAX_CORPUS_BYTES}`,
+		);
+		expect(() => parseBenchmarkOptions([...base, "--repetitions", String(MAX_REPETITIONS + 1)])).toThrow(
+			`--repetitions must be a positive safe integer no greater than ${MAX_REPETITIONS}`,
+		);
+	});
+
+	it("accepts the fixed corpus boundary in the estimator without allocating the corpus", () => {
+		const plan = estimateCorpusPlan(MAX_CORPUS_BYTES, false);
+		expect(plan.estimatedBytes).toBeLessThanOrEqual(MAX_CORPUS_BYTES);
+		expect(plan.entries).toBeGreaterThan(0);
+	});
+
+	it("keeps the nested corpus structural minimum unchanged", () => {
+		expect(() => estimateCorpusPlan(67, false)).toThrow("requested 67 bytes is below structural minimum 68");
+		expect(estimateCorpusPlan(68, false).structuralMinimum).toBe(68);
 	});
 
 	it("rejects a target below the nested corpus structural minimum before measuring", () => {

--- a/packages/ai/test/streaming-json-parse-cpu-bench.test.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.test.ts
@@ -1,8 +1,13 @@
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+
+const tsxPath = fileURLToPath(new URL("../../../node_modules/tsx/dist/cli.mjs", import.meta.url));
+const benchmarkPath = fileURLToPath(new URL("./streaming-json-parse-cpu-bench.ts", import.meta.url));
+const packagePath = fileURLToPath(new URL("../", import.meta.url));
 
 const temporaryDirectories: string[] = [];
 
@@ -18,8 +23,8 @@ describe("streaming JSON CPU benchmark CLI", () => {
 		execFileSync(
 			process.execPath,
 			[
-				resolve(process.cwd(), "../../node_modules/tsx/dist/cli.mjs"),
-				"test/streaming-json-parse-cpu-bench.ts",
+				tsxPath,
+				benchmarkPath,
 				"--name",
 				"N01-streaming-structured-output-parse-cpu",
 				"--json",
@@ -31,7 +36,7 @@ describe("streaming JSON CPU benchmark CLI", () => {
 				"--repetitions",
 				"3",
 			],
-			{ cwd: process.cwd(), stdio: "pipe" },
+			{ cwd: packagePath, stdio: "pipe" },
 		);
 		const result = JSON.parse(readFileSync(output, "utf8")) as {
 			name: string;

--- a/packages/ai/test/streaming-json-parse-cpu-bench.test.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.test.ts
@@ -40,7 +40,7 @@ describe("streaming JSON CPU benchmark CLI", () => {
 		);
 		const result = JSON.parse(readFileSync(output, "utf8")) as {
 			name: string;
-			results: Array<{ repetitions: number; inputLength: number; order: string }>;
+			results: Array<{ name: string; repetitions: number; inputBytes: number; inputLength: number; order: string }>;
 		};
 		expect(result.name).toBe("N01-streaming-structured-output-parse-cpu");
 		expect(result.results).toHaveLength(2);
@@ -49,6 +49,34 @@ describe("streaming JSON CPU benchmark CLI", () => {
 				expect.objectContaining({ repetitions: 3, order: "alternating legacy/incremental by repetition" }),
 			]),
 		);
+		expect(result.results).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: "escaped-nested-4096-64", inputBytes: 4096, inputLength: 4096 }),
+				expect.objectContaining({ name: "unicode-nested-4096-7", inputBytes: 4096 }),
+			]),
+		);
+		expect(result.results.find(({ name }) => name.startsWith("unicode"))?.inputLength).toBeLessThan(4096);
 		expect(JSON.stringify(result)).not.toContain('"outer"');
+	});
+
+	it("rejects a target below the nested corpus structural minimum before measuring", () => {
+		const directory = mkdtempSync(join(tmpdir(), "n01-benchmark-"));
+		temporaryDirectories.push(directory);
+		expect(() =>
+			execFileSync(
+				process.execPath,
+				[
+					tsxPath,
+					benchmarkPath,
+					"--name",
+					"N01-streaming-structured-output-parse-cpu",
+					"--json",
+					join(directory, "result.json"),
+					"--escaped-bytes",
+					"1",
+				],
+				{ cwd: packagePath, stdio: "pipe" },
+			),
+		).toThrow(/below structural minimum/);
 	});
 });

--- a/packages/ai/test/streaming-json-parse-cpu-bench.test.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.test.ts
@@ -1,0 +1,49 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { force: true, recursive: true });
+});
+
+describe("streaming JSON CPU benchmark CLI", () => {
+	it("parses requested corpus options and writes a content-free atomic JSON result", () => {
+		const directory = mkdtempSync(join(tmpdir(), "n01-benchmark-"));
+		temporaryDirectories.push(directory);
+		const output = join(directory, "result.json");
+		execFileSync(
+			process.execPath,
+			[
+				resolve(process.cwd(), "../../node_modules/tsx/dist/cli.mjs"),
+				"test/streaming-json-parse-cpu-bench.ts",
+				"--name",
+				"N01-streaming-structured-output-parse-cpu",
+				"--json",
+				output,
+				"--escaped-bytes",
+				"4096",
+				"--unicode-bytes",
+				"4096",
+				"--repetitions",
+				"3",
+			],
+			{ cwd: process.cwd(), stdio: "pipe" },
+		);
+		const result = JSON.parse(readFileSync(output, "utf8")) as {
+			name: string;
+			results: Array<{ repetitions: number; inputLength: number; order: string }>;
+		};
+		expect(result.name).toBe("N01-streaming-structured-output-parse-cpu");
+		expect(result.results).toHaveLength(2);
+		expect(result.results).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ repetitions: 3, order: "alternating legacy/incremental by repetition" }),
+			]),
+		);
+		expect(JSON.stringify(result)).not.toContain('"outer"');
+	});
+});

--- a/packages/ai/test/streaming-json-parse-cpu-bench.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { createStreamingJsonParseState, parseStreamingJson } from "../src/utils/json-parse.js";
+
+const args = process.argv.slice(2);
+const name = args[args.indexOf("--name") + 1];
+const output = args[args.indexOf("--json") + 1];
+if (name !== "N01-streaming-structured-output-parse-cpu" || !output)
+	throw new Error("Use --name N01-streaming-structured-output-parse-cpu --json FILE");
+function corpus(bytes: number, unicode: boolean): string {
+	const unit = unicode ? "😀\\u2028 nested é " : '\\"escaped\\n nested ';
+	return JSON.stringify({
+		outer: Array.from({ length: Math.ceil(bytes / unit.length) }, (_, index) => ({ index, text: unit })),
+	});
+}
+function measure(document: string, size: number, incremental: boolean) {
+	const chunks = Array.from({ length: Math.ceil(document.length / size) }, (_, i) =>
+		document.slice(i * size, (i + 1) * size),
+	);
+	const before = process.cpuUsage();
+	const start = process.hrtime.bigint();
+	let final: unknown;
+	if (incremental) {
+		const state = createStreamingJsonParseState();
+		for (const chunk of chunks) state.append(chunk);
+		final = state.finalize();
+	} else {
+		let prefix = "";
+		for (const chunk of chunks) {
+			prefix += chunk;
+			parseStreamingJson(prefix);
+		}
+		final = JSON.parse(prefix);
+	}
+	const cpu = process.cpuUsage(before);
+	const wallNs = Number(process.hrtime.bigint() - start);
+	if (JSON.stringify(final) !== document) throw new Error("parser paths differ");
+	return {
+		wallNs,
+		cpuUs: cpu.user + cpu.system,
+		chunks: chunks.length,
+		inputExamined: incremental ? document.length * 2 : (document.length * chunks.length) / 2,
+	};
+}
+function stats(values: number[]) {
+	const ordered = [...values].sort((a, b) => a - b);
+	return { min: ordered[0], median: ordered[Math.floor(ordered.length / 2)], max: ordered.at(-1) };
+}
+const corpora = [
+	{ name: "1MiB-escaped-nested-64", document: corpus(1024 * 1024, false), size: 64 },
+	{ name: "256KiB-unicode-nested-7", document: corpus(256 * 1024, true), size: 7 },
+];
+const results = corpora.map(({ name, document, size }) => {
+	measure(document, size, true); // unreported warm-up
+	const legacy = Array.from({ length: 7 }, () => measure(document, size, false));
+	const incremental = Array.from({ length: 7 }, () => measure(document, size, true));
+	return {
+		name,
+		inputHash: createHash("sha256").update(document).digest("hex"),
+		chunkCount: incremental[0].chunks,
+		legacy: { wallNs: stats(legacy.map((x) => x.wallNs)), cpuUs: stats(legacy.map((x) => x.cpuUs)) },
+		incremental: {
+			wallNs: stats(incremental.map((x) => x.wallNs)),
+			cpuUs: stats(incremental.map((x) => x.cpuUs)),
+			inputExamined: incremental[0].inputExamined,
+		},
+	};
+});
+writeFileSync(
+	output,
+	JSON.stringify(
+		{
+			name,
+			node: process.version,
+			platform: process.platform,
+			arch: process.arch,
+			cpu: process.arch,
+			command: process.argv.join(" "),
+			results,
+		},
+		null,
+		2,
+	),
+);

--- a/packages/ai/test/streaming-json-parse-cpu-bench.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.ts
@@ -58,10 +58,35 @@ function stats(values: number[]) {
 	const sorted = [...values].sort((a, b) => a - b);
 	return { min: sorted[0], median: sorted[Math.floor(sorted.length / 2)], max: sorted.at(-1) };
 }
-const repetitions = 7;
+function option(name: string, defaultValue: number): number {
+	const index = args.indexOf(name);
+	if (index === -1) return defaultValue;
+	const value = args[index + 1];
+	if (value === undefined) throw new Error(`${name} requires a value`);
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`);
+	return parsed;
+}
+
+// Defaults are deliberately local-friendly: the legacy baseline reparses each
+// prefix, so small chunks make its examined-input total grow quadratically.
+// The remote command below retains the original 1 MiB corpus sizes.
+const repetitions = option("--repetitions", 5);
+const escapedBytes = option("--escaped-bytes", 32 * 1024);
+const unicodeBytes = option("--unicode-bytes", 8 * 1024);
+const escapedChunkSize = option("--escaped-chunk-size", 64);
+const unicodeChunkSize = option("--unicode-chunk-size", 7);
 const results = [
-	{ name: "1MiB-escaped-nested-64", document: corpus(1024 * 1024, false), chunkSize: 64 },
-	{ name: "256KiB-unicode-nested-7", document: corpus(256 * 1024, true), chunkSize: 7 },
+	{
+		name: `escaped-nested-${escapedBytes}-${escapedChunkSize}`,
+		document: corpus(escapedBytes, false),
+		chunkSize: escapedChunkSize,
+	},
+	{
+		name: `unicode-nested-${unicodeBytes}-${unicodeChunkSize}`,
+		document: corpus(unicodeBytes, true),
+		chunkSize: unicodeChunkSize,
+	},
 ].map(({ name: corpusName, document, chunkSize }) => {
 	measured(document, chunkSize, "legacy");
 	measured(document, chunkSize, "incremental"); // unreported warm-ups

--- a/packages/ai/test/streaming-json-parse-cpu-bench.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.ts
@@ -1,5 +1,5 @@
-import { createHash } from "node:crypto";
-import { writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { renameSync, writeFileSync } from "node:fs";
 import { cpus, release, type } from "node:os";
 import {
 	createStreamingJsonParseState,
@@ -9,11 +9,41 @@ import {
 	resetStreamingJsonParseInstrumentationForTesting,
 } from "../src/utils/json-parse.js";
 
-const args = process.argv.slice(2);
-const name = args[args.indexOf("--name") + 1];
-const output = args[args.indexOf("--json") + 1];
-if (name !== "N01-streaming-structured-output-parse-cpu" || !output)
-	throw new Error("Use --name N01-streaming-structured-output-parse-cpu --json FILE");
+const BENCHMARK_NAME = "N01-streaming-structured-output-parse-cpu";
+type Mode = "legacy" | "incremental";
+type Options = {
+	name: string;
+	output: string;
+	escapedBytes: number;
+	unicodeBytes: number;
+	repetitions: number;
+};
+
+function requiredOption(args: string[], name: string): string {
+	const index = args.indexOf(name);
+	if (index === -1 || args[index + 1] === undefined) throw new Error(`${name} requires a value`);
+	return args[index + 1];
+}
+
+function positiveIntegerOption(args: string[], name: string, defaultValue: number): number {
+	const index = args.indexOf(name);
+	if (index === -1) return defaultValue;
+	const parsed = Number(args[index + 1]);
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`);
+	return parsed;
+}
+
+function parseOptions(args: string[]): Options {
+	const name = requiredOption(args, "--name");
+	if (name !== BENCHMARK_NAME) throw new Error(`--name must be ${BENCHMARK_NAME}`);
+	return {
+		name,
+		output: requiredOption(args, "--json"),
+		escapedBytes: positiveIntegerOption(args, "--escaped-bytes", 1024 * 1024),
+		unicodeBytes: positiveIntegerOption(args, "--unicode-bytes", 256 * 1024),
+		repetitions: positiveIntegerOption(args, "--repetitions", 7),
+	};
+}
 
 function corpus(bytes: number, unicode: boolean): string {
 	const unit = unicode ? "😀\u2028 nested é " : '\\"escaped\\n nested ';
@@ -21,13 +51,16 @@ function corpus(bytes: number, unicode: boolean): string {
 		outer: Array.from({ length: Math.ceil(bytes / unit.length) }, (_, index) => ({ index, text: unit })),
 	});
 }
+
 function chunks(document: string, size: number): string[] {
-	return Array.from({ length: Math.ceil(document.length / size) }, (_, i) => document.slice(i * size, (i + 1) * size));
+	return Array.from({ length: Math.ceil(document.length / size) }, (_, index) =>
+		document.slice(index * size, (index + 1) * size),
+	);
 }
-function measured(document: string, chunkSize: number, mode: "legacy" | "incremental") {
-	const input = chunks(document, chunkSize);
+
+function measured(document: string, input: string[], mode: Mode) {
 	resetStreamingJsonParseInstrumentationForTesting();
-	const cpuBefore = process.cpuUsage();
+	const resourcesBefore = process.resourceUsage();
 	const wallBefore = process.hrtime.bigint();
 	let result: unknown;
 	let examined: number;
@@ -46,94 +79,84 @@ function measured(document: string, chunkSize: number, mode: "legacy" | "increme
 		examined = getStreamingJsonInputExaminedForTesting(state).total;
 	}
 	if (JSON.stringify(result) !== document) throw new Error(`${mode} result differs from source document`);
-	const cpu = process.cpuUsage(cpuBefore);
+	const resourcesAfter = process.resourceUsage();
 	return {
 		wallNs: Number(process.hrtime.bigint() - wallBefore),
-		cpuUs: cpu.user + cpu.system,
+		cpuUs:
+			resourcesAfter.userCPUTime -
+			resourcesBefore.userCPUTime +
+			(resourcesAfter.systemCPUTime - resourcesBefore.systemCPUTime),
 		inputExamined: examined,
 		chunkCount: input.length,
 	};
 }
+
 function stats(values: number[]) {
 	const sorted = [...values].sort((a, b) => a - b);
 	return { min: sorted[0], median: sorted[Math.floor(sorted.length / 2)], max: sorted.at(-1) };
 }
-function option(name: string, defaultValue: number): number {
-	const index = args.indexOf(name);
-	if (index === -1) return defaultValue;
-	const value = args[index + 1];
-	if (value === undefined) throw new Error(`${name} requires a value`);
-	const parsed = Number(value);
-	if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`);
-	return parsed;
+
+function writeJsonAtomically(output: string, value: unknown): void {
+	const temporary = `${output}.${process.pid}.${randomUUID()}.tmp`;
+	writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+	renameSync(temporary, output);
 }
 
-// Defaults are deliberately local-friendly: the legacy baseline reparses each
-// prefix, so small chunks make its examined-input total grow quadratically.
-// The remote command below retains the original 1 MiB corpus sizes.
-const repetitions = option("--repetitions", 5);
-const escapedBytes = option("--escaped-bytes", 32 * 1024);
-const unicodeBytes = option("--unicode-bytes", 8 * 1024);
-const escapedChunkSize = option("--escaped-chunk-size", 64);
-const unicodeChunkSize = option("--unicode-chunk-size", 7);
-const results = [
-	{
-		name: `escaped-nested-${escapedBytes}-${escapedChunkSize}`,
-		document: corpus(escapedBytes, false),
-		chunkSize: escapedChunkSize,
-	},
-	{
-		name: `unicode-nested-${unicodeBytes}-${unicodeChunkSize}`,
-		document: corpus(unicodeBytes, true),
-		chunkSize: unicodeChunkSize,
-	},
-].map(({ name: corpusName, document, chunkSize }) => {
-	measured(document, chunkSize, "legacy");
-	measured(document, chunkSize, "incremental"); // unreported warm-ups
-	const legacy = Array.from({ length: repetitions }, () => measured(document, chunkSize, "legacy"));
-	const incremental = Array.from({ length: repetitions }, () => measured(document, chunkSize, "incremental"));
-	const legacyCpuUs = stats(legacy.map((sample) => sample.cpuUs));
-	const incrementalCpuUs = stats(incremental.map((sample) => sample.cpuUs));
-	if (incremental[0].inputExamined !== document.length * 2)
-		throw new Error("incremental input examination is not linear");
-	if (incrementalCpuUs.median >= legacyCpuUs.median)
-		throw new Error("incremental median CPU did not beat legacy replay");
-	return {
-		name: corpusName,
-		inputHash: createHash("sha256").update(document).digest("hex"),
-		inputLength: document.length,
-		chunkCount: incremental[0].chunkCount,
-		repetitions,
-		legacy: {
-			wallNs: stats(legacy.map((sample) => sample.wallNs)),
-			cpuUs: legacyCpuUs,
-			inputExamined: legacy[0].inputExamined,
-		},
-		incremental: {
-			wallNs: stats(incremental.map((sample) => sample.wallNs)),
-			cpuUs: incrementalCpuUs,
-			inputExamined: incremental[0].inputExamined,
-		},
-	};
-});
-writeFileSync(
-	output,
-	JSON.stringify(
+function run(options: Options): void {
+	const results = [
 		{
-			name,
-			command: process.argv.join(" "),
-			node: process.version,
-			os: {
-				platform: process.platform,
-				release: release(),
-				version: process.version,
-				arch: process.arch,
-				type: type(),
-			},
-			cpu: cpus()[0]?.model ?? "unknown",
-			results,
+			name: `escaped-nested-${options.escapedBytes}-64`,
+			document: corpus(options.escapedBytes, false),
+			chunkSize: 64,
 		},
-		null,
-		2,
-	),
-);
+		{ name: `unicode-nested-${options.unicodeBytes}-7`, document: corpus(options.unicodeBytes, true), chunkSize: 7 },
+	].map(({ name, document, chunkSize }) => {
+		const input = chunks(document, chunkSize);
+		measured(document, input, "legacy");
+		measured(document, input, "incremental");
+		const samples: Record<Mode, ReturnType<typeof measured>[]> = { legacy: [], incremental: [] };
+		for (let repetition = 0; repetition < options.repetitions; repetition++) {
+			const order: Mode[] = repetition % 2 === 0 ? ["legacy", "incremental"] : ["incremental", "legacy"];
+			for (const mode of order) samples[mode].push(measured(document, input, mode));
+		}
+		const legacyCpuUs = stats(samples.legacy.map((sample) => sample.cpuUs));
+		const incrementalCpuUs = stats(samples.incremental.map((sample) => sample.cpuUs));
+		if (samples.incremental[0].inputExamined !== document.length * 2)
+			throw new Error("incremental input examination is not linear");
+		if (incrementalCpuUs.median >= legacyCpuUs.median)
+			throw new Error("incremental median CPU did not beat legacy replay");
+		return {
+			name,
+			inputHash: createHash("sha256").update(document).digest("hex"),
+			inputLength: document.length,
+			chunkCount: input.length,
+			repetitions: options.repetitions,
+			order: "alternating legacy/incremental by repetition",
+			legacy: {
+				wallNs: stats(samples.legacy.map((sample) => sample.wallNs)),
+				cpuUs: legacyCpuUs,
+				inputExamined: samples.legacy[0].inputExamined,
+			},
+			incremental: {
+				wallNs: stats(samples.incremental.map((sample) => sample.wallNs)),
+				cpuUs: incrementalCpuUs,
+				inputExamined: samples.incremental[0].inputExamined,
+			},
+		};
+	});
+	writeJsonAtomically(options.output, {
+		name: options.name,
+		command: process.argv.join(" "),
+		node: process.version,
+		os: {
+			platform: process.platform,
+			release: release(),
+			arch: process.arch,
+			type: type(),
+		},
+		cpu: cpus()[0]?.model ?? "unknown",
+		results,
+	});
+}
+
+run(parseOptions(process.argv.slice(2)));

--- a/packages/ai/test/streaming-json-parse-cpu-bench.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.ts
@@ -45,11 +45,52 @@ function parseOptions(args: string[]): Options {
 	};
 }
 
+function corpusDocument(outer: Array<{ index: number; text: string }>, padding: string): string {
+	return JSON.stringify({ outer, padding });
+}
+
+/** Returns the UTF-8 byte count for a corpus with `count` nested entries and no padding. */
+function estimateNestedCorpusBytes(count: number, text: string, emptyBytes: number): number {
+	if (count === 0) return emptyBytes;
+	const firstEntryBytes = Buffer.byteLength(JSON.stringify({ index: 0, text }));
+	let indexedDigits = 0;
+	let start = 0;
+	for (let digits = 1; start < count; digits++) {
+		const end = Math.min(count, 10 ** digits);
+		indexedDigits += (end - start) * digits;
+		start = end;
+	}
+	// One comma separates every pair; entry zero already accounts for its one digit.
+	return emptyBytes + count * (firstEntryBytes - 1) + indexedDigits + count - 1;
+}
+
+/**
+ * Find a bounded number of nested entries before filling the exact remaining
+ * UTF-8 budget with ASCII. The estimator makes the preflight logarithmic,
+ * rather than constructing increasingly large candidate documents.
+ */
 function corpus(bytes: number, unicode: boolean): string {
-	const unit = unicode ? "😀\u2028 nested é " : '\\"escaped\\n nested ';
-	return JSON.stringify({
-		outer: Array.from({ length: Math.ceil(bytes / unit.length) }, (_, index) => ({ index, text: unit })),
-	});
+	const text = unicode ? "😀\u2028 nested é " : '\\"escaped\\n nested ';
+	const emptyBytes = Buffer.byteLength(corpusDocument([], ""));
+	const structuralBytes = estimateNestedCorpusBytes(1, text, emptyBytes);
+	if (bytes < structuralBytes)
+		throw new Error(`requested ${bytes} bytes is below structural minimum ${structuralBytes}`);
+
+	const firstEntryBytes = structuralBytes - emptyBytes;
+	const maximumEntries = Math.floor((bytes - emptyBytes) / firstEntryBytes);
+	let lower = 1;
+	let upper = maximumEntries;
+	while (lower < upper) {
+		const middle = Math.ceil((lower + upper) / 2);
+		if (estimateNestedCorpusBytes(middle, text, emptyBytes) <= bytes) lower = middle;
+		else upper = middle - 1;
+	}
+
+	const outer = Array.from({ length: lower }, (_, index) => ({ index, text }));
+	const paddingBytes = bytes - estimateNestedCorpusBytes(lower, text, emptyBytes);
+	const document = corpusDocument(outer, "x".repeat(paddingBytes));
+	if (Buffer.byteLength(document) !== bytes) throw new Error("corpus did not meet requested UTF-8 byte length");
+	return document;
 }
 
 function chunks(document: string, size: number): string[] {
@@ -125,9 +166,13 @@ function run(options: Options): void {
 			throw new Error("incremental input examination is not linear");
 		if (incrementalCpuUs.median >= legacyCpuUs.median)
 			throw new Error("incremental median CPU did not beat legacy replay");
+		const inputBytes = Buffer.byteLength(document);
+		if (inputBytes !== (name.startsWith("escaped") ? options.escapedBytes : options.unicodeBytes))
+			throw new Error("corpus byte length differs from requested target");
 		return {
 			name,
 			inputHash: createHash("sha256").update(document).digest("hex"),
+			inputBytes,
 			inputLength: document.length,
 			chunkCount: input.length,
 			repetitions: options.repetitions,

--- a/packages/ai/test/streaming-json-parse-cpu-bench.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.ts
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import { renameSync, writeFileSync } from "node:fs";
 import { cpus, release, type } from "node:os";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
 	createStreamingJsonParseState,
 	getLegacyStreamingJsonInputExaminedForTesting,
@@ -9,14 +11,22 @@ import {
 	resetStreamingJsonParseInstrumentationForTesting,
 } from "../src/utils/json-parse.js";
 
-const BENCHMARK_NAME = "N01-streaming-structured-output-parse-cpu";
+export const BENCHMARK_NAME = "N01-streaming-structured-output-parse-cpu";
+export const MAX_CORPUS_BYTES = 16 * 1024 * 1024;
+export const MAX_REPETITIONS = 21;
 type Mode = "legacy" | "incremental";
-type Options = {
+export type BenchmarkOptions = {
 	name: string;
 	output: string;
 	escapedBytes: number;
 	unicodeBytes: number;
 	repetitions: number;
+};
+
+type CorpusPlan = {
+	entries: number;
+	structuralMinimum: number;
+	estimatedBytes: number;
 };
 
 function requiredOption(args: string[], name: string): string {
@@ -25,43 +35,98 @@ function requiredOption(args: string[], name: string): string {
 	return args[index + 1];
 }
 
-function positiveIntegerOption(args: string[], name: string, defaultValue: number): number {
+function positiveBoundedIntegerOption(args: string[], name: string, defaultValue: number, maximum: number): number {
 	const index = args.indexOf(name);
 	if (index === -1) return defaultValue;
 	const parsed = Number(args[index + 1]);
-	if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`);
+	if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > maximum)
+		throw new Error(`${name} must be a positive safe integer no greater than ${maximum}`);
 	return parsed;
 }
 
-function parseOptions(args: string[]): Options {
+/** Parses and bounds every allocation-driving option before corpus estimation or allocation. */
+export function parseBenchmarkOptions(args: string[]): BenchmarkOptions {
 	const name = requiredOption(args, "--name");
 	if (name !== BENCHMARK_NAME) throw new Error(`--name must be ${BENCHMARK_NAME}`);
 	return {
 		name,
 		output: requiredOption(args, "--json"),
-		escapedBytes: positiveIntegerOption(args, "--escaped-bytes", 1024 * 1024),
-		unicodeBytes: positiveIntegerOption(args, "--unicode-bytes", 256 * 1024),
-		repetitions: positiveIntegerOption(args, "--repetitions", 7),
+		escapedBytes: positiveBoundedIntegerOption(args, "--escaped-bytes", 1024 * 1024, MAX_CORPUS_BYTES),
+		unicodeBytes: positiveBoundedIntegerOption(args, "--unicode-bytes", 256 * 1024, MAX_CORPUS_BYTES),
+		repetitions: positiveBoundedIntegerOption(args, "--repetitions", 7, MAX_REPETITIONS),
 	};
+}
+
+function nonnegativeSafeInteger(value: number, name: string): void {
+	if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${name} must be a nonnegative safe integer`);
+}
+
+function safeNumber(value: bigint, name: string): number {
+	if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER))
+		throw new Error(`${name} exceeds Number.MAX_SAFE_INTEGER`);
+	return Number(value);
 }
 
 function corpusDocument(outer: Array<{ index: number; text: string }>, padding: string): string {
 	return JSON.stringify({ outer, padding });
 }
 
-/** Returns the UTF-8 byte count for a corpus with `count` nested entries and no padding. */
-function estimateNestedCorpusBytes(count: number, text: string, emptyBytes: number): number {
+/**
+ * Returns the UTF-8 byte count for a corpus with `count` nested entries and no padding.
+ * BigInt keeps every multiplication and addition exact before the checked Number conversion.
+ */
+export function estimateNestedCorpusBytes(count: number, text: string, emptyBytes: number): number {
+	nonnegativeSafeInteger(count, "entry count");
+	nonnegativeSafeInteger(emptyBytes, "empty corpus bytes");
 	if (count === 0) return emptyBytes;
 	const firstEntryBytes = Buffer.byteLength(JSON.stringify({ index: 0, text }));
-	let indexedDigits = 0;
-	let start = 0;
-	for (let digits = 1; start < count; digits++) {
-		const end = Math.min(count, 10 ** digits);
+	nonnegativeSafeInteger(firstEntryBytes, "first entry bytes");
+
+	const countBig = BigInt(count);
+	let indexedDigits = 0n;
+	let start = 0n;
+	let threshold = 10n;
+	for (let digits = 1n; start < countBig; digits++) {
+		const end = countBig < threshold ? countBig : threshold;
 		indexedDigits += (end - start) * digits;
 		start = end;
+		threshold *= 10n;
 	}
-	// One comma separates every pair; entry zero already accounts for its one digit.
-	return emptyBytes + count * (firstEntryBytes - 1) + indexedDigits + count - 1;
+	return safeNumber(
+		BigInt(emptyBytes) + countBig * BigInt(firstEntryBytes - 1) + indexedDigits + countBig - 1n,
+		"estimated corpus bytes",
+	);
+}
+
+function corpusText(unicode: boolean): string {
+	return unicode ? "😀\u2028 nested é " : '\\"escaped\\n nested ';
+}
+
+/** Estimates the largest nested corpus that fits a target without constructing its document. */
+export function estimateCorpusPlan(bytes: number, unicode: boolean): CorpusPlan {
+	nonnegativeSafeInteger(bytes, "requested corpus bytes");
+	if (bytes > MAX_CORPUS_BYTES) throw new Error(`requested corpus bytes must be no greater than ${MAX_CORPUS_BYTES}`);
+	const text = corpusText(unicode);
+	const emptyBytes = Buffer.byteLength(corpusDocument([], ""));
+	const structuralMinimum = estimateNestedCorpusBytes(1, text, emptyBytes);
+	if (bytes < structuralMinimum)
+		throw new Error(`requested ${bytes} bytes is below structural minimum ${structuralMinimum}`);
+
+	const firstEntryBytes = structuralMinimum - emptyBytes;
+	const maximumEntries = Math.floor((bytes - emptyBytes) / firstEntryBytes);
+	nonnegativeSafeInteger(maximumEntries, "maximum entries");
+	let lower = 1;
+	let upper = maximumEntries;
+	while (lower < upper) {
+		const middle = Math.ceil((lower + upper) / 2);
+		if (estimateNestedCorpusBytes(middle, text, emptyBytes) <= bytes) lower = middle;
+		else upper = middle - 1;
+	}
+	return {
+		entries: lower,
+		structuralMinimum,
+		estimatedBytes: estimateNestedCorpusBytes(lower, text, emptyBytes),
+	};
 }
 
 /**
@@ -70,24 +135,10 @@ function estimateNestedCorpusBytes(count: number, text: string, emptyBytes: numb
  * rather than constructing increasingly large candidate documents.
  */
 function corpus(bytes: number, unicode: boolean): string {
-	const text = unicode ? "😀\u2028 nested é " : '\\"escaped\\n nested ';
-	const emptyBytes = Buffer.byteLength(corpusDocument([], ""));
-	const structuralBytes = estimateNestedCorpusBytes(1, text, emptyBytes);
-	if (bytes < structuralBytes)
-		throw new Error(`requested ${bytes} bytes is below structural minimum ${structuralBytes}`);
-
-	const firstEntryBytes = structuralBytes - emptyBytes;
-	const maximumEntries = Math.floor((bytes - emptyBytes) / firstEntryBytes);
-	let lower = 1;
-	let upper = maximumEntries;
-	while (lower < upper) {
-		const middle = Math.ceil((lower + upper) / 2);
-		if (estimateNestedCorpusBytes(middle, text, emptyBytes) <= bytes) lower = middle;
-		else upper = middle - 1;
-	}
-
-	const outer = Array.from({ length: lower }, (_, index) => ({ index, text }));
-	const paddingBytes = bytes - estimateNestedCorpusBytes(lower, text, emptyBytes);
+	const text = corpusText(unicode);
+	const plan = estimateCorpusPlan(bytes, unicode);
+	const outer = Array.from({ length: plan.entries }, (_, index) => ({ index, text }));
+	const paddingBytes = bytes - plan.estimatedBytes;
 	const document = corpusDocument(outer, "x".repeat(paddingBytes));
 	if (Buffer.byteLength(document) !== bytes) throw new Error("corpus did not meet requested UTF-8 byte length");
 	return document;
@@ -143,7 +194,7 @@ function writeJsonAtomically(output: string, value: unknown): void {
 	renameSync(temporary, output);
 }
 
-function run(options: Options): void {
+function run(options: BenchmarkOptions): void {
 	const results = [
 		{
 			name: `escaped-nested-${options.escapedBytes}-64`,
@@ -204,4 +255,8 @@ function run(options: Options): void {
 	});
 }
 
-run(parseOptions(process.argv.slice(2)));
+function isDirectExecution(): boolean {
+	return process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isDirectExecution()) run(parseBenchmarkOptions(process.argv.slice(2)));

--- a/packages/ai/test/streaming-json-parse-cpu-bench.ts
+++ b/packages/ai/test/streaming-json-parse-cpu-bench.ts
@@ -1,67 +1,92 @@
 import { createHash } from "node:crypto";
 import { writeFileSync } from "node:fs";
-import { createStreamingJsonParseState, parseStreamingJson } from "../src/utils/json-parse.js";
+import { cpus, release, type } from "node:os";
+import {
+	createStreamingJsonParseState,
+	getLegacyStreamingJsonInputExaminedForTesting,
+	getStreamingJsonInputExaminedForTesting,
+	parseStreamingJson,
+	resetStreamingJsonParseInstrumentationForTesting,
+} from "../src/utils/json-parse.js";
 
 const args = process.argv.slice(2);
 const name = args[args.indexOf("--name") + 1];
 const output = args[args.indexOf("--json") + 1];
 if (name !== "N01-streaming-structured-output-parse-cpu" || !output)
 	throw new Error("Use --name N01-streaming-structured-output-parse-cpu --json FILE");
+
 function corpus(bytes: number, unicode: boolean): string {
-	const unit = unicode ? "😀\\u2028 nested é " : '\\"escaped\\n nested ';
+	const unit = unicode ? "😀\u2028 nested é " : '\\"escaped\\n nested ';
 	return JSON.stringify({
 		outer: Array.from({ length: Math.ceil(bytes / unit.length) }, (_, index) => ({ index, text: unit })),
 	});
 }
-function measure(document: string, size: number, incremental: boolean) {
-	const chunks = Array.from({ length: Math.ceil(document.length / size) }, (_, i) =>
-		document.slice(i * size, (i + 1) * size),
-	);
-	const before = process.cpuUsage();
-	const start = process.hrtime.bigint();
-	let final: unknown;
-	if (incremental) {
-		const state = createStreamingJsonParseState();
-		for (const chunk of chunks) state.append(chunk);
-		final = state.finalize();
-	} else {
+function chunks(document: string, size: number): string[] {
+	return Array.from({ length: Math.ceil(document.length / size) }, (_, i) => document.slice(i * size, (i + 1) * size));
+}
+function measured(document: string, chunkSize: number, mode: "legacy" | "incremental") {
+	const input = chunks(document, chunkSize);
+	resetStreamingJsonParseInstrumentationForTesting();
+	const cpuBefore = process.cpuUsage();
+	const wallBefore = process.hrtime.bigint();
+	let result: unknown;
+	let examined: number;
+	if (mode === "legacy") {
 		let prefix = "";
-		for (const chunk of chunks) {
+		for (const chunk of input) {
 			prefix += chunk;
 			parseStreamingJson(prefix);
 		}
-		final = JSON.parse(prefix);
+		result = JSON.parse(prefix);
+		examined = getLegacyStreamingJsonInputExaminedForTesting() + document.length;
+	} else {
+		const state = createStreamingJsonParseState();
+		for (const chunk of input) state.append(chunk);
+		result = state.finalize();
+		examined = getStreamingJsonInputExaminedForTesting(state).total;
 	}
-	const cpu = process.cpuUsage(before);
-	const wallNs = Number(process.hrtime.bigint() - start);
-	if (JSON.stringify(final) !== document) throw new Error("parser paths differ");
+	if (JSON.stringify(result) !== document) throw new Error(`${mode} result differs from source document`);
+	const cpu = process.cpuUsage(cpuBefore);
 	return {
-		wallNs,
+		wallNs: Number(process.hrtime.bigint() - wallBefore),
 		cpuUs: cpu.user + cpu.system,
-		chunks: chunks.length,
-		inputExamined: incremental ? document.length * 2 : (document.length * chunks.length) / 2,
+		inputExamined: examined,
+		chunkCount: input.length,
 	};
 }
 function stats(values: number[]) {
-	const ordered = [...values].sort((a, b) => a - b);
-	return { min: ordered[0], median: ordered[Math.floor(ordered.length / 2)], max: ordered.at(-1) };
+	const sorted = [...values].sort((a, b) => a - b);
+	return { min: sorted[0], median: sorted[Math.floor(sorted.length / 2)], max: sorted.at(-1) };
 }
-const corpora = [
-	{ name: "1MiB-escaped-nested-64", document: corpus(1024 * 1024, false), size: 64 },
-	{ name: "256KiB-unicode-nested-7", document: corpus(256 * 1024, true), size: 7 },
-];
-const results = corpora.map(({ name, document, size }) => {
-	measure(document, size, true); // unreported warm-up
-	const legacy = Array.from({ length: 7 }, () => measure(document, size, false));
-	const incremental = Array.from({ length: 7 }, () => measure(document, size, true));
+const repetitions = 7;
+const results = [
+	{ name: "1MiB-escaped-nested-64", document: corpus(1024 * 1024, false), chunkSize: 64 },
+	{ name: "256KiB-unicode-nested-7", document: corpus(256 * 1024, true), chunkSize: 7 },
+].map(({ name: corpusName, document, chunkSize }) => {
+	measured(document, chunkSize, "legacy");
+	measured(document, chunkSize, "incremental"); // unreported warm-ups
+	const legacy = Array.from({ length: repetitions }, () => measured(document, chunkSize, "legacy"));
+	const incremental = Array.from({ length: repetitions }, () => measured(document, chunkSize, "incremental"));
+	const legacyCpuUs = stats(legacy.map((sample) => sample.cpuUs));
+	const incrementalCpuUs = stats(incremental.map((sample) => sample.cpuUs));
+	if (incremental[0].inputExamined !== document.length * 2)
+		throw new Error("incremental input examination is not linear");
+	if (incrementalCpuUs.median >= legacyCpuUs.median)
+		throw new Error("incremental median CPU did not beat legacy replay");
 	return {
-		name,
+		name: corpusName,
 		inputHash: createHash("sha256").update(document).digest("hex"),
-		chunkCount: incremental[0].chunks,
-		legacy: { wallNs: stats(legacy.map((x) => x.wallNs)), cpuUs: stats(legacy.map((x) => x.cpuUs)) },
+		inputLength: document.length,
+		chunkCount: incremental[0].chunkCount,
+		repetitions,
+		legacy: {
+			wallNs: stats(legacy.map((sample) => sample.wallNs)),
+			cpuUs: legacyCpuUs,
+			inputExamined: legacy[0].inputExamined,
+		},
 		incremental: {
-			wallNs: stats(incremental.map((x) => x.wallNs)),
-			cpuUs: stats(incremental.map((x) => x.cpuUs)),
+			wallNs: stats(incremental.map((sample) => sample.wallNs)),
+			cpuUs: incrementalCpuUs,
 			inputExamined: incremental[0].inputExamined,
 		},
 	};
@@ -71,11 +96,16 @@ writeFileSync(
 	JSON.stringify(
 		{
 			name,
-			node: process.version,
-			platform: process.platform,
-			arch: process.arch,
-			cpu: process.arch,
 			command: process.argv.join(" "),
+			node: process.version,
+			os: {
+				platform: process.platform,
+				release: release(),
+				version: process.version,
+				arch: process.arch,
+				type: type(),
+			},
+			cpu: cpus()[0]?.model ?? "unknown",
 			results,
 		},
 		null,

--- a/packages/ai/test/streaming-json-parse-state.test.ts
+++ b/packages/ai/test/streaming-json-parse-state.test.ts
@@ -18,6 +18,18 @@ function chunks(input: string, sizes: number[]): string[] {
 	return result;
 }
 
+function expectLegacyParityAtEveryPrefix(document: string, finalValue?: unknown): void {
+	const state = createStreamingJsonParseState<Record<string, unknown>>();
+	for (let end = 1; end <= document.length; end++) {
+		const prefix = document.slice(0, end);
+		expect(state.append(document.slice(end - 1, end))).toEqual(parseStreamingJson(prefix));
+		expect(state.preview()).toEqual(parseStreamingJson(prefix));
+	}
+	if (finalValue === undefined) expect(() => state.finalize()).toThrow();
+	else expect(state.finalize()).toEqual(finalValue);
+	expect(getStreamingJsonStrictValidationCountForTesting(state)).toBe(1);
+}
+
 describe("incremental streaming JSON parse state", () => {
 	it("matches legacy previews and strictly validates exactly once", () => {
 		const document = JSON.stringify({ empty: {}, array: [true, null, { nested: [1, 2, "ok"] }], number: -12.5e2 });
@@ -32,6 +44,15 @@ describe("incremental streaming JSON parse state", () => {
 		expect(getStreamingJsonStrictValidationCountForTesting(state)).toBe(1);
 		expect(() => state.finalize()).toThrow();
 		expect(() => state.append(" ")).toThrow();
+	});
+
+	it("matches every prefix of a deterministic representative valid nested corpus", () => {
+		const document =
+			'{"outer":[{"empty":{},"array":[true,false,null,{"number":-12.5e2}],"escaped":"\\"\\\\\\/\\b\\f\\n\\r\\t","unicode":"\\uD83D\\uDE00","literal":"é😀é"}],"tail":{"ok":true}}';
+		const emoji = document.indexOf("😀");
+		expect(document.charCodeAt(emoji)).toBeGreaterThanOrEqual(0xd800);
+		expect(document.charCodeAt(emoji + 1)).toBeLessThanOrEqual(0xdfff);
+		expectLegacyParityAtEveryPrefix(document, JSON.parse(document));
 	});
 
 	it("preserves literal unicode, surrogate, and escape chunk boundaries", () => {
@@ -64,26 +85,24 @@ describe("incremental streaming JSON parse state", () => {
 		}
 	});
 
-	it("differentially matches legacy for every prefix of invalid escapes, unicode splits, and malformed structures", () => {
+	it("keeps unknown escapes and split Unicode boundaries legacy-compatible but rejects invalid finals", () => {
+		const document = '{"literal":"😀","escaped":"\\uD83D\\uDE00","unknown":"\\q"}';
+		const emoji = document.indexOf("😀");
+		expect(document.slice(emoji, emoji + 2)).toBe("😀");
+		expectLegacyParityAtEveryPrefix(document);
+	});
+
+	it("differentially matches legacy for every prefix of malformed structures", () => {
 		const documents = [
-			'{"escape":"\\q"}',
 			'{"unicode":"\\u12x"}',
-			'{"unicode":"\\uD83D\\uDE00"}',
 			'{"raw-control":"x\ny"}',
-			'{"line-separator":"x y"}',
-			'{"split":"😀"}',
 			'{"nested":[{"x":1},]}',
 			'{"number":1e+}',
 			'{"junk":true} trailing',
 			'{"unterminated": [1, {"x": "value',
 		];
-		for (const document of documents) {
-			const state = createStreamingJsonParseState<Record<string, unknown>>();
-			for (let end = 1; end <= document.length; end++) {
-				const prefix = document.slice(0, end);
-				expect(state.append(document.slice(end - 1, end))).toEqual(parseStreamingJson(prefix));
-			}
-		}
+		for (const document of documents) expectLegacyParityAtEveryPrefix(document);
+		expectLegacyParityAtEveryPrefix('{"line-separator":"x y"}', { "line-separator": "x y" });
 	});
 
 	it("accounts for only new input until its one strict terminal parse", () => {

--- a/packages/ai/test/streaming-json-parse-state.test.ts
+++ b/packages/ai/test/streaming-json-parse-state.test.ts
@@ -69,6 +69,8 @@ describe("incremental streaming JSON parse state", () => {
 			'{"escape":"\\q"}',
 			'{"unicode":"\\u12x"}',
 			'{"unicode":"\\uD83D\\uDE00"}',
+			'{"raw-control":"x\ny"}',
+			'{"line-separator":"x y"}',
 			'{"split":"😀"}',
 			'{"nested":[{"x":1},]}',
 			'{"number":1e+}',

--- a/packages/ai/test/streaming-json-parse-state.test.ts
+++ b/packages/ai/test/streaming-json-parse-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	createStreamingJsonParseState,
+	getStreamingJsonInputExaminedForTesting,
 	getStreamingJsonStrictValidationCountForTesting,
 	parseStreamingJson,
 } from "../src/utils/json-parse.js";
@@ -61,6 +62,43 @@ describe("incremental streaming JSON parse state", () => {
 			expect(() => state.finalize()).toThrow();
 			expect(getStreamingJsonStrictValidationCountForTesting(state)).toBe(1);
 		}
+	});
+
+	it("differentially matches legacy for every prefix of invalid escapes, unicode splits, and malformed structures", () => {
+		const documents = [
+			'{"escape":"\\q"}',
+			'{"unicode":"\\u12x"}',
+			'{"unicode":"\\uD83D\\uDE00"}',
+			'{"split":"😀"}',
+			'{"nested":[{"x":1},]}',
+			'{"number":1e+}',
+			'{"junk":true} trailing',
+			'{"unterminated": [1, {"x": "value',
+		];
+		for (const document of documents) {
+			const state = createStreamingJsonParseState<Record<string, unknown>>();
+			for (let end = 1; end <= document.length; end++) {
+				const prefix = document.slice(0, end);
+				expect(state.append(document.slice(end - 1, end))).toEqual(parseStreamingJson(prefix));
+			}
+		}
+	});
+
+	it("accounts for only new input until its one strict terminal parse", () => {
+		const document = JSON.stringify({ payload: "x".repeat(128 * 1024), nested: [{ ok: true }] });
+		const state = createStreamingJsonParseState();
+		for (const chunk of chunks(document, [1, 7, 31, 257])) state.append(chunk);
+		expect(getStreamingJsonInputExaminedForTesting(state)).toEqual({
+			incremental: document.length,
+			final: 0,
+			total: document.length,
+		});
+		state.finalize();
+		expect(getStreamingJsonInputExaminedForTesting(state)).toEqual({
+			incremental: document.length,
+			final: document.length,
+			total: document.length * 2,
+		});
 	});
 
 	it("handles depth 64 incrementally", () => {

--- a/packages/ai/test/streaming-json-parse-state.test.ts
+++ b/packages/ai/test/streaming-json-parse-state.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+	createStreamingJsonParseState,
+	getStreamingJsonStrictValidationCountForTesting,
+	parseStreamingJson,
+} from "../src/utils/json-parse.js";
+
+function chunks(input: string, sizes: number[]): string[] {
+	const result: string[] = [];
+	let offset = 0;
+	let step = 0;
+	while (offset < input.length) {
+		const size = sizes[step++ % sizes.length];
+		result.push(input.slice(offset, offset + size));
+		offset += size;
+	}
+	return result;
+}
+
+describe("incremental streaming JSON parse state", () => {
+	it("matches legacy previews and strictly validates exactly once", () => {
+		const document = JSON.stringify({ empty: {}, array: [true, null, { nested: [1, 2, "ok"] }], number: -12.5e2 });
+		const state = createStreamingJsonParseState<Record<string, unknown>>();
+		let prefix = "";
+		for (const chunk of chunks(document, [1, 7, 31])) {
+			prefix += chunk;
+			expect(state.append(chunk)).toEqual(parseStreamingJson(prefix));
+			expect(state.preview()).toEqual(parseStreamingJson(prefix));
+		}
+		expect(state.finalize()).toEqual(JSON.parse(document));
+		expect(getStreamingJsonStrictValidationCountForTesting(state)).toBe(1);
+		expect(() => state.finalize()).toThrow();
+		expect(() => state.append(" ")).toThrow();
+	});
+
+	it("preserves literal unicode, surrogate, and escape chunk boundaries", () => {
+		const document = '{"literal":"é😀\\u2028\\u2029","decomposed":"é","escaped":"\\uD83D\\uDE00"}';
+		const split = document.indexOf("😀") + 1;
+		const pieces = [
+			document.slice(0, split),
+			document.slice(split, split + 1),
+			...chunks(document.slice(split + 1), [1, 2, 7]),
+		];
+		const state = createStreamingJsonParseState<Record<string, unknown>>();
+		let prefix = "";
+		for (const chunk of pieces) {
+			prefix += chunk;
+			expect(state.append(chunk)).toEqual(parseStreamingJson(prefix));
+		}
+		expect(state.finalize()).toEqual(JSON.parse(document));
+	});
+
+	it("keeps malformed, nesting, and truncation input non-authoritative", () => {
+		for (const document of ['{"a":"\\u12', '{"a":[1,2}', '{"a":1} junk', '{"a":"raw\ncontrol"}', '{"a":1e}']) {
+			const state = createStreamingJsonParseState<Record<string, unknown>>();
+			let prefix = "";
+			for (const chunk of chunks(document, [1, 7])) {
+				prefix += chunk;
+				expect(state.append(chunk)).toEqual(parseStreamingJson(prefix));
+			}
+			expect(() => state.finalize()).toThrow();
+			expect(getStreamingJsonStrictValidationCountForTesting(state)).toBe(1);
+		}
+	});
+
+	it("handles depth 64 incrementally", () => {
+		let value: unknown = { leaf: "value" };
+		for (let index = 0; index < 64; index++) value = { index, value };
+		const document = JSON.stringify(value);
+		const state = createStreamingJsonParseState();
+		for (const chunk of chunks(document, [257])) state.append(chunk);
+		expect(state.finalize()).toEqual(JSON.parse(document));
+	});
+});

--- a/packages/coding-agent/src/modes/daemon/compact-session-stream.ts
+++ b/packages/coding-agent/src/modes/daemon/compact-session-stream.ts
@@ -1,4 +1,9 @@
-import { type AssistantMessage, type AssistantMessageEvent, parseStreamingJson } from "@earendil-works/pi-ai";
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	createStreamingJsonParseState,
+	type StreamingJsonParseState,
+} from "@earendil-works/pi-ai";
 import type { DaemonEventMeta, DaemonOutbound } from "./daemon-protocol.js";
 
 type SessionEvent = Extract<DaemonOutbound, { type: "session_event" }>["event"];
@@ -71,10 +76,14 @@ function compactContentStart(
 
 export class CompactAssistantStreamReconstructor {
 	private readonly partialMessages = new Map<string, AssistantMessage>();
-	private readonly toolCallJson = new Map<string, string>();
+	private readonly toolCallParsers = new Map<string, StreamingJsonParseState<Record<string, unknown>>>();
+	private readonly toolCallSnapshots = new Set<string>();
 
 	seed(activeSessionId: string, message: AssistantMessage): void {
 		this.partialMessages.set(activeSessionId, message);
+		for (const [contentIndex, content] of message.content.entries()) {
+			if (content.type === "toolCall") this.toolCallSnapshots.add(this.toolCallKey(activeSessionId, contentIndex));
+		}
 	}
 
 	observe(message: DaemonOutbound): void {
@@ -147,27 +156,38 @@ export class CompactAssistantStreamReconstructor {
 					return undefined;
 				}
 				partial.content[event.contentIndex] = delta.contentStart;
-				this.toolCallJson.set(this.toolCallKey(delta.activeSessionId, event.contentIndex), "");
+				this.toolCallParsers.set(
+					this.toolCallKey(delta.activeSessionId, event.contentIndex),
+					createStreamingJsonParseState(),
+				);
 				break;
 			case "toolcall_delta": {
 				const content = partial.content[event.contentIndex];
 				if (content?.type !== "toolCall") {
 					return undefined;
 				}
+				const key = this.toolCallKey(delta.activeSessionId, event.contentIndex);
 				if (delta.toolCallArguments) {
+					// Producer snapshots are already materialized; never reconstruct them.
 					content.arguments = delta.toolCallArguments;
+					this.toolCallSnapshots.add(key);
 				} else {
-					const key = this.toolCallKey(delta.activeSessionId, event.contentIndex);
-					const partialJson = `${this.toolCallJson.get(key) ?? ""}${event.delta}`;
-					this.toolCallJson.set(key, partialJson);
-					content.arguments = parseStreamingJson<Record<string, unknown>>(partialJson);
+					// A snapshot has no corresponding raw prefix. Ask the caller to resync
+					// rather than treating a later raw suffix as a whole document.
+					if (this.toolCallSnapshots.has(key)) return undefined;
+					const parser = this.toolCallParsers.get(key);
+					if (!parser) return undefined;
+					content.arguments = parser.append(event.delta);
 				}
 				break;
 			}
-			case "toolcall_end":
+			case "toolcall_end": {
 				partial.content[event.contentIndex] = event.toolCall;
-				this.toolCallJson.delete(this.toolCallKey(delta.activeSessionId, event.contentIndex));
+				const key = this.toolCallKey(delta.activeSessionId, event.contentIndex);
+				this.toolCallParsers.delete(key);
+				this.toolCallSnapshots.delete(key);
 				break;
+			}
 			case "start":
 			case "done":
 			case "error":
@@ -187,10 +207,11 @@ export class CompactAssistantStreamReconstructor {
 
 	clear(activeSessionId: string): void {
 		this.partialMessages.delete(activeSessionId);
-		for (const key of this.toolCallJson.keys()) {
-			if (key.startsWith(`${activeSessionId}:`)) {
-				this.toolCallJson.delete(key);
-			}
+		for (const key of this.toolCallParsers.keys()) {
+			if (key.startsWith(`${activeSessionId}:`)) this.toolCallParsers.delete(key);
+		}
+		for (const key of this.toolCallSnapshots) {
+			if (key.startsWith(`${activeSessionId}:`)) this.toolCallSnapshots.delete(key);
 		}
 	}
 

--- a/packages/coding-agent/test/compact-session-stream.test.ts
+++ b/packages/coding-agent/test/compact-session-stream.test.ts
@@ -189,4 +189,29 @@ describe("compact daemon assistant streaming", () => {
 		reconstructor.clear("legacy-tool");
 		expect(reconstructor.reconstruct(delta)).toBeUndefined();
 	});
+	it("clears fallback parser state for every compact terminal lifecycle event", () => {
+		for (const terminal of ["message_end", "session_replaced", "session_resynced", "session_closed"] as const) {
+			const reconstructor = new CompactAssistantStreamReconstructor();
+			reconstructor.observe({
+				type: "session_event",
+				activeSessionId: terminal,
+				event: { type: "message_start", message: assistant([]) },
+			});
+			const start = {
+				type: "assistant_stream_delta" as const,
+				activeSessionId: terminal,
+				contentStart: { type: "toolCall" as const, id: "tool", name: "search", arguments: {} },
+				assistantMessageEvent: { type: "toolcall_start" as const, contentIndex: 0 },
+			};
+			expect(reconstructor.reconstruct(start)).toBeDefined();
+			if (terminal === "message_end")
+				reconstructor.observe({
+					type: "session_event",
+					activeSessionId: terminal,
+					event: { type: "message_end" },
+				} as DaemonOutbound);
+			else reconstructor.observe({ type: terminal, activeSessionId: terminal } as DaemonOutbound);
+			expect(reconstructor.reconstruct(start)).toBeUndefined();
+		}
+	});
 });

--- a/packages/coding-agent/test/compact-session-stream.test.ts
+++ b/packages/coding-agent/test/compact-session-stream.test.ts
@@ -140,34 +140,53 @@ describe("compact daemon assistant streaming", () => {
 		});
 	});
 
-	it("continues tool arguments after reconstructing from a snapshot", () => {
+	it("requests resync when a raw suffix follows an authoritative snapshot", () => {
 		const reconstructor = new CompactAssistantStreamReconstructor();
 		reconstructor.seed(
 			"active-tool",
 			assistant([{ type: "toolCall", id: "tool-1", name: "search", arguments: { query: "hel" } }]),
 		);
 		const updated = assistant([{ type: "toolCall", id: "tool-1", name: "search", arguments: { query: "hello" } }]);
-		const delta = createCompactAssistantDelta({
+		const snapshot = createCompactAssistantDelta({
 			type: "session_event",
 			activeSessionId: "active-tool",
 			event: {
 				type: "message_update",
 				message: updated,
-				assistantMessageEvent: {
-					type: "toolcall_delta",
-					contentIndex: 0,
-					delta: 'lo"}',
-					partial: updated,
-				},
+				assistantMessageEvent: { type: "toolcall_delta", contentIndex: 0, delta: 'lo"}', partial: updated },
 			},
 		});
-
-		expect(reconstructor.reconstruct(delta!)).toMatchObject({
-			event: {
-				message: {
-					content: [{ type: "toolCall", id: "tool-1", name: "search", arguments: { query: "hello" } }],
-				},
-			},
+		expect(reconstructor.reconstruct(snapshot!)).toBeDefined();
+		const rawSuffix = {
+			type: "assistant_stream_delta" as const,
+			activeSessionId: "active-tool",
+			assistantMessageEvent: { type: "toolcall_delta" as const, contentIndex: 0, delta: " " },
+		};
+		expect(reconstructor.reconstruct(rawSuffix)).toBeUndefined();
+	});
+	it("reconstructs legacy raw tool deltas incrementally", () => {
+		const reconstructor = new CompactAssistantStreamReconstructor();
+		reconstructor.observe({
+			type: "session_event",
+			activeSessionId: "legacy-tool",
+			event: { type: "message_start", message: assistant([]) },
 		});
+		const start = {
+			type: "assistant_stream_delta" as const,
+			activeSessionId: "legacy-tool",
+			contentStart: { type: "toolCall" as const, id: "tool", name: "search", arguments: {} },
+			assistantMessageEvent: { type: "toolcall_start" as const, contentIndex: 0 },
+		};
+		expect(reconstructor.reconstruct(start)).toBeDefined();
+		const delta = {
+			type: "assistant_stream_delta" as const,
+			activeSessionId: "legacy-tool",
+			assistantMessageEvent: { type: "toolcall_delta" as const, contentIndex: 0, delta: '{"query":"hello"}' },
+		};
+		expect(reconstructor.reconstruct(delta)).toMatchObject({
+			event: { message: { content: [{ arguments: { query: "hello" } }] } },
+		});
+		reconstructor.clear("legacy-tool");
+		expect(reconstructor.reconstruct(delta)).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## N01 — incremental structured output

**Status:** Draft. Source reviewed; final remote CPU validation is currently running. **Not merge-ready.**

### Scope / feature
Implements incremental parsing of streamed structured tool arguments across AI providers, with streaming JSON state/parity coverage and a bounded CPU benchmark corpus.

### Contracts
- Preserves streaming partial-JSON and cleanup parity across supported provider paths.
- Keeps benchmark corpus inputs bounded and uses the exact UTF-8 byte corpus.
- Includes location-independent CLI smoke coverage and parser-state tests.

### No limiter
This change adds **no client-side rate limiter**, shared semaphore, admission queue, or synthetic local 429 behavior. Independent model requests remain independent.

### Rollback
Revert this PR's commit range (or the feature commits) to return to B00B behavior; the change is isolated to the AI streaming/parser paths and their tests/benchmarks.

### Evidence retained
The source branch retains review fixes and validation artifacts in commit history and test/benchmark fixtures, including evidence from known failed attempts and their subsequent corrections. Final remote CPU validation is currently running and is not represented as complete.

### Exact provenance
- **Base:** B00B PR [#1115](https://github.com/PrimeIntellect-ai/prime-agent/pull/1115) head branch `perf/b00b-production-gate` at `9d9cf28d51490ef06efba738c3fff788463acdff` (not `main`)
- **Source branch:** `perf/n01-incremental-structured-output`
- **Exact reviewed and published source head:** `5835416078b7440cbf479c007e43b63d4ae55416`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add incremental structured-output streaming parser to replace repeated JSON reparsing
> - Introduces `createStreamingJsonParseState` in [`utils/json-parse.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1169/files#diff-77e0781eb08fb6dbe9c71a2343a1245f2481e3525365953f99dcdd8228affa94), an incremental JSON parser that processes tool call argument deltas without replaying the full prefix on each chunk.
> - Replaces `partialJson`/`partialArgs` scratch buffers and repeated `parseStreamingJson` calls across all providers (Anthropic, Bedrock, Mistral, OpenAI completions/responses/Codex/Azure) with the new stateful parser's `append`/`finalize` lifecycle.
> - Adds `discardStreamingJsonParseState` for cleanup on error/abort paths in all providers, and `getStreamingJsonRawForProviderCheck` for prefix-continuation validation in the OpenAI Responses shared stream.
> - Updates `CompactAssistantStreamReconstructor` in [`compact-session-stream.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1169/files#diff-832e108256eb0bfb6547c941fe490afaf85aef748b6e34a3871fcf13e70dbcfe) to use per-tool parser instances and reject raw suffixes after a producer snapshot is applied.
> - Includes a CPU benchmark ([`streaming-json-parse-cpu-bench.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1169/files#diff-5dcb059d5c37b359fa4d20ba88ccffc2eab32cd19c9297bb40f3d8ef51cf2c74)) comparing legacy vs. incremental parsers, plus unit tests for parity and strict-validation counts.
> - Behavioral Change: missing parser during a tool call delta now throws instead of silently continuing; OpenAI Responses stream throws if an authoritative `done` payload replaces rather than extends the streamed prefix.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e8b407f. 11 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
