### PR TITLE
fix(coding-agent): retain root kill cleanup ownership

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1906,11 +1906,16 @@ export class DaemonSupervisor {
 				return await forward();
 			}
 			this.persistWorkerStopTombstone(match.worker, true);
+			const releaseStopOwnership = this.acquireWorkerStopOwnership(match.worker);
 			let response: DaemonResponse;
 			try {
 				response = await this.forwardToWorker(match.worker, resolvedCommand);
 			} finally {
-				await this.stopWorker(match.worker, true, false, true);
+				try {
+					await this.stopWorker(match.worker, true, false, true);
+				} finally {
+					releaseStopOwnership();
+				}
 			}
 			return response;
 		} finally {
@@ -4242,9 +4247,14 @@ export class DaemonSupervisor {
 			!this.shuttingDown
 		) {
 			worker.intentionalStop = true;
-			this.workers.delete(worker.descriptor.workerId);
-			this.deleteWorkerDescriptor(worker);
-			void this.syncAgentPeers().catch(() => undefined);
+			// An exact stop owns its registration and descriptor cleanup until its
+			// tuple assertions complete. A synchronous root shutdown event can arrive
+			// before its request resolves, so leave both intact while it is active.
+			if ((this.workerStopCounts?.get(worker) ?? 0) === 0) {
+				this.workers.delete(worker.descriptor.workerId);
+				this.deleteWorkerDescriptor(worker);
+				void this.syncAgentPeers().catch(() => undefined);
+			}
 		}
 	}
 
@@ -4624,6 +4634,25 @@ export class DaemonSupervisor {
 		return observed === processStartId ? "current" : "replaced";
 	}
 
