### PR TITLE
[WIP prerequisite] preserve cached snapshot semantics for #850

### DIFF
--- a/packages/coding-agent/src/core/session-action-store.ts
+++ b/packages/coding-agent/src/core/session-action-store.ts
@@ -362,7 +362,7 @@ export interface SessionPassivationSnapshot extends SessionEvictionSnapshot {
 }
 
 export interface WorkerEvictionSnapshot {
-	lifecycle: "starting" | "ready" | "recovering" | "failed";
+	lifecycle: "starting" | "ready" | "recovering" | "stopping" | "failed";
 	isConnected: boolean;
 	isStopping: boolean;
 	hasOwnerClient: boolean;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -108,7 +108,7 @@ export function shouldShowAgentsViewSession(summary: SessionSummary, manuallyIna
 	if (manuallyInactive) {
 		return false;
 	}
-	return summary.lifecycle === "live";
+	return summary.lifecycle === "live" && (summary.workerState === undefined || summary.workerState === "ready");
 }
 
 export function sectionTitle(section: AgentsViewSection): string {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -62,7 +62,7 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
 export const DAEMON_SCHEMA_REVISION = 16;
 // Keep this digest synchronized with the wire shapes below (daemon-protocol.test.ts verifies it).
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-cb14c6f40d53";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -59,8 +59,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 13 narrows agent-origin reach and roster wire shapes to the nuclear family.
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
-export const DAEMON_SCHEMA_REVISION = 15;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-15-1bcb9e7f1a49";
+// Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
+export const DAEMON_SCHEMA_REVISION = 16;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -59,8 +59,10 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 13 narrows agent-origin reach and roster wire shapes to the nuclear family.
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
-export const DAEMON_SCHEMA_REVISION = 15;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-15-1bcb9e7f1a49";
+// Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
+export const DAEMON_SCHEMA_REVISION = 16;
+// Keep this digest synchronized with the wire shapes below (daemon-protocol.test.ts verifies it).
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -78,7 +78,7 @@ export interface SessionSummary {
 	/** Completion verdict for an idle session; absent while working or unjudged. */
 	taskState?: AgentTaskState;
 	/** Resident session-host process state, populated by the global supervisor. */
-	workerState?: "starting" | "ready" | "recovering" | "failed";
+	workerState?: "starting" | "ready" | "recovering" | "stopping" | "failed";
 	/** Diagnostic process identity; clients must not use this as a stable session identifier. */
 	workerPid?: number;
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1927,13 +1927,13 @@ export class DaemonSupervisor {
 		);
 		await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 		const clientOwnedWorkers = [...this.workers.values()].filter((worker) => !this.isVisibleWorker(worker));
+		// Stopping workers stay listed (with an honest workerState) because this
+		// list also feeds busy-daemon safety checks in daemon-launch.
 		const active = [...this.workers.values()]
 			.filter(
 				(worker) =>
-					this.isLiveWorker(worker) ||
-					(command.includeClientOwned === true &&
-						!this.isWorkerStopping(worker) &&
-						this.isWorkerAccessibleToClient(client, worker)),
+					this.isVisibleWorker(worker) ||
+					(command.includeClientOwned === true && this.isWorkerAccessibleToClient(client, worker)),
 			)
 			.flatMap((worker) => [...worker.summaries.values()].map((summary) => this.publicSummary(worker, summary)));
 		const busyClientOwnedSessionCount = clientOwnedWorkers

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3320,7 +3320,6 @@ export class DaemonSupervisor {
 		}
 		const match = await this.findWorkerForClient(client, command.activeSessionId);
 		this.assertTelemetryAttachAllowed(match.worker, command.telemetryDisabled);
-		this.requireAvailableWorkerClient(match.worker);
 		const activeSessionId = match.summary.activeSessionId ?? match.summary.id;
 		const duplicateValidation = this.currentSnapshotGeneration(match.worker, activeSessionId)?.validation;
 		if (duplicateValidation) {
@@ -3408,7 +3407,6 @@ export class DaemonSupervisor {
 				}
 			}
 		}
-		this.requireAvailableWorkerClient(match.worker);
 		const wasAttached = client.attachedActiveSessionIds.has(activeSessionId);
 		let transcript: SnapshotTranscriptCache | undefined;
 		if (client.capabilities.has("chunked_snapshot")) {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1836,10 +1836,8 @@ export class DaemonSupervisor {
 				if ((source.summary.activeSessionId ?? source.summary.id) === targetActiveSessionId) {
 					throw new Error("Agent messaging cannot target the sending session");
 				}
-				if (!target.worker.client) {
-					throw new Error("Target session worker is not connected");
-				}
-				const response = await target.worker.client.requestWorker(
+				const targetClient = this.requireAvailableWorkerClient(target.worker);
+				const response = await targetClient.requestWorker(
 					{
 						type: "worker_deliver_message",
 						targetActiveSessionId,
@@ -1923,7 +1921,9 @@ export class DaemonSupervisor {
 		command: Extract<DaemonCommand, { type: "list" }>,
 	): Promise<DaemonResponse> {
 		await Promise.all(
-			[...this.workers.values()].map((worker) => this.refreshWorkerSummaries(worker).catch(() => undefined)),
+			[...this.workers.values()]
+				.filter((worker) => !this.isWorkerStopping(worker))
+				.map((worker) => this.refreshWorkerSummaries(worker).catch(() => undefined)),
 		);
 		await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 		const clientOwnedWorkers = [...this.workers.values()].filter((worker) => !this.isVisibleWorker(worker));
@@ -2907,6 +2907,9 @@ export class DaemonSupervisor {
 	}
 
 	private async refreshWorkerSummaries(worker: ResidentWorker, recovery = false): Promise<void> {
+		if (this.isWorkerStopping(worker)) {
+			throw new Error("Session worker is stopping");
+		}
 		if (!worker.client) {
 			throw new Error("Session worker is not connected");
 		}
@@ -3114,6 +3117,17 @@ export class DaemonSupervisor {
 		return worker.descriptor.lifecycle;
 	}
 
+	private requireAvailableWorkerClient(worker: ResidentWorker, allowStopping = false): DaemonWorkerClient {
+		if (
+			!worker.client ||
+			worker.descriptor.lifecycle !== "ready" ||
+			(!allowStopping && this.isWorkerStopping(worker))
+		) {
+			throw new Error(`Session worker is ${this.effectiveWorkerState(worker)}`);
+		}
+		return worker.client;
+	}
+
 	private familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry {
 		const depth = summary.rlmDepth ?? (summary.parentSessionPath ? 1 : 0);
 		return {
@@ -3263,10 +3277,8 @@ export class DaemonSupervisor {
 		command: DaemonCommand,
 		timeoutMs = WORKER_REQUEST_TIMEOUT_MS,
 	): Promise<DaemonResponse> {
-		if (!worker.client || worker.descriptor.lifecycle !== "ready") {
-			throw new Error(`Session worker is ${this.effectiveWorkerState(worker)}`);
-		}
-		const response = await worker.client.request(withoutCommandId(command), timeoutMs);
+		const client = this.requireAvailableWorkerClient(worker, command.type === "kill");
+		const response = await client.request(withoutCommandId(command), timeoutMs);
 		if (command.type === "get_state" && response.success && isSessionSummary(response.data)) {
 			return { ...response, id: command.id, data: this.publicSummary(worker, response.data) };
 		}
@@ -3308,6 +3320,7 @@ export class DaemonSupervisor {
 		}
 		const match = await this.findWorkerForClient(client, command.activeSessionId);
 		this.assertTelemetryAttachAllowed(match.worker, command.telemetryDisabled);
+		this.requireAvailableWorkerClient(match.worker);
 		const activeSessionId = match.summary.activeSessionId ?? match.summary.id;
 		const duplicateValidation = this.currentSnapshotGeneration(match.worker, activeSessionId)?.validation;
 		if (duplicateValidation) {
@@ -3337,10 +3350,8 @@ export class DaemonSupervisor {
 						match.worker.transcriptCaches.get(activeSessionId)?.snapshotId ??
 						match.worker.snapshotCache.get(activeSessionId)?.snapshotStream?.id;
 					loading = (async () => {
-						if (!match.worker.client) {
-							throw new Error("Session worker is not connected");
-						}
-						const response = await match.worker.client.request({
+						const workerClient = this.requireAvailableWorkerClient(match.worker);
+						const response = await workerClient.request({
 							type: "attach",
 							activeSessionId,
 							capabilities: client.capabilities.has("chunked_snapshot")
@@ -3397,6 +3408,7 @@ export class DaemonSupervisor {
 				}
 			}
 		}
+		this.requireAvailableWorkerClient(match.worker);
 		const wasAttached = client.attachedActiveSessionIds.has(activeSessionId);
 		let transcript: SnapshotTranscriptCache | undefined;
 		if (client.capabilities.has("chunked_snapshot")) {
@@ -4356,11 +4368,12 @@ export class DaemonSupervisor {
 	private async prepareUpdateRestartFenced(deadline: number): Promise<DaemonUpdateRestartManifest> {
 		const residents = [...this.workers.values()];
 		const unavailable = residents.find(
-			(worker) => worker.descriptor.lifecycle !== "ready" || worker.client === undefined,
+			(worker) =>
+				this.isWorkerStopping(worker) || worker.descriptor.lifecycle !== "ready" || worker.client === undefined,
 		);
 		if (unavailable) {
 			throw new Error(
-				`Cannot prepare update restart while resident worker ${unavailable.descriptor.workerId} is ${unavailable.descriptor.lifecycle}${unavailable.client ? "" : " and disconnected"}`,
+				`Cannot prepare update restart while resident worker ${unavailable.descriptor.workerId} is ${this.effectiveWorkerState(unavailable)}${unavailable.client ? "" : " and disconnected"}`,
 			);
 		}
 		const workers = residents as Array<ResidentWorker & { client: DaemonWorkerClient }>;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -113,6 +113,7 @@ import {
 	type DaemonCreateCommand,
 	type DaemonWorkerDescriptor,
 	type DaemonWorkerFrameHeader,
+	type DaemonWorkerLifecycle,
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 } from "./daemon-worker-protocol.js";
@@ -766,7 +767,7 @@ export class DaemonSupervisor {
 		return {
 			lifecycle: worker.descriptor.lifecycle,
 			isConnected: worker.client !== undefined,
-			isStopping: worker.intentionalStop || worker.descriptor.stopRequestedAt !== undefined,
+			isStopping: this.isWorkerStopping(worker),
 			hasOwnerClient: worker.descriptor.ownerClientId !== undefined,
 			isPreparingUpdateRestart:
 				this.updateRestartPhase !== undefined || worker.updateRestartPrepareClient !== undefined,
@@ -1581,7 +1582,7 @@ export class DaemonSupervisor {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return this.forwardToWorker(match.worker, command);
 				}
-				const first = [...this.workers.values()].find((worker) => this.isVisibleWorker(worker) && worker.client);
+				const first = [...this.workers.values()].find((worker) => this.isLiveWorker(worker) && worker.client);
 				if (!first) {
 					return success(command.id, command.type, { paused: false, limits: {} });
 				}
@@ -1595,7 +1596,7 @@ export class DaemonSupervisor {
 				}
 				const responses = await Promise.all(
 					[...this.workers.values()]
-						.filter((worker) => this.isVisibleWorker(worker) && worker.client)
+						.filter((worker) => this.isLiveWorker(worker) && worker.client)
 						.map((worker) => this.forwardToWorker(worker, command)),
 				);
 				const failed = responses.find((response) => !response.success);
@@ -1610,8 +1611,7 @@ export class DaemonSupervisor {
 				const responses = await Promise.all(
 					[...this.workers.values()]
 						.filter(
-							(worker) =>
-								this.isVisibleWorker(worker) && worker.client && worker.descriptor.lifecycle === "ready",
+							(worker) => this.isLiveWorker(worker) && worker.client && worker.descriptor.lifecycle === "ready",
 						)
 						.map((worker) =>
 							this.forwardToWorker(worker, command, 5000).catch((error: unknown) =>
@@ -1635,7 +1635,7 @@ export class DaemonSupervisor {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return this.forwardToWorker(match.worker, command);
 				}
-				const workers = [...this.workers.values()].filter((worker) => this.isVisibleWorker(worker));
+				const workers = [...this.workers.values()].filter((worker) => this.isLiveWorker(worker));
 				const heartbeats = new Map<string, AgentConnectionHeartbeat>();
 				const snapshots: Array<{ heartbeats?: AgentConnectionHeartbeat[]; response?: DaemonResponse }> =
 					await Promise.all(
@@ -1719,8 +1719,7 @@ export class DaemonSupervisor {
 				const listed = await Promise.all(
 					[...this.workers.values()]
 						.filter(
-							(worker) =>
-								this.isVisibleWorker(worker) && worker.client && worker.descriptor.lifecycle === "ready",
+							(worker) => this.isLiveWorker(worker) && worker.client && worker.descriptor.lifecycle === "ready",
 						)
 						.map(async (worker) => ({
 							worker,
@@ -1931,8 +1930,10 @@ export class DaemonSupervisor {
 		const active = [...this.workers.values()]
 			.filter(
 				(worker) =>
-					this.isVisibleWorker(worker) ||
-					(command.includeClientOwned === true && this.isWorkerAccessibleToClient(client, worker)),
+					this.isLiveWorker(worker) ||
+					(command.includeClientOwned === true &&
+						!this.isWorkerStopping(worker) &&
+						this.isWorkerAccessibleToClient(client, worker)),
 			)
 			.flatMap((worker) => [...worker.summaries.values()].map((summary) => this.publicSummary(worker, summary)));
 		const busyClientOwnedSessionCount = clientOwnedWorkers
@@ -3062,9 +3063,7 @@ export class DaemonSupervisor {
 			.then(async () => {
 				const readyWorkers = [...this.workers.values()].filter(
 					(worker): worker is ResidentWorker & { client: DaemonWorkerClient } =>
-						this.isVisibleWorker(worker) &&
-						worker.descriptor.lifecycle === "ready" &&
-						worker.client !== undefined,
+						this.isLiveWorker(worker) && worker.descriptor.lifecycle === "ready" && worker.client !== undefined,
 				);
 				await Promise.all(
 					readyWorkers.map(async (worker) => {
@@ -3089,6 +3088,30 @@ export class DaemonSupervisor {
 
 	private isVisibleWorker(worker: ResidentWorker): boolean {
 		return worker.descriptor.ownerClientId === undefined;
+	}
+
+	/** A worker with a durable or in-memory stop intent is stopping, never live. */
+	private isWorkerStopping(worker: ResidentWorker): boolean {
+		return worker.intentionalStop || worker.descriptor.stopRequestedAt !== undefined;
+	}
+
+	/** Live workers are visible to all clients and not stopping. */
+	private isLiveWorker(worker: ResidentWorker): boolean {
+		return this.isVisibleWorker(worker) && !this.isWorkerStopping(worker);
+	}
+
+	/**
+	 * The lifecycle reported to clients. A stop intent always wins, and a worker
+	 * whose process connection is gone is never reported as "ready".
+	 */
+	private effectiveWorkerState(worker: ResidentWorker): DaemonWorkerLifecycle {
+		if (this.isWorkerStopping(worker)) {
+			return "stopping";
+		}
+		if (worker.descriptor.lifecycle === "ready" && worker.client === undefined) {
+			return "recovering";
+		}
+		return worker.descriptor.lifecycle;
 	}
 
 	private familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry {
@@ -3135,7 +3158,7 @@ export class DaemonSupervisor {
 			...summary,
 			attachedClients: [...this.clients].filter((client) => client.attachedActiveSessionIds.has(activeSessionId))
 				.length,
-			workerState: worker.descriptor.lifecycle,
+			workerState: this.effectiveWorkerState(worker),
 			workerPid: worker.descriptor.pid,
 		};
 	}
@@ -3241,7 +3264,7 @@ export class DaemonSupervisor {
 		timeoutMs = WORKER_REQUEST_TIMEOUT_MS,
 	): Promise<DaemonResponse> {
 		if (!worker.client || worker.descriptor.lifecycle !== "ready") {
-			throw new Error(`Session worker is ${worker.descriptor.lifecycle}`);
+			throw new Error(`Session worker is ${this.effectiveWorkerState(worker)}`);
 		}
 		const response = await worker.client.request(withoutCommandId(command), timeoutMs);
 		if (command.type === "get_state" && response.success && isSessionSummary(response.data)) {

--- a/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
@@ -17,7 +17,7 @@ export const DAEMON_WORKER_SUPERVISOR_SOCKET_ENV = "PRIME_AGENT_INTERNAL_DAEMON_
 export const DAEMON_WORKER_RECOVERY_JOURNAL_ENV = "PRIME_AGENT_INTERNAL_DAEMON_WORKER_RECOVERY_JOURNAL";
 export const DAEMON_WORKER_STARTUP_GATE_FD_ENV = "PRIME_AGENT_INTERNAL_DAEMON_WORKER_STARTUP_GATE_FD";
 export const DAEMON_WORKER_STARTUP_GATE_COMMIT = "start\n";
-export type DaemonWorkerLifecycle = "starting" | "ready" | "recovering" | "failed";
+export type DaemonWorkerLifecycle = "starting" | "ready" | "recovering" | "stopping" | "failed";
 
 export type DaemonWorkerFrameHeader =
 	| {

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -37,8 +37,16 @@ describe("daemon protocol helpers", () => {
 			source.indexOf("export type DaemonOutbound ="),
 			source.indexOf("export const DAEMON_OUTBOUND_COMPATIBILITY"),
 		);
+		// DaemonOutbound carries SessionSummary by reference, so include the
+		// exported wire shape rather than leaving summary-field changes invisible
+		// to the advertised schema identity.
+		const sessionListSource = readFileSync(resolve(__dirname, "../src/modes/daemon/daemon-session-list.ts"), "utf8");
+		const sessionSummarySource = sessionListSource.slice(
+			sessionListSource.indexOf("export interface SessionSummary"),
+			sessionListSource.indexOf("/**\n * Pick the model fallback message"),
+		);
 		const digest = createHash("sha256")
-			.update(`${commandSource}\n${savedSessionSource}\n${outboundSource}`)
+			.update(`${commandSource}\n${savedSessionSource}\n${outboundSource}\n${sessionSummarySource}`)
 			.digest("hex")
 			.slice(0, 12);
 		expect(DAEMON_SCHEMA_ID).toBe(`protocol-${DAEMON_PROTOCOL_VERSION}-schema-${DAEMON_SCHEMA_REVISION}-${digest}`);

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -130,6 +130,14 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("prompt_admission_cancellation");
 	});
 
+	it("gates honest worker-state reporting at its introducing schema revision", () => {
+		// Revision 16 adds the "stopping" workerState and stops reporting
+		// disconnected workers as "ready". The field is optional and old clients
+		// ignore unknown values, so no capability gate is needed; the revision
+		// lets version probes distinguish daemons with the old semantics.
+		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(16);
+	});
+
 	it("keeps refine failure events backward-compatible on the existing session event channel", () => {
 		const event: DaemonOutbound = {
 			type: "session_event",

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1771,6 +1771,9 @@ describe("daemon worker supervisor monitoring", () => {
 		} as unknown as DaemonAttachResult;
 		const worker = {
 			descriptor: { workerId: "worker-1", lifecycle: "ready", pid: 1234 },
+			// A ready lifecycle now requires an available worker client; this fixture
+			// represents the connected worker whose snapshot is being attached.
+			client: {},
 			summaries: new Map([[activeSessionId, summary]]),
 			snapshotCache: new Map([[activeSessionId, result]]),
 			snapshotTransferFrames: new Map(),

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1601,6 +1601,98 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(worker.descriptor.consecutiveFailures).toBe(0);
 	});
 
+	it("reports a stop-tombstoned worker as stopping, not ready", () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-tombstoned",
+				pid: process.pid,
+				lifecycle: "ready" as const,
+				stopRequestedAt: new Date().toISOString(),
+			},
+			client: {},
+			intentionalStop: false,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {}) as {
+			effectiveWorkerState(target: object): string;
+		};
+
+		expect(supervisor.effectiveWorkerState(worker)).toBe("stopping");
+	});
+
+	it("never reports a disconnected worker as ready", () => {
+		const worker = {
+			descriptor: { workerId: "worker-disconnected", pid: process.pid, lifecycle: "ready" as const },
+			client: undefined,
+			intentionalStop: false,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {}) as {
+			effectiveWorkerState(target: object): string;
+		};
+
+		expect(supervisor.effectiveWorkerState(worker)).toBe("recovering");
+	});
+
+	it("reports a connected ready worker as ready", () => {
+		const worker = {
+			descriptor: { workerId: "worker-live", pid: process.pid, lifecycle: "ready" as const },
+			client: {},
+			intentionalStop: false,
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {}) as {
+			effectiveWorkerState(target: object): string;
+		};
+
+		expect(supervisor.effectiveWorkerState(worker)).toBe("ready");
+	});
+
+	it("excludes stopping workers from the live session list", async () => {
+		const makeWorker = (workerId: string, stopRequestedAt?: string) => ({
+			descriptor: {
+				workerId,
+				pid: process.pid,
+				rootActiveSessionId: `${workerId}-active`,
+				lifecycle: "ready" as const,
+				...(stopRequestedAt ? { stopRequestedAt } : {}),
+			},
+			client: {},
+			intentionalStop: false,
+			summaries: new Map([
+				[
+					`${workerId}-active`,
+					{
+						id: `${workerId}-active`,
+						activeSessionId: `${workerId}-active`,
+						sessionId: `${workerId}-session`,
+						cwd: "/tmp",
+					} as unknown as SessionSummary,
+				],
+			]),
+		});
+		const liveWorker = makeWorker("worker-live");
+		const stoppingWorker = makeWorker("worker-stopping", new Date().toISOString());
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([
+				[liveWorker.descriptor.workerId, liveWorker],
+				[stoppingWorker.descriptor.workerId, stoppingWorker],
+			]),
+			clients: new Set(),
+			refreshWorkerSummaries: vi.fn(async () => {}),
+			syncAgentPeers: vi.fn(async () => {}),
+			log: vi.fn(),
+		}) as {
+			handleList(
+				client: object,
+				command: { id: string; type: "list" },
+			): Promise<{ success: boolean; data?: { sessions: Array<{ activeSessionId?: string; id: string }> } }>;
+		};
+
+		const response = await supervisor.handleList({}, { id: "list-1", type: "list" });
+
+		expect(response.success).toBe(true);
+		const sessions = response.data?.sessions ?? [];
+		expect(sessions.map((session) => session.activeSessionId ?? session.id)).toEqual(["worker-live-active"]);
+	});
+
 	it("ignores malformed persisted worker descriptors", () => {
 		const descriptorDir = mkdtempSync(join(tmpdir(), "prime-supervisor-descriptor-test-"));
 		try {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1964,6 +1964,61 @@ describe("daemon worker supervisor monitoring", () => {
 		});
 	});
 
+	it("does not retain an attachment when snapshot loading fails", async () => {
+		type AttachClient = {
+			id: string;
+			capabilities: Set<string>;
+			supportsExtensionUi: boolean;
+			attachedActiveSessionIds: Set<string>;
+		};
+		const activeSessionId = "active-failed-attach";
+		const summary = {
+			id: activeSessionId,
+			activeSessionId,
+			lifecycle: "live",
+			activity: "idle",
+			isSessionActive: false,
+			sessionId: "session-failed-attach",
+			cwd: "/tmp/project",
+			isStreaming: false,
+			isCompacting: false,
+			attachedClients: 0,
+			messageCount: 0,
+			sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+		} satisfies SessionSummary;
+		const worker = {
+			descriptor: { workerId: "worker-1", lifecycle: "ready", pid: 1234 },
+			client: {
+				request: vi.fn(async () => {
+					throw new Error("snapshot failed");
+				}),
+			},
+			summaries: new Map([[activeSessionId, summary]]),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			incomingTranscriptActiveSessionIds: new Set(),
+			snapshotTransferFrames: new Map(),
+			snapshotLoads: new Map(),
+		};
+		const client: AttachClient = {
+			id: "client-1",
+			capabilities: new Set<string>(),
+			supportsExtensionUi: false,
+			attachedActiveSessionIds: new Set<string>(),
+		};
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers: new Map([[worker.descriptor.workerId, worker]]),
+			clients: new Set([client]),
+		}) as {
+			attachClient(client: AttachClient, command: { type: "attach"; activeSessionId: string }): Promise<unknown>;
+		};
+
+		await expect(supervisor.attachClient(client, { type: "attach", activeSessionId })).rejects.toThrow(
+			"snapshot failed",
+		);
+		expect(client.attachedActiveSessionIds).toEqual(new Set());
+	});
+
 	it("rejects an unavailable worker when attach needs an uncached snapshot", async () => {
 		const activeSessionId = "active-unavailable-attach";
 		const summary = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1771,6 +1771,7 @@ describe("daemon worker supervisor monitoring", () => {
 		} as unknown as DaemonAttachResult;
 		const worker = {
 			descriptor: { workerId: "worker-1", lifecycle: "ready", pid: 1234 },
+			client: {},
 			summaries: new Map([[activeSessionId, summary]]),
 			snapshotCache: new Map([[activeSessionId, result]]),
 			snapshotTransferFrames: new Map(),

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1645,7 +1645,7 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(supervisor.effectiveWorkerState(worker)).toBe("ready");
 	});
 
-	it("excludes stopping workers from the live session list", async () => {
+	it("keeps stopping workers listed with an honest state for busy-daemon checks", async () => {
 		const makeWorker = (workerId: string, stopRequestedAt?: string) => ({
 			descriptor: {
 				workerId,
@@ -1683,14 +1683,20 @@ describe("daemon worker supervisor monitoring", () => {
 			handleList(
 				client: object,
 				command: { id: string; type: "list" },
-			): Promise<{ success: boolean; data?: { sessions: Array<{ activeSessionId?: string; id: string }> } }>;
+			): Promise<{
+				success: boolean;
+				data?: { sessions: Array<{ activeSessionId?: string; id: string; workerState?: string }> };
+			}>;
 		};
 
 		const response = await supervisor.handleList({}, { id: "list-1", type: "list" });
 
 		expect(response.success).toBe(true);
 		const sessions = response.data?.sessions ?? [];
-		expect(sessions.map((session) => session.activeSessionId ?? session.id)).toEqual(["worker-live-active"]);
+		expect(sessions.map((session) => [session.activeSessionId ?? session.id, session.workerState]).sort()).toEqual([
+			["worker-live-active", "ready"],
+			["worker-stopping-active", "stopping"],
+		]);
 	});
 
 	it("ignores malformed persisted worker descriptors", () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1964,21 +1964,15 @@ describe("daemon worker supervisor monitoring", () => {
 		});
 	});
 
-	it("does not retain an attachment when snapshot loading fails", async () => {
-		type AttachClient = {
-			id: string;
-			capabilities: Set<string>;
-			supportsExtensionUi: boolean;
-			attachedActiveSessionIds: Set<string>;
-		};
-		const activeSessionId = "active-failed-attach";
+	it("rejects an unavailable worker when attach needs an uncached snapshot", async () => {
+		const activeSessionId = "active-unavailable-attach";
 		const summary = {
 			id: activeSessionId,
 			activeSessionId,
 			lifecycle: "live",
 			activity: "idle",
 			isSessionActive: false,
-			sessionId: "session-failed-attach",
+			sessionId: "session-unavailable-attach",
 			cwd: "/tmp/project",
 			isStreaming: false,
 			isCompacting: false,
@@ -1987,12 +1981,7 @@ describe("daemon worker supervisor monitoring", () => {
 			sessionActions: { queuedCount: 0, steering: [], followUps: [] },
 		} satisfies SessionSummary;
 		const worker = {
-			descriptor: { workerId: "worker-1", lifecycle: "ready", pid: 1234 },
-			client: {
-				request: vi.fn(async () => {
-					throw new Error("snapshot failed");
-				}),
-			},
+			descriptor: { workerId: "worker-unavailable-attach", lifecycle: "ready", pid: 1234 },
 			summaries: new Map([[activeSessionId, summary]]),
 			snapshotCache: new Map(),
 			transcriptCaches: new Map(),
@@ -2000,7 +1989,7 @@ describe("daemon worker supervisor monitoring", () => {
 			snapshotTransferFrames: new Map(),
 			snapshotLoads: new Map(),
 		};
-		const client: AttachClient = {
+		const client = {
 			id: "client-1",
 			capabilities: new Set<string>(),
 			supportsExtensionUi: false,
@@ -2010,11 +1999,11 @@ describe("daemon worker supervisor monitoring", () => {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			clients: new Set([client]),
 		}) as {
-			attachClient(client: AttachClient, command: { type: "attach"; activeSessionId: string }): Promise<unknown>;
+			attachClient(client: typeof client, command: { type: "attach"; activeSessionId: string }): Promise<unknown>;
 		};
 
 		await expect(supervisor.attachClient(client, { type: "attach", activeSessionId })).rejects.toThrow(
-			"snapshot failed",
+			"Session worker is recovering",
 		);
 		expect(client.attachedActiveSessionIds).toEqual(new Set());
 	});

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -2054,7 +2054,7 @@ describe("daemon worker supervisor monitoring", () => {
 			workers: new Map([[worker.descriptor.workerId, worker]]),
 			clients: new Set([client]),
 		}) as {
-			attachClient(client: typeof client, command: { type: "attach"; activeSessionId: string }): Promise<unknown>;
+			attachClient(inputClient: typeof client, command: { type: "attach"; activeSessionId: string }): Promise<unknown>;
 		};
 
 		await expect(supervisor.attachClient(client, { type: "attach", activeSessionId })).rejects.toThrow(

--- a/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
@@ -339,7 +339,6 @@ describe("ENG-4602 snapshot transfer containment", () => {
 			descriptorDir: "/tmp/eng-4602-supervisor-state",
 		});
 		const { close, worker } = workerHarness();
-		worker.intentionalStop = true;
 		const client = socketClient("public", new PassThrough());
 		const streamSnapshot = vi.fn(async () => {});
 		const internals = supervisor as unknown as {
@@ -424,7 +423,6 @@ describe("ENG-4602 snapshot transfer containment", () => {
 			descriptorDir: "/tmp/eng-4602-supervisor-gate-state",
 		});
 		const { close, request, worker } = workerHarness();
-		worker.intentionalStop = true;
 		const client = socketClient("catchup", new PassThrough());
 		const streamSnapshot = vi.fn(async () => {});
 		const internals = supervisor as unknown as {


### PR DESCRIPTION
## Purpose

Draft prerequisite validation of the contributor #850 semantics plus the cached-snapshot correction, based on `main` solely so the repository CI workflow runs. This is a CI-validation and collaboration surface, **not a v0.8 stack deliverable and not ready for human merge review**.

## Exact candidate

- Reviewed tree commit: `dba83904c43f0f32be4e62c74e8678d9a0bd7abc`
- CI head: `a6db0246b52cea74f2f675fea95ac43c9842d39a` (one-line test-type fixture repair atop the ancestry/CI commits; production tree remains reviewed `dba83904...`; contributor head is a parent)
- Parent reviewed restack backup: `0026c8adc13d29fd9efcb52b28fe2adbb9dbb7a0`
- Contributor #850 head observed before this Draft: `749831dd9dd1a0b35708513390080030878d9e4f`

## Corrections

- Preserve supervisor-owned cached/retained snapshot attachment without requiring a live worker connection.
- Continue rejecting unavailable workers when an uncached attach requires actual worker RPC.
- Correct two ENG-4602 fixtures that incorrectly marked otherwise-live catch-up workers as intentionally stopping.
- Preserve the existing snapshot-loading-failure regression and add the unavailable-worker regression separately.
- Preserve schema revision 16 digest coverage for the referenced `SessionSummary.workerState` wire shape.

## Evidence and hold

Focused daemon protocol, supervisor monitor, ENG-4602, and ENG-4677 coverage: 69/69 passed locally with direct pinned dependencies. Independent review found no remaining P0/P1 in this delta. Local full-shard evidence was rejected as environment-contaminated (`FORCE_COLOR` plus live HOME/daemon state), so this Draft exists to obtain clean GitHub CI evidence.

Do not merge or restack #851/#852 from this head until CI is green and the prerequisite is accepted. No contributor branch was force-pushed or mutated.

### First remote CI attempt

Run `31455798294` classified the product candidate: all production/process/kernel/shards except one unrelated 60-second IPython bootstrap outlier passed. Build/check found a test-only TS2502 self-referential parameter name introduced by the added regression fixture. Head `a6db0246...` changes only that parameter name; direct monitor 51/51 and direct tsgo passed. Failed-run evidence is retained with SHA-256 `e262fcd750b9c54a6248d01ca68a86a81da25f04bc7cda674118c7b12e9133ab`.
