### PR TITLE
feat(coding-agent): add Anthropic quota status extension

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added an opt-in Anthropic quota status extension ([#1184](https://github.com/PrimeIntellect-ai/prime-agent/pull/1184) by [@nnunley](https://github.com/nnunley)).
 - Added `app.messages.expand` (`ctrl+p`) to collapse or expand agent-to-agent messages separately from `ctrl+o` tool output.
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.

--- a/packages/coding-agent/examples/extensions/anthropic-quota.ts
+++ b/packages/coding-agent/examples/extensions/anthropic-quota.ts
@@ -1,0 +1,101 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export interface AnthropicQuotaWindow {
+	name: "5h" | "7d";
+	utilization: number;
+	resetAt?: Date;
+}
+
+export interface AnthropicQuotaSnapshot {
+	status?: string;
+	windows: AnthropicQuotaWindow[];
+}
+
+const PREFIX = "anthropic-ratelimit-unified-";
+
+function parseUtilization(value: string | undefined): number | undefined {
+	if (value === undefined) return undefined;
+	const parsed = Number.parseFloat(value);
+	if (!Number.isFinite(parsed) || parsed < 0) return undefined;
+	return parsed <= 1 ? parsed : parsed / 100;
+}
+
+function parseReset(value: string | undefined): Date | undefined {
+	if (!value) return undefined;
+	const epochSeconds = Number(value);
+	const timestamp = Number.isFinite(epochSeconds) ? epochSeconds * 1000 : Date.parse(value);
+	if (!Number.isFinite(timestamp)) return undefined;
+	return new Date(timestamp);
+}
+
+export function parseAnthropicQuota(headers: Record<string, string>): AnthropicQuotaSnapshot | undefined {
+	const normalized = Object.fromEntries(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]));
+	const windows: AnthropicQuotaWindow[] = [];
+
+	for (const [name, aliases] of [
+		["5h", ["5h"]],
+		["7d", ["7d", "weekly"]],
+	] as const) {
+		for (const alias of aliases) {
+			const utilization = parseUtilization(normalized[`${PREFIX}${alias}-utilization`]);
+			if (utilization === undefined) continue;
+			windows.push({
+				name,
+				utilization,
+				resetAt: parseReset(normalized[`${PREFIX}${alias}-reset`]),
+			});
+			break;
+		}
+	}
+
+	if (windows.length === 0) return undefined;
+	return { status: normalized[`${PREFIX}status`], windows };
+}
+
+export function formatAnthropicQuota(snapshot: AnthropicQuotaSnapshot): string {
+	const windows = snapshot.windows.map(({ name, utilization }) => `${name} ${Math.round(utilization * 100)}%`);
+	return `Claude quota ${windows.join(" · ")}`;
+}
+
+function warningBand(snapshot: AnthropicQuotaSnapshot): number {
+	const utilization = Math.max(...snapshot.windows.map((window) => window.utilization));
+	if (utilization >= 1) return 100;
+	if (utilization >= 0.9) return 90;
+	if (utilization >= 0.8) return 80;
+	return 0;
+}
+
+function formatReset(window: AnthropicQuotaWindow | undefined): string {
+	if (!window?.resetAt) return "reset time unavailable";
+	return `resets ${window.resetAt.toLocaleString()}`;
+}
+
+export default function anthropicQuotaExtension(pi: ExtensionAPI): void {
+	let previousBand = 0;
+
+	pi.on("after_provider_response", (event, ctx) => {
+		const snapshot = parseAnthropicQuota(event.headers);
+		if (!snapshot) {
+			ctx.ui.setStatus("anthropic-quota", undefined);
+			previousBand = 0;
+			return;
+		}
+
+		ctx.ui.setStatus("anthropic-quota", formatAnthropicQuota(snapshot));
+		const band = warningBand(snapshot);
+		if (band <= previousBand) return;
+		previousBand = band;
+
+		const limitingWindow = snapshot.windows.reduce((current, candidate) =>
+			candidate.utilization > current.utilization ? candidate : current,
+		);
+		if (band === 100) {
+			ctx.ui.notify(`Claude quota exhausted; ${formatReset(limitingWindow)}`, "error");
+		} else if (band >= 90) {
+			ctx.ui.notify(
+				`Claude quota at ${Math.round(limitingWindow.utilization * 100)}%; ${formatReset(limitingWindow)}`,
+				"warning",
+			);
+		}
+	});
+}

--- a/packages/coding-agent/test/anthropic-quota-extension.test.ts
+++ b/packages/coding-agent/test/anthropic-quota-extension.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { formatAnthropicQuota, parseAnthropicQuota } from "../examples/extensions/anthropic-quota.js";
+
+describe("Anthropic quota extension", () => {
+	it("parses subscription quota windows and reset times", () => {
+		const snapshot = parseAnthropicQuota({
+			"Anthropic-Ratelimit-Unified-Status": "allowed",
+			"Anthropic-Ratelimit-Unified-5h-Utilization": "0.84",
+			"Anthropic-Ratelimit-Unified-5h-Reset": "1786421400",
+			"Anthropic-Ratelimit-Unified-7d-Utilization": "0.37",
+			"Anthropic-Ratelimit-Unified-7d-Reset": "2026-08-16T01:10:00Z",
+		});
+
+		expect(snapshot).toEqual({
+			status: "allowed",
+			windows: [
+				{ name: "5h", utilization: 0.84, resetAt: new Date("2026-08-11T04:10:00.000Z") },
+				{ name: "7d", utilization: 0.37, resetAt: new Date("2026-08-16T01:10:00.000Z") },
+			],
+		});
+		expect(formatAnthropicQuota(snapshot!)).toBe("Claude quota 5h 84% · 7d 37%");
+	});
+
+	it("accepts weekly aliases and percentage utilization", () => {
+		const snapshot = parseAnthropicQuota({
+			"anthropic-ratelimit-unified-weekly-utilization": "84",
+		});
+		expect(snapshot?.windows).toEqual([{ name: "7d", utilization: 0.84, resetAt: undefined }]);
+	});
+
+	it("ignores unrelated and malformed headers", () => {
+		expect(parseAnthropicQuota({ "x-ratelimit-remaining": "10" })).toBeUndefined();
+		expect(parseAnthropicQuota({ "anthropic-ratelimit-unified-5h-utilization": "not-a-number" })).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- add an opt-in extension that parses Anthropic OAuth unified `5h` and `7d` quota headers
- display the latest utilization snapshot in the status footer
- warn once when utilization crosses 90% and report the provider reset time at exhaustion
- accept case-insensitive headers, `7d`/`weekly` aliases, epoch resets, and ISO resets

## Scope

This uses the existing `after_provider_response` extension hook and does not change provider or daemon protocols. #1180 tracks promoting the same normalized state into built-in cross-client runtime behavior.

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/anthropic-quota-extension.test.ts` (3 tests passed)
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Anthropic quota status extension to coding-agent
> - Adds an opt-in extension in [anthropic-quota.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1184/files#diff-6347a995c96ebc02f4ca786e4d35f2a55b4b40eae91b1eb3a586ae75056868f7) that parses Anthropic rate-limit headers after each provider response and displays a quota utilization summary in the UI status bar (e.g. `Claude quota 5h 84% · 7d 37%`).
> - Emits a warning notification at ≥90% utilization and an error at 100%, triggering only on upward threshold crossings to avoid repeated alerts.
> - Supports `5h` and `7d`/`weekly` quota windows, parsing utilization as fractions or percentages and reset times as epoch seconds or ISO strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75648be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->