### PR TITLE
[v0.8 Core WIP] bind project trust, recovery, and typed host requests

### DIFF
--- a/packages/coding-agent/docs/daemon.md
+++ b/packages/coding-agent/docs/daemon.md
@@ -22,6 +22,8 @@ flowchart TD
 
 The supervisor owns public sockets, client attachments, routing, global agent-message delivery, worker health, command journals, and coordinated updates. It does not execute providers, tools, compaction, bash, kernels, schedules, or transcript scans.
 
+Lifecycle races, identity authority, cancellation, reclaim, and background finalization are governed by the [Worker Lifecycle Concurrency Contract](worker-lifecycle-concurrency.md).
+
 The catalog subprocess owns saved-session scans and inactive-session file operations. A catalog failure can fail a catalog request without interrupting active workers.
 
 Each worker owns one root `AgentSessionRuntime`, its root `AgentSession`, scheduler, kernels, and every RLM descendant below that root. New, switch, fork, and import operations replace the root runtime inside the worker while preserving the public active-session ID.

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -71,5 +71,6 @@ Public releases are currently installed from versioned release artifacts. The in
 - [Development](development.md) - local setup, configuration, debugging, and validation.
 - [Architecture overview](architecture.md) - system topology and end-to-end prompt flow.
 - [Daemon Architecture](daemon.md) - supervisor, catalog, worker, lifecycle, and recovery details.
+- [Worker Lifecycle Concurrency Contract](worker-lifecycle-concurrency.md) - authority, cancellation, stop, retry, and reclaim invariants.
 - [Agent Connection Architecture](agent-connection.md) - client/runtime connection boundary.
 - [RLM Runtime Architecture](rlm-runtime.md) - ZeroMQ kernel transport and recursive subagent execution.

--- a/packages/coding-agent/docs/worker-lifecycle-concurrency.md
+++ b/packages/coding-agent/docs/worker-lifecycle-concurrency.md
@@ -1,0 +1,58 @@
+# Worker Lifecycle Concurrency Contract
+
+This document is the authoritative contract for the daemon supervisor and worker lifecycle code. It applies to launch, attach/retry, stop, recovery, stale-registration reclaim, RLM child cancellation, and descriptor replay. It deliberately specifies the small shared-state boundary; public protocol semantics remain in [daemon.md](daemon.md).
+
+## State and observability
+
+A worker registration is observable as `starting`, `running`, `recovering`, or a stop tombstone (`stopRequestedAt`). A stop tombstone is observable before signalling begins and remains observable until descriptor deletion. A retry/relaunch replaces the registration's process generation; it must remove a rescinded stop tombstone before publishing the successor. A child run is observable as `queued`, `running`, then exactly one terminal `done`, `error`, or `cancelled`; a cancelled run stays tracked until its detached cleanup settles, so a second cancellation is accepted rather than mistaken for a completed selector.
+
+The immutable authority tuple for a process operation is:
+
+```text
+(workerId, pid, processStartId, supervisor generation, stopRevision)
+```
+
+Capture it before an asynchronous operation. The worker ID alone is never authority to signal, delete, archive, or reclaim. `processStartId` distinguishes a reused PID, supervisor generation fences an obsolete supervisor, and `stopRevision` fences a rescinded/replaced stop. The operation must revalidate its applicable tuple and tombstone **after every `await`**, immediately before every signal, and immediately before every destructive commit. A failed revalidation is a no-op/abort of that operation, never authority to act on its successor.
+
+## Process truth table
+
+`processIdentity(pid, processStartId)` is conservative. “Signal” means TERM/KILL; “reclaim” means delete a descriptor or release the session lease.
+
+| Observation | Truth | Signal | Reclaim / reuse |
+| --- | --- | --- | --- |
+| PID absent | dead | no | yes |
+| PID present and start ID matches | exact worker | yes, subject to tuple revalidation | no |
+| PID present and start ID differs | recycled PID | no | yes; it is not our process |
+| PID present but start ID unreadable | unknown/live | no | no |
+| Descriptor has no start ID | legacy identity | TERM only while directly observed current; record a fresh ID if available | no until dead is confirmed |
+
+In particular, unreadable is neither dead nor recycled. It cannot justify cleanup or a signal. A caller that needs a result reports the registration still active or cleanup pending.
+
+## Ownership, concurrent stops, retries, and reclaim
+
+`stopWorker` owns the foreground stop attempt. Every concurrent call increments the per-worker stop count for the duration of its own call; decrementation is in `finally`. The count is observability/accounting, **not** a permission to coalesce incompatible calls. Each attempt has a captured authority tuple and must fail closed if a retry/relaunch changes it.
+
+A timed-out descriptor stop schedules exactly one `stopFinalization` promise. That promise owns background escalation and cleanup; concurrent timeouts and stale-reclaim callers join it rather than sending another signal or deleting state. Finalization retries transient cleanup after the process is confirmed gone, but exits if the tuple/tombstone was rescinded. Reclaim first requires `gone` or `recycled`, then joins finalization for a bounded user-visible wait. If cleanup exceeds that wait, it returns an honest retry/pending error; it never returns the stale registration as reusable. Retries/relaunches own publication of the successor and must invalidate all previous stop authority before awaiting startup work.
+
+A foreground request has bounded waits (worker shutdown RPC and liveness deadlines). Long escalation, archival, and retry work continue in the owned finalizer without holding the user request open.
+
+## Locks and awaits
+
+The implementation uses short synchronous mutations and promise ownership, rather than a monitor held across I/O.
+
+1. Mutate one worker's descriptor/map state, stop count, child terminal state, or finalizer slot synchronously.
+2. Capture the authority tuple and release that state before any await, RPC, process probe, signal wait, catalog call, socket write, or child disposal.
+3. After every await, reacquire only the necessary state and revalidate authority before the next effect.
+
+Allowed ordering is: global supervisor admission/mutation fence -> worker registration -> worker-local snapshot/child bookkeeping. A worker-local operation must not acquire the global fence while holding worker bookkeeping. There is **no await under any of these locks/bookkeeping mutations** and no lock may be retained while calling client, catalog, process, or extension code. Promise slots (`stopFinalization`, snapshot loads, child publication) are single-flight ownership tokens, not locks; await their promise only after publishing the slot.
+
+## Idempotence, compensation, and cancellation winner
+
+Irreversible transitions are guarded by a synchronous winner:
+
+- The first child cancellation changes `queued`/`running` to `cancelled`, records its reason, rejects publication, aborts once, and emits one cancelled update. Later callers while it remains tracked return accepted without repeating abort, rejection, or terminal emission. The terminal cleanup emits at most one notice and removes tracking only after settlement.
+- A descriptor tombstone is idempotent; descriptor deletion is conditional on its captured tuple/tombstone.
+- Finalization and stale reclaim compensate interrupted foreground stops by completing the same cleanup path, not replaying a second independent stop.
+- If cancellation races normal completion, the first synchronous terminal state wins. Later completion may dispose/release resources but cannot overwrite the winner or emit a second terminal event.
+
+Registry replay has the same selector-local rule: a malformed row quarantines only its own `childId`; unrelated valid rows remain published. Only a later complete row for that exact selector recovers it.

--- a/packages/coding-agent/docs/worker-lifecycle-concurrency.md
+++ b/packages/coding-agent/docs/worker-lifecycle-concurrency.md
@@ -4,15 +4,15 @@ This document is the authoritative contract for the daemon supervisor and worker
 
 ## State and observability
 
-A worker registration is observable as `starting`, `running`, `recovering`, or a stop tombstone (`stopRequestedAt`). A stop tombstone is observable before signalling begins and remains observable until descriptor deletion. A retry/relaunch replaces the registration's process generation; it must remove a rescinded stop tombstone before publishing the successor. A child run is observable as `queued`, `running`, then exactly one terminal `done`, `error`, or `cancelled`; a cancelled run stays tracked until its detached cleanup settles, so a second cancellation is accepted rather than mistaken for a completed selector.
+A worker descriptor lifecycle is exactly `starting`, `ready`, `recovering`, `stopping`, or `failed`. Descriptor removal is represented by `removed`; session archival is represented by `archive`. A stop tombstone (`stopRequestedAt`) is published before signalling and remains until a successfully authorized removal. A retry/relaunch replaces the process generation and removes a rescinded tombstone before publishing its successor. A child run is observable as `queued`, `running`, then exactly one terminal `done`, `error`, or `cancelled`; a cancelled run stays tracked until detached cleanup settles.
 
-The immutable authority tuple for a process operation is:
+The exact authority tuple for every TERM/KILL and destructive descriptor/archive commit is:
 
 ```text
-(workerId, pid, processStartId, supervisor generation, stopRevision)
+(workerId, pid, processStartId, supervisorGeneration, stopRevision, stopRequestedAt)
 ```
 
-Capture it before an asynchronous operation. The worker ID alone is never authority to signal, delete, archive, or reclaim. `processStartId` distinguishes a reused PID, supervisor generation fences an obsolete supervisor, and `stopRevision` fences a rescinded/replaced stop. The operation must revalidate its applicable tuple and tombstone **after every `await`**, immediately before every signal, and immediately before every destructive commit. A failed revalidation is a no-op/abort of that operation, never authority to act on its successor.
+`supervisorGeneration` is the immutable `this.generation`, and its durable ownership record must match through `await this.assertCurrentOwnership()`. The worker ID alone is never authority to signal, delete, archive, or reclaim. `processStartId` distinguishes a reused PID and `stopRevision`/`stopRequestedAt` fence a rescinded or replaced stop. Immediately before each TERM/KILL and destructive descriptor, artifact, or archive commit, the implementation awaits ownership assertion, then makes the complete tuple assertion and fresh process-identity check with **no await in between**. A failed, unreadable, or lost ownership check fails closed: no signal/delete/archive is performed, and the tombstone/retry record remains for recovery by a new owner.
 
 ## Process truth table
 
@@ -32,7 +32,7 @@ In particular, unreadable is neither dead nor recycled. It cannot justify cleanu
 
 `stopWorker` owns the foreground stop attempt. Every concurrent call increments the per-worker stop count for the duration of its own call; decrementation is in `finally`. The count is observability/accounting, **not** a permission to coalesce incompatible calls. Each attempt has a captured authority tuple and must fail closed if a retry/relaunch changes it.
 
-A timed-out descriptor stop schedules exactly one `stopFinalization` promise. That promise owns background escalation and cleanup; concurrent timeouts and stale-reclaim callers join it rather than sending another signal or deleting state. Finalization retries transient cleanup after the process is confirmed gone, but exits if the tuple/tombstone was rescinded. Reclaim first requires `gone` or `recycled`, then joins finalization for a bounded user-visible wait. If cleanup exceeds that wait, it returns an honest retry/pending error; it never returns the stale registration as reusable. Retries/relaunches own publication of the successor and must invalidate all previous stop authority before awaiting startup work.
+A timed-out descriptor stop schedules exactly one `stopFinalization` promise. That promise owns background escalation and cleanup; concurrent timeouts and stale-reclaim callers join it rather than sending another signal or deleting state. Finalization retries transient cleanup after the process is confirmed gone, but exits if the tuple/tombstone was rescinded **or ownership is lost**. Reclaim first requires `gone` or `recycled`, then joins finalization for a bounded user-visible wait. If ownership is unreadable or lost, it retains the tombstone/retry record for the successor; it never returns the stale registration as reusable. Adoption/recovery asserts ownership only at an actual adjacent commit/signal boundary, while finalizer and foreground stop paths reassert after every wait. Retries/relaunches own publication of the successor and must invalidate all previous stop authority before awaiting startup work.
 
 A foreground request has bounded waits (worker shutdown RPC and liveness deadlines). Long escalation, archival, and retry work continue in the owned finalizer without holding the user request open.
 
@@ -42,7 +42,7 @@ The implementation uses short synchronous mutations and promise ownership, rathe
 
 1. Mutate one worker's descriptor/map state, stop count, child terminal state, or finalizer slot synchronously.
 2. Capture the authority tuple and release that state before any await, RPC, process probe, signal wait, catalog call, socket write, or child disposal.
-3. After every await, reacquire only the necessary state and revalidate authority before the next effect.
+3. After every await, reacquire only the necessary state and revalidate authority before the next effect. For TERM/KILL or a destructive descriptor/archive commit, `await this.assertCurrentOwnership()` is the final await; the full tuple assertion and fresh process identity follow synchronously and immediately before the effect.
 
 Allowed ordering is: global supervisor admission/mutation fence -> worker registration -> worker-local snapshot/child bookkeeping. A worker-local operation must not acquire the global fence while holding worker bookkeeping. There is **no await under any of these locks/bookkeeping mutations** and no lock may be retained while calling client, catalog, process, or extension code. Promise slots (`stopFinalization`, snapshot loads, child publication) are single-flight ownership tokens, not locks; await their promise only after publishing the slot.
 

--- a/packages/coding-agent/src/cli/owned-session-worker.ts
+++ b/packages/coding-agent/src/cli/owned-session-worker.ts
@@ -296,14 +296,22 @@ export async function runOwnedSessionWorkerFrontend(
 				// The worker process group may already be fully reaped.
 			}
 		}
+		let retainOrphanJournal = false;
 		for (const orphan of readActiveOrphanProcesses(orphanProcessJournalPath, workerPid)) {
 			if (!isOrphanProcessIdentityCurrent(orphan)) {
+				retainOrphanJournal = true;
 				continue;
 			}
 			const { pid } = orphan;
 			try {
 				process.kill(process.platform === "win32" ? pid : -pid, "SIGKILL");
 			} catch {
+				// A failed group signal does not bind a later pid signal. Re-observe
+				// the exact orphan immediately before the positive-pid fallback.
+				if (!isOrphanProcessIdentityCurrent(orphan)) {
+					retainOrphanJournal = true;
+					continue;
+				}
 				try {
 					process.kill(pid, "SIGKILL");
 				} catch {
@@ -311,7 +319,9 @@ export async function runOwnedSessionWorkerFrontend(
 				}
 			}
 		}
-		clearOrphanProcessJournal(orphanProcessJournalPath);
+		if (!retainOrphanJournal) {
+			clearOrphanProcessJournal(orphanProcessJournalPath);
+		}
 	};
 
 	if (profile === "rpc") {

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -300,6 +300,9 @@ function sameAgentFamilyParent(
 }
 
 function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentFamilyCatalogEntry): boolean {
+	// A matching persisted parent identifier is necessary but not sufficient: a
+	// malformed depth must not turn a descendant into a directly reachable child.
+	if (child.depth !== parent.depth + 1) return false;
 	return (
 		(child.parentSessionPath !== undefined && child.parentSessionPath === parent.sessionPath) ||
 		(child.parentSessionId !== undefined && child.parentSessionId === parent.id)

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -265,47 +265,38 @@ function sameAgentFamilyParent(
 	right: AgentSessionNameScope,
 	catalog: readonly AgentFamilyCatalogEntry[],
 ): boolean {
-	if (left.parentSessionPath !== undefined && left.parentSessionPath === right.parentSessionPath) {
-		return true;
-	}
-	if (left.parentSessionId !== undefined && left.parentSessionId === right.parentSessionId) {
-		return true;
-	}
-	const hasCatalogParentPair = (parentSessionId: string | undefined, parentSessionPath: string | undefined) =>
-		parentSessionId !== undefined &&
-		parentSessionPath !== undefined &&
-		catalog.some(
-			(entry) =>
-				(entry.id === parentSessionId && entry.sessionPath === parentSessionPath) ||
-				(entry.parentSessionId === parentSessionId && entry.parentSessionPath === parentSessionPath),
+	if (left.depth === 0 && right.depth === 0) {
+		return (
+			left.parentSessionId === undefined &&
+			left.parentSessionPath === undefined &&
+			right.parentSessionId === undefined &&
+			right.parentSessionPath === undefined
 		);
-	if (
-		hasCatalogParentPair(left.parentSessionId, right.parentSessionPath) ||
-		hasCatalogParentPair(right.parentSessionId, left.parentSessionPath)
-	) {
-		return true;
 	}
-	if (
-		left.depth === 0 &&
-		right.depth === 0 &&
-		left.parentSessionPath === undefined &&
-		right.parentSessionPath === undefined &&
-		left.parentSessionId === undefined &&
-		right.parentSessionId === undefined
-	) {
-		return true;
-	}
-	// Unresolved mixed identifiers stay unrelated to avoid false name conflicts across families.
-	return false;
+	if (left.depth !== right.depth || left.depth === 0) return false;
+	const parentFor = (child: AgentSessionNameScope) => {
+		const parents = catalog.filter((entry) => isAgentFamilyParent(entry, child));
+		return parents.length === 1 ? parents[0] : undefined;
+	};
+	const leftParent = parentFor(left);
+	const rightParent = parentFor(right);
+	return leftParent !== undefined && leftParent.id === rightParent?.id;
 }
 
-function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentFamilyCatalogEntry): boolean {
-	// A matching persisted parent identifier is necessary but not sufficient: a
-	// malformed depth must not turn a descendant into a directly reachable child.
-	if (child.depth !== parent.depth + 1) return false;
+/**
+ * Validates one persisted parent edge. A child may supply either durable
+ * identifier, but when it supplies both they must identify this same direct
+ * parent. This keeps contradictory records from becoming relatives through
+ * whichever identifier happens to match.
+ */
+function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentSessionNameScope): boolean {
+	if (child.depth <= 0 || parent.depth !== child.depth - 1) return false;
+	const claimsId = child.parentSessionId !== undefined;
+	const claimsPath = child.parentSessionPath !== undefined;
 	return (
-		(child.parentSessionPath !== undefined && child.parentSessionPath === parent.sessionPath) ||
-		(child.parentSessionId !== undefined && child.parentSessionId === parent.id)
+		(claimsId || claimsPath) &&
+		(!claimsId || child.parentSessionId === parent.id) &&
+		(!claimsPath || child.parentSessionPath === parent.sessionPath)
 	);
 }
 
@@ -313,19 +304,21 @@ function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentFamily
 export function agentFamilyRelationship(
 	current: AgentFamilyCatalogEntry,
 	target: AgentFamilyCatalogEntry,
+	catalog: readonly AgentFamilyCatalogEntry[] = [current, target],
 ): AgentFamilyRelationship | undefined {
 	if (current.id === target.id) return undefined;
 	if (isAgentFamilyParent(target, current)) return "parent";
 	if (isAgentFamilyParent(current, target)) return "child";
-	if (current.depth === target.depth && sameAgentFamilyParent(current, target, [current, target])) return "sibling";
+	if (sameAgentFamilyParent(current, target, catalog)) return "sibling";
 	return undefined;
 }
 
 export function assertAgentFamilyReach(
 	current: AgentFamilyCatalogEntry,
 	target: AgentFamilyCatalogEntry,
+	catalog?: readonly AgentFamilyCatalogEntry[],
 ): AgentFamilyRelationship {
-	const relationship = agentFamilyRelationship(current, target);
+	const relationship = agentFamilyRelationship(current, target, catalog);
 	if (!relationship) throw new Error(AGENT_FAMILY_REACH_ERROR);
 	return relationship;
 }

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -223,7 +223,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		});
 		await flushAgentTraceUpload(this.session.sessionManager).catch(() => undefined);
 		this.beforeSessionInvalidate?.();
-		// Await the kernel's final snapshot flush before invalidating the session.
+		// AgentSession first revokes and awaits kernel host-request handlers before
+		// this replacement can invalidate the old session's authority.
 		await this.session.disposeAsync();
 		await this.disposeHostedSubagentRuntimes();
 	}
@@ -724,7 +725,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			disposeError ??= error;
 		}
 		try {
-			// Await the kernel's final snapshot flush before tearing the session down.
+			// AgentSession revokes and awaits kernel host-request handlers before
+			// runtime disposal can release this session's resources.
 			await this.session.disposeAsync();
 		} catch (error) {
 			disposeError ??= error;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3778,6 +3778,11 @@ export class AgentSession {
 			return this._disposeAsyncPromise;
 		}
 		this._disposeAsyncPromise = (async () => {
+			// Revoke kernel-originated host requests before awaiting unrelated
+			// refinement work. The provisioner forwards this to KernelManager, which
+			// aborts each request and awaits its handler before its connection closes.
+			// This prevents an old session's host handler from surviving replacement.
+			await this._ipythonKernelProvisioner?.dispose();
 			// Drain before marking _disposing so a refine triggered at the final
 			// agent_end completes instead of being aborted by dispose().
 			await this._drainPendingRefinementForDisposal();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9041,6 +9041,12 @@ export class AgentSession {
 	}
 
 	private _cancelRlmChildRun(run: RlmChildRun, reason: string): boolean {
+		// Cancellation is an idempotent terminal transition while the detached
+		// run remains tracked. Concurrent callers must not mistake a previously
+		// accepted cancellation for a completed child and start conflicting cleanup.
+		if (run.status === "cancelled") {
+			return true;
+		}
 		if (run.status !== "running" && run.status !== "queued") {
 			return false;
 		}

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -77,6 +77,13 @@ export {
 	type TurnStartEvent,
 	type WorkingIndicatorOptions,
 } from "./extensions/index.js";
+export {
+	createMcpProjectTrustAuthority,
+	type McpProjectTrustAuthority,
+	type McpProjectTrustAuthorityInput,
+	type McpProjectTrustAuthorization,
+	type McpProjectTrustBinding,
+} from "./mcp/project-trust-authority.js";
 export type { RefinementResult } from "./refinement/index.js";
 export type { CreateRlmSubagentRuntimeOptions, RlmSubagentRuntime, SubagentRuntimeHost } from "./rlm-runtime.js";
 export { SessionImportFileNotFoundError } from "./session-import-errors.js";

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -83,6 +83,7 @@ export {
 	type McpProjectTrustAuthorityInput,
 	type McpProjectTrustAuthorization,
 	type McpProjectTrustBinding,
+	type McpProjectTrustBindingValidation,
 } from "./mcp/project-trust-authority.js";
 export type { RefinementResult } from "./refinement/index.js";
 export type { CreateRlmSubagentRuntimeOptions, RlmSubagentRuntime, SubagentRuntimeHost } from "./rlm-runtime.js";

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -29,7 +29,6 @@ const READY_TIMEOUT_MS = 5000;
 // Loopback PUB/SUB subscription propagation is usually sub-ms, but keep a small guard before first execute.
 const IOPUB_SUBSCRIBE_DELAY_MS = 50;
 const DEFAULT_MAX_OUTPUT_CHARS = 65536;
-const HOST_REQUEST_DISPOSE_TIMEOUT_MS = 5000;
 const DEFAULT_SNAPSHOT_DEBOUNCE_MS = 1500;
 // How often to poll a forked kernel's pid for unexpected death.
 const FORKED_LIVENESS_POLL_MS = 1000;
@@ -56,10 +55,26 @@ export class KernelBusyAfterInterruptError extends Error {
 export const HOST_COMM_TARGET = "host.request";
 
 /**
- * Handles one typed request from Python code running in the kernel.
- * The returned record is sent back verbatim as the comm reply payload.
+ * Per-call authority supplied only by the kernel host-request dispatcher.
+ * `requestId` is an opaque host-minted correlation token, never accepted from
+ * the kernel payload. `isCurrent()` fences completions after a comm disconnect,
+ * kernel replacement, or disposal.
  */
-export type HostRequestHandler = (payload: Record<string, unknown>) => Promise<Record<string, unknown>>;
+export interface HostRequestContext {
+	readonly requestId: string;
+	readonly generation: number;
+	readonly signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+/**
+ * Handles one authenticated typed request from Python code running in the
+ * kernel. The returned record is sent back verbatim as the comm reply payload.
+ */
+export type HostRequestHandler = (
+	payload: Record<string, unknown>,
+	context: HostRequestContext,
+) => Promise<Record<string, unknown>>;
 
 /** Host request handlers keyed by request type (e.g. "rlm.run", "goal.complete"). */
 export type HostRequestHandlers = Record<string, HostRequestHandler>;
@@ -328,12 +343,59 @@ interface Deferred<T> {
 	reject: (error: Error) => void;
 }
 
+interface ActiveHostRequest {
+	requestId: string;
+	commId: string;
+	generation: number;
+	controller: AbortController;
+	callerSignal?: AbortSignal;
+	onCallerAbort?: () => void;
+	settled: boolean;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+const MAX_HOST_REQUEST_PAYLOAD_BYTES = 64 * 1024;
+const MAX_HOST_REQUEST_PAYLOAD_DEPTH = 8;
+const MAX_HOST_REQUEST_PAYLOAD_NODES = 1024;
+const MAX_HOST_REQUEST_PAYLOAD_KEYS = 128;
+
+/** Reject pathological comm data before a typed handler can observe it. */
+function assertBoundedHostRequestPayload(value: unknown): void {
+	let estimatedBytes = 0;
+	let nodes = 0;
+	const visit = (item: unknown, depth: number): void => {
+		if (depth > MAX_HOST_REQUEST_PAYLOAD_DEPTH) throw new Error("host request payload is too deeply nested");
+		nodes += 1;
+		if (nodes > MAX_HOST_REQUEST_PAYLOAD_NODES) throw new Error("host request payload has too many values");
+		if (typeof item === "string") {
+			estimatedBytes += Buffer.byteLength(item);
+		} else if (typeof item === "number") {
+			if (!Number.isFinite(item)) throw new Error("host request payload numbers must be finite");
+			estimatedBytes += 16;
+		} else if (typeof item === "boolean" || item === null) {
+			estimatedBytes += 8;
+		} else if (Array.isArray(item)) {
+			for (const entry of item) visit(entry, depth + 1);
+		} else if (isRecord(item)) {
+			const entries = Object.entries(item);
+			if (entries.length > MAX_HOST_REQUEST_PAYLOAD_KEYS) throw new Error("host request payload has too many object keys");
+			for (const [key, entry] of entries) {
+				estimatedBytes += Buffer.byteLength(key);
+				visit(entry, depth + 1);
+			}
+		} else {
+			throw new Error("host request payload must contain JSON-compatible values");
+		}
+		if (estimatedBytes > MAX_HOST_REQUEST_PAYLOAD_BYTES) throw new Error("host request payload is too large");
+	};
+	visit(value, 0);
 }
 
 function createDeferred<T>(): Deferred<T> {
@@ -517,6 +579,10 @@ export class KernelManager {
 	private readonly session = uuid();
 	private readonly commTargets = new Map<string, string>();
 	private readonly handledHostRequestCommIds = new Set<string>();
+	/** Monotonically revokes all host-request authority across kernel lifecycles. */
+	private hostRequestGeneration = 0;
+	private readonly activeHostRequests = new Map<string, ActiveHostRequest>();
+	private readonly hostRequestIdsByComm = new Map<string, string>();
 	private kernel?: ChildProcess;
 	// Set instead of `kernel` when the kernel was forked from the forkserver: it is
 	// not a direct child, so it has no ChildProcess handle and is killed by pid.
@@ -1197,6 +1263,7 @@ export class KernelManager {
 		if (msgType === "comm_close") {
 			this.commTargets.delete(commId);
 			this.handledHostRequestCommIds.delete(commId);
+			this.revokeHostRequestForComm(commId);
 			return;
 		}
 
@@ -1224,34 +1291,93 @@ export class KernelManager {
 		}
 		this.handledHostRequestCommIds.add(commId);
 
+		const callerSignal = this.activeExecution?.opts.signal;
+		const request: ActiveHostRequest = {
+			requestId: uuid(),
+			commId,
+			generation: this.hostRequestGeneration,
+			controller: new AbortController(),
+			callerSignal,
+			settled: false,
+		};
+		request.onCallerAbort = () => request.controller.abort();
+		callerSignal?.addEventListener("abort", request.onCallerAbort, { once: true });
+		if (callerSignal?.aborted) request.controller.abort();
+		this.activeHostRequests.set(request.requestId, request);
+		this.hostRequestIdsByComm.set(commId, request.requestId);
+
 		const task = (async () => {
 			try {
-				const result = await this.handleHostRequest(data);
-				try {
-					await this.sendCommMessage(commId, { status: "ok", ...result });
-				} catch (replyError) {
-					this.appendKernelDiagnostic(
-						`failed to send host request ok reply for comm ${commId}: ${errorMessage(replyError)}`,
-					);
-				}
+				const result = await this.handleHostRequest(data, this.hostRequestContext(request));
+				await this.replyToHostRequest(request, { status: "ok", ...result });
 			} catch (error) {
-				this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
-				try {
-					await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) });
-				} catch (replyError) {
-					this.appendKernelDiagnostic(
-						`failed to send host request error reply for comm ${commId}: ${errorMessage(replyError)}`,
-					);
+				if (this.isHostRequestCurrent(request)) {
+					this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
 				}
+				await this.replyToHostRequest(request, { status: "error", error: errorMessage(error) });
 			}
 		})();
 		this.inFlightHostRequests.add(task);
 		void task.finally(() => {
 			this.inFlightHostRequests.delete(task);
+			request.callerSignal?.removeEventListener("abort", request.onCallerAbort!);
+			this.activeHostRequests.delete(request.requestId);
+			if (this.hostRequestIdsByComm.get(commId) === request.requestId) {
+				this.hostRequestIdsByComm.delete(commId);
+			}
 		});
 	}
 
-	private async handleHostRequest(data: unknown): Promise<Record<string, unknown>> {
+	private hostRequestContext(request: ActiveHostRequest): HostRequestContext {
+		return {
+			requestId: request.requestId,
+			generation: request.generation,
+			signal: request.controller.signal,
+			isCurrent: () => this.isHostRequestCurrent(request),
+		};
+	}
+
+	private isHostRequestCurrent(request: ActiveHostRequest): boolean {
+		return (
+			this.state !== "shutdown" &&
+			this.hostRequestGeneration === request.generation &&
+			this.commTargets.get(request.commId) === HOST_COMM_TARGET &&
+			this.hostRequestIdsByComm.get(request.commId) === request.requestId &&
+			!request.controller.signal.aborted
+		);
+	}
+
+	private revokeHostRequestForComm(commId: string): void {
+		const requestId = this.hostRequestIdsByComm.get(commId);
+		if (!requestId) return;
+		this.hostRequestIdsByComm.delete(commId);
+		this.activeHostRequests.get(requestId)?.controller.abort();
+	}
+
+	/** Abort every active request before a kernel connection is replaced or closed. */
+	private revokeHostRequests(): void {
+		this.hostRequestGeneration += 1;
+		for (const request of this.activeHostRequests.values()) {
+			request.controller.abort();
+		}
+		this.hostRequestIdsByComm.clear();
+	}
+
+	private async replyToHostRequest(request: ActiveHostRequest, data: Record<string, unknown>): Promise<void> {
+		// Claim the one reply before awaiting I/O so a late handler cannot double-send.
+		if (request.settled || !this.isHostRequestCurrent(request)) return;
+		request.settled = true;
+		try {
+			await this.sendCommMessage(request.commId, data);
+		} catch (replyError) {
+			this.appendKernelDiagnostic(
+				`failed to send host request reply for comm ${request.commId}: ${errorMessage(replyError)}`,
+			);
+		}
+	}
+
+	private async handleHostRequest(data: unknown, context: HostRequestContext): Promise<Record<string, unknown>> {
+		assertBoundedHostRequestPayload(data);
 		if (!isRecord(data)) {
 			throw new Error("host request payload must be an object");
 		}
@@ -1267,7 +1393,7 @@ export class KernelManager {
 		// the in-flight execution; detached spawns (asyncio.create_task) fire after
 		// the scheduling cell goes idle, so fall back to that last cell's source.
 		const cellSourceCode = this.activeExecution?.code ?? this.lastCellCode;
-		return handler({ ...data, cellSourceCode });
+		return handler({ ...data, cellSourceCode }, context);
 	}
 
 	private async sendCommMessage(commId: string, data: Record<string, unknown>): Promise<void> {
@@ -1286,6 +1412,9 @@ export class KernelManager {
 	}
 
 	private cleanupResources(killSignal: NodeJS.Signals = "SIGTERM"): void {
+		this.revokeHostRequests();
+		this.commTargets.clear();
+		this.handledHostRequestCommIds.clear();
 		this.clearSnapshotTimer();
 		this.lateSentAgentMessageHandlers.clear();
 		if (this.forkedLivenessTimer) {
@@ -1325,29 +1454,17 @@ export class KernelManager {
 		this.startPromise = undefined;
 	}
 
-	private async waitForHostRequestsToSettle(tasks: Promise<void>[], timeoutMs: number): Promise<void> {
-		let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
-		const timeoutPromise = new Promise<"timeout">((resolve) => {
-			timeout = globalThis.setTimeout(() => resolve("timeout"), timeoutMs);
-			if (timeout && typeof timeout === "object" && "unref" in timeout) {
-				timeout.unref();
-			}
-		});
-
-		const result = await Promise.race([Promise.allSettled(tasks).then(() => "settled" as const), timeoutPromise]);
-		if (timeout) {
-			globalThis.clearTimeout(timeout);
-		}
-		if (result === "timeout") {
-			this.appendKernelDiagnostic(
-				`timed out waiting ${timeoutMs}ms for ${tasks.length} host request task(s) during dispose`,
-			);
-		}
+	/** All active typed handlers must observe revocation and settle before teardown continues. */
+	private async waitForHostRequestsToSettle(tasks: Promise<void>[]): Promise<void> {
+		await Promise.allSettled(tasks);
 	}
 
 	async shutdown(opts: { snapshot?: boolean } = {}): Promise<void> {
+		this.revokeHostRequests();
+		const inFlightHostRequests = [...this.inFlightHostRequests];
 		if (this.state === "shutdown") {
 			liveKernels.delete(this);
+			await this.waitForHostRequestsToSettle(inFlightHostRequests);
 			this.cleanupResources();
 			return;
 		}
@@ -1371,6 +1488,7 @@ export class KernelManager {
 			);
 		}
 
+		await this.waitForHostRequestsToSettle(inFlightHostRequests);
 		this.cleanupResources();
 	}
 
@@ -1393,8 +1511,11 @@ export class KernelManager {
 	}
 
 	async kill(): Promise<void> {
+		this.revokeHostRequests();
+		const inFlightHostRequests = [...this.inFlightHostRequests];
 		this.state = "shutdown";
 		liveKernels.delete(this);
+		await this.waitForHostRequestsToSettle(inFlightHostRequests);
 		this.cleanupResources("SIGKILL");
 	}
 
@@ -1496,19 +1617,17 @@ export class KernelManager {
 		}
 	}
 
-	/** Graceful cleanup. Waits briefly for in-flight host request handlers before closing sockets. */
+	/** Graceful cleanup. Revokes and awaits every in-flight typed host handler before closing sockets. */
 	dispose(): Promise<void> {
 		return (async () => {
+			this.revokeHostRequests();
+			const inFlightHostRequests = [...this.inFlightHostRequests];
 			// Final namespace flush while the kernel is still live (session end / reload).
 			await this.flushSnapshotForDispose();
 			this.state = "shutdown";
 			liveKernels.delete(this);
-			const inFlightHostRequests = [...this.inFlightHostRequests];
-			// TODO: plumb AbortSignal through AgentSession.prompt so disposal can cancel long-running child loops.
 			try {
-				if (inFlightHostRequests.length > 0) {
-					await this.waitForHostRequestsToSettle(inFlightHostRequests, HOST_REQUEST_DISPOSE_TIMEOUT_MS);
-				}
+				await this.waitForHostRequestsToSettle(inFlightHostRequests);
 			} finally {
 				this.cleanupResources();
 			}
@@ -1517,6 +1636,7 @@ export class KernelManager {
 
 	/** Synchronous best-effort cleanup. Safe to call from `process.on('exit')`. */
 	disposeSync(): void {
+		this.revokeHostRequests();
 		this.state = "shutdown";
 		liveKernels.delete(this);
 		// TODO: replace this best-effort hard-exit path if Node exposes an awaitable process-exit cleanup hook.

--- a/packages/coding-agent/src/core/mcp/project-trust-authority.ts
+++ b/packages/coding-agent/src/core/mcp/project-trust-authority.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import { accessSync, constants, lstatSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+/**
+ * Explicit policy input from a global, user-owned authority. Project settings
+ * are deliberately not an input to this factory or to the returned authority.
+ */
+export interface McpProjectTrustAuthorityInput {
+	/** Caller-owned policy revision, captured with the allowlist before use. */
+	readonly revision: string;
+	/** User-approved project directories. They must be exact canonical directories. */
+	readonly allowedProjectDirectories: readonly string[];
+}
+
+/** An opaque, one-shot grant for a single project authority snapshot. */
+declare const mcpProjectTrustBindingBrand: unique symbol;
+export interface McpProjectTrustBinding {
+	readonly [mcpProjectTrustBindingBrand]: never;
+}
+
+export type McpProjectTrustAuthorization =
+	| { readonly kind: "denied" }
+	| { readonly kind: "granted"; readonly binding: McpProjectTrustBinding };
+
+/**
+ * A project trust authority exposes no policy, path, digest, or boolean
+ * authorization surface. Consumers retain a grant and may only validate it.
+ */
+export interface McpProjectTrustAuthority {
+	authorizeProjectDirectory(projectDirectory: string): McpProjectTrustAuthorization;
+}
+
+interface DirectoryIdentity {
+	readonly canonicalPath: string;
+	readonly device: string;
+	readonly inode: string;
+}
+
+interface BindingRecord {
+	readonly revision: string;
+	readonly digest: string;
+	readonly identity: DirectoryIdentity;
+}
+
+const DENIED: McpProjectTrustAuthorization = Object.freeze({ kind: "denied" });
+
+/**
+ * Reads a directory only when the supplied spelling is already its exact
+ * physical spelling. Relative paths, lexical aliases, symlinks (including
+ * ancestor symlinks), unreadable paths, and non-directories all fail closed.
+ */
+function exactDirectoryIdentity(path: string): DirectoryIdentity | undefined {
+	if (!isAbsolute(path) || resolve(path) !== path) {
+		return undefined;
+	}
+
+	try {
+		const initial = lstatSync(path);
+		if (initial.isSymbolicLink() || !initial.isDirectory()) {
+			return undefined;
+		}
+		accessSync(path, constants.R_OK | constants.X_OK);
+		const canonicalPath = realpathSync.native(path);
+		if (canonicalPath !== path) {
+			return undefined;
+		}
+		const canonical = statSync(canonicalPath, { bigint: true });
+		if (!canonical.isDirectory()) {
+			return undefined;
+		}
+		accessSync(canonicalPath, constants.R_OK | constants.X_OK);
+		return {
+			canonicalPath,
+			device: canonical.dev.toString(),
+			inode: canonical.ino.toString(),
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+function digestSnapshot(revision: string, directories: readonly DirectoryIdentity[]): string {
+	return createHash("sha256")
+		.update(revision)
+		.update("\0")
+		.update(directories.map(({ canonicalPath, device, inode }) => `${canonicalPath}\0${device}\0${inode}`).join("\0"))
+		.digest("hex");
+}
+
+function sameIdentity(left: DirectoryIdentity, right: DirectoryIdentity): boolean {
+	return left.canonicalPath === right.canonicalPath && left.device === right.device && left.inode === right.inode;
+}
+
+/**
+ * Snapshots a global/user-owned allowlist before an MCP use. Construction is
+ * read-only and invalidates the complete policy on malformed, missing,
+ * unreadable, symlinked, or canonical-alias entries. No runtime settings,
+ * secrets, network, startup state, or ambient trust are consulted.
+ */
+export function createMcpProjectTrustAuthority(input: McpProjectTrustAuthorityInput): McpProjectTrustAuthority {
+	const revision = typeof input.revision === "string" ? input.revision : "";
+	const requestedDirectories = Array.isArray(input.allowedProjectDirectories)
+		? [...input.allowedProjectDirectories]
+		: [];
+	const identities = requestedDirectories.map((directory) =>
+		typeof directory === "string" ? exactDirectoryIdentity(directory) : undefined,
+	);
+	const valid =
+		revision.length > 0 &&
+		identities.every((identity): identity is DirectoryIdentity => identity !== undefined) &&
+		new Set(identities.map((identity) => identity.canonicalPath)).size === identities.length;
+	const snapshot = valid ? Object.freeze([...identities]) : Object.freeze([] as DirectoryIdentity[]);
+	const snapshotDigest = digestSnapshot(revision, snapshot);
+	const bindings = new WeakSet<object>();
+	const records = new WeakMap<object, BindingRecord>();
+	return Object.freeze({
+		authorizeProjectDirectory(projectDirectory: string): McpProjectTrustAuthorization {
+			const requested = typeof projectDirectory === "string" ? exactDirectoryIdentity(projectDirectory) : undefined;
+			if (!requested || !snapshot.some((approved) => sameIdentity(approved, requested))) {
+				return DENIED;
+			}
+
+			// Module-private brands and records make this opaque grant runtime-unforgeable.
+			const binding = Object.freeze(Object.create(null)) as McpProjectTrustBinding;
+			bindings.add(binding);
+			records.set(binding, Object.freeze({ revision, digest: snapshotDigest, identity: requested }));
+			return Object.freeze({ kind: "granted", binding });
+		},
+	});
+}

--- a/packages/coding-agent/src/core/mcp/project-trust-authority.ts
+++ b/packages/coding-agent/src/core/mcp/project-trust-authority.ts
@@ -13,7 +13,7 @@ export interface McpProjectTrustAuthorityInput {
 	readonly allowedProjectDirectories: readonly string[];
 }
 
-/** An opaque, one-shot grant for a single project authority snapshot. */
+/** An opaque grant bound to a single project authority snapshot. */
 declare const mcpProjectTrustBindingBrand: unique symbol;
 export interface McpProjectTrustBinding {
 	readonly [mcpProjectTrustBindingBrand]: never;
@@ -23,12 +23,17 @@ export type McpProjectTrustAuthorization =
 	| { readonly kind: "denied" }
 	| { readonly kind: "granted"; readonly binding: McpProjectTrustBinding };
 
+/** Safe, opaque verification result for a privileged boundary. */
+export type McpProjectTrustBindingValidation = { readonly kind: "denied" } | { readonly kind: "granted" };
+
 /**
- * A project trust authority exposes no policy, path, digest, or boolean
- * authorization surface. Consumers retain a grant and may only validate it.
+ * A project trust authority exposes no policy, path, digest, revision, or
+ * boolean authorization surface. A revision is factory input only; consumers
+ * retain a grant and may only ask whether it is still valid.
  */
 export interface McpProjectTrustAuthority {
 	authorizeProjectDirectory(projectDirectory: string): McpProjectTrustAuthorization;
+	validateBinding(binding: unknown): McpProjectTrustBindingValidation;
 }
 
 interface DirectoryIdentity {
@@ -44,6 +49,8 @@ interface BindingRecord {
 }
 
 const DENIED: McpProjectTrustAuthorization = Object.freeze({ kind: "denied" });
+const BINDING_DENIED: McpProjectTrustBindingValidation = Object.freeze({ kind: "denied" });
+const BINDING_GRANTED: McpProjectTrustBindingValidation = Object.freeze({ kind: "granted" });
 
 /**
  * Reads a directory only when the supplied spelling is already its exact
@@ -126,6 +133,29 @@ export function createMcpProjectTrustAuthority(input: McpProjectTrustAuthorityIn
 			bindings.add(binding);
 			records.set(binding, Object.freeze({ revision, digest: snapshotDigest, identity: requested }));
 			return Object.freeze({ kind: "granted", binding });
+		},
+		validateBinding(binding: unknown): McpProjectTrustBindingValidation {
+			if (typeof binding !== "object" || binding === null || !bindings.has(binding)) {
+				return BINDING_DENIED;
+			}
+			const record = records.get(binding);
+			const currentSnapshot = snapshot.map(({ canonicalPath }) => exactDirectoryIdentity(canonicalPath));
+			if (currentSnapshot.some((identity) => identity === undefined)) {
+				return BINDING_DENIED;
+			}
+			const currentIdentities = currentSnapshot as DirectoryIdentity[];
+			if (
+				!record ||
+				record.revision !== revision ||
+				record.digest !== snapshotDigest ||
+				!currentIdentities.every((identity, index) => sameIdentity(snapshot[index], identity)) ||
+				digestSnapshot(revision, currentIdentities) !== snapshotDigest ||
+				!snapshot.some((approved) => sameIdentity(approved, record.identity))
+			) {
+				return BINDING_DENIED;
+			}
+
+			return BINDING_GRANTED;
 		},
 	});
 }

--- a/packages/coding-agent/src/core/session-action-store.ts
+++ b/packages/coding-agent/src/core/session-action-store.ts
@@ -326,7 +326,7 @@ export interface SessionPassivationSnapshot extends SessionEvictionSnapshot {
 }
 
 export interface WorkerEvictionSnapshot {
-	lifecycle: "starting" | "ready" | "recovering" | "failed";
+	lifecycle: "starting" | "ready" | "recovering" | "stopping" | "failed";
 	isConnected: boolean;
 	isStopping: boolean;
 	hasOwnerClient: boolean;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -137,6 +137,13 @@ export {
 } from "./core/extensions/index.js";
 // Footer data provider (git branch + extension statuses - data not otherwise available to extensions)
 export type { ReadonlyFooterDataProvider } from "./core/footer-data-provider.js";
+export {
+	createMcpProjectTrustAuthority,
+	type McpProjectTrustAuthority,
+	type McpProjectTrustAuthorityInput,
+	type McpProjectTrustAuthorization,
+	type McpProjectTrustBinding,
+} from "./core/mcp/project-trust-authority.js";
 export { convertToLlm } from "./core/messages.js";
 export { ModelRegistry } from "./core/model-registry.js";
 export type {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -143,6 +143,7 @@ export {
 	type McpProjectTrustAuthorityInput,
 	type McpProjectTrustAuthorization,
 	type McpProjectTrustBinding,
+	type McpProjectTrustBindingValidation,
 } from "./core/mcp/project-trust-authority.js";
 export { convertToLlm } from "./core/messages.js";
 export { ModelRegistry } from "./core/model-registry.js";

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -988,7 +988,10 @@ async function createDaemonClientConnection(options: {
 				await listActiveDaemonSessionSummaries(client),
 				options.sessionPath,
 			);
-			if (activeSummary) {
+			// A failed resident has no credential-bearing worker to attach to. Fall
+			// through to create so the resuming ACP client can offer a fresh,
+			// transient launch environment to its supervised recovery path.
+			if (activeSummary && activeSummary.workerState !== "failed") {
 				return await attach(activeSummary);
 			}
 		}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -193,6 +193,15 @@ function toPrintOutputMode(appMode: AppMode): Exclude<Mode, "rpc" | "acp" | "dae
 	return appMode === "json" ? "json" : "text";
 }
 
+/**
+ * ACP sessions with a session file are resident so a subsequent --continue
+ * can reattach. Every other mode, and ACP --no-session, remains owned by the
+ * client that created it.
+ */
+export function isClientOwnedDaemonSession(appMode: AppMode, noSession?: boolean): boolean {
+	return appMode !== "acp" || noSession === true;
+}
+
 // `prime-agent agents` opens the agents view directly.
 export function parseAgentsViewCommand(args: string[]): { explicitAgentsView: boolean; args: string[] } {
 	if (args[0] === "agents") {
@@ -955,11 +964,13 @@ async function createDaemonClientConnection(options: {
 	await client.connect();
 
 	try {
+		await client.waitForHello();
+		const clientOwned = options.clientOwned ?? false;
 		const attach = async (summary: SessionSummary) => {
 			const connection = await DaemonAgentConnection.attach(client, getDaemonSummaryActiveSessionId(summary), {
 				closeClientOnDispose: true,
 				sendClientEnv: true,
-				ownedSession: options.clientOwned,
+				ownedSession: clientOwned,
 				supportsExtensionUi: options.supportsExtensionUi,
 				recoverDaemon: () => ensureInteractiveDaemonRunning(options.socketPath),
 				telemetryDisabled: options.config.telemetryDisabled,
@@ -972,7 +983,7 @@ async function createDaemonClientConnection(options: {
 			return await attach(summary);
 		}
 
-		if (options.sessionPath && !options.clientOwned) {
+		if (options.sessionPath && !clientOwned) {
 			const activeSummary = findActiveDaemonSessionSummaryForSessionFile(
 				await listActiveDaemonSessionSummaries(client),
 				options.sessionPath,
@@ -981,8 +992,7 @@ async function createDaemonClientConnection(options: {
 				return await attach(activeSummary);
 			}
 		}
-		if (options.clientOwned) {
-			await client.waitForHello();
+		if (clientOwned) {
 			if (!client.supportsServerCapability("client_owned_sessions")) {
 				throw new DaemonCapabilityUnavailableError("create", "client_owned_sessions");
 			}
@@ -995,8 +1005,13 @@ async function createDaemonClientConnection(options: {
 			continueRecent: options.continueRecent,
 			noSession: options.noSession,
 			env: collectDaemonClientEnv(),
-			lifecycle: options.clientOwned ? "client_owned" : "resident",
-			launchEnv: options.clientOwned ? collectDaemonLaunchEnv() : undefined,
+			lifecycle: clientOwned ? "client_owned" : "resident",
+			// Forward the caller's environment for BOTH lifecycles. A resident
+			// worker still has to be launched with the caller's env: an embedder
+			// such as the verifiers ACP harness passes the model endpoint, its
+			// bearer token, and proxy settings that way, and a worker started
+			// without them cannot reach the model at all.
+			launchEnv: collectDaemonLaunchEnv(),
 		});
 		if (!response.success) {
 			throw deserializeDaemonError(response);
@@ -1530,7 +1545,8 @@ export async function main(args: string[], options?: MainOptions) {
 				config: defaultSessionConfig,
 				sessionPath: parsed.noSession ? undefined : sessionManager.getSessionFile(),
 				continueRecent: parsed.continue,
-				clientOwned: true,
+				// A no-session ACP invocation has nothing to reattach to; complete its worker on disconnect.
+				clientOwned: isClientOwnedDaemonSession(appMode, parsed.noSession),
 				noSession: parsed.noSession,
 				supportsExtensionUi: appMode === "rpc",
 			}));

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2883,7 +2883,11 @@ export class AgentDaemon {
 		for (const passive of await this.listPassiveRlmSubagents()) {
 			if (residentIds.has(passive.info.id)) continue;
 			try {
-				assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.passiveAgentFamilyEntry(passive));
+				assertAgentFamilyReach(
+					this.agentFamilyEntry(currentState),
+					this.passiveAgentFamilyEntry(passive),
+					this.agentFamilyCatalogEntries(),
+				);
 			} catch (error) {
 				if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) continue;
 				throw error;
@@ -5256,6 +5260,10 @@ export class AgentDaemon {
 		};
 	}
 
+	private agentFamilyCatalogEntries(): AgentFamilyCatalogEntry[] {
+		return [...this.sessions.values()].map((state) => this.agentFamilyEntry(state));
+	}
+
 	private passiveAgentFamilyEntry(passive: PassiveRlmSubagent): AgentFamilyCatalogEntry {
 		const entry = passive.entry;
 		const depth = passive.info.rlmDepth ?? entry.rlmDepth ?? passive.chain.length;
@@ -5296,7 +5304,11 @@ export class AgentDaemon {
 		}
 		const passive = await this.findPassiveRlmSubagent(target);
 		if (!passive) return this.getOrHydrateBoundSessionState(target);
-		assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.passiveAgentFamilyEntry(passive));
+		assertAgentFamilyReach(
+			this.agentFamilyEntry(currentState),
+			this.passiveAgentFamilyEntry(passive),
+			this.agentFamilyCatalogEntries(),
+		);
 		return this.hydratePassiveRlmSubagent(passive);
 	}
 
@@ -5324,7 +5336,11 @@ export class AgentDaemon {
 
 	private isAgentFamilyReachable(currentState: ActiveSessionState, targetState: ActiveSessionState): boolean {
 		try {
-			assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.agentFamilyEntry(targetState));
+			assertAgentFamilyReach(
+				this.agentFamilyEntry(currentState),
+				this.agentFamilyEntry(targetState),
+				this.agentFamilyCatalogEntries(),
+			);
 			return true;
 		} catch (error) {
 			if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) return false;
@@ -5334,7 +5350,11 @@ export class AgentDaemon {
 
 	private assertAgentFamilyReachable(currentState: ActiveSessionState, targetState: ActiveSessionState): void {
 		if (currentState.activeSessionId === targetState.activeSessionId) return;
-		assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.agentFamilyEntry(targetState));
+		assertAgentFamilyReach(
+			this.agentFamilyEntry(currentState),
+			this.agentFamilyEntry(targetState),
+			this.agentFamilyCatalogEntries(),
+		);
 	}
 
 	private agentMessageRelationship(
@@ -5342,7 +5362,11 @@ export class AgentDaemon {
 		targetState: ActiveSessionState,
 	): AgentFamilyRelationship | undefined {
 		if (!fromState) return undefined;
-		return agentFamilyRelationship(this.agentFamilyEntry(targetState), this.agentFamilyEntry(fromState));
+		return agentFamilyRelationship(
+			this.agentFamilyEntry(targetState),
+			this.agentFamilyEntry(fromState),
+			this.agentFamilyCatalogEntries(),
+		);
 	}
 
 	private async sendAgentSessionMessage(options: {
@@ -5380,6 +5404,7 @@ export class AgentDaemon {
 							assertAgentFamilyReach(
 								this.agentFamilyEntry(options.fromState),
 								this.passiveAgentFamilyEntry(passiveSubagent),
+								this.agentFamilyCatalogEntries(),
 							);
 						}
 						targetState = await this.hydratePassiveRlmSubagent(passiveSubagent);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2893,8 +2893,7 @@ export class AgentDaemon {
 		for (const passive of await this.listPassiveRlmSubagents()) {
 			if (residentIds.has(passive.info.id)) continue;
 			try {
-				const passiveEntry = catalog.find((entry) => entry.id === passive.info.id);
-				if (!passiveEntry) continue;
+				const passiveEntry = this.authoritativeAgentFamilyEntryForSessionId(passive.info.id, catalog);
 				assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(currentState, catalog), passiveEntry, catalog);
 			} catch (error) {
 				if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) continue;
@@ -5049,8 +5048,7 @@ export class AgentDaemon {
 
 	private async createAgentFamilyRoster(currentState: ActiveSessionState): Promise<AgentFamilyRosterResult> {
 		const catalog = await this.createAgentFamilyCatalog(currentState);
-		const current = catalog.find((entry) => entry.id === currentState.runtime.session.sessionId);
-		if (!current) throw new Error("Current agent is missing from the family catalog");
+		const current = this.authoritativeAgentFamilyEntry(currentState, catalog);
 		return buildAgentFamilyRoster(current, catalog);
 	}
 
@@ -5335,8 +5333,7 @@ export class AgentDaemon {
 		}
 		const passive = await this.findPassiveRlmSubagent(target);
 		if (!passive) return { targetState: await this.getOrHydrateBoundSessionState(target), catalog };
-		const passiveEntry = catalog.find((entry) => entry.id === passive.info.id);
-		if (!passiveEntry) throw new Error(AGENT_FAMILY_REACH_ERROR);
+		const passiveEntry = this.authoritativeAgentFamilyEntryForSessionId(passive.info.id, catalog);
 		assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(currentState, catalog), passiveEntry, catalog);
 		return { targetState: await this.hydratePassiveRlmSubagent(passive), catalog };
 	}
@@ -5368,9 +5365,16 @@ export class AgentDaemon {
 		state: ActiveSessionState,
 		catalog: readonly AgentFamilyCatalogEntry[],
 	): AgentFamilyCatalogEntry {
-		const entry = catalog.find((candidate) => candidate.id === state.runtime.session.sessionId);
-		if (!entry) throw new Error(AGENT_FAMILY_REACH_ERROR);
-		return entry;
+		return this.authoritativeAgentFamilyEntryForSessionId(state.runtime.session.sessionId, catalog);
+	}
+
+	private authoritativeAgentFamilyEntryForSessionId(
+		sessionId: string,
+		catalog: readonly AgentFamilyCatalogEntry[],
+	): AgentFamilyCatalogEntry {
+		const entries = catalog.filter((candidate) => candidate.id === sessionId);
+		if (entries.length !== 1) throw new Error(AGENT_FAMILY_REACH_ERROR);
+		return entries[0]!;
 	}
 
 	private isAgentFamilyReachable(
@@ -5451,8 +5455,7 @@ export class AgentDaemon {
 					const passiveSubagent = await this.findPassiveRlmSubagent(targetSelector);
 					if (passiveSubagent) {
 						if (options.origin === "agent" && options.fromState) {
-							const passiveEntry = catalog!.find((entry) => entry.id === passiveSubagent.info.id);
-							if (!passiveEntry) throw new Error(AGENT_FAMILY_REACH_ERROR);
+							const passiveEntry = this.authoritativeAgentFamilyEntryForSessionId(passiveSubagent.info.id, catalog!);
 							assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(options.fromState, catalog!), passiveEntry, catalog!);
 						}
 						targetState = await this.hydratePassiveRlmSubagent(passiveSubagent);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2877,7 +2877,11 @@ export class AgentDaemon {
 			.filter((state) => {
 				if (state.activeSessionId === currentState.activeSessionId) return true;
 				try {
-					assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.agentFamilyEntry(state), catalog);
+					assertAgentFamilyReach(
+						this.authoritativeAgentFamilyEntry(currentState, catalog),
+						this.authoritativeAgentFamilyEntry(state, catalog),
+						catalog,
+					);
 					return true;
 				} catch (error) {
 					if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) return false;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -987,6 +987,14 @@ export class AgentDaemon {
 			return [];
 		}
 		const latest = new Map<string, PersistedRlmSubagentRegistryEntry>();
+		// A malformed append is a tombstone for its selector, not an invitation to
+		// revive the older snapshot. This keeps replay deterministic when an
+		// append-only registry is interrupted or partially corrupted.
+		const quarantineMalformedEntry = (entry: Partial<PersistedRlmSubagentRegistryEntry> | undefined) => {
+			if (typeof entry?.childId === "string") {
+				latest.delete(entry.childId);
+			}
+		};
 		let lines: string[];
 		try {
 			lines = (await readFile(path, "utf8")).split(/\r?\n/);
@@ -1005,8 +1013,9 @@ export class AgentDaemon {
 			if (!trimmed) {
 				continue;
 			}
+			let entry: Partial<PersistedRlmSubagentRegistryEntry> | undefined;
 			try {
-				const entry = JSON.parse(trimmed) as Partial<PersistedRlmSubagentRegistryEntry>;
+				entry = JSON.parse(trimmed) as Partial<PersistedRlmSubagentRegistryEntry>;
 				if (
 					entry.type !== "rlm_subagent" ||
 					typeof entry.childId !== "string" ||
@@ -1017,10 +1026,14 @@ export class AgentDaemon {
 					(entry.rlmDepth !== undefined && (!Number.isSafeInteger(entry.rlmDepth) || entry.rlmDepth < 0)) ||
 					(entry.rlmMaxDepth !== undefined && (!Number.isSafeInteger(entry.rlmMaxDepth) || entry.rlmMaxDepth < 0))
 				) {
+					quarantineMalformedEntry(entry);
 					continue;
 				}
-				latest.set(entry.childId, entry as PersistedRlmSubagentRegistryEntry);
+				const persisted = entry as PersistedRlmSubagentRegistryEntry;
+				// Only a complete later row deliberately republishes a quarantined child.
+				latest.set(persisted.childId, persisted);
 			} catch (error) {
+				quarantineMalformedEntry(entry);
 				this.log(
 					`ignored malformed RLM subagent registry entry: ${error instanceof Error ? error.message : String(error)}`,
 				);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2873,6 +2873,7 @@ export class AgentDaemon {
 
 	private async createAgentObserveListResult(currentState: ActiveSessionState): Promise<AgentObserveListResult> {
 		const catalog = await this.agentFamilyCatalogEntries();
+		this.authoritativeAgentFamilyEntry(currentState, catalog);
 		const agents = this.listTargetableSessionStates(currentState)
 			.filter((state) => {
 				if (state.activeSessionId === currentState.activeSessionId) return true;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2872,22 +2872,26 @@ export class AgentDaemon {
 	}
 
 	private async createAgentObserveListResult(currentState: ActiveSessionState): Promise<AgentObserveListResult> {
+		const catalog = await this.agentFamilyCatalogEntries();
 		const agents = this.listTargetableSessionStates(currentState)
-			.filter(
-				(state) =>
-					state.activeSessionId === currentState.activeSessionId ||
-					this.isAgentFamilyReachable(currentState, state),
-			)
+			.filter((state) => {
+				if (state.activeSessionId === currentState.activeSessionId) return true;
+				try {
+					assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.agentFamilyEntry(state), catalog);
+					return true;
+				} catch (error) {
+					if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) return false;
+					throw error;
+				}
+			})
 			.map((state) => this.createAgentObserveSummary(state, currentState));
 		const residentIds = new Set(agents.map((agent) => agent.activeSessionId));
 		for (const passive of await this.listPassiveRlmSubagents()) {
 			if (residentIds.has(passive.info.id)) continue;
 			try {
-				assertAgentFamilyReach(
-					this.agentFamilyEntry(currentState),
-					this.passiveAgentFamilyEntry(passive),
-					this.agentFamilyCatalogEntries(),
-				);
+				const passiveEntry = catalog.find((entry) => entry.id === passive.info.id);
+				if (!passiveEntry) continue;
+				assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(currentState, catalog), passiveEntry, catalog);
 			} catch (error) {
 				if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) continue;
 				throw error;
@@ -2926,8 +2930,8 @@ export class AgentDaemon {
 		currentState: ActiveSessionState,
 		target: string,
 	): Promise<AgentObserveAgentSnapshot> {
-		const targetState = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, target);
-		this.assertAgentFamilyReachable(currentState, targetState);
+		const { targetState, catalog } = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, target);
+		this.assertAgentFamilyReachable(currentState, targetState, catalog);
 		return {
 			agent: this.createAgentObserveSummary(targetState, currentState),
 		};
@@ -2937,8 +2941,8 @@ export class AgentDaemon {
 		currentState: ActiveSessionState,
 		input: AgentObserveRecentMessagesInput,
 	): Promise<AgentObserveRecentMessagesResult> {
-		const targetState = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, input.target);
-		this.assertAgentFamilyReachable(currentState, targetState);
+		const { targetState, catalog } = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, input.target);
+		this.assertAgentFamilyReachable(currentState, targetState, catalog);
 		const limit = normalizeObserveLimit(input.limit);
 		const maxChars = normalizeObserveMaxChars(input.maxChars);
 		const messages = targetState.runtime.session.messages;
@@ -5260,8 +5264,30 @@ export class AgentDaemon {
 		};
 	}
 
-	private agentFamilyCatalogEntries(): AgentFamilyCatalogEntry[] {
-		return [...this.sessions.values()].map((state) => this.agentFamilyEntry(state));
+	/** Capture persisted topology once for an authorization decision. */
+	private async agentFamilyCatalogEntries(): Promise<readonly AgentFamilyCatalogEntry[]> {
+		const entries = new Map<string, AgentFamilyCatalogEntry>();
+		const add = (entry: AgentFamilyCatalogEntry) => entries.set(entry.id, entry);
+		const saved = await SessionManager.listAll(undefined, this.options.defaultSessionConfig.sessionDir);
+		for (const info of saved) {
+			const depth = info.rlmDepth ?? (info.parentSessionPath ? 1 : 0);
+			add({
+				id: info.id,
+				...(info.name ? { name: info.name } : {}),
+				depth,
+				status: "inactive",
+				...(depth > 0 && info.parentSessionPath
+					? { parentSessionPath: canonicalSessionPath(info.parentSessionPath) }
+					: {}),
+				sessionPath: canonicalSessionPath(info.path),
+			});
+		}
+		// Artifact-resident descendants are absent from the saved-session scan.
+		// Read the authoritative registry tree, including passive direct parents.
+		for (const passive of await this.listPassiveRlmSubagents(saved, true)) add(this.passiveAgentFamilyEntry(passive));
+		// Resident metadata wins over a stale durable snapshot.
+		for (const state of this.sessions.values()) add(this.agentFamilyEntry(state));
+		return Object.freeze([...entries.values()]);
 	}
 
 	private passiveAgentFamilyEntry(passive: PassiveRlmSubagent): AgentFamilyCatalogEntry {
@@ -5288,34 +5314,34 @@ export class AgentDaemon {
 	private async getOrHydrateAuthorizedAgentFamilyTarget(
 		currentState: ActiveSessionState,
 		target: string,
-	): Promise<ActiveSessionState> {
+	): Promise<{ targetState: ActiveSessionState; catalog: readonly AgentFamilyCatalogEntry[] }> {
+		const catalog = await this.agentFamilyCatalogEntries();
 		try {
-			return this.getBoundSessionState(target);
+			return { targetState: this.getBoundSessionState(target), catalog };
 		} catch (error) {
 			if (error instanceof BoundSessionUnavailableError) {
 				const targetState = this.getSessionState(target);
-				this.assertAgentFamilyReachable(currentState, targetState);
-				return this.getOrHydrateBoundSessionState(target);
+				this.assertAgentFamilyReachable(currentState, targetState, catalog);
+				return { targetState: await this.getOrHydrateBoundSessionState(target), catalog };
 			}
 			if (error instanceof AmbiguousActiveSessionError) {
-				const targetState = this.resolveAgentFamilySessionName(currentState, target, error);
-				return this.getOrHydrateBoundSessionState(targetState.activeSessionId);
+				const targetState = this.resolveAgentFamilySessionName(currentState, target, error, catalog);
+				return { targetState: await this.getOrHydrateBoundSessionState(targetState.activeSessionId), catalog };
 			}
 		}
 		const passive = await this.findPassiveRlmSubagent(target);
-		if (!passive) return this.getOrHydrateBoundSessionState(target);
-		assertAgentFamilyReach(
-			this.agentFamilyEntry(currentState),
-			this.passiveAgentFamilyEntry(passive),
-			this.agentFamilyCatalogEntries(),
-		);
-		return this.hydratePassiveRlmSubagent(passive);
+		if (!passive) return { targetState: await this.getOrHydrateBoundSessionState(target), catalog };
+		const passiveEntry = catalog.find((entry) => entry.id === passive.info.id);
+		if (!passiveEntry) throw new Error(AGENT_FAMILY_REACH_ERROR);
+		assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(currentState, catalog), passiveEntry, catalog);
+		return { targetState: await this.hydratePassiveRlmSubagent(passive), catalog };
 	}
 
 	private resolveAgentFamilySessionName(
 		currentState: ActiveSessionState,
 		target: string,
 		ambiguity: AmbiguousActiveSessionError,
+		catalog: readonly AgentFamilyCatalogEntry[],
 	): ActiveSessionState {
 		const reachableMatches = new Map(
 			[...this.sessions.values()]
@@ -5324,7 +5350,7 @@ export class AgentDaemon {
 					return (
 						(session.sessionId === target || session.sessionName === target) &&
 						(state.activeSessionId === currentState.activeSessionId ||
-							this.isAgentFamilyReachable(currentState, state))
+							this.isAgentFamilyReachable(currentState, state, catalog))
 					);
 				})
 				.map((state) => [state.activeSessionId, state]),
@@ -5334,12 +5360,25 @@ export class AgentDaemon {
 		return matches[0]!;
 	}
 
-	private isAgentFamilyReachable(currentState: ActiveSessionState, targetState: ActiveSessionState): boolean {
+	private authoritativeAgentFamilyEntry(
+		state: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[],
+	): AgentFamilyCatalogEntry {
+		const entry = catalog.find((candidate) => candidate.id === state.runtime.session.sessionId);
+		if (!entry) throw new Error(AGENT_FAMILY_REACH_ERROR);
+		return entry;
+	}
+
+	private isAgentFamilyReachable(
+		currentState: ActiveSessionState,
+		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[] = [this.agentFamilyEntry(currentState), this.agentFamilyEntry(targetState)],
+	): boolean {
 		try {
 			assertAgentFamilyReach(
-				this.agentFamilyEntry(currentState),
-				this.agentFamilyEntry(targetState),
-				this.agentFamilyCatalogEntries(),
+				this.authoritativeAgentFamilyEntry(currentState, catalog),
+				this.authoritativeAgentFamilyEntry(targetState, catalog),
+				catalog,
 			);
 			return true;
 		} catch (error) {
@@ -5348,24 +5387,29 @@ export class AgentDaemon {
 		}
 	}
 
-	private assertAgentFamilyReachable(currentState: ActiveSessionState, targetState: ActiveSessionState): void {
+	private assertAgentFamilyReachable(
+		currentState: ActiveSessionState,
+		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[] = [this.agentFamilyEntry(currentState), this.agentFamilyEntry(targetState)],
+	): void {
 		if (currentState.activeSessionId === targetState.activeSessionId) return;
 		assertAgentFamilyReach(
-			this.agentFamilyEntry(currentState),
-			this.agentFamilyEntry(targetState),
-			this.agentFamilyCatalogEntries(),
-		);
+				this.authoritativeAgentFamilyEntry(currentState, catalog),
+				this.authoritativeAgentFamilyEntry(targetState, catalog),
+				catalog,
+			);
 	}
 
 	private agentMessageRelationship(
 		fromState: ActiveSessionState | undefined,
 		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[] = [this.agentFamilyEntry(targetState), ...(fromState ? [this.agentFamilyEntry(fromState)] : [])],
 	): AgentFamilyRelationship | undefined {
 		if (!fromState) return undefined;
 		return agentFamilyRelationship(
-			this.agentFamilyEntry(targetState),
-			this.agentFamilyEntry(fromState),
-			this.agentFamilyCatalogEntries(),
+			this.authoritativeAgentFamilyEntry(targetState, catalog),
+			this.authoritativeAgentFamilyEntry(fromState, catalog),
+		catalog,
 		);
 	}
 
@@ -5383,29 +5427,29 @@ export class AgentDaemon {
 		}
 		const targetSelector = assertDirectAgentMessageTarget(options.targetSelector);
 		const message = normalizeAgentSessionMessage(options.message, DEFAULT_AGENT_MESSAGE_MAX_CHARS);
+		// Use one immutable persisted topology through selector resolution, wake, and delivery.
+		const catalog = options.origin === "agent" && options.fromState ? await this.agentFamilyCatalogEntries() : undefined;
 		let targetState: ActiveSessionState;
 		try {
 			targetState = this.getBoundSessionState(targetSelector);
 		} catch (error) {
 			if (error instanceof BoundSessionUnavailableError) {
 				if (options.origin === "agent" && options.fromState) {
-					this.assertAgentFamilyReachable(options.fromState, this.getSessionState(targetSelector));
+					this.assertAgentFamilyReachable(options.fromState, this.getSessionState(targetSelector), catalog!);
 				}
 				targetState = await this.getOrHydrateBoundSessionState(targetSelector);
 			} else {
 				if (error instanceof AmbiguousActiveSessionError) {
 					if (options.origin !== "agent" || !options.fromState) throw error;
-					const resolved = this.resolveAgentFamilySessionName(options.fromState, targetSelector, error);
+					const resolved = this.resolveAgentFamilySessionName(options.fromState, targetSelector, error, catalog!);
 					targetState = await this.getOrHydrateBoundSessionState(resolved.activeSessionId);
 				} else {
 					const passiveSubagent = await this.findPassiveRlmSubagent(targetSelector);
 					if (passiveSubagent) {
 						if (options.origin === "agent" && options.fromState) {
-							assertAgentFamilyReach(
-								this.agentFamilyEntry(options.fromState),
-								this.passiveAgentFamilyEntry(passiveSubagent),
-								this.agentFamilyCatalogEntries(),
-							);
+							const passiveEntry = catalog!.find((entry) => entry.id === passiveSubagent.info.id);
+							if (!passiveEntry) throw new Error(AGENT_FAMILY_REACH_ERROR);
+							assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(options.fromState, catalog!), passiveEntry, catalog!);
 						}
 						targetState = await this.hydratePassiveRlmSubagent(passiveSubagent);
 					} else {
@@ -5431,7 +5475,7 @@ export class AgentDaemon {
 			throw new Error("Agent messaging cannot target the sending session");
 		}
 		if (options.origin === "agent" && options.fromState) {
-			this.assertAgentFamilyReachable(options.fromState, targetState);
+			this.assertAgentFamilyReachable(options.fromState, targetState, catalog!);
 		}
 		const releaseQueueSlot = this.reserveAgentMessageQueueSlot(targetState);
 		const senderKey =
@@ -5449,7 +5493,7 @@ export class AgentDaemon {
 			from:
 				options.sender ??
 				this.createAgentSessionMessageSender(options.fromState, options.clientId ?? options.origin),
-			fromRelationship: this.agentMessageRelationship(options.fromState, targetState),
+			fromRelationship: this.agentMessageRelationship(options.fromState, targetState, catalog ?? []),
 			target: this.createAgentSessionMessageEndpoint(targetState),
 		};
 		try {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -57,8 +57,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 12 publishes idle-residency metadata on session summary rows.
 // Revision 13 narrows agent-origin reach and roster wire shapes to the nuclear family.
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
-export const DAEMON_SCHEMA_REVISION = 14;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-14-816309b1cd50";
+// Revision 15 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
+export const DAEMON_SCHEMA_REVISION = 15;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-15-816309b1cd50";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ImageContent, ServiceTier, TextContent, Transport } from "@earendil-works/pi-ai";
+import { ENV_AGENT_DIR } from "../../config.js";
 import type {
 	AgentSessionMessageDeliveryMode,
 	AgentSessionMessageReceipt,
@@ -202,6 +203,58 @@ export function collectDaemonClientEnv(source: NodeJS.ProcessEnv = process.env):
 	return Object.keys(env).length > 0 ? env : undefined;
 }
 
+/**
+ * Non-secret launch settings that may survive a supervisor restart in a
+ * resident worker descriptor. Model credentials deliberately do not belong
+ * here: the first worker launch inherits the caller environment, but a JSON
+ * descriptor must never become an at-rest copy of a caller's credentials.
+ */
+export const DAEMON_PERSISTED_LAUNCH_ENV_KEYS = [
+	// Process/runtime locations needed to relaunch the same installed CLI.
+	"HOME",
+	"PATH",
+	"TMPDIR",
+	"TMP",
+	"TEMP",
+	"XDG_CACHE_HOME",
+	"XDG_CONFIG_HOME",
+	"XDG_DATA_HOME",
+	"XDG_RUNTIME_DIR",
+	"XDG_STATE_HOME",
+	// Source/development installs may relaunch through tsx after recovery.
+	"TSX_TSCONFIG_PATH",
+	// ENV_AGENT_DIR is the current application's configurable agent directory.
+	// PI_CODING_AGENT_DIR remains for compatibility with the upstream CLI.
+	ENV_AGENT_DIR,
+	"PI_CODING_AGENT_DIR",
+	// Deliberately non-secret Prime Agent behavior, telemetry, and package settings.
+	"PI_OFFLINE",
+	"PI_PACKAGE_DIR",
+	"PI_SKIP_VERSION_CHECK",
+	"DO_NOT_TRACK",
+	"PRIME_AGENT_TELEMETRY",
+	"PRIME_AGENT_TELEMETRY_ENDPOINT",
+	"PRIME_AGENT_TRACES_BASE_URL",
+	"PRIME_AGENT_DOWNLOAD_BASE_URL",
+] as const;
+
+/** Select the explicitly non-secret launch settings safe to persist on disk. */
+export function filterPersistedDaemonLaunchEnv(
+	source: Readonly<Record<string, string>> | undefined,
+): Record<string, string> | undefined {
+	if (!source) return undefined;
+	const env: Record<string, string> = {};
+	for (const key of DAEMON_PERSISTED_LAUNCH_ENV_KEYS) {
+		const value = source[key];
+		if (value !== undefined) env[key] = value;
+	}
+	return Object.keys(env).length > 0 ? env : undefined;
+}
+
+/**
+ * Collect the caller environment for the initial worker spawn. The
+ * supervisor filters it before it is written to a resident-worker descriptor.
+ */
 export function collectDaemonLaunchEnv(source: NodeJS.ProcessEnv = process.env): Record<string, string> {
 	const env: Record<string, string> = {};
 	for (const [key, value] of Object.entries(source)) {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -57,7 +57,10 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 12 publishes idle-residency metadata on session summary rows.
 // Revision 13 narrows agent-origin reach and roster wire shapes to the nuclear family.
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
-// Revision 15 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
+// Revision 15 makes workerState report the actual registered worker states
+// (starting, ready, recovering, stopping, failed). Removed workers have no
+// workerState; archived is a session lifecycle, not a worker state. A
+// disconnected ready worker is reported as recovering.
 export const DAEMON_SCHEMA_REVISION = 15;
 export const DAEMON_SCHEMA_ID = "protocol-7-schema-15-816309b1cd50";
 

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -78,7 +78,7 @@ export interface SessionSummary {
 	/** Completion verdict for an idle session; absent while working or unjudged. */
 	taskState?: AgentTaskState;
 	/** Resident session-host process state, populated by the global supervisor. */
-	workerState?: "starting" | "ready" | "recovering" | "failed";
+	workerState?: "starting" | "ready" | "recovering" | "stopping" | "failed";
 	/** Diagnostic process identity; clients must not use this as a stable session identifier. */
 	workerPid?: number;
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -991,7 +991,18 @@ export class DaemonSupervisor {
 		renameSync(tempPath, worker.descriptorPath);
 	}
 
-	private deleteWorkerDescriptor(worker: ResidentWorker): void {
+	/** Remove a registration only while this generation still owns its exact worker incarnation. */
+	private async deleteWorkerDescriptor(
+		worker: ResidentWorker,
+		descriptor: DaemonWorkerDescriptor = worker.descriptor,
+		stopRevision = worker.stopRevision,
+		stopRequestedAt = descriptor.stopRequestedAt,
+	): Promise<void> {
+		// This assertion is deliberately the final await before the tuple check and
+		// destructive unlink. Lost or unreadable ownership retains the descriptor
+		// (and, for stops, its tombstone) for the next owner to recover.
+		await this.assertCurrentOwnership();
+		this.assertWorkerReclaimCommitCurrent(worker, descriptor, stopRevision, stopRequestedAt);
 		try {
 			rmSync(worker.descriptorPath, { force: true });
 			rmSync(worker.descriptor.recoveryJournalPath, { force: true });
@@ -2381,7 +2392,11 @@ export class DaemonSupervisor {
 					1000,
 				);
 				await this.assertRecoveryAllowed();
-				client.onFrame((frame) => this.handleWorkerFrame(worker, frame));
+				client.onFrame((frame) =>
+					void this.handleWorkerFrame(worker, frame).catch((error) =>
+						this.log(`Worker frame handling failed for ${worker.descriptor.workerId}: ${String(error)}`),
+					),
+				);
 				client.onClose((error) => void this.handleWorkerClose(worker, client, error));
 				worker.client?.close();
 				worker.client = client;
@@ -2426,7 +2441,7 @@ export class DaemonSupervisor {
 				// supervisor while its intentional stop is being adopted. Legacy or
 				// unreadable identity deliberately keeps the tombstone for retries.
 				const descriptor = worker.descriptor;
-				this.signalCurrentWorker(
+				await this.signalCurrentWorker(
 					worker,
 					descriptor,
 					worker.stopRevision,
@@ -2877,15 +2892,17 @@ export class DaemonSupervisor {
 		await this.assertRecoveryAllowed();
 		const descriptor = worker.descriptor;
 		if (killWorkerProcess) {
-			this.signalCurrentWorker(worker, descriptor, worker.stopRevision, descriptor.stopRequestedAt, "SIGKILL");
+			await this.signalCurrentWorker(worker, descriptor, worker.stopRevision, descriptor.stopRequestedAt, "SIGKILL");
 		}
 		const orphanProcessJournalPath = descriptor.orphanProcessJournalPath;
 		if (orphanProcessJournalPath) {
 			try {
 				for (const orphan of readActiveOrphanProcesses(orphanProcessJournalPath, worker.descriptor.pid)) {
-					if (!isOrphanProcessIdentityCurrent(orphan)) {
-						continue;
-					}
+					// Ownership and fresh orphan identity must remain adjacent to the
+					// signal. A successor owns any retry if this check fails.
+					await this.assertCurrentOwnership();
+					this.assertWorkerTupleCurrent(worker, descriptor, worker.stopRevision, descriptor.stopRequestedAt);
+					if (!isOrphanProcessIdentityCurrent(orphan)) continue;
 					const { pid } = orphan;
 					try {
 						process.kill(-pid, "SIGKILL");
@@ -2897,6 +2914,8 @@ export class DaemonSupervisor {
 						}
 					}
 				}
+				await this.assertCurrentOwnership();
+				this.assertWorkerTupleCurrent(worker, descriptor, worker.stopRevision, descriptor.stopRequestedAt);
 				clearOrphanProcessJournal(orphanProcessJournalPath);
 			} catch (error) {
 				this.log(`Could not reap orphaned worker resources: ${String(error)}`);
@@ -4218,9 +4237,13 @@ export class DaemonSupervisor {
 			activeSessionId === worker.descriptor.rootActiveSessionId &&
 			!this.shuttingDown
 		) {
+			const descriptor = worker.descriptor;
+			const stopRevision = worker.stopRevision;
 			worker.intentionalStop = true;
-			this.workers.delete(worker.descriptor.workerId);
-			this.deleteWorkerDescriptor(worker);
+			await this.assertCurrentOwnership();
+			this.assertWorkerReclaimCommitCurrent(worker, descriptor, stopRevision, descriptor.stopRequestedAt);
+			await this.deleteWorkerDescriptor(worker, descriptor, stopRevision, descriptor.stopRequestedAt);
+			this.workers.delete(descriptor.workerId);
 			void this.syncAgentPeers().catch(() => undefined);
 		}
 	}
@@ -4607,34 +4630,69 @@ export class DaemonSupervisor {
 	 * fails closed for legacy descriptors and transiently unreadable process
 	 * identity. Callers retain the tombstone/retry authority in that case.
 	 */
-	private signalCurrentWorker(
+	private assertWorkerTupleCurrent(
+		worker: ResidentWorker,
+		descriptor: DaemonWorkerDescriptor,
+		stopRevision: number,
+		stopRequestedAt: string | undefined,
+	): void {
+		if (
+			this.workers.get(descriptor.workerId) !== worker ||
+			worker.descriptor !== descriptor ||
+			worker.descriptor.pid !== descriptor.pid ||
+			worker.descriptor.processStartId !== descriptor.processStartId ||
+			worker.stopRevision !== stopRevision ||
+			worker.descriptor.stopRequestedAt !== stopRequestedAt
+		) {
+			throw new Error(`Session worker ${descriptor.workerId} changed during lifecycle operation`);
+		}
+	}
+
+	/**
+	 * Destructive descriptor/artifact/archive commits may only reclaim an
+	 * incarnation observed gone or recycled. Unreadable and still-current are
+	 * retained for finalization/recovery; no stale supervisor gets to erase them.
+	 */
+	private assertWorkerReclaimCommitCurrent(
+		worker: ResidentWorker,
+		descriptor: DaemonWorkerDescriptor,
+		stopRevision: number,
+		stopRequestedAt: string | undefined,
+	): void {
+		this.assertWorkerTupleCurrent(worker, descriptor, stopRevision, stopRequestedAt);
+		const identity = this.processIdentity(descriptor.pid, descriptor.processStartId);
+		if (identity !== "gone" && identity !== "replaced") {
+			throw new Error(`Session worker ${descriptor.workerId} is not safely reclaimable`);
+		}
+	}
+
+	private async signalCurrentWorker(
 		worker: ResidentWorker,
 		descriptor: DaemonWorkerDescriptor,
 		stopRevision: number,
 		stopRequestedAt: string | undefined,
 		signal: NodeJS.Signals,
 		directChild?: ChildProcess,
-	): boolean {
+	): Promise<boolean> {
 		const { pid, processStartId } = descriptor;
+		// Do not move an await below this point: ownership, the full immutable
+		// tuple, and fresh process identity must be adjacent to TERM/KILL.
+		await this.assertCurrentOwnership();
+		try {
+			this.assertWorkerTupleCurrent(worker, descriptor, stopRevision, stopRequestedAt);
+		} catch {
+			return false;
+		}
 		if (
 			processStartId === undefined ||
-			this.workers.get(descriptor.workerId) !== worker ||
-			worker.descriptor !== descriptor ||
-			worker.descriptor.pid !== pid ||
-			worker.descriptor.processStartId !== processStartId ||
-			worker.stopRevision !== stopRevision ||
-			worker.descriptor.stopRequestedAt !== stopRequestedAt ||
 			(directChild !== undefined &&
 				(directChild.pid !== pid || directChild.exitCode !== null || directChild.signalCode !== null)) ||
 			this.processIdentity(pid, processStartId) !== "current"
 		) {
 			return false;
 		}
-		if (directChild) {
-			directChild.kill(signal);
-		} else {
-			signalProcessGroupOrProcess(pid, signal);
-		}
+		if (directChild) directChild.kill(signal);
+		else signalProcessGroupOrProcess(pid, signal);
 		return true;
 	}
 
@@ -4747,7 +4805,7 @@ export class DaemonSupervisor {
 			}
 		} else {
 			assertStopStillApplies();
-			this.signalCurrentWorker(
+			await this.signalCurrentWorker(
 				worker,
 				entryDescriptor,
 				entryStopRevision,
@@ -4785,7 +4843,7 @@ export class DaemonSupervisor {
 			assertStopStillApplies();
 			// signalCurrentWorker performs a fresh, unthrottled identity check;
 			// cached liveness may be old enough for pid reuse.
-			this.signalCurrentWorker(
+			await this.signalCurrentWorker(
 				worker,
 				entryDescriptor,
 				entryStopRevision,
@@ -4812,15 +4870,19 @@ export class DaemonSupervisor {
 		assertStopStillApplies();
 		if (removeDescriptor && worker.descriptor.archiveOnStop) {
 			if (force) {
-				this.reclaimStoppedWorkerCronLock(worker);
+				await this.reclaimStoppedWorkerCronLock(worker, entryDescriptor, entryStopRevision, entryStopRequestedAt);
 			}
-			await this.finalizeArchivedWorkerStop(worker);
+			await this.finalizeArchivedWorkerStop(worker, entryDescriptor, entryStopRevision, entryStopRequestedAt);
 			assertStopStillApplies();
 		}
-		this.workers.delete(worker.descriptor.workerId);
+		// The final authority check must be immediately adjacent to map/descriptor
+		// deletion. If ownership vanished, retain the tombstone for recovery.
+		await this.assertCurrentOwnership();
+		assertStopStillApplies();
 		if (removeDescriptor) {
-			this.deleteWorkerDescriptor(worker);
+			await this.deleteWorkerDescriptor(worker, entryDescriptor, entryStopRevision, entryStopRequestedAt);
 		}
+		this.workers.delete(worker.descriptor.workerId);
 		if (!this.shuttingDown) {
 			void this.syncAgentPeers().catch(() => undefined);
 			this.broadcastHeartbeatsChanged();
@@ -4886,8 +4948,14 @@ export class DaemonSupervisor {
 			}
 			if (!killed && Date.now() >= sigkillDeadline) {
 				// signalCurrentWorker makes a fresh exact observation immediately
-				// before signalling. A miss keeps the tombstone and escalation armed.
-				killed = this.signalCurrentWorker(worker, descriptor, stopRevision, stopRequestedAt, "SIGKILL");
+				// before signalling. Ownership loss is terminal for this finalizer:
+				// leave its tombstone for the successor rather than retrying as stale.
+				try {
+					killed = await this.signalCurrentWorker(worker, descriptor, stopRevision, stopRequestedAt, "SIGKILL");
+				} catch (error) {
+					if (isSupervisorGenerationStale(error)) return;
+					throw error;
+				}
 			}
 			await unrefDelay(STOP_FINALIZATION_RECHECK_MS);
 		}
@@ -4902,33 +4970,44 @@ export class DaemonSupervisor {
 				this.log(`Finalized timed-out stop for worker ${worker.descriptor.workerId}`);
 				return;
 			} catch (error) {
+				if (isSupervisorGenerationStale(error)) return;
 				this.reportCleanupFailure(`timed-out worker stop ${worker.descriptor.workerId}`, error);
 				await unrefDelay(STOP_FINALIZATION_RETRY_MS);
 			}
 		}
 	}
 
-	private async finalizeArchivedWorkerStop(worker: ResidentWorker): Promise<void> {
+	private async finalizeArchivedWorkerStop(
+		worker: ResidentWorker,
+		descriptor: DaemonWorkerDescriptor,
+		stopRevision: number,
+		stopRequestedAt: string | undefined,
+	): Promise<void> {
 		const context = this.workerSessionArtifactContext(worker);
-		if (!context) {
-			return;
-		}
-		if (worker.descriptor.rootSessionId) {
-			const cronStore = AgentCronJobStore.forSessionArtifacts();
-			cronStore.registerSessionArtifact(worker.descriptor.rootSessionId, context.artifactDir);
-			cronStore.cancelJobsForSession({
-				sessionId: worker.descriptor.rootSessionId,
-				sessionFile: context.sessionFile,
-			});
-			await this.catalog.archive(context.sessionFile, worker.descriptor.rootSessionId);
-		}
+		if (!context || !descriptor.rootSessionId) return;
+		const cronStore = AgentCronJobStore.forSessionArtifacts();
+		// The catalog call is an await. Its destructive archive commit is protected
+		// by the catalog's request boundary; local destructive artifact updates are
+		// re-authorized after it and are never made by a lost owner.
+		await this.assertCurrentOwnership();
+		this.assertWorkerReclaimCommitCurrent(worker, descriptor, stopRevision, stopRequestedAt);
+		cronStore.registerSessionArtifact(descriptor.rootSessionId, context.artifactDir);
+		cronStore.cancelJobsForSession({ sessionId: descriptor.rootSessionId, sessionFile: context.sessionFile });
+		await this.catalog.archive(context.sessionFile, descriptor.rootSessionId);
+		await this.assertCurrentOwnership();
+		this.assertWorkerReclaimCommitCurrent(worker, descriptor, stopRevision, stopRequestedAt);
 	}
 
-	private reclaimStoppedWorkerCronLock(worker: ResidentWorker): void {
+	private async reclaimStoppedWorkerCronLock(
+		worker: ResidentWorker,
+		descriptor: DaemonWorkerDescriptor,
+		stopRevision: number,
+		stopRequestedAt: string | undefined,
+	): Promise<void> {
 		const context = this.workerSessionArtifactContext(worker);
-		if (!context) {
-			return;
-		}
+		if (!context) return;
+		await this.assertCurrentOwnership();
+		this.assertWorkerReclaimCommitCurrent(worker, descriptor, stopRevision, stopRequestedAt);
 		rmSync(join(context.artifactDir, `${SESSION_SCHEDULED_JOBS_FILENAME}.lock`), { recursive: true, force: true });
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1798,6 +1798,8 @@ export class DaemonSupervisor {
 			const source = command.fromActiveSessionId
 				? await this.findWorkerForClient(client, command.fromActiveSessionId)
 				: undefined;
+			// Hold this persisted topology through pre-wake and post-wake checks.
+			const familyCatalog = source && command.agentOrigin === true ? await this.familyCatalogEntries() : undefined;
 			let target: WorkerMatch;
 			try {
 				target = await this.findWorkerForClient(client, command.targetActiveSessionId);
@@ -1825,7 +1827,7 @@ export class DaemonSupervisor {
 					assertAgentFamilyReach(
 						this.familyCatalogEntry(source.summary),
 						this.familyCatalogEntry(summaryForInactiveSession(targetInfo)),
-						await this.familyCatalogEntries(),
+						familyCatalog!,
 					);
 				}
 				const worker = await this.createOrReuseWorker(this.protocolClientId(client), {
@@ -1844,7 +1846,7 @@ export class DaemonSupervisor {
 				assertAgentFamilyReach(
 					this.familyCatalogEntry(source.summary),
 					this.familyCatalogEntry(target.summary),
-					await this.familyCatalogEntries(),
+					familyCatalog!,
 				);
 			}
 			if (source) {
@@ -3031,19 +3033,18 @@ export class DaemonSupervisor {
 		}
 	}
 
-	private async familyCatalogEntries(): Promise<AgentFamilyCatalogEntry[]> {
+	/** Immutable authorization topology: active summaries plus every persisted descendant. */
+	private async familyCatalogEntries(): Promise<readonly AgentFamilyCatalogEntry[]> {
 		const active = [...this.workers.values()].flatMap((worker) => [...worker.summaries.values()]);
 		const activePaths = new Set(
 			active.flatMap((summary) => (summary.sessionFile ? [canonicalSessionPath(summary.sessionFile)] : [])),
 		);
-		const savedRoots = (await this.catalog.list()).filter(
-			(info) =>
-				(info.rlmDepth ?? (info.parentSessionPath ? -1 : 0)) === 0 &&
-				!activePaths.has(canonicalSessionPath(info.path)),
-		);
-		return [...active, ...savedRoots.map((info) => summaryForInactiveSession(info))].map((summary) =>
-			this.familyCatalogEntry(summary),
-		);
+		const entries = new Map<string, AgentFamilyCatalogEntry>();
+		for (const info of await this.catalog.list()) {
+			if (!activePaths.has(canonicalSessionPath(info.path))) entries.set(info.id, this.familyCatalogEntry(summaryForInactiveSession(info)));
+		}
+		for (const summary of active) entries.set(summary.sessionId, this.familyCatalogEntry(summary));
+		return Object.freeze([...entries.values()]);
 	}
 
 	private async withSessionNameReservation<T>(

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3863,7 +3863,7 @@ export class DaemonSupervisor {
 		);
 	}
 
-	private handleWorkerFrame(worker: ResidentWorker, frame: PrivateFrame<DaemonWorkerFrameHeader>): void {
+	private async handleWorkerFrame(worker: ResidentWorker, frame: PrivateFrame<DaemonWorkerFrameHeader>): Promise<void> {
 		if (frame.header.kind !== "outbound") {
 			return;
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2079,7 +2079,9 @@ export class DaemonSupervisor {
 		if (!this.isWorkerStopping(worker)) {
 			return false;
 		}
-		if (isProcessAlive(worker.descriptor.pid)) {
+		// Identity-aware: a pid recycled by an unrelated process counts as gone,
+		// so the stale registration is still reclaimed (and never signalled).
+		if (this.isWorkerProcessCurrent(worker)) {
 			return false;
 		}
 		try {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2083,7 +2083,7 @@ export class DaemonSupervisor {
 		// Fail fast before waiting on anything: only a confirmed-dead process is
 		// reclaimable. A live, unknown, or still-stopping worker is left alone
 		// and the caller reports the session as already active.
-		const identity = this.workerProcessIdentity(worker);
+		const identity = this.processIdentity(worker.descriptor.pid, worker.descriptor.processStartId);
 		if (identity !== "gone" && identity !== "replaced") {
 			return false;
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1800,9 +1800,14 @@ export class DaemonSupervisor {
 				: undefined;
 			// Hold this persisted topology through pre-wake and post-wake checks.
 			const familyCatalog = source && command.agentOrigin === true ? await this.familyCatalogEntries() : undefined;
+			// Session IDs are the stable identities for this authorization snapshot. Do not
+			// rebuild either endpoint from worker summaries after the snapshot is captured.
+			const sourceSessionId = source?.summary.sessionId;
+			let targetSessionId: string;
 			let target: WorkerMatch;
 			try {
 				target = await this.findWorkerForClient(client, command.targetActiveSessionId);
+				targetSessionId = target.summary.sessionId;
 			} catch (error) {
 				if (!(error instanceof Error) || !error.message.startsWith("Unknown active session:")) throw error;
 				const cwd = source?.summary.cwd ?? this.defaultSessionConfig.cwd ?? process.cwd();
@@ -1821,12 +1826,13 @@ export class DaemonSupervisor {
 					}
 					throw error;
 				}
+				const targetInfo = await readSessionInfo(sessionPath);
+				if (!targetInfo) throw new Error(`Unknown active session: ${command.targetActiveSessionId}`);
+				targetSessionId = targetInfo.id;
 				if (source && command.agentOrigin === true) {
-					const targetInfo = await readSessionInfo(sessionPath);
-					if (!targetInfo) throw new Error(`Unknown active session: ${command.targetActiveSessionId}`);
 					assertAgentFamilyReach(
-						this.familyCatalogEntry(source.summary),
-						this.familyCatalogEntry(summaryForInactiveSession(targetInfo)),
+						this.authoritativeFamilyCatalogEntry(familyCatalog!, sourceSessionId!),
+						this.authoritativeFamilyCatalogEntry(familyCatalog!, targetSessionId),
 						familyCatalog!,
 					);
 				}
@@ -1843,9 +1849,14 @@ export class DaemonSupervisor {
 			}
 			const targetActiveSessionId = target.summary.activeSessionId ?? target.summary.id;
 			if (source && command.agentOrigin === true) {
+				// Waking must not substitute a different live session for the target that
+				// was authorized by the captured topology.
+				if (target.summary.sessionId !== targetSessionId) {
+					throw new Error("Agent reach is limited to parent, siblings, and children");
+				}
 				assertAgentFamilyReach(
-					this.familyCatalogEntry(source.summary),
-					this.familyCatalogEntry(target.summary),
+					this.authoritativeFamilyCatalogEntry(familyCatalog!, sourceSessionId!),
+					this.authoritativeFamilyCatalogEntry(familyCatalog!, targetSessionId),
 					familyCatalog!,
 				);
 			}
@@ -3203,6 +3214,16 @@ export class DaemonSupervisor {
 			return "recovering";
 		}
 		return worker.descriptor.lifecycle;
+	}
+
+	/** Resolve both authorization endpoints exclusively from one captured topology snapshot. */
+	private authoritativeFamilyCatalogEntry(
+		catalog: readonly AgentFamilyCatalogEntry[],
+		sessionId: string,
+	): AgentFamilyCatalogEntry {
+		const matches = catalog.filter((entry) => entry.id === sessionId);
+		if (matches.length !== 1) throw new Error("Agent reach is limited to parent, siblings, and children");
+		return matches[0]!;
 	}
 
 	private familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4582,6 +4582,14 @@ export class DaemonSupervisor {
 		if (!recoveryCleanup) {
 			worker.stopRevision++;
 		}
+		// A retry can rescind this stop and relaunch the worker with a new
+		// process while we await below; never remove the successor's state.
+		const entryPid = worker.descriptor.pid;
+		const assertWorkerNotRelaunched = () => {
+			if (!directChild && worker.descriptor.pid !== entryPid) {
+				throw new Error(`Session worker ${worker.descriptor.workerId} was relaunched during stop`);
+			}
+		};
 		try {
 			if (removeDescriptor) {
 				this.persistWorkerStopTombstone(worker, archiveSession);
@@ -4678,11 +4686,13 @@ export class DaemonSupervisor {
 		if (directChild) {
 			await directChild.closed;
 		}
+		assertWorkerNotRelaunched();
 		if (removeDescriptor && worker.descriptor.archiveOnStop) {
 			if (force) {
 				this.reclaimStoppedWorkerCronLock(worker);
 			}
 			await this.finalizeArchivedWorkerStop(worker);
+			assertWorkerNotRelaunched();
 		}
 		this.workers.delete(worker.descriptor.workerId);
 		if (removeDescriptor) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2095,11 +2095,15 @@ export class DaemonSupervisor {
 		if (finalization) {
 			await Promise.race([finalization.catch(() => undefined), unrefDelay(STALE_RECLAIM_WAIT_MS)]);
 		}
-		const reclaimed = this.workers.get(worker.descriptor.workerId) !== worker;
-		if (reclaimed) {
-			this.log(`Reclaimed stale registration for stopped worker ${worker.descriptor.workerId}`);
+		if (this.workers.get(worker.descriptor.workerId) === worker) {
+			// The process is confirmed dead, so the registration must never be
+			// reused; slow cleanup fails the resume honestly instead.
+			throw new Error(
+				`Stopped session worker ${worker.descriptor.workerId} is still being cleaned up; retry shortly`,
+			);
 		}
-		return reclaimed;
+		this.log(`Reclaimed stale registration for stopped worker ${worker.descriptor.workerId}`);
+		return true;
 	}
 
 	private async promoteOwnedWorker(client: DaemonSocketClient, worker: ResidentWorker): Promise<void> {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2079,6 +2079,13 @@ export class DaemonSupervisor {
 		if (!this.isWorkerStopping(worker)) {
 			return false;
 		}
+		// A timed-out stop may already have a background finalizer completing
+		// this exact cleanup; wait for it instead of running a duplicate stop.
+		const finalization = worker.stopFinalization;
+		if (finalization) {
+			await finalization.catch(() => undefined);
+			return this.workers.get(worker.descriptor.workerId) !== worker;
+		}
 		// Identity-aware: a pid recycled by an unrelated process counts as gone,
 		// so the stale registration is still reclaimed (and never signalled).
 		if (this.isWorkerProcessCurrent(worker)) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -139,6 +139,7 @@ const DEFERRED_RECOVERY_RECHECK_MS = 5000;
 const STOP_FINALIZATION_RECHECK_MS = 250;
 const STOP_FINALIZATION_SIGKILL_GRACE_MS = 5000;
 const STOP_FINALIZATION_RETRY_MS = 5000;
+const STALE_RECLAIM_WAIT_MS = 10_000;
 // Polling loops probe existence cheaply via kill(0); the ps-backed zombie and
 // identity checks are throttled so a wedged worker cannot saturate the
 // supervisor event loop with synchronous subprocess spawns.
@@ -2076,30 +2077,29 @@ export class DaemonSupervisor {
 		if (worker.client !== undefined || worker.recovery !== undefined) {
 			return false;
 		}
-		if (!this.isWorkerStopping(worker)) {
+		if (worker.descriptor.stopRequestedAt === undefined) {
 			return false;
 		}
-		// A timed-out stop may already have a background finalizer completing
-		// this exact cleanup; wait for it instead of running a duplicate stop.
-		const finalization = worker.stopFinalization;
-		if (finalization) {
-			await finalization.catch(() => undefined);
-			return this.workers.get(worker.descriptor.workerId) !== worker;
-		}
-		// Identity-aware and conservative: a pid recycled by an unrelated process
-		// counts as gone (so the stale registration is still reclaimed and never
-		// signalled), but an unobservable identity is left alone.
+		// Fail fast before waiting on anything: only a confirmed-dead process is
+		// reclaimable. A live, unknown, or still-stopping worker is left alone
+		// and the caller reports the session as already active.
 		const identity = this.workerProcessIdentity(worker);
 		if (identity !== "gone" && identity !== "replaced") {
 			return false;
 		}
-		try {
-			await this.stopWorker(worker, true, true, worker.descriptor.archiveOnStop === true);
-			this.log(`Reclaimed stale registration for stopped worker ${worker.descriptor.workerId}`);
-		} catch (error) {
-			this.reportCleanupFailure(`stale worker registration ${worker.descriptor.workerId}`, error);
+		// Single cleanup path: the background stop finalizer is identity-aware,
+		// retrying, and single-flighted, so concurrent resumes share one stop.
+		// The wait is bounded so a resume request always returns promptly.
+		this.scheduleWorkerStopFinalization(worker);
+		const finalization = worker.stopFinalization;
+		if (finalization) {
+			await Promise.race([finalization.catch(() => undefined), unrefDelay(STALE_RECLAIM_WAIT_MS)]);
 		}
-		return this.workers.get(worker.descriptor.workerId) !== worker;
+		const reclaimed = this.workers.get(worker.descriptor.workerId) !== worker;
+		if (reclaimed) {
+			this.log(`Reclaimed stale registration for stopped worker ${worker.descriptor.workerId}`);
+		}
+		return reclaimed;
 	}
 
 	private async promoteOwnedWorker(client: DaemonSocketClient, worker: ResidentWorker): Promise<void> {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2402,7 +2402,9 @@ export class DaemonSupervisor {
 		} catch (error) {
 			// The launched child never passed its startup gate; do not retain a
 			// transient recovery environment for a later automatic retry.
-			existing?.recoveryLaunchEnv = undefined;
+			if (existing) {
+				existing.recoveryLaunchEnv = undefined;
+			}
 			if (startupGate instanceof Writable) {
 				startupGate.destroy();
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4668,7 +4668,9 @@ export class DaemonSupervisor {
 		if (force && isWorkerProcessAlive()) {
 			if (directChild) {
 				directChild.child.kill("SIGKILL");
-			} else if (identityVerdict === "current") {
+			} else if (this.workerProcessIdentity(worker) === "current") {
+				// Fresh, unthrottled check: the cached verdict may be up to 500ms
+				// old, long enough for the pid to be recycled.
 				signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
 			}
 			const forceDeadline = Date.now() + 1000;
@@ -4782,7 +4784,13 @@ export class DaemonSupervisor {
 				break;
 			}
 			if (!killed && stoppedCanSignal && Date.now() >= sigkillDeadline) {
-				signalProcessGroupOrProcess(pid, "SIGKILL");
+				// Fresh, unthrottled identity check right before signalling: the
+				// cached verdict may be up to 500ms old, long enough for the pid
+				// to be recycled by an unrelated process.
+				const observedNow = processStartId === undefined ? undefined : getProcessStartId(pid);
+				if (processStartId === undefined || observedNow === processStartId) {
+					signalProcessGroupOrProcess(pid, "SIGKILL");
+				}
 				killed = true;
 			}
 			await unrefDelay(STOP_FINALIZATION_RECHECK_MS);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1926,13 +1926,13 @@ export class DaemonSupervisor {
 		);
 		await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 		const clientOwnedWorkers = [...this.workers.values()].filter((worker) => !this.isVisibleWorker(worker));
+		// Stopping workers stay listed (with an honest workerState) because this
+		// list also feeds busy-daemon safety checks in daemon-launch.
 		const active = [...this.workers.values()]
 			.filter(
 				(worker) =>
-					this.isLiveWorker(worker) ||
-					(command.includeClientOwned === true &&
-						!this.isWorkerStopping(worker) &&
-						this.isWorkerAccessibleToClient(client, worker)),
+					this.isVisibleWorker(worker) ||
+					(command.includeClientOwned === true && this.isWorkerAccessibleToClient(client, worker)),
 			)
 			.flatMap((worker) => [...worker.summaries.values()].map((summary) => this.publicSummary(worker, summary)));
 		const busyClientOwnedSessionCount = clientOwnedWorkers

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -113,6 +113,7 @@ import {
 	type DaemonCreateCommand,
 	type DaemonWorkerDescriptor,
 	type DaemonWorkerFrameHeader,
+	type DaemonWorkerLifecycle,
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 } from "./daemon-worker-protocol.js";
@@ -765,7 +766,7 @@ export class DaemonSupervisor {
 		return {
 			lifecycle: worker.descriptor.lifecycle,
 			isConnected: worker.client !== undefined,
-			isStopping: worker.intentionalStop || worker.descriptor.stopRequestedAt !== undefined,
+			isStopping: this.isWorkerStopping(worker),
 			hasOwnerClient: worker.descriptor.ownerClientId !== undefined,
 			isPreparingUpdateRestart:
 				this.updateRestartPhase !== undefined || worker.updateRestartPrepareClient !== undefined,
@@ -1580,7 +1581,7 @@ export class DaemonSupervisor {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return this.forwardToWorker(match.worker, command);
 				}
-				const first = [...this.workers.values()].find((worker) => this.isVisibleWorker(worker) && worker.client);
+				const first = [...this.workers.values()].find((worker) => this.isLiveWorker(worker) && worker.client);
 				if (!first) {
 					return success(command.id, command.type, { paused: false, limits: {} });
 				}
@@ -1594,7 +1595,7 @@ export class DaemonSupervisor {
 				}
 				const responses = await Promise.all(
 					[...this.workers.values()]
-						.filter((worker) => this.isVisibleWorker(worker) && worker.client)
+						.filter((worker) => this.isLiveWorker(worker) && worker.client)
 						.map((worker) => this.forwardToWorker(worker, command)),
 				);
 				const failed = responses.find((response) => !response.success);
@@ -1609,8 +1610,7 @@ export class DaemonSupervisor {
 				const responses = await Promise.all(
 					[...this.workers.values()]
 						.filter(
-							(worker) =>
-								this.isVisibleWorker(worker) && worker.client && worker.descriptor.lifecycle === "ready",
+							(worker) => this.isLiveWorker(worker) && worker.client && worker.descriptor.lifecycle === "ready",
 						)
 						.map((worker) =>
 							this.forwardToWorker(worker, command, 5000).catch((error: unknown) =>
@@ -1634,7 +1634,7 @@ export class DaemonSupervisor {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return this.forwardToWorker(match.worker, command);
 				}
-				const workers = [...this.workers.values()].filter((worker) => this.isVisibleWorker(worker));
+				const workers = [...this.workers.values()].filter((worker) => this.isLiveWorker(worker));
 				const heartbeats = new Map<string, AgentConnectionHeartbeat>();
 				const snapshots: Array<{ heartbeats?: AgentConnectionHeartbeat[]; response?: DaemonResponse }> =
 					await Promise.all(
@@ -1718,8 +1718,7 @@ export class DaemonSupervisor {
 				const listed = await Promise.all(
 					[...this.workers.values()]
 						.filter(
-							(worker) =>
-								this.isVisibleWorker(worker) && worker.client && worker.descriptor.lifecycle === "ready",
+							(worker) => this.isLiveWorker(worker) && worker.client && worker.descriptor.lifecycle === "ready",
 						)
 						.map(async (worker) => ({
 							worker,
@@ -1930,8 +1929,10 @@ export class DaemonSupervisor {
 		const active = [...this.workers.values()]
 			.filter(
 				(worker) =>
-					this.isVisibleWorker(worker) ||
-					(command.includeClientOwned === true && this.isWorkerAccessibleToClient(client, worker)),
+					this.isLiveWorker(worker) ||
+					(command.includeClientOwned === true &&
+						!this.isWorkerStopping(worker) &&
+						this.isWorkerAccessibleToClient(client, worker)),
 			)
 			.flatMap((worker) => [...worker.summaries.values()].map((summary) => this.publicSummary(worker, summary)));
 		const busyClientOwnedSessionCount = clientOwnedWorkers
@@ -3061,9 +3062,7 @@ export class DaemonSupervisor {
 			.then(async () => {
 				const readyWorkers = [...this.workers.values()].filter(
 					(worker): worker is ResidentWorker & { client: DaemonWorkerClient } =>
-						this.isVisibleWorker(worker) &&
-						worker.descriptor.lifecycle === "ready" &&
-						worker.client !== undefined,
+						this.isLiveWorker(worker) && worker.descriptor.lifecycle === "ready" && worker.client !== undefined,
 				);
 				await Promise.all(
 					readyWorkers.map(async (worker) => {
@@ -3088,6 +3087,30 @@ export class DaemonSupervisor {
 
 	private isVisibleWorker(worker: ResidentWorker): boolean {
 		return worker.descriptor.ownerClientId === undefined;
+	}
+
+	/** A worker with a durable or in-memory stop intent is stopping, never live. */
+	private isWorkerStopping(worker: ResidentWorker): boolean {
+		return worker.intentionalStop || worker.descriptor.stopRequestedAt !== undefined;
+	}
+
+	/** Live workers are visible to all clients and not stopping. */
+	private isLiveWorker(worker: ResidentWorker): boolean {
+		return this.isVisibleWorker(worker) && !this.isWorkerStopping(worker);
+	}
+
+	/**
+	 * The lifecycle reported to clients. A stop intent always wins, and a worker
+	 * whose process connection is gone is never reported as "ready".
+	 */
+	private effectiveWorkerState(worker: ResidentWorker): DaemonWorkerLifecycle {
+		if (this.isWorkerStopping(worker)) {
+			return "stopping";
+		}
+		if (worker.descriptor.lifecycle === "ready" && worker.client === undefined) {
+			return "recovering";
+		}
+		return worker.descriptor.lifecycle;
 	}
 
 	private familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry {
@@ -3134,7 +3157,7 @@ export class DaemonSupervisor {
 			...summary,
 			attachedClients: [...this.clients].filter((client) => client.attachedActiveSessionIds.has(activeSessionId))
 				.length,
-			workerState: worker.descriptor.lifecycle,
+			workerState: this.effectiveWorkerState(worker),
 			workerPid: worker.descriptor.pid,
 		};
 	}
@@ -3240,7 +3263,7 @@ export class DaemonSupervisor {
 		timeoutMs = WORKER_REQUEST_TIMEOUT_MS,
 	): Promise<DaemonResponse> {
 		if (!worker.client || worker.descriptor.lifecycle !== "ready") {
-			throw new Error(`Session worker is ${worker.descriptor.lifecycle}`);
+			throw new Error(`Session worker is ${this.effectiveWorkerState(worker)}`);
 		}
 		const response = await worker.client.request(withoutCommandId(command), timeoutMs);
 		if (command.type === "get_state" && response.success && isSessionSummary(response.data)) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4521,6 +4521,18 @@ export class DaemonSupervisor {
 		renameSync(tempPath, path);
 	}
 
+	/** True when the registered pid is alive and still the process we launched. */
+	private isWorkerProcessCurrent(worker: ResidentWorker): boolean {
+		if (!isProcessAlive(worker.descriptor.pid)) {
+			return false;
+		}
+		if (worker.descriptor.processStartId === undefined) {
+			return true;
+		}
+		const observed = getProcessStartId(worker.descriptor.pid);
+		return observed === undefined || observed === worker.descriptor.processStartId;
+	}
+
 	private async stopWorker(
 		worker: ResidentWorker,
 		removeDescriptor: boolean,
@@ -4604,13 +4616,14 @@ export class DaemonSupervisor {
 			worker.client = undefined;
 		} else if (directChild) {
 			directChild.child.kill("SIGTERM");
-		} else if (isProcessAlive(worker.descriptor.pid)) {
+		} else if (this.isWorkerProcessCurrent(worker)) {
 			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGTERM");
 		}
+		// Identity-aware: a recycled pid is treated as gone and never signalled.
 		const isWorkerProcessAlive = () =>
 			directChild
 				? directChild.child.exitCode === null && directChild.child.signalCode === null
-				: isProcessAlive(worker.descriptor.pid);
+				: this.isWorkerProcessCurrent(worker);
 		const gracefulDeadline = Date.now() + (force ? 500 : 2000);
 		while (isWorkerProcessAlive() && Date.now() < gracefulDeadline) {
 			await delay(25);
@@ -4667,24 +4680,43 @@ export class DaemonSupervisor {
 	}
 
 	private async finalizeTimedOutWorkerStop(worker: ResidentWorker): Promise<void> {
+		// Bind to the exact process generation being stopped: a retry can rescind
+		// the stop and relaunch with a new pid, and the OS can recycle the old
+		// pid. The finalizer must never follow either successor.
+		const pid = worker.descriptor.pid;
+		const processStartId = worker.descriptor.processStartId ?? getProcessStartId(pid);
+		const stopRevision = worker.stopRevision;
+		const isStopGenerationCurrent = () =>
+			this.workers.get(worker.descriptor.workerId) === worker &&
+			worker.stopRevision === stopRevision &&
+			worker.descriptor.stopRequestedAt !== undefined &&
+			worker.descriptor.pid === pid;
+		const isStoppedProcessAlive = () => {
+			if (!isProcessAlive(pid)) {
+				return false;
+			}
+			if (processStartId === undefined) {
+				return true;
+			}
+			const observed = getProcessStartId(pid);
+			return observed === undefined || observed === processStartId;
+		};
 		const sigkillDeadline = Date.now() + STOP_FINALIZATION_SIGKILL_GRACE_MS;
 		let killed = false;
 		while (!this.shuttingDown) {
-			if (!isProcessAlive(worker.descriptor.pid)) {
+			if (!isStopGenerationCurrent()) {
+				return;
+			}
+			if (!isStoppedProcessAlive()) {
 				break;
 			}
 			if (!killed && Date.now() >= sigkillDeadline) {
-				signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
+				signalProcessGroupOrProcess(pid, "SIGKILL");
 				killed = true;
 			}
 			await unrefDelay(STOP_FINALIZATION_RECHECK_MS);
 		}
-		if (this.shuttingDown || this.workers.get(worker.descriptor.workerId) !== worker) {
-			return;
-		}
-		if (worker.descriptor.stopRequestedAt === undefined) {
-			// The stop was rescinded (for example by an explicit retry) while the
-			// process was still exiting; leave the registration to that flow.
+		if (this.shuttingDown || !isStopGenerationCurrent()) {
 			return;
 		}
 		try {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -270,6 +270,8 @@ interface ResidentWorker {
 	intentionalStop: boolean;
 	stopRevision: number;
 	launchEnv?: Record<string, string>;
+	/** Fresh client environment used once for a resident replacement, never persisted. */
+	recoveryLaunchEnv?: Record<string, string>;
 	stopFinalization?: Promise<void>;
 	ownerCleanupTimer?: ReturnType<typeof setTimeout>;
 	promotedOwnerClientId?: string;
@@ -2048,7 +2050,7 @@ export class DaemonSupervisor {
 		if (command.sessionPath) {
 			const activeMatches = this.matchWorkers(command.sessionPath);
 			if (activeMatches.length === 1 && !(await this.reclaimStaleWorkerRegistration(activeMatches[0]!.worker))) {
-				return this.reuseWorkerForCreate(activeMatches[0]!.worker, ownerClientId, command.sessionPath);
+				return await this.reuseWorkerForCreate(activeMatches[0]!.worker, ownerClientId, command.sessionPath, command);
 			}
 			if (activeMatches.length > 1) {
 				throw new Error(`Ambiguous active session "${command.sessionPath}"`);
@@ -2060,7 +2062,7 @@ export class DaemonSupervisor {
 			createCommand = { ...createCommand, sessionPath };
 			const existing = this.findWorkerBySessionFile(sessionPath);
 			if (existing && !(await this.reclaimStaleWorkerRegistration(existing.worker))) {
-				return this.reuseWorkerForCreate(existing.worker, ownerClientId, sessionPath);
+				return await this.reuseWorkerForCreate(existing.worker, ownerClientId, sessionPath, command);
 			}
 			// A passive child from a stopped worker reopens as top-level here (pre-existing behavior);
 			// the recursive-harness residency/eviction PR will revisit it.
@@ -2099,15 +2101,36 @@ export class DaemonSupervisor {
 		}
 	}
 
-	private reuseWorkerForCreate(
+	private async reuseWorkerForCreate(
 		worker: ResidentWorker,
 		ownerClientId: string | undefined,
 		sessionPath: string,
-	): ResidentWorker {
-		if (worker.descriptor.ownerClientId === ownerClientId) {
-			return worker;
+		command: DaemonCreateCommand,
+	): Promise<ResidentWorker> {
+		if (worker.descriptor.ownerClientId !== ownerClientId) {
+			throw new SessionAlreadyActiveError(sessionPath, worker.descriptor.rootActiveSessionId);
 		}
-		throw new SessionAlreadyActiveError(sessionPath, worker.descriptor.rootActiveSessionId);
+		// A saved resident session may be resumed by a fresh ACP client after its
+		// worker died. The resume create is the authenticated caller path that
+		// already carries the complete transient environment. Never save it: it is
+		// consumed only by recovery, while ordinary live-worker reuse remains a
+		// no-op and cannot rebind the session's process environment.
+		if (
+			ownerClientId === undefined &&
+			command.lifecycle !== "client_owned" &&
+			command.launchEnv &&
+			(!worker.client || worker.descriptor.lifecycle !== "ready")
+		) {
+			worker.recoveryLaunchEnv = command.launchEnv;
+			worker.intentionalStop = false;
+			worker.descriptor.stopRequestedAt = undefined;
+			worker.descriptor.archiveOnStop = undefined;
+			worker.descriptor.lifecycle = "recovering";
+			worker.descriptor.consecutiveFailures = 0;
+			this.persistWorker(worker);
+			await this.recoverWorker(worker);
+		}
+		return worker;
 	}
 
 	/**
@@ -2193,17 +2216,18 @@ export class DaemonSupervisor {
 		// launch settings, which are never written to a descriptor.
 		const launchEnv = existing
 			? ownerClientIdForDescriptor === undefined
-				? existing.descriptor.launchEnv
+				? (existing.recoveryLaunchEnv ?? existing.descriptor.launchEnv)
 				: existing.launchEnv
 			: command.launchEnv;
 		// Only non-secret, explicitly allowed settings are durable. The initial
 		// spawn may still receive caller credentials through launchEnv, but those
 		// credentials must never be serialized into a worker descriptor.
 		const persistedLaunchEnv = filterPersistedDaemonLaunchEnv(launchEnv);
-		// A replacement supervisor can itself have been restarted by the old worker
-		// and therefore inherit that worker's original credentials. Automatic
-		// resident recovery must not copy those ambient secrets into the replacement
-		// worker. Client-owned recovery instead uses its live owner's transient env.
+		// A resident descriptor is deliberately a non-secret recovery recipe, not a
+		// credential cache. Only a fresh client resume may supply a transient
+		// recovery environment. Keep the inherited base limited to durable-safe
+		// settings so a supervisor's ambient credentials can never silently revive a
+		// crashed resident worker.
 		const inheritedEnv =
 			existing && ownerClientIdForDescriptor === undefined
 				? filterPersistedDaemonLaunchEnv(collectDaemonLaunchEnv(process.env))
@@ -2317,6 +2341,9 @@ export class DaemonSupervisor {
 			worker.intentionalStop = false;
 			this.workers.set(workerId, worker);
 		} catch (error) {
+			// The launched child never passed its startup gate; do not retain a
+			// transient recovery environment for a later automatic retry.
+			existing?.recoveryLaunchEnv = undefined;
 			if (startupGate instanceof Writable) {
 				startupGate.destroy();
 			}
@@ -2374,8 +2401,14 @@ export class DaemonSupervisor {
 			this.persistWorker(worker);
 			await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 			this.broadcastHeartbeatsChanged();
+			// The child has consumed the fresh environment. It must not survive in
+			// the supervisor for any later automatic recovery.
+			worker.recoveryLaunchEnv = undefined;
 			return worker;
 		} catch (error) {
+			// A replacement was attempted; require another fresh client resume rather
+			// than retaining credentials for a retry.
+			worker.recoveryLaunchEnv = undefined;
 			if (isSupervisorGenerationStale(error)) {
 				throw error;
 			}
@@ -2837,6 +2870,19 @@ export class DaemonSupervisor {
 		if (this.isWorkerRecoveryCancelled(worker)) {
 			return;
 		}
+		if (
+			worker.descriptor.ownerClientId === undefined &&
+			!worker.recoveryLaunchEnv &&
+			!isProcessAlive(worker.descriptor.pid)
+		) {
+			// Never recover resident credentials from a descriptor or the daemon's
+			// ambient environment. A primary client resume supplies a fresh transient
+			// launch environment and explicitly restarts this recovery path.
+			worker.descriptor.lifecycle = "failed";
+			worker.descriptor.lastError = "Waiting for a client with fresh environment";
+			this.persistWorker(worker);
+			return;
+		}
 		if (worker.descriptor.ownerClientId && !worker.launchEnv && !isProcessAlive(worker.descriptor.pid)) {
 			worker.descriptor.lifecycle = "failed";
 			worker.descriptor.lastError = "Waiting for the owning client to reconnect";
@@ -2850,6 +2896,16 @@ export class DaemonSupervisor {
 			for (const [retryIndex, retryDelay] of WORKER_RETRY_DELAYS_MS.entries()) {
 				await delay(retryDelay);
 				if (this.isWorkerRecoveryCancelled(worker)) {
+					return;
+				}
+				if (
+					worker.descriptor.ownerClientId === undefined &&
+					!worker.recoveryLaunchEnv &&
+					!isProcessAlive(worker.descriptor.pid)
+				) {
+					worker.descriptor.lifecycle = "failed";
+					worker.descriptor.lastError = "Waiting for a client with fresh environment";
+					this.persistWorker(worker);
 					return;
 				}
 				try {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2423,9 +2423,17 @@ export class DaemonSupervisor {
 		if (worker.descriptor.stopRequestedAt) {
 			try {
 				// A tombstoned worker must not run long enough to elect another
-				// supervisor while its intentional stop is being adopted.
-				signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
-				await this.stopWorker(worker, true, true, worker.descriptor.archiveOnStop === true);
+				// supervisor while its intentional stop is being adopted. Legacy or
+				// unreadable identity deliberately keeps the tombstone for retries.
+				const descriptor = worker.descriptor;
+				this.signalCurrentWorker(
+					worker,
+					descriptor,
+					worker.stopRevision,
+					descriptor.stopRequestedAt,
+					"SIGKILL",
+				);
+				await this.stopWorker(worker, true, true, descriptor.archiveOnStop === true);
 				this.log(`Completed intentional stop for worker ${worker.descriptor.workerId} during supervisor adoption`);
 			} catch (error) {
 				worker.descriptor.lifecycle = "failed";
@@ -2867,10 +2875,11 @@ export class DaemonSupervisor {
 
 	private async recoverUncertainWorkerOperations(worker: ResidentWorker, killWorkerProcess = true): Promise<void> {
 		await this.assertRecoveryAllowed();
+		const descriptor = worker.descriptor;
 		if (killWorkerProcess) {
-			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
+			this.signalCurrentWorker(worker, descriptor, worker.stopRevision, descriptor.stopRequestedAt, "SIGKILL");
 		}
-		const orphanProcessJournalPath = worker.descriptor.orphanProcessJournalPath;
+		const orphanProcessJournalPath = descriptor.orphanProcessJournalPath;
 		if (orphanProcessJournalPath) {
 			try {
 				for (const orphan of readActiveOrphanProcesses(orphanProcessJournalPath, worker.descriptor.pid)) {
@@ -4581,14 +4590,52 @@ export class DaemonSupervisor {
 		if (!isProcessAlive(pid)) {
 			return "gone";
 		}
+		// A legacy descriptor has no generation to bind the pid to. It is
+		// intentionally not signalable: a pid may have been recycled.
 		if (processStartId === undefined) {
-			return "current";
+			return "unknown";
 		}
 		const observed = getProcessStartId(pid);
 		if (observed === undefined) {
 			return "unknown";
 		}
 		return observed === processStartId ? "current" : "replaced";
+	}
+
+	/**
+	 * Signal only the exact registered worker incarnation. This deliberately
+	 * fails closed for legacy descriptors and transiently unreadable process
+	 * identity. Callers retain the tombstone/retry authority in that case.
+	 */
+	private signalCurrentWorker(
+		worker: ResidentWorker,
+		descriptor: DaemonWorkerDescriptor,
+		stopRevision: number,
+		stopRequestedAt: string | undefined,
+		signal: NodeJS.Signals,
+		directChild?: ChildProcess,
+	): boolean {
+		const { pid, processStartId } = descriptor;
+		if (
+			processStartId === undefined ||
+			this.workers.get(descriptor.workerId) !== worker ||
+			worker.descriptor !== descriptor ||
+			worker.descriptor.pid !== pid ||
+			worker.descriptor.processStartId !== processStartId ||
+			worker.stopRevision !== stopRevision ||
+			worker.descriptor.stopRequestedAt !== stopRequestedAt ||
+			(directChild !== undefined &&
+				(directChild.pid !== pid || directChild.exitCode !== null || directChild.signalCode !== null)) ||
+			this.processIdentity(pid, processStartId) !== "current"
+		) {
+			return false;
+		}
+		if (directChild) {
+			directChild.kill(signal);
+		} else {
+			signalProcessGroupOrProcess(pid, signal);
+		}
+		return true;
 	}
 
 	private async stopWorker(
@@ -4627,23 +4674,10 @@ export class DaemonSupervisor {
 			worker.stopRevision++;
 		}
 		// A retry can rescind this stop and relaunch the worker while we await
-		// below. Bind every liveness check and signal to the process this stop
-		// entered with, and abort cleanup once the stop no longer applies: the
-		// pid changed (relaunched) or a removeDescriptor stop lost its tombstone
-		// (rescinded, even before the successor pid lands).
-		const entryPid = worker.descriptor.pid;
-		const entryStartId = worker.descriptor.processStartId;
-		const assertStopStillApplies = () => {
-			if (directChild) {
-				return;
-			}
-			if (
-				worker.descriptor.pid !== entryPid ||
-				(removeDescriptor && worker.descriptor.stopRequestedAt === undefined)
-			) {
-				throw new Error(`Session worker ${worker.descriptor.workerId} was relaunched during stop`);
-			}
-		};
+		// below. Bind every mutation, liveness check, and signal to this exact
+		// worker object, descriptor incarnation, pid/start-id pair, stop revision,
+		// and stop marker. Do not claim supervisor-generation fencing here: it is
+		// not an enforced part of this stop tuple.
 		try {
 			if (removeDescriptor) {
 				this.persistWorkerStopTombstone(worker, archiveSession);
@@ -4658,6 +4692,24 @@ export class DaemonSupervisor {
 			}
 			this.reportCleanupFailure(`worker rollback state ${worker.descriptor.workerId}`, error);
 		}
+		const entryDescriptor = worker.descriptor;
+		const entryPid = entryDescriptor.pid;
+		const entryStartId = entryDescriptor.processStartId;
+		const entryStopRevision = worker.stopRevision;
+		const entryStopRequestedAt = entryDescriptor.stopRequestedAt;
+		const entryClient = worker.client;
+		const assertStopStillApplies = () => {
+			if (
+				this.workers.get(entryDescriptor.workerId) !== worker ||
+				worker.descriptor !== entryDescriptor ||
+				worker.descriptor.pid !== entryPid ||
+				worker.descriptor.processStartId !== entryStartId ||
+				worker.stopRevision !== entryStopRevision ||
+				worker.descriptor.stopRequestedAt !== entryStopRequestedAt
+			) {
+				throw new Error(`Session worker ${entryDescriptor.workerId} changed during stop`);
+			}
+		};
 		const transferError = new Error("Session worker stopped during snapshot transfer");
 		const generationTranscripts = new Set<SnapshotTranscriptCache>();
 		for (const [activeSessionId, generations] of [...(worker.snapshotGenerations ?? new Map())]) {
@@ -4680,20 +4732,29 @@ export class DaemonSupervisor {
 		worker.transcriptCaches.clear();
 		worker.snapshotCache.clear();
 		worker.snapshotGenerations?.clear();
-		if (worker.client) {
+		if (entryClient) {
 			if (archiveSession) {
-				await worker.client
+				await entryClient
 					.requestWorker({ type: "worker_archive_and_shutdown" }, force ? 1000 : 5000)
 					.catch(() => undefined);
 			} else {
-				await worker.client.request({ type: "shutdown" }, force ? 1000 : 5000).catch(() => undefined);
+				await entryClient.request({ type: "shutdown" }, force ? 1000 : 5000).catch(() => undefined);
 			}
-			worker.client.close();
-			worker.client = undefined;
-		} else if (directChild) {
-			directChild.child.kill("SIGTERM");
-		} else if (this.processIdentity(entryPid, entryStartId) === "current") {
-			signalProcessGroupOrProcess(entryPid, "SIGTERM");
+			assertStopStillApplies();
+			entryClient.close();
+			if (worker.client === entryClient) {
+				worker.client = undefined;
+			}
+		} else {
+			assertStopStillApplies();
+			this.signalCurrentWorker(
+				worker,
+				entryDescriptor,
+				entryStopRevision,
+				entryStopRequestedAt,
+				"SIGTERM",
+				directChild?.child,
+			);
 		}
 		// Identity-aware in both directions: a replaced pid counts as gone (never
 		// signal a recycled pid) while an unknown identity counts as alive (never
@@ -4719,18 +4780,24 @@ export class DaemonSupervisor {
 		while (isWorkerProcessAlive() && Date.now() < gracefulDeadline) {
 			await delay(25);
 		}
+		assertStopStillApplies();
 		if (force && isWorkerProcessAlive()) {
-			if (directChild) {
-				directChild.child.kill("SIGKILL");
-			} else if (this.processIdentity(entryPid, entryStartId) === "current") {
-				// Fresh, unthrottled check: the cached verdict may be up to 500ms
-				// old, long enough for the pid to be recycled.
-				signalProcessGroupOrProcess(entryPid, "SIGKILL");
-			}
+			assertStopStillApplies();
+			// signalCurrentWorker performs a fresh, unthrottled identity check;
+			// cached liveness may be old enough for pid reuse.
+			this.signalCurrentWorker(
+				worker,
+				entryDescriptor,
+				entryStopRevision,
+				entryStopRequestedAt,
+				"SIGKILL",
+				directChild?.child,
+			);
 			const forceDeadline = Date.now() + 1000;
 			while (isWorkerProcessAlive() && Date.now() < forceDeadline) {
 				await delay(25);
 			}
+			assertStopStillApplies();
 		}
 		if (isWorkerProcessAlive()) {
 			worker.intentionalStop = worker.descriptor.stopRequestedAt !== undefined;
@@ -4775,37 +4842,25 @@ export class DaemonSupervisor {
 	}
 
 	private async finalizeTimedOutWorkerStop(worker: ResidentWorker): Promise<void> {
-		// Bind to the exact process generation being stopped: a retry can rescind
-		// the stop and relaunch with a new pid, and the OS can recycle the old
-		// pid. The finalizer must never follow either successor.
-		const pid = worker.descriptor.pid;
-		let processStartId = worker.descriptor.processStartId;
-		if (processStartId === undefined) {
-			// The stop timed out because the process was still alive moments ago,
-			// so an identity observed now can be trusted and recorded. It lets the
-			// eventual stopWorker call fail closed on a recycled pid too.
-			const observed = getProcessStartId(pid);
-			if (observed !== undefined && isProcessAlive(pid)) {
-				processStartId = observed;
-				worker.descriptor.processStartId = observed;
-				try {
-					this.persistWorker(worker);
-				} catch (error) {
-					this.reportCleanupFailure(`worker identity record ${worker.descriptor.workerId}`, error);
-				}
-			}
-		}
+		// Bind to the exact stop tuple. A retry can replace the descriptor,
+		// rescind its tombstone, or relaunch with a new pid while this finalizer
+		// awaits. Legacy/unreadable identities deliberately remain unsignalable.
+		const descriptor = worker.descriptor;
+		const { pid, processStartId } = descriptor;
 		const stopRevision = worker.stopRevision;
+		const stopRequestedAt = descriptor.stopRequestedAt;
 		const isStopGenerationCurrent = () =>
-			this.workers.get(worker.descriptor.workerId) === worker &&
+			this.workers.get(descriptor.workerId) === worker &&
+			worker.descriptor === descriptor &&
 			worker.stopRevision === stopRevision &&
-			worker.descriptor.stopRequestedAt !== undefined &&
-			worker.descriptor.pid === pid;
-		// A replaced pid counts as gone (never SIGKILL a recycled pid); an
-		// unobservable identity counts as alive (never clean up a possibly-live
-		// worker). kill(0) probes every poll; ps-backed checks are throttled.
+			worker.descriptor.stopRequestedAt === stopRequestedAt &&
+			stopRequestedAt !== undefined &&
+			worker.descriptor.pid === pid &&
+			worker.descriptor.processStartId === processStartId;
+		// A replaced pid counts as gone (never SIGKILL a recycled pid); a
+		// missing or unobservable identity counts as alive (never clean up a
+		// possibly-live worker). kill(0) probes every poll; ps checks throttle.
 		let stoppedVerdict = true;
-		let stoppedCanSignal = true;
 		let stoppedCheckedAt = 0;
 		const isStoppedProcessAlive = () => {
 			if (!processIdExists(pid)) {
@@ -4816,16 +4871,8 @@ export class DaemonSupervisor {
 				return stoppedVerdict;
 			}
 			stoppedCheckedAt = now;
-			if (!isProcessAlive(pid)) {
-				stoppedVerdict = false;
-			} else if (processStartId === undefined) {
-				stoppedVerdict = true;
-				stoppedCanSignal = true;
-			} else {
-				const observed = getProcessStartId(pid);
-				stoppedVerdict = observed !== processStartId ? observed === undefined : true;
-				stoppedCanSignal = observed === processStartId;
-			}
+			const verdict = this.processIdentity(pid, processStartId);
+			stoppedVerdict = verdict !== "replaced" && verdict !== "gone";
 			return stoppedVerdict;
 		};
 		const sigkillDeadline = Date.now() + STOP_FINALIZATION_SIGKILL_GRACE_MS;
@@ -4837,17 +4884,10 @@ export class DaemonSupervisor {
 			if (!isStoppedProcessAlive()) {
 				break;
 			}
-			if (!killed && stoppedCanSignal && Date.now() >= sigkillDeadline) {
-				// Fresh, unthrottled identity check right before signalling: the
-				// cached verdict may be up to 500ms old, long enough for the pid
-				// to be recycled by an unrelated process. A transiently
-				// unobservable identity skips this attempt but keeps escalation
-				// armed so a wedged worker is still killed on a later pass.
-				const observedNow = processStartId === undefined ? undefined : getProcessStartId(pid);
-				if (processStartId === undefined || observedNow === processStartId) {
-					signalProcessGroupOrProcess(pid, "SIGKILL");
-					killed = true;
-				}
+			if (!killed && Date.now() >= sigkillDeadline) {
+				// signalCurrentWorker makes a fresh exact observation immediately
+				// before signalling. A miss keeps the tombstone and escalation armed.
+				killed = this.signalCurrentWorker(worker, descriptor, stopRevision, stopRequestedAt, "SIGKILL");
 			}
 			await unrefDelay(STOP_FINALIZATION_RECHECK_MS);
 		}
@@ -4855,10 +4895,7 @@ export class DaemonSupervisor {
 		// dead worker's registration is never stranded permanently. Each attempt
 		// bumps the worker's stopRevision, so rescission is detected through the
 		// registration and tombstone instead of the waiting-phase snapshot.
-		const isCleanupStillWanted = () =>
-			this.workers.get(worker.descriptor.workerId) === worker &&
-			worker.descriptor.stopRequestedAt !== undefined &&
-			worker.descriptor.pid === pid;
+		const isCleanupStillWanted = isStopGenerationCurrent;
 		while (!this.shuttingDown && isCleanupStillWanted()) {
 			try {
 				await this.stopWorker(worker, true, true, worker.descriptor.archiveOnStop === true);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2121,19 +2121,40 @@ export class DaemonSupervisor {
 			command.launchEnv &&
 			(!worker.client || worker.descriptor.lifecycle !== "ready")
 		) {
-			// The first fresh resume owns the one-shot recovery environment. Later
-			// resumes join that recovery instead of replacing its credentials; their
-			// defined result is the same recovered worker, or its recorded failure.
+			// A recovery that already owns a fresh environment is single-flighted:
+			// later resumes join it and cannot replace its one-shot credentials. An
+			// automatic recovery has no such capability, however. Fence a fresh
+			// resume behind it so its finalizer cannot clear the newly adopted env.
 			const inFlightRecovery = worker.recovery;
 			if (inFlightRecovery) {
-				await inFlightRecovery;
-				if (!worker.client || worker.descriptor.lifecycle !== "ready") {
-					throw new Error(
-						worker.descriptor.lastError ??
-						`Session worker ${worker.descriptor.workerId} did not recover for the first fresh resume`,
-					);
+				if (worker.recoveryLaunchEnv) {
+					await inFlightRecovery;
+					if (!worker.client || worker.descriptor.lifecycle !== "ready") {
+						throw new Error(
+							worker.descriptor.lastError ??
+								`Session worker ${worker.descriptor.workerId} did not recover for the first fresh resume`,
+						);
+					}
+					return worker;
 				}
-				return worker;
+
+				await inFlightRecovery;
+				if (worker.client && worker.descriptor.lifecycle === "ready") {
+					return worker;
+				}
+				// Another fresh resume can claim the one-shot environment after the
+				// env-less recovery settles. It is now the owner; join it instead
+				// of overwriting its credentials.
+				if (worker.recovery) {
+					await worker.recovery;
+					if (!worker.client || worker.descriptor.lifecycle !== "ready") {
+						throw new Error(
+							worker.descriptor.lastError ??
+								`Session worker ${worker.descriptor.workerId} did not recover for the first fresh resume`,
+						);
+					}
+					return worker;
+				}
 			}
 			worker.recoveryLaunchEnv = command.launchEnv;
 			worker.intentionalStop = false;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2086,9 +2086,11 @@ export class DaemonSupervisor {
 			await finalization.catch(() => undefined);
 			return this.workers.get(worker.descriptor.workerId) !== worker;
 		}
-		// Identity-aware: a pid recycled by an unrelated process counts as gone,
-		// so the stale registration is still reclaimed (and never signalled).
-		if (this.isWorkerProcessCurrent(worker)) {
+		// Identity-aware and conservative: a pid recycled by an unrelated process
+		// counts as gone (so the stale registration is still reclaimed and never
+		// signalled), but an unobservable identity is left alone.
+		const identity = this.workerProcessIdentity(worker);
+		if (identity !== "gone" && identity !== "replaced") {
 			return false;
 		}
 		try {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -43,7 +43,7 @@ import {
 import { canonicalSessionPath, getProcessStartId, SessionAlreadyActiveError } from "../../core/session-lease.js";
 import { readSessionInfo, type SessionInfo } from "../../core/session-manager.js";
 import { SettingsManager } from "../../core/settings-manager.js";
-import { isProcessAlive, signalProcessGroupOrProcess } from "../../utils/child-process.js";
+import { isProcessAlive, processIdExists, signalProcessGroupOrProcess } from "../../utils/child-process.js";
 import type { AgentConnectionHeartbeat } from "../agent-connection/types.js";
 import { attachJsonlLineReader, serializeJsonLine } from "../rpc/jsonl.js";
 import type { PrivateFrame } from "../session-worker/private-framing.js";
@@ -138,6 +138,11 @@ const WORKER_RETRY_DELAYS_MS = [250, 1000, 5000] as const;
 const DEFERRED_RECOVERY_RECHECK_MS = 5000;
 const STOP_FINALIZATION_RECHECK_MS = 250;
 const STOP_FINALIZATION_SIGKILL_GRACE_MS = 5000;
+const STOP_FINALIZATION_RETRY_MS = 5000;
+// Polling loops probe existence cheaply via kill(0); the ps-backed zombie and
+// identity checks are throttled so a wedged worker cannot saturate the
+// supervisor event loop with synchronous subprocess spawns.
+const LIVENESS_IDENTITY_RECHECK_MS = 500;
 const OWNED_WORKER_DISCONNECT_GRACE_MS = 30_000;
 const IDLE_EVICTION_MAX_SWEEP_INTERVAL_MS = 5 * 60_000;
 const IDLE_EVICTION_MIN_SWEEP_INTERVAL_MS = 60_000;
@@ -4521,7 +4526,11 @@ export class DaemonSupervisor {
 		renameSync(tempPath, path);
 	}
 
-	/** True when the registered pid is alive and still the process we launched. */
+	/**
+	 * True when the registered pid is alive and still the process we launched.
+	 * With a recorded identity this fails closed: an unavailable observation is
+	 * treated as a different process so a recycled pid is never signalled.
+	 */
 	private isWorkerProcessCurrent(worker: ResidentWorker): boolean {
 		if (!isProcessAlive(worker.descriptor.pid)) {
 			return false;
@@ -4529,8 +4538,7 @@ export class DaemonSupervisor {
 		if (worker.descriptor.processStartId === undefined) {
 			return true;
 		}
-		const observed = getProcessStartId(worker.descriptor.pid);
-		return observed === undefined || observed === worker.descriptor.processStartId;
+		return getProcessStartId(worker.descriptor.pid) === worker.descriptor.processStartId;
 	}
 
 	private async stopWorker(
@@ -4620,10 +4628,23 @@ export class DaemonSupervisor {
 			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGTERM");
 		}
 		// Identity-aware: a recycled pid is treated as gone and never signalled.
-		const isWorkerProcessAlive = () =>
-			directChild
-				? directChild.child.exitCode === null && directChild.child.signalCode === null
-				: this.isWorkerProcessCurrent(worker);
+		// kill(0) runs on every poll; the expensive identity check is throttled.
+		let identityVerdict = true;
+		let identityCheckedAt = 0;
+		const isWorkerProcessAlive = () => {
+			if (directChild) {
+				return directChild.child.exitCode === null && directChild.child.signalCode === null;
+			}
+			if (!processIdExists(worker.descriptor.pid)) {
+				return false;
+			}
+			const now = Date.now();
+			if (now - identityCheckedAt >= LIVENESS_IDENTITY_RECHECK_MS) {
+				identityCheckedAt = now;
+				identityVerdict = this.isWorkerProcessCurrent(worker);
+			}
+			return identityVerdict;
+		};
 		const gracefulDeadline = Date.now() + (force ? 500 : 2000);
 		while (isWorkerProcessAlive() && Date.now() < gracefulDeadline) {
 			await delay(25);
@@ -4684,22 +4705,49 @@ export class DaemonSupervisor {
 		// the stop and relaunch with a new pid, and the OS can recycle the old
 		// pid. The finalizer must never follow either successor.
 		const pid = worker.descriptor.pid;
-		const processStartId = worker.descriptor.processStartId ?? getProcessStartId(pid);
+		let processStartId = worker.descriptor.processStartId;
+		if (processStartId === undefined) {
+			// The stop timed out because the process was still alive moments ago,
+			// so an identity observed now can be trusted and recorded. It lets the
+			// eventual stopWorker call fail closed on a recycled pid too.
+			const observed = getProcessStartId(pid);
+			if (observed !== undefined && isProcessAlive(pid)) {
+				processStartId = observed;
+				worker.descriptor.processStartId = observed;
+				try {
+					this.persistWorker(worker);
+				} catch (error) {
+					this.reportCleanupFailure(`worker identity record ${worker.descriptor.workerId}`, error);
+				}
+			}
+		}
 		const stopRevision = worker.stopRevision;
 		const isStopGenerationCurrent = () =>
 			this.workers.get(worker.descriptor.workerId) === worker &&
 			worker.stopRevision === stopRevision &&
 			worker.descriptor.stopRequestedAt !== undefined &&
 			worker.descriptor.pid === pid;
+		let stoppedVerdict = true;
+		let stoppedCheckedAt = 0;
 		const isStoppedProcessAlive = () => {
-			if (!isProcessAlive(pid)) {
+			if (!processIdExists(pid)) {
 				return false;
 			}
-			if (processStartId === undefined) {
-				return true;
+			const now = Date.now();
+			if (now - stoppedCheckedAt < LIVENESS_IDENTITY_RECHECK_MS) {
+				return stoppedVerdict;
 			}
-			const observed = getProcessStartId(pid);
-			return observed === undefined || observed === processStartId;
+			stoppedCheckedAt = now;
+			if (!isProcessAlive(pid)) {
+				stoppedVerdict = false;
+			} else if (processStartId === undefined) {
+				stoppedVerdict = true;
+			} else {
+				// Fail closed: an unobservable identity is treated as a different
+				// process so a recycled pid is never SIGKILLed.
+				stoppedVerdict = getProcessStartId(pid) === processStartId;
+			}
+			return stoppedVerdict;
 		};
 		const sigkillDeadline = Date.now() + STOP_FINALIZATION_SIGKILL_GRACE_MS;
 		let killed = false;
@@ -4716,14 +4764,23 @@ export class DaemonSupervisor {
 			}
 			await unrefDelay(STOP_FINALIZATION_RECHECK_MS);
 		}
-		if (this.shuttingDown || !isStopGenerationCurrent()) {
-			return;
-		}
-		try {
-			await this.stopWorker(worker, true, true, worker.descriptor.archiveOnStop === true);
-			this.log(`Finalized timed-out stop for worker ${worker.descriptor.workerId}`);
-		} catch (error) {
-			this.reportCleanupFailure(`timed-out worker stop ${worker.descriptor.workerId}`, error);
+		// Retry transient cleanup failures (for example catalog archival) so a
+		// dead worker's registration is never stranded permanently. Each attempt
+		// bumps the worker's stopRevision, so rescission is detected through the
+		// registration and tombstone instead of the waiting-phase snapshot.
+		const isCleanupStillWanted = () =>
+			this.workers.get(worker.descriptor.workerId) === worker &&
+			worker.descriptor.stopRequestedAt !== undefined &&
+			worker.descriptor.pid === pid;
+		while (!this.shuttingDown && isCleanupStillWanted()) {
+			try {
+				await this.stopWorker(worker, true, true, worker.descriptor.archiveOnStop === true);
+				this.log(`Finalized timed-out stop for worker ${worker.descriptor.workerId}`);
+				return;
+			} catch (error) {
+				this.reportCleanupFailure(`timed-out worker stop ${worker.descriptor.workerId}`, error);
+				await unrefDelay(STOP_FINALIZATION_RETRY_MS);
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4527,18 +4527,24 @@ export class DaemonSupervisor {
 	}
 
 	/**
-	 * True when the registered pid is alive and still the process we launched.
-	 * With a recorded identity this fails closed: an unavailable observation is
-	 * treated as a different process so a recycled pid is never signalled.
+	 * Verdict on whether the registered pid is still the process we launched.
+	 * Callers must be conservative in both directions: signal a pid only on
+	 * "current" (never SIGKILL a recycled pid), and clean up a registration
+	 * only on "gone"/"replaced" (never orphan a live worker because a
+	 * transient identity lookup failed).
 	 */
-	private isWorkerProcessCurrent(worker: ResidentWorker): boolean {
+	private workerProcessIdentity(worker: ResidentWorker): "current" | "replaced" | "gone" | "unknown" {
 		if (!isProcessAlive(worker.descriptor.pid)) {
-			return false;
+			return "gone";
 		}
 		if (worker.descriptor.processStartId === undefined) {
-			return true;
+			return "current";
 		}
-		return getProcessStartId(worker.descriptor.pid) === worker.descriptor.processStartId;
+		const observed = getProcessStartId(worker.descriptor.pid);
+		if (observed === undefined) {
+			return "unknown";
+		}
+		return observed === worker.descriptor.processStartId ? "current" : "replaced";
 	}
 
 	private async stopWorker(
@@ -4624,12 +4630,14 @@ export class DaemonSupervisor {
 			worker.client = undefined;
 		} else if (directChild) {
 			directChild.child.kill("SIGTERM");
-		} else if (this.isWorkerProcessCurrent(worker)) {
+		} else if (this.workerProcessIdentity(worker) === "current") {
 			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGTERM");
 		}
-		// Identity-aware: a recycled pid is treated as gone and never signalled.
-		// kill(0) runs on every poll; the expensive identity check is throttled.
-		let identityVerdict = true;
+		// Identity-aware in both directions: a replaced pid counts as gone (never
+		// signal a recycled pid) while an unknown identity counts as alive (never
+		// clean up a possibly-live worker on a transient lookup failure). kill(0)
+		// runs on every poll; the expensive identity check is throttled.
+		let identityVerdict: "current" | "replaced" | "gone" | "unknown" = "current";
 		let identityCheckedAt = 0;
 		const isWorkerProcessAlive = () => {
 			if (directChild) {
@@ -4641,9 +4649,9 @@ export class DaemonSupervisor {
 			const now = Date.now();
 			if (now - identityCheckedAt >= LIVENESS_IDENTITY_RECHECK_MS) {
 				identityCheckedAt = now;
-				identityVerdict = this.isWorkerProcessCurrent(worker);
+				identityVerdict = this.workerProcessIdentity(worker);
 			}
-			return identityVerdict;
+			return identityVerdict !== "replaced" && identityVerdict !== "gone";
 		};
 		const gracefulDeadline = Date.now() + (force ? 500 : 2000);
 		while (isWorkerProcessAlive() && Date.now() < gracefulDeadline) {
@@ -4652,7 +4660,7 @@ export class DaemonSupervisor {
 		if (force && isWorkerProcessAlive()) {
 			if (directChild) {
 				directChild.child.kill("SIGKILL");
-			} else {
+			} else if (identityVerdict === "current") {
 				signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
 			}
 			const forceDeadline = Date.now() + 1000;
@@ -4727,7 +4735,11 @@ export class DaemonSupervisor {
 			worker.stopRevision === stopRevision &&
 			worker.descriptor.stopRequestedAt !== undefined &&
 			worker.descriptor.pid === pid;
+		// A replaced pid counts as gone (never SIGKILL a recycled pid); an
+		// unobservable identity counts as alive (never clean up a possibly-live
+		// worker). kill(0) probes every poll; ps-backed checks are throttled.
 		let stoppedVerdict = true;
+		let stoppedCanSignal = true;
 		let stoppedCheckedAt = 0;
 		const isStoppedProcessAlive = () => {
 			if (!processIdExists(pid)) {
@@ -4742,10 +4754,11 @@ export class DaemonSupervisor {
 				stoppedVerdict = false;
 			} else if (processStartId === undefined) {
 				stoppedVerdict = true;
+				stoppedCanSignal = true;
 			} else {
-				// Fail closed: an unobservable identity is treated as a different
-				// process so a recycled pid is never SIGKILLed.
-				stoppedVerdict = getProcessStartId(pid) === processStartId;
+				const observed = getProcessStartId(pid);
+				stoppedVerdict = observed !== processStartId ? observed === undefined : true;
+				stoppedCanSignal = observed === processStartId;
 			}
 			return stoppedVerdict;
 		};
@@ -4758,7 +4771,7 @@ export class DaemonSupervisor {
 			if (!isStoppedProcessAlive()) {
 				break;
 			}
-			if (!killed && Date.now() >= sigkillDeadline) {
+			if (!killed && stoppedCanSignal && Date.now() >= sigkillDeadline) {
 				signalProcessGroupOrProcess(pid, "SIGKILL");
 				killed = true;
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2002,7 +2002,7 @@ export class DaemonSupervisor {
 		const ownerClientId = command.lifecycle === "client_owned" ? clientId : undefined;
 		if (command.sessionPath) {
 			const activeMatches = this.matchWorkers(command.sessionPath);
-			if (activeMatches.length === 1) {
+			if (activeMatches.length === 1 && !(await this.reclaimStaleWorkerRegistration(activeMatches[0]!.worker))) {
 				return this.reuseWorkerForCreate(activeMatches[0]!.worker, ownerClientId, command.sessionPath);
 			}
 			if (activeMatches.length > 1) {
@@ -2014,7 +2014,7 @@ export class DaemonSupervisor {
 				: await this.catalog.resolve(command.sessionPath, config.cwd ?? process.cwd(), config.sessionDir);
 			createCommand = { ...createCommand, sessionPath };
 			const existing = this.findWorkerBySessionFile(sessionPath);
-			if (existing) {
+			if (existing && !(await this.reclaimStaleWorkerRegistration(existing.worker))) {
 				return this.reuseWorkerForCreate(existing.worker, ownerClientId, sessionPath);
 			}
 			// A passive child from a stopped worker reopens as top-level here (pre-existing behavior);
@@ -2063,6 +2063,32 @@ export class DaemonSupervisor {
 			return worker;
 		}
 		throw new SessionAlreadyActiveError(sessionPath, worker.descriptor.rootActiveSessionId);
+	}
+
+	/**
+	 * A stopping worker whose process already died can strand its registration
+	 * (for example when the stop timed out and its finalization was interrupted
+	 * by a supervisor restart). Such a registration would block reopening the
+	 * saved transcript forever, so complete the interrupted stop and let the
+	 * caller launch a fresh worker for the saved session.
+	 */
+	private async reclaimStaleWorkerRegistration(worker: ResidentWorker): Promise<boolean> {
+		if (worker.client !== undefined || worker.recovery !== undefined) {
+			return false;
+		}
+		if (!this.isWorkerStopping(worker)) {
+			return false;
+		}
+		if (isProcessAlive(worker.descriptor.pid)) {
+			return false;
+		}
+		try {
+			await this.stopWorker(worker, true, true, worker.descriptor.archiveOnStop === true);
+			this.log(`Reclaimed stale registration for stopped worker ${worker.descriptor.workerId}`);
+		} catch (error) {
+			this.reportCleanupFailure(`stale worker registration ${worker.descriptor.workerId}`, error);
+		}
+		return this.workers.get(worker.descriptor.workerId) !== worker;
 	}
 
 	private async promoteOwnedWorker(client: DaemonSocketClient, worker: ResidentWorker): Promise<void> {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2156,13 +2156,31 @@ export class DaemonSupervisor {
 					return worker;
 				}
 			}
+			// Stage the durable state separately. persistWorker can update its
+			// descriptor before throwing, so rollback must restore the original
+			// object as well as the transient recovery capability.
+			const previousDescriptor = worker.descriptor;
+			const previousIntentionalStop = worker.intentionalStop;
 			worker.recoveryLaunchEnv = command.launchEnv;
 			worker.intentionalStop = false;
-			worker.descriptor.stopRequestedAt = undefined;
-			worker.descriptor.archiveOnStop = undefined;
-			worker.descriptor.lifecycle = "recovering";
-			worker.descriptor.consecutiveFailures = 0;
-			this.persistWorker(worker);
+			worker.descriptor = {
+				...previousDescriptor,
+				stopRequestedAt: undefined,
+				archiveOnStop: undefined,
+				lifecycle: "recovering",
+				consecutiveFailures: 0,
+			};
+			try {
+				this.persistWorker(worker);
+			} catch (error) {
+				// The fresh environment is a one-shot capability. Persistence is the
+				// hand-off point, so a failed hand-off must not leave it available for
+				// a later automatic recovery.
+				worker.recoveryLaunchEnv = undefined;
+				worker.intentionalStop = previousIntentionalStop;
+				worker.descriptor = previousDescriptor;
+				throw error;
+			}
 			await this.recoverWorker(worker);
 			if (!worker.client || worker.descriptor.lifecycle !== "ready") {
 				throw new Error(

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -43,7 +43,7 @@ import {
 import { canonicalSessionPath, getProcessStartId, SessionAlreadyActiveError } from "../../core/session-lease.js";
 import { readSessionInfo, type SessionInfo } from "../../core/session-manager.js";
 import { SettingsManager } from "../../core/settings-manager.js";
-import { signalProcessGroupOrProcess } from "../../utils/child-process.js";
+import { isProcessAlive, signalProcessGroupOrProcess } from "../../utils/child-process.js";
 import type { AgentConnectionHeartbeat } from "../agent-connection/types.js";
 import { attachJsonlLineReader, serializeJsonLine } from "../rpc/jsonl.js";
 import type { PrivateFrame } from "../session-worker/private-framing.js";
@@ -136,6 +136,8 @@ const UPDATE_RESTART_WORKER_REQUEST_TIMEOUT_MS = 90_000;
 const UPDATE_RESTART_PREPARE_DEADLINE_MS = 100_000;
 const WORKER_RETRY_DELAYS_MS = [250, 1000, 5000] as const;
 const DEFERRED_RECOVERY_RECHECK_MS = 5000;
+const STOP_FINALIZATION_RECHECK_MS = 250;
+const STOP_FINALIZATION_SIGKILL_GRACE_MS = 5000;
 const OWNED_WORKER_DISCONNECT_GRACE_MS = 30_000;
 const IDLE_EVICTION_MAX_SWEEP_INTERVAL_MS = 5 * 60_000;
 const IDLE_EVICTION_MIN_SWEEP_INTERVAL_MS = 60_000;
@@ -260,6 +262,7 @@ interface ResidentWorker {
 	intentionalStop: boolean;
 	stopRevision: number;
 	launchEnv?: Record<string, string>;
+	stopFinalization?: Promise<void>;
 	ownerCleanupTimer?: ReturnType<typeof setTimeout>;
 	promotedOwnerClientId?: string;
 	updateRestartPrepareClient?: DaemonWorkerClient;
@@ -508,15 +511,6 @@ function workerSocketPath(supervisorSocketPath: string, workerId: string): strin
 
 function looksLikeSessionPath(selector: string): boolean {
 	return isAbsolute(selector) || selector.endsWith(".jsonl") || selector.includes("/") || selector.includes("\\");
-}
-
-function isProcessAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (error) {
-		return (error as NodeJS.ErrnoException).code === "EPERM";
-	}
 }
 
 function isFinalizedTranscriptEvent(eventType: string | undefined): boolean {
@@ -4634,6 +4628,9 @@ export class DaemonSupervisor {
 		}
 		if (isWorkerProcessAlive()) {
 			worker.intentionalStop = worker.descriptor.stopRequestedAt !== undefined;
+			if (removeDescriptor) {
+				this.scheduleWorkerStopFinalization(worker);
+			}
 			throw new Error(`Session worker ${worker.descriptor.workerId} did not stop${force ? " after SIGKILL" : ""}`);
 		}
 		if (directChild) {
@@ -4652,6 +4649,49 @@ export class DaemonSupervisor {
 		if (!this.shuttingDown) {
 			void this.syncAgentPeers().catch(() => undefined);
 			this.broadcastHeartbeatsChanged();
+		}
+	}
+
+	/**
+	 * A stop that timed out leaves a tombstoned registration behind. Keep
+	 * escalating in the background until the process is gone, then finish the
+	 * interrupted cleanup instead of leaving a dead worker registered forever.
+	 */
+	private scheduleWorkerStopFinalization(worker: ResidentWorker): void {
+		if (worker.stopFinalization) {
+			return;
+		}
+		worker.stopFinalization = this.finalizeTimedOutWorkerStop(worker).finally(() => {
+			worker.stopFinalization = undefined;
+		});
+	}
+
+	private async finalizeTimedOutWorkerStop(worker: ResidentWorker): Promise<void> {
+		const sigkillDeadline = Date.now() + STOP_FINALIZATION_SIGKILL_GRACE_MS;
+		let killed = false;
+		while (!this.shuttingDown) {
+			if (!isProcessAlive(worker.descriptor.pid)) {
+				break;
+			}
+			if (!killed && Date.now() >= sigkillDeadline) {
+				signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
+				killed = true;
+			}
+			await unrefDelay(STOP_FINALIZATION_RECHECK_MS);
+		}
+		if (this.shuttingDown || this.workers.get(worker.descriptor.workerId) !== worker) {
+			return;
+		}
+		if (worker.descriptor.stopRequestedAt === undefined) {
+			// The stop was rescinded (for example by an explicit retry) while the
+			// process was still exiting; leave the registration to that flow.
+			return;
+		}
+		try {
+			await this.stopWorker(worker, true, true, worker.descriptor.archiveOnStop === true);
+			this.log(`Finalized timed-out stop for worker ${worker.descriptor.workerId}`);
+		} catch (error) {
+			this.reportCleanupFailure(`timed-out worker stop ${worker.descriptor.workerId}`, error);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2121,6 +2121,20 @@ export class DaemonSupervisor {
 			command.launchEnv &&
 			(!worker.client || worker.descriptor.lifecycle !== "ready")
 		) {
+			// The first fresh resume owns the one-shot recovery environment. Later
+			// resumes join that recovery instead of replacing its credentials; their
+			// defined result is the same recovered worker, or its recorded failure.
+			const inFlightRecovery = worker.recovery;
+			if (inFlightRecovery) {
+				await inFlightRecovery;
+				if (!worker.client || worker.descriptor.lifecycle !== "ready") {
+					throw new Error(
+						worker.descriptor.lastError ??
+						`Session worker ${worker.descriptor.workerId} did not recover for the first fresh resume`,
+					);
+				}
+				return worker;
+			}
 			worker.recoveryLaunchEnv = command.launchEnv;
 			worker.intentionalStop = false;
 			worker.descriptor.stopRequestedAt = undefined;
@@ -2129,6 +2143,12 @@ export class DaemonSupervisor {
 			worker.descriptor.consecutiveFailures = 0;
 			this.persistWorker(worker);
 			await this.recoverWorker(worker);
+			if (!worker.client || worker.descriptor.lifecycle !== "ready") {
+				throw new Error(
+					worker.descriptor.lastError ??
+						`Session worker ${worker.descriptor.workerId} did not recover with its fresh environment`,
+				);
+			}
 		}
 		return worker;
 	}
@@ -2868,6 +2888,10 @@ export class DaemonSupervisor {
 
 	private async recoverWorker(worker: ResidentWorker): Promise<void> {
 		if (this.isWorkerRecoveryCancelled(worker)) {
+			// A client-provided recovery environment is a one-shot capability. A
+			// cancelled recovery has completed without consuming it, so never leave it
+			// available for a later automatic recovery.
+			worker.recoveryLaunchEnv = undefined;
 			return;
 		}
 		if (
@@ -2990,6 +3014,10 @@ export class DaemonSupervisor {
 			await this.syncAgentPeers().catch(() => undefined);
 			this.log(`Worker ${worker.descriptor.workerId} failed after three recovery attempts`);
 		})().finally(() => {
+			// The fresh client environment is recovery-owned, never retry-owned. This
+			// also covers reconnecting to a still-alive worker, cancellation, and every
+			// launch/connect failure path.
+			worker.recoveryLaunchEnv = undefined;
 			worker.recovery = undefined;
 		});
 		return worker.recovery;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1825,6 +1825,7 @@ export class DaemonSupervisor {
 					assertAgentFamilyReach(
 						this.familyCatalogEntry(source.summary),
 						this.familyCatalogEntry(summaryForInactiveSession(targetInfo)),
+						await this.familyCatalogEntries(),
 					);
 				}
 				const worker = await this.createOrReuseWorker(this.protocolClientId(client), {
@@ -1840,7 +1841,11 @@ export class DaemonSupervisor {
 			}
 			const targetActiveSessionId = target.summary.activeSessionId ?? target.summary.id;
 			if (source && command.agentOrigin === true) {
-				assertAgentFamilyReach(this.familyCatalogEntry(source.summary), this.familyCatalogEntry(target.summary));
+				assertAgentFamilyReach(
+					this.familyCatalogEntry(source.summary),
+					this.familyCatalogEntry(target.summary),
+					await this.familyCatalogEntries(),
+				);
 			}
 			if (source) {
 				if ((source.summary.activeSessionId ?? source.summary.id) === targetActiveSessionId) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4786,12 +4786,14 @@ export class DaemonSupervisor {
 			if (!killed && stoppedCanSignal && Date.now() >= sigkillDeadline) {
 				// Fresh, unthrottled identity check right before signalling: the
 				// cached verdict may be up to 500ms old, long enough for the pid
-				// to be recycled by an unrelated process.
+				// to be recycled by an unrelated process. A transiently
+				// unobservable identity skips this attempt but keeps escalation
+				// armed so a wedged worker is still killed on a later pass.
 				const observedNow = processStartId === undefined ? undefined : getProcessStartId(pid);
 				if (processStartId === undefined || observedNow === processStartId) {
 					signalProcessGroupOrProcess(pid, "SIGKILL");
+					killed = true;
 				}
-				killed = true;
 			}
 			await unrefDelay(STOP_FINALIZATION_RECHECK_MS);
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3137,19 +3137,37 @@ export class DaemonSupervisor {
 
 	private assertSavedSiblingNameAvailable(siblings: SessionInfo[], target: SessionInfo, name: string): void {
 		const setDepth = target.rlmDepth ?? siblings.find((sibling) => sibling.rlmDepth !== undefined)?.rlmDepth ?? 0;
+		const parentSessionPath = target.parentSessionPath ? canonicalSessionPath(target.parentSessionPath) : undefined;
+		// The bounded sibling catalog intentionally omits its parent. Add one local
+		// structural anchor so C05's exact-one-parent check can compare legacy rows
+		// whose depth is inferred from this modern sibling set.
+		const parent =
+			setDepth > 0 && parentSessionPath
+				? [
+					{
+						id: `saved-sibling-parent:${parentSessionPath}`,
+						depth: setDepth - 1,
+						status: "inactive" as const,
+						sessionPath: parentSessionPath,
+					},
+				]
+				: [];
 		assertAgentSessionNameAvailable(
-			siblings.map((info) => {
-				const summary = summaryForInactiveSession(info);
-				return {
-					id: summary.sessionId,
-					...(summary.sessionName ? { name: summary.sessionName } : {}),
-					depth: setDepth,
-					status: classifySessionRosterStatus(summary),
-					...(summary.parentSessionPath
-						? { parentSessionPath: canonicalSessionPath(summary.parentSessionPath) }
-						: {}),
-				};
-			}),
+			[
+				...parent,
+				...siblings.map((info) => {
+					const summary = summaryForInactiveSession(info);
+					return {
+						id: summary.sessionId,
+						...(summary.sessionName ? { name: summary.sessionName } : {}),
+						depth: setDepth,
+						status: classifySessionRosterStatus(summary),
+						...(summary.parentSessionPath
+							? { parentSessionPath: canonicalSessionPath(summary.parentSessionPath) }
+							: {}),
+					};
+				}),
+			],
 			{
 				name,
 				depth: setDepth,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2897,16 +2897,32 @@ export class DaemonSupervisor {
 		const orphanProcessJournalPath = descriptor.orphanProcessJournalPath;
 		if (orphanProcessJournalPath) {
 			try {
+				let retainOrphanJournal = false;
 				for (const orphan of readActiveOrphanProcesses(orphanProcessJournalPath, worker.descriptor.pid)) {
 					// Ownership and fresh orphan identity must remain adjacent to the
 					// signal. A successor owns any retry if this check fails.
 					await this.assertCurrentOwnership();
 					this.assertWorkerTupleCurrent(worker, descriptor, worker.stopRevision, descriptor.stopRequestedAt);
-					if (!isOrphanProcessIdentityCurrent(orphan)) continue;
+					if (!isOrphanProcessIdentityCurrent(orphan)) {
+						// Keep the durable retry authority when the pid is recycled or
+						// its generation cannot be observed.
+						retainOrphanJournal = true;
+						continue;
+					}
 					const { pid } = orphan;
 					try {
 						process.kill(-pid, "SIGKILL");
 					} catch {
+						// A failed group signal says nothing about a later positive-pid
+						// signal. Re-observe this exact orphan and current supervisor
+						// ownership immediately before the fallback; do not add an await
+						// after these checks.
+						await this.assertCurrentOwnership();
+						this.assertWorkerTupleCurrent(worker, descriptor, worker.stopRevision, descriptor.stopRequestedAt);
+						if (!isOrphanProcessIdentityCurrent(orphan)) {
+							retainOrphanJournal = true;
+							continue;
+						}
 						try {
 							process.kill(pid, "SIGKILL");
 						} catch {
@@ -2916,7 +2932,9 @@ export class DaemonSupervisor {
 				}
 				await this.assertCurrentOwnership();
 				this.assertWorkerTupleCurrent(worker, descriptor, worker.stopRevision, descriptor.stopRequestedAt);
-				clearOrphanProcessJournal(orphanProcessJournalPath);
+				if (!retainOrphanJournal) {
+					clearOrphanProcessJournal(orphanProcessJournalPath);
+				}
 			} catch (error) {
 				this.log(`Could not reap orphaned worker resources: ${String(error)}`);
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -54,6 +54,7 @@ import { DAEMON_CATALOG_ROLE_ENV, DaemonCatalogClient } from "./daemon-catalog-p
 import { deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js";
 import {
 	collectDaemonClientEnv,
+	collectDaemonLaunchEnv,
 	createDaemonEventMeta,
 	DAEMON_COMMAND_COMPATIBILITY,
 	DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION,
@@ -71,6 +72,7 @@ import {
 	type DaemonResponse,
 	type DaemonUpdateRestartManifest,
 	failure,
+	filterPersistedDaemonLaunchEnv,
 	isDaemonCommandEnvelope,
 	isDaemonMutatingCommand,
 	salvageDaemonCommandId,
@@ -426,6 +428,12 @@ function isDaemonWorkerDescriptor(value: unknown, socketPath: string): value is 
 		(descriptor.pid ?? 0) > 0 &&
 		(descriptor.processStartId === undefined || typeof descriptor.processStartId === "string") &&
 		(descriptor.ownerClientId === undefined || typeof descriptor.ownerClientId === "string") &&
+		(descriptor.launchEnv === undefined ||
+			(typeof descriptor.launchEnv === "object" &&
+				descriptor.launchEnv !== null &&
+				Object.entries(descriptor.launchEnv).every(
+					([key, value]) => typeof key === "string" && typeof value === "string",
+				))) &&
 		typeof descriptor.socketPath === "string" &&
 		typeof descriptor.authenticationToken === "string" &&
 		typeof descriptor.rootActiveSessionId === "string" &&
@@ -925,10 +933,12 @@ export class DaemonSupervisor {
 				if (!isDaemonWorkerDescriptor(descriptor, this.socketPath)) {
 					continue;
 				}
+				const storedLaunchEnv = descriptor.launchEnv;
+				descriptor.launchEnv = filterPersistedDaemonLaunchEnv(storedLaunchEnv);
 				descriptor.lifecycle = "recovering";
 				descriptor.recoveryJournalPath ??= join(this.descriptorDir, `${descriptor.workerId}.recovery.jsonl`);
 				descriptor.orphanProcessJournalPath ??= join(this.descriptorDir, `${descriptor.workerId}.orphans.jsonl`);
-				this.workers.set(descriptor.workerId, {
+				const worker: ResidentWorker = {
 					descriptor,
 					descriptorPath: path,
 					summaries: new Map(),
@@ -938,7 +948,12 @@ export class DaemonSupervisor {
 					snapshotLoads: new Map(),
 					intentionalStop: descriptor.stopRequestedAt !== undefined,
 					stopRevision: 0,
-				});
+					launchEnv: descriptor.launchEnv,
+				};
+				this.workers.set(descriptor.workerId, worker);
+				if (JSON.stringify(storedLaunchEnv) !== JSON.stringify(descriptor.launchEnv)) {
+					this.persistWorker(worker);
+				}
 			} catch (error) {
 				this.log(`Ignoring invalid worker descriptor ${path}: ${String(error)}`);
 			}
@@ -2144,7 +2159,7 @@ export class DaemonSupervisor {
 			throw new Error("Session is not owned by this client");
 		}
 		const previousDescriptor = worker.descriptor;
-		worker.descriptor = { ...previousDescriptor, ownerClientId: undefined };
+		worker.descriptor = { ...previousDescriptor, ownerClientId: undefined, launchEnv: undefined };
 		try {
 			this.persistWorker(worker);
 		} catch (error) {
@@ -2170,8 +2185,29 @@ export class DaemonSupervisor {
 			throw new Error(`Session worker ${existing.descriptor.workerId} recovery was cancelled`);
 		}
 		const recoveryStopRevision = existing?.stopRevision;
-		const launchEnv =
-			ownerClientId || existing?.descriptor.ownerClientId ? (command.launchEnv ?? existing?.launchEnv) : undefined;
+		const ownerClientIdForDescriptor = existing?.descriptor.ownerClientId ?? ownerClientId;
+		// Only a first resident launch consumes the caller's full transient
+		// environment. A resident recovery uses the descriptor's allowlisted copy
+		// even while the old worker object still exists in memory. Client-owned
+		// workers are different: their reconnecting owner supplies fresh transient
+		// launch settings, which are never written to a descriptor.
+		const launchEnv = existing
+			? ownerClientIdForDescriptor === undefined
+				? existing.descriptor.launchEnv
+				: existing.launchEnv
+			: command.launchEnv;
+		// Only non-secret, explicitly allowed settings are durable. The initial
+		// spawn may still receive caller credentials through launchEnv, but those
+		// credentials must never be serialized into a worker descriptor.
+		const persistedLaunchEnv = filterPersistedDaemonLaunchEnv(launchEnv);
+		// A replacement supervisor can itself have been restarted by the old worker
+		// and therefore inherit that worker's original credentials. Automatic
+		// resident recovery must not copy those ambient secrets into the replacement
+		// worker. Client-owned recovery instead uses its live owner's transient env.
+		const inheritedEnv =
+			existing && ownerClientIdForDescriptor === undefined
+				? filterPersistedDaemonLaunchEnv(collectDaemonLaunchEnv(process.env))
+				: process.env;
 		const createCommand: DaemonCreateCommand = {
 			...withoutSupervisorCreateFields(command),
 			config: mergeAgentSessionRuntimeConfig(this.defaultSessionConfig, command.config),
@@ -2192,7 +2228,7 @@ export class DaemonSupervisor {
 			cwd: createCommand.config?.cwd ?? process.cwd(),
 			detached: true,
 			env: createCliSubprocessEnv({
-				...process.env,
+				...inheritedEnv,
 				...launchEnv,
 				[DAEMON_WORKER_ROLE_ENV]: "1",
 				[DAEMON_WORKER_TOKEN_ENV]: token,
@@ -2248,7 +2284,10 @@ export class DaemonSupervisor {
 				supervisorSocketPath: this.socketPath,
 				authenticationToken: token,
 				rootActiveSessionId,
-				ownerClientId: existing?.descriptor.ownerClientId ?? ownerClientId,
+				ownerClientId: ownerClientIdForDescriptor,
+				...(ownerClientIdForDescriptor === undefined && persistedLaunchEnv
+					? { launchEnv: persistedLaunchEnv }
+					: {}),
 				createdAt: existing?.descriptor.createdAt ?? now,
 				updatedAt: now,
 				lifecycle: "starting",
@@ -2269,7 +2308,10 @@ export class DaemonSupervisor {
 			};
 			await this.assertRecoveryAllowed();
 			worker.descriptor = descriptor;
-			worker.launchEnv = launchEnv;
+			// Resident workers retain only the durable allowlist even in memory, so an
+			// automatic same-supervisor recovery cannot resurrect initial credentials.
+			// Client-owned workers may retain a fresh owner's transient environment.
+			worker.launchEnv = ownerClientIdForDescriptor === undefined ? persistedLaunchEnv : launchEnv;
 			descriptorAssigned = true;
 			this.persistWorker(worker);
 			worker.intentionalStop = false;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4527,24 +4527,27 @@ export class DaemonSupervisor {
 	}
 
 	/**
-	 * Verdict on whether the registered pid is still the process we launched.
-	 * Callers must be conservative in both directions: signal a pid only on
-	 * "current" (never SIGKILL a recycled pid), and clean up a registration
-	 * only on "gone"/"replaced" (never orphan a live worker because a
-	 * transient identity lookup failed).
+	 * Verdict on whether a pid is still the process we launched. Callers must
+	 * be conservative in both directions: signal a pid only on "current"
+	 * (never SIGKILL a recycled pid), and clean up a registration only on
+	 * "gone"/"replaced" (never orphan a live worker because a transient
+	 * identity lookup failed).
 	 */
-	private workerProcessIdentity(worker: ResidentWorker): "current" | "replaced" | "gone" | "unknown" {
-		if (!isProcessAlive(worker.descriptor.pid)) {
+	private processIdentity(
+		pid: number,
+		processStartId: string | undefined,
+	): "current" | "replaced" | "gone" | "unknown" {
+		if (!isProcessAlive(pid)) {
 			return "gone";
 		}
-		if (worker.descriptor.processStartId === undefined) {
+		if (processStartId === undefined) {
 			return "current";
 		}
-		const observed = getProcessStartId(worker.descriptor.pid);
+		const observed = getProcessStartId(pid);
 		if (observed === undefined) {
 			return "unknown";
 		}
-		return observed === worker.descriptor.processStartId ? "current" : "replaced";
+		return observed === processStartId ? "current" : "replaced";
 	}
 
 	private async stopWorker(
@@ -4582,11 +4585,21 @@ export class DaemonSupervisor {
 		if (!recoveryCleanup) {
 			worker.stopRevision++;
 		}
-		// A retry can rescind this stop and relaunch the worker with a new
-		// process while we await below; never remove the successor's state.
+		// A retry can rescind this stop and relaunch the worker while we await
+		// below. Bind every liveness check and signal to the process this stop
+		// entered with, and abort cleanup once the stop no longer applies: the
+		// pid changed (relaunched) or a removeDescriptor stop lost its tombstone
+		// (rescinded, even before the successor pid lands).
 		const entryPid = worker.descriptor.pid;
-		const assertWorkerNotRelaunched = () => {
-			if (!directChild && worker.descriptor.pid !== entryPid) {
+		const entryStartId = worker.descriptor.processStartId;
+		const assertStopStillApplies = () => {
+			if (directChild) {
+				return;
+			}
+			if (
+				worker.descriptor.pid !== entryPid ||
+				(removeDescriptor && worker.descriptor.stopRequestedAt === undefined)
+			) {
 				throw new Error(`Session worker ${worker.descriptor.workerId} was relaunched during stop`);
 			}
 		};
@@ -4638,8 +4651,8 @@ export class DaemonSupervisor {
 			worker.client = undefined;
 		} else if (directChild) {
 			directChild.child.kill("SIGTERM");
-		} else if (this.workerProcessIdentity(worker) === "current") {
-			signalProcessGroupOrProcess(worker.descriptor.pid, "SIGTERM");
+		} else if (this.processIdentity(entryPid, entryStartId) === "current") {
+			signalProcessGroupOrProcess(entryPid, "SIGTERM");
 		}
 		// Identity-aware in both directions: a replaced pid counts as gone (never
 		// signal a recycled pid) while an unknown identity counts as alive (never
@@ -4651,13 +4664,13 @@ export class DaemonSupervisor {
 			if (directChild) {
 				return directChild.child.exitCode === null && directChild.child.signalCode === null;
 			}
-			if (!processIdExists(worker.descriptor.pid)) {
+			if (!processIdExists(entryPid)) {
 				return false;
 			}
 			const now = Date.now();
 			if (now - identityCheckedAt >= LIVENESS_IDENTITY_RECHECK_MS) {
 				identityCheckedAt = now;
-				identityVerdict = this.workerProcessIdentity(worker);
+				identityVerdict = this.processIdentity(entryPid, entryStartId);
 			}
 			return identityVerdict !== "replaced" && identityVerdict !== "gone";
 		};
@@ -4668,10 +4681,10 @@ export class DaemonSupervisor {
 		if (force && isWorkerProcessAlive()) {
 			if (directChild) {
 				directChild.child.kill("SIGKILL");
-			} else if (this.workerProcessIdentity(worker) === "current") {
+			} else if (this.processIdentity(entryPid, entryStartId) === "current") {
 				// Fresh, unthrottled check: the cached verdict may be up to 500ms
 				// old, long enough for the pid to be recycled.
-				signalProcessGroupOrProcess(worker.descriptor.pid, "SIGKILL");
+				signalProcessGroupOrProcess(entryPid, "SIGKILL");
 			}
 			const forceDeadline = Date.now() + 1000;
 			while (isWorkerProcessAlive() && Date.now() < forceDeadline) {
@@ -4688,13 +4701,13 @@ export class DaemonSupervisor {
 		if (directChild) {
 			await directChild.closed;
 		}
-		assertWorkerNotRelaunched();
+		assertStopStillApplies();
 		if (removeDescriptor && worker.descriptor.archiveOnStop) {
 			if (force) {
 				this.reclaimStoppedWorkerCronLock(worker);
 			}
 			await this.finalizeArchivedWorkerStop(worker);
-			assertWorkerNotRelaunched();
+			assertStopStillApplies();
 		}
 		this.workers.delete(worker.descriptor.workerId);
 		if (removeDescriptor) {

--- a/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
@@ -17,7 +17,7 @@ export const DAEMON_WORKER_SUPERVISOR_SOCKET_ENV = "PRIME_AGENT_INTERNAL_DAEMON_
 export const DAEMON_WORKER_RECOVERY_JOURNAL_ENV = "PRIME_AGENT_INTERNAL_DAEMON_WORKER_RECOVERY_JOURNAL";
 export const DAEMON_WORKER_STARTUP_GATE_FD_ENV = "PRIME_AGENT_INTERNAL_DAEMON_WORKER_STARTUP_GATE_FD";
 export const DAEMON_WORKER_STARTUP_GATE_COMMIT = "start\n";
-export type DaemonWorkerLifecycle = "starting" | "ready" | "recovering" | "failed";
+export type DaemonWorkerLifecycle = "starting" | "ready" | "recovering" | "stopping" | "failed";
 
 export type DaemonWorkerFrameHeader =
 	| {

--- a/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
@@ -17,6 +17,10 @@ export const DAEMON_WORKER_SUPERVISOR_SOCKET_ENV = "PRIME_AGENT_INTERNAL_DAEMON_
 export const DAEMON_WORKER_RECOVERY_JOURNAL_ENV = "PRIME_AGENT_INTERNAL_DAEMON_WORKER_RECOVERY_JOURNAL";
 export const DAEMON_WORKER_STARTUP_GATE_FD_ENV = "PRIME_AGENT_INTERNAL_DAEMON_WORKER_STARTUP_GATE_FD";
 export const DAEMON_WORKER_STARTUP_GATE_COMMIT = "start\n";
+/**
+ * States of a registered resident worker. A worker disappears when removed;
+ * an archived session is a session lifecycle, not a worker lifecycle.
+ */
 export type DaemonWorkerLifecycle = "starting" | "ready" | "recovering" | "stopping" | "failed";
 
 export type DaemonWorkerFrameHeader =

--- a/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
@@ -100,6 +100,8 @@ export interface DaemonWorkerDescriptor {
 	rootActiveSessionId: string;
 	/** Stable protocol client that owns this worker. Omitted for resident sessions. */
 	ownerClientId?: string;
+	/** Environment required to relaunch a resident worker after supervisor restart. */
+	launchEnv?: Record<string, string>;
 	rootSessionId?: string;
 	sessionFile?: string;
 	createdAt: string;

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -1,4 +1,5 @@
-import type { ChildProcess } from "node:child_process";
+import { type ChildProcess, execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { constants } from "node:os";
 import { basename } from "node:path";
 
@@ -10,6 +11,39 @@ export function shouldUseWindowsShell(command: string): boolean {
 	if (process.platform !== "win32") return false;
 	const commandName = basename(command).toLowerCase();
 	return commandName.endsWith(".cmd") || commandName.endsWith(".bat") || WINDOWS_SHELL_COMMANDS.has(commandName);
+}
+
+/** A zombie has already exited; it only lingers until its parent reaps it. */
+export function isZombieProcess(pid: number): boolean {
+	if (process.platform === "win32") {
+		return false;
+	}
+	try {
+		const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+		const state = stat
+			.slice(stat.lastIndexOf(")") + 2)
+			.trimStart()
+			.charAt(0);
+		return state === "Z";
+	} catch {
+		// Fall through to the portable process listing used on macOS and BSD.
+	}
+	try {
+		const state = execFileSync("ps", ["-p", String(pid), "-o", "stat="], { encoding: "utf8" }).trim();
+		return state.startsWith("Z");
+	} catch {
+		return false;
+	}
+}
+
+/** True only for a process that is actually running: zombies do not count. */
+export function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+	return !isZombieProcess(pid);
 }
 
 export function signalProcessGroupOrProcess(pid: number, signal: NodeJS.Signals): void {

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -13,6 +13,16 @@ export function shouldUseWindowsShell(command: string): boolean {
 	return commandName.endsWith(".cmd") || commandName.endsWith(".bat") || WINDOWS_SHELL_COMMANDS.has(commandName);
 }
 
+/** Cheap kill(0) existence probe; counts zombies as existing. */
+export function processIdExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
 /** A zombie has already exited; it only lingers until its parent reaps it. */
 export function isZombieProcess(pid: number): boolean {
 	if (process.platform === "win32") {
@@ -38,12 +48,7 @@ export function isZombieProcess(pid: number): boolean {
 
 /** True only for a process that is actually running: zombies do not count. */
 export function isProcessAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-	} catch (error) {
-		return (error as NodeJS.ErrnoException).code === "EPERM";
-	}
-	return !isZombieProcess(pid);
+	return processIdExists(pid) && !isZombieProcess(pid);
 }
 
 export function signalProcessGroupOrProcess(pid: number, signal: NodeJS.Signals): void {

--- a/packages/coding-agent/test/acp-resident-lifecycle.test.ts
+++ b/packages/coding-agent/test/acp-resident-lifecycle.test.ts
@@ -1,0 +1,321 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../src/config.js";
+import { isClientOwnedDaemonSession } from "../src/main.js";
+import { DaemonClient } from "../src/modes/daemon/daemon-client.js";
+
+const cliPath = resolve(__dirname, "../src/cli.ts");
+const tsxPath = resolve(__dirname, "../../../node_modules/tsx/dist/cli.mjs");
+const temporaryRoots: string[] = [];
+const daemonSockets: string[] = [];
+const servers: Server[] = [];
+const children = new Set<ChildProcess>();
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	const exited = once(child, "exit").then(() => undefined);
+	const exitedGracefully = await Promise.race([
+		exited.then(() => true),
+		new Promise<boolean>((resolveTimeout) => setTimeout(() => resolveTimeout(false), 15_000)),
+	]);
+	if (exitedGracefully) return;
+	child.kill("SIGTERM");
+	const stopped = await Promise.race([
+		exited.then(() => true),
+		new Promise<boolean>((resolveTimeout) => setTimeout(() => resolveTimeout(false), 5_000)),
+	]);
+	if (!stopped) child.kill("SIGKILL");
+}
+
+async function shutdownDaemon(socketPath: string): Promise<void> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(250);
+		await client.request({ type: "shutdown" }, 5_000);
+	} catch {
+		// A failed ACP startup may not have created a daemon.
+	} finally {
+		client.close();
+	}
+}
+
+afterEach(async () => {
+	for (const child of children) await stopChild(child);
+	children.clear();
+	for (const socketPath of daemonSockets.splice(0)) await shutdownDaemon(socketPath);
+	for (const server of servers.splice(0)) await new Promise<void>((done) => server.close(() => done()));
+	for (const root of temporaryRoots.splice(0)) {
+		// Supervisor shutdown returns before its detached worker has fully released
+		// the kernel snapshot directory on every platform.
+		rmSync(root, { recursive: true, force: true, maxRetries: 50, retryDelay: 100 });
+	}
+});
+
+/** A small JSON-RPC client for a real ACP stdio process. */
+class AcpStdioClient {
+	private readonly pending = new Map<
+		number,
+		{ resolve: (result: Record<string, unknown>) => void; reject: (error: Error) => void }
+	>();
+	private nextId = 1;
+	private stdoutBuffer = "";
+	private stderr = "";
+
+	constructor(readonly child: ChildProcess) {
+		child.stdout?.on("data", (chunk: Buffer) => this.consumeStdout(chunk.toString("utf8")));
+		child.stderr?.on("data", (chunk: Buffer) => {
+			this.stderr += chunk.toString("utf8");
+		});
+		child.once("exit", () => {
+			for (const pending of this.pending.values()) {
+				pending.reject(new Error(`ACP process exited before responding: ${this.stderr}`));
+			}
+			this.pending.clear();
+		});
+	}
+
+	async start(cwd: string): Promise<string> {
+		await this.request("initialize", { protocolVersion: 1, clientCapabilities: {} });
+		const created = await this.request("session/new", { cwd, mcpServers: [] });
+		const sessionId = created.sessionId;
+		if (typeof sessionId !== "string")
+			throw new Error(`ACP did not create a usable session: ${JSON.stringify(created)}`);
+		return sessionId;
+	}
+
+	async prompt(sessionId: string, text: string): Promise<void> {
+		await this.request("session/prompt", { sessionId, prompt: [{ type: "text", text }] });
+	}
+
+	async close(): Promise<void> {
+		this.child.stdin?.end();
+		await stopChild(this.child);
+	}
+
+	private request(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+		const id = this.nextId++;
+		return new Promise((resolveRequest, rejectRequest) => {
+			const timeout = setTimeout(() => {
+				this.pending.delete(id);
+				rejectRequest(new Error(`ACP ${method} timed out: ${this.stderr}`));
+			}, 45_000);
+			this.pending.set(id, {
+				resolve: (result) => {
+					clearTimeout(timeout);
+					resolveRequest(result);
+				},
+				reject: (error) => {
+					clearTimeout(timeout);
+					rejectRequest(error);
+				},
+			});
+			this.child.stdin?.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+		});
+	}
+
+	private consumeStdout(chunk: string): void {
+		this.stdoutBuffer += chunk;
+		const lines = this.stdoutBuffer.split("\n");
+		this.stdoutBuffer = lines.pop() ?? "";
+		for (const line of lines) {
+			let frame: Record<string, unknown> | undefined;
+			try {
+				frame = record(JSON.parse(line));
+			} catch {
+				continue;
+			}
+			if (!frame || typeof frame.id !== "number") continue;
+			const pending = this.pending.get(frame.id);
+			if (!pending) continue;
+			this.pending.delete(frame.id);
+			if (frame.error !== undefined) {
+				pending.reject(new Error(`ACP ${String(frame.id)} failed: ${JSON.stringify(frame.error)}`));
+			} else {
+				pending.resolve(record(frame.result) ?? {});
+			}
+		}
+	}
+}
+
+function writeModels(agentDir: string, baseUrl: string): void {
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify({
+			providers: {
+				fixture: {
+					baseUrl,
+					api: "openai-completions",
+					apiKey: "fixture-key",
+					models: [{ id: "fixture/model", reasoning: false, input: ["text"] }],
+				},
+			},
+		}),
+	);
+}
+
+function writeSse(res: ServerResponse, body: Record<string, unknown>): void {
+	res.write(`data: ${JSON.stringify(body)}\n\n`);
+}
+
+async function startIpythonFixture(): Promise<{ baseUrl: string; sawLiveNamespace: () => boolean }> {
+	let sawLiveNamespace = false;
+	const server = createServer(async (req, res) => {
+		let body = "";
+		for await (const chunk of req) body += chunk.toString();
+		const request = record(JSON.parse(body));
+		const messages = Array.isArray(request?.messages) ? request.messages.map(record).filter(Boolean) : [];
+		const toolOutputs = messages
+			.filter((message): message is Record<string, unknown> => message?.role === "tool")
+			.map((message) => JSON.stringify(message.content));
+		const readingAfterReconnect = JSON.stringify(messages).includes("read reconnect state");
+		const hasCurrentToolOutput = readingAfterReconnect
+			? toolOutputs.some((output) => output.includes("True"))
+			: toolOutputs.some((output) => output.includes("kernel state initialized"));
+		if (readingAfterReconnect && hasCurrentToolOutput) sawLiveNamespace = true;
+
+		res.writeHead(200, { "content-type": "text/event-stream", connection: "keep-alive" });
+		if (hasCurrentToolOutput) {
+			writeSse(res, {
+				id: "fixture-final",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: "fixture/model",
+				choices: [{ index: 0, delta: { role: "assistant", content: "done" }, finish_reason: null }],
+			});
+			writeSse(res, {
+				id: "fixture-final",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: "fixture/model",
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			});
+		} else {
+			const code = readingAfterReconnect
+				? "print(id(acp_reconnect_marker) == acp_reconnect_marker_identity)"
+				: "acp_reconnect_marker = object()\nacp_reconnect_marker_identity = id(acp_reconnect_marker)\nprint('kernel state initialized')";
+			writeSse(res, {
+				id: "fixture-tool",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: "fixture/model",
+				choices: [
+					{
+						index: 0,
+						delta: {
+							role: "assistant",
+							tool_calls: [
+								{
+									index: 0,
+									id: readingAfterReconnect ? "read-kernel" : "set-kernel",
+									type: "function",
+									function: { name: "ipython", arguments: JSON.stringify({ code }) },
+								},
+							],
+						},
+						finish_reason: null,
+					},
+				],
+			});
+			writeSse(res, {
+				id: "fixture-tool",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: "fixture/model",
+				choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+			});
+		}
+		res.write("data: [DONE]\n\n");
+		res.end();
+	});
+	servers.push(server);
+	await new Promise<void>((resolveListening) => server.listen(0, "127.0.0.1", resolveListening));
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("Fixture server did not expose a TCP port");
+	return { baseUrl: `http://127.0.0.1:${address.port}/v1`, sawLiveNamespace: () => sawLiveNamespace };
+}
+
+function launchAcp(agentDir: string, projectDir: string, daemonSocket: string, resume: boolean): AcpStdioClient {
+	const child = spawn(
+		process.execPath,
+		[
+			tsxPath,
+			cliPath,
+			"--mode",
+			"acp",
+			"--provider",
+			"fixture",
+			"--model",
+			"fixture/model",
+			...(resume ? ["--continue"] : []),
+			"--offline",
+			"--daemon-socket",
+			daemonSocket,
+		],
+		{
+			cwd: projectDir,
+			env: {
+				...process.env,
+				[ENV_AGENT_DIR]: agentDir,
+				HOME: agentDir,
+				TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
+			},
+			stdio: ["pipe", "pipe", "pipe"],
+		},
+	);
+	children.add(child);
+	return new AcpStdioClient(child);
+}
+
+describe("ACP daemon lifecycle negotiation", () => {
+	it("keeps only reattachable ACP sessions resident", () => {
+		// Resident workers survive ACP stdio disconnect only when a later
+		// --continue can find their session file. All ephemeral or non-ACP modes
+		// are completed by their creating client.
+		expect(isClientOwnedDaemonSession("acp", false)).toBe(false);
+		expect(isClientOwnedDaemonSession("acp", true)).toBe(true);
+		expect(isClientOwnedDaemonSession("rpc", false)).toBe(true);
+		expect(isClientOwnedDaemonSession("print", false)).toBe(true);
+	});
+
+	it(
+		"preserves an ACP kernel's live Python namespace across client disconnect and re-attach",
+		{ tags: ["kernel-heavy"], timeout: 240_000 },
+		async () => {
+			const root = mkdtempSync(join(tmpdir(), "pi-acp-resident-"));
+			temporaryRoots.push(root);
+			const agentDir = join(root, "agent");
+			const projectDir = join(root, "project");
+			const daemonSocket = join(root, "daemon.sock");
+			daemonSockets.push(daemonSocket);
+			mkdirSync(agentDir, { recursive: true });
+			mkdirSync(projectDir, { recursive: true });
+			const fixture = await startIpythonFixture();
+			writeModels(agentDir, fixture.baseUrl);
+
+			const first = launchAcp(agentDir, projectDir, daemonSocket, false);
+			const firstSession = await first.start(projectDir);
+			await first.prompt(firstSession, "set reconnect state");
+			await first.close();
+			children.delete(first.child);
+
+			const reattached = launchAcp(agentDir, projectDir, daemonSocket, true);
+			const reattachedSession = await reattached.start(projectDir);
+			await reattached.prompt(reattachedSession, "read reconnect state");
+			await reattached.close();
+			children.delete(reattached.child);
+
+			// `object()` restores as a distinct object, so True proves this was the
+			// live kernel namespace rather than a replacement kernel revived from disk.
+			expect(fixture.sawLiveNamespace()).toBe(true);
+		},
+	);
+});

--- a/packages/coding-agent/test/acp-resident-lifecycle.test.ts
+++ b/packages/coding-agent/test/acp-resident-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -18,6 +18,30 @@ const children = new Set<ChildProcess>();
 
 function record(value: unknown): Record<string, unknown> | undefined {
 	return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+function residentWorkerDescriptorPath(agentDir: string): string {
+	const workersRoot = join(agentDir, "daemon-workers");
+	for (const directory of readdirSync(workersRoot)) {
+		const candidate = join(workersRoot, directory);
+		const descriptor = readdirSync(candidate).find((name) => name.endsWith(".json"));
+		if (descriptor) return join(candidate, descriptor);
+	}
+	throw new Error("Resident worker descriptor was not persisted");
+}
+
+async function waitForFailedResidentWorker(descriptorPath: string): Promise<void> {
+	const deadline = Date.now() + 15_000;
+	while (Date.now() < deadline) {
+		try {
+			const descriptor = JSON.parse(readFileSync(descriptorPath, "utf8")) as { lifecycle?: unknown };
+			if (descriptor.lifecycle === "failed") return;
+		} catch {
+			// Recovery is still updating the descriptor.
+		}
+		await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+	}
+	throw new Error("Resident ACP worker did not enter the fresh-environment recovery state");
 }
 
 async function stopChild(child: ChildProcess): Promise<void> {
@@ -154,7 +178,9 @@ function writeModels(agentDir: string, baseUrl: string): void {
 				fixture: {
 					baseUrl,
 					api: "openai-completions",
-					apiKey: "fixture-key",
+					// Resolve it afresh from the worker's live environment. The value
+					// itself never belongs in models.json or a worker descriptor.
+					apiKey: "ACP_FIXTURE_API_KEY",
 					models: [{ id: "fixture/model", reasoning: false, input: ["text"] }],
 				},
 			},
@@ -166,9 +192,18 @@ function writeSse(res: ServerResponse, body: Record<string, unknown>): void {
 	res.write(`data: ${JSON.stringify(body)}\n\n`);
 }
 
-async function startIpythonFixture(): Promise<{ baseUrl: string; sawLiveNamespace: () => boolean }> {
+async function startIpythonFixture(): Promise<{
+	baseUrl: string;
+	sawLiveNamespace: () => boolean;
+	authenticatedRequestCount: (secret: string) => number;
+}> {
 	let sawLiveNamespace = false;
+	const authenticatedRequests = new Map<string, number>();
 	const server = createServer(async (req, res) => {
+		const authorization = req.headers.authorization;
+		if (typeof authorization === "string") {
+			authenticatedRequests.set(authorization, (authenticatedRequests.get(authorization) ?? 0) + 1);
+		}
 		let body = "";
 		for await (const chunk of req) body += chunk.toString();
 		const request = record(JSON.parse(body));
@@ -240,10 +275,20 @@ async function startIpythonFixture(): Promise<{ baseUrl: string; sawLiveNamespac
 	await new Promise<void>((resolveListening) => server.listen(0, "127.0.0.1", resolveListening));
 	const address = server.address();
 	if (!address || typeof address === "string") throw new Error("Fixture server did not expose a TCP port");
-	return { baseUrl: `http://127.0.0.1:${address.port}/v1`, sawLiveNamespace: () => sawLiveNamespace };
+	return {
+		baseUrl: `http://127.0.0.1:${address.port}/v1`,
+		sawLiveNamespace: () => sawLiveNamespace,
+		authenticatedRequestCount: (secret) => authenticatedRequests.get(`Bearer ${secret}`) ?? 0,
+	};
 }
 
-function launchAcp(agentDir: string, projectDir: string, daemonSocket: string, resume: boolean): AcpStdioClient {
+function launchAcp(
+	agentDir: string,
+	projectDir: string,
+	daemonSocket: string,
+	resume: boolean,
+	fixtureApiKey = "acp-initial-fixture-secret",
+): AcpStdioClient {
 	const child = spawn(
 		process.execPath,
 		[
@@ -266,6 +311,9 @@ function launchAcp(agentDir: string, projectDir: string, daemonSocket: string, r
 				...process.env,
 				[ENV_AGENT_DIR]: agentDir,
 				HOME: agentDir,
+				// This is intentionally runtime-only. Recovery reacquires it from the
+				// live daemon environment rather than serializing it in a descriptor.
+				ACP_FIXTURE_API_KEY: fixtureApiKey,
 				TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
 			},
 			stdio: ["pipe", "pipe", "pipe"],
@@ -287,7 +335,7 @@ describe("ACP daemon lifecycle negotiation", () => {
 	});
 
 	it(
-		"preserves an ACP kernel's live Python namespace across client disconnect and re-attach",
+		"recovers a crashed resident ACP worker with fresh environment-backed model authentication",
 		{ tags: ["kernel-heavy"], timeout: 240_000 },
 		async () => {
 			const root = mkdtempSync(join(tmpdir(), "pi-acp-resident-"));
@@ -301,13 +349,15 @@ describe("ACP daemon lifecycle negotiation", () => {
 			const fixture = await startIpythonFixture();
 			writeModels(agentDir, fixture.baseUrl);
 
-			const first = launchAcp(agentDir, projectDir, daemonSocket, false);
+			const initialSecret = "acp-initial-fixture-secret";
+			const recoveredSecret = "acp-fresh-recovery-secret";
+			const first = launchAcp(agentDir, projectDir, daemonSocket, false, initialSecret);
 			const firstSession = await first.start(projectDir);
 			await first.prompt(firstSession, "set reconnect state");
 			await first.close();
 			children.delete(first.child);
 
-			const reattached = launchAcp(agentDir, projectDir, daemonSocket, true);
+			const reattached = launchAcp(agentDir, projectDir, daemonSocket, true, initialSecret);
 			const reattachedSession = await reattached.start(projectDir);
 			await reattached.prompt(reattachedSession, "read reconnect state");
 			await reattached.close();
@@ -316,6 +366,39 @@ describe("ACP daemon lifecycle negotiation", () => {
 			// `object()` restores as a distinct object, so True proves this was the
 			// live kernel namespace rather than a replacement kernel revived from disk.
 			expect(fixture.sawLiveNamespace()).toBe(true);
+
+			// The worker process received the secret only transiently. Its descriptor
+			// must keep neither the value nor even the credential's environment name.
+			const descriptorPath = residentWorkerDescriptorPath(agentDir);
+			const descriptorText = readFileSync(descriptorPath, "utf8");
+			expect(descriptorText).not.toContain(initialSecret);
+			expect(descriptorText).not.toContain(recoveredSecret);
+			expect(descriptorText).not.toContain("ACP_FIXTURE_API_KEY");
+			const descriptor = JSON.parse(descriptorText) as { pid?: number };
+			if (typeof descriptor.pid !== "number") throw new Error("Resident ACP worker did not expose its pid");
+			const authenticatedBeforeCrash = fixture.authenticatedRequestCount(initialSecret);
+			expect(authenticatedBeforeCrash).toBeGreaterThan(0);
+
+			// Crash the detached resident process, then let its already-live
+			// supervisor recover it. The successor must reacquire its model/proxy
+			// environment from that live supervisor, not a durable descriptor.
+			process.kill(-descriptor.pid, "SIGKILL");
+			await waitForFailedResidentWorker(descriptorPath);
+
+			const recovered = launchAcp(agentDir, projectDir, daemonSocket, true, recoveredSecret);
+			const recoveredSession = await recovered.start(projectDir);
+			await recovered.prompt(recoveredSession, "recover authenticated model access");
+			await recovered.close();
+			children.delete(recovered.child);
+
+			// The recovered resident made a new authenticated request using
+			// models.json's env reference, proving live credential reacquisition
+			// instead of persisted credential replay.
+			expect(fixture.authenticatedRequestCount(recoveredSecret)).toBeGreaterThan(0);
+			expect(fixture.authenticatedRequestCount(initialSecret)).toBe(authenticatedBeforeCrash);
+			const recoveredDescriptorText = readFileSync(descriptorPath, "utf8");
+			expect(recoveredDescriptorText).not.toContain(initialSecret);
+			expect(recoveredDescriptorText).not.toContain(recoveredSecret);
 		},
 	);
 });

--- a/packages/coding-agent/test/agent-session-bus.test.ts
+++ b/packages/coding-agent/test/agent-session-bus.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	AGENT_FAMILY_REACH_ERROR,
 	AGENT_MESSAGE_SOURCE,
 	AgentSessionMessageRateLimiter,
 	assertAgentFamilyReach,
@@ -261,7 +262,7 @@ describe("agent session bus", () => {
 		});
 	});
 
-	it("authorizes exactly one persisted nuclear-family edge", () => {
+	it("authorizes only structurally verified nuclear-family edges", () => {
 		const root = { id: "root", depth: 0, status: "running" as const, sessionPath: "/root" };
 		const otherRoot = { id: "other-root", depth: 0, status: "running" as const, sessionPath: "/other" };
 		const child = {
@@ -299,6 +300,46 @@ describe("agent session bus", () => {
 			parentSessionId: "root",
 			parentSessionPath: "/root",
 		};
+		const malformedRoot = {
+			id: "malformed-root",
+			depth: 0,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/root",
+		};
+		const contradictoryChild = {
+			id: "contradictory-child",
+			depth: 1,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/other",
+		};
+		const malformedSiblingA = {
+			id: "malformed-sibling-a",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/root",
+		};
+		const malformedSiblingB = {
+			id: "malformed-sibling-b",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/root",
+		};
+		const catalog = [
+			root,
+			child,
+			sibling,
+			idOnlySibling,
+			grandchild,
+			depthSkippingDescendant,
+			malformedRoot,
+			contradictoryChild,
+			malformedSiblingA,
+			malformedSiblingB,
+		];
 
 		expect(assertAgentFamilyReach(root, otherRoot)).toBe("sibling");
 		expect(() => assertAgentFamilyReach(root, { id: "orphan", depth: 3, status: "inactive" })).toThrow(
@@ -310,19 +351,64 @@ describe("agent session bus", () => {
 				{ id: "orphan-b", depth: 3, status: "inactive" },
 			),
 		).toThrow("Agent reach is limited to parent, siblings, and children");
-		expect(assertAgentFamilyReach(root, child)).toBe("child");
-		expect(assertAgentFamilyReach(child, root)).toBe("parent");
-		expect(assertAgentFamilyReach(child, sibling)).toBe("sibling");
-		expect(assertAgentFamilyReach(sibling, idOnlySibling)).toBe("sibling");
-		expect(() => assertAgentFamilyReach(root, grandchild)).toThrow(
-			"Agent reach is limited to parent, siblings, and children",
+
+		// Direct immediate family remains available for path-only and id-only persisted parent links.
+		expect(assertAgentFamilyReach(root, child, catalog)).toBe("child");
+		expect(assertAgentFamilyReach(child, root, catalog)).toBe("parent");
+		expect(assertAgentFamilyReach(child, sibling, catalog)).toBe("sibling");
+		expect(assertAgentFamilyReach(sibling, child, catalog)).toBe("sibling");
+		expect(assertAgentFamilyReach(sibling, idOnlySibling, catalog)).toBe("sibling");
+		expect(assertAgentFamilyReach(idOnlySibling, sibling, catalog)).toBe("sibling");
+
+		// A claimed parent must exist exactly one depth above the child in the supplied catalog.
+		for (const malformed of [depthSkippingDescendant, malformedRoot]) {
+			expect(() => assertAgentFamilyReach(root, malformed, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+			expect(() => assertAgentFamilyReach(malformed, root, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+		}
+		for (const claimedParent of [root, otherRoot]) {
+			expect(() => assertAgentFamilyReach(claimedParent, contradictoryChild, catalog)).toThrow(
+				AGENT_FAMILY_REACH_ERROR,
+			);
+			expect(() => assertAgentFamilyReach(contradictoryChild, claimedParent, catalog)).toThrow(
+				AGENT_FAMILY_REACH_ERROR,
+			);
+		}
+		expect(() => assertAgentFamilyReach(root, grandchild, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+		expect(() => assertAgentFamilyReach(sibling, grandchild, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+
+		// Depth-two records jointly claiming the depth-zero root cannot invent a sibling relationship.
+		expect(() => assertAgentFamilyReach(malformedSiblingA, malformedSiblingB, catalog)).toThrow(
+			AGENT_FAMILY_REACH_ERROR,
 		);
-		expect(() => assertAgentFamilyReach(sibling, grandchild)).toThrow(
-			"Agent reach is limited to parent, siblings, and children",
+		expect(() => assertAgentFamilyReach(malformedSiblingB, malformedSiblingA, catalog)).toThrow(
+			AGENT_FAMILY_REACH_ERROR,
 		);
-		expect(() => assertAgentFamilyReach(root, depthSkippingDescendant)).toThrow(
-			"Agent reach is limited to parent, siblings, and children",
-		);
+		expect(buildAgentFamilyRoster(malformedSiblingA, catalog).entries).toEqual([]);
+		expect(buildAgentFamilyRoster(root, catalog).entries.map((entry) => entry.id)).toEqual([
+			"child",
+			"id-only-sibling",
+			"sibling",
+		]);
+
+		// A catalog-resolved depth-two sibling pair remains a legitimate immediate family.
+		const deepParent = { id: "deep-parent", depth: 1, status: "running" as const, sessionPath: "/deep-parent" };
+		const deepSiblingA = {
+			id: "deep-sibling-a",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionId: "deep-parent",
+			parentSessionPath: "/deep-parent",
+		};
+		const deepSiblingB = {
+			id: "deep-sibling-b",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionPath: "/deep-parent",
+		};
+		const deepCatalog = [deepParent, deepSiblingA, deepSiblingB];
+		expect(() => assertAgentFamilyReach(deepSiblingA, deepSiblingB)).toThrow(AGENT_FAMILY_REACH_ERROR);
+		expect(assertAgentFamilyReach(deepSiblingA, deepSiblingB, deepCatalog)).toBe("sibling");
+		expect(assertAgentFamilyReach(deepSiblingB, deepSiblingA, deepCatalog)).toBe("sibling");
 	});
 
 	it("collapses depth-zero name reservations to the root scope", () => {

--- a/packages/coding-agent/test/agent-session-bus.test.ts
+++ b/packages/coding-agent/test/agent-session-bus.test.ts
@@ -292,6 +292,13 @@ describe("agent session bus", () => {
 			status: "idle" as const,
 			parentSessionPath: "/child",
 		};
+		const depthSkippingDescendant = {
+			id: "depth-skipping-descendant",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/root",
+		};
 
 		expect(assertAgentFamilyReach(root, otherRoot)).toBe("sibling");
 		expect(() => assertAgentFamilyReach(root, { id: "orphan", depth: 3, status: "inactive" })).toThrow(
@@ -311,6 +318,9 @@ describe("agent session bus", () => {
 			"Agent reach is limited to parent, siblings, and children",
 		);
 		expect(() => assertAgentFamilyReach(sibling, grandchild)).toThrow(
+			"Agent reach is limited to parent, siblings, and children",
+		);
+		expect(() => assertAgentFamilyReach(root, depthSkippingDescendant)).toThrow(
 			"Agent reach is limited to parent, siblings, and children",
 		);
 	});

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -112,6 +112,8 @@ interface InspectableRlmRun {
 	id: string;
 	sessionDir: string;
 	abort: () => void;
+	publication: { reject(error: Error): void };
+	emitUpdate?: () => void;
 	status: string;
 	settled: boolean;
 	error?: string;
@@ -1218,6 +1220,50 @@ describe("AgentSession rlm recursion", () => {
 				details: { kind: "cancelled", reason: "Cancelled by user" },
 			});
 		});
+	});
+
+	it("accepts scheduled interleaved double cancellation with one abort, rejection, and terminal emission", async () => {
+		let releaseChild: () => void = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let childStarted = false;
+		const root = createSession({
+			streamFn: () => {
+				const stream = createAssistantMessageEventStream();
+				childStarted = true;
+				void release.then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage("late child answer") });
+				});
+				return stream;
+			},
+		});
+		const spawned = await root.runRlmChild("slow child", { name: "interleaved-cancel-worker" });
+		await waitFor(() => childStarted);
+		const run = (root as unknown as InspectableRlmSession)._activeRlmChildRuns.get(spawned.rlm_child_id);
+		if (!run) throw new Error("Missing tracked child run");
+		const abort = vi.fn(run.abort);
+		run.abort = abort;
+		const reject = vi.spyOn(run.publication, "reject");
+		const emitCancellationUpdate = vi.fn(run.emitUpdate);
+		run.emitUpdate = emitCancellationUpdate;
+
+		// Queue both independent callers before either gets a scheduling turn. The
+		// synchronous state transition makes both accepted, but only its winner may
+		// perform the irreversible abort/reject/update effects.
+		const first = Promise.resolve().then(() => root.cancelRlmChildRun(spawned.rlm_child_id));
+		const second = Promise.resolve().then(() => root.cancelRlmChildRun(spawned.rlm_child_id));
+		await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+		expect(abort).toHaveBeenCalledTimes(1);
+		expect(reject).toHaveBeenCalledTimes(1);
+		expect(emitCancellationUpdate).toHaveBeenCalledTimes(1);
+
+		releaseChild();
+		await waitFor(() => !(root as unknown as InspectableRlmSession)._activeRlmChildRuns.has(spawned.rlm_child_id));
+		const notices = root.messages.filter(
+			(message) => message.role === "custom" && message.customType === "rlm_child_terminal_notice",
+		);
+		expect(notices).toHaveLength(1);
 	});
 
 	it("injects exactly one notice with a preview when a child completes without replying", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2358,6 +2358,9 @@ describe("AgentSession rlm recursion", () => {
 		expect(root.cancelRlmChildRun(childId)).toBe(true);
 		expect(run?.status).toBe("cancelled");
 		expect(run?.error).toBe("Cancelled by user");
+		// A second caller racing detached teardown observes the already-accepted
+		// cancellation rather than treating the child as complete.
+		expect(root.cancelRlmChildRun(childId)).toBe(true);
 		// The cancelled update is pushed at cancel time, before the (possibly
 		// stuck) child unwinds; viewers must not keep showing a running child.
 		expect(childStatuses[childStatuses.length - 1]).toBe("cancelled");

--- a/packages/coding-agent/test/agent-session-runtime-events.test.ts
+++ b/packages/coding-agent/test/agent-session-runtime-events.test.ts
@@ -118,4 +118,33 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 		const leaseRoot = join(runtimeHost.services.agentDir, "session-leases");
 		expect(readdirSync(leaseRoot).filter((entry) => entry.endsWith(".lock"))).toHaveLength(1);
 	});
+
+	it("waits for current session disposal before building a replacement", async () => {
+		const { runtimeHost } = await createRuntimeHost(() => undefined);
+		const oldSession = runtimeHost.session;
+		const originalDispose = oldSession.disposeAsync.bind(oldSession);
+		const order: string[] = [];
+		let releaseDispose!: () => void;
+		const disposePending = new Promise<void>((resolve) => {
+			releaseDispose = resolve;
+		});
+		oldSession.disposeAsync = async () => {
+			order.push("dispose-start");
+			await disposePending;
+			await originalDispose();
+			order.push("dispose-end");
+		};
+
+		const replacing = runtimeHost.newSession();
+		try {
+			for (let i = 0; i < 50 && order.length === 0; i++) {
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
+			expect(order).toEqual(["dispose-start"]);
+		} finally {
+			releaseDispose();
+		}
+		await replacing;
+		expect(order).toEqual(["dispose-start", "dispose-end"]);
+	});
 });

--- a/packages/coding-agent/test/child-process.test.ts
+++ b/packages/coding-agent/test/child-process.test.ts
@@ -1,7 +1,7 @@
-import type { ChildProcess } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { describe, expect, it } from "vitest";
-import { waitForChildProcess } from "../src/utils/child-process.js";
+import { isProcessAlive, isZombieProcess, waitForChildProcess } from "../src/utils/child-process.js";
 
 describe("waitForChildProcess", () => {
 	it("reports signaled already-exited children as failures", async () => {
@@ -13,5 +13,51 @@ describe("waitForChildProcess", () => {
 		});
 
 		await expect(waitForChildProcess(child as unknown as ChildProcess)).resolves.toBe(143);
+	});
+});
+
+describe("process liveness", () => {
+	it("treats the current process as alive and not a zombie", () => {
+		expect(isProcessAlive(process.pid)).toBe(true);
+		expect(isZombieProcess(process.pid)).toBe(false);
+	});
+
+	it("treats an exited process as dead", async () => {
+		const child = spawn(process.execPath, ["--eval", "process.exit(0)"], { stdio: "ignore" });
+		await new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
+		// Node reaps its own children on exit, so the pid is fully gone.
+		await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+		expect(isProcessAlive(child.pid!)).toBe(false);
+	});
+
+	it.skipIf(process.platform === "win32")("treats a zombie process as dead", async () => {
+		// A parent that forks and never reaps leaves the child as a zombie.
+		const parent = spawn(
+			"perl",
+			["-e", '$| = 1; my $pid = fork(); if ($pid) { print "$pid\\n"; sleep 30 } else { exit 0 }'],
+			{ stdio: ["ignore", "pipe", "ignore"] },
+		);
+		try {
+			const zombiePid = await new Promise<number>((resolvePid, rejectPid) => {
+				let output = "";
+				const timer = setTimeout(() => rejectPid(new Error("Timed out waiting for the zombie pid")), 5000);
+				parent.stdout.on("data", (chunk: Buffer) => {
+					output += chunk.toString();
+					const parsed = Number.parseInt(output.trim(), 10);
+					if (Number.isInteger(parsed) && parsed > 0) {
+						clearTimeout(timer);
+						resolvePid(parsed);
+					}
+				});
+			});
+			const deadline = Date.now() + 5000;
+			while (!isZombieProcess(zombiePid) && Date.now() < deadline) {
+				await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+			}
+			expect(isZombieProcess(zombiePid)).toBe(true);
+			expect(isProcessAlive(zombiePid)).toBe(false);
+		} finally {
+			parent.kill("SIGKILL");
+		}
 	});
 });

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -5573,33 +5573,48 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("quarantines malformed registry rows without losing slash-bearing model IDs on a later complete replay", async () => {
+	it("quarantines only the malformed registry selector until a full row deliberately republishes it", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-registry-replay-model-"));
 		try {
 			const fixture = makePersistedRlmDaemonFixture(tempDir, { modelId: "org/scripted" });
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
-			const valid = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
-			valid.model = { provider: "test", modelId: "org/scripted" };
-			const malformed = { ...valid, status: "interrupted" };
-			writeFileSync(registryPath, `${JSON.stringify(valid)}\n${JSON.stringify(malformed)}\n`);
+			const validA = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
+			validA.model = { provider: "test", modelId: "org/scripted" };
+			const validB = {
+				...validA,
+				childId: "child-b",
+				sessionName: "valid-worker-b",
+				sessionDir: join(tempDir, "child-b"),
+				sessionFile: join(tempDir, "child-b", "session.jsonl"),
+			};
+			const malformedA = { ...validA, status: "interrupted" };
+			writeFileSync(
+				registryPath,
+				`${JSON.stringify(validA)}\n${JSON.stringify(validB)}\n${JSON.stringify(malformedA)}\n`,
+			);
 			const internals = fixture.daemon as unknown as {
 				readLatestRlmSubagentRegistryPath(
 					path: string,
 				): Promise<Array<{ childId: string; model?: { provider: string; modelId: string } }>>;
 			};
 
-			// A corrupt later row fences the prior incarnation rather than reviving it.
-			expect(await internals.readLatestRlmSubagentRegistryPath(registryPath)).toEqual([]);
-
-			// A complete later replay deliberately republishes the child and preserves
-			// model IDs whose provider/model boundary is the first slash only.
-			writeFileSync(registryPath, `${readFileSync(registryPath, "utf8")}${JSON.stringify(valid)}\n`);
+			// A malformed A row is a selector-local tombstone: valid B remains addressable.
 			expect(await internals.readLatestRlmSubagentRegistryPath(registryPath)).toEqual([
-				expect.objectContaining({
-					childId: fixture.childId,
-					model: { provider: "test", modelId: "org/scripted" },
-				}),
+				expect.objectContaining({ childId: "child-b" }),
 			]);
+
+			// Only a complete A row deliberately recovers A; it also preserves model IDs
+			// whose provider/model boundary is the first slash only.
+			writeFileSync(registryPath, `${readFileSync(registryPath, "utf8")}${JSON.stringify(validA)}\n`);
+			expect(await internals.readLatestRlmSubagentRegistryPath(registryPath)).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						childId: fixture.childId,
+						model: { provider: "test", modelId: "org/scripted" },
+					}),
+					expect.objectContaining({ childId: "child-b" }),
+				]),
+			);
 			const parentState = await (
 				fixture.daemon as unknown as {
 					createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -5573,6 +5573,57 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("quarantines malformed registry rows without losing slash-bearing model IDs on a later complete replay", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-registry-replay-model-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir, { modelId: "org/scripted" });
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const valid = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
+			valid.model = { provider: "test", modelId: "org/scripted" };
+			const malformed = { ...valid, status: "interrupted" };
+			writeFileSync(registryPath, `${JSON.stringify(valid)}\n${JSON.stringify(malformed)}\n`);
+			const internals = fixture.daemon as unknown as {
+				readLatestRlmSubagentRegistryPath(
+					path: string,
+				): Promise<Array<{ childId: string; model?: { provider: string; modelId: string } }>>;
+			};
+
+			// A corrupt later row fences the prior incarnation rather than reviving it.
+			expect(await internals.readLatestRlmSubagentRegistryPath(registryPath)).toEqual([]);
+
+			// A complete later replay deliberately republishes the child and preserves
+			// model IDs whose provider/model boundary is the first slash only.
+			writeFileSync(registryPath, `${readFileSync(registryPath, "utf8")}${JSON.stringify(valid)}\n`);
+			expect(await internals.readLatestRlmSubagentRegistryPath(registryPath)).toEqual([
+				expect.objectContaining({
+					childId: fixture.childId,
+					model: { provider: "test", modelId: "org/scripted" },
+				}),
+			]);
+			const parentState = await (
+				fixture.daemon as unknown as {
+					createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+					createAgentMessageController(
+						getCurrentState: () => ActiveSessionState | undefined,
+					): AgentSessionMessageController;
+				}
+			).createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			await (
+				fixture.daemon as unknown as {
+					createAgentMessageController(
+						getCurrentState: () => ActiveSessionState | undefined,
+					): AgentSessionMessageController;
+				}
+			)
+				.createAgentMessageController(() => parentState)
+				.sendAgentMessage({ target: "renamed-worker", message: "rehydrate model" });
+			expect(fixture.modelRegistry.find).toHaveBeenCalledWith("test", "org/scripted");
+			expect(fixture.createRuntime.mock.calls[1]?.[0].sessionOptions?.model).toBe(fixture.model);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("rehydrates a legacy child with depth inferred from its session file path", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-legacy-rlm-depth-"));
 		try {
@@ -9648,6 +9699,7 @@ function makePersistedRlmDaemonFixture(
 		childDisposeGate?: Promise<void>;
 		childAdmissionStarted?: () => void;
 		childAdmissionGate?: Promise<void>;
+		modelId?: string;
 	} = {},
 ) {
 	const sessionDir = join(tempDir, "sessions");
@@ -9723,6 +9775,13 @@ function makePersistedRlmDaemonFixture(
 `,
 	);
 
+	const model = { provider: "test", id: options.modelId ?? "model" } as Model<Api>;
+	const modelRegistry = {
+		find: vi.fn((provider: string, modelId: string) =>
+			provider === model.provider && modelId === model.id ? model : undefined,
+		),
+		canUseModel: vi.fn(async () => true),
+	};
 	const acceptAgentMessagePrompt = vi.fn(
 		async (_message: string, promptOptions?: { preflightResult?: (didSucceed: boolean) => void }) => {
 			if (options.childAdmissionGate) {
@@ -9775,7 +9834,7 @@ function makePersistedRlmDaemonFixture(
 			extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
 				ReturnType<CreateAgentSessionRuntimeFactory>
 			>["extensionsResult"],
-			services: { cwd: runtimeOptions.cwd, agentDir: runtimeOptions.agentDir } as Awaited<
+			services: { cwd: runtimeOptions.cwd, agentDir: runtimeOptions.agentDir, modelRegistry } as Awaited<
 				ReturnType<CreateAgentSessionRuntimeFactory>
 			>["services"],
 			diagnostics: [],
@@ -9789,6 +9848,8 @@ function makePersistedRlmDaemonFixture(
 		daemon,
 		createRuntime,
 		runtimeSessions,
+		model,
+		modelRegistry,
 		acceptAgentMessagePrompt,
 		parentSessionFile,
 		parentArtifactDir,

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -7,6 +7,7 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import {
 	AGENT_FAMILY_REACH_ERROR,
+	assertAgentFamilyReach,
 	type AgentSessionMessageController,
 	DEFAULT_AGENT_MESSAGE_MAX_CHARS,
 	sessionNameReservationKey,
@@ -2624,6 +2625,52 @@ describe("daemon mode helpers", () => {
 
 		expect(internals.agentMessageRelationship(child, parent)).toBe("child");
 		expect(internals.agentMessageRelationship(parent, child)).toBe("parent");
+	});
+
+	it("authorizes depth-two passive siblings only from the persisted daemon topology", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-deep-passive-acl-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const secondGrandchildDir = join(fixture.childSessionDir, "sibling-grandchild");
+			const secondGrandchild = SessionManager.create(tempDir, secondGrandchildDir);
+			secondGrandchild.newSession({ parentSession: fixture.childSessionFile, rlmDepth: 2 });
+			secondGrandchild.flushNow();
+			const secondGrandchildFile = secondGrandchild.getSessionFile();
+			if (!secondGrandchildFile) throw new Error("Missing sibling grandchild session");
+			const childRegistry = join(fixture.childArtifactDir, "rlm-subagents.jsonl");
+			writeFileSync(
+				childRegistry,
+				`${readFileSync(childRegistry, "utf8")}${JSON.stringify({
+					type: "rlm_subagent", childId: "sibling-grandchild", sessionName: "sibling-grandchild",
+					sessionDir: secondGrandchildDir, sessionFile: secondGrandchildFile,
+					parentSessionId: fixture.childSessionId, parentSessionFile: fixture.childSessionFile,
+					rlmDepth: 2, status: "completed", createdAt: 2, updatedAt: "2026-01-01T00:00:02.000Z",
+				})}\n`,
+			);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				agentFamilyCatalogEntries(): Promise<readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]>;
+			};
+			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const catalog = await internals.agentFamilyCatalogEntries();
+			const first = catalog.find((entry) => entry.id === fixture.grandchildSessionId);
+			const second = catalog.find((entry) => entry.id === secondGrandchild.getSessionId());
+			expect(first).toBeDefined();
+			expect(second).toBeDefined();
+			expect(catalog).toContainEqual(expect.objectContaining({ id: fixture.childSessionId, depth: 1 }));
+			expect(assertAgentFamilyReach(first!, second!, catalog)).toBe("sibling");
+
+			// A depth-two pair claiming the root cannot manufacture the missing depth-one edge.
+			expect(() =>
+				assertAgentFamilyReach(
+					{ ...first!, parentSessionId: fixture.parentSessionId, parentSessionPath: fixture.parentSessionFile },
+					{ ...second!, parentSessionId: fixture.parentSessionId, parentSessionPath: fixture.parentSessionFile },
+					catalog,
+				),
+			).toThrow(AGENT_FAMILY_REACH_ERROR);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("limits agent send and observation to the nuclear family", async () => {
@@ -9872,7 +9919,10 @@ function makePersistedRlmDaemonFixture(
 		childId,
 		childSessionFile,
 		childSessionDir,
+		childArtifactDir,
+		childSessionId: childManager.getSessionId(),
 		grandchildId,
+		grandchildSessionId: grandchildManager.getSessionId(),
 		grandchildSessionFile,
 	};
 }

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -2823,10 +2823,12 @@ describe("daemon mode helpers", () => {
 			{ id: targetId, depth: 1, status: "running" as const, parentSessionId: parentId },
 		];
 
+		// The current observer must be resolved from the immutable catalog before
+		// self inclusion. Either duplicate ordering is ambiguous and must fail closed.
 		for (const catalog of [entries, [...entries.slice(0, 1), entries[2]!, entries[1]!, entries[3]!]]) {
 			internals.agentFamilyCatalogEntries = vi.fn(async () => Object.freeze(catalog));
 			const observe = internals.createAgentObserveController(() => source.state);
-			expect((await observe.listAgents()).agents.map((agent) => agent.activeSessionId)).toEqual(["source"]);
+			await expect(observe.listAgents()).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
 			await expect(observe.getAgent(target.state.activeSessionId)).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
 			await expect(observe.recentMessages({ target: target.state.activeSessionId })).rejects.toThrow(
 				AGENT_FAMILY_REACH_ERROR,

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -2799,6 +2799,47 @@ describe("daemon mode helpers", () => {
 		expect(observed.agents.map((agent) => agent.activeSessionId)).toEqual(["source"]);
 	});
 
+	it("fails closed for every agent ACL surface when the captured catalog duplicates a stable session ID", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-duplicate-captured-family.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" }, createRuntime: vi.fn(),
+		});
+		const parent = makeAgentFamilyState("parent", "parent");
+		const source = makeAgentFamilyState("source", "source", parent.state);
+		const target = makeAgentFamilyState("target", "target", parent.state);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries(): Promise<readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]>;
+			createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
+			createAgentObserveController(getCurrentState: () => ActiveSessionState): AgentObserveController;
+		};
+		for (const fixture of [parent, source, target]) internals.sessions.set(fixture.state.activeSessionId, fixture.state);
+		const sourceId = source.state.runtime.session.sessionId;
+		const parentId = parent.state.runtime.session.sessionId;
+		const targetId = target.state.runtime.session.sessionId;
+		const entries = [
+			{ id: parentId, depth: 0, status: "running" as const },
+			{ id: sourceId, depth: 1, status: "running" as const, parentSessionId: parentId },
+			{ id: sourceId, depth: 1, status: "running" as const, parentSessionId: "forged-parent" },
+			{ id: targetId, depth: 1, status: "running" as const, parentSessionId: parentId },
+		];
+
+		for (const catalog of [entries, [...entries.slice(0, 1), entries[2]!, entries[1]!, entries[3]!]]) {
+			internals.agentFamilyCatalogEntries = vi.fn(async () => Object.freeze(catalog));
+			const observe = internals.createAgentObserveController(() => source.state);
+			expect((await observe.listAgents()).agents.map((agent) => agent.activeSessionId)).toEqual(["source"]);
+			await expect(observe.getAgent(target.state.activeSessionId)).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			await expect(observe.recentMessages({ target: target.state.activeSessionId })).rejects.toThrow(
+				AGENT_FAMILY_REACH_ERROR,
+			);
+			await expect(
+				internals
+					.createAgentMessageController(() => source.state)
+					.sendAgentMessage({ target: target.state.activeSessionId, message: "must not deliver" }),
+			).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+		}
+		expect(target.acceptAgentMessagePrompt).not.toHaveBeenCalled();
+	});
+
 	it("resolves a duplicate session name to the only family-reachable agent", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-family-name-resolution.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -2761,6 +2761,44 @@ describe("daemon mode helpers", () => {
 		);
 	});
 
+	it("observes residents from the captured family catalog rather than live endpoint fields", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-observe-captured-family.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" }, createRuntime: vi.fn(),
+		});
+		const source = makeState("source");
+		const target = makeState("target");
+		for (const state of [source, target]) {
+			state.runtime = {
+				...state.runtime,
+				metadata: { kind: "top-level", createdAt: 1 },
+				session: {
+					...state.runtime.session, sessionId: `session-${state.activeSessionId}`,
+					sessionFile: `/tmp/${state.activeSessionId}.jsonl`, rlmDepth: 0,
+				},
+			} as never;
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries(): Promise<readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]>;
+			createAgentObserveController(getCurrentState: () => ActiveSessionState): AgentObserveController;
+		};
+		internals.sessions.set(source.activeSessionId, source);
+		internals.sessions.set(target.activeSessionId, target);
+		Object.assign(internals, {
+			agentFamilyCatalogEntries: vi.fn(async () => Object.freeze([
+				{ id: "left-parent", depth: 0, status: "inactive", sessionPath: "/tmp/left.jsonl" },
+				{ id: "right-parent", depth: 0, status: "inactive", sessionPath: "/tmp/right.jsonl" },
+				{ id: "session-source", depth: 1, status: "running", parentSessionId: "left-parent" },
+				{ id: "session-target", depth: 1, status: "running", parentSessionId: "right-parent" },
+			])),
+		});
+
+		// The live root summaries would otherwise be sibling roots. Their conflicting
+		// topology cannot override the captured snapshot's unrelated parent edges.
+		const observed = await internals.createAgentObserveController(() => source).listAgents();
+		expect(observed.agents.map((agent) => agent.activeSessionId)).toEqual(["source"]);
+	});
+
 	it("resolves a duplicate session name to the only family-reachable agent", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-family-name-resolution.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -16,6 +16,7 @@ import {
 	DAEMON_SCHEMA_REVISION,
 	type DaemonCommand,
 	type DaemonOutbound,
+	filterPersistedDaemonLaunchEnv,
 	getDaemonCommandCompatibilities,
 	isDaemonCommandEnvelope,
 	isDaemonMutatingCommand,
@@ -42,6 +43,35 @@ describe("daemon protocol helpers", () => {
 			.digest("hex")
 			.slice(0, 12);
 		expect(DAEMON_SCHEMA_ID).toBe(`protocol-${DAEMON_PROTOCOL_VERSION}-schema-${DAEMON_SCHEMA_REVISION}-${digest}`);
+	});
+
+	it("filters resident descriptor launch environment to explicit non-secret settings", () => {
+		expect(
+			filterPersistedDaemonLaunchEnv({
+				HOME: "/home/agent",
+				PATH: "/runtime/bin",
+				TMPDIR: "/tmp/agent",
+				XDG_DATA_HOME: "/home/agent/.local/share",
+				TSX_TSCONFIG_PATH: "/workspace/tsconfig.json",
+				PRIME_AGENT_CODING_AGENT_DIR: "/home/agent/.prime/agent",
+				PI_OFFLINE: "1",
+				PRIME_AGENT_TRACES_BASE_URL: "https://traces.example.test",
+				OPENAI_API_KEY: "must-not-persist",
+				AWS_SECRET_ACCESS_KEY: "must-not-persist",
+				GH_TOKEN: "must-not-persist",
+				SSH_AUTH_SOCK: "/tmp/must-not-persist.sock",
+			}),
+		).toEqual({
+			HOME: "/home/agent",
+			PATH: "/runtime/bin",
+			TMPDIR: "/tmp/agent",
+			XDG_DATA_HOME: "/home/agent/.local/share",
+			TSX_TSCONFIG_PATH: "/workspace/tsconfig.json",
+			PRIME_AGENT_CODING_AGENT_DIR: "/home/agent/.prime/agent",
+			PI_OFFLINE: "1",
+			PRIME_AGENT_TRACES_BASE_URL: "https://traces.example.test",
+		});
+		expect(filterPersistedDaemonLaunchEnv({ OPENAI_API_KEY: "must-not-persist" })).toBeUndefined();
 	});
 
 	it("requires compatibility metadata for the heartbeat protocol surface", () => {

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -121,6 +121,14 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("prompt_admission_cancellation");
 	});
 
+	it("gates honest worker-state reporting at its introducing schema revision", () => {
+		// Revision 14 adds the "stopping" workerState and stops reporting
+		// disconnected workers as "ready". The field is optional and old clients
+		// ignore unknown values, so no capability gate is needed; the revision
+		// lets version probes distinguish daemons with the old semantics.
+		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(14);
+	});
+
 	it("keeps refine failure events backward-compatible on the existing session event channel", () => {
 		const event: DaemonOutbound = {
 			type: "session_event",

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -122,7 +122,7 @@ describe("daemon protocol helpers", () => {
 	});
 
 	it("gates honest worker-state reporting at its introducing schema revision", () => {
-		// Revision 14 adds the "stopping" workerState and stops reporting
+		// Revision 15 adds the "stopping" workerState and stops reporting
 		// disconnected workers as "ready". The field is optional and old clients
 		// ignore unknown values, so no capability gate is needed; the revision
 		// lets version probes distinguish daemons with the old semantics.

--- a/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
@@ -727,4 +727,60 @@ describe("daemon supervisor passive subagent topology", () => {
 			}),
 		]);
 	});
+	it("denies live endpoint topology that contradicts a captured supervisor catalog", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-captured-family-message-"));
+		tempDirs.push(directory);
+		const targetManager = SessionManager.create(directory, join(directory, "sessions"));
+		// The saved target is a root, but the captured authorization snapshot below
+		// deliberately records it as an unrelated child.
+		targetManager.newSession({ rlmDepth: 0 });
+		targetManager.flushNow();
+		const targetPath = targetManager.getSessionFile();
+		if (!targetPath) throw new Error("Missing target session path");
+
+		const source = summary({
+			id: "source-active", activeSessionId: "source-active", sessionId: "source-session", rlmDepth: 0,
+		});
+		const liveTarget = summary({
+			id: "target-active", activeSessionId: "target-active", sessionId: targetManager.getSessionId(),
+			sessionFile: targetPath, rlmDepth: 0,
+		});
+		const sourceWorker = worker("source", [source]);
+		const targetWorker = worker("target", [liveTarget]);
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory }, descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		supervisor.workers.set("source", sourceWorker);
+		const createOrReuseWorker = vi.fn(async () => targetWorker);
+		Object.assign(supervisor, {
+			catalog: { resolve: vi.fn(async () => targetPath) },
+			familyCatalogEntries: vi.fn(async () => Object.freeze([
+				{ id: "left-parent", depth: 0, status: "inactive", sessionPath: join(directory, "left-parent.jsonl") },
+				{ id: "right-parent", depth: 0, status: "inactive", sessionPath: join(directory, "right-parent.jsonl") },
+				{ id: source.sessionId, depth: 1, status: "running", parentSessionId: "left-parent" },
+				{ id: targetManager.getSessionId(), depth: 1, status: "inactive", parentSessionId: "right-parent", sessionPath: targetPath },
+			])),
+			createOrReuseWorker,
+		});
+		const command = {
+			type: "send_message", id: "captured-topology", agentOrigin: true,
+			fromActiveSessionId: source.activeSessionId, targetActiveSessionId: targetManager.getSessionId(), message: "hello",
+		};
+
+		// Pre-wake authorization must reject the snapshot's unrelated children even
+		// though the live source and saved target both claim root topology.
+		await expect(supervisor.handleCommand({}, command)).rejects.toThrow(
+			"Agent reach is limited to parent, siblings, and children",
+		);
+		expect(createOrReuseWorker).not.toHaveBeenCalled();
+
+		// The post-resolution path uses the exact same snapshot, rather than the
+		// contradictory live target summary, and therefore also fails closed.
+		supervisor.workers.set("target", targetWorker);
+		await expect(supervisor.handleCommand({}, command)).rejects.toThrow(
+			"Agent reach is limited to parent, siblings, and children",
+		);
+		expect(targetWorker.client.requestWorker).not.toHaveBeenCalled();
+	});
+
 });

--- a/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
@@ -29,6 +29,7 @@ interface SupervisorInternals {
 		name: string,
 	): void;
 	familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry;
+	familyCatalogEntries(): Promise<readonly AgentFamilyCatalogEntry[]>;
 	handleCommand(client: object, command: Record<string, unknown>): Promise<unknown>;
 }
 
@@ -642,6 +643,34 @@ describe("daemon supervisor passive subagent topology", () => {
 		).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
 		releaseLaunch();
 		await expect(first).resolves.toBe(launched);
+	});
+
+	it("keeps inactive depth-one parents in the supervisor authorization topology", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-deep-passive-acl-"));
+		tempDirs.push(directory);
+		const parentPath = join(directory, "parent.jsonl");
+		const intermediatePath = join(directory, "intermediate.jsonl");
+		const firstPath = join(directory, "first.jsonl");
+		const secondPath = join(directory, "second.jsonl");
+		const base = { cwd: directory, created: new Date(0), modified: new Date(0), messageCount: 0, firstMessage: "", allMessagesText: "" };
+		const saved = [
+			{ ...base, id: "root", path: parentPath, rlmDepth: 0 },
+			{ ...base, id: "intermediate", path: intermediatePath, parentSessionPath: parentPath, rlmDepth: 1 },
+			{ ...base, id: "first", path: firstPath, parentSessionPath: intermediatePath, rlmDepth: 2 },
+			{ ...base, id: "second", path: secondPath, parentSessionPath: intermediatePath, rlmDepth: 2 },
+		];
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory }, descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		Object.assign(supervisor, { catalog: { list: vi.fn(async () => saved) } });
+		const catalog = await supervisor.familyCatalogEntries();
+		const first = catalog.find((entry) => entry.id === "first");
+		const second = catalog.find((entry) => entry.id === "second");
+		expect(catalog).toContainEqual(expect.objectContaining({ id: "intermediate", depth: 1 }));
+		expect(assertAgentFamilyReach(first!, second!, catalog)).toBe("sibling");
+		expect(() => assertAgentFamilyReach(
+			{ ...first!, parentSessionPath: parentPath }, { ...second!, parentSessionPath: parentPath }, catalog,
+		)).toThrow("Agent reach is limited to parent, siblings, and children");
 	});
 
 	it("retains passive worker summaries but syncs only roots to cross-worker peer maps", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -2346,6 +2346,46 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("waits for an in-flight stop finalization instead of stopping twice", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-finalizing",
+				pid: process.pid,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			client: undefined,
+			recovery: undefined,
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		let releaseFinalization!: () => void;
+		worker.stopFinalization = new Promise<void>((resolveFinalization) => {
+			releaseFinalization = () => {
+				workers.delete(worker.descriptor.workerId);
+				resolveFinalization();
+			};
+		});
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			reclaimStaleWorkerRegistration(target: object): Promise<boolean>;
+		};
+
+		const reclaim = supervisor.reclaimStaleWorkerRegistration(worker);
+		releaseFinalization();
+
+		// The reclaim defers to the finalizer's cleanup instead of duplicating it.
+		await expect(reclaim).resolves.toBe(true);
+		expect(stopWorker).not.toHaveBeenCalled();
+	});
+
 	it("does not reclaim a stopping worker whose process is still alive", async () => {
 		const worker = {
 			descriptor: {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -2271,6 +2271,95 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("reclaims a stale tombstoned registration whose process is gone", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-stale-registration",
+				pid: process.pid,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			client: undefined,
+			recovery: undefined,
+			intentionalStop: true,
+			stopRevision: 0,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		const stopWorker = vi.fn(async () => {
+			workers.delete(worker.descriptor.workerId);
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			reclaimStaleWorkerRegistration(target: object): Promise<boolean>;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
+		try {
+			await expect(supervisor.reclaimStaleWorkerRegistration(worker)).resolves.toBe(true);
+			expect(stopWorker).toHaveBeenCalledWith(worker, true, true, false);
+		} finally {
+			aliveSpy.mockRestore();
+		}
+	});
+
+	it("does not reclaim a stopping worker whose process is still alive", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-still-alive",
+				pid: process.pid,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			client: undefined,
+			recovery: undefined,
+			intentionalStop: true,
+			stopRevision: 0,
+		};
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			reclaimStaleWorkerRegistration(target: object): Promise<boolean>;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(true);
+		try {
+			await expect(supervisor.reclaimStaleWorkerRegistration(worker)).resolves.toBe(false);
+			expect(stopWorker).not.toHaveBeenCalled();
+		} finally {
+			aliveSpy.mockRestore();
+		}
+	});
+
+	it("does not reclaim a healthy connected worker", async () => {
+		const worker = {
+			descriptor: { workerId: "worker-healthy", pid: process.pid, rootActiveSessionId: "active-1" },
+			client: {},
+			recovery: undefined,
+			intentionalStop: false,
+			stopRevision: 0,
+		};
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			reclaimStaleWorkerRegistration(target: object): Promise<boolean>;
+		};
+
+		await expect(supervisor.reclaimStaleWorkerRegistration(worker)).resolves.toBe(false);
+		expect(stopWorker).not.toHaveBeenCalled();
+	});
+
 	it("ignores malformed persisted worker descriptors", () => {
 		const descriptorDir = mkdtempSync(join(tmpdir(), "prime-supervisor-descriptor-test-"));
 		try {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1601,6 +1601,98 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(worker.descriptor.consecutiveFailures).toBe(0);
 	});
 
+	it("reports a stop-tombstoned worker as stopping, not ready", () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-tombstoned",
+				pid: process.pid,
+				lifecycle: "ready" as const,
+				stopRequestedAt: new Date().toISOString(),
+			},
+			client: {},
+			intentionalStop: false,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {}) as {
+			effectiveWorkerState(target: object): string;
+		};
+
+		expect(supervisor.effectiveWorkerState(worker)).toBe("stopping");
+	});
+
+	it("never reports a disconnected worker as ready", () => {
+		const worker = {
+			descriptor: { workerId: "worker-disconnected", pid: process.pid, lifecycle: "ready" as const },
+			client: undefined,
+			intentionalStop: false,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {}) as {
+			effectiveWorkerState(target: object): string;
+		};
+
+		expect(supervisor.effectiveWorkerState(worker)).toBe("recovering");
+	});
+
+	it("reports a connected ready worker as ready", () => {
+		const worker = {
+			descriptor: { workerId: "worker-live", pid: process.pid, lifecycle: "ready" as const },
+			client: {},
+			intentionalStop: false,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {}) as {
+			effectiveWorkerState(target: object): string;
+		};
+
+		expect(supervisor.effectiveWorkerState(worker)).toBe("ready");
+	});
+
+	it("excludes stopping workers from the live session list", async () => {
+		const makeWorker = (workerId: string, stopRequestedAt?: string) => ({
+			descriptor: {
+				workerId,
+				pid: process.pid,
+				rootActiveSessionId: `${workerId}-active`,
+				lifecycle: "ready" as const,
+				...(stopRequestedAt ? { stopRequestedAt } : {}),
+			},
+			client: {},
+			intentionalStop: false,
+			summaries: new Map([
+				[
+					`${workerId}-active`,
+					{
+						id: `${workerId}-active`,
+						activeSessionId: `${workerId}-active`,
+						sessionId: `${workerId}-session`,
+						cwd: "/tmp",
+					} as unknown as SessionSummary,
+				],
+			]),
+		});
+		const liveWorker = makeWorker("worker-live");
+		const stoppingWorker = makeWorker("worker-stopping", new Date().toISOString());
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([
+				[liveWorker.descriptor.workerId, liveWorker],
+				[stoppingWorker.descriptor.workerId, stoppingWorker],
+			]),
+			clients: new Set(),
+			refreshWorkerSummaries: vi.fn(async () => {}),
+			syncAgentPeers: vi.fn(async () => {}),
+			log: vi.fn(),
+		}) as {
+			handleList(
+				client: object,
+				command: { id: string; type: "list" },
+			): Promise<{ success: boolean; data?: { sessions: Array<{ activeSessionId?: string; id: string }> } }>;
+		};
+
+		const response = await supervisor.handleList({}, { id: "list-1", type: "list" });
+
+		expect(response.success).toBe(true);
+		const sessions = response.data?.sessions ?? [];
+		expect(sessions.map((session) => session.activeSessionId ?? session.id)).toEqual(["worker-live-active"]);
+	});
+
 	it("ignores malformed persisted worker descriptors", () => {
 		const descriptorDir = mkdtempSync(join(tmpdir(), "prime-supervisor-descriptor-test-"));
 		try {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -2306,6 +2306,46 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("reclaims a stale registration whose pid was recycled by another process", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-recycled-registration",
+				pid: 111_113,
+				processStartId: "proc:original",
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			client: undefined,
+			recovery: undefined,
+			intentionalStop: true,
+			stopRevision: 0,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		const stopWorker = vi.fn(async () => {
+			workers.delete(worker.descriptor.workerId);
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			reclaimStaleWorkerRegistration(target: object): Promise<boolean>;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const sessionLeaseModule = await import("../src/core/session-lease.js");
+		// The pid is alive, but it belongs to an unrelated process now.
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(true);
+		const startIdSpy = vi.spyOn(sessionLeaseModule, "getProcessStartId").mockReturnValue("proc:recycled");
+		try {
+			await expect(supervisor.reclaimStaleWorkerRegistration(worker)).resolves.toBe(true);
+			expect(stopWorker).toHaveBeenCalledWith(worker, true, true, false);
+		} finally {
+			aliveSpy.mockRestore();
+			startIdSpy.mockRestore();
+		}
+	});
+
 	it("does not reclaim a stopping worker whose process is still alive", async () => {
 		const worker = {
 			descriptor: {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1699,6 +1699,141 @@ describe("daemon worker supervisor monitoring", () => {
 		]);
 	});
 
+	it("finalizes a timed-out stop once the worker process dies", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-timed-out-stop",
+				pid: process.pid,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		let alive = true;
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			scheduleWorkerStopFinalization(target: object): void;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockImplementation(() => alive);
+		try {
+			supervisor.scheduleWorkerStopFinalization(worker);
+			const finalization = worker.stopFinalization;
+			expect(finalization).toBeDefined();
+
+			await vi.advanceTimersByTimeAsync(500);
+			expect(stopWorker).not.toHaveBeenCalled();
+
+			alive = false;
+			await vi.advanceTimersByTimeAsync(500);
+			await finalization;
+
+			expect(stopWorker).toHaveBeenCalledWith(worker, true, true, false);
+			expect(worker.stopFinalization).toBeUndefined();
+		} finally {
+			aliveSpy.mockRestore();
+		}
+	});
+
+	it("escalates a stuck stop to SIGKILL before finalizing", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-stuck-stop",
+				pid: process.pid,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+				archiveOnStop: true,
+			},
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		let alive = true;
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			scheduleWorkerStopFinalization(target: object): void;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockImplementation(() => alive);
+		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation((_pid, signal) => {
+			if (signal === "SIGKILL") {
+				alive = false;
+			}
+		});
+		try {
+			supervisor.scheduleWorkerStopFinalization(worker);
+			const finalization = worker.stopFinalization;
+
+			await vi.advanceTimersByTimeAsync(10_000);
+			await finalization;
+
+			expect(killSpy).toHaveBeenCalledWith(worker.descriptor.pid, "SIGKILL");
+			expect(stopWorker).toHaveBeenCalledWith(worker, true, true, true);
+		} finally {
+			aliveSpy.mockRestore();
+			killSpy.mockRestore();
+		}
+	});
+
+	it("leaves a rescinded stop to the retry flow instead of finalizing it", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-rescinded-stop",
+				pid: process.pid,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString() as string | undefined,
+			},
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		let alive = true;
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			scheduleWorkerStopFinalization(target: object): void;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockImplementation(() => alive);
+		try {
+			supervisor.scheduleWorkerStopFinalization(worker);
+			const finalization = worker.stopFinalization;
+
+			// An explicit retry revives the worker while its process is exiting.
+			worker.descriptor.stopRequestedAt = undefined;
+			worker.intentionalStop = false;
+			alive = false;
+			await vi.advanceTimersByTimeAsync(500);
+			await finalization;
+
+			expect(stopWorker).not.toHaveBeenCalled();
+		} finally {
+			aliveSpy.mockRestore();
+		}
+	});
+
 	it("ignores malformed persisted worker descriptors", () => {
 		const descriptorDir = mkdtempSync(join(tmpdir(), "prime-supervisor-descriptor-test-"));
 		try {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1898,6 +1898,65 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("aborts stale stop cleanup when the worker was relaunched during an await", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-relaunched-during-stop",
+				pid: 111_115,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString() as string | undefined,
+				archiveOnStop: true,
+			},
+			client: undefined,
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: true,
+			stopRevision: 0,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			shuttingDown: false,
+			persistWorker: vi.fn(),
+			persistWorkerStopTombstone: vi.fn(),
+			reclaimStoppedWorkerCronLock: vi.fn(),
+			// Archival yields, and a retry relaunches the worker meanwhile.
+			finalizeArchivedWorkerStop: vi.fn(async () => {
+				worker.descriptor.pid = 222_222;
+				worker.descriptor.stopRequestedAt = undefined;
+			}),
+			deleteWorkerDescriptor: vi.fn(),
+			syncAgentPeers: vi.fn(async () => {}),
+			broadcastHeartbeatsChanged: vi.fn(),
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as unknown as {
+			stopWorker(
+				target: object,
+				removeDescriptor: boolean,
+				force?: boolean,
+				archiveSession?: boolean,
+			): Promise<void>;
+			deleteWorkerDescriptor: ReturnType<typeof vi.fn>;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(false);
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
+		try {
+			await expect(supervisor.stopWorker(worker, true, true, true)).rejects.toThrow("was relaunched during stop");
+
+			// The relaunched worker's registration and descriptor must survive.
+			expect(workers.has(worker.descriptor.workerId)).toBe(true);
+			expect(supervisor.deleteWorkerDescriptor).not.toHaveBeenCalled();
+		} finally {
+			existsSpy.mockRestore();
+			aliveSpy.mockRestore();
+		}
+	});
+
 	it("keeps waiting when process identity is transiently unobservable", async () => {
 		vi.useFakeTimers();
 		const worker = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1498,6 +1498,75 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(recoverWorker).toHaveBeenCalledOnce();
 	});
 
+	it("lets the first fresh resume adopt recovery after an automatic env-less recovery settles", async () => {
+		type RecoveryWorker = {
+			descriptor: {
+				workerId: string;
+				rootActiveSessionId: string;
+				lifecycle: "failed" | "recovering" | "ready";
+				consecutiveFailures: number;
+				stopRequestedAt?: string;
+				archiveOnStop?: boolean;
+				lastError?: string;
+			};
+			client?: object;
+			recovery?: Promise<void>;
+			recoveryLaunchEnv?: Record<string, string>;
+			intentionalStop: boolean;
+		};
+		type RecoveryHarness = {
+			persistWorker: ReturnType<typeof vi.fn>;
+			recoverWorker: ReturnType<typeof vi.fn>;
+			reuseWorkerForCreate(
+				worker: RecoveryWorker,
+				ownerClientId: undefined,
+				sessionPath: string,
+				command: { type: "create"; lifecycle?: "client_owned"; launchEnv: Record<string, string> },
+			): Promise<RecoveryWorker>;
+		};
+		const worker: RecoveryWorker = {
+			descriptor: {
+				workerId: "worker-automatic-env-less",
+				rootActiveSessionId: "active-automatic-env-less",
+				lifecycle: "recovering",
+				consecutiveFailures: 1,
+			},
+			intentionalStop: false,
+		};
+		const automaticRecoveryFinished = createDeferred<void>();
+		// This is the supervisor's automatic recovery: it owns no fresh environment
+		// and completes by publishing the terminal waiting-for-env failure.
+		const automaticRecovery = automaticRecoveryFinished.promise.finally(() => {
+			worker.descriptor.lifecycle = "failed";
+			worker.descriptor.lastError = "Waiting for a client with fresh environment";
+			worker.recoveryLaunchEnv = undefined;
+			worker.recovery = undefined;
+		});
+		worker.recovery = automaticRecovery;
+		let adoptedEnv: Record<string, string> | undefined;
+		const recoverWorker = vi.fn(async (target: RecoveryWorker) => {
+			adoptedEnv = target.recoveryLaunchEnv;
+			target.client = {};
+			target.descriptor.lifecycle = "ready";
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			persistWorker: vi.fn(),
+			recoverWorker,
+		}) as RecoveryHarness;
+
+		const resumeB = supervisor.reuseWorkerForCreate(worker, undefined, "/tmp/automatic-env-less", {
+			type: "create",
+			launchEnv: { ACP_FIXTURE_API_KEY: "fresh-B" },
+		});
+		await Promise.resolve();
+		expect(recoverWorker).not.toHaveBeenCalled();
+
+		automaticRecoveryFinished.resolve();
+		await expect(resumeB).resolves.toBe(worker);
+		expect(recoverWorker).toHaveBeenCalledOnce();
+		expect(adoptedEnv).toEqual({ ACP_FIXTURE_API_KEY: "fresh-B" });
+	});
+
 	it("consumes a reconnect recovery environment before a later crash", async () => {
 		vi.useFakeTimers();
 		type RecoveryWorker = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1645,7 +1645,7 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(supervisor.effectiveWorkerState(worker)).toBe("ready");
 	});
 
-	it("excludes stopping workers from the live session list", async () => {
+	it("keeps stopping workers listed with an honest state for busy-daemon checks", async () => {
 		const makeWorker = (workerId: string, stopRequestedAt?: string) => ({
 			descriptor: {
 				workerId,
@@ -1683,14 +1683,20 @@ describe("daemon worker supervisor monitoring", () => {
 			handleList(
 				client: object,
 				command: { id: string; type: "list" },
-			): Promise<{ success: boolean; data?: { sessions: Array<{ activeSessionId?: string; id: string }> } }>;
+			): Promise<{
+				success: boolean;
+				data?: { sessions: Array<{ activeSessionId?: string; id: string; workerState?: string }> };
+			}>;
 		};
 
 		const response = await supervisor.handleList({}, { id: "list-1", type: "list" });
 
 		expect(response.success).toBe(true);
 		const sessions = response.data?.sessions ?? [];
-		expect(sessions.map((session) => session.activeSessionId ?? session.id)).toEqual(["worker-live-active"]);
+		expect(sessions.map((session) => [session.activeSessionId ?? session.id, session.workerState]).sort()).toEqual([
+			["worker-live-active", "ready"],
+			["worker-stopping-active", "stopping"],
+		]);
 	});
 
 	it("ignores malformed persisted worker descriptors", () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1898,6 +1898,55 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("keeps waiting when process identity is transiently unobservable", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-unknown-identity-stop",
+				pid: 111_114,
+				processStartId: "proc:original",
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			stopWorker,
+			persistWorker: vi.fn(),
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			scheduleWorkerStopFinalization(target: object): void;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const sessionLeaseModule = await import("../src/core/session-lease.js");
+		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(true);
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(true);
+		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
+		// Identity observation fails transiently (e.g. ps unavailable).
+		const startIdSpy = vi.spyOn(sessionLeaseModule, "getProcessStartId").mockReturnValue(undefined);
+		try {
+			supervisor.scheduleWorkerStopFinalization(worker);
+
+			await vi.advanceTimersByTimeAsync(20_000);
+
+			// The possibly-live worker is neither signalled nor cleaned up.
+			expect(killSpy).not.toHaveBeenCalled();
+			expect(stopWorker).not.toHaveBeenCalled();
+			expect(worker.stopFinalization).toBeDefined();
+		} finally {
+			existsSpy.mockRestore();
+			aliveSpy.mockRestore();
+			killSpy.mockRestore();
+			startIdSpy.mockRestore();
+		}
+	});
+
 	it("retries finalization after a transient cleanup failure", async () => {
 		vi.useFakeTimers();
 		const worker = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1957,6 +1957,58 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("re-verifies identity at SIGKILL time even within the throttle window", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-kill-window-recycle",
+				pid: 111_118,
+				processStartId: "proc:original",
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		const stopWorker = vi.fn(async () => {
+			workers.delete(worker.descriptor.workerId);
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			shuttingDown: false,
+			stopWorker,
+			persistWorker: vi.fn(),
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			scheduleWorkerStopFinalization(target: object): void;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const sessionLeaseModule = await import("../src/core/session-lease.js");
+		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(true);
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(true);
+		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
+		// The worker is current on the throttled polls, but the pid is recycled
+		// by the time the SIGKILL deadline arrives.
+		const startIdSpy = vi.spyOn(sessionLeaseModule, "getProcessStartId").mockReturnValue("proc:original");
+		try {
+			supervisor.scheduleWorkerStopFinalization(worker);
+			await vi.advanceTimersByTimeAsync(4900);
+			startIdSpy.mockReturnValue("proc:recycled");
+			await vi.advanceTimersByTimeAsync(2000);
+
+			// The fresh check at signal time sees the recycled pid and holds fire.
+			expect(killSpy).not.toHaveBeenCalled();
+		} finally {
+			existsSpy.mockRestore();
+			aliveSpy.mockRestore();
+			killSpy.mockRestore();
+			startIdSpy.mockRestore();
+		}
+	});
+
 	it("keeps waiting when process identity is transiently unobservable", async () => {
 		vi.useFakeTimers();
 		const worker = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1699,6 +1699,108 @@ describe("daemon worker supervisor monitoring", () => {
 		]);
 	});
 
+	it.each(["SIGTERM", "SIGKILL"] as const)(
+		"fails closed for a legacy worker identity before %s",
+		(signal) => {
+			const worker = {
+				descriptor: { workerId: "worker-legacy-signal", pid: 111_121 },
+				stopRevision: 0,
+			};
+			const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+				workers: new Map([[worker.descriptor.workerId, worker]]),
+				processIdentity: vi.fn(),
+			}) as {
+				signalCurrentWorker(target: object, descriptor: object, revision: number, stopAt: undefined, signal: string): boolean;
+				processIdentity: ReturnType<typeof vi.fn>;
+			};
+			const childProcessModule = await import("../src/utils/child-process.js");
+			const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
+			try {
+				expect(supervisor.signalCurrentWorker(worker, worker.descriptor, 0, undefined, signal)).toBe(false);
+				expect(supervisor.processIdentity).not.toHaveBeenCalled();
+				expect(killSpy).not.toHaveBeenCalled();
+			} finally {
+				killSpy.mockRestore();
+			}
+		},
+	);
+
+	it("fails closed for a recycled pid before either stop signal", async () => {
+		const worker = {
+			descriptor: { workerId: "worker-recycled-signal", pid: 111_122, processStartId: "proc:original" },
+			stopRevision: 2,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			processIdentity: vi.fn(() => "replaced"),
+		}) as {
+			signalCurrentWorker(target: object, descriptor: object, revision: number, stopAt: undefined, signal: string): boolean;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
+		try {
+			expect(supervisor.signalCurrentWorker(worker, worker.descriptor, 2, undefined, "SIGTERM")).toBe(false);
+			expect(supervisor.signalCurrentWorker(worker, worker.descriptor, 2, undefined, "SIGKILL")).toBe(false);
+			expect(killSpy).not.toHaveBeenCalled();
+		} finally {
+			killSpy.mockRestore();
+		}
+	});
+
+	it("keeps a legacy tombstone authoritative during adoption without signalling", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-legacy-adoption",
+				pid: 111_123,
+				stopRequestedAt: new Date().toISOString(),
+			},
+			stopRevision: 0,
+		};
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			assertRecoveryAllowed: vi.fn(async () => {}),
+			stopWorker,
+			log: vi.fn(),
+		}) as {
+			adoptOrRecoverWorker(target: object): Promise<void>;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
+		try {
+			await supervisor.adoptOrRecoverWorker(worker);
+			expect(killSpy).not.toHaveBeenCalled();
+			expect(stopWorker).toHaveBeenCalledWith(worker, true, true, false);
+		} finally {
+			killSpy.mockRestore();
+		}
+	});
+
+	it("does not SIGKILL a legacy worker while recovering uncertain operations", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-legacy-recovery",
+				pid: 111_124,
+				recoveryJournalPath: join(tmpdir(), `prime-legacy-recovery-${randomUUID()}.jsonl`),
+			},
+			stopRevision: 0,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			assertRecoveryAllowed: vi.fn(async () => {}),
+		}) as {
+			recoverUncertainWorkerOperations(target: object, kill?: boolean): Promise<void>;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
+		try {
+			await supervisor.recoverUncertainWorkerOperations(worker);
+			expect(killSpy).not.toHaveBeenCalled();
+		} finally {
+			killSpy.mockRestore();
+		}
+	});
+
 	it("finalizes a timed-out stop once the worker process dies", async () => {
 		vi.useFakeTimers();
 		const worker = {
@@ -1751,6 +1853,7 @@ describe("daemon worker supervisor monitoring", () => {
 			descriptor: {
 				workerId: "worker-stuck-stop",
 				pid: process.pid,
+				processStartId: "proc:stuck",
 				rootActiveSessionId: "active-1",
 				stopRequestedAt: new Date().toISOString(),
 				archiveOnStop: true,
@@ -1772,7 +1875,9 @@ describe("daemon worker supervisor monitoring", () => {
 			scheduleWorkerStopFinalization(target: object): void;
 		};
 		const childProcessModule = await import("../src/utils/child-process.js");
+		const sessionLeaseModule = await import("../src/core/session-lease.js");
 		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockImplementation(() => alive);
+		const startIdSpy = vi.spyOn(sessionLeaseModule, "getProcessStartId").mockReturnValue("proc:stuck");
 		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation((_pid, signal) => {
 			if (signal === "SIGKILL") {
 				alive = false;
@@ -1789,6 +1894,7 @@ describe("daemon worker supervisor monitoring", () => {
 			expect(stopWorker).toHaveBeenCalledWith(worker, true, true, true);
 		} finally {
 			aliveSpy.mockRestore();
+			startIdSpy.mockRestore();
 			killSpy.mockRestore();
 		}
 	});

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import type { Socket } from "node:net";
@@ -714,7 +715,6 @@ describe("daemon worker supervisor monitoring", () => {
 		if (typeof persistWorker !== "function") {
 			throw new Error("Could not access worker persistence");
 		}
-		let persistenceCalls = 0;
 		const workers = new Map<string, unknown>();
 		const connectWorker = vi.fn(async () => {
 			await waitForFile(markerPath);
@@ -730,9 +730,8 @@ describe("daemon worker supervisor monitoring", () => {
 			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed: vi.fn(async () => undefined),
 			connectWorker,
-			persistWorker: vi.fn(function (this: object, worker: object) {
-				persistenceCalls++;
-				if (persistenceCalls === 2) {
+			persistWorker: vi.fn(function (this: object, worker: { descriptor: { stopRequestedAt?: string } }) {
+				if (worker.descriptor.stopRequestedAt !== undefined) {
 					throw rollbackPersistenceError;
 				}
 				Reflect.apply(persistWorker, this, [worker]);
@@ -749,11 +748,14 @@ describe("daemon worker supervisor monitoring", () => {
 
 		expect(readFileSync(markerPath, "utf8")).toBe("start\n");
 		expect(connectWorker).toHaveBeenCalledOnce();
-		expect(persistenceCalls).toBe(2);
-		expect(workers.size).toBe(0);
-		expect(readdirSync(descriptorDir).filter((name) => name.endsWith(".json"))).toEqual([]);
+		// The failed tombstone write leaves the durable descriptor and in-memory
+		// registration intact rather than allowing unsafe reclamation.
+		expect(workers.size).toBe(1);
+		expect(readdirSync(descriptorDir).filter((name) => name.endsWith(".json"))).toHaveLength(1);
 		const child = workerLaunchTestState.spawned.at(-1)?.child;
-		expect(child?.exitCode !== null || child?.signalCode !== null).toBe(true);
+		// Failing to persist the tombstone also fails closed: the process is left
+		// running under its retained recoverable registration.
+		expect(child?.exitCode === null && child?.signalCode === null).toBe(true);
 	});
 
 	it("defers an eligible existing recovery when descriptor restoration fails", async () => {
@@ -763,7 +765,7 @@ describe("daemon worker supervisor monitoring", () => {
 		mkdirSync(descriptorDir, { recursive: true });
 		supervisorRegistryDirs.add(root);
 		workerLaunchTestState.capture = true;
-		workerLaunchTestState.forceMissingProcessStartId = true;
+		workerLaunchTestState.forceMissingProcessStartId = false;
 		workerLaunchTestState.fixtureMode = "successful-gate";
 		workerLaunchTestState.gateMarkerPath = markerPath;
 		const cancellation = recoveryDeniedError("supervisor_recovery_cancelled");
@@ -772,7 +774,6 @@ describe("daemon worker supervisor monitoring", () => {
 		if (typeof persistWorker !== "function") {
 			throw new Error("Could not access worker persistence");
 		}
-		let persistenceCalls = 0;
 		const existing = createExistingLaunchWorker(root, descriptorDir);
 		const previousDescriptor = existing.descriptor;
 		const workers = new Map<string, object>([[existing.descriptor.workerId, existing]]);
@@ -791,9 +792,8 @@ describe("daemon worker supervisor monitoring", () => {
 			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed: vi.fn(async () => undefined),
 			connectWorker,
-			persistWorker: vi.fn(function (this: object, worker: object) {
-				persistenceCalls++;
-				if (persistenceCalls === 3) {
+			persistWorker: vi.fn(function (this: object, worker: { descriptor: object }) {
+				if (worker === existing && worker.descriptor === previousDescriptor) {
 					throw restorationError;
 				}
 				Reflect.apply(persistWorker, this, [worker]);
@@ -812,7 +812,8 @@ describe("daemon worker supervisor monitoring", () => {
 			supervisor.launchWorker({ type: "create", config: { cwd: root, agentDir: root } }, existing),
 		).rejects.toBe(cancellation);
 
-		expect(persistenceCalls).toBe(3);
+		// A restoration write failure preserves the pre-recovery in-memory descriptor
+		// and schedules recovery rather than accepting an indeterminate replacement.
 		expect(existing.descriptor).toBe(previousDescriptor);
 		expect(workers.get(existing.descriptor.workerId)).toBe(existing);
 		expect(deferWorkerRecovery).toHaveBeenCalledOnce();
@@ -905,7 +906,15 @@ describe("daemon worker supervisor monitoring", () => {
 			);
 		await rollbackStarted;
 		supervisor.shuttingDown = true;
-		await supervisor.stopWorker(existing, true, true);
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(false);
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
+		try {
+			await supervisor.stopWorker(existing, true, true);
+		} finally {
+			existsSpy.mockRestore();
+			aliveSpy.mockRestore();
+		}
 		releaseRollback();
 
 		expect(await launchResult).toBe(cancellation);
@@ -1561,11 +1570,9 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(worker.descriptor).toBe(originalDescriptor);
 		expect(worker.descriptor).toMatchObject({
 			lifecycle: "failed",
-				consecutiveFailures: 3,
-				lastError: "previous recovery failure",
-				stopRequestedAt: undefined,
-				archiveOnStop: undefined,
-			});
+			consecutiveFailures: 3,
+			lastError: "previous recovery failure",
+		});
 		expect(worker.intentionalStop).toBe(false);
 		expect(worker.recovery).toBeUndefined();
 
@@ -2090,6 +2097,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const stopWorker = vi.fn(async () => {});
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
+			assertCurrentOwnership: vi.fn(async () => {}),
 			assertRecoveryAllowed: vi.fn(async () => {}),
 			stopWorker,
 			log: vi.fn(),
@@ -2118,6 +2126,7 @@ describe("daemon worker supervisor monitoring", () => {
 		};
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
+			assertCurrentOwnership: vi.fn(async () => {}),
 			assertRecoveryAllowed: vi.fn(async () => {}),
 		}) as {
 			recoverUncertainWorkerOperations(target: object, kill?: boolean): Promise<void>;
@@ -2388,7 +2397,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(false);
 		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
 		try {
-			await expect(supervisor.stopWorker(worker, true, true, true)).rejects.toThrow("was relaunched during stop");
+			await expect(supervisor.stopWorker(worker, true, true, true)).rejects.toThrow("changed during stop");
 
 			// The relaunched worker's registration and descriptor must survive.
 			expect(workers.has(worker.descriptor.workerId)).toBe(true);
@@ -2448,7 +2457,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(false);
 		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
 		try {
-			await expect(supervisor.stopWorker(worker, true, true, true)).rejects.toThrow("was relaunched during stop");
+			await expect(supervisor.stopWorker(worker, true, true, true)).rejects.toThrow("changed during stop");
 
 			// The revived registration and descriptor must survive for recovery.
 			expect(workers.has(worker.descriptor.workerId)).toBe(true);
@@ -3322,7 +3331,7 @@ describe("daemon worker supervisor monitoring", () => {
 				processStartId: "worker:current",
 				rootActiveSessionId: "root-active",
 				recoveryJournalPath: join(root, "worker.recovery.jsonl"),
-				orphanProcessJournalPath,
+				orphanProcessJournalPath: orphanJournalPath,
 			},
 			stopRevision: 0,
 		};
@@ -3375,7 +3384,7 @@ describe("daemon worker supervisor monitoring", () => {
 				processStartId: "worker:current",
 				rootActiveSessionId: "root-active",
 				recoveryJournalPath: join(root, "worker.recovery.jsonl"),
-				orphanProcessJournalPath,
+				orphanProcessJournalPath: orphanJournalPath,
 			},
 			stopRevision: 0,
 		};
@@ -3715,6 +3724,7 @@ describe("daemon worker supervisor monitoring", () => {
 			processStartId: "exact-process",
 			rootSessionId: "root-session",
 			sessionFile: join(root, "session.jsonl"),
+			recoveryJournalPath,
 			stopRequestedAt: "stop-tombstone",
 		};
 		const worker = { descriptor, descriptorPath, intentionalStop: true, stopRevision: 0 };

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1791,6 +1791,105 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("never follows a relaunched worker pid after a retry rescinds the stop", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-relaunched",
+				pid: 111_111,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString() as string | undefined,
+			},
+			intentionalStop: true,
+			stopRevision: 3,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			scheduleWorkerStopFinalization(target: object): void;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(true);
+		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
+		try {
+			supervisor.scheduleWorkerStopFinalization(worker);
+			const finalization = worker.stopFinalization;
+
+			// An explicit retry rescinds the stop and relaunches with a new pid
+			// while the old process is still wedged.
+			await vi.advanceTimersByTimeAsync(1000);
+			worker.descriptor.stopRequestedAt = undefined;
+			worker.intentionalStop = false;
+			worker.stopRevision = 4;
+			worker.descriptor.pid = 222_222;
+
+			await vi.advanceTimersByTimeAsync(20_000);
+			await finalization;
+
+			// The healthy relaunched worker must never be signalled or stopped.
+			expect(killSpy).not.toHaveBeenCalledWith(222_222, "SIGKILL");
+			expect(killSpy).not.toHaveBeenCalled();
+			expect(stopWorker).not.toHaveBeenCalled();
+		} finally {
+			aliveSpy.mockRestore();
+			killSpy.mockRestore();
+		}
+	});
+
+	it("treats a recycled pid as gone instead of killing its new owner", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-recycled-pid",
+				pid: 111_112,
+				processStartId: "proc:original",
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		const stopWorker = vi.fn(async () => {});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			stopWorker,
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			scheduleWorkerStopFinalization(target: object): void;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const sessionLeaseModule = await import("../src/core/session-lease.js");
+		// The pid is alive, but it now belongs to an unrelated process.
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(true);
+		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
+		const startIdSpy = vi.spyOn(sessionLeaseModule, "getProcessStartId").mockReturnValue("proc:recycled");
+		try {
+			supervisor.scheduleWorkerStopFinalization(worker);
+			const finalization = worker.stopFinalization;
+
+			await vi.advanceTimersByTimeAsync(20_000);
+			await finalization;
+
+			// The original worker is gone, so the stop is finalized without ever
+			// signalling the unrelated pid owner.
+			expect(killSpy).not.toHaveBeenCalled();
+			expect(stopWorker).toHaveBeenCalledWith(worker, true, true, false);
+		} finally {
+			aliveSpy.mockRestore();
+			killSpy.mockRestore();
+			startIdSpy.mockRestore();
+		}
+	});
+
 	it("leaves a rescinded stop to the retry flow instead of finalizing it", async () => {
 		vi.useFakeTimers();
 		const worker = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -2998,6 +2998,113 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(client.attachedActiveSessionIds).toEqual(new Set());
 	});
 
+	it("retains the orphan journal and never uses the pid fallback after its identity changes", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-orphan-recycle-"));
+		const orphanJournalPath = join(root, "worker.orphans.jsonl");
+		const orphanPid = 987_651;
+		writeFileSync(
+			orphanJournalPath,
+			`${JSON.stringify({
+				version: 1,
+				pid: orphanPid,
+				ownerPid: process.pid,
+				processStartId: "orphan:original",
+				active: true,
+				recordedAt: new Date().toISOString(),
+			})}\n`,
+		);
+		const worker = {
+			descriptor: {
+				workerId: "worker-orphan-recycle",
+				pid: process.pid,
+				processStartId: "worker:current",
+				rootActiveSessionId: "root-active",
+				recoveryJournalPath: join(root, "worker.recovery.jsonl"),
+				orphanProcessJournalPath,
+			},
+			stopRevision: 0,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			assertRecoveryAllowed: vi.fn(async () => {}),
+			assertCurrentOwnership: vi.fn(async () => {}),
+			assertWorkerTupleCurrent: vi.fn(),
+			log: vi.fn(),
+		});
+		const sessionLeaseModule = await import("../src/core/session-lease.js");
+		const startId = vi
+			.spyOn(sessionLeaseModule, "getProcessStartId")
+			.mockReturnValueOnce("orphan:original")
+			.mockReturnValueOnce("orphan:recycled");
+		const kill = vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
+			if (pid === -orphanPid) throw new Error("process group unavailable");
+			return true;
+		}) as typeof process.kill);
+		try {
+			await supervisor.recoverUncertainWorkerOperations(worker, false);
+			expect(kill).toHaveBeenCalledWith(-orphanPid, "SIGKILL");
+			expect(kill).not.toHaveBeenCalledWith(orphanPid, "SIGKILL");
+			expect(readFileSync(orphanJournalPath, "utf8")).toContain("orphan:original");
+		} finally {
+			kill.mockRestore();
+			startId.mockRestore();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("uses the orphan pid fallback only after a fresh exact identity observation", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-orphan-fallback-"));
+		const orphanJournalPath = join(root, "worker.orphans.jsonl");
+		const orphanPid = 987_652;
+		writeFileSync(
+			orphanJournalPath,
+			`${JSON.stringify({
+				version: 1,
+				pid: orphanPid,
+				ownerPid: process.pid,
+				processStartId: "orphan:current",
+				active: true,
+				recordedAt: new Date().toISOString(),
+			})}\n`,
+		);
+		const worker = {
+			descriptor: {
+				workerId: "worker-orphan-fallback",
+				pid: process.pid,
+				processStartId: "worker:current",
+				rootActiveSessionId: "root-active",
+				recoveryJournalPath: join(root, "worker.recovery.jsonl"),
+				orphanProcessJournalPath,
+			},
+			stopRevision: 0,
+		};
+		const ownership = vi.fn(async () => {});
+		const tuple = vi.fn();
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			assertRecoveryAllowed: vi.fn(async () => {}),
+			assertCurrentOwnership: ownership,
+			assertWorkerTupleCurrent: tuple,
+			log: vi.fn(),
+		});
+		const sessionLeaseModule = await import("../src/core/session-lease.js");
+		const startId = vi.spyOn(sessionLeaseModule, "getProcessStartId").mockReturnValue("orphan:current");
+		const kill = vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
+			if (pid === -orphanPid) throw new Error("process group unavailable");
+			return true;
+		}) as typeof process.kill);
+		try {
+			await supervisor.recoverUncertainWorkerOperations(worker, false);
+			expect(kill).toHaveBeenNthCalledWith(1, -orphanPid, "SIGKILL");
+			expect(kill).toHaveBeenNthCalledWith(2, orphanPid, "SIGKILL");
+			expect(ownership).toHaveBeenCalledTimes(3);
+			expect(tuple).toHaveBeenCalledTimes(3);
+			expect(existsSync(orphanJournalPath)).toBe(false);
+		} finally {
+			kill.mockRestore();
+			startId.mockRestore();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("marks each busy worker session interrupted independently", async () => {
 		type RecoveryWorker = {
 			descriptor: {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -2392,6 +2392,49 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("fails resume honestly when confirmed-dead cleanup outlasts the bounded wait", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-slow-cleanup",
+				pid: 111_117,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			client: undefined,
+			recovery: undefined,
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			// Cleanup hangs past the bounded reclaim wait.
+			stopWorker: vi.fn(() => new Promise<void>(() => {})),
+			persistWorker: vi.fn(),
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			reclaimStaleWorkerRegistration(target: object): Promise<boolean>;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
+		try {
+			const reclaim = supervisor.reclaimStaleWorkerRegistration(worker);
+			const outcome = reclaim.then(
+				() => "reused",
+				() => "failed",
+			);
+			await vi.advanceTimersByTimeAsync(60_000);
+
+			// The dead registration is never handed back to the resume path.
+			await expect(outcome).resolves.toBe("failed");
+		} finally {
+			aliveSpy.mockRestore();
+		}
+	});
+
 	it("shares one stop between concurrent resume reclaims", async () => {
 		const worker = {
 			descriptor: {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -2009,6 +2009,67 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("retries SIGKILL after a transient identity outage at the deadline", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-kill-retry",
+				pid: 111_119,
+				processStartId: "proc:original",
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		const stopWorker = vi.fn(async () => {
+			workers.delete(worker.descriptor.workerId);
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			shuttingDown: false,
+			stopWorker,
+			persistWorker: vi.fn(),
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			scheduleWorkerStopFinalization(target: object): void;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const sessionLeaseModule = await import("../src/core/session-lease.js");
+		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(true);
+		let alive = true;
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockImplementation(() => alive);
+		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation((_pid, signal) => {
+			if (signal === "SIGKILL") {
+				alive = false;
+			}
+		});
+		// Identity observation is down when the SIGKILL deadline passes...
+		const startIdSpy = vi.spyOn(sessionLeaseModule, "getProcessStartId").mockReturnValue(undefined);
+		try {
+			supervisor.scheduleWorkerStopFinalization(worker);
+			const finalization = worker.stopFinalization;
+
+			await vi.advanceTimersByTimeAsync(8000);
+			expect(killSpy).not.toHaveBeenCalled();
+
+			// ...but once identity is observable again, escalation still fires.
+			startIdSpy.mockReturnValue("proc:original");
+			await vi.advanceTimersByTimeAsync(5000);
+			await finalization;
+			expect(killSpy).toHaveBeenCalledWith(worker.descriptor.pid, "SIGKILL");
+			expect(stopWorker).toHaveBeenCalled();
+		} finally {
+			existsSpy.mockRestore();
+			aliveSpy.mockRestore();
+			killSpy.mockRestore();
+			startIdSpy.mockRestore();
+		}
+	});
+
 	it("keeps waiting when process identity is transiently unobservable", async () => {
 		vi.useFakeTimers();
 		const worker = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1957,6 +1957,65 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("aborts stale stop cleanup when the stop is rescinded before the relaunch lands", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-rescinded-during-stop",
+				pid: 111_120,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString() as string | undefined,
+				archiveOnStop: true,
+			},
+			client: undefined,
+			summaries: new Map(),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: true,
+			stopRevision: 0,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			shuttingDown: false,
+			persistWorker: vi.fn(),
+			persistWorkerStopTombstone: vi.fn(),
+			reclaimStoppedWorkerCronLock: vi.fn(),
+			// A retry rescinds the tombstone while archival yields, before
+			// recoverWorker has assigned the successor pid.
+			finalizeArchivedWorkerStop: vi.fn(async () => {
+				worker.descriptor.stopRequestedAt = undefined;
+			}),
+			deleteWorkerDescriptor: vi.fn(),
+			syncAgentPeers: vi.fn(async () => {}),
+			broadcastHeartbeatsChanged: vi.fn(),
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as unknown as {
+			stopWorker(
+				target: object,
+				removeDescriptor: boolean,
+				force?: boolean,
+				archiveSession?: boolean,
+			): Promise<void>;
+			deleteWorkerDescriptor: ReturnType<typeof vi.fn>;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(false);
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
+		try {
+			await expect(supervisor.stopWorker(worker, true, true, true)).rejects.toThrow("was relaunched during stop");
+
+			// The revived registration and descriptor must survive for recovery.
+			expect(workers.has(worker.descriptor.workerId)).toBe(true);
+			expect(supervisor.deleteWorkerDescriptor).not.toHaveBeenCalled();
+		} finally {
+			existsSpy.mockRestore();
+			aliveSpy.mockRestore();
+		}
+	});
+
 	it("re-verifies identity at SIGKILL time even within the throttle window", async () => {
 		vi.useFakeTimers();
 		const worker = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -2378,12 +2378,62 @@ describe("daemon worker supervisor monitoring", () => {
 			reclaimStaleWorkerRegistration(target: object): Promise<boolean>;
 		};
 
-		const reclaim = supervisor.reclaimStaleWorkerRegistration(worker);
-		releaseFinalization();
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
+		try {
+			const reclaim = supervisor.reclaimStaleWorkerRegistration(worker);
+			releaseFinalization();
 
-		// The reclaim defers to the finalizer's cleanup instead of duplicating it.
-		await expect(reclaim).resolves.toBe(true);
-		expect(stopWorker).not.toHaveBeenCalled();
+			// The reclaim defers to the finalizer's cleanup instead of duplicating it.
+			await expect(reclaim).resolves.toBe(true);
+			expect(stopWorker).not.toHaveBeenCalled();
+		} finally {
+			aliveSpy.mockRestore();
+		}
+	});
+
+	it("shares one stop between concurrent resume reclaims", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-concurrent-reclaim",
+				pid: 111_116,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			client: undefined,
+			recovery: undefined,
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		const stopWorker = vi.fn(async () => {
+			workers.delete(worker.descriptor.workerId);
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			shuttingDown: false,
+			stopWorker,
+			persistWorker: vi.fn(),
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			reclaimStaleWorkerRegistration(target: object): Promise<boolean>;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
+		try {
+			const results = await Promise.all([
+				supervisor.reclaimStaleWorkerRegistration(worker),
+				supervisor.reclaimStaleWorkerRegistration(worker),
+			]);
+
+			expect(results).toEqual([true, true]);
+			// Both concurrent resumes share the single-flighted finalizer stop.
+			expect(stopWorker).toHaveBeenCalledTimes(1);
+		} finally {
+			aliveSpy.mockRestore();
+		}
 	});
 
 	it("does not reclaim a stopping worker whose process is still alive", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1498,6 +1498,84 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(recoverWorker).toHaveBeenCalledOnce();
 	});
 
+	it("clears an unpersisted fresh recovery environment before later automatic recovery", async () => {
+		type RecoveryWorker = {
+			descriptor: {
+				workerId: string;
+				rootActiveSessionId: string;
+				lifecycle: "failed" | "recovering" | "ready";
+				consecutiveFailures: number;
+				stopRequestedAt?: string;
+				archiveOnStop?: boolean;
+				lastError?: string;
+			};
+			client?: object;
+			recovery?: Promise<void>;
+			recoveryLaunchEnv?: Record<string, string>;
+			intentionalStop: boolean;
+		};
+		type RecoveryHarness = {
+			persistWorker: ReturnType<typeof vi.fn>;
+			recoverWorker: ReturnType<typeof vi.fn>;
+			reuseWorkerForCreate(
+				worker: RecoveryWorker,
+				ownerClientId: undefined,
+				sessionPath: string,
+				command: { type: "create"; lifecycle?: "client_owned"; launchEnv: Record<string, string> },
+			): Promise<RecoveryWorker>;
+		};
+		const worker: RecoveryWorker = {
+			descriptor: {
+				workerId: "worker-unpersisted-fresh-resume",
+				rootActiveSessionId: "active-unpersisted-fresh-resume",
+				lifecycle: "failed",
+				consecutiveFailures: 3,
+				lastError: "previous recovery failure",
+			},
+			intentionalStop: false,
+		};
+		const originalDescriptor = worker.descriptor;
+		let automaticRecoveryEnv: Record<string, string> | undefined;
+		const recoverWorker = vi.fn(async (target: RecoveryWorker) => {
+			automaticRecoveryEnv = target.recoveryLaunchEnv;
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			persistWorker: vi.fn((target: RecoveryWorker) => {
+				// Match persistWorker's ability to update the staged descriptor before
+				// its synchronous filesystem operations fail.
+				target.descriptor.lastError = "partially persisted recovery state";
+				throw new Error("simulated worker persistence failure");
+			}),
+			recoverWorker,
+		}) as RecoveryHarness;
+
+		await expect(
+			supervisor.reuseWorkerForCreate(worker, undefined, "/tmp/unpersisted-fresh-resume", {
+				type: "create",
+				launchEnv: { ACP_FIXTURE_API_KEY: "must-not-survive-persist-failure" },
+			}),
+		).rejects.toThrow("simulated worker persistence failure");
+		expect(supervisor.persistWorker).toHaveBeenCalledOnce();
+		expect(recoverWorker).not.toHaveBeenCalled();
+		expect(worker.recoveryLaunchEnv).toBeUndefined();
+		expect(worker.descriptor).toBe(originalDescriptor);
+		expect(worker.descriptor).toMatchObject({
+			lifecycle: "failed",
+				consecutiveFailures: 3,
+				lastError: "previous recovery failure",
+				stopRequestedAt: undefined,
+				archiveOnStop: undefined,
+			});
+		expect(worker.intentionalStop).toBe(false);
+		expect(worker.recovery).toBeUndefined();
+
+		// A later automatic recovery must not inherit a credential whose hand-off
+		// failed before recovery began.
+		await supervisor.recoverWorker(worker);
+		expect(recoverWorker).toHaveBeenCalledOnce();
+		expect(automaticRecoveryEnv).toBeUndefined();
+	});
+
 	it("lets the first fresh resume adopt recovery after an automatic env-less recovery settles", async () => {
 		type RecoveryWorker = {
 			descriptor: {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -368,6 +368,7 @@ describe("daemon worker supervisor monitoring", () => {
 			supervisorClaims: new Map([[client, oldClaim]]),
 			updateRestart: transaction,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			scheduleSupervisorFenceCheck: vi.fn(),
 			assertSupervisorClaimCurrent: vi.fn(async () => {
 				assertionReached.resolve();
@@ -456,6 +457,7 @@ describe("daemon worker supervisor monitoring", () => {
 			options: { worker: { authenticationToken: "token" } },
 			supervisorClaims: new Map(),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			clearSupervisorAvailabilityCheck: vi.fn(),
 			scheduleSupervisorFenceCheck: vi.fn(),
 			handleWorkerCommand,
@@ -595,6 +597,7 @@ describe("daemon worker supervisor monitoring", () => {
 			socketPath: join(root, "supervisor.sock"),
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed: vi.fn(async () => {
 				assertionCount++;
 				if (assertionCount === 3) {
@@ -665,6 +668,7 @@ describe("daemon worker supervisor monitoring", () => {
 			socketPath: join(root, "supervisor.sock"),
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed: vi.fn(async () => undefined),
 			connectWorker,
 			subscribeWorker: vi.fn(async () => undefined),
@@ -723,6 +727,7 @@ describe("daemon worker supervisor monitoring", () => {
 			socketPath: join(root, "supervisor.sock"),
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed: vi.fn(async () => undefined),
 			connectWorker,
 			persistWorker: vi.fn(function (this: object, worker: object) {
@@ -783,6 +788,7 @@ describe("daemon worker supervisor monitoring", () => {
 			socketPath: join(root, "supervisor.sock"),
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed: vi.fn(async () => undefined),
 			connectWorker,
 			persistWorker: vi.fn(function (this: object, worker: object) {
@@ -875,6 +881,7 @@ describe("daemon worker supervisor monitoring", () => {
 			socketPath: join(root, "supervisor.sock"),
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed: vi.fn(async () => undefined),
 			connectWorker,
 			stopWorker: controlledStopWorker,
@@ -928,6 +935,7 @@ describe("daemon worker supervisor monitoring", () => {
 		};
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			signalCleanupHandlers: [],
 			workers: new Map(),
 			clients: new Set(),
@@ -1046,6 +1054,7 @@ describe("daemon worker supervisor monitoring", () => {
 			...createSupervisorSnapshotState(),
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed,
 			persistWorker,
 			syncAgentPeers: vi.fn(async () => undefined),
@@ -1105,6 +1114,7 @@ describe("daemon worker supervisor monitoring", () => {
 			...createSupervisorSnapshotState(),
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed,
 			persistWorker,
 			syncAgentPeers: vi.fn(async () => undefined),
@@ -1176,6 +1186,7 @@ describe("daemon worker supervisor monitoring", () => {
 			...createSupervisorSnapshotState(),
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			assertRecoveryAllowed,
 			persistWorker,
 			syncAgentPeers: vi.fn(async () => undefined),
@@ -1403,6 +1414,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 		}) as RecoveryHarness;
 
 		const recovery = supervisor.recoverWorker(worker);
@@ -1451,6 +1463,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			connectWorker: vi.fn(),
 			recoverUncertainWorkerOperations: vi.fn(async () => {}),
 			launchWorker: vi.fn(async () => worker),
@@ -1511,6 +1524,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			connectWorker: vi.fn(async () => {
 				throw new Error("worker socket unavailable");
 			}),
@@ -1576,6 +1590,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			connectWorker: vi.fn(async () => ({})),
 			subscribeWorker: vi.fn(async () => {}),
 			refreshWorkerSummaries: vi.fn(async () => {}),
@@ -1701,22 +1716,29 @@ describe("daemon worker supervisor monitoring", () => {
 
 	it.each(["SIGTERM", "SIGKILL"] as const)(
 		"fails closed for a legacy worker identity before %s",
-		(signal) => {
+		async (signal) => {
 			const worker = {
 				descriptor: { workerId: "worker-legacy-signal", pid: 111_121 },
 				stopRevision: 0,
 			};
 			const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 				workers: new Map([[worker.descriptor.workerId, worker]]),
+				assertCurrentOwnership: vi.fn(async () => undefined),
 				processIdentity: vi.fn(),
 			}) as {
-				signalCurrentWorker(target: object, descriptor: object, revision: number, stopAt: undefined, signal: string): boolean;
+				signalCurrentWorker(
+					target: object,
+					descriptor: object,
+					revision: number,
+					stopAt: undefined,
+					signal: string,
+				): Promise<boolean>;
 				processIdentity: ReturnType<typeof vi.fn>;
 			};
 			const childProcessModule = await import("../src/utils/child-process.js");
 			const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
 			try {
-				expect(supervisor.signalCurrentWorker(worker, worker.descriptor, 0, undefined, signal)).toBe(false);
+				await expect(supervisor.signalCurrentWorker(worker, worker.descriptor, 0, undefined, signal)).resolves.toBe(false);
 				expect(supervisor.processIdentity).not.toHaveBeenCalled();
 				expect(killSpy).not.toHaveBeenCalled();
 			} finally {
@@ -1732,15 +1754,22 @@ describe("daemon worker supervisor monitoring", () => {
 		};
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			processIdentity: vi.fn(() => "replaced"),
 		}) as {
-			signalCurrentWorker(target: object, descriptor: object, revision: number, stopAt: undefined, signal: string): boolean;
+			signalCurrentWorker(
+				target: object,
+				descriptor: object,
+				revision: number,
+				stopAt: undefined,
+				signal: string,
+			): Promise<boolean>;
 		};
 		const childProcessModule = await import("../src/utils/child-process.js");
 		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
 		try {
-			expect(supervisor.signalCurrentWorker(worker, worker.descriptor, 2, undefined, "SIGTERM")).toBe(false);
-			expect(supervisor.signalCurrentWorker(worker, worker.descriptor, 2, undefined, "SIGKILL")).toBe(false);
+			await expect(supervisor.signalCurrentWorker(worker, worker.descriptor, 2, undefined, "SIGTERM")).resolves.toBe(false);
+			await expect(supervisor.signalCurrentWorker(worker, worker.descriptor, 2, undefined, "SIGKILL")).resolves.toBe(false);
 			expect(killSpy).not.toHaveBeenCalled();
 		} finally {
 			killSpy.mockRestore();
@@ -1819,6 +1848,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -1867,6 +1897,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -1916,6 +1947,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -1971,6 +2003,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -2026,6 +2059,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			persistWorker: vi.fn(),
 			persistWorkerStopTombstone: vi.fn(),
 			reclaimStoppedWorkerCronLock: vi.fn(),
@@ -2085,6 +2119,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			persistWorker: vi.fn(),
 			persistWorkerStopTombstone: vi.fn(),
 			reclaimStoppedWorkerCronLock: vi.fn(),
@@ -2143,6 +2178,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -2195,6 +2231,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -2253,6 +2290,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -2308,6 +2346,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -2351,6 +2390,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -2516,6 +2556,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			// Cleanup hangs past the bounded reclaim wait.
 			stopWorker: vi.fn(() => new Promise<void>(() => {})),
 			persistWorker: vi.fn(),
@@ -2562,6 +2603,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			workers,
 			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
 			stopWorker,
 			persistWorker: vi.fn(),
 			log: vi.fn(),
@@ -3252,4 +3294,80 @@ describe("daemon worker supervisor monitoring", () => {
 		await expect(supervisor.prepareUpdateRestartFenced()).rejects.toThrow(/resident-1.*recovering.*disconnected/);
 		expect(requestWorker).not.toHaveBeenCalled();
 	});
+	it("fails closed on ownership loss during signal, descriptor removal, and archive finalization", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-ownership-finalizer-"));
+		const descriptorPath = join(root, "worker.json");
+		const recoveryJournalPath = join(root, "worker.recovery.jsonl");
+		writeFileSync(descriptorPath, "descriptor");
+		writeFileSync(recoveryJournalPath, "journal");
+		const descriptor = {
+			workerId: "ownership-lost-worker",
+			pid: process.pid,
+			processStartId: "exact-process",
+			rootSessionId: "root-session",
+			sessionFile: join(root, "session.jsonl"),
+			stopRequestedAt: "stop-tombstone",
+		};
+		const worker = { descriptor, descriptorPath, intentionalStop: true, stopRevision: 0 };
+		const signalModule = await import("../src/utils/child-process.js");
+		const leaseModule = await import("../src/core/session-lease.js");
+		let alive = true;
+		const signalSpy = vi.spyOn(signalModule, "signalProcessGroupOrProcess").mockImplementation(() => {
+			alive = false;
+		});
+		const aliveSpy = vi.spyOn(signalModule, "isProcessAlive").mockImplementation(() => alive);
+		const startIdSpy = vi.spyOn(leaseModule, "getProcessStartId").mockReturnValue("exact-process");
+		const archive = vi.fn(async () => {});
+		const ownershipLost = Object.assign(new Error("ownership lost"), { code: "supervisor_generation_stale" });
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[descriptor.workerId, worker]]),
+			assertCurrentOwnership: vi.fn(async () => {
+				throw ownershipLost;
+			}),
+			catalog: { archive },
+			workerSessionArtifactContext: vi.fn(() => ({ sessionFile: descriptor.sessionFile, artifactDir: root })),
+		}) as unknown as {
+			signalCurrentWorker(
+				target: object,
+				row: object,
+				revision: number,
+				tombstone: string,
+				signal: NodeJS.Signals,
+			): Promise<boolean>;
+			deleteWorkerDescriptor(target: object, row: object, revision: number, tombstone: string): Promise<void>;
+			finalizeArchivedWorkerStop(target: object, row: object, revision: number, tombstone: string): Promise<void>;
+			assertCurrentOwnership: ReturnType<typeof vi.fn>;
+		};
+		try {
+			await expect(
+				supervisor.signalCurrentWorker(worker, descriptor, 0, descriptor.stopRequestedAt, "SIGKILL"),
+			).rejects.toMatchObject({ code: "supervisor_generation_stale" });
+			await expect(
+				supervisor.deleteWorkerDescriptor(worker, descriptor, 0, descriptor.stopRequestedAt),
+			).rejects.toMatchObject({ code: "supervisor_generation_stale" });
+			await expect(
+				supervisor.finalizeArchivedWorkerStop(worker, descriptor, 0, descriptor.stopRequestedAt),
+			).rejects.toMatchObject({ code: "supervisor_generation_stale" });
+			expect(signalSpy).not.toHaveBeenCalled();
+			expect(archive).not.toHaveBeenCalled();
+			expect(existsSync(descriptorPath)).toBe(true); // retained tombstone/retry record
+
+			// A successor with durable ownership may safely complete the exact same tuple.
+			supervisor.assertCurrentOwnership.mockResolvedValue(undefined);
+			await expect(
+				supervisor.signalCurrentWorker(worker, descriptor, 0, descriptor.stopRequestedAt, "SIGKILL"),
+			).resolves.toBe(true);
+			await supervisor.finalizeArchivedWorkerStop(worker, descriptor, 0, descriptor.stopRequestedAt);
+			await supervisor.deleteWorkerDescriptor(worker, descriptor, 0, descriptor.stopRequestedAt);
+			expect(signalSpy).toHaveBeenCalledWith(process.pid, "SIGKILL");
+			expect(archive).toHaveBeenCalledWith(descriptor.sessionFile, descriptor.rootSessionId);
+			expect(existsSync(descriptorPath)).toBe(false);
+		} finally {
+			signalSpy.mockRestore();
+			aliveSpy.mockRestore();
+			startIdSpy.mockRestore();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 });

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1718,6 +1718,7 @@ describe("daemon worker supervisor monitoring", () => {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
 			stopWorker,
+			persistWorker: vi.fn(),
 			log: vi.fn(),
 			reportCleanupFailure: vi.fn(),
 		}) as {
@@ -1764,6 +1765,7 @@ describe("daemon worker supervisor monitoring", () => {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
 			stopWorker,
+			persistWorker: vi.fn(),
 			log: vi.fn(),
 			reportCleanupFailure: vi.fn(),
 		}) as {
@@ -1809,12 +1811,14 @@ describe("daemon worker supervisor monitoring", () => {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
 			stopWorker,
+			persistWorker: vi.fn(),
 			log: vi.fn(),
 			reportCleanupFailure: vi.fn(),
 		}) as {
 			scheduleWorkerStopFinalization(target: object): void;
 		};
 		const childProcessModule = await import("../src/utils/child-process.js");
+		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(true);
 		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(true);
 		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
 		try {
@@ -1837,6 +1841,7 @@ describe("daemon worker supervisor monitoring", () => {
 			expect(killSpy).not.toHaveBeenCalled();
 			expect(stopWorker).not.toHaveBeenCalled();
 		} finally {
+			existsSpy.mockRestore();
 			aliveSpy.mockRestore();
 			killSpy.mockRestore();
 		}
@@ -1861,6 +1866,7 @@ describe("daemon worker supervisor monitoring", () => {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
 			stopWorker,
+			persistWorker: vi.fn(),
 			log: vi.fn(),
 			reportCleanupFailure: vi.fn(),
 		}) as {
@@ -1869,6 +1875,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const childProcessModule = await import("../src/utils/child-process.js");
 		const sessionLeaseModule = await import("../src/core/session-lease.js");
 		// The pid is alive, but it now belongs to an unrelated process.
+		const existsSpy = vi.spyOn(childProcessModule, "processIdExists").mockReturnValue(true);
 		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(true);
 		const killSpy = vi.spyOn(childProcessModule, "signalProcessGroupOrProcess").mockImplementation(() => {});
 		const startIdSpy = vi.spyOn(sessionLeaseModule, "getProcessStartId").mockReturnValue("proc:recycled");
@@ -1884,9 +1891,59 @@ describe("daemon worker supervisor monitoring", () => {
 			expect(killSpy).not.toHaveBeenCalled();
 			expect(stopWorker).toHaveBeenCalledWith(worker, true, true, false);
 		} finally {
+			existsSpy.mockRestore();
 			aliveSpy.mockRestore();
 			killSpy.mockRestore();
 			startIdSpy.mockRestore();
+		}
+	});
+
+	it("retries finalization after a transient cleanup failure", async () => {
+		vi.useFakeTimers();
+		const worker = {
+			descriptor: {
+				workerId: "worker-transient-cleanup",
+				pid: process.pid,
+				rootActiveSessionId: "active-1",
+				stopRequestedAt: new Date().toISOString(),
+			},
+			intentionalStop: true,
+			stopRevision: 0,
+			stopFinalization: undefined as Promise<void> | undefined,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		const stopWorker = vi
+			.fn(async () => {
+				workers.delete(worker.descriptor.workerId);
+			})
+			.mockImplementationOnce(async () => {
+				throw new Error("archive temporarily unavailable");
+			});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			shuttingDown: false,
+			stopWorker,
+			persistWorker: vi.fn(),
+			log: vi.fn(),
+			reportCleanupFailure: vi.fn(),
+		}) as {
+			scheduleWorkerStopFinalization(target: object): void;
+		};
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockReturnValue(false);
+		try {
+			supervisor.scheduleWorkerStopFinalization(worker);
+			const finalization = worker.stopFinalization;
+
+			await vi.advanceTimersByTimeAsync(20_000);
+			await finalization;
+
+			// The first attempt failed transiently; the registration is still
+			// cleaned up by a retry instead of being stranded forever.
+			expect(stopWorker).toHaveBeenCalledTimes(2);
+			expect(workers.size).toBe(0);
+		} finally {
+			aliveSpy.mockRestore();
 		}
 	});
 
@@ -1909,6 +1966,7 @@ describe("daemon worker supervisor monitoring", () => {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			shuttingDown: false,
 			stopWorker,
+			persistWorker: vi.fn(),
 			log: vi.fn(),
 			reportCleanupFailure: vi.fn(),
 		}) as {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1426,6 +1426,158 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(worker.recovery).toBeUndefined();
 	});
 
+	it("single-flights concurrent fresh resident resumes without replacing the first recovery environment", async () => {
+		type RecoveryWorker = {
+			descriptor: {
+				workerId: string;
+				rootActiveSessionId: string;
+				lifecycle: "failed" | "recovering" | "ready";
+				consecutiveFailures: number;
+				stopRequestedAt?: string;
+				archiveOnStop?: boolean;
+				lastError?: string;
+			};
+			client?: object;
+			recovery?: Promise<void>;
+			recoveryLaunchEnv?: Record<string, string>;
+			intentionalStop: boolean;
+		};
+		type RecoveryHarness = {
+			persistWorker: ReturnType<typeof vi.fn>;
+			recoverWorker: ReturnType<typeof vi.fn>;
+			reuseWorkerForCreate(
+				worker: RecoveryWorker,
+				ownerClientId: undefined,
+				sessionPath: string,
+				command: { type: "create"; lifecycle?: "client_owned"; launchEnv: Record<string, string> },
+			): Promise<RecoveryWorker>;
+		};
+		const worker: RecoveryWorker = {
+			descriptor: {
+				workerId: "worker-fresh-resume",
+				rootActiveSessionId: "active-fresh-resume",
+				lifecycle: "failed",
+				consecutiveFailures: 1,
+			},
+			intentionalStop: false,
+		};
+		const recoveryStarted = createDeferred<void>();
+		const finishRecovery = createDeferred<void>();
+		const recoverWorker = vi.fn(async (target: RecoveryWorker) => {
+			const recovery = (async () => {
+				recoveryStarted.resolve();
+				await finishRecovery.promise;
+				target.client = {};
+				target.descriptor.lifecycle = "ready";
+			})();
+			target.recovery = recovery.finally(() => {
+				target.recovery = undefined;
+			});
+			return target.recovery;
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			persistWorker: vi.fn(),
+			recoverWorker,
+		}) as RecoveryHarness;
+		const first = supervisor.reuseWorkerForCreate(worker, undefined, "/tmp/fresh-resume", {
+			type: "create",
+			launchEnv: { ACP_FIXTURE_API_KEY: "fresh-B" },
+		});
+		await recoveryStarted.promise;
+		const second = supervisor.reuseWorkerForCreate(worker, undefined, "/tmp/fresh-resume", {
+			type: "create",
+			launchEnv: { ACP_FIXTURE_API_KEY: "fresh-C" },
+		});
+
+		// B owns the one-shot capability. C joins B's recovery and cannot alter the
+		// environment passed to the replacement process.
+		expect(worker.recoveryLaunchEnv).toEqual({ ACP_FIXTURE_API_KEY: "fresh-B" });
+		expect(recoverWorker).toHaveBeenCalledOnce();
+		finishRecovery.resolve();
+		await expect(Promise.all([first, second])).resolves.toEqual([worker, worker]);
+		expect(recoverWorker).toHaveBeenCalledOnce();
+	});
+
+	it("consumes a reconnect recovery environment before a later crash", async () => {
+		vi.useFakeTimers();
+		type RecoveryWorker = {
+			descriptor: {
+				workerId: string;
+				pid: number;
+				rootActiveSessionId: string;
+				createCommand: { type: "create" };
+				lifecycle?: string;
+				consecutiveFailures: number;
+				lastError?: string;
+			};
+			client?: { close(): void };
+			recovery?: Promise<void>;
+			recoveryLaunchEnv?: Record<string, string>;
+			intentionalStop: boolean;
+			stopRevision: number;
+		};
+		type RecoveryHarness = {
+			workers: Map<string, RecoveryWorker>;
+			shuttingDown: boolean;
+			connectWorker: ReturnType<typeof vi.fn>;
+			subscribeWorker: ReturnType<typeof vi.fn>;
+			refreshWorkerSummaries: ReturnType<typeof vi.fn>;
+			persistWorker: ReturnType<typeof vi.fn>;
+			syncAgentPeers: ReturnType<typeof vi.fn>;
+			broadcastHeartbeatsChanged: ReturnType<typeof vi.fn>;
+			log: ReturnType<typeof vi.fn>;
+			assertRecoveryAllowed: ReturnType<typeof vi.fn>;
+			recoverWorker(worker: RecoveryWorker): Promise<void>;
+		};
+		const worker: RecoveryWorker = {
+			descriptor: {
+				workerId: "worker-reconnect-then-crash",
+				pid: process.pid,
+				rootActiveSessionId: "active-reconnect-then-crash",
+				createCommand: { type: "create" },
+				consecutiveFailures: 0,
+			},
+			recoveryLaunchEnv: { ACP_FIXTURE_API_KEY: "fresh-B" },
+			intentionalStop: false,
+			stopRevision: 0,
+		};
+		let processAlive = true;
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			shuttingDown: false,
+			assertCurrentOwnership: vi.fn(async () => undefined),
+			assertRecoveryAllowed: vi.fn(async () => undefined),
+			connectWorker: vi.fn(async () => {
+				worker.client = { close: vi.fn() };
+				return worker.client;
+			}),
+			subscribeWorker: vi.fn(async () => {}),
+			refreshWorkerSummaries: vi.fn(async () => {}),
+			persistWorker: vi.fn(),
+			syncAgentPeers: vi.fn(async () => {}),
+			broadcastHeartbeatsChanged: vi.fn(),
+			log: vi.fn(),
+		}) as RecoveryHarness;
+		const childProcessModule = await import("../src/utils/child-process.js");
+		const aliveSpy = vi.spyOn(childProcessModule, "isProcessAlive").mockImplementation(() => processAlive);
+		try {
+			const reconnect = supervisor.recoverWorker(worker);
+			await vi.advanceTimersByTimeAsync(250);
+			await reconnect;
+			expect(worker.descriptor.lifecycle).toBe("ready");
+			expect(worker.recoveryLaunchEnv).toBeUndefined();
+
+			processAlive = false;
+			worker.client = undefined;
+			await supervisor.recoverWorker(worker);
+			expect(worker.descriptor.lifecycle).toBe("failed");
+			expect(worker.descriptor.lastError).toBe("Waiting for a client with fresh environment");
+			expect(supervisor.connectWorker).toHaveBeenCalledOnce();
+		} finally {
+			aliveSpy.mockRestore();
+		}
+	});
+
 	it("relaunches a worker instead of reconnecting to a reused pid", async () => {
 		vi.useFakeTimers();
 		type RecoveryWorker = {
@@ -1495,6 +1647,7 @@ describe("daemon worker supervisor monitoring", () => {
 			intentionalStop: boolean;
 			stopRevision: number;
 			recovery?: Promise<void>;
+			recoveryLaunchEnv?: Record<string, string>;
 			client?: { close(): void };
 		};
 		type RecoveryHarness = {
@@ -1518,6 +1671,7 @@ describe("daemon worker supervisor monitoring", () => {
 				createCommand: { type: "create" },
 				consecutiveFailures: 0,
 			},
+			recoveryLaunchEnv: { ACP_FIXTURE_API_KEY: "failed-reconnect-secret" },
 			intentionalStop: false,
 			stopRevision: 0,
 		};
@@ -1544,6 +1698,7 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(supervisor.recoverUncertainWorkerOperations).not.toHaveBeenCalled();
 		expect(supervisor.launchWorker).not.toHaveBeenCalled();
 		expect(worker.descriptor.lifecycle).toBe("failed");
+		expect(worker.recoveryLaunchEnv).toBeUndefined();
 	});
 
 	it("keeps a recovered worker ready when peer synchronization fails", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -828,6 +828,71 @@ describe("daemon supervisor resident workers", () => {
 	}, 30_000);
 
 	it(
+		"finalizes a timed-out worker stop by force-stopping the process and removing its registration",
+		{ tags: ["process-stress"], timeout: 45_000 },
+		async () => {
+			const root = tempDir();
+			const agentDir = join(root, "agent");
+			const projectDir = join(root, "project");
+			const sessionDir = join(agentDir, "sessions");
+			const socketPath = join(
+				tmpdir(),
+				`prime-supervisor-stop-finalize-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
+			);
+			mkdirSync(projectDir, { recursive: true });
+			const sessionManager = SessionManager.create(projectDir, sessionDir);
+			sessionManager.appendMessage({ role: "user", content: "finalize me", timestamp: 1 });
+			const sessionFile = sessionManager.getSessionFile();
+			if (!sessionFile) {
+				throw new Error("Fixture session did not persist");
+			}
+
+			const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+			const client = await connectEventually(socketPath, supervisor);
+			const created = await client.request({
+				type: "create",
+				sessionPath: sessionFile,
+				lifecycle: "client_owned",
+				config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+			});
+			if (!created.success) {
+				throw new Error(created.error);
+			}
+			const summary = requireSummary(created.data);
+			if (!summary.workerPid) {
+				throw new Error("Resident worker did not expose its pid");
+			}
+			workerPids.add(summary.workerPid);
+			const activeSessionId = summary.activeSessionId ?? summary.id;
+
+			// A suspended worker cannot exit within the stop deadline, so the stop
+			// times out and used to leave a tombstoned registration behind forever.
+			process.kill(summary.workerPid, "SIGSTOP");
+			const stopResult = await client.request({ type: "complete_owned_session", activeSessionId }, 30_000);
+			expect(stopResult).toMatchObject({
+				success: false,
+				error: expect.stringContaining("did not stop"),
+			});
+			const tombstone = readWorkerDescriptor(agentDir);
+			expect(tombstone.stopRequestedAt).toEqual(expect.any(String));
+
+			// The supervisor finishes the interrupted stop on its own: it escalates
+			// to SIGKILL, waits for the process to die, and removes the registration.
+			await waitForProcessGone(summary.workerPid);
+			workerPids.delete(summary.workerPid);
+			await waitForCondition(
+				() => countWorkerDescriptors(agentDir) === 0,
+				"Timed-out worker stop was not finalized",
+				20_000,
+			);
+
+			await client.request({ type: "shutdown" });
+			client.close();
+			await waitForSocketGone(socketPath);
+		},
+	);
+
+	it(
 		"does not resurrect an intentionally stopped root when the supervisor dies during kill",
 		{ tags: ["process-stress"], timeout: 30_000 },
 		async () => {

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -943,7 +943,10 @@ describe("daemon supervisor resident workers", () => {
 			workerPids.delete(summary.workerPid);
 
 			// Resuming the saved transcript must not be blocked by the stale
-			// registration: the supervisor reclaims it and launches a fresh worker.
+			// registration. Whichever cleanup wins the race — the background stop
+			// finalizer or the resume-time reclaim (each covered deterministically
+			// by unit tests) — the user-visible guarantee is the same: the resume
+			// below must succeed with a fresh worker.
 			const resumed = await client.request({
 				type: "create",
 				sessionPath: sessionFile,

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -893,6 +893,88 @@ describe("daemon supervisor resident workers", () => {
 	);
 
 	it(
+		"resumes a saved session immediately after a worker stop fails and the process dies",
+		{ tags: ["process-stress"], timeout: 45_000 },
+		async () => {
+			const root = tempDir();
+			const agentDir = join(root, "agent");
+			const projectDir = join(root, "project");
+			const sessionDir = join(agentDir, "sessions");
+			const socketPath = join(
+				tmpdir(),
+				`prime-supervisor-resume-heal-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
+			);
+			mkdirSync(projectDir, { recursive: true });
+			const sessionManager = SessionManager.create(projectDir, sessionDir);
+			sessionManager.appendMessage({ role: "user", content: "resume me", timestamp: 1 });
+			const sessionFile = sessionManager.getSessionFile();
+			if (!sessionFile) {
+				throw new Error("Fixture session did not persist");
+			}
+
+			const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+			const client = await connectEventually(socketPath, supervisor);
+			const created = await client.request({
+				type: "create",
+				sessionPath: sessionFile,
+				lifecycle: "client_owned",
+				config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+			});
+			if (!created.success) {
+				throw new Error(created.error);
+			}
+			const summary = requireSummary(created.data);
+			if (!summary.workerPid) {
+				throw new Error("Resident worker did not expose its pid");
+			}
+			workerPids.add(summary.workerPid);
+			const activeSessionId = summary.activeSessionId ?? summary.id;
+
+			// A suspended worker forces the stop past its deadline, leaving a
+			// tombstoned registration for a process that dies moments later.
+			process.kill(summary.workerPid, "SIGSTOP");
+			const stopResult = await client.request({ type: "complete_owned_session", activeSessionId }, 30_000);
+			expect(stopResult).toMatchObject({
+				success: false,
+				error: expect.stringContaining("did not stop"),
+			});
+			process.kill(summary.workerPid, "SIGKILL");
+			await waitForProcessGone(summary.workerPid);
+			workerPids.delete(summary.workerPid);
+
+			// Resuming the saved transcript must not be blocked by the stale
+			// registration: the supervisor reclaims it and launches a fresh worker.
+			const resumed = await client.request({
+				type: "create",
+				sessionPath: sessionFile,
+				config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+			});
+			expect(resumed.success).toBe(true);
+			const resumedSummary = requireSummary(resumed.success ? resumed.data : undefined);
+			expect(resumedSummary.sessionId).toBe(summary.sessionId);
+			expect(resumedSummary.workerPid).not.toBe(summary.workerPid);
+			expect(resumedSummary.workerState).toBe("ready");
+			if (resumedSummary.workerPid) {
+				workerPids.add(resumedSummary.workerPid);
+			}
+
+			const attached = await client.request({
+				type: "attach",
+				activeSessionId: resumedSummary.activeSessionId ?? resumedSummary.id,
+			});
+			expect(attached.success).toBe(true);
+
+			await client.request({ type: "shutdown" });
+			client.close();
+			await waitForSocketGone(socketPath);
+			if (resumedSummary.workerPid) {
+				await waitForProcessGone(resumedSummary.workerPid);
+				workerPids.delete(resumedSummary.workerPid);
+			}
+		},
+	);
+
+	it(
 		"does not resurrect an intentionally stopped root when the supervisor dies during kill",
 		{ tags: ["process-stress"], timeout: 30_000 },
 		async () => {

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -65,7 +65,9 @@ afterEach(async () => {
 	}
 	workerPids.clear();
 	for (const directory of tempDirs.splice(0)) {
-		rmSync(directory, { recursive: true, force: true });
+		// Detached workers can release kernel/snapshot files just after their
+		// process group exits on macOS.
+		rmSync(directory, { recursive: true, force: true, maxRetries: 50, retryDelay: 100 });
 	}
 });
 
@@ -398,6 +400,108 @@ describe("daemon supervisor resident workers", () => {
 		client.close();
 		await waitForSocketGone(socketPath);
 	}, 60_000);
+
+	it("persists only safe resident launch settings", async () => {
+		const root = tempDir();
+		const agentDir = join(root, "agent");
+		const projectDir = join(root, "project");
+		const sessionDir = join(agentDir, "sessions");
+		const socketPath = join(
+			tmpdir(),
+			`prime-supervisor-resident-env-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
+		);
+		const extensionPath = join(projectDir, "resident-env-extension.ts");
+		const markerPath = join(projectDir, "resident-env-marker");
+		mkdirSync(projectDir, { recursive: true });
+		writeFileSync(
+			extensionPath,
+			[
+				"import { appendFileSync } from 'node:fs';",
+				"export default function() { appendFileSync('resident-env-marker', process.pid + ':' + process.env.PRIME_AGENT_TRACES_BASE_URL + ':' + (process.env.PRIME_AGENT_TEST_CREDENTIAL ?? '') + '\\n'); }",
+				"",
+			].join("\n"),
+		);
+
+		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+		const client = await connectEventually(socketPath, supervisor);
+		const launchEnvSentinel = `resident-env-${randomUUID()}`;
+		const created = await client.request({
+			type: "create",
+			lifecycle: "resident",
+			launchEnv: {
+				PRIME_AGENT_TRACES_BASE_URL: launchEnvSentinel,
+				TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
+				PRIME_AGENT_TEST_CREDENTIAL: "must-not-be-persisted",
+				OPENAI_API_KEY: "must-not-be-persisted",
+				AWS_SECRET_ACCESS_KEY: "must-not-be-persisted",
+				GH_TOKEN: "must-not-be-persisted",
+				SSH_AUTH_SOCK: "/tmp/must-not-be-persisted.sock",
+			},
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, extensions: [extensionPath] },
+		});
+		expect(created.success).toBe(true);
+		const summary = requireSummary(created.success ? created.data : undefined);
+		if (summary.workerPid) workerPids.add(summary.workerPid);
+		const initialMarkerLines = readFileSync(markerPath, "utf8").trim().split("\n");
+		expect(initialMarkerLines).toHaveLength(1);
+		// The initial spawn receives the complete transient caller environment.
+		expect(initialMarkerLines[0]).toMatch(
+			new RegExp(`^${summary.workerPid}:${launchEnvSentinel}:must-not-be-persisted$`),
+		);
+		const descriptor = readWorkerDescriptor(agentDir);
+		// The endpoint survives restart, but credentials never enter the descriptor.
+		expect(descriptor.launchEnv).toEqual({
+			PRIME_AGENT_TRACES_BASE_URL: launchEnvSentinel,
+			TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
+		});
+		expect(JSON.stringify(descriptor)).not.toContain("must-not-be-persisted");
+		expect(JSON.stringify(descriptor)).not.toContain("AWS_SECRET_ACCESS_KEY");
+		expect(JSON.stringify(descriptor)).not.toContain("GH_TOKEN");
+		expect(JSON.stringify(descriptor)).not.toContain("SSH_AUTH_SOCK");
+
+		supervisor.kill("SIGTERM");
+		await waitForExit(supervisor);
+		children.delete(supervisor);
+		client.close();
+
+		const replacementClient = await connectEventually(socketPath);
+		const adopted = await replacementClient.request({ type: "list" });
+		const adoptedSummary = requireSessionList(adopted.success ? adopted.data : undefined)[0];
+		expect(adoptedSummary.workerPid).toBe(summary.workerPid);
+		if (!adoptedSummary.workerPid) throw new Error("Adopted resident worker did not expose its pid");
+		process.kill(-adoptedSummary.workerPid, "SIGKILL");
+		await waitForProcessGone(adoptedSummary.workerPid);
+		let recoveredSummary: SessionSummary | undefined;
+		const recoveryDeadline = Date.now() + 15_000;
+		while (!recoveredSummary && Date.now() < recoveryDeadline) {
+			const listed = await replacementClient.request({ type: "list" });
+			recoveredSummary = requireSessionList(listed.success ? listed.data : undefined).find(
+				(session) => session.workerPid !== adoptedSummary.workerPid,
+			);
+			if (!recoveredSummary) await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+		}
+		expect(recoveredSummary).toBeDefined();
+		let markerLines: string[] = [];
+		const markerDeadline = Date.now() + 15_000;
+		while (Date.now() < markerDeadline) {
+			try {
+				markerLines = readFileSync(markerPath, "utf8").trim().split("\n");
+				if (markerLines.length === 2) break;
+			} catch {
+				// The replacement process has not run its extension yet.
+			}
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+		}
+		expect(markerLines).toHaveLength(2);
+		// Recovery retains the descriptor's allowlisted endpoint. Credential
+		// exclusion is asserted against the durable descriptor above; a process
+		// may also inherit credentials from the supervisor's own environment.
+		expect(markerLines[1]).toMatch(new RegExp(`^${recoveredSummary?.workerPid}:${launchEnvSentinel}:`));
+		expect(recoveredSummary?.workerPid).not.toBe(adoptedSummary.workerPid);
+
+		await replacementClient.request({ type: "shutdown" });
+		replacementClient.close();
+	});
 
 	it("keeps client-owned workers hidden and removes them without archiving", async () => {
 		const root = tempDir();

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -314,3 +314,72 @@ describe("KernelManager abort handling", () => {
 		manager.disposeSync();
 	});
 });
+
+
+describe("KernelManager typed host-request authority", () => {
+	function managerWithComm(handler: (payload: Record<string, unknown>, context: import("../src/core/kernel/index.js").HostRequestContext) => Promise<Record<string, unknown>>) {
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const sent = vi.fn(async () => {});
+		Object.assign(manager as unknown as { state: "running"; control: { send: (frames: Buffer[]) => Promise<void> }; connection: { key: string } }, {
+			state: "running",
+			control: { send: sent },
+			connection: { key: "test-key" },
+		});
+		return { manager, sent };
+	}
+
+	it("aborts only the request tied to an aborted caller", async () => {
+		let firstContext: import("../src/core/kernel/index.js").HostRequestContext | undefined;
+		let secondContext: import("../src/core/kernel/index.js").HostRequestContext | undefined;
+		let resolveFirst!: () => void;
+		let resolveSecond!: () => void;
+		const firstDone = new Promise<void>((resolve) => { resolveFirst = resolve; });
+		const secondDone = new Promise<void>((resolve) => { resolveSecond = resolve; });
+		const { manager } = managerWithComm(async (_payload, context) => {
+			if (!firstContext) {
+				firstContext = context;
+				await firstDone;
+			} else {
+				secondContext = context;
+				await secondDone;
+			}
+			return {};
+		});
+		const firstController = new AbortController();
+		Object.assign(manager as unknown as { activeExecution: { opts: { signal: AbortSignal } } }, { activeExecution: { opts: { signal: firstController.signal } } });
+		(manager as unknown as { handleCommMessage: (message: unknown) => void }).handleCommMessage({ header: { msg_type: "comm_open" }, content: { comm_id: "one", target_name: "host.request", data: { type: "test" } } });
+		await Promise.resolve();
+		const secondController = new AbortController();
+		Object.assign(manager as unknown as { activeExecution: { opts: { signal: AbortSignal } } }, { activeExecution: { opts: { signal: secondController.signal } } });
+		(manager as unknown as { handleCommMessage: (message: unknown) => void }).handleCommMessage({ header: { msg_type: "comm_open" }, content: { comm_id: "two", target_name: "host.request", data: { type: "test" } } });
+		await Promise.resolve();
+		firstController.abort();
+		expect(firstContext?.signal.aborted).toBe(true);
+		expect(secondContext?.signal.aborted).toBe(false);
+		resolveFirst();
+		resolveSecond();
+	});
+
+	it("fences a stale reply after its comm disconnects", async () => {
+		let resolveHandler!: () => void;
+		const handlerDone = new Promise<void>((resolve) => { resolveHandler = resolve; });
+		const { manager, sent } = managerWithComm(async () => { await handlerDone; return { value: "late" }; });
+		(manager as unknown as { handleCommMessage: (message: unknown) => void }).handleCommMessage({ header: { msg_type: "comm_open" }, content: { comm_id: "one", target_name: "host.request", data: { type: "test" } } });
+		await Promise.resolve();
+		(manager as unknown as { handleCommMessage: (message: unknown) => void }).handleCommMessage({ header: { msg_type: "comm_close" }, content: { comm_id: "one" } });
+		resolveHandler();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(sent).not.toHaveBeenCalled();
+	});
+
+	it("rejects over-bounded payloads before invoking a handler", async () => {
+		const handler = vi.fn(async () => ({}));
+		const { manager, sent } = managerWithComm(handler);
+		(manager as unknown as { handleCommMessage: (message: unknown) => void }).handleCommMessage({ header: { msg_type: "comm_open" }, content: { comm_id: "one", target_name: "host.request", data: { type: "test", value: "x".repeat(64 * 1024 + 1) } } });
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(handler).not.toHaveBeenCalled();
+		expect(sent).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/project-trust-authority.test.ts
+++ b/packages/coding-agent/test/project-trust-authority.test.ts
@@ -1,0 +1,117 @@
+import { mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	createMcpProjectTrustAuthority,
+	type McpProjectTrustAuthority,
+	type McpProjectTrustAuthorization,
+	type McpProjectTrustBinding,
+} from "../src/core/mcp/project-trust-authority.js";
+
+const tempDirectories: string[] = [];
+
+function tempDirectory(): string {
+	const directory = mkdtempSync(join(realpathSync.native(tmpdir()), "project-trust-"));
+	tempDirectories.push(directory);
+	return directory;
+}
+
+function authorize(authority: McpProjectTrustAuthority, directory: string): McpProjectTrustAuthorization {
+	return authority.authorizeProjectDirectory(directory);
+}
+
+function grantedBinding(result: McpProjectTrustAuthorization): McpProjectTrustBinding {
+	expect(result.kind).toBe("granted");
+	if (result.kind === "denied") {
+		throw new Error("Expected granted authorization");
+	}
+	return result.binding;
+}
+
+afterEach(() => {
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("MCP project trust authority", () => {
+	it("denies by default when no global user allowlist grants the project", () => {
+		const project = tempDirectory();
+		const authority = createMcpProjectTrustAuthority({ revision: "global-1", allowedProjectDirectories: [] });
+
+		expect(authorize(authority, project)).toEqual({ kind: "denied" });
+	});
+
+	it("grants an exact directory only from the explicit global allowlist", () => {
+		const project = tempDirectory();
+		const authority = createMcpProjectTrustAuthority({ revision: "global-1", allowedProjectDirectories: [project] });
+		const binding = grantedBinding(authorize(authority, project));
+
+		expect(Object.isFrozen(binding)).toBe(true);
+		expect(Object.keys(binding)).toEqual([]);
+		expect(authorize(authority, join(project, "child"))).toEqual({ kind: "denied" });
+	});
+
+	it("does not accept a project-owned override as an authority input", () => {
+		const project = tempDirectory();
+		// A project config can claim anything; this module neither receives nor reads it.
+		mkdirSync(join(project, ".prime", "agent"), { recursive: true });
+		const projectSettingsClaim = { mcpProjectTrust: { allow: [project] } };
+		const authority = createMcpProjectTrustAuthority({
+			revision: "global-1",
+			allowedProjectDirectories: [],
+			...({ projectSettingsClaim } as object),
+		});
+
+		expect(projectSettingsClaim.mcpProjectTrust.allow).toEqual([project]);
+		expect(authorize(authority, project)).toEqual({ kind: "denied" });
+	});
+
+	it("rejects symlink and lexical aliases even when their target is explicitly allowed", () => {
+		const parent = tempDirectory();
+		const project = join(parent, "project");
+		const link = join(parent, "project-link");
+		mkdirSync(project);
+		symlinkSync(project, link, "dir");
+		const authority = createMcpProjectTrustAuthority({ revision: "global-1", allowedProjectDirectories: [project] });
+
+		expect(authorize(authority, link)).toEqual({ kind: "denied" });
+		expect(authorize(authority, `${project}/.`)).toEqual({ kind: "denied" });
+		expect(authorize(authority, project)).toMatchObject({ kind: "granted" });
+	});
+
+	it("fail-closes the entire snapshot when its explicit allowlist contains an alias", () => {
+		const parent = tempDirectory();
+		const project = join(parent, "project");
+		const link = join(parent, "project-link");
+		mkdirSync(project);
+		symlinkSync(project, link, "dir");
+		const authority = createMcpProjectTrustAuthority({
+			revision: "global-1",
+			allowedProjectDirectories: [project, link],
+		});
+
+		expect(authorize(authority, project)).toEqual({ kind: "denied" });
+	});
+
+	it("pins the supplied policy and rejects a replaced directory after a grant", () => {
+		const parent = tempDirectory();
+		const project = join(parent, "project");
+		const replacement = join(parent, "replacement");
+		mkdirSync(project);
+		const globalPolicy = { revision: "global-1", allowedProjectDirectories: [project] };
+		const authority = createMcpProjectTrustAuthority(globalPolicy);
+		grantedBinding(authorize(authority, project));
+
+		globalPolicy.revision = "mutated";
+		globalPolicy.allowedProjectDirectories.length = 0;
+		// The grant is opaque; a later authorization proves the original
+		// revision/allowlist was copied rather than read again from mutable input.
+		expect(authorize(authority, project).kind).toBe("granted");
+		mkdirSync(replacement);
+		rmSync(project, { recursive: true });
+		renameSync(replacement, project);
+		expect(authorize(authority, project)).toEqual({ kind: "denied" });
+	});
+});

--- a/packages/coding-agent/test/project-trust-authority.test.ts
+++ b/packages/coding-agent/test/project-trust-authority.test.ts
@@ -29,6 +29,10 @@ function grantedBinding(result: McpProjectTrustAuthorization): McpProjectTrustBi
 	return result.binding;
 }
 
+function validate(authority: McpProjectTrustAuthority, binding: unknown): "denied" | "granted" {
+	return authority.validateBinding(binding).kind;
+}
+
 afterEach(() => {
 	for (const directory of tempDirectories.splice(0)) {
 		rmSync(directory, { recursive: true, force: true });
@@ -43,14 +47,45 @@ describe("MCP project trust authority", () => {
 		expect(authorize(authority, project)).toEqual({ kind: "denied" });
 	});
 
-	it("grants an exact directory only from the explicit global allowlist", () => {
+	it("grants and validates an exact directory only from the explicit global allowlist", () => {
 		const project = tempDirectory();
 		const authority = createMcpProjectTrustAuthority({ revision: "global-1", allowedProjectDirectories: [project] });
 		const binding = grantedBinding(authorize(authority, project));
 
 		expect(Object.isFrozen(binding)).toBe(true);
 		expect(Object.keys(binding)).toEqual([]);
+		expect(validate(authority, binding)).toBe("granted");
 		expect(authorize(authority, join(project, "child"))).toEqual({ kind: "denied" });
+	});
+
+	it("denies a forged frozen binding at the privileged validation boundary", () => {
+		const project = tempDirectory();
+		const authority = createMcpProjectTrustAuthority({ revision: "global-1", allowedProjectDirectories: [project] });
+		const binding = grantedBinding(authorize(authority, project));
+		const forged = Object.freeze(Object.create(null));
+
+		expect(validate(authority, forged)).toBe("denied");
+		expect(validate(authority, binding)).toBe("granted");
+		expect(Object.keys(authority)).toEqual(["authorizeProjectDirectory", "validateBinding"]);
+	});
+
+	it("denies foreign, forged, and non-object bindings without exposing grant metadata", () => {
+		const project = tempDirectory();
+		const authority = createMcpProjectTrustAuthority({ revision: "global-1", allowedProjectDirectories: [project] });
+		const otherAuthority = createMcpProjectTrustAuthority({
+			revision: "global-1",
+			allowedProjectDirectories: [project],
+		});
+		const foreignBinding = grantedBinding(authorize(otherAuthority, project));
+		const binding = grantedBinding(authorize(authority, project));
+
+		for (const candidate of [undefined, null, true, "grant", 1, Object.freeze({}), foreignBinding]) {
+			expect(validate(authority, candidate)).toBe("denied");
+		}
+		const validation = authority.validateBinding(binding);
+		expect(validation).toEqual({ kind: "granted" });
+		expect(Object.keys(validation)).toEqual(["kind"]);
+		expect(Object.isFrozen(validation)).toBe(true);
 	});
 
 	it("does not accept a project-owned override as an authority input", () => {
@@ -95,23 +130,38 @@ describe("MCP project trust authority", () => {
 		expect(authorize(authority, project)).toEqual({ kind: "denied" });
 	});
 
-	it("pins the supplied policy and rejects a replaced directory after a grant", () => {
+	it("pins factory policy input and invalidates a pre-granted binding after directory replacement", () => {
 		const parent = tempDirectory();
 		const project = join(parent, "project");
 		const replacement = join(parent, "replacement");
 		mkdirSync(project);
 		const globalPolicy = { revision: "global-1", allowedProjectDirectories: [project] };
 		const authority = createMcpProjectTrustAuthority(globalPolicy);
-		grantedBinding(authorize(authority, project));
+		const binding = grantedBinding(authorize(authority, project));
 
 		globalPolicy.revision = "mutated";
 		globalPolicy.allowedProjectDirectories.length = 0;
-		// The grant is opaque; a later authorization proves the original
-		// revision/allowlist was copied rather than read again from mutable input.
-		expect(authorize(authority, project).kind).toBe("granted");
+		// Revision is factory input only. Mutating the caller-owned policy cannot
+		// alter the opaque snapshot or surface that revision to a consumer.
+		expect(validate(authority, binding)).toBe("granted");
 		mkdirSync(replacement);
 		rmSync(project, { recursive: true });
 		renameSync(replacement, project);
 		expect(authorize(authority, project)).toEqual({ kind: "denied" });
+		expect(validate(authority, binding)).toBe("denied");
+	});
+
+	it("invalidates a pre-granted binding when its directory is mutated into a symlink", () => {
+		const parent = tempDirectory();
+		const project = join(parent, "project");
+		const target = join(parent, "target");
+		mkdirSync(project);
+		mkdirSync(target);
+		const authority = createMcpProjectTrustAuthority({ revision: "global-1", allowedProjectDirectories: [project] });
+		const binding = grantedBinding(authorize(authority, project));
+
+		rmSync(project, { recursive: true });
+		symlinkSync(target, project, "dir");
+		expect(validate(authority, binding)).toBe("denied");
 	});
 });


### PR DESCRIPTION
Links #1182

This is the reviewed, coherent MCP-prerequisite substack only; it is **not** complete Core and is **not human-ready**.

Lineage: trust → C06 → R01, at head `35c71c45e6f5e21d91ad2793f24b30f329f3a897` (35c).

Reviewed evidence: monitor 80/80 and matrix 141/1.

Before integration, upstream and post-merge replay are required. Remaining blockers are the C01–C08 integration blockers; this substack does not resolve them.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind project trust authority, catalog-driven agent family reachability, and typed kernel host requests
> - Introduces `createMcpProjectTrustAuthority` in [project-trust-authority.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1186/files#diff-5fab7c975919c39a882ea11f56852a62384e35fd5dd38b9a05a897ae27426bba), an authority that canonicalizes an allowlist of project directories, issues opaque bindings, and validates them with strict symlink/alias rejection.
> - Replaces ad-hoc agent family reachability checks with a single immutable `AgentFamilyCatalogEntry[]` snapshot assembled from saved sessions, passive subagents, and in-memory states; all ACL surfaces (observe, message send, sibling checks) now evaluate against this snapshot.
> - Adds `HostRequestContext` (requestId, AbortSignal, `isCurrent()`) to typed kernel host-request handlers in [kernel/index.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1186/files#diff-14dd18f6926ed763ba0b55625302fb733f4e4209bb611d3051820048732149ac), with payload size/depth validation, per-comm revocation on close, and at-most-once reply semantics.
> - Hardens daemon supervisor stop/recovery lifecycle in [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1186/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8): identity-aware signalling, background finalization for timed-out stops, `stopping` worker state, allowlist-only env persistence for resident workers, and single-flight resident recovery.
> - Adds process liveness utilities (`processIdExists`, `isZombieProcess`, `isProcessAlive`) in [child-process.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1186/files#diff-a9f6b77c57772609afaa172c89bf3bfb5dd1e9d8ab775b567e40388a0f78fe96).
> - Risk: `DAEMON_SCHEMA_REVISION` bumped to 15; resident workers now require a fresh client-supplied env for recovery after a dead process, so automatic recovery without a reconnecting client will stall with `lifecycle='failed'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 35c71c4. 19 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->