### PR TITLE
fix(coding-agent): restore externally deleted supervisor owner records

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -137,6 +137,46 @@ class DaemonSupervisorOwnership {
 		}
 	}
 
+	/**
+	 * Rewrite this owner's durable registry entry after an external removal.
+	 *
+	 * A long-running supervisor's owner.json lives under the OS temporary
+	 * directory, where system cleaners (for example the macOS /var/folders
+	 * reaper) can delete files out from under a live process. Losing the record
+	 * must not permanently poison the supervisor: it still holds the socket and
+	 * greets clients as current, so nothing would ever replace it.
+	 *
+	 * The record is restored only when it is genuinely gone and no other live
+	 * supervisor owns a conflicting scope, so a superseded generation can never
+	 * resurrect itself past its successor. Returns whether the durable record
+	 * once again matches this ownership.
+	 */
+	async restoreIfUnowned(): Promise<boolean> {
+		if (this.released || !matchesExactProcessIdentity(this.record)) {
+			return false;
+		}
+		return withDaemonSupervisorRegistryGuard(this.registryDir, () => {
+			const current = readOwnerRecord(this.ownerDirectory);
+			if (current) {
+				return sameOwnerRecord(current, this.record);
+			}
+			for (const directory of listOwnerDirectories(this.registryDir)) {
+				if (directory === this.ownerDirectory) {
+					continue;
+				}
+				const owner = readOwnerRecordForScope(directory, (scope) => ownerConflicts(scope, this.record));
+				if (owner && ownerConflicts(owner, this.record) && isProcessIdentityAlive(owner)) {
+					return false;
+				}
+			}
+			this.record.updatedAt = new Date().toISOString();
+			mkdirSync(this.ownerDirectory, { recursive: true, mode: 0o700 });
+			writeOwnerScope(this.ownerDirectory, this.record);
+			writeOwnerRecord(this.ownerDirectory, this.record);
+			return true;
+		});
+	}
+
 	async updatePhase(phase: DaemonSupervisorOwnerPhase): Promise<void> {
 		if (this.released) {
 			return;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -590,6 +590,7 @@ export class DaemonSupervisor {
 	private socketLease?: DaemonSocketPathLease;
 	private ownership?: Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>>;
 	private cleanupPromise?: Promise<void>;
+	private ownershipRestore?: Promise<boolean>;
 	private shuttingDown = false;
 	private updateRestartPhase?: "draining" | "fencing" | "prepared";
 	private readonly mutationDrain = new MutationDrainLatch();
@@ -792,6 +793,10 @@ export class DaemonSupervisor {
 
 	private async runIdleEvictionSweep(now = Date.now()): Promise<void> {
 		if (this.shuttingDown || this.updateRestartPhase !== undefined || this.idleEvictionFence) return;
+		// Piggyback an ownership self-check on the periodic sweep so an idle
+		// supervisor whose owner record was externally removed heals without
+		// waiting for the next client command.
+		await this.assertCurrentOwnership().catch(() => undefined);
 		await this.settingsManager.reload();
 		if (this.shuttingDown || this.updateRestartPhase !== undefined) return;
 		const idleEvictionMinutes = this.settingsManager.getIdleEvictionMinutes();
@@ -889,7 +894,46 @@ export class DaemonSupervisor {
 			Object.assign(error, { code: "supervisor_generation_stale" as const });
 			throw error;
 		}
-		await ownership.assertCurrent();
+		try {
+			await ownership.assertCurrent();
+		} catch (error) {
+			// An external cleaner (for example the macOS /var/folders reaper) can
+			// delete the durable owner record out from under a long-running
+			// supervisor. Without repair the supervisor keeps its socket and
+			// current-version hello while refusing every command, so clients can
+			// neither use it nor replace it. Restore the record when no live
+			// successor owns the scope; otherwise surface the original error.
+			if (!isSupervisorGenerationStale(error) || this.shuttingDown || !(await this.restoreOwnershipRecord())) {
+				throw error;
+			}
+			await ownership.assertCurrent();
+		}
+	}
+
+	/** Single-flight so a burst of concurrent commands shares one guarded restore. */
+	private restoreOwnershipRecord(): Promise<boolean> {
+		const ownership = this.ownership;
+		if (!ownership) {
+			return Promise.resolve(false);
+		}
+		this.ownershipRestore ??= ownership
+			.restoreIfUnowned()
+			.then((restored) => {
+				if (restored) {
+					this.log(`Restored supervisor owner record for generation ${this.generation} after external removal`);
+				}
+				return restored;
+			})
+			.catch((restoreError) => {
+				this.log(
+					`Could not restore supervisor owner record for generation ${this.generation}: ${String(restoreError)}`,
+				);
+				return false;
+			})
+			.finally(() => {
+				this.ownershipRestore = undefined;
+			});
+		return this.ownershipRestore;
 	}
 
 	private async assertRecoveryAllowed(): Promise<void> {

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -1148,6 +1148,95 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 		rmSync(join(paths.registryDir, `${ownership.record.generation}.owner`), { recursive: true, force: true });
 	});
 
+	it("restores an externally deleted owner record when no live conflicting owner exists", async () => {
+		const paths = await createPaths();
+		const ownership = await acquireDaemonSupervisorOwnership({
+			agentDir: paths.agentDir,
+			appVersion: "test",
+			descriptorDir: paths.descriptorDir,
+			generation: "externally-reaped-owner",
+			registryDir: paths.registryDir,
+			socketPath: paths.socketPath,
+		});
+
+		// System temp cleaners delete the files in place and leave the directory.
+		rmSync(ownerRecordPath(paths.registryDir, ownership.record.generation), { force: true });
+		rmSync(ownerScopePath(paths.registryDir, ownership.record.generation), { force: true });
+		await expect(ownership.assertCurrent()).rejects.toThrow(/no longer owns its registry entry/);
+		expect(await ownership.restoreIfUnowned()).toBe(true);
+		await ownership.assertCurrent();
+		expect(readOwnerRecord(paths.registryDir, ownership.record.generation)?.token).toBe(ownership.record.token);
+
+		// A cleaner may also remove the emptied owner directory itself.
+		rmSync(join(paths.registryDir, `${ownership.record.generation}.owner`), { recursive: true, force: true });
+		expect(await ownership.restoreIfUnowned()).toBe(true);
+		await ownership.assertCurrent();
+
+		await ownership.release();
+		expect(await ownership.restoreIfUnowned()).toBe(false);
+		expect(listOwnerRecords(paths.registryDir)).toEqual([]);
+	});
+
+	it("does not resurrect a reaped generation over a live successor", async () => {
+		const paths = await createPaths();
+		const predecessor = await acquireDaemonSupervisorOwnership({
+			agentDir: paths.agentDir,
+			appVersion: "test",
+			descriptorDir: paths.descriptorDir,
+			generation: "reaped-predecessor",
+			registryDir: paths.registryDir,
+			socketPath: paths.socketPath,
+		});
+		rmSync(join(paths.registryDir, `${predecessor.record.generation}.owner`), { recursive: true, force: true });
+		const successor = await acquireDaemonSupervisorOwnership({
+			agentDir: join(paths.agentDir, "successor-agent"),
+			appVersion: "test",
+			descriptorDir: join(paths.agentDir, "successor-workers"),
+			generation: "live-successor",
+			registryDir: paths.registryDir,
+			socketPath: paths.socketPath,
+		});
+		try {
+			expect(await predecessor.restoreIfUnowned()).toBe(false);
+			await expect(predecessor.assertCurrent()).rejects.toThrow(/no longer owns its registry entry/);
+			expect(readOwnerRecord(paths.registryDir, successor.record.generation)?.token).toBe(successor.record.token);
+		} finally {
+			await successor.release();
+		}
+	});
+
+	it("keeps serving daemon commands after the owner record is externally reaped", async () => {
+		const paths = await createPaths();
+		const supervisor = spawnRealSupervisor(paths, {});
+		cleanupRegistryDirs.add(paths.registryDir);
+		cleanupSupervisorSockets.add(paths.socketPath);
+		const client = await connectEventually(paths.socketPath);
+		try {
+			const before = await client.request({ type: "list" }, 20_000);
+			if (!before.success) {
+				throw new Error(`${before.error}\nfixture stderr:\n${supervisor.diagnostics.stderr}`);
+			}
+			const [owner] = await waitForOwnerCount(paths.registryDir, 1);
+			if (!owner) {
+				throw new Error("Supervisor did not publish an owner record");
+			}
+
+			rmSync(ownerRecordPath(paths.registryDir, owner.generation), { force: true });
+			rmSync(ownerScopePath(paths.registryDir, owner.generation), { force: true });
+
+			const after = await client.request({ type: "list" }, 20_000);
+			if (!after.success) {
+				throw new Error(`${after.error}\nfixture stderr:\n${supervisor.diagnostics.stderr}`);
+			}
+			const restored = readOwnerRecord(paths.registryDir, owner.generation);
+			expect(restored?.token).toBe(owner.token);
+			expect(restored?.generation).toBe(owner.generation);
+		} finally {
+			client.close();
+		}
+		await stopSupervisor(supervisor, paths.socketPath);
+	}, 90_000);
+
 	it("unwinds real pre-bind and post-bind startup failures before retry", async () => {
 		const paths = await createPaths();
 		writeFileSync(paths.socketPath, "not a socket");


### PR DESCRIPTION
## Summary

A daemon that runs for several days can stop accepting work. Every new CLI launch then fails within seconds. The daemon looks healthy from the outside, so nothing replaces it. Only a manual shutdown clears the state. This change lets the supervisor repair itself and keep serving.

## Crash signature

Every CLI launch exits with code 1 after 1-2 seconds:

```
Error: Daemon supervisor generation <uuid> no longer owns its registry entry
    at deserializeDaemonError (packages/coding-agent/src/modes/daemon/daemon-errors.ts:34:9)
    at createDaemonClientConnection (packages/coding-agent/src/main.ts:1002:10)
```

## Root cause

The supervisor writes an owner record to the registry. The registry is in the OS temporary directory: `os.tmpdir()/prime-agent-<uid>/supervisor-owners/<generation>.owner/`. The owner record has two files: `owner.json` and `scope.json`.

OS cleaners delete old files in temporary directories. The macOS `/var/folders` cleaner removes files after about three days. It deletes the two record files in place. It keeps the record directory, the socket, and the lockfile directories. We observed this on a supervisor with four days of uptime. The same sweep emptied hundreds of unrelated temporary directories.

The supervisor validates the owner record for each command (`daemon-supervisor-ownership.ts:130-138`). After the deletion, validation always fails. The supervisor rejects every command with the error above.

The supervisor keeps its socket. It still sends a current-version `daemon_hello`. Client probes report the daemon as current. So no client starts a replacement. The daemon stays in this state until a person stops it.

Workers validate the same owner record every 250 ms (`daemon-mode.ts`). They drop their supervisor connections for the same reason.

## Reproduction

The steps are deterministic and need no API keys:

```bash
SANDBOX=$(mktemp -d /tmp/pa-repro.XXXX)
export PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR=$SANDBOX/registry
export PRIME_AGENT_CODING_AGENT_DIR=$SANDBOX/agent
# 1. Start a sandbox supervisor.
prime-agent --mode daemon --daemon-socket $SANDBOX/daemon.sock --offline &
sleep 2
# 2. Delete the owner record files in place, as the cleaner does.
rm $SANDBOX/registry/*.owner/owner.json $SANDBOX/registry/*.owner/scope.json
# 3. Each client command now fails with the signature.
prime-agent --daemon-socket $SANDBOX/daemon.sock -p --no-skills --no-context-files -- 'hi'
```

On `main` (14d6e74), 15 of 15 concurrent CLI launches fail with the signature. With this fix, 0 of 15 fail. The supervisor logs one line: `Restored supervisor owner record for generation <uuid> after external removal`.

## Fix

The fix has two goals. A live supervisor must survive the loss of its owner record. A superseded generation must not replace its live successor.

- New method `DaemonSupervisorOwnership.restoreIfUnowned()`. It runs under the registry guard. It confirms that the owner record is absent. It then runs the same conflict scan as acquisition. If no live conflicting owner exists, it writes the owner record again with the same generation and token. If a live conflicting owner exists, it refuses. If a different record is present, it also refuses.
- `DaemonSupervisor.assertCurrentOwnership()` calls the restore when validation fails with `supervisor_generation_stale`. It then validates again. The restore is single-flight: concurrent commands share one scan. If the restore refuses, the original error propagates.
- The idle-eviction sweep runs the same ownership check. An idle supervisor heals without client traffic. Workers re-fence within 250 ms after the owner record returns.

## Tests

Three new cases in `test/suite/regressions/4600-supervisor-singleton.test.ts`:

- Restore succeeds after the record files are deleted in place. Restore also succeeds after the record directory is removed. A released ownership refuses to restore.
- A generation with a deleted record does not restore over a live successor.
- End to end: a supervisor with a deleted record continues to serve `list`. It writes the owner record again with the same generation and token.

Results: `4600-supervisor-singleton` 18/18 pass. `daemon-supervisor-process` 8 pass, 8 tag-skipped. `daemon-supervisor-eviction` 13/13 pass. `daemon-socket` 7/7 pass. `npm run check` passes.

Generated with [Claude Code](https://claude.com/claude-code)
