### PR TITLE
fix(coding-agent): acknowledge prompts queued during streaming

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed prompts queued during streaming lacking an immediate receipt acknowledgement ([#1185](https://github.com/PrimeIntellect-ai/prime-agent/pull/1185) by [@nnunley](https://github.com/nnunley)).
 - Added `app.messages.expand` (`ctrl+p`) to collapse or expand agent-to-agent messages separately from `ctrl+o` tool output.
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4979,12 +4979,18 @@ export class InteractiveMode {
 					submissionOutcome = "lifecycle-cancelled";
 					return;
 				}
+				const wasStreaming = this.isAgentStreaming();
 				try {
 					await this.agentConnection.prompt(text, {
 						streamingBehavior,
 						queueIfBusy: true,
 						images,
 					});
+					if (wasStreaming) {
+						const kind = streamingBehavior === "steer" ? "Steering" : "Follow-up";
+						const boundary = streamingBehavior === "steer" ? "next model boundary" : "current run finishes";
+						this.showStatus(`${kind} received — queued until the ${boundary}.`);
+					}
 				} catch (error) {
 					// Generation guards editor ownership, not draft durability: a stale
 					// rejection must be retained rather than overwrite newer input or vanish.

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -619,6 +619,8 @@ type SubmitHandlerHarness = {
 	clearShortcutGuide: () => void;
 	showWarning: (message: string) => void;
 	showError: (message: string) => void;
+	showStatus: (message: string) => void;
+	isAgentStreaming: () => boolean;
 	isBashRunning: () => boolean;
 	patchConnectionState: (patch: Record<string, unknown>) => void;
 	requestAgentsView: () => Promise<void>;
@@ -637,6 +639,8 @@ function createSubmitHandlerHarness(overrides: Partial<SubmitHandlerHarness> = {
 		clearShortcutGuide: vi.fn(),
 		showWarning: vi.fn(),
 		showError: vi.fn(),
+		showStatus: vi.fn(),
+		isAgentStreaming: () => false,
 		isBashRunning: () => false,
 		patchConnectionState: vi.fn(),
 		promptStashState: {},
@@ -679,6 +683,31 @@ function createSubmitHandlerHarness(overrides: Partial<SubmitHandlerHarness> = {
 }
 
 describe("InteractiveMode submit handling", () => {
+	test.each([
+		["steer", "Steering received — queued until the next model boundary."],
+		["followUp", "Follow-up received — queued until the current run finishes."],
+	] as const)("acknowledges %s submissions while the agent is streaming", async (behavior, expected) => {
+		const showStatus = vi.fn();
+		const fakeThis = createSubmitHandlerHarness({
+			isAgentStreaming: () => true,
+			showStatus,
+			submittedInputBehavior: behavior,
+		});
+
+		await fakeThis.defaultEditor.onSubmit?.("redirect the active run");
+
+		expect(showStatus).toHaveBeenCalledWith(expected);
+	});
+
+	test("does not describe a new idle prompt as queued steering", async () => {
+		const showStatus = vi.fn();
+		const fakeThis = createSubmitHandlerHarness({ showStatus, isAgentStreaming: () => false });
+
+		await fakeThis.defaultEditor.onSubmit?.("start a new run");
+
+		expect(showStatus).not.toHaveBeenCalled();
+	});
+
 	test.each(["normal Enter", "installed custom editor"])("captures exact rich state for %s", async () => {
 		const image = { type: "image", data: "base64", mimeType: "image/png" };
 		const pasteSnapshot = { pastes: [[1, "expanded paste"]] as const, pasteCounter: 2 };


### PR DESCRIPTION
## Summary

- acknowledge a prompt immediately after it is admitted while the agent is streaming
- distinguish steering queued for the next model boundary from follow-up queued until the run finishes
- avoid describing an idle prompt as queued

The acknowledgement is emitted by the interactive client after admission, so it does not depend on the active model producing another token. #1181 tracks the broader received/applied/discarded lifecycle across all clients.

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-status.test.ts` (154 tests passed)
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Acknowledge prompts queued during streaming in interactive mode
> When a prompt is submitted while the agent is streaming, `InteractiveMode.setupEditorSubmitHandler` now immediately shows a status message confirming the submission was received and queued. The message varies by `streamingBehavior`: `'steer'` reports queuing until the next model boundary; `'followUp'` reports queuing until the current run finishes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a298f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->