### PR TITLE
chore(ai): update @anthropic-ai/sdk to ^0.115.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,10 +72,13 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.91.1",
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+			"integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
 			"license": "MIT",
 			"dependencies": {
-				"json-schema-to-ts": "^3.1.1"
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
 			},
 			"bin": {
 				"anthropic-ai-sdk": "bin/cli"
@@ -1789,6 +1792,12 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"license": "MIT"
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2881,6 +2890,12 @@
 			"engines": {
 				"node": ">=8.6.0"
 			}
+		},
+		"node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"license": "Unlicense"
 		},
 		"node_modules/fastq": {
 			"version": "1.20.1",
@@ -4547,6 +4562,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/standardwebhooks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+			"license": "MIT",
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
+		},
 		"node_modules/std-env": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -5310,7 +5335,7 @@
 			"version": "0.7.1",
 			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/sdk": "^0.91.1",
+				"@anthropic-ai/sdk": "^0.115.0",
 				"@aws-sdk/client-bedrock-runtime": "^3.1083.0",
 				"@google/genai": "^1.40.0",
 				"@mistralai/mistralai": "^2.2.0",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Updated `@anthropic-ai/sdk` to ^0.115.0 and excluded its file-credential node builtins from the browser smoke bundle.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -72,7 +72,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@anthropic-ai/sdk": "^0.91.1",
+		"@anthropic-ai/sdk": "^0.115.0",
 		"@aws-sdk/client-bedrock-runtime": "^3.1083.0",
 		"@google/genai": "^1.40.0",
 		"@mistralai/mistralai": "^2.2.0",

--- a/scripts/check-browser-smoke.mjs
+++ b/scripts/check-browser-smoke.mjs
@@ -14,6 +14,10 @@ try {
 		format: "esm",
 		logLevel: "silent",
 		outfile: outputPath,
+		// @anthropic-ai/sdk dynamically imports node builtins in its
+		// file-credentials paths. Those never run in the browser (the provider
+		// always passes an explicit apiKey), so leave them out of the bundle.
+		external: ["node:fs", "node:path"],
 	});
 	process.exit(0);
 } catch (error) {


### PR DESCRIPTION
## Summary

Updates `@anthropic-ai/sdk` from ^0.91.1 to ^0.115.0.

Newer SDK releases add file-based credential modules (OAuth profiles, token cache) that dynamically `import("node:fs")` / `import("node:path")`. Those code paths only run when using file credentials; the provider always passes an explicit `apiKey`, so they never execute in the browser. The browser smoke build now marks `node:fs`/`node:path` as external to keep the bundle resolvable.

The version satisfies the 7-day minimum release age (0.115.0 was published 2026-07-24).

## Verification

- `npm run check` passes: biome, tsgo (provider code compiles unchanged against 0.115 types), installer check, and the browser smoke bundle that previously failed with `Could not resolve "node:fs"`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `@anthropic-ai/sdk` to `^0.115.0` and exclude Node builtins from browser bundle
> - Bumps `@anthropic-ai/sdk` from `^0.91.1` to `^0.115.0` in [package.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/1213/files#diff-3758ea4fd63e4789bf712baab7b4b0227fce843a17e2ed535091b9c3b83ff2df).
> - Adds `external: ["node:fs", "node:path"]` to the esbuild config in [check-browser-smoke.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/1213/files#diff-d04b77433400b3ad8e7067636829a9b1af683ed3ed6c7988a5a6b7c901d8543e), as the newer SDK dynamically imports these Node builtins in file-credential paths, which would otherwise break the browser smoke bundle build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc88293.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->