### PR TITLE
fix: fail closed on silent follow-ups and incomplete streams

### DIFF
--- a/docs/superpowers/plans/2026-08-11-retained-followup-incomplete-stream.md
+++ b/docs/superpowers/plans/2026-08-11-retained-followup-incomplete-stream.md
@@ -1,0 +1,135 @@
+# Retained Follow-up and Incomplete Stream Implementation Plan
+
+> Design: `docs/superpowers/specs/2026-08-11-retained-followup-incomplete-stream-design.md`
+
+## Goal
+
+Ship two independent fail-closed fixes on current `upstream/main`, preserve fire-and-forget agent messaging, open one minimal upstream PR, then cherry-pick and activate the functional commits on the existing local Prime Agent stack.
+
+## Fixed Point and Commit Shape
+
+- Base: `upstream/main` at `14d6e74919a5fba4916e5cc04b4f439a09a3750a`
+- Documentation commits already precede implementation.
+- Functional commit 1: `fix(coding-agent): report silent retained follow-ups`
+- Functional commit 2: `fix(ai): reject unterminated completion streams`
+- Keep the two functional fixes independently revertible.
+
+## Task 1: Silent Retained Follow-up Regression
+
+**Files**
+- Modify: `packages/coding-agent/test/agent-session-recursion.test.ts`
+- Read fully before editing: `packages/coding-agent/src/core/agent-session.ts`
+
+**Public seam**
+- `AgentSession.acceptAgentMessagePrompt`
+
+**RED**
+
+1. Create an RLM-depth-1 child with an agent-message controller whose `sendAgentMessage` calls are observable.
+2. Submit a direct parent `AgentSessionMessage` through `acceptAgentMessagePrompt` while the child is idle.
+3. Hold the faux assistant stream open long enough to prove admission returns before completion.
+4. End the assistant turn with reasoning-only content and no child reply.
+5. Assert the parent receives exactly one attributed `completed without sending a reply` message.
+6. Add the paired case where the child calls the existing `agent_message.send` host handler before completion and assert that no automatic terminal notice follows.
+7. Run:
+   `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-session-recursion.test.ts`
+8. Confirm the new silent-follow-up assertion fails for the missing notice, not for fixture setup.
+
+## Task 2: Follow-up Completion Monitor
+
+**Files**
+- Modify: `packages/coding-agent/src/core/agent-session.ts`
+- Modify: `packages/coding-agent/CHANGELOG.md`
+
+**GREEN**
+
+1. Reuse the existing agent-message outcome map to register a completion deferred under the incoming message ID before prompt admission.
+2. Capture `_parentReplyCount` before admission for direct parent messages at RLM depth greater than zero.
+3. Return from `acceptAgentMessagePrompt` at the existing acceptance boundary.
+4. Attach asynchronous success and error handlers to the completion promise:
+   - reply count changed: do nothing;
+   - success without reply: send `createRlmChildTerminalNoticeMessage` content to the stable sender session ID;
+   - failure without reply: send `createRlmChildFailureMessage` content.
+5. Use the existing child ID/name and message factories. Do not add daemon commands, events, polling, or durable registry fields.
+6. Ensure failed notice delivery is contained and cannot produce an unhandled rejection.
+7. Run the focused test file until GREEN.
+8. Add one `[Unreleased]` coding-agent changelog bullet.
+9. Commit only this slice.
+
+## Task 3: Unterminated Provider Stream Regression
+
+**Files**
+- Modify: `packages/ai/test/openai-completions-tool-choice.test.ts`
+- Read fully before editing: `packages/ai/src/providers/openai-completions.ts`
+
+**RED**
+
+1. Reuse the existing mocked OpenAI-compatible streaming client.
+2. Emit a reasoning delta with `finish_reason: null`, then close the async iterator without a terminal chunk.
+3. Consume `streamOpenAICompletions` and assert:
+   - the terminal event is `error`;
+   - the assistant stop reason is `error`;
+   - the error identifies a missing terminal `finish_reason`;
+   - no successful `done` event is emitted.
+4. Retain or add a control where `finish_reason: "stop"` remains successful.
+5. Run:
+   `cd packages/ai && npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-completions-tool-choice.test.ts`
+6. Confirm the new EOF test fails because current code emits `done/stop`.
+
+## Task 4: Require Terminal `finish_reason`
+
+**Files**
+- Modify: `packages/ai/src/providers/openai-completions.ts`
+- Modify: `packages/ai/CHANGELOG.md`
+
+**GREEN**
+
+1. Track whether any choice supplied a non-null terminal `finish_reason`.
+2. Preserve all existing reason mappings.
+3. After iteration and block finalization, fail before `done` when no terminal reason was observed.
+4. Let the existing catch path preserve partial content and convert the output to an error event.
+5. Run the focused AI test file until GREEN.
+6. Add one `[Unreleased]` AI changelog bullet.
+7. Commit only this slice.
+
+## Task 5: Integration Gate and Review
+
+1. Cherry-pick both functional commits onto the upstream contribution branch after the design/plan commits.
+2. From repo root run `npm run check` with complete output.
+3. Re-run both focused test files from their package roots.
+4. Run `git diff --check` and confirm a clean worktree.
+5. Review `upstream/main...HEAD` on two axes:
+   - repository standards and code smells;
+   - exact design/spec compliance.
+6. Resolve every blocker/high/medium finding and rerun affected tests/checks.
+
+## Task 6: Upstream Pull Request
+
+1. Rebase the contribution branch on the latest `upstream/main` if it moved, then rerun the gate.
+2. Push `fix/retained-followup-incomplete-stream` to `origin`.
+3. Open one PR to `PrimeIntellect-ai/prime-agent:main` with:
+   - incident and causal chain;
+   - both fail-closed fixes;
+   - focused RED/GREEN evidence;
+   - full `npm run check` result;
+   - no claim that raw provider chunks proved the original EOF trigger.
+4. Do not merge the upstream PR.
+
+## Task 7: Local Activation
+
+1. Create a local activation branch from `local/activated-subagent-thinking-level` at `d09d531e`.
+2. Cherry-pick the two functional commits plus changelog/test changes; omit upstream-only design/plan docs if they conflict with the local documentation stack.
+3. Resolve semantic conflicts against the local host-request/discovery/thinking-level commits without dropping either fix.
+4. Run both focused regressions and `npm run check`.
+5. Build/install using the repository-supported local package workflow already used by the current activation.
+6. Request a coordinated daemon update restart so all resident sessions checkpoint and recover on the new build.
+7. Verify daemon/client build identity and run an isolated retained-child silent-follow-up smoke test.
+8. Confirm all pre-existing sessions remain listed and attachable.
+
+## Completion Evidence
+
+- Upstream PR URL.
+- Functional commit SHAs.
+- Focused test counts and full check result.
+- Installed build identity and daemon restart log.
+- Isolated smoke result demonstrating parent wake-up on a silent retained-child follow-up.