+	/**
+	 * Keep an exact stop's registration and descriptor authoritative while any
+	 * part of its cleanup is in flight. Root kills acquire this before forwarding
+	 * because a synchronous shutdown event may arrive before the worker replies.
+	 */
+	private acquireWorkerStopOwnership(worker: ResidentWorker): () => void {
+		if (!this.workerStopCounts) this.workerStopCounts = new Map();
+		const stopCounts = this.workerStopCounts;
+		stopCounts.set(worker, (stopCounts.get(worker) ?? 0) + 1);
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			const remaining = (stopCounts.get(worker) ?? 1) - 1;
+			if (remaining === 0) stopCounts.delete(worker);
+			else stopCounts.set(worker, remaining);
+		};
+	}
+
 	private async stopWorker(
 		worker: ResidentWorker,
 		removeDescriptor: boolean,
@@ -4632,15 +4661,11 @@ export class DaemonSupervisor {
 		recoveryCleanup = false,
 		directChild?: { child: ChildProcess; closed: Promise<void> },
 	): Promise<void> {
-		if (!this.workerStopCounts) this.workerStopCounts = new Map();
-		const stopCounts = this.workerStopCounts;
-		stopCounts.set(worker, (stopCounts.get(worker) ?? 0) + 1);
+		const releaseStopOwnership = this.acquireWorkerStopOwnership(worker);
 		try {
 			await this.stopWorkerUntracked(worker, removeDescriptor, force, archiveSession, recoveryCleanup, directChild);
 		} finally {
-			const remaining = (stopCounts.get(worker) ?? 1) - 1;
-			if (remaining === 0) stopCounts.delete(worker);
-			else stopCounts.set(worker, remaining);
+			releaseStopOwnership();
 		}
 	}
 

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1464,10 +1464,7 @@ describe("daemon worker supervisor monitoring", () => {
 				lifecycle: "ready" as const,
 			},
 			summaries: new Map<string, SessionSummary>([
-				[
-					"root-active",
-					{ id: "root-active", sessionId: "root-session", activeSessionId: "root-active" } as SessionSummary,
-				],
+				["root-active", { id: "root-active", sessionId: "root-session", activeSessionId: "root-active" } as SessionSummary],
 			]),
 			snapshotCache: new Map(),
 			transcriptCaches: new Map(),
@@ -1515,16 +1512,13 @@ describe("daemon worker supervisor monitoring", () => {
 		}) as {
 			workers: typeof workers;
 			workerStopCounts: Map<typeof worker, number>;
-			handleCommand(
-				client: DaemonSocketClient,
-				command: { type: "kill"; activeSessionId: string },
-			): Promise<unknown>;
+			handleCommand(client: DaemonSocketClient, command: { type: "kill"; activeSessionId: string }): Promise<unknown>;
 			handleWorkerFrame(target: typeof worker, frame: PrivateFrame<DaemonWorkerFrameHeader>): void;
 		};
 
-		await expect(
-			supervisor.handleCommand({} as DaemonSocketClient, { type: "kill", activeSessionId: "root-active" }),
-		).resolves.toEqual(success(undefined, "kill"));
+		await expect(supervisor.handleCommand({} as DaemonSocketClient, { type: "kill", activeSessionId: "root-active" })).resolves.toEqual(
+			success(undefined, "kill"),
+		);
 		expect(stopWorkerUntracked).toHaveBeenCalledWith(worker, true, false, true, false, undefined);
 		expect(workers.has(worker.descriptor.workerId)).toBe(false);
 		expect(deleteWorkerDescriptor).toHaveBeenCalledWith(worker);

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1454,6 +1454,83 @@ describe("daemon worker supervisor monitoring", () => {
 		await stopping;
 	});
 
+	it("keeps a root kill registration through a synchronous shutdown event until exact cleanup", async () => {
+		const worker = {
+			descriptor: {
+				workerId: "worker-root-kill",
+				pid: 123_456,
+				processStartId: "proc:entry",
+				rootActiveSessionId: "root-active",
+				lifecycle: "ready" as const,
+			},
+			summaries: new Map<string, SessionSummary>([
+				[
+					"root-active",
+					{ id: "root-active", sessionId: "root-session", activeSessionId: "root-active" } as SessionSummary,
+				],
+			]),
+			snapshotCache: new Map(),
+			transcriptCaches: new Map(),
+			snapshotGenerations: new Map(),
+			snapshotLoads: new Map(),
+			intentionalStop: false,
+			stopRevision: 0,
+		};
+		const workers = new Map([[worker.descriptor.workerId, worker]]);
+		const deleteWorkerDescriptor = vi.fn();
+		const stopWorkerUntracked = vi.fn(async (target: typeof worker, removeDescriptor: boolean) => {
+			// The root-kill ownership and this exact stop are both active here.
+			expect(supervisor.workerStopCounts.get(target)).toBe(2);
+			expect(workers.get(target.descriptor.workerId)).toBe(target);
+			workers.delete(target.descriptor.workerId);
+			if (removeDescriptor) deleteWorkerDescriptor(target);
+		});
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			workers,
+			workerStopCounts: new Map(),
+			clients: new Set(),
+			shuttingDown: false,
+			streamReconstructor: { observe: vi.fn() },
+			invalidateWorkerSnapshot: vi.fn(),
+			refreshWorkerSummaries: vi.fn(async () => undefined),
+			syncAgentPeers: vi.fn(async () => undefined),
+			persistWorkerStopTombstone: vi.fn(),
+			deleteWorkerDescriptor,
+			broadcastHeartbeatsChanged: vi.fn(),
+			findWorkerForClient: vi.fn(async () => ({
+				worker,
+				summary: worker.summaries.get("root-active"),
+			})),
+			forwardToWorker: vi.fn(async () => {
+				supervisor.handleWorkerFrame(worker, {
+					header: { kind: "outbound", outboundType: "session_closed", activeSessionId: "root-active" },
+					payload: Buffer.from(JSON.stringify({ type: "session_closed", reason: "shutdown" })),
+				});
+				// The event arrives before the forwarded kill resolves.
+				expect(workers.get(worker.descriptor.workerId)).toBe(worker);
+				expect(deleteWorkerDescriptor).not.toHaveBeenCalled();
+				return success(undefined, "kill");
+			}),
+			stopWorkerUntracked,
+		}) as {
+			workers: typeof workers;
+			workerStopCounts: Map<typeof worker, number>;
+			handleCommand(
+				client: DaemonSocketClient,
+				command: { type: "kill"; activeSessionId: string },
+			): Promise<unknown>;
+			handleWorkerFrame(target: typeof worker, frame: PrivateFrame<DaemonWorkerFrameHeader>): void;
+		};
+
+		await expect(
+			supervisor.handleCommand({} as DaemonSocketClient, { type: "kill", activeSessionId: "root-active" }),
+		).resolves.toEqual(success(undefined, "kill"));
+		expect(stopWorkerUntracked).toHaveBeenCalledWith(worker, true, false, true, false, undefined);
+		expect(workers.has(worker.descriptor.workerId)).toBe(false);
+		expect(deleteWorkerDescriptor).toHaveBeenCalledWith(worker);
+		expect(supervisor.workerStopCounts.has(worker)).toBe(false);
+	});
+
 	it("cancels an in-flight recovery after an intentional stop tombstone", async () => {
 		vi.useFakeTimers();
 		type RecoveryWorker = {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1464,7 +1464,10 @@ describe("daemon worker supervisor monitoring", () => {
 				lifecycle: "ready" as const,
 			},
 			summaries: new Map<string, SessionSummary>([
-				["root-active", { id: "root-active", sessionId: "root-session", activeSessionId: "root-active" } as SessionSummary],
+				[
+					"root-active",
+					{ id: "root-active", sessionId: "root-session", activeSessionId: "root-active" } as SessionSummary,
+				],
 			]),
 			snapshotCache: new Map(),
 			transcriptCaches: new Map(),
@@ -1512,13 +1515,16 @@ describe("daemon worker supervisor monitoring", () => {
 		}) as {
 			workers: typeof workers;
 			workerStopCounts: Map<typeof worker, number>;
-			handleCommand(client: DaemonSocketClient, command: { type: "kill"; activeSessionId: string }): Promise<unknown>;
+			handleCommand(
+				client: DaemonSocketClient,
+				command: { type: "kill"; activeSessionId: string },
+			): Promise<unknown>;
 			handleWorkerFrame(target: typeof worker, frame: PrivateFrame<DaemonWorkerFrameHeader>): void;
 		};
 
-		await expect(supervisor.handleCommand({} as DaemonSocketClient, { type: "kill", activeSessionId: "root-active" })).resolves.toEqual(
-			success(undefined, "kill"),
-		);
+		await expect(
+			supervisor.handleCommand({} as DaemonSocketClient, { type: "kill", activeSessionId: "root-active" }),
+		).resolves.toEqual(success(undefined, "kill"));
 		expect(stopWorkerUntracked).toHaveBeenCalledWith(worker, true, false, true, false, undefined);
 		expect(workers.has(worker.descriptor.workerId)).toBe(false);
 		expect(deleteWorkerDescriptor).toHaveBeenCalledWith(worker);


### PR DESCRIPTION
## Summary
- Retain root-worker cleanup ownership during daemon kill shutdown, preventing a root shutdown ownership race.
- Add focused regression coverage for root kill cleanup ownership.

## Validation
- `biome check --diagnostic-level=error --no-errors-on-unmatched` (two changed paths)
- `tsgo --noEmit`
- focused daemon-supervisor monitor Vitest regression (75 tests)
- `git diff --check`

Stacked on #1238 (`core00-host-request-contracts`).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix root kill cleanup in `DaemonSupervisor` to retain worker registration through synchronous shutdown events
> - `DaemonSupervisor.handleCommand` now acquires stop-ownership via `acquireWorkerStopOwnership` before forwarding a kill command, holding ownership across both forwarding and cleanup via nested `finally` blocks.
> - `handleWorkerFrame` no longer deletes a worker and its descriptor on a `session_closed(shutdown)` event if a stop is already in flight (checks `workerStopCounts` before cleanup).
> - `acquireWorkerStopOwnership` is extracted as a shared helper used by both `handleCommand` and the refactored `stopWorker`, replacing duplicated increment/decrement logic.
> - Adds host-request handler branding and context validation infrastructure (`createHostRequestHandler`, `assertHostRequestHandler`, `assertGenuineHostRequestContext`) to the kernel, with tests covering forgery rejection and invalid-context early throws.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 313a481.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon supervisor worker lifecycle and kill/shutdown ordering; behavior change is narrow but critical for session residency and descriptor consistency.
> 
> **Overview**
> Fixes a race when killing a **root** session worker: a synchronous `session_closed` / shutdown frame could drop the worker from the supervisor map and delete its descriptor **before** the kill handler’s `stopWorker` finished, leaving cleanup assertions inconsistent.
> 
> **Root kill** now calls `acquireWorkerStopOwnership` before forwarding the kill and releases it only after `stopWorker` completes (nested with `stopWorker`’s own refcount via the same helper). **`handleWorkerFrame`** skips registry/descriptor removal on root shutdown while `workerStopCounts` is non-zero, so the in-flight exact stop owns teardown.
> 
> Adds a **daemon-supervisor monitor** regression test for kill + synchronous shutdown during forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5180591d65c397daf047de6300a51b8a5ae986f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->