### PR TITLE
feat(coding-agent): add host request contracts

### DIFF
--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -58,8 +58,84 @@ export const HOST_COMM_TARGET = "host.request";
 /**
  * Handles one typed request from Python code running in the kernel.
  * The returned record is sent back verbatim as the comm reply payload.
+ *
+ * This legacy unary compatibility alias remains the dispatcher and registration
+ * contract while context-aware handlers are staged separately below.
  */
 export type HostRequestHandler = (payload: Record<string, unknown>) => Promise<Record<string, unknown>>;
+
+/**
+ * Per-call authority supplied by the host-request dispatcher.
+ * `requestId` is an opaque host-minted correlation token and `isCurrent()`
+ * lets an implementation reject work after its authority is revoked.
+ */
+export interface HostRequestContext {
+	readonly requestId: string;
+	readonly generation: number;
+	readonly signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+const hostRequestHandlerBrand = Symbol("hostRequestHandler");
+
+/** A context-aware implementation that must receive dispatcher authority. */
+export type HostRequestHandlerImplementation = (
+	payload: Record<string, unknown>,
+	context: HostRequestContext,
+) => Promise<Record<string, unknown>>;
+
+/** A factory-minted, context-aware host-request handler capability. */
+type HostRequestHandlerCapability = HostRequestHandlerImplementation & { readonly [hostRequestHandlerBrand]: true };
+
+/** Runtime provenance cannot be recreated by copying the nominal symbol property. */
+const factoryCreatedHostRequestHandlers = new WeakSet<object>();
+
+function assertGenuineHostRequestContext(context: unknown): asserts context is HostRequestContext {
+	if (
+		typeof context !== "object" ||
+		context === null ||
+		typeof (context as HostRequestContext).requestId !== "string" ||
+		!(context as HostRequestContext).requestId ||
+		!Number.isSafeInteger((context as HostRequestContext).generation) ||
+		typeof (context as HostRequestContext).isCurrent !== "function" ||
+		typeof (context as HostRequestContext).signal !== "object" ||
+		(context as HostRequestContext).signal === null ||
+		typeof (context as HostRequestContext).signal.aborted !== "boolean" ||
+		typeof (context as HostRequestContext).signal.addEventListener !== "function"
+	) {
+		throw new Error("host request context is invalid");
+	}
+}
+
+/**
+ * Creates a branded wrapper rather than mutating its implementation. Both its
+ * generic shape and runtime arity reject unary callbacks before they can run.
+ */
+export function createHostRequestHandler<T extends HostRequestHandlerImplementation>(
+	implementation: T,
+	..._unaryRejection: Parameters<T> extends [unknown, unknown, ...unknown[]]
+		? []
+		: ["host request handlers must accept payload and context"]
+): HostRequestHandlerCapability {
+	if (implementation.length < 2) throw new Error("host request handlers must accept payload and context");
+	const handler = async (payload: Record<string, unknown>, context: HostRequestContext) => {
+		assertGenuineHostRequestContext(context);
+		return implementation(payload, context);
+	};
+	factoryCreatedHostRequestHandlers.add(handler);
+	return Object.defineProperty(handler, hostRequestHandlerBrand, { value: true }) as HostRequestHandlerCapability;
+}
+
+/** Reject copied-symbol and raw-function forgeries before they observe authenticated payloads. */
+export function assertHostRequestHandler(value: unknown): asserts value is HostRequestHandlerCapability {
+	if (
+		typeof value !== "function" ||
+		(value as Partial<HostRequestHandlerCapability>)[hostRequestHandlerBrand] !== true ||
+		!factoryCreatedHostRequestHandlers.has(value)
+	) {
+		throw new Error("host request handler is not a dispatcher-created capability");
+	}
+}
 
 /** Host request handlers keyed by request type (e.g. "rlm.run", "goal.complete"). */
 export type HostRequestHandlers = Record<string, HostRequestHandler>;

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -1,0 +1,39 @@
+import {
+	createHostRequestHandler,
+	type HostRequestContext,
+	type HostRequestHandlerImplementation,
+} from "../src/core/kernel/index.js";
+
+let nextSyntheticHostRequestId = 0;
+
+/** Create a distinct, current dispatcher context for direct host-handler tests. */
+export function createSyntheticHostRequestContext(): HostRequestContext {
+	const requestNumber = ++nextSyntheticHostRequestId;
+	const controller = new AbortController();
+	return {
+		requestId: `test-host-request-${requestNumber}`,
+		generation: requestNumber,
+		signal: controller.signal,
+		isCurrent: () => !controller.signal.aborted,
+	};
+}
+
+/** Invoke a production-shaped handler with a synthetic dispatcher context. */
+export function invokeHostRequest(
+	handler: HostRequestHandlerImplementation,
+	payload: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	return handler(payload, createSyntheticHostRequestContext());
+}
+
+/** Build staged context-aware fixture handlers through the production factory. */
+export function createTestHostHandlers<
+	T extends Record<
+		string,
+		(payload: Record<string, unknown>, context: HostRequestContext) => Promise<Record<string, unknown>>
+	>,
+>(handlers: T): Record<keyof T, HostRequestHandlerImplementation> {
+	return Object.fromEntries(
+		Object.entries(handlers).map(([type, handler]) => [type, createHostRequestHandler(handler)]),
+	) as unknown as Record<keyof T, HostRequestHandlerImplementation>;
+}

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+	assertHostRequestHandler,
+	createHostRequestHandler,
+	type HostRequestContext,
+} from "../src/core/kernel/index.js";
+
+describe("staged host-request handler authority", () => {
+	it("rejects unary factory inputs before they run", () => {
+		let calls = 0;
+		const unary = async (_payload: Record<string, unknown>): Promise<Record<string, unknown>> => {
+			calls += 1;
+			return {};
+		};
+
+		expect(() => {
+			// @ts-expect-error Staged handlers must accept dispatcher context as their second argument.
+			createHostRequestHandler(unary);
+		}).toThrow("host request handlers must accept payload and context");
+		expect(calls).toBe(0);
+	});
+
+	it("rejects missing or invalid context before a genuine handler runs", async () => {
+		let calls = 0;
+		const handler = createHostRequestHandler(async (_payload, _context) => {
+			calls += 1;
+			return {};
+		});
+
+		assertHostRequestHandler(handler);
+		// @ts-expect-error A staged handler cannot be invoked without dispatcher context.
+		await expect(handler({})).rejects.toThrow("host request context is invalid");
+		await expect(handler({}, {} as HostRequestContext)).rejects.toThrow("host request context is invalid");
+		expect(calls).toBe(0);
+	});
+
+	it("rejects copied-symbol forgeries through WeakSet provenance before they run", () => {
+		const genuine = createHostRequestHandler(async (_payload, _context) => ({}));
+		let calls = 0;
+		const forged = async (): Promise<Record<string, unknown>> => {
+			calls += 1;
+			return {};
+		};
+		const brand = Object.getOwnPropertySymbols(genuine)[0];
+		Object.defineProperty(forged, brand, Object.getOwnPropertyDescriptor(genuine, brand)!);
+
+		expect(() => assertHostRequestHandler(forged)).toThrow(
+			"host request handler is not a dispatcher-created capability",
+		);
+		expect(calls).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- define host request context contracts
- add request contract coverage

## Testing
- Not run (per task instruction)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add host request handler contracts with context validation and forgery prevention
> - Introduces `HostRequestContext` interface in [`packages/coding-agent/src/core/kernel/index.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1238/files#diff-14dd18f6926ed763ba0b55625302fb733f4e4209bb611d3051820048732149ac) providing per-call `requestId`, `generation`, `AbortSignal`, and `isCurrent()` for authority checks.
> - Adds `createHostRequestHandler` factory that enforces two-argument implementations and validates context via `assertGenuineHostRequestContext` before delegating to user code.
> - Adds `assertHostRequestHandler` guard that rejects forged handlers using a branded symbol plus `WeakSet` provenance tracking, preventing copied-symbol or raw-function spoofing.
> - Tests in [`packages/coding-agent/test/host-request-contract.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1238/files#diff-1d41d816783c229c1a93c4e708bbfd8e0807b975cb12e10e27ff567726d9cffb) cover factory rejection of unary implementations, invalid context detection, and forgery prevention.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c24e46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive contracts and tests only; `KernelManager` still invokes legacy unary `hostHandlers` without wiring the new context yet.
> 
> **Overview**
> Introduces **staged** host-request APIs in the kernel module so future dispatcher work can pass per-call authority without changing the existing unary `HostRequestHandler` registration path yet.
> 
> Adds **`HostRequestContext`** (`requestId`, `generation`, `AbortSignal`, `isCurrent()`) and **`createHostRequestHandler`**, which wraps two-argument implementations, validates context before user code runs, and brands handlers via a symbol plus **`WeakSet`** provenance. **`assertHostRequestHandler`** rejects forged or unary handlers.
> 
> Test helpers build synthetic contexts and invoke handlers through the factory; contract tests cover unary rejection, invalid context, and symbol-copy forgery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c24e461b6d09b506394ad782b6c97256de19729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->