### PR TITLE
fix(coding-agent): keep Down Arrow in unfinished prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed Down Arrow focusing the Agents View entry before moving a nonempty prompt cursor to the end ([ENG-5147](https://linear.app/primeintellect/issue/ENG-5147/keep-down-arrow-in-the-prompt-until-the-cursor-reaches-the-end)).
 - Added `app.messages.expand` (`ctrl+p`) to collapse or expand agent-to-agent messages separately from `ctrl+o` tool output.
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -218,7 +218,7 @@ export class CustomEditor extends Editor {
 			this.keybindings.matches(data, "tui.editor.cursorDown") &&
 			!this.isShowingAutocomplete() &&
 			!this.isHistoryNavigationActive() &&
-			this.isCursorOnLastVisualLine() &&
+			this.isCursorAtEnd() &&
 			this.onMoveBelowPrompt?.()
 		) {
 			return;
@@ -226,6 +226,12 @@ export class CustomEditor extends Editor {
 
 		// Pass to parent for editor handling
 		super.handleInput(data);
+	}
+
+	private isCursorAtEnd(): boolean {
+		const lines = this.getLines();
+		const cursor = this.getCursor();
+		return cursor.line === lines.length - 1 && cursor.col === (lines[cursor.line]?.length ?? 0);
 	}
 
 	private splitRepeatedKeybinding(data: string, keybinding: AppKeybinding): string[] | undefined {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -470,10 +470,6 @@ export class Editor implements Component, Focusable {
 		return this.historyIndex > -1;
 	}
 
-	protected isCursorOnLastVisualLine(): boolean {
-		return this.isOnLastVisualLine();
-	}
-
 	private navigateHistory(direction: 1 | -1): void {
 		this.lastAction = null;
 		if (this.history.length === 0) return;


### PR DESCRIPTION
## Summary

- keep Down Arrow in the chat prompt until the cursor reaches the end before focusing the Agents View entry below it
- replace the old last-visual-line interception with an exact prompt-end boundary
- remove the now-unused protected visual-line wrapper from the base editor

## Testing

- `npm run check`

Linear: [ENG-5147](https://linear.app/primeintellect/issue/ENG-5147/keep-down-arrow-in-the-prompt-until-the-cursor-reaches-the-end)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized interactive prompt keybinding change with no auth, data, or API impact; behavior is covered by regression tests referenced in the PR.
> 
> **Overview**
> **Down Arrow** in the chat prompt no longer jumps to the Agents View entry (subagent summary below the prompt) until the cursor is at the **end of the prompt text** on the last line.
> 
> `CustomEditor` now gates `onMoveBelowPrompt` on a new `isCursorAtEnd()` check instead of only being on the last **visual** (wrapped) line. The first Down press still moves within the editor (e.g. to line end); focus moves below only when the cursor is already at the true end. **Empty prompts** behave as before: Down can focus below immediately.
> 
> The unused `isCursorOnLastVisualLine()` bridge on the base `Editor` in `pi-tui` was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ae068e74580d5a0053f9029f7aef43cd79b370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Down Arrow in `CustomEditor` to stay in nonempty prompts until cursor reaches end
> Previously, pressing Down Arrow on any wrapped last visual line would immediately move focus to the Agents View. Now, `CustomEditor.handleInput` only calls `onMoveBelowPrompt()` when the cursor is at the end of the last line, using a new `isCursorAtEnd()` helper. The old `isCursorOnLastVisualLine()` method on `Editor` is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55ae068.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->