--- a/docs/superpowers/specs/2026-08-11-retained-followup-incomplete-stream-design.md
+++ b/docs/superpowers/specs/2026-08-11-retained-followup-incomplete-stream-design.md
@@ -1,0 +1,113 @@
+# Retained Follow-up and Incomplete Stream Hardening Design
+
+## Objective
+
+Prevent an idle parent from waiting forever when a retained RLM child accepts a follow-up but finishes without replying, and prevent an OpenAI-compatible stream that ends without a terminal `finish_reason` from being recorded as a successful completion.
+
+## Incident
+
+A retained child accepted a direct parent follow-up and executed normally, then produced an assistant message containing only reasoning with `stopReason: "stop"`. It did not call `agent_message.send`. The parent remained idle because the automatic `completed without sending a reply` notice only covered the original `rlm()` task. The child's durable RLM row still described the completed original task and did not monitor later follow-ups.
+
+The same assistant record was consistent with a second fail-open path: the OpenAI-compatible stream adapter initializes the output as `stop` and emits it after clean iterator exhaustion even when no chunk supplied a terminal `finish_reason`.
+
+## Repository Topology
+
+- Upstream: `https://github.com/PrimeIntellect-ai/prime-agent.git`
+- Fork: `https://github.com/ProDrifterDK/prime-agent.git`
+- Upstream contribution branch: `fix/retained-followup-incomplete-stream`
+- Upstream base: current `upstream/main`
+- Local activation base: the currently activated local stack at `d09d531e5cc29ee0f161543e00f163522c58f49e`
+
+The upstream pull request will contain only the design, regressions, implementation, and changelog entries for these two defects. After review, its functional commits will be cherry-picked onto the local activation stack rather than replacing that stack.
+
+## Design 1: Retained Child Follow-up Completion
+
+### Boundary
+
+`AgentSession.acceptAgentMessagePrompt` is the task-admission seam for an idle session receiving an agent message. A direct parent-to-child message at RLM depth greater than zero defines a follow-up task whose completion must result in either an explicit child reply or a host-generated terminal notice.
+
+### Flow
+
+1. Before admitting the prompt, identify a direct parent message and capture the child's monotonic parent-reply count.
+2. Register a completion waiter under the incoming agent-message ID before the action can settle.
+3. Admit the prompt through the existing agent-message path and return at acceptance so the sender is never blocked on the target's model turn.
+4. Observe completion asynchronously:
+   - if the parent-reply count increased, the child replied explicitly and no host notice is emitted;
+   - if completion succeeds without a parent reply, send the existing `completed without sending a reply` content to the stable parent session ID;
+   - if completion fails definitively without a parent reply, send the existing child-failure content.
+5. Delivery uses the child session's existing agent-message controller, preserving child attribution and the parent's normal event-driven wake-up behavior.
+
+### Scope
+
+The change applies only to an idle RLM child accepting a direct message from its parent. It does not create a new RLM handle, reinterpret the durable registry row, change daemon wire protocol, or add polling/watchdog behavior. Busy-session steering and queued follow-ups keep their existing semantics.
+
+### Exactly-once and Races
+
+The incoming agent-message ID owns one completion waiter. The reply-count baseline is captured before admission, so a fast child reply cannot be lost by a later boolean reset. Completion handlers compare the counter once and attach both success and rejection branches to avoid unhandled promises. Parent targeting prefers the stable session ID supplied by the accepted message over an active runtime ID that may later change.
+
+## Design 2: OpenAI-compatible Stream Completion
+
+### Boundary
+
+`streamOpenAICompletions` is the public provider seam. A successful streamed response requires a terminal non-null `finish_reason` from at least one choice.
+
+### Flow
+
+1. Initialize a `sawTerminalFinishReason` flag as false.
+2. Set it when a choice carries any non-null `finish_reason`, before mapping that reason to the internal stop reason.
+3. After stream iteration and block finalization, but before emitting `done`, fail if no terminal finish reason was observed.
+4. Preserve partial text/reasoning/tool blocks on the error assistant message for diagnostics, but mark the message `error`; never emit a successful `stop` solely because the iterator ended.
+5. Existing coding-agent retry policy treats the provider error as transient unless a structured permanent-failure rule says otherwise.
+
+This is deliberately strict. OpenAI-compatible streaming requires a terminal finish reason, and accepting an unframed EOF risks committing truncated reasoning, text, or tool arguments as complete work.
+
+## Test Seams
+
+Tests exercise public behavior rather than private state.
+
+### Coding Agent
+
+Using `AgentSession.acceptAgentMessagePrompt` with the existing faux stream and an agent-message controller:
+
+1. An idle retained child accepts a direct parent follow-up, completes with reasoning-only output, and sends no reply. The parent receives exactly one attributed terminal notice.
+2. The child explicitly replies to its parent during the follow-up. No automatic terminal notice is sent.
+3. The sender-facing admission call still returns before the child completion, preserving fire-and-forget messaging.
+
+### AI Provider
+
+Using `streamOpenAICompletions` with the existing mocked OpenAI-compatible stream:
+
+1. A reasoning delta followed by iterator EOF with only `finish_reason: null` produces an error event and no successful done event.
+2. A normal terminal `finish_reason: "stop"` remains a successful stop.
+3. Existing non-standard terminal reasons retain their current mappings.
+
+## Validation
+
+From each affected package root:
+
+1. Run only the modified focused test file with `npx tsx ../../node_modules/vitest/dist/cli.js --run <test-file>` while iterating RED to GREEN.
+2. Run repository-required `npm run check` after code changes; capture full output.
+3. Review the complete diff against `upstream/main` for spec compliance and repository standards.
+4. Push the fork branch and open one pull request against `PrimeIntellect-ai/prime-agent:main`.
+
+No test uses live providers, credentials, paid APIs, or another user's session.
+
+## Local Activation
+
+After the upstream-ready commits pass review:
+
+1. Cherry-pick the two functional fixes and their regressions/changelog entries onto a local activation branch based on `d09d531e`.
+2. Run the same focused regressions and full repository check on the activation branch.
+3. Build and install Prime Agent through the repository's supported local package path.
+4. Perform a coordinated daemon update restart so resident sessions checkpoint and recover under the new build.
+5. Verify the daemon build identity and run an isolated smoke test: a retained child that ends a follow-up silently must wake its parent with a terminal notice.
+
+## Success Criteria
+
+- A silent retained-child follow-up cannot leave its parent waiting indefinitely.
+- An explicit child reply never receives a duplicate automatic notice.
+- OpenAI-compatible EOF without a terminal `finish_reason` is an error and eligible for retry.
+- Standards-compliant streams remain unchanged.
+- No daemon protocol or registry migration is introduced.
+- The upstream pull request is minimal and based on current `upstream/main`.
+- The local activated stack preserves its existing custom commits and runs the verified fixes for all sessions.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed OpenAI-compatible streams ending without a terminal finish_reason being recorded as successful completions.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -169,6 +169,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			type StreamingBlock = TextContent | ThinkingContent | StreamingToolCallBlock;
 			type StreamingToolCallDelta = NonNullable<ChatCompletionChunk.Choice.Delta["tool_calls"]>[number];
 
