### PR TITLE
fix(kernel): serialize prewarm with root turns

### DIFF
--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -353,9 +353,19 @@ export class IpythonKernelProvisioner {
 		return this._lastRestore;
 	}
 
-	/** Start the kernel in the background. Failures are swallowed here and surface on the next ensure(). */
+	/**
+	 * Start the kernel in the background. Foreground admission prevents the first root turn from
+	 * overtaking bootstrap and then waiting on it. Failures surface on the next ensure().
+	 */
 	prewarm(): void {
-		void this.ensure().catch(() => {});
+		const foreground = this.options?.foregroundLease;
+		if (!foreground) {
+			void this.ensure().catch(() => {});
+			return;
+		}
+		void foreground
+			.run("root-cell", () => this.ensure(undefined, this.disposeController.signal), this.disposeController.signal)
+			.catch(() => {});
 	}
 
 	/** Whether a kernel has finished starting and is currently running. */

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import type { ExtensionContext } from "../src/core/extensions/types.js";
 import type { KernelBootstrapProgressHandler } from "../src/core/kernel/bootstrap.js";
 import { type ExecuteResult, KernelBusyAfterInterruptError, KernelManager } from "../src/core/kernel/index.js";
+import { RootForegroundLease } from "../src/core/root-foreground-lease.js";
 import { createIpythonToolDefinition, IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
 let tempDir = "";
@@ -114,6 +115,29 @@ describe("IpythonKernelProvisioner", () => {
 			await expect(provisioner.ensure()).rejects.toThrow();
 			expect(countRuns()).toBeGreaterThanOrEqual(2);
 		});
+	});
+
+	it("admits prewarm before an immediately following root turn", async () => {
+		const { python } = writeFakePython();
+		const foregroundLease = new RootForegroundLease();
+		let releaseBoot: () => void = () => {};
+		const readyGate = new Promise<void>((resolve) => {
+			releaseBoot = resolve;
+		});
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python, foregroundLease, readyGate });
+		const events: string[] = [];
+
+		provisioner.prewarm();
+		const rootTurn = foregroundLease.run("root-turn", async () => {
+			events.push("root-turn");
+		});
+
+		expect(foregroundLease.busy).toBe(true);
+		expect(foregroundLease.pendingCount).toBe(1);
+		expect(events).toEqual([]);
+		releaseBoot();
+		await rootTurn;
+		expect(events).toEqual(["root-turn"]);
 	});
 
 	it("replays the current startup stage to listeners attaching mid-flight", async () => {


### PR DESCRIPTION
Kernel prewarm starts outside the root foreground context. A root turn can acquire the foreground lease while kernel startup is still preparing its bootstrap cell. Bootstrap then waits for the root-cell lease, while the turn's first IPython call waits for bootstrap to finish.

Acquire the root-cell lease before prewarm starts kernel initialization. An immediately following root turn now waits behind bootstrap instead of overtaking it. Abort the admission when the provisioner is disposed so a queued prewarm cannot outlive its session.

Retain a deterministic readiness-gate regression that proves the root turn queues behind prewarm without relying on scheduler timing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize kernel prewarm with root turns in `IpythonKernelProvisioner`
> When a `foregroundLease` is passed to `prewarm()`, the kernel bootstrap now runs under that lease (labeled `"root-cell"`), blocking any subsequent root turn from starting until bootstrap completes or is aborted. Without a lease, the prior background behavior is unchanged. A new test in [ipython-provisioner.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1220/files#diff-acde112b894c2a7c08a290667fa9aa34fccd3aeb6a7044304afdd76c5a945ae0) validates that a root turn queued immediately after `prewarm()` waits until the readyGate is released.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e24f73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->