### PR TITLE
fix(coding-agent): bound refinement drain during disposal and extend session-replacement timeouts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
+- Fixed `/new`, `/resume`, and fork surfacing a false 30s client timeout while the server was still draining in-flight refinement during session disposal ([#1190](https://github.com/PrimeIntellect-ai/prime-agent/issues/1190)).
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -224,7 +224,10 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		await flushAgentTraceUpload(this.session.sessionManager).catch(() => undefined);
 		this.beforeSessionInvalidate?.();
 		// Await the kernel's final snapshot flush before invalidating the session.
-		await this.session.disposeAsync();
+		// Session replacement is user-initiated: never start a fresh due auto-refine
+		// here, and bound any in-flight refinement wait so /new, /resume and fork
+		// stay well within the client-side command timeout.
+		await this.session.disposeAsync({ runDueRefineOnDispose: false });
 		await this.disposeHostedSubagentRuntimes();
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -963,6 +963,28 @@ const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "hi
 
 /** Cap on the post-compaction kernel namespace probe so a wedged kernel can't stall recovery. */
 const KERNEL_STATE_LISTING_TIMEOUT_MS = 5000;
+
+/**
+ * Default upper bound for awaiting in-flight refinement during async disposal.
+ * Refinement is a best-effort persistence step; abandoning it past this budget
+ * is preferable to stalling session replacement (e.g. /new) past client timeouts.
+ */
+const DEFAULT_REFINE_DISPOSE_DRAIN_BUDGET_MS = 15_000;
+
+export interface AgentSessionDisposeOptions {
+	/**
+	 * Max milliseconds to wait for in-flight refinement before abandoning it
+	 * and continuing teardown. Defaults to DEFAULT_REFINE_DISPOSE_DRAIN_BUDGET_MS.
+	 */
+	refineDrainBudgetMs?: number;
+	/**
+	 * Whether a due-but-not-yet-started auto-refine (turn interval reached, or a
+	 * compaction review still pending) is run before disposal. Pass false for
+	 * user-initiated session replacement (/new, /resume, fork) so leaving the
+	 * session never triggers a fresh model call. Defaults to true.
+	 */
+	runDueRefineOnDispose?: boolean;
+}
 const RLM_MAX_DEPTH_STATE_CUSTOM_TYPE = "rlm_max_depth_state";
 
 function noopRlmChildAbort(): void {}
@@ -3768,7 +3790,7 @@ export class AgentSession {
 	 * (which flushes a final namespace snapshot) before the synchronous dispose, so
 	 * the latest state reaches disk instead of racing process exit.
 	 */
-	async disposeAsync(): Promise<void> {
+	async disposeAsync(options: AgentSessionDisposeOptions = {}): Promise<void> {
 		if (this._disposed) {
 			return this._disposeCallbacksPromise;
 		}
@@ -3780,7 +3802,7 @@ export class AgentSession {
 		this._disposeAsyncPromise = (async () => {
 			// Drain before marking _disposing so a refine triggered at the final
 			// agent_end completes instead of being aborted by dispose().
-			await this._drainPendingRefinementForDisposal();
+			await this._drainPendingRefinementForDisposal(options);
 			if (this._disposed) {
 				return this._disposeCallbacksPromise;
 			}
@@ -3797,12 +3819,53 @@ export class AgentSession {
 	 * from disposeAsync before _disposing is set so refinement completes
 	 * before disposal.
 	 */
-	private async _drainPendingRefinementForDisposal(): Promise<void> {
+	private async _drainPendingRefinementForDisposal(options: AgentSessionDisposeOptions = {}): Promise<void> {
+		const budgetMs = options.refineDrainBudgetMs ?? DEFAULT_REFINE_DISPOSE_DRAIN_BUDGET_MS;
+		const deadline = Date.now() + budgetMs;
+		// Runs `operation` bounded by the remaining drain budget. Resolves false when
+		// the budget is exhausted first; the refinement keeps running in the
+		// background and is aborted by the teardown that follows. A stalled drain
+		// must not hold session replacement (e.g. /new) past client timeouts.
+		const runWithinBudget = async (operation: () => Promise<unknown>): Promise<boolean> => {
+			const remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) {
+				return false;
+			}
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			try {
+				return await Promise.race([
+					Promise.resolve()
+						.then(operation)
+						.then(
+							() => true,
+							() => true,
+						),
+					new Promise<false>((resolve) => {
+						timer = setTimeout(() => resolve(false), remainingMs);
+						timer.unref?.();
+					}),
+				]);
+			} finally {
+				if (timer) {
+					clearTimeout(timer);
+				}
+			}
+		};
+		const abandonDrain = (): void => {
+			this._emitRefineFailed(
+				new Error(
+					`Abandoned pending refinement after waiting ${budgetMs}ms during session disposal; teardown continues without it.`,
+				),
+			);
+		};
 		for (const timer of this._scheduledAutoRefineTimers) {
 			clearTimeout(timer);
 		}
 		this._scheduledAutoRefineTimers.clear();
-		await Promise.allSettled([...this._autoRefineOperations]);
+		if (!(await runWithinBudget(() => Promise.allSettled([...this._autoRefineOperations])))) {
+			abandonDrain();
+			return;
+		}
 		for (const timer of this._scheduledAutoRefineTimers) {
 			clearTimeout(timer);
 		}
@@ -3810,14 +3873,22 @@ export class AgentSession {
 		// Wait for in-flight refinement (including serialized background plan) to settle.
 		while (this._refineInFlight || this._refinePlanInFlight || this._serializedPlanInFlight) {
 			if (this._refineInFlight) {
-				await this._refineInFlight;
+				const inFlight = this._refineInFlight;
+				if (!(await runWithinBudget(() => inFlight))) {
+					abandonDrain();
+					return;
+				}
 			} else if (this._refinePlanInFlight) {
-				await this._refinePlanInFlight;
+				const planInFlight = this._refinePlanInFlight;
+				if (!(await runWithinBudget(() => planInFlight))) {
+					abandonDrain();
+					return;
+				}
 			} else if (this._serializedPlanInFlight) {
 				// Fix 5: Await the background plan and apply a ready "plan"
 				// result before teardown so the refinement is persisted.
 				// Do NOT discard a ready plan.
-				await this._consumeSerializedBackgroundPlan(async (bgResult) => {
+				const consumeSerializedPlan = this._consumeSerializedBackgroundPlan(async (bgResult) => {
 					if (bgResult?.status === "plan" && bgResult.branchVersion === this._autoRefineBranchVersion) {
 						try {
 							await this._applySerializedPlan(bgResult);
@@ -3853,6 +3924,10 @@ export class AgentSession {
 					}
 					return false;
 				});
+				if (!(await runWithinBudget(() => consumeSerializedPlan))) {
+					abandonDrain();
+					return;
+				}
 			} else {
 				await new Promise<void>((resolve) => setTimeout(resolve, 0));
 			}
@@ -3864,7 +3939,10 @@ export class AgentSession {
 			const pending = this._pendingRequestedRefine;
 			this._pendingRequestedRefine = undefined;
 			try {
-				await this._runSerializedRefine(pending);
+				if (!(await runWithinBudget(() => this._runSerializedRefine(pending)))) {
+					abandonDrain();
+					return;
+				}
 			} catch {
 				// Best-effort drain; refinement errors must not block disposal.
 			}
@@ -3875,7 +3953,12 @@ export class AgentSession {
 		}
 		// A serialized compaction can finish without another model turn. Drain its
 		// pending review here so disposal does not silently lose the trigger.
-		if (this._serializedRefine && this._compactAutoRefinePending && this._autoRefineAllowedForSession()) {
+		if (
+			options.runDueRefineOnDispose !== false &&
+			this._serializedRefine &&
+			this._compactAutoRefinePending &&
+			this._autoRefineAllowedForSession()
+		) {
 			const compactSettings = this.settingsManager.getAutoRefineSettings();
 			if (!compactSettings.enabled || !compactSettings.compact) {
 				this._compactAutoRefinePending = false;
@@ -3886,7 +3969,13 @@ export class AgentSession {
 				this._compactAutoRefinePending = false;
 				if (!underCooldown) {
 					try {
-						await this._runSerializedAutoRefineReview("compact", this._autoRefineBranchVersion);
+						if (
+							!(await runWithinBudget(() =>
+								this._runSerializedAutoRefineReview("compact", this._autoRefineBranchVersion),
+							))
+						) {
+							abandonDrain();
+						}
 					} catch {
 						// Best-effort drain; refinement errors must not block disposal.
 					}
@@ -3898,7 +3987,12 @@ export class AgentSession {
 		// If auto-refine is due but has not started yet, run it now so the
 		// refinement is persisted before disposal. Use the direct serialized
 		// path in serialized mode, or _maybeAutoRefine in interactive mode
-		// (where the agent is idle at this point).
+		// (where the agent is idle at this point). Skipped entirely for
+		// user-initiated session replacement (runDueRefineOnDispose: false):
+		// leaving the session must not trigger a fresh model call.
+		if (options.runDueRefineOnDispose === false) {
+			return;
+		}
 		if (this._disposed || !this._autoRefineAllowedForSession()) {
 			return;
 		}
@@ -3916,9 +4010,13 @@ export class AgentSession {
 			return;
 		}
 		if (this._serializedRefine) {
-			await this._runSerializedRefineCheckpoint();
+			if (!(await runWithinBudget(() => this._runSerializedRefineCheckpoint()))) {
+				abandonDrain();
+			}
 		} else {
-			await this._maybeAutoRefine("turn_interval");
+			if (!(await runWithinBudget(() => this._maybeAutoRefine("turn_interval")))) {
+				abandonDrain();
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -98,6 +98,13 @@ interface DaemonSnapshotAssembly {
 export const DAEMON_REFINE_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const DAEMON_LONG_RUNNING_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 export const DAEMON_RECONNECT_TIMEOUT_MS = 60_000;
+/**
+ * new_session / switch_session / fork tear down the current session first, which
+ * may wait on in-flight refinement (bounded server-side). Use a dedicated,
+ * generous timeout instead of the generic 30s default so a slow-but-healthy
+ * replacement never surfaces as a false client-side failure.
+ */
+export const DAEMON_SESSION_REPLACEMENT_TIMEOUT_MS = 120_000;
 export const DAEMON_SNAPSHOT_TIMEOUT_MS = 30_000;
 const MAX_IGNORED_SNAPSHOT_IDS = 128;
 const UPDATE_RECONNECT_TIMEOUT_MS = 120000;
@@ -1072,11 +1079,14 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async newSession(options?: AgentConnectionNewSessionOptions): Promise<{ cancelled: boolean }> {
-		return this.requestData<{ cancelled: boolean }>({
-			type: "new_session",
-			activeSessionId: this.activeSessionId,
-			parentSession: options?.parentSession,
-		});
+		return this.requestData<{ cancelled: boolean }>(
+			{
+				type: "new_session",
+				activeSessionId: this.activeSessionId,
+				parentSession: options?.parentSession,
+			},
+			DAEMON_SESSION_REPLACEMENT_TIMEOUT_MS,
+		);
 	}
 
 	async switchSession(
@@ -1085,12 +1095,15 @@ export class DaemonAgentConnection implements AgentConnection {
 	): Promise<{ cancelled: boolean }> {
 		const sourceActiveSessionId = this.activeSessionId;
 		try {
-			return await this.requestData<{ cancelled: boolean }>({
-				type: "switch_session",
-				activeSessionId: sourceActiveSessionId,
-				sessionPath,
-				cwdOverride: options?.cwdOverride,
-			});
+			return await this.requestData<{ cancelled: boolean }>(
+				{
+					type: "switch_session",
+					activeSessionId: sourceActiveSessionId,
+					sessionPath,
+					cwdOverride: options?.cwdOverride,
+				},
+				DAEMON_SESSION_REPLACEMENT_TIMEOUT_MS,
+			);
 		} catch (error) {
 			if (!(error instanceof SessionAlreadyActiveError) || !error.activeSessionId) {
 				throw error;
@@ -1187,12 +1200,15 @@ export class DaemonAgentConnection implements AgentConnection {
 		entryId: string,
 		options?: AgentConnectionForkOptions,
 	): Promise<{ cancelled: boolean; selectedText?: string }> {
-		return this.requestData<{ cancelled: boolean; selectedText?: string }>({
-			type: "fork",
-			activeSessionId: this.activeSessionId,
-			entryId,
-			position: options?.position,
-		});
+		return this.requestData<{ cancelled: boolean; selectedText?: string }>(
+			{
+				type: "fork",
+				activeSessionId: this.activeSessionId,
+				entryId,
+				position: options?.position,
+			},
+			DAEMON_SESSION_REPLACEMENT_TIMEOUT_MS,
+		);
 	}
 
 	async navigateTree(

--- a/packages/coding-agent/test/agent-connection-daemon.test.ts
+++ b/packages/coding-agent/test/agent-connection-daemon.test.ts
@@ -5,6 +5,7 @@ import { MissingSessionCwdError } from "../src/core/session-cwd.js";
 import { SessionImportFileNotFoundError } from "../src/core/session-import-errors.js";
 import {
 	DAEMON_REFINE_REQUEST_TIMEOUT_MS,
+	DAEMON_SESSION_REPLACEMENT_TIMEOUT_MS,
 	DaemonAgentConnection,
 } from "../src/modes/agent-connection/daemon-agent-connection.js";
 import type {
@@ -47,6 +48,7 @@ class FakeDaemonClient {
 	connectionStateGate: Promise<void> | undefined;
 	connectionStateFactory: ((activeSessionId: string) => AgentConnectionState) | undefined;
 	abortBashUnknownCommand = false;
+	switchSessionSucceeds = false;
 	abortAndClearQueueUnknownCommand = false;
 	cronAddGate: Promise<void> | undefined;
 	promptGate: Promise<void> | undefined;
@@ -436,6 +438,9 @@ class FakeDaemonClient {
 					},
 				};
 			case "switch_session":
+				if (this.switchSessionSucceeds) {
+					return { type: "response", command: command.type, success: true, data: { cancelled: false } };
+				}
 				return {
 					type: "response",
 					command: command.type,
@@ -461,6 +466,9 @@ class FakeDaemonClient {
 						filePath: "/tmp/not-found.jsonl",
 					},
 				};
+			case "new_session":
+			case "fork":
+				return { type: "response", command: command.type, success: true, data: { cancelled: false } };
 			default:
 				throw new Error(`Unexpected command: ${command.type}`);
 		}
@@ -709,6 +717,23 @@ describe("DaemonAgentConnection", () => {
 			activeSessionId: "active-1",
 			telemetryDisabled: true,
 		});
+	});
+
+	it("uses a dedicated replacement timeout for new/switch/fork session commands", async () => {
+		const fakeClient = new FakeDaemonClient();
+		fakeClient.switchSessionSucceeds = true;
+		const connection = new DaemonAgentConnection(asDaemonClient(fakeClient), "active-1");
+
+		await connection.newSession();
+		await connection.fork("entry-1");
+		await connection.switchSession("/tmp/other-session.jsonl");
+
+		expect(fakeClient.requests.map((request) => request.type)).toEqual(["new_session", "fork", "switch_session"]);
+		expect(fakeClient.requestTimeouts).toEqual([
+			DAEMON_SESSION_REPLACEMENT_TIMEOUT_MS,
+			DAEMON_SESSION_REPLACEMENT_TIMEOUT_MS,
+			DAEMON_SESSION_REPLACEMENT_TIMEOUT_MS,
+		]);
 	});
 
 	it("forwards queueIfBusy for prompt admission", async () => {

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -519,6 +519,19 @@ describe("AgentSessionRuntime characterization", () => {
 		]);
 	});
 
+	it("skips due auto-refine when tearing down for user-initiated session replacement", async () => {
+		const { runtime } = await createRuntimeForTest(() => {});
+
+		await runtime.session.prompt("hello");
+		const originalSession = runtime.session;
+		const disposeSpy = vi.spyOn(originalSession, "disposeAsync");
+
+		const newSessionResult = await runtime.newSession();
+		expect(newSessionResult.cancelled).toBe(false);
+
+		expect(disposeSpy).toHaveBeenCalledWith({ runDueRefineOnDispose: false });
+	});
+
 	it("honors session_before_switch cancellation for new and resume", async () => {
 		const events: RecordedSessionEvent[] = [];
 		let cancelReason: "new" | "resume" | undefined;

--- a/packages/coding-agent/test/suite/agent-session-serialized-refine.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-serialized-refine.test.ts
@@ -68,7 +68,11 @@ type SerializedInternals = {
 		firstKeptEntryId: string;
 		tokensBefore: number;
 	}>;
-	_drainPendingRefinementForDisposal(): Promise<void>;
+	_drainPendingRefinementForDisposal(options?: {
+		refineDrainBudgetMs?: number;
+		runDueRefineOnDispose?: boolean;
+	}): Promise<void>;
+	_emitRefineFailed(error: unknown): void;
 	_autoRefineOperations: Set<Promise<void>>;
 };
 
@@ -233,6 +237,56 @@ describe("Serialized auto-refine checkpoint", () => {
 		// The drain path ran the serialized checkpoint which called _applyRefine.
 		expect(applyRefine).toHaveBeenCalled();
 		expect(internals._disposed).toBe(true);
+	});
+
+	it("skips a due auto-refine when disposal is user-initiated", async () => {
+		const reviewer = vi.fn(async () => ({
+			shouldRefine: true,
+			rationale: "test",
+			instructions: "test",
+		}));
+		const harness = await createHarness({
+			persistSession: true,
+			serializedRefine: true,
+			settings: { autoRefine: { enabled: true, turnInterval: 1, cooldownMs: 0 } },
+			autoRefineReviewer: reviewer,
+		});
+		harnesses.push(harness);
+		const { applyRefine } = mockSerializedRefine(harness);
+
+		const internals = harness.session as unknown as SerializedInternals;
+		internals._assistantTurnsSinceAutoRefine = 1;
+
+		await harness.session.disposeAsync({ runDueRefineOnDispose: false });
+
+		// Leaving the session must not trigger a fresh refinement model call.
+		expect(applyRefine).not.toHaveBeenCalled();
+		expect(reviewer).not.toHaveBeenCalled();
+		expect(internals._disposed).toBe(true);
+	});
+
+	it("bounds the in-flight refinement wait by the disposal drain budget", async () => {
+		const harness = await createHarness({
+			persistSession: true,
+			serializedRefine: true,
+			settings: { autoRefine: { enabled: false } },
+		});
+		harnesses.push(harness);
+
+		const internals = harness.session as unknown as SerializedInternals;
+		const failSpy = vi.spyOn(internals, "_emitRefineFailed");
+		// A refinement that never settles must not stall disposal.
+		internals._refineInFlight = new Promise<void>(() => {});
+
+		const start = Date.now();
+		await harness.session.disposeAsync({ refineDrainBudgetMs: 50 });
+		const elapsed = Date.now() - start;
+
+		expect(elapsed).toBeLessThan(5000);
+		expect(internals._disposed).toBe(true);
+		expect(failSpy).toHaveBeenCalledOnce();
+		expect(failSpy.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+		expect((failSpy.mock.calls[0]?.[0] as Error).message).toContain("50ms");
 	});
 
 	it("interactive background refine behavior preserved when serializedRefine is false", async () => {


### PR DESCRIPTION
## Summary

`/new` (daemon `new_session` command), `/resume` (`switch_session`), and `fork` can fail on the client with a false 30s timeout while the server is still draining in-flight continual-harness refinement during session disposal. The command actually succeeds server-side a few seconds later.

Fixes #1190.

## Changes

- Bound the refinement drain during async disposal with a 15s default budget (`AgentSessionDisposeOptions.refineDrainBudgetMs`); refinement is best-effort persistence, so abandoning it past the budget is preferable to stalling session replacement past client timeouts.
- Skip starting a due-but-not-yet-started auto-refine for user-initiated session replacement (`runDueRefineOnDispose: false`), so `/new`, `/resume`, and fork never trigger a fresh model call while leaving a session.
- Give `new_session`, `switch_session`, and `fork` a dedicated 120s client timeout instead of the generic 30s default, so a slow-but-healthy replacement never surfaces as a false client-side failure.

## Tests

- `agent-connection-daemon.test.ts`: replacement commands use the dedicated timeout.
- `agent-session-runtime.test.ts`: session replacement passes `runDueRefineOnDispose: false`.
- `agent-session-serialized-refine.test.ts`: drain budget bounds in-flight refinement waits; due refinement is skipped on user-initiated disposal.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound refinement drain during session disposal and extend session-replacement timeouts
> - Adds a 15s drain budget (`DEFAULT_REFINE_DISPOSE_DRAIN_BUDGET_MS`) to [`AgentSession._drainPendingRefinementForDisposal`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1205/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae) so in-flight refinement cannot block teardown indefinitely; emits a refine-failed error if the budget is exhausted.
> - Adds `AgentSessionDisposeOptions` to let callers skip due auto-refine on disposal; session replacement (via `AgentSessionRuntime.teardownCurrent`) passes `{ runDueRefineOnDispose: false }` to avoid starting a fresh auto-refine during user-initiated teardown.
> - Raises the client-side timeout for `new_session`, `switch_session`, and `fork` requests to 120s (`DAEMON_SESSION_REPLACEMENT_TIMEOUT_MS`) in [`DaemonAgentConnection`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1205/files#diff-66527ed3d3b73a3797f1340b8144764da96d80786580f7cbc5fb08cc3739b8fb), preventing false 30s timeout errors while the server drains refinement.
> - Behavioral Change: disposal that previously waited unboundedly on in-flight refinement now abandons and emits a refine-failed error after 15s (or a caller-supplied budget).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50653d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->