### PR TITLE
docs: add Lynkr custom-provider example extension

### DIFF
--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -13,6 +13,7 @@ See these complete provider examples:
 
 - [`examples/extensions/custom-provider-anthropic/`](../examples/extensions/custom-provider-anthropic/)
 - [`examples/extensions/custom-provider-gitlab-duo/`](../examples/extensions/custom-provider-gitlab-duo/)
+- [`examples/extensions/custom-provider-lynkr/`](../examples/extensions/custom-provider-lynkr/) - self-hosted OpenAI-compatible gateway with dynamic model discovery
 
 ## Table of Contents
 
@@ -126,7 +127,7 @@ export default async function (pi: ExtensionAPI) {
 }
 ```
 
-This registers the fetched models before startup finishes.
+This registers the fetched models before startup finishes. For a concrete, real-world version of this pattern, see the [Lynkr example](../examples/extensions/custom-provider-lynkr/) - Lynkr is an open-source self-hosted LLM gateway that exposes this same `/v1/models` discovery endpoint.
 
 ```typescript
 pi.registerProvider("my-llm", {

--- a/packages/coding-agent/examples/extensions/custom-provider-lynkr/.gitignore
+++ b/packages/coding-agent/examples/extensions/custom-provider-lynkr/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/coding-agent/examples/extensions/custom-provider-lynkr/index.ts
+++ b/packages/coding-agent/examples/extensions/custom-provider-lynkr/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Lynkr Provider Extension
+ *
+ * Lynkr (https://github.com/Fast-Editor/Lynkr) is an open-source, self-hosted
+ * LLM gateway that exposes an OpenAI-compatible API (/v1/chat/completions,
+ * /v1/models) in front of local backends (Ollama, llama.cpp, LM Studio, MLX
+ * Server) and/or cloud providers it's configured to route to.
+ *
+ * Because Lynkr already speaks the standard OpenAI Chat Completions wire
+ * format, no custom streaming implementation is needed here -- this registers
+ * it as an `openai-completions` provider and discovers whatever models are
+ * currently configured on the gateway via its `/v1/models` endpoint.
+ *
+ * Usage:
+ *   1. Run Lynkr locally (defaults to http://localhost:8081).
+ *   2. pi -e ./packages/coding-agent/examples/extensions/custom-provider-lynkr
+ *   3. prime-agent model list   # should list your Lynkr-routed models
+ *
+ * Lynkr doesn't validate the API key, so any non-empty string works -- set
+ * LYNKR_API_KEY if your deployment does enforce one.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const DEFAULT_BASE_URL = "http://localhost:8081/v1";
+
+interface LynkrModel {
+	id: string;
+	name?: string;
+	context_window?: number;
+	max_tokens?: number;
+}
+
+export default async function (pi: ExtensionAPI) {
+	const baseUrl = process.env.LYNKR_BASE_URL ?? DEFAULT_BASE_URL;
+
+	let models: LynkrModel[] = [];
+	try {
+		const response = await fetch(`${baseUrl}/models`);
+		if (response.ok) {
+			const payload = (await response.json()) as { data: LynkrModel[] };
+			models = payload.data ?? [];
+		}
+	} catch {
+		// Lynkr not running yet -- fall back to an empty model list rather than
+		// failing startup. Restart prime-agent once Lynkr is up to pick up models.
+	}
+
+	pi.registerProvider("lynkr", {
+		name: "Lynkr",
+		baseUrl,
+		apiKey: process.env.LYNKR_API_KEY ?? "local",
+		api: "openai-completions",
+		models: models.map((model) => ({
+			id: model.id,
+			name: model.name ?? model.id,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: model.context_window ?? 128000,
+			maxTokens: model.max_tokens ?? 16384,
+		})),
+	});
+}

--- a/packages/coding-agent/examples/extensions/custom-provider-lynkr/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-lynkr/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pi-extension-custom-provider-lynkr",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "clean": "echo 'nothing to clean'",
+    "build": "echo 'nothing to build'",
+    "check": "echo 'nothing to check'"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds a new example extension, `custom-provider-lynkr/`, demonstrating how to register [Lynkr](https://github.com/Fast-Editor/Lynkr) as a custom model provider — an open-source, self-hosted LLM gateway exposing an OpenAI-compatible API in front of local backends (Ollama, llama.cpp, LM Studio, MLX Server) and cloud providers.

Since Lynkr already speaks the standard OpenAI Chat Completions wire format, the example just uses `openai-completions` with no custom streaming implementation — it discovers whatever models are currently configured on the gateway via Lynkr's `/v1/models` endpoint, following the same dynamic-discovery pattern already shown generically in `custom-provider.md`.

## Scope

This is docs/examples only:
- `packages/coding-agent/examples/extensions/custom-provider-lynkr/` (`index.ts`, `package.json`, `.gitignore`) — mirrors the existing `custom-provider-gitlab-duo` example's layout.
- `packages/coding-agent/docs/custom-provider.md` — links the new example and cross-references it from the existing generic dynamic-discovery snippet.

No changes to `models.generated.ts` or core provider registration — that file is auto-generated from models.dev/AI Gateway and isn't the right place for a single self-hosted gateway, so this stays at the example/extension layer that's already the sanctioned way to add custom providers.

## Disclosure

I'm the maintainer of Lynkr. Flagging that plainly since this adds an example referencing my own project — happy to adjust scope, wording, or drop this entirely if maintainers would rather not have vendor-specific examples in-tree.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Lynkr custom-provider example extension for coding agent
> Adds a new example extension at [`examples/extensions/custom-provider-lynkr/`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1178/files#diff-50405c9e1e089f2c1f452b899fd520db55669fd80cb4e740157b90e1a2b6dba9) that registers a `lynkr` provider using the OpenAI Chat Completions API.
>
> - Models are dynamically discovered from the Lynkr `/v1/models` endpoint at startup; if discovery fails, the provider registers with an empty model list.
> - The base URL defaults to `http://localhost:8081/v1` (overridden via `LYNKR_BASE_URL`); the API key is read from `LYNKR_API_KEY` or defaults to `'local'`.
> - Updates [`custom-provider.md`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1178/files#diff-13b5babedc02e62033740425608dfca2fabc2c2b89eb264cce4f11778e1af882) to reference this example and note that Lynkr exposes the `/v1/models` discovery endpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 149766b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->