### PR TITLE
Gate project-scoped configuration behind workspace trust

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added workspace trust: project-scoped extensions, skills, packages, executable settings keys, and `SYSTEM.md`/`APPEND_SYSTEM.md` now only load for trusted workspaces, with a one-time consent prompt on interactive startup and the new `prime-agent trust` / `prime-agent untrust` commands. Untrusted workspaces run without project-committed executable configuration.
 - Added `app.messages.expand` (`ctrl+p`) to collapse or expand agent-to-agent messages separately from `ctrl+o` tool output.
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -115,8 +115,33 @@ Extensions are auto-discovered from:
 |----------|-------|
 | `~/.prime/agent/extensions/*.ts` | Global (all projects) |
 | `~/.prime/agent/extensions/*/index.ts` | Global (subdirectory) |
-| `.prime/agent/extensions/*.ts` | Project-local |
-| `.prime/agent/extensions/*/index.ts` | Project-local (subdirectory) |
+| `.prime/agent/extensions/*.ts` | Project-local (trusted workspaces only) |
+| `.prime/agent/extensions/*/index.ts` | Project-local (subdirectory; trusted workspaces only) |
+
+Project-local extensions execute automatically when a session starts in that
+directory, before any agent turn. Because a cloned repository can commit
+extensions, project-local discovery only runs for **trusted workspaces**. See
+[Workspace Trust](#workspace-trust).
+
+## Workspace Trust
+
+A repository can commit executable configuration: `.prime/agent/extensions/`,
+`.prime/agent/settings.json` keys such as `extensions`, `packages`, `mcpServers`,
+`shellCommandPrefix`, `shellPath`, `npmCommand`, and `sessionDir`, Python skills
+(installed into the kernel environment), and `SYSTEM.md` / `APPEND_SYSTEM.md`.
+Opening an uninspected repository must never execute its committed code, so
+project-scoped configuration only applies to workspaces you explicitly trust.
+
+- Interactive startup in an untrusted workspace with such configuration asks
+  for consent once; trusting persists to
+  `~/.prime/agent/trusted-workspaces.json`.
+- Headless modes never prompt: untrusted workspaces run without the
+  project-scoped configuration, with a notice on stderr.
+- `prime-agent trust [path]` trusts a directory (default: current), ahead of
+  time or for headless use. `prime-agent untrust [path]` revokes it,
+  `prime-agent trust --list` shows all trusted workspaces.
+
+Global configuration in `~/.prime/agent/` is your own and always applies.
 
 Additional paths via `settings.json`:
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -126,17 +126,19 @@ extensions, project-local discovery only runs for **trusted workspaces**. See
 ## Workspace Trust
 
 A repository can commit executable configuration: `.prime/agent/extensions/`,
-`.prime/agent/settings.json` keys such as `extensions`, `packages`, `mcpServers`,
-`shellCommandPrefix`, `shellPath`, `npmCommand`, and `sessionDir`, Python skills
-(installed into the kernel environment), and `SYSTEM.md` / `APPEND_SYSTEM.md`.
-Opening an uninspected repository must never execute its committed code, so
-project-scoped configuration only applies to workspaces you explicitly trust.
+`.prime/agent/settings.json` keys such as `extensions`, `skills`, `prompts`,
+`themes`, `packages`, `mcpServers`, `shellCommandPrefix`, `shellPath`,
+`npmCommand`, and `sessionDir`, Python skills (installed into the kernel
+environment), and `SYSTEM.md` / `APPEND_SYSTEM.md`. Opening an uninspected
+repository must never execute its committed code, so project-scoped
+configuration only applies to workspaces you explicitly trust.
 
 - Interactive startup in an untrusted workspace with such configuration asks
   for consent once; trusting persists to
   `~/.prime/agent/trusted-workspaces.json`.
 - Headless modes never prompt: untrusted workspaces run without the
-  project-scoped configuration, with a notice on stderr.
+  project-scoped configuration, with a startup warning listing what was
+  skipped.
 - `prime-agent trust [path]` trusts a directory (default: current), ahead of
   time or for headless use. `prime-agent untrust [path]` revokes it,
   `prime-agent trust --list` shows all trusted workspaces.

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -143,7 +143,12 @@ configuration only applies to workspaces you explicitly trust.
   time or for headless use. `prime-agent untrust [path]` revokes it,
   `prime-agent trust --list` shows all trusted workspaces.
 
-Global configuration in `~/.prime/agent/` is your own and always applies.
+Global configuration in `~/.prime/agent/` is your own and always applies. Two
+edge cases worth knowing: if the global agent directory is pointed inside the
+project (a portable setup), its files count as project-committed and are gated
+the same way; and ordinary context files (`AGENTS.md`, `CLAUDE.md`) are read
+from the project like any other repo content — they are not executable
+configuration and are not gated.
 
 Additional paths via `settings.json`:
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -316,7 +316,12 @@ See [packages.md](packages.md) for package management details.
 
 ## Project Overrides
 
-Project settings (`.prime/agent/settings.json`) override global settings. Nested objects are merged:
+Project settings (`.prime/agent/settings.json`) override global settings, with one exception: in
+workspaces that are not trusted (see [Workspace Trust](extensions.md#workspace-trust)), the
+project-scoped keys that can execute commands or redirect resources are ignored —
+`extensions`, `skills`, `packages`, `mcpServers`, `shellCommandPrefix`, `shellPath`,
+`npmCommand`, and `sessionDir`. Cosmetic and behavioral project settings still apply.
+Nested objects are merged:
 
 ```json
 // ~/.prime/agent/settings.json (global)

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -318,9 +318,10 @@ See [packages.md](packages.md) for package management details.
 
 Project settings (`.prime/agent/settings.json`) override global settings, with one exception: in
 workspaces that are not trusted (see [Workspace Trust](extensions.md#workspace-trust)), the
-project-scoped keys that can execute commands or redirect resources are ignored —
-`extensions`, `skills`, `packages`, `mcpServers`, `shellCommandPrefix`, `shellPath`,
-`npmCommand`, and `sessionDir`. Cosmetic and behavioral project settings still apply.
+project-scoped keys that execute commands or auto-load resources are ignored —
+`extensions`, `skills`, `prompts`, `themes`, `packages`, `mcpServers`, `shellCommandPrefix`,
+`shellPath`, `npmCommand`, and `sessionDir`. Cosmetic and behavioral project settings
+(theme, model preferences, and so on) still apply.
 Nested objects are merged:
 
 ```json

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -182,7 +182,13 @@ prime-agent package list
 prime-agent package update [source]
 prime-agent update [--force]
 prime-agent config
+
+prime-agent trust [path] [--list]
+prime-agent untrust [path]
 ```
+
+See [Workspace Trust](extensions.md#workspace-trust) for what project-scoped
+configuration is gated behind trust.
 
 See [Prime Agent Packages](packages.md) for package sources and security notes.
 

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -150,6 +150,20 @@ export const COMMAND_SPECS: readonly CommandSpec[] = [
 		usage: "config",
 		summary: "Configure package resources",
 	},
+	{
+		path: ["trust"],
+		usage: "trust [path] [--list]",
+		summary: "Trust a workspace's project-scoped configuration",
+		description:
+			"Trusted workspaces auto-load committed extensions, skills, prompts, themes, and executable settings keys. Without a path, trusts the current directory.",
+		options: ["--list  List trusted workspaces"],
+	},
+	{
+		path: ["untrust"],
+		usage: "untrust [path]",
+		summary: "Revoke workspace trust",
+		description: "Without a path, revokes trust for the current directory.",
+	},
 ];
 
 export const PUBLIC_COMMAND_NAMES = new Set(

--- a/packages/coding-agent/src/cli/public-command.ts
+++ b/packages/coding-agent/src/cli/public-command.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import chalk from "chalk";
 import { APP_NAME, expandTildePath, getAgentDir, SELF_UPDATE_INTERACTIVE_CHILD_ENV } from "../config.js";
-import { canonicalizeWorkspacePath, WorkspaceTrustStore } from "../core/workspace-trust.js";
+import { canonicalizeWorkspacePath, canPersistWorkspaceTrust, WorkspaceTrustStore } from "../core/workspace-trust.js";
 import { handlePackageCommand, isSelfUpdateSource } from "../package-manager-cli.js";
 import { INTERNAL_RUNTIME_COMMAND_MARKER, parseArgs } from "./args.js";
 import {
@@ -448,7 +448,14 @@ function runTrust(args: string[]): PublicCommandResult {
 		return fail(`Unknown option: ${unknownOption}`, `Usage: ${APP_NAME} ${getCommandSpec(["trust"])!.usage}`);
 	}
 	const target = args[0] ? resolve(expandTildePath(args[0])) : process.cwd();
-	const store = WorkspaceTrustStore.create(getAgentDir());
+	const agentDir = getAgentDir();
+	if (!canPersistWorkspaceTrust(target, agentDir)) {
+		return fail(
+			`Cannot trust ${canonicalizeWorkspacePath(target)}: the trust store would live inside the workspace itself.`,
+			"Trust state must persist outside the workspace; point the agent dir elsewhere to use project trust here.",
+		);
+	}
+	const store = WorkspaceTrustStore.create(agentDir);
 	const canonical = canonicalizeWorkspacePath(target);
 	store.trust(target);
 	console.log(`Trusted workspace: ${canonical}`);

--- a/packages/coding-agent/src/cli/public-command.ts
+++ b/packages/coding-agent/src/cli/public-command.ts
@@ -1,5 +1,7 @@
+import { resolve } from "node:path";
 import chalk from "chalk";
-import { APP_NAME, SELF_UPDATE_INTERACTIVE_CHILD_ENV } from "../config.js";
+import { APP_NAME, expandTildePath, getAgentDir, SELF_UPDATE_INTERACTIVE_CHILD_ENV } from "../config.js";
+import { canonicalizeWorkspacePath, WorkspaceTrustStore } from "../core/workspace-trust.js";
 import { handlePackageCommand, isSelfUpdateSource } from "../package-manager-cli.js";
 import { INTERNAL_RUNTIME_COMMAND_MARKER, parseArgs } from "./args.js";
 import {
@@ -140,6 +142,10 @@ async function runPublicCommand(args: string[]): Promise<PublicCommandResult> {
 		case "config":
 			if (!requireArgumentCount(args.slice(1), 0, "config")) return HANDLED;
 			return continueWith(args);
+		case "trust":
+			return runTrust(args.slice(1));
+		case "untrust":
+			return runUntrust(args.slice(1));
 		default:
 			return continueWith(args);
 	}
@@ -423,6 +429,48 @@ function validateScheduleArgs(args: string[]): boolean {
 		return false;
 	}
 	return true;
+}
+
+function runTrust(args: string[]): PublicCommandResult {
+	if (args.includes("--list")) {
+		const trusted = WorkspaceTrustStore.create(getAgentDir()).list();
+		if (trusted.length === 0) {
+			console.log("No trusted workspaces.");
+		} else {
+			for (const path of trusted) {
+				console.log(path);
+			}
+		}
+		return HANDLED;
+	}
+	const unknownOption = args.find((arg) => arg.startsWith("-"));
+	if (unknownOption) {
+		return fail(`Unknown option: ${unknownOption}`, `Usage: ${APP_NAME} ${getCommandSpec(["trust"])!.usage}`);
+	}
+	const target = args[0] ? resolve(expandTildePath(args[0])) : process.cwd();
+	const store = WorkspaceTrustStore.create(getAgentDir());
+	const canonical = canonicalizeWorkspacePath(target);
+	store.trust(target);
+	console.log(`Trusted workspace: ${canonical}`);
+	console.log(
+		chalk.dim("New sessions in this directory will auto-load its project-scoped extensions, skills, and settings."),
+	);
+	return HANDLED;
+}
+
+function runUntrust(args: string[]): PublicCommandResult {
+	const unknownOption = args.find((arg) => arg.startsWith("-"));
+	if (unknownOption) {
+		return fail(`Unknown option: ${unknownOption}`, `Usage: ${APP_NAME} ${getCommandSpec(["untrust"])!.usage}`);
+	}
+	const target = args[0] ? resolve(expandTildePath(args[0])) : process.cwd();
+	const store = WorkspaceTrustStore.create(getAgentDir());
+	if (!store.untrust(target)) {
+		console.log(`Workspace is not trusted: ${canonicalizeWorkspacePath(target)}`);
+		return HANDLED;
+	}
+	console.log(`Revoked trust for workspace: ${canonicalizeWorkspacePath(target)}`);
+	return HANDLED;
 }
 
 function fail(message: string, hint?: string): PublicCommandResult {

--- a/packages/coding-agent/src/cli/workspace-trust-prompt.ts
+++ b/packages/coding-agent/src/cli/workspace-trust-prompt.ts
@@ -1,0 +1,68 @@
+/**
+ * Startup workspace-trust gate.
+ *
+ * Runs before session services are created. If the effective working directory
+ * commits project-scoped configuration that would execute code (extensions,
+ * shell prefixes, MCP servers, Python skills, ...) and the workspace is not
+ * trusted yet, interactive startup asks for consent; every other mode skips
+ * the project configuration and prints a notice. Trusting writes the shared
+ * trust store, which daemon workers and future sessions read at service
+ * creation.
+ */
+
+import chalk from "chalk";
+import { APP_NAME } from "../config.js";
+import {
+	detectProjectScopedConfig,
+	type ProjectScopedConfigFinding,
+	WorkspaceTrustStore,
+} from "../core/workspace-trust.js";
+import { promptYesNo } from "./daemon-stop-confirm.js";
+
+export interface WorkspaceTrustGateOptions {
+	cwd: string;
+	agentDir: string;
+	/** Only interactive startup may block on a prompt. */
+	interactive: boolean;
+}
+
+function printUntrustedNotice(findings: ProjectScopedConfigFinding[]): void {
+	console.error(
+		chalk.yellow(
+			`Workspace not trusted; disabled project-scoped configuration: ${findings
+				.map((finding) => finding.summary)
+				.join("; ")}. Run \`${APP_NAME} trust\` to enable it.`,
+		),
+	);
+}
+
+export async function gateWorkspaceTrustOnStartup(options: WorkspaceTrustGateOptions): Promise<void> {
+	const { cwd, agentDir } = options;
+	const store = WorkspaceTrustStore.create(agentDir);
+	if (store.isTrusted(cwd)) {
+		return;
+	}
+	const findings = detectProjectScopedConfig(cwd);
+	if (findings.length === 0) {
+		return;
+	}
+
+	if (!options.interactive || !process.stdin.isTTY || !process.stdout.isTTY) {
+		printUntrustedNotice(findings);
+		return;
+	}
+
+	console.error(chalk.yellow("This workspace contains project-scoped configuration:"));
+	for (const finding of findings) {
+		console.error(chalk.yellow(`  - ${finding.summary}`));
+		console.error(chalk.dim(`    ${finding.path}`));
+	}
+	console.error(chalk.dim("Only trust repositories you have inspected. Untrusted workspaces run without the above."));
+	const trusted = await promptYesNo("Trust this workspace and enable its project-scoped configuration?");
+	if (trusted) {
+		store.trust(cwd);
+		console.error(chalk.dim(`Trusted ${cwd} (stored in trusted-workspaces.json).`));
+		return;
+	}
+	printUntrustedNotice(findings);
+}

--- a/packages/coding-agent/src/cli/workspace-trust-prompt.ts
+++ b/packages/coding-agent/src/cli/workspace-trust-prompt.ts
@@ -1,22 +1,18 @@
 /**
- * Startup workspace-trust gate.
+ * Startup workspace-trust consent prompt.
  *
  * Runs before session services are created. If the effective working directory
  * commits project-scoped configuration that would execute code (extensions,
  * shell prefixes, MCP servers, Python skills, ...) and the workspace is not
- * trusted yet, interactive startup asks for consent; every other mode skips
- * the project configuration and prints a notice. Trusting writes the shared
- * trust store, which daemon workers and future sessions read at service
- * creation.
+ * trusted yet, interactive startup asks for consent once. All other modes
+ * stay silent here: createAgentSessionServices emits a warning diagnostic
+ * listing what was disabled, which every client surface prints. Trusting
+ * writes the shared trust store, which daemon workers and future sessions
+ * read at service creation.
  */
 
 import chalk from "chalk";