+			let sawTerminalFinishReason = false;
 			let textBlock: TextContent | null = null;
 			let thinkingBlock: ThinkingContent | null = null;
 			const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
@@ -279,7 +280,13 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 					output.usage = parseChunkUsage(chunk.usage, model, cacheWriteCost);
 				}
 
-				const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
+				const choices = Array.isArray(chunk.choices) ? chunk.choices : [];
+				if (
+					choices.some((candidate) => candidate.finish_reason !== null && candidate.finish_reason !== undefined)
+				) {
+					sawTerminalFinishReason = true;
+				}
+				const choice = choices[0];
 				if (!choice) continue;
 
 				// Fallback: some providers (e.g., Moonshot) return usage
@@ -395,6 +402,9 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			}
 			if (output.stopReason === "error") {
 				throw new Error(output.errorMessage || "Provider returned an error stop reason");
+			}
+			if (!sawTerminalFinishReason) {
+				throw new Error("OpenAI-compatible stream ended without a terminal finish_reason");
 			}
 
 			stream.push({ type: "done", reason: output.stopReason, message: output });

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -375,6 +375,77 @@ describe("openai-completions tool_choice", () => {
 		expect(response.errorMessage).toBe("Provider finish_reason: network_error");
 	});
 
+	it("fails closed when the stream ends without a terminal finish_reason", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-unterminated",
+				choices: [{ delta: { reasoning_content: "partial thinking" }, finish_reason: null }],
+			},
+		];
+
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = { ...baseModel, api: "openai-completions" } as const;
+		const s = streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Think quietly",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{ apiKey: "test" },
+		);
+
+		const eventTypes: string[] = [];
+		for await (const event of s) {
+			eventTypes.push(event.type);
+		}
+
+		expect(eventTypes).not.toContain("done");
+		expect(eventTypes[eventTypes.length - 1]).toBe("error");
+
+		const response = await s.result();
+		expect(response.stopReason).toBe("error");
+		expect(response.errorMessage).toMatch(/finish_reason/);
+		expect(response.content).toEqual([
+			{ type: "thinking", thinking: "partial thinking", thinkingSignature: "reasoning_content" },
+		]);
+	});
+
+	it("accepts a terminal finish_reason from a later choice", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-multiple-choices",
+				choices: [
+					{ delta: { content: "first choice" }, finish_reason: null },
+					{ delta: {}, finish_reason: "stop" },
+				],
+			},
+		];
+
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = { ...baseModel, api: "openai-completions" } as const;
+		const response = await streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Choose",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		expect(response.stopReason).toBe("stop");
+		expect(response.content).toEqual([{ type: "text", text: "first choice" }]);
+	});
+
 	it("ignores null stream chunks from openai-compatible providers", async () => {
 		mockState.chunks = [
 			null,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
 - Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
 - Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
+- Fixed a retained RLM child that completed a parent follow-up without sending a reply leaving the parent waiting; the parent now receives the existing automatic terminal notice.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,11 +14,7 @@
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))
 - Fixed the agents view collapsing expanded subagent lists when returning from an opened agent ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
 - Kept the subagent summary row visible and selectable while its list is expanded in the agents view, so pressing enter on it collapses the list again ([ENG-5105](https://linear.app/primeintellect/issue/ENG-5105/keep-the-agents-view-state-persistent)).
-- Added in-place editing of queued steering and follow-up messages: Alt+Up/Alt+Down browse the queue from the draft, Enter applies the edit as steering, Alt+Enter as a follow-up, and submitting an empty editor deletes the item; interrupts now preserve the queue ([#838](https://github.com/PrimeIntellect-ai/prime-agent/pull/838)).
-- Fixed workers with no live connection reporting as `ready`; stopping workers now report a `stopping` state, are hidden from live sessions, and no longer receive daemon-wide commands ([#850](https://github.com/PrimeIntellect-ai/prime-agent/pull/850)).
-- Fixed timed-out worker stops stranding dead-but-registered workers ("Session worker is not connected"); stops now finalize in the background once the process exits, and zombie processes are no longer counted as alive ([#851](https://github.com/PrimeIntellect-ai/prime-agent/pull/851)).
-- Fixed sessions becoming permanently unopenable after a stale worker registration was left behind; open/resume now self-heals by finishing the old cleanup and starting a fresh worker ([#852](https://github.com/PrimeIntellect-ai/prime-agent/pull/852)).
-- Fixed a retained RLM child that completed a parent follow-up without sending a reply leaving the parent waiting; the parent now receives the existing automatic terminal notice.
+- Fixed retained RLM child notices firing before newer queued parent work or post-compaction continuations finished; only the latest silent parent task now emits one notice after the child is idle.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4479,15 +4479,43 @@ export class AgentSession {
 	async acceptAgentMessagePrompt(text: string, options?: PromptOptions): Promise<void> {
 		const customMessage =
 			options?.customMessage && isAgentSessionMessage(options.customMessage) ? options.customMessage : undefined;
-		await this._prompt(text, {
-			...options,
-			expandPromptTemplates: false,
-			skipInputHandlers: true,
-			skipPrePromptWork: true,
-			returnAfterAccepted: true,
-			agentMessageId: options?.agentMessageId ?? customMessage?.details.id ?? parseAgentSessionMessagePromptId(text),
-			customMessage,
-		});
+		const agentMessageId =
+			options?.agentMessageId ?? customMessage?.details.id ?? parseAgentSessionMessagePromptId(text);
+		// A direct parent message defines a follow-up task for an idle RLM child: its
+		// completion must produce either an explicit child reply or a host notice.
+		const parentTarget =
+			customMessage?.details.fromRelationship === "parent" && this._rlmDepth > 0 && this._agentMessageController
+				? (customMessage.details.from?.sessionId ?? customMessage.details.from?.activeSessionId)
+				: undefined;
+		if (parentTarget && agentMessageId) {
+			if (this._agentMessageOutcomes.get(agentMessageId)?.completion) {
+				throw new Error(`Prompt completion id is already in use: ${agentMessageId}`);
+			}
+			const parentReplyCountBefore = this._parentReplyCount;
+			const outcome = this._agentMessageOutcome(agentMessageId);
+			const completion = createAgentMessageDeferred();
+			outcome.completion = completion;
+			void completion.promise
+				.then(
+					() => this._reportRetainedFollowUpCompletion(parentTarget, parentReplyCountBefore),
+					(error: Error) => this._reportRetainedFollowUpFailure(parentTarget, parentReplyCountBefore, error),
+				)
+				.catch(() => undefined);
+		}
+		try {
+			await this._prompt(text, {
+				...options,
+				expandPromptTemplates: false,
+				skipInputHandlers: true,
+				skipPrePromptWork: true,
+				returnAfterAccepted: true,
+				agentMessageId,
+				customMessage,
+			});
+		} catch (error) {
+			if (agentMessageId) this._settleAgentMessage(agentMessageId, "completion", this._asError(error));
+			throw error;
+		}
 		if (customMessage?.details.fromRelationship === "parent") this._repliedToParentSinceTask = false;
 	}
 
@@ -4511,6 +4539,46 @@ export class AgentSession {
 		});
 		if (queued && customMessage?.details.fromRelationship === "parent") this._repliedToParentSinceTask = false;
 		return queued;
+	}
+
+	private _reportRetainedFollowUpCompletion(targetSessionId: string, parentReplyCountBefore: number): void {
+		if (this._parentReplyCount !== parentReplyCountBefore) return;
+		const lastAssistantText = this.getLastAssistantText();
+		this._deliverRetainedFollowUpNotice(
+			targetSessionId,
+			createRlmChildTerminalNoticeMessage({
+				kind: "completed_without_reply",
+				childId: this._rlmNoticeChildId(),
+				sessionName: this.sessionName ?? this.sessionId,
+				lastAssistantTextPreview: lastAssistantText ? compactRlmText(lastAssistantText) : undefined,
+			}).content as string,
+		);
+	}
+
+	private _reportRetainedFollowUpFailure(targetSessionId: string, parentReplyCountBefore: number, error: Error): void {
+		if (this._parentReplyCount !== parentReplyCountBefore) return;
+		this._deliverRetainedFollowUpNotice(
+			targetSessionId,
+			createRlmChildFailureMessage({
+				childId: this._rlmNoticeChildId(),
+				sessionName: this.sessionName ?? this.sessionId,
+				error: error instanceof Error ? error.message : String(error),
+			}).content as string,
+		);
+	}
+
+	private _rlmNoticeChildId(): string {
+		return this._rlmParentNodeId ?? this.sessionId;
+	}
+
+	private _deliverRetainedFollowUpNotice(targetSessionId: string, message: string): void {
+		const controller = this._agentMessageController;
+		if (!controller) return;
+		try {
+			void Promise.resolve(controller.sendAgentMessage({ target: targetSessionId, message })).catch(() => undefined);
+		} catch {
+			// A failed notice delivery must not surface as an unhandled rejection.
+		}
 	}
 
 	async promptHeartbeat(job: AgentCronJob, options?: PromptOptions): Promise<void> {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1214,6 +1214,14 @@ export class AgentSession {
 	private _rlmParentAgent?: string;
 	private _repliedToParentSinceTask: boolean | undefined;
 	private _parentReplyCount = 0;
+	/**
+	 * Monotonic epoch of parent-directed work admitted to this session. Every
+	 * accepted direct or queued message from this RLM child's parent (including
+	 * the original rlm() task) binds to the next epoch. A terminal/failure notice
+	 * is emitted only for the latest silent epoch, so a notice belonging to older
+	 * parent work can never fire once newer parent work has been admitted.
+	 */
+	private _parentWorkEpoch = 0;
 	private _subagentRuntimeHost?: SubagentRuntimeHost;
 	private _activeRlmChildRuns = new Map<string, RlmChildRun>();
 	private _pendingRlmSubagentSessionNames = new Set<string>();
@@ -1258,6 +1266,9 @@ export class AgentSession {
 	private _turnIntervalAutoRefinePending = false;
 	private _postCompactionContinuationScheduled = false;
 	private _postCompactionContinuationTimer: ReturnType<typeof setTimeout> | undefined;
+	// Event-driven wakeup for waiters on a timer-scheduled post-compaction
+	// continuation: waitForIdle() alone can return before agent.continue() starts.
+	private _postCompactionContinuationWake?: AgentMessageDeferred;
 	private _postCompactionContinuationMessages: AgentMessage[] = [];
 	private _scheduledPostCompactionContinuationMessages: AgentMessage[] = [];
 	private _queuedAutonomousThresholdContinuations = new WeakMap<AssistantMessage, AgentMessage>();
@@ -3244,6 +3255,15 @@ export class AgentSession {
 		return outcome;
 	}
 
+	private _registerAgentMessageCompletion(agentMessageId: string): AgentMessageDeferred {
+		if (this._agentMessageOutcomes.get(agentMessageId)?.completion) {
+			throw new Error(`Prompt completion id is already in use: ${agentMessageId}`);
+		}
+		const completion = createAgentMessageDeferred();
+		this._agentMessageOutcome(agentMessageId).completion = completion;
+		return completion;
+	}
+
 	/**
 	 * Register a delivery waiter before submitting the prompt. Delivery outcomes are not retained
 	 * for late lookup, so callers that register after admission may wait for a future use of the id.
@@ -4461,12 +4481,7 @@ export class AgentSession {
 
 	async promptAndWait(text: string, options?: PromptOptions): Promise<void> {
 		const agentMessageId = options?.agentMessageId ?? `prompt-wait:${randomUUID()}`;
-		if (this._agentMessageOutcomes.get(agentMessageId)?.completion) {
-			throw new Error(`Prompt completion id is already in use: ${agentMessageId}`);
-		}
-		const outcome = this._agentMessageOutcome(agentMessageId);
-		outcome.completion = createAgentMessageDeferred();
-		const completion = outcome.completion.promise;
+		const completion = this._registerAgentMessageCompletion(agentMessageId).promise;
 		try {
 			await this.promptUntilAccepted(text, { ...options, agentMessageId });
 			await completion;
@@ -4481,26 +4496,12 @@ export class AgentSession {
 			options?.customMessage && isAgentSessionMessage(options.customMessage) ? options.customMessage : undefined;
 		const agentMessageId =
 			options?.agentMessageId ?? customMessage?.details.id ?? parseAgentSessionMessagePromptId(text);
-		// A direct parent message defines a follow-up task for an idle RLM child: its
+		// A direct parent message defines a follow-up task for an RLM child: its
 		// completion must produce either an explicit child reply or a host notice.
-		const parentTarget =
-			customMessage?.details.fromRelationship === "parent" && this._rlmDepth > 0 && this._agentMessageController
-				? (customMessage.details.from?.sessionId ?? customMessage.details.from?.activeSessionId)
-				: undefined;
+		const parentTarget = this._parentMessageTarget(customMessage);
 		if (parentTarget && agentMessageId) {
-			if (this._agentMessageOutcomes.get(agentMessageId)?.completion) {
-				throw new Error(`Prompt completion id is already in use: ${agentMessageId}`);
-			}
-			const parentReplyCountBefore = this._parentReplyCount;
-			const outcome = this._agentMessageOutcome(agentMessageId);
-			const completion = createAgentMessageDeferred();
-			outcome.completion = completion;
-			void completion.promise
-				.then(
-					() => this._reportRetainedFollowUpCompletion(parentTarget, parentReplyCountBefore),
-					(error: Error) => this._reportRetainedFollowUpFailure(parentTarget, parentReplyCountBefore, error),
-				)
-				.catch(() => undefined);
+			const completion = this._registerAgentMessageCompletion(agentMessageId);
+			this._monitorParentWorkCompletion(parentTarget, completion);
 		}
 		try {
 			await this._prompt(text, {
@@ -4525,23 +4526,76 @@ export class AgentSession {
 		customMessage?: AgentSessionMessage,
 	): Promise<boolean> {
 		const agentMessageId = customMessage?.details.id ?? parseAgentSessionMessagePromptId(text);
-		if (streamingBehavior === "steer") {
-			await this._queuePreparedPrompt("steer", text, undefined, {
+		const parentTarget = this._parentMessageTarget(customMessage);
+		const parentCompletion =
+			parentTarget && agentMessageId ? this._registerAgentMessageCompletion(agentMessageId) : undefined;
+		void parentCompletion?.promise.catch(() => undefined);
+		try {
+			const queued = await this._queuePreparedPrompt(streamingBehavior, text, undefined, {
 				agentMessageId,
 				message: customMessage,
 			});
+			if (!queued) return false;
+			if (parentTarget && parentCompletion) this._monitorParentWorkCompletion(parentTarget, parentCompletion);
 			if (customMessage?.details.fromRelationship === "parent") this._repliedToParentSinceTask = false;
 			return true;
+		} catch (error) {
+			if (parentCompletion && agentMessageId) {
+				this._settleAgentMessage(agentMessageId, "completion", this._asError(error));
+			}
+			throw error;
 		}
-		const queued = await this._queuePreparedPrompt("followUp", text, undefined, {
-			agentMessageId,
-			message: customMessage,
-		});
-		if (queued && customMessage?.details.fromRelationship === "parent") this._repliedToParentSinceTask = false;
-		return queued;
 	}
 
-	private _reportRetainedFollowUpCompletion(targetSessionId: string, parentReplyCountBefore: number): void {
+	/** Stable parent session target of an agent message, when this session is an RLM child. */
+	private _parentMessageTarget(customMessage: AgentSessionMessage | undefined): string | undefined {
+		return customMessage?.details.fromRelationship === "parent" && this._rlmDepth > 0 && this._agentMessageController
+			? (customMessage.details.from?.sessionId ?? customMessage.details.from?.activeSessionId)
+			: undefined;
+	}
+
+	/**
+	 * Register event-driven completion monitoring for accepted parent-directed
+	 * work. The completion leg settles when the work's action terminates; the
+	 * handler then waits for true session quiescence (including any
+	 * timer-scheduled post-compaction continuation) and re-checks epoch,
+	 * explicit-reply, and disposal state before delivering exactly one
+	 * terminal/failure notice for the latest silent parent-work epoch.
+	 */
+	private _monitorParentWorkCompletion(parentTarget: string, completion: AgentMessageDeferred): void {
+		const parentWorkEpoch = this._bindParentWorkEpoch();
+		const parentReplyCountBefore = this._parentReplyCount;
+		void completion.promise
+			.then(
+				async () => {
+					if (this._disposed || this._disposing) return;
+					await this._waitForRetainedParentQuiescence();
+					this._reportRetainedFollowUpCompletion(parentTarget, parentWorkEpoch, parentReplyCountBefore);
+				},
+				async (error: Error) => {
+					if (this._disposed || this._disposing) return;
+					await this._waitForRetainedParentQuiescence();
+					this._reportRetainedFollowUpFailure(parentTarget, parentWorkEpoch, parentReplyCountBefore, error);
+				},
+			)
+			.catch(() => undefined);
+	}
+
+	/** Bind the next monotonic parent-directed work epoch and return its number. */
+	private _bindParentWorkEpoch(): number {
+		this._parentWorkEpoch += 1;
+		return this._parentWorkEpoch;
+	}
+
+	private _reportRetainedFollowUpCompletion(
+		targetSessionId: string,
+		parentWorkEpoch: number,
+		parentReplyCountBefore: number,
+	): void {
+		if (this._disposed || this._disposing) return;
+		// A newer parent-directed work item supersedes this one: only the latest
+		// silent epoch may emit a terminal notice.
+		if (this._parentWorkEpoch !== parentWorkEpoch) return;
 		if (this._parentReplyCount !== parentReplyCountBefore) return;
 		const lastAssistantText = this.getLastAssistantText();
 		this._deliverRetainedFollowUpNotice(
@@ -4555,7 +4609,14 @@ export class AgentSession {
 		);
 	}
 
-	private _reportRetainedFollowUpFailure(targetSessionId: string, parentReplyCountBefore: number, error: Error): void {
+	private _reportRetainedFollowUpFailure(
+		targetSessionId: string,
+		parentWorkEpoch: number,
+		parentReplyCountBefore: number,
+		error: Error,
+	): void {
+		if (this._disposed || this._disposing) return;
+		if (this._parentWorkEpoch !== parentWorkEpoch) return;
 		if (this._parentReplyCount !== parentReplyCountBefore) return;
 		this._deliverRetainedFollowUpNotice(
 			targetSessionId,
@@ -4579,6 +4640,29 @@ export class AgentSession {
 		} catch {
 			// A failed notice delivery must not surface as an unhandled rejection.
 		}
+	}
+
+	/**
+	 * Event-driven quiescence for retained-parent notices. The public
+	 * waitForIdle() does not cover a timer-scheduled post-compaction continuation
+	 * (agent.continue() starts 100ms later), so also wait for that scheduled
+	 * continuation to start or be cancelled before deciding a silent parent-work
+	 * epoch is terminal. No polling: waiters are woken by the continuation's own
+	 * lifecycle transitions.
+	 */
+	private async _waitForRetainedParentQuiescence(): Promise<void> {
+		while (true) {
+			await this.waitForIdle();
+			if (!this._postCompactionContinuationScheduled) return;
+			this._postCompactionContinuationWake ??= createAgentMessageDeferred();
+			await this._postCompactionContinuationWake.promise;
+		}
+	}
+
+	private _wakePostCompactionContinuationWaiters(): void {
+		const wake = this._postCompactionContinuationWake;
+		this._postCompactionContinuationWake = undefined;
+		wake?.resolve();
 	}
 
 	async promptHeartbeat(job: AgentCronJob, options?: PromptOptions): Promise<void> {
@@ -7348,6 +7432,7 @@ export class AgentSession {
 		}
 		this._postCompactionContinuationScheduled = false;
 		this._scheduledPostCompactionContinuationMessages = [];
+		this._wakePostCompactionContinuationWaiters();
 	}
 
 	private _discardPendingAutoRefine(options: { cancelPostCompactionContinue?: boolean } = {}): void {
@@ -7465,6 +7550,7 @@ export class AgentSession {
 		}
 		if (this.isStreaming || this.isCompacting || this.isRetrying || this._queuedWorkPauses.size > 0) {
 			this._postCompactionContinuationScheduled = false;
+			this._wakePostCompactionContinuationWaiters();
 			this._schedulePostCompactionContinue();
 			return;
 		}
@@ -7481,6 +7567,7 @@ export class AgentSession {
 			await this._sessionInputPump;
 			if (this._postCompactionContinuationScheduled) {
 				this._postCompactionContinuationScheduled = false;
+				this._wakePostCompactionContinuationWaiters();
 				const shouldReschedule =
 					continuationMessages.length === 0
 						? this.unfinishedActionCount > 0
@@ -7496,6 +7583,7 @@ export class AgentSession {
 		}
 
 		this._postCompactionContinuationScheduled = false;
+		this._wakePostCompactionContinuationWaiters();
 		try {
 			await this.agent.continue();
 			this._forgetConsumedPostCompactionContinuations(continuationMessages);
@@ -9880,6 +9968,10 @@ export class AgentSession {
 		// retention, cancellation, and late-startup cleanup.
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
+			// Bound when the spawn task is admitted; undefined when the runtime failed
+			// to start (in which case no child session ever existed to accept newer
+			// parent work, so the failure notice still applies).
+			let parentWorkEpochAtRun: number | undefined;
 			try {
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
 				const child = childRuntime.session;
@@ -9973,6 +10065,7 @@ export class AgentSession {
 				};
 				throwIfCancelled();
 				const parentReplyCountBeforeRun = child._parentReplyCount;
+				parentWorkEpochAtRun = child._bindParentWorkEpoch();
 				await child.promptAndWait(content, {
 					expandPromptTemplates: false,
 					source: "extension",
@@ -9983,16 +10076,26 @@ export class AgentSession {
 				durationMs = Date.now() - startedAt;
 				activity = undefined;
 				emitChildUpdate();
-				if (!run.detachedDeletion && child._parentReplyCount === parentReplyCountBeforeRun) {
-					const lastAssistantText = child.getLastAssistantText();
-					await deliverTerminalMessageToParent(
-						createRlmChildTerminalNoticeMessage({
-							kind: "completed_without_reply",
-							childId: run.id,
-							sessionName,
-							lastAssistantTextPreview: lastAssistantText ? compactRlmText(lastAssistantText) : undefined,
-						}),
-					);
+				if (!run.detachedDeletion) {
+					// A turn action settling is not quiescence: queued session input and
+					// timer-scheduled post-compaction continuations can still restart the
+					// agent. Wait for true idle, then re-check that no newer parent work
+					// was admitted and no explicit reply arrived before noticing.
+					await child._waitForRetainedParentQuiescence();
+					if (
+						child._parentWorkEpoch === parentWorkEpochAtRun &&
+						child._parentReplyCount === parentReplyCountBeforeRun
+					) {
+						const lastAssistantText = child.getLastAssistantText();
+						await deliverTerminalMessageToParent(
+							createRlmChildTerminalNoticeMessage({
+								kind: "completed_without_reply",
+								childId: run.id,
+								sessionName,
+								lastAssistantTextPreview: lastAssistantText ? compactRlmText(lastAssistantText) : undefined,
+							}),
+						);
+					}
 				}
 				if (!this.registerRlmChildSession(run.id, child)) {
 					if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
@@ -10015,13 +10118,17 @@ export class AgentSession {
 				emitChildUpdate();
 				if (!run.detachedDeletion) {
 					if (run.status === "error") {
-						await deliverTerminalMessageToParent(
-							createRlmChildFailureMessage({
-								childId: run.id,
-								sessionName,
-								error: run.error ?? "unknown error",
-							}),
-						);
+						const parentWorkEpochUnchanged =
+							childSession === undefined || childSession._parentWorkEpoch === parentWorkEpochAtRun;
+						if (parentWorkEpochUnchanged) {
+							await deliverTerminalMessageToParent(
+								createRlmChildFailureMessage({
+									childId: run.id,
+									sessionName,
+									error: run.error ?? "unknown error",
+								}),
+							);
+						}
 					} else if (run.status === "cancelled") {
 						await deliverTerminalMessageToParent(
 							createRlmChildTerminalNoticeMessage({

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -11,6 +11,7 @@ import {
 	getModel,
 	type TextContent,
 	type Usage,
+	type UserMessage,
 } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -133,6 +134,8 @@ interface InspectableRlmSession {
 	_rlmChildUnsubscribes: Map<string, () => void>;
 	_createKernelHostHandlers(): HostRequestHandlers;
 	_reapDeletedRlmSubagentRuntimesAfterCompaction(): Promise<void>;
+	_schedulePostCompactionContinue(): void;
+	_postCompactionContinuationMessages: AgentMessage[];
 }
 
 interface KernelPumpTestApi {
@@ -1457,6 +1460,257 @@ describe("AgentSession rlm recursion", () => {
 				message: "RLM child followup-worker (silent-followup-child) completed without sending a reply",
 			}),
 		);
+	});
+
+	it("defers a silent child notice until newer queued parent work is idle", async () => {
+		let releaseInitial: () => void = () => {};
+		const initialGate = new Promise<void>((resolve) => {
+			releaseInitial = resolve;
+		});
+		let releaseFollowUp: () => void = () => {};
+		const followUpGate = new Promise<void>((resolve) => {
+			releaseFollowUp = resolve;
+		});
+		let initialStarted = false;
+		let followUpStarted = false;
+		const sendAgentMessage = vi.fn(async () => ({
+			id: "agentmsg-quiescent-notice",
+			source: "agent_message" as const,
+			target: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			message: "notice",
+			deliveryStatus: "delivered" as const,
+		}));
+		const child = createSession({
+			depth: 1,
+			rlmSessionDir: join(tempDir, "quiescent-child"),
+			rlmParentNodeId: "quiescent-child",
+			streamFn: (_model, context) => {
+				const stream = createAssistantMessageEventStream();
+				if (userText(context) === "initial task") {
+					initialStarted = true;
+					void initialGate.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage("") });
+					});
+				} else {
+					followUpStarted = true;
+					void followUpGate.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage("") });
+					});
+				}
+				return stream;
+			},
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage,
+			},
+		});
+		child.setSessionName("quiescent-worker");
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		await root.runRlmChild("initial task", { name: "quiescent-worker" });
+		await waitFor(() => initialStarted);
+		const followUp = createAgentSessionMessage({
+			id: "agentmsg-newer-parent-work",
+			source: "agent_message",
+			message: "additional review requirement",
+			from: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			fromRelationship: "parent",
+			target: { activeSessionId: "child-active", sessionId: child.sessionId },
+		});
+		await child.queueAgentMessagePrompt(followUp.content as string, "steer", followUp);
+		releaseInitial();
+		await waitFor(() => followUpStarted);
+
+		expect(child.isStreaming).toBe(true);
+		expect(sendAgentMessage).not.toHaveBeenCalled();
+		releaseFollowUp();
+		await child.waitForIdle();
+		await vi.waitFor(() => expect(sendAgentMessage).toHaveBeenCalledTimes(1));
+		expect(sendAgentMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				target: "parent-session",
+				message: "RLM child quiescent-worker (quiescent-child) completed without sending a reply",
+			}),
+		);
+		await sleep(50);
+		expect(sendAgentMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("emits one notice for the latest of multiple queued parent messages", async () => {
+		let releaseInitial: () => void = () => {};
+		const initialGate = new Promise<void>((resolve) => {
+			releaseInitial = resolve;
+		});
+		let releaseQueuedWork: () => void = () => {};
+		const queuedWorkGate = new Promise<void>((resolve) => {
+			releaseQueuedWork = resolve;
+		});
+		let initialStarted = false;
+		let queuedWorkStarted = false;
+		const sendAgentMessage = vi.fn(async () => ({
+			id: "agentmsg-latest-queued-notice",
+			source: "agent_message" as const,
+			target: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			message: "notice",
+			deliveryStatus: "delivered" as const,
+		}));
+		const child = createSession({
+			depth: 1,
+			rlmSessionDir: join(tempDir, "multiple-queued-child"),
+			rlmParentNodeId: "multiple-queued-child",
+			streamFn: (_model, context) => {
+				const stream = createAssistantMessageEventStream();
+				if (userText(context) === "initial task") {
+					initialStarted = true;
+					void initialGate.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage("") });
+					});
+				} else {
+					queuedWorkStarted = true;
+					void queuedWorkGate.then(() => {
+						stream.push({ type: "done", reason: "stop", message: assistantMessage("") });
+					});
+				}
+				return stream;
+			},
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage,
+			},
+		});
+		child.setSessionName("multiple-queued-worker");
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+
+		await root.runRlmChild("initial task", { name: "multiple-queued-worker" });
+		await waitFor(() => initialStarted);
+		for (const [id, message] of [
+			["agentmsg-queued-first", "first queued requirement"],
+			["agentmsg-queued-latest", "latest queued requirement"],
+		] as const) {
+			const parentMessage = createAgentSessionMessage({
+				id,
+				source: "agent_message",
+				message,
+				from: { activeSessionId: "parent-active", sessionId: "parent-session" },
+				fromRelationship: "parent",
+				target: { activeSessionId: "child-active", sessionId: child.sessionId },
+			});
+			await child.queueAgentMessagePrompt(parentMessage.content as string, "steer", parentMessage);
+		}
+		releaseInitial();
+		await waitFor(() => queuedWorkStarted);
+		expect(sendAgentMessage).not.toHaveBeenCalled();
+		releaseQueuedWork();
+		await child.waitForIdle();
+		await vi.waitFor(() => expect(sendAgentMessage).toHaveBeenCalledTimes(1));
+		await sleep(50);
+		expect(sendAgentMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("defers a silent notice across a scheduled post-compaction continuation", async () => {
+		let releaseInitial: () => void = () => {};
+		const initialGate = new Promise<void>((resolve) => {
+			releaseInitial = resolve;
+		});
+		let releaseContinuation: () => void = () => {};
+		const continuationGate = new Promise<void>((resolve) => {
+			releaseContinuation = resolve;
+		});
+		let run = 0;
+		const sendAgentMessage = vi.fn(async () => ({
+			id: "agentmsg-post-compaction-notice",
+			source: "agent_message" as const,
+			target: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			message: "notice",
+			deliveryStatus: "delivered" as const,
+		}));
+		const child = createSession({
+			depth: 1,
+			rlmSessionDir: join(tempDir, "post-compaction-child"),
+			rlmParentNodeId: "post-compaction-child",
+			streamFn: () => {
+				run += 1;
+				const stream = createAssistantMessageEventStream();
+				void (run === 1 ? initialGate : continuationGate).then(() => {
+					stream.push({ type: "done", reason: "stop", message: assistantMessage("") });
+				});
+				return stream;
+			},
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage,
+			},
+		});
+		child.setSessionName("post-compaction-worker");
+		const message = createAgentSessionMessage({
+			id: "agentmsg-post-compaction-parent-work",
+			source: "agent_message",
+			message: "continue through compaction",
+			from: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			fromRelationship: "parent",
+			target: { activeSessionId: "child-active", sessionId: child.sessionId },
+		});
+
+		const admission = child.acceptAgentMessagePrompt(message.content as string, { customMessage: message });
+		await expectSettlesWithin(admission, 250);
+		const continuation = {
+			role: "user",
+			content: "resume after compaction",
+			timestamp: Date.now(),
+		} satisfies UserMessage;
+		child.agent.followUp(continuation);
+		const internals = child as unknown as InspectableRlmSession;
+		internals._postCompactionContinuationMessages = [continuation];
+		internals._schedulePostCompactionContinue();
+		releaseInitial();
+		await waitFor(() => run === 2);
+		expect(child.isStreaming).toBe(true);
+		expect(sendAgentMessage).not.toHaveBeenCalled();
+		releaseContinuation();
+		await child.waitForIdle();
+		await vi.waitFor(() => expect(sendAgentMessage).toHaveBeenCalledTimes(1));
+	});
+
+	it("monitors queued parent work before an immediate completion can settle", async () => {
+		const sendAgentMessage = vi.fn(async () => ({
+			id: "agentmsg-immediate-queue-notice",
+			source: "agent_message" as const,
+			target: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			message: "notice",
+			deliveryStatus: "delivered" as const,
+		}));
+		const child = createSession({
+			depth: 1,
+			rlmSessionDir: join(tempDir, "immediate-queue-child"),
+			rlmParentNodeId: "immediate-queue-child",
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage,
+			},
+		});
+		child.setSessionName("immediate-queue-worker");
+		const message = createAgentSessionMessage({
+			id: "agentmsg-immediate-queue-parent-work",
+			source: "agent_message",
+			message: "finish immediately",
+			from: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			fromRelationship: "parent",
+			target: { activeSessionId: "child-active", sessionId: child.sessionId },
+		});
+
+		await child.queueAgentMessagePrompt(message.content as string, "steer", message);
+		await child.waitForIdle();
+		await vi.waitFor(() => expect(sendAgentMessage).toHaveBeenCalledTimes(1));
 	});
 
 	it("does not send a terminal notice when a retained child replies during a follow-up", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -255,6 +255,7 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost?: SubagentRuntimeHost;
 			customTools?: ConstructorParameters<typeof AgentSession>[0]["customTools"];
 			rlmSessionDir?: string;
+			rlmParentNodeId?: string;
 			sessionManager?: SessionManager;
 			settingsManager?: SettingsManager;
 			extensionsResult?: LoadExtensionsResult;
@@ -310,6 +311,7 @@ describe("AgentSession rlm recursion", () => {
 			rlmDepth: options.depth,
 			rlmMaxDepth: options.maxDepth,
 			rlmSessionDir: options.rlmSessionDir,
+			rlmParentNodeId: options.rlmParentNodeId,
 		});
 		return session;
 	}
@@ -1388,6 +1390,135 @@ describe("AgentSession rlm recursion", () => {
 		expect((await root.listRlmSubagents()).subagents).toContainEqual(
 			expect.objectContaining({ rlm_child_id: spawned.rlm_child_id, status: "completed" }),
 		);
+	});
+
+	it("reports a retained child follow-up that completes without a reply", async () => {
+		let releaseFollowUp: () => void = () => {};
+		const followUpGate = new Promise<void>((resolve) => {
+			releaseFollowUp = resolve;
+		});
+		const sendAgentMessage = vi.fn(async () => ({
+			id: "agentmsg-follow-up-notice",
+			source: "agent_message" as const,
+			target: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			message: "notice",
+			deliveryStatus: "delivered" as const,
+		}));
+		const child = createSession({
+			depth: 1,
+			rlmSessionDir: join(tempDir, "silent-followup-child"),
+			rlmParentNodeId: "silent-followup-child",
+			streamFn: () => {
+				const stream = createAssistantMessageEventStream();
+				void followUpGate.then(() => {
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: {
+							role: "assistant",
+							content: [{ type: "thinking", thinking: "deliberating silently" }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: usage(),
+							stopReason: "stop",
+							timestamp: Date.now(),
+						},
+					});
+				});
+				return stream;
+			},
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				sendAgentMessage,
+			},
+		});
+		child.setSessionName("followup-worker");
+		const message = createAgentSessionMessage({
+			id: "agentmsg-parent-follow-up",
+			source: "agent_message",
+			message: "continue work",
+			from: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			fromRelationship: "parent",
+			target: { activeSessionId: "child-active", sessionId: child.sessionId },
+		});
+
+		const admission = child.acceptAgentMessagePrompt(message.content as string, { customMessage: message });
+		// Admission must return while the follow-up turn is still running.
+		await expectSettlesWithin(admission, 250);
+		expect(sendAgentMessage).not.toHaveBeenCalled();
+		releaseFollowUp();
+		await vi.waitFor(() => {
+			expect(sendAgentMessage).toHaveBeenCalledTimes(1);
+		});
+		expect(sendAgentMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				target: "parent-session",
+				message: "RLM child followup-worker (silent-followup-child) completed without sending a reply",
+			}),
+		);
+	});
+
+	it("does not send a terminal notice when a retained child replies during a follow-up", async () => {
+		let releaseFollowUp: () => void = () => {};
+		const followUpGate = new Promise<void>((resolve) => {
+			releaseFollowUp = resolve;
+		});
+		let child: AgentSession;
+		const sendAgentMessage = vi.fn(async () => ({
+			id: "agentmsg-follow-up-reply",
+			source: "agent_message" as const,
+			target: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			message: "done",
+			deliveryStatus: "delivered" as const,
+		}));
+		child = createSession({
+			depth: 1,
+			rlmSessionDir: join(tempDir, "replying-followup-child"),
+			rlmParentNodeId: "replying-followup-child",
+			streamFn: () => {
+				const stream = createAssistantMessageEventStream();
+				void followUpGate.then(async () => {
+					const handlers = (child as unknown as InspectableRlmSession)._createKernelHostHandlers();
+					const send = handlers["agent_message.send"];
+					if (!send) throw new Error("Missing agent_message.send host handler");
+					await send({ message: "done", receiver_role: "parent" });
+					stream.push({ type: "done", reason: "stop", message: assistantMessage("follow-up answer") });
+				});
+				return stream;
+			},
+			agentMessageController: {
+				listAgents: () => ({ agents: [] }),
+				roster: () => ({
+					current: { name: "followup-worker", id: child.sessionId, depth: 1 },
+					entries: [{ relationship: "parent", name: "parent", id: "parent-session", depth: 0, status: "idle" }],
+				}),
+				sendAgentMessage,
+			},
+		});
+		child.setSessionName("followup-worker");
+		const message = createAgentSessionMessage({
+			id: "agentmsg-parent-follow-up-reply",
+			source: "agent_message",
+			message: "continue work",
+			from: { activeSessionId: "parent-active", sessionId: "parent-session" },
+			fromRelationship: "parent",
+			target: { activeSessionId: "child-active", sessionId: child.sessionId },
+		});
+
+		const admission = child.acceptAgentMessagePrompt(message.content as string, { customMessage: message });
+		await expectSettlesWithin(admission, 250);
+		expect(sendAgentMessage).not.toHaveBeenCalled();
+		releaseFollowUp();
+		await vi.waitFor(() => {
+			expect(sendAgentMessage).toHaveBeenCalledTimes(1);
+		});
+		expect(sendAgentMessage).toHaveBeenCalledWith(
+			expect.objectContaining({ target: "parent-session", message: "done" }),
+		);
+		// No automatic terminal notice may follow the explicit reply.
+		await sleep(50);
+		expect(sendAgentMessage).toHaveBeenCalledTimes(1);
 	});
 
 	it("projects retained child follow-up turns into parent child-update activity", async () => {


### PR DESCRIPTION
## Summary

- Track every accepted parent-directed child task with a monotonic work epoch, including messages queued while the child is busy.
- Emit exactly one automatic notice only for the latest silent epoch, after session input and scheduled post-compaction continuation work are quiescent; explicit replies still suppress it.
- Reject OpenAI-compatible streams that reach EOF without a terminal `finish_reason`, while preserving partial content for diagnostics.

## Why

The retained-child notice previously observed one action-completion deferred, not the child session's logical quiescence. A newer parent message could be accepted and queued while the original task was streaming; when the original action settled, its completion callback sent `completed without sending a reply` even though the child was already processing the newer work. Busy-path messages also lacked equivalent monitoring, so merely suppressing the old notice could leave the parent waiting forever.

The child now binds each accepted direct, queued, or spawn task to a monotonic epoch. A completion/failure handler awaits the event-driven session idle barrier plus any timer-scheduled post-compaction continuation, then re-checks epoch, explicit-reply count, and disposal state. Completion monitoring is registered before queued admission so an immediately completed action cannot lose its settlement; rejected admission does not advance the epoch. The original spawn notice uses the same epoch/quiescence fence.

Separately, the OpenAI-compatible adapter initialized responses as successful stops and accepted clean iterator EOF even when no terminal chunk framed the completion. The incident transcript did not retain raw provider chunks, so this remains independent fail-closed hardening rather than a claimed incident trigger.

No daemon protocol, registry schema, or production polling behavior changes.

## TDD evidence

- Original coding-agent RED: silent retained follow-up had 0 terminal notices (97 passed, 1 failed).
- Exact incident RED: the original task emitted its notice while newer queued parent work was still streaming.
- AI RED: unterminated reasoning stream incorrectly emitted `done` (16 passed, 1 failed).
- Coding-agent GREEN after rebase: `agent-session-recursion.test.ts` — 102 passed, covering exact queued-work deferral, multiple queued epochs, immediate completion registration, post-compaction continuation quiescence, and explicit-reply suppression.
- AI GREEN: `openai-completions-tool-choice.test.ts` — 18 passed.
- Full gate after rebase onto `a3b3e7534`: `npm run check` passed, including Biome, `tsgo --noEmit`, installer render, and browser smoke checks.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fail-closed behavior for silent RLM child follow-ups and incomplete OpenAI streams
> - OpenAI-compatible streams that end without any terminal `finish_reason` now emit an error event with `stopReason: 'error'` instead of being recorded as successful completions, tracked in [`openai-completions.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1241/files#diff-d3f9c03940767ab76191513078367a64d9e38e58fbdff99f5ad7bf65786b4246).
> - Retained RLM child follow-up notices are deferred until true session quiescence and suppressed if newer parent work arrives or the child replies, preventing out-of-order or duplicate notices in [`agent-session.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1241/files#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448ae).
> - Queued parent-directed messages to a retained child are also monitored; only the latest silent parent task emits one terminal/failure notice after the child is idle.
> - Post-compaction continuation cancellation now wakes quiescence waiters so notice deferral logic resolves correctly.
> - Behavioral Change: OpenAI-compatible streams that previously silently succeeded without a terminal `finish_reason` will now surface as errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9d2b29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->