### PR TITLE
docs: document waiting for agent idle before sending the next RPC prompt

### DIFF
--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -74,6 +74,27 @@ Response:
 
 `success: true` means the prompt was accepted, queued, or handled immediately. `success: false` means the prompt was rejected before acceptance. Failures after acceptance are reported through the normal event and message stream, not as a second `response` for the same request id.
 
+**Waiting for completion**: The `response` for a `prompt` is admission-only; it does not mean the agent has finished processing. A common mistake is sending the next `prompt` immediately after the previous `response` while the agent is still streaming or executing tools, which fails with `Agent is already processing`. To wait until the agent is idle, poll `get_state` until `isStreaming` is `false`, `unfinishedActionCount` is `0`, and `sessionActions.queuedCount` is `0`:
+
+```json
+{"type": "get_state"}
+```
+
+```json
+{
+  "type": "response",
+  "command": "get_state",
+  "success": true,
+  "data": {
+    "isStreaming": false,
+    "unfinishedActionCount": 0,
+    "sessionActions": {"queuedCount": 0, "steering": [], "followUps": []}
+  }
+}
+```
+
+Alternatively, send the next prompt with `"streamingBehavior": "followUp"` so it is queued and delivered only after the agent finishes. See [steer](#steer) and [follow_up](#follow_up) for the delivery semantics of queued messages.
+
 The `images` field is optional. Each image uses `ImageContent` format: `{"type": "image", "data": "base64-encoded-data", "mimeType": "image/png"}`.
 
 #### steer


### PR DESCRIPTION
## Summary

Closes #1206

The RPC `prompt` `response` is admission-only. A common failure when scripting RPC mode is sending the next `prompt` immediately after the previous `response` while the agent is still streaming or executing tools, which fails with `Agent is already processing`.

## Changes

- Added a **Waiting for completion** note in the `prompt` command section of `docs/rpc.md`.
- Documented the `get_state` polling pattern (`isStreaming=false`, `unfinishedActionCount=0`, `sessionActions.queuedCount=0`) for waiting until the agent is idle.
- Pointed to `streamingBehavior: "followUp"` as the queueing alternative, with links to the `steer` and `follow_up` sections.

## Verification

Docs-only change; no code paths touched. The described failure was reproduced against v0.7.1 (see #1206).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document how to wait for agent idle before sending the next RPC prompt
> Adds a guidance section to [rpc.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1209/files#diff-9cdce3c0b76820edb3a48842524d4add29e3355a12afc8a7fe292492ee408182) clarifying that the `response` to a `prompt` RPC is admission-only and does not indicate completion. Explains how to poll `get_state` until `isStreaming` is false, `unfinishedActionCount` is 0, and `sessionActions.queuedCount` is 0, with example JSON. Also notes the alternative of using `"streamingBehavior": "followUp"` to queue the next prompt and references the steer and follow_up sections for queued message delivery semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd7af06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->