-import { APP_NAME } from "../config.js";
-import {
-	detectProjectScopedConfig,
-	type ProjectScopedConfigFinding,
-	WorkspaceTrustStore,
-} from "../core/workspace-trust.js";
+import { canonicalizeWorkspacePath, detectProjectScopedConfig, WorkspaceTrustStore } from "../core/workspace-trust.js";
 import { promptYesNo } from "./daemon-stop-confirm.js";
 
 export interface WorkspaceTrustGateOptions {
@@ -26,31 +22,27 @@ export interface WorkspaceTrustGateOptions {
 	interactive: boolean;
 }
 
-function printUntrustedNotice(findings: ProjectScopedConfigFinding[]): void {
-	console.error(
-		chalk.yellow(
-			`Workspace not trusted; disabled project-scoped configuration: ${findings
-				.map((finding) => finding.summary)
-				.join("; ")}. Run \`${APP_NAME} trust\` to enable it.`,
-		),
-	);
-}
+/** Canonical paths already prompted for in this process (accept or decline). */
+const promptedThisProcess = new Set<string>();
 
 export async function gateWorkspaceTrustOnStartup(options: WorkspaceTrustGateOptions): Promise<void> {
 	const { cwd, agentDir } = options;
+	const canonical = canonicalizeWorkspacePath(cwd);
+	if (promptedThisProcess.has(canonical)) {
+		return;
+	}
 	const store = WorkspaceTrustStore.create(agentDir);
 	if (store.isTrusted(cwd)) {
+		return;
+	}
+	if (!options.interactive || !process.stdin.isTTY || !process.stdout.isTTY) {
 		return;
 	}
 	const findings = detectProjectScopedConfig(cwd);
 	if (findings.length === 0) {
 		return;
 	}
-
-	if (!options.interactive || !process.stdin.isTTY || !process.stdout.isTTY) {
-		printUntrustedNotice(findings);
-		return;
-	}
+	promptedThisProcess.add(canonical);
 
 	console.error(chalk.yellow("This workspace contains project-scoped configuration:"));
 	for (const finding of findings) {
@@ -62,7 +54,5 @@ export async function gateWorkspaceTrustOnStartup(options: WorkspaceTrustGateOpt
 	if (trusted) {
 		store.trust(cwd);
 		console.error(chalk.dim(`Trusted ${cwd} (stored in trusted-workspaces.json).`));
-		return;
 	}
-	printUntrustedNotice(findings);
 }

--- a/packages/coding-agent/src/cli/workspace-trust-prompt.ts
+++ b/packages/coding-agent/src/cli/workspace-trust-prompt.ts
@@ -12,7 +12,13 @@
  */
 
 import chalk from "chalk";
-import { canonicalizeWorkspacePath, detectProjectScopedConfig, WorkspaceTrustStore } from "../core/workspace-trust.js";
+import {
+	canonicalizeWorkspacePath,
+	canPersistWorkspaceTrust,
+	detectProjectScopedConfig,
+	isWorkspaceTrusted,
+	WorkspaceTrustStore,
+} from "../core/workspace-trust.js";
 import { promptYesNo } from "./daemon-stop-confirm.js";
 
 export interface WorkspaceTrustGateOptions {
@@ -31,8 +37,12 @@ export async function gateWorkspaceTrustOnStartup(options: WorkspaceTrustGateOpt
 	if (promptedThisProcess.has(canonical)) {
 		return;
 	}
-	const store = WorkspaceTrustStore.create(agentDir);
-	if (store.isTrusted(cwd)) {
+	// When the trust store would live inside the workspace it cannot vouch for
+	// it (a checkout could commit one), so trust is impossible: never prompt.
+	if (!canPersistWorkspaceTrust(cwd, agentDir)) {
+		return;
+	}
+	if (isWorkspaceTrusted(cwd, agentDir)) {
 		return;
 	}
 	if (!options.interactive || !process.stdin.isTTY || !process.stdout.isTTY) {
@@ -52,7 +62,7 @@ export async function gateWorkspaceTrustOnStartup(options: WorkspaceTrustGateOpt
 	console.error(chalk.dim("Only trust repositories you have inspected. Untrusted workspaces run without the above."));
 	const trusted = await promptYesNo("Trust this workspace and enable its project-scoped configuration?");
 	if (trusted) {
-		store.trust(cwd);
+		WorkspaceTrustStore.create(agentDir).trust(cwd);
 		console.error(chalk.dim(`Trusted ${cwd} (stored in trusted-workspaces.json).`));
 	}
 }

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -19,7 +19,7 @@ import { type CreateAgentSessionResult, createAgentSession } from "./sdk.js";
 import type { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
 import { installAgentTelemetry, isTelemetryEnabled } from "./telemetry.js";
-import { detectProjectScopedConfig, isWorkspaceTrusted } from "./workspace-trust.js";
+import { canPersistWorkspaceTrust, detectProjectScopedConfig, isWorkspaceTrusted } from "./workspace-trust.js";
 
 /**
  * Non-fatal issues collected while creating services or sessions.
@@ -227,11 +227,16 @@ export async function createAgentSessionServices(
 	if (!projectTrusted) {
 		const findings = detectProjectScopedConfig(cwd);
 		if (findings.length > 0) {
+			// When the trust store would live inside the workspace, trusting is
+			// impossible; do not point users at a command that refuses.
+			const remediation = canPersistWorkspaceTrust(cwd, agentDir)
+				? 'Run "prime-agent trust" to enable it.'
+				: "It cannot be enabled here: the trust store would live inside the workspace itself.";
 			diagnostics.push({
 				type: "warning",
 				message: `Workspace is not trusted; disabled project-scoped configuration: ${findings
 					.map((finding) => finding.summary)
-					.join("; ")}. Run "prime-agent trust" to enable it.`,
+					.join("; ")}. ${remediation}`,
 			});
 		}
 	}

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -19,6 +19,7 @@ import { type CreateAgentSessionResult, createAgentSession } from "./sdk.js";
 import type { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
 import { installAgentTelemetry, isTelemetryEnabled } from "./telemetry.js";
+import { detectProjectScopedConfig, isWorkspaceTrusted } from "./workspace-trust.js";
 
 /**
  * Non-fatal issues collected while creating services or sessions.
@@ -180,7 +181,15 @@ export async function createAgentSessionServices(
 	const cwd = options.cwd;
 	const agentDir = options.agentDir ?? getAgentDir();
 	const authStorage = options.authStorage ?? AuthStorage.create(join(agentDir, "auth.json"));
-	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
+	// Workspace trust is the security boundary for project-committed executable
+	// configuration. It is enforced here, at service creation, so every mode
+	// (interactive, headless, daemon worker, SDK) gets the same behavior.
+	// Narrowing only: an explicitly untrusted manager is never re-trusted.
+	const projectTrusted = isWorkspaceTrusted(cwd, agentDir);
+	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir, { projectTrusted });
+	if (!projectTrusted) {
+		settingsManager.setProjectTrusted(false);
+	}
 	const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, join(agentDir, "models.json"));
 
 	// MCP integrations: registers OAuth providers and gates the built-in
@@ -215,6 +224,17 @@ export async function createAgentSessionServices(
 	await resourceLoader.reload();
 
 	const diagnostics: AgentSessionRuntimeDiagnostic[] = [];
+	if (!projectTrusted) {
+		const findings = detectProjectScopedConfig(cwd);
+		if (findings.length > 0) {
+			diagnostics.push({
+				type: "warning",
+				message: `Workspace is not trusted; disabled project-scoped configuration: ${findings
+					.map((finding) => finding.summary)
+					.join("; ")}. Run "prime-agent trust" to enable it.`,
+			});
+		}
+	}
 	if (
 		!options.telemetryDisabled &&
 		isTelemetryEnabled(settingsManager) &&

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -486,6 +486,9 @@ function resolveExtensionEntries(dir: string): string[] | null {
 		if (manifest?.extensions?.length) {
 			const entries: string[] = [];
 			for (const extPath of manifest.extensions) {
+				if (typeof extPath !== "string") {
+					continue;
+				}
 				const resolvedExtPath = path.resolve(dir, extPath);
 				if (fs.existsSync(resolvedExtPath)) {
 					entries.push(resolvedExtPath);

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -15,8 +15,8 @@ import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
 import { createSyntheticSourceInfo } from "../source-info.js";
 import {
+	isAgentDirWithinWorkspace,
 	isProjectConfigDirTheUserGlobalDir,
-	isWithinProjectConfigDir,
 	isWorkspaceTrusted,
 } from "../workspace-trust.js";
 import type {
@@ -587,13 +587,13 @@ export async function discoverAndLoadExtensions(
 		addPaths(discoverExtensionsInDir(localExtDir));
 	}
 
-	// 2. Global extensions: agentDir/extensions/. Skipped when agentDir is
-	// project-controlled (portable agentDir) and the workspace is untrusted;
+	// 2. Global extensions: agentDir/extensions/. Skipped when agentDir lives
+	// inside the workspace (portable agentDir) and the workspace is untrusted;
 	// the user's own home-based global directory is exempt.
 	const globalExtDir = path.join(agentDir, "extensions");
 	if (
 		isWorkspaceTrusted(cwd, agentDir) ||
-		!isWithinProjectConfigDir(globalExtDir, cwd) ||
+		!isAgentDirWithinWorkspace(agentDir, cwd) ||
 		isProjectConfigDirTheUserGlobalDir(cwd)
 	) {
 		addPaths(discoverExtensionsInDir(globalExtDir));

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -14,11 +14,7 @@ import { createEventBus, type EventBus } from "../event-bus.js";
 import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
 import { createSyntheticSourceInfo } from "../source-info.js";
-import {
-	isAgentDirWithinWorkspace,
-	isProjectConfigDirTheUserGlobalDir,
-	isWorkspaceTrusted,
-} from "../workspace-trust.js";
+import { isAgentDirWithinWorkspace, isDefaultUserGlobalAgentDir, isWorkspaceTrusted } from "../workspace-trust.js";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -594,7 +590,7 @@ export async function discoverAndLoadExtensions(
 	if (
 		isWorkspaceTrusted(cwd, agentDir) ||
 		!isAgentDirWithinWorkspace(agentDir, cwd) ||
-		isProjectConfigDirTheUserGlobalDir(cwd)
+		isDefaultUserGlobalAgentDir(agentDir)
 	) {
 		addPaths(discoverExtensionsInDir(globalExtDir));
 	}

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -14,7 +14,11 @@ import { createEventBus, type EventBus } from "../event-bus.js";
 import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
 import { createSyntheticSourceInfo } from "../source-info.js";
-import { isWithinProjectConfigDir, isWorkspaceTrusted } from "../workspace-trust.js";
+import {
+	isProjectConfigDirTheUserGlobalDir,
+	isWithinProjectConfigDir,
+	isWorkspaceTrusted,
+} from "../workspace-trust.js";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -584,9 +588,14 @@ export async function discoverAndLoadExtensions(
 	}
 
 	// 2. Global extensions: agentDir/extensions/. Skipped when agentDir is
-	// project-controlled (portable agentDir) and the workspace is untrusted.
+	// project-controlled (portable agentDir) and the workspace is untrusted;
+	// the user's own home-based global directory is exempt.
 	const globalExtDir = path.join(agentDir, "extensions");
-	if (isWorkspaceTrusted(cwd, agentDir) || !isWithinProjectConfigDir(globalExtDir, cwd)) {
+	if (
+		isWorkspaceTrusted(cwd, agentDir) ||
+		!isWithinProjectConfigDir(globalExtDir, cwd) ||
+		isProjectConfigDirTheUserGlobalDir(cwd)
+	) {
 		addPaths(discoverExtensionsInDir(globalExtDir));
 	}
 

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -14,6 +14,7 @@ import { createEventBus, type EventBus } from "../event-bus.js";
 import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
 import { createSyntheticSourceInfo } from "../source-info.js";
+import { isWithinProjectConfigDir, isWorkspaceTrusted } from "../workspace-trust.js";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -576,12 +577,18 @@ export async function discoverAndLoadExtensions(
 	};
 
 	// 1. Project-local extensions: cwd/${CONFIG_DIR_NAME}/extensions/
-	const localExtDir = path.join(cwd, CONFIG_DIR_NAME, "extensions");
-	addPaths(discoverExtensionsInDir(localExtDir));
+	// Gated by workspace trust: they execute on load.
+	if (isWorkspaceTrusted(cwd, agentDir)) {
+		const localExtDir = path.join(cwd, CONFIG_DIR_NAME, "extensions");
+		addPaths(discoverExtensionsInDir(localExtDir));
+	}
 
-	// 2. Global extensions: agentDir/extensions/
+	// 2. Global extensions: agentDir/extensions/. Skipped when agentDir is
+	// project-controlled (portable agentDir) and the workspace is untrusted.
 	const globalExtDir = path.join(agentDir, "extensions");
-	addPaths(discoverExtensionsInDir(globalExtDir));
+	if (isWorkspaceTrusted(cwd, agentDir) || !isWithinProjectConfigDir(globalExtDir, cwd)) {
+		addPaths(discoverExtensionsInDir(globalExtDir));
+	}
 
 	// 3. Explicitly configured paths
 	for (const p of configuredPaths) {

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -542,6 +542,9 @@ function resolveExtensionEntries(dir: string): string[] | null {
 		if (manifest?.extensions?.length) {
 			const entries: string[] = [];
 			for (const extPath of manifest.extensions) {
+				if (typeof extPath !== "string") {
+					continue;
+				}
 				const resolvedExtPath = resolve(dir, extPath);
 				if (existsSync(resolvedExtPath)) {
 					entries.push(resolvedExtPath);

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -1017,6 +1017,11 @@ export class DefaultPackageManager implements PackageManager {
 	async update(source?: string): Promise<void> {
 		const globalSettings = this.settingsManager.getGlobalSettings();
 		const projectSettings = this.settingsManager.getProjectSettings();
+		// Workspace trust: updating installs package-controlled code (npm
+		// lifecycle scripts, git checkouts), so untrusted projects contribute
+		// no package sources.
+		const projectTrusted = this.settingsManager.isProjectTrusted();
+		const projectPackages = projectTrusted ? (projectSettings.packages ?? []) : [];
 		const identity = source ? this.getPackageIdentity(source) : undefined;
 		let matched = false;
 		const updateSources: ConfiguredUpdateSource[] = [];
@@ -1027,7 +1032,7 @@ export class DefaultPackageManager implements PackageManager {
 			matched = true;
 			updateSources.push({ source: sourceStr, scope: "user" });
 		}
-		for (const pkg of projectSettings.packages ?? []) {
+		for (const pkg of projectPackages) {
 			const sourceStr = typeof pkg === "string" ? pkg : pkg.source;
 			if (identity && this.getPackageIdentity(sourceStr, "project") !== identity) continue;
 			matched = true;
@@ -1036,10 +1041,7 @@ export class DefaultPackageManager implements PackageManager {
 
 		if (source && !matched) {
 			throw new Error(
-				this.buildNoMatchingPackageMessage(source, [
-					...(globalSettings.packages ?? []),
-					...(projectSettings.packages ?? []),
-				]),
+				this.buildNoMatchingPackageMessage(source, [...(globalSettings.packages ?? []), ...projectPackages]),
 			);
 		}
 
@@ -1152,8 +1154,10 @@ export class DefaultPackageManager implements PackageManager {
 		const globalSettings = this.settingsManager.getGlobalSettings();
 		const projectSettings = this.settingsManager.getProjectSettings();
 		const allPackages: Array<{ pkg: PackageSource; scope: SourceScope }> = [];
-		for (const pkg of projectSettings.packages ?? []) {
-			allPackages.push({ pkg, scope: "project" });
+		if (this.settingsManager.isProjectTrusted()) {
+			for (const pkg of projectSettings.packages ?? []) {
+				allPackages.push({ pkg, scope: "project" });
+			}
 		}
 		for (const pkg of globalSettings.packages ?? []) {
 			allPackages.push({ pkg, scope: "user" });

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -787,6 +787,20 @@ export class DefaultPackageManager implements PackageManager {
 		this.progressCallback = callback;
 	}
 
+	/**
+	 * Whether user-scoped ("global") packages and resource directories are
+	 * safe to load. A portable agentDir inside the project config directory
+	 * makes them project-committed content, so they count only when the
+	 * project itself is trusted.
+	 */
+	private globalScopeTrusted(): boolean {
+		return this.settingsManager.isProjectTrusted() || !this.settingsManager.isGlobalConfigAliasedToProject();
+	}
+
+	private effectiveGlobalSettings(): ReturnType<SettingsManager["getGlobalSettings"]> {
+		return this.globalScopeTrusted() ? this.settingsManager.getGlobalSettings() : {};
+	}
+
 	addSourceToSettings(source: string, options?: { local?: boolean }): boolean {
 		const scope: SourceScope = options?.local ? "project" : "user";
 		const currentSettings =
@@ -865,7 +879,7 @@ export class DefaultPackageManager implements PackageManager {
 
 	async resolve(onMissing?: (source: string) => Promise<MissingSourceAction>): Promise<ResolvedPaths> {
 		const accumulator = this.createAccumulator();
-		const globalSettings = this.settingsManager.getGlobalSettings();
+		const globalSettings = this.effectiveGlobalSettings();
 		const projectSettings = this.settingsManager.getProjectSettings();
 		// Workspace trust: an untrusted project contributes no packages, resource
 		// entries, or auto-discovered directories. Committed configuration must
@@ -1015,7 +1029,7 @@ export class DefaultPackageManager implements PackageManager {
 	}
 
 	async update(source?: string): Promise<void> {
-		const globalSettings = this.settingsManager.getGlobalSettings();
+		const globalSettings = this.effectiveGlobalSettings();
 		const projectSettings = this.settingsManager.getProjectSettings();
 		// Workspace trust: updating installs package-controlled code (npm
 		// lifecycle scripts, git checkouts), so untrusted projects contribute
@@ -1151,7 +1165,7 @@ export class DefaultPackageManager implements PackageManager {
 			return [];
 		}
 
-		const globalSettings = this.settingsManager.getGlobalSettings();
+		const globalSettings = this.effectiveGlobalSettings();
 		const projectSettings = this.settingsManager.getProjectSettings();
 		const allPackages: Array<{ pkg: PackageSource; scope: SourceScope }> = [];
 		if (this.settingsManager.isProjectTrusted()) {
@@ -2241,16 +2255,25 @@ export class DefaultPackageManager implements PackageManager {
 			);
 		}
 
-		addResources(
-			"extensions",
-			collectAutoExtensionEntries(userDirs.extensions),
-			userMetadata,
-			userOverrides.extensions,
-			globalBaseDir,
-		);
+		// User-scoped directories live under agentDir; when that is aliased into
+		// the project they are project-committed and load only with trust. The
+		// home-based ~/.agents/skills directory is always the user's own.
+		const globalAutoDirsTrusted = this.globalScopeTrusted();
+		if (globalAutoDirsTrusted) {
+			addResources(
+				"extensions",
+				collectAutoExtensionEntries(userDirs.extensions),
+				userMetadata,
+				userOverrides.extensions,
+				globalBaseDir,
+			);
+		}
 		addResources(
 			"skills",
-			[...collectAutoSkillEntries(userDirs.skills, "pi"), ...collectAutoSkillEntries(userAgentsSkillsDir, "agents")],
+			[
+				...(globalAutoDirsTrusted ? collectAutoSkillEntries(userDirs.skills, "pi") : []),
+				...collectAutoSkillEntries(userAgentsSkillsDir, "agents"),
+			],
 			userMetadata,
 			userOverrides.skills,
 			globalBaseDir,
@@ -2285,20 +2308,22 @@ export class DefaultPackageManager implements PackageManager {
 			];
 			addResources("skills", builtinEntries, builtinMetadata, builtinSkillOverrides, this.bundledSkillsDir);
 		}
-		addResources(
-			"prompts",
-			collectAutoPromptEntries(userDirs.prompts),
-			userMetadata,
-			userOverrides.prompts,
-			globalBaseDir,
-		);
-		addResources(
-			"themes",
-			collectAutoThemeEntries(userDirs.themes),
-			userMetadata,
-			userOverrides.themes,
-			globalBaseDir,
-		);
+		if (globalAutoDirsTrusted) {
+			addResources(
+				"prompts",
+				collectAutoPromptEntries(userDirs.prompts),
+				userMetadata,
+				userOverrides.prompts,
+				globalBaseDir,
+			);
+			addResources(
+				"themes",
+				collectAutoThemeEntries(userDirs.themes),
+				userMetadata,
+				userOverrides.themes,
+				globalBaseDir,
+			);
+		}
 	}
 
 	private collectFilesFromPaths(paths: string[], resourceType: ResourceType): string[] {

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -867,11 +867,17 @@ export class DefaultPackageManager implements PackageManager {
 		const accumulator = this.createAccumulator();
 		const globalSettings = this.settingsManager.getGlobalSettings();
 		const projectSettings = this.settingsManager.getProjectSettings();
+		// Workspace trust: an untrusted project contributes no packages, resource
+		// entries, or auto-discovered directories. Committed configuration must
+		// never turn into executed code without explicit consent.
+		const projectTrusted = this.settingsManager.isProjectTrusted();
 
 		// Collect all packages with scope (project first so cwd resources win collisions)
 		const allPackages: Array<{ pkg: PackageSource; scope: SourceScope }> = [];
-		for (const pkg of projectSettings.packages ?? []) {
-			allPackages.push({ pkg, scope: "project" });
+		if (projectTrusted) {
+			for (const pkg of projectSettings.packages ?? []) {
+				allPackages.push({ pkg, scope: "project" });
+			}
 		}
 		for (const pkg of globalSettings.packages ?? []) {
 			allPackages.push({ pkg, scope: "user" });
@@ -887,7 +893,7 @@ export class DefaultPackageManager implements PackageManager {
 		for (const resourceType of RESOURCE_TYPES) {
 			const target = this.getTargetMap(accumulator, resourceType);
 			const globalEntries = (globalSettings[resourceType] ?? []) as string[];
-			const projectEntries = (projectSettings[resourceType] ?? []) as string[];
+			const projectEntries = projectTrusted ? ((projectSettings[resourceType] ?? []) as string[]) : [];
 			this.resolveLocalEntries(
 				projectEntries,
 				resourceType,
@@ -2197,37 +2203,39 @@ export class DefaultPackageManager implements PackageManager {
 			}
 		};
 
-		addResources(
-			"extensions",
-			collectAutoExtensionEntries(projectDirs.extensions),
-			projectMetadata,
-			projectOverrides.extensions,
-			projectBaseDir,
-		);
-		addResources(
-			"skills",
-			[
-				...collectAutoSkillEntries(projectDirs.skills, "pi"),
-				...projectAgentsSkillDirs.flatMap((dir) => collectAutoSkillEntries(dir, "agents")),
-			],
-			projectMetadata,
-			projectOverrides.skills,
-			projectBaseDir,
-		);
-		addResources(
-			"prompts",
-			collectAutoPromptEntries(projectDirs.prompts),
-			projectMetadata,
-			projectOverrides.prompts,
-			projectBaseDir,
-		);
-		addResources(
-			"themes",
-			collectAutoThemeEntries(projectDirs.themes),
-			projectMetadata,
-			projectOverrides.themes,
-			projectBaseDir,
-		);
+		if (this.settingsManager.isProjectTrusted()) {
+			addResources(
+				"extensions",
+				collectAutoExtensionEntries(projectDirs.extensions),
+				projectMetadata,
+				projectOverrides.extensions,
+				projectBaseDir,
+			);
+			addResources(
+				"skills",
+				[
+					...collectAutoSkillEntries(projectDirs.skills, "pi"),
+					...projectAgentsSkillDirs.flatMap((dir) => collectAutoSkillEntries(dir, "agents")),
+				],
+				projectMetadata,
+				projectOverrides.skills,
+				projectBaseDir,
+			);
+			addResources(
+				"prompts",
+				collectAutoPromptEntries(projectDirs.prompts),
+				projectMetadata,
+				projectOverrides.prompts,
+				projectBaseDir,
+			);
+			addResources(
+				"themes",
+				collectAutoThemeEntries(projectDirs.themes),
+				projectMetadata,
+				projectOverrides.themes,
+				projectBaseDir,
+			);
+		}
 
 		addResources(
 			"extensions",

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -19,11 +19,7 @@ import { SettingsManager } from "./settings-manager.js";
 import type { Skill } from "./skills.js";
 import { loadSkills } from "./skills.js";
 import { createSourceInfo, type SourceInfo } from "./source-info.js";
-import {
-	isAgentDirWithinWorkspace,
-	isProjectConfigDirTheUserGlobalDir,
-	isWorkspaceTrusted,
-} from "./workspace-trust.js";
+import { isAgentDirWithinWorkspace, isDefaultUserGlobalAgentDir, isWorkspaceTrusted } from "./workspace-trust.js";
 
 export interface ResourceExtensionPaths {
 	skillPaths?: Array<{ path: string; metadata: PathMetadata }>;
@@ -500,7 +496,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 						includeGlobal:
 							this.settingsManager.isProjectTrusted() ||
 							!isAgentDirWithinWorkspace(this.agentDir, this.cwd) ||
-							isProjectConfigDirTheUserGlobalDir(this.cwd),
+							isDefaultUserGlobalAgentDir(this.agentDir),
 					}),
 		};
 		const resolvedAgentsFiles = this.agentsFilesOverride ? this.agentsFilesOverride(agentsFiles) : agentsFiles;
@@ -903,7 +899,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 			existsSync(globalPath) &&
 			(this.settingsManager.isProjectTrusted() ||
 				!isAgentDirWithinWorkspace(this.agentDir, this.cwd) ||
-				isProjectConfigDirTheUserGlobalDir(this.cwd))
+				isDefaultUserGlobalAgentDir(this.agentDir))
 		) {
 			return globalPath;
 		}
@@ -924,7 +920,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 			existsSync(globalPath) &&
 			(this.settingsManager.isProjectTrusted() ||
 				!isAgentDirWithinWorkspace(this.agentDir, this.cwd) ||
-				isProjectConfigDirTheUserGlobalDir(this.cwd))
+				isDefaultUserGlobalAgentDir(this.agentDir))
 		) {
 			return globalPath;
 		}

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -19,6 +19,7 @@ import { SettingsManager } from "./settings-manager.js";
 import type { Skill } from "./skills.js";
 import { loadSkills } from "./skills.js";
 import { createSourceInfo, type SourceInfo } from "./source-info.js";
+import { isWorkspaceTrusted } from "./workspace-trust.js";
 
 export interface ResourceExtensionPaths {
 	skillPaths?: Array<{ path: string; metadata: PathMetadata }>;
@@ -213,7 +214,11 @@ export class DefaultResourceLoader implements ResourceLoader {
 	constructor(options: DefaultResourceLoaderOptions) {
 		this.cwd = options.cwd;
 		this.agentDir = options.agentDir;
-		this.settingsManager = options.settingsManager ?? SettingsManager.create(this.cwd, this.agentDir);
+		this.settingsManager =
+			options.settingsManager ??
+			SettingsManager.create(this.cwd, this.agentDir, {
+				projectTrusted: isWorkspaceTrusted(this.cwd, this.agentDir),
+			});
 		this.eventBus = options.eventBus ?? createEventBus();
 		this.bundledSkillsDir = options.bundledSkillsDir === undefined ? getBundledSkillsDir() : options.bundledSkillsDir;
 		this.packageManager = new DefaultPackageManager({
@@ -863,7 +868,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 	private discoverSystemPromptFile(): string | undefined {
 		const projectPath = join(this.cwd, CONFIG_DIR_NAME, "SYSTEM.md");
-		if (existsSync(projectPath)) {
+		if (this.settingsManager.isProjectTrusted() && existsSync(projectPath)) {
 			return projectPath;
 		}
 
@@ -877,7 +882,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 	private discoverAppendSystemPromptFile(): string | undefined {
 		const projectPath = join(this.cwd, CONFIG_DIR_NAME, "APPEND_SYSTEM.md");
-		if (existsSync(projectPath)) {
+		if (this.settingsManager.isProjectTrusted() && existsSync(projectPath)) {
 			return projectPath;
 		}
 

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -77,6 +77,8 @@ function loadContextFileFromDir(dir: string): { path: string; content: string } 
 export function loadProjectContextFiles(options: {
 	cwd: string;
 	agentDir: string;
+	/** Set false when the agent dir is project-controlled and untrusted. */
+	includeGlobal?: boolean;
 }): Array<{ path: string; content: string }> {
 	const resolvedCwd = options.cwd;
 	const resolvedAgentDir = options.agentDir;
@@ -84,7 +86,7 @@ export function loadProjectContextFiles(options: {
 	const contextFiles: Array<{ path: string; content: string }> = [];
 	const seenPaths = new Set<string>();
 
-	const globalContext = loadContextFileFromDir(resolvedAgentDir);
+	const globalContext = options.includeGlobal === false ? null : loadContextFileFromDir(resolvedAgentDir);
 	if (globalContext) {
 		contextFiles.push(globalContext);
 		seenPaths.add(globalContext.path);
@@ -483,7 +485,16 @@ export class DefaultResourceLoader implements ResourceLoader {
 		}
 
 		const agentsFiles = {
-			agentsFiles: this.noContextFiles ? [] : loadProjectContextFiles({ cwd: this.cwd, agentDir: this.agentDir }),
+			agentsFiles: this.noContextFiles
+				? []
+				: loadProjectContextFiles({
+						cwd: this.cwd,
+						agentDir: this.agentDir,
+						// A "global" context file inside the project config directory
+						// (portable agentDir) is project-controlled; skip it when untrusted.
+						includeGlobal:
+							this.settingsManager.isProjectTrusted() || !isWithinProjectConfigDir(this.agentDir, this.cwd),
+					}),
 		};
 		const resolvedAgentsFiles = this.agentsFilesOverride ? this.agentsFilesOverride(agentsFiles) : agentsFiles;
 		this.agentsFiles = resolvedAgentsFiles.agentsFiles;

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -19,7 +19,7 @@ import { SettingsManager } from "./settings-manager.js";
 import type { Skill } from "./skills.js";
 import { loadSkills } from "./skills.js";
 import { createSourceInfo, type SourceInfo } from "./source-info.js";
-import { isWithinProjectConfigDir, isWorkspaceTrusted } from "./workspace-trust.js";
+import { isProjectConfigDirTheUserGlobalDir, isWithinProjectConfigDir, isWorkspaceTrusted } from "./workspace-trust.js";
 
 export interface ResourceExtensionPaths {
 	skillPaths?: Array<{ path: string; metadata: PathMetadata }>;
@@ -492,8 +492,11 @@ export class DefaultResourceLoader implements ResourceLoader {
 						agentDir: this.agentDir,
 						// A "global" context file inside the project config directory
 						// (portable agentDir) is project-controlled; skip it when untrusted.
+						// The user's own home-based config dir is exempt.
 						includeGlobal:
-							this.settingsManager.isProjectTrusted() || !isWithinProjectConfigDir(this.agentDir, this.cwd),
+							this.settingsManager.isProjectTrusted() ||
+							!isWithinProjectConfigDir(this.agentDir, this.cwd) ||
+							isProjectConfigDirTheUserGlobalDir(this.cwd),
 					}),
 		};
 		const resolvedAgentsFiles = this.agentsFilesOverride ? this.agentsFilesOverride(agentsFiles) : agentsFiles;
@@ -890,10 +893,13 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 		const globalPath = join(this.agentDir, "SYSTEM.md");
 		// When untrusted, a "global" prompt file inside the project config
-		// directory (portable agentDir) is project-controlled; skip it.
+		// directory (portable agentDir) is project-controlled; skip it. The
+		// home-directory case is exempt: there the file is the user's own.
 		if (
 			existsSync(globalPath) &&
-			(this.settingsManager.isProjectTrusted() || !isWithinProjectConfigDir(globalPath, this.cwd))
+			(this.settingsManager.isProjectTrusted() ||
+				!isWithinProjectConfigDir(globalPath, this.cwd) ||
+				isProjectConfigDirTheUserGlobalDir(this.cwd))
 		) {
 			return globalPath;
 		}
@@ -909,10 +915,12 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 		const globalPath = join(this.agentDir, "APPEND_SYSTEM.md");
 		// See discoverSystemPromptFile: project-controlled "global" files are
-		// skipped for untrusted workspaces.
+		// skipped for untrusted workspaces, except the user's own home config.
 		if (
 			existsSync(globalPath) &&
-			(this.settingsManager.isProjectTrusted() || !isWithinProjectConfigDir(globalPath, this.cwd))
+			(this.settingsManager.isProjectTrusted() ||
+				!isWithinProjectConfigDir(globalPath, this.cwd) ||
+				isProjectConfigDirTheUserGlobalDir(this.cwd))
 		) {
 			return globalPath;
 		}

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -19,7 +19,7 @@ import { SettingsManager } from "./settings-manager.js";
 import type { Skill } from "./skills.js";
 import { loadSkills } from "./skills.js";
 import { createSourceInfo, type SourceInfo } from "./source-info.js";
-import { isWorkspaceTrusted } from "./workspace-trust.js";
+import { isWithinProjectConfigDir, isWorkspaceTrusted } from "./workspace-trust.js";
 
 export interface ResourceExtensionPaths {
 	skillPaths?: Array<{ path: string; metadata: PathMetadata }>;
@@ -219,6 +219,11 @@ export class DefaultResourceLoader implements ResourceLoader {
 			SettingsManager.create(this.cwd, this.agentDir, {
 				projectTrusted: isWorkspaceTrusted(this.cwd, this.agentDir),
 			});
+		// Narrowing applies to caller-provided managers too: a manager at its
+		// trusted default must not bypass an untrusted workspace.
+		if (!isWorkspaceTrusted(this.cwd, this.agentDir)) {
+			this.settingsManager.setProjectTrusted(false);
+		}
 		this.eventBus = options.eventBus ?? createEventBus();
 		this.bundledSkillsDir = options.bundledSkillsDir === undefined ? getBundledSkillsDir() : options.bundledSkillsDir;
 		this.packageManager = new DefaultPackageManager({
@@ -873,7 +878,12 @@ export class DefaultResourceLoader implements ResourceLoader {
 		}
 
 		const globalPath = join(this.agentDir, "SYSTEM.md");
-		if (existsSync(globalPath)) {
+		// When untrusted, a "global" prompt file inside the project config
+		// directory (portable agentDir) is project-controlled; skip it.
+		if (
+			existsSync(globalPath) &&
+			(this.settingsManager.isProjectTrusted() || !isWithinProjectConfigDir(globalPath, this.cwd))
+		) {
 			return globalPath;
 		}
 
@@ -887,7 +897,12 @@ export class DefaultResourceLoader implements ResourceLoader {
 		}
 
 		const globalPath = join(this.agentDir, "APPEND_SYSTEM.md");
-		if (existsSync(globalPath)) {
+		// See discoverSystemPromptFile: project-controlled "global" files are
+		// skipped for untrusted workspaces.
+		if (
+			existsSync(globalPath) &&
+			(this.settingsManager.isProjectTrusted() || !isWithinProjectConfigDir(globalPath, this.cwd))
+		) {
 			return globalPath;
 		}
 

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -19,7 +19,11 @@ import { SettingsManager } from "./settings-manager.js";
 import type { Skill } from "./skills.js";
 import { loadSkills } from "./skills.js";
 import { createSourceInfo, type SourceInfo } from "./source-info.js";
-import { isProjectConfigDirTheUserGlobalDir, isWithinProjectConfigDir, isWorkspaceTrusted } from "./workspace-trust.js";
+import {
+	isAgentDirWithinWorkspace,
+	isProjectConfigDirTheUserGlobalDir,
+	isWorkspaceTrusted,
+} from "./workspace-trust.js";
 
 export interface ResourceExtensionPaths {
 	skillPaths?: Array<{ path: string; metadata: PathMetadata }>;
@@ -495,7 +499,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 						// The user's own home-based config dir is exempt.
 						includeGlobal:
 							this.settingsManager.isProjectTrusted() ||
-							!isWithinProjectConfigDir(this.agentDir, this.cwd) ||
+							!isAgentDirWithinWorkspace(this.agentDir, this.cwd) ||
 							isProjectConfigDirTheUserGlobalDir(this.cwd),
 					}),
 		};
@@ -892,13 +896,13 @@ export class DefaultResourceLoader implements ResourceLoader {
 		}
 
 		const globalPath = join(this.agentDir, "SYSTEM.md");
-		// When untrusted, a "global" prompt file inside the project config
-		// directory (portable agentDir) is project-controlled; skip it. The
+		// When untrusted, a "global" prompt file from an agent dir inside the
+		// workspace (portable agentDir) is project-controlled; skip it. The
 		// home-directory case is exempt: there the file is the user's own.
 		if (
 			existsSync(globalPath) &&
 			(this.settingsManager.isProjectTrusted() ||
-				!isWithinProjectConfigDir(globalPath, this.cwd) ||
+				!isAgentDirWithinWorkspace(this.agentDir, this.cwd) ||
 				isProjectConfigDirTheUserGlobalDir(this.cwd))
 		) {
 			return globalPath;
@@ -919,7 +923,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		if (
 			existsSync(globalPath) &&
 			(this.settingsManager.isProjectTrusted() ||
-				!isWithinProjectConfigDir(globalPath, this.cwd) ||
+				!isAgentDirWithinWorkspace(this.agentDir, this.cwd) ||
 				isProjectConfigDirTheUserGlobalDir(this.cwd))
 		) {
 			return globalPath;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -19,6 +19,7 @@ import { getDefaultSessionDir, SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
 import { time } from "./timings.js";
 import { createBashTool, createEditTool, createIpythonTool, withFileMutationQueue } from "./tools/index.js";
+import { isWorkspaceTrusted } from "./workspace-trust.js";
 
 export interface CreateAgentSessionOptions extends AgentSessionCreationOptions {
 	/** Working directory for project-local discovery. Default: process.cwd() */
@@ -163,7 +164,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const authStorage = options.authStorage ?? AuthStorage.create(authPath);
 	const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, modelsPath);
 
-	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
+	const projectTrusted = isWorkspaceTrusted(cwd, agentDir);
+	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir, { projectTrusted });
+	if (!projectTrusted) {
+		settingsManager.setProjectTrusted(false);
+	}
 	const sessionManager = options.sessionManager ?? SessionManager.create(cwd, getDefaultSessionDir(cwd, agentDir));
 
 	// Ensure MCP providers are registered and built-in MCP skills are gated by

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -4,7 +4,7 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
-import { isAgentDirWithinWorkspace, isProjectConfigDirTheUserGlobalDir } from "./workspace-trust.js";
+import { isAgentDirWithinWorkspace, isDefaultUserGlobalAgentDir } from "./workspace-trust.js";
 
 const RECENT_MODELS_LIMIT = 20;
 export const DEFAULT_IDLE_EVICTION_MINUTES = 90;
@@ -363,7 +363,7 @@ export class SettingsManager {
 		// just the conventional config path), except the user's own home-based
 		// global directory.
 		const globalConfigAliasedToProject =
-			isAgentDirWithinWorkspace(agentDir, cwd) && !isProjectConfigDirTheUserGlobalDir(cwd);
+			isAgentDirWithinWorkspace(agentDir, cwd) && !isDefaultUserGlobalAgentDir(agentDir);
 		return SettingsManager.fromStorage(storage, { globalConfigAliasedToProject, ...options });
 	}
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
+import { isWithinProjectConfigDir } from "./workspace-trust.js";
 
 const RECENT_MODELS_LIMIT = 20;
 export const DEFAULT_IDLE_EVICTION_MINUTES = 90;
@@ -215,6 +216,13 @@ export interface SettingsManagerOptions {
 	 * workspace-trust decision explicitly.
 	 */
 	projectTrusted?: boolean;
+	/**
+	 * Set when the global settings file lives inside the project config
+	 * directory (portable agentDir). In untrusted workspaces such "global"
+	 * values are project-controlled, so executable keys are ignored too.
+	 * Computed by SettingsManager.create; rarely set directly.
+	 */
+	globalConfigAliasedToProject?: boolean;
 }
 
 export interface SettingsStorage {
@@ -316,6 +324,7 @@ export class SettingsManager {
 	private projectSettings: Settings;
 	private settings: Settings;
 	private projectTrusted: boolean;
+	private globalConfigAliasedToProject: boolean;
 	private runtimeOverrides: Settings = {};
 	private modifiedFields = new Set<keyof Settings>(); // Track global fields modified during session
 	private modifiedNestedFields = new Map<keyof Settings, Set<string>>(); // Track global nested field modifications
@@ -334,11 +343,13 @@ export class SettingsManager {
 		projectLoadError: Error | null = null,
 		initialErrors: SettingsError[] = [],
 		projectTrusted = true,
+		globalConfigAliasedToProject = false,
 	) {
 		this.storage = storage;
 		this.globalSettings = initialGlobal;
 		this.projectSettings = initialProject;
 		this.projectTrusted = projectTrusted;
+		this.globalConfigAliasedToProject = globalConfigAliasedToProject;
 		this.globalSettingsLoadError = globalLoadError;
 		this.projectSettingsLoadError = projectLoadError;
 		this.errors = [...initialErrors];
@@ -348,7 +359,8 @@ export class SettingsManager {
 	/** Create a SettingsManager that loads from files */
 	static create(cwd: string, agentDir: string = getAgentDir(), options?: SettingsManagerOptions): SettingsManager {
 		const storage = new FileSettingsStorage(cwd, agentDir);
-		return SettingsManager.fromStorage(storage, options);
+		const globalConfigAliasedToProject = isWithinProjectConfigDir(join(agentDir, "settings.json"), cwd);
+		return SettingsManager.fromStorage(storage, { globalConfigAliasedToProject, ...options });
 	}
 
 	/** Create a SettingsManager from an arbitrary storage backend */
@@ -371,6 +383,7 @@ export class SettingsManager {
 			projectLoad.error,
 			initialErrors,
 			options?.projectTrusted ?? true,
+			options?.globalConfigAliasedToProject ?? false,
 		);
 	}
 
@@ -386,6 +399,15 @@ export class SettingsManager {
 
 	setProjectTrusted(trusted: boolean): void {
 		this.projectTrusted = trusted;
+	}
+
+	/**
+	 * Global settings as a source of executable configuration for untrusted
+	 * workspaces. Empty when the global file is project-controlled (agentDir
+	 * aliased into the project), because then "global" is attacker-committed.
+	 */
+	private untrustedGlobalSettings(): Settings {
+		return this.globalConfigAliasedToProject ? {} : this.globalSettings;
 	}
 
 	/** Create an in-memory SettingsManager (no file I/O) */
@@ -694,7 +716,7 @@ export class SettingsManager {
 	getSessionDir(): string | undefined {
 		// Project sessionDir redirects where session files are written; untrusted
 		// projects keep the global/default location.
-		const sessionDir = (this.projectTrusted ? this.settings : this.globalSettings).sessionDir;
+		const sessionDir = (this.projectTrusted ? this.settings : this.untrustedGlobalSettings()).sessionDir;
 		if (!sessionDir) {
 			return sessionDir;
 		}
@@ -977,7 +999,7 @@ export class SettingsManager {
 	}
 
 	getShellPath(): string | undefined {
-		return this.projectTrusted ? this.settings.shellPath : this.globalSettings.shellPath;
+		return this.projectTrusted ? this.settings.shellPath : this.untrustedGlobalSettings().shellPath;
 	}
 
 	setShellPath(path: string | undefined): void {
@@ -997,7 +1019,7 @@ export class SettingsManager {
 	}
 
 	getShellCommandPrefix(): string | undefined {
-		return this.projectTrusted ? this.settings.shellCommandPrefix : this.globalSettings.shellCommandPrefix;
+		return this.projectTrusted ? this.settings.shellCommandPrefix : this.untrustedGlobalSettings().shellCommandPrefix;
 	}
 
 	setShellCommandPrefix(prefix: string | undefined): void {
@@ -1007,7 +1029,7 @@ export class SettingsManager {
 	}
 
 	getNpmCommand(): string[] | undefined {
-		const command = this.projectTrusted ? this.settings.npmCommand : this.globalSettings.npmCommand;
+		const command = this.projectTrusted ? this.settings.npmCommand : this.untrustedGlobalSettings().npmCommand;
 		return command ? [...command] : undefined;
 	}
 
@@ -1240,7 +1262,7 @@ export class SettingsManager {
 	}
 
 	getMcpServers(): Record<string, McpServerConfig> | undefined {
-		return this.projectTrusted ? this.settings.mcpServers : this.globalSettings.mcpServers;
+		return this.projectTrusted ? this.settings.mcpServers : this.untrustedGlobalSettings().mcpServers;
 	}
 
 	setEnabledModels(patterns: string[] | undefined): void {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -208,6 +208,15 @@ function deepMergeSettings(base: Settings, overrides: Settings): Settings {
 
 export type SettingsScope = "global" | "project";
 
+export interface SettingsManagerOptions {
+	/**
+	 * Whether project-scoped settings may contribute executable configuration.
+	 * Defaults to true for direct library use; the app layer passes the
+	 * workspace-trust decision explicitly.
+	 */
+	projectTrusted?: boolean;
+}
+
 export interface SettingsStorage {
 	withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void;
 }
@@ -306,6 +315,7 @@ export class SettingsManager {
 	private globalSettings: Settings;
 	private projectSettings: Settings;
 	private settings: Settings;
+	private projectTrusted: boolean;
 	private runtimeOverrides: Settings = {};
 	private modifiedFields = new Set<keyof Settings>(); // Track global fields modified during session
 	private modifiedNestedFields = new Map<keyof Settings, Set<string>>(); // Track global nested field modifications
@@ -323,10 +333,12 @@ export class SettingsManager {
 		globalLoadError: Error | null = null,
 		projectLoadError: Error | null = null,
 		initialErrors: SettingsError[] = [],
+		projectTrusted = true,
 	) {
 		this.storage = storage;
 		this.globalSettings = initialGlobal;
 		this.projectSettings = initialProject;
+		this.projectTrusted = projectTrusted;
 		this.globalSettingsLoadError = globalLoadError;
 		this.projectSettingsLoadError = projectLoadError;
 		this.errors = [...initialErrors];
@@ -334,13 +346,13 @@ export class SettingsManager {
 	}
 
 	/** Create a SettingsManager that loads from files */
-	static create(cwd: string, agentDir: string = getAgentDir()): SettingsManager {
+	static create(cwd: string, agentDir: string = getAgentDir(), options?: SettingsManagerOptions): SettingsManager {
 		const storage = new FileSettingsStorage(cwd, agentDir);
-		return SettingsManager.fromStorage(storage);
+		return SettingsManager.fromStorage(storage, options);
 	}
 
 	/** Create a SettingsManager from an arbitrary storage backend */
-	static fromStorage(storage: SettingsStorage): SettingsManager {
+	static fromStorage(storage: SettingsStorage, options?: SettingsManagerOptions): SettingsManager {
 		const globalLoad = SettingsManager.tryLoadFromStorage(storage, "global");
 		const projectLoad = SettingsManager.tryLoadFromStorage(storage, "project");
 		const initialErrors: SettingsError[] = [];
@@ -358,7 +370,22 @@ export class SettingsManager {
 			globalLoad.error,
 			projectLoad.error,
 			initialErrors,
+			options?.projectTrusted ?? true,
 		);
+	}
+
+	/**
+	 * Whether the project directory is trusted to contribute executable
+	 * configuration (extensions, shell command prefix, MCP servers, ...).
+	 * Untrusted projects still contribute cosmetic settings, but anything that
+	 * turns committed files into executed commands is ignored.
+	 */
+	isProjectTrusted(): boolean {
+		return this.projectTrusted;
+	}
+
+	setProjectTrusted(trusted: boolean): void {
+		this.projectTrusted = trusted;
 	}
 
 	/** Create an in-memory SettingsManager (no file I/O) */
@@ -665,7 +692,9 @@ export class SettingsManager {
 	}
 
 	getSessionDir(): string | undefined {
-		const sessionDir = this.settings.sessionDir;
+		// Project sessionDir redirects where session files are written; untrusted
+		// projects keep the global/default location.
+		const sessionDir = (this.projectTrusted ? this.settings : this.globalSettings).sessionDir;
 		if (!sessionDir) {
 			return sessionDir;
 		}
@@ -948,7 +977,7 @@ export class SettingsManager {
 	}
 
 	getShellPath(): string | undefined {
-		return this.settings.shellPath;
+		return this.projectTrusted ? this.settings.shellPath : this.globalSettings.shellPath;
 	}
 
 	setShellPath(path: string | undefined): void {
@@ -968,7 +997,7 @@ export class SettingsManager {
 	}
 
 	getShellCommandPrefix(): string | undefined {
-		return this.settings.shellCommandPrefix;
+		return this.projectTrusted ? this.settings.shellCommandPrefix : this.globalSettings.shellCommandPrefix;
 	}
 
 	setShellCommandPrefix(prefix: string | undefined): void {
@@ -978,7 +1007,8 @@ export class SettingsManager {
 	}
 
 	getNpmCommand(): string[] | undefined {
-		return this.settings.npmCommand ? [...this.settings.npmCommand] : undefined;
+		const command = this.projectTrusted ? this.settings.npmCommand : this.globalSettings.npmCommand;
+		return command ? [...command] : undefined;
 	}
 
 	setNpmCommand(command: string[] | undefined): void {
@@ -1210,7 +1240,7 @@ export class SettingsManager {
 	}
 
 	getMcpServers(): Record<string, McpServerConfig> | undefined {
-		return this.settings.mcpServers;
+		return this.projectTrusted ? this.settings.mcpServers : this.globalSettings.mcpServers;
 	}
 
 	setEnabledModels(patterns: string[] | undefined): void {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -4,7 +4,7 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
-import { isProjectConfigDirTheUserGlobalDir, isWithinProjectConfigDir } from "./workspace-trust.js";
+import { isAgentDirWithinWorkspace, isProjectConfigDirTheUserGlobalDir } from "./workspace-trust.js";
 
 const RECENT_MODELS_LIMIT = 20;
 export const DEFAULT_IDLE_EVICTION_MINUTES = 90;
@@ -359,8 +359,11 @@ export class SettingsManager {
 	/** Create a SettingsManager that loads from files */
 	static create(cwd: string, agentDir: string = getAgentDir(), options?: SettingsManagerOptions): SettingsManager {
 		const storage = new FileSettingsStorage(cwd, agentDir);
+		// Any agent dir inside the workspace tree is checkout-controlled (not
+		// just the conventional config path), except the user's own home-based
+		// global directory.
 		const globalConfigAliasedToProject =
-			isWithinProjectConfigDir(join(agentDir, "settings.json"), cwd) && !isProjectConfigDirTheUserGlobalDir(cwd);
+			isAgentDirWithinWorkspace(agentDir, cwd) && !isProjectConfigDirTheUserGlobalDir(cwd);
 		return SettingsManager.fromStorage(storage, { globalConfigAliasedToProject, ...options });
 	}
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -4,7 +4,7 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
-import { isWithinProjectConfigDir } from "./workspace-trust.js";
+import { isProjectConfigDirTheUserGlobalDir, isWithinProjectConfigDir } from "./workspace-trust.js";
 
 const RECENT_MODELS_LIMIT = 20;
 export const DEFAULT_IDLE_EVICTION_MINUTES = 90;
@@ -359,7 +359,8 @@ export class SettingsManager {
 	/** Create a SettingsManager that loads from files */
 	static create(cwd: string, agentDir: string = getAgentDir(), options?: SettingsManagerOptions): SettingsManager {
 		const storage = new FileSettingsStorage(cwd, agentDir);
-		const globalConfigAliasedToProject = isWithinProjectConfigDir(join(agentDir, "settings.json"), cwd);
+		const globalConfigAliasedToProject =
+			isWithinProjectConfigDir(join(agentDir, "settings.json"), cwd) && !isProjectConfigDirTheUserGlobalDir(cwd);
 		return SettingsManager.fromStorage(storage, { globalConfigAliasedToProject, ...options });
 	}
 
@@ -399,6 +400,15 @@ export class SettingsManager {
 
 	setProjectTrusted(trusted: boolean): void {
 		this.projectTrusted = trusted;
+	}
+
+	/**
+	 * Whether the global settings file lives inside the project config
+	 * directory (portable agentDir), making "global" configuration
+	 * project-controlled. Always false for the default home-based agent dir.
+	 */
+	isGlobalConfigAliasedToProject(): boolean {
+		return this.globalConfigAliasedToProject;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -420,6 +420,15 @@ export class SettingsManager {
 		return this.globalConfigAliasedToProject ? {} : this.globalSettings;
 	}
 
+	/**
+	 * Executable settings for untrusted workspaces: global values (when not
+	 * project-controlled) plus runtime overrides, which are process-driven
+	 * and never come from the workspace.
+	 */
+	private untrustedExecutableSettings(): Settings {
+		return deepMergeSettings(this.untrustedGlobalSettings(), this.runtimeOverrides);
+	}
+
 	/** Create an in-memory SettingsManager (no file I/O) */
 	static inMemory(settings: Partial<Settings> = {}): SettingsManager {
 		const storage = new InMemorySettingsStorage();
@@ -726,7 +735,7 @@ export class SettingsManager {
 	getSessionDir(): string | undefined {
 		// Project sessionDir redirects where session files are written; untrusted
 		// projects keep the global/default location.
-		const sessionDir = (this.projectTrusted ? this.settings : this.untrustedGlobalSettings()).sessionDir;
+		const sessionDir = (this.projectTrusted ? this.settings : this.untrustedExecutableSettings()).sessionDir;
 		if (!sessionDir) {
 			return sessionDir;
 		}
@@ -1009,7 +1018,7 @@ export class SettingsManager {
 	}
 
 	getShellPath(): string | undefined {
-		return this.projectTrusted ? this.settings.shellPath : this.untrustedGlobalSettings().shellPath;
+		return this.projectTrusted ? this.settings.shellPath : this.untrustedExecutableSettings().shellPath;
 	}
 
 	setShellPath(path: string | undefined): void {
@@ -1029,7 +1038,9 @@ export class SettingsManager {
 	}
 
 	getShellCommandPrefix(): string | undefined {
-		return this.projectTrusted ? this.settings.shellCommandPrefix : this.untrustedGlobalSettings().shellCommandPrefix;
+		return this.projectTrusted
+			? this.settings.shellCommandPrefix
+			: this.untrustedExecutableSettings().shellCommandPrefix;
 	}
 
 	setShellCommandPrefix(prefix: string | undefined): void {
@@ -1039,7 +1050,7 @@ export class SettingsManager {
 	}
 
 	getNpmCommand(): string[] | undefined {
-		const command = this.projectTrusted ? this.settings.npmCommand : this.untrustedGlobalSettings().npmCommand;
+		const command = this.projectTrusted ? this.settings.npmCommand : this.untrustedExecutableSettings().npmCommand;
 		return command ? [...command] : undefined;
 	}
 
@@ -1272,7 +1283,7 @@ export class SettingsManager {
 	}
 
 	getMcpServers(): Record<string, McpServerConfig> | undefined {
-		return this.projectTrusted ? this.settings.mcpServers : this.untrustedGlobalSettings().mcpServers;
+		return this.projectTrusted ? this.settings.mcpServers : this.untrustedExecutableSettings().mcpServers;
 	}
 
 	setEnabledModels(patterns: string[] | undefined): void {

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -197,12 +197,23 @@ export class WorkspaceTrustStore {
 		try {
 			linkSync(tmpPath, this.filePath);
 		} catch {
-			// Lost the create race; the other process's file stands.
+			// Lost the create race, or hard links are unsupported here.
+		}
+		if (!existsSync(this.filePath)) {
+			// Hard links unsupported: move the staging file instead.
+			try {
+				renameSync(tmpPath, this.filePath);
+			} catch {
+				// Another writer won in the meantime.
+			}
 		}
 		try {
 			rmSync(tmpPath, { force: true });
 		} catch {
 			// Best effort.
+		}
+		if (!existsSync(this.filePath)) {
+			throw new Error(`Failed to create workspace trust store at ${this.filePath}`);
 		}
 	}
 
@@ -317,9 +328,21 @@ function countExtensionEntries(extensionsDir: string): number {
 	for (const entry of entries) {
 		if (entry.name.startsWith(".") || entry.name === "node_modules" || entry.name === "package.json") continue;
 		const fullPath = join(extensionsDir, entry.name);
-		if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".js"))) {
+		// Symlinks are followed like the loader does.
+		let isFile = entry.isFile();
+		let isDir = entry.isDirectory();
+		if (entry.isSymbolicLink()) {
+			try {
+				const stats = statSync(fullPath);
+				isFile = stats.isFile();
+				isDir = stats.isDirectory();
+			} catch {
+				continue;
+			}
+		}
+		if (isFile && (entry.name.endsWith(".ts") || entry.name.endsWith(".js"))) {
 			count++;
-		} else if (entry.isDirectory() && hasExtensionEntry(fullPath)) {
+		} else if (isDir && hasExtensionEntry(fullPath)) {
 			count++;
 		}
 	}

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -1,0 +1,216 @@
+/**
+ * Workspace trust: gates project-committed executable configuration behind
+ * explicit user consent.
+ *
+ * A repository can commit `.prime/agent/extensions/*.ts` (auto-executed via
+ * jiti at session start), `.prime/agent/settings.json` keys that turn into
+ * executed commands (shellCommandPrefix, shellPath, npmCommand, mcpServers
+ * stdio entries, package sources), Python skills (pip-installed into the
+ * kernel venv and imported), and SYSTEM.md/APPEND_SYSTEM.md (auto-injected
+ * into the system prompt). Loading any of that from a cloned, uninspected
+ * repository is a drive-by code-execution vector, so project-scoped
+ * configuration only applies to directories the user has explicitly trusted.
+ *
+ * Trust state lives in `<agentDir>/trusted-workspaces.json` and is shared by
+ * every process on this machine (CLI client, daemon workers, SDK hosts).
+ */
+
+import type { Dirent } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	realpathSync,
+	renameSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { CONFIG_DIR_NAME } from "../config.js";
+
+const TRUST_FILE_NAME = "trusted-workspaces.json";
+
+/** Project settings keys that can turn committed config into executed commands. */
+export const RISKY_PROJECT_SETTINGS_KEYS = [
+	"extensions",
+	"skills",
+	"packages",
+	"mcpServers",
+	"shellCommandPrefix",
+	"shellPath",
+	"npmCommand",
+	"sessionDir",
+] as const;
+
+/** Canonicalize a workspace path so trust entries survive symlinks (e.g. /tmp on macOS). */
+export function canonicalizeWorkspacePath(path: string): string {
+	const resolved = resolve(path);
+	try {
+		return realpathSync.native(resolved);
+	} catch {
+		return resolved;
+	}
+}
+
+interface WorkspaceTrustFile {
+	version: 1;
+	trusted: string[];
+}
+
+export class WorkspaceTrustStore {
+	private constructor(
+		private readonly filePath: string,
+		private readonly trusted: Set<string>,
+	) {}
+
+	static create(agentDir: string): WorkspaceTrustStore {
+		const filePath = join(agentDir, TRUST_FILE_NAME);
+		const trusted = new Set<string>();
+		try {
+			const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<WorkspaceTrustFile>;
+			if (Array.isArray(parsed.trusted)) {
+				for (const entry of parsed.trusted) {
+					if (typeof entry === "string") {
+						trusted.add(entry);
+					}
+				}
+			}
+		} catch {
+			// Missing or unreadable trust file means nothing is trusted.
+		}
+		return new WorkspaceTrustStore(filePath, trusted);
+	}
+
+	isTrusted(cwd: string): boolean {
+		return this.trusted.has(canonicalizeWorkspacePath(cwd));
+	}
+
+	trust(cwd: string): void {
+		this.trusted.add(canonicalizeWorkspacePath(cwd));
+		this.save();
+	}
+
+	untrust(cwd: string): boolean {
+		const removed = this.trusted.delete(canonicalizeWorkspacePath(cwd));
+		if (removed) {
+			this.save();
+		}
+		return removed;
+	}
+
+	list(): string[] {
+		return [...this.trusted].sort();
+	}
+
+	private save(): void {
+		mkdirSync(dirname(this.filePath), { recursive: true });
+		const contents: WorkspaceTrustFile = { version: 1, trusted: this.list() };
+		const tmpPath = `${this.filePath}.tmp`;
+		writeFileSync(tmpPath, `${JSON.stringify(contents, null, 2)}\n`, "utf-8");
+		renameSync(tmpPath, this.filePath);
+	}
+}
+
+/** Convenience for one-off checks at call sites that do not keep a store around. */
+export function isWorkspaceTrusted(cwd: string, agentDir: string): boolean {
+	return WorkspaceTrustStore.create(agentDir).isTrusted(cwd);
+}
+
+export interface ProjectScopedConfigFinding {
+	path: string;
+	summary: string;
+}
+
+function isNonEmptyDirectory(dir: string): boolean {
+	try {
+		return statSync(dir).isDirectory() && readdirSync(dir).some((entry) => !entry.startsWith("."));
+	} catch {
+		return false;
+	}
+}
+
+function collectExtensionFiles(dir: string): string[] {
+	const files: string[] = [];
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return files;
+	}
+	for (const entry of entries) {
+		if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+		if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".js"))) {
+			files.push(join(dir, entry.name));
+		} else if (entry.isDirectory()) {
+			for (const indexName of ["index.ts", "index.js"]) {
+				const indexPath = join(dir, entry.name, indexName);
+				if (existsSync(indexPath)) {
+					files.push(indexPath);
+					break;
+				}
+			}
+		}
+	}
+	return files;
+}
+
+/**
+ * Synchronously detect project-committed configuration that workspace trust
+ * gates. Used for the interactive consent prompt and headless notices; the
+ * enforcement itself lives in SettingsManager/DefaultPackageManager.
+ */
+export function detectProjectScopedConfig(cwd: string): ProjectScopedConfigFinding[] {
+	const findings: ProjectScopedConfigFinding[] = [];
+	const configDir = join(cwd, CONFIG_DIR_NAME);
+
+	const extensionFiles = collectExtensionFiles(join(configDir, "extensions"));
+	if (extensionFiles.length > 0) {
+		findings.push({
+			path: join(configDir, "extensions"),
+			summary: `project extensions (${extensionFiles.length} file${extensionFiles.length === 1 ? "" : "s"}) execute automatically at session start`,
+		});
+	}
+
+	const settingsPath = join(configDir, "settings.json");
+	try {
+		const projectSettings = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+		const riskyKeys = RISKY_PROJECT_SETTINGS_KEYS.filter((key) => projectSettings[key] !== undefined);
+		if (riskyKeys.length > 0) {
+			findings.push({
+				path: settingsPath,
+				summary: `project settings.json sets ${riskyKeys.join(", ")}`,
+			});
+		}
+	} catch {
+		// No readable project settings.
+	}
+
+	for (const fileName of ["SYSTEM.md", "APPEND_SYSTEM.md"]) {
+		const promptPath = join(configDir, fileName);
+		if (existsSync(promptPath)) {
+			findings.push({
+				path: promptPath,
+				summary: `project ${fileName} is injected into the system prompt`,
+			});
+		}
+	}
+
+	const skillsDir = join(configDir, "skills");
+	if (isNonEmptyDirectory(skillsDir)) {
+		findings.push({
+			path: skillsDir,
+			summary: "project skills are auto-discovered (Python skills install code into the agent kernel environment)",
+		});
+	}
+
+	const agentsSkillsDir = join(cwd, ".agents", "skills");
+	if (isNonEmptyDirectory(agentsSkillsDir)) {
+		findings.push({
+			path: agentsSkillsDir,
+			summary: ".agents/skills is auto-discovered (Python skills install code into the agent kernel environment)",
+		});
+	}
+
+	return findings;
+}

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -26,15 +26,23 @@ import {
 	statSync,
 	writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join, resolve, sep } from "node:path";
+import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME } from "../config.js";
 
 const TRUST_FILE_NAME = "trusted-workspaces.json";
 
-/** Project settings keys that can turn committed config into executed commands. */
+/**
+ * Project settings keys that turn committed config into executed commands or
+ * auto-loaded resources. Used for detection and documentation; enforcement
+ * lives in SettingsManager and DefaultPackageManager.
+ */
 export const RISKY_PROJECT_SETTINGS_KEYS = [
 	"extensions",
 	"skills",
+	"prompts",
+	"themes",
 	"packages",
 	"mcpServers",
 	"shellCommandPrefix",
@@ -53,33 +61,48 @@ export function canonicalizeWorkspacePath(path: string): string {
 	}
 }
 
+/**
+ * Whether `target` lies inside the project's committed config directory.
+ * Guards against portable setups that point the global agent dir into the
+ * workspace: such "global" files are project-controlled and must not be
+ * treated as trusted user configuration.
+ */
+export function isWithinProjectConfigDir(target: string, cwd: string): boolean {
+	const root = canonicalizeWorkspacePath(join(cwd, CONFIG_DIR_NAME));
+	const resolved = canonicalizeWorkspacePath(target);
+	return resolved === root || resolved.startsWith(root + sep);
+}
+
 interface WorkspaceTrustFile {
 	version: 1;
 	trusted: string[];
 }
 
+function readTrustFile(filePath: string): Set<string> {
+	const trusted = new Set<string>();
+	try {
+		const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<WorkspaceTrustFile>;
+		if (Array.isArray(parsed.trusted)) {
+			for (const entry of parsed.trusted) {
+				if (typeof entry === "string") {
+					trusted.add(entry);
+				}
+			}
+		}
+	} catch {
+		// Missing or unreadable trust file means nothing is trusted.
+	}
+	return trusted;
+}
+
 export class WorkspaceTrustStore {
 	private constructor(
 		private readonly filePath: string,
-		private readonly trusted: Set<string>,
+		private trusted: Set<string>,
 	) {}
 
 	static create(agentDir: string): WorkspaceTrustStore {
-		const filePath = join(agentDir, TRUST_FILE_NAME);
-		const trusted = new Set<string>();
-		try {
-			const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<WorkspaceTrustFile>;
-			if (Array.isArray(parsed.trusted)) {
-				for (const entry of parsed.trusted) {
-					if (typeof entry === "string") {
-						trusted.add(entry);
-					}
-				}
-			}
-		} catch {
-			// Missing or unreadable trust file means nothing is trusted.
-		}
-		return new WorkspaceTrustStore(filePath, trusted);
+		return new WorkspaceTrustStore(join(agentDir, TRUST_FILE_NAME), readTrustFile(join(agentDir, TRUST_FILE_NAME)));
 	}
 
 	isTrusted(cwd: string): boolean {
@@ -87,15 +110,18 @@ export class WorkspaceTrustStore {
 	}
 
 	trust(cwd: string): void {
-		this.trusted.add(canonicalizeWorkspacePath(cwd));
-		this.save();
+		const canonical = canonicalizeWorkspacePath(cwd);
+		this.mutate((trusted) => {
+			trusted.add(canonical);
+		});
 	}
 
 	untrust(cwd: string): boolean {
-		const removed = this.trusted.delete(canonicalizeWorkspacePath(cwd));
-		if (removed) {
-			this.save();
-		}
+		const canonical = canonicalizeWorkspacePath(cwd);
+		let removed = false;
+		this.mutate((trusted) => {
+			removed = trusted.delete(canonical);
+		});
 		return removed;
 	}
 
@@ -103,12 +129,57 @@ export class WorkspaceTrustStore {
 		return [...this.trusted].sort();
 	}
 
-	private save(): void {
+	/**
+	 * Locked read-modify-write against the shared file. Re-reading under the
+	 * lock keeps concurrent processes from clobbering each other's trust and
+	 * untrust operations with stale snapshots.
+	 */
+	private mutate(apply: (trusted: Set<string>) => void): void {
 		mkdirSync(dirname(this.filePath), { recursive: true });
-		const contents: WorkspaceTrustFile = { version: 1, trusted: this.list() };
+		if (!existsSync(this.filePath)) {
+			this.writeFile(this.trusted);
+		}
+		const release = this.acquireLock();
+		try {
+			const trusted = readTrustFile(this.filePath);
+			apply(trusted);
+			this.writeFile(trusted);
+			this.trusted = trusted;
+		} finally {
+			release();
+		}
+	}
+
+	private writeFile(trusted: Set<string>): void {
+		const contents: WorkspaceTrustFile = { version: 1, trusted: [...trusted].sort() };
 		const tmpPath = `${this.filePath}.tmp`;
 		writeFileSync(tmpPath, `${JSON.stringify(contents, null, 2)}\n`, "utf-8");
 		renameSync(tmpPath, this.filePath);
+	}
+
+	private acquireLock(): () => void {
+		const maxAttempts = 10;
+		const delayMs = 20;
+		let lastError: unknown;
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			try {
+				return lockfile.lockSync(this.filePath, { realpath: false });
+			} catch (error) {
+				const code =
+					typeof error === "object" && error !== null && "code" in error
+						? String((error as { code?: unknown }).code)
+						: undefined;
+				if (code !== "ELOCKED" || attempt === maxAttempts) {
+					throw error;
+				}
+				lastError = error;
+				const start = Date.now();
+				while (Date.now() - start < delayMs) {
+					// Sleep synchronously to avoid changing callers to async.
+				}
+			}
+		}
+		throw (lastError as Error) ?? new Error("Failed to acquire workspace trust lock");
 	}
 }
 
@@ -130,45 +201,102 @@ function isNonEmptyDirectory(dir: string): boolean {
 	}
 }
 
-function collectExtensionFiles(dir: string): string[] {
-	const files: string[] = [];
-	let entries: Dirent[];
+interface PiManifestLike {
+	extensions?: string[];
+}
+
+function readPiManifest(packageJsonPath: string): PiManifestLike | null {
 	try {
-		entries = readdirSync(dir, { withFileTypes: true });
+		const pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { pi?: PiManifestLike };
+		return pkg.pi ?? null;
 	} catch {
-		return files;
+		return null;
 	}
-	for (const entry of entries) {
-		if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
-		if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".js"))) {
-			files.push(join(dir, entry.name));
-		} else if (entry.isDirectory()) {
-			for (const indexName of ["index.ts", "index.js"]) {
-				const indexPath = join(dir, entry.name, indexName);
-				if (existsSync(indexPath)) {
-					files.push(indexPath);
-					break;
-				}
-			}
+}
+
+/** Mirrors the discovery rules of DefaultPackageManager's extension collection. */
+function hasExtensionEntry(dir: string): boolean {
+	const packageJsonPath = join(dir, "package.json");
+	if (existsSync(packageJsonPath)) {
+		const manifest = readPiManifest(packageJsonPath);
+		if (manifest?.extensions?.some((entry) => existsSync(resolve(dir, entry)))) {
+			return true;
 		}
 	}
-	return files;
+	return existsSync(join(dir, "index.ts")) || existsSync(join(dir, "index.js"));
+}
+
+function countExtensionEntries(extensionsDir: string): number {
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(extensionsDir, { withFileTypes: true });
+	} catch {
+		return 0;
+	}
+	let count = 0;
+	for (const entry of entries) {
+		if (entry.name.startsWith(".") || entry.name === "node_modules" || entry.name === "package.json") continue;
+		const fullPath = join(extensionsDir, entry.name);
+		if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".js"))) {
+			count++;
+		} else if (entry.isDirectory() && hasExtensionEntry(fullPath)) {
+			count++;
+		}
+	}
+	return count;
+}
+
+function findGitRepoRoot(startDir: string): string | null {
+	let dir = resolve(startDir);
+	while (true) {
+		if (existsSync(join(dir, ".git"))) {
+			return dir;
+		}
+		const parent = dirname(dir);
+		if (parent === dir) {
+			return null;
+		}
+		dir = parent;
+	}
+}
+
+/** Mirrors DefaultPackageManager's ancestor `.agents/skills` discovery (cwd up to the git root). */
+function collectAncestorAgentsSkillDirs(cwd: string): string[] {
+	const dirs: string[] = [];
+	const gitRepoRoot = findGitRepoRoot(cwd);
+	const userAgentsSkillsDir = join(homedir(), ".agents", "skills");
+	let dir = resolve(cwd);
+	while (true) {
+		const candidate = join(dir, ".agents", "skills");
+		if (resolve(candidate) !== resolve(userAgentsSkillsDir)) {
+			dirs.push(candidate);
+		}
+		if (gitRepoRoot && dir === gitRepoRoot) {
+			break;
+		}
+		const parent = dirname(dir);
+		if (parent === dir) {
+			break;
+		}
+		dir = parent;
+	}
+	return dirs;
 }
 
 /**
  * Synchronously detect project-committed configuration that workspace trust
- * gates. Used for the interactive consent prompt and headless notices; the
- * enforcement itself lives in SettingsManager/DefaultPackageManager.
+ * gates. Used for the interactive consent prompt; the enforcement itself
+ * lives in SettingsManager/DefaultPackageManager/DefaultResourceLoader.
  */
 export function detectProjectScopedConfig(cwd: string): ProjectScopedConfigFinding[] {
 	const findings: ProjectScopedConfigFinding[] = [];
 	const configDir = join(cwd, CONFIG_DIR_NAME);
 
-	const extensionFiles = collectExtensionFiles(join(configDir, "extensions"));
-	if (extensionFiles.length > 0) {
+	const extensionCount = countExtensionEntries(join(configDir, "extensions"));
+	if (extensionCount > 0) {
 		findings.push({
 			path: join(configDir, "extensions"),
-			summary: `project extensions (${extensionFiles.length} file${extensionFiles.length === 1 ? "" : "s"}) execute automatically at session start`,
+			summary: `project extensions (${extensionCount} ${extensionCount === 1 ? "entry" : "entries"}) execute automatically at session start`,
 		});
 	}
 
@@ -204,12 +332,26 @@ export function detectProjectScopedConfig(cwd: string): ProjectScopedConfigFindi
 		});
 	}
 
-	const agentsSkillsDir = join(cwd, ".agents", "skills");
-	if (isNonEmptyDirectory(agentsSkillsDir)) {
-		findings.push({
-			path: agentsSkillsDir,
-			summary: ".agents/skills is auto-discovered (Python skills install code into the agent kernel environment)",
-		});
+	for (const ancestorSkillsDir of collectAncestorAgentsSkillDirs(cwd)) {
+		if (isNonEmptyDirectory(ancestorSkillsDir)) {
+			findings.push({
+				path: ancestorSkillsDir,
+				summary: ".agents/skills is auto-discovered (Python skills install code into the agent kernel environment)",
+			});
+		}
+	}
+
+	for (const [dirName, label] of [
+		["prompts", "prompt templates"],
+		["themes", "themes"],
+	] as const) {
+		const dir = join(configDir, dirName);
+		if (isNonEmptyDirectory(dir)) {
+			findings.push({
+				path: dir,
+				summary: `project ${label} are auto-discovered`,
+			});
+		}
 	}
 
 	return findings;

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -18,11 +18,13 @@
 import type { Dirent } from "node:fs";
 import {
 	existsSync,
+	linkSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
 	realpathSync,
 	renameSync,
+	rmSync,
 	statSync,
 	writeFileSync,
 } from "node:fs";
@@ -168,9 +170,7 @@ export class WorkspaceTrustStore {
 	 */
 	private mutate(apply: (trusted: Set<string>) => void): void {
 		mkdirSync(dirname(this.filePath), { recursive: true });
-		if (!existsSync(this.filePath)) {
-			this.writeFile(this.trusted);
-		}
+		this.ensureFileExists();
 		const release = this.acquireLock();
 		try {
 			const trusted = readTrustFile(this.filePath);
@@ -179,6 +179,30 @@ export class WorkspaceTrustStore {
 			this.trusted = trusted;
 		} finally {
 			release();
+		}
+	}
+
+	/**
+	 * Create the store file for lock acquisition without ever clobbering
+	 * committed content: linkSync fails atomically when another process won
+	 * the create race, and the winner's file stands.
+	 */
+	private ensureFileExists(): void {
+		if (existsSync(this.filePath)) {
+			return;
+		}
+		const tmpPath = `${this.filePath}.${process.pid}.tmp`;
+		const empty: WorkspaceTrustFile = { version: 1, trusted: [] };
+		writeFileSync(tmpPath, `${JSON.stringify(empty, null, 2)}\n`, "utf-8");
+		try {
+			linkSync(tmpPath, this.filePath);
+		} catch {
+			// Lost the create race; the other process's file stands.
+		}
+		try {
+			rmSync(tmpPath, { force: true });
+		} catch {
+			// Best effort.
 		}
 	}
 
@@ -217,8 +241,25 @@ export class WorkspaceTrustStore {
 	}
 }
 
-/** Convenience for one-off checks at call sites that do not keep a store around. */
+/**
+ * Whether trust for this workspace can persist outside the workspace itself.
+ * A trust store inside the workspace tree is checkout-controlled content: a
+ * repository could commit `trusted-workspaces.json` and trust itself.
+ */
+export function canPersistWorkspaceTrust(cwd: string, agentDir: string): boolean {
+	const canonicalCwd = canonicalizeWorkspacePath(cwd);
+	const storePath = join(canonicalizeWorkspacePath(agentDir), TRUST_FILE_NAME);
+	return storePath !== canonicalCwd && !storePath.startsWith(canonicalCwd + sep);
+}
+
+/**
+ * Convenience for one-off checks at call sites that do not keep a store
+ * around. Fail-closed when the store would live inside the workspace.
+ */
 export function isWorkspaceTrusted(cwd: string, agentDir: string): boolean {
+	if (!canPersistWorkspaceTrust(cwd, agentDir)) {
+		return false;
+	}
 	return WorkspaceTrustStore.create(agentDir).isTrusted(cwd);
 }
 

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -27,7 +27,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME } from "../config.js";
 
@@ -57,7 +57,23 @@ export function canonicalizeWorkspacePath(path: string): string {
 	try {
 		return realpathSync.native(resolved);
 	} catch {
-		return resolved;
+		// The path does not exist: canonicalize the nearest existing ancestor so
+		// symlinked prefixes still resolve consistently with existing paths.
+		const missing: string[] = [];
+		let current = resolved;
+		while (true) {
+			const parent = dirname(current);
+			if (parent === current) {
+				return resolved;
+			}
+			missing.unshift(basename(current));
+			current = parent;
+			try {
+				return join(realpathSync.native(current), ...missing);
+			} catch {
+				// Keep walking up.
+			}
+		}
 	}
 }
 
@@ -71,6 +87,19 @@ export function isWithinProjectConfigDir(target: string, cwd: string): boolean {
 	const root = canonicalizeWorkspacePath(join(cwd, CONFIG_DIR_NAME));
 	const resolved = canonicalizeWorkspacePath(target);
 	return resolved === root || resolved.startsWith(root + sep);
+}
+
+/**
+ * Whether the project's config directory is the user's own global config
+ * directory (home-directory cwd with the default agent dir). Those files are
+ * the user's own configuration, not checkout-controlled content, so the
+ * aliasing guards must not treat them as hostile.
+ */
+export function isProjectConfigDirTheUserGlobalDir(cwd: string): boolean {
+	return (
+		canonicalizeWorkspacePath(join(cwd, CONFIG_DIR_NAME)) ===
+		canonicalizeWorkspacePath(join(homedir(), CONFIG_DIR_NAME))
+	);
 }
 
 interface WorkspaceTrustFile {
@@ -102,7 +131,10 @@ export class WorkspaceTrustStore {
 	) {}
 
 	static create(agentDir: string): WorkspaceTrustStore {
-		return new WorkspaceTrustStore(join(agentDir, TRUST_FILE_NAME), readTrustFile(join(agentDir, TRUST_FILE_NAME)));
+		// Canonicalize so differently-spelled agent dirs (/tmp vs /private/tmp)
+		// share one file and one lock path.
+		const filePath = join(canonicalizeWorkspacePath(agentDir), TRUST_FILE_NAME);
+		return new WorkspaceTrustStore(filePath, readTrustFile(filePath));
 	}
 
 	isTrusted(cwd: string): boolean {
@@ -152,7 +184,9 @@ export class WorkspaceTrustStore {
 
 	private writeFile(trusted: Set<string>): void {
 		const contents: WorkspaceTrustFile = { version: 1, trusted: [...trusted].sort() };
-		const tmpPath = `${this.filePath}.tmp`;
+		// Per-process tmp name: concurrent first-writers must not rename each
+		// other's staging file out from under themselves.
+		const tmpPath = `${this.filePath}.${process.pid}.tmp`;
 		writeFileSync(tmpPath, `${JSON.stringify(contents, null, 2)}\n`, "utf-8");
 		renameSync(tmpPath, this.filePath);
 	}
@@ -295,6 +329,11 @@ function collectAncestorAgentsSkillDirs(cwd: string): string[] {
  */
 export function detectProjectScopedConfig(cwd: string): ProjectScopedConfigFinding[] {
 	const findings: ProjectScopedConfigFinding[] = [];
+	// Running from the home directory: the "project" config dir is the user's
+	// own global one; there is nothing checkout-controlled to report.
+	if (isProjectConfigDirTheUserGlobalDir(cwd)) {
+		return findings;
+	}
 	const configDir = join(cwd, CONFIG_DIR_NAME);
 
 	const extensionCount = countExtensionEntries(join(configDir, "extensions"));

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -18,13 +18,11 @@
 import type { Dirent } from "node:fs";
 import {
 	existsSync,
-	linkSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
 	realpathSync,
 	renameSync,
-	rmSync,
 	statSync,
 	writeFileSync,
 } from "node:fs";
@@ -202,26 +200,13 @@ export class WorkspaceTrustStore {
 		if (existsSync(this.filePath)) {
 			return;
 		}
-		const tmpPath = `${this.filePath}.${process.pid}.tmp`;
+		// O_EXCL create: atomic create-or-fail on every filesystem, so a
+		// concurrent creator never clobbers already-committed trust data.
 		const empty: WorkspaceTrustFile = { version: 1, trusted: [] };
-		writeFileSync(tmpPath, `${JSON.stringify(empty, null, 2)}\n`, "utf-8");
 		try {
-			linkSync(tmpPath, this.filePath);
+			writeFileSync(this.filePath, `${JSON.stringify(empty, null, 2)}\n`, { flag: "wx" });
 		} catch {
-			// Lost the create race, or hard links are unsupported here.
-		}
-		if (!existsSync(this.filePath)) {
-			// Hard links unsupported: move the staging file instead.
-			try {
-				renameSync(tmpPath, this.filePath);
-			} catch {
-				// Another writer won in the meantime.
-			}
-		}
-		try {
-			rmSync(tmpPath, { force: true });
-		} catch {
-			// Best effort.
+			// Another process created it first; its content stands.
 		}
 		if (!existsSync(this.filePath)) {
 			throw new Error(`Failed to create workspace trust store at ${this.filePath}`);

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -92,6 +92,17 @@ export function isWithinProjectConfigDir(target: string, cwd: string): boolean {
 }
 
 /**
+ * Whether the agent dir lives inside the workspace tree. Everything under it
+ * is then checkout-controlled content, regardless of whether it sits at the
+ * conventional config path.
+ */
+export function isAgentDirWithinWorkspace(agentDir: string, cwd: string): boolean {
+	const canonicalCwd = canonicalizeWorkspacePath(cwd);
+	const canonicalAgentDir = canonicalizeWorkspacePath(agentDir);
+	return canonicalAgentDir === canonicalCwd || canonicalAgentDir.startsWith(canonicalCwd + sep);
+}
+
+/**
  * Whether the project's config directory is the user's own global config
  * directory (home-directory cwd with the default agent dir). Those files are
  * the user's own configuration, not checkout-controlled content, so the
@@ -258,9 +269,7 @@ export class WorkspaceTrustStore {
  * repository could commit `trusted-workspaces.json` and trust itself.
  */
 export function canPersistWorkspaceTrust(cwd: string, agentDir: string): boolean {
-	const canonicalCwd = canonicalizeWorkspacePath(cwd);
-	const storePath = join(canonicalizeWorkspacePath(agentDir), TRUST_FILE_NAME);
-	return storePath !== canonicalCwd && !storePath.startsWith(canonicalCwd + sep);
+	return !isAgentDirWithinWorkspace(agentDir, cwd);
 }
 
 /**

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -94,7 +94,9 @@ export function isDefaultUserGlobalAgentDir(agentDir: string): boolean {
 export function isAgentDirWithinWorkspace(agentDir: string, cwd: string): boolean {
 	const canonicalCwd = canonicalizeWorkspacePath(cwd);
 	const canonicalAgentDir = canonicalizeWorkspacePath(agentDir);
-	return canonicalAgentDir === canonicalCwd || canonicalAgentDir.startsWith(canonicalCwd + sep);
+	// Avoid "//" when the workspace is a filesystem root.
+	const prefix = canonicalCwd.endsWith(sep) ? canonicalCwd : canonicalCwd + sep;
+	return canonicalAgentDir === canonicalCwd || canonicalAgentDir.startsWith(prefix);
 }
 
 /**
@@ -296,7 +298,8 @@ function hasExtensionEntry(dir: string): boolean {
 	const packageJsonPath = join(dir, "package.json");
 	if (existsSync(packageJsonPath)) {
 		const manifest = readPiManifest(packageJsonPath);
-		if (manifest?.extensions?.some((entry) => existsSync(resolve(dir, entry)))) {
+		// Malformed manifests (non-string entries) must not crash detection.
+		if (manifest?.extensions?.some((entry) => typeof entry === "string" && existsSync(resolve(dir, entry)))) {
 			return true;
 		}
 	}

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -227,6 +227,11 @@ function hasExtensionEntry(dir: string): boolean {
 }
 
 function countExtensionEntries(extensionsDir: string): number {
+	// The extensions directory itself may be a package (pi.extensions manifest
+	// or index file), in which case its contents are not scanned individually.
+	if (hasExtensionEntry(extensionsDir)) {
+		return 1;
+	}
 	let entries: Dirent[];
 	try {
 		entries = readdirSync(extensionsDir, { withFileTypes: true });

--- a/packages/coding-agent/src/core/workspace-trust.ts
+++ b/packages/coding-agent/src/core/workspace-trust.ts
@@ -78,15 +78,12 @@ export function canonicalizeWorkspacePath(path: string): string {
 }
 
 /**
- * Whether `target` lies inside the project's committed config directory.
- * Guards against portable setups that point the global agent dir into the
- * workspace: such "global" files are project-controlled and must not be
- * treated as trusted user configuration.
+ * Whether the agent dir is the user's own home-based global config directory.
+ * Its contents are the user's own configuration — never checkout-controlled —
+ * regardless of the current working directory.
  */
-export function isWithinProjectConfigDir(target: string, cwd: string): boolean {
-	const root = canonicalizeWorkspacePath(join(cwd, CONFIG_DIR_NAME));
-	const resolved = canonicalizeWorkspacePath(target);
-	return resolved === root || resolved.startsWith(root + sep);
+export function isDefaultUserGlobalAgentDir(agentDir: string): boolean {
+	return canonicalizeWorkspacePath(agentDir) === canonicalizeWorkspacePath(join(homedir(), CONFIG_DIR_NAME));
 }
 
 /**

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1137,6 +1137,11 @@ export async function main(args: string[], options?: MainOptions) {
 	time("runMigrations");
 
 	const agentDir = getAgentDir();
+	// Early workspace-trust consent gate: accepting here makes trust effective
+	// for this launch (project sessionDir, settings, and service creation all
+	// read the store afterwards). A second gate runs after session resolution
+	// in case --resume selected a session from a different project.
+	await gateWorkspaceTrustOnStartup({ cwd, agentDir, interactive: appMode === "interactive" });
 	const startupSettingsManager = SettingsManager.create(cwd, agentDir, {
 		projectTrusted: isWorkspaceTrusted(cwd, agentDir),
 	});
@@ -1246,9 +1251,9 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 	time("createSessionManager");
 
-	// Workspace-trust consent gate: must run before any runtime services are
-	// created for the effective session cwd (daemon workers read the shared
-	// trust store at session creation).
+	// Second workspace-trust gate for the effective session cwd, which may
+	// differ from the startup cwd when --resume selects another project's
+	// session. No-op when both are the same directory.
 	await gateWorkspaceTrustOnStartup({
 		cwd: sessionManager.getCwd(),
 		agentDir,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -33,6 +33,7 @@ import {
 	SessionSelectorError,
 	SessionSelectorNotFoundError,
 } from "./cli/session-resolver.js";
+import { gateWorkspaceTrustOnStartup } from "./cli/workspace-trust-prompt.js";
 import { APP_NAME, expandTildePath, getAgentDir, getSessionDirEnvOverride, VERSION } from "./config.js";
 import {
 	type AgentExecutionMode,
@@ -72,6 +73,7 @@ import { SessionManager } from "./core/session-manager.js";
 import { SettingsManager } from "./core/settings-manager.js";
 import { isTelemetryEnabled } from "./core/telemetry.js";
 import { printTimings, resetTimings, time } from "./core/timings.js";
+import { isWorkspaceTrusted } from "./core/workspace-trust.js";
 import { runMigrations, showDeprecationWarnings } from "./migrations.js";
 import { isDaemonCatalogProcess, runDaemonCatalogProcess } from "./modes/daemon/daemon-catalog-process.js";
 import { deserializeDaemonError } from "./modes/daemon/daemon-errors.js";
@@ -1135,7 +1137,9 @@ export async function main(args: string[], options?: MainOptions) {
 	time("runMigrations");
 
 	const agentDir = getAgentDir();
-	const startupSettingsManager = SettingsManager.create(cwd, agentDir);
+	const startupSettingsManager = SettingsManager.create(cwd, agentDir, {
+		projectTrusted: isWorkspaceTrusted(cwd, agentDir),
+	});
 	reportDiagnostics(collectSettingsDiagnostics(startupSettingsManager, "startup session lookup"));
 	const startupBenchmark = isTruthyEnvFlag(process.env.PI_STARTUP_BENCHMARK);
 	if (startupBenchmark && appMode !== "interactive") {
@@ -1242,10 +1246,21 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 	time("createSessionManager");
 
+	// Workspace-trust consent gate: must run before any runtime services are
+	// created for the effective session cwd (daemon workers read the shared
+	// trust store at session creation).
+	await gateWorkspaceTrustOnStartup({
+		cwd: sessionManager.getCwd(),
+		agentDir,
+		interactive: appMode === "interactive",
+	});
+
 	const telemetrySettingsManager =
-		sessionManager.getCwd() === cwd
+		sessionManager.getCwd() === cwd && startupSettingsManager.isProjectTrusted()
 			? startupSettingsManager
-			: SettingsManager.create(sessionManager.getCwd(), agentDir);
+			: SettingsManager.create(sessionManager.getCwd(), agentDir, {
+					projectTrusted: isWorkspaceTrusted(sessionManager.getCwd(), agentDir),
+				});
 	const telemetryDisabled = isTelemetryEnabled(telemetrySettingsManager) ? undefined : true;
 	const defaultSessionConfig = runtimeConfigFromArgs(
 		parsed,
@@ -1506,7 +1521,9 @@ export async function main(args: string[], options?: MainOptions) {
 		return;
 	}
 	if (useDaemonClient) {
-		const settingsManager = SettingsManager.create(sessionManager.getCwd(), agentDir);
+		const settingsManager = SettingsManager.create(sessionManager.getCwd(), agentDir, {
+			projectTrusted: isWorkspaceTrusted(sessionManager.getCwd(), agentDir),
+		});
 		let stdinContent: string | undefined;
 		if (appMode !== "rpc" && appMode !== "acp") {
 			stdinContent = await readPipedStdin();

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1132,16 +1132,17 @@ export async function main(args: string[], options?: MainOptions) {
 		}
 	}
 
-	// Run migrations (pass cwd for project-local migrations)
-	const { migratedAuthProviders: migratedProviders, deprecationWarnings } = runMigrations(cwd);
-	time("runMigrations");
-
 	const agentDir = getAgentDir();
 	// Early workspace-trust consent gate: accepting here makes trust effective
 	// for this launch (project sessionDir, settings, and service creation all
 	// read the store afterwards). A second gate runs after session resolution
 	// in case --resume selected a session from a different project.
 	await gateWorkspaceTrustOnStartup({ cwd, agentDir, interactive: appMode === "interactive" });
+
+	// Run migrations (pass cwd for project-local migrations; the project side
+	// only mutates trusted workspaces, so this runs after the consent gate).
+	const { migratedAuthProviders: migratedProviders, deprecationWarnings } = runMigrations(cwd);
+	time("runMigrations");
 	const startupSettingsManager = SettingsManager.create(cwd, agentDir, {
 		projectTrusted: isWorkspaceTrusted(cwd, agentDir),
 	});

--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -18,6 +18,7 @@ import {
 import { basename, dirname, join } from "path";
 import { CONFIG_DIR_NAME, getAgentDir, getBinDir, getSessionsDir } from "./config.js";
 import { migrateKeybindingsConfig } from "./core/keybindings.js";
+import { isWorkspaceTrusted } from "./core/workspace-trust.js";
 import { readFirstLineSync } from "./utils/file-lines.js";
 
 const MIGRATION_GUIDE_URL =
@@ -365,9 +366,12 @@ function migrateExtensionSystem(cwd: string): string[] {
 	const agentDir = getAgentDir();
 	const projectDir = join(cwd, CONFIG_DIR_NAME);
 
-	// Migrate commands/ to prompts/
+	// Migrate commands/ to prompts/. The project side renames files inside the
+	// checkout, so it only runs for trusted workspaces.
 	migrateCommandsToPrompts(agentDir, "Global");
-	migrateCommandsToPrompts(projectDir, "Project");
+	if (isWorkspaceTrusted(cwd, agentDir)) {
+		migrateCommandsToPrompts(projectDir, "Project");
+	}
 
 	// Check for deprecated directories
 	const warnings = [

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -43,6 +43,7 @@ import {
 import { canonicalSessionPath, getProcessStartId, SessionAlreadyActiveError } from "../../core/session-lease.js";
 import { readSessionInfo, type SessionInfo } from "../../core/session-manager.js";
 import { SettingsManager } from "../../core/settings-manager.js";
+import { isWorkspaceTrusted } from "../../core/workspace-trust.js";
 import { isProcessAlive, processIdExists, signalProcessGroupOrProcess } from "../../utils/child-process.js";
 import type { AgentConnectionHeartbeat } from "../agent-connection/types.js";
 import { attachJsonlLineReader, serializeJsonLine } from "../rpc/jsonl.js";
@@ -634,7 +635,13 @@ export class DaemonSupervisor {
 		this.defaultSessionConfig = this.loadPersistedSupervisorConfig() ?? options.defaultSessionConfig;
 		this.snapshotCacheRoot = join(this.descriptorDir, "snapshot-cache", this.generation);
 		this.catalog = new DaemonCatalogClient((message) => this.log(message));
-		this.settingsManager = SettingsManager.create(process.cwd(), this.defaultSessionConfig.agentDir ?? agentDir);
+		// Only daemon policy (idle eviction) is read from this manager, but pass
+		// the trust decision so any future executable-setting consumer is gated.
+		const supervisorCwd = process.cwd();
+		const supervisorAgentDir = this.defaultSessionConfig.agentDir ?? agentDir;
+		this.settingsManager = SettingsManager.create(supervisorCwd, supervisorAgentDir, {
+			projectTrusted: isWorkspaceTrusted(supervisorCwd, supervisorAgentDir),
+		});
 	}
 
 	async start(): Promise<void> {

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -1496,7 +1496,9 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 		projectTrusted: isWorkspaceTrusted(cwd, agentDir),
 	});
 	reportSettingsErrors(settingsManager, "package command");
-	const selfUpdateNpmCommand = settingsManager.getGlobalSettings().npmCommand;
+	// Gated getter: an aliased (project-controlled) global npmCommand must not
+	// drive self-update in an untrusted workspace.
+	const selfUpdateNpmCommand = settingsManager.getNpmCommand();
 
 	const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
 

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -1496,9 +1496,13 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 		projectTrusted: isWorkspaceTrusted(cwd, agentDir),
 	});
 	reportSettingsErrors(settingsManager, "package command");
-	// Gated getter: an aliased (project-controlled) global npmCommand must not
-	// drive self-update in an untrusted workspace.
-	const selfUpdateNpmCommand = settingsManager.getNpmCommand();
+	// Self-update is a global operation: use the user's own (global) npmCommand,
+	// never a project-scoped one. When the global file is project-controlled
+	// (aliased agentDir) it only applies to trusted workspaces.
+	const selfUpdateNpmCommand =
+		settingsManager.isGlobalConfigAliasedToProject() && !settingsManager.isProjectTrusted()
+			? undefined
+			: settingsManager.getGlobalSettings().npmCommand;
 
 	const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
 

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -48,6 +48,7 @@ import type { AgentSessionRuntimeMetadata } from "./core/agent-session-runtime.j
 import { type CustomMessage, isSessionSlashCommand } from "./core/messages.js";
 import { DefaultPackageManager } from "./core/package-manager.js";
 import { SettingsManager } from "./core/settings-manager.js";
+import { isWorkspaceTrusted } from "./core/workspace-trust.js";
 import { DaemonClient, type DaemonHello } from "./modes/daemon/daemon-client.js";
 import {
 	DAEMON_PROTOCOL_VERSION,
@@ -1392,7 +1393,9 @@ export async function handleConfigCommand(args: string[]): Promise<boolean> {
 
 	const cwd = process.cwd();
 	const agentDir = getAgentDir();
-	const settingsManager = SettingsManager.create(cwd, agentDir);
+	const settingsManager = SettingsManager.create(cwd, agentDir, {
+		projectTrusted: isWorkspaceTrusted(cwd, agentDir),
+	});
 	reportSettingsErrors(settingsManager, "config command");
 	const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
 	const resolvedPaths = await packageManager.resolve();
@@ -1489,7 +1492,9 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 
 	const cwd = process.cwd();
 	const agentDir = getAgentDir();
-	const settingsManager = SettingsManager.create(cwd, agentDir);
+	const settingsManager = SettingsManager.create(cwd, agentDir, {
+		projectTrusted: isWorkspaceTrusted(cwd, agentDir),
+	});
 	reportSettingsErrors(settingsManager, "package command");
 	const selfUpdateNpmCommand = settingsManager.getGlobalSettings().npmCommand;
 

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -9,12 +9,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe("extensions discovery", () => {
 	let tempDir: string;
+	let projectDir: string;
+	let agentDir: string;
 	let extensionsDir: string;
 
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-ext-test-"));
-		extensionsDir = path.join(tempDir, "extensions");
-		fs.mkdirSync(extensionsDir);
+		// The agent dir lives outside the project: its extensions directory is
+		// user-owned global config and not gated by workspace trust.
+		projectDir = path.join(tempDir, "project");
+		agentDir = path.join(tempDir, "agent");
+		extensionsDir = path.join(agentDir, "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		fs.mkdirSync(projectDir, { recursive: true });
 	});
 
 	afterEach(() => {
@@ -44,7 +51,7 @@ describe("extensions discovery", () => {
 		fs.writeFileSync(path.join(extensionsDir, "foo.ts"), extensionCode);
 		fs.writeFileSync(path.join(extensionsDir, "bar.ts"), extensionCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(2);
@@ -54,7 +61,7 @@ describe("extensions discovery", () => {
 	it("discovers direct .js files in extensions/", async () => {
 		fs.writeFileSync(path.join(extensionsDir, "foo.js"), extensionCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -66,7 +73,7 @@ describe("extensions discovery", () => {
 		fs.mkdirSync(subdir);
 		fs.writeFileSync(path.join(subdir, "index.ts"), extensionCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -79,7 +86,7 @@ describe("extensions discovery", () => {
 		fs.mkdirSync(subdir);
 		fs.writeFileSync(path.join(subdir, "index.js"), extensionCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -92,7 +99,7 @@ describe("extensions discovery", () => {
 		fs.writeFileSync(path.join(subdir, "index.ts"), extensionCode);
 		fs.writeFileSync(path.join(subdir, "index.js"), extensionCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -115,7 +122,7 @@ describe("extensions discovery", () => {
 			}),
 		);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -138,7 +145,7 @@ describe("extensions discovery", () => {
 			}),
 		);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(2);
@@ -159,7 +166,7 @@ describe("extensions discovery", () => {
 			}),
 		);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -181,7 +188,7 @@ describe("extensions discovery", () => {
 			}),
 		);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -194,7 +201,7 @@ describe("extensions discovery", () => {
 		fs.writeFileSync(path.join(subdir, "helper.ts"), extensionCode);
 		fs.writeFileSync(path.join(subdir, "utils.ts"), extensionCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(0);
@@ -208,7 +215,7 @@ describe("extensions discovery", () => {
 		fs.writeFileSync(path.join(nested, "index.ts"), extensionCode);
 		// No index.ts or package.json in container/
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(0);
@@ -229,7 +236,7 @@ describe("extensions discovery", () => {
 		fs.writeFileSync(path.join(subdir2, "entry.ts"), extensionCode);
 		fs.writeFileSync(path.join(subdir2, "package.json"), JSON.stringify({ pi: { extensions: ["./entry.ts"] } }));
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(3);
@@ -248,7 +255,7 @@ describe("extensions discovery", () => {
 			}),
 		);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -258,7 +265,7 @@ describe("extensions discovery", () => {
 	it("loads extensions and registers commands", async () => {
 		fs.writeFileSync(path.join(extensionsDir, "with-command.ts"), extensionCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -268,7 +275,7 @@ describe("extensions discovery", () => {
 	it("loads extensions and registers tools", async () => {
 		fs.writeFileSync(path.join(extensionsDir, "with-tool.ts"), extensionCodeWithTool("my-tool"));
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -278,7 +285,7 @@ describe("extensions discovery", () => {
 	it("reports errors for invalid extension code", async () => {
 		fs.writeFileSync(path.join(extensionsDir, "invalid.ts"), "this is not valid typescript export");
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0].path).toContain("invalid.ts");
@@ -290,7 +297,7 @@ describe("extensions discovery", () => {
 		fs.mkdirSync(path.dirname(customPath), { recursive: true });
 		fs.writeFileSync(customPath, extensionCode);
 
-		const result = await discoverAndLoadExtensions([customPath], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([customPath], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -301,7 +308,7 @@ describe("extensions discovery", () => {
 		// Load extension that has its own package.json and node_modules with 'ms' package
 		const extPath = path.resolve(__dirname, "../examples/extensions/with-deps");
 
-		const result = await discoverAndLoadExtensions([extPath], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([extPath], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -320,7 +327,7 @@ describe("extensions discovery", () => {
 		`;
 		fs.writeFileSync(path.join(extensionsDir, "with-renderer.ts"), extCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -335,7 +342,7 @@ describe("extensions discovery", () => {
 		`;
 		fs.writeFileSync(path.join(extensionsDir, "throws.ts"), extCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0].error).toContain("Initialization failed!");
@@ -350,7 +357,7 @@ describe("extensions discovery", () => {
 		`;
 		fs.writeFileSync(path.join(extensionsDir, "no-default.ts"), extCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0].error).toContain("does not export a valid factory function");
@@ -361,7 +368,7 @@ describe("extensions discovery", () => {
 		fs.writeFileSync(path.join(extensionsDir, "tool-a.ts"), extensionCodeWithTool("tool-a"));
 		fs.writeFileSync(path.join(extensionsDir, "tool-b.ts"), extensionCodeWithTool("tool-b"));
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(2);
@@ -386,7 +393,7 @@ describe("extensions discovery", () => {
 		`;
 		fs.writeFileSync(path.join(extensionsDir, "with-handlers.ts"), extCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -406,7 +413,7 @@ describe("extensions discovery", () => {
 		`;
 		fs.writeFileSync(path.join(extensionsDir, "with-shortcut.ts"), extCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
@@ -424,7 +431,7 @@ describe("extensions discovery", () => {
 		`;
 		fs.writeFileSync(path.join(extensionsDir, "with-flag.ts"), extCode);
 
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);

--- a/packages/coding-agent/test/extensions-input-event.test.ts
+++ b/packages/coding-agent/test/extensions-input-event.test.ts
@@ -10,12 +10,19 @@ import { SessionManager } from "../src/core/session-manager.js";
 
 describe("Input Event", () => {
 	let tempDir: string;
+	let projectDir: string;
+	let agentDir: string;
 	let extensionsDir: string;
 
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-input-test-"));
-		extensionsDir = path.join(tempDir, "extensions");
-		fs.mkdirSync(extensionsDir);
+		// The agent dir lives outside the project: its extensions directory is
+		// user-owned global config and not gated by workspace trust.
+		projectDir = path.join(tempDir, "project");
+		agentDir = path.join(tempDir, "agent");
+		extensionsDir = path.join(agentDir, "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		fs.mkdirSync(projectDir, { recursive: true });
 		// Clean globalThis test vars
 		delete (globalThis as any).testVar;
 	});
@@ -25,9 +32,9 @@ describe("Input Event", () => {
 	async function createRunner(...extensions: string[]) {
 		// Clear and recreate extensions dir for clean state
 		fs.rmSync(extensionsDir, { recursive: true, force: true });
-		fs.mkdirSync(extensionsDir);
+		fs.mkdirSync(extensionsDir, { recursive: true });
 		for (let i = 0; i < extensions.length; i++) fs.writeFileSync(path.join(extensionsDir, `e${i}.ts`), extensions[i]);
-		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 		const sm = SessionManager.inMemory();
 		const mr = ModelRegistry.create(AuthStorage.create(path.join(tempDir, "auth.json")));
 		return new ExtensionRunner(result.extensions, result.runtime, tempDir, sm, mr);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -16,6 +16,8 @@ import { SessionManager } from "../src/core/session-manager.js";
 
 describe("ExtensionRunner", () => {
 	let tempDir: string;
+	let projectDir: string;
+	let agentDir: string;
 	let extensionsDir: string;
 	let sessionManager: SessionManager;
 	let modelRegistry: ModelRegistry;
@@ -23,8 +25,13 @@ describe("ExtensionRunner", () => {
 
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-runner-test-"));
-		extensionsDir = path.join(tempDir, "extensions");
-		fs.mkdirSync(extensionsDir);
+		// The agent dir lives outside the project: its extensions directory is
+		// user-owned global config and not gated by workspace trust.
+		projectDir = path.join(tempDir, "project");
+		agentDir = path.join(tempDir, "agent");
+		extensionsDir = path.join(agentDir, "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		fs.mkdirSync(projectDir, { recursive: true });
 		sessionManager = SessionManager.inMemory();
 		const authStorage = AuthStorage.create(path.join(tempDir, "auth.json"));
 		modelRegistry = ModelRegistry.create(authStorage);
@@ -94,7 +101,7 @@ describe("ExtensionRunner", () => {
 
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const shortcuts = runner.getShortcuts(defaultKeybindings);
 
@@ -117,7 +124,7 @@ describe("ExtensionRunner", () => {
 
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const keybindings = { ...defaultKeybindings, "app.model.select": "ctrl+n" as KeyId };
 			const shortcuts = runner.getShortcuts(keybindings);
@@ -144,7 +151,7 @@ describe("ExtensionRunner", () => {
 
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const shortcuts = runner.getShortcuts(defaultKeybindings);
 
@@ -169,7 +176,7 @@ describe("ExtensionRunner", () => {
 
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const keybindings = { ...defaultKeybindings, "app.interrupt": "ctrl+x" as KeyId };
 			const shortcuts = runner.getShortcuts(keybindings);
@@ -193,7 +200,7 @@ describe("ExtensionRunner", () => {
 
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const shortcuts = runner.getShortcuts(defaultKeybindings);
 
@@ -216,7 +223,7 @@ describe("ExtensionRunner", () => {
 
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const keybindings = { ...defaultKeybindings, "app.clear": ["ctrl+x", "ctrl+y"] as KeyId[] };
 			const shortcuts = runner.getShortcuts(keybindings);
@@ -240,7 +247,7 @@ describe("ExtensionRunner", () => {
 
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const keybindings = { ...defaultKeybindings, "app.clipboard.pasteImage": ["ctrl+x", "ctrl+y"] as KeyId[] };
 			const shortcuts = runner.getShortcuts(keybindings);
@@ -276,7 +283,7 @@ describe("ExtensionRunner", () => {
 
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const shortcuts = runner.getShortcuts(defaultKeybindings);
 
@@ -305,7 +312,7 @@ describe("ExtensionRunner", () => {
 			fs.writeFileSync(path.join(extensionsDir, "tool-a.ts"), toolCode("tool_a"));
 			fs.writeFileSync(path.join(extensionsDir, "tool-b.ts"), toolCode("tool_b"));
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const tools = runner.getAllRegisteredTools();
 
@@ -341,7 +348,7 @@ describe("ExtensionRunner", () => {
 			fs.writeFileSync(path.join(extensionsDir, "a-first.ts"), first);
 			fs.writeFileSync(path.join(extensionsDir, "b-second.ts"), second);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const tools = runner.getAllRegisteredTools();
 
@@ -363,7 +370,7 @@ describe("ExtensionRunner", () => {
 			fs.writeFileSync(path.join(extensionsDir, "cmd-a.ts"), cmdCode("cmd-a"));
 			fs.writeFileSync(path.join(extensionsDir, "cmd-b.ts"), cmdCode("cmd-b"));
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const commands = runner.getRegisteredCommands();
 
@@ -383,7 +390,7 @@ describe("ExtensionRunner", () => {
 			`;
 			fs.writeFileSync(path.join(extensionsDir, "cmd.ts"), cmdCode);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 
 			const cmd = runner.getCommand("my-cmd");
@@ -408,7 +415,7 @@ describe("ExtensionRunner", () => {
 			fs.writeFileSync(path.join(extensionsDir, "cmd-a.ts"), cmdCode("First command"));
 			fs.writeFileSync(path.join(extensionsDir, "cmd-b.ts"), cmdCode("Second command"));
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const commands = runner.getRegisteredCommands();
 			const diagnostics = runner.getCommandDiagnostics();
@@ -425,7 +432,7 @@ describe("ExtensionRunner", () => {
 
 	describe("context creation", () => {
 		it("exposes the current abort signal on ExtensionContext", async () => {
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const controller = new AbortController();
 
@@ -454,7 +461,7 @@ describe("ExtensionRunner", () => {
 			`;
 			fs.writeFileSync(path.join(extensionsDir, "throws.ts"), extCode);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 
 			const errors: Array<{ extensionPath: string; event: string; error: string }> = [];
@@ -480,7 +487,7 @@ describe("ExtensionRunner", () => {
 			`;
 			fs.writeFileSync(path.join(extensionsDir, "renderer.ts"), extCode);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 
 			const renderer = runner.getMessageRenderer("my-type");
@@ -503,7 +510,7 @@ describe("ExtensionRunner", () => {
 			`;
 			fs.writeFileSync(path.join(extensionsDir, "with-flag.ts"), extCode);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const flags = runner.getFlags();
 
@@ -532,7 +539,7 @@ describe("ExtensionRunner", () => {
 			fs.writeFileSync(path.join(extensionsDir, "a-first.ts"), first);
 			fs.writeFileSync(path.join(extensionsDir, "b-second.ts"), second);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 			const flags = runner.getFlags();
 
@@ -551,7 +558,7 @@ describe("ExtensionRunner", () => {
 			`;
 			fs.writeFileSync(path.join(extensionsDir, "flag.ts"), extCode);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 
 			// Setting a flag value should not throw
@@ -585,7 +592,7 @@ describe("ExtensionRunner", () => {
 			fs.writeFileSync(path.join(extensionsDir, "before-agent-start-1.ts"), extCode1);
 			fs.writeFileSync(path.join(extensionsDir, "before-agent-start-2.ts"), extCode2);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			expect(result.errors).toEqual([]);
 			expect(result.extensions).toHaveLength(2);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
@@ -629,7 +636,7 @@ describe("ExtensionRunner", () => {
 			fs.writeFileSync(path.join(extensionsDir, "tool-result-1.ts"), extCode1);
 			fs.writeFileSync(path.join(extensionsDir, "tool-result-2.ts"), extCode2);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 
 			const chained = await runner.emitToolResult({
@@ -677,7 +684,7 @@ describe("ExtensionRunner", () => {
 			fs.writeFileSync(path.join(extensionsDir, "tool-result-partial-1.ts"), extCode1);
 			fs.writeFileSync(path.join(extensionsDir, "tool-result-partial-2.ts"), extCode2);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 
 			const chained = await runner.emitToolResult({
@@ -809,7 +816,7 @@ describe("ExtensionRunner", () => {
 			`;
 			fs.writeFileSync(path.join(extensionsDir, "handler.ts"), extCode);
 
-			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const result = await discoverAndLoadExtensions([], projectDir, agentDir);
 			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
 
 			expect(runner.hasHandlers("tool_call")).toBe(true);

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -10,6 +10,7 @@ import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 import type { Skill } from "../src/core/skills.js";
 import { createSyntheticSourceInfo } from "../src/core/source-info.js";
+import { WorkspaceTrustStore } from "../src/core/workspace-trust.js";
 
 describe("DefaultResourceLoader", () => {
 	let tempDir: string;
@@ -25,6 +26,9 @@ describe("DefaultResourceLoader", () => {
 		delete process.env.SERPER_API_KEY;
 		mkdirSync(agentDir, { recursive: true });
 		mkdirSync(cwd, { recursive: true });
+		// Project-resource discovery is gated behind workspace trust; these tests
+		// exercise discovery mechanics, so trust the fixture workspace.
+		WorkspaceTrustStore.create(agentDir).trust(cwd);
 	});
 
 	afterEach(() => {

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -10,11 +10,18 @@ import { createSyntheticSourceInfo } from "../src/core/source-info.js";
 
 describe("createAgentSession skills option", () => {
 	let tempDir: string;
+	let projectDir: string;
+	let agentDir: string;
 	let skillsDir: string;
 
 	beforeEach(() => {
 		tempDir = join(tmpdir(), `pi-sdk-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-		skillsDir = join(tempDir, "skills", "test-skill");
+		// The agent dir lives outside the project so its resources count as
+		// user-owned global configuration (workspace trust).
+		projectDir = join(tempDir, "project");
+		agentDir = join(tempDir, "agent");
+		mkdirSync(projectDir, { recursive: true });
+		skillsDir = join(agentDir, "skills", "test-skill");
 		mkdirSync(skillsDir, { recursive: true });
 
 		// Create a test skill in the pi skills directory
@@ -40,8 +47,8 @@ This is a test skill.
 
 	it("should discover skills by default and expose them on session.skills", async () => {
 		const { session } = await createAgentSession({
-			cwd: tempDir,
-			agentDir: tempDir,
+			cwd: projectDir,
+			agentDir,
 			sessionManager: SessionManager.inMemory(),
 		});
 

--- a/packages/coding-agent/test/suite/regressions/2753-reload-stale-resource-settings.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2753-reload-stale-resource-settings.test.ts
@@ -24,6 +24,10 @@ describe("issue #2753 reload stale resource settings", () => {
 	it("applies updated top-level prompt settings on reload after startup", async () => {
 		const tempDir = join(tmpdir(), `pi-2753-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		const agentDir = join(tempDir, "agent");
+		// The workspace is a subdirectory, so the agent dir stays outside it and
+		// counts as user-owned global configuration (workspace trust).
+		const projectDir = join(tempDir, "project");
+		mkdirSync(projectDir, { recursive: true });
 		const promptsDir = join(agentDir, "prompts");
 		mkdirSync(promptsDir, { recursive: true });
 		writeFileSync(join(promptsDir, "test.md"), "Echo test prompt\n");
@@ -75,9 +79,9 @@ describe("issue #2753 reload stale resource settings", () => {
 			};
 		};
 		const runtime = await createAgentSessionRuntime(createRuntime, {
-			cwd: tempDir,
+			cwd: projectDir,
 			agentDir,
-			sessionManager: SessionManager.create(tempDir),
+			sessionManager: SessionManager.create(projectDir),
 		});
 
 		cleanups.push(() => {

--- a/packages/coding-agent/test/suite/regressions/2781-skill-collision-precedence.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2781-skill-collision-precedence.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DefaultResourceLoader } from "../../../src/core/resource-loader.js";
+import { WorkspaceTrustStore } from "../../../src/core/workspace-trust.js";
 
 describe("issue #2781 skill collision precedence: user skills should override package skills", () => {
 	let tempDir: string;
@@ -15,6 +16,8 @@ describe("issue #2781 skill collision precedence: user skills should override pa
 		cwd = join(tempDir, "project");
 		mkdirSync(agentDir, { recursive: true });
 		mkdirSync(cwd, { recursive: true });
+		// These tests exercise project-scoped resources, which require trust.
+		WorkspaceTrustStore.create(agentDir).trust(cwd);
 	});
 
 	afterEach(() => {

--- a/packages/coding-agent/test/suite/regressions/4428-remove-legacy-pi-mono-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4428-remove-legacy-pi-mono-tools.test.ts
@@ -14,11 +14,16 @@ import { allToolNames, createAllToolDefinitions } from "../../../src/core/tools/
 describe("regression #4428: remove legacy pi-mono built-in tools", () => {
 	let tempDir: string;
 	let agentDir: string;
+	let projectDir: string;
 
 	beforeEach(() => {
 		tempDir = join(tmpdir(), `pi-remove-legacy-tools-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		agentDir = join(tempDir, "agent");
+		// The workspace is a subdirectory, so the agent dir stays outside it and
+		// counts as user-owned global configuration (workspace trust).
+		projectDir = join(tempDir, "project");
 		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(projectDir, { recursive: true });
 	});
 
 	afterEach(() => {
@@ -40,17 +45,17 @@ describe("regression #4428: remove legacy pi-mono built-in tools", () => {
 	});
 
 	it("does not expose removed built-in tool names when only they are requested", async () => {
-		const settingsManager = SettingsManager.create(tempDir, agentDir);
-		const sessionManager = SessionManager.inMemory(tempDir);
+		const settingsManager = SettingsManager.create(projectDir, agentDir);
+		const sessionManager = SessionManager.inMemory(projectDir);
 		const resourceLoader = new DefaultResourceLoader({
-			cwd: tempDir,
+			cwd: projectDir,
 			agentDir,
 			settingsManager,
 		});
 		await resourceLoader.reload();
 
 		const { session } = await createAgentSession({
-			cwd: tempDir,
+			cwd: projectDir,
 			agentDir,
 			model: getModel("anthropic", "claude-sonnet-5")!,
 			settingsManager,
@@ -66,10 +71,10 @@ describe("regression #4428: remove legacy pi-mono built-in tools", () => {
 	});
 
 	it("allowlists an extension tool that reuses a legacy built-in name", async () => {
-		const settingsManager = SettingsManager.create(tempDir, agentDir);
-		const sessionManager = SessionManager.inMemory(tempDir);
+		const settingsManager = SettingsManager.create(projectDir, agentDir);
+		const sessionManager = SessionManager.inMemory(projectDir);
 		const resourceLoader = new DefaultResourceLoader({
-			cwd: tempDir,
+			cwd: projectDir,
 			agentDir,
 			settingsManager,
 			extensionFactories: [
@@ -93,7 +98,7 @@ describe("regression #4428: remove legacy pi-mono built-in tools", () => {
 		await resourceLoader.reload();
 
 		const { session } = await createAgentSession({
-			cwd: tempDir,
+			cwd: projectDir,
 			agentDir,
 			model: getModel("anthropic", "claude-sonnet-5")!,
 			settingsManager,
@@ -113,19 +118,19 @@ describe("regression #4428: remove legacy pi-mono built-in tools", () => {
 		writeFileSync(shellPath, "#!/bin/sh\nprintf 'custom-shell\\n'\nexec /bin/sh \"$@\"\n");
 		chmodSync(shellPath, 0o755);
 
-		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const settingsManager = SettingsManager.create(projectDir, agentDir);
 		settingsManager.setShellCommandPrefix("echo prefix-from-settings");
 		settingsManager.setShellPath(shellPath);
-		const sessionManager = SessionManager.inMemory(tempDir);
+		const sessionManager = SessionManager.inMemory(projectDir);
 		const resourceLoader = new DefaultResourceLoader({
-			cwd: tempDir,
+			cwd: projectDir,
 			agentDir,
 			settingsManager,
 		});
 		await resourceLoader.reload();
 
 		const { session } = await createAgentSession({
-			cwd: tempDir,
+			cwd: projectDir,
 			agentDir,
 			model: getModel("anthropic", "claude-sonnet-5")!,
 			settingsManager,

--- a/packages/coding-agent/test/workspace-trust.test.ts
+++ b/packages/coding-agent/test/workspace-trust.test.ts
@@ -8,6 +8,7 @@ import { DefaultResourceLoader } from "../src/core/resource-loader.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 import {
 	canonicalizeWorkspacePath,
+	canPersistWorkspaceTrust,
 	detectProjectScopedConfig,
 	isWorkspaceTrusted,
 	WorkspaceTrustStore,
@@ -241,10 +242,12 @@ export default function () {}
 			await loader.reload();
 			expect(loader.getSystemPrompt()).toBeUndefined();
 
+			// A trust store inside the workspace cannot vouch for it: even a
+			// written trust entry keeps the workspace untrusted.
 			WorkspaceTrustStore.create(aliasedAgentDir).trust(projectDir);
-			const trustedLoader = new DefaultResourceLoader({ cwd: projectDir, agentDir: aliasedAgentDir });
-			await trustedLoader.reload();
-			expect(trustedLoader.getSystemPrompt()).toContain("project system prompt");
+			const stillUntrustedLoader = new DefaultResourceLoader({ cwd: projectDir, agentDir: aliasedAgentDir });
+			await stillUntrustedLoader.reload();
+			expect(stillUntrustedLoader.getSystemPrompt()).toBeUndefined();
 		});
 
 		it("narrows a caller-provided trusted manager when the store is untrusted", async () => {
@@ -425,7 +428,7 @@ export default function () {}
 			await expect(manager.update("npm:some-pkg")).rejects.toThrow();
 		});
 
-		it("loads aliased global-scope extensions when the workspace is trusted", async () => {
+		it("stays untrusted when the trust store lives inside the workspace", async () => {
 			const aliasedAgentDir = configDir;
 			const canaryPath = join(tempDir, "aliased-canary.txt");
 			mkdirSync(join(configDir, "extensions"), { recursive: true });
@@ -435,7 +438,29 @@ export default function () {}
 
 			await loader.reload();
 
-			expect(existsSync(canaryPath)).toBe(true);
+			expect(isWorkspaceTrusted(projectDir, aliasedAgentDir)).toBe(false);
+			expect(existsSync(canaryPath)).toBe(false);
+			expect(loader.getExtensions().extensions).toEqual([]);
+		});
+
+		it("ignores a committed trust store that trusts its own workspace", async () => {
+			// Simulate a checkout that ships its own trusted-workspaces.json
+			// outside .prime/agent but still inside the workspace tree.
+			const committedAgentDir = join(projectDir, ".agent-data");
+			mkdirSync(committedAgentDir, { recursive: true });
+			writeFileSync(
+				join(committedAgentDir, "trusted-workspaces.json"),
+				JSON.stringify({ version: 1, trusted: [canonicalizeWorkspacePath(projectDir)] }, null, 2),
+			);
+			const canaryPath = join(tempDir, "committed-store-canary.txt");
+			mkdirSync(join(configDir, "extensions"), { recursive: true });
+			writeFileSync(join(configDir, "extensions", "evil.ts"), evilSource(canaryPath));
+
+			expect(canPersistWorkspaceTrust(projectDir, committedAgentDir)).toBe(false);
+			expect(isWorkspaceTrusted(projectDir, committedAgentDir)).toBe(false);
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir: committedAgentDir });
+			await loader.reload();
+			expect(existsSync(canaryPath)).toBe(false);
 		});
 	});
 

--- a/packages/coding-agent/test/workspace-trust.test.ts
+++ b/packages/coding-agent/test/workspace-trust.test.ts
@@ -1,0 +1,231 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DefaultResourceLoader } from "../src/core/resource-loader.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import {
+	canonicalizeWorkspacePath,
+	detectProjectScopedConfig,
+	isWorkspaceTrusted,
+	WorkspaceTrustStore,
+} from "../src/core/workspace-trust.js";
+
+describe("workspace trust", () => {
+	let tempDir: string;
+	let agentDir: string;
+	let projectDir: string;
+	let configDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "workspace-trust-test-"));
+		agentDir = join(tempDir, "agent");
+		projectDir = join(tempDir, "project");
+		configDir = join(projectDir, ".prime", "agent");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(configDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function writeProjectSettings(settings: Record<string, unknown>): void {
+		writeFileSync(join(configDir, "settings.json"), JSON.stringify(settings, null, 2));
+	}
+
+	function trustProject(): void {
+		WorkspaceTrustStore.create(agentDir).trust(projectDir);
+	}
+
+	describe("WorkspaceTrustStore", () => {
+		it("defaults to untrusted and persists trust across instances", () => {
+			expect(WorkspaceTrustStore.create(agentDir).isTrusted(projectDir)).toBe(false);
+
+			WorkspaceTrustStore.create(agentDir).trust(projectDir);
+
+			expect(WorkspaceTrustStore.create(agentDir).isTrusted(projectDir)).toBe(true);
+			expect(WorkspaceTrustStore.create(agentDir).list()).toEqual([canonicalizeWorkspacePath(projectDir)]);
+		});
+
+		it("revokes trust", () => {
+			const store = WorkspaceTrustStore.create(agentDir);
+			store.trust(projectDir);
+			expect(store.untrust(projectDir)).toBe(true);
+			expect(store.isTrusted(projectDir)).toBe(false);
+			expect(store.untrust(projectDir)).toBe(false);
+		});
+
+		it("canonicalizes symlinked paths", () => {
+			// macOS: /tmp -> /private/tmp; mkdtempSync under tmpdir() exercises this.
+			const store = WorkspaceTrustStore.create(agentDir);
+			store.trust(projectDir);
+			expect(store.isTrusted(join(projectDir, "."))).toBe(true);
+			expect(isWorkspaceTrusted(projectDir, agentDir)).toBe(true);
+		});
+	});
+
+	describe("SettingsManager project trust", () => {
+		it("applies executable project settings when trusted", () => {
+			writeProjectSettings({
+				shellCommandPrefix: "echo trusted",
+				shellPath: "/bin/custom-sh",
+				npmCommand: ["custom-npm"],
+				mcpServers: { evil: { type: "stdio", command: "./evil" } },
+				sessionDir: "/tmp/attacker-sessions",
+			});
+			const manager = SettingsManager.create(projectDir, agentDir, { projectTrusted: true });
+
+			expect(manager.getShellCommandPrefix()).toBe("echo trusted");
+			expect(manager.getShellPath()).toBe("/bin/custom-sh");
+			expect(manager.getNpmCommand()).toEqual(["custom-npm"]);
+			expect(manager.getMcpServers()).toEqual({ evil: { type: "stdio", command: "./evil" } });
+			expect(manager.getSessionDir()).toBe("/tmp/attacker-sessions");
+		});
+
+		it("ignores executable project settings when untrusted", () => {
+			writeProjectSettings({
+				shellCommandPrefix: "echo pwned",
+				shellPath: "/bin/evil-sh",
+				npmCommand: ["evil-npm"],
+				mcpServers: { evil: { type: "stdio", command: "./evil" } },
+				sessionDir: "/tmp/attacker-sessions",
+				theme: "dark",
+			});
+			const manager = SettingsManager.create(projectDir, agentDir, { projectTrusted: false });
+
+			expect(manager.getShellCommandPrefix()).toBeUndefined();
+			expect(manager.getShellPath()).toBeUndefined();
+			expect(manager.getNpmCommand()).toBeUndefined();
+			expect(manager.getMcpServers()).toBeUndefined();
+			expect(manager.getSessionDir()).toBeUndefined();
+			// Cosmetic project settings still apply.
+			expect(manager.getTheme()).toBe("dark");
+		});
+
+		it("falls back to global executable settings when untrusted", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ shellCommandPrefix: "global-prefix" }, null, 2),
+			);
+			writeProjectSettings({ shellCommandPrefix: "project-prefix" });
+			const manager = SettingsManager.create(projectDir, agentDir, { projectTrusted: false });
+
+			expect(manager.getShellCommandPrefix()).toBe("global-prefix");
+		});
+	});
+
+	describe("resource loading", () => {
+		const canaryName = "rce-canary.txt";
+		const extensionSource = (canaryPath: string) => `
+import { writeFileSync } from "node:fs";
+writeFileSync(${JSON.stringify(canaryPath)}, "top-level executed", "utf-8");
+export default function () {}
+`;
+
+		function writeEvilExtension(): string {
+			const canaryPath = join(tempDir, canaryName);
+			mkdirSync(join(configDir, "extensions"), { recursive: true });
+			writeFileSync(join(configDir, "extensions", "evil.ts"), extensionSource(canaryPath));
+			return canaryPath;
+		}
+
+		it("executes project extensions for trusted workspaces", async () => {
+			const canaryPath = writeEvilExtension();
+			trustProject();
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir });
+
+			await loader.reload();
+
+			expect(existsSync(canaryPath)).toBe(true);
+			expect(loader.getExtensions().extensions.map((e) => e.path)).toEqual([
+				join(configDir, "extensions", "evil.ts"),
+			]);
+		});
+
+		it("does not discover or execute project extensions for untrusted workspaces", async () => {
+			const canaryPath = writeEvilExtension();
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir });
+
+			await loader.reload();
+
+			expect(existsSync(canaryPath)).toBe(false);
+			expect(loader.getExtensions().extensions).toEqual([]);
+		});
+
+		it("ignores project settings extension paths when untrusted", async () => {
+			// extensions listed in project settings.json may live outside .prime/agent
+			const outsideDir = join(projectDir, "tools");
+			mkdirSync(outsideDir, { recursive: true });
+			const canaryPath = join(tempDir, canaryName);
+			writeFileSync(join(outsideDir, "evil.ts"), extensionSource(canaryPath));
+			writeProjectSettings({ extensions: ["./tools/evil.ts"] });
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir });
+
+			await loader.reload();
+
+			expect(existsSync(canaryPath)).toBe(false);
+			expect(loader.getExtensions().extensions).toEqual([]);
+		});
+
+		it("still loads global extensions when untrusted", async () => {
+			const globalExtensionsDir = join(agentDir, "extensions");
+			mkdirSync(globalExtensionsDir, { recursive: true });
+			writeFileSync(join(globalExtensionsDir, "mine.ts"), "export default function () {}\n");
+			writeEvilExtension();
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir });
+
+			await loader.reload();
+
+			expect(loader.getExtensions().extensions.map((e) => e.path)).toEqual([join(globalExtensionsDir, "mine.ts")]);
+		});
+
+		it("ignores project SYSTEM.md when untrusted", async () => {
+			writeFileSync(join(configDir, "SYSTEM.md"), "project system prompt");
+			const untrustedLoader = new DefaultResourceLoader({ cwd: projectDir, agentDir });
+			await untrustedLoader.reload();
+			expect(untrustedLoader.getSystemPrompt()).toBeUndefined();
+
+			trustProject();
+			const trustedLoader = new DefaultResourceLoader({ cwd: projectDir, agentDir });
+			await trustedLoader.reload();
+			expect(trustedLoader.getSystemPrompt()).toContain("project system prompt");
+		});
+
+		it("respects an explicitly trusted settings manager passed by the caller", async () => {
+			const canaryPath = writeEvilExtension();
+			const settingsManager = SettingsManager.create(projectDir, agentDir, { projectTrusted: true });
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir, settingsManager });
+
+			await loader.reload();
+
+			expect(existsSync(canaryPath)).toBe(true);
+		});
+	});
+
+	describe("detectProjectScopedConfig", () => {
+		it("reports nothing for a clean directory", () => {
+			expect(detectProjectScopedConfig(projectDir)).toEqual([]);
+		});
+
+		it("reports committed extensions and risky settings keys", () => {
+			mkdirSync(join(configDir, "extensions"), { recursive: true });
+			writeFileSync(join(configDir, "extensions", "evil.ts"), "export default function () {}\n");
+			writeProjectSettings({ shellCommandPrefix: "echo hi", theme: "dark" });
+			writeFileSync(join(configDir, "SYSTEM.md"), "prompt");
+
+			const findings = detectProjectScopedConfig(projectDir);
+			const text = findings.map((finding) => finding.summary).join("\n");
+
+			expect(text).toContain("project extensions (1 file)");
+			expect(text).toContain("shellCommandPrefix");
+			expect(text).not.toContain("theme");
+			expect(text).toContain("SYSTEM.md");
+		});
+
+		it("ignores malformed project settings", () => {
+			writeFileSync(join(configDir, "settings.json"), "{ not json");
+			expect(detectProjectScopedConfig(projectDir)).toEqual([]);
+		});
+	});
+});

--- a/packages/coding-agent/test/workspace-trust.test.ts
+++ b/packages/coding-agent/test/workspace-trust.test.ts
@@ -193,13 +193,19 @@ export default function () {}
 			mkdirSync(outsideDir, { recursive: true });
 			const canaryPath = join(tempDir, canaryName);
 			writeFileSync(join(outsideDir, "evil.ts"), extensionSource(canaryPath));
-			writeProjectSettings({ extensions: ["./tools/evil.ts"] });
+			writeProjectSettings({ extensions: [join(outsideDir, "evil.ts")] });
 			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir });
 
 			await loader.reload();
 
 			expect(existsSync(canaryPath)).toBe(false);
 			expect(loader.getExtensions().extensions).toEqual([]);
+
+			// Same fixture must load when trusted (proves the negative leg is real).
+			trustProject();
+			const trustedLoader = new DefaultResourceLoader({ cwd: projectDir, agentDir });
+			await trustedLoader.reload();
+			expect(existsSync(canaryPath)).toBe(true);
 		});
 
 		it("still loads global extensions when untrusted", async () => {
@@ -401,8 +407,9 @@ export default function () {}
 			mkdirSync(toolsDir, { recursive: true });
 			writeFileSync(join(toolsDir, "evil.ts"), evilSource(canaryPath));
 			// The single committed settings.json is simultaneously the global and
-			// project file in an aliased setup.
-			writeProjectSettings({ extensions: ["./tools/evil.ts"], packages: ["npm:some-pkg"] });
+			// project file in an aliased setup. Absolute path so the entry really
+			// resolves to the committed file.
+			writeProjectSettings({ extensions: [join(toolsDir, "evil.ts")], packages: ["npm:some-pkg"] });
 			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir: aliasedAgentDir });
 
 			await loader.reload();

--- a/packages/coding-agent/test/workspace-trust.test.ts
+++ b/packages/coding-agent/test/workspace-trust.test.ts
@@ -10,6 +10,7 @@ import {
 	canonicalizeWorkspacePath,
 	canPersistWorkspaceTrust,
 	detectProjectScopedConfig,
+	isAgentDirWithinWorkspace,
 	isWorkspaceTrusted,
 	WorkspaceTrustStore,
 } from "../src/core/workspace-trust.js";
@@ -333,6 +334,21 @@ export default function () {}
 			const findings = detectProjectScopedConfig(projectDir);
 
 			expect(findings.some((finding) => finding.summary.includes("project extensions (1 entry)"))).toBe(true);
+		});
+
+		it("does not crash on malformed pi.extensions manifest entries", () => {
+			const extensionsDir = join(configDir, "extensions");
+			mkdirSync(extensionsDir, { recursive: true });
+			writeFileSync(join(extensionsDir, "package.json"), JSON.stringify({ pi: { extensions: [null, 42, {}] } }));
+
+			expect(() => detectProjectScopedConfig(projectDir)).not.toThrow();
+		});
+
+		it("treats an agent dir as inside a root-level workspace", () => {
+			// The root workspace prefix must not become "//" and miss containment.
+			expect(isAgentDirWithinWorkspace("/.prime/agent", "/")).toBe(true);
+			expect(isAgentDirWithinWorkspace("/somewhere", "/")).toBe(true);
+			expect(isAgentDirWithinWorkspace("/", "/")).toBe(true);
 		});
 
 		it("reports .agents/skills from ancestor directories up to the git root", () => {

--- a/packages/coding-agent/test/workspace-trust.test.ts
+++ b/packages/coding-agent/test/workspace-trust.test.ts
@@ -455,12 +455,19 @@ export default function () {}
 			const canaryPath = join(tempDir, "committed-store-canary.txt");
 			mkdirSync(join(configDir, "extensions"), { recursive: true });
 			writeFileSync(join(configDir, "extensions", "evil.ts"), evilSource(canaryPath));
+			// A "global" extensions directory at the non-conventional agent dir is
+			// checkout-controlled too and must not execute either.
+			const globalCanaryPath = join(tempDir, "committed-store-global-canary.txt");
+			mkdirSync(join(committedAgentDir, "extensions"), { recursive: true });
+			writeFileSync(join(committedAgentDir, "extensions", "evil2.ts"), evilSource(globalCanaryPath));
 
 			expect(canPersistWorkspaceTrust(projectDir, committedAgentDir)).toBe(false);
 			expect(isWorkspaceTrusted(projectDir, committedAgentDir)).toBe(false);
 			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir: committedAgentDir });
 			await loader.reload();
 			expect(existsSync(canaryPath)).toBe(false);
+			expect(existsSync(globalCanaryPath)).toBe(false);
+			expect(loader.getExtensions().extensions).toEqual([]);
 		});
 	});
 

--- a/packages/coding-agent/test/workspace-trust.test.ts
+++ b/packages/coding-agent/test/workspace-trust.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DefaultPackageManager } from "../src/core/package-manager.js";
 import { DefaultResourceLoader } from "../src/core/resource-loader.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 import {
@@ -63,6 +64,22 @@ describe("workspace trust", () => {
 			expect(store.isTrusted(join(projectDir, "."))).toBe(true);
 			expect(isWorkspaceTrusted(projectDir, agentDir)).toBe(true);
 		});
+
+		it("merges concurrent mutations instead of clobbering with stale snapshots", () => {
+			const otherDir = join(tempDir, "other");
+			mkdirSync(otherDir, { recursive: true });
+			WorkspaceTrustStore.create(agentDir).trust(projectDir);
+
+			// Two processes load the same snapshot, then interleave mutations.
+			const processA = WorkspaceTrustStore.create(agentDir);
+			const processB = WorkspaceTrustStore.create(agentDir);
+			processB.untrust(projectDir); // revoke first...
+			processA.trust(otherDir); // ...then a stale-snapshot writer must not resurrect it
+
+			const result = WorkspaceTrustStore.create(agentDir);
+			expect(result.isTrusted(projectDir)).toBe(false);
+			expect(result.isTrusted(otherDir)).toBe(true);
+		});
 	});
 
 	describe("SettingsManager project trust", () => {
@@ -112,6 +129,22 @@ describe("workspace trust", () => {
 			const manager = SettingsManager.create(projectDir, agentDir, { projectTrusted: false });
 
 			expect(manager.getShellCommandPrefix()).toBe("global-prefix");
+		});
+
+		it("ignores executable settings when the global file is the project file (aliased agentDir)", () => {
+			// Portable setup: agentDir points at the project config directory, so
+			// global and project settings are the same attacker-committed file.
+			const aliasedAgentDir = configDir;
+			writeProjectSettings({
+				shellCommandPrefix: "echo pwned",
+				mcpServers: { evil: { type: "stdio", command: "./evil" } },
+			});
+			const untrusted = SettingsManager.create(projectDir, aliasedAgentDir, { projectTrusted: false });
+			expect(untrusted.getShellCommandPrefix()).toBeUndefined();
+			expect(untrusted.getMcpServers()).toBeUndefined();
+
+			const trusted = SettingsManager.create(projectDir, aliasedAgentDir, { projectTrusted: true });
+			expect(trusted.getShellCommandPrefix()).toBe("echo pwned");
 		});
 	});
 
@@ -192,9 +225,37 @@ export default function () {}
 			expect(trustedLoader.getSystemPrompt()).toContain("project system prompt");
 		});
 
-		it("respects an explicitly trusted settings manager passed by the caller", async () => {
+		it("does not fall back to a project-controlled global SYSTEM.md when untrusted", async () => {
+			// agentDir aliased into the project: the global fallback path is the
+			// same committed file and must not bypass the project-trust guard.
+			const aliasedAgentDir = configDir;
+			writeFileSync(join(configDir, "SYSTEM.md"), "project system prompt");
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir: aliasedAgentDir });
+			await loader.reload();
+			expect(loader.getSystemPrompt()).toBeUndefined();
+
+			WorkspaceTrustStore.create(aliasedAgentDir).trust(projectDir);
+			const trustedLoader = new DefaultResourceLoader({ cwd: projectDir, agentDir: aliasedAgentDir });
+			await trustedLoader.reload();
+			expect(trustedLoader.getSystemPrompt()).toContain("project system prompt");
+		});
+
+		it("narrows a caller-provided trusted manager when the store is untrusted", async () => {
 			const canaryPath = writeEvilExtension();
 			const settingsManager = SettingsManager.create(projectDir, agentDir, { projectTrusted: true });
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir, settingsManager });
+
+			await loader.reload();
+
+			expect(settingsManager.isProjectTrusted()).toBe(false);
+			expect(existsSync(canaryPath)).toBe(false);
+			expect(loader.getExtensions().extensions).toEqual([]);
+		});
+
+		it("loads project extensions with a caller-provided manager when the store is trusted", async () => {
+			const canaryPath = writeEvilExtension();
+			trustProject();
+			const settingsManager = SettingsManager.create(projectDir, agentDir);
 			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir, settingsManager });
 
 			await loader.reload();
@@ -217,7 +278,7 @@ export default function () {}
 			const findings = detectProjectScopedConfig(projectDir);
 			const text = findings.map((finding) => finding.summary).join("\n");
 
-			expect(text).toContain("project extensions (1 file)");
+			expect(text).toContain("project extensions (1 entry)");
 			expect(text).toContain("shellCommandPrefix");
 			expect(text).not.toContain("theme");
 			expect(text).toContain("SYSTEM.md");
@@ -226,6 +287,76 @@ export default function () {}
 		it("ignores malformed project settings", () => {
 			writeFileSync(join(configDir, "settings.json"), "{ not json");
 			expect(detectProjectScopedConfig(projectDir)).toEqual([]);
+		});
+
+		it("reports prompts and themes directories", () => {
+			mkdirSync(join(configDir, "prompts"), { recursive: true });
+			writeFileSync(join(configDir, "prompts", "review.md"), "prompt");
+			mkdirSync(join(configDir, "themes"), { recursive: true });
+			writeFileSync(join(configDir, "themes", "dark.json"), "{}");
+
+			const text = detectProjectScopedConfig(projectDir)
+				.map((finding) => finding.summary)
+				.join("\n");
+
+			expect(text).toContain("project prompt templates are auto-discovered");
+			expect(text).toContain("project themes are auto-discovered");
+		});
+
+		it("reports manifest-based extensions", () => {
+			const pkgDir = join(configDir, "extensions", "pkg-ext");
+			mkdirSync(pkgDir, { recursive: true });
+			writeFileSync(join(pkgDir, "main.ts"), "export default function () {}\n");
+			writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ pi: { extensions: ["./main.ts"] } }));
+
+			const findings = detectProjectScopedConfig(projectDir);
+
+			expect(findings.some((finding) => finding.summary.includes("project extensions (1 entry)"))).toBe(true);
+		});
+
+		it("reports .agents/skills from ancestor directories up to the git root", () => {
+			// Launch from a subdirectory; skills committed at the repo root are
+			// discovered by the loader and must produce a finding.
+			mkdirSync(join(projectDir, ".git"));
+			mkdirSync(join(projectDir, ".agents", "skills", "evil"), { recursive: true });
+			writeFileSync(join(projectDir, ".agents", "skills", "evil", "SKILL.md"), "---\nname: evil\n---\n");
+			const subDir = join(projectDir, "packages", "sub");
+			mkdirSync(subDir, { recursive: true });
+
+			const findings = detectProjectScopedConfig(subDir);
+
+			expect(findings.some((finding) => finding.summary.includes(".agents/skills"))).toBe(true);
+		});
+	});
+
+	describe("package updates", () => {
+		it("skips project package sources when untrusted", async () => {
+			writeProjectSettings({ packages: ["npm:some-pkg"] });
+			const untrusted = new DefaultPackageManager({
+				cwd: projectDir,
+				agentDir,
+				settingsManager: SettingsManager.create(projectDir, agentDir, { projectTrusted: false }),
+			});
+			// The project-committed source is invisible, so it cannot be matched.
+			await expect(untrusted.update("npm:some-pkg")).rejects.toThrow();
+
+			const previousOffline = process.env.PI_OFFLINE;
+			process.env.PI_OFFLINE = "1";
+			try {
+				const trusted = new DefaultPackageManager({
+					cwd: projectDir,
+					agentDir,
+					settingsManager: SettingsManager.create(projectDir, agentDir, { projectTrusted: true }),
+				});
+				// Trusted: the source matches; offline mode short-circuits before npm.
+				await expect(trusted.update("npm:some-pkg")).resolves.toBeUndefined();
+			} finally {
+				if (previousOffline === undefined) {
+					delete process.env.PI_OFFLINE;
+				} else {
+					process.env.PI_OFFLINE = previousOffline;
+				}
+			}
 		});
 	});
 });

--- a/packages/coding-agent/test/workspace-trust.test.ts
+++ b/packages/coding-agent/test/workspace-trust.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { discoverAndLoadExtensions } from "../src/core/extensions/loader.js";
 import { DefaultPackageManager } from "../src/core/package-manager.js";
 import { DefaultResourceLoader } from "../src/core/resource-loader.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
@@ -368,6 +369,109 @@ export default function () {}
 					process.env.PI_OFFLINE = previousOffline;
 				}
 			}
+		});
+	});
+
+	describe("aliased agent dir (portable setup)", () => {
+		const evilSource = (canaryPath: string) => `
+import { writeFileSync } from "node:fs";
+writeFileSync(${JSON.stringify(canaryPath)}, "executed", "utf-8");
+export default function () {}
+`;
+
+		it("treats global-scope extensions as project-controlled when untrusted", async () => {
+			// agentDir == project config dir: the "global" extensions directory
+			// is the same committed directory as the project one.
+			const aliasedAgentDir = configDir;
+			const canaryPath = join(tempDir, "aliased-canary.txt");
+			mkdirSync(join(configDir, "extensions"), { recursive: true });
+			writeFileSync(join(configDir, "extensions", "evil.ts"), evilSource(canaryPath));
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir: aliasedAgentDir });
+
+			await loader.reload();
+
+			expect(existsSync(canaryPath)).toBe(false);
+			expect(loader.getExtensions().extensions).toEqual([]);
+		});
+
+		it("ignores aliased global settings-driven extension paths and packages when untrusted", async () => {
+			const aliasedAgentDir = configDir;
+			const canaryPath = join(tempDir, "aliased-canary.txt");
+			const toolsDir = join(projectDir, "tools");
+			mkdirSync(toolsDir, { recursive: true });
+			writeFileSync(join(toolsDir, "evil.ts"), evilSource(canaryPath));
+			// The single committed settings.json is simultaneously the global and
+			// project file in an aliased setup.
+			writeProjectSettings({ extensions: ["./tools/evil.ts"], packages: ["npm:some-pkg"] });
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir: aliasedAgentDir });
+
+			await loader.reload();
+
+			expect(existsSync(canaryPath)).toBe(false);
+			expect(loader.getExtensions().extensions).toEqual([]);
+
+			const manager = new DefaultPackageManager({
+				cwd: projectDir,
+				agentDir: aliasedAgentDir,
+				settingsManager: SettingsManager.create(projectDir, aliasedAgentDir, { projectTrusted: false }),
+			});
+			await expect(manager.update("npm:some-pkg")).rejects.toThrow();
+		});
+
+		it("loads aliased global-scope extensions when the workspace is trusted", async () => {
+			const aliasedAgentDir = configDir;
+			const canaryPath = join(tempDir, "aliased-canary.txt");
+			mkdirSync(join(configDir, "extensions"), { recursive: true });
+			writeFileSync(join(configDir, "extensions", "evil.ts"), evilSource(canaryPath));
+			WorkspaceTrustStore.create(aliasedAgentDir).trust(projectDir);
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir: aliasedAgentDir });
+
+			await loader.reload();
+
+			expect(existsSync(canaryPath)).toBe(true);
+		});
+	});
+
+	describe("home-directory cwd", () => {
+		it("does not treat the user's own global config as hostile when cwd is the home directory", () => {
+			// Fake HOME so the default agent dir lives under the temp dir, then
+			// run with cwd == that home: project config dir == global agent dir.
+			const fakeHome = join(tempDir, "home");
+			mkdirSync(join(fakeHome, ".prime", "agent"), { recursive: true });
+			writeFileSync(
+				join(fakeHome, ".prime", "agent", "settings.json"),
+				JSON.stringify({ shellCommandPrefix: "my-own-prefix" }, null, 2),
+			);
+			const previousHome = process.env.HOME;
+			process.env.HOME = fakeHome;
+			try {
+				const manager = SettingsManager.create(fakeHome, join(fakeHome, ".prime", "agent"), {
+					projectTrusted: false,
+				});
+				expect(manager.isGlobalConfigAliasedToProject()).toBe(false);
+				expect(manager.getShellCommandPrefix()).toBe("my-own-prefix");
+				expect(detectProjectScopedConfig(fakeHome)).toEqual([]);
+			} finally {
+				if (previousHome === undefined) {
+					delete process.env.HOME;
+				} else {
+					process.env.HOME = previousHome;
+				}
+			}
+		});
+	});
+
+	describe("discoverAndLoadExtensions (public API)", () => {
+		it("skips project extensions for untrusted workspaces", async () => {
+			mkdirSync(join(configDir, "extensions"), { recursive: true });
+			writeFileSync(join(configDir, "extensions", "evil.ts"), "export default function () {}\n");
+
+			const untrusted = await discoverAndLoadExtensions([], projectDir, agentDir);
+			expect(untrusted.extensions).toEqual([]);
+
+			trustProject();
+			const trusted = await discoverAndLoadExtensions([], projectDir, agentDir);
+			expect(trusted.extensions.map((e) => e.path)).toEqual([join(configDir, "extensions", "evil.ts")]);
 		});
 	});
 });

--- a/packages/coding-agent/test/workspace-trust.test.ts
+++ b/packages/coding-agent/test/workspace-trust.test.ts
@@ -303,6 +303,17 @@ export default function () {}
 			expect(text).toContain("project themes are auto-discovered");
 		});
 
+		it("reports an extensions directory that is itself a manifest package", () => {
+			const extensionsDir = join(configDir, "extensions");
+			mkdirSync(join(extensionsDir, "src"), { recursive: true });
+			writeFileSync(join(extensionsDir, "src", "main.ts"), "export default function () {}\n");
+			writeFileSync(join(extensionsDir, "package.json"), JSON.stringify({ pi: { extensions: ["./src/main.ts"] } }));
+
+			const findings = detectProjectScopedConfig(projectDir);
+
+			expect(findings.some((finding) => finding.summary.includes("project extensions (1 entry)"))).toBe(true);
+		});
+
 		it("reports manifest-based extensions", () => {
 			const pkgDir = join(configDir, "extensions", "pkg-ext");
 			mkdirSync(pkgDir, { recursive: true });


### PR DESCRIPTION
## What this does

Until now, opening a folder with Prime Agent would automatically run code that the folder contains. If a repository commits a file at `.prime/agent/extensions/anything.ts`, that file executed the moment a session started — before you typed a single message, with nothing asking whether you wanted that. A committed `.prime/agent/settings.json` could do the same through settings keys that run shell commands or install packages, and a committed `SYSTEM.md` was silently injected into the system prompt.

In practice that meant: clone a stranger's repo, open it with Prime Agent, and their code runs on your machine with your permissions.

After this change, project-committed automation only runs in workspaces you have explicitly trusted:

- The first time you open a workspace that carries this kind of configuration, interactive startup asks once. Your answer is remembered in `~/.prime/agent/trusted-workspaces.json`.
- Scripts, CI, and other non-interactive modes never ask — they skip the project configuration and print a short note saying so.
- New commands: `prime-agent trust [path] [--list]` and `prime-agent untrust [path]`.
- Your global config in `~/.prime/agent/` is unaffected — it is yours, not a repo's.

## What gets gated in untrusted workspaces

- `.prime/agent/extensions/` — auto-executed code
- `.prime/agent/settings.json` keys that run commands or redirect where things go: `extensions`, `packages`, `mcpServers`, `shellCommandPrefix`, `shellPath`, `npmCommand`, `sessionDir`
- `.prime/agent/skills/` and `.agents/skills/` — Python skills install code into the agent's kernel environment
- `.prime/agent/prompts/`, `.prime/agent/themes/`, and `SYSTEM.md` / `APPEND_SYSTEM.md`

Everyday project settings (theme, model preferences, and so on) still apply in untrusted workspaces — only the parts that can execute something are held back.

## How it works

One shared trust store is consulted when session services are created, so every entry point (interactive, print, RPC, ACP, daemon worker, SDK) enforces the same answer. Untrusted workspaces simply contribute nothing executable; when something was skipped, startup says exactly what and why, and how to enable it.

## Testing

- New `workspace-trust` test suite (15 tests), including a regression test for the attack itself: a canary file proves a committed extension runs when trusted and stays inert when not.
- Verified end to end with the real built CLI: untrusted run blocks everything, `prime-agent trust` enables it, `untrust` revokes it; the interactive consent prompt was exercised under a pty.
- One existing suite (`resource-loader.test.ts`) now marks its fixture directory as trusted in setup; all other suites pass unchanged.
- `npm run check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a security boundary change: untrusted clones stop executing committed extensions and executable settings until consent, which can break workflows that relied on implicit auto-load of project config.
> 
> **Overview**
> **Untrusted workspaces no longer auto-run repo-committed agent configuration.** Project-local extensions, skills, prompts, themes, packages, MCP servers, shell/npm/session settings, and `SYSTEM.md` / `APPEND_SYSTEM.md` are skipped until the directory is trusted; cosmetic project settings still apply.
> 
> Trust is stored in `~/.prime/agent/trusted-workspaces.json` via a new `WorkspaceTrustStore`. **Interactive startup** shows a one-time consent prompt when risky project config is detected; **headless modes** skip silently and emit a warning listing what was disabled. **`prime-agent trust` / `untrust` / `trust --list`** manage trust ahead of time.
> 
> Enforcement is centralized at **`createAgentSessionServices`** (and mirrored in SDK/resource loading): `SettingsManager` gets `projectTrusted`, `DefaultPackageManager` and extension discovery respect it, and portable setups (agent dir inside the repo) treat “global” paths as project-controlled so they cannot bypass the gate. Trust cannot persist when the store would live inside the workspace itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b23acd215ff080b2095e1a30471f007eceb2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate project-scoped executable configuration behind workspace trust
> - Adds a `WorkspaceTrustStore` in [`workspace-trust.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1223/files#diff-6fe9f376a6fa5292f060d9048f99a4970dc343e1c2bd509140c77da67dae8098) that persists trusted workspace paths in a file-backed, lock-protected store outside the workspace tree.
> - On interactive startup, `gateWorkspaceTrustOnStartup` prompts once when project-scoped config (extensions, skills, SYSTEM.md, MCP servers, shell settings, etc.) is detected and trust can be persisted; consent is stored for future sessions.
> - Adds `trust` and `untrust` CLI commands to manage trusted workspaces manually.
> - In untrusted workspaces, project-scoped executable settings, auto-discovered project extensions/skills/prompts/themes, and project-controlled global config are all suppressed across `SettingsManager`, `DefaultResourceLoader`, `DefaultPackageManager`, and `discoverAndLoadExtensions`.
> - When `agentDir` lives inside the workspace (portable config), trust cannot be persisted and the entire global config scope is treated as project-controlled and gated accordingly.
> - Risk: Existing workflows that rely on project-scoped config (extensions, MCP servers, shell overrides) will be silently disabled until the workspace is trusted, which may surprise users on first run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10b23ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->