### PR TITLE
fix(coding-agent): pin a stable locale for ps-based process start identities

### DIFF
--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -112,10 +112,11 @@ function isProcessAlive(pid: number): boolean {
 
 type ProcessQuery = (command: string, args: string[]) => string;
 
-function runProcessQuery(command: string, args: string[]): string {
+function runProcessQuery(command: string, args: string[], env?: NodeJS.ProcessEnv): string {
 	return execFileSync(command, args, {
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		...(env ? { env } : {}),
 	});
 }
 
@@ -137,7 +138,13 @@ export function getWindowsProcessStartId(pid: number, query: ProcessQuery = runP
 	}
 }
 
-export function getProcessStartId(pid: number): string | undefined {
+type PosixProcessQuery = (command: string, args: string[], env: NodeJS.ProcessEnv) => string;
+
+// `ps -o lstart` formats start times in the active locale, so an identity recorded
+// under one locale can read as "replaced" under another. Pin a stable C locale.
+const POSIX_PROCESS_QUERY_ENV: NodeJS.ProcessEnv = { ...process.env, LC_ALL: "C", LC_TIME: "C", LANG: "C" };
+
+export function getProcessStartId(pid: number, query: PosixProcessQuery = runProcessQuery): string | undefined {
 	if (!Number.isInteger(pid) || pid <= 0) {
 		return undefined;
 	}
@@ -156,7 +163,7 @@ export function getProcessStartId(pid: number): string | undefined {
 		// Fall through to the portable process listing used on macOS and BSD.
 	}
 	try {
-		const startTime = runProcessQuery("ps", ["-p", String(pid), "-o", "lstart="]).trim();
+		const startTime = query("ps", ["-p", String(pid), "-o", "lstart="], POSIX_PROCESS_QUERY_ENV).trim();
 		return startTime ? `ps:${startTime}` : undefined;
 	} catch {
 		return undefined;

--- a/packages/coding-agent/test/session-lease.test.ts
+++ b/packages/coding-agent/test/session-lease.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	acquireSessionLease,
 	canonicalSessionPath,
+	getProcessStartId,
 	getWindowsProcessStartId,
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
@@ -67,6 +68,22 @@ describe("session leases", () => {
 		expect(getWindowsProcessStartId(42, query)).toBeUndefined();
 		expect(getWindowsProcessStartId(0, query)).toBeUndefined();
 		expect(queryCount).toBe(1);
+	});
+
+	it.skipIf(process.platform === "win32")("records a locale-stable POSIX process start identity", () => {
+		const calls: Array<{ command: string; args: string[]; env: NodeJS.ProcessEnv }> = [];
+		const processStartId = getProcessStartId(2_147_483_647, (command, args, env) => {
+			calls.push({ command, args, env });
+			return "Sun Aug  9 00:00:00 2026\n";
+		});
+
+		expect(processStartId).toBe("ps:Sun Aug  9 00:00:00 2026");
+		expect(calls).toHaveLength(1);
+		expect(calls[0].command).toBe("ps");
+		expect(calls[0].args).toEqual(["-p", "2147483647", "-o", "lstart="]);
+		expect(calls[0].env.LC_ALL).toBe("C");
+		expect(calls[0].env.LC_TIME).toBe("C");
+		expect(calls[0].env.LANG).toBe("C");
 	});
 
 	it("rejects a second live owner with a typed active-session error", () => {


### PR DESCRIPTION
## Problem

`getProcessStartId` reads the macOS/BSD start time from `ps -p <pid> -o lstart=`, which formats the date in the active locale. A start id recorded under one locale (or from a supervisor spawned in a different environment) no longer matches the same live process under another locale, so `processIdentity` returns `"replaced"` for a worker that is still running.

Recovery then refuses to signal the live worker (a replaced pid is treated as a recycled pid and never SIGKILLed), the worker keeps its socket, and any replacement fails with `Daemon socket already in use`. The session stays unavailable until the worker is killed by hand. A system locale change, or a supervisor relaunched from a shell with a different locale, is enough to trigger this.

## Fix

Run the `ps` query under a pinned `C` locale (`LC_ALL`, `LC_TIME`, `LANG`) so the start id is reproducible regardless of the system or caller locale. `process.env` is still spread so `PATH` (and the rest of the environment) is preserved.

The POSIX query is made injectable, mirroring `getWindowsProcessStartId`, so the locale pinning is covered by a unit test.

## What this does not change

- The Linux `/proc/<pid>/stat` path is already locale-independent and untouched.
- The Windows path is untouched.
- No stop, recovery, or ownership behavior changes. This only makes the identity stable so the existing identity checks stop misclassifying live workers as replaced.

## Note

Start ids recorded before this change under a non-C locale will not match ids computed after this change, so a worker that outlives an upgrade under a non-English locale is seen as replaced once and recovered (or relaunched from its saved transcript). English-locale installs already produce C-equivalent output and are unaffected. Per the project rule, no backward-compatibility shim is added.

## Validation

- `npm run check` passed (biome, tsgo, installer, browser-smoke).
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/session-lease.test.ts`: 9 passed (was 8; added a POSIX locale-stable case, skipped on Windows where the POSIX path is unreachable).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin C locale for `ps`-based process start identities in `getProcessStartId`
> On non-Windows systems, `ps -o lstart` output varies by locale, causing inconsistent process start identities. The fix passes `LC_ALL=C`, `LC_TIME=C`, and `LANG=C` via a new `POSIX_PROCESS_QUERY_ENV` constant when invoking `ps`, ensuring stable output regardless of the host locale. `runProcessQuery` is extended to accept an optional `env` parameter, and `getProcessStartId` supports dependency injection of the query function for testability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c1e413.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->