### PR TITLE
feat(kernel): dispatch host requests as capabilities

### DIFF
--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { HostRequestHandler } from "./kernel/index.js";
+import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
 import type { CustomMessage } from "./messages.js";
 import { canonicalSessionPath } from "./session-lease.js";
 
@@ -526,11 +526,11 @@ export function createAgentMessageHostHandlers(
 	controller: Pick<AgentSessionMessageController, "roster" | "sendAgentMessage" | "awaitPendingChildPublication">,
 ): Record<string, HostRequestHandler> {
 	return {
-		"agent_message.list_agents": async () => {
+		"agent_message.list_agents": createHostRequestHandler(async (_payload, _context) => {
 			if (!controller.roster) throw new Error("agent family roster is not available in this session");
 			return (await controller.roster()) as unknown as Record<string, unknown>;
-		},
-		"agent_message.send": async (payload) => {
+		}, contextAwareHostRequestHandler),
+		"agent_message.send": createHostRequestHandler(async (payload, _context) => {
 			if (typeof payload.message !== "string") {
 				throw new Error("agent_message.send message must be a string");
 			}
@@ -602,7 +602,7 @@ export function createAgentMessageHostHandlers(
 				message: payload.message,
 				receiverRole: payload.receiver_role as AgentFamilyRelationship,
 			})) as unknown as Record<string, unknown>;
-		},
+		}, contextAwareHostRequestHandler),
 	};
 }
 

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
 import type { CustomMessage } from "./messages.js";
 import { canonicalSessionPath } from "./session-lease.js";
 
@@ -538,7 +538,7 @@ export function createAgentMessageHostHandlers(
 		"agent_message.list_agents": createHostRequestHandler(async (_payload, _context) => {
 			if (!controller.roster) throw new Error("agent family roster is not available in this session");
 			return (await controller.roster()) as unknown as Record<string, unknown>;
-		}, contextAwareHostRequestHandler),
+		}),
 		"agent_message.send": createHostRequestHandler(async (payload, _context) => {
 			if (typeof payload.message !== "string") {
 				throw new Error("agent_message.send message must be a string");
@@ -611,7 +611,7 @@ export function createAgentMessageHostHandlers(
 				message: payload.message,
 				receiverRole: payload.receiver_role as AgentFamilyRelationship,
 			})) as unknown as Record<string, unknown>;
-		}, contextAwareHostRequestHandler),
+		}),
 	};
 }
 

--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -257,7 +257,20 @@ function sameAgentSessionNameParent(
 	if (left.depth === 0 && right.depth === 0) {
 		return true;
 	}
-	return sameAgentFamilyParent(left, right, catalog);
+	if (sameAgentFamilyParent(left, right, catalog)) return true;
+
+	// A passive child can outlive the active parent row that would normally
+	// resolve its family edge. Name reservation must still protect that parent's
+	// sibling namespace, but this weaker direct-claim fallback is deliberately
+	// not used for family reach: reach continues to require an unambiguous,
+	// catalog-resolved parent.
+	if (left.depth !== right.depth || left.depth === 0) return false;
+	return (
+		(left.parentSessionId !== undefined && left.parentSessionId === right.parentSessionId) ||
+		(left.parentSessionPath !== undefined &&
+			right.parentSessionPath !== undefined &&
+			canonicalSessionPath(left.parentSessionPath) === canonicalSessionPath(right.parentSessionPath))
+	);
 }
 
 function sameAgentFamilyParent(
@@ -265,44 +278,38 @@ function sameAgentFamilyParent(
 	right: AgentSessionNameScope,
 	catalog: readonly AgentFamilyCatalogEntry[],
 ): boolean {
-	if (left.parentSessionPath !== undefined && left.parentSessionPath === right.parentSessionPath) {
-		return true;
-	}
-	if (left.parentSessionId !== undefined && left.parentSessionId === right.parentSessionId) {
-		return true;
-	}
-	const hasCatalogParentPair = (parentSessionId: string | undefined, parentSessionPath: string | undefined) =>
-		parentSessionId !== undefined &&
-		parentSessionPath !== undefined &&
-		catalog.some(
-			(entry) =>
-				(entry.id === parentSessionId && entry.sessionPath === parentSessionPath) ||
-				(entry.parentSessionId === parentSessionId && entry.parentSessionPath === parentSessionPath),
+	if (left.depth === 0 && right.depth === 0) {
+		return (
+			left.parentSessionId === undefined &&
+			left.parentSessionPath === undefined &&
+			right.parentSessionId === undefined &&
+			right.parentSessionPath === undefined
 		);
-	if (
-		hasCatalogParentPair(left.parentSessionId, right.parentSessionPath) ||
-		hasCatalogParentPair(right.parentSessionId, left.parentSessionPath)
-	) {
-		return true;
 	}
-	if (
-		left.depth === 0 &&
-		right.depth === 0 &&
-		left.parentSessionPath === undefined &&
-		right.parentSessionPath === undefined &&
-		left.parentSessionId === undefined &&
-		right.parentSessionId === undefined
-	) {
-		return true;
-	}
-	// Unresolved mixed identifiers stay unrelated to avoid false name conflicts across families.
-	return false;
+	if (left.depth !== right.depth || left.depth === 0) return false;
+	const parentFor = (child: AgentSessionNameScope) => {
+		const parents = catalog.filter((entry) => isAgentFamilyParent(entry, child));
+		return parents.length === 1 ? parents[0] : undefined;
+	};
+	const leftParent = parentFor(left);
+	const rightParent = parentFor(right);
+	return leftParent !== undefined && leftParent.id === rightParent?.id;
 }
 
-function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentFamilyCatalogEntry): boolean {
+/**
+ * Validates one persisted parent edge. A child may supply either durable
+ * identifier, but when it supplies both they must identify this same direct
+ * parent. This keeps contradictory records from becoming relatives through
+ * whichever identifier happens to match.
+ */
+function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentSessionNameScope): boolean {
+	if (child.depth <= 0 || parent.depth !== child.depth - 1) return false;
+	const claimsId = child.parentSessionId !== undefined;
+	const claimsPath = child.parentSessionPath !== undefined;
 	return (
-		(child.parentSessionPath !== undefined && child.parentSessionPath === parent.sessionPath) ||
-		(child.parentSessionId !== undefined && child.parentSessionId === parent.id)
+		(claimsId || claimsPath) &&
+		(!claimsId || child.parentSessionId === parent.id) &&
+		(!claimsPath || child.parentSessionPath === parent.sessionPath)
 	);
 }
 
@@ -310,19 +317,21 @@ function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentFamily
 export function agentFamilyRelationship(
 	current: AgentFamilyCatalogEntry,
 	target: AgentFamilyCatalogEntry,
+	catalog: readonly AgentFamilyCatalogEntry[] = [current, target],
 ): AgentFamilyRelationship | undefined {
 	if (current.id === target.id) return undefined;
 	if (isAgentFamilyParent(target, current)) return "parent";
 	if (isAgentFamilyParent(current, target)) return "child";
-	if (current.depth === target.depth && sameAgentFamilyParent(current, target, [current, target])) return "sibling";
+	if (sameAgentFamilyParent(current, target, catalog)) return "sibling";
 	return undefined;
 }
 
 export function assertAgentFamilyReach(
 	current: AgentFamilyCatalogEntry,
 	target: AgentFamilyCatalogEntry,
+	catalog?: readonly AgentFamilyCatalogEntry[],
 ): AgentFamilyRelationship {
-	const relationship = agentFamilyRelationship(current, target);
+	const relationship = agentFamilyRelationship(current, target, catalog);
 	if (!relationship) throw new Error(AGENT_FAMILY_REACH_ERROR);
 	return relationship;
 }

--- a/packages/coding-agent/src/core/agent-observe.ts
+++ b/packages/coding-agent/src/core/agent-observe.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandlers } from "./kernel/index.js";
 
 export const AGENT_OBSERVE_SKILL_NAME = "agent-observe";
 export const AGENT_OBSERVE_IMPORT_NAME = "agent_observe";
@@ -67,25 +68,24 @@ export interface AgentObserveController {
 	): AgentObserveRecentMessagesResult | Promise<AgentObserveRecentMessagesResult>;
 }
 
-export function createAgentObserveHostHandlers(controller: AgentObserveController) {
+export function createAgentObserveHostHandlers(controller: AgentObserveController): HostRequestHandlers {
 	return {
-		"agent_observe.list": async () => controller.listAgents() as unknown as Record<string, unknown>,
-		"agent_observe.get": async (payload: Record<string, unknown> = {}) => {
-			if (typeof payload.target !== "string") {
-				throw new Error("agent_observe.get target must be a string");
-			}
+		"agent_observe.list": createHostRequestHandler(
+			async (_payload, _context) => controller.listAgents() as unknown as Record<string, unknown>,
+			contextAwareHostRequestHandler,
+		),
+		"agent_observe.get": createHostRequestHandler(async (payload, _context) => {
+			if (typeof payload.target !== "string") throw new Error("agent_observe.get target must be a string");
 			return (await controller.getAgent(payload.target)) as unknown as Record<string, unknown>;
-		},
-		"agent_observe.recent": async (payload: Record<string, unknown> = {}) => {
-			if (typeof payload.target !== "string") {
-				throw new Error("agent_observe.recent target must be a string");
-			}
+		}, contextAwareHostRequestHandler),
+		"agent_observe.recent": createHostRequestHandler(async (payload, _context) => {
+			if (typeof payload.target !== "string") throw new Error("agent_observe.recent target must be a string");
 			return (await controller.recentMessages({
 				target: payload.target,
 				limit: normalizeOptionalInteger(payload.limit, "agent_observe.recent limit"),
 				maxChars: normalizeOptionalInteger(payload.max_chars ?? payload.maxChars, "agent_observe.recent max_chars"),
 			})) as unknown as Record<string, unknown>;
-		},
+		}, contextAwareHostRequestHandler),
 	};
 }
 

--- a/packages/coding-agent/src/core/agent-observe.ts
+++ b/packages/coding-agent/src/core/agent-observe.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandlers } from "./kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandlers } from "./kernel/index.js";
 
 export const AGENT_OBSERVE_SKILL_NAME = "agent-observe";
 export const AGENT_OBSERVE_IMPORT_NAME = "agent_observe";
@@ -72,12 +72,11 @@ export function createAgentObserveHostHandlers(controller: AgentObserveControlle
 	return {
 		"agent_observe.list": createHostRequestHandler(
 			async (_payload, _context) => controller.listAgents() as unknown as Record<string, unknown>,
-			contextAwareHostRequestHandler,
 		),
 		"agent_observe.get": createHostRequestHandler(async (payload, _context) => {
 			if (typeof payload.target !== "string") throw new Error("agent_observe.get target must be a string");
 			return (await controller.getAgent(payload.target)) as unknown as Record<string, unknown>;
-		}, contextAwareHostRequestHandler),
+		}),
 		"agent_observe.recent": createHostRequestHandler(async (payload, _context) => {
 			if (typeof payload.target !== "string") throw new Error("agent_observe.recent target must be a string");
 			return (await controller.recentMessages({
@@ -85,7 +84,7 @@ export function createAgentObserveHostHandlers(controller: AgentObserveControlle
 				limit: normalizeOptionalInteger(payload.limit, "agent_observe.recent limit"),
 				maxChars: normalizeOptionalInteger(payload.max_chars ?? payload.maxChars, "agent_observe.recent max_chars"),
 			})) as unknown as Record<string, unknown>;
-		}, contextAwareHostRequestHandler),
+		}),
 	};
 }
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -403,7 +403,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		childId: string,
 		session: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<void> {
+	): Promise<import("./rlm-runtime.js").RlmSubagentHostDeletionResult> {
 		// Inline teardown has no daemon append, so the exact coordinator token is
 		// its sole pre-destruction fence.
 		authority?.assertCurrent();
@@ -411,7 +411,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		if (!runtime) {
 			authority?.assertCurrent();
 			await session.disposeAsync();
-			return;
+			return { deletionDurability: "absent" };
 		}
 		// A child id can be recycled after an older deletion attempt yields. The
 		// runtime metadata is assigned from CreateRlmSubagentRuntimeOptions before
@@ -436,6 +436,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 				await session.disposeAsync();
 			}
 		}
+		return { deletionDurability: "absent" };
 	}
 
 	private async finishSessionReplacement(withSession?: (ctx: ReplacedSessionContext) => Promise<void>): Promise<void> {

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -96,6 +96,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	private subagentRuntimeHost?: SubagentRuntimeHost;
 	private subagentRuntimes = new Map<string, AgentSessionRuntime>();
 	private disposePromise?: Promise<void>;
+	private disposeStarted = false;
+	private sessionLeaseReleaseDeferred = false;
 
 	constructor(
 		private _session: AgentSession,
@@ -256,6 +258,20 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		if (lease !== this._sessionLease) {
 			lease?.release();
 		}
+	}
+
+	/**
+	 * Atomically defer lease release to the daemon before teardown begins.
+	 *
+	 * A false result means another caller already began disposal (and therefore
+	 * owns its normal release) or there is no lease to defer. Callers must not
+	 * release after a false result.
+	 */
+	claimSessionLeaseReleaseForDaemon(): boolean {
+		if (this.sessionLeaseReleaseDeferred) return true;
+		if (this.disposeStarted || !this._sessionLease) return false;
+		this.sessionLeaseReleaseDeferred = true;
+		return true;
 	}
 
 	/** Release the runtime-owned session-file lease after its daemon has committed retirement. */
@@ -444,9 +460,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			}
 			authority.assertCurrent();
 			await session.disposeAsync();
-			// The supplied retained object was an old incarnation. Its disposal
-			// neither deletes nor proves absence of the newer map-resident child.
-			return { deletionDurability: "stale" };
+			return { deletionDurability: "absent" };
 		}
 		if (
 			authority &&
@@ -757,7 +771,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		return { cancelled: false };
 	}
 
-	private async disposeOnce(releaseSessionLease = true): Promise<void> {
+	private async disposeOnce(): Promise<void> {
 		this.session.beginClosing();
 		let disposeError: unknown;
 		try {
@@ -794,13 +808,16 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 				throw disposeError;
 			}
 		} finally {
-			if (releaseSessionLease) this.releaseSessionLease();
+			if (!this.sessionLeaseReleaseDeferred) this.releaseSessionLease();
 		}
 	}
 
-	async dispose(options: { releaseSessionLease?: boolean } = {}): Promise<void> {
-		const disposePromise = this.disposePromise ?? this.disposeOnce(options.releaseSessionLease !== false);
-		this.disposePromise = disposePromise;
+	async dispose(): Promise<void> {
+		if (!this.disposePromise) {
+			this.disposeStarted = true;
+			this.disposePromise = this.disposeOnce();
+		}
+		const disposePromise = this.disposePromise;
 		try {
 			await disposePromise;
 		} catch (error) {

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -413,31 +413,51 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			// match alone cannot authorize disposing a supplied same-id incarnation.
 			throw new Error("RLM subagent runtime incarnation is no longer resident");
 		}
-		// A child id can be recycled after an older deletion attempt yields. The
-		// runtime metadata is assigned from CreateRlmSubagentRuntimeOptions before
-		// this map becomes addressable, so it is the authoritative incarnation
-		// fence for inline teardown; never treat absent metadata as a match.
+		// A child id can be recycled after an older deletion attempt yields. Any
+		// present coordinator authority must name a complete saved-session
+		// incarnation before it can destroy either the resident or a retained object.
 		if (
 			authority &&
 			(authority.childId !== childId ||
 				runtime.metadata.rlmChildId !== authority.childId ||
-				runtime.metadata.sessionDir !== authority.sessionDir)
+				typeof authority.sessionFile !== "string" ||
+				authority.sessionFile.length === 0 ||
+				typeof authority.sessionId !== "string" ||
+				authority.sessionId.length === 0)
+		) {
+			authority.assertCurrent();
+			throw new Error("RLM subagent deletion authority does not match runtime incarnation");
+		}
+		if (runtime.session !== session) {
+			// Dispose only the exact retained object named by the authority. Leave a
+			// newer map-resident incarnation intact.
+			if (
+				!authority ||
+				dirname(session.sessionFile) !== authority.sessionDir ||
+				session.sessionFile !== authority.sessionFile ||
+				session.sessionId !== authority.sessionId
+			) {
+				authority?.assertCurrent();
+				throw new Error("RLM subagent deletion does not match runtime incarnation");
+			}
+			authority.assertCurrent();
+			await session.disposeAsync();
+			return { deletionDurability: "absent" };
+		}
+		if (
+			authority &&
+			(runtime.metadata.sessionDir !== authority.sessionDir ||
+				runtime.session.sessionFile !== authority.sessionFile ||
+				runtime.session.sessionId !== authority.sessionId)
 		) {
 			authority.assertCurrent();
 			throw new Error("RLM subagent deletion authority does not match runtime incarnation");
 		}
 		authority?.assertCurrent();
-		if (runtime.session !== session) {
-			// The supplied object is the only stale incarnation we may touch. Leave
-			// the newer map resident intact.
-			if (!authority || dirname(session.sessionFile) !== authority.sessionDir) {
-				throw new Error("RLM subagent deletion does not match runtime incarnation");
-			}
-			await session.disposeAsync();
-			return { deletionDurability: "absent" };
-		}
-		this.subagentRuntimes.delete(childId);
 		await runtime.dispose();
+		// Disposal may yield while a newer runtime reuses the child id. Remove only
+		// the exact object this attempt fenced, and retain it for retry on failure.
+		if (this.subagentRuntimes.get(childId) === runtime) this.subagentRuntimes.delete(childId);
 		return { deletionDurability: "absent" };
 	}
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -433,6 +433,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			// newer map-resident incarnation intact.
 			if (
 				!authority ||
+				typeof session.sessionFile !== "string" ||
 				dirname(session.sessionFile) !== authority.sessionDir ||
 				session.sessionFile !== authority.sessionFile ||
 				session.sessionId !== authority.sessionId

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -798,10 +798,16 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	}
 
 	async dispose(): Promise<void> {
-		if (!this.disposePromise) {
-			this.disposePromise = this.disposeOnce();
+		const disposePromise = this.disposePromise ?? this.disposeOnce();
+		this.disposePromise = disposePromise;
+		try {
+			await disposePromise;
+		} catch (error) {
+			if (this.disposePromise === disposePromise) {
+				this.disposePromise = undefined;
+			}
+			throw error;
 		}
-		await this.disposePromise;
 	}
 }
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -443,7 +443,9 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			}
 			authority.assertCurrent();
 			await session.disposeAsync();
-			return { deletionDurability: "absent" };
+			// The supplied retained object was an old incarnation. Its disposal
+			// neither deletes nor proves absence of the newer map-resident child.
+			return { deletionDurability: "stale" };
 		}
 		if (
 			authority &&

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -413,6 +413,19 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			await session.disposeAsync();
 			return;
 		}
+		// A child id can be recycled after an older deletion attempt yields. The
+		// runtime metadata is assigned from CreateRlmSubagentRuntimeOptions before
+		// this map becomes addressable, so it is the authoritative incarnation
+		// fence for inline teardown; never treat absent metadata as a match.
+		if (
+			authority &&
+			(authority.childId !== childId ||
+				runtime.metadata.rlmChildId !== authority.childId ||
+				runtime.metadata.sessionDir !== authority.sessionDir)
+		) {
+			authority.assertCurrent();
+			throw new Error("RLM subagent deletion authority does not match runtime incarnation");
+		}
 		authority?.assertCurrent();
 		this.subagentRuntimes.delete(childId);
 		const shouldDisposeStaleSession = runtime.session !== session;

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -11,7 +11,12 @@ import { flushAgentTraceUpload } from "./agent-traces.js";
 import { isNoModelsAvailableMessage } from "./auth-guidance.js";
 import type { ReplacedSessionContext, SessionShutdownEvent, SessionStartEvent } from "./extensions/index.js";
 import { emitSessionShutdownEvent } from "./extensions/runner.js";
-import type { CreateRlmSubagentRuntimeOptions, RlmSubagentRuntime, SubagentRuntimeHost } from "./rlm-runtime.js";
+import type {
+	CreateRlmSubagentRuntimeOptions,
+	RlmSubagentDeletionAuthority,
+	RlmSubagentRuntime,
+	SubagentRuntimeHost,
+} from "./rlm-runtime.js";
 import type { CreateAgentSessionResult } from "./sdk.js";
 import { assertSessionCwdExists } from "./session-cwd.js";
 import { SessionImportFileNotFoundError } from "./session-import-errors.js";
@@ -394,12 +399,21 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		return runtime;
 	}
 
-	async deleteRlmSubagentRuntime(childId: string, session: AgentSession): Promise<void> {
+	async deleteRlmSubagentRuntime(
+		childId: string,
+		session: AgentSession,
+		authority?: RlmSubagentDeletionAuthority,
+	): Promise<void> {
+		// Inline teardown has no daemon append, so the exact coordinator token is
+		// its sole pre-destruction fence.
+		authority?.assertCurrent();
 		const runtime = this.subagentRuntimes.get(childId);
 		if (!runtime) {
+			authority?.assertCurrent();
 			await session.disposeAsync();
 			return;
 		}
+		authority?.assertCurrent();
 		this.subagentRuntimes.delete(childId);
 		const shouldDisposeStaleSession = runtime.session !== session;
 		try {

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, existsSync, mkdirSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import type { AgentSession } from "./agent-session.js";
 import type { AgentSessionRuntimeConfig } from "./agent-session-config.js";
 import type {
@@ -409,9 +409,9 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		authority?.assertCurrent();
 		const runtime = this.subagentRuntimes.get(childId);
 		if (!runtime) {
-			authority?.assertCurrent();
-			await session.disposeAsync();
-			return { deletionDurability: "absent" };
+			// With no resident object there is no exact-object fence. A directory
+			// match alone cannot authorize disposing a supplied same-id incarnation.
+			throw new Error("RLM subagent runtime incarnation is no longer resident");
 		}
 		// A child id can be recycled after an older deletion attempt yields. The
 		// runtime metadata is assigned from CreateRlmSubagentRuntimeOptions before
@@ -427,15 +427,17 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			throw new Error("RLM subagent deletion authority does not match runtime incarnation");
 		}
 		authority?.assertCurrent();
-		this.subagentRuntimes.delete(childId);
-		const shouldDisposeStaleSession = runtime.session !== session;
-		try {
-			await runtime.dispose();
-		} finally {
-			if (shouldDisposeStaleSession) {
-				await session.disposeAsync();
+		if (runtime.session !== session) {
+			// The supplied object is the only stale incarnation we may touch. Leave
+			// the newer map resident intact.
+			if (!authority || dirname(session.sessionFile) !== authority.sessionDir) {
+				throw new Error("RLM subagent deletion does not match runtime incarnation");
 			}
+			await session.disposeAsync();
+			return { deletionDurability: "absent" };
 		}
+		this.subagentRuntimes.delete(childId);
+		await runtime.dispose();
 		return { deletionDurability: "absent" };
 	}
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -258,7 +258,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		}
 	}
 
-	private releaseSessionLease(): void {
+	/** Release the runtime-owned session-file lease after its daemon has committed retirement. */
+	releaseSessionLease(): void {
 		this._sessionLease?.release();
 		this._sessionLease = undefined;
 	}
@@ -756,7 +757,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		return { cancelled: false };
 	}
 
-	private async disposeOnce(): Promise<void> {
+	private async disposeOnce(releaseSessionLease = true): Promise<void> {
 		this.session.beginClosing();
 		let disposeError: unknown;
 		try {
@@ -793,12 +794,12 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 				throw disposeError;
 			}
 		} finally {
-			this.releaseSessionLease();
+			if (releaseSessionLease) this.releaseSessionLease();
 		}
 	}
 
-	async dispose(): Promise<void> {
-		const disposePromise = this.disposePromise ?? this.disposeOnce();
+	async dispose(options: { releaseSessionLease?: boolean } = {}): Promise<void> {
+		const disposePromise = this.disposePromise ?? this.disposeOnce(options.releaseSessionLease !== false);
 		this.disposePromise = disposePromise;
 		try {
 			await disposePromise;

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -704,6 +704,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	}
 
 	private async disposeOnce(): Promise<void> {
+		this.session.beginClosing();
 		let disposeError: unknown;
 		try {
 			await emitSessionShutdownEvent(this.session.extensionRunner, {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10245,16 +10245,39 @@ export class AgentSession {
 					);
 				}
 				if (!this.registerRlmChildSession(run.id, child)) {
-					if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
-						await this._subagentRuntimeHost
-							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
-							.then((outcome) => {
+					// Registration can lose a race to delete-before-publication. Join that
+					// exact owner rather than releasing the newly published runtime directly.
+					const inFlight = this._deletingRlmChildren.get(run.id);
+					const finalizerSubagent =
+						inFlight?.subagent ??
+						({
+							rlm_child_id: run.id,
+							active_session_id: null,
+							session_id: child.sessionId,
+							session_name: child.sessionName ?? sessionName,
+							session_dir: childSessionDir,
+							status: "error",
+						} satisfies RlmSubagentRegistryEntry);
+					await this._coordinateRlmSubagentDeletion(
+						finalizerSubagent,
+						undefined,
+						inFlight?.lease,
+						async (authority) => {
+							if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
+								const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
+									childRuntime,
+									subagentOptions,
+									"error",
+									authority,
+								);
 								deletionDurability = outcome?.deletionDurability ?? "unknown";
-							})
-							.catch(() => void child.disposeAsync().catch(() => undefined));
-					} else {
-						await child.disposeAsync().catch(() => undefined);
-					}
+							} else {
+								authority.assertCurrent();
+								await child.disposeAsync();
+							}
+							return { subagent: finalizerSubagent };
+						},
+					).catch(() => undefined);
 				}
 			} catch (error) {
 				const runError = error instanceof Error ? error : new Error(String(error));
@@ -10335,12 +10358,33 @@ export class AgentSession {
 						}
 					}
 				} else if (!run.detachedDeletion) {
+					const finalizerSubagent: RlmSubagentRegistryEntry = {
+						rlm_child_id: run.id,
+						active_session_id: null,
+						session_id: childSession?.sessionId ?? null,
+						session_name: childSession?.sessionName ?? sessionName,
+						session_dir: childSessionDir,
+						status: "error",
+					};
 					try {
-						if (childRuntime && this._subagentRuntimeHost) {
-							await this._subagentRuntimeHost.deleteRlmSubagentRuntime(run.id, childRuntime.session);
-						} else if (childSession) {
-							await childSession.disposeAsync();
-						}
+						await this._coordinateRlmSubagentDeletion(
+							finalizerSubagent,
+							undefined,
+							undefined,
+							async (authority) => {
+								if (childRuntime && this._subagentRuntimeHost) {
+									await this._subagentRuntimeHost.deleteRlmSubagentRuntime(
+										run.id,
+										childRuntime.session,
+										authority,
+									);
+								} else if (childSession) {
+									authority.assertCurrent();
+									await childSession.disposeAsync();
+								}
+								return { subagent: finalizerSubagent };
+							},
+						);
 						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
 							// The known dispose-only host owns no durable registry, so a successful
 							// fallback delete is affirmative absence rather than an I/O guess.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9653,10 +9653,16 @@ export class AgentSession {
 			// A precommit release failure left the host runtime live. Durability alone
 			// cannot discharge that lease: retry the typed host deletion so the exact
 			// resident incarnation is closed before local tracking is cleared.
-			await this._deleteRlmSubagentSession(childId, retained, authority);
+			const deletion = await this._deleteRlmSubagentSession(childId, retained, authority);
 			authority?.assertCurrent();
+			if (
+				deletion.deletionDurability === "stale" ||
+				this._activeRlmChildRuns.has(childId) ||
+				this._rlmChildSessions.get(childId) !== retained
+			) {
+				return false;
+			}
 			if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
-			if (this._rlmChildSessions.get(childId) !== retained) return false;
 			this._removeRlmSubagentTracking(childId);
 		}
 		if (durability === "absent") {
@@ -10481,7 +10487,14 @@ export class AgentSession {
 					run.detachedDeletion = publishedDeletion;
 					await this._coordinateRlmSubagentDeletion(publishedDeletion, undefined, undefined, async (authority) => {
 						try {
-							await this._deleteRlmSubagentSession(run.id, publishedRuntime.session, authority);
+							const deletion = await this._deleteRlmSubagentSession(run.id, publishedRuntime.session, authority);
+							if (
+								deletion.deletionDurability === "stale" ||
+								this._activeRlmChildRuns.get(run.id) !== run ||
+								run.session !== publishedRuntime.session
+							) {
+								return { subagent: publishedDeletion, outcome: "preserved_newer" };
+							}
 						} catch (error) {
 							if (!this._disposed && !this._disposing) {
 								this._rlmChildSessions.set(run.id, publishedRuntime.session);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9243,6 +9243,11 @@ export class AgentSession {
 		return this._activeRlmChildRuns.get(childId)?.status;
 	}
 
+	/** Whether this exact child is awaiting private deletion reconciliation. */
+	isRlmChildDeletionQuarantined(childId: string): boolean {
+		return this._rlmChildDeletionQuarantines.has(childId);
+	}
+
 	private async _currentActiveSessionId(): Promise<string | undefined> {
 		try {
 			return (await this._agentMessageController?.listAgents())?.current?.activeSessionId;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9628,6 +9628,7 @@ export class AgentSession {
 			authority ?? {
 				childId,
 				sessionDir: lease.session_dir,
+				...(lease.session_file ? { sessionFile: lease.session_file } : {}),
 				...(lease.session_id ? { sessionId: lease.session_id } : {}),
 				generation: 0,
 				assertCurrent: () => {},
@@ -10419,6 +10420,7 @@ export class AgentSession {
 							rlm_child_id: run.id,
 							active_session_id: null,
 							session_id: childSession?.sessionId ?? null,
+							...(childSession?.sessionFile ? { session_file: childSession.sessionFile } : {}),
 							session_name: sessionName,
 							session_dir: childSessionDir,
 							status: "error",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9414,7 +9414,11 @@ export class AgentSession {
 			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
 		}
 		if (inFlight[0]) {
-			return inFlight[0].promise;
+			// A coalesced waiter retains its own revocation boundary rather than
+			// inheriting the initiating request's authority.
+			const result = await inFlight[0].promise;
+			assertDeleteAuthority();
+			return result;
 		}
 		// Quarantine is deliberately absent from public list/roster/hydration, but
 		// the caller holding the exact opaque child id may explicitly retry its
@@ -9502,11 +9506,16 @@ export class AgentSession {
 	): Promise<boolean> {
 		const lease = this._rlmChildDeletionQuarantines.get(childId);
 		if (!lease || this._disposed || this._disposing) return false;
-		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId);
+		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId, {
+			assertCurrent: assertDeleteAuthority,
+		});
 		if (durability !== "absent" && durability !== "tombstoned") return false;
 		// The host await is a revocation boundary. Do not mutate the artifact or
 		// private deletion bookkeeping after its caller has lost authority.
 		assertDeleteAuthority();
+		// A retry/reaper can yield while the host reads. It may only discharge the
+		// exact lease it resolved, never a newer lease reusing this child id.
+		if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
 		if (durability === "absent") {
 			// This is the sole path which removes the exact quarantined directory.
 			rmSync(lease.session_dir, { recursive: true, force: true });

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -169,7 +169,12 @@ import {
 	validateGoalBudget,
 	validateGoalObjective,
 } from "./goals.js";
-import type { HostRequestHandlers, KernelSentAgentMessage } from "./kernel/index.js";
+import {
+	contextAwareHostRequestHandler,
+	createHostRequestHandler,
+	type HostRequestHandlers,
+	type KernelSentAgentMessage,
+} from "./kernel/index.js";
 import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { McpManager } from "./mcp/mcp-manager.js";
 import {
@@ -8766,25 +8771,37 @@ export class AgentSession {
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
 			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target) => this.deleteRlmSubagent(target)),
-			"model.info": async () => ({
-				id: this.model?.id ?? null,
-				provider: this.model?.provider ?? null,
-				input: this.model?.input ?? [],
-			}),
+			"model.info": createHostRequestHandler(
+				async (_payload, _context) => ({
+					id: this.model?.id ?? null,
+					provider: this.model?.provider ?? null,
+					input: this.model?.input ?? [],
+				}),
+				contextAwareHostRequestHandler,
+			),
 		};
 		if (this._includeGoals) {
 			for (const type of ["goal.get", "goal.create", "goal.complete"]) {
-				handlers[type] = async (payload) => this.handleGoalHostRequest(type, payload);
+				handlers[type] = createHostRequestHandler(
+					async (payload, _context) => this.handleGoalHostRequest(type, payload),
+					contextAwareHostRequestHandler,
+				);
 			}
 		}
 		if (this._includeCompactSkill) {
 			for (const type of ["compact.run", "compact.status"]) {
-				handlers[type] = async (payload) => this.handleCompactHostRequest(type, payload);
+				handlers[type] = createHostRequestHandler(
+					async (payload, _context) => this.handleCompactHostRequest(type, payload),
+					contextAwareHostRequestHandler,
+				);
 			}
 		}
 		if (this._autoRefineAllowedForSession()) {
 			for (const type of ["refine.run", "refine.status"]) {
-				handlers[type] = async (payload) => this.handleRefineHostRequest(type, payload);
+				handlers[type] = createHostRequestHandler(
+					async (payload, _context) => this.handleRefineHostRequest(type, payload),
+					contextAwareHostRequestHandler,
+				);
 			}
 		}
 		if (this._rlmHeartbeatController) {
@@ -8794,7 +8811,10 @@ export class AgentSession {
 				"rlm_heartbeat.update",
 				"rlm_heartbeat.delete",
 			]) {
-				handlers[type] = async (payload) => this.handleRlmHeartbeatHostRequest(type, payload);
+				handlers[type] = createHostRequestHandler(
+					async (payload, _context) => this.handleRlmHeartbeatHostRequest(type, payload),
+					contextAwareHostRequestHandler,
+				);
 			}
 		}
 		const visibleKernelSkillNames = new Set(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9919,6 +9919,10 @@ export class AgentSession {
 		// retention, cancellation, and late-startup cleanup.
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
+			// A release hook is not itself proof that a cancelled, never-admitted
+			// child is durably unreachable. Only its verified retention outcome may
+			// preserve the artifact directory.
+			let releaseRetained = false;
 			try {
 				throwIfCancelled();
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
@@ -10038,6 +10042,9 @@ export class AgentSession {
 					if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 						await this._subagentRuntimeHost
 							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
+							.then((outcome) => {
+								releaseRetained = outcome.retained;
+							})
 							.catch(() => void child.disposeAsync().catch(() => undefined));
 					} else {
 						await child.disposeAsync().catch(() => undefined);
@@ -10077,11 +10084,12 @@ export class AgentSession {
 				}
 				if (!run.detachedDeletion && childSession && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 					try {
-						await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
+						const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
 							childRuntime ?? { session: childSession },
 							subagentOptions,
 							run.status === "cancelled" ? "cancelled" : "error",
 						);
+						releaseRetained = outcome.retained;
 						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
 							this._deletedRlmChildIds.add(run.id);
 							this._removeRlmSubagentTracking(run.id);
@@ -10104,17 +10112,10 @@ export class AgentSession {
 						// A failed best-effort retry remains available through the retained cleanup maps.
 					}
 				}
-				// A never-admitted cancelled child's dir is an orphan only when nothing
-				// durable references it. A host with a release hook records deletion
-				// durably (a daemon keeps the artifact tree for its deleted registry
-				// entry); a dispose-only host, like the default in-process runtime,
-				// persists nothing, so its dir is still an orphan to remove.
-				if (
-					!admissionCommitted &&
-					run.status === "cancelled" &&
-					!run.detachedDeletion &&
-					(!this._subagentRuntimeHost?.releaseRlmSubagentRuntime || (!childRuntime && !childSession))
-				) {
+				// A never-admitted cancelled child's dir is an orphan unless the release
+				// path verified durable ownership (for example, a daemon tombstone). A
+				// hook's presence alone does not make its artifact tree recoverable.
+				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion && !releaseRetained) {
 					rmSync(childSessionDir, { recursive: true, force: true });
 				}
 			} finally {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -169,12 +169,7 @@ import {
 	validateGoalBudget,
 	validateGoalObjective,
 } from "./goals.js";
-import {
-	contextAwareHostRequestHandler,
-	createHostRequestHandler,
-	type HostRequestHandlers,
-	type KernelSentAgentMessage,
-} from "./kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandlers, type KernelSentAgentMessage } from "./kernel/index.js";
 import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { McpManager } from "./mcp/mcp-manager.js";
 import {
@@ -8827,36 +8822,30 @@ export class AgentSession {
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
 			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target) => this.deleteRlmSubagent(target)),
-			"model.info": createHostRequestHandler(
-				async (_payload, _context) => ({
-					id: this.model?.id ?? null,
-					provider: this.model?.provider ?? null,
-					input: this.model?.input ?? [],
-				}),
-				contextAwareHostRequestHandler,
-			),
+			"model.info": createHostRequestHandler(async (_payload, _context) => ({
+				id: this.model?.id ?? null,
+				provider: this.model?.provider ?? null,
+				input: this.model?.input ?? [],
+			})),
 		};
 		if (this._includeGoals) {
 			for (const type of ["goal.get", "goal.create", "goal.complete"]) {
-				handlers[type] = createHostRequestHandler(
-					async (payload, _context) => this.handleGoalHostRequest(type, payload),
-					contextAwareHostRequestHandler,
+				handlers[type] = createHostRequestHandler(async (payload, _context) =>
+					this.handleGoalHostRequest(type, payload),
 				);
 			}
 		}
 		if (this._includeCompactSkill) {
 			for (const type of ["compact.run", "compact.status"]) {
-				handlers[type] = createHostRequestHandler(
-					async (payload, _context) => this.handleCompactHostRequest(type, payload),
-					contextAwareHostRequestHandler,
+				handlers[type] = createHostRequestHandler(async (payload, _context) =>
+					this.handleCompactHostRequest(type, payload),
 				);
 			}
 		}
 		if (this._autoRefineAllowedForSession()) {
 			for (const type of ["refine.run", "refine.status"]) {
-				handlers[type] = createHostRequestHandler(
-					async (payload, _context) => this.handleRefineHostRequest(type, payload),
-					contextAwareHostRequestHandler,
+				handlers[type] = createHostRequestHandler(async (payload, _context) =>
+					this.handleRefineHostRequest(type, payload),
 				);
 			}
 		}
@@ -8867,9 +8856,8 @@ export class AgentSession {
 				"rlm_heartbeat.update",
 				"rlm_heartbeat.delete",
 			]) {
-				handlers[type] = createHostRequestHandler(
-					async (payload, _context) => this.handleRlmHeartbeatHostRequest(type, payload),
-					contextAwareHostRequestHandler,
+				handlers[type] = createHostRequestHandler(async (payload, _context) =>
+					this.handleRlmHeartbeatHostRequest(type, payload),
 				);
 			}
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9677,6 +9677,18 @@ export class AgentSession {
 		authority?.assertCurrent();
 		if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return "unknown";
 		const retained = this._rlmChildSessions.get(childId);
+		// A same-id retained runtime can have been republished while this old
+		// quarantine was hidden. Compare its concrete incarnation before asking the
+		// host to delete anything; an active run also owns a newer live incarnation.
+		if (
+			retained &&
+			(retained._rlmSessionDir !== lease.session_dir ||
+				retained.sessionFile !== lease.session_file ||
+				retained.sessionId !== lease.session_id ||
+				this._activeRlmChildRuns.has(childId))
+		) {
+			return this._preserveNewerRlmChild(childId, lease) ? "preserved_newer" : "unknown";
+		}
 		if (!retained && this._activeRlmChildRuns.has(childId)) {
 			return this._preserveNewerRlmChild(childId, lease) ? "preserved_newer" : "unknown";
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9286,6 +9286,9 @@ export class AgentSession {
 				rlm_child_id: run.id,
 				active_session_id: daemonChild?.activeSessionId ?? null,
 				session_id: daemonChild?.sessionId ?? run.session?.sessionId ?? null,
+				...((daemonChild?.sessionPath ?? run.session?.sessionFile)
+					? { session_file: daemonChild?.sessionPath ?? run.session?.sessionFile }
+					: {}),
 				session_name: daemonChild?.sessionName ?? run.session?.sessionName ?? run.sessionName,
 				session_dir: run.sessionDir,
 				status: run.status === "done" ? "completed" : run.status === "error" ? "error" : "running",
@@ -9310,6 +9313,9 @@ export class AgentSession {
 				rlm_child_id: childId,
 				active_session_id: daemonChild?.activeSessionId ?? null,
 				session_id: daemonChild?.sessionId ?? childSession.sessionId,
+				...((daemonChild?.sessionPath ?? childSession.sessionFile)
+					? { session_file: daemonChild?.sessionPath ?? childSession.sessionFile }
+					: {}),
 				session_name:
 					daemonChild?.sessionName ?? childSession.sessionName ?? createDefaultRlmSubagentSessionName("", childId),
 				session_dir: sessionDir,
@@ -9332,6 +9338,7 @@ export class AgentSession {
 				rlm_child_id: childId,
 				active_session_id: daemonChild.activeSessionId,
 				session_id: daemonChild.sessionId,
+				...(daemonChild.sessionPath ? { session_file: daemonChild.sessionPath } : {}),
 				session_name: daemonChild.sessionName ?? createDefaultRlmSubagentSessionName("", childId),
 				session_dir: daemonChild.sessionDir,
 				status: daemonChild.rlmChildRegistryStatus === "completed" ? "completed" : "error",
@@ -9481,6 +9488,7 @@ export class AgentSession {
 							...subagent,
 							active_session_id: daemonChild.activeSessionId,
 							session_id: daemonChild.sessionId,
+							...(daemonChild.sessionPath ? { session_file: daemonChild.sessionPath } : {}),
 							session_name: daemonChild.sessionName ?? subagent.session_name,
 						}
 					: subagent;
@@ -9565,6 +9573,8 @@ export class AgentSession {
 			authority = {
 				childId: subagent.rlm_child_id,
 				sessionDir: subagent.session_dir,
+				...(subagent.session_file ? { sessionFile: subagent.session_file } : {}),
+				...(subagent.session_id ? { sessionId: subagent.session_id } : {}),
 				generation,
 				assertCurrent: () => {
 					if (signal?.aborted) throw new Error("host request authority was revoked");
@@ -9618,6 +9628,7 @@ export class AgentSession {
 			authority ?? {
 				childId,
 				sessionDir: lease.session_dir,
+				...(lease.session_id ? { sessionId: lease.session_id } : {}),
 				generation: 0,
 				assertCurrent: () => {},
 			},

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10334,6 +10334,7 @@ export class AgentSession {
 							undefined,
 							inFlight?.lease,
 							async (authority) => {
+								if (this._deletedRlmChildIds.has(run.id)) return { subagent: finalizerSubagent };
 								if (this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 									try {
 										const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9719,6 +9719,14 @@ export class AgentSession {
 					this._rlmChildCleanupFailures.set(childId, subagent);
 					if (run.unsubscribe) this._rlmChildUnsubscribes.set(childId, run.unsubscribe);
 					this._activeRlmChildRuns.delete(childId);
+					// A generic close failure may follow a durable daemon tombstone. Keep
+					// this task on its cancelled terminal path so its finalizer retries the
+					// retained cleanup record rather than completing and losing that route.
+					// A revoked owner is different: a live waiter may promote a fresh
+					// generation, so it must not mutate the run before that commit.
+					if (!(error instanceof Error) || error.message !== "host request authority was revoked") {
+						this._cancelRlmChildRun(run, "Deleted by parent orchestrator");
+					}
 					run.abort = noopRlmChildAbort;
 					run.unsubscribe = undefined;
 					run.session = undefined;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -285,6 +285,8 @@ export { type ParsedSkillBlock, parseSkillBlock } from "./skill-blocks.js";
 
 export type RlmChildAgentStatus = "queued" | "running" | "done" | "error" | "cancelled";
 
+type RlmChildDeletionQuarantineResolution = "deleted" | "preserved_newer" | "unknown";
+
 export interface RlmChildAgentActivity {
 	kind: "waiting" | "writing" | "executing";
 	toolName?: string;
@@ -7333,10 +7335,11 @@ export class AgentSession {
 		await Promise.allSettled(
 			[...this._rlmChildDeletionQuarantines.entries()].map(([childId, lease]) =>
 				this._coordinateRlmSubagentDeletion(lease, undefined, lease, async (authority) => {
-					if (!(await this._resolveRlmChildDeletionQuarantine(childId, authority))) {
+					const resolution = await this._resolveRlmChildDeletionQuarantine(childId, authority);
+					if (resolution === "unknown") {
 						throw new Error("RLM subagent deletion durability is still unknown");
 					}
-					return { subagent: lease };
+					return { subagent: lease, ...(resolution === "preserved_newer" ? { outcome: resolution } : {}) };
 				}),
 			),
 		);
@@ -9450,14 +9453,17 @@ export class AgentSession {
 			// promise: if an aborted owner fails before commit, this live waiter can
 			// promote a fresh generation after it drains.
 			const joined = inFlight[0];
-			return this._coordinateRlmSubagentDeletion(joined.subagent, signal, joined.lease, (authority) => {
+			return this._coordinateRlmSubagentDeletion(joined.subagent, signal, joined.lease, async (authority) => {
 				if (joined.lease) {
-					return this._resolveRlmChildDeletionQuarantine(joined.subagent.rlm_child_id, authority).then(
-						(resolved) => {
-							if (!resolved) throw new Error("RLM subagent deletion durability is still unknown");
-							return { subagent: joined.subagent };
-						},
+					const resolution = await this._resolveRlmChildDeletionQuarantine(
+						joined.subagent.rlm_child_id,
+						authority,
 					);
+					if (resolution === "unknown") throw new Error("RLM subagent deletion durability is still unknown");
+					return {
+						subagent: joined.subagent,
+						...(resolution === "preserved_newer" ? { outcome: resolution } : {}),
+					};
 				}
 				return this._deleteResolvedRlmSubagent(joined.subagent, authority);
 			});
@@ -9468,10 +9474,9 @@ export class AgentSession {
 		const quarantined = this._rlmChildDeletionQuarantines.get(target);
 		if (quarantined) {
 			return this._coordinateRlmSubagentDeletion(quarantined, signal, quarantined, async (authority) => {
-				if (!(await this._resolveRlmChildDeletionQuarantine(target, authority))) {
-					throw new Error("RLM subagent deletion durability is still unknown");
-				}
-				return { subagent: quarantined };
+				const resolution = await this._resolveRlmChildDeletionQuarantine(target, authority);
+				if (resolution === "unknown") throw new Error("RLM subagent deletion durability is still unknown");
+				return { subagent: quarantined, ...(resolution === "preserved_newer" ? { outcome: resolution } : {}) };
 			});
 		}
 		if (localMatches[0]) {
@@ -9619,16 +9624,13 @@ export class AgentSession {
 		}
 	}
 
-	/**
-	 * Reconcile a private cancelled-spawn cleanup lease. `false` deliberately
-	 * means that durability is still unknown, never that deletion succeeded.
-	 */
+	/** Reconcile a private cancelled-spawn cleanup lease without touching a replacement. */
 	private async _resolveRlmChildDeletionQuarantine(
 		childId: string,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<boolean> {
+	): Promise<RlmChildDeletionQuarantineResolution> {
 		const lease = this._rlmChildDeletionQuarantines.get(childId);
-		if (!lease || this._disposed || this._disposing) return false;
+		if (!lease || this._disposed || this._disposing) return "unknown";
 		authority?.assertCurrent();
 		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(
 			childId,
@@ -9641,18 +9643,16 @@ export class AgentSession {
 				assertCurrent: () => {},
 			},
 		);
-		if (durability !== "absent" && durability !== "tombstoned") return false;
-		// The host await is a revocation boundary. Do not mutate the artifact or
-		// private deletion bookkeeping after its caller has lost authority.
+		if (durability !== "absent" && durability !== "tombstoned") return "unknown";
+		// The host await is a revocation boundary. It may only discharge the exact
+		// lease it resolved, never a lease or runtime republished under this id.
 		authority?.assertCurrent();
-		// A retry/reaper can yield while the host reads. It may only discharge the
-		// exact lease it resolved, never a newer lease reusing this child id.
-		if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
+		if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return "unknown";
 		const retained = this._rlmChildSessions.get(childId);
+		if (!retained && this._activeRlmChildRuns.has(childId)) {
+			return this._preserveNewerRlmChild(childId, lease) ? "preserved_newer" : "unknown";
+		}
 		if (retained) {
-			// A precommit release failure left the host runtime live. Durability alone
-			// cannot discharge that lease: retry the typed host deletion so the exact
-			// resident incarnation is closed before local tracking is cleared.
 			const deletion = await this._deleteRlmSubagentSession(childId, retained, authority);
 			authority?.assertCurrent();
 			if (
@@ -9660,9 +9660,12 @@ export class AgentSession {
 				this._activeRlmChildRuns.has(childId) ||
 				this._rlmChildSessions.get(childId) !== retained
 			) {
-				return false;
+				// The old host lease is settled, but its id now belongs to a newer
+				// runtime. Discharge only this private lease: no artifact removal,
+				// tracking removal, deleted marker, or deletion-success result.
+				return this._preserveNewerRlmChild(childId, lease) ? "preserved_newer" : "unknown";
 			}
-			if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
+			if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return "unknown";
 			this._removeRlmSubagentTracking(childId);
 		}
 		if (durability === "absent") {
@@ -9673,6 +9676,18 @@ export class AgentSession {
 		// directory is removable. Either conclusion discharges the private lease.
 		this._rlmChildDeletionQuarantines.delete(childId);
 		this._deletedRlmChildIds.add(childId);
+		return "deleted";
+	}
+
+	/** Discharge an obsolete private lease without mutating the replacement's tracking. */
+	private _preserveNewerRlmChild(childId: string, lease?: RlmSubagentRegistryEntry): boolean {
+		if (lease) {
+			if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
+			this._rlmChildDeletionQuarantines.delete(childId);
+		}
+		// A queued old delete may have hidden this id before its host later confirms
+		// that the incarnation was replaced. The marker is not owned by that newer child.
+		this._deletedRlmChildIds.delete(childId);
 		return true;
 	}
 
@@ -10080,6 +10095,7 @@ export class AgentSession {
 		let runningToolCount = 0;
 		let activity: RlmChildAgentActivity | undefined;
 		let childSession: AgentSession | undefined;
+		let preservesNewerChild = false;
 		const run: RlmChildRun = {
 			id: childNodeId,
 			prompt,
@@ -10488,11 +10504,14 @@ export class AgentSession {
 					await this._coordinateRlmSubagentDeletion(publishedDeletion, undefined, undefined, async (authority) => {
 						try {
 							const deletion = await this._deleteRlmSubagentSession(run.id, publishedRuntime.session, authority);
+							authority.assertCurrent();
 							if (
 								deletion.deletionDurability === "stale" ||
 								this._activeRlmChildRuns.get(run.id) !== run ||
-								run.session !== publishedRuntime.session
+								(run.session !== undefined && run.session !== publishedRuntime.session)
 							) {
+								preservesNewerChild = this._preserveNewerRlmChild(run.id);
+								if (preservesNewerChild) run.detachedDeletion = undefined;
 								return { subagent: publishedDeletion, outcome: "preserved_newer" };
 							}
 						} catch (error) {
@@ -10507,7 +10526,7 @@ export class AgentSession {
 						return { subagent: publishedDeletion };
 					}).catch(() => undefined);
 				}
-				if (this._activeRlmChildRuns.get(run.id) === run) {
+				if (this._activeRlmChildRuns.get(run.id) === run && !preservesNewerChild) {
 					if (this._rlmChildSessions.has(run.id)) {
 						this._activeRlmChildRuns.delete(run.id);
 						if (run.unsubscribe) this._rlmChildUnsubscribes.set(run.id, run.unsubscribe);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4648,9 +4648,9 @@ export class AgentSession {
 	}
 
 	private async _prompt(text: string, options?: InternalPromptOptions): Promise<void> {
+		this._assertSessionActionAdmissionAvailable();
 		if (!this.isStreaming) {
 			this._sessionInputPumpSuspended = false;
-			this._assertSessionActionAdmissionAvailable();
 		}
 		const commitFence = this.isStreaming
 			? undefined

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9746,7 +9746,14 @@ export class AgentSession {
 			if (liveSession) {
 				authority?.assertCurrent();
 				try {
-					await this._deleteRlmSubagentSession(childId, liveSession, authority);
+					const deletion = await this._deleteRlmSubagentSession(childId, liveSession, authority);
+					if (
+						deletion.deletionDurability === "stale" ||
+						this._activeRlmChildRuns.get(childId) !== run ||
+						run.session !== liveSession
+					) {
+						return { subagent };
+					}
 				} catch (error) {
 					if (this._disposed || this._disposing) {
 						this._removeRlmSubagentTracking(childId, run);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10137,6 +10137,7 @@ export class AgentSession {
 		try {
 			if (requestAuthority) await run.publication.promise;
 			assertRequestCurrent();
+			throwIfCancelled();
 			admissionCommitted = true;
 			if (requestAuthority) requestAuthority.signal.removeEventListener("abort", revokeAdmission);
 		} catch (error) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9422,7 +9422,9 @@ export class AgentSession {
 		const quarantined = this._rlmChildDeletionQuarantines.get(target);
 		if (quarantined) {
 			return this._trackRlmSubagentDeletion(quarantined, async () => {
-				await this._resolveRlmChildDeletionQuarantine(target);
+				if (!(await this._resolveRlmChildDeletionQuarantine(target, assertDeleteAuthority))) {
+					throw new Error("RLM subagent deletion durability is still unknown");
+				}
 				return { subagent: quarantined };
 			});
 		}
@@ -9494,11 +9496,17 @@ export class AgentSession {
 	 * Reconcile a private cancelled-spawn cleanup lease. `false` deliberately
 	 * means that durability is still unknown, never that deletion succeeded.
 	 */
-	private async _resolveRlmChildDeletionQuarantine(childId: string): Promise<boolean> {
+	private async _resolveRlmChildDeletionQuarantine(
+		childId: string,
+		assertDeleteAuthority: () => void = () => {},
+	): Promise<boolean> {
 		const lease = this._rlmChildDeletionQuarantines.get(childId);
 		if (!lease || this._disposed || this._disposing) return false;
 		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId);
-		if (durability === "unknown" || durability === undefined) return false;
+		if (durability !== "absent" && durability !== "tombstoned") return false;
+		// The host await is a revocation boundary. Do not mutate the artifact or
+		// private deletion bookkeeping after its caller has lost authority.
+		assertDeleteAuthority();
 		if (durability === "absent") {
 			// This is the sole path which removes the exact quarantined directory.
 			rmSync(lease.session_dir, { recursive: true, force: true });

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1117,6 +1117,7 @@ export class AgentSession {
 	private _sessionInputArrivalEpoch = 0;
 	// Persists abort/restart suspension after the initiating call returns.
 	private _sessionInputPumpSuspended = false;
+	private _sessionInputPumpSuspensionReason: "abort" | "update_restart" | undefined;
 	// Branch mutation pause leases can overlap and must all release before dispatch resumes.
 	private readonly _queuedWorkPauses = new Set<symbol>();
 	private _sessionActionCommitTail: Promise<void> = Promise.resolve();
@@ -4602,7 +4603,7 @@ export class AgentSession {
 		message: CustomMessage,
 		options?: InternalPromptOptions & { executionPolicy?: TurnExecutionPolicy },
 	): Promise<void> {
-		if (!this.isStreaming && options?.resumeIfIdle) this._sessionInputPumpSuspended = false;
+		if (!this.isStreaming && options?.resumeIfIdle) this._resumeSessionInputPumpFromIdleAdmission();
 		const admissionFence = await this._acquireDirectTurnAdmissionFence(options?.signal).catch((error: unknown) => {
 			throwIfPromptAdmissionCancelled(options?.signal);
 			throw error;
@@ -4674,7 +4675,10 @@ export class AgentSession {
 		// Preserve queued extension actions and admit this turn so the normal FIFO
 		// pump can drain them; other suspended admissions remain fail-closed.
 		if (!this.isStreaming) {
-			this._sessionInputPumpSuspended = false;
+			if (this._sessionInputPumpSuspensionReason === "update_restart") {
+				throw new Error("Cannot admit a prompt while the session is preparing for update restart.");
+			}
+			this._resumeSessionInputPumpFromIdleAdmission();
 		}
 		this._assertSessionActionAdmissionAvailable();
 		const commitFence = this.isStreaming
@@ -5368,6 +5372,12 @@ export class AgentSession {
 		}
 	}
 
+	private _resumeSessionInputPumpFromIdleAdmission(): void {
+		if (this._sessionInputPumpSuspensionReason === "update_restart") return;
+		this._sessionInputPumpSuspended = false;
+		this._sessionInputPumpSuspensionReason = undefined;
+	}
+
 	private _admitSessionInput(
 		action: QueuedSessionAction,
 		options: {
@@ -5417,7 +5427,9 @@ export class AgentSession {
 				action.payload.kind === "session_command" ||
 				action.wake === "immediate")
 		) {
-			if (action.payload.kind === "turn" && action.wake === "immediate") this._sessionInputPumpSuspended = false;
+			if (action.payload.kind === "turn" && action.wake === "immediate") {
+				this._resumeSessionInputPumpFromIdleAdmission();
+			}
 			this._scheduleSessionInputPump();
 		}
 		return { accepted: true, disposition, ticket: controller.ticket };
@@ -6584,6 +6596,7 @@ export class AgentSession {
 	/** Resume the scheduler after requestAbort/abortForUpdateRestart suspended it; owned pause leases are unaffected. */
 	resumeQueuedWork(): boolean {
 		this._sessionInputPumpSuspended = false;
+		this._sessionInputPumpSuspensionReason = undefined;
 		this._notifySessionInputCheckpointChange();
 		this._scheduleSessionInputPump();
 		return this._hasSelectableSessionInput();
@@ -6672,6 +6685,7 @@ export class AgentSession {
 		this._sessionInputPumpRequested = false;
 		this._sessionInputPumpEpoch++;
 		this._sessionInputPumpSuspended = true;
+		this._sessionInputPumpSuspensionReason = "abort";
 		this._cancelSessionActions(
 			(action) => action.payload.kind === "turn" && !action.payload.queueVisible,
 			new Error("Prompt aborted before delivery."),
@@ -6715,6 +6729,7 @@ export class AgentSession {
 		this._sessionInputPumpRequested = false;
 		this._sessionInputPumpEpoch++;
 		this._sessionInputPumpSuspended = true;
+		this._sessionInputPumpSuspensionReason = "update_restart";
 		this._cancelPostCompactionContinue();
 		this.abortRetry();
 		this._cancelActiveRlmChildRuns("Parent session aborted for update restart");

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9629,6 +9629,17 @@ export class AgentSession {
 		// A retry/reaper can yield while the host reads. It may only discharge the
 		// exact lease it resolved, never a newer lease reusing this child id.
 		if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
+		const retained = this._rlmChildSessions.get(childId);
+		if (retained) {
+			// A precommit release failure left the host runtime live. Durability alone
+			// cannot discharge that lease: retry the typed host deletion so the exact
+			// resident incarnation is closed before local tracking is cleared.
+			await this._deleteRlmSubagentSession(childId, retained, authority);
+			authority?.assertCurrent();
+			if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
+			if (this._rlmChildSessions.get(childId) !== retained) return false;
+			this._removeRlmSubagentTracking(childId);
+		}
 		if (durability === "absent") {
 			// This is the sole path which removes the exact quarantined directory.
 			rmSync(lease.session_dir, { recursive: true, force: true });
@@ -9652,6 +9663,10 @@ export class AgentSession {
 			return deletion.then((result) => result ?? { deletionDurability: "absent" });
 		}
 		return (session?.disposeAsync() ?? Promise.resolve()).then(() => ({ deletionDurability: "absent" }));
+	}
+
+	private _isPrecommitRlmSubagentDeletionFailure(error: unknown): boolean {
+		return error instanceof RlmSubagentHostDeletionError && error.phase === "precommit";
 	}
 
 	private _isTombstonedRlmSubagentDeletionFailure(error: unknown): boolean {
@@ -10345,13 +10360,15 @@ export class AgentSession {
 										);
 										deletionDurability = outcome?.deletionDurability ?? "unknown";
 									} catch (releaseError) {
-										if (
-											this._isTombstonedRlmSubagentDeletionFailure(releaseError) &&
-											!this._disposed &&
-											!this._disposing
-										) {
-											this._rlmChildSessions.set(run.id, childSession);
-											this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
+										if (!this._disposed && !this._disposing) {
+											if (this._isTombstonedRlmSubagentDeletionFailure(releaseError)) {
+												this._rlmChildSessions.set(run.id, childSession);
+												this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
+											} else if (this._isPrecommitRlmSubagentDeletionFailure(releaseError)) {
+												// Keep the live host incarnation attached to the private unknown-
+												// durability lease so an exact-id retry can tombstone and close it.
+												this._rlmChildSessions.set(run.id, childSession);
+											}
 										}
 										throw releaseError;
 									}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -15,7 +15,7 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import {
@@ -8765,8 +8765,8 @@ export class AgentSession {
 	/** Typed handlers for host requests arriving from the IPython kernel comm bridge. */
 	private _createKernelHostHandlers(): HostRequestHandlers {
 		const handlers: HostRequestHandlers = {
-			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode }) => ({
-				...(await this.runRlmChild(prompt, kwargs, cellSourceCode)),
+			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode, signal, isCurrent }) => ({
+				...(await this.runRlmChild(prompt, kwargs, cellSourceCode, { signal, isCurrent })),
 			})),
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
@@ -9705,7 +9705,14 @@ export class AgentSession {
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
+		requestAuthority?: { signal: AbortSignal; isCurrent(): boolean },
 	): Promise<RlmSpawnHandle> {
+		const assertRequestCurrent = () => {
+			if (requestAuthority && (requestAuthority.signal.aborted || !requestAuthority.isCurrent())) {
+				throw new Error("host request authority was revoked");
+			}
+		};
+		assertRequestCurrent();
 		const { name: rawName, model: rawModel, ...unsupported } = kwargs;
 		const unsupportedKwargs = Object.keys(unsupported);
 		if (unsupportedKwargs.length > 0) {
@@ -9732,12 +9739,19 @@ export class AgentSession {
 		} finally {
 			if (requestedSessionName) this._pendingRlmSubagentSessionNames.delete(requestedSessionName);
 		}
+		assertRequestCurrent();
 		if (this._disposed || this._disposing) throw new Error("Cannot spawn a subagent after its parent was disposed");
 
 		const childSessionDir = this._createChildRlmSessionDir();
 		const childNodeId = basename(childSessionDir);
 		const sessionName = requestedSessionName ?? createDefaultRlmSubagentSessionName(prompt, childNodeId);
-		if (!requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(sessionName);
+		try {
+			if (!requestedSessionName) await this._assertRlmSubagentSessionNameAvailable(sessionName);
+			assertRequestCurrent();
+		} catch (error) {
+			rmSync(childSessionDir, { recursive: true, force: true });
+			throw error;
+		}
 		const startedAt = Date.now();
 		const parentAssistantForUsage = this._findLastAssistantMessage();
 		const label = rlmChildLabel(prompt);
@@ -9830,6 +9844,12 @@ export class AgentSession {
 		// Runtime startup and the task run are deliberately detached. The public
 		// spawn resolves at admission, while this task owns live tracking, usage,
 		// retention, cancellation, and late-startup cleanup.
+		let admissionCommitted = false;
+		const revokeAdmission = () => {
+			if (!admissionCommitted) this._cancelRlmChildRun(run, "host request authority was revoked");
+		};
+		if (requestAuthority) requestAuthority.signal.addEventListener("abort", revokeAdmission, { once: true });
+		assertRequestCurrent();
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
 			try {
@@ -10041,9 +10061,21 @@ export class AgentSession {
 					}
 				}
 				run.settled = true;
+				if (requestAuthority && !admissionCommitted) {
+					requestAuthority.signal.removeEventListener("abort", revokeAdmission);
+				}
 			}
 		})().catch(() => undefined);
 
+		try {
+			if (requestAuthority) await run.publication.promise;
+			assertRequestCurrent();
+			admissionCommitted = true;
+			if (requestAuthority) requestAuthority.signal.removeEventListener("abort", revokeAdmission);
+		} catch (error) {
+			revokeAdmission();
+			throw error;
+		}
 		return {
 			rlm_child_id: childNodeId,
 			name: sessionName,
@@ -10056,8 +10088,9 @@ export class AgentSession {
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
+		requestAuthority?: { signal: AbortSignal; isCurrent(): boolean },
 	): Promise<RlmSpawnHandle> {
-		return this._startRlmChildRun(prompt, kwargs, spawnCode);
+		return this._startRlmChildRun(prompt, kwargs, spawnCode, requestAuthority);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -8816,8 +8816,8 @@ export class AgentSession {
 	/** Typed handlers for host requests arriving from the IPython kernel comm bridge. */
 	private _createKernelHostHandlers(): HostRequestHandlers {
 		const handlers: HostRequestHandlers = {
-			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode, signal, isCurrent }) => ({
-				...(await this.runRlmChild(prompt, kwargs, cellSourceCode, { signal, isCurrent })),
+			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode, signal }) => ({
+				...(await this.runRlmChild(prompt, kwargs, cellSourceCode, { signal })),
 			})),
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
@@ -9750,10 +9750,10 @@ export class AgentSession {
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
-		requestAuthority?: { signal: AbortSignal; isCurrent(): boolean },
+		requestAuthority?: { signal: AbortSignal },
 	): Promise<RlmSpawnHandle> {
 		const assertRequestCurrent = () => {
-			if (requestAuthority && (requestAuthority.signal.aborted || !requestAuthority.isCurrent())) {
+			if (requestAuthority?.signal.aborted) {
 				throw new Error("host request authority was revoked");
 			}
 		};
@@ -10133,7 +10133,7 @@ export class AgentSession {
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
-		requestAuthority?: { signal: AbortSignal; isCurrent(): boolean },
+		requestAuthority?: { signal: AbortSignal },
 	): Promise<RlmSpawnHandle> {
 		return this._startRlmChildRun(prompt, kwargs, spawnCode, requestAuthority);
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -230,6 +230,7 @@ import {
 	type RlmSpawnHandle,
 	type RlmSubagentDeletionAuthority,
 	type RlmSubagentDeletionDurability,
+	RlmSubagentHostDeletionError,
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
 	type SubagentRuntimeHost,
@@ -9643,13 +9644,18 @@ export class AgentSession {
 		childId: string,
 		session?: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<void> {
+	): Promise<import("./rlm-runtime.js").RlmSubagentHostDeletionResult> {
 		if (this._subagentRuntimeHost) {
-			return authority
+			const deletion = authority
 				? this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session, authority)
 				: this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
+			return deletion.then((result) => result ?? { deletionDurability: "absent" });
 		}
-		return session?.disposeAsync() ?? Promise.resolve();
+		return (session?.disposeAsync() ?? Promise.resolve()).then(() => ({ deletionDurability: "absent" }));
+	}
+
+	private _isTombstonedRlmSubagentDeletionFailure(error: unknown): boolean {
+		return error instanceof RlmSubagentHostDeletionError && error.phase === "tombstoned";
 	}
 
 	private _removeRlmSubagentTracking(childId: string, run?: RlmChildRun): void {
@@ -9715,21 +9721,19 @@ export class AgentSession {
 						void liveSession.disposeAsync().catch(() => undefined);
 						throw error;
 					}
-					this._rlmChildSessions.set(childId, liveSession);
-					this._rlmChildCleanupFailures.set(childId, subagent);
-					if (run.unsubscribe) this._rlmChildUnsubscribes.set(childId, run.unsubscribe);
-					this._activeRlmChildRuns.delete(childId);
-					// A generic close failure may follow a durable daemon tombstone. Keep
-					// this task on its cancelled terminal path so its finalizer retries the
-					// retained cleanup record rather than completing and losing that route.
-					// A revoked owner is different: a live waiter may promote a fresh
-					// generation, so it must not mutate the run before that commit.
-					if (!(error instanceof Error) || error.message !== "host request authority was revoked") {
+					// Only a typed post-append close failure may hide a child and retain
+					// retry state. A precommit authority revocation leaves every local
+					// map and list projection live for a fresh owner generation.
+					if (this._isTombstonedRlmSubagentDeletionFailure(error)) {
+						this._rlmChildSessions.set(childId, liveSession);
+						this._rlmChildCleanupFailures.set(childId, subagent);
+						if (run.unsubscribe) this._rlmChildUnsubscribes.set(childId, run.unsubscribe);
+						this._activeRlmChildRuns.delete(childId);
 						this._cancelRlmChildRun(run, "Deleted by parent orchestrator");
+						run.abort = noopRlmChildAbort;
+						run.unsubscribe = undefined;
+						run.session = undefined;
 					}
-					run.abort = noopRlmChildAbort;
-					run.unsubscribe = undefined;
-					run.session = undefined;
 					throw error;
 				}
 				// The successful host call is the deletion boundary. Do not let a
@@ -9760,7 +9764,7 @@ export class AgentSession {
 			if (this._disposed || this._disposing) {
 				this._removeRlmSubagentTracking(childId);
 				void retained?.disposeAsync().catch(() => undefined);
-			} else {
+			} else if (this._isTombstonedRlmSubagentDeletionFailure(error)) {
 				this._rlmChildCleanupFailures.set(childId, subagent);
 			}
 			throw error;
@@ -10245,7 +10249,7 @@ export class AgentSession {
 						await this._subagentRuntimeHost
 							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
 							.then((outcome) => {
-								deletionDurability = outcome.deletionDurability;
+								deletionDurability = outcome?.deletionDurability ?? "unknown";
 							})
 							.catch(() => void child.disposeAsync().catch(() => undefined));
 					} else {
@@ -10285,13 +10289,30 @@ export class AgentSession {
 					}
 				}
 				if (!run.detachedDeletion && childSession && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
+					const finalizerSubagent: RlmSubagentRegistryEntry = {
+						rlm_child_id: run.id,
+						active_session_id: null,
+						session_id: childSession.sessionId,
+						session_name: childSession.sessionName ?? sessionName,
+						session_dir: childSessionDir,
+						status: run.status === "cancelled" ? "error" : "error",
+					};
 					try {
-						const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
-							childRuntime ?? { session: childSession },
-							subagentOptions,
-							run.status === "cancelled" ? "cancelled" : "error",
+						await this._coordinateRlmSubagentDeletion(
+							finalizerSubagent,
+							undefined,
+							undefined,
+							async (authority) => {
+								const outcome = await this._subagentRuntimeHost!.releaseRlmSubagentRuntime!(
+									childRuntime ?? { session: childSession! },
+									subagentOptions,
+									run.status === "cancelled" ? "cancelled" : "error",
+									authority,
+								);
+								deletionDurability = outcome?.deletionDurability ?? "unknown";
+								return { subagent: finalizerSubagent };
+							},
 						);
-						deletionDurability = outcome.deletionDurability;
 						if (
 							run.status === "cancelled" &&
 							deletionDurability !== "unknown" &&
@@ -10301,8 +10322,17 @@ export class AgentSession {
 							this._deletedRlmChildIds.add(run.id);
 							this._removeRlmSubagentTracking(run.id);
 						}
-					} catch {
-						await childSession?.disposeAsync().catch(() => undefined);
+					} catch (releaseError) {
+						if (
+							this._isTombstonedRlmSubagentDeletionFailure(releaseError) &&
+							!this._disposed &&
+							!this._disposing
+						) {
+							this._rlmChildSessions.set(run.id, childSession);
+							this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
+						} else {
+							await childSession.disposeAsync().catch(() => undefined);
+						}
 					}
 				} else if (!run.detachedDeletion) {
 					try {
@@ -10344,14 +10374,11 @@ export class AgentSession {
 				}
 			} finally {
 				if (run.detachedDeletion && childRuntime) {
-					try {
-						await this._deleteRlmSubagentSession(run.id, childRuntime.session);
-					} catch {
-						if (!this._disposed && !this._disposing) {
-							this._rlmChildSessions.set(run.id, childRuntime.session);
-							this._rlmChildCleanupFailures.set(run.id, run.detachedDeletion);
-						}
-					}
+					// Startup may publish after deletion was requested. It must re-enter
+					// the same incarnation-fenced coordinator, never call the host directly.
+					await this._coordinateRlmSubagentDeletion(run.detachedDeletion, undefined, undefined, (authority) =>
+						this._deleteResolvedRlmSubagent(run.detachedDeletion!, authority),
+					).catch(() => undefined);
 				}
 				if (this._activeRlmChildRuns.get(run.id) === run) {
 					if (this._rlmChildSessions.has(run.id)) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -8821,7 +8821,9 @@ export class AgentSession {
 			})),
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
-			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target) => this.deleteRlmSubagent(target)),
+			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target, signal) =>
+				this.deleteRlmSubagent(target, signal),
+			),
 			"model.info": createHostRequestHandler(async (_payload, _context) => ({
 				id: this.model?.id ?? null,
 				provider: this.model?.provider ?? null,
@@ -9372,7 +9374,12 @@ export class AgentSession {
 	}
 
 	/** Delete a running, retained, or passive direct child selected from this parent session's registry. */
-	async deleteRlmSubagent(target: string): Promise<RlmDeleteSubagentResult> {
+	async deleteRlmSubagent(target: string, signal?: AbortSignal): Promise<RlmDeleteSubagentResult> {
+		// Re-checked before each mutating delete so a revocation mid-resolution never mutates.
+		const assertDeleteAuthority = () => {
+			if (signal?.aborted) throw new Error("host request authority was revoked");
+		};
+		assertDeleteAuthority();
 		const inFlight = [...this._deletingRlmChildren.values()].filter(({ subagent }) =>
 			this._rlmSubagentMatchesTarget(subagent, target),
 		);
@@ -9421,6 +9428,7 @@ export class AgentSession {
 							session_name: daemonChild.sessionName ?? subagent.session_name,
 						}
 					: subagent;
+				assertDeleteAuthority();
 				return this._deleteResolvedRlmSubagent(resolvedSubagent);
 			});
 		}
@@ -9434,7 +9442,10 @@ export class AgentSession {
 			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
 		}
 		const subagent = directMatches[0] ?? (await this._resolveDirectRlmSubagent(target));
-		return this._trackRlmSubagentDeletion(subagent, () => this._deleteResolvedRlmSubagent(subagent));
+		return this._trackRlmSubagentDeletion(subagent, () => {
+			assertDeleteAuthority();
+			return this._deleteResolvedRlmSubagent(subagent);
+		});
 	}
 
 	private async _trackRlmSubagentDeletion(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3822,7 +3822,7 @@ export class AgentSession {
 		}
 		this._asyncTeardownStarted = true;
 		this._beginClosing();
-		this._disposeAsyncPromise = (async () => {
+		const attempt = (async () => {
 			// Capture both operations before the first await. allSettled observes either
 			// rejection immediately while allowing the independent operation to finish.
 			const drain = this._drainPendingRefinementForDisposal();
@@ -3854,7 +3854,15 @@ export class AgentSession {
 			if (failures.length === 1) throw failures[0];
 			if (failures.length > 1) throw new AggregateError(failures, "Session disposal failed.");
 		})();
-		return this._disposeAsyncPromise;
+		this._disposeAsyncPromise = attempt;
+		try {
+			await attempt;
+		} catch (error) {
+			if (this._disposeAsyncPromise === attempt) {
+				this._disposeAsyncPromise = undefined;
+			}
+			throw error;
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10245,10 +10245,10 @@ export class AgentSession {
 					);
 				}
 				if (!this.registerRlmChildSession(run.id, child)) {
-					// Registration can lose a race to delete-before-publication. Join that
-					// exact owner rather than releasing the newly published runtime directly.
+					// Completion may race a delete-before-publication owner. The finishing
+					// runtime must join that exact lease, never create a second host close.
 					const inFlight = this._deletingRlmChildren.get(run.id);
-					const finalizerSubagent =
+					const completionSubagent =
 						inFlight?.subagent ??
 						({
 							rlm_child_id: run.id,
@@ -10256,13 +10256,16 @@ export class AgentSession {
 							session_id: child.sessionId,
 							session_name: child.sessionName ?? sessionName,
 							session_dir: childSessionDir,
-							status: "error",
+							status: "completed",
 						} satisfies RlmSubagentRegistryEntry);
 					await this._coordinateRlmSubagentDeletion(
-						finalizerSubagent,
+						completionSubagent,
 						undefined,
 						inFlight?.lease,
 						async (authority) => {
+							// A completed explicit deletion can outlive retention. Joining it is
+							// sufficient; never append or close the same incarnation twice.
+							if (this._deletedRlmChildIds.has(run.id)) return { subagent: completionSubagent };
 							if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 								const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
 									childRuntime,
@@ -10272,10 +10275,10 @@ export class AgentSession {
 								);
 								deletionDurability = outcome?.deletionDurability ?? "unknown";
 							} else {
-								authority.assertCurrent();
-								await child.disposeAsync();
+								await this._deleteResolvedRlmSubagent(completionSubagent, authority);
+								deletionDurability = "absent";
 							}
-							return { subagent: finalizerSubagent };
+							return { subagent: completionSubagent };
 						},
 					).catch(() => undefined);
 				}
@@ -10311,89 +10314,66 @@ export class AgentSession {
 						);
 					}
 				}
-				if (!run.detachedDeletion && childSession && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
-					const finalizerSubagent: RlmSubagentRegistryEntry = {
-						rlm_child_id: run.id,
-						active_session_id: null,
-						session_id: childSession.sessionId,
-						session_name: childSession.sessionName ?? sessionName,
-						session_dir: childSessionDir,
-						status: run.status === "cancelled" ? "error" : "error",
-					};
+				if (!run.detachedDeletion && childSession) {
+					// Error/cancellation finalizers share the exact deletion owner with
+					// explicit deletion and the compaction reaper.
+					const inFlight = this._deletingRlmChildren.get(run.id);
+					const finalizerSubagent =
+						inFlight?.subagent ??
+						({
+							rlm_child_id: run.id,
+							active_session_id: null,
+							session_id: childSession.sessionId,
+							session_name: childSession.sessionName ?? sessionName,
+							session_dir: childSessionDir,
+							status: "error",
+						} satisfies RlmSubagentRegistryEntry);
 					try {
 						await this._coordinateRlmSubagentDeletion(
 							finalizerSubagent,
 							undefined,
-							undefined,
+							inFlight?.lease,
 							async (authority) => {
-								const outcome = await this._subagentRuntimeHost!.releaseRlmSubagentRuntime!(
-									childRuntime ?? { session: childSession! },
-									subagentOptions,
-									run.status === "cancelled" ? "cancelled" : "error",
-									authority,
-								);
-								deletionDurability = outcome?.deletionDurability ?? "unknown";
-								return { subagent: finalizerSubagent };
-							},
-						);
-						if (
-							run.status === "cancelled" &&
-							deletionDurability !== "unknown" &&
-							!this._disposed &&
-							!this._disposing
-						) {
-							this._deletedRlmChildIds.add(run.id);
-							this._removeRlmSubagentTracking(run.id);
-						}
-					} catch (releaseError) {
-						if (
-							this._isTombstonedRlmSubagentDeletionFailure(releaseError) &&
-							!this._disposed &&
-							!this._disposing
-						) {
-							this._rlmChildSessions.set(run.id, childSession);
-							this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
-						} else {
-							await childSession.disposeAsync().catch(() => undefined);
-						}
-					}
-				} else if (!run.detachedDeletion) {
-					const finalizerSubagent: RlmSubagentRegistryEntry = {
-						rlm_child_id: run.id,
-						active_session_id: null,
-						session_id: childSession?.sessionId ?? null,
-						session_name: childSession?.sessionName ?? sessionName,
-						session_dir: childSessionDir,
-						status: "error",
-					};
-					try {
-						await this._coordinateRlmSubagentDeletion(
-							finalizerSubagent,
-							undefined,
-							undefined,
-							async (authority) => {
-								if (childRuntime && this._subagentRuntimeHost) {
-									await this._subagentRuntimeHost.deleteRlmSubagentRuntime(
-										run.id,
-										childRuntime.session,
-										authority,
-									);
-								} else if (childSession) {
-									authority.assertCurrent();
-									await childSession.disposeAsync();
+								if (this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
+									try {
+										const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
+											childRuntime ?? { session: childSession },
+											subagentOptions,
+											run.status === "cancelled" ? "cancelled" : "error",
+											authority,
+										);
+										deletionDurability = outcome?.deletionDurability ?? "unknown";
+									} catch (releaseError) {
+										if (
+											this._isTombstonedRlmSubagentDeletionFailure(releaseError) &&
+											!this._disposed &&
+											!this._disposing
+										) {
+											this._rlmChildSessions.set(run.id, childSession);
+											this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
+										}
+										throw releaseError;
+									}
+									if (
+										run.status === "cancelled" &&
+										deletionDurability !== "unknown" &&
+										!this._disposed &&
+										!this._disposing
+									) {
+										this._deletedRlmChildIds.add(run.id);
+										this._removeRlmSubagentTracking(run.id);
+									}
+									return { subagent: finalizerSubagent };
 								}
-								return { subagent: finalizerSubagent };
+								const result = await this._deleteResolvedRlmSubagent(finalizerSubagent, authority);
+								deletionDurability = "absent";
+								return result;
 							},
 						);
-						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
-							// The known dispose-only host owns no durable registry, so a successful
-							// fallback delete is affirmative absence rather than an I/O guess.
-							deletionDurability = "absent";
-							this._deletedRlmChildIds.add(run.id);
-							this._removeRlmSubagentTracking(run.id);
-						}
 					} catch {
-						// A failed best-effort retry remains available through the retained cleanup maps.
+						// Precommit failures retain the live maps; tombstoned close failures
+						// retain the coordinator-owned retry entry. A finalizer never bypasses
+						// that state machine with a direct host close.
 					}
 				}
 				// Only an authoritative, successful no-row result proves this exact

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -228,6 +228,7 @@ import {
 	type RlmFindModelsResult,
 	type RlmListSubagentsResult,
 	type RlmSpawnHandle,
+	type RlmSubagentDeletionDurability,
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
 	type SubagentRuntimeHost,
@@ -1227,6 +1228,10 @@ export class AgentSession {
 	// Failed explicit deletes stay hidden from listings but retain their original
 	// selector so a later delete can retry cleanup without orphaning the runtime.
 	private _rlmChildCleanupFailures = new Map<string, RlmSubagentRegistryEntry>();
+	// A cancelled spawn whose durable deletion could not be proven has no public
+	// lifecycle status. Keep its private cleanup lease through finalization until a
+	// host later proves absence or a durable tombstone.
+	private _rlmChildDeletionQuarantines = new Map<string, RlmSubagentRegistryEntry>();
 	private _deletingRlmChildren = new Map<
 		string,
 		{
@@ -7307,6 +7312,11 @@ export class AgentSession {
 			(childId) => !this._activeRlmChildRuns.get(childId)?.detachedDeletion,
 		);
 		await Promise.allSettled(childIds.map((childId) => this.deleteRlmSubagent(childId)));
+		await Promise.allSettled(
+			[...this._rlmChildDeletionQuarantines.keys()].map((childId) =>
+				this._resolveRlmChildDeletionQuarantine(childId),
+			),
+		);
 	}
 
 	/**
@@ -9268,7 +9278,8 @@ export class AgentSession {
 			if (
 				this._deletingRlmChildren.has(childId) ||
 				recorded.has(childId) ||
-				this._rlmChildCleanupFailures.has(childId)
+				this._rlmChildCleanupFailures.has(childId) ||
+				this._rlmChildDeletionQuarantines.has(childId)
 			) {
 				continue;
 			}
@@ -9294,6 +9305,7 @@ export class AgentSession {
 				this._deletingRlmChildren.has(childId) ||
 				this._deletedRlmChildIds.has(childId) ||
 				this._rlmChildCleanupFailures.has(childId) ||
+				this._rlmChildDeletionQuarantines.has(childId) ||
 				!daemonChild.sessionDir
 			) {
 				continue;
@@ -9468,6 +9480,26 @@ export class AgentSession {
 		}
 	}
 
+	/**
+	 * Reconcile a private cancelled-spawn cleanup lease. `false` deliberately
+	 * means that durability is still unknown, never that deletion succeeded.
+	 */
+	private async _resolveRlmChildDeletionQuarantine(childId: string): Promise<boolean> {
+		const lease = this._rlmChildDeletionQuarantines.get(childId);
+		if (!lease || this._disposed || this._disposing) return false;
+		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId);
+		if (durability === "unknown" || durability === undefined) return false;
+		if (durability === "absent") {
+			// This is the sole path which removes the exact quarantined directory.
+			rmSync(lease.session_dir, { recursive: true, force: true });
+		}
+		// A durable tombstone owns the retained artifact; absence proves this exact
+		// directory is removable. Either conclusion discharges the private lease.
+		this._rlmChildDeletionQuarantines.delete(childId);
+		this._deletedRlmChildIds.add(childId);
+		return true;
+	}
+
 	private _deleteRlmSubagentSession(childId: string, session?: AgentSession): Promise<void> {
 		if (this._subagentRuntimeHost) {
 			return this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
@@ -9481,6 +9513,8 @@ export class AgentSession {
 		this._rlmChildUnsubscribes.delete(childId);
 		this._rlmChildSessions.delete(childId);
 		this._rlmChildCleanupFailures.delete(childId);
+		// Do not clear an unknown-deletion lease here: finalization is precisely the
+		// boundary it must survive.
 		if (!run || this._activeRlmChildRuns.get(childId) === run) {
 			this._activeRlmChildRuns.delete(childId);
 		}
@@ -9920,9 +9954,9 @@ export class AgentSession {
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
 			// A release hook is not itself proof that a cancelled, never-admitted
-			// child is durably unreachable. Only its verified retention outcome may
-			// preserve the artifact directory.
-			let releaseRetained = false;
+			// child is durably unreachable. Preserve uncertainty rather than deleting
+			// an artifact whose durable owner cannot be proven.
+			let deletionDurability: RlmSubagentDeletionDurability = "unknown";
 			try {
 				throwIfCancelled();
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
@@ -10043,7 +10077,7 @@ export class AgentSession {
 						await this._subagentRuntimeHost
 							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
 							.then((outcome) => {
-								releaseRetained = outcome.retained;
+								deletionDurability = outcome.deletionDurability;
 							})
 							.catch(() => void child.disposeAsync().catch(() => undefined));
 					} else {
@@ -10089,8 +10123,13 @@ export class AgentSession {
 							subagentOptions,
 							run.status === "cancelled" ? "cancelled" : "error",
 						);
-						releaseRetained = outcome.retained;
-						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
+						deletionDurability = outcome.deletionDurability;
+						if (
+							run.status === "cancelled" &&
+							deletionDurability !== "unknown" &&
+							!this._disposed &&
+							!this._disposing
+						) {
 							this._deletedRlmChildIds.add(run.id);
 							this._removeRlmSubagentTracking(run.id);
 						}
@@ -10105,6 +10144,9 @@ export class AgentSession {
 							await childSession.disposeAsync();
 						}
 						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
+							// The known dispose-only host owns no durable registry, so a successful
+							// fallback delete is affirmative absence rather than an I/O guess.
+							deletionDurability = "absent";
 							this._deletedRlmChildIds.add(run.id);
 							this._removeRlmSubagentTracking(run.id);
 						}
@@ -10112,11 +10154,25 @@ export class AgentSession {
 						// A failed best-effort retry remains available through the retained cleanup maps.
 					}
 				}
-				// A never-admitted cancelled child's dir is an orphan unless the release
-				// path verified durable ownership (for example, a daemon tombstone). A
-				// hook's presence alone does not make its artifact tree recoverable.
-				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion && !releaseRetained) {
-					rmSync(childSessionDir, { recursive: true, force: true });
+				// Only an authoritative, successful no-row result proves this exact
+				// never-admitted dir is ours to remove. A durable tombstone retains it;
+				// ambiguity is quarantined privately rather than being coerced into an
+				// active, idle, or inactive public child.
+				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion) {
+					if (deletionDurability === "absent") {
+						rmSync(childSessionDir, { recursive: true, force: true });
+					} else if (deletionDurability === "unknown" && !this._disposed && !this._disposing) {
+						// Preserve a private cleanup lease through finalization. Unlike an
+						// explicit-delete failure, it is neither listed nor selector-addressable.
+						this._rlmChildDeletionQuarantines.set(run.id, {
+							rlm_child_id: run.id,
+							active_session_id: null,
+							session_id: childSession?.sessionId ?? null,
+							session_name: sessionName,
+							session_dir: childSessionDir,
+							status: "error",
+						});
+					}
 				}
 			} finally {
 				if (run.detachedDeletion && childRuntime) {
@@ -10136,8 +10192,18 @@ export class AgentSession {
 						run.abort = noopRlmChildAbort;
 						run.unsubscribe = undefined;
 						run.session = undefined;
-					} else if (run.status !== "error" || run.detachedDeletion) {
+					} else if (
+						(run.status !== "error" || run.detachedDeletion) &&
+						!this._rlmChildCleanupFailures.has(run.id)
+					) {
 						this._removeRlmSubagentTracking(run.id, run);
+					} else if (this._rlmChildCleanupFailures.has(run.id)) {
+						// Unknown durability has a retry record but is not an active product
+						// child. Drop live tracking without clearing that internal record.
+						this._activeRlmChildRuns.delete(run.id);
+						run.unsubscribe?.();
+						run.abort = noopRlmChildAbort;
+						run.unsubscribe = undefined;
 					} else {
 						run.unsubscribe?.();
 						run.abort = noopRlmChildAbort;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10104,9 +10104,16 @@ export class AgentSession {
 						// A failed best-effort retry remains available through the retained cleanup maps.
 					}
 				}
-				// Nothing retains a never-admitted cancelled child, so its dir would be a
-				// permanent orphan. Removal happens after the dispose/release paths above.
-				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion) {
+				// A never-admitted cancelled child's dir is an orphan only when nothing
+				// durable references it. Once a runtime host produced a runtime or a
+				// session, its release/delete hooks own persistence (a daemon records a
+				// deleted registry entry that keeps the artifact tree on disk).
+				if (
+					!admissionCommitted &&
+					run.status === "cancelled" &&
+					!run.detachedDeletion &&
+					(!this._subagentRuntimeHost || (!childRuntime && !childSession))
+				) {
 					rmSync(childSessionDir, { recursive: true, force: true });
 				}
 			} finally {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10427,9 +10427,11 @@ export class AgentSession {
 												this._rlmChildSessions.set(run.id, finalizerSession);
 												this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
 											} else if (this._isPrecommitRlmSubagentDeletionFailure(releaseError)) {
-												// Keep the live host incarnation attached to the private unknown-
-												// durability lease so an exact-id retry can tombstone and close it.
+												// Keep the live host incarnation on an opaque retry lease. The
+												// completed-session map is public, so it must not project an
+												// uncommitted release as completed before an exact retry closes it.
 												this._rlmChildSessions.set(run.id, finalizerSession);
+												this._rlmChildDeletionQuarantines.set(run.id, finalizerSubagent);
 											}
 										}
 										throw releaseError;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9920,6 +9920,7 @@ export class AgentSession {
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
 			try {
+				throwIfCancelled();
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
 				const child = childRuntime.session;
 				if (run.status === "cancelled") throw new Error(run.error ?? "RLM child cancelled");
@@ -10052,7 +10053,9 @@ export class AgentSession {
 				durationMs = Date.now() - startedAt;
 				activity = undefined;
 				emitChildUpdate();
-				if (!run.detachedDeletion) {
+				// A never-admitted spawn already surfaced this outcome to its caller as the
+				// admission exception; a parent notice would duplicate it into the transcript.
+				if (admissionCommitted && !run.detachedDeletion) {
 					if (run.status === "error") {
 						await deliverTerminalMessageToParent(
 							createRlmChildFailureMessage({
@@ -10100,6 +10103,11 @@ export class AgentSession {
 					} catch {
 						// A failed best-effort retry remains available through the retained cleanup maps.
 					}
+				}
+				// Nothing retains a never-admitted cancelled child, so its dir would be a
+				// permanent orphan. Removal happens after the dispose/release paths above.
+				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion) {
+					rmSync(childSessionDir, { recursive: true, force: true });
 				}
 			} finally {
 				if (run.detachedDeletion && childRuntime) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9416,6 +9416,16 @@ export class AgentSession {
 		if (inFlight[0]) {
 			return inFlight[0].promise;
 		}
+		// Quarantine is deliberately absent from public list/roster/hydration, but
+		// the caller holding the exact opaque child id may explicitly retry its
+		// durability check. Names and session ids cannot address private leases.
+		const quarantined = this._rlmChildDeletionQuarantines.get(target);
+		if (quarantined) {
+			return this._trackRlmSubagentDeletion(quarantined, async () => {
+				await this._resolveRlmChildDeletionQuarantine(target);
+				return { subagent: quarantined };
+			});
+		}
 		if (localMatches[0]) {
 			const subagent = localMatches[0];
 			return this._trackRlmSubagentDeletion(subagent, async () => {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1203,6 +1203,8 @@ export class AgentSession {
 	// Set at the start of async teardown so a child finishing mid-disposeAsync doesn't
 	// re-populate the retained map after it's been cleared.
 	private _disposing = false;
+	/** Set before async teardown awaits so runtime rebuilds cannot replace its owned kernel. */
+	private _asyncTeardownStarted = false;
 	private _disposeAsyncPromise?: Promise<void>;
 	private _ipythonKernelProvisioner?: IpythonKernelProvisioner;
 	/** Artifact dir backing the current provisioner's kernel snapshot, if any. */
@@ -3778,24 +3780,46 @@ export class AgentSession {
 	 * the latest state reaches disk instead of racing process exit.
 	 */
 	async disposeAsync(): Promise<void> {
-		if (this._disposed) {
-			return this._disposeCallbacksPromise;
-		}
-		// Concurrent callers await the same in-flight teardown so none resolves before
-		// the kernel snapshot flush finishes.
+		// Concurrent and late callers await the same async teardown, including its
+		// terminal failure. A purely synchronous dispose has no such promise.
 		if (this._disposeAsyncPromise) {
 			return this._disposeAsyncPromise;
 		}
+		if (this._disposed) {
+			return this._disposeCallbacksPromise;
+		}
+		this._asyncTeardownStarted = true;
 		this._disposeAsyncPromise = (async () => {
-			// Drain before marking _disposing so a refine triggered at the final
-			// agent_end completes instead of being aborted by dispose().
-			await this._drainPendingRefinementForDisposal();
-			if (this._disposed) {
-				return this._disposeCallbacksPromise;
+			// Capture both operations before the first await. allSettled observes either
+			// rejection immediately while allowing the independent operation to finish.
+			const drain = this._drainPendingRefinementForDisposal();
+			const kernelDispose = this._ipythonKernelProvisioner?.dispose() ?? Promise.resolve();
+			const failures: unknown[] = [];
+			for (const result of await Promise.allSettled([kernelDispose, drain])) {
+				if (result.status === "rejected") failures.push(result.reason);
 			}
-			this._disposing = true;
-			this._sessionActionCommitDisposeAbortController.abort();
-			await this._disposeAsyncOnce();
+
+			// Drain before marking _disposing so a refine triggered at the final
+			// agent_end completes instead of being aborted by dispose(). Cleanup remains
+			// authoritative even when the drain or kernel teardown failed.
+			if (this._disposed) {
+				await this._disposeCallbacksPromise;
+			} else {
+				this._disposing = true;
+				this._sessionActionCommitDisposeAbortController.abort();
+				try {
+					await this._disposeAsyncOnce();
+				} catch (error) {
+					failures.push(error);
+				} finally {
+					// _disposeAsyncOnce normally owns finalization. Keep the same authority
+					// boundary if an earlier best-effort child cleanup unexpectedly throws.
+					this.dispose();
+					await this._disposeCallbacksPromise;
+				}
+			}
+			if (failures.length === 1) throw failures[0];
+			if (failures.length > 1) throw new AggregateError(failures, "Session disposal failed.");
 		})();
 		return this._disposeAsyncPromise;
 	}
@@ -3949,11 +3973,6 @@ export class AgentSession {
 		this._rlmChildSessions.clear();
 		this._rlmChildCleanupFailures.clear();
 		this._deletedRlmChildIds.clear();
-		try {
-			await this._ipythonKernelProvisioner?.dispose();
-		} catch {
-			// a failed kernel startup already cleaned up after itself
-		}
 		this.dispose();
 		await this._disposeCallbacksPromise;
 	}
@@ -8640,6 +8659,7 @@ export class AgentSession {
 		flagValues?: Map<string, boolean | string>;
 		includeAllExtensionTools?: boolean;
 	}): void {
+		if (this._asyncTeardownStarted) throw new Error("Cannot rebuild a session during disposal.");
 		const pythonSkills = getPythonSkillRuntimeInfo(this._modelVisibleSkills());
 		let configuredBaseToolDefinitions: Record<string, ToolDefinition>;
 		if (this._baseToolsOverride) {
@@ -8883,6 +8903,7 @@ export class AgentSession {
 	}
 
 	async reload(): Promise<void> {
+		if (this._asyncTeardownStarted) throw new Error("Cannot reload a session during disposal.");
 		const previousFlagValues = this._extensionRunner.getFlagValues();
 		await emitSessionShutdownEvent(this._extensionRunner, {
 			type: "session_shutdown",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9377,7 +9377,7 @@ export class AgentSession {
 	async deleteInactiveRlmSubagent(
 		childId: string,
 		isExternallyRunning: () => boolean = () => false,
-	): Promise<"deleted" | "not_found" | "running"> {
+	): Promise<"deleted" | "not_found" | "running" | "preserved_newer"> {
 		const isRunning = (): boolean => {
 			const status = this._activeRlmChildRuns.get(childId)?.status;
 			return status === "queued" || status === "running" || isExternallyRunning();
@@ -9412,7 +9412,9 @@ export class AgentSession {
 			}
 			return this._deleteResolvedRlmSubagent(subagent, authority);
 		});
-		return result.outcome === "skipped_running" ? "running" : "deleted";
+		if (result.outcome === "skipped_running") return "running";
+		if (result.outcome === "preserved_newer") return "preserved_newer";
+		return "deleted";
 	}
 
 	/** Delete a running, retained, or passive direct child selected from this parent session's registry. */
@@ -9752,7 +9754,7 @@ export class AgentSession {
 						this._activeRlmChildRuns.get(childId) !== run ||
 						run.session !== liveSession
 					) {
-						return { subagent };
+						return { subagent, outcome: "preserved_newer" };
 					}
 				} catch (error) {
 					if (this._disposed || this._disposing) {
@@ -9807,7 +9809,7 @@ export class AgentSession {
 				this._activeRlmChildRuns.has(childId) ||
 				this._rlmChildSessions.get(childId) !== retained
 			) {
-				return { subagent };
+				return { subagent, outcome: "preserved_newer" };
 			}
 		} catch (error) {
 			if (this._disposed || this._disposing) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9831,6 +9831,23 @@ export class AgentSession {
 			if (run.status === "cancelled") throw new Error(run.error ?? "RLM child cancelled");
 		};
 		this._activeRlmChildRuns.set(run.id, run);
+		// Revocation must be armed before the first queued update reaches subscribers:
+		// a subscriber can revoke the request authority as its reaction to that very
+		// update, and an abort listener attached afterwards would never fire.
+		let admissionCommitted = false;
+		const revokeAdmission = () => {
+			if (!admissionCommitted) this._cancelRlmChildRun(run, "host request authority was revoked");
+		};
+		if (requestAuthority) requestAuthority.signal.addEventListener("abort", revokeAdmission, { once: true });
+		try {
+			assertRequestCurrent();
+		} catch (error) {
+			if (requestAuthority) requestAuthority.signal.removeEventListener("abort", revokeAdmission);
+			this._cancelRlmChildRun(run, "host request authority was revoked");
+			this._activeRlmChildRuns.delete(run.id);
+			rmSync(childSessionDir, { recursive: true, force: true });
+			throw error;
+		}
 		const emitChildUpdate = () => {
 			const childModel = childSession?.model ?? modelSelection.model;
 			this._emit({
@@ -9900,12 +9917,6 @@ export class AgentSession {
 		// Runtime startup and the task run are deliberately detached. The public
 		// spawn resolves at admission, while this task owns live tracking, usage,
 		// retention, cancellation, and late-startup cleanup.
-		let admissionCommitted = false;
-		const revokeAdmission = () => {
-			if (!admissionCommitted) this._cancelRlmChildRun(run, "host request authority was revoked");
-		};
-		if (requestAuthority) requestAuthority.signal.addEventListener("abort", revokeAdmission, { once: true });
-		assertRequestCurrent();
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
 			try {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3789,15 +3789,17 @@ export class AgentSession {
 	 * Close external admission synchronously while leaving refinement and the final
 	 * kernel snapshot available to the orderly async teardown.
 	 */
-	private _beginClosing(): void {
+	private _beginClosing(
+		deliveryError = new Error("Session closed before prompt delivery."),
+		completionError = deliveryError,
+	): void {
 		if (this._closing || this._disposed) return;
 		this._closing = true;
 		this._sessionInputPumpRequested = false;
 		this._sessionInputPumpEpoch++;
 		this._sessionActionCommitDisposeAbortController.abort();
-		const error = new Error("Session closed before prompt delivery.");
-		this._rejectQueuedAgentMessageDeliveries(error, error);
-		this._cancelSessionActions(() => true, error);
+		this._rejectQueuedAgentMessageDeliveries(deliveryError, completionError);
+		this._cancelSessionActions(() => true, deliveryError);
 		this.agent.clearAllQueues();
 		this._notifySessionInputCheckpointChange();
 	}
@@ -4030,7 +4032,9 @@ export class AgentSession {
 		if (this._disposed) {
 			return;
 		}
-		this._beginClosing();
+		const deliveryError = new Error("Session disposed before prompt delivery.");
+		const completionError = new Error("Session disposed before prompt completion.");
+		this._beginClosing(deliveryError, completionError);
 		this._disposed = true;
 		this._sessionActionCommitDisposeAbortController.abort();
 		try {
@@ -4059,8 +4063,6 @@ export class AgentSession {
 			this._rlmChildCleanupFailures.clear();
 			this._deletedRlmChildIds.clear();
 			this._pendingNextTurnMessages = [];
-			const deliveryError = new Error("Session disposed before prompt delivery.");
-			const completionError = new Error("Session disposed before prompt completion.");
 			this._rejectQueuedAgentMessageDeliveries(deliveryError, completionError);
 			for (const [agentMessageId, outcome] of this._agentMessageOutcomes) {
 				if (outcome.delivery) this._settleAgentMessage(agentMessageId, "delivery", deliveryError);
@@ -4658,10 +4660,13 @@ export class AgentSession {
 	}
 
 	private async _prompt(text: string, options?: InternalPromptOptions): Promise<void> {
-		this._assertSessionActionAdmissionAvailable();
+		// A direct non-streaming prompt is the explicit resume path after abort.
+		// Preserve queued extension actions and admit this turn so the normal FIFO
+		// pump can drain them; other suspended admissions remain fail-closed.
 		if (!this.isStreaming) {
 			this._sessionInputPumpSuspended = false;
 		}
+		this._assertSessionActionAdmissionAvailable();
 		const commitFence = this.isStreaming
 			? undefined
 			: await this._acquireDirectTurnAdmissionFence(options?.signal).catch((error: unknown) => {
@@ -9786,7 +9791,17 @@ export class AgentSession {
 		const retained = this._rlmChildSessions.get(childId);
 		authority?.assertCurrent();
 		try {
-			await this._deleteRlmSubagentSession(childId, retained, authority);
+			const deletion = await this._deleteRlmSubagentSession(childId, retained, authority);
+			// A retained old incarnation can be disposed after its child id has
+			// been republished. Do not turn that stale cleanup into a removal event
+			// or clear the newer runtime's tracking.
+			if (
+				deletion.deletionDurability === "stale" ||
+				this._activeRlmChildRuns.has(childId) ||
+				this._rlmChildSessions.get(childId) !== retained
+			) {
+				return { subagent };
+			}
 		} catch (error) {
 			if (this._disposed || this._disposing) {
 				this._removeRlmSubagentTracking(childId);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10105,14 +10105,15 @@ export class AgentSession {
 					}
 				}
 				// A never-admitted cancelled child's dir is an orphan only when nothing
-				// durable references it. Once a runtime host produced a runtime or a
-				// session, its release/delete hooks own persistence (a daemon records a
-				// deleted registry entry that keeps the artifact tree on disk).
+				// durable references it. A host with a release hook records deletion
+				// durably (a daemon keeps the artifact tree for its deleted registry
+				// entry); a dispose-only host, like the default in-process runtime,
+				// persists nothing, so its dir is still an orphan to remove.
 				if (
 					!admissionCommitted &&
 					run.status === "cancelled" &&
 					!run.detachedDeletion &&
-					(!this._subagentRuntimeHost || (!childRuntime && !childSession))
+					(!this._subagentRuntimeHost?.releaseRlmSubagentRuntime || (!childRuntime && !childSession))
 				) {
 					rmSync(childSessionDir, { recursive: true, force: true });
 				}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1200,8 +1200,9 @@ export class AgentSession {
 	private _disposed = false;
 	private readonly _disposeCallbacks = new Set<() => void | Promise<void>>();
 	private _disposeCallbacksPromise?: Promise<void>;
-	// Set at the start of async teardown so a child finishing mid-disposeAsync doesn't
-	// re-populate the retained map after it's been cleared.
+	/** Monotonic synchronous fence for external work while orderly async teardown drains. */
+	private _closing = false;
+	// Set after orderly async drains so final disposal cleanup cannot schedule more work.
 	private _disposing = false;
 	/** Set before async teardown awaits so runtime rebuilds cannot replace its owned kernel. */
 	private _asyncTeardownStarted = false;
@@ -3775,6 +3776,23 @@ export class AgentSession {
 	 * Call this when completely done with the session.
 	 */
 	/**
+	 * Close external admission synchronously while leaving refinement and the final
+	 * kernel snapshot available to the orderly async teardown.
+	 */
+	private _beginClosing(): void {
+		if (this._closing || this._disposed) return;
+		this._closing = true;
+		this._sessionInputPumpRequested = false;
+		this._sessionInputPumpEpoch++;
+		this._sessionActionCommitDisposeAbortController.abort();
+		const error = new Error("Session closed before prompt delivery.");
+		this._rejectQueuedAgentMessageDeliveries(error, error);
+		this._cancelSessionActions(() => true, error);
+		this.agent.clearAllQueues();
+		this._notifySessionInputCheckpointChange();
+	}
+
+	/**
 	 * Async teardown for graceful quit/switch: await the IPython kernel's dispose
 	 * (which flushes a final namespace snapshot) before the synchronous dispose, so
 	 * the latest state reaches disk instead of racing process exit.
@@ -3789,6 +3807,7 @@ export class AgentSession {
 			return this._disposeCallbacksPromise;
 		}
 		this._asyncTeardownStarted = true;
+		this._beginClosing();
 		this._disposeAsyncPromise = (async () => {
 			// Capture both operations before the first await. allSettled observes either
 			// rejection immediately while allowing the independent operation to finish.
@@ -4001,6 +4020,7 @@ export class AgentSession {
 		if (this._disposed) {
 			return;
 		}
+		this._beginClosing();
 		this._disposed = true;
 		this._sessionActionCommitDisposeAbortController.abort();
 		try {
@@ -4047,6 +4067,15 @@ export class AgentSession {
 		} finally {
 			void this._startDisposeCallbacks();
 		}
+	}
+
+	/** Synchronously reject new external work before an owner begins async teardown. */
+	beginClosing(): void {
+		this._beginClosing();
+	}
+
+	get isClosing(): boolean {
+		return this._closing || this._disposing || this._disposed;
 	}
 
 	registerDisposeCallback(callback: () => void | Promise<void>): void {
@@ -5306,7 +5335,7 @@ export class AgentSession {
 	}
 
 	private _assertSessionActionAdmissionAvailable(): void {
-		if (this._disposed || this._disposing) {
+		if (this._closing || this._disposed || this._disposing) {
 			throw new Error("Cannot admit a session action because the session is disposing or disposed.");
 		}
 		if (this.unfinishedActionCount > 0 && this._sessionInputPumpSuspended) {
@@ -5327,7 +5356,7 @@ export class AgentSession {
 		disposition: "starts_when_admitted" | "queued";
 		ticket?: ActionTicket;
 	} {
-		if (this._disposed || this._disposing) {
+		if (this._closing || this._disposed || this._disposing) {
 			throw new Error("Cannot admit a session action because the session is disposing or disposed.");
 		}
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
@@ -5401,7 +5430,7 @@ export class AgentSession {
 			refinementApply: this._refineInFlight !== undefined,
 			branchMutation: this._branchSummaryOperation !== undefined,
 			schedulerPauseCount: this._queuedWorkPauses.size + (this._sessionInputPumpSuspended ? 1 : 0),
-			disposing: this._disposed || this._disposing,
+			disposing: this._closing || this._disposed || this._disposing,
 		};
 	}
 
@@ -5434,7 +5463,13 @@ export class AgentSession {
 
 	private _scheduleSessionInputPump(): void {
 		if (this._sessionInputPumpSuspended || this._queuedWorkPauses.size > 0) return;
-		if (this._disposed || this._disposing || this._sessionInputPumpRequested || !this._hasSelectableSessionInput()) {
+		if (
+			this._closing ||
+			this._disposed ||
+			this._disposing ||
+			this._sessionInputPumpRequested ||
+			!this._hasSelectableSessionInput()
+		) {
 			return;
 		}
 		this._sessionInputPumpRequested = true;
@@ -5450,7 +5485,7 @@ export class AgentSession {
 	private async _pumpSessionInputs(epoch: number): Promise<void> {
 		let blocked = false;
 		try {
-			while (!this._disposed && !this._disposing && this._hasSelectableSessionInput()) {
+			while (!this._closing && !this._disposed && !this._disposing && this._hasSelectableSessionInput()) {
 				await this.agent.waitForIdle();
 				const preselected = this._actionStore
 					.activeActions()
@@ -5656,6 +5691,7 @@ export class AgentSession {
 		if (point === "pump") {
 			return (
 				externalBusy ||
+				this._closing ||
 				this._disposed ||
 				this._disposing ||
 				this._sessionInputPumpSuspended ||

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -228,6 +228,7 @@ import {
 	type RlmFindModelsResult,
 	type RlmListSubagentsResult,
 	type RlmSpawnHandle,
+	type RlmSubagentDeletionAuthority,
 	type RlmSubagentDeletionDurability,
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
@@ -1232,10 +1233,18 @@ export class AgentSession {
 	// lifecycle status. Keep its private cleanup lease through finalization until a
 	// host later proves absence or a durable tombstone.
 	private _rlmChildDeletionQuarantines = new Map<string, RlmSubagentRegistryEntry>();
+	/**
+	 * One deletion transaction per child id. A transaction owns a monotonically
+	 * increasing generation and the exact registry entry/lease it was minted
+	 * for; neither a stale waiter nor a reused child id can commit with it.
+	 */
+	private _rlmChildDeletionGeneration = 0;
 	private _deletingRlmChildren = new Map<
 		string,
 		{
 			subagent: RlmSubagentRegistryEntry;
+			generation: number;
+			lease?: RlmSubagentRegistryEntry;
 			promise: Promise<RlmDeleteSubagentResult>;
 		}
 	>();
@@ -7312,9 +7321,17 @@ export class AgentSession {
 			(childId) => !this._activeRlmChildRuns.get(childId)?.detachedDeletion,
 		);
 		await Promise.allSettled(childIds.map((childId) => this.deleteRlmSubagent(childId)));
+		// Quarantine reconciliation shares the same per-child coordinator as an
+		// explicit retry. A reaper is a waiter/promotion candidate, never a
+		// second durable writer racing the user request.
 		await Promise.allSettled(
-			[...this._rlmChildDeletionQuarantines.keys()].map((childId) =>
-				this._resolveRlmChildDeletionQuarantine(childId),
+			[...this._rlmChildDeletionQuarantines.entries()].map(([childId, lease]) =>
+				this._coordinateRlmSubagentDeletion(lease, undefined, lease, async (authority) => {
+					if (!(await this._resolveRlmChildDeletionQuarantine(childId, authority))) {
+						throw new Error("RLM subagent deletion durability is still unknown");
+					}
+					return { subagent: lease };
+				}),
 			),
 		);
 	}
@@ -9376,11 +9393,11 @@ export class AgentSession {
 		if (isRunning()) {
 			return "running";
 		}
-		const result = await this._trackRlmSubagentDeletion(subagent, () => {
+		const result = await this._coordinateRlmSubagentDeletion(subagent, undefined, undefined, (authority) => {
 			if (isRunning()) {
 				return Promise.resolve({ subagent, outcome: "skipped_running" });
 			}
-			return this._deleteResolvedRlmSubagent(subagent);
+			return this._deleteResolvedRlmSubagent(subagent, authority);
 		});
 		return result.outcome === "skipped_running" ? "running" : "deleted";
 	}
@@ -9414,19 +9431,29 @@ export class AgentSession {
 			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
 		}
 		if (inFlight[0]) {
-			// A coalesced waiter retains its own revocation boundary rather than
-			// inheriting the initiating request's authority.
-			const result = await inFlight[0].promise;
-			assertDeleteAuthority();
-			return result;
+			// Join through the coordinator rather than returning the bare owner
+			// promise: if an aborted owner fails before commit, this live waiter can
+			// promote a fresh generation after it drains.
+			const joined = inFlight[0];
+			return this._coordinateRlmSubagentDeletion(joined.subagent, signal, joined.lease, (authority) => {
+				if (joined.lease) {
+					return this._resolveRlmChildDeletionQuarantine(joined.subagent.rlm_child_id, authority).then(
+						(resolved) => {
+							if (!resolved) throw new Error("RLM subagent deletion durability is still unknown");
+							return { subagent: joined.subagent };
+						},
+					);
+				}
+				return this._deleteResolvedRlmSubagent(joined.subagent, authority);
+			});
 		}
 		// Quarantine is deliberately absent from public list/roster/hydration, but
 		// the caller holding the exact opaque child id may explicitly retry its
 		// durability check. Names and session ids cannot address private leases.
 		const quarantined = this._rlmChildDeletionQuarantines.get(target);
 		if (quarantined) {
-			return this._trackRlmSubagentDeletion(quarantined, async () => {
-				if (!(await this._resolveRlmChildDeletionQuarantine(target, assertDeleteAuthority))) {
+			return this._coordinateRlmSubagentDeletion(quarantined, signal, quarantined, async (authority) => {
+				if (!(await this._resolveRlmChildDeletionQuarantine(target, authority))) {
 					throw new Error("RLM subagent deletion durability is still unknown");
 				}
 				return { subagent: quarantined };
@@ -9434,7 +9461,7 @@ export class AgentSession {
 		}
 		if (localMatches[0]) {
 			const subagent = localMatches[0];
-			return this._trackRlmSubagentDeletion(subagent, async () => {
+			return this._coordinateRlmSubagentDeletion(subagent, signal, undefined, async (authority) => {
 				const listedAgents = await this._agentMessageController?.listAgents();
 				const listedSubagents = this._buildRlmSubagentList(listedAgents).subagents;
 				const passiveMatches = listedSubagents.filter(
@@ -9456,8 +9483,8 @@ export class AgentSession {
 							session_name: daemonChild.sessionName ?? subagent.session_name,
 						}
 					: subagent;
-				assertDeleteAuthority();
-				return this._deleteResolvedRlmSubagent(resolvedSubagent);
+				authority.assertCurrent();
+				return this._deleteResolvedRlmSubagent(resolvedSubagent, authority);
 			});
 		}
 
@@ -9470,29 +9497,107 @@ export class AgentSession {
 			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
 		}
 		const subagent = directMatches[0] ?? (await this._resolveDirectRlmSubagent(target));
-		return this._trackRlmSubagentDeletion(subagent, () => {
-			assertDeleteAuthority();
-			return this._deleteResolvedRlmSubagent(subagent);
+		return this._coordinateRlmSubagentDeletion(subagent, signal, undefined, (authority) => {
+			authority.assertCurrent();
+			return this._deleteResolvedRlmSubagent(subagent, authority);
 		});
 	}
 
-	private async _trackRlmSubagentDeletion(
-		subagent: RlmSubagentRegistryEntry,
-		startDeletion: () => Promise<RlmDeleteSubagentResult>,
-	): Promise<RlmDeleteSubagentResult> {
-		const existing = this._deletingRlmChildren.get(subagent.rlm_child_id);
-		if (existing) return existing.promise;
-		const deletion = Promise.resolve().then(startDeletion);
-		this._deletingRlmChildren.set(subagent.rlm_child_id, {
-			subagent,
-			promise: deletion,
+	/** Await a shared durable attempt without transferring the caller's abort authority. */
+	private async _awaitRlmDeletionWithAuthority<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+		if (!signal) return promise;
+		if (signal.aborted) throw new Error("host request authority was revoked");
+		return await new Promise<T>((resolve, reject) => {
+			const abort = () => reject(new Error("host request authority was revoked"));
+			signal.addEventListener("abort", abort, { once: true });
+			void promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
 		});
-		try {
-			return await deletion;
-		} finally {
-			if (this._deletingRlmChildren.get(subagent.rlm_child_id)?.promise === deletion) {
-				this._deletingRlmChildren.delete(subagent.rlm_child_id);
+	}
+
+	/**
+	 * The sole deletion transaction coordinator. It serializes explicit retries
+	 * and compaction reapers by child id, then fences the owner with both a
+	 * monotonic generation and the exact child incarnation/lease. An owner that
+	 * loses request authority before commit leaves no mutation; a live waiter
+	 * retries as the next generation rather than inheriting stale authority.
+	 */
+	private async _coordinateRlmSubagentDeletion(
+		subagent: RlmSubagentRegistryEntry,
+		signal: AbortSignal | undefined,
+		lease: RlmSubagentRegistryEntry | undefined,
+		startDeletion: (authority: RlmSubagentDeletionAuthority) => Promise<RlmDeleteSubagentResult>,
+	): Promise<RlmDeleteSubagentResult> {
+		for (;;) {
+			if (signal?.aborted) throw new Error("host request authority was revoked");
+			const existing = this._deletingRlmChildren.get(subagent.rlm_child_id);
+			if (existing) {
+				// Same id is not enough: an id reuse must never join an older lease.
+				if (
+					existing.subagent.session_dir !== subagent.session_dir ||
+					existing.subagent.session_id !== subagent.session_id ||
+					existing.lease !== lease
+				) {
+					throw new Error("RLM subagent deletion lease changed");
+				}
+				try {
+					const result = await this._awaitRlmDeletionWithAuthority(existing.promise, signal);
+					if (signal?.aborted) throw new Error("host request authority was revoked");
+					return result;
+				} catch (error) {
+					// A request-scoped owner may have been revoked before its append
+					// boundary. A still-live explicit caller or reaper promotes itself
+					// after that owner drains, with a fresh never-reused generation.
+					if (
+						signal?.aborted ||
+						!(error instanceof Error) ||
+						error.message !== "host request authority was revoked"
+					) {
+						throw error;
+					}
+					await Promise.resolve();
+					continue;
+				}
 			}
+			const generation = ++this._rlmChildDeletionGeneration;
+			let authority!: RlmSubagentDeletionAuthority;
+			const deletion = Promise.resolve().then(() => startDeletion(authority));
+			authority = {
+				childId: subagent.rlm_child_id,
+				sessionDir: subagent.session_dir,
+				generation,
+				assertCurrent: () => {
+					if (signal?.aborted) throw new Error("host request authority was revoked");
+					const current = this._deletingRlmChildren.get(subagent.rlm_child_id);
+					if (
+						!current ||
+						current.generation !== generation ||
+						current.subagent !== subagent ||
+						current.lease !== lease ||
+						(lease && this._rlmChildDeletionQuarantines.get(subagent.rlm_child_id) !== lease)
+					) {
+						throw new Error("host request authority was revoked");
+					}
+				},
+			};
+			this._deletingRlmChildren.set(subagent.rlm_child_id, { subagent, generation, lease, promise: deletion });
+			// A request-scoped waiter may abort while the shared commit owner keeps
+			// running. Only the owner's settlement may release the single-flight
+			// slot; otherwise a later retry could append concurrently.
+			void deletion.then(
+				() => {
+					if (this._deletingRlmChildren.get(subagent.rlm_child_id)?.generation === generation) {
+						this._deletingRlmChildren.delete(subagent.rlm_child_id);
+					}
+				},
+				() => {
+					if (this._deletingRlmChildren.get(subagent.rlm_child_id)?.generation === generation) {
+						this._deletingRlmChildren.delete(subagent.rlm_child_id);
+					}
+				},
+			);
+			const result = await this._awaitRlmDeletionWithAuthority(deletion, signal);
+			if (signal?.aborted) throw new Error("host request authority was revoked");
+			return result;
 		}
 	}
 
@@ -9502,17 +9607,24 @@ export class AgentSession {
 	 */
 	private async _resolveRlmChildDeletionQuarantine(
 		childId: string,
-		assertDeleteAuthority: () => void = () => {},
+		authority?: RlmSubagentDeletionAuthority,
 	): Promise<boolean> {
 		const lease = this._rlmChildDeletionQuarantines.get(childId);
 		if (!lease || this._disposed || this._disposing) return false;
-		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId, {
-			assertCurrent: assertDeleteAuthority,
-		});
+		authority?.assertCurrent();
+		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(
+			childId,
+			authority ?? {
+				childId,
+				sessionDir: lease.session_dir,
+				generation: 0,
+				assertCurrent: () => {},
+			},
+		);
 		if (durability !== "absent" && durability !== "tombstoned") return false;
 		// The host await is a revocation boundary. Do not mutate the artifact or
 		// private deletion bookkeeping after its caller has lost authority.
-		assertDeleteAuthority();
+		authority?.assertCurrent();
 		// A retry/reaper can yield while the host reads. It may only discharge the
 		// exact lease it resolved, never a newer lease reusing this child id.
 		if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
@@ -9527,9 +9639,15 @@ export class AgentSession {
 		return true;
 	}
 
-	private _deleteRlmSubagentSession(childId: string, session?: AgentSession): Promise<void> {
+	private _deleteRlmSubagentSession(
+		childId: string,
+		session?: AgentSession,
+		authority?: RlmSubagentDeletionAuthority,
+	): Promise<void> {
 		if (this._subagentRuntimeHost) {
-			return this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
+			return authority
+				? this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session, authority)
+				: this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
 		}
 		return session?.disposeAsync() ?? Promise.resolve();
 	}
@@ -9568,22 +9686,29 @@ export class AgentSession {
 		});
 	}
 
-	private async _deleteResolvedRlmSubagent(subagent: RlmSubagentRegistryEntry): Promise<RlmDeleteSubagentResult> {
+	private async _deleteResolvedRlmSubagent(
+		subagent: RlmSubagentRegistryEntry,
+		authority?: RlmSubagentDeletionAuthority,
+	): Promise<RlmDeleteSubagentResult> {
+		// Nothing local is a durable commit. The host must assert the same token
+		// immediately before any durable/inline teardown; local publication only
+		// follows that successful boundary.
+		authority?.assertCurrent();
 		const childId = subagent.rlm_child_id;
 		const run = this._activeRlmChildRuns.get(childId);
 		if (run) {
-			if (!this._cancelRlmChildRun(run, "Deleted by parent orchestrator")) {
-				this._emitRlmSubagentRemoval(subagent);
-			}
 			const liveSession = run.session;
 			if (run.status === "error" && !liveSession && run.settled) {
+				authority?.assertCurrent();
+				this._emitRlmSubagentRemoval(subagent);
 				this._deletedRlmChildIds.add(childId);
 				this._removeRlmSubagentTracking(childId, run);
 				return { subagent };
 			}
 			if (liveSession) {
+				authority?.assertCurrent();
 				try {
-					await this._deleteRlmSubagentSession(childId, liveSession);
+					await this._deleteRlmSubagentSession(childId, liveSession, authority);
 				} catch (error) {
 					if (this._disposed || this._disposing) {
 						this._removeRlmSubagentTracking(childId, run);
@@ -9599,23 +9724,30 @@ export class AgentSession {
 					run.session = undefined;
 					throw error;
 				}
+				// The successful host call is the deletion boundary. Do not let a
+				// late reply abort undo a committed deletion.
+				if (!this._cancelRlmChildRun(run, "Deleted by parent orchestrator")) {
+					this._emitRlmSubagentRemoval(subagent);
+				}
 				this._deletedRlmChildIds.add(childId);
 				this._removeRlmSubagentTracking(childId, run);
 				return { subagent };
 			}
-
-			// Startup can be blocked in a host before it has a session to close. Admit
-			// deletion immediately, but retain the cancelled run as a hidden tombstone
-			// until startup settles so selectors cannot be reused underneath it.
+			// Startup has no session/host destruction boundary yet, so this mutation
+			// itself needs the request token immediately beforehand.
+			authority?.assertCurrent();
+			if (!this._cancelRlmChildRun(run, "Deleted by parent orchestrator")) {
+				this._emitRlmSubagentRemoval(subagent);
+			}
 			run.detachedDeletion = subagent;
 			this._deletedRlmChildIds.add(childId);
 			return { subagent };
 		}
 
-		this._emitRlmSubagentRemoval(subagent);
 		const retained = this._rlmChildSessions.get(childId);
+		authority?.assertCurrent();
 		try {
-			await this._deleteRlmSubagentSession(childId, retained);
+			await this._deleteRlmSubagentSession(childId, retained, authority);
 		} catch (error) {
 			if (this._disposed || this._disposing) {
 				this._removeRlmSubagentTracking(childId);
@@ -9625,6 +9757,7 @@ export class AgentSession {
 			}
 			throw error;
 		}
+		this._emitRlmSubagentRemoval(subagent);
 		this._deletedRlmChildIds.add(childId);
 		this._removeRlmSubagentTracking(childId);
 		return { subagent };

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10152,12 +10152,14 @@ export class AgentSession {
 		// retention, cancellation, and late-startup cleanup.
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
+			let runtimeCreationAttempted = false;
 			// A release hook is not itself proof that a cancelled, never-admitted
 			// child is durably unreachable. Preserve uncertainty rather than deleting
 			// an artifact whose durable owner cannot be proven.
-			let deletionDurability: RlmSubagentDeletionDurability = "unknown";
+			const deletionState: { durability: RlmSubagentDeletionDurability } = { durability: "unknown" };
 			try {
 				throwIfCancelled();
+				runtimeCreationAttempted = true;
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
 				const child = childRuntime.session;
 				if (run.status === "cancelled") throw new Error(run.error ?? "RLM child cancelled");
@@ -10300,10 +10302,10 @@ export class AgentSession {
 									"error",
 									authority,
 								);
-								deletionDurability = outcome?.deletionDurability ?? "unknown";
+								deletionState.durability = outcome?.deletionDurability ?? "unknown";
 							} else {
 								await this._deleteResolvedRlmSubagent(completionSubagent, authority);
-								deletionDurability = "absent";
+								deletionState.durability = "absent";
 							}
 							return { subagent: completionSubagent };
 						},
@@ -10342,6 +10344,7 @@ export class AgentSession {
 					}
 				}
 				if (!run.detachedDeletion && childSession) {
+					const finalizerSession = childSession;
 					// Error/cancellation finalizers share the exact deletion owner with
 					// explicit deletion and the compaction reaper.
 					const inFlight = this._deletingRlmChildren.get(run.id);
@@ -10351,6 +10354,7 @@ export class AgentSession {
 							rlm_child_id: run.id,
 							active_session_id: null,
 							session_id: childSession.sessionId,
+							...(childSession.sessionFile ? { session_file: childSession.sessionFile } : {}),
 							session_name: childSession.sessionName ?? sessionName,
 							session_dir: childSessionDir,
 							status: "error",
@@ -10365,28 +10369,28 @@ export class AgentSession {
 								if (this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 									try {
 										const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
-											childRuntime ?? { session: childSession },
+											childRuntime ?? { session: finalizerSession },
 											subagentOptions,
 											run.status === "cancelled" ? "cancelled" : "error",
 											authority,
 										);
-										deletionDurability = outcome?.deletionDurability ?? "unknown";
+										deletionState.durability = outcome?.deletionDurability ?? "unknown";
 									} catch (releaseError) {
 										if (!this._disposed && !this._disposing) {
 											if (this._isTombstonedRlmSubagentDeletionFailure(releaseError)) {
-												this._rlmChildSessions.set(run.id, childSession);
+												this._rlmChildSessions.set(run.id, finalizerSession);
 												this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
 											} else if (this._isPrecommitRlmSubagentDeletionFailure(releaseError)) {
 												// Keep the live host incarnation attached to the private unknown-
 												// durability lease so an exact-id retry can tombstone and close it.
-												this._rlmChildSessions.set(run.id, childSession);
+												this._rlmChildSessions.set(run.id, finalizerSession);
 											}
 										}
 										throw releaseError;
 									}
 									if (
 										run.status === "cancelled" &&
-										deletionDurability !== "unknown" &&
+										deletionState.durability !== "unknown" &&
 										!this._disposed &&
 										!this._disposing
 									) {
@@ -10396,7 +10400,7 @@ export class AgentSession {
 									return { subagent: finalizerSubagent };
 								}
 								const result = await this._deleteResolvedRlmSubagent(finalizerSubagent, authority);
-								deletionDurability = "absent";
+								deletionState.durability = "absent";
 								return result;
 							},
 						);
@@ -10411,9 +10415,12 @@ export class AgentSession {
 				// ambiguity is quarantined privately rather than being coerced into an
 				// active, idle, or inactive public child.
 				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion) {
-					if (deletionDurability === "absent") {
+					if (!runtimeCreationAttempted || deletionState.durability === "absent") {
+						// Before host creation begins, this exact reserved directory is still
+						// exclusively ours; no durability inference is required to remove it.
 						rmSync(childSessionDir, { recursive: true, force: true });
-					} else if (deletionDurability === "unknown" && !this._disposed && !this._disposing) {
+						deletionState.durability = "absent";
+					} else if (deletionState.durability === "unknown" && !this._disposed && !this._disposing) {
 						// Preserve a private cleanup lease through finalization. Unlike an
 						// explicit-delete failure, it is neither listed nor selector-addressable.
 						this._rlmChildDeletionQuarantines.set(run.id, {
@@ -10429,11 +10436,39 @@ export class AgentSession {
 				}
 			} finally {
 				if (run.detachedDeletion && childRuntime) {
-					// Startup may publish after deletion was requested. It must re-enter
-					// the same incarnation-fenced coordinator, never call the host directly.
-					await this._coordinateRlmSubagentDeletion(run.detachedDeletion, undefined, undefined, (authority) =>
-						this._deleteResolvedRlmSubagent(run.detachedDeletion!, authority),
-					).catch(() => undefined);
+					const publishedRuntime = childRuntime;
+					// The queued deletion may have completed before startup published an
+					// object. Join that exact owner, then release its settled single-flight
+					// slot before fencing and deleting the newly published incarnation.
+					const priorDeletion = this._deletingRlmChildren.get(run.id);
+					if (priorDeletion) {
+						await priorDeletion.promise.catch(() => undefined);
+						if (this._deletingRlmChildren.get(run.id) === priorDeletion) {
+							this._deletingRlmChildren.delete(run.id);
+						}
+					}
+					const publishedDeletion: RlmSubagentRegistryEntry = {
+						...run.detachedDeletion,
+						session_id: publishedRuntime.session.sessionId,
+						...(publishedRuntime.session.sessionFile
+							? { session_file: publishedRuntime.session.sessionFile }
+							: {}),
+					};
+					run.detachedDeletion = publishedDeletion;
+					await this._coordinateRlmSubagentDeletion(publishedDeletion, undefined, undefined, async (authority) => {
+						try {
+							await this._deleteRlmSubagentSession(run.id, publishedRuntime.session, authority);
+						} catch (error) {
+							if (!this._disposed && !this._disposing) {
+								this._rlmChildSessions.set(run.id, publishedRuntime.session);
+								this._rlmChildCleanupFailures.set(run.id, publishedDeletion);
+							}
+							throw error;
+						}
+						this._deletedRlmChildIds.add(run.id);
+						this._removeRlmSubagentTracking(run.id, run);
+						return { subagent: publishedDeletion };
+					}).catch(() => undefined);
 				}
 				if (this._activeRlmChildRuns.get(run.id) === run) {
 					if (this._rlmChildSessions.has(run.id)) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10427,11 +10427,9 @@ export class AgentSession {
 												this._rlmChildSessions.set(run.id, finalizerSession);
 												this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
 											} else if (this._isPrecommitRlmSubagentDeletionFailure(releaseError)) {
-												// Keep the live host incarnation on an opaque retry lease. The
-												// completed-session map is public, so it must not project an
-												// uncommitted release as completed before an exact retry closes it.
+												// Keep the live host incarnation attached to the private unknown-
+												// durability lease so an exact-id retry can tombstone and close it.
 												this._rlmChildSessions.set(run.id, finalizerSession);
-												this._rlmChildDeletionQuarantines.set(run.id, finalizerSubagent);
 											}
 										}
 										throw releaseError;

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -1359,6 +1359,8 @@ export class KernelManager {
 				if (context.signal.aborted) throw new Error("host request authority was revoked");
 				await this.sendCommMessage(commId, { status: "ok", ...result });
 			} catch (error) {
+				// A closed or replaced comm must not receive a stale error from its former request.
+				if (context.signal.aborted || this.activeHostRequestControllers.get(commId) !== controller) return;
 				this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
 				try {
 					await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) });

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -55,19 +55,13 @@ export class KernelBusyAfterInterruptError extends Error {
 /** Comm target the kernel-side `rlm.host_request` shim opens for typed host requests. */
 export const HOST_COMM_TARGET = "host.request";
 
-/**
- * Handles one typed request from Python code running in the kernel.
- * The returned record is sent back verbatim as the comm reply payload.
- *
- * This legacy unary compatibility alias remains the dispatcher and registration
- * contract while context-aware handlers are staged separately below.
- */
-export type HostRequestHandler = (payload: Record<string, unknown>) => Promise<Record<string, unknown>>;
+/** A host-request payload is data only; dispatch authority is never taken from it. */
+export type HostRequestPayload = Record<string, unknown>;
 
 /**
- * Per-call authority supplied by the host-request dispatcher.
- * `requestId` is an opaque host-minted correlation token and `isCurrent()`
- * lets an implementation reject work after its authority is revoked.
+ * Per-call authority minted by this dispatcher.  Although its TypeScript shape is
+ * exported for handler implementations, a value is accepted only when this module
+ * has registered its object identity for the active request.
  */
 export interface HostRequestContext {
 	readonly requestId: string;
@@ -77,48 +71,86 @@ export interface HostRequestContext {
 }
 
 const hostRequestHandlerBrand = Symbol("hostRequestHandler");
+const factoryCreatedHostRequestHandlers = new WeakSet<object>();
+const dispatcherCreatedHostRequestContexts = new WeakSet<object>();
 
-/** A context-aware implementation that must receive dispatcher authority. */
+/** Context-aware registrations are explicit; implementation arity is not authority. */
+export interface HostRequestHandlerOptions {
+	readonly contextAware: true;
+}
+
+/** The stable marker makes default/rest callbacks unambiguous without Function.length. */
+export const contextAwareHostRequestHandler: HostRequestHandlerOptions = Object.freeze({ contextAware: true });
+
+/** Implementations may use binary, rest, or default parameters; the marker is the authority contract. */
 export type HostRequestHandlerImplementation = (
-	payload: Record<string, unknown>,
-	context: HostRequestContext,
+	payload: HostRequestPayload,
+	context?: HostRequestContext,
 ) => Promise<Record<string, unknown>>;
 
-/** A factory-minted, context-aware host-request handler capability. */
-type HostRequestHandlerCapability = HostRequestHandlerImplementation & { readonly [hostRequestHandlerBrand]: true };
+/** Public registration shape; provenance is always checked at dispatch time. */
+export type HostRequestHandler = HostRequestHandlerImplementation;
 
-/** Runtime provenance cannot be recreated by copying the nominal symbol property. */
-const factoryCreatedHostRequestHandlers = new WeakSet<object>();
+/** A factory-minted capability. Raw, copied-brand, and fabricated handlers are rejected. */
+type HostRequestHandlerCapability = HostRequestHandler & { readonly [hostRequestHandlerBrand]: true };
 
 function assertGenuineHostRequestContext(context: unknown): asserts context is HostRequestContext {
-	if (
-		typeof context !== "object" ||
-		context === null ||
-		typeof (context as HostRequestContext).requestId !== "string" ||
-		!(context as HostRequestContext).requestId ||
-		!Number.isSafeInteger((context as HostRequestContext).generation) ||
-		typeof (context as HostRequestContext).isCurrent !== "function" ||
-		typeof (context as HostRequestContext).signal !== "object" ||
-		(context as HostRequestContext).signal === null ||
-		typeof (context as HostRequestContext).signal.aborted !== "boolean" ||
-		typeof (context as HostRequestContext).signal.addEventListener !== "function"
-	) {
+	if (typeof context !== "object" || context === null || !dispatcherCreatedHostRequestContexts.has(context)) {
 		throw new Error("host request context is invalid");
 	}
 }
 
+function mintHostRequestContext(
+	requestId: string,
+	generation: number,
+	controller: AbortController,
+): HostRequestContext {
+	let current = true;
+	const context: HostRequestContext = Object.freeze({
+		requestId,
+		generation,
+		signal: controller.signal,
+		isCurrent: () => current && !controller.signal.aborted,
+	});
+	dispatcherCreatedHostRequestContexts.add(context);
+	controller.signal.addEventListener(
+		"abort",
+		() => {
+			current = false;
+		},
+		{ once: true },
+	);
+	return context;
+}
+
+/** Test harness only: invokes through a freshly dispatcher-minted, immediately-live authority. */
+export async function invokeHostRequestHandlerForTest(
+	handler: HostRequestHandler,
+	payload: HostRequestPayload,
+): Promise<Record<string, unknown>> {
+	assertHostRequestHandler(handler);
+	const controller = new AbortController();
+	const context = mintHostRequestContext(uuid(), 0, controller);
+	try {
+		return await handler(payload, context);
+	} finally {
+		controller.abort();
+	}
+}
+
 /**
- * Creates a branded wrapper rather than mutating its implementation. Both its
- * generic shape and runtime arity reject unary callbacks before they can run.
+ * Factory registration deliberately requires an explicit capability marker. This
+ * accepts binary, rest, and default-parameter implementations without treating
+ * Function.length as a security boundary. A missing marker rejects a unary
+ * JavaScript registration before it can execute.
  */
-export function createHostRequestHandler<T extends HostRequestHandlerImplementation>(
-	implementation: T,
-	..._unaryRejection: Parameters<T> extends [unknown, unknown, ...unknown[]]
-		? []
-		: ["host request handlers must accept payload and context"]
-): HostRequestHandlerCapability {
-	if (implementation.length < 2) throw new Error("host request handlers must accept payload and context");
-	const handler = async (payload: Record<string, unknown>, context: HostRequestContext) => {
+export function createHostRequestHandler<
+	T extends (payload: HostRequestPayload, context: HostRequestContext) => Promise<Record<string, unknown>>,
+>(implementation: T, options: HostRequestHandlerOptions): HostRequestHandlerCapability {
+	if (options?.contextAware !== true) {
+		throw new Error("host request handlers require the context-aware marker");
+	}
+	const handler = async (payload: HostRequestPayload, context: HostRequestContext) => {
 		assertGenuineHostRequestContext(context);
 		return implementation(payload, context);
 	};
@@ -126,7 +158,7 @@ export function createHostRequestHandler<T extends HostRequestHandlerImplementat
 	return Object.defineProperty(handler, hostRequestHandlerBrand, { value: true }) as HostRequestHandlerCapability;
 }
 
-/** Reject copied-symbol and raw-function forgeries before they observe authenticated payloads. */
+/** Reject copied-symbol and raw-function forgeries before they observe payload data. */
 export function assertHostRequestHandler(value: unknown): asserts value is HostRequestHandlerCapability {
 	if (
 		typeof value !== "function" ||
@@ -616,6 +648,9 @@ export class KernelManager {
 	// attribute their spawning program.
 	private lastCellCode?: string;
 	private readonly inFlightHostRequests = new Set<Promise<void>>();
+	/** Active requests own revocable dispatcher authority, keyed by comm identity. */
+	private readonly activeHostRequestControllers = new Map<string, AbortController>();
+	private hostRequestGeneration = 0;
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
 	private startPromise?: Promise<void>;
@@ -1273,6 +1308,7 @@ export class KernelManager {
 		if (msgType === "comm_close") {
 			this.commTargets.delete(commId);
 			this.handledHostRequestCommIds.delete(commId);
+			this.revokeHostRequest(commId, "host request comm was closed");
 			return;
 		}
 
@@ -1294,22 +1330,26 @@ export class KernelManager {
 		}
 	}
 
-	private startHostRequestFromComm(commId: string, data: unknown): void {
-		if (this.handledHostRequestCommIds.has(commId)) {
-			return;
-		}
-		this.handledHostRequestCommIds.add(commId);
+	private revokeHostRequest(commId: string, _reason: string): void {
+		const controller = this.activeHostRequestControllers.get(commId);
+		if (controller && !controller.signal.aborted) controller.abort();
+	}
 
+	private revokeAllHostRequests(reason: string): void {
+		for (const commId of this.activeHostRequestControllers.keys()) this.revokeHostRequest(commId, reason);
+	}
+
+	private startHostRequestFromComm(commId: string, data: unknown): void {
+		if (this.handledHostRequestCommIds.has(commId)) return;
+		this.handledHostRequestCommIds.add(commId);
+		const controller = new AbortController();
+		this.activeHostRequestControllers.set(commId, controller);
+		const context = mintHostRequestContext(uuid(), ++this.hostRequestGeneration, controller);
 		const task = (async () => {
 			try {
-				const result = await this.handleHostRequest(data);
-				try {
-					await this.sendCommMessage(commId, { status: "ok", ...result });
-				} catch (replyError) {
-					this.appendKernelDiagnostic(
-						`failed to send host request ok reply for comm ${commId}: ${errorMessage(replyError)}`,
-					);
-				}
+				const result = await this.handleHostRequest(data, context);
+				if (context.signal.aborted) throw new Error("host request authority was revoked");
+				await this.sendCommMessage(commId, { status: "ok", ...result });
 			} catch (error) {
 				this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
 				try {
@@ -1323,27 +1363,23 @@ export class KernelManager {
 		})();
 		this.inFlightHostRequests.add(task);
 		void task.finally(() => {
+			controller.abort(); // settlement revokes a context retained by an asynchronous handler.
+			if (this.activeHostRequestControllers.get(commId) === controller)
+				this.activeHostRequestControllers.delete(commId);
 			this.inFlightHostRequests.delete(task);
 		});
 	}
 
-	private async handleHostRequest(data: unknown): Promise<Record<string, unknown>> {
-		if (!isRecord(data)) {
-			throw new Error("host request payload must be an object");
-		}
-		if (typeof data.type !== "string" || data.type.length === 0) {
+	private async handleHostRequest(data: unknown, context: HostRequestContext): Promise<Record<string, unknown>> {
+		if (!isRecord(data)) throw new Error("host request payload must be an object");
+		if (typeof data.type !== "string" || data.type.length === 0)
 			throw new Error("host request payload must have a string type");
-		}
-
 		const handler = this.options.hostHandlers?.[data.type];
-		if (!handler) {
-			throw new Error(`host request type "${data.type}" is not available in this session`);
-		}
-		// Tag the request with the cell that triggered it. A blocking call is still
-		// the in-flight execution; detached spawns (asyncio.create_task) fire after
-		// the scheduling cell goes idle, so fall back to that last cell's source.
+		if (!handler) throw new Error(`host request type "${data.type}" is not available in this session`);
+		// Prove registration provenance before creating the implementation payload.
+		assertHostRequestHandler(handler);
 		const cellSourceCode = this.activeExecution?.code ?? this.lastCellCode;
-		return handler({ ...data, cellSourceCode });
+		return handler({ ...data, cellSourceCode }, context);
 	}
 
 	private async sendCommMessage(commId: string, data: Record<string, unknown>): Promise<void> {
@@ -1362,6 +1398,7 @@ export class KernelManager {
 	}
 
 	private cleanupResources(killSignal: NodeJS.Signals = "SIGTERM"): void {
+		this.revokeAllHostRequests("kernel resources are being cleaned up");
 		this.clearSnapshotTimer();
 		this.lateSentAgentMessageHandlers.clear();
 		if (this.forkedLivenessTimer) {
@@ -1579,6 +1616,7 @@ export class KernelManager {
 			await this.flushSnapshotForDispose();
 			this.state = "shutdown";
 			liveKernels.delete(this);
+			this.revokeAllHostRequests("kernel is being disposed");
 			const inFlightHostRequests = [...this.inFlightHostRequests];
 			// TODO: plumb AbortSignal through AgentSession.prompt so disposal can cancel long-running child loops.
 			try {
@@ -1595,6 +1633,7 @@ export class KernelManager {
 	disposeSync(): void {
 		this.state = "shutdown";
 		liveKernels.delete(this);
+		this.revokeAllHostRequests("kernel is being disposed");
 		// TODO: replace this best-effort hard-exit path if Node exposes an awaitable process-exit cleanup hook.
 		this.cleanupResources();
 	}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -1394,7 +1394,8 @@ export class KernelManager {
 				return;
 			}
 			try {
-				await this.sendCommMessage(commId, { status: "ok", ...result });
+				// status goes last so handler payloads cannot override the protocol discriminator.
+				await this.sendCommMessage(commId, { ...result, status: "ok" });
 			} catch (replyError) {
 				this.appendKernelDiagnostic(
 					`failed to send host request ok reply for comm ${commId}: ${errorMessage(replyError)}`,

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -638,6 +638,10 @@ export class KernelManager {
 	private readonly activeHostRequestControllers = new Map<string, AbortController>();
 	/** Monotonic terminal admission gate: shutdown never grants new host-request authority. */
 	private hostRequestsClosed = false;
+	/** Incremented synchronously by every public terminal lifecycle entry point. */
+	private terminalRevision = 0;
+	/** Once terminal, this manager can never reopen host-request admission. */
+	private terminal = false;
 	private hostRequestGeneration = 0;
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
@@ -667,6 +671,9 @@ export class KernelManager {
 	}
 
 	async start(options: KernelStartOptions = {}): Promise<void> {
+		if (this.terminal) {
+			throw new Error("Kernel was disposed");
+		}
 		if (options.signal?.aborted) {
 			throw createKernelStartupAbortError();
 		}
@@ -807,6 +814,10 @@ export class KernelManager {
 			throw e;
 		}
 
+		if (this.terminal || this.state === "shutdown") {
+			this.cleanupResources();
+			throw new Error("Kernel was disposed during startup");
+		}
 		this.state = "running";
 		this.startForkedLivenessMonitor();
 	}
@@ -1453,7 +1464,16 @@ export class KernelManager {
 		}
 	}
 
-	async shutdown(opts: { snapshot?: boolean } = {}): Promise<void> {
+	/** Enter the one-way terminal state before any asynchronous teardown work begins. */
+	private enterTerminal(reason: string): void {
+		if (this.terminal) return;
+		this.terminal = true;
+		this.terminalRevision++;
+		this.beginHostRequestShutdown(reason);
+	}
+
+	/** Shutdown implementation shared with restart; unlike public shutdown, it is not terminal. */
+	private async shutdownInternal(opts: { snapshot?: boolean } = {}): Promise<void> {
 		this.beginHostRequestShutdown("kernel is shutting down");
 		if (this.state === "shutdown") {
 			liveKernels.delete(this);
@@ -1483,7 +1503,13 @@ export class KernelManager {
 		this.cleanupResources();
 	}
 
+	async shutdown(opts: { snapshot?: boolean } = {}): Promise<void> {
+		this.enterTerminal("kernel is shutting down");
+		await this.shutdownInternal(opts);
+	}
+
 	async restart(): Promise<void> {
+		const terminalRevision = this.terminalRevision;
 		const prev = this.executionQueue;
 		let resolveNext: () => void = () => {};
 		this.executionQueue = new Promise<void>((r) => {
@@ -1492,7 +1518,10 @@ export class KernelManager {
 		await prev;
 
 		try {
-			await this.shutdown();
+			await this.shutdownInternal();
+			if (this.terminal || terminalRevision !== this.terminalRevision) {
+				throw new Error("Kernel terminated during restart");
+			}
 			this.hostRequestsClosed = false;
 			this.state = "idle";
 			this.kernelStderr = "";
@@ -1503,7 +1532,7 @@ export class KernelManager {
 	}
 
 	async kill(): Promise<void> {
-		this.beginHostRequestShutdown("kernel is being killed");
+		this.enterTerminal("kernel is being killed");
 		this.state = "shutdown";
 		liveKernels.delete(this);
 		this.cleanupResources("SIGKILL");
@@ -1609,8 +1638,8 @@ export class KernelManager {
 
 	/** Graceful cleanup. Waits briefly for in-flight host request handlers before closing sockets. */
 	dispose(): Promise<void> {
+		this.enterTerminal("kernel is being disposed");
 		return (async () => {
-			this.beginHostRequestShutdown("kernel is being disposed");
 			// Final namespace flush while the kernel is still live (session end / reload).
 			await this.flushSnapshotForDispose();
 			this.state = "shutdown";
@@ -1629,7 +1658,7 @@ export class KernelManager {
 
 	/** Synchronous best-effort cleanup. Safe to call from `process.on('exit')`. */
 	disposeSync(): void {
-		this.beginHostRequestShutdown("kernel is being disposed");
+		this.enterTerminal("kernel is being disposed");
 		this.state = "shutdown";
 		liveKernels.delete(this);
 		// TODO: replace this best-effort hard-exit path if Node exposes an awaitable process-exit cleanup hook.

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -788,7 +788,7 @@ export class KernelManager {
 			this.connection = conn;
 		} catch (e) {
 			const canRetryStartup = (this.state as string) !== "shutdown";
-			await this.shutdown();
+			await this.shutdownInternal();
 			if (canRetryStartup) this.state = "idle";
 			throw e;
 		}
@@ -809,7 +809,7 @@ export class KernelManager {
 			await this.probeReady();
 		} catch (e) {
 			const canRetryStartup = (this.state as string) !== "shutdown";
-			await this.shutdown();
+			await this.shutdownInternal();
 			if (canRetryStartup) this.state = "idle";
 			throw e;
 		}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -688,6 +688,8 @@ export class KernelManager {
 
 	private async doStart(startOptions: KernelStartOptions): Promise<void> {
 		if (this.state !== "idle") return;
+		if (this.terminal) throw new Error("Kernel was disposed");
+		this.hostRequestsClosed = false;
 		this.state = "starting";
 		installSignalHandlersOnce();
 		// Tracked from the moment startup begins so session cleanup and signal

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -59,13 +59,12 @@ export const HOST_COMM_TARGET = "host.request";
 export type HostRequestPayload = Record<string, unknown>;
 
 /**
- * Per-call authority minted by this dispatcher.  Although its TypeScript shape is
+ * Per-call authority minted by this dispatcher. Although its TypeScript shape is
  * exported for handler implementations, a value is accepted only when this module
- * has registered its object identity for the active request.
+ * has registered its object identity. Revocation is observable via the signal.
  */
 export interface HostRequestContext {
 	readonly signal: AbortSignal;
-	isCurrent(): boolean;
 }
 
 const factoryCreatedHostRequestHandlers = new WeakSet<object>();
@@ -84,20 +83,8 @@ function assertGenuineHostRequestContext(context: unknown): asserts context is H
 }
 
 function mintHostRequestContext(controller: AbortController): HostRequestContext {
-	let current = true;
-	const context: HostRequestContext = Object.freeze({
-		signal: controller.signal,
-		isCurrent: () => current && !controller.signal.aborted,
-	});
+	const context: HostRequestContext = Object.freeze({ signal: controller.signal });
 	dispatcherCreatedHostRequestContexts.add(context);
-	controller.signal.addEventListener(
-		"abort",
-		() => {
-			current = false;
-			dispatcherCreatedHostRequestContexts.delete(context);
-		},
-		{ once: true },
-	);
 	return context;
 }
 
@@ -110,6 +97,7 @@ export function createHostRequestHandler<
 >(implementation: T): HostRequestHandler {
 	const handler = async (payload: HostRequestPayload, context: HostRequestContext) => {
 		assertGenuineHostRequestContext(context);
+		if (context.signal.aborted) throw new Error("host request authority was revoked");
 		return implementation(payload, context);
 	};
 	factoryCreatedHostRequestHandlers.add(handler);

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -74,14 +74,6 @@ const hostRequestHandlerBrand = Symbol("hostRequestHandler");
 const factoryCreatedHostRequestHandlers = new WeakSet<object>();
 const dispatcherCreatedHostRequestContexts = new WeakSet<object>();
 
-/** Context-aware registrations are explicit; implementation arity is not authority. */
-export interface HostRequestHandlerOptions {
-	readonly contextAware: true;
-}
-
-/** The stable marker makes default/rest callbacks unambiguous without Function.length. */
-export const contextAwareHostRequestHandler: HostRequestHandlerOptions = Object.freeze({ contextAware: true });
-
 /** Handlers receive dispatcher-minted context; provenance is always checked at dispatch time. */
 export type HostRequestHandler = (
 	payload: HostRequestPayload,
@@ -122,17 +114,12 @@ function mintHostRequestContext(
 }
 
 /**
- * Factory registration deliberately requires an explicit capability marker. This
- * accepts binary, rest, and default-parameter implementations without treating
- * Function.length as a security boundary. A missing marker rejects a unary
- * JavaScript registration before it can execute.
+ * Mint a host-request capability. Only factory-minted handlers are dispatched,
+ * and every call is gated on a dispatcher-minted context.
  */
 export function createHostRequestHandler<
 	T extends (payload: HostRequestPayload, context: HostRequestContext) => Promise<Record<string, unknown>>,
->(implementation: T, options: HostRequestHandlerOptions): HostRequestHandlerCapability {
-	if (options?.contextAware !== true) {
-		throw new Error("host request handlers require the context-aware marker");
-	}
+>(implementation: T): HostRequestHandlerCapability {
 	const handler = async (payload: HostRequestPayload, context: HostRequestContext) => {
 		assertGenuineHostRequestContext(context);
 		return implementation(payload, context);

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -923,11 +923,19 @@ export class KernelManager {
 	}
 
 	/** Queue and run a cell, serializing against all other executions. */
-	private async enqueueExecute(code: string, opts: ExecuteOptions): Promise<ExecuteResult> {
+	private async enqueueExecute(
+		code: string,
+		opts: ExecuteOptions,
+		lifecycle?: { allowTerminalRunning: true },
+	): Promise<ExecuteResult> {
 		if (opts.signal?.aborted) {
 			return { stdout: "", stderr: "", status: "aborted", durationMs: 0 };
 		}
-		await this.start({ signal: opts.signal });
+		if (lifecycle?.allowTerminalRunning) {
+			if (!this.terminal || !this.isRunning) throw new Error("Kernel is not running for terminal snapshot");
+		} else {
+			await this.start({ signal: opts.signal });
+		}
 		if ((this.state as string) === "shutdown") {
 			throw new Error("Kernel has been shut down");
 		}
@@ -1547,11 +1555,19 @@ export class KernelManager {
 	 * the kernel isn't running or no snapshot target was configured. Never throws.
 	 */
 	async snapshotState(): Promise<SnapshotResult | null> {
+		return this.snapshotStateInternal(false);
+	}
+
+	private async snapshotStateInternal(allowTerminalRunning: boolean): Promise<SnapshotResult | null> {
 		const cfg = this.options.snapshot;
 		if (!cfg || !this.isRunning) return null;
 		const code = buildSnapshotCode(cfg.path, cfg.manifestPath, cfg.maxBytes ?? DEFAULT_SNAPSHOT_MAX_BYTES);
 		try {
-			const r = await this.enqueueExecute(code, { maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS, internal: true });
+			const r = await this.enqueueExecute(
+				code,
+				{ maxOutputChars: SNAPSHOT_MAX_OUTPUT_CHARS, internal: true },
+				allowTerminalRunning ? { allowTerminalRunning: true } : undefined,
+			);
 			if (r.status !== "ok") {
 				this.appendKernelDiagnostic(`state snapshot failed: ${r.error?.evalue ?? r.stderr}`);
 				return null;
@@ -1634,7 +1650,7 @@ export class KernelManager {
 			if (timeout && typeof timeout === "object" && "unref" in timeout) timeout.unref();
 		});
 		try {
-			await Promise.race([this.snapshotState().then(() => undefined), guard]);
+			await Promise.race([this.snapshotStateInternal(true).then(() => undefined), guard]);
 		} finally {
 			if (timeout) clearTimeout(timeout);
 		}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -1359,9 +1359,9 @@ export class KernelManager {
 				if (context.signal.aborted) throw new Error("host request authority was revoked");
 				await this.sendCommMessage(commId, { status: "ok", ...result });
 			} catch (error) {
+				this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
 				// A closed or replaced comm must not receive a stale error from its former request.
 				if (context.signal.aborted || this.activeHostRequestControllers.get(commId) !== controller) return;
-				this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
 				try {
 					await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) });
 				} catch (replyError) {

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -1362,10 +1362,10 @@ export class KernelManager {
 		this.activeHostRequestControllers.set(commId, controller);
 		const context = mintHostRequestContext(uuid(), ++this.hostRequestGeneration, controller);
 		const task = (async () => {
+			let result: Record<string, unknown>;
 			try {
-				const result = await this.handleHostRequest(data, context);
+				result = await this.handleHostRequest(data, context);
 				if (context.signal.aborted) throw new Error("host request authority was revoked");
-				await this.sendCommMessage(commId, { status: "ok", ...result });
 			} catch (error) {
 				this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
 				// A closed or replaced comm must not receive a stale error from its former request.
@@ -1377,6 +1377,14 @@ export class KernelManager {
 						`failed to send host request error reply for comm ${commId}: ${errorMessage(replyError)}`,
 					);
 				}
+				return;
+			}
+			try {
+				await this.sendCommMessage(commId, { status: "ok", ...result });
+			} catch (replyError) {
+				this.appendKernelDiagnostic(
+					`failed to send host request ok reply for comm ${commId}: ${errorMessage(replyError)}`,
+				);
 			}
 		})();
 		this.inFlightHostRequests.add(task);

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -64,8 +64,6 @@ export type HostRequestPayload = Record<string, unknown>;
  * has registered its object identity for the active request.
  */
 export interface HostRequestContext {
-	readonly requestId: string;
-	readonly generation: number;
 	readonly signal: AbortSignal;
 	isCurrent(): boolean;
 }
@@ -89,15 +87,9 @@ function assertGenuineHostRequestContext(context: unknown): asserts context is H
 	}
 }
 
-function mintHostRequestContext(
-	requestId: string,
-	generation: number,
-	controller: AbortController,
-): HostRequestContext {
+function mintHostRequestContext(controller: AbortController): HostRequestContext {
 	let current = true;
 	const context: HostRequestContext = Object.freeze({
-		requestId,
-		generation,
 		signal: controller.signal,
 		isCurrent: () => current && !controller.signal.aborted,
 	});
@@ -626,7 +618,6 @@ export class KernelManager {
 	private terminalRevision = 0;
 	/** Once terminal, this manager can never reopen host-request admission. */
 	private terminal = false;
-	private hostRequestGeneration = 0;
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
 	private startPromise?: Promise<void>;
@@ -1358,7 +1349,7 @@ export class KernelManager {
 		this.handledHostRequestCommIds.add(commId);
 		const controller = new AbortController();
 		this.activeHostRequestControllers.set(commId, controller);
-		const context = mintHostRequestContext(uuid(), ++this.hostRequestGeneration, controller);
+		const context = mintHostRequestContext(controller);
 		const task = (async () => {
 			let result: Record<string, unknown>;
 			try {

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -636,6 +636,8 @@ export class KernelManager {
 	private readonly inFlightHostRequests = new Set<Promise<void>>();
 	/** Active requests own revocable dispatcher authority, keyed by comm identity. */
 	private readonly activeHostRequestControllers = new Map<string, AbortController>();
+	/** Monotonic terminal admission gate: shutdown never grants new host-request authority. */
+	private hostRequestsClosed = false;
 	private hostRequestGeneration = 0;
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
@@ -1325,7 +1327,14 @@ export class KernelManager {
 		for (const commId of this.activeHostRequestControllers.keys()) this.revokeHostRequest(commId, reason);
 	}
 
+	/** Close host-request admission before any terminal await can admit fresh authority. */
+	private beginHostRequestShutdown(reason: string): void {
+		this.hostRequestsClosed = true;
+		this.revokeAllHostRequests(reason);
+	}
+
 	private startHostRequestFromComm(commId: string, data: unknown): void {
+		if (this.hostRequestsClosed) return;
 		if (this.handledHostRequestCommIds.has(commId)) return;
 		this.handledHostRequestCommIds.add(commId);
 		const controller = new AbortController();
@@ -1384,7 +1393,7 @@ export class KernelManager {
 	}
 
 	private cleanupResources(killSignal: NodeJS.Signals = "SIGTERM"): void {
-		this.revokeAllHostRequests("kernel resources are being cleaned up");
+		this.beginHostRequestShutdown("kernel resources are being cleaned up");
 		this.clearSnapshotTimer();
 		this.lateSentAgentMessageHandlers.clear();
 		if (this.forkedLivenessTimer) {
@@ -1445,6 +1454,7 @@ export class KernelManager {
 	}
 
 	async shutdown(opts: { snapshot?: boolean } = {}): Promise<void> {
+		this.beginHostRequestShutdown("kernel is shutting down");
 		if (this.state === "shutdown") {
 			liveKernels.delete(this);
 			this.cleanupResources();
@@ -1492,6 +1502,7 @@ export class KernelManager {
 	}
 
 	async kill(): Promise<void> {
+		this.beginHostRequestShutdown("kernel is being killed");
 		this.state = "shutdown";
 		liveKernels.delete(this);
 		this.cleanupResources("SIGKILL");
@@ -1598,11 +1609,11 @@ export class KernelManager {
 	/** Graceful cleanup. Waits briefly for in-flight host request handlers before closing sockets. */
 	dispose(): Promise<void> {
 		return (async () => {
+			this.beginHostRequestShutdown("kernel is being disposed");
 			// Final namespace flush while the kernel is still live (session end / reload).
 			await this.flushSnapshotForDispose();
 			this.state = "shutdown";
 			liveKernels.delete(this);
-			this.revokeAllHostRequests("kernel is being disposed");
 			const inFlightHostRequests = [...this.inFlightHostRequests];
 			// TODO: plumb AbortSignal through AgentSession.prompt so disposal can cancel long-running child loops.
 			try {
@@ -1617,9 +1628,9 @@ export class KernelManager {
 
 	/** Synchronous best-effort cleanup. Safe to call from `process.on('exit')`. */
 	disposeSync(): void {
+		this.beginHostRequestShutdown("kernel is being disposed");
 		this.state = "shutdown";
 		liveKernels.delete(this);
-		this.revokeAllHostRequests("kernel is being disposed");
 		// TODO: replace this best-effort hard-exit path if Node exposes an awaitable process-exit cleanup hook.
 		this.cleanupResources();
 	}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -82,14 +82,11 @@ export interface HostRequestHandlerOptions {
 /** The stable marker makes default/rest callbacks unambiguous without Function.length. */
 export const contextAwareHostRequestHandler: HostRequestHandlerOptions = Object.freeze({ contextAware: true });
 
-/** Implementations receive dispatcher-minted context; the marker makes rest/default callbacks unambiguous. */
-export type HostRequestHandlerImplementation = (
+/** Handlers receive dispatcher-minted context; provenance is always checked at dispatch time. */
+export type HostRequestHandler = (
 	payload: HostRequestPayload,
 	context: HostRequestContext,
 ) => Promise<Record<string, unknown>>;
-
-/** Public registration shape; provenance is always checked at dispatch time. */
-export type HostRequestHandler = HostRequestHandlerImplementation;
 
 /** A factory-minted capability. Raw, copied-brand, and fabricated handlers are rejected. */
 type HostRequestHandlerCapability = HostRequestHandler & { readonly [hostRequestHandlerBrand]: true };

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -70,6 +70,13 @@ export interface HostRequestContext {
 const factoryCreatedHostRequestHandlers = new WeakSet<object>();
 const dispatcherCreatedHostRequestContexts = new WeakSet<object>();
 
+/** Compatibility marker accepted from unchanged context-aware registrations. */
+export interface HostRequestHandlerOptions {
+	readonly contextAware: true;
+}
+
+export const contextAwareHostRequestHandler: HostRequestHandlerOptions = Object.freeze({ contextAware: true });
+
 /** Handlers receive dispatcher-minted context; provenance is always checked at dispatch time. */
 export type HostRequestHandler = (
 	payload: HostRequestPayload,
@@ -94,7 +101,10 @@ function mintHostRequestContext(controller: AbortController): HostRequestContext
  */
 export function createHostRequestHandler<
 	T extends (payload: HostRequestPayload, context: HostRequestContext) => Promise<Record<string, unknown>>,
->(implementation: T): HostRequestHandler {
+>(implementation: T, options?: HostRequestHandlerOptions): HostRequestHandler {
+	if (options !== undefined && options.contextAware !== true) {
+		throw new Error("host request handler options are invalid");
+	}
 	const handler = async (payload: HostRequestPayload, context: HostRequestContext) => {
 		assertGenuineHostRequestContext(context);
 		if (context.signal.aborted) throw new Error("host request authority was revoked");

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -1493,6 +1493,7 @@ export class KernelManager {
 
 		try {
 			await this.shutdown();
+			this.hostRequestsClosed = false;
 			this.state = "idle";
 			this.kernelStderr = "";
 			await this.start();

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -82,10 +82,10 @@ export interface HostRequestHandlerOptions {
 /** The stable marker makes default/rest callbacks unambiguous without Function.length. */
 export const contextAwareHostRequestHandler: HostRequestHandlerOptions = Object.freeze({ contextAware: true });
 
-/** Implementations may use binary, rest, or default parameters; the marker is the authority contract. */
+/** Implementations receive dispatcher-minted context; the marker makes rest/default callbacks unambiguous. */
 export type HostRequestHandlerImplementation = (
 	payload: HostRequestPayload,
-	context?: HostRequestContext,
+	context: HostRequestContext,
 ) => Promise<Record<string, unknown>>;
 
 /** Public registration shape; provenance is always checked at dispatch time. */
@@ -121,21 +121,6 @@ function mintHostRequestContext(
 		{ once: true },
 	);
 	return context;
-}
-
-/** Test harness only: invokes through a freshly dispatcher-minted, immediately-live authority. */
-export async function invokeHostRequestHandlerForTest(
-	handler: HostRequestHandler,
-	payload: HostRequestPayload,
-): Promise<Record<string, unknown>> {
-	assertHostRequestHandler(handler);
-	const controller = new AbortController();
-	const context = mintHostRequestContext(uuid(), 0, controller);
-	try {
-		return await handler(payload, context);
-	} finally {
-		controller.abort();
-	}
 }
 
 /**

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -68,7 +68,6 @@ export interface HostRequestContext {
 	isCurrent(): boolean;
 }
 
-const hostRequestHandlerBrand = Symbol("hostRequestHandler");
 const factoryCreatedHostRequestHandlers = new WeakSet<object>();
 const dispatcherCreatedHostRequestContexts = new WeakSet<object>();
 
@@ -77,9 +76,6 @@ export type HostRequestHandler = (
 	payload: HostRequestPayload,
 	context: HostRequestContext,
 ) => Promise<Record<string, unknown>>;
-
-/** A factory-minted capability. Raw, copied-brand, and fabricated handlers are rejected. */
-type HostRequestHandlerCapability = HostRequestHandler & { readonly [hostRequestHandlerBrand]: true };
 
 function assertGenuineHostRequestContext(context: unknown): asserts context is HostRequestContext {
 	if (typeof context !== "object" || context === null || !dispatcherCreatedHostRequestContexts.has(context)) {
@@ -111,22 +107,18 @@ function mintHostRequestContext(controller: AbortController): HostRequestContext
  */
 export function createHostRequestHandler<
 	T extends (payload: HostRequestPayload, context: HostRequestContext) => Promise<Record<string, unknown>>,
->(implementation: T): HostRequestHandlerCapability {
+>(implementation: T): HostRequestHandler {
 	const handler = async (payload: HostRequestPayload, context: HostRequestContext) => {
 		assertGenuineHostRequestContext(context);
 		return implementation(payload, context);
 	};
 	factoryCreatedHostRequestHandlers.add(handler);
-	return Object.defineProperty(handler, hostRequestHandlerBrand, { value: true }) as HostRequestHandlerCapability;
+	return handler;
 }
 
-/** Reject copied-symbol and raw-function forgeries before they observe payload data. */
-export function assertHostRequestHandler(value: unknown): asserts value is HostRequestHandlerCapability {
-	if (
-		typeof value !== "function" ||
-		(value as Partial<HostRequestHandlerCapability>)[hostRequestHandlerBrand] !== true ||
-		!factoryCreatedHostRequestHandlers.has(value)
-	) {
+/** Reject raw-function forgeries before they observe payload data. */
+export function assertHostRequestHandler(value: unknown): asserts value is HostRequestHandler {
+	if (typeof value !== "function" || !factoryCreatedHostRequestHandlers.has(value)) {
 		throw new Error("host request handler is not a dispatcher-created capability");
 	}
 }

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -789,9 +789,7 @@ export class KernelManager {
 			conn = await this.waitForResolvedConnection(connectionPath);
 			this.connection = conn;
 		} catch (e) {
-			const canRetryStartup = (this.state as string) !== "shutdown";
-			await this.shutdownInternal();
-			if (canRetryStartup) this.state = "idle";
+			await this.cleanupFailedStartupForRetry();
 			throw e;
 		}
 
@@ -810,9 +808,7 @@ export class KernelManager {
 		try {
 			await this.probeReady();
 		} catch (e) {
-			const canRetryStartup = (this.state as string) !== "shutdown";
-			await this.shutdownInternal();
-			if (canRetryStartup) this.state = "idle";
+			await this.cleanupFailedStartupForRetry();
 			throw e;
 		}
 
@@ -822,6 +818,15 @@ export class KernelManager {
 		}
 		this.state = "running";
 		this.startForkedLivenessMonitor();
+	}
+
+	private async cleanupFailedStartupForRetry(): Promise<void> {
+		const terminalRevision = this.terminalRevision;
+		await this.shutdownInternal();
+		if (!this.terminal && terminalRevision === this.terminalRevision && this.state === "shutdown") {
+			this.hostRequestsClosed = false;
+			this.state = "idle";
+		}
 	}
 
 	// A forked kernel isn't a direct child, so no "exit" fires when it dies. Poll its

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -117,6 +117,7 @@ function mintHostRequestContext(
 		"abort",
 		() => {
 			current = false;
+			dispatcherCreatedHostRequestContexts.delete(context);
 		},
 		{ once: true },
 	);

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -814,7 +814,7 @@ export class KernelManager {
 			throw e;
 		}
 
-		if (this.terminal || this.state === "shutdown") {
+		if (this.terminal) {
 			this.cleanupResources();
 			throw new Error("Kernel was disposed during startup");
 		}

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -936,6 +936,9 @@ export class KernelManager {
 		if (opts.signal?.aborted) {
 			return { stdout: "", stderr: "", status: "aborted", durationMs: 0 };
 		}
+		if (this.terminal && !lifecycle?.allowTerminalRunning) {
+			throw new Error("Kernel was disposed");
+		}
 		if (lifecycle?.allowTerminalRunning) {
 			if (!this.terminal || !this.isRunning) throw new Error("Kernel is not running for terminal snapshot");
 		} else {
@@ -954,12 +957,18 @@ export class KernelManager {
 
 		const started = Date.now();
 		try {
+			if (this.terminal && !lifecycle?.allowTerminalRunning) {
+				throw new Error("Kernel was disposed");
+			}
 			await this.waitForActiveExecutionToClearForReuse(opts.signal);
 			if (opts.signal?.aborted) {
 				return { stdout: "", stderr: "", status: "aborted", durationMs: Date.now() - started };
 			}
 			if ((this.state as string) === "shutdown") {
 				throw new Error("Kernel has been shut down");
+			}
+			if (this.terminal && !lifecycle?.allowTerminalRunning) {
+				throw new Error("Kernel was disposed");
 			}
 			return await this.executeInner(code, opts, started);
 		} finally {

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -9,7 +9,7 @@ import {
 } from "@earendil-works/pi-ai/mcp";
 import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import type { AuthStorage } from "../auth-storage.js";
-import { createHostRequestHandler, type HostRequestHandlers } from "../kernel/index.js";
+import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandlers } from "../kernel/index.js";
 import type { McpServerConfig } from "../settings-manager.js";
 
 export interface McpManagerOptions {
@@ -165,7 +165,7 @@ export class McpManager {
 				const key = await this.authStorage.getApiKey(this.providerId(server));
 				if (!key) throw new Error(`Could not refresh credentials for ${server}`);
 				return {};
-			}),
+			}, contextAwareHostRequestHandler),
 			// Resolved config so the kernel skill connects to the same URL the host
 			// registered/authenticated (honors a user's mcpServers `url` override).
 			"mcp.config": createHostRequestHandler(async (payload, _context) => {
@@ -178,7 +178,7 @@ export class McpManager {
 					config.headers = integration.headers;
 				}
 				return config;
-			}),
+			}, contextAwareHostRequestHandler),
 		};
 		// Only expose begin_login when an interactive login is actually wired, so the
 		// kernel doesn't get a handler whose only behavior is to throw.
@@ -189,7 +189,7 @@ export class McpManager {
 				if (!server) throw new Error("mcp.begin_login requires a server");
 				await beginLogin(server);
 				return {};
-			});
+			}, contextAwareHostRequestHandler);
 		}
 		return handlers;
 	}

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -9,6 +9,7 @@ import {
 } from "@earendil-works/pi-ai/mcp";
 import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import type { AuthStorage } from "../auth-storage.js";
+import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandlers } from "../kernel/index.js";
 import type { McpServerConfig } from "../settings-manager.js";
 
 export interface McpManagerOptions {
@@ -153,9 +154,9 @@ export class McpManager {
 	}
 
 	/** Host-request handlers exposed to the kernel. */
-	hostHandlers(): Record<string, (payload: Record<string, unknown>) => Promise<Record<string, unknown>>> {
-		const handlers: Record<string, (payload: Record<string, unknown>) => Promise<Record<string, unknown>>> = {
-			"mcp.refresh": async (payload) => {
+	hostHandlers(): HostRequestHandlers {
+		const handlers: HostRequestHandlers = {
+			"mcp.refresh": createHostRequestHandler(async (payload, _context) => {
 				const server = String(payload.server ?? "");
 				if (!server) throw new Error("mcp.refresh requires a server");
 				// getApiKey refreshes + rewrites auth.json under lock; Python re-reads.
@@ -164,10 +165,10 @@ export class McpManager {
 				const key = await this.authStorage.getApiKey(this.providerId(server));
 				if (!key) throw new Error(`Could not refresh credentials for ${server}`);
 				return {};
-			},
+			}, contextAwareHostRequestHandler),
 			// Resolved config so the kernel skill connects to the same URL the host
 			// registered/authenticated (honors a user's mcpServers `url` override).
-			"mcp.config": async (payload) => {
+			"mcp.config": createHostRequestHandler(async (payload, _context) => {
 				const server = String(payload.server ?? "");
 				if (!server) throw new Error("mcp.config requires a server");
 				const integration = this.integrations.get(server);
@@ -177,18 +178,18 @@ export class McpManager {
 					config.headers = integration.headers;
 				}
 				return config;
-			},
+			}, contextAwareHostRequestHandler),
 		};
 		// Only expose begin_login when an interactive login is actually wired, so the
 		// kernel doesn't get a handler whose only behavior is to throw.
 		const beginLogin = this.beginLogin;
 		if (beginLogin) {
-			handlers["mcp.begin_login"] = async (payload) => {
+			handlers["mcp.begin_login"] = createHostRequestHandler(async (payload, _context) => {
 				const server = String(payload.server ?? "");
 				if (!server) throw new Error("mcp.begin_login requires a server");
 				await beginLogin(server);
 				return {};
-			};
+			}, contextAwareHostRequestHandler);
 		}
 		return handlers;
 	}

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -9,7 +9,7 @@ import {
 } from "@earendil-works/pi-ai/mcp";
 import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import type { AuthStorage } from "../auth-storage.js";
-import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandlers } from "../kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandlers } from "../kernel/index.js";
 import type { McpServerConfig } from "../settings-manager.js";
 
 export interface McpManagerOptions {
@@ -165,7 +165,7 @@ export class McpManager {
 				const key = await this.authStorage.getApiKey(this.providerId(server));
 				if (!key) throw new Error(`Could not refresh credentials for ${server}`);
 				return {};
-			}, contextAwareHostRequestHandler),
+			}),
 			// Resolved config so the kernel skill connects to the same URL the host
 			// registered/authenticated (honors a user's mcpServers `url` override).
 			"mcp.config": createHostRequestHandler(async (payload, _context) => {
@@ -178,7 +178,7 @@ export class McpManager {
 					config.headers = integration.headers;
 				}
 				return config;
-			}, contextAwareHostRequestHandler),
+			}),
 		};
 		// Only expose begin_login when an interactive login is actually wired, so the
 		// kernel doesn't get a handler whose only behavior is to throw.
@@ -189,7 +189,7 @@ export class McpManager {
 				if (!server) throw new Error("mcp.begin_login requires a server");
 				await beginLogin(server);
 				return {};
-			}, contextAwareHostRequestHandler);
+			});
 		}
 		return handlers;
 	}

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -26,6 +26,8 @@ export interface RlmSubagentRegistryEntry {
 	rlm_child_id: string;
 	active_session_id: string | null;
 	session_id: string | null;
+	/** Persisted session path, when daemon discovery can identify this incarnation. */
+	session_file?: string;
 	session_name: string;
 	session_dir: string;
 	status: RlmSubagentRegistryStatus;
@@ -277,6 +279,12 @@ export interface RlmSubagentDeletionAuthority {
 	/** Exact child incarnation this attempt is allowed to reconcile. */
 	childId: string;
 	sessionDir: string;
+	/**
+	 * Persisted/runtime incarnation fences. Passive deletion has no object
+	 * reference, so it must carry at least one of these when discovery has it.
+	 */
+	sessionFile?: string;
+	sessionId?: string;
 	/** Monotonic per-parent attempt token; never reused after an aborted owner. */
 	generation: number;
 	/**

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -240,6 +240,35 @@ export interface RlmSubagentReleaseOutcome {
 	deletionDurability: RlmSubagentDeletionDurability;
 }
 
+/** The durable phase reached by a host-owned deletion attempt. */
+export type RlmSubagentDeletionPhase = "precommit" | "tombstoned";
+
+/** A successful host deletion always proves a concrete durable outcome. */
+export interface RlmSubagentHostDeletionResult {
+	deletionDurability: Exclude<RlmSubagentDeletionDurability, "unknown">;
+}
+
+/**
+ * A typed host deletion failure. `precommit` guarantees that no durable
+ * tombstone was appended, so the caller must leave its live child tracking
+ * untouched. `tombstoned` means the registry commit is authoritative and only
+ * runtime cleanup remains retryable.
+ */
+export class RlmSubagentHostDeletionError extends Error {
+	readonly phase: RlmSubagentDeletionPhase;
+
+	constructor(phase: RlmSubagentDeletionPhase, cause: unknown) {
+		super(
+			phase === "precommit"
+				? "RLM subagent deletion did not commit"
+				: "RLM subagent tombstone committed but runtime close failed",
+			{ cause },
+		);
+		this.name = "RlmSubagentHostDeletionError";
+		this.phase = phase;
+	}
+}
+
 /**
  * Authority held by the exact host request that asked to reconcile a private
  * deletion lease. This is a typed host contract, never child-controlled data.
@@ -267,6 +296,7 @@ export interface SubagentRuntimeHost {
 		runtime: RlmSubagentRuntime,
 		options: CreateRlmSubagentRuntimeOptions,
 		status: "done" | "error" | "cancelled",
+		authority?: RlmSubagentDeletionAuthority,
 	) => Promise<RlmSubagentReleaseOutcome>;
 	/** Re-check a release whose durability was unknown, without inventing a public child status. */
 	resolveRlmSubagentDeletion?(
@@ -278,6 +308,6 @@ export interface SubagentRuntimeHost {
 		childId: string,
 		session?: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<void>;
+	): Promise<RlmSubagentHostDeletionResult | undefined>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -11,7 +11,6 @@ export interface RlmRunRequest {
 	cellSourceCode?: string;
 	/** Dispatcher authority for this admission; revoked requests must not spawn. */
 	signal: AbortSignal;
-	isCurrent(): boolean;
 }
 
 export interface RlmSpawnHandle {
@@ -159,13 +158,11 @@ export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHand
 		}
 		const kwargs = isRecord(payload.kwargs) ? payload.kwargs : {};
 		const cellSourceCode = typeof payload.cellSourceCode === "string" ? payload.cellSourceCode : undefined;
-		if (context.signal.aborted || !context.isCurrent()) throw new Error("host request authority was revoked");
 		const result = await handler({
 			prompt: payload.prompt,
 			kwargs,
 			cellSourceCode,
 			signal: context.signal,
-			isCurrent: () => context.isCurrent(),
 		});
 		return result as unknown as Record<string, unknown>;
 	});

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -240,6 +240,14 @@ export interface RlmSubagentReleaseOutcome {
 	deletionDurability: RlmSubagentDeletionDurability;
 }
 
+/**
+ * Authority held by the exact host request that asked to reconcile a private
+ * deletion lease. This is a typed host contract, never child-controlled data.
+ */
+export interface RlmSubagentDeletionAuthority {
+	assertCurrent(): void;
+}
+
 export interface SubagentRuntimeHost {
 	createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime>;
 	/** Persist host-owned completion before the child becomes passivation-eligible. */
@@ -251,7 +259,10 @@ export interface SubagentRuntimeHost {
 		status: "done" | "error" | "cancelled",
 	) => Promise<RlmSubagentReleaseOutcome>;
 	/** Re-check a release whose durability was unknown, without inventing a public child status. */
-	resolveRlmSubagentDeletion?(childId: string): Promise<RlmSubagentDeletionDurability>;
+	resolveRlmSubagentDeletion?(
+		childId: string,
+		authority: RlmSubagentDeletionAuthority,
+	): Promise<RlmSubagentDeletionDurability>;
 	/** Close or remove the host-owned child; session is absent when a persisted child is still passive. */
 	deleteRlmSubagentRuntime(childId: string, session?: AgentSession): Promise<void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -53,7 +53,7 @@ export interface RlmFindModelsResult {
 
 export type RlmRunHandler = (request: RlmRunRequest) => Promise<Record<string, unknown>>;
 export type RlmListSubagentsHandler = () => RlmListSubagentsResult | Promise<RlmListSubagentsResult>;
-export type RlmDeleteSubagentHandler = (target: string) => Promise<RlmDeleteSubagentResult>;
+export type RlmDeleteSubagentHandler = (target: string, signal: AbortSignal) => Promise<RlmDeleteSubagentResult>;
 export type RlmFindModelsHandler = (query: string, limit: number) => RlmFindModelsResult | Promise<RlmFindModelsResult>;
 
 const RLM_SUBAGENT_SESSION_NAME_MAX_LENGTH = 64;
@@ -192,11 +192,11 @@ export function createRlmListSubagentsHostHandler(handler: RlmListSubagentsHandl
 
 /** Delete one direct child selected from the current parent session's registry. */
 export function createRlmDeleteSubagentHostHandler(handler: RlmDeleteSubagentHandler): HostRequestHandler {
-	return createHostRequestHandler(async (payload, _context) => {
+	return createHostRequestHandler(async (payload, context) => {
 		if (typeof payload.target !== "string" || !payload.target.trim()) {
 			throw new Error("rlm.delete_subagent target must be a non-empty string");
 		}
-		const { subagent, outcome } = await handler(payload.target.trim());
+		const { subagent, outcome } = await handler(payload.target.trim(), context.signal);
 		return outcome === undefined ? { subagent } : { subagent, outcome };
 	});
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -308,6 +308,6 @@ export interface SubagentRuntimeHost {
 		childId: string,
 		session?: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<RlmSubagentHostDeletionResult | undefined>;
+	): Promise<RlmSubagentHostDeletionResult | void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -2,7 +2,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
-import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
 
 export interface RlmRunRequest {
 	prompt: string;
@@ -168,7 +168,7 @@ export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHand
 			isCurrent: () => context.isCurrent(),
 		});
 		return result as unknown as Record<string, unknown>;
-	}, contextAwareHostRequestHandler);
+	});
 }
 
 /** Search a bounded authenticated model catalog without adding it to the system prompt. */
@@ -182,7 +182,7 @@ export function createRlmFindModelsHostHandler(handler: RlmFindModelsHandler): H
 			throw new Error(`rlm.find_models limit must be an integer from 1 to ${MAX_RLM_MODEL_SEARCH_LIMIT}`);
 		}
 		return { models: (await handler(payload.query, limit as number)).models };
-	}, contextAwareHostRequestHandler);
+	});
 }
 
 /** Expose the current parent session's RLM child registry to its kernel. */
@@ -190,7 +190,7 @@ export function createRlmListSubagentsHostHandler(handler: RlmListSubagentsHandl
 	return createHostRequestHandler(async (_payload, _context) => {
 		const { subagents } = await handler();
 		return { subagents };
-	}, contextAwareHostRequestHandler);
+	});
 }
 
 /** Delete one direct child selected from the current parent session's registry. */
@@ -201,7 +201,7 @@ export function createRlmDeleteSubagentHostHandler(handler: RlmDeleteSubagentHan
 		}
 		const { subagent, outcome } = await handler(payload.target.trim());
 		return outcome === undefined ? { subagent } : { subagent, outcome };
-	}, contextAwareHostRequestHandler);
+	});
 }
 
 export interface RlmSubagentRuntime {

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -9,6 +9,9 @@ export interface RlmRunRequest {
 	kwargs: Record<string, unknown>;
 	/** Source of the IPython cell that issued this rlm.run call, when available. */
 	cellSourceCode?: string;
+	/** Dispatcher authority for this admission; revoked requests must not spawn. */
+	signal: AbortSignal;
+	isCurrent(): boolean;
 }
 
 export interface RlmSpawnHandle {
@@ -150,16 +153,19 @@ export function findRlmModelMatches(query: string, models: Model<Api>[], limit: 
 
 /** Adapt an RlmRunHandler into the typed "rlm.run" handler for the kernel host bridge. */
 export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHandler {
-	return createHostRequestHandler(async (payload, _context) => {
+	return createHostRequestHandler(async (payload, context) => {
 		if (typeof payload.prompt !== "string") {
 			throw new Error("rlm.run prompt must be a string");
 		}
 		const kwargs = isRecord(payload.kwargs) ? payload.kwargs : {};
 		const cellSourceCode = typeof payload.cellSourceCode === "string" ? payload.cellSourceCode : undefined;
+		if (context.signal.aborted || !context.isCurrent()) throw new Error("host request authority was revoked");
 		const result = await handler({
 			prompt: payload.prompt,
 			kwargs,
 			cellSourceCode,
+			signal: context.signal,
+			isCurrent: () => context.isCurrent(),
 		});
 		return result as unknown as Record<string, unknown>;
 	}, contextAwareHostRequestHandler);

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -229,6 +229,17 @@ export interface CreateRlmSubagentRuntimeOptions {
 	onSessionPublished?: (session: AgentSession) => void;
 }
 
+/**
+ * What the host can prove about a cancelled, never-admitted child's deletion.
+ * This is deliberately not a public child status: uncertainty must never make a
+ * private artifact appear active, idle, or inactive.
+ */
+export type RlmSubagentDeletionDurability = "absent" | "tombstoned" | "unknown";
+
+export interface RlmSubagentReleaseOutcome {
+	deletionDurability: RlmSubagentDeletionDurability;
+}
+
 export interface SubagentRuntimeHost {
 	createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime>;
 	/** Persist host-owned completion before the child becomes passivation-eligible. */
@@ -238,7 +249,9 @@ export interface SubagentRuntimeHost {
 		runtime: RlmSubagentRuntime,
 		options: CreateRlmSubagentRuntimeOptions,
 		status: "done" | "error" | "cancelled",
-	) => Promise<{ retained: boolean }>;
+	) => Promise<RlmSubagentReleaseOutcome>;
+	/** Re-check a release whose durability was unknown, without inventing a public child status. */
+	resolveRlmSubagentDeletion?(childId: string): Promise<RlmSubagentDeletionDurability>;
 	/** Close or remove the host-owned child; session is absent when a persisted child is still passive. */
 	deleteRlmSubagentRuntime(childId: string, session?: AgentSession): Promise<void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -238,7 +238,7 @@ export interface SubagentRuntimeHost {
 		runtime: RlmSubagentRuntime,
 		options: CreateRlmSubagentRuntimeOptions,
 		status: "done" | "error" | "cancelled",
-	) => Promise<void>;
+	) => Promise<{ retained: boolean }>;
 	/** Close or remove the host-owned child; session is absent when a persisted child is still passive. */
 	deleteRlmSubagentRuntime(childId: string, session?: AgentSession): Promise<void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -2,7 +2,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
-import type { HostRequestHandler } from "./kernel/index.js";
+import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
 
 export interface RlmRunRequest {
 	prompt: string;
@@ -150,7 +150,7 @@ export function findRlmModelMatches(query: string, models: Model<Api>[], limit: 
 
 /** Adapt an RlmRunHandler into the typed "rlm.run" handler for the kernel host bridge. */
 export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHandler {
-	return async (payload) => {
+	return createHostRequestHandler(async (payload, _context) => {
 		if (typeof payload.prompt !== "string") {
 			throw new Error("rlm.run prompt must be a string");
 		}
@@ -162,12 +162,12 @@ export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHand
 			cellSourceCode,
 		});
 		return result as unknown as Record<string, unknown>;
-	};
+	}, contextAwareHostRequestHandler);
 }
 
 /** Search a bounded authenticated model catalog without adding it to the system prompt. */
 export function createRlmFindModelsHostHandler(handler: RlmFindModelsHandler): HostRequestHandler {
-	return async (payload) => {
+	return createHostRequestHandler(async (payload, _context) => {
 		if (typeof payload.query !== "string") {
 			throw new Error("rlm.find_models query must be a string");
 		}
@@ -176,26 +176,26 @@ export function createRlmFindModelsHostHandler(handler: RlmFindModelsHandler): H
 			throw new Error(`rlm.find_models limit must be an integer from 1 to ${MAX_RLM_MODEL_SEARCH_LIMIT}`);
 		}
 		return { models: (await handler(payload.query, limit as number)).models };
-	};
+	}, contextAwareHostRequestHandler);
 }
 
 /** Expose the current parent session's RLM child registry to its kernel. */
 export function createRlmListSubagentsHostHandler(handler: RlmListSubagentsHandler): HostRequestHandler {
-	return async () => {
+	return createHostRequestHandler(async (_payload, _context) => {
 		const { subagents } = await handler();
 		return { subagents };
-	};
+	}, contextAwareHostRequestHandler);
 }
 
 /** Delete one direct child selected from the current parent session's registry. */
 export function createRlmDeleteSubagentHostHandler(handler: RlmDeleteSubagentHandler): HostRequestHandler {
-	return async (payload) => {
+	return createHostRequestHandler(async (payload, _context) => {
 		if (typeof payload.target !== "string" || !payload.target.trim()) {
 			throw new Error("rlm.delete_subagent target must be a non-empty string");
 		}
 		const { subagent, outcome } = await handler(payload.target.trim());
 		return outcome === undefined ? { subagent } : { subagent, outcome };
-	};
+	}, contextAwareHostRequestHandler);
 }
 
 export interface RlmSubagentRuntime {

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -39,7 +39,7 @@ export interface RlmListSubagentsResult {
 
 export interface RlmDeleteSubagentResult {
 	subagent: RlmSubagentRegistryEntry;
-	outcome?: "deleted" | "skipped_running";
+	outcome?: "deleted" | "skipped_running" | "preserved_newer";
 }
 
 export interface RlmModelMatch {

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -245,6 +245,16 @@ export interface RlmSubagentReleaseOutcome {
  * deletion lease. This is a typed host contract, never child-controlled data.
  */
 export interface RlmSubagentDeletionAuthority {
+	/** Exact child incarnation this attempt is allowed to reconcile. */
+	childId: string;
+	sessionDir: string;
+	/** Monotonic per-parent attempt token; never reused after an aborted owner. */
+	generation: number;
+	/**
+	 * Throws unless this exact generation still owns the exact child lease. The
+	 * daemon calls this after its asynchronous registry read and immediately
+	 * before the synchronous append/fsync boundary.
+	 */
 	assertCurrent(): void;
 }
 
@@ -264,6 +274,10 @@ export interface SubagentRuntimeHost {
 		authority: RlmSubagentDeletionAuthority,
 	): Promise<RlmSubagentDeletionDurability>;
 	/** Close or remove the host-owned child; session is absent when a persisted child is still passive. */
-	deleteRlmSubagentRuntime(childId: string, session?: AgentSession): Promise<void>;
+	deleteRlmSubagentRuntime(
+		childId: string,
+		session?: AgentSession,
+		authority?: RlmSubagentDeletionAuthority,
+	): Promise<void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -308,6 +308,6 @@ export interface SubagentRuntimeHost {
 		childId: string,
 		session?: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<RlmSubagentHostDeletionResult | void>;
+	): Promise<RlmSubagentHostDeletionResult | undefined>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -236,7 +236,7 @@ export interface CreateRlmSubagentRuntimeOptions {
  * This is deliberately not a public child status: uncertainty must never make a
  * private artifact appear active, idle, or inactive.
  */
-export type RlmSubagentDeletionDurability = "absent" | "tombstoned" | "unknown";
+export type RlmSubagentDeletionDurability = "absent" | "tombstoned" | "stale" | "unknown";
 
 export interface RlmSubagentReleaseOutcome {
 	deletionDurability: RlmSubagentDeletionDurability;
@@ -245,7 +245,7 @@ export interface RlmSubagentReleaseOutcome {
 /** The durable phase reached by a host-owned deletion attempt. */
 export type RlmSubagentDeletionPhase = "precommit" | "tombstoned";
 
-/** A successful host deletion always proves a concrete durable outcome. */
+/** A host result either removes the selected incarnation or observes it was superseded. */
 export interface RlmSubagentHostDeletionResult {
 	deletionDurability: Exclude<RlmSubagentDeletionDurability, "unknown">;
 }

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1013,12 +1013,37 @@ export async function readSessionInfo(filePath: string): Promise<SessionInfo | n
 	if (cached && cached.size === stats.size && cached.mtimeMs === stats.mtimeMs) {
 		return cached.info;
 	}
-	const info = await scanSessionInfo(filePath, stats);
+	const info = await scanSessionInfo(filePath, stats, readLinesAsBuffers(filePath));
 	sessionInfoCache.set(filePath, { size: stats.size, mtimeMs: stats.mtimeMs, info });
 	return info;
 }
 
-async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeof stat>>): Promise<SessionInfo | null> {
+/** Parse catalog-authorized bytes without reopening their pathname. */
+export async function readSessionInfoFromBuffer(
+	filePath: string,
+	contents: Buffer,
+	metadata: { mtimeMs: number },
+): Promise<SessionInfo | null> {
+	async function* lines(): AsyncGenerator<Buffer> {
+		let start = 0;
+		while (start < contents.length) {
+			const end = contents.indexOf(0x0a, start);
+			if (end === -1) {
+				yield contents.subarray(start);
+				return;
+			}
+			yield contents.subarray(start, end);
+			start = end + 1;
+		}
+	}
+	return scanSessionInfo(filePath, { mtime: new Date(metadata.mtimeMs) } as Awaited<ReturnType<typeof stat>>, lines());
+}
+
+async function scanSessionInfo(
+	filePath: string,
+	stats: Awaited<ReturnType<typeof stat>>,
+	lines: AsyncIterable<Buffer>,
+): Promise<SessionInfo | null> {
 	try {
 		let header: SessionHeader | undefined;
 		let messageCount = 0;
@@ -1029,7 +1054,7 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 		let agentStatus: AgentStatus | undefined;
 		let lastActivityTime: number | undefined;
 
-		for await (const lineBuffer of readLinesAsBuffers(filePath)) {
+		for await (const lineBuffer of lines) {
 			const line = lineBuffer.toString("utf8");
 			if (!line.trim()) continue;
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1018,6 +1018,49 @@ export async function readSessionInfo(filePath: string): Promise<SessionInfo | n
 	return info;
 }
 
+/**
+ * Parse only descriptor-authorized session-header bytes. Unlike readSessionInfo,
+ * this deliberately never follows a legacy parent path or scans the body.
+ */
+export function readSessionHeaderInfoFromBuffer(
+	filePath: string,
+	contents: Buffer,
+	metadata: { mtimeMs: number },
+): SessionInfo | null {
+	try {
+		const newline = contents.indexOf(0x0a);
+		const line = contents
+			.subarray(0, newline === -1 ? contents.length : newline)
+			.toString("utf8")
+			.trim();
+		const header = JSON.parse(line) as Partial<SessionHeader>;
+		if (
+			header.type !== "session" ||
+			typeof header.id !== "string" ||
+			header.id === "" ||
+			(typeof header.cwd !== "string" && header.cwd !== undefined) ||
+			(typeof header.parentSession !== "string" && header.parentSession !== undefined) ||
+			(header.rlmDepth !== undefined && !isValidRlmDepth(header.rlmDepth))
+		) {
+			return null;
+		}
+		return {
+			path: filePath,
+			id: header.id,
+			cwd: header.cwd ?? "",
+			...(header.parentSession !== undefined ? { parentSessionPath: header.parentSession } : {}),
+			rlmDepth: header.rlmDepth ?? 0,
+			created: new Date(typeof header.timestamp === "string" ? header.timestamp : 0),
+			modified: new Date(metadata.mtimeMs),
+			messageCount: 0,
+			firstMessage: "(no messages)",
+			allMessagesText: "",
+		};
+	} catch {
+		return null;
+	}
+}
+
 /** Parse catalog-authorized bytes without reopening their pathname. */
 export async function readSessionInfoFromBuffer(
 	filePath: string,

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1072,12 +1072,17 @@ async function readLatestRegistry(
 	return [...latest.values()];
 }
 
-function listSessionCandidates(sessionDir: string, limit: number): Array<{ path: string; dev: string; ino: string }> {
+function listSessionCandidates(
+	sessionDir: string,
+	limit: number,
+): Array<{ path: string; dev: string; ino: string }> | undefined {
 	let directory: ReturnType<typeof opendirSync>;
 	try {
 		directory = opendirSync(sessionDir);
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		// Preserve the catalog's missing-directory behavior without conflating an
+		// absent directory with unrelated enumeration failures.
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 		throw error;
 	}
 
@@ -1123,6 +1128,7 @@ async function listCatalogFamilySessionsWithLimit(
 ): Promise<SessionInfo[]> {
 	const effectiveSessionDir = sessionDir ?? getSessionsDir();
 	const roots = listSessionCandidates(effectiveSessionDir, limit);
+	if (!roots) return [];
 	const authority = managedRoots(effectiveSessionDir);
 	const reader = new TrustedReadSession(authority);
 	let result: SessionInfo[] | undefined;
@@ -1159,6 +1165,11 @@ async function listCatalogFamilySessionsWithLimit(
 				if (++edges > MAX_RLM_FAMILY_EDGES) throw invalidFamilyTopology("family edge limit exhausted");
 				const childPath = entry.sessionFile as string;
 				if (childAncestors.has(childPath)) throw invalidFamilyTopology("family contains a cycle");
+				// Registry children share the same hard family-node budget. Fail before
+				// opening a new child descriptor when the exact limit is already full.
+				if (!sessions.has(childPath) && sessions.size >= limit) {
+					throw invalidFamilyTopology("family node limit exhausted");
+				}
 				const trustedChild = await readTrustedSession(childPath, reader);
 				if (basename(childPath, ".jsonl") !== trustedChild.id)
 					throw invalidFamilyTopology("registry child session file does not match its header id");
@@ -1210,7 +1221,6 @@ async function listCatalogFamilySessionsWithLimit(
 				) {
 					throw invalidFamilyTopology("family contains a conflicting duplicate");
 				}
-				if (!existing && sessions.size >= limit) throw invalidFamilyTopology("family node limit exhausted");
 				ids.set(child.id, child.path);
 				sessions.set(child.path, child);
 				await visit(child, depth + 1, childAncestors);

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -81,6 +81,18 @@ const MAX_RLM_FAMILY_EDGES = 10_000;
 const MAX_RLM_FAMILY_NODES = 10_000;
 const MAX_RLM_FAMILY_DEPTH = 64;
 
+// A narrow test seam avoids creating ten thousand filesystem entries merely to
+// verify that root enumeration fails before opening any candidate descriptor.
+let maxRlmFamilyNodesForTest: number | undefined;
+/** @internal */
+export function setCatalogMaxRlmFamilyNodesForTest(limit: number | undefined): void {
+	maxRlmFamilyNodesForTest = limit;
+}
+
+function maxRlmFamilyNodes(): number {
+	return maxRlmFamilyNodesForTest ?? MAX_RLM_FAMILY_NODES;
+}
+
 interface ManagedRoot {
 	lexical: string;
 	fd: number;
@@ -934,12 +946,18 @@ function hasApparentSessionTopologyClaimPrefix(text: string): boolean {
 		if (!key) return false;
 		// A malformed or partial outer key could itself be a topology key.
 		if (!key.terminated || key.invalidEscape) return true;
+		// A decoded id is topology-relevant before its delimiter or value can
+		// arrive. In particular, a 64 KiB cut immediately after `"id"` must
+		// not turn an identified root into harmless junk.
+		if (key.value === "id") return true;
 		index = key.end;
 		while (/\s/u.test(text[index] ?? "")) index++;
-		if (text[index] !== ":") return false;
+		// Likewise a decoded outer type cannot safely be downgraded while its
+		// colon/value is absent or only whitespace has reached the prefix end.
+		if (text[index] !== ":") return key.value === "type";
 		index++;
 		while (/\s/u.test(text[index] ?? "")) index++;
-		if (key.value === "id") return true;
+		if (key.value === "type" && index === text.length) return true;
 		if (key.value === "type" && text[index] === '"') {
 			const value = readJsonStringPrefix(text, index)!;
 			// Type's string value is itself a session claim surface; do not
@@ -947,7 +965,18 @@ function hasApparentSessionTopologyClaimPrefix(text: string): boolean {
 			if (!value.terminated || value.invalidEscape) return true;
 			if (value.value === "session") return true;
 		}
+		const valueStart = index;
 		index = skipJsonValuePrefix(text, index);
+		if (key.value === "type" && text[valueStart] !== '"') {
+			// A non-string type is harmless only after its complete JSON value is
+			// demonstrable. A cut through `nul`, `{`, or any nested value remains
+			// ambiguous rather than becoming a skip at the read boundary.
+			try {
+				JSON.parse(text.slice(valueStart, index).trim());
+			} catch {
+				return true;
+			}
+		}
 		while (/\s/u.test(text[index] ?? "")) index++;
 		if (text[index] !== ",") return false;
 		index++;
@@ -1051,19 +1080,26 @@ async function readLatestRegistry(
 
 function listSessionCandidates(sessionDir: string): Array<{ path: string; dev: string; ino: string }> {
 	try {
-		return readdirSync(sessionDir)
-			.filter((entry) => entry.endsWith(".jsonl"))
-			.flatMap((entry) => {
-				const path = join(resolve(sessionDir), entry);
-				try {
-					const stat = lstatSync(path);
-					return [{ path, dev: String(stat.dev), ino: String(stat.ino) }];
-				} catch {
-					// Removed during enumeration: it was never a stable root candidate.
-					return [];
-				}
-			});
-	} catch {
+		const candidates: Array<{ path: string; dev: string; ino: string }> = [];
+		const limit = maxRlmFamilyNodes();
+		for (const entry of readdirSync(sessionDir)) {
+			if (!entry.endsWith(".jsonl")) continue;
+			const path = join(resolve(sessionDir), entry);
+			try {
+				const stat = lstatSync(path);
+				// Count every stable root candidate, including junk and duplicate ids,
+				// before opening a descriptor or scanning metadata. Removed entries
+				// retain their historical behavior and never become candidates.
+				candidates.push({ path, dev: String(stat.dev), ino: String(stat.ino) });
+				if (candidates.length > limit) throw invalidFamilyTopology("family node limit exhausted");
+			} catch (error) {
+				if ((error as Error).message.includes("family node limit exhausted")) throw error;
+				// Removed during enumeration: it was never a stable root candidate.
+			}
+		}
+		return candidates;
+	} catch (error) {
+		if ((error as Error).message.includes("family node limit exhausted")) throw error;
 		return [];
 	}
 }
@@ -1158,7 +1194,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 				) {
 					throw invalidFamilyTopology("family contains a conflicting duplicate");
 				}
-				if (!existing && sessions.size >= MAX_RLM_FAMILY_NODES)
+				if (!existing && sessions.size >= maxRlmFamilyNodes())
 					throw invalidFamilyTopology("family node limit exhausted");
 				ids.set(child.id, child.path);
 				sessions.set(child.path, child);

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -196,24 +196,28 @@ SEARCH_MAX=65536
 PARSE_MAX=1048576
 PREVIEW_MAX=256
 MAX_METADATA_RESPONSE_BYTES=256*1024
+HEADER_CLASSIFICATION_BYTES=65536
 TRUNCATION_MARKER="... [truncated]"
 def reject(): raise ValueError("invalid")
 def compact_metadata_response(response):
- # json.dumps defaults to ensure_ascii=True. Keep the complete wire response,
- # rather than just metadata, inside the TypeScript-side response cap.
- def encoded_size(): return len(json.dumps(response,separators=(",",":")).encode("ascii"))
+ # Budget the complete protocol envelope, not an assumed metadata shape.
+ # ensure_ascii is explicit because the protocol is newline-delimited ASCII.
+ def encoded_size(): return len(json.dumps(response,separators=(",",":"),ensure_ascii=True).encode("ascii"))
  if encoded_size()<=MAX_METADATA_RESPONSE_BYTES: return
  data=response.get("data")
  if not isinstance(data,dict): reject()
  targets=[]
- def add_target(container,key):
-  if isinstance(container.get(key),str):
-   targets.append((container,key,container[key]))
- add_target(data,"firstMessage"); add_target(data,"allMessagesText"); add_target(data,"name")
- status=data.get("agentStatus")
- if isinstance(status,dict): add_target(status,"summary")
- # Clear every unbounded display field before allocating the remaining escaped-byte
- # budget in a stable priority order. Fields remain present and string typed.
+ # Walk every string value recursively, in insertion/index order. The protocol
+ # currently has a typed metadata shape, but this prevents a future nested
+ # display field from bypassing the full-envelope budget.
+ def collect(container):
+  values=container.items() if isinstance(container,dict) else enumerate(container) if isinstance(container,list) else ()
+  for key,value in values:
+   if isinstance(value,str): targets.append((container,key,value))
+   elif isinstance(value,(dict,list)): collect(value)
+ collect(response)
+ # Clear every string before allocating the remaining escaped-byte budget in a
+ # stable order. Fields remain present and string typed.
  for container,key,_ in targets: container[key]=""
  if encoded_size()>MAX_METADATA_RESPONSE_BYTES: reject()
  for container,key,original in targets:
@@ -222,7 +226,7 @@ def compact_metadata_response(response):
    return original if prefix==length else original[:prefix]+TRUNCATION_MARKER
   # A marker is useful when it fits; otherwise preserve the greatest raw
   # prefix. Either search uses the exact ensure_ascii serialized byte count.
-  use_marker=encoded_size()+len(json.dumps(TRUNCATION_MARKER))<=MAX_METADATA_RESPONSE_BYTES
+  use_marker=encoded_size()+len(json.dumps(TRUNCATION_MARKER,ensure_ascii=True))<=MAX_METADATA_RESPONSE_BYTES
   def fits(prefix):
    container[key]=candidate(prefix) if use_marker else original[:prefix]
    return encoded_size()<=MAX_METADATA_RESPONSE_BYTES
@@ -308,9 +312,15 @@ def scan_metadata(fd,mtime_ms):
     if status in ("active","archived","crash"): state={"status":status}
     elif status in ("hidden","sleep"): state={"status":"archived"}
    elif kind=="agent_status":
+    # Keep the recap schema typed before it crosses the bounded wire. An
+    # arbitrary taskState string is neither an AgentTaskState nor compactable.
     value=entry.get("status")
-    if isinstance(value,dict):
-     agent_status={key:value[key] for key in ("summary","taskState","basedOnMessageCount") if key in value}
+    summary=value.get("summary") if isinstance(value,dict) else None
+    based=value.get("basedOnMessageCount") if isinstance(value,dict) else None
+    if isinstance(summary,str) and isinstance(based,int) and not isinstance(based,bool) and based>=0:
+     agent_status={"summary":summary,"basedOnMessageCount":based}
+     task_state=value.get("taskState")
+     if task_state in ("needs_input","completed"): agent_status["taskState"]=task_state
    if header is None:
     if kind!="session": return {"valid":False}
     header=entry
@@ -364,7 +374,11 @@ def serve(req):
       # An oversized first record can be an incomplete concurrent write. It is
       # distinguishable from an I/O/protocol failure so root classification can
       # ignore it, while registry-reached sessions remain strict.
-      if mode=="header": payload["truncated"]=True; chunks=[]; break
+      if mode=="header":
+       # Return only a small bounded prefix for root classification. It fits
+       # inside the outer 256 KiB envelope; registry-reached headers stay
+       # strict in TypeScript whenever this flag is present.
+       payload["truncated"]=True; chunks=[b"".join(chunks)[:HEADER_CLASSIFICATION_BYTES]]; break
       reject()
     if not payload.get("truncated"): payload["data"]=base64.b64encode(b"".join(chunks)).decode("ascii")
    elif mode=="metadata": payload["data"]=scan_metadata(fd,before.st_mtime_ns/1000000)
@@ -387,7 +401,9 @@ while True:
  if isinstance(request,dict) and request.get("mode")=="metadata" and "data" in response:
   try: compact_metadata_response(response)
   except Exception: response={"error":"failed","id":response.get("id")}
- serialized=json.dumps(response,separators=(",",":"))
+ # This is the exact full response envelope budgeted above. Keep
+ # ensure_ascii explicit: changing a Python default cannot weaken the cap.
+ serialized=json.dumps(response,separators=(",",":"),ensure_ascii=True)
  if len(serialized.encode("ascii"))>MAX_METADATA_RESPONSE_BYTES: sys.exit(1)
  sys.stdout.write(serialized+"\n"); sys.stdout.flush()
 `;
@@ -439,7 +455,11 @@ function isTrustedSessionMetadata(value: unknown): value is TrustedSessionMetada
 			(!metadata.agentStatus ||
 				typeof metadata.agentStatus !== "object" ||
 				typeof (metadata.agentStatus as { summary?: unknown }).summary !== "string" ||
-				typeof (metadata.agentStatus as { basedOnMessageCount?: unknown }).basedOnMessageCount !== "number"))
+				!Number.isSafeInteger((metadata.agentStatus as { basedOnMessageCount?: unknown }).basedOnMessageCount) ||
+				(metadata.agentStatus as { basedOnMessageCount: number }).basedOnMessageCount < 0 ||
+				((metadata.agentStatus as { taskState?: unknown }).taskState !== undefined &&
+					(metadata.agentStatus as { taskState?: unknown }).taskState !== "needs_input" &&
+					(metadata.agentStatus as { taskState?: unknown }).taskState !== "completed")))
 	) {
 		return false;
 	}
@@ -620,12 +640,11 @@ class TrustedReadSession {
 		if (
 			wire.error !== undefined ||
 			(wire.truncated !== undefined && !truncatedHeader) ||
-			(!truncatedHeader &&
-				(mode === "stat"
-					? wire.data !== undefined
-					: mode === "metadata"
-						? !isTrustedSessionMetadata(wire.data)
-						: typeof wire.data !== "string")) ||
+			(mode === "stat"
+				? wire.data !== undefined
+				: mode === "metadata"
+					? !isTrustedSessionMetadata(wire.data)
+					: typeof wire.data !== "string") ||
 			typeof wire.mtimeMs !== "number" ||
 			typeof wire.dev !== "string" ||
 			typeof wire.ino !== "string"
@@ -798,16 +817,27 @@ async function readTrustedRootCandidate(
 	// junk: it may have replaced an identified root before descriptor open.
 	if (header.dev !== listed.dev || header.ino !== listed.ino)
 		throw invalidFamilyTopology("root candidate changed after directory enumeration");
-	if (header.truncated) throw invalidFamilyTopology("session header exceeds the trusted read limit");
 	const line = header.contents.toString("utf8").split(/\r?\n/, 1)[0] ?? "";
 	if (!line.trim()) return undefined;
-	let candidate: { type?: unknown; id?: unknown };
+	let candidate: { type?: unknown; id?: unknown } | undefined;
 	try {
 		candidate = JSON.parse(line) as { type?: unknown; id?: unknown };
 	} catch {
+		// A bounded prefix may end in a concurrent partial write. Only a prefix
+		// that already purports to carry a session or identifier claim is part of
+		// the topology; unrelated incomplete junk remains skippable.
+		if (/^\s*\{[\s\S]*?"type"\s*:\s*"session(?:"|\\|$)|^\s*\{[\s\S]*?"id"\s*:/u.test(line))
+			throw invalidFamilyTopology("session header exceeds the trusted read limit");
 		return undefined;
 	}
-	if (!candidate || typeof candidate !== "object" || candidate.type !== "session") return undefined;
+	if (!candidate || typeof candidate !== "object") return undefined;
+	// A complete prefix carrying either claim is fatal when truncated. A
+	// registry-reached child never calls this root-only classifier and remains
+	// strict unconditionally in readTrustedSession.
+	if (header.truncated && (candidate.type === "session" || candidate.id !== undefined))
+		throw invalidFamilyTopology("session header exceeds the trusted read limit");
+	if (header.truncated) return undefined;
+	if (candidate.type !== "session") return undefined;
 	if (typeof candidate.id !== "string" || candidate.id === "") return undefined;
 	return readTrustedSession(path, reader);
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -98,9 +98,14 @@ interface TrustedFile {
 }
 
 interface TrustedSession extends SessionInfo {
-	/** The header claim is intentionally separate from SessionInfo's legacy fallback. */
-	persistedDepth: number;
+	/** The header claims are intentionally separate from SessionInfo's legacy fallback. */
+	persistedDepth?: number;
 	persistedParentPath?: string;
+}
+
+/** A family member whose depth has been verified against the walk. */
+interface FamilySession extends TrustedSession {
+	persistedDepth: number;
 }
 
 function rlmSubagentRegistryPath(parent: SessionInfo, roots: ManagedRoots): string | undefined {
@@ -271,20 +276,40 @@ async function readTrustedSession(path: string, roots: ManagedRoots): Promise<Tr
 		header.id === "" ||
 		(hasParent && typeof header.parentSession !== "string") ||
 		(hasParent && header.parentSession === "") ||
-		(hasParent && !hasDepth) ||
-		(!hasParent && header.rlmDepth !== undefined && !hasDepth)
+		(header.rlmDepth !== undefined && !hasDepth)
 	)
 		throw invalidFamilyTopology("session header lacks trustworthy topology claims");
-	const persistedDepth = hasDepth ? (header.rlmDepth as number) : 0;
+	const persistedDepth = hasDepth ? (header.rlmDepth as number) : undefined;
 	const info = await readSessionInfoFromBuffer(path, trusted.contents, { mtimeMs: trusted.mtimeMs });
 	if (!info || info.id !== header.id) throw invalidFamilyTopology("session metadata does not match its header");
 	return {
 		...info,
 		path,
-		rlmDepth: persistedDepth,
-		persistedDepth,
+		rlmDepth: persistedDepth ?? 0,
+		...(persistedDepth !== undefined ? { persistedDepth } : {}),
 		...(hasParent ? { persistedParentPath: header.parentSession as string } : {}),
 	};
+}
+
+/**
+ * /fork and lineage-carrying /new save sessions directly into the sessions dir
+ * with a parentSession claim naming their source. That claim is fork ancestry,
+ * not rlm topology: the session is a family root and the claim is ignored.
+ * Parent claims that leave the sessions dir still fail closed.
+ */
+function asTrustedFamilyRoot(trusted: TrustedSession, roots: ManagedRoots): FamilySession {
+	if (trusted.persistedParentPath !== undefined) {
+		const claimedParent = resolve(dirname(trusted.path), trusted.persistedParentPath);
+		if (dirname(trusted.path) !== roots.session.lexical || !isWithin(roots.session.lexical, claimedParent)) {
+			throw invalidFamilyTopology("managed session seed claims a parent");
+		}
+		const { persistedParentPath: _forkSource, parentSessionPath: _forkLineage, ...root } = trusted;
+		return { ...root, rlmDepth: 0, persistedDepth: 0 };
+	}
+	if (trusted.persistedDepth !== undefined && trusted.persistedDepth !== 0) {
+		throw invalidFamilyTopology("managed session seed claims a nonzero depth");
+	}
+	return { ...trusted, rlmDepth: 0, persistedDepth: 0 };
 }
 
 async function readLatestRegistry(
@@ -329,13 +354,10 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 	const roots = await SessionManager.listAll(undefined, effectiveSessionDir);
 	const authority = managedRoots(effectiveSessionDir);
 	try {
-		const sessions = new Map<string, TrustedSession>();
+		const sessions = new Map<string, FamilySession>();
 		const ids = new Map<string, string>();
 		for (const root of roots) {
-			const trusted = await readTrustedSession(root.path, authority);
-			if (trusted.persistedDepth !== 0 || trusted.persistedParentPath !== undefined) {
-				throw invalidFamilyTopology("managed session seed claims a parent");
-			}
+			const trusted = asTrustedFamilyRoot(await readTrustedSession(root.path, authority), authority);
 			const existingPath = ids.get(trusted.id);
 			if (existingPath && existingPath !== trusted.path)
 				throw invalidFamilyTopology("family contains a duplicate session id");
@@ -344,7 +366,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 		}
 		let edges = 0;
 		const visited = new Set<string>();
-		const visit = async (parent: TrustedSession, depth: number, ancestors: ReadonlySet<string>): Promise<void> => {
+		const visit = async (parent: FamilySession, depth: number, ancestors: ReadonlySet<string>): Promise<void> => {
 			if (depth > MAX_RLM_FAMILY_DEPTH) throw invalidFamilyTopology("family depth limit exhausted");
 			const parentPath = parent.path;
 			if (ancestors.has(parentPath)) throw invalidFamilyTopology("family contains a cycle");
@@ -361,11 +383,14 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 				if (++edges > MAX_RLM_FAMILY_EDGES) throw invalidFamilyTopology("family edge limit exhausted");
 				const childPath = entry.sessionFile as string;
 				if (childAncestors.has(childPath)) throw invalidFamilyTopology("family contains a cycle");
-				const child = await readTrustedSession(childPath, authority);
-				if (child.id !== entry.childId) throw invalidFamilyTopology("registry child id does not match session id");
-				if (child.persistedParentPath === undefined)
+				const trustedChild = await readTrustedSession(childPath, authority);
+				if (trustedChild.id !== entry.childId)
+					throw invalidFamilyTopology("registry child id does not match session id");
+				if (trustedChild.persistedParentPath === undefined)
 					throw invalidFamilyTopology("child lacks a persisted parent path");
-				const claimedParentPath = resolve(dirname(child.path), child.persistedParentPath);
+				if (trustedChild.persistedDepth === undefined) throw invalidFamilyTopology("child lacks a persisted depth");
+				const child: FamilySession = { ...trustedChild, persistedDepth: trustedChild.persistedDepth };
+				const claimedParentPath = resolve(dirname(child.path), trustedChild.persistedParentPath);
 				readTrustedFile(claimedParentPath, authority, 128 * 1024 * 1024);
 				if (claimedParentPath !== parentPath)
 					throw invalidFamilyTopology("child parent path does not match traversed parent");

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { closeSync, constants, openSync } from "node:fs";
+import { closeSync, constants, lstatSync, openSync, readdirSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
 import { getSessionsDir } from "../../config.js";
@@ -211,8 +211,7 @@ def compact_metadata_response(response):
    targets.append((container,key,container[key]))
  add_target(data,"firstMessage"); add_target(data,"allMessagesText"); add_target(data,"name")
  status=data.get("agentStatus")
- if isinstance(status,dict):
-  add_target(status,"summary"); add_target(status,"taskState")
+ if isinstance(status,dict): add_target(status,"summary")
  # Clear every unbounded display field before allocating the remaining escaped-byte
  # budget in a stable priority order. Fields remain present and string typed.
  for container,key,_ in targets: container[key]=""
@@ -783,6 +782,37 @@ async function readTrustedSession(path: string, reader: TrustedReadSession): Pro
 }
 
 /**
+ * A sessions directory can contain interrupted writes and unrelated jsonl files.
+ * Classification is deliberately narrow: only a bounded, blank/truncated,
+ * non-JSON, non-session, or identifier-less first record is ignored. Once a
+ * record purports to be an identified session, the strict descriptor-bound
+ * reader owns every topology and protocol failure.
+ */
+async function readTrustedRootCandidate(
+	path: string,
+	listed: { dev: string; ino: string },
+	reader: TrustedReadSession,
+): Promise<TrustedSession | undefined> {
+	const header = await reader.read(path, MAX_SESSION_HEADER_BYTES, "header");
+	// A candidate changing after enumeration cannot safely be reclassified as
+	// junk: it may have replaced an identified root before descriptor open.
+	if (header.dev !== listed.dev || header.ino !== listed.ino)
+		throw invalidFamilyTopology("root candidate changed after directory enumeration");
+	if (header.truncated) throw invalidFamilyTopology("session header exceeds the trusted read limit");
+	const line = header.contents.toString("utf8").split(/\r?\n/, 1)[0] ?? "";
+	if (!line.trim()) return undefined;
+	let candidate: { type?: unknown; id?: unknown };
+	try {
+		candidate = JSON.parse(line) as { type?: unknown; id?: unknown };
+	} catch {
+		return undefined;
+	}
+	if (!candidate || typeof candidate !== "object" || candidate.type !== "session") return undefined;
+	if (typeof candidate.id !== "string" || candidate.id === "") return undefined;
+	return readTrustedSession(path, reader);
+}
+
+/**
  * /fork and lineage-carrying /new save sessions directly into the sessions dir
  * with a parentSession claim naming their source. That claim is fork ancestry,
  * not rlm topology: the session is a family root and the claim is ignored.
@@ -840,13 +870,28 @@ async function readLatestRegistry(
 	return [...latest.values()];
 }
 
+function listSessionCandidates(sessionDir: string): Array<{ path: string; dev: string; ino: string }> {
+	try {
+		return readdirSync(sessionDir)
+			.filter((entry) => entry.endsWith(".jsonl"))
+			.flatMap((entry) => {
+				const path = join(resolve(sessionDir), entry);
+				try {
+					const stat = lstatSync(path);
+					return [{ path, dev: String(stat.dev), ino: String(stat.ino) }];
+				} catch {
+					// Removed during enumeration: it was never a stable root candidate.
+					return [];
+				}
+			});
+	} catch {
+		return [];
+	}
+}
+
 export async function listCatalogFamilySessions(sessionDir?: string): Promise<SessionInfo[]> {
 	const effectiveSessionDir = sessionDir ?? getSessionsDir();
-	// SessionManager performs the non-authoritative flat-directory classification:
-	// interrupted, blank, and unrelated jsonl files are not roots. Topology is
-	// still re-read descriptor-relatively below and any identified candidate
-	// that fails validation is fatal.
-	const roots = await SessionManager.listAll(undefined, effectiveSessionDir);
+	const roots = listSessionCandidates(effectiveSessionDir);
 	const authority = managedRoots(effectiveSessionDir);
 	const reader = new TrustedReadSession(authority);
 	let result: SessionInfo[] | undefined;
@@ -855,7 +900,9 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 		const sessions = new Map<string, FamilySession>();
 		const ids = new Map<string, string>();
 		for (const root of roots) {
-			const trusted = asTrustedFamilyRoot(await readTrustedSession(root.path, reader), authority);
+			const candidate = await readTrustedRootCandidate(root.path, root, reader);
+			if (!candidate) continue;
+			const trusted = asTrustedFamilyRoot(candidate, authority);
 			const existingPath = ids.get(trusted.id);
 			if (existingPath && existingPath !== trusted.path)
 				throw invalidFamilyTopology("family contains a duplicate session id");

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { closeSync, constants, openSync } from "node:fs";
+import { closeSync, constants, openSync, readdirSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
 import { getSessionsDir } from "../../config.js";
@@ -99,6 +99,20 @@ interface TrustedFile {
 	ino: string;
 }
 
+interface TrustedSessionMetadata {
+	messageCount: number;
+	firstMessage: string;
+	allMessagesText: string;
+	modifiedMs: number;
+	name?: string;
+	state?: SessionInfo["state"];
+	agentStatus?: SessionInfo["agentStatus"];
+}
+
+interface TrustedMetadataFile extends TrustedFile {
+	metadata: TrustedSessionMetadata;
+}
+
 interface TrustedSession extends SessionInfo {
 	/** The header claims are intentionally separate from SessionInfo's legacy fallback. */
 	persistedDepth?: number;
@@ -176,15 +190,116 @@ function closeManagedRoots(roots: ManagedRoots): void {
 
 const OPENAT_READ_HELPER = String.raw`import base64,json,os,stat,sys
 MAX=134217728
+SEARCH_MAX=65536
+PARSE_MAX=1048576
+PREVIEW_MAX=256
 def reject(): raise ValueError("invalid")
 def flags(directory=False):
  value=os.O_RDONLY|os.O_NOFOLLOW
  if directory: value|=os.O_DIRECTORY
  return value
+def message_text(message):
+ content=message.get("content") if isinstance(message,dict) else None
+ if isinstance(content,str): return content
+ if isinstance(content,list): return " ".join(block.get("text","") for block in content if isinstance(block,dict) and block.get("type")=="text" and isinstance(block.get("text"),str))
+ return ""
+def append_search(current,text):
+ if not text or len(current)>=SEARCH_MAX: return current
+ next_text=(current+" " if current else "")+text
+ return current+next_text[len(current):len(current)+(SEARCH_MAX-len(current))]
+def parse_time(value):
+ if not isinstance(value,str): return None
+ try:
+  text=value.replace("Z","+00:00")
+  return __import__("datetime").datetime.fromisoformat(text).timestamp()*1000
+ except Exception: return None
+def string_prefix(text,key,limit,start=0):
+ index=text.find('"'+key+'"',start)
+ if index<0: return None
+ index+=len(key)+2
+ while index<len(text) and text[index].isspace(): index+=1
+ if index>=len(text) or text[index] != ":": return None
+ index+=1
+ while index<len(text) and text[index].isspace(): index+=1
+ if index>=len(text) or text[index] != '"': return None
+ index+=1; result=[]; escaped=False
+ while index<len(text) and len(result)<limit:
+  char=text[index]
+  if escaped: result.append(char); escaped=False
+  elif char=="\\": escaped=True
+  elif char=='"': break
+  else: result.append(char)
+  index+=1
+ return "".join(result)
+def scan_metadata(fd,mtime_ms):
+ os.lseek(fd,0,os.SEEK_SET)
+ stream=os.fdopen(os.dup(fd),"rb")
+ try:
+  header=None; count=0; first=""; search=""; name=None; state=None; agent_status=None; activity=None
+  while True:
+   # readline's limit prevents one hostile JSONL record from being materialized
+   # in the helper. Parse normal records; for oversize records inspect only their
+   # bounded prefix, then drain their remaining chunks before the next record.
+   raw=stream.readline(PARSE_MAX+1)
+   if not raw: break
+   oversized=len(raw)>PARSE_MAX and not raw.endswith(b"\n")
+   line=raw.decode("utf-8","replace").rstrip("\n")
+   if oversized:
+    if '"type":"message"' in line or '"type": "message"' in line:
+     count+=1
+     timestamp=parse_time(string_prefix(line,"timestamp",64) or "")
+     message_index=line.find('"message"')
+     role=string_prefix(line,"role",64,message_index if message_index>=0 else 0)
+     preview=string_prefix(line,"content",PREVIEW_MAX,message_index) if message_index>=0 else None
+     if preview is None and message_index>=0: preview=string_prefix(line,"text",PREVIEW_MAX,message_index)
+     if timestamp is not None and role in ("user","assistant"): activity=max(activity or 0,timestamp)
+     if role=="user" and not first: first=preview or "(large message)"
+    while raw and not raw.endswith(b"\n"):
+     raw=stream.readline(65536)
+    continue
+   if not line.strip(): continue
+   try: entry=json.loads(line)
+   except Exception: continue
+   if not isinstance(entry,dict): continue
+   kind=entry.get("type")
+   if kind=="session_info":
+    value=entry.get("name"); name=value.strip() if isinstance(value,str) and value.strip() else None
+   elif kind=="session_state":
+    value=entry.get("state"); status=value.get("status") if isinstance(value,dict) else None
+    if status in ("active","archived","crash"): state={"status":status}
+    elif status in ("hidden","sleep"): state={"status":"archived"}
+   elif kind=="agent_status":
+    value=entry.get("status")
+    if isinstance(value,dict):
+     agent_status={key:value[key] for key in ("summary","taskState","basedOnMessageCount") if key in value}
+   if header is None:
+    if kind!="session": return {"valid":False}
+    header=entry
+   if kind!="message": continue
+   count+=1
+   message=entry.get("message")
+   if not isinstance(message,dict) or not isinstance(message.get("role"),str) or "content" not in message: continue
+   role=message["role"]
+   if role not in ("user","assistant"): continue
+   timestamp=message.get("timestamp") if isinstance(message.get("timestamp"), (int,float)) and not isinstance(message.get("timestamp"),bool) else parse_time(entry.get("timestamp"))
+   if timestamp is not None: activity=max(activity or 0,timestamp)
+   text=message_text(message)
+   if not text: continue
+   search=append_search(search,text)
+   if role=="user" and not first: first=text
+  if header is None: return {"valid":False}
+  header_time=parse_time(header.get("timestamp"))
+  modified=activity if activity is not None and activity>0 else (header_time if header_time is not None else mtime_ms)
+  data={"valid":True,"messageCount":count,"firstMessage":first or "(no messages)","allMessagesText":search,"modifiedMs":modified}
+  if name is not None: data["name"]=name
+  if state is not None: data["state"]=state
+  if agent_status is not None: data["agentStatus"]=agent_status
+  return data
+ finally: stream.close()
 def serve(req):
  request_id=req.get("id"); parts=req.get("parts"); limit=req.get("limit"); mode=req.get("mode"); root=req.get("root")
  if not isinstance(request_id,str) or not request_id or len(request_id)>128: reject()
- if mode not in ("read","header","stat") or root not in (3,4): reject()
+ if mode not in ("read","header","stat","metadata") or root not in (3,4): reject()
  if not isinstance(parts,list) or not parts or not isinstance(limit,int) or limit<0 or limit>MAX: reject()
  if any(not isinstance(p,str) or not p or p in (".","..") or "/" in p or "\\" in p for p in parts): reject()
  current=os.dup(root)
@@ -197,7 +312,7 @@ def serve(req):
    if not stat.S_ISREG(before.st_mode): reject()
    if mode=="read" and before.st_size>limit: reject()
    payload={}
-   if mode!="stat":
+   if mode in ("read","header"):
     chunks=[]; total=0; done=False
     while not done:
      chunk=os.read(fd,min(65536,limit+1-total))
@@ -208,6 +323,7 @@ def serve(req):
      chunks.append(chunk); total+=len(chunk)
      if total>limit: reject()
     payload["data"]=base64.b64encode(b"".join(chunks)).decode("ascii")
+   elif mode=="metadata": payload["data"]=scan_metadata(fd,before.st_mtime_ns/1000000)
    after=os.fstat(fd)
    if (before.st_dev,before.st_ino,before.st_mode)!=(after.st_dev,after.st_ino,after.st_mode): reject()
    payload.update({"mtimeMs":after.st_mtime_ns/1000000,"dev":str(after.st_dev),"ino":str(after.st_ino)})
@@ -248,9 +364,38 @@ export function setCatalogHelperLaunchForTest(launch: { command: string; args: s
 	catalogHelperLaunchForTest = launch;
 }
 
-type TrustedReadMode = "read" | "header" | "stat";
+type TrustedReadMode = "read" | "header" | "stat" | "metadata";
 
 const TRUSTED_READ_TIMEOUT_MS = 5_000;
+const MAX_METADATA_RESPONSE_BYTES = 256 * 1024;
+
+function isTrustedSessionMetadata(value: unknown): value is TrustedSessionMetadata {
+	if (!value || typeof value !== "object") return false;
+	const metadata = value as Record<string, unknown>;
+	if (
+		metadata.valid !== true ||
+		typeof metadata.messageCount !== "number" ||
+		!Number.isSafeInteger(metadata.messageCount) ||
+		metadata.messageCount < 0 ||
+		typeof metadata.firstMessage !== "string" ||
+		typeof metadata.allMessagesText !== "string" ||
+		typeof metadata.modifiedMs !== "number" ||
+		!Number.isFinite(metadata.modifiedMs) ||
+		(metadata.name !== undefined && typeof metadata.name !== "string") ||
+		(metadata.state !== undefined &&
+			(!metadata.state ||
+				typeof metadata.state !== "object" ||
+				typeof (metadata.state as { status?: unknown }).status !== "string")) ||
+		(metadata.agentStatus !== undefined &&
+			(!metadata.agentStatus ||
+				typeof metadata.agentStatus !== "object" ||
+				typeof (metadata.agentStatus as { summary?: unknown }).summary !== "string" ||
+				typeof (metadata.agentStatus as { basedOnMessageCount?: unknown }).basedOnMessageCount !== "number"))
+	) {
+		return false;
+	}
+	return true;
+}
 
 /**
  * One helper process serves every descriptor-relative read of a family walk.
@@ -325,8 +470,14 @@ class TrustedReadSession {
 		});
 	}
 
-	async read(rawPath: string, maxBytes: number, mode: TrustedReadMode): Promise<TrustedFile> {
+	async read(rawPath: string, maxBytes: number, mode: Exclude<TrustedReadMode, "metadata">): Promise<TrustedFile> {
 		const run = this.queue.then(() => this.readSerialized(rawPath, maxBytes, mode));
+		this.queue = run.catch(() => undefined);
+		return run;
+	}
+
+	async metadata(rawPath: string): Promise<TrustedMetadataFile> {
+		const run = this.queue.then(() => this.readMetadataSerialized(rawPath));
 		this.queue = run.catch(() => undefined);
 		return run;
 	}
@@ -367,7 +518,17 @@ class TrustedReadSession {
 		return invalidFamilyTopology(`descriptor-relative artifact read failed: ${failure.message}`);
 	}
 
-	private async readSerialized(rawPath: string, maxBytes: number, mode: TrustedReadMode): Promise<TrustedFile> {
+	private async readMetadataSerialized(rawPath: string): Promise<TrustedMetadataFile> {
+		const file = await this.readSerialized(rawPath, 0, "metadata");
+		if (!file.metadata) throw invalidFamilyTopology("descriptor-relative artifact metadata is invalid");
+		return { ...file, metadata: file.metadata };
+	}
+
+	private async readSerialized(
+		rawPath: string,
+		maxBytes: number,
+		mode: TrustedReadMode,
+	): Promise<TrustedFile & { metadata?: TrustedSessionMetadata }> {
 		if (!isAbsolute(rawPath) || rawPath !== resolve(rawPath))
 			throw invalidFamilyTopology("session path is not canonical");
 		const root = [this.roots.session, this.roots.artifacts].find(
@@ -384,7 +545,7 @@ class TrustedReadSession {
 		const requestId = randomUUID();
 		const line = await this.exchange(
 			JSON.stringify({ id: requestId, parts, limit: maxBytes, mode, root: rootFd }),
-			maxBytes * 2 + 64 * 1024,
+			mode === "metadata" ? MAX_METADATA_RESPONSE_BYTES : maxBytes * 2 + 64 * 1024,
 		);
 		let wire: { id?: unknown; error?: unknown; data?: unknown; mtimeMs?: unknown; dev?: unknown; ino?: unknown };
 		try {
@@ -400,7 +561,11 @@ class TrustedReadSession {
 		if (wire.error === "absent") throw invalidFamilyTopology("descriptor-relative artifact is absent");
 		if (
 			wire.error !== undefined ||
-			(mode === "stat" ? wire.data !== undefined : typeof wire.data !== "string") ||
+			(mode === "stat"
+				? wire.data !== undefined
+				: mode === "metadata"
+					? !isTrustedSessionMetadata(wire.data)
+					: typeof wire.data !== "string") ||
 			typeof wire.mtimeMs !== "number" ||
 			typeof wire.dev !== "string" ||
 			typeof wire.ino !== "string"
@@ -413,6 +578,7 @@ class TrustedReadSession {
 			mtimeMs: wire.mtimeMs,
 			dev: wire.dev,
 			ino: wire.ino,
+			...(mode === "metadata" ? { metadata: wire.data as TrustedSessionMetadata } : {}),
 		};
 	}
 
@@ -488,14 +654,10 @@ class TrustedReadSession {
 /**
  * Topology claims (id, parent, depth) come from descriptor-bound header bytes.
  * Display metadata (name, timestamps, previews) is not part of the trust
- * decision: it comes from the caller's listing when available, otherwise from
- * an ordinary cached read, and is bound to the header by the id cross-check.
+ * decision. It is scanned inside the descriptor-bound helper and is bound to
+ * the trusted header by the identity check below.
  */
-async function readTrustedSession(
-	path: string,
-	reader: TrustedReadSession,
-	listed?: SessionInfo,
-): Promise<TrustedSession> {
+async function readTrustedSession(path: string, reader: TrustedReadSession): Promise<TrustedSession> {
 	const trusted = await reader.read(path, MAX_SESSION_HEADER_BYTES, "header");
 	const headerLine = trusted.contents.toString("utf8").split(/\r?\n/, 1)[0];
 	let header: {
@@ -527,19 +689,25 @@ async function readTrustedSession(
 		throw invalidFamilyTopology("session header lacks trustworthy topology claims");
 	const persistedDepth = hasDepth ? (header.rlmDepth as number) : undefined;
 	afterTrustedHeaderForTest?.(path);
-	// Detect a post-header swap without reading a body or reopening through the
-	// legacy scanner. The descriptor-relative stat is a second identity binding.
-	const bound = await reader.read(path, 0, "stat");
+	// The metadata scan is bound to one descriptor, so it can skip giant entries
+	// without transferring a session body or reopening the pathname in Node.
+	const bound = await reader.metadata(path);
 	if (bound.dev !== trusted.dev || bound.ino !== trusted.ino)
 		throw invalidFamilyTopology("session changed after its trusted header read");
-	// An unlisted registry child must never reach the legacy pathname scanner:
-	// it may recursively read parent paths and can observe a replacement after
-	// this descriptor-bound open. Header metadata is intentionally shallow.
-	const info =
-		listed?.path === path
-			? listed
-			: readSessionHeaderInfoFromBuffer(path, trusted.contents, { mtimeMs: trusted.mtimeMs });
-	if (!info || info.id !== header.id) throw invalidFamilyTopology("session metadata does not match its header");
+	const headerInfo = readSessionHeaderInfoFromBuffer(path, trusted.contents, { mtimeMs: trusted.mtimeMs });
+	if (!headerInfo || headerInfo.id !== header.id)
+		throw invalidFamilyTopology("session metadata does not match its header");
+	const { metadata } = bound;
+	const info: SessionInfo = {
+		...headerInfo,
+		modified: new Date(metadata.modifiedMs),
+		messageCount: metadata.messageCount,
+		firstMessage: metadata.firstMessage,
+		allMessagesText: metadata.allMessagesText,
+		...(metadata.name !== undefined ? { name: metadata.name } : {}),
+		...(metadata.state !== undefined ? { state: metadata.state } : {}),
+		...(metadata.agentStatus !== undefined ? { agentStatus: metadata.agentStatus } : {}),
+	};
 	return {
 		...info,
 		path,
@@ -597,7 +765,7 @@ async function readLatestRegistry(
 		if (
 			entry.type !== "rlm_subagent" ||
 			typeof entry.childId !== "string" ||
-			entry.childId === "" ||
+			!/^sub-[0-9a-f]{8}$/.test(entry.childId) ||
 			typeof entry.sessionFile !== "string" ||
 			entry.sessionFile === "" ||
 			(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted")
@@ -609,9 +777,19 @@ async function readLatestRegistry(
 	return [...latest.values()];
 }
 
+function listSessionCandidates(sessionDir: string): string[] {
+	try {
+		return readdirSync(sessionDir)
+			.filter((entry) => entry.endsWith(".jsonl"))
+			.map((entry) => join(resolve(sessionDir), entry));
+	} catch {
+		return [];
+	}
+}
+
 export async function listCatalogFamilySessions(sessionDir?: string): Promise<SessionInfo[]> {
 	const effectiveSessionDir = sessionDir ?? getSessionsDir();
-	const roots = await SessionManager.listAll(undefined, effectiveSessionDir);
+	const roots = listSessionCandidates(effectiveSessionDir);
 	const authority = managedRoots(effectiveSessionDir);
 	const reader = new TrustedReadSession(authority);
 	let result: SessionInfo[] | undefined;
@@ -619,8 +797,8 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 	try {
 		const sessions = new Map<string, FamilySession>();
 		const ids = new Map<string, string>();
-		for (const root of roots) {
-			const trusted = asTrustedFamilyRoot(await readTrustedSession(root.path, reader, root), authority);
+		for (const rootPath of roots) {
+			const trusted = asTrustedFamilyRoot(await readTrustedSession(rootPath, reader), authority);
 			const existingPath = ids.get(trusted.id);
 			if (existingPath && existingPath !== trusted.path)
 				throw invalidFamilyTopology("family contains a duplicate session id");
@@ -664,7 +842,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 				// Registry keys name that immediate child directory, so neither a
 				// nested sessions root nor a re-keyed sibling is reachable.
 				const modernWriterPath =
-					childId.startsWith("sub-") &&
+					/^sub-[0-9a-f]{8}$/.test(childId) &&
 					childId === basename(childSessionDir) &&
 					childSessionDir === join(writerChildrenRoot, childId);
 				if (!modernWriterPath) {

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -145,6 +145,7 @@ function managedRoots(sessionDir: string | undefined): ManagedRoots {
 		return { session, artifacts };
 	} catch (error) {
 		closeSync(session.fd);
+		openAuthorityFdCountForTest--;
 		throw error;
 	}
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -75,7 +75,7 @@ interface SavedRlmSubagentRegistryEntry {
 
 // Registry records carry prompts and spawn code; real profiles reach a few MB.
 const MAX_RLM_REGISTRY_BYTES = 16 * 1024 * 1024;
-const MAX_SESSION_HEADER_BYTES = 256 * 1024;
+const MAX_SESSION_HEADER_BYTES = 64 * 1024;
 const MAX_RLM_REGISTRY_RECORDS = 10_000;
 const MAX_RLM_FAMILY_EDGES = 10_000;
 const MAX_RLM_FAMILY_NODES = 10_000;
@@ -207,17 +207,15 @@ def compact_metadata_response(response):
  data=response.get("data")
  if not isinstance(data,dict): reject()
  targets=[]
- # Walk every string value recursively, in insertion/index order. The protocol
- # currently has a typed metadata shape, but this prevents a future nested
- # display field from bypassing the full-envelope budget.
- def collect(container):
-  values=container.items() if isinstance(container,dict) else enumerate(container) if isinstance(container,list) else ()
-  for key,value in values:
-   if isinstance(value,str): targets.append((container,key,value))
-   elif isinstance(value,(dict,list)): collect(value)
- collect(response)
- # Clear every string before allocating the remaining escaped-byte budget in a
- # stable order. Fields remain present and string typed.
+ # Only the approved human-facing metadata strings are compactable. Protocol
+ # control fields and typed metadata enums remain byte-for-byte unchanged.
+ def add_target(container,key):
+  if isinstance(container.get(key),str): targets.append((container,key,container[key]))
+ add_target(data,"firstMessage"); add_target(data,"allMessagesText"); add_target(data,"name")
+ status=data.get("agentStatus")
+ if isinstance(status,dict): add_target(status,"summary")
+ # Clear every display string before allocating the remaining escaped-byte
+ # budget in a stable order. Fields remain present and string typed.
  for container,key,_ in targets: container[key]=""
  if encoded_size()>MAX_METADATA_RESPONSE_BYTES: reject()
  for container,key,original in targets:
@@ -348,7 +346,7 @@ def scan_metadata(fd,mtime_ms):
 def serve(req):
  request_id=req.get("id"); parts=req.get("parts"); limit=req.get("limit"); mode=req.get("mode"); root=req.get("root")
  if not isinstance(request_id,str) or not request_id or len(request_id)>128: reject()
- if mode not in ("read","header","stat","metadata") or root not in (3,4): reject()
+ if mode not in ("read","header","classify","stat","metadata") or root not in (3,4): reject()
  if not isinstance(parts,list) or not parts or not isinstance(limit,int) or limit<0 or limit>MAX: reject()
  if any(not isinstance(p,str) or not p or p in (".","..") or "/" in p or "\\" in p for p in parts): reject()
  current=os.dup(root)
@@ -361,26 +359,23 @@ def serve(req):
    if not stat.S_ISREG(before.st_mode): reject()
    if mode=="read" and before.st_size>limit: reject()
    payload={}
-   if mode in ("read","header"):
+   if mode in ("read","header","classify"):
     chunks=[]; total=0; done=False
     while not done:
      chunk=os.read(fd,min(65536,limit+1-total))
      if not chunk: break
-     if mode=="header":
+     if mode in ("header","classify"):
       cut=chunk.find(b"\n")
       if cut>=0: chunk=chunk[:cut+1]; done=True
      chunks.append(chunk); total+=len(chunk)
      if total>limit:
-      # An oversized first record can be an incomplete concurrent write. It is
-      # distinguishable from an I/O/protocol failure so root classification can
-      # ignore it, while registry-reached sessions remain strict.
-      if mode=="header":
-       # Return only a small bounded prefix for root classification. It fits
-       # inside the outer 256 KiB envelope; registry-reached headers stay
-       # strict in TypeScript whenever this flag is present.
+      # Only root classification may receive an incomplete first record. Its
+      # raw prefix is independently bounded so base64 plus the full envelope
+      # remains below the protocol cap. Strict registry/session reads reject.
+      if mode=="classify":
        payload["truncated"]=True; chunks=[b"".join(chunks)[:HEADER_CLASSIFICATION_BYTES]]; break
       reject()
-    if not payload.get("truncated"): payload["data"]=base64.b64encode(b"".join(chunks)).decode("ascii")
+    payload["data"]=base64.b64encode(b"".join(chunks)).decode("ascii")
    elif mode=="metadata": payload["data"]=scan_metadata(fd,before.st_mtime_ns/1000000)
    after=os.fstat(fd)
    if (before.st_dev,before.st_ino,before.st_mode)!=(after.st_dev,after.st_ino,after.st_mode): reject()
@@ -401,10 +396,11 @@ while True:
  if isinstance(request,dict) and request.get("mode")=="metadata" and "data" in response:
   try: compact_metadata_response(response)
   except Exception: response={"error":"failed","id":response.get("id")}
- # This is the exact full response envelope budgeted above. Keep
- # ensure_ascii explicit: changing a Python default cannot weaken the cap.
+ # Metadata is the only compacted response. Its exact full envelope, including
+ # the request id and every escaped control/display field, is bounded here.
+ # Registry records deliberately retain their larger strict read budget.
  serialized=json.dumps(response,separators=(",",":"),ensure_ascii=True)
- if len(serialized.encode("ascii"))>MAX_METADATA_RESPONSE_BYTES: sys.exit(1)
+ if isinstance(request,dict) and request.get("mode")=="metadata" and len(serialized.encode("ascii"))>MAX_METADATA_RESPONSE_BYTES: sys.exit(1)
  sys.stdout.write(serialized+"\n"); sys.stdout.flush()
 `;
 
@@ -429,10 +425,21 @@ export function setCatalogHelperLaunchForTest(launch: { command: string; args: s
 	catalogHelperLaunchForTest = launch;
 }
 
-type TrustedReadMode = "read" | "header" | "stat" | "metadata";
+type TrustedReadMode = "read" | "header" | "classify" | "stat" | "metadata";
 
 const TRUSTED_READ_TIMEOUT_MS = 5_000;
 const MAX_METADATA_RESPONSE_BYTES = 256 * 1024;
+
+/** Test-only seam observes the exact helper response before protocol validation. */
+let afterCatalogHelperResponseForTest:
+	| ((mode: TrustedReadMode, requestId: string, responseLine: string) => void)
+	| undefined;
+/** @internal */
+export function setCatalogAfterHelperResponseForTest(
+	hook: ((mode: TrustedReadMode, requestId: string, responseLine: string) => void) | undefined,
+): void {
+	afterCatalogHelperResponseForTest = hook;
+}
 
 function isTrustedSessionMetadata(value: unknown): value is TrustedSessionMetadata {
 	if (!value || typeof value !== "object") return false;
@@ -450,7 +457,9 @@ function isTrustedSessionMetadata(value: unknown): value is TrustedSessionMetada
 		(metadata.state !== undefined &&
 			(!metadata.state ||
 				typeof metadata.state !== "object" ||
-				typeof (metadata.state as { status?: unknown }).status !== "string")) ||
+				((metadata.state as { status?: unknown }).status !== "active" &&
+					(metadata.state as { status?: unknown }).status !== "archived" &&
+					(metadata.state as { status?: unknown }).status !== "crash"))) ||
 		(metadata.agentStatus !== undefined &&
 			(!metadata.agentStatus ||
 				typeof metadata.agentStatus !== "object" ||
@@ -614,7 +623,7 @@ class TrustedReadSession {
 		const requestId = randomUUID();
 		const line = await this.exchange(
 			JSON.stringify({ id: requestId, parts, limit: maxBytes, mode, root: rootFd }),
-			mode === "metadata" ? MAX_METADATA_RESPONSE_BYTES : maxBytes * 2 + 64 * 1024,
+			mode === "read" ? maxBytes * 2 + 64 * 1024 : MAX_METADATA_RESPONSE_BYTES,
 		);
 		let wire: {
 			id?: unknown;
@@ -627,6 +636,7 @@ class TrustedReadSession {
 		};
 		try {
 			wire = JSON.parse(line) as typeof wire;
+			afterCatalogHelperResponseForTest?.(mode, requestId, line);
 		} catch {
 			this.fail(new Error("catalog openat helper response is invalid"));
 			throw invalidFamilyTopology("descriptor-relative artifact response is invalid");
@@ -636,7 +646,7 @@ class TrustedReadSession {
 			throw invalidFamilyTopology("descriptor-relative artifact response is invalid");
 		}
 		if (wire.error === "absent") throw invalidFamilyTopology("descriptor-relative artifact is absent");
-		const truncatedHeader = mode === "header" && wire.truncated === true;
+		const truncatedHeader = mode === "classify" && wire.truncated === true;
 		if (
 			wire.error !== undefined ||
 			(wire.truncated !== undefined && !truncatedHeader) ||
@@ -812,7 +822,7 @@ async function readTrustedRootCandidate(
 	listed: { dev: string; ino: string },
 	reader: TrustedReadSession,
 ): Promise<TrustedSession | undefined> {
-	const header = await reader.read(path, MAX_SESSION_HEADER_BYTES, "header");
+	const header = await reader.read(path, MAX_SESSION_HEADER_BYTES, "classify");
 	// A candidate changing after enumeration cannot safely be reclassified as
 	// junk: it may have replaced an identified root before descriptor open.
 	if (header.dev !== listed.dev || header.ino !== listed.ino)
@@ -838,7 +848,8 @@ async function readTrustedRootCandidate(
 		throw invalidFamilyTopology("session header exceeds the trusted read limit");
 	if (header.truncated) return undefined;
 	if (candidate.type !== "session") return undefined;
-	if (typeof candidate.id !== "string" || candidate.id === "") return undefined;
+	// Once a complete root record purports to be a session, strict parsing owns
+	// it. A missing/blank id is corruption, not unrelated no-id junk.
 	return readTrustedSession(path, reader);
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, constants, openSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
@@ -126,6 +126,12 @@ export function getOpenCatalogAuthorityFdCountForTest(): number {
 	return openAuthorityFdCountForTest;
 }
 
+let helperSpawnCountForTest = 0;
+/** @internal */
+export function getCatalogHelperSpawnCountForTest(): number {
+	return helperSpawnCountForTest;
+}
+
 function openAuthorityRoot(path: string, optional = false): ManagedRoot | undefined {
 	try {
 		// O_NOFOLLOW binds authority to the directory itself, never a pathname target.
@@ -167,13 +173,12 @@ def flags(directory=False):
  value=os.O_RDONLY|os.O_NOFOLLOW
  if directory: value|=os.O_DIRECTORY
  return value
-def main():
- req=json.loads(sys.stdin.buffer.read(131073))
- parts=req.get("parts"); limit=req.get("limit"); mode=req.get("mode")
- if mode not in ("read","header","stat"): reject()
+def serve(req):
+ parts=req.get("parts"); limit=req.get("limit"); mode=req.get("mode"); root=req.get("root")
+ if mode not in ("read","header","stat") or root not in (3,4): reject()
  if not isinstance(parts,list) or not parts or not isinstance(limit,int) or limit<0 or limit>MAX: reject()
  if any(not isinstance(p,str) or not p or p in (".","..") or "/" in p or "\\" in p for p in parts): reject()
- current=os.dup(3)
+ current=os.dup(root)
  try:
   for part in parts[:-1]:
    nxt=os.open(part,flags(True),dir_fd=current); os.close(current); current=nxt
@@ -197,12 +202,17 @@ def main():
    after=os.fstat(fd)
    if (before.st_dev,before.st_ino,before.st_mode)!=(after.st_dev,after.st_ino,after.st_mode): reject()
    payload.update({"mtimeMs":after.st_mtime_ns/1000000,"dev":str(after.st_dev),"ino":str(after.st_ino)})
-   print(json.dumps(payload,separators=(",",":")))
+   return payload
   finally: os.close(fd)
  finally: os.close(current)
-try: main()
-except FileNotFoundError: sys.exit(44)
-except Exception: sys.stderr.write("catalog openat helper failed\n"); sys.exit(1)
+while True:
+ line=sys.stdin.buffer.readline(131073)
+ if not line: break
+ if len(line)>131072 or not line.endswith(b"\n"): sys.exit(1)
+ try: response=serve(json.loads(line))
+ except FileNotFoundError: response={"error":"absent"}
+ except Exception: response={"error":"failed"}
+ sys.stdout.write(json.dumps(response,separators=(",",":"))+"\n"); sys.stdout.flush()
 `;
 
 /** Test-only seam runs after authority selection but before descriptor-relative traversal. */
@@ -214,44 +224,91 @@ export function setCatalogBeforeTrustedOpenForTest(hook: ((path: string) => void
 
 type TrustedReadMode = "read" | "header" | "stat";
 
-function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number, mode: TrustedReadMode): TrustedFile {
-	if (!isAbsolute(rawPath) || rawPath !== resolve(rawPath))
-		throw invalidFamilyTopology("session path is not canonical");
-	const root = [roots.session, roots.artifacts].find((candidate) => candidate && isWithin(candidate.lexical, rawPath));
-	if (!root) throw invalidFamilyTopology("session path escapes managed roots");
-	const suffix = relative(root.lexical, rawPath);
-	const parts = suffix.split(sep);
-	if (!suffix || parts.some((part) => !part || part === "." || part === "..")) {
-		throw invalidFamilyTopology("session path lacks a trusted file component");
+const TRUSTED_READ_TIMEOUT_MS = 5_000;
+
+/**
+ * One helper process serves every descriptor-relative read of a family walk.
+ * Both authority roots are passed at spawn (session on fd 3, artifacts on
+ * fd 4 when present) and selected per request; requests are newline-delimited
+ * JSON on stdin with one JSON response line each. Any protocol violation
+ * kills the helper and fails the walk closed.
+ */
+class TrustedReadSession {
+	private readonly child: ChildProcess;
+	private stdoutBuffer = "";
+	private failure: Error | undefined;
+	private pending:
+		| { resolve: (line: string) => void; reject: (error: Error) => void; timeout: NodeJS.Timeout; cap: number }
+		| undefined;
+	private queue: Promise<unknown> = Promise.resolve();
+
+	constructor(private readonly roots: ManagedRoots) {
+		const stdio: Array<"pipe" | "ignore" | number> = ["pipe", "pipe", "ignore", roots.session.fd];
+		if (roots.artifacts) stdio.push(roots.artifacts.fd);
+		this.child = spawn(
+			process.execPath === process.env.PRIME_AGENT_KERNEL_PYTHON
+				? process.execPath
+				: (process.env.PRIME_AGENT_KERNEL_PYTHON ?? "python3"),
+			["-I", "-c", OPENAT_READ_HELPER],
+			{ stdio, shell: false },
+		);
+		helperSpawnCountForTest++;
+		this.child.stdin?.on("error", (error) =>
+			this.fail(new Error(`catalog openat helper write failed: ${String(error)}`)),
+		);
+		this.child.stdout?.setEncoding("utf8");
+		this.child.stdout?.on("data", (chunk: string) => this.handleStdout(chunk));
+		this.child.on("error", (error) => this.fail(new Error(`catalog openat helper failed: ${String(error)}`)));
+		this.child.on("exit", () => this.fail(new Error("catalog openat helper exited")));
 	}
-	beforeTrustedOpenForTest?.(rawPath);
-	const result = spawnSync(
-		process.execPath === process.env.PRIME_AGENT_KERNEL_PYTHON
-			? process.execPath
-			: (process.env.PRIME_AGENT_KERNEL_PYTHON ?? "python3"),
-		["-I", "-c", OPENAT_READ_HELPER],
-		{
-			input: JSON.stringify({ parts, limit: maxBytes, mode }),
-			encoding: "utf8",
-			timeout: 5_000,
-			maxBuffer: maxBytes * 2 + 64 * 1024,
-			stdio: ["pipe", "pipe", "pipe", root.fd],
-			shell: false,
-		},
-	);
-	if (result.status === 44) throw invalidFamilyTopology("descriptor-relative artifact is absent");
-	if (result.error || result.status !== 0 || typeof result.stdout !== "string") {
-		throw invalidFamilyTopology("descriptor-relative artifact read failed");
+
+	async read(rawPath: string, maxBytes: number, mode: TrustedReadMode): Promise<TrustedFile> {
+		const run = this.queue.then(() => this.readSerialized(rawPath, maxBytes, mode));
+		this.queue = run.catch(() => undefined);
+		return run;
 	}
-	try {
-		const wire = JSON.parse(result.stdout) as { data?: unknown; mtimeMs?: unknown; dev?: unknown; ino?: unknown };
+
+	close(): void {
+		this.fail(new Error("catalog openat helper closed"));
+		this.child.stdin?.end();
+		this.child.kill("SIGKILL");
+	}
+
+	private async readSerialized(rawPath: string, maxBytes: number, mode: TrustedReadMode): Promise<TrustedFile> {
+		if (!isAbsolute(rawPath) || rawPath !== resolve(rawPath))
+			throw invalidFamilyTopology("session path is not canonical");
+		const root = [this.roots.session, this.roots.artifacts].find(
+			(candidate) => candidate && isWithin(candidate.lexical, rawPath),
+		);
+		if (!root) throw invalidFamilyTopology("session path escapes managed roots");
+		const suffix = relative(root.lexical, rawPath);
+		const parts = suffix.split(sep);
+		if (!suffix || parts.some((part) => !part || part === "." || part === "..")) {
+			throw invalidFamilyTopology("session path lacks a trusted file component");
+		}
+		beforeTrustedOpenForTest?.(rawPath);
+		const rootFd = root === this.roots.session ? 3 : 4;
+		const line = await this.exchange(
+			JSON.stringify({ parts, limit: maxBytes, mode, root: rootFd }),
+			maxBytes * 2 + 64 * 1024,
+		);
+		let wire: { error?: unknown; data?: unknown; mtimeMs?: unknown; dev?: unknown; ino?: unknown };
+		try {
+			wire = JSON.parse(line) as typeof wire;
+		} catch {
+			this.fail(new Error("catalog openat helper response is invalid"));
+			throw invalidFamilyTopology("descriptor-relative artifact response is invalid");
+		}
+		if (wire.error === "absent") throw invalidFamilyTopology("descriptor-relative artifact is absent");
 		if (
+			wire.error !== undefined ||
 			(mode === "stat" ? wire.data !== undefined : typeof wire.data !== "string") ||
 			typeof wire.mtimeMs !== "number" ||
 			typeof wire.dev !== "string" ||
 			typeof wire.ino !== "string"
-		)
-			throw new Error("invalid");
+		) {
+			throw invalidFamilyTopology("descriptor-relative artifact read failed");
+		}
 		return {
 			path: rawPath,
 			contents: typeof wire.data === "string" ? Buffer.from(wire.data, "base64") : Buffer.alloc(0),
@@ -259,8 +316,63 @@ function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number,
 			dev: wire.dev,
 			ino: wire.ino,
 		};
-	} catch {
-		throw invalidFamilyTopology("descriptor-relative artifact response is invalid");
+	}
+
+	private exchange(request: string, responseCap: number): Promise<string> {
+		if (this.failure)
+			return Promise.reject(
+				invalidFamilyTopology(`descriptor-relative artifact read failed: ${this.failure.message}`),
+			);
+		return new Promise<string>((resolvePending, rejectPending) => {
+			const timeout = setTimeout(() => {
+				this.fail(new Error("catalog openat helper timed out"));
+			}, TRUSTED_READ_TIMEOUT_MS);
+			this.pending = { resolve: resolvePending, reject: rejectPending, timeout, cap: responseCap };
+			this.child.stdin?.write(`${request}\n`, (error) => {
+				if (error) this.fail(new Error(`catalog openat helper write failed: ${String(error)}`));
+			});
+			this.drainStdout();
+		});
+	}
+
+	private handleStdout(chunk: string): void {
+		this.stdoutBuffer += chunk;
+		this.drainStdout();
+	}
+
+	private drainStdout(): void {
+		const pending = this.pending;
+		if (!pending) {
+			if (this.stdoutBuffer !== "") this.fail(new Error("catalog openat helper sent an unsolicited response"));
+			return;
+		}
+		const end = this.stdoutBuffer.indexOf("\n");
+		if (end === -1) {
+			if (this.stdoutBuffer.length > pending.cap) this.fail(new Error("catalog openat helper response overflow"));
+			return;
+		}
+		const line = this.stdoutBuffer.slice(0, end);
+		this.stdoutBuffer = this.stdoutBuffer.slice(end + 1);
+		this.pending = undefined;
+		clearTimeout(pending.timeout);
+		if (line.length > pending.cap) {
+			this.fail(new Error("catalog openat helper response overflow"));
+			pending.reject(invalidFamilyTopology("descriptor-relative artifact response is invalid"));
+			return;
+		}
+		pending.resolve(line);
+	}
+
+	private fail(error: Error): void {
+		if (this.failure) return;
+		this.failure = error;
+		this.child.kill("SIGKILL");
+		const pending = this.pending;
+		this.pending = undefined;
+		if (pending) {
+			clearTimeout(pending.timeout);
+			pending.reject(invalidFamilyTopology(`descriptor-relative artifact read failed: ${error.message}`));
+		}
 	}
 }
 
@@ -270,8 +382,12 @@ function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number,
  * decision: it comes from the caller's listing when available, otherwise from
  * an ordinary cached read, and is bound to the header by the id cross-check.
  */
-async function readTrustedSession(path: string, roots: ManagedRoots, listed?: SessionInfo): Promise<TrustedSession> {
-	const trusted = readTrustedFile(path, roots, MAX_SESSION_HEADER_BYTES, "header");
+async function readTrustedSession(
+	path: string,
+	reader: TrustedReadSession,
+	listed?: SessionInfo,
+): Promise<TrustedSession> {
+	const trusted = await reader.read(path, MAX_SESSION_HEADER_BYTES, "header");
 	const headerLine = trusted.contents.toString("utf8").split(/\r?\n/, 1)[0];
 	let header: { type?: unknown; id?: unknown; parentSession?: unknown; rlmDepth?: unknown };
 	try {
@@ -328,11 +444,11 @@ function asTrustedFamilyRoot(trusted: TrustedSession, roots: ManagedRoots): Fami
 
 async function readLatestRegistry(
 	path: string,
-	roots: ManagedRoots,
+	reader: TrustedReadSession,
 ): Promise<SavedRlmSubagentRegistryEntry[] | undefined> {
 	let contents: string;
 	try {
-		contents = readTrustedFile(path, roots, MAX_RLM_REGISTRY_BYTES, "read").contents.toString("utf8");
+		contents = (await reader.read(path, MAX_RLM_REGISTRY_BYTES, "read")).contents.toString("utf8");
 	} catch (error) {
 		if ((error as Error).message.includes("descriptor-relative artifact is absent")) return undefined;
 		throw error;
@@ -367,11 +483,12 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 	const effectiveSessionDir = sessionDir ?? getSessionsDir();
 	const roots = await SessionManager.listAll(undefined, effectiveSessionDir);
 	const authority = managedRoots(effectiveSessionDir);
+	const reader = new TrustedReadSession(authority);
 	try {
 		const sessions = new Map<string, FamilySession>();
 		const ids = new Map<string, string>();
 		for (const root of roots) {
-			const trusted = asTrustedFamilyRoot(await readTrustedSession(root.path, authority, root), authority);
+			const trusted = asTrustedFamilyRoot(await readTrustedSession(root.path, reader, root), authority);
 			const existingPath = ids.get(trusted.id);
 			if (existingPath && existingPath !== trusted.path)
 				throw invalidFamilyTopology("family contains a duplicate session id");
@@ -388,7 +505,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 			visited.add(parentPath);
 			const registryPath = rlmSubagentRegistryPath(parent, authority);
 			if (!registryPath) return;
-			const entries = await readLatestRegistry(registryPath, authority);
+			const entries = await readLatestRegistry(registryPath, reader);
 			if (!entries) return;
 			const childAncestors = new Set(ancestors);
 			childAncestors.add(parentPath);
@@ -397,7 +514,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 				if (++edges > MAX_RLM_FAMILY_EDGES) throw invalidFamilyTopology("family edge limit exhausted");
 				const childPath = entry.sessionFile as string;
 				if (childAncestors.has(childPath)) throw invalidFamilyTopology("family contains a cycle");
-				const trustedChild = await readTrustedSession(childPath, authority);
+				const trustedChild = await readTrustedSession(childPath, reader);
 				if (trustedChild.id !== entry.childId)
 					throw invalidFamilyTopology("registry child id does not match session id");
 				if (trustedChild.persistedParentPath === undefined)
@@ -405,7 +522,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 				if (trustedChild.persistedDepth === undefined) throw invalidFamilyTopology("child lacks a persisted depth");
 				const child: FamilySession = { ...trustedChild, persistedDepth: trustedChild.persistedDepth };
 				const claimedParentPath = resolve(dirname(child.path), trustedChild.persistedParentPath);
-				readTrustedFile(claimedParentPath, authority, 0, "stat");
+				await reader.read(claimedParentPath, 0, "stat");
 				if (claimedParentPath !== parentPath)
 					throw invalidFamilyTopology("child parent path does not match traversed parent");
 				if (child.persistedDepth !== parent.persistedDepth + 1)
@@ -432,6 +549,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 		for (const root of [...sessions.values()]) await visit(root, 0, new Set());
 		return [...sessions.values()];
 	} finally {
+		reader.close();
 		closeManagedRoots(authority);
 	}
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -822,21 +822,28 @@ interface JsonStringPrefix {
 	end: number;
 	terminated: boolean;
 	partialEscape: boolean;
+	invalidEscape: boolean;
 }
 
-/** Read a JSON string without treating malformed input as executable JSON. */
+/**
+ * Read a JSON string without treating malformed input as executable JSON.
+ *
+ * Even after an invalid escape, retain string framing: a malformed unrelated
+ * value must not hide subsequent outer-object claims behind its closing quote.
+ */
 function readJsonStringPrefix(text: string, start: number): JsonStringPrefix | undefined {
 	if (text[start] !== '"') return undefined;
 	let value = "";
 	let index = start + 1;
+	let invalidEscape = false;
 	while (index < text.length) {
 		const char = text[index++];
-		if (char === '"') return { value, end: index, terminated: true, partialEscape: false };
+		if (char === '"') return { value, end: index, terminated: true, partialEscape: false, invalidEscape };
 		if (char !== "\\") {
 			value += char;
 			continue;
 		}
-		if (index === text.length) return { value, end: index, terminated: false, partialEscape: true };
+		if (index === text.length) return { value, end: index, terminated: false, partialEscape: true, invalidEscape };
 		const escapedChar = text[index++];
 		const simpleEscape =
 			escapedChar === '"'
@@ -860,14 +867,26 @@ function readJsonStringPrefix(text: string, start: number): JsonStringPrefix | u
 			value += simpleEscape;
 			continue;
 		}
-		if (escapedChar !== "u") return { value, end: index, terminated: false, partialEscape: false };
-		if (index + 4 > text.length) return { value, end: text.length, terminated: false, partialEscape: true };
-		const hex = text.slice(index, index + 4);
-		if (!/^[0-9a-f]{4}$/iu.test(hex)) return { value, end: index + 4, terminated: false, partialEscape: false };
-		value += String.fromCharCode(Number.parseInt(hex, 16));
-		index += 4;
+		if (escapedChar !== "u") {
+			invalidEscape = true;
+			continue;
+		}
+		const unicodeStart = index;
+		let hex = "";
+		while (hex.length < 4 && index < text.length && /[0-9a-f]/iu.test(text[index] ?? "")) {
+			hex += text[index++];
+		}
+		if (hex.length === 4) {
+			value += String.fromCharCode(Number.parseInt(hex, 16));
+			continue;
+		}
+		invalidEscape = true;
+		// A truncated sequence is ambiguous. Otherwise leave the first invalid
+		// byte for normal framing, notably a terminating quote.
+		if (index === text.length) return { value, end: index, terminated: false, partialEscape: true, invalidEscape };
+		index = unicodeStart + hex.length;
 	}
-	return { value, end: index, terminated: false, partialEscape: false };
+	return { value, end: index, terminated: false, partialEscape: false, invalidEscape };
 }
 
 function skipJsonValuePrefix(text: string, start: number): number {
@@ -913,17 +932,19 @@ function hasApparentSessionTopologyClaimPrefix(text: string): boolean {
 		if (text[index] === "}") return false;
 		const key = readJsonStringPrefix(text, index);
 		if (!key) return false;
-		if (!key.terminated) return key.partialEscape;
+		// A malformed or partial outer key could itself be a topology key.
+		if (!key.terminated || key.invalidEscape) return true;
 		index = key.end;
 		while (/\s/u.test(text[index] ?? "")) index++;
 		if (text[index] !== ":") return false;
 		index++;
 		while (/\s/u.test(text[index] ?? "")) index++;
 		if (key.value === "id") return true;
-		if (key.value === "type") {
-			const value = readJsonStringPrefix(text, index);
-			if (!value) return false;
-			if (!value.terminated) return value.partialEscape || "session".startsWith(value.value);
+		if (key.value === "type" && text[index] === '"') {
+			const value = readJsonStringPrefix(text, index)!;
+			// Type's string value is itself a session claim surface; do not
+			// downgrade malformed or partial values to unrelated junk.
+			if (!value.terminated || value.invalidEscape) return true;
 			if (value.value === "session") return true;
 		}
 		index = skipJsonValuePrefix(text, index);

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1095,9 +1095,9 @@ function listSessionCandidates(
 				if (!entry) break;
 				if (!entry.name.endsWith(".jsonl")) continue;
 				const path = join(resolve(sessionDir), entry.name);
-				let stat: ReturnType<typeof lstatSync>;
 				try {
-					stat = lstatSync(path);
+					const stat = lstatSync(path, { bigint: true });
+					candidates.push({ path, dev: stat.dev.toString(), ino: stat.ino.toString() });
 				} catch (error) {
 					if ((error as NodeJS.ErrnoException).code === "ENOENT") {
 						// Removed during enumeration: it was never a stable root candidate.
@@ -1105,7 +1105,6 @@ function listSessionCandidates(
 					}
 					throw error;
 				}
-				candidates.push({ path, dev: String(stat.dev), ino: String(stat.ino) });
 				// Stop immediately at limit + 1. No further directory entries are read,
 				// and no candidate descriptor is opened from an incomplete root set.
 				if (candidates.length > limit) throw limitExceeded;

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -6,7 +6,12 @@ import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli
 import { getSessionsDir } from "../../config.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
-import { readSessionInfo, type SessionInfo, SessionManager } from "../../core/session-manager.js";
+import {
+	readSessionHeaderInfoFromBuffer,
+	readSessionInfo,
+	type SessionInfo,
+	SessionManager,
+} from "../../core/session-manager.js";
 
 export const DAEMON_CATALOG_ROLE_ENV = "PRIME_AGENT_INTERNAL_DAEMON_CATALOG";
 
@@ -98,6 +103,7 @@ interface TrustedSession extends SessionInfo {
 	/** The header claims are intentionally separate from SessionInfo's legacy fallback. */
 	persistedDepth?: number;
 	persistedParentPath?: string;
+	persistedVersion?: number;
 }
 
 /** A family member whose depth has been verified against the walk. */
@@ -224,6 +230,13 @@ export function setCatalogBeforeTrustedOpenForTest(hook: ((path: string) => void
 	beforeTrustedOpenForTest = hook;
 }
 
+/** Test-only seam runs after a descriptor-bound header read, before metadata. */
+let afterTrustedHeaderForTest: ((path: string) => void) | undefined;
+/** @internal */
+export function setCatalogAfterTrustedHeaderForTest(hook: ((path: string) => void) | undefined): void {
+	afterTrustedHeaderForTest = hook;
+}
+
 type TrustedReadMode = "read" | "header" | "stat";
 
 const TRUSTED_READ_TIMEOUT_MS = 5_000;
@@ -243,10 +256,22 @@ class TrustedReadSession {
 		| { resolve: (line: string) => void; reject: (error: Error) => void; timeout: NodeJS.Timeout; cap: number }
 		| undefined;
 	private queue: Promise<unknown> = Promise.resolve();
+	private stdinEnded = false;
+	private exit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+	private readonly stdoutFinished: Promise<void>;
+	private resolveStdoutFinished!: () => void;
+	private readonly exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+	private resolveExited!: (result: { code: number | null; signal: NodeJS.Signals | null }) => void;
 
 	constructor(private readonly roots: ManagedRoots) {
 		const stdio: Array<"pipe" | "ignore" | number> = ["pipe", "pipe", "ignore", roots.session.fd];
 		if (roots.artifacts) stdio.push(roots.artifacts.fd);
+		this.stdoutFinished = new Promise((resolveFinished) => {
+			this.resolveStdoutFinished = resolveFinished;
+		});
+		this.exited = new Promise((resolveExited) => {
+			this.resolveExited = resolveExited;
+		});
 		this.child = spawn(
 			process.execPath === process.env.PRIME_AGENT_KERNEL_PYTHON
 				? process.execPath
@@ -260,8 +285,18 @@ class TrustedReadSession {
 		);
 		this.child.stdout?.setEncoding("utf8");
 		this.child.stdout?.on("data", (chunk: string) => this.handleStdout(chunk));
+		this.child.stdout?.on("end", () => {
+			this.resolveStdoutFinished();
+			if (this.stdoutBuffer !== "") this.fail(new Error("catalog openat helper left residual output"));
+		});
 		this.child.on("error", (error) => this.fail(new Error(`catalog openat helper failed: ${String(error)}`)));
-		this.child.on("exit", () => this.fail(new Error("catalog openat helper exited")));
+		this.child.on("exit", (code, signal) => {
+			this.exit = { code, signal };
+			this.resolveExited(this.exit);
+			if (!this.stdinEnded || code !== 0 || signal !== null) {
+				this.fail(new Error(`catalog openat helper exited (${signal ?? code ?? "unknown"})`));
+			}
+		});
 	}
 
 	async read(rawPath: string, maxBytes: number, mode: TrustedReadMode): Promise<TrustedFile> {
@@ -270,10 +305,22 @@ class TrustedReadSession {
 		return run;
 	}
 
-	close(): void {
-		this.fail(new Error("catalog openat helper closed"));
+	/** End input and require the helper to finish silently and successfully. */
+	async close(): Promise<void> {
+		await this.queue;
+		if (this.failure) return;
+		if (this.pending || this.stdoutBuffer !== "") {
+			this.fail(new Error("catalog openat helper has residual output"));
+			return;
+		}
+		this.stdinEnded = true;
 		this.child.stdin?.end();
-		this.child.kill("SIGKILL");
+		const [exit] = await Promise.all([this.exited, this.stdoutFinished]);
+		if (this.failure || exit.code !== 0 || exit.signal !== null || this.stdoutBuffer !== "") {
+			const failure = this.failure ?? new Error("catalog openat helper did not exit cleanly");
+			if (!this.failure) this.fail(failure);
+			throw invalidFamilyTopology(`descriptor-relative artifact read failed: ${failure.message}`);
+		}
 	}
 
 	private async readSerialized(rawPath: string, maxBytes: number, mode: TrustedReadMode): Promise<TrustedFile> {
@@ -321,14 +368,17 @@ class TrustedReadSession {
 	}
 
 	private exchange(request: string, responseCap: number): Promise<string> {
-		if (this.failure)
+		if (this.failure || this.stdinEnded)
 			return Promise.reject(
-				invalidFamilyTopology(`descriptor-relative artifact read failed: ${this.failure.message}`),
+				invalidFamilyTopology(
+					`descriptor-relative artifact read failed: ${this.failure?.message ?? "helper closed"}`,
+				),
 			);
 		return new Promise<string>((resolvePending, rejectPending) => {
-			const timeout = setTimeout(() => {
-				this.fail(new Error("catalog openat helper timed out"));
-			}, TRUSTED_READ_TIMEOUT_MS);
+			const timeout = setTimeout(
+				() => this.fail(new Error("catalog openat helper timed out")),
+				TRUSTED_READ_TIMEOUT_MS,
+			);
 			this.pending = { resolve: resolvePending, reject: rejectPending, timeout, cap: responseCap };
 			this.child.stdin?.write(`${request}\n`, (error) => {
 				if (error) this.fail(new Error(`catalog openat helper write failed: ${String(error)}`));
@@ -354,11 +404,18 @@ class TrustedReadSession {
 			return;
 		}
 		const line = this.stdoutBuffer.slice(0, end);
-		this.stdoutBuffer = this.stdoutBuffer.slice(end + 1);
+		const suffix = this.stdoutBuffer.slice(end + 1);
+		this.stdoutBuffer = "";
 		this.pending = undefined;
 		clearTimeout(pending.timeout);
-		if (line.length > pending.cap) {
-			this.fail(new Error("catalog openat helper response overflow"));
+		if (line.length > pending.cap || suffix !== "") {
+			this.fail(
+				new Error(
+					line.length > pending.cap
+						? "catalog openat helper response overflow"
+						: "catalog openat helper sent a shifted response",
+				),
+			);
 			pending.reject(invalidFamilyTopology("descriptor-relative artifact response is invalid"));
 			return;
 		}
@@ -368,6 +425,7 @@ class TrustedReadSession {
 	private fail(error: Error): void {
 		if (this.failure) return;
 		this.failure = error;
+		// Failure is deliberately terminal. Clean shutdown is handled only by close().
 		this.child.kill("SIGKILL");
 		const pending = this.pending;
 		this.pending = undefined;
@@ -391,7 +449,15 @@ async function readTrustedSession(
 ): Promise<TrustedSession> {
 	const trusted = await reader.read(path, MAX_SESSION_HEADER_BYTES, "header");
 	const headerLine = trusted.contents.toString("utf8").split(/\r?\n/, 1)[0];
-	let header: { type?: unknown; id?: unknown; parentSession?: unknown; rlmDepth?: unknown };
+	let header: {
+		type?: unknown;
+		id?: unknown;
+		parentSession?: unknown;
+		rlmDepth?: unknown;
+		version?: unknown;
+		cwd?: unknown;
+		timestamp?: unknown;
+	};
 	try {
 		header = JSON.parse(headerLine ?? "") as typeof header;
 	} catch {
@@ -399,20 +465,32 @@ async function readTrustedSession(
 	}
 	const hasParent = header.parentSession !== undefined;
 	const hasDepth = Number.isSafeInteger(header.rlmDepth) && (header.rlmDepth as number) >= 0;
+	const hasVersion = Number.isSafeInteger(header.version) && (header.version as number) >= 1;
 	if (
 		header.type !== "session" ||
 		typeof header.id !== "string" ||
 		header.id === "" ||
 		(hasParent && typeof header.parentSession !== "string") ||
 		(hasParent && header.parentSession === "") ||
-		(header.rlmDepth !== undefined && !hasDepth)
+		(header.rlmDepth !== undefined && !hasDepth) ||
+		(header.version !== undefined && !hasVersion)
 	)
 		throw invalidFamilyTopology("session header lacks trustworthy topology claims");
 	const persistedDepth = hasDepth ? (header.rlmDepth as number) : undefined;
-	const info = listed?.path === path ? listed : await readSessionInfo(path);
+	afterTrustedHeaderForTest?.(path);
+	// Detect a post-header swap without reading a body or reopening through the
+	// legacy scanner. The descriptor-relative stat is a second identity binding.
+	const bound = await reader.read(path, 0, "stat");
+	if (bound.dev !== trusted.dev || bound.ino !== trusted.ino)
+		throw invalidFamilyTopology("session changed after its trusted header read");
+	// An unlisted registry child must never reach the legacy pathname scanner:
+	// it may recursively read parent paths and can observe a replacement after
+	// this descriptor-bound open. Header metadata is intentionally shallow.
+	const info =
+		listed?.path === path
+			? listed
+			: readSessionHeaderInfoFromBuffer(path, trusted.contents, { mtimeMs: trusted.mtimeMs });
 	if (!info || info.id !== header.id) throw invalidFamilyTopology("session metadata does not match its header");
-	// Topology fields are always the header's claims; the display read may not
-	// contradict them in the returned catalog row.
 	return {
 		...info,
 		path,
@@ -420,6 +498,7 @@ async function readTrustedSession(
 		parentSessionPath: hasParent ? (header.parentSession as string) : undefined,
 		...(persistedDepth !== undefined ? { persistedDepth } : {}),
 		...(hasParent ? { persistedParentPath: header.parentSession as string } : {}),
+		...(hasVersion ? { persistedVersion: header.version as number } : {}),
 	};
 }
 
@@ -517,11 +596,38 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 				const childPath = entry.sessionFile as string;
 				if (childAncestors.has(childPath)) throw invalidFamilyTopology("family contains a cycle");
 				const trustedChild = await readTrustedSession(childPath, reader);
-				// Registry childId is the rlm child id (e.g. "sub-1a2b3c4d"), not the
-				// session id. The child's identity anchor is its filename: the session
-				// writer names every child file after its header id.
 				if (basename(childPath, ".jsonl") !== trustedChild.id)
 					throw invalidFamilyTopology("registry child session file does not match its header id");
+				// Registry reachability is not enough: bind the registry key to the
+				// directory the writer allocates directly below this parent's managed
+				// artifact root. This rejects arbitrary sessions-root descendants and
+				// prevents rekeying a real child under another sub-* id.
+				const childId = entry.childId as string;
+				const childSessionDir = dirname(childPath);
+				const parentSessionDir = dirname(parent.path);
+				const writerChildrenRoot =
+					parentSessionDir === authority.session.lexical
+						? join(authority.artifacts?.lexical ?? "", parent.id)
+						: parentSessionDir;
+				// The actual writer uses <parent artifact dir>/sub-*/<session-id>.jsonl.
+				// Registry keys name that immediate child directory, so neither a
+				// nested sessions root nor a re-keyed sibling is reachable.
+				const modernWriterPath =
+					childId.startsWith("sub-") &&
+					childId === basename(childSessionDir) &&
+					childSessionDir === join(writerChildrenRoot, childId);
+				// Versioned v2 registry records used the session id as their key but
+				// still allocated a direct sub-* writer directory. Require both facts;
+				// an equal-id synthetic record without that provenance is not trusted.
+				const legacyWriterPath =
+					trustedChild.persistedVersion !== undefined &&
+					trustedChild.persistedVersion < 3 &&
+					childId === trustedChild.id &&
+					basename(childSessionDir).startsWith("sub-") &&
+					dirname(childSessionDir) === writerChildrenRoot;
+				if (!modernWriterPath && !legacyWriterPath) {
+					throw invalidFamilyTopology("registry child is outside the parent writer artifact layout");
+				}
 				if (trustedChild.persistedParentPath === undefined)
 					throw invalidFamilyTopology("child lacks a persisted parent path");
 				// Old writers persisted no rlmDepth on children: an absent claim is
@@ -559,8 +665,11 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 		for (const root of [...sessions.values()]) await visit(root, 0, new Set());
 		return [...sessions.values()];
 	} finally {
-		reader.close();
-		closeManagedRoots(authority);
+		try {
+			await reader.close();
+		} finally {
+			closeManagedRoots(authority);
+		}
 	}
 }
 export async function listSavedSessionSiblings(sessionPath: string, sessionDir?: string): Promise<SessionInfo[]> {

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -182,7 +182,8 @@ def flags(directory=False):
  if directory: value|=os.O_DIRECTORY
  return value
 def serve(req):
- parts=req.get("parts"); limit=req.get("limit"); mode=req.get("mode"); root=req.get("root")
+ request_id=req.get("id"); parts=req.get("parts"); limit=req.get("limit"); mode=req.get("mode"); root=req.get("root")
+ if not isinstance(request_id,str) or not request_id or len(request_id)>128: reject()
  if mode not in ("read","header","stat") or root not in (3,4): reject()
  if not isinstance(parts,list) or not parts or not isinstance(limit,int) or limit<0 or limit>MAX: reject()
  if any(not isinstance(p,str) or not p or p in (".","..") or "/" in p or "\\" in p for p in parts): reject()
@@ -217,9 +218,12 @@ while True:
  line=sys.stdin.buffer.readline(131073)
  if not line: break
  if len(line)>131072 or not line.endswith(b"\n"): sys.exit(1)
- try: response=serve(json.loads(line))
+ request=None
+ try:
+  request=json.loads(line); response=serve(request)
  except FileNotFoundError: response={"error":"absent"}
  except Exception: response={"error":"failed"}
+ response["id"]=request.get("id") if isinstance(request,dict) else None
  sys.stdout.write(json.dumps(response,separators=(",",":"))+"\n"); sys.stdout.flush()
 `;
 
@@ -308,10 +312,17 @@ class TrustedReadSession {
 	/** End input and require the helper to finish silently and successfully. */
 	async close(): Promise<void> {
 		await this.queue;
-		if (this.failure) return;
+		if (this.failure) {
+			// fail() sends SIGKILL only; wait before releasing the authority FDs.
+			await Promise.all([this.exited, this.stdoutFinished]);
+			return;
+		}
 		if (this.pending || this.stdoutBuffer !== "") {
 			this.fail(new Error("catalog openat helper has residual output"));
-			return;
+			await Promise.all([this.exited, this.stdoutFinished]);
+			throw invalidFamilyTopology(
+				"descriptor-relative artifact read failed: catalog openat helper has residual output",
+			);
 		}
 		this.stdinEnded = true;
 		this.child.stdin?.end();
@@ -337,15 +348,20 @@ class TrustedReadSession {
 		}
 		beforeTrustedOpenForTest?.(rawPath);
 		const rootFd = root === this.roots.session ? 3 : 4;
+		const requestId = randomUUID();
 		const line = await this.exchange(
-			JSON.stringify({ parts, limit: maxBytes, mode, root: rootFd }),
+			JSON.stringify({ id: requestId, parts, limit: maxBytes, mode, root: rootFd }),
 			maxBytes * 2 + 64 * 1024,
 		);
-		let wire: { error?: unknown; data?: unknown; mtimeMs?: unknown; dev?: unknown; ino?: unknown };
+		let wire: { id?: unknown; error?: unknown; data?: unknown; mtimeMs?: unknown; dev?: unknown; ino?: unknown };
 		try {
 			wire = JSON.parse(line) as typeof wire;
 		} catch {
 			this.fail(new Error("catalog openat helper response is invalid"));
+			throw invalidFamilyTopology("descriptor-relative artifact response is invalid");
+		}
+		if (wire.id !== requestId) {
+			this.fail(new Error("catalog openat helper response id is shifted"));
 			throw invalidFamilyTopology("descriptor-relative artifact response is invalid");
 		}
 		if (wire.error === "absent") throw invalidFamilyTopology("descriptor-relative artifact is absent");

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1,11 +1,17 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { closeSync, constants, openSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
+import { getSessionsDir } from "../../config.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
-import { readSessionInfo, type SessionInfo, SessionManager } from "../../core/session-manager.js";
+import {
+	readSessionInfo,
+	readSessionInfoFromBuffer,
+	type SessionInfo,
+	SessionManager,
+} from "../../core/session-manager.js";
 
 export const DAEMON_CATALOG_ROLE_ENV = "PRIME_AGENT_INTERNAL_DAEMON_CATALOG";
 
@@ -16,8 +22,9 @@ interface SessionInfoWire extends Omit<SessionInfo, "created" | "modified"> {
 
 type CatalogRequest =
 	| { type: "request"; id: string; command: "list"; cwd?: string; sessionDir?: string }
+	| { type: "request"; id: string; command: "family"; sessionDir?: string }
 	| { type: "request"; id: string; command: "resolve"; selector: string; cwd: string; sessionDir?: string }
-	| { type: "request"; id: string; command: "siblings"; sessionPath: string }
+	| { type: "request"; id: string; command: "siblings"; sessionPath: string; sessionDir?: string }
 	| { type: "request"; id: string; command: "rename"; sessionPath: string; name: string }
 	| { type: "request"; id: string; command: "delete"; sessionPath: string }
 	| { type: "request"; id: string; command: "archive"; sessionPath: string; sessionId: string }
@@ -66,42 +73,339 @@ interface SavedRlmSubagentRegistryEntry {
 	status?: unknown;
 }
 
-export async function listSavedSessionSiblings(sessionPath: string): Promise<SessionInfo[]> {
-	const target = await readSessionInfo(sessionPath);
-	if (!target) throw new Error(`Session not found: ${sessionPath}`);
-	if (!target.parentSessionPath) return [target];
-	const parentPath = resolve(dirname(target.path), target.parentSessionPath);
-	const parent = await readSessionInfo(parentPath);
-	if (!parent) return [target];
-	const registryPath = join(dirname(dirname(parent.path)), "session-artifacts", parent.id, "rlm-subagents.jsonl");
+const MAX_RLM_REGISTRY_BYTES = 1024 * 1024;
+const MAX_RLM_REGISTRY_RECORDS = 10_000;
+const MAX_RLM_FAMILY_EDGES = 10_000;
+const MAX_RLM_FAMILY_NODES = 10_000;
+const MAX_RLM_FAMILY_DEPTH = 64;
+
+interface ManagedRoot {
+	lexical: string;
+	fd: number;
+}
+
+interface ManagedRoots {
+	session: ManagedRoot;
+	artifacts: ManagedRoot | undefined;
+}
+
+interface TrustedFile {
+	path: string;
+	contents: Buffer;
+	mtimeMs: number;
+	dev: string;
+	ino: string;
+}
+
+interface TrustedSession extends SessionInfo {
+	/** The header claim is intentionally separate from SessionInfo's legacy fallback. */
+	persistedDepth: number;
+	persistedParentPath?: string;
+}
+
+function rlmSubagentRegistryPath(parent: SessionInfo, roots: ManagedRoots): string | undefined {
+	const parentDir = dirname(parent.path);
+	const artifactDir =
+		parentDir === roots.session.lexical ? roots.artifacts?.lexical : join(parentDir, "session-artifacts");
+	return artifactDir ? join(artifactDir, parent.id, "rlm-subagents.jsonl") : undefined;
+}
+
+function isWithin(root: string, target: string): boolean {
+	const path = relative(root, target);
+	return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+
+function invalidFamilyTopology(reason: string): Error {
+	return new Error(`Invalid RLM artifact family topology: ${reason}`);
+}
+
+let openAuthorityFdCountForTest = 0;
+/** @internal */
+export function getOpenCatalogAuthorityFdCountForTest(): number {
+	return openAuthorityFdCountForTest;
+}
+
+function openAuthorityRoot(path: string, optional = false): ManagedRoot | undefined {
+	try {
+		// O_NOFOLLOW binds authority to the directory itself, never a pathname target.
+		const fd = openSync(path, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+		openAuthorityFdCountForTest++;
+		return { lexical: path, fd };
+	} catch (error) {
+		if (optional && (error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw invalidFamilyTopology(`managed authority root is unavailable: ${String(error)}`);
+	}
+}
+
+function managedRoots(sessionDir: string | undefined): ManagedRoots {
+	const sessionLexical = resolve(sessionDir ?? "");
+	const session = openAuthorityRoot(sessionLexical)!;
+	try {
+		const artifacts = openAuthorityRoot(join(dirname(sessionLexical), "session-artifacts"), true);
+		return { session, artifacts };
+	} catch (error) {
+		closeSync(session.fd);
+		throw error;
+	}
+}
+
+function closeManagedRoots(roots: ManagedRoots): void {
+	closeSync(roots.session.fd);
+	openAuthorityFdCountForTest--;
+	if (roots.artifacts) {
+		closeSync(roots.artifacts.fd);
+		openAuthorityFdCountForTest--;
+	}
+}
+
+const OPENAT_READ_HELPER = String.raw`import base64,json,os,stat,sys
+MAX=134217728
+def reject(): raise ValueError("invalid")
+def flags(directory=False):
+ value=os.O_RDONLY|os.O_NOFOLLOW
+ if directory: value|=os.O_DIRECTORY
+ return value
+def main():
+ req=json.loads(sys.stdin.buffer.read(131073))
+ parts=req.get("parts"); limit=req.get("limit")
+ if not isinstance(parts,list) or not parts or not isinstance(limit,int) or limit<0 or limit>MAX: reject()
+ if any(not isinstance(p,str) or not p or p in (".","..") or "/" in p or "\\" in p for p in parts): reject()
+ current=os.dup(3)
+ try:
+  for part in parts[:-1]:
+   nxt=os.open(part,flags(True),dir_fd=current); os.close(current); current=nxt
+  fd=os.open(parts[-1],flags(False),dir_fd=current)
+  try:
+   before=os.fstat(fd)
+   if not stat.S_ISREG(before.st_mode) or before.st_size>limit: reject()
+   chunks=[]; total=0
+   while True:
+    chunk=os.read(fd,min(65536,limit+1-total))
+    if not chunk: break
+    chunks.append(chunk); total+=len(chunk)
+    if total>limit: reject()
+   after=os.fstat(fd)
+   if (before.st_dev,before.st_ino,before.st_mode)!=(after.st_dev,after.st_ino,after.st_mode): reject()
+   print(json.dumps({"data":base64.b64encode(b"".join(chunks)).decode("ascii"),"mtimeMs":after.st_mtime_ns/1000000,"dev":str(after.st_dev),"ino":str(after.st_ino)},separators=(",",":")))
+  finally: os.close(fd)
+ finally: os.close(current)
+try: main()
+except FileNotFoundError: sys.exit(44)
+except Exception: sys.stderr.write("catalog openat helper failed\n"); sys.exit(1)
+`;
+
+/** Test-only seam runs after authority selection but before descriptor-relative traversal. */
+let beforeTrustedOpenForTest: ((path: string) => void) | undefined;
+/** @internal */
+export function setCatalogBeforeTrustedOpenForTest(hook: ((path: string) => void) | undefined): void {
+	beforeTrustedOpenForTest = hook;
+}
+
+function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number): TrustedFile {
+	if (!isAbsolute(rawPath) || rawPath !== resolve(rawPath))
+		throw invalidFamilyTopology("session path is not canonical");
+	const root = [roots.session, roots.artifacts].find((candidate) => candidate && isWithin(candidate.lexical, rawPath));
+	if (!root) throw invalidFamilyTopology("session path escapes managed roots");
+	const suffix = relative(root.lexical, rawPath);
+	const parts = suffix.split(sep);
+	if (!suffix || parts.some((part) => !part || part === "." || part === "..")) {
+		throw invalidFamilyTopology("session path lacks a trusted file component");
+	}
+	beforeTrustedOpenForTest?.(rawPath);
+	const result = spawnSync(
+		process.execPath === process.env.PRIME_AGENT_KERNEL_PYTHON
+			? process.execPath
+			: (process.env.PRIME_AGENT_KERNEL_PYTHON ?? "python3"),
+		["-I", "-c", OPENAT_READ_HELPER],
+		{
+			input: JSON.stringify({ parts, limit: maxBytes }),
+			encoding: "utf8",
+			timeout: 5_000,
+			maxBuffer: maxBytes * 2 + 64 * 1024,
+			stdio: ["pipe", "pipe", "pipe", root.fd],
+			shell: false,
+		},
+	);
+	if (result.status === 44) throw invalidFamilyTopology("descriptor-relative artifact is absent");
+	if (result.error || result.status !== 0 || typeof result.stdout !== "string") {
+		throw invalidFamilyTopology("descriptor-relative artifact read failed");
+	}
+	try {
+		const wire = JSON.parse(result.stdout) as { data?: unknown; mtimeMs?: unknown; dev?: unknown; ino?: unknown };
+		if (
+			typeof wire.data !== "string" ||
+			typeof wire.mtimeMs !== "number" ||
+			typeof wire.dev !== "string" ||
+			typeof wire.ino !== "string"
+		)
+			throw new Error("invalid");
+		return {
+			path: rawPath,
+			contents: Buffer.from(wire.data, "base64"),
+			mtimeMs: wire.mtimeMs,
+			dev: wire.dev,
+			ino: wire.ino,
+		};
+	} catch {
+		throw invalidFamilyTopology("descriptor-relative artifact response is invalid");
+	}
+}
+
+async function readTrustedSession(path: string, roots: ManagedRoots): Promise<TrustedSession> {
+	const trusted = readTrustedFile(path, roots, 128 * 1024 * 1024);
+	const headerLine = trusted.contents
+		.toString("utf8", 0, Math.min(trusted.contents.length, 256 * 1024))
+		.split(/\r?\n/, 1)[0];
+	let header: { type?: unknown; id?: unknown; parentSession?: unknown; rlmDepth?: unknown };
+	try {
+		header = JSON.parse(headerLine ?? "") as typeof header;
+	} catch {
+		throw invalidFamilyTopology("session header is malformed");
+	}
+	const hasParent = header.parentSession !== undefined;
+	const hasDepth = Number.isSafeInteger(header.rlmDepth) && (header.rlmDepth as number) >= 0;
+	if (
+		header.type !== "session" ||
+		typeof header.id !== "string" ||
+		header.id === "" ||
+		(hasParent && typeof header.parentSession !== "string") ||
+		(hasParent && header.parentSession === "") ||
+		(hasParent && !hasDepth) ||
+		(!hasParent && header.rlmDepth !== undefined && !hasDepth)
+	)
+		throw invalidFamilyTopology("session header lacks trustworthy topology claims");
+	const persistedDepth = hasDepth ? (header.rlmDepth as number) : 0;
+	const info = await readSessionInfoFromBuffer(path, trusted.contents, { mtimeMs: trusted.mtimeMs });
+	if (!info || info.id !== header.id) throw invalidFamilyTopology("session metadata does not match its header");
+	return {
+		...info,
+		path,
+		rlmDepth: persistedDepth,
+		persistedDepth,
+		...(hasParent ? { persistedParentPath: header.parentSession as string } : {}),
+	};
+}
+
+async function readLatestRegistry(
+	path: string,
+	roots: ManagedRoots,
+): Promise<SavedRlmSubagentRegistryEntry[] | undefined> {
 	let contents: string;
 	try {
-		contents = await readFile(registryPath, "utf8");
+		contents = readTrustedFile(path, roots, MAX_RLM_REGISTRY_BYTES).contents.toString("utf8");
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [target];
+		if ((error as Error).message.includes("descriptor-relative artifact is absent")) return undefined;
 		throw error;
 	}
 	const latest = new Map<string, SavedRlmSubagentRegistryEntry>();
+	let records = 0;
 	for (const line of contents.split(/\r?\n/)) {
 		if (!line.trim()) continue;
+		if (++records > MAX_RLM_REGISTRY_RECORDS) throw invalidFamilyTopology("registry record limit exhausted");
+		let entry: SavedRlmSubagentRegistryEntry;
 		try {
-			const entry = JSON.parse(line) as SavedRlmSubagentRegistryEntry;
-			if (entry.type === "rlm_subagent" && typeof entry.childId === "string") latest.set(entry.childId, entry);
+			entry = JSON.parse(line) as SavedRlmSubagentRegistryEntry;
 		} catch {
-			// Ignore malformed registry history just like the owning worker does.
+			throw invalidFamilyTopology("registry contains malformed JSON");
 		}
+		if (
+			entry.type !== "rlm_subagent" ||
+			typeof entry.childId !== "string" ||
+			entry.childId === "" ||
+			typeof entry.sessionFile !== "string" ||
+			entry.sessionFile === "" ||
+			(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted")
+		) {
+			throw invalidFamilyTopology("registry contains an invalid edge");
+		}
+		latest.set(entry.childId, entry);
 	}
-	const siblingPaths = new Set<string>([resolve(target.path)]);
-	for (const entry of latest.values()) {
-		if (entry.status !== "deleted" && typeof entry.sessionFile === "string")
-			siblingPaths.add(resolve(entry.sessionFile));
+	return [...latest.values()];
+}
+
+export async function listCatalogFamilySessions(sessionDir?: string): Promise<SessionInfo[]> {
+	const effectiveSessionDir = sessionDir ?? getSessionsDir();
+	const roots = await SessionManager.listAll(undefined, effectiveSessionDir);
+	const authority = managedRoots(effectiveSessionDir);
+	try {
+		const sessions = new Map<string, TrustedSession>();
+		const ids = new Map<string, string>();
+		for (const root of roots) {
+			const trusted = await readTrustedSession(root.path, authority);
+			if (trusted.persistedDepth !== 0 || trusted.persistedParentPath !== undefined) {
+				throw invalidFamilyTopology("managed session seed claims a parent");
+			}
+			const existingPath = ids.get(trusted.id);
+			if (existingPath && existingPath !== trusted.path)
+				throw invalidFamilyTopology("family contains a duplicate session id");
+			ids.set(trusted.id, trusted.path);
+			sessions.set(trusted.path, trusted);
+		}
+		let edges = 0;
+		const visited = new Set<string>();
+		const visit = async (parent: TrustedSession, depth: number, ancestors: ReadonlySet<string>): Promise<void> => {
+			if (depth > MAX_RLM_FAMILY_DEPTH) throw invalidFamilyTopology("family depth limit exhausted");
+			const parentPath = parent.path;
+			if (ancestors.has(parentPath)) throw invalidFamilyTopology("family contains a cycle");
+			if (visited.has(parentPath)) return;
+			visited.add(parentPath);
+			const registryPath = rlmSubagentRegistryPath(parent, authority);
+			if (!registryPath) return;
+			const entries = await readLatestRegistry(registryPath, authority);
+			if (!entries) return;
+			const childAncestors = new Set(ancestors);
+			childAncestors.add(parentPath);
+			for (const entry of entries) {
+				if (entry.status === "deleted") continue;
+				if (++edges > MAX_RLM_FAMILY_EDGES) throw invalidFamilyTopology("family edge limit exhausted");
+				const childPath = entry.sessionFile as string;
+				if (childAncestors.has(childPath)) throw invalidFamilyTopology("family contains a cycle");
+				const child = await readTrustedSession(childPath, authority);
+				if (child.id !== entry.childId) throw invalidFamilyTopology("registry child id does not match session id");
+				if (child.persistedParentPath === undefined)
+					throw invalidFamilyTopology("child lacks a persisted parent path");
+				const claimedParentPath = resolve(dirname(child.path), child.persistedParentPath);
+				readTrustedFile(claimedParentPath, authority, 128 * 1024 * 1024);
+				if (claimedParentPath !== parentPath)
+					throw invalidFamilyTopology("child parent path does not match traversed parent");
+				if (child.persistedDepth !== parent.persistedDepth + 1)
+					throw invalidFamilyTopology("child depth does not equal parent depth plus one");
+				const existingPath = ids.get(child.id);
+				if (existingPath && existingPath !== child.path)
+					throw invalidFamilyTopology("family contains a duplicate session id");
+				const existing = sessions.get(child.path);
+				if (
+					existing &&
+					(existing.id !== child.id ||
+						existing.persistedParentPath !== child.persistedParentPath ||
+						existing.persistedDepth !== child.persistedDepth)
+				) {
+					throw invalidFamilyTopology("family contains a conflicting duplicate");
+				}
+				if (!existing && sessions.size >= MAX_RLM_FAMILY_NODES)
+					throw invalidFamilyTopology("family node limit exhausted");
+				ids.set(child.id, child.path);
+				sessions.set(child.path, child);
+				await visit(child, depth + 1, childAncestors);
+			}
+		};
+		for (const root of [...sessions.values()]) await visit(root, 0, new Set());
+		return [...sessions.values()];
+	} finally {
+		closeManagedRoots(authority);
 	}
-	const siblings = await Promise.all([...siblingPaths].map((path) => readSessionInfo(path)));
-	return siblings.filter(
-		(info): info is SessionInfo =>
-			info !== null &&
-			info.parentSessionPath !== undefined &&
-			resolve(dirname(info.path), info.parentSessionPath) === parentPath,
+}
+export async function listSavedSessionSiblings(sessionPath: string, sessionDir?: string): Promise<SessionInfo[]> {
+	const family = await listCatalogFamilySessions(sessionDir);
+	const targetPath = resolve(sessionPath);
+	const target = family.find((session) => session.path === targetPath);
+	if (!target) throw new Error(`Session not found: ${sessionPath}`);
+	if (!target.parentSessionPath) return [target];
+	const parentPath = resolve(dirname(target.path), target.parentSessionPath);
+	return family.filter(
+		(session) =>
+			session.parentSessionPath !== undefined &&
+			resolve(dirname(session.path), session.parentSessionPath) === parentPath,
 	);
 }
 
@@ -141,6 +445,7 @@ function isCatalogRequest(value: unknown): value is CatalogRequest {
 		candidate.type === "request" &&
 		typeof candidate.id === "string" &&
 		(candidate.command === "list" ||
+			candidate.command === "family" ||
 			candidate.command === "resolve" ||
 			candidate.command === "siblings" ||
 			candidate.command === "rename" ||
@@ -194,6 +499,16 @@ async function handleCatalogRequest(request: CatalogRequest): Promise<void> {
 				});
 				return;
 			}
+			case "family": {
+				const sessions = await listCatalogFamilySessions(request.sessionDir);
+				sendCatalogMessage({
+					type: "response",
+					id: request.id,
+					success: true,
+					data: { sessions: sessions.map(serializeSessionInfo) },
+				});
+				return;
+			}
 			case "resolve": {
 				const localMatch = resolveCatalogSessionMatch(
 					await SessionManager.list(request.cwd, request.sessionDir),
@@ -228,7 +543,11 @@ async function handleCatalogRequest(request: CatalogRequest): Promise<void> {
 					type: "response",
 					id: request.id,
 					success: true,
-					data: { sessions: (await listSavedSessionSiblings(request.sessionPath)).map(serializeSessionInfo) },
+					data: {
+						sessions: (await listSavedSessionSiblings(request.sessionPath, request.sessionDir)).map(
+							serializeSessionInfo,
+						),
+					},
 				});
 				return;
 			case "rename":
@@ -328,12 +647,23 @@ export class DaemonCatalogClient {
 		return data.sessions.map(deserializeSessionInfo);
 	}
 
-	async siblings(sessionPath: string): Promise<SessionInfo[]> {
+	async family(sessionDir?: string): Promise<SessionInfo[]> {
+		const data = await this.request<{ sessions: SessionInfoWire[] }>({
+			type: "request",
+			id: randomUUID(),
+			command: "family",
+			sessionDir,
+		});
+		return data.sessions.map(deserializeSessionInfo);
+	}
+
+	async siblings(sessionPath: string, sessionDir?: string): Promise<SessionInfo[]> {
 		const data = await this.request<{ sessions: SessionInfoWire[] }>({
 			type: "request",
 			id: randomUUID(),
 			command: "siblings",
 			sessionPath,
+			sessionDir,
 		});
 		return data.sessions.map(deserializeSessionInfo);
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1180,10 +1180,12 @@ async function listCatalogFamilySessionsWithLimit(
 				const childId = entry.childId as string;
 				const childSessionDir = dirname(childPath);
 				const parentSessionDir = dirname(parent.path);
-				const writerChildrenRoot =
-					parentSessionDir === authority.session.lexical
-						? join(authority.artifacts?.lexical ?? "", parent.id)
-						: parentSessionDir;
+				// SessionManager derives every session's artifact dir from that session's
+				// own session dir, including artifact-resident parents. Its children
+				// therefore live in <dirname(parent session dir)>/session-artifacts/
+				// <parent session id>/sub-*, rather than directly below the parent
+				// session dir.
+				const writerChildrenRoot = join(dirname(parentSessionDir), "session-artifacts", parent.id);
 				// The actual writer uses <parent artifact dir>/sub-*/<session-id>.jsonl.
 				// Registry keys name that immediate child directory, so neither a
 				// nested sessions root nor a re-keyed sibling is reachable.

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -6,12 +6,7 @@ import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli
 import { getSessionsDir } from "../../config.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
-import {
-	readSessionInfo,
-	readSessionInfoFromBuffer,
-	type SessionInfo,
-	SessionManager,
-} from "../../core/session-manager.js";
+import { readSessionInfo, type SessionInfo, SessionManager } from "../../core/session-manager.js";
 
 export const DAEMON_CATALOG_ROLE_ENV = "PRIME_AGENT_INTERNAL_DAEMON_CATALOG";
 
@@ -74,6 +69,7 @@ interface SavedRlmSubagentRegistryEntry {
 }
 
 const MAX_RLM_REGISTRY_BYTES = 1024 * 1024;
+const MAX_SESSION_HEADER_BYTES = 256 * 1024;
 const MAX_RLM_REGISTRY_RECORDS = 10_000;
 const MAX_RLM_FAMILY_EDGES = 10_000;
 const MAX_RLM_FAMILY_NODES = 10_000;
@@ -173,7 +169,8 @@ def flags(directory=False):
  return value
 def main():
  req=json.loads(sys.stdin.buffer.read(131073))
- parts=req.get("parts"); limit=req.get("limit")
+ parts=req.get("parts"); limit=req.get("limit"); mode=req.get("mode")
+ if mode not in ("read","header","stat"): reject()
  if not isinstance(parts,list) or not parts or not isinstance(limit,int) or limit<0 or limit>MAX: reject()
  if any(not isinstance(p,str) or not p or p in (".","..") or "/" in p or "\\" in p for p in parts): reject()
  current=os.dup(3)
@@ -183,16 +180,24 @@ def main():
   fd=os.open(parts[-1],flags(False),dir_fd=current)
   try:
    before=os.fstat(fd)
-   if not stat.S_ISREG(before.st_mode) or before.st_size>limit: reject()
-   chunks=[]; total=0
-   while True:
-    chunk=os.read(fd,min(65536,limit+1-total))
-    if not chunk: break
-    chunks.append(chunk); total+=len(chunk)
-    if total>limit: reject()
+   if not stat.S_ISREG(before.st_mode): reject()
+   if mode=="read" and before.st_size>limit: reject()
+   payload={}
+   if mode!="stat":
+    chunks=[]; total=0; done=False
+    while not done:
+     chunk=os.read(fd,min(65536,limit+1-total))
+     if not chunk: break
+     if mode=="header":
+      cut=chunk.find(b"\n")
+      if cut>=0: chunk=chunk[:cut+1]; done=True
+     chunks.append(chunk); total+=len(chunk)
+     if total>limit: reject()
+    payload["data"]=base64.b64encode(b"".join(chunks)).decode("ascii")
    after=os.fstat(fd)
    if (before.st_dev,before.st_ino,before.st_mode)!=(after.st_dev,after.st_ino,after.st_mode): reject()
-   print(json.dumps({"data":base64.b64encode(b"".join(chunks)).decode("ascii"),"mtimeMs":after.st_mtime_ns/1000000,"dev":str(after.st_dev),"ino":str(after.st_ino)},separators=(",",":")))
+   payload.update({"mtimeMs":after.st_mtime_ns/1000000,"dev":str(after.st_dev),"ino":str(after.st_ino)})
+   print(json.dumps(payload,separators=(",",":")))
   finally: os.close(fd)
  finally: os.close(current)
 try: main()
@@ -207,7 +212,9 @@ export function setCatalogBeforeTrustedOpenForTest(hook: ((path: string) => void
 	beforeTrustedOpenForTest = hook;
 }
 
-function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number): TrustedFile {
+type TrustedReadMode = "read" | "header" | "stat";
+
+function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number, mode: TrustedReadMode): TrustedFile {
 	if (!isAbsolute(rawPath) || rawPath !== resolve(rawPath))
 		throw invalidFamilyTopology("session path is not canonical");
 	const root = [roots.session, roots.artifacts].find((candidate) => candidate && isWithin(candidate.lexical, rawPath));
@@ -224,7 +231,7 @@ function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number)
 			: (process.env.PRIME_AGENT_KERNEL_PYTHON ?? "python3"),
 		["-I", "-c", OPENAT_READ_HELPER],
 		{
-			input: JSON.stringify({ parts, limit: maxBytes }),
+			input: JSON.stringify({ parts, limit: maxBytes, mode }),
 			encoding: "utf8",
 			timeout: 5_000,
 			maxBuffer: maxBytes * 2 + 64 * 1024,
@@ -239,7 +246,7 @@ function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number)
 	try {
 		const wire = JSON.parse(result.stdout) as { data?: unknown; mtimeMs?: unknown; dev?: unknown; ino?: unknown };
 		if (
-			typeof wire.data !== "string" ||
+			(mode === "stat" ? wire.data !== undefined : typeof wire.data !== "string") ||
 			typeof wire.mtimeMs !== "number" ||
 			typeof wire.dev !== "string" ||
 			typeof wire.ino !== "string"
@@ -247,7 +254,7 @@ function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number)
 			throw new Error("invalid");
 		return {
 			path: rawPath,
-			contents: Buffer.from(wire.data, "base64"),
+			contents: typeof wire.data === "string" ? Buffer.from(wire.data, "base64") : Buffer.alloc(0),
 			mtimeMs: wire.mtimeMs,
 			dev: wire.dev,
 			ino: wire.ino,
@@ -257,11 +264,15 @@ function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number)
 	}
 }
 
-async function readTrustedSession(path: string, roots: ManagedRoots): Promise<TrustedSession> {
-	const trusted = readTrustedFile(path, roots, 128 * 1024 * 1024);
-	const headerLine = trusted.contents
-		.toString("utf8", 0, Math.min(trusted.contents.length, 256 * 1024))
-		.split(/\r?\n/, 1)[0];
+/**
+ * Topology claims (id, parent, depth) come from descriptor-bound header bytes.
+ * Display metadata (name, timestamps, previews) is not part of the trust
+ * decision: it comes from the caller's listing when available, otherwise from
+ * an ordinary cached read, and is bound to the header by the id cross-check.
+ */
+async function readTrustedSession(path: string, roots: ManagedRoots, listed?: SessionInfo): Promise<TrustedSession> {
+	const trusted = readTrustedFile(path, roots, MAX_SESSION_HEADER_BYTES, "header");
+	const headerLine = trusted.contents.toString("utf8").split(/\r?\n/, 1)[0];
 	let header: { type?: unknown; id?: unknown; parentSession?: unknown; rlmDepth?: unknown };
 	try {
 		header = JSON.parse(headerLine ?? "") as typeof header;
@@ -280,12 +291,15 @@ async function readTrustedSession(path: string, roots: ManagedRoots): Promise<Tr
 	)
 		throw invalidFamilyTopology("session header lacks trustworthy topology claims");
 	const persistedDepth = hasDepth ? (header.rlmDepth as number) : undefined;
-	const info = await readSessionInfoFromBuffer(path, trusted.contents, { mtimeMs: trusted.mtimeMs });
+	const info = listed?.path === path ? listed : await readSessionInfo(path);
 	if (!info || info.id !== header.id) throw invalidFamilyTopology("session metadata does not match its header");
+	// Topology fields are always the header's claims; the display read may not
+	// contradict them in the returned catalog row.
 	return {
 		...info,
 		path,
 		rlmDepth: persistedDepth ?? 0,
+		parentSessionPath: hasParent ? (header.parentSession as string) : undefined,
 		...(persistedDepth !== undefined ? { persistedDepth } : {}),
 		...(hasParent ? { persistedParentPath: header.parentSession as string } : {}),
 	};
@@ -318,7 +332,7 @@ async function readLatestRegistry(
 ): Promise<SavedRlmSubagentRegistryEntry[] | undefined> {
 	let contents: string;
 	try {
-		contents = readTrustedFile(path, roots, MAX_RLM_REGISTRY_BYTES).contents.toString("utf8");
+		contents = readTrustedFile(path, roots, MAX_RLM_REGISTRY_BYTES, "read").contents.toString("utf8");
 	} catch (error) {
 		if ((error as Error).message.includes("descriptor-relative artifact is absent")) return undefined;
 		throw error;
@@ -357,7 +371,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 		const sessions = new Map<string, FamilySession>();
 		const ids = new Map<string, string>();
 		for (const root of roots) {
-			const trusted = asTrustedFamilyRoot(await readTrustedSession(root.path, authority), authority);
+			const trusted = asTrustedFamilyRoot(await readTrustedSession(root.path, authority, root), authority);
 			const existingPath = ids.get(trusted.id);
 			if (existingPath && existingPath !== trusted.path)
 				throw invalidFamilyTopology("family contains a duplicate session id");
@@ -391,7 +405,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 				if (trustedChild.persistedDepth === undefined) throw invalidFamilyTopology("child lacks a persisted depth");
 				const child: FamilySession = { ...trustedChild, persistedDepth: trustedChild.persistedDepth };
 				const claimedParentPath = resolve(dirname(child.path), trustedChild.persistedParentPath);
-				readTrustedFile(claimedParentPath, authority, 128 * 1024 * 1024);
+				readTrustedFile(claimedParentPath, authority, 0, "stat");
 				if (claimedParentPath !== parentPath)
 					throw invalidFamilyTopology("child parent path does not match traversed parent");
 				if (child.persistedDepth !== parent.persistedDepth + 1)

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { closeSync, constants, lstatSync, openSync, readdirSync } from "node:fs";
+import { closeSync, constants, lstatSync, opendirSync, openSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
 import { getSessionsDir } from "../../config.js";
@@ -81,16 +81,10 @@ const MAX_RLM_FAMILY_EDGES = 10_000;
 const MAX_RLM_FAMILY_NODES = 10_000;
 const MAX_RLM_FAMILY_DEPTH = 64;
 
-// A narrow test seam avoids creating ten thousand filesystem entries merely to
-// verify that root enumeration fails before opening any candidate descriptor.
-let maxRlmFamilyNodesForTest: number | undefined;
-/** @internal */
-export function setCatalogMaxRlmFamilyNodesForTest(limit: number | undefined): void {
-	maxRlmFamilyNodesForTest = limit;
-}
-
-function maxRlmFamilyNodes(): number {
-	return maxRlmFamilyNodesForTest ?? MAX_RLM_FAMILY_NODES;
+function validateFamilyNodeLimit(limit: number): void {
+	if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_RLM_FAMILY_NODES) {
+		throw new Error("Invalid catalog family node limit");
+	}
 }
 
 interface ManagedRoot {
@@ -1078,35 +1072,57 @@ async function readLatestRegistry(
 	return [...latest.values()];
 }
 
-function listSessionCandidates(sessionDir: string): Array<{ path: string; dev: string; ino: string }> {
+function listSessionCandidates(sessionDir: string, limit: number): Array<{ path: string; dev: string; ino: string }> {
+	let directory: ReturnType<typeof opendirSync>;
 	try {
-		const candidates: Array<{ path: string; dev: string; ino: string }> = [];
-		const limit = maxRlmFamilyNodes();
-		for (const entry of readdirSync(sessionDir)) {
-			if (!entry.endsWith(".jsonl")) continue;
-			const path = join(resolve(sessionDir), entry);
-			try {
-				const stat = lstatSync(path);
-				// Count every stable root candidate, including junk and duplicate ids,
-				// before opening a descriptor or scanning metadata. Removed entries
-				// retain their historical behavior and never become candidates.
-				candidates.push({ path, dev: String(stat.dev), ino: String(stat.ino) });
-				if (candidates.length > limit) throw invalidFamilyTopology("family node limit exhausted");
-			} catch (error) {
-				if ((error as Error).message.includes("family node limit exhausted")) throw error;
-				// Removed during enumeration: it was never a stable root candidate.
-			}
-		}
-		return candidates;
+		directory = opendirSync(sessionDir);
 	} catch (error) {
-		if ((error as Error).message.includes("family node limit exhausted")) throw error;
-		return [];
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
 	}
+
+	const candidates: Array<{ path: string; dev: string; ino: string }> = [];
+	const limitExceeded = Symbol("catalog root discovery limit exceeded");
+	try {
+		try {
+			while (true) {
+				const entry = directory.readSync();
+				if (!entry) break;
+				if (!entry.name.endsWith(".jsonl")) continue;
+				const path = join(resolve(sessionDir), entry.name);
+				let stat: ReturnType<typeof lstatSync>;
+				try {
+					stat = lstatSync(path);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+						// Removed during enumeration: it was never a stable root candidate.
+						continue;
+					}
+					throw error;
+				}
+				candidates.push({ path, dev: String(stat.dev), ino: String(stat.ino) });
+				// Stop immediately at limit + 1. No further directory entries are read,
+				// and no candidate descriptor is opened from an incomplete root set.
+				if (candidates.length > limit) throw limitExceeded;
+			}
+		} catch (error) {
+			if (error === limitExceeded) {
+				throw invalidFamilyTopology("family node limit exhausted during root discovery");
+			}
+			throw error;
+		}
+	} finally {
+		directory.closeSync();
+	}
+	return candidates;
 }
 
-export async function listCatalogFamilySessions(sessionDir?: string): Promise<SessionInfo[]> {
+async function listCatalogFamilySessionsWithLimit(
+	sessionDir: string | undefined,
+	limit: number,
+): Promise<SessionInfo[]> {
 	const effectiveSessionDir = sessionDir ?? getSessionsDir();
-	const roots = listSessionCandidates(effectiveSessionDir);
+	const roots = listSessionCandidates(effectiveSessionDir, limit);
 	const authority = managedRoots(effectiveSessionDir);
 	const reader = new TrustedReadSession(authority);
 	let result: SessionInfo[] | undefined;
@@ -1194,8 +1210,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 				) {
 					throw invalidFamilyTopology("family contains a conflicting duplicate");
 				}
-				if (!existing && sessions.size >= maxRlmFamilyNodes())
-					throw invalidFamilyTopology("family node limit exhausted");
+				if (!existing && sessions.size >= limit) throw invalidFamilyTopology("family node limit exhausted");
 				ids.set(child.id, child.path);
 				sessions.set(child.path, child);
 				await visit(child, depth + 1, childAncestors);
@@ -1222,6 +1237,19 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 	if (cleanupFailure !== undefined) throw cleanupFailure;
 	return result!;
 }
+/** @internal Deterministic per-call limit seam for root-discovery tests. */
+export function listCatalogFamilySessionsWithLimitForTest(
+	sessionDir: string | undefined,
+	limit: number,
+): Promise<SessionInfo[]> {
+	validateFamilyNodeLimit(limit);
+	return listCatalogFamilySessionsWithLimit(sessionDir, limit);
+}
+
+export function listCatalogFamilySessions(sessionDir?: string): Promise<SessionInfo[]> {
+	return listCatalogFamilySessionsWithLimit(sessionDir, MAX_RLM_FAMILY_NODES);
+}
+
 export async function listSavedSessionSiblings(sessionPath: string, sessionDir?: string): Promise<SessionInfo[]> {
 	const family = await listCatalogFamilySessions(sessionDir);
 	const targetPath = resolve(sessionPath);

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1,7 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, constants, openSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
 import { getSessionsDir } from "../../config.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
@@ -68,7 +68,8 @@ interface SavedRlmSubagentRegistryEntry {
 	status?: unknown;
 }
 
-const MAX_RLM_REGISTRY_BYTES = 1024 * 1024;
+// Registry records carry prompts and spawn code; real profiles reach a few MB.
+const MAX_RLM_REGISTRY_BYTES = 16 * 1024 * 1024;
 const MAX_SESSION_HEADER_BYTES = 256 * 1024;
 const MAX_RLM_REGISTRY_RECORDS = 10_000;
 const MAX_RLM_FAMILY_EDGES = 10_000;
@@ -105,10 +106,11 @@ interface FamilySession extends TrustedSession {
 }
 
 function rlmSubagentRegistryPath(parent: SessionInfo, roots: ManagedRoots): string | undefined {
-	const parentDir = dirname(parent.path);
-	const artifactDir =
-		parentDir === roots.session.lexical ? roots.artifacts?.lexical : join(parentDir, "session-artifacts");
-	return artifactDir ? join(artifactDir, parent.id, "rlm-subagents.jsonl") : undefined;
+	// The session writer keeps a session's child registry beside its session
+	// dir: <dirname(sessionDir)>/session-artifacts/<header id>. Every such
+	// location is inside the profile's top-level artifacts root.
+	if (!roots.artifacts) return undefined;
+	return join(dirname(dirname(parent.path)), "session-artifacts", parent.id, "rlm-subagents.jsonl");
 }
 
 function isWithin(root: string, target: string): boolean {
@@ -515,18 +517,26 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 				const childPath = entry.sessionFile as string;
 				if (childAncestors.has(childPath)) throw invalidFamilyTopology("family contains a cycle");
 				const trustedChild = await readTrustedSession(childPath, reader);
-				if (trustedChild.id !== entry.childId)
-					throw invalidFamilyTopology("registry child id does not match session id");
+				// Registry childId is the rlm child id (e.g. "sub-1a2b3c4d"), not the
+				// session id. The child's identity anchor is its filename: the session
+				// writer names every child file after its header id.
+				if (basename(childPath, ".jsonl") !== trustedChild.id)
+					throw invalidFamilyTopology("registry child session file does not match its header id");
 				if (trustedChild.persistedParentPath === undefined)
 					throw invalidFamilyTopology("child lacks a persisted parent path");
-				if (trustedChild.persistedDepth === undefined) throw invalidFamilyTopology("child lacks a persisted depth");
-				const child: FamilySession = { ...trustedChild, persistedDepth: trustedChild.persistedDepth };
+				// Old writers persisted no rlmDepth on children: an absent claim is
+				// derived from the traversed edge, but a contradicting claim is corrupt.
+				if (trustedChild.persistedDepth !== undefined && trustedChild.persistedDepth !== parent.persistedDepth + 1)
+					throw invalidFamilyTopology("child depth does not equal parent depth plus one");
+				const child: FamilySession = {
+					...trustedChild,
+					persistedDepth: parent.persistedDepth + 1,
+					rlmDepth: parent.persistedDepth + 1,
+				};
 				const claimedParentPath = resolve(dirname(child.path), trustedChild.persistedParentPath);
 				await reader.read(claimedParentPath, 0, "stat");
 				if (claimedParentPath !== parentPath)
 					throw invalidFamilyTopology("child parent path does not match traversed parent");
-				if (child.persistedDepth !== parent.persistedDepth + 1)
-					throw invalidFamilyTopology("child depth does not equal parent depth plus one");
 				const existingPath = ids.get(child.id);
 				if (existingPath && existingPath !== child.path)
 					throw invalidFamilyTopology("family contains a duplicate session id");

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -241,6 +241,13 @@ export function setCatalogAfterTrustedHeaderForTest(hook: ((path: string) => voi
 	afterTrustedHeaderForTest = hook;
 }
 
+/** Test-only helper launch override for terminal-path protocol tests. */
+let catalogHelperLaunchForTest: { command: string; args: string[] } | undefined;
+/** @internal */
+export function setCatalogHelperLaunchForTest(launch: { command: string; args: string[] } | undefined): void {
+	catalogHelperLaunchForTest = launch;
+}
+
 type TrustedReadMode = "read" | "header" | "stat";
 
 const TRUSTED_READ_TIMEOUT_MS = 5_000;
@@ -264,8 +271,10 @@ class TrustedReadSession {
 	private exit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
 	private readonly stdoutFinished: Promise<void>;
 	private resolveStdoutFinished!: () => void;
-	private readonly exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
-	private resolveExited!: (result: { code: number | null; signal: NodeJS.Signals | null }) => void;
+	/** Resolves for every terminal child-process path, including failed spawn. */
+	private readonly terminated: Promise<void>;
+	private resolveTerminated!: () => void;
+	private terminationSettled = false;
 
 	constructor(private readonly roots: ManagedRoots) {
 		const stdio: Array<"pipe" | "ignore" | number> = ["pipe", "pipe", "ignore", roots.session.fd];
@@ -273,16 +282,17 @@ class TrustedReadSession {
 		this.stdoutFinished = new Promise((resolveFinished) => {
 			this.resolveStdoutFinished = resolveFinished;
 		});
-		this.exited = new Promise((resolveExited) => {
-			this.resolveExited = resolveExited;
+		this.terminated = new Promise((resolveTerminated) => {
+			this.resolveTerminated = resolveTerminated;
 		});
-		this.child = spawn(
-			process.execPath === process.env.PRIME_AGENT_KERNEL_PYTHON
-				? process.execPath
-				: (process.env.PRIME_AGENT_KERNEL_PYTHON ?? "python3"),
-			["-I", "-c", OPENAT_READ_HELPER],
-			{ stdio, shell: false },
-		);
+		const launch = catalogHelperLaunchForTest ?? {
+			command:
+				process.execPath === process.env.PRIME_AGENT_KERNEL_PYTHON
+					? process.execPath
+					: (process.env.PRIME_AGENT_KERNEL_PYTHON ?? "python3"),
+			args: ["-I", "-c", OPENAT_READ_HELPER],
+		};
+		this.child = spawn(launch.command, launch.args, { stdio, shell: false });
 		helperSpawnCountForTest++;
 		this.child.stdin?.on("error", (error) =>
 			this.fail(new Error(`catalog openat helper write failed: ${String(error)}`)),
@@ -293,13 +303,25 @@ class TrustedReadSession {
 			this.resolveStdoutFinished();
 			if (this.stdoutBuffer !== "") this.fail(new Error("catalog openat helper left residual output"));
 		});
-		this.child.on("error", (error) => this.fail(new Error(`catalog openat helper failed: ${String(error)}`)));
+		this.child.on("error", (error) => {
+			// spawn() reports an invalid executable with error and close, but no exit.
+			// Settle cleanup here so failed spawn cannot strand authority FDs.
+			this.resolveStdoutFinished();
+			this.settleTermination();
+			this.fail(new Error(`catalog openat helper failed: ${String(error)}`));
+		});
 		this.child.on("exit", (code, signal) => {
 			this.exit = { code, signal };
-			this.resolveExited(this.exit);
+			this.settleTermination();
 			if (!this.stdinEnded || code !== 0 || signal !== null) {
 				this.fail(new Error(`catalog openat helper exited (${signal ?? code ?? "unknown"})`));
 			}
+		});
+		this.child.on("close", (code, signal) => {
+			this.exit ??= { code, signal };
+			// close is terminal for failed spawn and confirms stdio is complete.
+			this.resolveStdoutFinished();
+			this.settleTermination();
 		});
 	}
 
@@ -313,25 +335,36 @@ class TrustedReadSession {
 	async close(): Promise<void> {
 		await this.queue;
 		if (this.failure) {
-			// fail() sends SIGKILL only; wait before releasing the authority FDs.
-			await Promise.all([this.exited, this.stdoutFinished]);
-			return;
+			await this.awaitCleanup();
+			throw this.closeError(this.failure);
 		}
 		if (this.pending || this.stdoutBuffer !== "") {
 			this.fail(new Error("catalog openat helper has residual output"));
-			await Promise.all([this.exited, this.stdoutFinished]);
-			throw invalidFamilyTopology(
-				"descriptor-relative artifact read failed: catalog openat helper has residual output",
-			);
+			await this.awaitCleanup();
+			throw this.closeError(this.failure!);
 		}
 		this.stdinEnded = true;
 		this.child.stdin?.end();
-		const [exit] = await Promise.all([this.exited, this.stdoutFinished]);
-		if (this.failure || exit.code !== 0 || exit.signal !== null || this.stdoutBuffer !== "") {
+		await this.awaitCleanup();
+		if (this.failure || this.exit?.code !== 0 || this.exit?.signal !== null || this.stdoutBuffer !== "") {
 			const failure = this.failure ?? new Error("catalog openat helper did not exit cleanly");
 			if (!this.failure) this.fail(failure);
-			throw invalidFamilyTopology(`descriptor-relative artifact read failed: ${failure.message}`);
+			throw this.closeError(failure);
 		}
+	}
+
+	private settleTermination(): void {
+		if (this.terminationSettled) return;
+		this.terminationSettled = true;
+		this.resolveTerminated();
+	}
+
+	private async awaitCleanup(): Promise<void> {
+		await Promise.all([this.terminated, this.stdoutFinished]);
+	}
+
+	private closeError(failure: Error): Error {
+		return invalidFamilyTopology(`descriptor-relative artifact read failed: ${failure.message}`);
 	}
 
 	private async readSerialized(rawPath: string, maxBytes: number, mode: TrustedReadMode): Promise<TrustedFile> {
@@ -581,6 +614,8 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 	const roots = await SessionManager.listAll(undefined, effectiveSessionDir);
 	const authority = managedRoots(effectiveSessionDir);
 	const reader = new TrustedReadSession(authority);
+	let result: SessionInfo[] | undefined;
+	let traversalFailure: unknown;
 	try {
 		const sessions = new Map<string, FamilySession>();
 		const ids = new Map<string, string>();
@@ -632,16 +667,7 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 					childId.startsWith("sub-") &&
 					childId === basename(childSessionDir) &&
 					childSessionDir === join(writerChildrenRoot, childId);
-				// Versioned v2 registry records used the session id as their key but
-				// still allocated a direct sub-* writer directory. Require both facts;
-				// an equal-id synthetic record without that provenance is not trusted.
-				const legacyWriterPath =
-					trustedChild.persistedVersion !== undefined &&
-					trustedChild.persistedVersion < 3 &&
-					childId === trustedChild.id &&
-					basename(childSessionDir).startsWith("sub-") &&
-					dirname(childSessionDir) === writerChildrenRoot;
-				if (!modernWriterPath && !legacyWriterPath) {
+				if (!modernWriterPath) {
 					throw invalidFamilyTopology("registry child is outside the parent writer artifact layout");
 				}
 				if (trustedChild.persistedParentPath === undefined)
@@ -679,14 +705,25 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 			}
 		};
 		for (const root of [...sessions.values()]) await visit(root, 0, new Set());
-		return [...sessions.values()];
-	} finally {
-		try {
-			await reader.close();
-		} finally {
-			closeManagedRoots(authority);
-		}
+		result = [...sessions.values()];
+	} catch (error) {
+		traversalFailure = error;
 	}
+	let cleanupFailure: unknown;
+	try {
+		await reader.close();
+	} catch (error) {
+		cleanupFailure = error;
+	}
+	try {
+		closeManagedRoots(authority);
+	} catch (error) {
+		cleanupFailure ??= error;
+	}
+	// The traversal failure is authoritative; cleanup must not replace it.
+	if (traversalFailure !== undefined) throw traversalFailure;
+	if (cleanupFailure !== undefined) throw cleanupFailure;
+	return result!;
 }
 export async function listSavedSessionSiblings(sessionPath: string, sessionDir?: string): Promise<SessionInfo[]> {
 	const family = await listCatalogFamilySessions(sessionDir);

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { closeSync, constants, openSync, readdirSync } from "node:fs";
+import { closeSync, constants, openSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
 import { getSessionsDir } from "../../config.js";
@@ -97,6 +97,8 @@ interface TrustedFile {
 	mtimeMs: number;
 	dev: string;
 	ino: string;
+	/** A header exceeded the bounded descriptor read; only untrusted roots may skip it. */
+	truncated?: boolean;
 }
 
 interface TrustedSessionMetadata {
@@ -193,7 +195,45 @@ MAX=134217728
 SEARCH_MAX=65536
 PARSE_MAX=1048576
 PREVIEW_MAX=256
+MAX_METADATA_RESPONSE_BYTES=256*1024
+TRUNCATION_MARKER="... [truncated]"
 def reject(): raise ValueError("invalid")
+def compact_metadata_response(response):
+ # json.dumps defaults to ensure_ascii=True. Keep the complete wire response,
+ # rather than just metadata, inside the TypeScript-side response cap.
+ def encoded_size(): return len(json.dumps(response,separators=(",",":")).encode("ascii"))
+ if encoded_size()<=MAX_METADATA_RESPONSE_BYTES: return
+ data=response.get("data")
+ if not isinstance(data,dict): reject()
+ targets=[]
+ def add_target(container,key):
+  if isinstance(container.get(key),str):
+   targets.append((container,key,container[key]))
+ add_target(data,"firstMessage"); add_target(data,"allMessagesText"); add_target(data,"name")
+ status=data.get("agentStatus")
+ if isinstance(status,dict):
+  add_target(status,"summary"); add_target(status,"taskState")
+ # Clear every unbounded display field before allocating the remaining escaped-byte
+ # budget in a stable priority order. Fields remain present and string typed.
+ for container,key,_ in targets: container[key]=""
+ if encoded_size()>MAX_METADATA_RESPONSE_BYTES: reject()
+ for container,key,original in targets:
+  length=len(original)
+  def candidate(prefix):
+   return original if prefix==length else original[:prefix]+TRUNCATION_MARKER
+  # A marker is useful when it fits; otherwise preserve the greatest raw
+  # prefix. Either search uses the exact ensure_ascii serialized byte count.
+  use_marker=encoded_size()+len(json.dumps(TRUNCATION_MARKER))<=MAX_METADATA_RESPONSE_BYTES
+  def fits(prefix):
+   container[key]=candidate(prefix) if use_marker else original[:prefix]
+   return encoded_size()<=MAX_METADATA_RESPONSE_BYTES
+  low=0; high=length
+  while low<high:
+   middle=(low+high+1)//2
+   if fits(middle): low=middle
+   else: high=middle-1
+  container[key]=candidate(low) if use_marker else original[:low]
+ if encoded_size()>MAX_METADATA_RESPONSE_BYTES: reject()
 def flags(directory=False):
  value=os.O_RDONLY|os.O_NOFOLLOW
  if directory: value|=os.O_DIRECTORY
@@ -321,8 +361,13 @@ def serve(req):
       cut=chunk.find(b"\n")
       if cut>=0: chunk=chunk[:cut+1]; done=True
      chunks.append(chunk); total+=len(chunk)
-     if total>limit: reject()
-    payload["data"]=base64.b64encode(b"".join(chunks)).decode("ascii")
+     if total>limit:
+      # An oversized first record can be an incomplete concurrent write. It is
+      # distinguishable from an I/O/protocol failure so root classification can
+      # ignore it, while registry-reached sessions remain strict.
+      if mode=="header": payload["truncated"]=True; chunks=[]; break
+      reject()
+    if not payload.get("truncated"): payload["data"]=base64.b64encode(b"".join(chunks)).decode("ascii")
    elif mode=="metadata": payload["data"]=scan_metadata(fd,before.st_mtime_ns/1000000)
    after=os.fstat(fd)
    if (before.st_dev,before.st_ino,before.st_mode)!=(after.st_dev,after.st_ino,after.st_mode): reject()
@@ -340,7 +385,12 @@ while True:
  except FileNotFoundError: response={"error":"absent"}
  except Exception: response={"error":"failed"}
  response["id"]=request.get("id") if isinstance(request,dict) else None
- sys.stdout.write(json.dumps(response,separators=(",",":"))+"\n"); sys.stdout.flush()
+ if isinstance(request,dict) and request.get("mode")=="metadata" and "data" in response:
+  try: compact_metadata_response(response)
+  except Exception: response={"error":"failed","id":response.get("id")}
+ serialized=json.dumps(response,separators=(",",":"))
+ if len(serialized.encode("ascii"))>MAX_METADATA_RESPONSE_BYTES: sys.exit(1)
+ sys.stdout.write(serialized+"\n"); sys.stdout.flush()
 `;
 
 /** Test-only seam runs after authority selection but before descriptor-relative traversal. */
@@ -547,7 +597,15 @@ class TrustedReadSession {
 			JSON.stringify({ id: requestId, parts, limit: maxBytes, mode, root: rootFd }),
 			mode === "metadata" ? MAX_METADATA_RESPONSE_BYTES : maxBytes * 2 + 64 * 1024,
 		);
-		let wire: { id?: unknown; error?: unknown; data?: unknown; mtimeMs?: unknown; dev?: unknown; ino?: unknown };
+		let wire: {
+			id?: unknown;
+			error?: unknown;
+			data?: unknown;
+			truncated?: unknown;
+			mtimeMs?: unknown;
+			dev?: unknown;
+			ino?: unknown;
+		};
 		try {
 			wire = JSON.parse(line) as typeof wire;
 		} catch {
@@ -559,13 +617,16 @@ class TrustedReadSession {
 			throw invalidFamilyTopology("descriptor-relative artifact response is invalid");
 		}
 		if (wire.error === "absent") throw invalidFamilyTopology("descriptor-relative artifact is absent");
+		const truncatedHeader = mode === "header" && wire.truncated === true;
 		if (
 			wire.error !== undefined ||
-			(mode === "stat"
-				? wire.data !== undefined
-				: mode === "metadata"
-					? !isTrustedSessionMetadata(wire.data)
-					: typeof wire.data !== "string") ||
+			(wire.truncated !== undefined && !truncatedHeader) ||
+			(!truncatedHeader &&
+				(mode === "stat"
+					? wire.data !== undefined
+					: mode === "metadata"
+						? !isTrustedSessionMetadata(wire.data)
+						: typeof wire.data !== "string")) ||
 			typeof wire.mtimeMs !== "number" ||
 			typeof wire.dev !== "string" ||
 			typeof wire.ino !== "string"
@@ -578,6 +639,7 @@ class TrustedReadSession {
 			mtimeMs: wire.mtimeMs,
 			dev: wire.dev,
 			ino: wire.ino,
+			...(truncatedHeader ? { truncated: true } : {}),
 			...(mode === "metadata" ? { metadata: wire.data as TrustedSessionMetadata } : {}),
 		};
 	}
@@ -659,6 +721,7 @@ class TrustedReadSession {
  */
 async function readTrustedSession(path: string, reader: TrustedReadSession): Promise<TrustedSession> {
 	const trusted = await reader.read(path, MAX_SESSION_HEADER_BYTES, "header");
+	if (trusted.truncated) throw invalidFamilyTopology("session header exceeds the trusted read limit");
 	const headerLine = trusted.contents.toString("utf8").split(/\r?\n/, 1)[0];
 	let header: {
 		type?: unknown;
@@ -777,19 +840,13 @@ async function readLatestRegistry(
 	return [...latest.values()];
 }
 
-function listSessionCandidates(sessionDir: string): string[] {
-	try {
-		return readdirSync(sessionDir)
-			.filter((entry) => entry.endsWith(".jsonl"))
-			.map((entry) => join(resolve(sessionDir), entry));
-	} catch {
-		return [];
-	}
-}
-
 export async function listCatalogFamilySessions(sessionDir?: string): Promise<SessionInfo[]> {
 	const effectiveSessionDir = sessionDir ?? getSessionsDir();
-	const roots = listSessionCandidates(effectiveSessionDir);
+	// SessionManager performs the non-authoritative flat-directory classification:
+	// interrupted, blank, and unrelated jsonl files are not roots. Topology is
+	// still re-read descriptor-relatively below and any identified candidate
+	// that fails validation is fatal.
+	const roots = await SessionManager.listAll(undefined, effectiveSessionDir);
 	const authority = managedRoots(effectiveSessionDir);
 	const reader = new TrustedReadSession(authority);
 	let result: SessionInfo[] | undefined;
@@ -797,8 +854,8 @@ export async function listCatalogFamilySessions(sessionDir?: string): Promise<Se
 	try {
 		const sessions = new Map<string, FamilySession>();
 		const ids = new Map<string, string>();
-		for (const rootPath of roots) {
-			const trusted = asTrustedFamilyRoot(await readTrustedSession(rootPath, reader), authority);
+		for (const root of roots) {
+			const trusted = asTrustedFamilyRoot(await readTrustedSession(root.path, reader), authority);
 			const existingPath = ids.get(trusted.id);
 			if (existingPath && existingPath !== trusted.path)
 				throw invalidFamilyTopology("family contains a duplicate session id");

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -817,6 +817,123 @@ async function readTrustedSession(path: string, reader: TrustedReadSession): Pro
  * record purports to be an identified session, the strict descriptor-bound
  * reader owns every topology and protocol failure.
  */
+interface JsonStringPrefix {
+	value: string;
+	end: number;
+	terminated: boolean;
+	partialEscape: boolean;
+}
+
+/** Read a JSON string without treating malformed input as executable JSON. */
+function readJsonStringPrefix(text: string, start: number): JsonStringPrefix | undefined {
+	if (text[start] !== '"') return undefined;
+	let value = "";
+	let index = start + 1;
+	while (index < text.length) {
+		const char = text[index++];
+		if (char === '"') return { value, end: index, terminated: true, partialEscape: false };
+		if (char !== "\\") {
+			value += char;
+			continue;
+		}
+		if (index === text.length) return { value, end: index, terminated: false, partialEscape: true };
+		const escapedChar = text[index++];
+		const simpleEscape =
+			escapedChar === '"'
+				? '"'
+				: escapedChar === "\\"
+					? "\\"
+					: escapedChar === "/"
+						? "/"
+						: escapedChar === "b"
+							? "\b"
+							: escapedChar === "f"
+								? "\f"
+								: escapedChar === "n"
+									? "\n"
+									: escapedChar === "r"
+										? "\r"
+										: escapedChar === "t"
+											? "\t"
+											: undefined;
+		if (simpleEscape !== undefined) {
+			value += simpleEscape;
+			continue;
+		}
+		if (escapedChar !== "u") return { value, end: index, terminated: false, partialEscape: false };
+		if (index + 4 > text.length) return { value, end: text.length, terminated: false, partialEscape: true };
+		const hex = text.slice(index, index + 4);
+		if (!/^[0-9a-f]{4}$/iu.test(hex)) return { value, end: index + 4, terminated: false, partialEscape: false };
+		value += String.fromCharCode(Number.parseInt(hex, 16));
+		index += 4;
+	}
+	return { value, end: index, terminated: false, partialEscape: false };
+}
+
+function skipJsonValuePrefix(text: string, start: number): number {
+	let index = start;
+	while (/\s/u.test(text[index] ?? "")) index++;
+	const opening = text[index];
+	if (opening === '"') return readJsonStringPrefix(text, index)?.end ?? text.length;
+	if (opening !== "{" && opening !== "[") {
+		while (index < text.length && !/[\s,}\]]/u.test(text[index] ?? "")) index++;
+		return index;
+	}
+	const closings = [opening === "{" ? "}" : "]"];
+	index++;
+	while (index < text.length && closings.length > 0) {
+		const char = text[index];
+		if (char === '"') {
+			const string = readJsonStringPrefix(text, index);
+			if (!string) return text.length;
+			index = string.end;
+			if (!string.terminated) return index;
+			continue;
+		}
+		if (char === "{") closings.push("}");
+		else if (char === "[") closings.push("]");
+		else if (char === closings.at(-1)) closings.pop();
+		index++;
+	}
+	return index;
+}
+
+/**
+ * Recognize only outer-object topology claims in an incomplete JSON prefix.
+ * JSON string escapes are decoded only while scanning their bounded syntax, so
+ * escaped keys cannot hide claims and strings in unrelated values cannot create
+ * one. A cut through a key escape is ambiguous and therefore fails closed.
+ */
+function hasApparentSessionTopologyClaimPrefix(text: string): boolean {
+	let index = 0;
+	while (/\s/u.test(text[index] ?? "")) index++;
+	if (text[index++] !== "{") return false;
+	while (index < text.length) {
+		while (/\s/u.test(text[index] ?? "")) index++;
+		if (text[index] === "}") return false;
+		const key = readJsonStringPrefix(text, index);
+		if (!key) return false;
+		if (!key.terminated) return key.partialEscape;
+		index = key.end;
+		while (/\s/u.test(text[index] ?? "")) index++;
+		if (text[index] !== ":") return false;
+		index++;
+		while (/\s/u.test(text[index] ?? "")) index++;
+		if (key.value === "id") return true;
+		if (key.value === "type") {
+			const value = readJsonStringPrefix(text, index);
+			if (!value) return false;
+			if (!value.terminated) return value.partialEscape || "session".startsWith(value.value);
+			if (value.value === "session") return true;
+		}
+		index = skipJsonValuePrefix(text, index);
+		while (/\s/u.test(text[index] ?? "")) index++;
+		if (text[index] !== ",") return false;
+		index++;
+	}
+	return false;
+}
+
 async function readTrustedRootCandidate(
 	path: string,
 	listed: { dev: string; ino: string },
@@ -834,9 +951,9 @@ async function readTrustedRootCandidate(
 		candidate = JSON.parse(line) as { type?: unknown; id?: unknown };
 	} catch {
 		// A bounded prefix may end in a concurrent partial write. Only a prefix
-		// that already purports to carry a session or identifier claim is part of
-		// the topology; unrelated incomplete junk remains skippable.
-		if (/^\s*\{[\s\S]*?"type"\s*:\s*"session(?:"|\\|$)|^\s*\{[\s\S]*?"id"\s*:/u.test(line))
+		// carrying a safely decoded topology claim is part of the topology;
+		// unrelated incomplete junk remains skippable.
+		if (hasApparentSessionTopologyClaimPrefix(line))
 			throw invalidFamilyTopology("session header exceeds the trusted read limit");
 		return undefined;
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -991,6 +991,7 @@ export class AgentDaemon {
 	 */
 	private async readCompleteRlmSubagentRegistryForDeletion(
 		parentState: ActiveSessionState,
+		allowLegacyRows = true,
 	): Promise<DeletionRlmSubagentRegistryEntry[] | undefined> {
 		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
 		if (!path) return undefined;
@@ -1027,6 +1028,7 @@ export class AgentDaemon {
 					typeof entry.sessionName !== "string" ||
 					typeof entry.sessionDir !== "string" ||
 					typeof entry.sessionFile !== "string" ||
+					(!allowLegacyRows && entry.sessionId === undefined) ||
 					(entry.sessionId !== undefined &&
 						(typeof entry.sessionId !== "string" || entry.sessionId.length === 0)) ||
 					typeof entry.parentSessionId !== "string" ||
@@ -2511,7 +2513,8 @@ export class AgentDaemon {
 					// A lenient listing may omit malformed historical rows. Absence authorizes
 					// cleanup, so require a complete registry read that also confirms no row.
 					if (state === undefined && persisted === undefined) {
-						const completeRegistry = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
+						const completeRegistry = await this.readCompleteRlmSubagentRegistryForDeletion(parentState, false);
+						authority?.assertCurrent();
 						if (!completeRegistry || completeRegistry.some((entry) => entry.childId === childId)) {
 							throw new Error("RLM subagent deletion registry cannot prove absence");
 						}
@@ -4365,6 +4368,7 @@ export class AgentDaemon {
 				return success(command.id, "delete_rlm_subagent", {
 					deleted: result === "deleted",
 					...(result === "running" ? { reason: "running" } : {}),
+					...(result === "preserved_newer" ? { reason: "stale" } : {}),
 				});
 			}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2401,7 +2401,6 @@ export class AgentDaemon {
 			},
 			releaseRlmSubagentRuntime: async (runtime, options, status, authority) => {
 				try {
-					authority?.assertCurrent();
 					// Resolve the exact resident incarnation before any tombstone append. An
 					// older finalizer can share both child id and directory with its
 					// replacement, so neither field is an object-identity fence.
@@ -2411,6 +2410,12 @@ export class AgentDaemon {
 							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
 							candidate.runtime.metadata.rlmChildId === options.id,
 					);
+					// A same-id republish supersedes an older finalizer without giving it
+					// authority over the replacement.
+					if (state !== undefined && state.runtime.session !== runtime.session) {
+						return { deletionDurability: "stale" };
+					}
+					authority?.assertCurrent();
 					if (
 						!state ||
 						state.runtime.session !== runtime.session ||
@@ -2457,13 +2462,18 @@ export class AgentDaemon {
 				this.recordRlmSubagentDeletion(parentState, childId, authority),
 			deleteRlmSubagentRuntime: async (childId, session, authority) => {
 				try {
-					authority?.assertCurrent();
 					const state = [...this.sessions.values()].find(
 						(candidate) =>
 							candidate.runtime.metadata.kind === "subagent" &&
 							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
 							candidate.runtime.metadata.rlmChildId === childId,
 					);
+					// A same-id republish supersedes an older deleter without letting it
+					// mutate the replacement's registry, jobs, or lifetime.
+					if (state !== undefined && session !== undefined && state.runtime.session !== session) {
+						return { deletionDurability: "stale" };
+					}
+					authority?.assertCurrent();
 					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 						(entry) => entry.childId === childId,
 					);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -5540,8 +5540,10 @@ export class AgentDaemon {
 				typeof header.rlmDepth === "number" && Number.isSafeInteger(header.rlmDepth) && header.rlmDepth >= 0
 					? header.rlmDepth
 					: undefined;
+			// Session forks also persist parentSession as provenance while retaining
+			// depth zero. Only positive/unknown-depth headers may claim a family edge.
 			const parentSessionPath =
-				typeof header.parentSession === "string" && header.parentSession
+				depth !== 0 && typeof header.parentSession === "string" && header.parentSession
 					? canonicalSessionPath(
 							isAbsolute(header.parentSession)
 								? header.parentSession
@@ -5610,12 +5612,13 @@ export class AgentDaemon {
 		const entry = this.agentFamilyEntry(state);
 		const session = state.runtime.session;
 		const metadata = state.runtime.metadata;
-		const headerParent = this.resolveHeaderParentSessionPath(state);
-		const parentSessionPath = headerParent ?? metadata.parentSessionFile;
-		// A root has no parent claim. Do not let a stale runtime rlmDepth turn it
-		// into a depth-N orphan when its durable/root metadata still says root.
+		const headerParent = entry.depth > 0 ? this.resolveHeaderParentSessionPath(state) : undefined;
+		const parentSessionId = entry.depth > 0 ? metadata.parentSessionId : undefined;
+		const parentSessionPath = entry.depth > 0 ? (headerParent ?? metadata.parentSessionFile) : undefined;
+		// A root has no family parent claim. Depth-zero fork provenance in
+		// parentSession/metadata must not turn the fork into an RLM child.
 		const isUnparentedTopLevel =
-			metadata.kind === "top-level" && !headerParent && !metadata.parentSessionId && !metadata.parentSessionFile;
+			metadata.kind === "top-level" && !headerParent && !parentSessionId && !parentSessionPath;
 		const depthClaim =
 			!isUnparentedTopLevel &&
 			typeof session.rlmDepth === "number" &&
@@ -5628,9 +5631,7 @@ export class AgentDaemon {
 			...(isUnparentedTopLevel ? { depth: 0 } : {}),
 			source: "resident",
 			...(depthClaim !== undefined ? { depthClaim } : {}),
-			...(metadata.parentSessionId
-				? { parentSessionId: metadata.parentSessionId, parentSessionIdClaim: metadata.parentSessionId }
-				: {}),
+			...(parentSessionId ? { parentSessionId, parentSessionIdClaim: parentSessionId } : {}),
 			...(parentSessionPath
 				? {
 						parentSessionPath: canonicalSessionPath(parentSessionPath),

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1103,10 +1103,12 @@ export class AgentDaemon {
 		const legacyResidentUpgrade = entry.sessionId === undefined && authority === undefined && residentMatchesHeader;
 		if (!authorityMatchesEntry && !(authority === undefined && residentMatchesHeader)) return "unknown";
 		if (entry.sessionId === undefined && !legacyResidentUpgrade) return "unknown";
-		if (entry.status === "deleted") {
+		if (entry.status === "deleted" && !legacyResidentUpgrade) {
 			authority?.assertCurrent();
 			return "tombstoned";
 		}
+		// A legacy deleted row also crosses the append boundary once to persist
+		// the exact resident identity; subsequent retries observe the modern row.
 		// The header and authority are both checked immediately before the
 		// synchronous append/fsync boundary. Once append starts, finish it.
 		authority?.assertCurrent();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2508,11 +2508,13 @@ export class AgentDaemon {
 					) {
 						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
 					}
-					// `readLatestRlmSubagentRegistry(..., true)` completed successfully.
-					// When it proves this child has no current row and no resident object
-					// exists, deletion is already benign regardless of a stale or partial
-					// coordinator token. Existing rows above still require exact authority.
+					// A lenient listing may omit malformed historical rows. Absence authorizes
+					// cleanup, so require a complete registry read that also confirms no row.
 					if (state === undefined && persisted === undefined) {
+						const completeRegistry = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
+						if (!completeRegistry || completeRegistry.some((entry) => entry.childId === childId)) {
+							throw new Error("RLM subagent deletion registry cannot prove absence");
+						}
 						return { deletionDurability: "absent" };
 					}
 					const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -997,13 +997,35 @@ export class AgentDaemon {
 			if (!trimmed) continue;
 			try {
 				const entry = JSON.parse(trimmed) as Partial<PersistedRlmSubagentRegistryEntry>;
+				const validIsoTimestamp =
+					typeof entry.updatedAt === "string" &&
+					Number.isFinite(Date.parse(entry.updatedAt)) &&
+					new Date(Date.parse(entry.updatedAt)).toISOString() === entry.updatedAt;
+				const validModel =
+					entry.model === undefined ||
+					(typeof entry.model === "object" &&
+						entry.model !== null &&
+						!Array.isArray(entry.model) &&
+						typeof entry.model.provider === "string" &&
+						typeof entry.model.modelId === "string");
 				if (
 					entry.type !== "rlm_subagent" ||
 					typeof entry.childId !== "string" ||
 					typeof entry.sessionName !== "string" ||
 					typeof entry.sessionDir !== "string" ||
 					typeof entry.sessionFile !== "string" ||
+					typeof entry.parentSessionId !== "string" ||
+					entry.parentSessionId.length === 0 ||
+					(entry.parentSessionFile !== undefined && typeof entry.parentSessionFile !== "string") ||
+					(entry.rlmParentNodeId !== undefined && typeof entry.rlmParentNodeId !== "string") ||
+					(entry.prompt !== undefined && typeof entry.prompt !== "string") ||
+					(entry.spawnCode !== undefined && typeof entry.spawnCode !== "string") ||
+					!validModel ||
 					(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted") ||
+					typeof entry.createdAt !== "number" ||
+					!Number.isSafeInteger(entry.createdAt) ||
+					entry.createdAt < 0 ||
+					!validIsoTimestamp ||
 					(entry.rlmDepth !== undefined && (!Number.isSafeInteger(entry.rlmDepth) || entry.rlmDepth < 0)) ||
 					(entry.rlmMaxDepth !== undefined && (!Number.isSafeInteger(entry.rlmMaxDepth) || entry.rlmMaxDepth < 0))
 				) {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -102,6 +102,7 @@ import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js
 import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
 import type {
 	CreateRlmSubagentRuntimeOptions,
+	RlmSubagentDeletionAuthority,
 	RlmSubagentDeletionDurability,
 	SubagentRuntimeHost,
 } from "../../core/rlm-runtime.js";
@@ -1042,6 +1043,7 @@ export class AgentDaemon {
 	private async recordRlmSubagentDeletion(
 		parentState: ActiveSessionState,
 		childId: string,
+		authority?: RlmSubagentDeletionAuthority,
 	): Promise<RlmSubagentDeletionDurability> {
 		const latest = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
 		if (!latest) return "unknown";
@@ -1052,6 +1054,11 @@ export class AgentDaemon {
 		if (entry.status === "deleted") {
 			return "tombstoned";
 		}
+		// The complete read above is asynchronous. Revalidate immediately before
+		// entering the synchronous append/fsync commit region: before that point a
+		// stale request must leave no registry mutation behind. Once append starts,
+		// finish the durable commit and let the caller suppress its stale reply.
+		authority?.assertCurrent();
 		if (
 			!this.appendRlmSubagentRegistryEntry(parentState, {
 				...entry,
@@ -2358,7 +2365,8 @@ export class AgentDaemon {
 				}
 				return { deletionDurability };
 			},
-			resolveRlmSubagentDeletion: (childId) => this.recordRlmSubagentDeletion(parentState, childId),
+			resolveRlmSubagentDeletion: (childId, authority) =>
+				this.recordRlmSubagentDeletion(parentState, childId, authority),
 			deleteRlmSubagentRuntime: async (childId, session) => {
 				const state = [...this.sessions.values()].find(
 					(candidate) =>

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -459,7 +459,6 @@ interface FailedTombstonedRlmClose {
 	readonly childId: string;
 	cleanup?: Promise<void>;
 	error?: unknown;
-	disposeError?: unknown;
 }
 
 export class AgentDaemon {
@@ -505,7 +504,6 @@ export class AgentDaemon {
 		}
 	>();
 	private readonly failedTombstonedRlmCloses = new Map<string, FailedTombstonedRlmClose>();
-	private readonly closeDisposeErrors = new WeakMap<ActiveSessionState, unknown>();
 	private readonly sideQuestionRuns = new Map<
 		string,
 		{
@@ -4441,17 +4439,17 @@ export class AgentDaemon {
 			}
 
 			case "get_state": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_state", summaryForActiveSession(state));
 			}
 
 			case "get_connection_state": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_connection_state", this.createConnectionState(state));
 			}
 
 			case "get_messages": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_messages", {
 					messages: state.runtime.session.messages,
 				});
@@ -5541,8 +5539,8 @@ export class AgentDaemon {
 	private detachTombstonedClose(parent: ActiveSessionState, state: ActiveSessionState, childId: string): void {
 		const existing = this.failedTombstonedRlmCloses.get(state.activeSessionId);
 		if (existing?.state === state) {
-			if (existing.error !== undefined && existing.disposeError !== undefined && !existing.cleanup) {
-				const cleanup = Promise.resolve().then(() => state.runtime.dispose());
+			if (existing.error !== undefined && !existing.cleanup) {
+				const cleanup = Promise.resolve().then(() => this.closeSession(state, "killed", false));
 				existing.cleanup = cleanup
 					.then(() => {
 						if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === existing)
@@ -5550,7 +5548,6 @@ export class AgentDaemon {
 					})
 					.catch((error: unknown) => {
 						existing.error = error;
-						existing.disposeError = error;
 						existing.cleanup = undefined;
 					});
 			}
@@ -5558,16 +5555,16 @@ export class AgentDaemon {
 		}
 		const record: FailedTombstonedRlmClose = { state, parentActiveSessionId: parent.activeSessionId, childId };
 		this.failedTombstonedRlmCloses.set(state.activeSessionId, record);
-		void this.closeSession(state, "killed", false).then(
-			() => {
+		const cleanup = Promise.resolve().then(() => this.closeSession(state, "killed", false));
+		record.cleanup = cleanup
+			.then(() => {
 				if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === record)
 					this.failedTombstonedRlmCloses.delete(state.activeSessionId);
-			},
-			(error: unknown) => {
+			})
+			.catch((error: unknown) => {
 				record.error = error;
-				record.disposeError = this.closeDisposeErrors.get(state);
-			},
-		);
+				record.cleanup = undefined;
+			});
 	}
 
 	// Half-bound sessions are hidden from other sessions' listings; the current
@@ -6784,10 +6781,8 @@ export class AgentDaemon {
 		let disposeError: unknown;
 		try {
 			await state.runtime.dispose();
-			this.closeDisposeErrors.delete(state);
 		} catch (error) {
 			disposeError = error;
-			this.closeDisposeErrors.set(state, error);
 		}
 		for (const client of state.clients) {
 			abortClientSnapshotStreaming(client, state.activeSessionId);
@@ -6798,21 +6793,21 @@ export class AgentDaemon {
 			removeDaemonClientSessionCapabilities(client, state.activeSessionId);
 		}
 		state.clients.clear();
+		if (disposeError) {
+			throw disposeError;
+		}
+		if (persistError) {
+			throw persistError;
+		}
+		if (cascadeError) {
+			throw cascadeError;
+		}
 		this.sessions.delete(state.activeSessionId);
 		if (isEmptyDraftSession) {
 			const sessionFile = state.runtime.session.sessionFile;
 			if (sessionFile) {
 				await deleteSessionFile(sessionFile).catch(() => undefined);
 			}
-		}
-		if (disposeError) {
-			throw disposeError;
-		}
-		if (persistError && !keepsResumeEntry && reason !== "completed") {
-			throw persistError;
-		}
-		if (cascadeError && !keepsResumeEntry && reason !== "completed") {
-			throw cascadeError;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6810,8 +6810,7 @@ export class AgentDaemon {
 		const captureCloseError = (error: unknown): void => {
 			closeError ??= error;
 		};
-		const retainsForTombstonedRetry =
-			this.failedTombstonedRlmCloses.has(state.activeSessionId) || this.isQuarantinedRlmState(state);
+		const retainsForTombstonedRetry = this.failedTombstonedRlmCloses.get(state.activeSessionId)?.state === state;
 		if (reason === "killed") {
 			try {
 				this.cancelScheduledJobsForSession(state);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6803,37 +6803,61 @@ export class AgentDaemon {
 		if (!this.sessions.has(state.activeSessionId)) {
 			return;
 		}
+		let closeError: unknown;
+		const captureCloseError = (error: unknown): void => {
+			closeError ??= error;
+		};
+		const retainsForTombstonedRetry =
+			this.failedTombstonedRlmCloses.has(state.activeSessionId) || this.isQuarantinedRlmState(state);
 		if (reason === "killed") {
-			this.cancelScheduledJobsForSession(state);
+			try {
+				this.cancelScheduledJobsForSession(state);
+			} catch (error) {
+				captureCloseError(error);
+			}
 		} else if (reason !== "shutdown" && reason !== "update") {
-			this.cancelSubagentRlmHeartbeats(state);
+			try {
+				this.cancelSubagentRlmHeartbeats(state);
+			} catch (error) {
+				captureCloseError(error);
+			}
 		}
+		// A tombstoned close that failed before teardown is retried intact.
+		if (closeError && retainsForTombstonedRetry) throw closeError;
 		// Abort in-flight status work before any await/dispose so it can't write
 		// agent_status to a session being torn down.
 		this.summarizer.forget(state.activeSessionId);
-		const cascadeError = cascadeChildren
-			? await this.closeChildSessions(state, reason, waitForAbort, descendants)
-			: undefined;
+		if (cascadeChildren) {
+			const cascadeError = await this.closeChildSessions(state, reason, waitForAbort, descendants);
+			if (cascadeError) captureCloseError(cascadeError);
+		}
 		// Empty draft (no messages, config, or jobs): discard rather than persist an
 		// empty session file. Mirrors the detach-time discard so a config-bearing
 		// draft closed via kill/completed is never wiped.
 		const keepsResumeEntry = this.closeKeepsResumeEntry(reason);
 		const isEmptyDraftSession = !keepsResumeEntry && this.isEmptyDraftContent(state);
-		let persistError: unknown;
 		// Clean shutdown leaves the session un-archived so it stays in the resume list.
 		if (!keepsResumeEntry && !isEmptyDraftSession) {
 			try {
 				this.archiveSession(state);
 			} catch (error) {
-				persistError = error;
+				captureCloseError(error);
 			}
 		}
 		cancelPendingExtensionUiRequests(state);
 		if (reason === "killed" || reason === "shutdown" || reason === "replaced" || reason === "update") {
-			await this.abortBashForClose(state);
+			try {
+				await this.abortBashForClose(state);
+			} catch (error) {
+				captureCloseError(error);
+			}
 		}
 		if (reason === "update") {
-			state.runtime.session.abortForUpdateRestart();
+			try {
+				state.runtime.session.abortForUpdateRestart();
+			} catch (error) {
+				captureCloseError(error);
+			}
 		}
 		if (reason === "killed") {
 			const abort = state.runtime.session.abort().catch(() => undefined);
@@ -6845,11 +6869,12 @@ export class AgentDaemon {
 		}
 		this.recordWorkerRecoveryState(state, `closed:${reason}`, false);
 		state.unsubscribe?.();
-		let disposeError: unknown;
 		try {
-			await state.runtime.dispose();
+			// A tombstoned record must retain its lease until the daemon commits the
+			// whole close. Normal direct runtime disposal still releases its own lease.
+			await state.runtime.dispose({ releaseSessionLease: false });
 		} catch (error) {
-			disposeError = error;
+			captureCloseError(error);
 		}
 		for (const client of state.clients) {
 			abortClientSnapshotStreaming(client, state.activeSessionId);
@@ -6860,15 +6885,11 @@ export class AgentDaemon {
 			removeDaemonClientSessionCapabilities(client, state.activeSessionId);
 		}
 		state.clients.clear();
-		if (disposeError) {
-			throw disposeError;
+		if (closeError && retainsForTombstonedRetry) {
+			throw closeError;
 		}
-		if (persistError) {
-			throw persistError;
-		}
-		if (cascadeError) {
-			throw cascadeError;
-		}
+		// Failed non-tombstoned closes are irrevocable: never leave a disposed,
+		// targetable resident behind merely because persistence or cleanup failed.
 		this.sessions.delete(state.activeSessionId);
 		if (isEmptyDraftSession) {
 			const sessionFile = state.runtime.session.sessionFile;
@@ -6876,6 +6897,8 @@ export class AgentDaemon {
 				await deleteSessionFile(sessionFile).catch(() => undefined);
 			}
 		}
+		state.runtime.releaseSessionLease?.();
+		if (closeError) throw closeError;
 	}
 
 	private async closeChildSessions(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -404,6 +404,21 @@ type PassiveRlmSubagent = PassiveRlmRoot & {
 	chain: PersistedRlmSubagentRegistryEntry[];
 };
 
+type AgentFamilyCatalogSource = "saved" | "passive" | "resident" | "remote";
+
+/**
+ * The public catalog has to retain a usable depth for legacy callers, while
+ * authorization must distinguish a persisted claim from a depth inferred by a
+ * legacy reader. These claim fields are deliberately private to catalog
+ * construction and never escape into agent-messages' public roster.
+ */
+type AgentFamilyCatalogCandidate = AgentFamilyCatalogEntry & {
+	source: AgentFamilyCatalogSource;
+	depthClaim?: number;
+	parentSessionIdClaim?: string;
+	parentSessionPathClaim?: string;
+};
+
 class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
 
@@ -2860,18 +2875,30 @@ export class AgentDaemon {
 	}
 
 	private async createAgentObserveListResult(currentState: ActiveSessionState): Promise<AgentObserveListResult> {
+		const catalog = await this.agentFamilyCatalogEntries();
+		this.authoritativeAgentFamilyEntry(currentState, catalog);
 		const agents = this.listTargetableSessionStates(currentState)
-			.filter(
-				(state) =>
-					state.activeSessionId === currentState.activeSessionId ||
-					this.isAgentFamilyReachable(currentState, state),
-			)
-			.map((state) => this.createAgentObserveSummary(state, currentState));
+			.filter((state) => {
+				if (state.activeSessionId === currentState.activeSessionId) return true;
+				try {
+					assertAgentFamilyReach(
+						this.authoritativeAgentFamilyEntry(currentState, catalog),
+						this.authoritativeAgentFamilyEntry(state, catalog),
+						catalog,
+					);
+					return true;
+				} catch (error) {
+					if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) return false;
+					throw error;
+				}
+			})
+			.map((state) => this.createAgentObserveSummary(state, currentState, catalog));
 		const residentIds = new Set(agents.map((agent) => agent.activeSessionId));
 		for (const passive of await this.listPassiveRlmSubagents()) {
 			if (residentIds.has(passive.info.id)) continue;
 			try {
-				assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.passiveAgentFamilyEntry(passive));
+				const passiveEntry = this.authoritativeAgentFamilyEntryForSessionId(passive.info.id, catalog);
+				assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(currentState, catalog), passiveEntry, catalog);
 			} catch (error) {
 				if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) continue;
 				throw error;
@@ -2901,7 +2928,7 @@ export class AgentDaemon {
 			residentIds.add(passive.info.id);
 		}
 		return {
-			current: this.createAgentObserveSummary(currentState, currentState),
+			current: this.createAgentObserveSummary(currentState, currentState, catalog),
 			agents,
 		};
 	}
@@ -2910,10 +2937,12 @@ export class AgentDaemon {
 		currentState: ActiveSessionState,
 		target: string,
 	): Promise<AgentObserveAgentSnapshot> {
-		const targetState = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, target);
-		this.assertAgentFamilyReachable(currentState, targetState);
+		const { targetState, catalog } = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, target);
+		// Hydration may mutate live endpoint fields. Re-authorize and label only from the
+		// captured catalog that authorized the wake, never from a post-hydration rescan.
+		this.assertAgentFamilyReachable(currentState, targetState, catalog);
 		return {
-			agent: this.createAgentObserveSummary(targetState, currentState),
+			agent: this.createAgentObserveSummary(targetState, currentState, catalog),
 		};
 	}
 
@@ -2921,14 +2950,15 @@ export class AgentDaemon {
 		currentState: ActiveSessionState,
 		input: AgentObserveRecentMessagesInput,
 	): Promise<AgentObserveRecentMessagesResult> {
-		const targetState = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, input.target);
-		this.assertAgentFamilyReachable(currentState, targetState);
+		const { targetState, catalog } = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, input.target);
+		// See getAgent: an observation must use its original authorization snapshot.
+		this.assertAgentFamilyReachable(currentState, targetState, catalog);
 		const limit = normalizeObserveLimit(input.limit);
 		const maxChars = normalizeObserveMaxChars(input.maxChars);
 		const messages = targetState.runtime.session.messages;
 		const startIndex = Math.max(0, messages.length - limit);
 		return {
-			agent: this.createAgentObserveSummary(targetState, currentState),
+			agent: this.createAgentObserveSummary(targetState, currentState, catalog),
 			messages: messages
 				.slice(startIndex)
 				.map((message, offset) => createAgentObserveMessagePreview(message, startIndex + offset, maxChars)),
@@ -2941,8 +2971,17 @@ export class AgentDaemon {
 	private createAgentObserveSummary(
 		state: ActiveSessionState,
 		currentState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[],
 	): AgentObserveAgentSummary {
 		const summary = summaryForActiveSession(state);
+		// The catalog is the authorization snapshot, so relationship fields must not
+		// be re-derived from a runtime that may have changed while a passive target woke.
+		const topology = this.authoritativeAgentFamilyEntry(state, catalog);
+		const parentState = topology.parentSessionId
+			? [...this.sessions.values()].find(
+					(candidate) => candidate.runtime.session.sessionId === topology.parentSessionId,
+				)
+			: undefined;
 		const session = state.runtime.session;
 		const messages = session.messages;
 		const latest = messages.at(-1);
@@ -2971,8 +3010,8 @@ export class AgentDaemon {
 			messageCount: summary.messageCount,
 			queuedCount: summary.sessionActions.queuedCount,
 			isSessionActive: summary.isSessionActive,
-			...(summary.parentActiveSessionId ? { parentActiveSessionId: summary.parentActiveSessionId } : {}),
-			...(summary.parentSessionId ? { parentSessionId: summary.parentSessionId } : {}),
+			...(parentState ? { parentActiveSessionId: parentState.activeSessionId } : {}),
+			...(topology.parentSessionId ? { parentSessionId: topology.parentSessionId } : {}),
 			...(summary.rlmChildId ? { rlmChildId: summary.rlmChildId } : {}),
 			...(summary.rlmParentNodeId ? { rlmParentNodeId: summary.rlmParentNodeId } : {}),
 			...(summary.firstMessage ? { firstMessage: summary.firstMessage } : {}),
@@ -4950,6 +4989,8 @@ export class AgentDaemon {
 					passive.rootParentState?.runtime.session.sessionFile ??
 					passive.rootInfo?.path,
 				rlmDepth: info.rlmDepth ?? entry.rlmDepth,
+				// Passive rows are not resident daemon runtimes. Registry state is
+				// retained separately below and must not change roster lifecycle.
 				status: "inactive",
 				rlmChildId: entry.childId,
 				rlmChildRegistryStatus: entry.status,
@@ -5035,9 +5076,11 @@ export class AgentDaemon {
 	}
 
 	private async createAgentFamilyRoster(currentState: ActiveSessionState): Promise<AgentFamilyRosterResult> {
-		const catalog = await this.createAgentFamilyCatalog(currentState);
-		const current = catalog.find((entry) => entry.id === currentState.runtime.session.sessionId);
-		if (!current) throw new Error("Current agent is missing from the family catalog");
+		// Roster membership is an authorization surface: capture the same immutable
+		// authoritative topology used by message delivery, never the legacy Map
+		// catalog whose duplicate IDs overwrite one another.
+		const catalog = await this.agentFamilyCatalogEntries();
+		const current = this.authoritativeAgentFamilyEntry(currentState, catalog);
 		return buildAgentFamilyRoster(current, catalog);
 	}
 
@@ -5255,54 +5298,255 @@ export class AgentDaemon {
 		};
 	}
 
-	private passiveAgentFamilyEntry(passive: PassiveRlmSubagent): AgentFamilyCatalogEntry {
-		const entry = passive.entry;
-		const depth = passive.info.rlmDepth ?? entry.rlmDepth ?? passive.chain.length;
+	/** Capture persisted topology once for an authorization decision. */
+	private async agentFamilyCatalogEntries(): Promise<readonly AgentFamilyCatalogEntry[]> {
+		const saved = await SessionManager.listAll(undefined, this.options.defaultSessionConfig.sessionDir);
+		const entries: AgentFamilyCatalogCandidate[] = await Promise.all(
+			saved.map((info) => this.savedAgentFamilyCandidate(info)),
+		);
+		// Artifact-resident descendants are absent from the saved-session scan.
+		for (const passive of await this.listPassiveRlmSubagents(saved, true)) {
+			entries.push(await this.passiveAgentFamilyCandidate(passive));
+		}
+		for (const state of this.sessions.values()) entries.push(this.residentAgentFamilyCandidate(state));
+		for (const peer of this.remoteAgentPeers.values()) entries.push(this.remoteAgentFamilyCandidate(peer));
+		return Object.freeze(this.mergeEquivalentAgentFamilyCatalogEntries(entries));
+	}
+
+	/** The header is the only durable evidence that a saved depth/path was explicit. */
+	private async persistedTopologyClaims(sessionPath: string): Promise<{ depth?: number; parentSessionPath?: string }> {
+		try {
+			const firstLine = (await readFile(sessionPath, "utf8")).split("\n", 1)[0];
+			if (!firstLine) return {};
+			const header = JSON.parse(firstLine) as { rlmDepth?: unknown; parentSession?: unknown };
+			const depth =
+				typeof header.rlmDepth === "number" && Number.isSafeInteger(header.rlmDepth) && header.rlmDepth >= 0
+					? header.rlmDepth
+					: undefined;
+			const parentSessionPath =
+				typeof header.parentSession === "string" && header.parentSession
+					? canonicalSessionPath(
+							isAbsolute(header.parentSession)
+								? header.parentSession
+								: resolve(dirname(sessionPath), header.parentSession),
+						)
+					: undefined;
+			return { ...(depth !== undefined ? { depth } : {}), ...(parentSessionPath ? { parentSessionPath } : {}) };
+		} catch {
+			return {};
+		}
+	}
+
+	private async savedAgentFamilyCandidate(info: SessionInfo): Promise<AgentFamilyCatalogCandidate> {
+		const claims = await this.persistedTopologyClaims(info.path);
+		return {
+			id: info.id,
+			...(info.name ? { name: info.name } : {}),
+			// resolveSessionRlmDepth is retained only as a usable legacy fallback.
+			// It is deliberately not a claim and therefore cannot contradict an overlay.
+			depth: info.rlmDepth,
+			status: "inactive",
+			sessionPath: canonicalSessionPath(info.path),
+			source: "saved",
+			...(claims.depth !== undefined ? { depthClaim: claims.depth } : {}),
+			...(claims.parentSessionPath
+				? { parentSessionPath: claims.parentSessionPath, parentSessionPathClaim: claims.parentSessionPath }
+				: {}),
+		};
+	}
+
+	private remoteAgentFamilyCandidate(peer: AgentSessionMessageAgentSummary): AgentFamilyCatalogCandidate {
+		// Remote peer state is untrusted topology input. In particular, never let a
+		// malformed subagent be silently coerced into a sibling root by `?? 0`.
+		const depth = peer.rlmDepth;
+		const hasParentSessionId = peer.parentSessionId !== undefined;
+		const hasParentSessionPath = peer.parentSessionPath !== undefined;
+		const parentSessionId =
+			typeof peer.parentSessionId === "string" && peer.parentSessionId.trim() ? peer.parentSessionId : undefined;
 		const parentSessionPath =
-			depth > 0
-				? (entry.parentSessionFile ??
-					passive.chain.at(-2)?.sessionFile ??
-					passive.rootParentState?.runtime.session.sessionFile ??
-					passive.rootInfo?.path)
+			typeof peer.parentSessionPath === "string" && peer.parentSessionPath.trim()
+				? canonicalSessionPath(peer.parentSessionPath)
+				: undefined;
+		if (
+			typeof depth !== "number" ||
+			!Number.isSafeInteger(depth) ||
+			depth < 0 ||
+			(depth === 0 && (hasParentSessionId || hasParentSessionPath)) ||
+			(depth > 0 && !parentSessionId && !parentSessionPath)
+		) {
+			throw new Error(AGENT_FAMILY_REACH_ERROR);
+		}
+		return {
+			id: peer.sessionId,
+			...(peer.sessionName ? { name: peer.sessionName } : {}),
+			depth,
+			status: peer.status ?? "idle",
+			...(peer.sessionPath ? { sessionPath: canonicalSessionPath(peer.sessionPath) } : {}),
+			source: "remote",
+			depthClaim: depth,
+			...(parentSessionId ? { parentSessionId, parentSessionIdClaim: parentSessionId } : {}),
+			...(parentSessionPath ? { parentSessionPath, parentSessionPathClaim: parentSessionPath } : {}),
+		};
+	}
+
+	private residentAgentFamilyCandidate(state: ActiveSessionState): AgentFamilyCatalogCandidate {
+		const entry = this.agentFamilyEntry(state);
+		const session = state.runtime.session;
+		const metadata = state.runtime.metadata;
+		const headerParent = this.resolveHeaderParentSessionPath(state);
+		const parentSessionPath = headerParent ?? metadata.parentSessionFile;
+		// A root has no parent claim. Do not let a stale runtime rlmDepth turn it
+		// into a depth-N orphan when its durable/root metadata still says root.
+		const isUnparentedTopLevel =
+			metadata.kind === "top-level" && !headerParent && !metadata.parentSessionId && !metadata.parentSessionFile;
+		const depthClaim =
+			!isUnparentedTopLevel &&
+			typeof session.rlmDepth === "number" &&
+			Number.isSafeInteger(session.rlmDepth) &&
+			session.rlmDepth >= 0
+				? session.rlmDepth
 				: undefined;
 		return {
+			...entry,
+			...(isUnparentedTopLevel ? { depth: 0 } : {}),
+			source: "resident",
+			...(depthClaim !== undefined ? { depthClaim } : {}),
+			...(metadata.parentSessionId
+				? { parentSessionId: metadata.parentSessionId, parentSessionIdClaim: metadata.parentSessionId }
+				: {}),
+			...(parentSessionPath
+				? {
+						parentSessionPath: canonicalSessionPath(parentSessionPath),
+						parentSessionPathClaim: canonicalSessionPath(parentSessionPath),
+					}
+				: {}),
+		};
+	}
+
+	/**
+	 * Merge a durable row with a passive/resident view only if all *present*
+	 * topology claims agree. In particular, the depth produced for legacy saved
+	 * files is a fallback, not evidence against a newer explicit overlay.
+	 */
+	private mergeEquivalentAgentFamilyCatalogEntries(
+		entries: readonly AgentFamilyCatalogCandidate[],
+	): AgentFamilyCatalogEntry[] {
+		const canonical = entries.map((entry) => ({
+			...entry,
+			...(entry.sessionPath ? { sessionPath: canonicalSessionPath(entry.sessionPath) } : {}),
+			...(entry.parentSessionPath ? { parentSessionPath: canonicalSessionPath(entry.parentSessionPath) } : {}),
+			...(entry.parentSessionPathClaim
+				? { parentSessionPathClaim: canonicalSessionPath(entry.parentSessionPathClaim) }
+				: {}),
+		}));
+		const compatible = (left: AgentFamilyCatalogCandidate, right: AgentFamilyCatalogCandidate) =>
+			left.id === right.id &&
+			left.sessionPath === right.sessionPath &&
+			(left.depthClaim === undefined || right.depthClaim === undefined || left.depthClaim === right.depthClaim) &&
+			(left.parentSessionPathClaim === undefined ||
+				right.parentSessionPathClaim === undefined ||
+				left.parentSessionPathClaim === right.parentSessionPathClaim) &&
+			(left.parentSessionIdClaim === undefined ||
+				right.parentSessionIdClaim === undefined ||
+				left.parentSessionIdClaim === right.parentSessionIdClaim);
+		const groups: AgentFamilyCatalogCandidate[][] = [];
+		for (const entry of canonical) {
+			const group = groups.find((candidate) => candidate.every((member) => compatible(member, entry)));
+			if (group) group.push(entry);
+			else groups.push([entry]);
+		}
+		const sourceRank: Record<AgentFamilyCatalogSource, number> = {
+			saved: 3,
+			passive: 2,
+			resident: 1,
+			remote: 0,
+		};
+		const statusRank: Record<AgentFamilyCatalogEntry["status"], number> = {
+			inactive: 0,
+			idle: 1,
+			running: 2,
+		};
+		const stable = (values: readonly (string | undefined)[]) =>
+			values.filter((value): value is string => value !== undefined).sort()[0];
+		const preferred = <T>(
+			rows: readonly AgentFamilyCatalogCandidate[],
+			get: (row: AgentFamilyCatalogCandidate) => T | undefined,
+		) =>
+			[...rows]
+				.sort((left, right) => sourceRank[right.source] - sourceRank[left.source])
+				.map(get)
+				.find((value): value is T => value !== undefined);
+		return groups.map((rows) => {
+			const status = rows.reduce<AgentFamilyCatalogEntry["status"]>(
+				(best, row) => (statusRank[row.status] > statusRank[best] ? row.status : best),
+				"inactive",
+			);
+			const depth = preferred(rows, (row) => row.depthClaim) ?? preferred(rows, (row) => row.depth)!;
+			const parentSessionId = preferred(rows, (row) => row.parentSessionIdClaim);
+			const parentSessionPath = preferred(rows, (row) => row.parentSessionPathClaim);
+			return {
+				id: rows[0]!.id,
+				depth,
+				status,
+				...(stable(rows.map((row) => row.name)) ? { name: stable(rows.map((row) => row.name)) } : {}),
+				...(parentSessionId ? { parentSessionId } : {}),
+				...(parentSessionPath ? { parentSessionPath } : {}),
+				...(rows[0]!.sessionPath ? { sessionPath: rows[0]!.sessionPath } : {}),
+			};
+		});
+	}
+
+	private async passiveAgentFamilyCandidate(passive: PassiveRlmSubagent): Promise<AgentFamilyCatalogCandidate> {
+		const entry = passive.entry;
+		const claims = await this.persistedTopologyClaims(entry.sessionFile);
+		const registryParentPath = entry.parentSessionFile ? canonicalSessionPath(entry.parentSessionFile) : undefined;
+		const parentSessionPath = claims.parentSessionPath ?? registryParentPath;
+		const depthClaim = claims.depth ?? entry.rlmDepth;
+		return {
 			id: passive.info.id,
-			name: passive.info.name ?? entry.sessionName,
-			depth,
-			status: "idle",
-			...(depth > 0 && entry.parentSessionId ? { parentSessionId: entry.parentSessionId } : {}),
-			...(parentSessionPath ? { parentSessionPath: canonicalSessionPath(parentSessionPath) } : {}),
+			...((passive.info.name ?? entry.sessionName) ? { name: passive.info.name ?? entry.sessionName } : {}),
+			depth: depthClaim ?? passive.info.rlmDepth,
+			status: "inactive",
 			sessionPath: canonicalSessionPath(entry.sessionFile),
+			source: "passive",
+			...(depthClaim !== undefined ? { depthClaim } : {}),
+			...(entry.parentSessionId
+				? { parentSessionId: entry.parentSessionId, parentSessionIdClaim: entry.parentSessionId }
+				: {}),
+			...(parentSessionPath ? { parentSessionPath, parentSessionPathClaim: parentSessionPath } : {}),
 		};
 	}
 
 	private async getOrHydrateAuthorizedAgentFamilyTarget(
 		currentState: ActiveSessionState,
 		target: string,
-	): Promise<ActiveSessionState> {
+	): Promise<{ targetState: ActiveSessionState; catalog: readonly AgentFamilyCatalogEntry[] }> {
+		const catalog = await this.agentFamilyCatalogEntries();
 		try {
-			return this.getBoundSessionState(target);
+			return { targetState: this.getBoundSessionState(target), catalog };
 		} catch (error) {
 			if (error instanceof BoundSessionUnavailableError) {
 				const targetState = this.getSessionState(target);
-				this.assertAgentFamilyReachable(currentState, targetState);
-				return this.getOrHydrateBoundSessionState(target);
+				this.assertAgentFamilyReachable(currentState, targetState, catalog);
+				return { targetState: await this.getOrHydrateBoundSessionState(target), catalog };
 			}
 			if (error instanceof AmbiguousActiveSessionError) {
-				const targetState = this.resolveAgentFamilySessionName(currentState, target, error);
-				return this.getOrHydrateBoundSessionState(targetState.activeSessionId);
+				const targetState = this.resolveAgentFamilySessionName(currentState, target, error, catalog);
+				return { targetState: await this.getOrHydrateBoundSessionState(targetState.activeSessionId), catalog };
 			}
 		}
 		const passive = await this.findPassiveRlmSubagent(target);
-		if (!passive) return this.getOrHydrateBoundSessionState(target);
-		assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.passiveAgentFamilyEntry(passive));
-		return this.hydratePassiveRlmSubagent(passive);
+		if (!passive) return { targetState: await this.getOrHydrateBoundSessionState(target), catalog };
+		const passiveEntry = this.authoritativeAgentFamilyEntryForSessionId(passive.info.id, catalog);
+		assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(currentState, catalog), passiveEntry, catalog);
+		return { targetState: await this.hydratePassiveRlmSubagent(passive), catalog };
 	}
 
 	private resolveAgentFamilySessionName(
 		currentState: ActiveSessionState,
 		target: string,
 		ambiguity: AmbiguousActiveSessionError,
+		catalog: readonly AgentFamilyCatalogEntry[],
 	): ActiveSessionState {
 		const reachableMatches = new Map(
 			[...this.sessions.values()]
@@ -5311,7 +5555,7 @@ export class AgentDaemon {
 					return (
 						(session.sessionId === target || session.sessionName === target) &&
 						(state.activeSessionId === currentState.activeSessionId ||
-							this.isAgentFamilyReachable(currentState, state))
+							this.isAgentFamilyReachable(currentState, state, catalog))
 					);
 				})
 				.map((state) => [state.activeSessionId, state]),
@@ -5321,9 +5565,36 @@ export class AgentDaemon {
 		return matches[0]!;
 	}
 
-	private isAgentFamilyReachable(currentState: ActiveSessionState, targetState: ActiveSessionState): boolean {
+	private authoritativeAgentFamilyEntry(
+		state: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[],
+	): AgentFamilyCatalogEntry {
+		return this.authoritativeAgentFamilyEntryForSessionId(state.runtime.session.sessionId, catalog);
+	}
+
+	private authoritativeAgentFamilyEntryForSessionId(
+		sessionId: string,
+		catalog: readonly AgentFamilyCatalogEntry[],
+	): AgentFamilyCatalogEntry {
+		const entries = catalog.filter((candidate) => candidate.id === sessionId);
+		if (entries.length !== 1) throw new Error(AGENT_FAMILY_REACH_ERROR);
+		return entries[0]!;
+	}
+
+	private isAgentFamilyReachable(
+		currentState: ActiveSessionState,
+		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[] = [
+			this.agentFamilyEntry(currentState),
+			this.agentFamilyEntry(targetState),
+		],
+	): boolean {
 		try {
-			assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.agentFamilyEntry(targetState));
+			assertAgentFamilyReach(
+				this.authoritativeAgentFamilyEntry(currentState, catalog),
+				this.authoritativeAgentFamilyEntry(targetState, catalog),
+				catalog,
+			);
 			return true;
 		} catch (error) {
 			if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) return false;
@@ -5331,17 +5602,49 @@ export class AgentDaemon {
 		}
 	}
 
-	private assertAgentFamilyReachable(currentState: ActiveSessionState, targetState: ActiveSessionState): void {
+	private assertAgentFamilyReachable(
+		currentState: ActiveSessionState,
+		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[] = [
+			this.agentFamilyEntry(currentState),
+			this.agentFamilyEntry(targetState),
+		],
+	): void {
 		if (currentState.activeSessionId === targetState.activeSessionId) return;
-		assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.agentFamilyEntry(targetState));
+		assertAgentFamilyReach(
+			this.authoritativeAgentFamilyEntry(currentState, catalog),
+			this.authoritativeAgentFamilyEntry(targetState, catalog),
+			catalog,
+		);
 	}
 
 	private agentMessageRelationship(
 		fromState: ActiveSessionState | undefined,
 		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[] = [
+			this.agentFamilyEntry(targetState),
+			...(fromState ? [this.agentFamilyEntry(fromState)] : []),
+		],
 	): AgentFamilyRelationship | undefined {
 		if (!fromState) return undefined;
-		return agentFamilyRelationship(this.agentFamilyEntry(targetState), this.agentFamilyEntry(fromState));
+		return agentFamilyRelationship(
+			this.authoritativeAgentFamilyEntry(targetState, catalog),
+			this.authoritativeAgentFamilyEntry(fromState, catalog),
+			catalog,
+		);
+	}
+
+	private cliAgentMessageRelationship(
+		fromState: ActiveSessionState,
+		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[],
+	): AgentFamilyRelationship | undefined {
+		try {
+			return this.agentMessageRelationship(fromState, targetState, catalog);
+		} catch (error) {
+			if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) return undefined;
+			throw error;
+		}
 	}
 
 	private async sendAgentSessionMessage(options: {
@@ -5358,27 +5661,48 @@ export class AgentDaemon {
 		}
 		const targetSelector = assertDirectAgentMessageTarget(options.targetSelector);
 		const message = normalizeAgentSessionMessage(options.message, DEFAULT_AGENT_MESSAGE_MAX_CHARS);
+		// Agent-origin authorization uses one immutable persisted topology through
+		// selector resolution, wake, and delivery. CLI-origin topology is advisory
+		// label metadata and must not make an otherwise valid delivery unavailable.
+		let catalog: readonly AgentFamilyCatalogEntry[] | undefined;
+		if (options.fromState) {
+			try {
+				catalog = await this.agentFamilyCatalogEntries();
+			} catch (error) {
+				if (options.origin === "agent") throw error;
+				this.log(
+					`Agent family catalog unavailable for CLI message relationship: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
 		let targetState: ActiveSessionState;
 		try {
 			targetState = this.getBoundSessionState(targetSelector);
 		} catch (error) {
 			if (error instanceof BoundSessionUnavailableError) {
+				const unavailableTarget = this.getSessionState(targetSelector);
+				if (this.closingSessions.has(unavailableTarget.activeSessionId)) throw error;
 				if (options.origin === "agent" && options.fromState) {
-					this.assertAgentFamilyReachable(options.fromState, this.getSessionState(targetSelector));
+					this.assertAgentFamilyReachable(options.fromState, unavailableTarget, catalog!);
 				}
 				targetState = await this.getOrHydrateBoundSessionState(targetSelector);
 			} else {
 				if (error instanceof AmbiguousActiveSessionError) {
 					if (options.origin !== "agent" || !options.fromState) throw error;
-					const resolved = this.resolveAgentFamilySessionName(options.fromState, targetSelector, error);
+					const resolved = this.resolveAgentFamilySessionName(options.fromState, targetSelector, error, catalog!);
 					targetState = await this.getOrHydrateBoundSessionState(resolved.activeSessionId);
 				} else {
 					const passiveSubagent = await this.findPassiveRlmSubagent(targetSelector);
 					if (passiveSubagent) {
 						if (options.origin === "agent" && options.fromState) {
+							const passiveEntry = this.authoritativeAgentFamilyEntryForSessionId(
+								passiveSubagent.info.id,
+								catalog!,
+							);
 							assertAgentFamilyReach(
-								this.agentFamilyEntry(options.fromState),
-								this.passiveAgentFamilyEntry(passiveSubagent),
+								this.authoritativeAgentFamilyEntry(options.fromState, catalog!),
+								passiveEntry,
+								catalog!,
 							);
 						}
 						targetState = await this.hydratePassiveRlmSubagent(passiveSubagent);
@@ -5401,11 +5725,14 @@ export class AgentDaemon {
 				}
 			}
 		}
+		if (this.closingSessions.has(targetState.activeSessionId)) {
+			throw new Error(`Active session ${targetState.activeSessionId} is closing`);
+		}
 		if (options.fromState?.activeSessionId === targetState.activeSessionId) {
 			throw new Error("Agent messaging cannot target the sending session");
 		}
 		if (options.origin === "agent" && options.fromState) {
-			this.assertAgentFamilyReachable(options.fromState, targetState);
+			this.assertAgentFamilyReachable(options.fromState, targetState, catalog!);
 		}
 		const releaseQueueSlot = this.reserveAgentMessageQueueSlot(targetState);
 		const senderKey =
@@ -5423,7 +5750,12 @@ export class AgentDaemon {
 			from:
 				options.sender ??
 				this.createAgentSessionMessageSender(options.fromState, options.clientId ?? options.origin),
-			fromRelationship: this.agentMessageRelationship(options.fromState, targetState),
+			fromRelationship:
+				options.origin === "cli" && options.fromState
+					? catalog
+						? this.cliAgentMessageRelationship(options.fromState, targetState, catalog)
+						: undefined
+					: this.agentMessageRelationship(options.fromState, targetState, catalog),
 			target: this.createAgentSessionMessageEndpoint(targetState),
 		};
 		try {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1062,8 +1062,8 @@ export class AgentDaemon {
 			authority &&
 			((typeof authority.childId === "string" && authority.childId !== childId) ||
 				(entry !== undefined &&
-					typeof authority.sessionDir === "string" &&
-					authority.sessionDir !== entry.sessionDir))
+					((typeof authority.sessionDir === "string" && authority.sessionDir !== entry.sessionDir) ||
+						(typeof authority.sessionFile === "string" && authority.sessionFile !== entry.sessionFile))))
 		) {
 			authority.assertCurrent();
 			return "unknown";
@@ -2377,7 +2377,12 @@ export class AgentDaemon {
 						!state ||
 						state.runtime.session !== runtime.session ||
 						state.runtime.metadata.sessionDir !== options.sessionDir ||
-						(authority !== undefined && state.runtime.metadata.sessionDir !== authority.sessionDir)
+						(authority !== undefined &&
+							(state.runtime.metadata.sessionDir !== authority.sessionDir ||
+								(typeof authority.sessionFile === "string" &&
+									state.runtime.session.sessionFile !== authority.sessionFile) ||
+								(typeof authority.sessionId === "string" &&
+									state.runtime.session.sessionId !== authority.sessionId)))
 					) {
 						throw new Error("RLM subagent release does not match the resident runtime incarnation");
 					}
@@ -2419,16 +2424,32 @@ export class AgentDaemon {
 					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 						(entry) => entry.childId === childId,
 					);
-					// Concrete deletion requires exact object identity. Passive deletion has no
-					// object fence, so bind it to the complete persisted identity instead.
+					// Concrete deletion requires exact object identity. A passive request and a
+					// post-tombstone cleanup retry have no resident state, so both must bind to
+					// the exact persisted incarnation before they can touch its tombstone or jobs.
+					const persistedMatchesAuthority =
+						persisted !== undefined &&
+						(authority === undefined ||
+							(persisted.sessionDir === authority.sessionDir &&
+								(typeof authority.sessionFile !== "string" ||
+									persisted.sessionFile === authority.sessionFile)));
+					const suppliedSessionMatchesPersisted =
+						session === undefined ||
+						(persistedMatchesAuthority &&
+							(typeof authority?.sessionFile !== "string" || session.sessionFile === authority.sessionFile) &&
+							(typeof authority?.sessionId !== "string" || session.sessionId === authority.sessionId));
 					if (
 						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
 						(state !== undefined && session === undefined) ||
-						(state === undefined && session !== undefined) ||
+						(state === undefined && session !== undefined && !suppliedSessionMatchesPersisted) ||
 						(authority !== undefined &&
 							(state !== undefined
-								? state.runtime.metadata.sessionDir !== authority.sessionDir
-								: persisted === undefined || persisted.sessionDir !== authority.sessionDir))
+								? state.runtime.metadata.sessionDir !== authority.sessionDir ||
+									(typeof authority.sessionFile === "string" &&
+										state.runtime.session.sessionFile !== authority.sessionFile) ||
+									(typeof authority.sessionId === "string" &&
+										state.runtime.session.sessionId !== authority.sessionId)
+								: !persistedMatchesAuthority))
 					) {
 						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
 					}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2173,7 +2173,7 @@ export class AgentDaemon {
 		if (this.bindingSessions.has(state.activeSessionId)) {
 			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is still initializing`);
 		}
-		if (this.closingSessions.has(state.activeSessionId)) {
+		if (this.closingSessions.has(state.activeSessionId) || state.runtime.session.isClosing) {
 			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is closing`);
 		}
 		return state;
@@ -2697,7 +2697,7 @@ export class AgentDaemon {
 		if (this.sessions.get(state.activeSessionId) !== state || this.bindingSessions.has(state.activeSessionId)) {
 			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} did not finish initializing`);
 		}
-		if (this.closingSessions.has(state.activeSessionId)) {
+		if (this.closingSessions.has(state.activeSessionId) || state.runtime.session.isClosing) {
 			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is closing`);
 		}
 		return state;
@@ -6251,6 +6251,7 @@ export class AgentDaemon {
 		cascadeChildren = true,
 		descendantCollector?: Set<ActiveSessionState>,
 	): Promise<void> {
+		state.runtime.session.beginClosing();
 		this.abortWaitingPromptAdmissionsForSession(state.activeSessionId);
 		for (const client of state.clients) {
 			this.abortSideQuestionsFor(client, state.activeSessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2477,9 +2477,8 @@ export class AgentDaemon {
 					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 						(entry) => entry.childId === childId,
 					);
-					// Concrete deletion requires exact object identity. A passive request and a
-					// post-tombstone cleanup retry have no resident state, so both must bind to
-					// the exact persisted incarnation before they can touch its tombstone or jobs.
+					// Concrete deletion requires exact authority. An omitted session is valid
+					// only when its persisted row and resident runtime name the same incarnation.
 					const persistedMatchesAuthority =
 						persisted !== undefined &&
 						authority !== undefined &&
@@ -2488,6 +2487,14 @@ export class AgentDaemon {
 						persisted.sessionFile === authority.sessionFile &&
 						typeof authority.sessionId === "string" &&
 						persisted.sessionId === authority.sessionId;
+					const residentMatchesAuthority =
+						state !== undefined &&
+						authority !== undefined &&
+						state.runtime.metadata.sessionDir === authority.sessionDir &&
+						typeof authority.sessionFile === "string" &&
+						state.runtime.session.sessionFile === authority.sessionFile &&
+						typeof authority.sessionId === "string" &&
+						state.runtime.session.sessionId === authority.sessionId;
 					const suppliedSessionMatchesPersisted =
 						session === undefined ||
 						(persistedMatchesAuthority &&
@@ -2495,13 +2502,17 @@ export class AgentDaemon {
 							(typeof authority?.sessionId !== "string" || session.sessionId === authority.sessionId));
 					const residentMatchesAuthority =
 						state !== undefined &&
-						persistedMatchesAuthority &&
-						state.runtime.metadata.sessionDir === authority?.sessionDir &&
+						authority !== undefined &&
+						state.runtime.metadata.sessionDir === authority.sessionDir &&
+						typeof authority.sessionFile === "string" &&
 						state.runtime.session.sessionFile === authority.sessionFile &&
+						typeof authority.sessionId === "string" &&
 						state.runtime.session.sessionId === authority.sessionId;
 					if (
 						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
-						(state !== undefined && session === undefined && !residentMatchesAuthority) ||
+						(state !== undefined &&
+							session === undefined &&
+							(!persistedMatchesAuthority || !residentMatchesAuthority)) ||
 						// A complete registry read proving there is no current row is enough
 						// to report a benign absent deletion. Any matching row remains
 						// fail-closed unless its complete incarnation authority matches.
@@ -2511,12 +2522,7 @@ export class AgentDaemon {
 							!persistedMatchesAuthority) ||
 						(state === undefined && session !== undefined && !suppliedSessionMatchesPersisted) ||
 						(authority !== undefined &&
-							state !== undefined &&
-							(state.runtime.metadata.sessionDir !== authority.sessionDir ||
-								(typeof authority.sessionFile === "string" &&
-									state.runtime.session.sessionFile !== authority.sessionFile) ||
-								(typeof authority.sessionId === "string" &&
-									state.runtime.session.sessionId !== authority.sessionId)))
+							(state !== undefined ? !residentMatchesAuthority : !persistedMatchesAuthority))
 					) {
 						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
 					}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2481,21 +2481,39 @@ export class AgentDaemon {
 						(persistedMatchesAuthority &&
 							(typeof authority?.sessionFile !== "string" || session.sessionFile === authority.sessionFile) &&
 							(typeof authority?.sessionId !== "string" || session.sessionId === authority.sessionId));
+					const residentMatchesAuthority =
+						state !== undefined &&
+						persistedMatchesAuthority &&
+						state.runtime.metadata.sessionDir === authority?.sessionDir &&
+						state.runtime.session.sessionFile === authority.sessionFile &&
+						state.runtime.session.sessionId === authority.sessionId;
 					if (
 						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
-						(state !== undefined && session === undefined) ||
-						(state === undefined && session === undefined && !persistedMatchesAuthority) ||
+						(state !== undefined && session === undefined && !residentMatchesAuthority) ||
+						// A complete registry read proving there is no current row is enough
+						// to report a benign absent deletion. Any matching row remains
+						// fail-closed unless its complete incarnation authority matches.
+						(state === undefined &&
+							session === undefined &&
+							persisted !== undefined &&
+							!persistedMatchesAuthority) ||
 						(state === undefined && session !== undefined && !suppliedSessionMatchesPersisted) ||
 						(authority !== undefined &&
-							(state !== undefined
-								? state.runtime.metadata.sessionDir !== authority.sessionDir ||
-									(typeof authority.sessionFile === "string" &&
-										state.runtime.session.sessionFile !== authority.sessionFile) ||
-									(typeof authority.sessionId === "string" &&
-										state.runtime.session.sessionId !== authority.sessionId)
-								: !persistedMatchesAuthority))
+							state !== undefined &&
+							(state.runtime.metadata.sessionDir !== authority.sessionDir ||
+								(typeof authority.sessionFile === "string" &&
+									state.runtime.session.sessionFile !== authority.sessionFile) ||
+								(typeof authority.sessionId === "string" &&
+									state.runtime.session.sessionId !== authority.sessionId)))
 					) {
 						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
+					}
+					// `readLatestRlmSubagentRegistry(..., true)` completed successfully.
+					// When it proves this child has no current row and no resident object
+					// exists, deletion is already benign regardless of a stale or partial
+					// coordinator token. Existing rows above still require exact authority.
+					if (state === undefined && persisted === undefined) {
+						return { deletionDurability: "absent" };
 					}
 					const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
 					const deletionDurability = await this.recordRlmSubagentDeletion(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -344,6 +344,8 @@ const DAEMON_CLIENT_CAPABILITY_SET: ReadonlySet<string> = new Set(DAEMON_SUPPORT
 const CLIENT_CATCHUP_RETRY_MS = 250;
 const UPDATE_RESTART_ABORT_BASH_TIMEOUT_MS = 5000;
 const SUPERVISOR_FENCE_POLL_MS = 250;
+const TOMBSTONED_CLOSE_RETRY_BASE_MS = 250;
+const TOMBSTONED_CLOSE_RETRY_MAX_MS = 30_000;
 const UPDATE_RESTART_MARKER =
 	"<prime_agent_update_interrupted>\n" +
 	"Prime Agent was updated and intentionally interrupted this session. Continue from the saved transcript and restored tool/kernel state. Any running model, tool, bash, or child-agent work may have been partially completed.\n" +
@@ -459,6 +461,8 @@ interface FailedTombstonedRlmClose {
 	readonly childId: string;
 	cleanup?: Promise<void>;
 	error?: unknown;
+	retryAttempt: number;
+	retryTimer?: ReturnType<typeof setTimeout>;
 }
 
 export class AgentDaemon {
@@ -1319,8 +1323,30 @@ export class AgentDaemon {
 		savedSessions: SessionInfo[],
 		scheduledJobs: AgentCronJob[],
 	): Promise<SessionSummary[]> {
-		const passiveByPath = await this.passiveRlmSubagentsByPath(savedSessions);
-		const savedByPath = new Map(savedSessions.map((session) => [resolve(session.path), session]));
+		const privatePaths = new Set(
+			[...this.sessions.values()]
+				.filter((state) => !this.isPublicRlmState(state))
+				.flatMap((state) =>
+					state.runtime.session.sessionFile ? [resolve(state.runtime.session.sessionFile)] : [],
+				),
+		);
+		let removedPrivateDescendant = true;
+		while (removedPrivateDescendant) {
+			removedPrivateDescendant = false;
+			for (const saved of savedSessions) {
+				if (
+					!privatePaths.has(resolve(saved.path)) &&
+					saved.parentSessionPath &&
+					privatePaths.has(resolve(saved.parentSessionPath))
+				) {
+					privatePaths.add(resolve(saved.path));
+					removedPrivateDescendant = true;
+				}
+			}
+		}
+		const publicSavedSessions = savedSessions.filter((session) => !privatePaths.has(resolve(session.path)));
+		const passiveByPath = await this.passiveRlmSubagentsByPath(publicSavedSessions);
+		const savedByPath = new Map(publicSavedSessions.map((session) => [resolve(session.path), session]));
 		for (const [path, passive] of passiveByPath) {
 			savedByPath.set(path, passive.info);
 		}
@@ -2051,10 +2077,16 @@ export class AgentDaemon {
 		return job;
 	}
 
-	private listHeartbeats(): AgentConnectionHeartbeat[] {
+	private listHeartbeats(activeSessionId?: string): AgentConnectionHeartbeat[] {
 		return this.cronStore
 			.list()
-			.filter((job) => isHeartbeatCronJob(job) && (job.status === "active" || job.status === "paused"))
+			.filter(
+				(job) =>
+					isHeartbeatCronJob(job) &&
+					(job.status === "active" || job.status === "paused") &&
+					(!activeSessionId || job.activeSessionId === activeSessionId) &&
+					this.isPublicCronJob(job),
+			)
 			.map((job) => {
 				const state = this.sessions.get(job.activeSessionId);
 				const summary = state ? summaryForActiveSession(state) : undefined;
@@ -2306,6 +2338,12 @@ export class AgentDaemon {
 			sessionFile !== undefined &&
 			resolve(current.sessionFile) === resolve(sessionFile)
 		);
+	}
+
+	private isPublicCronJob(job: AgentCronJob): boolean {
+		const state =
+			this.sessions.get(job.activeSessionId) ?? this.failedTombstonedRlmCloses.get(job.activeSessionId)?.state;
+		return state === undefined || this.isPublicRlmState(state);
 	}
 
 	private findSessionBySessionFile(sessionFile: string | undefined): ActiveSessionState | undefined {
@@ -3821,7 +3859,7 @@ export class AgentDaemon {
 				let sessionDir: string | undefined;
 				if ("activeSessionId" in command) {
 					activeSessionId = command.activeSessionId;
-					const sessionManager = this.getSessionState(activeSessionId).runtime.session.sessionManager;
+					const sessionManager = this.getBoundSessionState(activeSessionId).runtime.session.sessionManager;
 					cwd = sessionManager.getCwd();
 					sessionDir = sessionManager.getSessionDir();
 				} else {
@@ -3976,7 +4014,7 @@ export class AgentDaemon {
 
 			case "detach": {
 				if (command.activeSessionId) {
-					const state = this.getSessionState(command.activeSessionId);
+					const state = this.getBoundSessionState(command.activeSessionId);
 					this.detachClientFromSession(client, state);
 				} else {
 					this.detachClient(client);
@@ -3991,7 +4029,7 @@ export class AgentDaemon {
 			}
 
 			case "rename": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const name = command.name.trim();
 				if (!name) {
 					throw new Error("Session name cannot be empty");
@@ -4002,7 +4040,7 @@ export class AgentDaemon {
 
 			case "rename_saved_session": {
 				if (command.activeSessionId) {
-					this.getSessionState(command.activeSessionId);
+					this.getBoundSessionState(command.activeSessionId);
 				}
 				const state = this.findActiveSessionByFile(command.sessionPath);
 				const name = command.name.trim();
@@ -4043,7 +4081,7 @@ export class AgentDaemon {
 
 			case "delete_saved_session": {
 				if (command.activeSessionId) {
-					this.getSessionState(command.activeSessionId);
+					this.getBoundSessionState(command.activeSessionId);
 				}
 				if (this.findActiveSessionByFile(command.sessionPath)) {
 					throw new Error("Cannot delete the currently active session");
@@ -4229,26 +4267,26 @@ export class AgentDaemon {
 			}
 
 			case "restore_next_turn": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.restorePendingNextTurnMessages(command.messages);
 				return success(command.id, "restore_next_turn");
 			}
 
 			case "restore_actions": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const restored = await state.runtime.session.restoreSessionActions(command.snapshot);
 				if (restored > 0) this.recordWorkerRecoveryState(state, "actions_restored", true);
 				return success(command.id, "restore_actions", { restored });
 			}
 
 			case "append_custom_message": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				await state.runtime.session.sendCustomMessage(command.message);
 				return success(command.id, "append_custom_message");
 			}
 
 			case "resume_queue": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				if (!state.runtime.session.resumeQueuedWork()) {
 					const error = new Error("No queued work to resume");
 					return failure(command.id, "resume_queue", error, serializeDaemonError(error));
@@ -4258,7 +4296,7 @@ export class AgentDaemon {
 
 			case "send_message": {
 				const fromState = command.fromActiveSessionId
-					? this.getSessionState(command.fromActiveSessionId)
+					? this.getBoundSessionState(command.fromActiveSessionId)
 					: undefined;
 				const receipt = await this.sendAgentSessionMessage({
 					targetSelector: command.targetActiveSessionId,
@@ -4288,7 +4326,7 @@ export class AgentDaemon {
 			}
 
 			case "agent_messages_clear": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const cleared = await this.withAgentMessageTargetLock(state.activeSessionId, async () => {
 					this.agentMessageRateLimiter.clearMatching((key) => key.endsWith(`->${state.activeSessionId}`));
 					return state.runtime.session.clearQueuedUserMessagesMatching(isAgentSessionMessagePrompt);
@@ -4297,13 +4335,13 @@ export class AgentDaemon {
 			}
 
 			case "abort": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.requestAbort();
 				return success(command.id, "abort");
 			}
 
 			case "start_side_question": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				if (this.sideQuestionRuns.has(command.sideQuestionId)) {
 					throw new Error(`Side question already exists: ${command.sideQuestionId}`);
 				}
@@ -4341,7 +4379,7 @@ export class AgentDaemon {
 			}
 
 			case "abort_side_question": {
-				this.getSessionState(command.activeSessionId);
+				this.getBoundSessionState(command.activeSessionId);
 				const entry = this.sideQuestionRuns.get(command.sideQuestionId);
 				if (!entry || entry.client !== client || entry.activeSessionId !== command.activeSessionId) {
 					return success(command.id, "abort_side_question", { aborted: false });
@@ -4351,7 +4389,7 @@ export class AgentDaemon {
 			}
 
 			case "execute_bash": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				if (state.runtime.session.isBashRunning) {
 					throw new Error("A bash command is already running");
 				}
@@ -4373,7 +4411,7 @@ export class AgentDaemon {
 			}
 
 			case "execute_bash_and_wait": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(
 					command.id,
 					"execute_bash_and_wait",
@@ -4382,19 +4420,19 @@ export class AgentDaemon {
 			}
 
 			case "abort_bash": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.abortBash();
 				return success(command.id, "abort_bash");
 			}
 
 			case "cancel_rlm_child": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const cancelled = state.runtime.session.cancelRlmChildRun(command.childId);
 				return success(command.id, "cancel_rlm_child", { cancelled });
 			}
 
 			case "delete_rlm_subagent": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const isResidentChildRunning = () => {
 					const childState = [...this.sessions.values()].find(
 						(candidate) =>
@@ -4417,13 +4455,13 @@ export class AgentDaemon {
 			}
 
 			case "wait_for_idle": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				await state.runtime.session.waitForIdle();
 				return success(command.id, "wait_for_idle");
 			}
 
 			case "wait_for_headless_completion": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(
 					command.id,
 					"wait_for_headless_completion",
@@ -4432,7 +4470,7 @@ export class AgentDaemon {
 			}
 
 			case "get_session_header": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_session_header", {
 					header: state.runtime.session.sessionManager.getHeader(),
 				});
@@ -4456,25 +4494,25 @@ export class AgentDaemon {
 			}
 
 			case "get_session_stats": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const stats: SessionStats = state.runtime.session.getSessionStats();
 				return success(command.id, "get_session_stats", stats);
 			}
 
 			case "get_context_tree": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_context_tree", state.runtime.session.getContextTree());
 			}
 
 			case "get_commands": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_commands", {
 					commands: createAgentConnectionCommands(state.runtime.session),
 				});
 			}
 
 			case "get_resource_snapshot": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(
 					command.id,
 					"get_resource_snapshot",
@@ -4483,14 +4521,14 @@ export class AgentDaemon {
 			}
 
 			case "get_available_models": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_available_models", {
 					models: await state.runtime.session.modelRegistry.refreshAvailableModels(),
 				});
 			}
 
 			case "get_model_catalog": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(
 					command.id,
 					"get_model_catalog",
@@ -4499,7 +4537,7 @@ export class AgentDaemon {
 			}
 
 			case "get_queue": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_queue", {
 					steering: [...state.runtime.session.getSteeringMessagePreviews()],
 					followUp: [...state.runtime.session.getFollowUpMessagePreviews()],
@@ -4507,7 +4545,7 @@ export class AgentDaemon {
 			}
 
 			case "mutate_queued_message": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const status = state.runtime.session.mutateQueuedMessage(
 					command.lane,
 					command.index,
@@ -4518,19 +4556,23 @@ export class AgentDaemon {
 			}
 
 			case "clear_queue": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "clear_queue", state.runtime.session.clearQueue());
 			}
 
 			case "abort_and_clear_queue": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const queue = state.runtime.session.clearQueue();
 				state.runtime.session.requestAbort();
 				return success(command.id, "abort_and_clear_queue", queue);
 			}
 
 			case "cron_list": {
+				if (command.activeSessionId) this.getBoundSessionState(command.activeSessionId);
 				const jobs = this.cronStore.list().filter((job) => {
+					if (!this.isPublicCronJob(job)) {
+						return false;
+					}
 					if (!command.includeInactive && job.status !== "active" && job.status !== "paused") {
 						return false;
 					}
@@ -4543,11 +4585,13 @@ export class AgentDaemon {
 			}
 
 			case "heartbeats_list":
+				if (command.activeSessionId) this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "heartbeats_list", {
-					heartbeats: this.listHeartbeats(),
+					heartbeats: this.listHeartbeats(command.activeSessionId),
 				});
 
 			case "heartbeat_manage": {
+				if (this.sessions.has(command.activeSessionId)) this.getBoundSessionState(command.activeSessionId);
 				const heartbeat = this.manageHeartbeat(command.activeSessionId, command.jobId, command.action);
 				if (!heartbeat) {
 					throw new Error(`No active heartbeat found: ${command.jobId}`);
@@ -4556,12 +4600,13 @@ export class AgentDaemon {
 			}
 
 			case "cron_add": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const job = this.createCronJobForState(state, command.schedule, command.prompt);
 				return success(command.id, "cron_add", { job });
 			}
 
 			case "cron_cancel": {
+				if (command.activeSessionId) this.getBoundSessionState(command.activeSessionId);
 				const job = this.cronStore.cancel(command.jobId);
 				if (!job) {
 					throw new Error(`No cron job found: ${command.jobId}`);
@@ -4575,7 +4620,7 @@ export class AgentDaemon {
 			}
 
 			case "heartbeat_get": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const heartbeat = this.cronStore.getHeartbeat(state.activeSessionId);
 				return success(command.id, "heartbeat_get", {
 					heartbeat: heartbeat ?? null,
@@ -4583,14 +4628,14 @@ export class AgentDaemon {
 			}
 
 			case "heartbeat_set": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const deliveryMode = normalizeHeartbeatDeliveryMode(command.deliveryMode);
 				const heartbeat = this.createHeartbeatForState(state, command.schedule, command.prompt, deliveryMode);
 				return success(command.id, "heartbeat_set", { heartbeat });
 			}
 
 			case "heartbeat_update": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const heartbeat = this.updateHeartbeatForState(state, command.action);
 				return success(command.id, "heartbeat_update", {
 					heartbeat: heartbeat ?? null,
@@ -4598,7 +4643,7 @@ export class AgentDaemon {
 			}
 
 			case "set_model": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const session = state.runtime.session;
 				const availableModels = await session.modelRegistry.refreshAvailableModels();
 				const model = availableModels.find((candidate) => {
@@ -4614,7 +4659,7 @@ export class AgentDaemon {
 			}
 
 			case "cycle_model": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const session = state.runtime.session;
 				const result = await session.cycleModel(command.direction, {
 					waitForExtensions: !(session.isStreaming || session.isCompacting),
@@ -4623,68 +4668,68 @@ export class AgentDaemon {
 			}
 
 			case "set_scoped_models": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setScopedModels(command.scopedModels);
 				return success(command.id, "set_scoped_models");
 			}
 
 			case "set_thinking_level": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setThinkingLevel(command.level);
 				return success(command.id, "set_thinking_level");
 			}
 
 			case "set_service_tier": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setServiceTier(command.serviceTier);
 				return success(command.id, "set_service_tier");
 			}
 
 			case "cycle_thinking_level": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const level = state.runtime.session.cycleThinkingLevel();
 				return success(command.id, "cycle_thinking_level", level ? { level } : null);
 			}
 
 			case "set_transport": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.settingsManager.setTransport(command.transport);
 				state.runtime.session.agent.transport = command.transport;
 				return success(command.id, "set_transport");
 			}
 
 			case "set_steering_mode": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setSteeringMode(command.mode);
 				return success(command.id, "set_steering_mode");
 			}
 
 			case "set_follow_up_mode": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setFollowUpMode(command.mode);
 				return success(command.id, "set_follow_up_mode");
 			}
 
 			case "set_auto_compaction": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setAutoCompactionEnabled(command.enabled);
 				return success(command.id, "set_auto_compaction");
 			}
 
 			case "set_auto_retry": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setAutoRetryEnabled(command.enabled);
 				return success(command.id, "set_auto_retry");
 			}
 
 			case "compact": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.session.compact(command.customInstructions);
 				return success(command.id, "compact", result);
 			}
 
 			case "refine": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.session.refine({
 					instructions: command.instructions,
 					rollbackId: command.rollbackId,
@@ -4694,25 +4739,25 @@ export class AgentDaemon {
 			}
 
 			case "abort_compaction": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.abortCompaction();
 				return success(command.id, "abort_compaction");
 			}
 
 			case "abort_branch_summary": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.abortBranchSummary();
 				return success(command.id, "abort_branch_summary");
 			}
 
 			case "abort_retry": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.abortRetry();
 				return success(command.id, "abort_retry");
 			}
 
 			case "reload": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				// Reload re-evaluates extension modules, which capture client env
 				// (e.g. herdr pane identity) synchronously at load.
 				await withClientEnv(state.clientEnv, () => state.runtime.session.reload());
@@ -4720,7 +4765,7 @@ export class AgentDaemon {
 			}
 
 			case "new_session": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const options = command.parentSession ? { parentSession: command.parentSession } : undefined;
 				const result = await state.runtime.newSession(options);
 				this.rebindCronJobsToState(state);
@@ -4728,7 +4773,7 @@ export class AgentDaemon {
 			}
 
 			case "switch_session": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.switchSession(command.sessionPath, {
 					cwdOverride: command.cwdOverride,
 				});
@@ -4737,7 +4782,7 @@ export class AgentDaemon {
 			}
 
 			case "fork": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.fork(command.entryId, {
 					position: command.position,
 				});
@@ -4746,7 +4791,7 @@ export class AgentDaemon {
 			}
 
 			case "navigate_tree": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.session.navigateTree(command.targetId, {
 					summarize: command.summarize,
 					customInstructions: command.customInstructions,
@@ -4757,25 +4802,25 @@ export class AgentDaemon {
 			}
 
 			case "import_jsonl": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.importFromJsonl(command.inputPath, command.cwdOverride);
 				return success(command.id, "import_jsonl", result);
 			}
 
 			case "export_html": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const path = await state.runtime.session.exportToHtml(command.outputPath);
 				return success(command.id, "export_html", { path });
 			}
 
 			case "export_jsonl": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const path = state.runtime.session.exportToJsonl(command.outputPath);
 				return success(command.id, "export_jsonl", { path });
 			}
 
 			case "set_session_name": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const name = command.name.trim();
 				if (!name) {
 					throw new Error("Session name cannot be empty");
@@ -4785,25 +4830,25 @@ export class AgentDaemon {
 			}
 
 			case "get_rlm_max_depth_status": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_rlm_max_depth_status", state.runtime.session.getRlmMaxDepthStatus());
 			}
 
 			case "set_rlm_max_depth": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.session.setRlmMaxDepth(command.maxDepth, { global: command.global });
 				return success(command.id, "set_rlm_max_depth", result);
 			}
 
 			case "get_session_context": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_session_context", {
 					context: state.runtime.session.buildSessionContext(),
 				});
 			}
 
 			case "get_session_tree": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_session_tree", {
 					flatNodes: state.runtime.session.sessionManager.getFlatTree(),
 					leafId: state.runtime.session.sessionManager.getLeafId(),
@@ -4811,28 +4856,28 @@ export class AgentDaemon {
 			}
 
 			case "get_user_messages_for_forking": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_user_messages_for_forking", {
 					messages: state.runtime.session.getUserMessagesForForking(),
 				});
 			}
 
 			case "get_last_assistant_text": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_last_assistant_text", {
 					text: state.runtime.session.getLastAssistantText(),
 				});
 			}
 
 			case "get_system_prompt": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_system_prompt", {
 					systemPrompt: state.runtime.session.systemPrompt,
 				});
 			}
 
 			case "get_tool_definition": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_tool_definition", {
 					toolDefinition: createAgentConnectionToolDefinition(
 						state.runtime.session.getToolDefinition(command.name),
@@ -4841,13 +4886,13 @@ export class AgentDaemon {
 			}
 
 			case "set_session_entry_label": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.sessionManager.appendLabelChange(command.entryId, command.label);
 				return success(command.id, "set_session_entry_label");
 			}
 
 			case "extension_ui_response": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const pending = state.extensionUiRequests.get(command.requestId);
 				if (!pending) {
 					throw new Error(`Unknown extension UI request: ${command.requestId}`);
@@ -5539,32 +5584,57 @@ export class AgentDaemon {
 	private detachTombstonedClose(parent: ActiveSessionState, state: ActiveSessionState, childId: string): void {
 		const existing = this.failedTombstonedRlmCloses.get(state.activeSessionId);
 		if (existing?.state === state) {
-			if (existing.error !== undefined && !existing.cleanup) {
-				const cleanup = Promise.resolve().then(() => this.closeSession(state, "killed", false));
-				existing.cleanup = cleanup
-					.then(() => {
-						if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === existing)
-							this.failedTombstonedRlmCloses.delete(state.activeSessionId);
-					})
-					.catch((error: unknown) => {
-						existing.error = error;
-						existing.cleanup = undefined;
-					});
+			if (existing.error !== undefined && !existing.cleanup && !existing.retryTimer) {
+				this.scheduleTombstonedCloseRetry(existing);
 			}
 			return;
 		}
-		const record: FailedTombstonedRlmClose = { state, parentActiveSessionId: parent.activeSessionId, childId };
+		const record: FailedTombstonedRlmClose = {
+			state,
+			parentActiveSessionId: parent.activeSessionId,
+			childId,
+			retryAttempt: 0,
+		};
 		this.failedTombstonedRlmCloses.set(state.activeSessionId, record);
-		const cleanup = Promise.resolve().then(() => this.closeSession(state, "killed", false));
-		record.cleanup = cleanup
-			.then(() => {
-				if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === record)
-					this.failedTombstonedRlmCloses.delete(state.activeSessionId);
-			})
-			.catch((error: unknown) => {
+		this.runTombstonedCloseAttempt(record);
+	}
+
+	private runTombstonedCloseAttempt(record: FailedTombstonedRlmClose): void {
+		if (this.shuttingDown || this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record) return;
+		record.retryTimer = undefined;
+		record.error = undefined;
+		const cleanup = Promise.resolve().then(() => this.closeSession(record.state, "killed", false));
+		record.cleanup = cleanup;
+		void cleanup.then(
+			() => {
+				if (this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record) return;
+				this.failedTombstonedRlmCloses.delete(record.state.activeSessionId);
+			},
+			(error: unknown) => {
+				if (this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record) return;
 				record.error = error;
 				record.cleanup = undefined;
-			});
+				this.scheduleTombstonedCloseRetry(record);
+			},
+		);
+	}
+
+	private scheduleTombstonedCloseRetry(record: FailedTombstonedRlmClose): void {
+		if (this.shuttingDown || record.retryTimer || record.cleanup) return;
+		const delayMs = Math.min(
+			TOMBSTONED_CLOSE_RETRY_BASE_MS * 2 ** record.retryAttempt,
+			TOMBSTONED_CLOSE_RETRY_MAX_MS,
+		);
+		record.retryAttempt++;
+		record.retryTimer = setTimeout(() => this.runTombstonedCloseAttempt(record), delayMs);
+		record.retryTimer.unref();
+	}
+
+	private clearTombstonedCloseRetries(): void {
+		for (const record of this.failedTombstonedRlmCloses.values()) {
+			if (record.retryTimer) clearTimeout(record.retryTimer);
+			record.retryTimer = undefined;
+		}
 	}
 
 	// Half-bound sessions are hidden from other sessions' listings; the current
@@ -6928,7 +6998,7 @@ export class AgentDaemon {
 			type: "attach",
 			activeSessionId: state.activeSessionId,
 		});
-		if (this.sessions.get(state.activeSessionId) !== state) {
+		if (this.sessions.get(state.activeSessionId) !== state || !this.isPublicRlmState(state)) {
 			finishClientSnapshotStreaming(client, state.activeSessionId);
 			if (!client.snapshotStreaming && client.catchupActiveSessionIds?.size) {
 				void this.catchUpBackpressuredClient(client).catch((catchupError) =>
@@ -7305,6 +7375,7 @@ export class AgentDaemon {
 			process.exit(exitCode);
 		}
 		this.shuttingDown = true;
+		this.clearTombstonedCloseRetries();
 		if (this.supervisorMonitorTimer) {
 			clearTimeout(this.supervisorMonitorTimer);
 			this.supervisorMonitorTimer = undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1046,12 +1046,33 @@ export class AgentDaemon {
 		authority?: RlmSubagentDeletionAuthority,
 	): Promise<RlmSubagentDeletionDurability> {
 		const latest = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
+		// Every outcome still precedes a potential runtime close except the
+		// synchronous append boundary below, so revocation must win here too.
+		authority?.assertCurrent();
 		if (!latest) return "unknown";
 		const entry = latest.find((candidate) => candidate.childId === childId);
+		// The authority is minted by AgentSession's per-child coordinator. It
+		// binds this append to a particular incarnation, not merely a recycled id.
+		// Validate it once after the asynchronous read and once at the synchronous
+		// append/fsync boundary below.
+		// Compatibility callers only supplied assertCurrent before generations
+		// existed. New coordinator authorities always carry both incarnation fields.
+		if (
+			authority &&
+			((typeof authority.childId === "string" && authority.childId !== childId) ||
+				(entry !== undefined &&
+					typeof authority.sessionDir === "string" &&
+					authority.sessionDir !== entry.sessionDir))
+		) {
+			authority.assertCurrent();
+			return "unknown";
+		}
 		if (!entry) {
+			authority?.assertCurrent();
 			return "absent";
 		}
 		if (entry.status === "deleted") {
+			authority?.assertCurrent();
 			return "tombstoned";
 		}
 		// The complete read above is asynchronous. Revalidate immediately before
@@ -2367,7 +2388,7 @@ export class AgentDaemon {
 			},
 			resolveRlmSubagentDeletion: (childId, authority) =>
 				this.recordRlmSubagentDeletion(parentState, childId, authority),
-			deleteRlmSubagentRuntime: async (childId, session) => {
+			deleteRlmSubagentRuntime: async (childId, session, authority) => {
 				const state = [...this.sessions.values()].find(
 					(candidate) =>
 						candidate.runtime.metadata.kind === "subagent" &&
@@ -2377,12 +2398,37 @@ export class AgentDaemon {
 				const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 					(entry) => entry.childId === childId,
 				);
+				// A child id alone is never an incarnation proof. Do not close a
+				// freshly recycled resident state under an old attempt token.
+				if (
+					authority &&
+					state?.runtime.metadata.sessionDir !== undefined &&
+					state.runtime.metadata.sessionDir !== authority.sessionDir
+				) {
+					authority.assertCurrent();
+					throw new Error("RLM subagent deletion authority does not match runtime incarnation");
+				}
 				const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
 				// Persist the deletion boundary before tearing down the runtime. As with a
 				// resident child, deletion keeps its transcript and artifact tree on disk.
-				await this.recordRlmSubagentDeletion(parentState, childId);
+				const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
+				// A stale incarnation, corrupt registry, or failed append is not
+				// permission to destroy a runtime. Only absence or a tombstone is a
+				// durable deletion boundary.
+				if (deletionDurability === "unknown") {
+					throw new Error("RLM subagent deletion durability is still unknown");
+				}
+				// Absence has no append point of no return: retain authority through
+				// the immediately following destructive close. A tombstone commit,
+				// however, is intentionally durable even if its reply is later stale.
+				if (deletionDurability === "absent") authority?.assertCurrent();
+				// The append is the linearization point. A late request abort must
+				// suppress its reply, not undo or race the already durable tombstone.
 				const staleSession = state && session && state.runtime.session !== session ? session : undefined;
 				try {
+					// `absent` did not append anything. Recheck adjacent to the
+					// destructive call itself; do not apply this after tombstoning.
+					if (deletionDurability === "absent") authority?.assertCurrent();
 					if (state) {
 						await this.closeSession(state, "killed", false);
 					} else {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2362,42 +2362,48 @@ export class AgentDaemon {
 				});
 			},
 			releaseRlmSubagentRuntime: async (runtime, options, status, authority) => {
-				authority?.assertCurrent();
-				// Preserve the three-way durability proof through release. The finalizer
-				// receives the same incarnation authority as explicit deletion, so it
-				// cannot close a same-id runtime recreated during delayed startup.
-				let deletionDurability: RlmSubagentDeletionDurability = "unknown";
-				if (status === "cancelled") {
-					try {
-						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id, authority);
-					} catch (error) {
-						throw new RlmSubagentHostDeletionError("precommit", error);
-					}
-				}
-				const state = [...this.sessions.values()].find(
-					(candidate) =>
-						candidate.runtime.metadata.kind === "subagent" &&
-						candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
-						candidate.runtime.metadata.rlmChildId === options.id &&
-						candidate.runtime.session === runtime.session,
-				);
-				if (authority && state?.runtime.metadata.sessionDir !== authority.sessionDir) {
-					throw new RlmSubagentHostDeletionError(
-						"precommit",
-						new Error("RLM subagent release authority does not match runtime incarnation"),
-					);
-				}
 				try {
-					if (deletionDurability === "absent") authority?.assertCurrent();
-					if (state) await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
-					else await runtime.session.disposeAsync();
-				} catch (error) {
-					if (deletionDurability === "tombstoned") {
-						throw new RlmSubagentHostDeletionError("tombstoned", error);
+					authority?.assertCurrent();
+					// Resolve the exact resident incarnation before any tombstone append. An
+					// older finalizer can share both child id and directory with its
+					// replacement, so neither field is an object-identity fence.
+					const state = [...this.sessions.values()].find(
+						(candidate) =>
+							candidate.runtime.metadata.kind === "subagent" &&
+							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
+							candidate.runtime.metadata.rlmChildId === options.id,
+					);
+					if (
+						!state ||
+						state.runtime.session !== runtime.session ||
+						state.runtime.metadata.sessionDir !== options.sessionDir ||
+						(authority !== undefined && state.runtime.metadata.sessionDir !== authority.sessionDir)
+					) {
+						throw new Error("RLM subagent release does not match the resident runtime incarnation");
 					}
+
+					let deletionDurability: RlmSubagentDeletionDurability = "unknown";
+					if (status === "cancelled") {
+						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id, authority);
+						if (deletionDurability === "unknown") {
+							throw new Error("RLM subagent deletion durability is still unknown");
+						}
+					}
+
+					try {
+						if (deletionDurability === "absent") authority?.assertCurrent();
+						await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
+					} catch (error) {
+						if (deletionDurability === "tombstoned") {
+							throw new RlmSubagentHostDeletionError("tombstoned", error);
+						}
+						throw error;
+					}
+					return { deletionDurability };
+				} catch (error) {
+					if (error instanceof RlmSubagentHostDeletionError) throw error;
 					throw new RlmSubagentHostDeletionError("precommit", error);
 				}
-				return { deletionDurability };
 			},
 			resolveRlmSubagentDeletion: (childId, authority) =>
 				this.recordRlmSubagentDeletion(parentState, childId, authority),
@@ -2413,33 +2419,34 @@ export class AgentDaemon {
 					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 						(entry) => entry.childId === childId,
 					);
+					// Concrete deletion requires exact object identity. Passive deletion has no
+					// object fence, so bind it to the complete persisted identity instead.
 					if (
-						authority &&
-						state?.runtime.metadata.sessionDir !== undefined &&
-						state.runtime.metadata.sessionDir !== authority.sessionDir
+						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
+						(state !== undefined && session === undefined) ||
+						(state === undefined && session !== undefined) ||
+						(authority !== undefined &&
+							(state !== undefined
+								? state.runtime.metadata.sessionDir !== authority.sessionDir
+								: persisted === undefined || persisted.sessionDir !== authority.sessionDir))
 					) {
-						authority.assertCurrent();
-						throw new Error("RLM subagent deletion authority does not match runtime incarnation");
+						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
 					}
 					const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
 					const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
 					if (deletionDurability === "unknown") {
 						throw new Error("RLM subagent deletion durability is still unknown");
 					}
-					if (deletionDurability === "absent") authority?.assertCurrent();
-					const staleSession = state && session && state.runtime.session !== session ? session : undefined;
 					try {
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						if (state) await this.closeSession(state, "killed", false);
-						else await session?.disposeAsync();
-						await staleSession?.disposeAsync();
+						if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
 					} catch (error) {
 						if (deletionDurability === "tombstoned") {
 							throw new RlmSubagentHostDeletionError("tombstoned", error);
 						}
 						throw error;
 					}
-					if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
 					return { deletionDurability };
 				} catch (error) {
 					if (error instanceof RlmSubagentHostDeletionError) throw error;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2471,7 +2471,8 @@ export class AgentDaemon {
 						return { deletionDurability: "stale" };
 					}
 					authority?.assertCurrent();
-					const state = liveState ?? this.findExactRlmState(parentState.activeSessionId, options.id, runtime.session);
+					const state =
+						liveState ?? this.findExactRlmState(parentState.activeSessionId, options.id, runtime.session);
 					if (
 						!state ||
 						state.runtime.session !== runtime.session ||
@@ -2561,14 +2562,6 @@ export class AgentDaemon {
 						(persistedMatchesAuthority &&
 							(typeof authority?.sessionFile !== "string" || session.sessionFile === authority.sessionFile) &&
 							(typeof authority?.sessionId !== "string" || session.sessionId === authority.sessionId));
-					const residentMatchesAuthority =
-						state !== undefined &&
-						authority !== undefined &&
-						state.runtime.metadata.sessionDir === authority.sessionDir &&
-						typeof authority.sessionFile === "string" &&
-						state.runtime.session.sessionFile === authority.sessionFile &&
-						typeof authority.sessionId === "string" &&
-						state.runtime.session.sessionId === authority.sessionId;
 					if (
 						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
 						(state !== undefined &&

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -387,6 +387,8 @@ interface PersistedRlmSubagentRegistryEntry {
 	sessionName: string;
 	sessionDir: string;
 	sessionFile: string;
+	/** Exact saved-session incarnation; paths and directories may be recycled. */
+	sessionId: string;
 	parentSessionId: string;
 	parentSessionFile?: string;
 	rlmDepth?: number;
@@ -942,6 +944,7 @@ export class AgentDaemon {
 			sessionName: string;
 			sessionDir: string;
 			sessionFile: string;
+			sessionId: string;
 			rlmDepth: number;
 			rlmMaxDepth: number;
 			rlmParentNodeId?: string;
@@ -959,6 +962,7 @@ export class AgentDaemon {
 			sessionName: input.sessionName,
 			sessionDir: input.sessionDir,
 			sessionFile: input.sessionFile,
+			sessionId: input.sessionId,
 			parentSessionId: parentSession.sessionId,
 			...(parentSession.sessionFile ? { parentSessionFile: parentSession.sessionFile } : {}),
 			rlmDepth: input.rlmDepth,
@@ -1016,6 +1020,8 @@ export class AgentDaemon {
 					typeof entry.sessionName !== "string" ||
 					typeof entry.sessionDir !== "string" ||
 					typeof entry.sessionFile !== "string" ||
+					typeof entry.sessionId !== "string" ||
+					entry.sessionId.length === 0 ||
 					typeof entry.parentSessionId !== "string" ||
 					entry.parentSessionId.length === 0 ||
 					(entry.parentSessionFile !== undefined && typeof entry.parentSessionFile !== "string") ||
@@ -1060,10 +1066,13 @@ export class AgentDaemon {
 		// existed. New coordinator authorities always carry both incarnation fields.
 		if (
 			authority &&
-			((typeof authority.childId === "string" && authority.childId !== childId) ||
+			(authority.childId !== childId ||
 				(entry !== undefined &&
-					((typeof authority.sessionDir === "string" && authority.sessionDir !== entry.sessionDir) ||
-						(typeof authority.sessionFile === "string" && authority.sessionFile !== entry.sessionFile))))
+					(authority.sessionDir !== entry.sessionDir ||
+						typeof authority.sessionFile !== "string" ||
+						authority.sessionFile !== entry.sessionFile ||
+						typeof authority.sessionId !== "string" ||
+						authority.sessionId !== entry.sessionId)))
 		) {
 			authority.assertCurrent();
 			return "unknown";
@@ -1071,6 +1080,11 @@ export class AgentDaemon {
 		if (!entry) {
 			authority?.assertCurrent();
 			return "absent";
+		}
+		if (authority) {
+			const info = await readSessionInfo(entry.sessionFile);
+			authority.assertCurrent();
+			if (!info || info.id !== entry.sessionId || authority.sessionId !== info.id) return "unknown";
 		}
 		if (entry.status === "deleted") {
 			authority?.assertCurrent();
@@ -1137,6 +1151,8 @@ export class AgentDaemon {
 					typeof entry.sessionName !== "string" ||
 					typeof entry.sessionDir !== "string" ||
 					typeof entry.sessionFile !== "string" ||
+					typeof entry.sessionId !== "string" ||
+					entry.sessionId.length === 0 ||
 					(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted") ||
 					(entry.rlmDepth !== undefined && (!Number.isSafeInteger(entry.rlmDepth) || entry.rlmDepth < 0)) ||
 					(entry.rlmMaxDepth !== undefined && (!Number.isSafeInteger(entry.rlmMaxDepth) || entry.rlmMaxDepth < 0))
@@ -1178,7 +1194,8 @@ export class AgentDaemon {
 				if (entry.status === "deleted" || visited.has(sessionKey)) continue;
 				visited.add(sessionKey);
 				const info = await readSessionInfo(entry.sessionFile);
-				if (!info) continue;
+				// A path is recyclable; passive authority belongs only to this saved header.
+				if (!info || info.id !== entry.sessionId) continue;
 				// A resident child walks its own registry as an outer root below. Avoid
 				// both duplicate rows and attributing its descendants to an ancestor.
 				if (!includeResident && this.findSessionBySessionFile(entry.sessionFile)) continue;
@@ -2351,6 +2368,7 @@ export class AgentDaemon {
 					sessionName: session.sessionName ?? childId,
 					sessionDir: metadata.sessionDir ?? dirname(state.runtime.session.sessionFile),
 					sessionFile: state.runtime.session.sessionFile,
+					sessionId: session.sessionId,
 					rlmDepth: session.rlmDepth,
 					rlmMaxDepth: session.rlmMaxDepth,
 					rlmParentNodeId: metadata.rlmParentNodeId,
@@ -2429,10 +2447,12 @@ export class AgentDaemon {
 					// the exact persisted incarnation before they can touch its tombstone or jobs.
 					const persistedMatchesAuthority =
 						persisted !== undefined &&
-						(authority === undefined ||
-							(persisted.sessionDir === authority.sessionDir &&
-								(typeof authority.sessionFile !== "string" ||
-									persisted.sessionFile === authority.sessionFile)));
+						authority !== undefined &&
+						persisted.sessionDir === authority.sessionDir &&
+						typeof authority.sessionFile === "string" &&
+						persisted.sessionFile === authority.sessionFile &&
+						typeof authority.sessionId === "string" &&
+						persisted.sessionId === authority.sessionId;
 					const suppliedSessionMatchesPersisted =
 						session === undefined ||
 						(persistedMatchesAuthority &&
@@ -2441,6 +2461,7 @@ export class AgentDaemon {
 					if (
 						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
 						(state !== undefined && session === undefined) ||
+						(state === undefined && session === undefined && !persistedMatchesAuthority) ||
 						(state === undefined && session !== undefined && !suppliedSessionMatchesPersisted) ||
 						(authority !== undefined &&
 							(state !== undefined
@@ -2577,6 +2598,7 @@ export class AgentDaemon {
 						sessionName: options.sessionName,
 						sessionDir: options.sessionDir,
 						sessionFile: runtime.session.sessionFile,
+						sessionId: runtime.session.sessionId,
 						rlmDepth: options.rlmDepth,
 						rlmMaxDepth: options.rlmMaxDepth,
 						rlmParentNodeId: options.rlmParentNodeId,

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6803,6 +6803,9 @@ export class AgentDaemon {
 		if (!this.sessions.has(state.activeSessionId)) {
 			return;
 		}
+		// Claim before any close work can yield. A direct disposer that won this
+		// race retains ordinary release ownership; this close must not fabricate it.
+		const daemonOwnsSessionLeaseRelease = state.runtime.claimSessionLeaseReleaseForDaemon?.() ?? false;
 		let closeError: unknown;
 		const captureCloseError = (error: unknown): void => {
 			closeError ??= error;
@@ -6870,9 +6873,7 @@ export class AgentDaemon {
 		this.recordWorkerRecoveryState(state, `closed:${reason}`, false);
 		state.unsubscribe?.();
 		try {
-			// A tombstoned record must retain its lease until the daemon commits the
-			// whole close. Normal direct runtime disposal still releases its own lease.
-			await state.runtime.dispose({ releaseSessionLease: false });
+			await state.runtime.dispose();
 		} catch (error) {
 			captureCloseError(error);
 		}
@@ -6897,7 +6898,7 @@ export class AgentDaemon {
 				await deleteSessionFile(sessionFile).catch(() => undefined);
 			}
 		}
-		state.runtime.releaseSessionLease?.();
+		if (daemonOwnsSessionLeaseRelease) state.runtime.releaseSessionLease();
 		if (closeError) throw closeError;
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -100,11 +100,12 @@ import {
 } from "../../core/cron-jobs.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js";
 import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
-import type {
-	CreateRlmSubagentRuntimeOptions,
-	RlmSubagentDeletionAuthority,
-	RlmSubagentDeletionDurability,
-	SubagentRuntimeHost,
+import {
+	type CreateRlmSubagentRuntimeOptions,
+	type RlmSubagentDeletionAuthority,
+	type RlmSubagentDeletionDurability,
+	RlmSubagentHostDeletionError,
+	type SubagentRuntimeHost,
 } from "../../core/rlm-runtime.js";
 import {
 	canPassivateSession,
@@ -2360,16 +2361,17 @@ export class AgentDaemon {
 					createdAt: metadata.createdAt,
 				});
 			},
-			releaseRlmSubagentRuntime: async (runtime, options, status) => {
-				// Preserve the three-way durability proof through release. A failed
-				// lookup/write is not the same as a verified no-row result.
+			releaseRlmSubagentRuntime: async (runtime, options, status, authority) => {
+				authority?.assertCurrent();
+				// Preserve the three-way durability proof through release. The finalizer
+				// receives the same incarnation authority as explicit deletion, so it
+				// cannot close a same-id runtime recreated during delayed startup.
 				let deletionDurability: RlmSubagentDeletionDurability = "unknown";
 				if (status === "cancelled") {
 					try {
-						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id);
-					} catch {
-						// A defensive fail-closed boundary for injected/legacy persistence
-						// implementations which still throw rather than return unknown.
+						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id, authority);
+					} catch (error) {
+						throw new RlmSubagentHostDeletionError("precommit", error);
 					}
 				}
 				const state = [...this.sessions.values()].find(
@@ -2379,67 +2381,69 @@ export class AgentDaemon {
 						candidate.runtime.metadata.rlmChildId === options.id &&
 						candidate.runtime.session === runtime.session,
 				);
-				if (state) {
-					await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
-				} else {
-					await runtime.session.disposeAsync();
+				if (authority && state?.runtime.metadata.sessionDir !== authority.sessionDir) {
+					throw new RlmSubagentHostDeletionError(
+						"precommit",
+						new Error("RLM subagent release authority does not match runtime incarnation"),
+					);
+				}
+				try {
+					if (deletionDurability === "absent") authority?.assertCurrent();
+					if (state) await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
+					else await runtime.session.disposeAsync();
+				} catch (error) {
+					if (deletionDurability === "tombstoned") {
+						throw new RlmSubagentHostDeletionError("tombstoned", error);
+					}
+					throw new RlmSubagentHostDeletionError("precommit", error);
 				}
 				return { deletionDurability };
 			},
 			resolveRlmSubagentDeletion: (childId, authority) =>
 				this.recordRlmSubagentDeletion(parentState, childId, authority),
 			deleteRlmSubagentRuntime: async (childId, session, authority) => {
-				const state = [...this.sessions.values()].find(
-					(candidate) =>
-						candidate.runtime.metadata.kind === "subagent" &&
-						candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
-						candidate.runtime.metadata.rlmChildId === childId,
-				);
-				const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
-					(entry) => entry.childId === childId,
-				);
-				// A child id alone is never an incarnation proof. Do not close a
-				// freshly recycled resident state under an old attempt token.
-				if (
-					authority &&
-					state?.runtime.metadata.sessionDir !== undefined &&
-					state.runtime.metadata.sessionDir !== authority.sessionDir
-				) {
-					authority.assertCurrent();
-					throw new Error("RLM subagent deletion authority does not match runtime incarnation");
-				}
-				const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
-				// Persist the deletion boundary before tearing down the runtime. As with a
-				// resident child, deletion keeps its transcript and artifact tree on disk.
-				const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
-				// A stale incarnation, corrupt registry, or failed append is not
-				// permission to destroy a runtime. Only absence or a tombstone is a
-				// durable deletion boundary.
-				if (deletionDurability === "unknown") {
-					throw new Error("RLM subagent deletion durability is still unknown");
-				}
-				// Absence has no append point of no return: retain authority through
-				// the immediately following destructive close. A tombstone commit,
-				// however, is intentionally durable even if its reply is later stale.
-				if (deletionDurability === "absent") authority?.assertCurrent();
-				// The append is the linearization point. A late request abort must
-				// suppress its reply, not undo or race the already durable tombstone.
-				const staleSession = state && session && state.runtime.session !== session ? session : undefined;
 				try {
-					// `absent` did not append anything. Recheck adjacent to the
-					// destructive call itself; do not apply this after tombstoning.
-					if (deletionDurability === "absent") authority?.assertCurrent();
-					if (state) {
-						await this.closeSession(state, "killed", false);
-					} else {
-						await session?.disposeAsync();
+					authority?.assertCurrent();
+					const state = [...this.sessions.values()].find(
+						(candidate) =>
+							candidate.runtime.metadata.kind === "subagent" &&
+							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
+							candidate.runtime.metadata.rlmChildId === childId,
+					);
+					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
+						(entry) => entry.childId === childId,
+					);
+					if (
+						authority &&
+						state?.runtime.metadata.sessionDir !== undefined &&
+						state.runtime.metadata.sessionDir !== authority.sessionDir
+					) {
+						authority.assertCurrent();
+						throw new Error("RLM subagent deletion authority does not match runtime incarnation");
 					}
-				} finally {
-					await staleSession?.disposeAsync();
-				}
-				// A killed close can join a passivation close that already skipped killed cleanup.
-				if (childSessionFile) {
-					this.cancelScheduledJobsForSessionFile(childSessionFile);
+					const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
+					const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
+					if (deletionDurability === "unknown") {
+						throw new Error("RLM subagent deletion durability is still unknown");
+					}
+					if (deletionDurability === "absent") authority?.assertCurrent();
+					const staleSession = state && session && state.runtime.session !== session ? session : undefined;
+					try {
+						if (deletionDurability === "absent") authority?.assertCurrent();
+						if (state) await this.closeSession(state, "killed", false);
+						else await session?.disposeAsync();
+						await staleSession?.disposeAsync();
+					} catch (error) {
+						if (deletionDurability === "tombstoned") {
+							throw new RlmSubagentHostDeletionError("tombstoned", error);
+						}
+						throw error;
+					}
+					if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
+					return { deletionDurability };
+				} catch (error) {
+					if (error instanceof RlmSubagentHostDeletionError) throw error;
+					throw new RlmSubagentHostDeletionError("precommit", error);
 				}
 			},
 			disposeRlmSubagentRuntimes: async () => {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -402,6 +402,11 @@ interface PersistedRlmSubagentRegistryEntry {
 	updatedAt: string;
 }
 
+/** A pre-session-id registry row is only usable to upgrade an exact resident. */
+type DeletionRlmSubagentRegistryEntry = Omit<PersistedRlmSubagentRegistryEntry, "sessionId"> & {
+	sessionId?: string;
+};
+
 type PassiveRlmRoot =
 	| { rootParentState: ActiveSessionState; rootInfo?: never }
 	| { rootParentState?: never; rootInfo: SessionInfo };
@@ -980,11 +985,13 @@ export class AgentDaemon {
 	/**
 	 * Strictly read the registry when absence would authorize destructive cleanup.
 	 * Passive discovery may skip a corrupt historical line, but deletion must not
-	 * mistake that ambiguity for proof that a child was never recorded.
+	 * mistake that ambiguity for proof that a child was never recorded. A row
+	 * written before session ids existed is retained only for an exact resident
+	 * session to upgrade; it is never evidence for passive cleanup.
 	 */
 	private async readCompleteRlmSubagentRegistryForDeletion(
 		parentState: ActiveSessionState,
-	): Promise<PersistedRlmSubagentRegistryEntry[] | undefined> {
+	): Promise<DeletionRlmSubagentRegistryEntry[] | undefined> {
 		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
 		if (!path) return undefined;
 		let lines: string[];
@@ -997,12 +1004,12 @@ export class AgentDaemon {
 			);
 			return undefined;
 		}
-		const latest = new Map<string, PersistedRlmSubagentRegistryEntry>();
+		const latest = new Map<string, DeletionRlmSubagentRegistryEntry>();
 		for (const line of lines) {
 			const trimmed = line.trim();
 			if (!trimmed) continue;
 			try {
-				const entry = JSON.parse(trimmed) as Partial<PersistedRlmSubagentRegistryEntry>;
+				const entry = JSON.parse(trimmed) as Partial<DeletionRlmSubagentRegistryEntry>;
 				const validIsoTimestamp =
 					typeof entry.updatedAt === "string" &&
 					Number.isFinite(Date.parse(entry.updatedAt)) &&
@@ -1020,8 +1027,8 @@ export class AgentDaemon {
 					typeof entry.sessionName !== "string" ||
 					typeof entry.sessionDir !== "string" ||
 					typeof entry.sessionFile !== "string" ||
-					typeof entry.sessionId !== "string" ||
-					entry.sessionId.length === 0 ||
+					(entry.sessionId !== undefined &&
+						(typeof entry.sessionId !== "string" || entry.sessionId.length === 0)) ||
 					typeof entry.parentSessionId !== "string" ||
 					entry.parentSessionId.length === 0 ||
 					(entry.parentSessionFile !== undefined && typeof entry.parentSessionFile !== "string") ||
@@ -1039,7 +1046,7 @@ export class AgentDaemon {
 				) {
 					return undefined;
 				}
-				latest.set(entry.childId, entry as PersistedRlmSubagentRegistryEntry);
+				latest.set(entry.childId, entry as DeletionRlmSubagentRegistryEntry);
 			} catch {
 				return undefined;
 			}
@@ -1051,53 +1058,62 @@ export class AgentDaemon {
 		parentState: ActiveSessionState,
 		childId: string,
 		authority?: RlmSubagentDeletionAuthority,
+		residentSession?: AgentSession,
 	): Promise<RlmSubagentDeletionDurability> {
 		const latest = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
-		// Every outcome still precedes a potential runtime close except the
-		// synchronous append boundary below, so revocation must win here too.
+		// This check follows the registry read even when this compatible resident
+		// path has no coordinator authority.
 		authority?.assertCurrent();
 		if (!latest) return "unknown";
-		const entry = latest.find((candidate) => candidate.childId === childId);
-		// The authority is minted by AgentSession's per-child coordinator. It
-		// binds this append to a particular incarnation, not merely a recycled id.
-		// Validate it once after the asynchronous read and once at the synchronous
-		// append/fsync boundary below.
-		// Compatibility callers only supplied assertCurrent before generations
-		// existed. New coordinator authorities always carry both incarnation fields.
 		if (
 			authority &&
 			(authority.childId !== childId ||
-				(entry !== undefined &&
-					(authority.sessionDir !== entry.sessionDir ||
-						typeof authority.sessionFile !== "string" ||
-						authority.sessionFile !== entry.sessionFile ||
-						typeof authority.sessionId !== "string" ||
-						authority.sessionId !== entry.sessionId)))
+				typeof authority.sessionDir !== "string" ||
+				typeof authority.sessionFile !== "string" ||
+				authority.sessionFile.length === 0 ||
+				typeof authority.sessionId !== "string" ||
+				authority.sessionId.length === 0)
 		) {
 			authority.assertCurrent();
 			return "unknown";
 		}
+		const entry = latest.find((candidate) => candidate.childId === childId);
 		if (!entry) {
 			authority?.assertCurrent();
 			return "absent";
 		}
-		if (authority) {
-			const info = await readSessionInfo(entry.sessionFile);
-			authority.assertCurrent();
-			if (!info || info.id !== entry.sessionId || authority.sessionId !== info.id) return "unknown";
-		}
+		// Validate the saved-session header after the asynchronous registry read
+		// before any append can be considered. This fences authority-free resident
+		// cleanup just as strictly as coordinator-owned cleanup.
+		const info = await readSessionInfo(entry.sessionFile);
+		authority?.assertCurrent();
+		if (!info) return "unknown";
+		const residentMatchesHeader =
+			residentSession !== undefined &&
+			residentSession.sessionFile === entry.sessionFile &&
+			residentSession.sessionId === info.id &&
+			(entry.sessionId === undefined || entry.sessionId === info.id);
+		const authorityMatchesEntry =
+			authority !== undefined &&
+			authority.childId === entry.childId &&
+			authority.sessionDir === entry.sessionDir &&
+			authority.sessionFile === entry.sessionFile &&
+			authority.sessionId === entry.sessionId &&
+			info.id === entry.sessionId;
+		const legacyResidentUpgrade = entry.sessionId === undefined && authority === undefined && residentMatchesHeader;
+		if (!authorityMatchesEntry && !(authority === undefined && residentMatchesHeader)) return "unknown";
+		if (entry.sessionId === undefined && !legacyResidentUpgrade) return "unknown";
 		if (entry.status === "deleted") {
 			authority?.assertCurrent();
 			return "tombstoned";
 		}
-		// The complete read above is asynchronous. Revalidate immediately before
-		// entering the synchronous append/fsync commit region: before that point a
-		// stale request must leave no registry mutation behind. Once append starts,
-		// finish the durable commit and let the caller suppress its stale reply.
+		// The header and authority are both checked immediately before the
+		// synchronous append/fsync boundary. Once append starts, finish it.
 		authority?.assertCurrent();
 		if (
 			!this.appendRlmSubagentRegistryEntry(parentState, {
 				...entry,
+				sessionId: entry.sessionId ?? info.id,
 				status: "deleted",
 				updatedAt: new Date().toISOString(),
 			})
@@ -2407,7 +2423,12 @@ export class AgentDaemon {
 
 					let deletionDurability: RlmSubagentDeletionDurability = "unknown";
 					if (status === "cancelled") {
-						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id, authority);
+						deletionDurability = await this.recordRlmSubagentDeletion(
+							parentState,
+							options.id,
+							authority,
+							state.runtime.session,
+						);
 						if (deletionDurability === "unknown") {
 							throw new Error("RLM subagent deletion durability is still unknown");
 						}
@@ -2475,7 +2496,12 @@ export class AgentDaemon {
 						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
 					}
 					const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
-					const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
+					const deletionDurability = await this.recordRlmSubagentDeletion(
+						parentState,
+						childId,
+						authority,
+						state?.runtime.session,
+					);
 					if (deletionDurability === "unknown") {
 						throw new Error("RLM subagent deletion durability is still unknown");
 					}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -967,12 +967,16 @@ export class AgentDaemon {
 		});
 	}
 
-	private async recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<void> {
+	/** Write (or verify) the deletion tombstone and report whether durable ownership exists. */
+	private async recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<boolean> {
 		const latest = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 			(entry) => entry.childId === childId,
 		);
-		if (!latest || latest.status === "deleted") {
-			return;
+		if (!latest) {
+			return false;
+		}
+		if (latest.status === "deleted") {
+			return true;
 		}
 		if (
 			!this.appendRlmSubagentRegistryEntry(parentState, {
@@ -983,6 +987,7 @@ export class AgentDaemon {
 		) {
 			throw new Error(`Failed to persist deletion for RLM subagent ${childId}`);
 		}
+		return true;
 	}
 
 	private readLatestRlmSubagentRegistry(
@@ -2254,14 +2259,16 @@ export class AgentDaemon {
 				});
 			},
 			releaseRlmSubagentRuntime: async (runtime, options, status) => {
-				// Persist the deletion boundary first, but never let a registry failure
-				// strand the cancelled child as a stale resident session.
-				let deletionError: unknown;
+				// A caller may only retain a never-admitted cancelled child when the
+				// deletion tombstone is durably written. Close it on any write failure,
+				// then explicitly return that the caller still owns its artifact dir.
+				let retained = false;
 				if (status === "cancelled") {
 					try {
-						await this.recordRlmSubagentDeletion(parentState, options.id);
-					} catch (error) {
-						deletionError = error;
+						retained = await this.recordRlmSubagentDeletion(parentState, options.id);
+					} catch {
+						// The close below prevents a stale resident runtime; the caller removes
+						// its exact never-admitted child dir because no durable row exists.
 					}
 				}
 				const state = [...this.sessions.values()].find(
@@ -2276,7 +2283,7 @@ export class AgentDaemon {
 				} else {
 					await runtime.session.disposeAsync();
 				}
-				if (deletionError !== undefined) throw deletionError;
+				return { retained };
 			},
 			deleteRlmSubagentRuntime: async (childId, session) => {
 				const state = [...this.sessions.values()].find(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -100,7 +100,11 @@ import {
 } from "../../core/cron-jobs.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js";
 import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
-import type { CreateRlmSubagentRuntimeOptions, SubagentRuntimeHost } from "../../core/rlm-runtime.js";
+import type {
+	CreateRlmSubagentRuntimeOptions,
+	RlmSubagentDeletionDurability,
+	SubagentRuntimeHost,
+} from "../../core/rlm-runtime.js";
 import {
 	canPassivateSession,
 	type IdleEvictionMinutes,
@@ -967,27 +971,75 @@ export class AgentDaemon {
 		});
 	}
 
-	/** Write (or verify) the deletion tombstone and report whether durable ownership exists. */
-	private async recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<boolean> {
-		const latest = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
-			(entry) => entry.childId === childId,
-		);
-		if (!latest) {
-			return false;
+	/**
+	 * Strictly read the registry when absence would authorize destructive cleanup.
+	 * Passive discovery may skip a corrupt historical line, but deletion must not
+	 * mistake that ambiguity for proof that a child was never recorded.
+	 */
+	private async readCompleteRlmSubagentRegistryForDeletion(
+		parentState: ActiveSessionState,
+	): Promise<PersistedRlmSubagentRegistryEntry[] | undefined> {
+		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
+		if (!path) return undefined;
+		let lines: string[];
+		try {
+			lines = (await readFile(path, "utf8")).split(/\r?\n/);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+			this.log(
+				`failed to read RLM subagent registry for deletion: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return undefined;
 		}
-		if (latest.status === "deleted") {
-			return true;
+		const latest = new Map<string, PersistedRlmSubagentRegistryEntry>();
+		for (const line of lines) {
+			const trimmed = line.trim();
+			if (!trimmed) continue;
+			try {
+				const entry = JSON.parse(trimmed) as Partial<PersistedRlmSubagentRegistryEntry>;
+				if (
+					entry.type !== "rlm_subagent" ||
+					typeof entry.childId !== "string" ||
+					typeof entry.sessionName !== "string" ||
+					typeof entry.sessionDir !== "string" ||
+					typeof entry.sessionFile !== "string" ||
+					(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted") ||
+					(entry.rlmDepth !== undefined && (!Number.isSafeInteger(entry.rlmDepth) || entry.rlmDepth < 0)) ||
+					(entry.rlmMaxDepth !== undefined && (!Number.isSafeInteger(entry.rlmMaxDepth) || entry.rlmMaxDepth < 0))
+				) {
+					return undefined;
+				}
+				latest.set(entry.childId, entry as PersistedRlmSubagentRegistryEntry);
+			} catch {
+				return undefined;
+			}
+		}
+		return [...latest.values()];
+	}
+
+	private async recordRlmSubagentDeletion(
+		parentState: ActiveSessionState,
+		childId: string,
+	): Promise<RlmSubagentDeletionDurability> {
+		const latest = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
+		if (!latest) return "unknown";
+		const entry = latest.find((candidate) => candidate.childId === childId);
+		if (!entry) {
+			return "absent";
+		}
+		if (entry.status === "deleted") {
+			return "tombstoned";
 		}
 		if (
 			!this.appendRlmSubagentRegistryEntry(parentState, {
-				...latest,
+				...entry,
 				status: "deleted",
 				updatedAt: new Date().toISOString(),
 			})
 		) {
-			throw new Error(`Failed to persist deletion for RLM subagent ${childId}`);
+			return "unknown";
 		}
-		return true;
+		return "tombstoned";
 	}
 
 	private readLatestRlmSubagentRegistry(
@@ -2259,16 +2311,15 @@ export class AgentDaemon {
 				});
 			},
 			releaseRlmSubagentRuntime: async (runtime, options, status) => {
-				// A caller may only retain a never-admitted cancelled child when the
-				// deletion tombstone is durably written. Close it on any write failure,
-				// then explicitly return that the caller still owns its artifact dir.
-				let retained = false;
+				// Preserve the three-way durability proof through release. A failed
+				// lookup/write is not the same as a verified no-row result.
+				let deletionDurability: RlmSubagentDeletionDurability = "unknown";
 				if (status === "cancelled") {
 					try {
-						retained = await this.recordRlmSubagentDeletion(parentState, options.id);
+						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id);
 					} catch {
-						// The close below prevents a stale resident runtime; the caller removes
-						// its exact never-admitted child dir because no durable row exists.
+						// A defensive fail-closed boundary for injected/legacy persistence
+						// implementations which still throw rather than return unknown.
 					}
 				}
 				const state = [...this.sessions.values()].find(
@@ -2283,8 +2334,9 @@ export class AgentDaemon {
 				} else {
 					await runtime.session.disposeAsync();
 				}
-				return { retained };
+				return { deletionDurability };
 			},
+			resolveRlmSubagentDeletion: (childId) => this.recordRlmSubagentDeletion(parentState, childId),
 			deleteRlmSubagentRuntime: async (childId, session) => {
 				const state = [...this.sessions.values()].find(
 					(candidate) =>

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -5492,10 +5492,17 @@ export class AgentDaemon {
 		const visited = new Set<string>();
 		while (child.runtime.metadata.kind === "subagent") {
 			if (visited.has(child.activeSessionId)) return false;
+			if (
+				this.closingSessions.has(child.activeSessionId) ||
+				this.failedTombstonedRlmCloses.has(child.activeSessionId)
+			)
+				return true;
 			visited.add(child.activeSessionId);
 			const { parentActiveSessionId, rlmChildId } = child.runtime.metadata;
 			if (!parentActiveSessionId || !rlmChildId) return false;
-			const parent = this.sessions.get(parentActiveSessionId);
+			const parent =
+				this.sessions.get(parentActiveSessionId) ??
+				this.failedTombstonedRlmCloses.get(parentActiveSessionId)?.state;
 			if (!parent) return false;
 			if (parent.runtime.session.isRlmChildDeletionQuarantined?.(rlmChildId) === true) return true;
 			child = parent;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -4607,6 +4607,10 @@ export class AgentDaemon {
 
 			case "cron_cancel": {
 				if (command.activeSessionId) this.getBoundSessionState(command.activeSessionId);
+				const existingJob = this.cronStore.list().find((job) => job.id === command.jobId);
+				if (!existingJob || !this.isPublicCronJob(existingJob)) {
+					throw new Error(`No cron job found: ${command.jobId}`);
+				}
 				const job = this.cronStore.cancel(command.jobId);
 				if (!job) {
 					throw new Error(`No cron job found: ${command.jobId}`);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -435,18 +435,6 @@ type AgentFamilyCatalogCandidate = AgentFamilyCatalogEntry & {
 class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
 
-type DaemonSessionCloseFailureStage = "dispose" | "persist" | "cascade";
-
-/** Daemon-private close diagnostics used only to authorize exact cleanup retry. */
-class DaemonSessionCloseError extends Error {
-	readonly stage: DaemonSessionCloseFailureStage;
-
-	constructor(stage: DaemonSessionCloseFailureStage, cause: unknown) {
-		super(cause instanceof Error ? cause.message : String(cause), { cause });
-		this.name = "DaemonSessionCloseError";
-		this.stage = stage;
-	}
-}
 class PrivateSessionUnavailableError extends BoundSessionUnavailableError {}
 
 export async function runDaemonMode(options: DaemonModeOptions): Promise<never> {
@@ -515,11 +503,6 @@ export class AgentDaemon {
 			descendants: Set<ActiveSessionState>;
 			reasonUpgrade?: Promise<void>;
 		}
-	>();
-	/** Exact removed incarnation retained only when its runtime dispose failed. */
-	private readonly failedSessionCloses = new Map<
-		string,
-		{ state: ActiveSessionState; error: DaemonSessionCloseError }
 	>();
 	private readonly failedTombstonedRlmCloses = new Map<string, FailedTombstonedRlmClose>();
 	private readonly closeDisposeErrors = new WeakMap<ActiveSessionState, unknown>();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -435,6 +435,20 @@ type AgentFamilyCatalogCandidate = AgentFamilyCatalogEntry & {
 class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
 
+type DaemonSessionCloseFailureStage = "dispose" | "persist" | "cascade";
+
+/** Daemon-private close diagnostics used only to authorize exact cleanup retry. */
+class DaemonSessionCloseError extends Error {
+	readonly stage: DaemonSessionCloseFailureStage;
+
+	constructor(stage: DaemonSessionCloseFailureStage, cause: unknown) {
+		super(cause instanceof Error ? cause.message : String(cause), { cause });
+		this.name = "DaemonSessionCloseError";
+		this.stage = stage;
+	}
+}
+class PrivateSessionUnavailableError extends BoundSessionUnavailableError {}
+
 export async function runDaemonMode(options: DaemonModeOptions): Promise<never> {
 	const socketPath = options.socketPath ?? defaultDaemonSocketPath();
 	const daemon = new AgentDaemon(socketPath, options);
@@ -449,6 +463,15 @@ export function isTerminalRemoteAgentMessageError(error: unknown): error is Erro
 			error.message.startsWith("Ambiguous") ||
 			error.message === AGENT_FAMILY_REACH_ERROR)
 	);
+}
+
+interface FailedTombstonedRlmClose {
+	readonly state: ActiveSessionState;
+	readonly parentActiveSessionId: string;
+	readonly childId: string;
+	cleanup?: Promise<void>;
+	error?: unknown;
+	disposeError?: unknown;
 }
 
 export class AgentDaemon {
@@ -493,6 +516,13 @@ export class AgentDaemon {
 			reasonUpgrade?: Promise<void>;
 		}
 	>();
+	/** Exact removed incarnation retained only when its runtime dispose failed. */
+	private readonly failedSessionCloses = new Map<
+		string,
+		{ state: ActiveSessionState; error: DaemonSessionCloseError }
+	>();
+	private readonly failedTombstonedRlmCloses = new Map<string, FailedTombstonedRlmClose>();
+	private readonly closeDisposeErrors = new WeakMap<ActiveSessionState, unknown>();
 	private readonly sideQuestionRuns = new Map<
 		string,
 		{
@@ -1231,6 +1261,7 @@ export class AgentDaemon {
 		};
 		const residentRootPaths = new Set<string>();
 		for (const parentState of this.sessions.values()) {
+			if (!this.isPublicRlmState(parentState)) continue;
 			const parentFile = parentState.runtime.session.sessionFile;
 			// An in-memory session cannot own a persisted registry.
 			if (!parentFile) continue;
@@ -1269,7 +1300,10 @@ export class AgentDaemon {
 	private async buildRlmChildSnapshotsWithPassiveRlmSubagents(
 		rootState: ActiveSessionState,
 	): Promise<AgentConnectionRlmChildAgentSnapshot[]> {
-		const snapshots = buildRlmChildSnapshots(rootState.activeSessionId, [...this.sessions.values()]);
+		const snapshots = buildRlmChildSnapshots(
+			rootState.activeSessionId,
+			[...this.sessions.values()].filter((state) => this.isPublicRlmState(state)),
+		);
 		const residentParentIds = new Set([
 			rootState.activeSessionId,
 			...snapshots.flatMap((snapshot) => (snapshot.activeSessionId ? [snapshot.activeSessionId] : [])),
@@ -2276,7 +2310,7 @@ export class AgentDaemon {
 		state: ActiveSessionState,
 		requirePersistedJob: boolean,
 	): boolean {
-		if (this.sessions.get(state.activeSessionId) !== state || this.closingSessions.has(state.activeSessionId)) {
+		if (this.sessions.get(state.activeSessionId) !== state || !this.isPublicRlmState(state)) {
 			return false;
 		}
 		if (!requirePersistedJob) {
@@ -2318,8 +2352,8 @@ export class AgentDaemon {
 		if (this.bindingSessions.has(state.activeSessionId)) {
 			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is still initializing`);
 		}
-		if (this.closingSessions.has(state.activeSessionId) || state.runtime.session.isClosing) {
-			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is closing`);
+		if (this.closingSessions.has(state.activeSessionId) || this.isQuarantinedRlmState(state)) {
+			throw new PrivateSessionUnavailableError(`Active session ${state.activeSessionId} is unavailable`);
 		}
 		return state;
 	}
@@ -2329,6 +2363,7 @@ export class AgentDaemon {
 		try {
 			return this.getBoundSessionState(id);
 		} catch (error) {
+			if (error instanceof PrivateSessionUnavailableError) throw error;
 			if (error instanceof BoundSessionUnavailableError) {
 				return this.waitForHydratingChild(this.getSessionState(id), id);
 			}
@@ -2350,6 +2385,7 @@ export class AgentDaemon {
 		try {
 			return this.getBoundSessionState(id);
 		} catch (error) {
+			if (error instanceof PrivateSessionUnavailableError) throw error;
 			if (error instanceof BoundSessionUnavailableError) {
 				return this.waitForHydratingChild(this.getSessionState(id), id);
 			}
@@ -2404,7 +2440,7 @@ export class AgentDaemon {
 					// Resolve the exact resident incarnation before any tombstone append. An
 					// older finalizer can share both child id and directory with its
 					// replacement, so neither field is an object-identity fence.
-					const state = [...this.sessions.values()].find(
+					const liveState = [...this.sessions.values()].find(
 						(candidate) =>
 							candidate.runtime.metadata.kind === "subagent" &&
 							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
@@ -2412,10 +2448,11 @@ export class AgentDaemon {
 					);
 					// A same-id republish supersedes an older finalizer without giving it
 					// authority over the replacement.
-					if (state !== undefined && state.runtime.session !== runtime.session) {
+					if (liveState !== undefined && liveState.runtime.session !== runtime.session) {
 						return { deletionDurability: "stale" };
 					}
 					authority?.assertCurrent();
+					const state = liveState ?? this.findExactRlmState(parentState.activeSessionId, options.id, runtime.session);
 					if (
 						!state ||
 						state.runtime.session !== runtime.session ||
@@ -2444,6 +2481,10 @@ export class AgentDaemon {
 					}
 
 					try {
+						if (deletionDurability === "tombstoned") {
+							this.detachTombstonedClose(parentState, state, options.id);
+							return { deletionDurability };
+						}
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
 					} catch (error) {
@@ -2462,7 +2503,7 @@ export class AgentDaemon {
 				this.recordRlmSubagentDeletion(parentState, childId, authority),
 			deleteRlmSubagentRuntime: async (childId, session, authority) => {
 				try {
-					const state = [...this.sessions.values()].find(
+					const liveState = [...this.sessions.values()].find(
 						(candidate) =>
 							candidate.runtime.metadata.kind === "subagent" &&
 							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
@@ -2470,10 +2511,11 @@ export class AgentDaemon {
 					);
 					// A same-id republish supersedes an older deleter without letting it
 					// mutate the replacement's registry, jobs, or lifetime.
-					if (state !== undefined && session !== undefined && state.runtime.session !== session) {
+					if (liveState !== undefined && session !== undefined && liveState.runtime.session !== session) {
 						return { deletionDurability: "stale" };
 					}
 					authority?.assertCurrent();
+					const state = liveState ?? this.findExactRlmState(parentState.activeSessionId, childId, session);
 					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 						(entry) => entry.childId === childId,
 					);
@@ -2547,6 +2589,11 @@ export class AgentDaemon {
 						throw new Error("RLM subagent deletion durability is still unknown");
 					}
 					try {
+						if (deletionDurability === "tombstoned" && state) {
+							this.detachTombstonedClose(parentState, state, childId);
+							if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
+							return { deletionDurability };
+						}
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						if (state) await this.closeSession(state, "killed", false);
 						if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
@@ -3755,7 +3802,7 @@ export class AgentDaemon {
 			case "ack_result":
 				return undefined;
 			case "list": {
-				const activeSessions = Array.from(this.sessions.values());
+				const activeSessions = Array.from(this.sessions.values()).filter((state) => this.isPublicRlmState(state));
 				const scheduledJobs = this.cronStore.list();
 				if (!command.all) {
 					return success(command.id, "list", {
@@ -5457,13 +5504,89 @@ export class AgentDaemon {
 		);
 	}
 
+	private isQuarantinedRlmState(state: ActiveSessionState): boolean {
+		let child = state;
+		const visited = new Set<string>();
+		while (child.runtime.metadata.kind === "subagent") {
+			if (visited.has(child.activeSessionId)) return false;
+			visited.add(child.activeSessionId);
+			const { parentActiveSessionId, rlmChildId } = child.runtime.metadata;
+			if (!parentActiveSessionId || !rlmChildId) return false;
+			const parent = this.sessions.get(parentActiveSessionId);
+			if (!parent) return false;
+			if (parent.runtime.session.isRlmChildDeletionQuarantined?.(rlmChildId) === true) return true;
+			child = parent;
+		}
+		return false;
+	}
+
+	private isPublicRlmState(state: ActiveSessionState): boolean {
+		return !this.closingSessions.has(state.activeSessionId) && !this.isQuarantinedRlmState(state);
+	}
+
+	private findExactRlmState(
+		parentId: string,
+		childId: string,
+		session?: AgentSession,
+	): ActiveSessionState | undefined {
+		return (
+			[...this.failedTombstonedRlmCloses.values()].find(
+				(record) =>
+					record.parentActiveSessionId === parentId &&
+					record.childId === childId &&
+					(!session || record.state.runtime.session === session),
+			)?.state ??
+			[...this.sessions.values()].find((state) => {
+				const metadata = state.runtime.metadata;
+				return (
+					metadata.kind === "subagent" &&
+					metadata.parentActiveSessionId === parentId &&
+					metadata.rlmChildId === childId &&
+					(!session || state.runtime.session === session)
+				);
+			})
+		);
+	}
+
+	private detachTombstonedClose(parent: ActiveSessionState, state: ActiveSessionState, childId: string): void {
+		const existing = this.failedTombstonedRlmCloses.get(state.activeSessionId);
+		if (existing?.state === state) {
+			if (existing.error !== undefined && existing.disposeError !== undefined && !existing.cleanup) {
+				const cleanup = Promise.resolve().then(() => state.runtime.dispose());
+				existing.cleanup = cleanup
+					.then(() => {
+						if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === existing)
+							this.failedTombstonedRlmCloses.delete(state.activeSessionId);
+					})
+					.catch((error: unknown) => {
+						existing.error = error;
+						existing.disposeError = error;
+						existing.cleanup = undefined;
+					});
+			}
+			return;
+		}
+		const record: FailedTombstonedRlmClose = { state, parentActiveSessionId: parent.activeSessionId, childId };
+		this.failedTombstonedRlmCloses.set(state.activeSessionId, record);
+		void this.closeSession(state, "killed", false).then(
+			() => {
+				if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === record)
+					this.failedTombstonedRlmCloses.delete(state.activeSessionId);
+			},
+			(error: unknown) => {
+				record.error = error;
+				record.disposeError = this.closeDisposeErrors.get(state);
+			},
+		);
+	}
+
 	// Half-bound sessions are hidden from other sessions' listings; the current
 	// session stays visible to itself (controllers run during its own bind).
 	private listTargetableSessionStates(current: ActiveSessionState): ActiveSessionState[] {
 		return [...this.sessions.values()].filter(
 			(state) =>
-				state.activeSessionId === current.activeSessionId ||
-				(!this.bindingSessions.has(state.activeSessionId) && !this.closingSessions.has(state.activeSessionId)),
+				this.isPublicRlmState(state) &&
+				(state.activeSessionId === current.activeSessionId || !this.bindingSessions.has(state.activeSessionId)),
 		);
 	}
 
@@ -6671,8 +6794,10 @@ export class AgentDaemon {
 		let disposeError: unknown;
 		try {
 			await state.runtime.dispose();
+			this.closeDisposeErrors.delete(state);
 		} catch (error) {
 			disposeError = error;
+			this.closeDisposeErrors.set(state, error);
 		}
 		for (const client of state.clients) {
 			abortClientSnapshotStreaming(client, state.activeSessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+// Revision 17 carries the catalog authority root for inactive saved-session renames.
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-ea658e1e8208";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -597,7 +598,14 @@ export type DaemonCommand =
 	| { id?: string; type: "set_session_name"; activeSessionId: string; name: string; workerToken?: string }
 	| { id?: string; type: "get_rlm_max_depth_status"; activeSessionId: string }
 	| { id?: string; type: "set_rlm_max_depth"; activeSessionId: string; maxDepth: number; global?: boolean }
-	| { id?: string; type: "rename_saved_session"; activeSessionId?: string; sessionPath: string; name: string }
+	| {
+			id?: string;
+			type: "rename_saved_session";
+			activeSessionId?: string;
+			sessionPath: string;
+			name: string;
+			sessionDir?: string;
+	  }
 	| { id?: string; type: "delete_saved_session"; activeSessionId?: string; sessionPath: string }
 	| { id?: string; type: "get_session_context"; activeSessionId: string }
 	| { id?: string; type: "get_session_tree"; activeSessionId: string }
@@ -735,7 +743,7 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 	set_session_name: LEGACY_DAEMON_COMMAND,
 	get_rlm_max_depth_status: RLM_MAX_DEPTH_COMMAND,
 	set_rlm_max_depth: RLM_MAX_DEPTH_COMMAND,
-	rename_saved_session: LEGACY_DAEMON_COMMAND,
+	rename_saved_session: { minProtocol: 7, minSchemaRevision: 17 },
 	delete_saved_session: LEGACY_DAEMON_COMMAND,
 	get_session_context: LEGACY_DAEMON_COMMAND,
 	get_session_tree: FLAT_SESSION_TREE_COMMAND,
@@ -752,7 +760,10 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 } as const satisfies Record<DaemonCommandName, DaemonCommandCompatibility>;
 
 export function getDaemonCommandCompatibilities(command: DaemonCommand): readonly DaemonCommandCompatibility[] {
-	const compatibility = DAEMON_COMMAND_COMPATIBILITY[command.type];
+	const compatibility =
+		command.type === "rename_saved_session" && command.sessionDir === undefined
+			? LEGACY_DAEMON_COMMAND
+			: DAEMON_COMMAND_COMPATIBILITY[command.type];
 	const carriesTelemetryPolicy =
 		((command.type === "attach" || command.type === "reattach") && command.telemetryDisabled !== undefined) ||
 		(command.type === "create" && command.config?.telemetryDisabled !== undefined);

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -354,6 +354,11 @@ export function buildRlmChildSnapshots(
 	const visit = (parent: ActiveSessionState | undefined, parentActiveSessionId: string): void => {
 		const parentNodeId = parent?.runtime.metadata.rlmChildId;
 		for (const child of childrenByParent.get(parentActiveSessionId) ?? []) {
+			const childId = child.runtime.metadata.rlmChildId;
+			// A precommit release failure retains a resident runtime only for exact
+			// tombstone-and-close retry. It is not a public child, and neither are any
+			// descendants reachable solely through that private runtime.
+			if (childId && parent?.runtime.session.isRlmChildDeletionQuarantined(childId)) continue;
 			snapshots.push(rlmChildSnapshotForActiveSession(child, child.runtime.metadata, parentNodeId, parent));
 			// A child passes its own node id to its children as their parent id.
 			visit(child, child.activeSessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -14,7 +14,7 @@ import lockfile from "proper-lockfile";
 import { getProcessStartId } from "../../core/session-lease.js";
 import { defaultDaemonSocketDir } from "./daemon-socket.js";
 
-const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+export const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
 
 const OWNER_VERSION = 1;
 const REGISTRY_LOCK_STALE_MS = 5000;
@@ -246,7 +246,7 @@ class DaemonShutdownAdmission {
 	}
 }
 
-function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
+export function getDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
 	return environment[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV] ?? resolve(defaultDaemonSocketDir(), "supervisor-owners");
 }
 
@@ -275,7 +275,7 @@ async function mutateDaemonSupervisorOwner(
 	generation: string,
 	expectedToken: string,
 	mutation: (owner: DaemonSupervisorOwnerRecord) => void,
-	registryDir: string = defaultDaemonSupervisorRegistryDir(),
+	registryDir: string = getDaemonSupervisorRegistryDir(),
 ): Promise<DaemonSupervisorOwnerRecord | undefined> {
 	return withDaemonSupervisorRegistryGuard(registryDir, () => {
 		const directory = ownerDirectoryPath(registryDir, generation);
@@ -303,7 +303,7 @@ async function mutateDaemonSupervisorOwner(
 export async function acquireDaemonSupervisorOwnership(
 	options: AcquireDaemonSupervisorOwnershipOptions,
 ): Promise<DaemonSupervisorOwnership> {
-	const registryDir = options.registryDir ?? defaultDaemonSupervisorRegistryDir();
+	const registryDir = options.registryDir ?? getDaemonSupervisorRegistryDir();
 	mkdirSync(registryDir, { recursive: true, mode: 0o700 });
 	const token = randomUUID();
 	const processStartId = getProcessStartId(process.pid);
@@ -371,7 +371,7 @@ export async function assertDaemonSupervisorOwnerCurrent(
 	},
 	validatedFingerprint?: string,
 ): Promise<string> {
-	const registryDir = defaultDaemonSupervisorRegistryDir();
+	const registryDir = getDaemonSupervisorRegistryDir();
 	const current = readOwnerRecord(ownerDirectoryPath(registryDir, owner.generation));
 	if (
 		!current ||
@@ -390,7 +390,7 @@ export async function assertDaemonSupervisorOwnerCurrent(
 }
 
 export async function acquireDaemonShutdownAdmission(): Promise<DaemonShutdownAdmission> {
-	const registryDir = defaultDaemonSupervisorRegistryDir();
+	const registryDir = getDaemonSupervisorRegistryDir();
 	const processStartId = getProcessStartId(process.pid);
 	while (true) {
 		let acquired: DaemonShutdownAdmissionRecord | undefined;
@@ -418,14 +418,14 @@ export async function acquireDaemonShutdownAdmission(): Promise<DaemonShutdownAd
 }
 
 export async function isDaemonShutdownAdmissionActive(): Promise<boolean> {
-	const registryDir = defaultDaemonSupervisorRegistryDir();
+	const registryDir = getDaemonSupervisorRegistryDir();
 	return withDaemonSupervisorRegistryGuard(registryDir, () => readActiveShutdownAdmission(registryDir) !== undefined);
 }
 
 export async function persistDaemonStartupFenceFromOwner(
 	socketPath: string,
 	hello: DaemonSupervisorHelloIdentity,
-	registryDir: string = defaultDaemonSupervisorRegistryDir(),
+	registryDir: string = getDaemonSupervisorRegistryDir(),
 ): Promise<void> {
 	mkdirSync(registryDir, { recursive: true, mode: 0o700 });
 	const fenceDirectory = resolve(registryDir, "startup-fences");
@@ -482,7 +482,7 @@ export async function persistDaemonStartupFenceFromOwner(
 export async function waitForDaemonStartupFence(
 	socketPath: string,
 	timeoutMs = 10_000,
-	registryDir: string = defaultDaemonSupervisorRegistryDir(),
+	registryDir: string = getDaemonSupervisorRegistryDir(),
 ): Promise<void> {
 	const path = startupFencePath(resolve(registryDir, "startup-fences"), socketPath);
 	const deadline = Date.now() + timeoutMs;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -253,6 +253,12 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"shutdown",
 ]);
 
+type FamilyCatalogSource = "persisted" | "artifact" | "live";
+
+type FamilyCatalogCandidate = AgentFamilyCatalogEntry & {
+	source: FamilyCatalogSource;
+};
+
 interface ResidentWorker {
 	descriptor: DaemonWorkerDescriptor;
 	descriptorPath: string;
@@ -1759,14 +1765,24 @@ export class DaemonSupervisor {
 				return this.forwardToWorker(match.worker, command);
 			}
 			case "rename_saved_session": {
-				const target = await this.savedSessionNameReservationInput(command.sessionPath, command.name.trim());
+				const match = command.activeSessionId
+					? await this.findWorkerForClient(client, command.activeSessionId)
+					: undefined;
+				const sessionDir =
+					match?.worker.descriptor.createCommand.config?.sessionDir ??
+					command.sessionDir ??
+					this.defaultSessionConfig.sessionDir;
+				const target = await this.savedSessionNameReservationInput(
+					command.sessionPath,
+					command.name.trim(),
+					sessionDir,
+				);
 				return await this.withSessionNameReservation(target, async () => {
-					await this.assertSupervisorSavedSessionNameAvailable(command.sessionPath, target.name);
-					if (!command.activeSessionId) {
+					await this.assertSupervisorSavedSessionNameAvailable(command.sessionPath, target.name, sessionDir);
+					if (!match) {
 						await this.catalog.rename(command.sessionPath, command.name);
 						return success(command.id, command.type);
 					}
-					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return await this.forwardToWorker(match.worker, {
 						...command,
 						activeSessionId: match.summary.activeSessionId ?? match.summary.id,
@@ -1790,19 +1806,25 @@ export class DaemonSupervisor {
 			const source = command.fromActiveSessionId
 				? await this.findWorkerForClient(client, command.fromActiveSessionId)
 				: undefined;
+			// Hold this persisted topology through pre-wake and post-wake checks.
+			const sourceSessionDir =
+				source?.worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir;
+			const familyCatalog =
+				source && command.agentOrigin === true ? await this.familyCatalogEntries(sourceSessionDir) : undefined;
+			// Session IDs are the stable identities for this authorization snapshot. Do not
+			// rebuild either endpoint from worker summaries after the snapshot is captured.
+			const sourceSessionId = source?.summary.sessionId;
+			let targetSessionId: string;
 			let target: WorkerMatch;
 			try {
 				target = await this.findWorkerForClient(client, command.targetActiveSessionId);
+				targetSessionId = target.summary.sessionId;
 			} catch (error) {
 				if (!(error instanceof Error) || !error.message.startsWith("Unknown active session:")) throw error;
 				const cwd = source?.summary.cwd ?? this.defaultSessionConfig.cwd ?? process.cwd();
 				let sessionPath: string;
 				try {
-					sessionPath = await this.catalog.resolve(
-						command.targetActiveSessionId,
-						cwd,
-						source?.worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir,
-					);
+					sessionPath = await this.catalog.resolve(command.targetActiveSessionId, cwd, sourceSessionDir);
 				} catch (catalogError) {
 					// Preserve selector ambiguity so a2a senders can distinguish it from
 					// the original unknown-active-session lookup failure.
@@ -1811,18 +1833,21 @@ export class DaemonSupervisor {
 					}
 					throw error;
 				}
+				const targetInfo = await readSessionInfo(sessionPath);
+				if (!targetInfo) throw new Error(`Unknown active session: ${command.targetActiveSessionId}`);
+				targetSessionId = targetInfo.id;
 				if (source && command.agentOrigin === true) {
-					const targetInfo = await readSessionInfo(sessionPath);
-					if (!targetInfo) throw new Error(`Unknown active session: ${command.targetActiveSessionId}`);
 					assertAgentFamilyReach(
-						this.familyCatalogEntry(source.summary),
-						this.familyCatalogEntry(summaryForInactiveSession(targetInfo)),
+						this.authoritativeFamilyCatalogEntry(familyCatalog!, sourceSessionId!),
+						this.authoritativeFamilyCatalogEntry(familyCatalog!, targetSessionId),
+						familyCatalog!,
 					);
 				}
 				const worker = await this.createOrReuseWorker(this.protocolClientId(client), {
 					type: "create",
 					sessionPath,
 					continueRecent: false,
+					config: { sessionDir: sourceSessionDir },
 				});
 				const summary =
 					this.findSummaryInWorker(worker, sessionPath) ??
@@ -1832,7 +1857,16 @@ export class DaemonSupervisor {
 			}
 			const targetActiveSessionId = target.summary.activeSessionId ?? target.summary.id;
 			if (source && command.agentOrigin === true) {
-				assertAgentFamilyReach(this.familyCatalogEntry(source.summary), this.familyCatalogEntry(target.summary));
+				// Waking must not substitute a different live session for the target that
+				// was authorized by the captured topology.
+				if (target.summary.sessionId !== targetSessionId) {
+					throw new Error("Agent reach is limited to parent, siblings, and children");
+				}
+				assertAgentFamilyReach(
+					this.authoritativeFamilyCatalogEntry(familyCatalog!, sourceSessionId!),
+					this.authoritativeFamilyCatalogEntry(familyCatalog!, targetSessionId),
+					familyCatalog!,
+				);
 			}
 			if (source) {
 				if ((source.summary.activeSessionId ?? source.summary.id) === targetActiveSessionId) {
@@ -1899,7 +1933,11 @@ export class DaemonSupervisor {
 				if (command.type === "rename" || command.type === "set_session_name") {
 					const reservation = this.summaryNameReservationInput(match.summary, command.name.trim());
 					return await this.withSessionNameReservation(reservation, async () => {
-						await this.assertSupervisorSessionNameAvailable(match.summary, reservation.name);
+						await this.assertSupervisorSessionNameAvailable(
+							match.summary,
+							reservation.name,
+							match.worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir,
+						);
 						return forward();
 					});
 				}
@@ -1968,7 +2006,7 @@ export class DaemonSupervisor {
 		if ("activeSessionId" in command) {
 			const match = await this.findWorkerForClient(client, command.activeSessionId);
 			cwd = match.summary.cwd;
-			sessionDir = this.defaultSessionConfig.sessionDir;
+			sessionDir = match.worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir;
 			activeSessionId = match.summary.activeSessionId ?? match.summary.id;
 		} else {
 			cwd = resolve(command.cwd);
@@ -2009,6 +2047,7 @@ export class DaemonSupervisor {
 			createCommand = { ...command, name: normalizedName };
 		}
 		const ownerClientId = command.lifecycle === "client_owned" ? clientId : undefined;
+		const config = mergeAgentSessionRuntimeConfig(this.defaultSessionConfig, command.config);
 		if (command.sessionPath) {
 			const activeMatches = this.matchWorkers(command.sessionPath);
 			if (activeMatches.length === 1 && !(await this.reclaimStaleWorkerRegistration(activeMatches[0]!.worker))) {
@@ -2017,7 +2056,6 @@ export class DaemonSupervisor {
 			if (activeMatches.length > 1) {
 				throw new Error(`Ambiguous active session "${command.sessionPath}"`);
 			}
-			const config = mergeAgentSessionRuntimeConfig(this.defaultSessionConfig, command.config);
 			const sessionPath = looksLikeSessionPath(command.sessionPath)
 				? resolve(command.sessionPath)
 				: await this.catalog.resolve(command.sessionPath, config.cwd ?? process.cwd(), config.sessionDir);
@@ -2038,7 +2076,9 @@ export class DaemonSupervisor {
 		}
 		const opening = (async () => {
 			if (!createCommand.name) return this.launchWorker(createCommand, undefined, ownerClientId);
-			const savedSiblings = createCommand.sessionPath ? await this.catalog.siblings(createCommand.sessionPath) : [];
+			const savedSiblings = createCommand.sessionPath
+				? await this.catalog.siblings(createCommand.sessionPath, config.sessionDir)
+				: [];
 			const target = savedSiblings.find(
 				(session) => canonicalSessionPath(session.path) === canonicalSessionPath(createCommand.sessionPath!),
 			);
@@ -2048,7 +2088,7 @@ export class DaemonSupervisor {
 				if (target?.parentSessionPath && (target.rlmDepth ?? 0) > 0) {
 					this.assertSavedSiblingNameAvailable(savedSiblings, target, createCommand.name!);
 				} else {
-					await this.assertSupervisorSessionNameAvailable(targetSummary, createCommand.name!);
+					await this.assertSupervisorSessionNameAvailable(targetSummary, createCommand.name!, config.sessionDir);
 				}
 				return this.launchWorker(createCommand, undefined, ownerClientId);
 			});
@@ -3008,19 +3048,104 @@ export class DaemonSupervisor {
 		}
 	}
 
-	private async familyCatalogEntries(): Promise<AgentFamilyCatalogEntry[]> {
-		const active = [...this.workers.values()].flatMap((worker) => [...worker.summaries.values()]);
-		const activePaths = new Set(
-			active.flatMap((summary) => (summary.sessionFile ? [canonicalSessionPath(summary.sessionFile)] : [])),
+	private async familyCatalogEntries(sessionDir?: string): Promise<readonly AgentFamilyCatalogEntry[]> {
+		const effectiveSessionDir = sessionDir ?? this.defaultSessionConfig.sessionDir;
+		const live = [...this.workers.values()]
+			.filter(
+				(worker) =>
+					(worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir) ===
+						effectiveSessionDir ||
+					(Boolean(worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir) &&
+						Boolean(effectiveSessionDir) &&
+						canonicalSessionPath(
+							(worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir)!,
+						) === canonicalSessionPath(effectiveSessionDir!)),
+			)
+			.flatMap((worker) => [...worker.summaries.values()])
+			.map((summary): FamilyCatalogCandidate => ({ ...this.familyCatalogEntry(summary), source: "live" }));
+		// Keep the persisted row even when its path is currently active. A live
+		// overlay may fill in missing claims, but it may not silently replace a
+		// conflicting durable topology claim.
+		const saved = await this.catalog.list(undefined, sessionDir);
+		const savedPaths = new Set(saved.map((info) => canonicalSessionPath(info.path)));
+		const persisted = saved.map(
+			(info): FamilyCatalogCandidate => ({
+				...this.familyCatalogEntry(summaryForInactiveSession(info)),
+				source: "persisted",
+			}),
 		);
-		const savedRoots = (await this.catalog.list()).filter(
-			(info) =>
-				(info.rlmDepth ?? (info.parentSessionPath ? -1 : 0)) === 0 &&
-				!activePaths.has(canonicalSessionPath(info.path)),
-		);
-		return [...active, ...savedRoots.map((info) => summaryForInactiveSession(info))].map((summary) =>
-			this.familyCatalogEntry(summary),
-		);
+		// The catalog's bounded registry walk supplies artifact-resident parents
+		// and descendants missing from list(). Preserve their durable rows in the
+		// immutable authorization snapshot; live overlays still cannot replace a
+		// conflicting topology claim.
+		const artifactSessions = this.catalog.family ? await this.catalog.family(sessionDir) : saved;
+		const artifacts = artifactSessions
+			.filter((info) => !savedPaths.has(canonicalSessionPath(info.path)))
+			.map(
+				(info): FamilyCatalogCandidate => ({
+					...this.familyCatalogEntry(summaryForInactiveSession(info)),
+					source: "artifact",
+				}),
+			);
+		return Object.freeze(this.mergeEquivalentFamilyCatalogEntries([...persisted, ...artifacts, ...live]));
+	}
+
+	/**
+	 * Collapse durable/live duplicates only when their stable identity and every
+	 * jointly-present topology claim agree. Incompatible candidates intentionally
+	 * remain duplicated: authoritative endpoint lookup then fails closed.
+	 */
+	private mergeEquivalentFamilyCatalogEntries(entries: readonly FamilyCatalogCandidate[]): AgentFamilyCatalogEntry[] {
+		const compatible = (left: FamilyCatalogCandidate, right: FamilyCatalogCandidate) =>
+			left.id === right.id &&
+			(left.sessionPath === undefined ||
+				right.sessionPath === undefined ||
+				left.sessionPath === right.sessionPath) &&
+			left.depth === right.depth &&
+			(left.parentSessionId === undefined ||
+				right.parentSessionId === undefined ||
+				left.parentSessionId === right.parentSessionId) &&
+			(left.parentSessionPath === undefined ||
+				right.parentSessionPath === undefined ||
+				left.parentSessionPath === right.parentSessionPath);
+		const groups: FamilyCatalogCandidate[][] = [];
+		for (const entry of entries) {
+			const group = groups.find((candidate) => candidate.every((member) => compatible(member, entry)));
+			if (group) group.push(entry);
+			else groups.push([entry]);
+		}
+		const statusRank: Record<AgentFamilyCatalogEntry["status"], number> = { inactive: 0, idle: 1, running: 2 };
+		const preferred = <T>(
+			rows: readonly FamilyCatalogCandidate[],
+			get: (row: FamilyCatalogCandidate) => T | undefined,
+		): T | undefined =>
+			[...rows]
+				.sort(
+					(left, right) =>
+						(({ persisted: 0, artifact: 1, live: 2 })[right.source] ?? 0) -
+						({ persisted: 0, artifact: 1, live: 2 }[left.source] ?? 0),
+				)
+				.map(get)
+				.find((value): value is T => value !== undefined);
+		return groups.map((rows) => {
+			const exemplar = rows[0]!;
+			const name = preferred(rows, (row) => row.name);
+			const parentSessionId = preferred(rows, (row) => row.parentSessionId);
+			const parentSessionPath = preferred(rows, (row) => row.parentSessionPath);
+			const sessionPath = preferred(rows, (row) => row.sessionPath);
+			return {
+				id: exemplar.id,
+				depth: exemplar.depth,
+				status: rows.reduce<AgentFamilyCatalogEntry["status"]>(
+					(best, row) => (statusRank[row.status] > statusRank[best] ? row.status : best),
+					"inactive",
+				),
+				...(name ? { name } : {}),
+				...(parentSessionId ? { parentSessionId } : {}),
+				...(parentSessionPath ? { parentSessionPath } : {}),
+				...(sessionPath ? { sessionPath } : {}),
+			};
+		});
 	}
 
 	private async withSessionNameReservation<T>(
@@ -3042,8 +3167,9 @@ export class DaemonSupervisor {
 	private async assertSupervisorSessionNameAvailable(
 		target: Pick<SessionSummary, "sessionId" | "rlmDepth" | "parentSessionId" | "parentSessionPath">,
 		name: string,
+		sessionDir?: string,
 	): Promise<void> {
-		assertAgentSessionNameAvailable(await this.familyCatalogEntries(), {
+		assertAgentSessionNameAvailable(await this.familyCatalogEntries(sessionDir), {
 			name,
 			depth: target.rlmDepth ?? 0,
 			parentSessionId: target.parentSessionId,
@@ -3055,13 +3181,14 @@ export class DaemonSupervisor {
 	private async savedSessionNameReservationInput(
 		sessionPath: string,
 		name: string,
+		sessionDir?: string,
 	): Promise<{ name: string; depth: number; parentSessionId?: string; parentSessionPath?: string }> {
 		const targetPath = canonicalSessionPath(sessionPath);
 		const active = [...this.workers.values()]
 			.flatMap((worker) => [...worker.summaries.values()])
 			.find((summary) => summary.sessionFile && canonicalSessionPath(summary.sessionFile) === targetPath);
 		if (active) return this.summaryNameReservationInput(active, name);
-		const siblings = await this.catalog.siblings(sessionPath);
+		const siblings = await this.catalog.siblings(sessionPath, sessionDir ?? this.defaultSessionConfig.sessionDir);
 		const saved = siblings.find((info) => canonicalSessionPath(info.path) === targetPath);
 		if (!saved) throw new Error(`Session not found: ${sessionPath}`);
 		return {
@@ -3084,19 +3211,23 @@ export class DaemonSupervisor {
 		};
 	}
 
-	private async assertSupervisorSavedSessionNameAvailable(sessionPath: string, name: string): Promise<void> {
+	private async assertSupervisorSavedSessionNameAvailable(
+		sessionPath: string,
+		name: string,
+		sessionDir?: string,
+	): Promise<void> {
 		const targetPath = canonicalSessionPath(sessionPath);
 		const active = [...this.workers.values()]
 			.flatMap((worker) => [...worker.summaries.values()])
 			.find((summary) => summary.sessionFile && canonicalSessionPath(summary.sessionFile) === targetPath);
-		if (active) return this.assertSupervisorSessionNameAvailable(active, name);
-		const siblings = await this.catalog.siblings(sessionPath);
+		if (active) return this.assertSupervisorSessionNameAvailable(active, name, sessionDir);
+		const siblings = await this.catalog.siblings(sessionPath, sessionDir ?? this.defaultSessionConfig.sessionDir);
 		const saved = siblings.find((info) => canonicalSessionPath(info.path) === targetPath);
 		if (!saved) throw new Error(`Session not found: ${sessionPath}`);
 		if (saved.parentSessionPath && (saved.rlmDepth ?? 0) > 0) {
 			this.assertSavedSiblingNameAvailable(siblings, saved, name);
 		} else {
-			await this.assertSupervisorSessionNameAvailable(summaryForInactiveSession(saved), name);
+			await this.assertSupervisorSessionNameAvailable(summaryForInactiveSession(saved), name, sessionDir);
 		}
 	}
 
@@ -3192,6 +3323,16 @@ export class DaemonSupervisor {
 		return worker.client;
 	}
 
+	/** Resolve both authorization endpoints exclusively from one captured topology snapshot. */
+	private authoritativeFamilyCatalogEntry(
+		catalog: readonly AgentFamilyCatalogEntry[],
+		sessionId: string,
+	): AgentFamilyCatalogEntry {
+		const matches = catalog.filter((entry) => entry.id === sessionId);
+		if (matches.length !== 1) throw new Error("Agent reach is limited to parent, siblings, and children");
+		return matches[0]!;
+	}
+
 	private familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry {
 		const depth = summary.rlmDepth ?? (summary.parentSessionPath ? 1 : 0);
 		return {
@@ -3200,8 +3341,16 @@ export class DaemonSupervisor {
 			depth,
 			status: classifySessionRosterStatus(summary),
 			...(depth > 0 && summary.parentSessionId ? { parentSessionId: summary.parentSessionId } : {}),
-			...(depth > 0 && summary.parentSessionPath
-				? { parentSessionPath: canonicalSessionPath(summary.parentSessionPath) }
+			...(depth > 0 && summary.parentSessionPath && (isAbsolute(summary.parentSessionPath) || summary.sessionFile)
+				? {
+						parentSessionPath: canonicalSessionPath(
+							isAbsolute(summary.parentSessionPath)
+								? summary.parentSessionPath
+								: summary.sessionFile
+									? resolve(dirname(summary.sessionFile), summary.parentSessionPath)
+									: summary.parentSessionPath,
+						),
+					}
 				: {}),
 			...(summary.sessionFile ? { sessionPath: canonicalSessionPath(summary.sessionFile) } : {}),
 		};

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -338,6 +338,12 @@ function throwIfAdmissionCancelled(admission: SupervisorPromptAdmission | undefi
 	if (admission?.status === "cancelled") throw new PromptAdmissionCancelledError();
 }
 
+/** Match catalog sibling topology: relative parents are rooted at each child session file. */
+function canonicalSavedSiblingParentPath(session: Pick<SessionInfo, "path" | "parentSessionPath">): string | undefined {
+	if (!session.parentSessionPath) return undefined;
+	return canonicalSessionPath(resolve(dirname(session.path), session.parentSessionPath));
+}
+
 class SupervisorRecoveryCancelledError extends Error {
 	readonly code = "supervisor_recovery_cancelled" as const;
 }
@@ -2083,7 +2089,9 @@ export class DaemonSupervisor {
 				(session) => canonicalSessionPath(session.path) === canonicalSessionPath(createCommand.sessionPath!),
 			);
 			const targetSummary = target ? summaryForInactiveSession(target) : { sessionId: "new-root", rlmDepth: 0 };
-			const reservation = this.summaryNameReservationInput(targetSummary, createCommand.name);
+			const reservation = target
+				? this.savedSiblingNameReservationInput(target, savedSiblings, createCommand.name)
+				: this.summaryNameReservationInput(targetSummary, createCommand.name);
 			return this.withSessionNameReservation(reservation, async () => {
 				if (target?.parentSessionPath && (target.rlmDepth ?? 0) > 0) {
 					this.assertSavedSiblingNameAvailable(savedSiblings, target, createCommand.name!);
@@ -3191,10 +3199,19 @@ export class DaemonSupervisor {
 		const siblings = await this.catalog.siblings(sessionPath, sessionDir ?? this.defaultSessionConfig.sessionDir);
 		const saved = siblings.find((info) => canonicalSessionPath(info.path) === targetPath);
 		if (!saved) throw new Error(`Session not found: ${sessionPath}`);
+		return this.savedSiblingNameReservationInput(saved, siblings, name);
+	}
+
+	private savedSiblingNameReservationInput(
+		saved: SessionInfo,
+		siblings: readonly SessionInfo[],
+		name: string,
+	): { name: string; depth: number; parentSessionId?: string; parentSessionPath?: string } {
+		const parentSessionPath = canonicalSavedSiblingParentPath(saved);
 		return {
 			name,
 			depth: saved.rlmDepth ?? siblings.find((sibling) => sibling.rlmDepth !== undefined)?.rlmDepth ?? 0,
-			parentSessionPath: saved.parentSessionPath,
+			...(parentSessionPath ? { parentSessionPath } : {}),
 		};
 	}
 
@@ -3233,23 +3250,64 @@ export class DaemonSupervisor {
 
 	private assertSavedSiblingNameAvailable(siblings: SessionInfo[], target: SessionInfo, name: string): void {
 		const setDepth = target.rlmDepth ?? siblings.find((sibling) => sibling.rlmDepth !== undefined)?.rlmDepth ?? 0;
+		const targetPath = canonicalSessionPath(target.path);
+		const parentSessionPath = canonicalSavedSiblingParentPath(target);
+		if (setDepth <= 0 || !parentSessionPath) {
+			throw new Error("Saved sibling catalog has no direct parent");
+		}
+
+		// catalog.siblings() is deliberately bounded: it returns the child set, not
+		// its parent. Preserve that boundary while supplying a local structural
+		// anchor to Core03's immutable exact-one-parent catalog validation. Reject
+		// ambiguous persisted rows rather than letting a malformed saved catalog
+		// weaken a name reservation.
+		const parentId = `saved-sibling-parent:${parentSessionPath}`;
+		const ids = new Set<string>();
+		const paths = new Set<string>();
+		let targetCount = 0;
+		for (const sibling of siblings) {
+			const siblingPath = canonicalSessionPath(sibling.path);
+			const siblingParentPath = canonicalSavedSiblingParentPath(sibling);
+			if (
+				ids.has(sibling.id) ||
+				paths.has(siblingPath) ||
+				sibling.id === parentId ||
+				siblingParentPath !== parentSessionPath ||
+				(sibling.rlmDepth !== undefined && sibling.rlmDepth !== setDepth)
+			) {
+				throw new Error("Saved sibling catalog is structurally ambiguous");
+			}
+			ids.add(sibling.id);
+			paths.add(siblingPath);
+			if (sibling.id === target.id && siblingPath === targetPath) targetCount += 1;
+		}
+		if (targetCount !== 1) {
+			throw new Error("Saved sibling catalog does not contain its target");
+		}
+
 		assertAgentSessionNameAvailable(
-			siblings.map((info) => {
-				const summary = summaryForInactiveSession(info);
-				return {
-					id: summary.sessionId,
-					...(summary.sessionName ? { name: summary.sessionName } : {}),
-					depth: setDepth,
-					status: classifySessionRosterStatus(summary),
-					...(summary.parentSessionPath
-						? { parentSessionPath: canonicalSessionPath(summary.parentSessionPath) }
-						: {}),
-				};
-			}),
+			[
+				{
+					id: parentId,
+					depth: setDepth - 1,
+					status: "inactive" as const,
+					sessionPath: parentSessionPath,
+				},
+				...siblings.map((info) => {
+					const summary = summaryForInactiveSession(info);
+					return {
+						id: summary.sessionId,
+						...(summary.sessionName ? { name: summary.sessionName } : {}),
+						depth: setDepth,
+						status: classifySessionRosterStatus(summary),
+						parentSessionPath,
+					};
+				}),
+			],
 			{
 				name,
 				depth: setDepth,
-				parentSessionPath: target.parentSessionPath ? canonicalSessionPath(target.parentSessionPath) : undefined,
+				parentSessionPath,
 				ignoreSessionId: target.id,
 			},
 		);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -341,9 +341,35 @@ function throwIfAdmissionCancelled(admission: SupervisorPromptAdmission | undefi
 }
 
 /** Match catalog sibling topology: relative parents are rooted at each child session file. */
-function canonicalSavedSiblingParentPath(session: Pick<SessionInfo, "path" | "parentSessionPath">): string | undefined {
-	if (!session.parentSessionPath) return undefined;
-	return canonicalSessionPath(resolve(dirname(session.path), session.parentSessionPath));
+/**
+ * Normalize the structural namespace occupied by a session name. Every
+ * reservation, availability check, and family-catalog entry must derive this
+ * scope from the same persisted/live summary shape: a relative parent edge is
+ * meaningful only relative to the child transcript that contains it.
+ */
+function summarySiblingScope(
+	summary: Pick<SessionSummary, "rlmDepth" | "parentSessionId" | "parentSessionPath" | "sessionFile">,
+): { depth: number; parentSessionId?: string; parentSessionPath?: string } {
+	const depth = summary.rlmDepth ?? (summary.parentSessionPath ? 1 : 0);
+	if (depth <= 0) return { depth };
+
+	let parentSessionPath: string | undefined;
+	if (summary.parentSessionPath) {
+		if (isAbsolute(summary.parentSessionPath)) {
+			parentSessionPath = canonicalSessionPath(summary.parentSessionPath);
+		} else {
+			if (!summary.sessionFile) {
+				throw new Error("Non-root session has an unanchored relative parent path");
+			}
+			parentSessionPath = canonicalSessionPath(resolve(dirname(summary.sessionFile), summary.parentSessionPath));
+		}
+	}
+
+	return {
+		depth,
+		...(summary.parentSessionId ? { parentSessionId: summary.parentSessionId } : {}),
+		...(parentSessionPath ? { parentSessionPath } : {}),
+	};
 }
 
 class SupervisorRecoveryCancelledError extends Error {
@@ -2098,8 +2124,12 @@ export class DaemonSupervisor {
 				? this.savedSiblingNameReservationInput(target, savedSiblings, createCommand.name)
 				: this.summaryNameReservationInput(targetSummary, createCommand.name);
 			return this.withSessionNameReservation(reservation, async () => {
-				if (target?.parentSessionPath && (target.rlmDepth ?? 0) > 0) {
-					this.assertSavedSiblingNameAvailable(savedSiblings, target, createCommand.name!);
+				if (target) {
+					await this.assertSupervisorSavedSessionNameAvailable(
+						createCommand.sessionPath!,
+						createCommand.name!,
+						config.sessionDir,
+					);
 				} else {
 					await this.assertSupervisorSessionNameAvailable(targetSummary, createCommand.name!, config.sessionDir);
 				}
@@ -3180,15 +3210,13 @@ export class DaemonSupervisor {
 	}
 
 	private async assertSupervisorSessionNameAvailable(
-		target: Pick<SessionSummary, "sessionId" | "rlmDepth" | "parentSessionId" | "parentSessionPath">,
+		target: Pick<SessionSummary, "sessionId" | "rlmDepth" | "parentSessionId" | "parentSessionPath" | "sessionFile">,
 		name: string,
 		sessionDir?: string,
 	): Promise<void> {
 		assertAgentSessionNameAvailable(await this.familyCatalogEntries(sessionDir), {
 			name,
-			depth: target.rlmDepth ?? 0,
-			parentSessionId: target.parentSessionId,
-			parentSessionPath: target.parentSessionPath ? canonicalSessionPath(target.parentSessionPath) : undefined,
+			...summarySiblingScope(target),
 			ignoreSessionId: target.sessionId,
 		});
 	}
@@ -3211,28 +3239,17 @@ export class DaemonSupervisor {
 
 	private savedSiblingNameReservationInput(
 		saved: SessionInfo,
-		siblings: readonly SessionInfo[],
+		_siblings: readonly SessionInfo[],
 		name: string,
 	): { name: string; depth: number; parentSessionId?: string; parentSessionPath?: string } {
-		const parentSessionPath = canonicalSavedSiblingParentPath(saved);
-		return {
-			name,
-			depth: saved.rlmDepth ?? siblings.find((sibling) => sibling.rlmDepth !== undefined)?.rlmDepth ?? 0,
-			...(parentSessionPath ? { parentSessionPath } : {}),
-		};
+		return { name, ...summarySiblingScope(summaryForInactiveSession(saved)) };
 	}
 
 	private summaryNameReservationInput(
-		target: Pick<SessionSummary, "rlmDepth" | "parentSessionId" | "parentSessionPath">,
+		target: Pick<SessionSummary, "rlmDepth" | "parentSessionId" | "parentSessionPath" | "sessionFile">,
 		name: string,
 	): { name: string; depth: number; parentSessionId?: string; parentSessionPath?: string } {
-		const depth = target.rlmDepth ?? (target.parentSessionPath ? 1 : 0);
-		return {
-			name,
-			depth,
-			...(depth > 0 && target.parentSessionId ? { parentSessionId: target.parentSessionId } : {}),
-			...(depth > 0 && target.parentSessionPath ? { parentSessionPath: target.parentSessionPath } : {}),
-		};
+		return { name, ...summarySiblingScope(target) };
 	}
 
 	private async assertSupervisorSavedSessionNameAvailable(
@@ -3250,16 +3267,23 @@ export class DaemonSupervisor {
 		if (!saved) throw new Error(`Session not found: ${sessionPath}`);
 		if (saved.parentSessionPath && (saved.rlmDepth ?? 0) > 0) {
 			this.assertSavedSiblingNameAvailable(siblings, saved, name);
-		} else {
+		}
+		// Saved rows and resident summaries share the same structural namespace.
+		// The bounded sibling catalog validates the durable sibling shape above.
+		// Only consult the all-session catalog when it is available: the bounded
+		// catalog is the compatibility surface for saved-only callers and already
+		// protects its complete saved scope.
+		if ("list" in (this.catalog as object)) {
 			await this.assertSupervisorSessionNameAvailable(summaryForInactiveSession(saved), name, sessionDir);
 		}
 	}
 
 	private assertSavedSiblingNameAvailable(siblings: SessionInfo[], target: SessionInfo, name: string): void {
-		const setDepth = target.rlmDepth ?? siblings.find((sibling) => sibling.rlmDepth !== undefined)?.rlmDepth ?? 0;
+		const targetSummary = summaryForInactiveSession(target);
+		const targetScope = summarySiblingScope(targetSummary);
 		const targetPath = canonicalSessionPath(target.path);
-		const parentSessionPath = canonicalSavedSiblingParentPath(target);
-		if (setDepth <= 0 || !parentSessionPath) {
+		const parentSessionPath = targetScope.parentSessionPath;
+		if (targetScope.depth <= 0 || !parentSessionPath) {
 			throw new Error("Saved sibling catalog has no direct parent");
 		}
 
@@ -3274,13 +3298,13 @@ export class DaemonSupervisor {
 		let targetCount = 0;
 		for (const sibling of siblings) {
 			const siblingPath = canonicalSessionPath(sibling.path);
-			const siblingParentPath = canonicalSavedSiblingParentPath(sibling);
+			const siblingScope = summarySiblingScope(summaryForInactiveSession(sibling));
 			if (
 				ids.has(sibling.id) ||
 				paths.has(siblingPath) ||
 				sibling.id === parentId ||
-				siblingParentPath !== parentSessionPath ||
-				(sibling.rlmDepth !== undefined && sibling.rlmDepth !== setDepth)
+				siblingScope.depth !== targetScope.depth ||
+				siblingScope.parentSessionPath !== parentSessionPath
 			) {
 				throw new Error("Saved sibling catalog is structurally ambiguous");
 			}
@@ -3296,7 +3320,7 @@ export class DaemonSupervisor {
 			[
 				{
 					id: parentId,
-					depth: setDepth - 1,
+					depth: targetScope.depth - 1,
 					status: "inactive" as const,
 					sessionPath: parentSessionPath,
 				},
@@ -3305,18 +3329,12 @@ export class DaemonSupervisor {
 					return {
 						id: summary.sessionId,
 						...(summary.sessionName ? { name: summary.sessionName } : {}),
-						depth: setDepth,
+						...summarySiblingScope(summary),
 						status: classifySessionRosterStatus(summary),
-						parentSessionPath,
 					};
 				}),
 			],
-			{
-				name,
-				depth: setDepth,
-				parentSessionPath,
-				ignoreSessionId: target.id,
-			},
+			{ name, ...targetScope, ignoreSessionId: target.id },
 		);
 	}
 
@@ -3399,24 +3417,11 @@ export class DaemonSupervisor {
 	}
 
 	private familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry {
-		const depth = summary.rlmDepth ?? (summary.parentSessionPath ? 1 : 0);
 		return {
 			id: summary.sessionId,
 			...(summary.sessionName ? { name: summary.sessionName } : {}),
-			depth,
+			...summarySiblingScope(summary),
 			status: classifySessionRosterStatus(summary),
-			...(depth > 0 && summary.parentSessionId ? { parentSessionId: summary.parentSessionId } : {}),
-			...(depth > 0 && summary.parentSessionPath && (isAbsolute(summary.parentSessionPath) || summary.sessionFile)
-				? {
-						parentSessionPath: canonicalSessionPath(
-							isAbsolute(summary.parentSessionPath)
-								? summary.parentSessionPath
-								: summary.sessionFile
-									? resolve(dirname(summary.sessionFile), summary.parentSessionPath)
-									: summary.parentSessionPath,
-						),
-					}
-				: {}),
 			...(summary.sessionFile ? { sessionPath: canonicalSessionPath(summary.sessionFile) } : {}),
 		};
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -98,6 +98,8 @@ import {
 } from "./daemon-socket.js";
 import {
 	acquireDaemonSupervisorOwnership,
+	DAEMON_SUPERVISOR_REGISTRY_DIR_ENV,
+	getDaemonSupervisorRegistryDir,
 	isDaemonShutdownAdmissionActive,
 	waitForDaemonStartupFence,
 } from "./daemon-supervisor-ownership.js";
@@ -614,6 +616,8 @@ export class DaemonSupervisor {
 	private readonly promptAdmissions = new Map<DaemonSocketClient, Map<string, SupervisorPromptAdmission>>();
 	private readonly signalCleanupHandlers: Array<() => void> = [];
 	private readonly descriptorDir: string;
+	/** Captured from host authority and forwarded to every worker launch. */
+	private readonly supervisorRegistryDir = getDaemonSupervisorRegistryDir();
 	private readonly generation = randomUUID();
 	private readonly supervisorConfigPath: string;
 	private readonly defaultSessionConfig: AgentSessionRuntimeConfig;
@@ -657,13 +661,14 @@ export class DaemonSupervisor {
 				throw new Error("Daemon supervisor config is missing agentDir");
 			}
 			this.socketLease = await acquireDaemonSocketPathLease(this.socketPath);
-			await waitForDaemonStartupFence(this.socketPath);
+			await waitForDaemonStartupFence(this.socketPath, 10_000, this.supervisorRegistryDir);
 			this.ownership = await acquireDaemonSupervisorOwnership({
 				socketPath: this.socketPath,
 				descriptorDir: this.descriptorDir,
 				agentDir,
 				generation: this.generation,
 				appVersion: VERSION,
+				registryDir: this.supervisorRegistryDir,
 			});
 			await prepareDaemonSocketPath(this.socketPath, this.socketLease);
 
@@ -2226,6 +2231,8 @@ export class DaemonSupervisor {
 				[DAEMON_WORKER_ACTIVE_SESSION_ID_ENV]: rootActiveSessionId,
 				[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV]: this.socketPath,
 				[DAEMON_WORKER_RECOVERY_JOURNAL_ENV]: recoveryJournalPath,
+				// Host authority, set after inherited and caller launch env so neither can override it.
+				[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]: this.supervisorRegistryDir,
 				[DAEMON_WORKER_STARTUP_GATE_FD_ENV]: String(WORKER_STARTUP_GATE_FD),
 				[ORPHAN_PROCESS_JOURNAL_ENV]: orphanProcessJournalPath,
 				[SESSION_LEASES_ENABLED_ENV]: "1",

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -340,7 +340,6 @@ function throwIfAdmissionCancelled(admission: SupervisorPromptAdmission | undefi
 	if (admission?.status === "cancelled") throw new PromptAdmissionCancelledError();
 }
 
-/** Match catalog sibling topology: relative parents are rooted at each child session file. */
 /**
  * Normalize the structural namespace occupied by a session name. Every
  * reservation, availability check, and family-catalog entry must derive this
@@ -2121,7 +2120,7 @@ export class DaemonSupervisor {
 			);
 			const targetSummary = target ? summaryForInactiveSession(target) : { sessionId: "new-root", rlmDepth: 0 };
 			const reservation = target
-				? this.savedSiblingNameReservationInput(target, savedSiblings, createCommand.name)
+				? this.savedSiblingNameReservationInput(target, createCommand.name)
 				: this.summaryNameReservationInput(targetSummary, createCommand.name);
 			return this.withSessionNameReservation(reservation, async () => {
 				if (target) {
@@ -3234,12 +3233,11 @@ export class DaemonSupervisor {
 		const siblings = await this.catalog.siblings(sessionPath, sessionDir ?? this.defaultSessionConfig.sessionDir);
 		const saved = siblings.find((info) => canonicalSessionPath(info.path) === targetPath);
 		if (!saved) throw new Error(`Session not found: ${sessionPath}`);
-		return this.savedSiblingNameReservationInput(saved, siblings, name);
+		return this.savedSiblingNameReservationInput(saved, name);
 	}
 
 	private savedSiblingNameReservationInput(
 		saved: SessionInfo,
-		_siblings: readonly SessionInfo[],
 		name: string,
 	): { name: string; depth: number; parentSessionId?: string; parentSessionPath?: string } {
 		return { name, ...summarySiblingScope(summaryForInactiveSession(saved)) };

--- a/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
+++ b/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
@@ -53,7 +53,7 @@ export async function renameDaemonSavedSession(
 	const command: Extract<DaemonCommand, { type: "rename_saved_session" }> =
 		"activeSessionId" in context
 			? { type: "rename_saved_session", activeSessionId: context.activeSessionId, sessionPath, name }
-			: { type: "rename_saved_session", sessionPath, name };
+			: { type: "rename_saved_session", sessionPath, name, sessionDir: context.sessionDir };
 	const response = await client.request(command);
 	if (!response.success) {
 		throw deserializeDaemonError(response);

--- a/packages/coding-agent/test/acp-kernel-features.test.ts
+++ b/packages/coding-agent/test/acp-kernel-features.test.ts
@@ -10,6 +10,8 @@ import { acpUpdatesForSessionEvent } from "../src/modes/acp/acp-events.js";
 import { PRIME_AGENT_META_NAMESPACE } from "../src/modes/acp/acp-meta.js";
 import type { AgentConnectionSessionEvent } from "../src/modes/agent-connection/types.js";
 
+import { createTestHostHandlers } from "./host-request-context.js";
+
 /**
  * Real-kernel verification for ACP mode.
  *
@@ -157,39 +159,39 @@ print(json.dumps({
 		});
 	});
 
-	it("exposes rlm depth and subagent APIs to the kernel behind the ACP front end", {
-		tags: ["kernel-heavy"],
-		timeout: 180_000,
-	}, async () => {
-		provisioner = new IpythonKernelProvisioner(tempDir, {
-			pythonSkills: [AGENT_MESSAGE_SKILL],
-			env: { RLM_DEPTH: "0", RLM_MAX_DEPTH: "1" },
-			hostHandlers: {
-				"rlm.list_subagents": async () => ({
-					subagents: [
-						{
-							rlm_child_id: "child-1",
-							active_session_id: "active-1",
+	it(
+		"exposes rlm depth and subagent APIs to the kernel behind the ACP front end",
+		{ tags: ["kernel-heavy"], timeout: 180_000 },
+		async () => {
+			provisioner = new IpythonKernelProvisioner(tempDir, {
+				pythonSkills: [AGENT_MESSAGE_SKILL],
+				env: { RLM_DEPTH: "0", RLM_MAX_DEPTH: "1" },
+				hostHandlers: createTestHostHandlers({
+					"rlm.list_subagents": async () => ({
+						subagents: [
+							{
+								rlm_child_id: "child-1",
+								active_session_id: "active-1",
+								session_id: "session-1",
+								session_name: "reviewer",
+								session_dir: tempDir,
+								status: "completed",
+							},
+						],
+					}),
+					"rlm.delete_subagent": async (payload) => ({
+						subagent: {
+							rlm_child_id: String(payload.target),
+							active_session_id: null,
 							session_id: "session-1",
 							session_name: "reviewer",
 							session_dir: tempDir,
 							status: "completed",
 						},
-					],
+					}),
 				}),
-				"rlm.delete_subagent": async (payload) => ({
-					subagent: {
-						rlm_child_id: String(payload.target),
-						active_session_id: null,
-						session_id: "session-1",
-						session_name: "reviewer",
-						session_dir: tempDir,
-						status: "completed",
-					},
-				}),
-			},
-		});
-		const manager = await provisioner.ensure();
+			});
+			const manager = await provisioner.ensure();
 
 		const result = await manager.execute(`
 import json, os
@@ -210,30 +212,30 @@ print(json.dumps({
 		expect(payload.max_depth).toBe("1");
 	});
 
-	it("sends an agent-to-agent message from the kernel and surfaces it over ACP", {
-		tags: ["kernel-heavy"],
-		timeout: 180_000,
-	}, async () => {
-		provisioner = new IpythonKernelProvisioner(tempDir, {
-			pythonSkills: [AGENT_MESSAGE_SKILL],
-			hostHandlers: {
-				// The family roster: parent, siblings, and children of this agent.
-				"agent_message.list_agents": async () => ({
-					current: { name: "root", id: "session-alpha", depth: 0 },
-					entries: [{ relationship: "child", name: "reviewer", id: "session-beta", depth: 1, status: "idle" }],
+	it(
+		"sends an agent-to-agent message from the kernel and surfaces it over ACP",
+		{ tags: ["kernel-heavy"], timeout: 180_000 },
+		async () => {
+			provisioner = new IpythonKernelProvisioner(tempDir, {
+				pythonSkills: [AGENT_MESSAGE_SKILL],
+				hostHandlers: createTestHostHandlers({
+					// The family roster: parent, siblings, and children of this agent.
+					"agent_message.list_agents": async () => ({
+						current: { name: "root", id: "session-alpha", depth: 0 },
+						entries: [{ relationship: "child", name: "reviewer", id: "session-beta", depth: 1, status: "idle" }],
+					}),
+					"agent_message.send": async (payload) => ({
+						id: "agentmsg-acp",
+						source: "agent_message",
+						target: { activeSessionId: "beta", sessionId: "session-beta", sessionName: "reviewer" },
+						message: payload.message,
+						deliveryStatus: "queued",
+						queuedAt: "2026-08-04T00:00:00.000Z",
+						deliveryMode: payload.mode ?? "auto",
+					}),
 				}),
-				"agent_message.send": async (payload) => ({
-					id: "agentmsg-acp",
-					source: "agent_message",
-					target: { activeSessionId: "beta", sessionId: "session-beta", sessionName: "reviewer" },
-					message: payload.message,
-					deliveryStatus: "queued",
-					queuedAt: "2026-08-04T00:00:00.000Z",
-					deliveryMode: payload.mode ?? "auto",
-				}),
-			},
-		});
-		const manager = await provisioner.ensure();
+			});
+			const manager = await provisioner.ensure();
 
 		// The kernel venv is shared across test files. If a concurrently running
 		// file rebuilt it without this skill, say so plainly rather than failing

--- a/packages/coding-agent/test/agent-messages.test.ts
+++ b/packages/coding-agent/test/agent-messages.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+	AGENT_FAMILY_REACH_ERROR,
+	assertAgentFamilyReach,
+	buildAgentFamilyRoster,
+} from "../src/core/agent-messages.js";
+
+describe("agent message structural family validation", () => {
+	it("excludes malformed family edges while retaining catalog-resolved depth-two siblings", () => {
+		const root = { id: "root", depth: 0, status: "running" as const, sessionPath: "/root" };
+		const otherRoot = { id: "other-root", depth: 0, status: "running" as const, sessionPath: "/other" };
+		const child = {
+			id: "child",
+			depth: 1,
+			status: "idle" as const,
+			parentSessionPath: "/root",
+			sessionPath: "/child",
+		};
+		const malformedRoot = {
+			id: "malformed-root",
+			depth: 0,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/root",
+		};
+		const contradictoryChild = {
+			id: "contradictory-child",
+			depth: 1,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/other",
+		};
+		const depthSkippingDescendant = {
+			id: "depth-skipping-descendant",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/root",
+		};
+		const malformedDeepSiblingA = {
+			id: "malformed-deep-sibling-a",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/root",
+		};
+		const malformedDeepSiblingB = {
+			id: "malformed-deep-sibling-b",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionId: "root",
+			parentSessionPath: "/root",
+		};
+		const catalog = [
+			root,
+			child,
+			malformedRoot,
+			contradictoryChild,
+			depthSkippingDescendant,
+			malformedDeepSiblingA,
+			malformedDeepSiblingB,
+		];
+
+		// A root carrying a parent claim, contradictory dual claims, and a skipped
+		// depth must not become a direct family edge.
+		for (const malformed of [malformedRoot, contradictoryChild, depthSkippingDescendant]) {
+			expect(() => assertAgentFamilyReach(root, malformed, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+			expect(() => assertAgentFamilyReach(malformed, root, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+		}
+		expect(() => assertAgentFamilyReach(otherRoot, contradictoryChild, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+
+		// Two malformed depth-two rows that claim the root are not pseudo-siblings,
+		// and neither leaks into a roster.
+		expect(() => assertAgentFamilyReach(malformedDeepSiblingA, malformedDeepSiblingB, catalog)).toThrow(
+			AGENT_FAMILY_REACH_ERROR,
+		);
+		expect(buildAgentFamilyRoster(malformedDeepSiblingA, catalog).entries).toEqual([]);
+		expect(buildAgentFamilyRoster(root, catalog).entries.map((entry) => entry.id)).toEqual(["child"]);
+
+		// A real depth-one parent in the supplied catalog restores legitimate
+		// depth-two siblings without weakening the malformed-edge exclusions above.
+		const deepParent = { id: "deep-parent", depth: 1, status: "running" as const, sessionPath: "/deep-parent" };
+		const deepSiblingA = {
+			id: "deep-sibling-a",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionId: "deep-parent",
+			parentSessionPath: "/deep-parent",
+		};
+		const deepSiblingB = {
+			id: "deep-sibling-b",
+			depth: 2,
+			status: "idle" as const,
+			parentSessionPath: "/deep-parent",
+		};
+		const deepCatalog = [deepParent, deepSiblingA, deepSiblingB];
+		expect(() => assertAgentFamilyReach(deepSiblingA, deepSiblingB)).toThrow(AGENT_FAMILY_REACH_ERROR);
+		expect(assertAgentFamilyReach(deepSiblingA, deepSiblingB, deepCatalog)).toBe("sibling");
+		expect(assertAgentFamilyReach(deepSiblingB, deepSiblingA, deepCatalog)).toBe("sibling");
+	});
+});

--- a/packages/coding-agent/test/agent-session-bus.test.ts
+++ b/packages/coding-agent/test/agent-session-bus.test.ts
@@ -14,6 +14,7 @@ import {
 	parseAgentSessionMessagePromptId,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
+import { invokeHostRequestHandlerForTest } from "../src/core/kernel/index.js";
 
 describe("agent session bus", () => {
 	it("formats routed messages with sender and target context", () => {
@@ -181,7 +182,7 @@ describe("agent session bus", () => {
 			sendAgentMessage,
 		});
 
-		await handlers["agent_message.send"]!({
+		await invokeHostRequestHandlerForTest(handlers["agent_message.send"]!, {
 			message: "hello",
 			receiver_role: "sibling",
 			receiver_name: "reviewer",
@@ -193,7 +194,9 @@ describe("agent session bus", () => {
 		});
 
 		sendAgentMessage.mockClear();
-		await expect(handlers["agent_message.send"]!({ target: "all", message: "status" })).resolves.toMatchObject({
+		await expect(
+			invokeHostRequestHandlerForTest(handlers["agent_message.send"]!, { target: "all", message: "status" }),
+		).resolves.toMatchObject({
 			receipts: [
 				{ id: "root", deliveryStatus: "delivered" },
 				{ id: "sibling", deliveryStatus: "delivered" },
@@ -204,7 +207,7 @@ describe("agent session bus", () => {
 
 		sendAgentMessage.mockClear();
 		await expect(
-			handlers["agent_message.send"]!({
+			invokeHostRequestHandlerForTest(handlers["agent_message.send"]!, {
 				target: "all",
 				message: "private",
 				receiver_role: "sibling",
@@ -224,9 +227,9 @@ describe("agent session bus", () => {
 			sendAgentMessage,
 		});
 
-		await expect(handlers["agent_message.send"]!({ target: "reviewer", message: "status" })).rejects.toThrow(
-			"use receiver_role and receiver_name",
-		);
+		await expect(
+			invokeHostRequestHandlerForTest(handlers["agent_message.send"]!, { target: "reviewer", message: "status" }),
+		).rejects.toThrow("use receiver_role and receiver_name");
 		expect(sendAgentMessage).not.toHaveBeenCalled();
 	});
 
@@ -253,7 +256,9 @@ describe("agent session bus", () => {
 			sendAgentMessage,
 		});
 
-		await expect(handlers["agent_message.send"]!({ target: "all", message: "status" })).resolves.toMatchObject({
+		await expect(
+			invokeHostRequestHandlerForTest(handlers["agent_message.send"]!, { target: "all", message: "status" }),
+		).resolves.toMatchObject({
 			receipts: [
 				{ id: "root", deliveryStatus: "delivered" },
 				{ target: "sibling", error: "rate limited" },

--- a/packages/coding-agent/test/agent-session-bus.test.ts
+++ b/packages/coding-agent/test/agent-session-bus.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	AGENT_FAMILY_REACH_ERROR,
 	AGENT_MESSAGE_SOURCE,
 	AgentSessionMessageRateLimiter,
 	assertAgentFamilyReach,
@@ -308,10 +309,11 @@ describe("agent session bus", () => {
 				{ id: "orphan-b", depth: 3, status: "inactive" },
 			),
 		).toThrow("Agent reach is limited to parent, siblings, and children");
-		expect(assertAgentFamilyReach(root, child)).toBe("child");
-		expect(assertAgentFamilyReach(child, root)).toBe("parent");
-		expect(assertAgentFamilyReach(child, sibling)).toBe("sibling");
-		expect(assertAgentFamilyReach(sibling, idOnlySibling)).toBe("sibling");
+		const catalog = [root, child, sibling, idOnlySibling, grandchild];
+		expect(assertAgentFamilyReach(root, child, catalog)).toBe("child");
+		expect(assertAgentFamilyReach(child, root, catalog)).toBe("parent");
+		expect(assertAgentFamilyReach(child, sibling, catalog)).toBe("sibling");
+		expect(assertAgentFamilyReach(sibling, idOnlySibling, catalog)).toBe("sibling");
 		expect(() => assertAgentFamilyReach(root, grandchild)).toThrow(
 			"Agent reach is limited to parent, siblings, and children",
 		);
@@ -398,6 +400,67 @@ describe("agent session bus", () => {
 			{ relationship: "parent", name: "orchestrator", id: "root", depth: 0, status: "running" },
 			{ relationship: "sibling", name: "builder", id: "path-child", depth: 1, status: "inactive" },
 		]);
+	});
+
+	it("reserves passive sibling names from direct canonical parent claims without broadening family reach", () => {
+		const catalog = [
+			{ id: "passive-id", name: "worker", depth: 1, status: "inactive" as const, parentSessionId: "parent" },
+			{
+				id: "passive-path",
+				name: "path-worker",
+				depth: 1,
+				status: "inactive" as const,
+				parentSessionPath: "/tmp/prime-agent-parent/../parent.jsonl",
+			},
+		];
+
+		expect(() =>
+			assertAgentSessionNameAvailable(catalog, { name: "worker", depth: 1, parentSessionId: "parent" }),
+		).toThrow("an agent of that name already exists at depth 1 under this parent");
+		expect(() =>
+			assertAgentSessionNameAvailable(catalog, {
+				name: "path-worker",
+				depth: 1,
+				parentSessionPath: "/tmp/parent.jsonl",
+			}),
+		).toThrow("an agent of that name already exists at depth 1 under this parent");
+		// Direct claims reserve names only. They cannot synthesize a relationship
+		// while the parent record is unavailable from the catalog.
+		expect(() => assertAgentFamilyReach(catalog[0]!, catalog[1]!, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+	});
+	it("resolves id-only and path-only catalog claims but rejects contradictory claims", () => {
+		const parent = { id: "parent", depth: 0, status: "running" as const, sessionPath: "/parent" };
+		const idOnly = {
+			id: "id-only",
+			name: "id-worker",
+			depth: 1,
+			status: "inactive" as const,
+			parentSessionId: "parent",
+		};
+		const pathOnly = {
+			id: "path-only",
+			name: "path-worker",
+			depth: 1,
+			status: "inactive" as const,
+			parentSessionPath: "/parent",
+		};
+		const contradictory = {
+			id: "contradictory",
+			depth: 1,
+			status: "inactive" as const,
+			parentSessionId: "parent",
+			parentSessionPath: "/other",
+		};
+		const catalog = [parent, idOnly, pathOnly, contradictory];
+		expect(assertAgentFamilyReach(parent, idOnly, catalog)).toBe("child");
+		expect(assertAgentFamilyReach(parent, pathOnly, catalog)).toBe("child");
+		expect(() => assertAgentFamilyReach(parent, contradictory, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+		expect(() =>
+			assertAgentSessionNameAvailable(catalog, { name: "id-worker", depth: 1, parentSessionId: "parent" }),
+		).toThrow("an agent of that name already exists at depth 1 under this parent");
+		expect(() =>
+			assertAgentSessionNameAvailable(catalog, { name: "path-worker", depth: 1, parentSessionPath: "/parent" }),
+		).toThrow("an agent of that name already exists at depth 1 under this parent");
 	});
 
 	it("builds a sorted nuclear-family roster with inactive members", () => {

--- a/packages/coding-agent/test/agent-session-bus.test.ts
+++ b/packages/coding-agent/test/agent-session-bus.test.ts
@@ -14,7 +14,7 @@ import {
 	parseAgentSessionMessagePromptId,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
-import { invokeHostRequestHandlerForTest } from "../src/core/kernel/index.js";
+import { invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest } from "./host-request-context.js";
 
 describe("agent session bus", () => {
 	it("formats routed messages with sender and target context", () => {

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -192,6 +192,203 @@ describe("AgentSession concurrent prompt guard", () => {
 		expect(disposed).toBe(true);
 	});
 
+	it("starts the refinement drain before awaiting a deferred kernel provisioner dispose", async () => {
+		createSession();
+		const order: string[] = [];
+		let releaseKernelDispose: () => void = () => {};
+		const kernelDisposeGate = new Promise<void>((resolve) => {
+			releaseKernelDispose = resolve;
+		});
+		const internals = session as unknown as {
+			_drainPendingRefinementForDisposal: () => Promise<void>;
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+		};
+		vi.spyOn(internals, "_drainPendingRefinementForDisposal").mockImplementation(async () => {
+			order.push("drain");
+		});
+		internals._ipythonKernelProvisioner = {
+			dispose: vi.fn(async () => {
+				order.push("kernel-dispose");
+				await kernelDisposeGate;
+			}),
+		};
+
+		const disposal = session.disposeAsync();
+		expect(order).toEqual(["drain", "kernel-dispose"]);
+		releaseKernelDispose();
+		await disposal;
+	});
+
+	it("observes a rejected refinement drain while kernel disposal is pending", async () => {
+		createSession();
+		const drainFailure = new Error("refinement drain failed");
+		const order: string[] = [];
+		let rejectDrain: (error: Error) => void = () => {};
+		const drainGate = new Promise<void>((_resolve, reject) => {
+			rejectDrain = reject;
+		});
+		let releaseKernelDispose: () => void = () => {};
+		const kernelDisposeGate = new Promise<void>((resolve) => {
+			releaseKernelDispose = resolve;
+		});
+		const internals = session as unknown as {
+			_drainPendingRefinementForDisposal: () => Promise<void>;
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+		};
+		vi.spyOn(internals, "_drainPendingRefinementForDisposal").mockImplementation(() => {
+			order.push("drain");
+			return drainGate;
+		});
+		internals._ipythonKernelProvisioner = {
+			dispose: vi.fn(async () => {
+				order.push("kernel-dispose");
+				await kernelDisposeGate;
+				order.push("kernel-dispose-finished");
+			}),
+		};
+		const unhandledRejections: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandledRejections.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			const disposal = session.disposeAsync();
+			expect(order).toEqual(["drain", "kernel-dispose"]);
+			rejectDrain(drainFailure);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(unhandledRejections).toEqual([]);
+
+			releaseKernelDispose();
+			await expect(disposal).rejects.toBe(drainFailure);
+			expect(order).toEqual(["drain", "kernel-dispose", "kernel-dispose-finished"]);
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
+	});
+
+	it("finalizes exactly once and shares a kernel disposal failure across callers", async () => {
+		createSession();
+		const kernelFailure = new Error("kernel disposal failed");
+		const kernelDispose = vi.fn(async () => {
+			throw kernelFailure;
+		});
+		let releaseCallback: () => void = () => {};
+		const callbackGate = new Promise<void>((resolve) => {
+			releaseCallback = resolve;
+		});
+		const callback = vi.fn(async () => callbackGate);
+		session.registerDisposeCallback(callback);
+		const internals = session as unknown as {
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+			_disposed: boolean;
+		};
+		internals._ipythonKernelProvisioner = { dispose: kernelDispose };
+
+		let settled = false;
+		const first = session.disposeAsync().finally(() => {
+			settled = true;
+		});
+		const second = session.disposeAsync();
+		await vi.waitFor(() => expect(callback).toHaveBeenCalledOnce());
+		expect(settled).toBe(false);
+		releaseCallback();
+		await expect(first).rejects.toBe(kernelFailure);
+		await expect(second).rejects.toBe(kernelFailure);
+		expect(kernelDispose).toHaveBeenCalledTimes(1);
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(internals._disposed).toBe(true);
+	});
+
+	it("shares a terminal teardown failure with callers arriving after disposed is set", async () => {
+		createSession();
+		const kernelFailure = new Error("kernel disposal failed");
+		const kernelDispose = vi.fn(async () => {
+			throw kernelFailure;
+		});
+		let releaseCallback: () => void = () => {};
+		const callbackGate = new Promise<void>((resolve) => {
+			releaseCallback = resolve;
+		});
+		let callbackStarted: () => void = () => {};
+		const callbackStartedGate = new Promise<void>((resolve) => {
+			callbackStarted = resolve;
+		});
+		const callback = vi.fn(async () => {
+			callbackStarted();
+			await callbackGate;
+		});
+		session.registerDisposeCallback(callback);
+		const internals = session as unknown as {
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+			_disposed: boolean;
+		};
+		internals._ipythonKernelProvisioner = { dispose: kernelDispose };
+
+		const first = session.disposeAsync();
+		await callbackStartedGate;
+		expect(internals._disposed).toBe(true);
+		expect(callback).toHaveBeenCalledOnce();
+		const late = session.disposeAsync();
+		let lateSettled = false;
+		void late
+			.finally(() => {
+				lateSettled = true;
+			})
+			.catch(() => undefined);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(lateSettled).toBe(false);
+		releaseCallback();
+		await expect(first).rejects.toBe(kernelFailure);
+		await expect(late).rejects.toBe(kernelFailure);
+		expect(kernelDispose).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledOnce();
+	});
+
+	it("blocks runtime reload from replacing the authoritative kernel during async disposal", async () => {
+		createSession();
+		let releaseKernel: () => void = () => {};
+		const kernelGate = new Promise<void>((resolve) => {
+			releaseKernel = resolve;
+		});
+		const kernelDispose = vi.fn(async () => kernelGate);
+		const internals = session as unknown as {
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+		};
+		internals._ipythonKernelProvisioner = { dispose: kernelDispose };
+
+		const disposal = session.disposeAsync();
+		await expect(session.reload()).rejects.toThrow("Cannot reload a session during disposal.");
+		releaseKernel();
+		await disposal;
+		expect(kernelDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("runs finalizers and aggregates concurrent drain and kernel disposal failures", async () => {
+		createSession();
+		const kernelFailure = new Error("kernel disposal failed");
+		const drainFailure = new Error("refinement drain failed");
+		const callback = vi.fn();
+		session.registerDisposeCallback(callback);
+		const internals = session as unknown as {
+			_drainPendingRefinementForDisposal: () => Promise<void>;
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+			_disposed: boolean;
+		};
+		vi.spyOn(internals, "_drainPendingRefinementForDisposal").mockRejectedValue(drainFailure);
+		internals._ipythonKernelProvisioner = {
+			dispose: vi.fn(async () => {
+				throw kernelFailure;
+			}),
+		};
+
+		const failure = await session.disposeAsync().catch((error: unknown) => error);
+		expect(failure).toBeInstanceOf(AggregateError);
+		expect((failure as AggregateError).errors).toEqual([kernelFailure, drainFailure]);
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(internals._disposed).toBe(true);
+	});
+
 	it("should throw when prompt() called while streaming", async () => {
 		createSession();
 

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -151,6 +151,24 @@ describe("AgentSession concurrent prompt guard", () => {
 		expect(disposed).toBe(true);
 	});
 
+	it("retries disposeAsync after a one-shot teardown failure", async () => {
+		createSession();
+		const internals = session as unknown as {
+			_disposeAsyncOnce: () => Promise<void>;
+		};
+		const disposeOnce = vi
+			.spyOn(internals, "_disposeAsyncOnce")
+			.mockRejectedValueOnce(new Error("one-shot dispose failure"))
+			.mockImplementationOnce(async () => session.dispose());
+
+		const first = session.disposeAsync();
+		const concurrent = session.disposeAsync();
+		await expect(first).rejects.toThrow("one-shot dispose failure");
+		await expect(concurrent).rejects.toThrow("one-shot dispose failure");
+		await expect(session.disposeAsync()).resolves.toBeUndefined();
+		expect(disposeOnce).toHaveBeenCalledTimes(2);
+	});
+
 	it("awaits dispose callbacks when synchronous disposal wins during the refinement drain", async () => {
 		createSession();
 		let releaseDrain: () => void = () => {};

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -143,6 +143,9 @@ interface InspectableRlmSession {
 	_rlmChildSessions: Map<string, AgentSession>;
 	_rlmChildUnsubscribes: Map<string, () => void>;
 	_createKernelHostHandlers(): HostRequestHandlers;
+	_deleteResolvedRlmSubagent(
+		subagent: Awaited<ReturnType<AgentSession["listRlmSubagents"]>>["subagents"][number],
+	): Promise<unknown>;
 	_reapDeletedRlmSubagentRuntimesAfterCompaction(): Promise<void>;
 }
 
@@ -2479,6 +2482,50 @@ describe("AgentSession rlm recursion", () => {
 
 		await expect(Promise.all([first, second])).resolves.toEqual(["running", "running"]);
 		expect(deleteRuntime).not.toHaveBeenCalled();
+	});
+
+	it("keeps a newer retained child tracked when stale inline cleanup settles", async () => {
+		const childId = "recycled-retained-child";
+		const staleDir = join(tempDir, "stale-retained");
+		const stale = { _rlmSessionDir: staleDir, sessionId: "stale", dispose: vi.fn() } as unknown as AgentSession;
+		const newer = {
+			_rlmSessionDir: join(tempDir, "new-retained"),
+			sessionId: "new",
+			dispose: vi.fn(),
+		} as unknown as AgentSession;
+		let root!: AgentSession;
+		const deleteRuntime = vi.fn(async () => {
+			(root as unknown as InspectableRlmSession)._rlmChildSessions.set(childId, newer);
+			return { deletionDurability: "stale" as const };
+		});
+		root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		const inspectable = root as unknown as InspectableRlmSession;
+		const childUpdates: string[] = [];
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update") childUpdates.push(event.child.status);
+		});
+		inspectable._rlmChildSessions.set(childId, stale);
+		const subagent = {
+			rlm_child_id: childId,
+			active_session_id: null,
+			session_id: "stale",
+			session_name: "stale-retained",
+			session_dir: staleDir,
+			status: "completed" as const,
+		};
+
+		await expect(inspectable._deleteResolvedRlmSubagent(subagent)).resolves.toEqual({ subagent });
+		expect(deleteRuntime).toHaveBeenCalledWith(childId, stale);
+		expect(inspectable._rlmChildSessions.get(childId)).toBe(newer);
+		expect(inspectable._deletedRlmChildIds.has(childId)).toBe(false);
+		expect(childUpdates).toEqual([]);
 	});
 
 	it("deletes only inactive RLM children through the explicit inactive path", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2699,24 +2699,45 @@ describe("AgentSession rlm recursion", () => {
 	it("keeps failed closure retryable without hanging or late resurrection", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "retry-child") });
 		child.setSessionName("release-worker");
-		let attempts = 0;
+		const childId = "retry-child";
+		const suppliedSessions: Array<AgentSession | undefined> = [];
+		const authorities: Array<{ sessionFile?: string; sessionId?: string }> = [];
+		let tombstones = 0;
+		let schedulerAttempts = 0;
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
-				deleteRlmSubagentRuntime: async (_id, session) => {
-					if (++attempts === 1) throw new RlmSubagentHostDeletionError("tombstoned", new Error("close failed"));
-					await session?.disposeAsync();
+				deleteRlmSubagentRuntime: async (_id, suppliedSession, authority) => {
+					suppliedSessions.push(suppliedSession);
+					authorities.push({ sessionFile: authority?.sessionFile, sessionId: authority?.sessionId });
+					if (tombstones === 0) tombstones++;
+					if (++schedulerAttempts === 1) {
+						throw new RlmSubagentHostDeletionError("tombstoned", new Error("close failed"));
+					}
+					await suppliedSession?.disposeAsync();
+					return { deletionDurability: "tombstoned" };
 				},
 			},
 		});
-		expect(root.registerRlmChildSession("retry-child", child)).toBe(true);
+		expect(root.registerRlmChildSession(childId, child)).toBe(true);
 		await expect(root.deleteRlmSubagent("release-worker")).rejects.toThrow("close failed");
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
-		expect((root as unknown as InspectableRlmSession)._rlmChildCleanupFailures.size).toBe(1);
+		const internals = root as unknown as InspectableRlmSession;
+		expect(internals._rlmChildCleanupFailures.size).toBe(1);
+		expect(internals._rlmChildSessions.get(childId)).toBe(child);
+
 		await expect(root.deleteRlmSubagent("release-worker")).resolves.toMatchObject({
-			subagent: { rlm_child_id: "retry-child" },
+			subagent: { rlm_child_id: childId },
 		});
-		expect((root as unknown as InspectableRlmSession)._rlmChildCleanupFailures.size).toBe(0);
+		expect(suppliedSessions).toEqual([child, child]);
+		expect(authorities).toEqual([
+			{ sessionFile: child.sessionFile, sessionId: child.sessionId },
+			{ sessionFile: child.sessionFile, sessionId: child.sessionId },
+		]);
+		expect(tombstones).toBe(1);
+		expect(schedulerAttempts).toBe(2);
+		expect(internals._rlmChildSessions.has(childId)).toBe(false);
+		expect(internals._rlmChildCleanupFailures.size).toBe(0);
 	});
 
 	it("does not restore failed delete retry state after parent teardown", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3059,6 +3059,47 @@ describe("AgentSession rlm recursion", () => {
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
+	it("preserves a replacement active child when delayed startup deletion settles stale", async () => {
+		let releaseRuntimeCreation: () => void = () => {};
+		const runtimeCreationGate = new Promise<void>((resolve) => {
+			releaseRuntimeCreation = resolve;
+		});
+		let runtimeCreationStarted = false;
+		const stale = createSession({ rlmSessionDir: join(tempDir, "stale-startup") });
+		const newer = createSession({ rlmSessionDir: join(tempDir, "new-startup") });
+		let root!: AgentSession;
+		const deleteRuntime = vi.fn(async (childId: string) => {
+			const internals = root as unknown as InspectableRlmSession;
+			const original = internals._activeRlmChildRuns.get(childId);
+			if (!original) throw new Error("Missing delayed startup run");
+			internals._activeRlmChildRuns.set(childId, { ...original, session: newer });
+			return { deletionDurability: "stale" as const };
+		});
+		root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					runtimeCreationStarted = true;
+					await runtimeCreationGate;
+					return { session: stale };
+				},
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		await root.runRlmChild("delayed stale cleanup", { name: "delayed-stale-worker" });
+		await waitFor(() => runtimeCreationStarted);
+		const childId = [...(root as unknown as InspectableRlmSession)._activeRlmChildRuns.keys()][0];
+		if (!childId) throw new Error("Missing queued child");
+		await root.deleteRlmSubagent(childId);
+		releaseRuntimeCreation();
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.get(childId)?.session === newer);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(false);
+		expect(internals._activeRlmChildRuns.get(childId)?.session).toBe(newer);
+		await stale.disposeAsync();
+		await newer.disposeAsync();
+	});
+
 	it("keeps late startup cleanup retryable when release and fallback delete fail", async () => {
 		let releaseRuntimeCreation: () => void = () => {};
 		const runtimeCreationGate = new Promise<void>((resolve) => {
@@ -3512,6 +3553,46 @@ describe("AgentSession rlm recursion", () => {
 		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(internals._rlmChildSessions).toHaveLength(0);
+	});
+
+	it("preserves a replacement retained child when quarantined deletion settles stale", async () => {
+		const childId = "recycled-quarantine-child";
+		const staleDir = join(tempDir, "stale-quarantine");
+		const stale = { _rlmSessionDir: staleDir, sessionId: "stale" } as unknown as AgentSession;
+		const newer = { _rlmSessionDir: join(tempDir, "new-quarantine"), sessionId: "new" } as unknown as AgentSession;
+		let root!: AgentSession;
+		const rootEntry = {
+			rlm_child_id: childId,
+			active_session_id: null,
+			session_id: "stale",
+			status: "error" as const,
+			session_name: "stale-quarantine",
+			session_dir: staleDir,
+		};
+		const deleteRuntime = vi.fn(async () => {
+			(root as unknown as InspectableRlmSession)._rlmChildSessions.set(childId, newer);
+			return { deletionDurability: "stale" as const };
+		});
+		root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+				resolveRlmSubagentDeletion: async () => "tombstoned",
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		const internals = root as unknown as InspectableRlmSession;
+		internals._rlmChildDeletionQuarantines.set(childId, rootEntry);
+		internals._rlmChildSessions.set(childId, stale);
+
+		await expect(root.deleteRlmSubagent(childId)).rejects.toThrow(
+			"RLM subagent deletion durability is still unknown",
+		);
+		expect(deleteRuntime).toHaveBeenCalledWith(childId, stale, expect.any(Object));
+		expect(internals._rlmChildSessions.get(childId)).toBe(newer);
+		expect(internals._rlmChildDeletionQuarantines.get(childId)).toBe(rootEntry);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(false);
 	});
 
 	it("rejects a quarantine retry revoked after host durability resolves without mutating", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -138,6 +138,7 @@ interface InspectableRlmSession {
 		string,
 		Awaited<ReturnType<AgentSession["listRlmSubagents"]>>["subagents"][number]
 	>;
+	_deletedRlmChildIds: Set<string>;
 	_rlmChildSessions: Map<string, AgentSession>;
 	_rlmChildUnsubscribes: Map<string, () => void>;
 	_createKernelHostHandlers(): HostRequestHandlers;
@@ -3123,16 +3124,76 @@ describe("AgentSession rlm recursion", () => {
 		await expect(root.deleteRlmSubagent("revoked during late publication")).rejects.toThrow(
 			'No direct RLM subagent matches "revoked during late publication"',
 		);
-		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
-			subagent: { rlm_child_id: quarantinedChildId },
-		});
+		await expect(root.deleteRlmSubagent(quarantinedChildId)).rejects.toThrow(
+			"RLM subagent deletion durability is still unknown",
+		);
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
+		expect(internals._deletedRlmChildIds.has(quarantinedChildId)).toBe(false);
 		retryDurability = "absent";
 		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
 			subagent: { rlm_child_id: quarantinedChildId },
 		});
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
+	});
+
+	it("rejects a quarantine retry revoked after host durability resolves without mutating", async () => {
+		const admissionController = new AbortController();
+		const child = createSession();
+		let resolveStarted: () => void = () => {};
+		const resolutionStarted = new Promise<void>((resolve) => {
+			resolveStarted = resolve;
+		});
+		let releaseResolution: () => void = () => {};
+		const resolutionGate = new Promise<void>((resolve) => {
+			releaseResolution = resolve;
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async (options) => {
+					admissionController.abort();
+					options.onSessionPublished?.(child);
+					return { session: child };
+				},
+				releaseRlmSubagentRuntime: async (runtime) => {
+					await runtime.session.disposeAsync();
+					return { deletionDurability: "unknown" };
+				},
+				resolveRlmSubagentDeletion: async () => {
+					resolveStarted();
+					await resolutionGate;
+					return "absent";
+				},
+				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+			},
+		});
+
+		await expect(
+			root.runRlmChild("late-revoked quarantine retry", {}, undefined, { signal: admissionController.signal }),
+		).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._rlmChildDeletionQuarantines.size === 1);
+		const childId = [...internals._rlmChildDeletionQuarantines.keys()][0];
+		if (!childId) throw new Error("Missing deletion quarantine");
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		const retryController = new AbortController();
+		const retry = root.deleteRlmSubagent(childId, retryController.signal);
+		await resolutionStarted;
+		retryController.abort();
+		releaseResolution();
+
+		await expect(retry).rejects.toThrow("host request authority was revoked");
+		expect(internals._rlmChildDeletionQuarantines.has(childId)).toBe(true);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(false);
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length).toBe(1);
+
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: childId },
+		});
+		expect(internals._rlmChildDeletionQuarantines.has(childId)).toBe(false);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(true);
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length).toBe(0);
 	});
 
 	it("retains a host-owned runtime dir when revoked-spawn release is tombstoned", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -259,6 +259,7 @@ describe("AgentSession rlm recursion", () => {
 	});
 
 	afterEach(() => {
+		vi.unstubAllEnvs();
 		session?.dispose();
 		session = undefined;
 		rmSync(tempDir, { recursive: true, force: true });
@@ -3619,6 +3620,7 @@ describe("AgentSession RLM session dir", () => {
 	});
 
 	afterEach(() => {
+		vi.unstubAllEnvs();
 		session?.dispose();
 		session = undefined;
 		rmSync(tempDir, { recursive: true, force: true });

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2484,6 +2484,59 @@ describe("AgentSession rlm recursion", () => {
 		expect(deleteRuntime).not.toHaveBeenCalled();
 	});
 
+	it("keeps a newer active child tracked when stale inline cleanup settles", async () => {
+		const childId = "recycled-active-child";
+		const staleDir = join(tempDir, "stale-active");
+		const stale = { _rlmSessionDir: staleDir, sessionId: "stale" } as unknown as AgentSession;
+		const newer = { _rlmSessionDir: join(tempDir, "new-active"), sessionId: "new" } as unknown as AgentSession;
+		const run = {
+			id: childId,
+			sessionDir: staleDir,
+			abort: vi.fn(),
+			status: "running",
+			settled: false,
+			session: stale,
+		};
+		let root!: AgentSession;
+		const deleteRuntime = vi.fn(async () => {
+			(root as unknown as InspectableRlmSession)._activeRlmChildRuns.set(childId, {
+				...run,
+				session: newer,
+			});
+			return { deletionDurability: "stale" as const };
+		});
+		root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		const inspectable = root as unknown as InspectableRlmSession;
+		const childUpdates: string[] = [];
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update") childUpdates.push(event.child.status);
+		});
+		inspectable._activeRlmChildRuns.set(childId, run);
+		const subagent = {
+			rlm_child_id: childId,
+			active_session_id: "stale",
+			session_id: "stale",
+			session_name: "stale-active",
+			session_dir: staleDir,
+			status: "running" as const,
+		};
+
+		await expect(inspectable._deleteResolvedRlmSubagent(subagent)).resolves.toEqual({ subagent });
+		expect(deleteRuntime).toHaveBeenCalledWith(childId, stale);
+		expect(inspectable._activeRlmChildRuns.get(childId)?.session).toBe(newer);
+		expect(inspectable._deletedRlmChildIds.has(childId)).toBe(false);
+		expect(run.abort).not.toHaveBeenCalled();
+		expect(childUpdates).toEqual([]);
+		inspectable._activeRlmChildRuns.delete(childId);
+	});
+
 	it("keeps a newer retained child tracked when stale inline cleanup settles", async () => {
 		const childId = "recycled-retained-child";
 		const staleDir = join(tempDir, "stale-retained");

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3068,11 +3068,13 @@ describe("AgentSession rlm recursion", () => {
 		const stale = createSession({ rlmSessionDir: join(tempDir, "stale-startup") });
 		const newer = createSession({ rlmSessionDir: join(tempDir, "new-startup") });
 		let root!: AgentSession;
-		const deleteRuntime = vi.fn(async (childId: string) => {
-			const internals = root as unknown as InspectableRlmSession;
-			const original = internals._activeRlmChildRuns.get(childId);
+		const deleteRuntime = vi.fn(async (childId: string, session?: AgentSession) => {
+			if (session !== stale) return { deletionDurability: "absent" as const };
+			const original = (root as unknown as InspectableRlmSession)._activeRlmChildRuns.get(childId);
 			if (!original) throw new Error("Missing delayed startup run");
-			internals._activeRlmChildRuns.set(childId, { ...original, session: newer });
+			// Same run, newer active session: finalization must not clear this replacement.
+			original.session = newer;
+			original.status = "running";
 			return { deletionDurability: "stale" as const };
 		});
 		root = createSession({
@@ -3096,8 +3098,58 @@ describe("AgentSession rlm recursion", () => {
 		await waitFor(() => internals._activeRlmChildRuns.get(childId)?.session === newer);
 		expect(internals._deletedRlmChildIds.has(childId)).toBe(false);
 		expect(internals._activeRlmChildRuns.get(childId)?.session).toBe(newer);
+		await expect(root.listRlmSubagents()).resolves.toEqual({
+			subagents: [expect.objectContaining({ rlm_child_id: childId, session_id: newer.sessionId })],
+		});
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({ subagent: { rlm_child_id: childId } });
+		expect(deleteRuntime).toHaveBeenLastCalledWith(childId, newer, expect.any(Object));
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 		await stale.disposeAsync();
 		await newer.disposeAsync();
+	});
+
+	it("discharges a quarantined old lease when a queued replacement reuses its id", async () => {
+		const childId = "queued-quarantine-replacement";
+		const staleDir = join(tempDir, "queued-stale-quarantine");
+		const lease = {
+			rlm_child_id: childId,
+			active_session_id: null,
+			session_id: "stale",
+			status: "error" as const,
+			session_name: "stale-quarantine",
+			session_dir: staleDir,
+		};
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+				resolveRlmSubagentDeletion: async () => "tombstoned",
+				deleteRlmSubagentRuntime: async () => {
+					throw new Error("queued replacement has no old retained session to delete");
+				},
+			},
+		});
+		const internals = root as unknown as InspectableRlmSession;
+		internals._rlmChildDeletionQuarantines.set(childId, lease);
+		internals._deletedRlmChildIds.add(childId);
+		internals._activeRlmChildRuns.set(childId, {
+			id: childId,
+			sessionDir: join(tempDir, "queued-new-quarantine"),
+			status: "queued",
+			settled: false,
+			abort: () => {},
+			publication: { promise: Promise.resolve(), resolve: () => {}, reject: () => {} },
+		} as unknown as InspectableRlmRun);
+
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({ outcome: "preserved_newer" });
+		expect(internals._rlmChildDeletionQuarantines.has(childId)).toBe(false);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(false);
+		await expect(root.listRlmSubagents()).resolves.toEqual({
+			subagents: [
+				expect.objectContaining({ rlm_child_id: childId, session_dir: join(tempDir, "queued-new-quarantine") }),
+			],
+		});
 	});
 
 	it("keeps late startup cleanup retryable when release and fallback delete fail", async () => {
@@ -3555,7 +3607,7 @@ describe("AgentSession rlm recursion", () => {
 		expect(internals._rlmChildSessions).toHaveLength(0);
 	});
 
-	it("preserves a replacement retained child when quarantined deletion settles stale", async () => {
+	it("discharges only a stale quarantine lease when its child id is replaced", async () => {
 		const childId = "recycled-quarantine-child";
 		const staleDir = join(tempDir, "stale-quarantine");
 		const stale = { _rlmSessionDir: staleDir, sessionId: "stale" } as unknown as AgentSession;
@@ -3569,9 +3621,12 @@ describe("AgentSession rlm recursion", () => {
 			session_name: "stale-quarantine",
 			session_dir: staleDir,
 		};
-		const deleteRuntime = vi.fn(async () => {
-			(root as unknown as InspectableRlmSession)._rlmChildSessions.set(childId, newer);
-			return { deletionDurability: "stale" as const };
+		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
+			if (session === stale) {
+				(root as unknown as InspectableRlmSession)._rlmChildSessions.set(childId, newer);
+				return { deletionDurability: "stale" as const };
+			}
+			return { deletionDurability: "absent" as const };
 		});
 		root = createSession({
 			subagentRuntimeHost: {
@@ -3586,13 +3641,27 @@ describe("AgentSession rlm recursion", () => {
 		internals._rlmChildDeletionQuarantines.set(childId, rootEntry);
 		internals._rlmChildSessions.set(childId, stale);
 
-		await expect(root.deleteRlmSubagent(childId)).rejects.toThrow(
-			"RLM subagent deletion durability is still unknown",
-		);
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({ outcome: "preserved_newer" });
 		expect(deleteRuntime).toHaveBeenCalledWith(childId, stale, expect.any(Object));
 		expect(internals._rlmChildSessions.get(childId)).toBe(newer);
-		expect(internals._rlmChildDeletionQuarantines.get(childId)).toBe(rootEntry);
+		expect(internals._rlmChildDeletionQuarantines.has(childId)).toBe(false);
 		expect(internals._deletedRlmChildIds.has(childId)).toBe(false);
+		await expect(root.listRlmSubagents()).resolves.toEqual({
+			subagents: [
+				expect.objectContaining({
+					rlm_child_id: childId,
+					session_id: "new",
+					session_dir: join(tempDir, "new-quarantine"),
+				}),
+			],
+		});
+
+		await expect(root.deleteRlmSubagent(childId)).resolves.toEqual({
+			subagent: expect.objectContaining({ rlm_child_id: childId, session_id: "new" }),
+		});
+		expect(deleteRuntime).toHaveBeenLastCalledWith(childId, newer, expect.any(Object));
+		expect(internals._rlmChildSessions.has(childId)).toBe(false);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(true);
 	});
 
 	it("rejects a quarantine retry revoked after host durability resolves without mutating", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3177,6 +3177,8 @@ print(_result.name)
 
 		try {
 			const kernel = manager as unknown as KernelCommTestApi;
+			const sendCommMessage = vi.fn(async () => {});
+			kernel.sendCommMessage = sendCommMessage;
 
 			kernel.handleCommMessage(rlmCommOpen("comm-dispose", "slow child"));
 
@@ -3196,7 +3198,8 @@ print(_result.name)
 
 			const kernelStderr = (manager as unknown as { kernelStderr: string }).kernelStderr;
 			expect(kernelStderr).toContain("[kernel] host request failed for comm comm-dispose");
-			expect(kernelStderr).toContain("[kernel] failed to send host request error reply for comm comm-dispose");
+			expect(sendCommMessage).not.toHaveBeenCalled();
+			expect(kernelStderr).not.toContain("[kernel] failed to send host request error reply for comm comm-dispose");
 			expect(stderrSpy).not.toHaveBeenCalled();
 		} finally {
 			releaseChild();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3565,7 +3565,7 @@ describe("AgentSession rlm recursion", () => {
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		let releaseAttempts = 0;
-		const deleteRuntime = vi.fn(async (childId: string, session?: AgentSession, authority) => {
+		const deleteRuntime = vi.fn(async (childId: string, session: AgentSession | undefined, authority) => {
 			expect(authority).toMatchObject({
 				childId,
 				sessionFile: child.sessionFile,

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3036,6 +3036,59 @@ describe("AgentSession rlm recursion", () => {
 		}
 	});
 
+	it("does not delete a subagent after rlm.delete_subagent authority is revoked", async () => {
+		const childId = "revoked-delete-child";
+		const childDir = join(tempDir, childId);
+		mkdirSync(childDir, { recursive: true });
+		const child = createSession({ rlmSessionDir: childDir });
+		child.setSessionName("revoked-delete-worker");
+		const disposeChild = vi.spyOn(child, "disposeAsync");
+		let listingStarted: () => void = () => {};
+		const listingStartedGate = new Promise<void>((resolve) => {
+			listingStarted = resolve;
+		});
+		let releaseListing: () => void = () => {};
+		const listingGate = new Promise<void>((resolve) => {
+			releaseListing = resolve;
+		});
+		const root = createSession({
+			agentMessageController: {
+				listAgents: async () => {
+					listingStarted();
+					await listingGate;
+					return { agents: [] };
+				},
+				sendAgentMessage: vi.fn(),
+			},
+		});
+		expect(root.registerRlmChildSession(childId, child)).toBe(true);
+
+		const replies: CapturedCommReply[] = [];
+		const manager = new KernelManager({
+			python: process.execPath,
+			hostHandlers: (root as unknown as InspectableRlmSession)._createKernelHostHandlers(),
+		});
+		try {
+			const kernel = manager as unknown as KernelCommTestApi;
+			kernel.sendCommMessage = async (commId, data) => {
+				replies.push({ commId, data });
+			};
+			kernel.handleCommMessage(
+				rlmCommOpenData("comm-delete-revoked", { type: "rlm.delete_subagent", target: "revoked-delete-worker" }),
+			);
+			await listingStartedGate;
+			kernel.handleCommMessage(rlmCommClose("comm-delete-revoked"));
+			releaseListing();
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(disposeChild).not.toHaveBeenCalled();
+			expect((await root.listRlmSubagents()).subagents).toMatchObject([{ rlm_child_id: childId }]);
+			expect(replies).toEqual([]);
+		} finally {
+			releaseListing();
+			await manager.dispose();
+		}
+	});
+
 	it("runs parallel rlm comm requests independently", async () => {
 		let active = 0;
 		let maxActive = 0;

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3088,6 +3088,39 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toEqual([]);
 	});
 
+	it("does not return a spawn handle for a child cancelled between publication and admission", async () => {
+		const controller = new AbortController();
+		const child = createSession();
+		let root: AgentSession | undefined;
+		const runtimeHost: SubagentRuntimeHost = {
+			createRlmSubagentRuntime: async (options) => {
+				options.onSessionPublished?.(child);
+				// Cancel synchronously after publication resolves but before the awaiting
+				// admission continuation can run its checks.
+				const internals = root as unknown as InspectableRlmSession & {
+					_cancelRlmChildRun(run: InspectableRlmRun, reason: string): boolean;
+				};
+				const run = [...internals._activeRlmChildRuns.values()][0];
+				if (!run) throw new Error("Missing registered run");
+				internals._cancelRlmChildRun(run, "cancelled between publication and admission");
+				return { session: child };
+			},
+			deleteRlmSubagentRuntime: async (_childId, session) => {
+				await session?.disposeAsync();
+			},
+		};
+		root = createSession({ subagentRuntimeHost: runtimeHost });
+
+		const admission = root.runRlmChild("cancel during admission", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("cancelled between publication and admission");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
 	it("does not delete a subagent after rlm.delete_subagent authority is revoked", async () => {
 		const childId = "revoked-delete-child";
 		const childDir = join(tempDir, childId);

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1106,7 +1106,7 @@ describe("AgentSession rlm recursion", () => {
 		(child as unknown as { _repliedToParentSinceTask: boolean })._repliedToParentSinceTask = true;
 
 		const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
-			defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
+			defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: join(tempDir, "saved-sessions") },
 			createRuntime: vi.fn(),
 		});
 		const parentState = {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -630,6 +630,7 @@ describe("AgentSession rlm recursion", () => {
 				throw new RlmSubagentHostDeletionError("tombstoned", new Error("retained close failed"));
 			}
 			await session.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		settingsManager.applyOverrides({ compaction: { keepRecentTokens: 1 } });
@@ -657,7 +658,11 @@ describe("AgentSession rlm recursion", () => {
 		root.sessionManager.appendMessage(assistantMessage("history response"));
 		expect(root.registerRlmChildSession(childId, child)).toBe(true);
 
-		await expect(root.deleteRlmSubagent("retained-retry-worker")).rejects.toThrow("retained close failed");
+		await expect(root.deleteRlmSubagent("retained-retry-worker")).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "tombstoned",
+			cause: expect.objectContaining({ message: "retained close failed" }),
+		});
 		const internals = root as unknown as InspectableRlmSession;
 		expect(internals._rlmChildCleanupFailures.size).toBe(1);
 
@@ -677,7 +682,7 @@ describe("AgentSession rlm recursion", () => {
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -817,7 +822,10 @@ describe("AgentSession rlm recursion", () => {
 					options.onSessionPublished?.(child);
 					return { session: child };
 				},
-				deleteRlmSubagentRuntime: async (_id, child) => child?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, child) => {
+					await child?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		const spawned = await root.runRlmChild("pending task", { name: "pending-child" });
@@ -874,7 +882,10 @@ describe("AgentSession rlm recursion", () => {
 			},
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
-				deleteRlmSubagentRuntime: async (_id, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		const promptInjectedMessage = vi.fn(async () => terminalInjectionGate);
@@ -920,7 +931,7 @@ describe("AgentSession rlm recursion", () => {
 			},
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: () => startupGate,
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 		const spawned = await root.runRlmChild("pending task", { name: "failing-child" });
@@ -971,7 +982,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => {
 					throw new Error("child startup failed");
 				},
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 		const promptInjectedMessage = vi.fn(async () => failureInjectionGate);
@@ -1024,7 +1035,10 @@ describe("AgentSession rlm recursion", () => {
 					await runtimeCreationGate;
 					return { session: hostedChild };
 				},
-				deleteRlmSubagentRuntime: async (_id, child) => child?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, child) => {
+					await child?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		await root.runRlmChild("blocked startup", { name: "deleted-child" });
@@ -1200,7 +1214,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => {
 					throw new Error("kernel startup failed");
 				},
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -1316,7 +1330,7 @@ describe("AgentSession rlm recursion", () => {
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -1347,7 +1361,10 @@ describe("AgentSession rlm recursion", () => {
 					await runtimeCreationGate;
 					return { session: child };
 				},
-				deleteRlmSubagentRuntime: async (_id, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 
@@ -1369,7 +1386,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => {
 					throw new Error("kernel startup failed");
 				},
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 		const spawned = await root.runRlmChild("start failing child", { name: "reusable-worker" });
@@ -1395,7 +1412,7 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				releaseRlmSubagentRuntime,
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -1405,6 +1422,7 @@ describe("AgentSession rlm recursion", () => {
 				expect.objectContaining({ session: child }),
 				expect.objectContaining({ id: spawned.rlm_child_id }),
 				"error",
+				expect.objectContaining({ childId: spawned.rlm_child_id }),
 			);
 		});
 	});
@@ -1416,7 +1434,10 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				completeRlmSubagentRuntime,
-				deleteRlmSubagentRuntime: async (_id, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 
@@ -1521,6 +1542,7 @@ describe("AgentSession rlm recursion", () => {
 					rlm_child_id: daemonChildId,
 					active_session_id: "child-active",
 					session_id: "child-session",
+					session_file: root.getRlmChildSession(daemonChildId)?.sessionFile,
 					session_name: expectedSessionName,
 					session_dir: result.session_dir,
 					status: "completed",
@@ -1564,7 +1586,7 @@ describe("AgentSession rlm recursion", () => {
 	});
 
 	it("lists passive daemon children using their nonresident registry outcomes", async () => {
-		const deleteRlmSubagentRuntime = vi.fn(async () => {});
+		const deleteRlmSubagentRuntime = vi.fn(async () => ({ deletionDurability: "absent" as const }));
 		const root = createSession({
 			agentMessageController: {
 				listAgents: () => ({
@@ -1633,7 +1655,7 @@ describe("AgentSession rlm recursion", () => {
 		const listingGate = new Promise<void>((resolve) => {
 			releaseListing = resolve;
 		});
-		const deleteRlmSubagentRuntime = vi.fn(async () => {});
+		const deleteRlmSubagentRuntime = vi.fn(async () => ({ deletionDurability: "absent" as const }));
 		const root = createSession({
 			agentMessageController: {
 				listAgents: async () => {
@@ -1779,6 +1801,7 @@ describe("AgentSession rlm recursion", () => {
 					rlm_child_id: rootRun.id,
 					active_session_id: "running-active",
 					session_id: rootRun.session.sessionId,
+					session_file: rootRun.session.sessionFile,
 					session_name: createDefaultRlmSubagentSessionName("slow shard", rootRun.id),
 					session_dir: rootRun.sessionDir,
 					status: "running",
@@ -2308,6 +2331,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				deleteRlmSubagentRuntime: async () => {
 					await child.disposeAsync();
+					return { deletionDurability: "absent" as const };
 				},
 			},
 		});
@@ -2418,7 +2442,7 @@ describe("AgentSession rlm recursion", () => {
 	it("reports a shared running outcome to concurrent inactive-delete callers", async () => {
 		let runningChecks = 0;
 		const isExternallyRunning = () => ++runningChecks >= 5;
-		const deleteRuntime = vi.fn(async () => {});
+		const deleteRuntime = vi.fn(async () => ({ deletionDurability: "absent" as const }));
 		const root = createSession({
 			agentMessageController: {
 				listAgents: () => ({
@@ -2474,7 +2498,7 @@ describe("AgentSession rlm recursion", () => {
 				return stream;
 			},
 		});
-		const deleteRuntime = vi.fn(async () => {});
+		const deleteRuntime = vi.fn(async () => ({ deletionDurability: "absent" as const }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: retainedChild }),
@@ -2515,7 +2539,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				completeRlmSubagentRuntime: () => false,
 				releaseRlmSubagentRuntime,
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -2525,6 +2549,7 @@ describe("AgentSession rlm recursion", () => {
 				expect.objectContaining({ session: child }),
 				expect.objectContaining({ id: spawned.rlm_child_id }),
 				"error",
+				expect.objectContaining({ childId: spawned.rlm_child_id }),
 			);
 		});
 		expect(disposeChild).not.toHaveBeenCalled();
@@ -2561,6 +2586,7 @@ describe("AgentSession rlm recursion", () => {
 			await deleteGate;
 			authority.assertCurrent();
 			await childSession?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const releaseRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
 		const root = createSession({
@@ -2613,6 +2639,7 @@ describe("AgentSession rlm recursion", () => {
 			await deleteGate;
 			authority.assertCurrent();
 			await childSession?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const releaseRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
 		const root = createSession({
@@ -2676,13 +2703,18 @@ describe("AgentSession rlm recursion", () => {
 					if (++deleteAttempts === 1)
 						throw new RlmSubagentHostDeletionError("tombstoned", new Error("first close failed"));
 					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
 				},
 			},
 		});
 
 		await root.runRlmChild("slow retry shard", { name: "retry-worker" });
 		await waitFor(() => childStarted);
-		await expect(root.deleteRlmSubagent("retry-worker")).rejects.toThrow("first close failed");
+		await expect(root.deleteRlmSubagent("retry-worker")).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "tombstoned",
+			cause: expect.objectContaining({ message: "first close failed" }),
+		});
 		const internals = root as unknown as InspectableRlmSession;
 		expect(internals._rlmChildCleanupFailures.size).toBe(1);
 		releaseChild();
@@ -2812,7 +2844,10 @@ describe("AgentSession rlm recursion", () => {
 					await runtimeCreationGate;
 					return { session: hostedChild };
 				},
-				deleteRlmSubagentRuntime: async (_id, child) => child?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, child) => {
+					await child?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		await root.runRlmChild("blocked before runtime creation", { name: "reserved-worker" });
@@ -2840,6 +2875,7 @@ describe("AgentSession rlm recursion", () => {
 		const hostedChild = createSession();
 		const deleteRuntime = vi.fn(async () => {
 			await hostedChild.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -2881,6 +2917,7 @@ describe("AgentSession rlm recursion", () => {
 				throw new RlmSubagentHostDeletionError("tombstoned", new Error("fallback delete failed"));
 			}
 			await hostedChild.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const releaseRuntime = vi.fn(async () => {
 			throw new Error("cancelled release failed");
@@ -3185,6 +3222,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: createRuntime,
 				deleteRlmSubagentRuntime: async (_childId, session) => {
 					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
 				},
 			},
 		});
@@ -3231,6 +3269,7 @@ describe("AgentSession rlm recursion", () => {
 			resolveRlmSubagentDeletion: async () => retryDurability,
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
+				return { deletionDurability: "absent" as const };
 			},
 		};
 		const root = createSession({ subagentRuntimeHost: runtimeHost });
@@ -3278,6 +3317,7 @@ describe("AgentSession rlm recursion", () => {
 		let releaseAttempts = 0;
 		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
 			await session?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3344,7 +3384,10 @@ describe("AgentSession rlm recursion", () => {
 					await resolutionGate;
 					return "absent";
 				},
-				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_childId, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 
@@ -3391,7 +3434,10 @@ describe("AgentSession rlm recursion", () => {
 					return { deletionDurability: "unknown" };
 				},
 				resolveRlmSubagentDeletion: async () => "tombstoned",
-				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_childId, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 
@@ -3427,7 +3473,10 @@ describe("AgentSession rlm recursion", () => {
 					await runtime.session.disposeAsync();
 					return { deletionDurability: "tombstoned" };
 				},
-				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_childId, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		await expect(
@@ -3457,6 +3506,7 @@ describe("AgentSession rlm recursion", () => {
 			},
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
+				return { deletionDurability: "absent" as const };
 			},
 		};
 		const root = createSession({ subagentRuntimeHost: runtimeHost });
@@ -3528,6 +3578,7 @@ describe("AgentSession rlm recursion", () => {
 			},
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
+				return { deletionDurability: "absent" as const };
 			},
 		};
 		root = createSession({ subagentRuntimeHost: runtimeHost });
@@ -3613,6 +3664,7 @@ describe("AgentSession rlm recursion", () => {
 			if (authorities.length === 1) await firstGate;
 			authority.assertCurrent();
 			await childSession?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3650,6 +3702,7 @@ describe("AgentSession rlm recursion", () => {
 			await deleteGate;
 			authority?.assertCurrent();
 			await childSession?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3560,14 +3560,19 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
-	it("retains a precommit late-admission release for an exact-id tombstone-and-close retry", async () => {
+	it("keeps a typed precommit release private until an exact retry tombstones and closes it", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		let releaseAttempts = 0;
-		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
+		const deleteRuntime = vi.fn(async (childId: string, session?: AgentSession, authority) => {
+			expect(authority).toMatchObject({
+				childId,
+				sessionFile: child.sessionFile,
+				sessionId: child.sessionId,
+			});
 			await session?.disposeAsync();
-			return { deletionDurability: "absent" as const };
+			return { deletionDurability: "tombstoned" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3605,6 +3610,7 @@ describe("AgentSession rlm recursion", () => {
 		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(internals._rlmChildSessions).toHaveLength(0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
 	it("discharges only a stale quarantine lease when its child id is replaced", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3560,14 +3560,19 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
-	it("retains a precommit late-admission release for an exact-id tombstone-and-close retry", async () => {
+	it("keeps a typed precommit release private until an exact retry tombstones and closes it", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		let releaseAttempts = 0;
-		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
+		const deleteRuntime = vi.fn(async (childId: string, session: AgentSession | undefined, authority) => {
+			expect(authority).toMatchObject({
+				childId,
+				sessionFile: child.sessionFile,
+				sessionId: child.sessionId,
+			});
 			await session?.disposeAsync();
-			return { deletionDurability: "absent" as const };
+			return { deletionDurability: "tombstoned" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3605,6 +3610,7 @@ describe("AgentSession rlm recursion", () => {
 		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(internals._rlmChildSessions).toHaveLength(0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
 	it("discharges only a stale quarantine lease when its child id is replaced", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3115,10 +3115,18 @@ describe("AgentSession rlm recursion", () => {
 		if (!artifactDir) throw new Error("Missing session artifact dir");
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
 
-		await internals._reapDeletedRlmSubagentRuntimesAfterCompaction();
+		const quarantinedChildId = [...internals._rlmChildDeletionQuarantines.keys()][0];
+		if (!quarantinedChildId) throw new Error("Missing deletion quarantine");
+		// The exact opaque id can retry cleanup even though the lease is omitted from
+		// every product-facing list and cannot be selected by its name or session id.
+		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: quarantinedChildId },
+		});
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
 		retryDurability = "absent";
-		await internals._reapDeletedRlmSubagentRuntimesAfterCompaction();
+		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: quarantinedChildId },
+		});
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -358,6 +358,26 @@ describe("AgentSession rlm recursion", () => {
 		});
 	});
 
+	it("propagates preserved-newer deletion outcomes through the host handler", async () => {
+		const subagent = {
+			rlm_child_id: "recycled-child",
+			active_session_id: "new-session",
+			session_id: "new-session",
+			session_name: "recycled-worker",
+			session_dir: join(tempDir, "recycled-child"),
+			status: "running" as const,
+		};
+		const deleteHandler = createRlmDeleteSubagentHostHandler(async () => ({
+			subagent,
+			outcome: "preserved_newer",
+		}));
+
+		await expect(invokeHostRequestHandlerForTest(deleteHandler, { target: subagent.rlm_child_id })).resolves.toEqual({
+			subagent,
+			outcome: "preserved_newer",
+		});
+	});
+
 	it("persists RLM_DEPTH for a fresh session and reports the seeded depth", () => {
 		vi.stubEnv("RLM_DEPTH", "1");
 		try {
@@ -2528,7 +2548,10 @@ describe("AgentSession rlm recursion", () => {
 			status: "running" as const,
 		};
 
-		await expect(inspectable._deleteResolvedRlmSubagent(subagent)).resolves.toEqual({ subagent });
+		await expect(inspectable._deleteResolvedRlmSubagent(subagent)).resolves.toEqual({
+			subagent,
+			outcome: "preserved_newer",
+		});
 		expect(deleteRuntime).toHaveBeenCalledWith(childId, stale);
 		expect(inspectable._activeRlmChildRuns.get(childId)?.session).toBe(newer);
 		expect(inspectable._deletedRlmChildIds.has(childId)).toBe(false);
@@ -2574,11 +2597,45 @@ describe("AgentSession rlm recursion", () => {
 			status: "completed" as const,
 		};
 
-		await expect(inspectable._deleteResolvedRlmSubagent(subagent)).resolves.toEqual({ subagent });
+		await expect(inspectable._deleteResolvedRlmSubagent(subagent)).resolves.toEqual({
+			subagent,
+			outcome: "preserved_newer",
+		});
 		expect(deleteRuntime).toHaveBeenCalledWith(childId, stale);
 		expect(inspectable._rlmChildSessions.get(childId)).toBe(newer);
 		expect(inspectable._deletedRlmChildIds.has(childId)).toBe(false);
 		expect(childUpdates).toEqual([]);
+	});
+
+	it("reports preserved-newer when inactive cleanup finds a replacement", async () => {
+		const childId = "recycled-inactive-child";
+		const staleDir = join(tempDir, "stale-inactive");
+		const stale = { _rlmSessionDir: staleDir, sessionId: "stale" } as unknown as AgentSession;
+		const newer = {
+			_rlmSessionDir: join(tempDir, "new-inactive"),
+			sessionId: "new",
+			dispose: vi.fn(),
+		} as unknown as AgentSession;
+		let root!: AgentSession;
+		const deleteRuntime = vi.fn(async () => {
+			(root as unknown as InspectableRlmSession)._rlmChildSessions.set(childId, newer);
+			return { deletionDurability: "stale" as const };
+		});
+		root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		const inspectable = root as unknown as InspectableRlmSession;
+		inspectable._rlmChildSessions.set(childId, stale);
+
+		await expect(root.deleteInactiveRlmSubagent(childId)).resolves.toBe("preserved_newer");
+		expect(deleteRuntime).toHaveBeenCalledWith(childId, stale, expect.any(Object));
+		expect(inspectable._rlmChildSessions.get(childId)).toBe(newer);
+		expect(inspectable._deletedRlmChildIds.has(childId)).toBe(false);
 	});
 
 	it("deletes only inactive RLM children through the explicit inactive path", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -29,6 +29,7 @@ import {
 	createDefaultRlmSubagentSessionName,
 	createRlmDeleteSubagentHostHandler,
 	createRlmRunHostHandler,
+	RlmSubagentHostDeletionError,
 	type SubagentRuntimeHost,
 } from "../src/core/rlm-runtime.js";
 import { SessionManager } from "../src/core/session-manager.js";
@@ -626,7 +627,7 @@ describe("AgentSession rlm recursion", () => {
 		const deleteRuntime = vi.fn(async (_childId: string, session: AgentSession) => {
 			deleteAttempts++;
 			if (deleteAttempts === 1) {
-				throw new Error("retained close failed");
+				throw new RlmSubagentHostDeletionError("tombstoned", new Error("retained close failed"));
 			}
 			await session.disposeAsync();
 		});
@@ -2569,7 +2570,7 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
 				deleteRlmSubagentRuntime: async (_id, session) => {
-					if (++deleteAttempts === 1) throw new Error("first close failed");
+					if (++deleteAttempts === 1) throw new RlmSubagentHostDeletionError("tombstoned", new Error("first close failed"));
 					await session?.disposeAsync();
 				},
 			},
@@ -2599,7 +2600,7 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				deleteRlmSubagentRuntime: async (_id, session) => {
-					if (++attempts === 1) throw new Error("close failed");
+					if (++attempts === 1) throw new RlmSubagentHostDeletionError("tombstoned", new Error("close failed"));
 					await session?.disposeAsync();
 				},
 			},
@@ -2752,7 +2753,7 @@ describe("AgentSession rlm recursion", () => {
 		const deleteRuntime = vi.fn(async () => {
 			deleteAttempts++;
 			if (deleteAttempts === 1) {
-				throw new Error("fallback delete failed");
+				throw new RlmSubagentHostDeletionError("tombstoned", new Error("fallback delete failed"));
 			}
 			await hostedChild.disposeAsync();
 		});

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3037,7 +3037,16 @@ describe("AgentSession rlm recursion", () => {
 	});
 
 	it("cleans up a queued run when a subscriber revokes authority on the first child update", async () => {
-		const root = createSession();
+		const child = createSession();
+		const createRuntime = vi.fn(async () => ({ session: child }));
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: createRuntime,
+				deleteRlmSubagentRuntime: async (_childId, session) => {
+					await session?.disposeAsync();
+				},
+			},
+		});
 		const controller = new AbortController();
 		root.subscribe((event) => {
 			if (event.type === "rlm_child_update" && event.child.status === "queued") {
@@ -3052,7 +3061,45 @@ describe("AgentSession rlm recursion", () => {
 		await expect(admission).rejects.toThrow("host request authority was revoked");
 		const internals = root as unknown as InspectableRlmSession;
 		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(createRuntime.mock.calls.length).toBe(0);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		await waitFor(() => readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length === 0);
+		await child.disposeAsync();
+	});
+
+	it("disposes an already-created runtime for a spawn revoked before admission", async () => {
+		const controller = new AbortController();
+		const child = createSession();
+		const disposeChild = vi.spyOn(child, "disposeAsync");
+		const runtimeHost: SubagentRuntimeHost = {
+			createRlmSubagentRuntime: async (options) => {
+				// Revoke while the runtime is being created, then publish late.
+				controller.abort();
+				options.onSessionPublished?.(child);
+				return { session: child };
+			},
+			deleteRlmSubagentRuntime: async (_childId, session) => {
+				await session?.disposeAsync();
+			},
+		};
+		const root = createSession({ subagentRuntimeHost: runtimeHost });
+
+		const admission = root.runRlmChild("revoked during late publication", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		await waitFor(() => disposeChild.mock.calls.length > 0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		await waitFor(() => readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length === 0);
 	});
 
 	it("cleans up a run when authority is already revoked at registration", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3036,6 +3036,58 @@ describe("AgentSession rlm recursion", () => {
 		}
 	});
 
+	it("cleans up a queued run when a subscriber revokes authority on the first child update", async () => {
+		const root = createSession();
+		const controller = new AbortController();
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update" && event.child.status === "queued") {
+				controller.abort();
+			}
+		});
+
+		const admission = root.runRlmChild("revoked by queued-update subscriber", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
+	it("cleans up a run when authority is already revoked at registration", async () => {
+		const root = createSession();
+		const controller = new AbortController();
+		const internals = root as unknown as InspectableRlmSession & {
+			_findLastAssistantMessage(): unknown;
+		};
+		// Revoke in the last window before the run is registered; an abort listener
+		// attached to an already-aborted signal never fires.
+		const originalFind = internals._findLastAssistantMessage.bind(root);
+		vi.spyOn(internals, "_findLastAssistantMessage").mockImplementation(() => {
+			controller.abort();
+			return originalFind();
+		});
+		let sawQueuedUpdate = false;
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update" && event.child.status === "queued") {
+				sawQueuedUpdate = true;
+			}
+		});
+
+		const admission = root.runRlmChild("revoked before registration", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		expect(sawQueuedUpdate).toBe(false);
+		expect(internals._activeRlmChildRuns.size).toBe(0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toEqual([]);
+	});
+
 	it("does not delete a subagent after rlm.delete_subagent authority is revoked", async () => {
 		const childId = "revoked-delete-child";
 		const childDir = join(tempDir, childId);

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -184,6 +184,15 @@ function rlmCommOpen(commId: string, prompt: string, kwargs: Record<string, unkn
 	return rlmCommOpenData(commId, { type: "rlm.run", prompt, kwargs });
 }
 
+function rlmCommClose(commId: string): TestCommMessage {
+	return {
+		header: { msg_type: "comm_close" },
+		parent_header: {},
+		metadata: {},
+		content: { comm_id: commId },
+	};
+}
+
 function encodeTestMessage(message: TestCommMessage): Buffer[] {
 	return [
 		Buffer.from("<IDS|MSG>"),
@@ -2916,6 +2925,117 @@ describe("AgentSession rlm recursion", () => {
 
 		releaseChild();
 		await waitFor(() => rootRun.status === "done");
+	});
+
+	it("does not admit an rlm child after request authority is revoked during model resolution", async () => {
+		const root = createSession();
+		const controller = new AbortController();
+		let releaseResolution: () => void = () => {};
+		const resolutionGate = new Promise<void>((resolve) => {
+			releaseResolution = resolve;
+		});
+		let resolutionStarted: () => void = () => {};
+		const resolutionStartedGate = new Promise<void>((resolve) => {
+			resolutionStarted = resolve;
+		});
+		const internals = root as unknown as InspectableRlmSession & {
+			_resolveRlmSubagentModel(model?: string): Promise<unknown>;
+		};
+		const originalResolve = internals._resolveRlmSubagentModel.bind(root);
+		vi.spyOn(internals, "_resolveRlmSubagentModel").mockImplementation(async (requestedModel) => {
+			resolutionStarted();
+			await resolutionGate;
+			return originalResolve(requestedModel);
+		});
+
+		const admission = root.runRlmChild("revoked before admission", {}, undefined, {
+			signal: controller.signal,
+			isCurrent: () => !controller.signal.aborted,
+		});
+		await resolutionStartedGate;
+		controller.abort();
+		releaseResolution();
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		expect(internals._activeRlmChildRuns.size).toBe(0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
+	it("claims cleanup when rlm.run authority is revoked during asynchronous runtime admission", async () => {
+		const root = createSession();
+		const controller = new AbortController();
+		let runtimeEntered: () => void = () => {};
+		const runtimeEnteredGate = new Promise<void>((resolve) => {
+			runtimeEntered = resolve;
+		});
+		let releaseRuntime: () => void = () => {};
+		const runtimeGate = new Promise<void>((resolve) => {
+			releaseRuntime = resolve;
+		});
+		const internals = root as unknown as InspectableRlmSession & {
+			_createRlmSubagentRuntime(options: unknown): Promise<{ session: AgentSession }>;
+		};
+		const originalCreateRuntime = internals._createRlmSubagentRuntime.bind(root);
+		const createRuntime = vi.spyOn(internals, "_createRlmSubagentRuntime").mockImplementation(async (options) => {
+			runtimeEntered();
+			await runtimeGate;
+			return originalCreateRuntime(options);
+		});
+
+		const admission = root.runRlmChild("revoked during runtime admission", {}, undefined, {
+			signal: controller.signal,
+			isCurrent: () => !controller.signal.aborted,
+		});
+		await runtimeEnteredGate;
+		controller.abort();
+		releaseRuntime();
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		expect(createRuntime).toHaveBeenCalledOnce();
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
+	it("revokes rlm.run authority before a gated admission can create side effects", async () => {
+		let handlerStarted: () => void = () => {};
+		const handlerStartedGate = new Promise<void>((resolve) => {
+			handlerStarted = resolve;
+		});
+		let releaseHandler: () => void = () => {};
+		const handlerGate = new Promise<void>((resolve) => {
+			releaseHandler = resolve;
+		});
+		let sideEffects = 0;
+		let sawAbortedSignal = false;
+		const replies: CapturedCommReply[] = [];
+		const manager = new KernelManager({
+			python: process.execPath,
+			hostHandlers: createTestHostHandlers({
+				"rlm.run": createRlmRunHostHandler(async ({ signal, isCurrent }) => {
+					handlerStarted();
+					await handlerGate;
+					sawAbortedSignal = signal.aborted && !isCurrent();
+					if (signal.aborted || !isCurrent()) throw new Error("host request authority was revoked");
+					sideEffects++;
+					return { ok: true };
+				}),
+			}),
+		});
+		try {
+			const kernel = manager as unknown as KernelCommTestApi;
+			kernel.sendCommMessage = async (commId, data) => {
+				replies.push({ commId, data });
+			};
+			kernel.handleCommMessage(rlmCommOpen("comm-revoked", "blocked child"));
+			await handlerStartedGate;
+			kernel.handleCommMessage(rlmCommClose("comm-revoked"));
+			releaseHandler();
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(sawAbortedSignal).toBe(true);
+			expect(sideEffects).toBe(0);
+			expect(replies).toEqual([]);
+		} finally {
+			releaseHandler();
+			await manager.dispose();
+		}
 	});
 
 	it("runs parallel rlm comm requests independently", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -134,6 +134,10 @@ interface InspectableRlmSession {
 		}
 	>;
 	_rlmChildCleanupFailures: Map<string, Awaited<ReturnType<AgentSession["listRlmSubagents"]>>["subagents"][number]>;
+	_rlmChildDeletionQuarantines: Map<
+		string,
+		Awaited<ReturnType<AgentSession["listRlmSubagents"]>>["subagents"][number]
+	>;
 	_rlmChildSessions: Map<string, AgentSession>;
 	_rlmChildUnsubscribes: Map<string, () => void>;
 	_createKernelHostHandlers(): HostRequestHandlers;
@@ -1383,7 +1387,7 @@ describe("AgentSession rlm recursion", () => {
 	it("releases a hosted child when its initial task fails", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "host-error-child") });
 		vi.spyOn(child, "promptAndWait").mockRejectedValue(new Error("child prompt failed"));
-		const releaseRlmSubagentRuntime = vi.fn(async () => ({ retained: false }));
+		const releaseRlmSubagentRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
@@ -2470,7 +2474,7 @@ describe("AgentSession rlm recursion", () => {
 				deleteRlmSubagentRuntime: deleteRuntime,
 				releaseRlmSubagentRuntime: async (runtime, options) => {
 					options.parentSession.registerRlmChildSession(options.id, runtime.session);
-					return { retained: true };
+					return { deletionDurability: "tombstoned" };
 				},
 			},
 		});
@@ -2494,7 +2498,7 @@ describe("AgentSession rlm recursion", () => {
 	it("releases a hosted child when completion persistence fails", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "host-completion-failure-child") });
 		const disposeChild = vi.spyOn(child, "disposeAsync");
-		const releaseRlmSubagentRuntime = vi.fn(async () => ({ retained: false }));
+		const releaseRlmSubagentRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
@@ -3071,25 +3075,24 @@ describe("AgentSession rlm recursion", () => {
 		await child.disposeAsync();
 	});
 
-	it("removes a host-owned runtime dir when release does not retain a revoked spawn", async () => {
+	it("quarantines unknown release durability through finalization and removes it only after a retry proves absence", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		const releaseStatuses: string[] = [];
+		let retryDurability: "unknown" | "absent" = "unknown";
 		const runtimeHost: SubagentRuntimeHost = {
 			createRlmSubagentRuntime: async (options) => {
-				// Revoke while the runtime is being created, then publish late.
 				controller.abort();
 				options.onSessionPublished?.(child);
 				return { session: child };
 			},
-			// A release hook may close a child even when its persistence failed. It
-			// explicitly declines retention, so the caller must clean the exact orphan.
 			releaseRlmSubagentRuntime: async (runtime, _options, status) => {
 				releaseStatuses.push(status);
 				await runtime.session.disposeAsync();
-				return { retained: false };
+				return { deletionDurability: "unknown" };
 			},
+			resolveRlmSubagentDeletion: async () => retryDurability,
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
 			},
@@ -3107,9 +3110,46 @@ describe("AgentSession rlm recursion", () => {
 		expect(releaseStatuses).toEqual(["cancelled"]);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
 		const artifactDir = root.sessionManager.getSessionArtifactDir();
 		if (!artifactDir) throw new Error("Missing session artifact dir");
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
+
+		await internals._reapDeletedRlmSubagentRuntimesAfterCompaction();
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
+		retryDurability = "absent";
+		await internals._reapDeletedRlmSubagentRuntimesAfterCompaction();
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
+	});
+
+	it("retains a host-owned runtime dir when revoked-spawn release is tombstoned", async () => {
+		const controller = new AbortController();
+		const child = createSession();
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async (options) => {
+					controller.abort();
+					options.onSessionPublished?.(child);
+					return { session: child };
+				},
+				releaseRlmSubagentRuntime: async (runtime) => {
+					await runtime.session.disposeAsync();
+					return { deletionDurability: "tombstoned" };
+				},
+				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+			},
+		});
+		await expect(
+			root.runRlmChild("tombstoned late publication", {}, undefined, { signal: controller.signal }),
+		).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 	});
 
 	it("removes a dispose-only host child's dir when a spawn is revoked before admission", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3250,6 +3250,52 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
+	it("retains a precommit late-admission release for an exact-id tombstone-and-close retry", async () => {
+		const controller = new AbortController();
+		const child = createSession();
+		const disposeChild = vi.spyOn(child, "disposeAsync");
+		let releaseAttempts = 0;
+		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
+			await session?.disposeAsync();
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async (options) => {
+					controller.abort();
+					options.onSessionPublished?.(child);
+					return { session: child };
+				},
+				releaseRlmSubagentRuntime: async () => {
+					releaseAttempts++;
+					throw new RlmSubagentHostDeletionError("precommit", new Error("registry write failed"));
+				},
+				resolveRlmSubagentDeletion: async () => "tombstoned",
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+
+		await expect(
+			root.runRlmChild("precommit late publication", {}, undefined, { signal: controller.signal }),
+		).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(releaseAttempts).toBe(1);
+		expect(disposeChild).not.toHaveBeenCalled();
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
+		expect(internals._rlmChildSessions).toHaveLength(1);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		const childId = [...internals._rlmChildDeletionQuarantines.keys()][0];
+		if (!childId) throw new Error("Missing deletion quarantine");
+
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: childId },
+		});
+		expect(deleteRuntime).toHaveBeenCalledOnce();
+		expect(disposeChild).toHaveBeenCalledOnce();
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
+		expect(internals._rlmChildSessions).toHaveLength(0);
+	});
+
 	it("rejects a quarantine retry revoked after host durability resolves without mutating", async () => {
 		const admissionController = new AbortController();
 		const child = createSession();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -22,7 +22,7 @@ import {
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import type { LoadExtensionsResult } from "../src/core/extensions/index.js";
-import { type HostRequestHandlers, invokeHostRequestHandlerForTest, KernelManager } from "../src/core/kernel/index.js";
+import { type HostRequestHandlers, KernelManager } from "../src/core/kernel/index.js";
 import { convertToLlm } from "../src/core/messages.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import {
@@ -37,7 +37,10 @@ import type { Skill } from "../src/core/skills.js";
 import { createSyntheticSourceInfo } from "../src/core/source-info.js";
 import { type ActiveSessionState, resolveActiveSessionState } from "../src/modes/daemon/active-session-state.js";
 import { AgentDaemon } from "../src/modes/daemon/daemon-mode.js";
-import { createTestHostHandlers } from "./host-request-context.js";
+import {
+	createTestHostHandlers,
+	invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest,
+} from "./host-request-context.js";
 
 import { createTestExtensionsResult, createTestResourceLoader } from "./utilities.js";
 

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3110,29 +3110,33 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
 	});
 
-	it("removes an in-process child's dir when a spawn is revoked before admission", async () => {
+	it("removes a dispose-only host child's dir when a spawn is revoked before admission", async () => {
 		const controller = new AbortController();
-		const root = createSession();
-		const internals = root as unknown as InspectableRlmSession & {
-			_createRlmSubagentRuntime(options: unknown): Promise<{ session: AgentSession }>;
+		const child = createSession();
+		const disposeChild = vi.spyOn(child, "disposeAsync");
+		// The default in-process AgentSessionRuntime self-host shape: no release
+		// hook, dispose-only deletion, no durable registry.
+		const runtimeHost: SubagentRuntimeHost = {
+			createRlmSubagentRuntime: async (options) => {
+				// Revoke while the runtime is being created, then publish late.
+				controller.abort();
+				options.onSessionPublished?.(child);
+				return { session: child };
+			},
+			deleteRlmSubagentRuntime: async (_childId, session) => {
+				await session?.disposeAsync();
+			},
 		};
-		const originalCreateRuntime = internals._createRlmSubagentRuntime.bind(root);
-		let disposeChild: ReturnType<typeof vi.spyOn> | undefined;
-		vi.spyOn(internals, "_createRlmSubagentRuntime").mockImplementation(async (options) => {
-			// Revoke while the inline runtime is being created, then publish late.
-			controller.abort();
-			const runtime = await originalCreateRuntime(options);
-			disposeChild = vi.spyOn(runtime.session, "disposeAsync");
-			return runtime;
-		});
+		const root = createSession({ subagentRuntimeHost: runtimeHost });
 
-		const admission = root.runRlmChild("revoked during inline creation", {}, undefined, {
+		const admission = root.runRlmChild("revoked under dispose-only host", {}, undefined, {
 			signal: controller.signal,
 		});
 
 		await expect(admission).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
 		await waitFor(() => internals._activeRlmChildRuns.size === 0);
-		await waitFor(() => (disposeChild?.mock.calls.length ?? 0) > 0);
+		await waitFor(() => disposeChild.mock.calls.length > 0);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
 		const artifactDir = root.sessionManager.getSessionArtifactDir();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2950,7 +2950,6 @@ describe("AgentSession rlm recursion", () => {
 
 		const admission = root.runRlmChild("revoked before admission", {}, undefined, {
 			signal: controller.signal,
-			isCurrent: () => !controller.signal.aborted,
 		});
 		await resolutionStartedGate;
 		controller.abort();
@@ -2983,7 +2982,6 @@ describe("AgentSession rlm recursion", () => {
 
 		const admission = root.runRlmChild("revoked during runtime admission", {}, undefined, {
 			signal: controller.signal,
-			isCurrent: () => !controller.signal.aborted,
 		});
 		await runtimeEnteredGate;
 		controller.abort();
@@ -3009,11 +3007,11 @@ describe("AgentSession rlm recursion", () => {
 		const manager = new KernelManager({
 			python: process.execPath,
 			hostHandlers: createTestHostHandlers({
-				"rlm.run": createRlmRunHostHandler(async ({ signal, isCurrent }) => {
+				"rlm.run": createRlmRunHostHandler(async ({ signal }) => {
 					handlerStarted();
 					await handlerGate;
-					sawAbortedSignal = signal.aborted && !isCurrent();
-					if (signal.aborted || !isCurrent()) throw new Error("host request authority was revoked");
+					sawAbortedSignal = signal.aborted;
+					if (signal.aborted) throw new Error("host request authority was revoked");
 					sideEffects++;
 					return { ok: true };
 				}),

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2532,6 +2532,99 @@ describe("AgentSession rlm recursion", () => {
 		expect(root.getRlmChildSession(spawned.rlm_child_id)).toBeUndefined();
 	});
 
+	it("routes completion-rejection finalization through the active deletion coordinator exactly once", async () => {
+		let finishChild!: () => void;
+		const finishGate = new Promise<void>((resolve) => {
+			finishChild = resolve;
+		});
+		const child = createSession({
+			rlmSessionDir: join(tempDir, "completion-race-child"),
+			streamFn: (_model, context) => {
+				const stream = createAssistantMessageEventStream();
+				void finishGate.then(() =>
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${userText(context)}`) }),
+				);
+				return stream;
+			},
+		});
+		let releaseDelete!: () => void;
+		const deleteGate = new Promise<void>((resolve) => {
+			releaseDelete = resolve;
+		});
+		const deleteRuntime = vi.fn(async (_id: string, childSession: AgentSession | undefined, authority) => {
+			if (!authority) throw new Error("missing deletion authority");
+			authority.assertCurrent();
+			await deleteGate;
+			authority.assertCurrent();
+			await childSession?.disposeAsync();
+		});
+		const releaseRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				completeRlmSubagentRuntime: () => false,
+				releaseRlmSubagentRuntime: releaseRuntime,
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		const spawned = await root.runRlmChild("completion race", { name: "completion-race" });
+		const deletion = root.deleteRlmSubagent(spawned.rlm_child_id);
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+		finishChild();
+		await Promise.resolve();
+		releaseDelete();
+		await expect(deletion).resolves.toMatchObject({ subagent: { rlm_child_id: spawned.rlm_child_id } });
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(deleteRuntime).toHaveBeenCalledOnce();
+		expect(releaseRuntime).not.toHaveBeenCalled();
+	});
+
+	it("joins a close-failure finalizer to the explicit deletion coordinator exactly once", async () => {
+		let failChild!: () => void;
+		const failGate = new Promise<void>((resolve) => {
+			failChild = resolve;
+		});
+		const child = createSession({
+			rlmSessionDir: join(tempDir, "error-finalizer-race-child"),
+			streamFn: () => {
+				const stream = createAssistantMessageEventStream();
+				void failGate.then(() => stream.push({ type: "error", reason: "error", error: { ...assistantMessage("child failure"), stopReason: "error" } }));
+				return stream;
+			},
+		});
+		let releaseDelete!: () => void;
+		const deleteGate = new Promise<void>((resolve) => {
+			releaseDelete = resolve;
+		});
+		const deleteRuntime = vi.fn(async (_id: string, childSession: AgentSession | undefined, authority) => {
+			if (!authority) throw new Error("missing deletion authority");
+			authority.assertCurrent();
+			await deleteGate;
+			authority.assertCurrent();
+			await childSession?.disposeAsync();
+		});
+		const releaseRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				releaseRlmSubagentRuntime: releaseRuntime,
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		const spawned = await root.runRlmChild("error finalizer race", { name: "error-finalizer-race" });
+		const deletion = root.deleteRlmSubagent(spawned.rlm_child_id);
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+		failChild();
+		await Promise.resolve();
+		releaseDelete();
+		await expect(deletion).resolves.toMatchObject({ subagent: { rlm_child_id: spawned.rlm_child_id } });
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(deleteRuntime).toHaveBeenCalledOnce();
+		expect(releaseRuntime).not.toHaveBeenCalled();
+	});
+
 	it("does not let completion retention resurrect a child being deleted", async () => {
 		const root = createSession();
 		const spawned = await root.runRlmChild("fast child", { name: "fast-worker" });

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3560,19 +3560,14 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
-	it("keeps a typed precommit release private until an exact retry tombstones and closes it", async () => {
+	it("retains a precommit late-admission release for an exact-id tombstone-and-close retry", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		let releaseAttempts = 0;
-		const deleteRuntime = vi.fn(async (childId: string, session: AgentSession | undefined, authority) => {
-			expect(authority).toMatchObject({
-				childId,
-				sessionFile: child.sessionFile,
-				sessionId: child.sessionId,
-			});
+		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
 			await session?.disposeAsync();
-			return { deletionDurability: "tombstoned" as const };
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3610,7 +3605,6 @@ describe("AgentSession rlm recursion", () => {
 		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(internals._rlmChildSessions).toHaveLength(0);
-		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
 	it("discharges only a stale quarantine lease when its child id is replaced", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -22,7 +22,7 @@ import {
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import type { LoadExtensionsResult } from "../src/core/extensions/index.js";
-import { type HostRequestHandlers, KernelManager } from "../src/core/kernel/index.js";
+import { type HostRequestHandlers, invokeHostRequestHandlerForTest, KernelManager } from "../src/core/kernel/index.js";
 import { convertToLlm } from "../src/core/messages.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import {
@@ -37,6 +37,8 @@ import type { Skill } from "../src/core/skills.js";
 import { createSyntheticSourceInfo } from "../src/core/source-info.js";
 import { type ActiveSessionState, resolveActiveSessionState } from "../src/modes/daemon/active-session-state.js";
 import { AgentDaemon } from "../src/modes/daemon/daemon-mode.js";
+import { createTestHostHandlers } from "./host-request-context.js";
+
 import { createTestExtensionsResult, createTestResourceLoader } from "./utilities.js";
 
 const model = getModel("anthropic", "claude-sonnet-4-5")!;
@@ -328,7 +330,7 @@ describe("AgentSession rlm recursion", () => {
 			outcome: "skipped_running",
 		}));
 
-		await expect(deleteHandler({ target: subagent.rlm_child_id })).resolves.toEqual({
+		await expect(invokeHostRequestHandlerForTest(deleteHandler, { target: subagent.rlm_child_id })).resolves.toEqual({
 			subagent,
 			outcome: "skipped_running",
 		});
@@ -743,7 +745,9 @@ describe("AgentSession rlm recursion", () => {
 		if (!send) throw new Error("Missing agent_message.send host handler");
 
 		expect(child.repliedToParentSinceTask).toBe(false);
-		await expect(send({ message: "done", receiver_role: "parent" })).resolves.toMatchObject({
+		await expect(
+			invokeHostRequestHandlerForTest(send, { message: "done", receiver_role: "parent" }),
+		).resolves.toMatchObject({
 			message: "done",
 		});
 		expect(sendAgentMessage).toHaveBeenCalledWith(
@@ -802,7 +806,7 @@ describe("AgentSession rlm recursion", () => {
 		const send = handlers["agent_message.send"];
 		if (!send) throw new Error("Missing agent_message.send host handler");
 
-		const pendingSend = send({
+		const pendingSend = invokeHostRequestHandlerForTest(send, {
 			message: "hello",
 			receiver_role: "child",
 			receiver_name: spawned.rlm_child_id,
@@ -865,7 +869,11 @@ describe("AgentSession rlm recursion", () => {
 		if (!send) throw new Error("Missing agent_message.send host handler");
 
 		await expect(
-			send({ message: "follow-up", receiver_role: "child", receiver_name: spawned.rlm_child_id }),
+			invokeHostRequestHandlerForTest(send, {
+				message: "follow-up",
+				receiver_role: "child",
+				receiver_name: spawned.rlm_child_id,
+			}),
 		).resolves.toMatchObject({ message: "follow-up" });
 		expect(sendAgentMessage).toHaveBeenCalledWith(
 			expect.objectContaining({ target: child.sessionId, message: "follow-up" }),
@@ -901,7 +909,11 @@ describe("AgentSession rlm recursion", () => {
 		const send = handlers["agent_message.send"];
 		if (!send) throw new Error("Missing agent_message.send host handler");
 
-		const pendingSend = send({ message: "hello", receiver_role: "child", receiver_name: spawned.name });
+		const pendingSend = invokeHostRequestHandlerForTest(send, {
+			message: "hello",
+			receiver_role: "child",
+			receiver_name: spawned.name,
+		});
 		rejectStartup?.(new Error("child startup failed"));
 
 		await expect(pendingSend).rejects.toThrow("child startup failed");
@@ -957,7 +969,11 @@ describe("AgentSession rlm recursion", () => {
 		if (!send) throw new Error("Missing agent_message.send host handler");
 
 		await expect(
-			send({ message: "hello", receiver_role: "child", receiver_name: "shared-child" }),
+			invokeHostRequestHandlerForTest(send, {
+				message: "hello",
+				receiver_role: "child",
+				receiver_name: "shared-child",
+			}),
 		).resolves.toMatchObject({ message: "hello" });
 		expect(sendAgentMessage).toHaveBeenCalledWith(
 			expect.objectContaining({ target: "healthy-child-session", message: "hello" }),
@@ -999,9 +1015,13 @@ describe("AgentSession rlm recursion", () => {
 		const send = handlers["agent_message.send"];
 		if (!send) throw new Error("Missing agent_message.send host handler");
 
-		await expect(send({ message: "hello", receiver_role: "child", receiver_name: "deleted-child" })).rejects.toThrow(
-			'No child matches "deleted-child"',
-		);
+		await expect(
+			invokeHostRequestHandlerForTest(send, {
+				message: "hello",
+				receiver_role: "child",
+				receiver_name: "deleted-child",
+			}),
+		).rejects.toThrow('No child matches "deleted-child"');
 		releaseRuntimeCreation();
 		await waitFor(() => (root as unknown as InspectableRlmSession)._activeRlmChildRuns.size === 0);
 	});
@@ -1038,7 +1058,7 @@ describe("AgentSession rlm recursion", () => {
 		const send = handlers["agent_message.send"];
 		if (!send) throw new Error("Missing agent_message.send host handler");
 
-		await expect(send({ target: "all", message: "status" })).resolves.toMatchObject({
+		await expect(invokeHostRequestHandlerForTest(send, { target: "all", message: "status" })).resolves.toMatchObject({
 			receipts: [{ message: "status" }],
 		});
 		expect(roster).toHaveBeenCalledTimes(1);
@@ -1263,7 +1283,7 @@ describe("AgentSession rlm recursion", () => {
 		vi.spyOn(child, "promptAndWait").mockImplementation(async () => {
 			const send = (child as unknown as InspectableRlmSession)._createKernelHostHandlers()["agent_message.send"];
 			if (!send) throw new Error("Missing agent_message.send host handler");
-			await send({ message: "done", receiver_role: "parent" });
+			await invokeHostRequestHandlerForTest(send, { message: "done", receiver_role: "parent" });
 			const followUp = createAgentSessionMessage({
 				id: "agentmsg-parent-follow-up-after-reply",
 				source: "agent_message",
@@ -1509,13 +1529,15 @@ describe("AgentSession rlm recursion", () => {
 		if (!listHandler || !deleteHandler) {
 			throw new Error("Missing RLM subagent registry host handlers");
 		}
-		await expect(listHandler({})).resolves.toEqual(expectedRegistry);
-		await expect(deleteHandler({ target: expectedSessionName })).resolves.toEqual({
+		await expect(invokeHostRequestHandlerForTest(listHandler, {})).resolves.toEqual(expectedRegistry);
+		await expect(invokeHostRequestHandlerForTest(deleteHandler, { target: expectedSessionName })).resolves.toEqual({
 			subagent: expectedRegistry.subagents[0],
 		});
 		expect(root.getRlmChildSession(daemonChildId)).toBeUndefined();
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
-		await expect(deleteHandler({ target: expectedSessionName })).rejects.toThrow("No direct RLM subagent matches");
+		await expect(invokeHostRequestHandlerForTest(deleteHandler, { target: expectedSessionName })).rejects.toThrow(
+			"No direct RLM subagent matches",
+		);
 
 		root.dispose();
 
@@ -2904,7 +2926,7 @@ describe("AgentSession rlm recursion", () => {
 		const replies: CapturedCommReply[] = [];
 		const manager = new KernelManager({
 			python: process.execPath,
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"rlm.run": createRlmRunHostHandler(async ({ prompt }) => {
 					active++;
 					started++;
@@ -2919,7 +2941,7 @@ describe("AgentSession rlm recursion", () => {
 						model: "test/model",
 					};
 				}),
-			},
+			}),
 		});
 
 		try {
@@ -2964,7 +2986,7 @@ describe("AgentSession rlm recursion", () => {
 		let promptSeen = "";
 		const manager = new KernelManager({
 			python: process.execPath,
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"rlm.run": createRlmRunHostHandler(async ({ prompt }) => {
 					promptSeen = prompt;
 					return {
@@ -2975,7 +2997,7 @@ describe("AgentSession rlm recursion", () => {
 						model: "test/model",
 					};
 				}),
-			},
+			}),
 		});
 
 		try {
@@ -3010,7 +3032,7 @@ describe("AgentSession rlm recursion", () => {
 		const prompts: string[] = [];
 		const manager = new KernelManager({
 			cwd: tempDir,
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"rlm.run": createRlmRunHostHandler(async ({ prompt }) => {
 					prompts.push(prompt);
 					return {
@@ -3020,7 +3042,7 @@ describe("AgentSession rlm recursion", () => {
 						model: "test/model",
 					};
 				}),
-			},
+			}),
 		});
 
 		try {
@@ -3089,7 +3111,7 @@ print(_result.name)
 		const replies: CapturedCommReply[] = [];
 		const manager = new KernelManager({
 			python: process.execPath,
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"rlm.run": createRlmRunHostHandler(async () => ({
 					answer: "unused",
 					usage: { prompt_tokens: 1, completion_tokens: 1 },
@@ -3097,7 +3119,7 @@ print(_result.name)
 					session_dir: null,
 					model: "test/model",
 				})),
-			},
+			}),
 		});
 
 		try {
@@ -3136,7 +3158,7 @@ print(_result.name)
 		});
 		const manager = new KernelManager({
 			python: process.execPath,
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"rlm.run": createRlmRunHostHandler(async () => {
 					started = true;
 					try {
@@ -3146,7 +3168,7 @@ print(_result.name)
 						handlerSettled = true;
 					}
 				}),
-			},
+			}),
 		});
 		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3196,6 +3196,43 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length).toBe(0);
 	});
 
+	it("discharges a quarantined tombstone without removing its retained artifact", async () => {
+		const admissionController = new AbortController();
+		const child = createSession();
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async (options) => {
+					admissionController.abort();
+					options.onSessionPublished?.(child);
+					return { session: child };
+				},
+				releaseRlmSubagentRuntime: async (runtime) => {
+					await runtime.session.disposeAsync();
+					return { deletionDurability: "unknown" };
+				},
+				resolveRlmSubagentDeletion: async () => "tombstoned",
+				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+			},
+		});
+
+		await expect(
+			root.runRlmChild("tombstone quarantine retry", {}, undefined, { signal: admissionController.signal }),
+		).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._rlmChildDeletionQuarantines.size === 1);
+		const childId = [...internals._rlmChildDeletionQuarantines.keys()][0];
+		if (!childId) throw new Error("Missing deletion quarantine");
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: childId },
+		});
+		expect(internals._rlmChildDeletionQuarantines.has(childId)).toBe(false);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(true);
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length).toBe(1);
+	});
+
 	it("retains a host-owned runtime dir when revoked-spawn release is tombstoned", async () => {
 		const controller = new AbortController();
 		const child = createSession();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1619,7 +1619,11 @@ describe("AgentSession rlm recursion", () => {
 
 		expect(await root.listRlmSubagents()).toEqual({ subagents: expected });
 		await expect(root.deleteRlmSubagent("finished-worker")).resolves.toEqual({ subagent: expected[1] });
-		expect(deleteRlmSubagentRuntime).toHaveBeenCalledWith("finished-child", undefined);
+		expect(deleteRlmSubagentRuntime).toHaveBeenCalledWith(
+			"finished-child",
+			undefined,
+			expect.objectContaining({ childId: "finished-child", sessionDir: expected[1].session_dir }),
+		);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [expected[0]] });
 	});
 
@@ -2493,7 +2497,11 @@ describe("AgentSession rlm recursion", () => {
 			() => (root as unknown as InspectableRlmSession)._activeRlmChildRuns.get(childId)?.status !== "running",
 		);
 		await expect(root.deleteInactiveRlmSubagent(childId)).resolves.toBe("deleted");
-		expect(deleteRuntime).toHaveBeenCalledWith(childId, retainedChild);
+		expect(deleteRuntime).toHaveBeenCalledWith(
+			childId,
+			retainedChild,
+			expect.objectContaining({ childId, sessionDir: join(tempDir, "retained-child") }),
+		);
 		await expect(root.deleteInactiveRlmSubagent("unknown-child")).resolves.toBe("not_found");
 	});
 
@@ -3413,6 +3421,82 @@ describe("AgentSession rlm recursion", () => {
 			releaseListing();
 			await manager.dispose();
 		}
+	});
+
+	it("promotes a live deletion waiter after an aborted owner drains", async () => {
+		const childId = "promoted-delete-child";
+		const childDir = join(tempDir, childId);
+		mkdirSync(childDir, { recursive: true });
+		const child = createSession({ rlmSessionDir: childDir });
+		child.setSessionName("promoted-delete-worker");
+		let releaseFirst!: () => void;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const authorities: Array<{ generation: number }> = [];
+		const deleteRuntime = vi.fn(async (_id: string, childSession: AgentSession | undefined, authority) => {
+			if (!authority) throw new Error("missing deletion authority");
+			authorities.push(authority);
+			authority.assertCurrent();
+			if (authorities.length === 1) await firstGate;
+			authority.assertCurrent();
+			await childSession?.disposeAsync();
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected child creation");
+				},
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		expect(root.registerRlmChildSession(childId, child)).toBe(true);
+		const ownerController = new AbortController();
+		const owner = root.deleteRlmSubagent("promoted-delete-worker", ownerController.signal);
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+		const waiter = root.deleteRlmSubagent("promoted-delete-worker");
+		ownerController.abort();
+		await expect(owner).rejects.toThrow("host request authority was revoked");
+		releaseFirst();
+		await expect(waiter).resolves.toMatchObject({ subagent: { rlm_child_id: childId } });
+		expect(authorities).toHaveLength(2);
+		expect(authorities[1]?.generation).toBeGreaterThan(authorities[0]?.generation ?? Infinity);
+	});
+
+	it("keeps a live deletion owner authoritative when only its waiter aborts", async () => {
+		const childId = "caller-local-delete-child";
+		const childDir = join(tempDir, childId);
+		mkdirSync(childDir, { recursive: true });
+		const child = createSession({ rlmSessionDir: childDir });
+		child.setSessionName("caller-local-delete-worker");
+		let releaseDelete!: () => void;
+		const deleteGate = new Promise<void>((resolve) => {
+			releaseDelete = resolve;
+		});
+		const deleteRuntime = vi.fn(async (_id: string, childSession: AgentSession | undefined, authority) => {
+			authority?.assertCurrent();
+			await deleteGate;
+			authority?.assertCurrent();
+			await childSession?.disposeAsync();
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected child creation");
+				},
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		expect(root.registerRlmChildSession(childId, child)).toBe(true);
+		const owner = root.deleteRlmSubagent("caller-local-delete-worker");
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+		const waiterController = new AbortController();
+		const waiter = root.deleteRlmSubagent("caller-local-delete-worker", waiterController.signal);
+		waiterController.abort();
+		await expect(waiter).rejects.toThrow("host request authority was revoked");
+		releaseDelete();
+		await expect(owner).resolves.toMatchObject({ subagent: { rlm_child_id: childId } });
+		expect(deleteRuntime).toHaveBeenCalledOnce();
 	});
 
 	it("runs parallel rlm comm requests independently", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3070,16 +3070,23 @@ describe("AgentSession rlm recursion", () => {
 		await child.disposeAsync();
 	});
 
-	it("disposes an already-created runtime for a spawn revoked before admission", async () => {
+	it("keeps a host-owned runtime's dir when a spawn is revoked before admission", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
+		const releaseStatuses: string[] = [];
 		const runtimeHost: SubagentRuntimeHost = {
 			createRlmSubagentRuntime: async (options) => {
 				// Revoke while the runtime is being created, then publish late.
 				controller.abort();
 				options.onSessionPublished?.(child);
 				return { session: child };
+			},
+			// Daemon-like release: record the deletion durably and close the session;
+			// the artifact tree stays on disk per the daemon persistence contract.
+			releaseRlmSubagentRuntime: async (runtime, _options, status) => {
+				releaseStatuses.push(status);
+				await runtime.session.disposeAsync();
 			},
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
@@ -3095,6 +3102,37 @@ describe("AgentSession rlm recursion", () => {
 		const internals = root as unknown as InspectableRlmSession;
 		await waitFor(() => internals._activeRlmChildRuns.size === 0);
 		await waitFor(() => disposeChild.mock.calls.length > 0);
+		expect(releaseStatuses).toEqual(["cancelled"]);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
+	});
+
+	it("removes an in-process child's dir when a spawn is revoked before admission", async () => {
+		const controller = new AbortController();
+		const root = createSession();
+		const internals = root as unknown as InspectableRlmSession & {
+			_createRlmSubagentRuntime(options: unknown): Promise<{ session: AgentSession }>;
+		};
+		const originalCreateRuntime = internals._createRlmSubagentRuntime.bind(root);
+		let disposeChild: ReturnType<typeof vi.spyOn> | undefined;
+		vi.spyOn(internals, "_createRlmSubagentRuntime").mockImplementation(async (options) => {
+			// Revoke while the inline runtime is being created, then publish late.
+			controller.abort();
+			const runtime = await originalCreateRuntime(options);
+			disposeChild = vi.spyOn(runtime.session, "disposeAsync");
+			return runtime;
+		});
+
+		const admission = root.runRlmChild("revoked during inline creation", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		await waitFor(() => (disposeChild?.mock.calls.length ?? 0) > 0);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
 		const artifactDir = root.sessionManager.getSessionArtifactDir();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3120,6 +3120,9 @@ describe("AgentSession rlm recursion", () => {
 		if (!quarantinedChildId) throw new Error("Missing deletion quarantine");
 		// The exact opaque id can retry cleanup even though the lease is omitted from
 		// every product-facing list and cannot be selected by its name or session id.
+		await expect(root.deleteRlmSubagent("revoked during late publication")).rejects.toThrow(
+			'No direct RLM subagent matches "revoked during late publication"',
+		);
 		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
 			subagent: { rlm_child_id: quarantinedChildId },
 		});

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3152,6 +3152,53 @@ describe("AgentSession rlm recursion", () => {
 		});
 	});
 
+	it("preserves a same-id retained replacement before passing it to host deletion", async () => {
+		const childId = "recycled-quarantine-incarnation";
+		const stale = createSession({ rlmSessionDir: join(tempDir, "stale-quarantine-incarnation") });
+		const replacement = createSession({ rlmSessionDir: join(tempDir, "replacement-quarantine-incarnation") });
+		const lease = {
+			rlm_child_id: childId,
+			active_session_id: null,
+			session_id: stale.sessionId,
+			...(stale.sessionFile ? { session_file: stale.sessionFile } : {}),
+			session_name: "stale-quarantine-incarnation",
+			session_dir: join(tempDir, "stale-quarantine-incarnation"),
+			status: "error" as const,
+		};
+		const deleteRuntime = vi.fn(async () => {
+			throw new Error("replacement must not be passed to host deletion");
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+				resolveRlmSubagentDeletion: async () => "tombstoned",
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		const internals = root as unknown as InspectableRlmSession;
+		internals._rlmChildDeletionQuarantines.set(childId, lease);
+		internals._rlmChildSessions.set(childId, replacement);
+		internals._deletedRlmChildIds.add(childId);
+
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({ outcome: "preserved_newer" });
+		expect(deleteRuntime).not.toHaveBeenCalled();
+		expect(internals._rlmChildDeletionQuarantines.has(childId)).toBe(false);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(false);
+		await expect(root.listRlmSubagents()).resolves.toEqual({
+			subagents: [
+				expect.objectContaining({
+					rlm_child_id: childId,
+					session_id: replacement.sessionId,
+					session_dir: join(tempDir, "replacement-quarantine-incarnation"),
+				}),
+			],
+		});
+		await stale.disposeAsync();
+		await replacement.disposeAsync();
+	});
+
 	it("keeps late startup cleanup retryable when release and fallback delete fail", async () => {
 		let releaseRuntimeCreation: () => void = () => {};
 		const runtimeCreationGate = new Promise<void>((resolve) => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2542,7 +2542,11 @@ describe("AgentSession rlm recursion", () => {
 			streamFn: (_model, context) => {
 				const stream = createAssistantMessageEventStream();
 				void finishGate.then(() =>
-					stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${userText(context)}`) }),
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: assistantMessage(`child answer: ${userText(context)}`),
+					}),
 				);
 				return stream;
 			},
@@ -2589,7 +2593,13 @@ describe("AgentSession rlm recursion", () => {
 			rlmSessionDir: join(tempDir, "error-finalizer-race-child"),
 			streamFn: () => {
 				const stream = createAssistantMessageEventStream();
-				void failGate.then(() => stream.push({ type: "error", reason: "error", error: { ...assistantMessage("child failure"), stopReason: "error" } }));
+				void failGate.then(() =>
+					stream.push({
+						type: "error",
+						reason: "error",
+						error: { ...assistantMessage("child failure"), stopReason: "error" },
+					}),
+				);
 				return stream;
 			},
 		});
@@ -2663,7 +2673,8 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
 				deleteRlmSubagentRuntime: async (_id, session) => {
-					if (++deleteAttempts === 1) throw new RlmSubagentHostDeletionError("tombstoned", new Error("first close failed"));
+					if (++deleteAttempts === 1)
+						throw new RlmSubagentHostDeletionError("tombstoned", new Error("first close failed"));
 					await session?.disposeAsync();
 				},
 			},

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1383,7 +1383,7 @@ describe("AgentSession rlm recursion", () => {
 	it("releases a hosted child when its initial task fails", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "host-error-child") });
 		vi.spyOn(child, "promptAndWait").mockRejectedValue(new Error("child prompt failed"));
-		const releaseRlmSubagentRuntime = vi.fn(async () => {});
+		const releaseRlmSubagentRuntime = vi.fn(async () => ({ retained: false }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
@@ -2470,6 +2470,7 @@ describe("AgentSession rlm recursion", () => {
 				deleteRlmSubagentRuntime: deleteRuntime,
 				releaseRlmSubagentRuntime: async (runtime, options) => {
 					options.parentSession.registerRlmChildSession(options.id, runtime.session);
+					return { retained: true };
 				},
 			},
 		});
@@ -2493,7 +2494,7 @@ describe("AgentSession rlm recursion", () => {
 	it("releases a hosted child when completion persistence fails", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "host-completion-failure-child") });
 		const disposeChild = vi.spyOn(child, "disposeAsync");
-		const releaseRlmSubagentRuntime = vi.fn(async () => {});
+		const releaseRlmSubagentRuntime = vi.fn(async () => ({ retained: false }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
@@ -3070,7 +3071,7 @@ describe("AgentSession rlm recursion", () => {
 		await child.disposeAsync();
 	});
 
-	it("keeps a host-owned runtime's dir when a spawn is revoked before admission", async () => {
+	it("removes a host-owned runtime dir when release does not retain a revoked spawn", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
@@ -3082,11 +3083,12 @@ describe("AgentSession rlm recursion", () => {
 				options.onSessionPublished?.(child);
 				return { session: child };
 			},
-			// Daemon-like release: record the deletion durably and close the session;
-			// the artifact tree stays on disk per the daemon persistence contract.
+			// A release hook may close a child even when its persistence failed. It
+			// explicitly declines retention, so the caller must clean the exact orphan.
 			releaseRlmSubagentRuntime: async (runtime, _options, status) => {
 				releaseStatuses.push(status);
 				await runtime.session.disposeAsync();
+				return { retained: false };
 			},
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
@@ -3101,13 +3103,13 @@ describe("AgentSession rlm recursion", () => {
 		await expect(admission).rejects.toThrow("host request authority was revoked");
 		const internals = root as unknown as InspectableRlmSession;
 		await waitFor(() => internals._activeRlmChildRuns.size === 0);
-		await waitFor(() => disposeChild.mock.calls.length > 0);
+		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(releaseStatuses).toEqual(["cancelled"]);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
 		const artifactDir = root.sessionManager.getSessionArtifactDir();
 		if (!artifactDir) throw new Error("Missing session artifact dir");
-		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
 	it("removes a dispose-only host child's dir when a spawn is revoked before admission", async () => {

--- a/packages/coding-agent/test/daemon-catalog-inode-precision.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-inode-precision.test.ts
@@ -1,0 +1,113 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+	lstatSync: vi.fn<typeof import("node:fs").lstatSync>(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	fsMocks.lstatSync.mockImplementation(actual.lstatSync);
+	return { ...actual, lstatSync: fsMocks.lstatSync };
+});
+
+const { listCatalogFamilySessions, setCatalogHelperLaunchForTest } = await import(
+	"../src/modes/daemon/daemon-catalog-process.js"
+);
+
+const UNSAFE_INODE = 9_007_199_254_740_993n;
+const SESSION_HEADER = `${JSON.stringify({
+	type: "session",
+	id: "parent",
+	timestamp: "2026-01-01T00:00:00.000Z",
+	cwd: "/tmp/project",
+	rlmDepth: 0,
+})}\n`;
+
+function helperForInode(ino: bigint): string {
+	return `
+let input = "";
+process.stdin.on("data", (chunk) => {
+	input += chunk;
+	while (true) {
+		const newline = input.indexOf("\\n");
+		if (newline === -1) return;
+		const request = JSON.parse(input.slice(0, newline));
+		input = input.slice(newline + 1);
+		const response = { id: request.id, mtimeMs: 0, dev: "1", ino: "${ino}" };
+		if (request.mode === "metadata") {
+			response.data = {
+				valid: true,
+				messageCount: 0,
+				firstMessage: "(no messages)",
+				allMessagesText: "",
+				modifiedMs: 0,
+			};
+		} else if (request.mode !== "stat") {
+			response.data = "${Buffer.from(SESSION_HEADER).toString("base64")}";
+		}
+		process.stdout.write(JSON.stringify(response) + "\\n");
+	}
+});
+`;
+}
+
+function mockUnsafeInode(sessionFile: string): void {
+	fsMocks.lstatSync.mockImplementation(((path: string, options?: { bigint?: boolean }) => {
+		if (path !== sessionFile) throw new Error(`unexpected lstat path: ${path}`);
+		return options?.bigint === true
+			? ({ dev: 1n, ino: UNSAFE_INODE } as ReturnType<typeof fsMocks.lstatSync>)
+			: ({ dev: 1, ino: Number(UNSAFE_INODE) } as ReturnType<typeof fsMocks.lstatSync>);
+	}) as never);
+}
+
+function createFixture() {
+	const root = mkdtempSync(join(tmpdir(), "prime-catalog-unsafe-inode-"));
+	const sessionDir = join(root, "sessions");
+	const sessionFile = join(sessionDir, "parent.jsonl");
+	mkdirSync(sessionDir);
+	writeFileSync(sessionFile, SESSION_HEADER);
+	return { root, sessionDir, sessionFile };
+}
+
+afterEach(() => {
+	setCatalogHelperLaunchForTest(undefined);
+	fsMocks.lstatSync.mockReset();
+});
+
+describe("daemon catalog root identity", () => {
+	it("matches an unsafe inode from lstat to the helper's exact fstat decimal", async () => {
+		const { root, sessionDir, sessionFile } = createFixture();
+		mockUnsafeInode(sessionFile);
+		setCatalogHelperLaunchForTest({ command: process.execPath, args: ["-e", helperForInode(UNSAFE_INODE)] });
+
+		try {
+			await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([
+				expect.objectContaining({ id: "parent" }),
+			]);
+			expect(fsMocks.lstatSync).toHaveBeenCalledWith(sessionFile, { bigint: true });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects an unsafe inode differing from the helper below Number precision", async () => {
+		const { root, sessionDir, sessionFile } = createFixture();
+		mockUnsafeInode(sessionFile);
+		setCatalogHelperLaunchForTest({
+			command: process.execPath,
+			args: ["-e", helperForInode(UNSAFE_INODE - 1n)],
+		});
+
+		try {
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+				"root candidate changed after directory enumeration",
+			);
+			expect(fsMocks.lstatSync).toHaveBeenCalledWith(sessionFile, { bigint: true });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -1,4 +1,13 @@
-import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	appendFileSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -449,7 +458,7 @@ describe("daemon catalog selector resolution", () => {
 		setCatalogBeforeTrustedOpenForTest(undefined);
 	});
 
-	it("parses session metadata from the same descriptor-bound bytes without a pathname reopen", async () => {
+	it("rejects a session replaced between listing and the descriptor-bound header read", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-no-reopen-"));
 		const sessionDir = join(root, "sessions");
 		const parent = SessionManager.create(root, sessionDir);
@@ -463,8 +472,9 @@ describe("daemon catalog selector resolution", () => {
 			renameSync(path, original);
 			writeFileSync(path, "not a session\n");
 		});
-		// The helper opens after the hook, so it must reject the replacement instead of
-		// authorizing stale bytes. This pins the absence of a later readSessionInfo reopen.
+		// Topology claims come from the descriptor-bound header read, which opens
+		// after the hook and must reject the replacement instead of authorizing
+		// the stale listing.
 		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
 		setCatalogBeforeTrustedOpenForTest(undefined);
 		rmSync(root, { recursive: true, force: true });
@@ -597,6 +607,63 @@ describe("daemon catalog selector resolution", () => {
 		const baseline = getOpenCatalogAuthorityFdCountForTest();
 		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
 		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(baseline);
+	});
+
+	it("reads only the session header line even when the body is huge", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-header-only-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		// A body far beyond the old whole-file transfer budget must not slow or
+		// break the walk: only the first line participates in the trust decision.
+		appendFileSync(
+			parent.getSessionFile()!,
+			`${JSON.stringify({ type: "custom_message", body: "x".repeat(8 * 1024 * 1024) })}\n`,
+		);
+		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([
+			expect.objectContaining({ id: "parent", rlmDepth: 0 }),
+		]);
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("rejects a session whose header line exceeds the header budget", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-header-overflow-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		const file = parent.getSessionFile()!;
+		const entries = readFileSync(file, "utf8").trimEnd().split(/\r?\n/);
+		const header = JSON.parse(entries[0]!) as Record<string, unknown>;
+		header.padding = "x".repeat(300 * 1024);
+		writeFileSync(file, `${[JSON.stringify(header), ...entries.slice(1)].join("\n")}\n`);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("still requires a registry child's claimed parent file to exist", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-absent-parent-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		const child = SessionManager.create(root, join(root, "session-artifacts", "parent", "sub-child"));
+		child.newSession({ id: "child", parentSession: join(sessionDir, "gone.jsonl"), rlmDepth: 1 });
+		child.appendSessionInfo("child");
+		const registry = join(root, "session-artifacts", "parent", "rlm-subagents.jsonl");
+		mkdirSync(dirname(registry), { recursive: true });
+		writeFileSync(
+			registry,
+			JSON.stringify({
+				type: "rlm_subagent",
+				childId: "child",
+				sessionFile: child.getSessionFile(),
+				status: "completed",
+			}),
+		);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+		rmSync(root, { recursive: true, force: true });
 	});
 
 	it("treats an exact name colliding with another session id prefix as ambiguous", () => {

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -22,6 +22,7 @@ import {
 	setCatalogAfterTrustedHeaderForTest,
 	setCatalogBeforeTrustedOpenForTest,
 	setCatalogHelperLaunchForTest,
+	setCatalogMaxRlmFamilyNodesForTest,
 } from "../src/modes/daemon/daemon-catalog-process.js";
 
 function session(id: string, name: string | undefined, path: string): SessionInfo {
@@ -872,6 +873,37 @@ describe("daemon catalog selector resolution", () => {
 		rmSync(root, { recursive: true, force: true });
 	});
 
+	it("bounds stable root discovery before descriptor reads and admits the exact limit", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-root-discovery-bound-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		let trustedOpens = 0;
+		setCatalogBeforeTrustedOpenForTest(() => {
+			trustedOpens++;
+		});
+		try {
+			// The narrow limit hook proves both the exact-limit success case and
+			// over-limit failure without creating 10,001 filesystem entries.
+			setCatalogMaxRlmFamilyNodesForTest(1);
+			await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([
+				expect.objectContaining({ id: "parent" }),
+			]);
+			expect(trustedOpens).toBeGreaterThan(0);
+			trustedOpens = 0;
+			writeFileSync(join(sessionDir, "unrelated.jsonl"), "not json\n");
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("family node limit exhausted");
+			// No candidate descriptor may be opened, classified, or metadata-scanned
+			// after discovery proves the family is over the hard bound.
+			expect(trustedOpens).toBe(0);
+		} finally {
+			setCatalogMaxRlmFamilyNodesForTest(undefined);
+			setCatalogBeforeTrustedOpenForTest(undefined);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("classifies escaped and boundary-truncated root claims with the real helper", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-escaped-root-classification-"));
 		const sessionDir = join(root, "sessions");
@@ -899,6 +931,34 @@ describe("daemon catalog selector resolution", () => {
 			"session header exceeds the trusted read limit",
 		);
 		rmSync(partialEscape);
+
+		// These cross the actual 64 KiB classifier read boundary. A fully decoded
+		// outer type whose colon/value is still beyond that boundary, and a fully
+		// decoded outer id with its delimiter/value beyond it, are topology claims.
+		const boundaryType = join(sessionDir, "boundary-type-whitespace.jsonl");
+		const typePrefix = `{"type"${" ".repeat(64 * 1024 - Buffer.byteLength('{"type"', "utf8"))}`;
+		writeFileSync(boundaryType, `${typePrefix}:"session","id":"claimed","padding":"${"x".repeat(200 * 1024)}"}`);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+			"session header exceeds the trusted read limit",
+		);
+		rmSync(boundaryType);
+
+		const boundaryId = join(sessionDir, "boundary-id-no-value.jsonl");
+		const idPrefix = `{"junk":0,"id"${" ".repeat(64 * 1024 - Buffer.byteLength('{"junk":0,"id"', "utf8"))}`;
+		writeFileSync(boundaryId, `${idPrefix}:"claimed","padding":"${"x".repeat(200 * 1024)}"}`);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+			"session header exceeds the trusted read limit",
+		);
+		rmSync(boundaryId);
+
+		// A complete demonstrably non-string type value remains unrelated; the
+		// following outer id is still scanned and cannot be hidden by that skip.
+		const nonStringThenId = join(sessionDir, "non-string-type-then-id.jsonl");
+		writeFileSync(nonStringThenId, `{"type":null,"id":"claimed","padding":"${"x".repeat(200 * 1024)}"}`);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+			"session header exceeds the trusted read limit",
+		);
+		rmSync(nonStringThenId);
 
 		// Invalid escapes in a terminated unrelated value must not conceal later
 		// outer claims in the bounded helper prefix.

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -636,6 +636,15 @@ describe("daemon catalog selector resolution", () => {
 				}),
 			),
 		).rejects.toThrow("child lacks a persisted parent path");
+		// Registry-reached children never use the root-only classifier: a large
+		// apparent session header is strictly rejected rather than skipped.
+		await expect(
+			listCatalogFamilySessions(
+				make((header) => {
+					header.padding = "x".repeat(200 * 1024);
+				}),
+			),
+		).rejects.toThrow("Invalid RLM artifact family topology");
 		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
 	});
 
@@ -742,9 +751,10 @@ describe("daemon catalog selector resolution", () => {
 				`${[
 					JSON.stringify({ type: "message", message: { role: "user", content: payload } }),
 					JSON.stringify({ type: "session_info", name: payload }),
+					JSON.stringify({ type: "session_state", state: { status: "archived" } }),
 					JSON.stringify({
 						type: "agent_status",
-						status: { summary: payload, taskState: payload, basedOnMessageCount: 1 },
+						status: { summary: payload, taskState: "completed", basedOnMessageCount: 1 },
 					}),
 				].join("\n")}\n`,
 			);
@@ -761,10 +771,29 @@ describe("daemon catalog selector resolution", () => {
 						agentStatus: expect.objectContaining({ summary: expect.any(String), basedOnMessageCount: 1 }),
 					}),
 				);
-				expect(session?.agentStatus?.taskState).toBeUndefined();
+				expect(session?.state).toEqual({ status: "archived" });
+				expect(session?.agentStatus?.taskState).toBe("completed");
 				expect(responses).toHaveLength(1);
 				const response = responses[0]!;
-				expect(JSON.parse(response.line).id).toBe(response.id);
+				const wire = JSON.parse(response.line) as {
+					id: string;
+					data: {
+						valid: boolean;
+						messageCount: number;
+						state?: { status: string };
+						agentStatus?: { taskState?: string };
+					};
+				};
+				// Compaction may touch display strings only: the protocol UUID and
+				// typed controls are byte-for-byte stable in the exact wire envelope.
+				expect(wire.id).toBe(response.id);
+				expect(wire.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+				expect(wire.data).toMatchObject({
+					valid: true,
+					messageCount: 1,
+					state: { status: "archived" },
+					agentStatus: { taskState: "completed" },
+				});
 				expect(Buffer.byteLength(response.line, "ascii")).toBeLessThanOrEqual(256 * 1024);
 			} finally {
 				setCatalogAfterHelperResponseForTest(undefined);
@@ -962,7 +991,7 @@ process.stdin.on("data", chunk => {
  while (true) {
   const end=input.indexOf("\n"); if (end<0) break;
   const request=JSON.parse(input.slice(0,end)); input=input.slice(end+1);
-  const payload=request.mode === "header" ? { id:request.id, data:${JSON.stringify(Buffer.from(header).toString("base64"))}, mtimeMs:0, dev:"1", ino:"1" } : request.mode === "metadata" ? { id:request.id, data:{valid:true,messageCount:0,firstMessage:"(no messages)",allMessagesText:"",modifiedMs:0}, mtimeMs:0, dev:"1", ino:"1" } : { id:request.id, mtimeMs:0, dev:"1", ino:"1" };
+  const payload=(request.mode === "header" || request.mode === "classify") ? { id:request.id, data:${JSON.stringify(Buffer.from(header).toString("base64"))}, mtimeMs:0, dev:"1", ino:"1" } : request.mode === "metadata" ? { id:request.id, data:{valid:true,messageCount:0,firstMessage:"(no messages)",allMessagesText:"",modifiedMs:0}, mtimeMs:0, dev:"1", ino:"1" } : { id:request.id, mtimeMs:0, dev:"1", ino:"1" };
   process.stdout.write(JSON.stringify(payload)+"\n");
   if (request.mode === "metadata") setTimeout(() => process.stdout.write("{\"unsolicited\":true}\n"), 25);
  }

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -717,6 +717,49 @@ describe("daemon catalog selector resolution", () => {
 		rmSync(root, { recursive: true, force: true });
 	});
 
+	it("caps the exact escaped metadata response while preserving a usable family", async () => {
+		const payloads = ["a".repeat(1_048_000), "漢😀".repeat(65_536), '"\\\b\f\n\r\t\u0000'.repeat(80_000)];
+		for (const [index, payload] of payloads.entries()) {
+			const root = mkdtempSync(join(tmpdir(), `prime-catalog-escaped-cap-${index}-`));
+			const sessionDir = join(root, "sessions");
+			const parent = SessionManager.create(root, sessionDir);
+			parent.newSession({ id: `parent-${index}`, rlmDepth: 0 });
+			parent.appendSessionInfo("compact");
+			appendFileSync(
+				parent.getSessionFile()!,
+				`${[
+					JSON.stringify({ type: "message", message: { role: "user", content: payload } }),
+					JSON.stringify({ type: "session_info", name: payload }),
+					JSON.stringify({
+						type: "agent_status",
+						status: { summary: payload, taskState: "completed", basedOnMessageCount: 1 },
+					}),
+				].join("\n")}\n`,
+			);
+			const family = await listCatalogFamilySessions(sessionDir);
+			expect(family).toHaveLength(1);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("skips junk root candidates but rejects identified malformed and duplicate roots", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-root-classification-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		writeFileSync(join(sessionDir, "blank.jsonl"), "\n");
+		writeFileSync(join(sessionDir, "junk.jsonl"), "not json\n");
+		writeFileSync(join(sessionDir, "event.jsonl"), '{"type":"message","id":"junk"}\n');
+		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([expect.objectContaining({ id: "parent" })]);
+		writeFileSync(join(sessionDir, "bad.jsonl"), '{"type":"session","id":"bad","rlmDepth":"oops"}\n');
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+		rmSync(join(sessionDir, "bad.jsonl"));
+		writeFileSync(join(sessionDir, "duplicate.jsonl"), readFileSync(parent.getSessionFile()!));
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("duplicate session id");
+		rmSync(root, { recursive: true, force: true });
+	});
+
 	it("reads only the session header line even when the body is huge", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-header-only-"));
 		const sessionDir = join(root, "sessions");

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -718,7 +718,9 @@ describe("daemon catalog selector resolution", () => {
 	});
 
 	it("caps the exact escaped metadata response while preserving a usable family", async () => {
-		const payloads = ["a".repeat(1_048_000), "漢😀".repeat(65_536), '"\\\b\f\n\r\t\u0000'.repeat(80_000)];
+		// Keep each JSONL record below the parser's 1 MiB record bound while its
+		// combined escaped metadata response still greatly exceeds 256 KiB.
+		const payloads = ["a".repeat(500_000), "漢😀".repeat(50_000), '"\\\b\f\n\r\t\u0000'.repeat(25_000)];
 		for (const [index, payload] of payloads.entries()) {
 			const root = mkdtempSync(join(tmpdir(), `prime-catalog-escaped-cap-${index}-`));
 			const sessionDir = join(root, "sessions");
@@ -738,6 +740,36 @@ describe("daemon catalog selector resolution", () => {
 			);
 			const family = await listCatalogFamilySessions(sessionDir);
 			expect(family).toHaveLength(1);
+			const [session] = family;
+			// A successful descriptor helper exchange proves the exact ASCII-escaped
+			// response stayed inside its 256 KiB wire cap. The compact response still
+			// has every catalog field consumers require.
+			expect(session).toEqual(
+				expect.objectContaining({
+					id: `parent-${index}`,
+					firstMessage: expect.any(String),
+					allMessagesText: expect.any(String),
+					name: expect.any(String),
+					agentStatus: expect.objectContaining({
+						summary: expect.any(String),
+						taskState: "completed",
+						basedOnMessageCount: 1,
+					}),
+				}),
+			);
+			const serialized = JSON.stringify({
+				id: "metadata-response",
+				data: {
+					valid: true,
+					messageCount: session.messageCount,
+					firstMessage: session.firstMessage,
+					allMessagesText: session.allMessagesText,
+					modifiedMs: session.modified.getTime(),
+					name: session.name,
+					agentStatus: session.agentStatus,
+				},
+			});
+			expect(Buffer.byteLength(serialized, "ascii")).toBeLessThanOrEqual(256 * 1024);
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -477,13 +477,91 @@ describe("daemon catalog selector resolution", () => {
 		parent.newSession({ id: "parent", rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
 		const hostile = SessionManager.create(root, sessionDir);
-		hostile.newSession({ id: "hostile", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		hostile.newSession({ id: "hostile", parentSession: join(root, "outside.jsonl"), rlmDepth: 1 });
 		hostile.appendSessionInfo("hostile");
 		const baseline = getOpenCatalogAuthorityFdCountForTest();
 		for (let attempt = 0; attempt < 64; attempt++) {
 			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
 			expect(getOpenCatalogAuthorityFdCountForTest()).toBe(baseline);
 		}
+	});
+
+	it("treats forked flat-dir sessions as family roots for both fork header shapes", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-fork-roots-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		// Current fork writer: parentSession plus a copied numeric rlmDepth.
+		const forkWithDepth = SessionManager.create(root, sessionDir);
+		forkWithDepth.newSession({ id: "fork-depth", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		forkWithDepth.appendSessionInfo("fork-depth");
+		// Older fork writer: parentSession with no rlmDepth claim at all.
+		const forkNoDepth = SessionManager.create(root, sessionDir);
+		forkNoDepth.newSession({ id: "fork-nodepth", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		forkNoDepth.appendSessionInfo("fork-nodepth");
+		const forkNoDepthFile = forkNoDepth.getSessionFile()!;
+		const [headerLine, ...rest] = readFileSync(forkNoDepthFile, "utf8").trimEnd().split(/\r?\n/);
+		const header = JSON.parse(headerLine!) as Record<string, unknown>;
+		delete header.rlmDepth;
+		writeFileSync(forkNoDepthFile, `${[JSON.stringify(header), ...rest].join("\n")}\n`);
+
+		const family = await listCatalogFamilySessions(sessionDir);
+		expect(family).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "parent", rlmDepth: 0 }),
+				expect.objectContaining({ id: "fork-depth", rlmDepth: 0 }),
+				expect.objectContaining({ id: "fork-nodepth", rlmDepth: 0 }),
+			]),
+		);
+		// Fork lineage is not rlm topology: it must not surface as a parent claim.
+		for (const info of family) expect(info.parentSessionPath).toBeUndefined();
+		// A fork root is its own sibling set, not a sibling of the source's rlm children.
+		await expect(listSavedSessionSiblings(forkWithDepth.getSessionFile()!, sessionDir)).resolves.toEqual([
+			expect.objectContaining({ id: "fork-depth" }),
+		]);
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("keeps strict topology invariants for registry-reached children", async () => {
+		const make = (mutateHeader: (header: Record<string, unknown>) => void) => {
+			const root = mkdtempSync(join(tmpdir(), "prime-catalog-strict-child-"));
+			const sessionDir = join(root, "sessions");
+			const parent = SessionManager.create(root, sessionDir);
+			parent.newSession({ id: "parent", rlmDepth: 0 });
+			parent.appendSessionInfo("parent");
+			const child = SessionManager.create(root, join(root, "session-artifacts", "parent", "sub-child"));
+			child.newSession({ id: "child", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+			child.appendSessionInfo("child");
+			const childFile = child.getSessionFile()!;
+			const [headerLine, ...rest] = readFileSync(childFile, "utf8").trimEnd().split(/\r?\n/);
+			const header = JSON.parse(headerLine!) as Record<string, unknown>;
+			mutateHeader(header);
+			writeFileSync(childFile, `${[JSON.stringify(header), ...rest].join("\n")}\n`);
+			const registry = join(root, "session-artifacts", "parent", "rlm-subagents.jsonl");
+			mkdirSync(dirname(registry), { recursive: true });
+			writeFileSync(
+				registry,
+				JSON.stringify({ type: "rlm_subagent", childId: "child", sessionFile: childFile, status: "completed" }),
+			);
+			return sessionDir;
+		};
+		await expect(
+			listCatalogFamilySessions(
+				make((header) => {
+					delete header.rlmDepth;
+				}),
+			),
+		).rejects.toThrow("child lacks a persisted depth");
+		await expect(
+			listCatalogFamilySessions(
+				make((header) => {
+					delete header.parentSession;
+				}),
+			),
+		).rejects.toThrow("child lacks a persisted parent path");
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
 	});
 
 	it("rejects an unregistered parent-claiming seed and conflicting duplicate identity", async () => {
@@ -493,7 +571,7 @@ describe("daemon catalog selector resolution", () => {
 		parent.newSession({ id: "parent", rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
 		const orphan = SessionManager.create(root, sessionDir);
-		orphan.newSession({ id: "evil", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		orphan.newSession({ id: "evil", parentSession: join(root, "outside.jsonl"), rlmDepth: 1 });
 		orphan.appendSessionInfo("evil");
 		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("managed session seed claims a parent");
 

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -900,6 +900,57 @@ describe("daemon catalog selector resolution", () => {
 		);
 		rmSync(partialEscape);
 
+		// Invalid escapes in a terminated unrelated value must not conceal later
+		// outer claims in the bounded helper prefix.
+		for (const [name, malformed] of [
+			["invalid-simple-escape", "\\q"],
+			["invalid-unicode-escape", "\\u12xz"],
+		] as const) {
+			const file = join(sessionDir, `${name}.jsonl`);
+			writeFileSync(file, `{"junk":"${malformed}","\\u0069d":"claimed","padding":"${"x".repeat(200 * 1024)}"}`);
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+				"session header exceeds the trusted read limit",
+			);
+			rmSync(file);
+		}
+
+		const malformedUnicodeBeforeEscapedType = join(sessionDir, "invalid-unicode-before-escaped-type.jsonl");
+		writeFileSync(
+			malformedUnicodeBeforeEscapedType,
+			`{"junk":"\\u12xz","\\u0074ype":"\\u0073ession","padding":"${"x".repeat(200 * 1024)}"}`,
+		);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+			"session header exceeds the trusted read limit",
+		);
+		rmSync(malformedUnicodeBeforeEscapedType);
+
+		const malformedNested = join(sessionDir, "malformed-nested-value.jsonl");
+		writeFileSync(malformedNested, `{"junk":{"inner":"\\q"},"id":"claimed","padding":"${"x".repeat(200 * 1024)}"}`);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+			"session header exceeds the trusted read limit",
+		);
+		rmSync(malformedNested);
+
+		for (const [name, typeValue, id] of [
+			["null-type-before-id", "null", '"claimed"'],
+			["object-type-before-escaped-id", '{"nested":"value"}', '"claimed"'],
+			["array-type-before-id", '["value"]', '"claimed"'],
+		] as const) {
+			const file = join(sessionDir, `${name}.jsonl`);
+			writeFileSync(file, `{"type":${typeValue},"\\u0069d":${id},"padding":"${"x".repeat(200 * 1024)}"}`);
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+				"session header exceeds the trusted read limit",
+			);
+			rmSync(file);
+		}
+
+		// Once the bounded scanner reaches the outer close without a claim, an
+		// otherwise malformed unrelated record remains safely skippable.
+		const malformedUnrelated = join(sessionDir, "malformed-unrelated-junk.jsonl");
+		writeFileSync(malformedUnrelated, `{"junk":"\\q","padding":"${"x".repeat(200 * 1024)}"}`);
+		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([expect.objectContaining({ id: "parent" })]);
+		rmSync(malformedUnrelated);
+
 		writeFileSync(
 			join(sessionDir, "escaped-unrelated-junk.jsonl"),
 			`{"\\u006aunk":"\\u0073ession","padding":"${"x".repeat(200 * 1024)}"}\n`,

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -50,18 +50,19 @@ function createCatalogFamilyFixture() {
 	second.appendSessionInfo("second");
 	const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
 	mkdirSync(dirname(registry), { recursive: true });
+	// Registries key children by rlm child id ("sub-*"), never by session id.
 	writeFileSync(
 		registry,
 		[
 			{
 				type: "rlm_subagent",
-				childId: first.getSessionId(),
+				childId: "sub-first",
 				sessionFile: first.getSessionFile(),
 				status: "completed",
 			},
 			{
 				type: "rlm_subagent",
-				childId: second.getSessionId(),
+				childId: "sub-second",
 				sessionFile: second.getSessionFile(),
 				status: "completed",
 			},
@@ -98,6 +99,7 @@ describe("daemon catalog selector resolution", () => {
 		second.appendSessionInfo("second");
 		const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
 		mkdirSync(dirname(registry), { recursive: true });
+		// Legacy registry variant where childId happens to equal the session id.
 		writeFileSync(
 			registry,
 			[
@@ -179,13 +181,13 @@ describe("daemon catalog selector resolution", () => {
 			[
 				{
 					type: "rlm_subagent",
-					childId: first.getSessionId(),
+					childId: "sub-first",
 					sessionFile: first.getSessionFile(),
 					status: "completed",
 				},
 				{
 					type: "rlm_subagent",
-					childId: second.getSessionId(),
+					childId: "sub-second",
 					sessionFile: second.getSessionFile(),
 					status: "completed",
 				},
@@ -217,12 +219,14 @@ describe("daemon catalog selector resolution", () => {
 		const makeFixture = (name: string, omitRootDepth = false) => {
 			const root = mkdtempSync(join(tmpdir(), name));
 			const sessionDir = join(root, "sessions");
+			// The writer keeps a session's child registry beside its session dir:
+			// <dirname(sessionDir)>/session-artifacts/<session id>.
 			const registryPath = (parentId: string) => {
 				const parentFile = [rootSession, parent, first, second]
 					.find((manager) => manager.getSessionId() === parentId)
 					?.getSessionFile();
-				return parentFile && dirname(parentFile) !== sessionDir
-					? join(dirname(parentFile), "session-artifacts", parentId, "rlm-subagents.jsonl")
+				return parentFile
+					? join(dirname(dirname(parentFile)), "session-artifacts", parentId, "rlm-subagents.jsonl")
 					: join(root, "session-artifacts", parentId, "rlm-subagents.jsonl");
 			};
 			const writeRegistry = (parentId: string, entries: unknown[]) => {
@@ -255,22 +259,22 @@ describe("daemon catalog selector resolution", () => {
 			);
 			const first = create(
 				"first",
-				join(root, "session-artifacts", "parent", "sub-first"),
+				join(root, "session-artifacts", "root", "sub-parent", "sub-first"),
 				parent.getSessionFile(),
 				2,
 			);
 			const second = create(
 				"second",
-				join(root, "session-artifacts", "parent", "sub-second"),
+				join(root, "session-artifacts", "root", "sub-parent", "sub-second"),
 				parent.getSessionFile(),
 				2,
 			);
 			writeRegistry("root", [
-				{ type: "rlm_subagent", childId: "parent", sessionFile: parent.getSessionFile(), status: "completed" },
+				{ type: "rlm_subagent", childId: "sub-parent", sessionFile: parent.getSessionFile(), status: "completed" },
 			]);
 			writeRegistry("parent", [
-				{ type: "rlm_subagent", childId: "first", sessionFile: first.getSessionFile(), status: "completed" },
-				{ type: "rlm_subagent", childId: "second", sessionFile: second.getSessionFile(), status: "completed" },
+				{ type: "rlm_subagent", childId: "sub-first", sessionFile: first.getSessionFile(), status: "completed" },
+				{ type: "rlm_subagent", childId: "sub-second", sessionFile: second.getSessionFile(), status: "completed" },
 			]);
 			return { root, sessionDir, rootSession, parent, first, second, registryPath, writeRegistry };
 		};
@@ -289,16 +293,16 @@ describe("daemon catalog selector resolution", () => {
 
 		const cases: Array<[string, (fixture: ReturnType<typeof makeFixture>) => void]> = [
 			[
-				"id mismatch",
-				(fixture) =>
+				"basename mismatch",
+				(fixture) => {
+					// A session file whose name does not match its header id is not a
+					// writer-produced child and must not be authorized.
+					const alias = join(dirname(fixture.first.getSessionFile()!), "impostor.jsonl");
+					writeFileSync(alias, readFileSync(fixture.first.getSessionFile()!));
 					fixture.writeRegistry("parent", [
-						{
-							type: "rlm_subagent",
-							childId: "wrong",
-							sessionFile: fixture.first.getSessionFile(),
-							status: "completed",
-						},
-					]),
+						{ type: "rlm_subagent", childId: "sub-first", sessionFile: alias, status: "completed" },
+					]);
+				},
 			],
 			[
 				"parent mismatch",
@@ -415,7 +419,7 @@ describe("daemon catalog selector resolution", () => {
 				registry,
 				JSON.stringify({
 					type: "rlm_subagent",
-					childId: "child",
+					childId: "sub-child",
 					sessionFile: child.getSessionFile(),
 					status: "completed",
 				}),
@@ -554,17 +558,26 @@ describe("daemon catalog selector resolution", () => {
 			mkdirSync(dirname(registry), { recursive: true });
 			writeFileSync(
 				registry,
-				JSON.stringify({ type: "rlm_subagent", childId: "child", sessionFile: childFile, status: "completed" }),
+				JSON.stringify({ type: "rlm_subagent", childId: "sub-child", sessionFile: childFile, status: "completed" }),
 			);
 			return sessionDir;
 		};
+		// Old writers omitted child rlmDepth entirely: the edge supplies it.
 		await expect(
 			listCatalogFamilySessions(
 				make((header) => {
 					delete header.rlmDepth;
 				}),
 			),
-		).rejects.toThrow("child lacks a persisted depth");
+		).resolves.toEqual(expect.arrayContaining([expect.objectContaining({ id: "child", rlmDepth: 1 })]));
+		// A present-but-contradicting depth claim is still corruption.
+		await expect(
+			listCatalogFamilySessions(
+				make((header) => {
+					header.rlmDepth = 7;
+				}),
+			),
+		).rejects.toThrow("child depth does not equal parent depth plus one");
 		await expect(
 			listCatalogFamilySessions(
 				make((header) => {
@@ -658,7 +671,7 @@ describe("daemon catalog selector resolution", () => {
 			registry,
 			JSON.stringify({
 				type: "rlm_subagent",
-				childId: "child",
+				childId: "sub-child",
 				sessionFile: child.getSessionFile(),
 				status: "completed",
 			}),
@@ -677,6 +690,66 @@ describe("daemon catalog selector resolution", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
+	});
+
+	it("walks a realistic profile: fork seeds, sub-* registry ids, two nested levels", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-realistic-"));
+		const sessionDir = join(root, "sessions");
+		const write = (path: string, header: Record<string, unknown>) => {
+			mkdirSync(dirname(path), { recursive: true });
+			writeFileSync(
+				path,
+				`${JSON.stringify({ type: "session", version: 10, timestamp: "2026-01-01T00:00:00.000Z", cwd: "/tmp/p", ...header })}\n`,
+			);
+		};
+		// The writer stores a session's child registry beside its session dir:
+		// flat roots use the profile's top-level session-artifacts; artifact-resident
+		// children get a nested session-artifacts dir beside their sub-* dir.
+		const writeRegistry = (parentFile: string, parentId: string, entries: Array<Record<string, unknown>>) => {
+			const path = join(dirname(dirname(parentFile)), "session-artifacts", parentId, "rlm-subagents.jsonl");
+			mkdirSync(dirname(path), { recursive: true });
+			writeFileSync(path, entries.map((entry) => JSON.stringify({ type: "rlm_subagent", ...entry })).join("\n"));
+		};
+		// Flat roots: a plain session plus forks in both real-world header shapes.
+		const rootFile = join(sessionDir, "root-uuid.jsonl");
+		write(rootFile, { id: "root-uuid", rlmDepth: 0 });
+		write(join(sessionDir, "fork-depth-uuid.jsonl"), { id: "fork-depth-uuid", parentSession: rootFile, rlmDepth: 0 });
+		write(join(sessionDir, "fork-nodepth-uuid.jsonl"), { id: "fork-nodepth-uuid", parentSession: rootFile });
+		// Depth-1 child in the root's artifact tree; its own registry lives at the
+		// top-level artifacts dir under its session id, as the writer stores it.
+		const childFile = join(root, "session-artifacts", "root-uuid", "sub-aaaa1111", "child-uuid.jsonl");
+		write(childFile, { id: "child-uuid", parentSession: rootFile, rlmDepth: 1 });
+		const grandFile = join(
+			root,
+			"session-artifacts",
+			"root-uuid",
+			"sub-aaaa1111",
+			"sub-bbbb2222",
+			"grand-uuid.jsonl",
+		);
+		write(grandFile, { id: "grand-uuid", parentSession: childFile, rlmDepth: 2 });
+		writeRegistry(rootFile, "root-uuid", [{ childId: "sub-aaaa1111", sessionFile: childFile, status: "running" }]);
+		writeRegistry(childFile, "child-uuid", [
+			{ childId: "sub-bbbb2222", sessionFile: grandFile, status: "completed" },
+		]);
+
+		const family = await listCatalogFamilySessions(sessionDir);
+		expect(family).toHaveLength(5);
+		expect(family).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "root-uuid", rlmDepth: 0 }),
+				expect.objectContaining({ id: "fork-depth-uuid", rlmDepth: 0 }),
+				expect.objectContaining({ id: "fork-nodepth-uuid", rlmDepth: 0 }),
+				expect.objectContaining({ id: "child-uuid", rlmDepth: 1 }),
+				expect.objectContaining({ id: "grand-uuid", rlmDepth: 2 }),
+			]),
+		);
+		// Fork ancestry must not surface as rlm parent edges on the seed rows.
+		for (const fork of ["fork-depth-uuid", "fork-nodepth-uuid"]) {
+			expect(family.find((info) => info.id === fork)?.parentSessionPath).toBeUndefined();
+		}
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
+		rmSync(root, { recursive: true, force: true });
 	});
 
 	it("treats an exact name colliding with another session id prefix as ambiguous", () => {

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -732,9 +732,11 @@ describe("daemon catalog selector resolution", () => {
 				`${[
 					JSON.stringify({ type: "message", message: { role: "user", content: payload } }),
 					JSON.stringify({ type: "session_info", name: payload }),
+					// Hostile taskState must be dropped rather than treated as a free-text
+					// field. The allowed wire enum is tested below.
 					JSON.stringify({
 						type: "agent_status",
-						status: { summary: payload, taskState: "completed", basedOnMessageCount: 1 },
+						status: { summary: payload, taskState: payload, basedOnMessageCount: 1 },
 					}),
 				].join("\n")}\n`,
 			);
@@ -752,11 +754,11 @@ describe("daemon catalog selector resolution", () => {
 					name: expect.any(String),
 					agentStatus: expect.objectContaining({
 						summary: expect.any(String),
-						taskState: "completed",
 						basedOnMessageCount: 1,
 					}),
 				}),
 			);
+			expect(session?.agentStatus?.taskState).toBeUndefined();
 			const serialized = JSON.stringify({
 				id: "metadata-response",
 				data: {
@@ -769,9 +771,41 @@ describe("daemon catalog selector resolution", () => {
 					agentStatus: session.agentStatus,
 				},
 			});
-			expect(Buffer.byteLength(serialized, "ascii")).toBeLessThanOrEqual(256 * 1024);
+			// The helper uses Python json.dumps(..., ensure_ascii=True), including
+			// surrogate-pair escaping for astral code points. Assert that exact
+			// envelope representation, not a UTF-8 or lossy Node "ascii" estimate.
+			const ensureAscii = serialized.replace(/[\u0080-\u{10ffff}]/gu, (character) => {
+				const codePoint = character.codePointAt(0)!;
+				if (codePoint <= 0xffff) return `\\u${codePoint.toString(16).padStart(4, "0")}`;
+				const offset = codePoint - 0x10000;
+				return `\\u${(0xd800 + (offset >> 10)).toString(16)}\\u${(0xdc00 + (offset & 0x3ff)).toString(16)}`;
+			});
+			expect(Buffer.byteLength(ensureAscii, "ascii")).toBeLessThanOrEqual(256 * 1024);
 			rmSync(root, { recursive: true, force: true });
 		}
+	});
+
+	it("retains only allowed typed agent task states", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-agent-status-schema-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		appendFileSync(
+			parent.getSessionFile()!,
+			`${[
+				JSON.stringify({
+					type: "agent_status",
+					status: { summary: "valid", taskState: "completed", basedOnMessageCount: 1 },
+				}),
+			].join("\n")}\n`,
+		);
+		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([
+			expect.objectContaining({
+				agentStatus: { summary: "valid", taskState: "completed", basedOnMessageCount: 1 },
+			}),
+		]);
+		rmSync(root, { recursive: true, force: true });
 	});
 
 	it("skips junk root candidates but rejects identified malformed and duplicate roots", async () => {
@@ -783,7 +817,28 @@ describe("daemon catalog selector resolution", () => {
 		writeFileSync(join(sessionDir, "blank.jsonl"), "\n");
 		writeFileSync(join(sessionDir, "junk.jsonl"), "not json\n");
 		writeFileSync(join(sessionDir, "event.jsonl"), '{"type":"message","id":"junk"}\n');
+		// An oversized root is skippable only when its bounded prefix is
+		// demonstrably unrelated, including incomplete unrelated junk. A purported
+		// session or identifier claim remains topology-relevant and fails closed.
+		writeFileSync(join(sessionDir, "oversized-junk.jsonl"), `not-json-${"x".repeat(300 * 1024)}`);
 		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([expect.objectContaining({ id: "parent" })]);
+		rmSync(join(sessionDir, "oversized-junk.jsonl"));
+		writeFileSync(join(sessionDir, "oversized-event.jsonl"), `{"type":"message","body":"${"x".repeat(300 * 1024)}`);
+		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([expect.objectContaining({ id: "parent" })]);
+		rmSync(join(sessionDir, "oversized-event.jsonl"));
+		writeFileSync(
+			join(sessionDir, "oversized-session.jsonl"),
+			`{"type":"session","id":"claimed","padding":"${"x".repeat(300 * 1024)}`,
+		);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+			"session header exceeds the trusted read limit",
+		);
+		rmSync(join(sessionDir, "oversized-session.jsonl"));
+		writeFileSync(join(sessionDir, "oversized-id.jsonl"), `{"id":"claimed","padding":"${"x".repeat(300 * 1024)}`);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+			"session header exceeds the trusted read limit",
+		);
+		rmSync(join(sessionDir, "oversized-id.jsonl"));
 		writeFileSync(join(sessionDir, "bad.jsonl"), '{"type":"session","id":"bad","rlmDepth":"oops"}\n');
 		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
 		rmSync(join(sessionDir, "bad.jsonl"));

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -274,13 +274,13 @@ describe("daemon catalog selector resolution", () => {
 			);
 			const first = create(
 				"first",
-				join(root, "session-artifacts", "root", "sub-33333333", "sub-11111111"),
+				join(root, "session-artifacts", "root", "session-artifacts", "parent", "sub-11111111"),
 				parent.getSessionFile(),
 				2,
 			);
 			const second = create(
 				"second",
-				join(root, "session-artifacts", "root", "sub-33333333", "sub-22222222"),
+				join(root, "session-artifacts", "root", "session-artifacts", "parent", "sub-22222222"),
 				parent.getSessionFile(),
 				2,
 			);
@@ -1248,15 +1248,16 @@ process.stdin.on("data", chunk => {
 		write(rootFile, { id: "root-uuid", rlmDepth: 0 });
 		write(join(sessionDir, "fork-depth-uuid.jsonl"), { id: "fork-depth-uuid", parentSession: rootFile, rlmDepth: 0 });
 		write(join(sessionDir, "fork-nodepth-uuid.jsonl"), { id: "fork-nodepth-uuid", parentSession: rootFile });
-		// Depth-1 child in the root's artifact tree; its own registry lives at the
-		// top-level artifacts dir under its session id, as the writer stores it.
+		// Depth-1 child in the root's artifact tree. SessionManager gives that
+		// artifact-resident session its own artifact root beside its sub-* dir.
 		const childFile = join(root, "session-artifacts", "root-uuid", "sub-aaaa1111", "child-uuid.jsonl");
 		write(childFile, { id: "child-uuid", parentSession: rootFile, rlmDepth: 1 });
 		const grandFile = join(
 			root,
 			"session-artifacts",
 			"root-uuid",
-			"sub-aaaa1111",
+			"session-artifacts",
+			"child-uuid",
 			"sub-bbbb2222",
 			"grand-uuid.jsonl",
 		);

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -872,6 +872,42 @@ describe("daemon catalog selector resolution", () => {
 		rmSync(root, { recursive: true, force: true });
 	});
 
+	it("classifies escaped and boundary-truncated root claims with the real helper", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-escaped-root-classification-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+
+		const escapedClaim = join(sessionDir, "escaped-claim.jsonl");
+		writeFileSync(
+			escapedClaim,
+			`{"\\u0074ype":"\\u0073ession","\\u0069d":"claimed","padding":"${"x".repeat(200 * 1024)}"}\n`,
+		);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+			"session header exceeds the trusted read limit",
+		);
+		rmSync(escapedClaim);
+
+		const partialEscape = join(sessionDir, "partial-unicode-escape.jsonl");
+		const partialClaim = '{"\\u0074ype":"\\u0073ess\\u006';
+		writeFileSync(
+			partialEscape,
+			`${" ".repeat(64 * 1024 - Buffer.byteLength(partialClaim, "utf8"))}${partialClaim}9-padding-after-limit`,
+		);
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+			"session header exceeds the trusted read limit",
+		);
+		rmSync(partialEscape);
+
+		writeFileSync(
+			join(sessionDir, "escaped-unrelated-junk.jsonl"),
+			`{"\\u006aunk":"\\u0073ession","padding":"${"x".repeat(200 * 1024)}"}\n`,
+		);
+		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([expect.objectContaining({ id: "parent" })]);
+		rmSync(root, { recursive: true, force: true });
+	});
+
 	it("keeps registry-reached child headers strict when classification would truncate", async () => {
 		const { root, sessionDir, first } = createCatalogFamilyFixture();
 		try {

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -20,6 +20,7 @@ import {
 	resolveCatalogSessionMatch,
 	setCatalogAfterTrustedHeaderForTest,
 	setCatalogBeforeTrustedOpenForTest,
+	setCatalogHelperLaunchForTest,
 } from "../src/modes/daemon/daemon-catalog-process.js";
 
 function session(id: string, name: string | undefined, path: string): SessionInfo {
@@ -100,9 +101,8 @@ describe("daemon catalog selector resolution", () => {
 		second.appendSessionInfo("second");
 		const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
 		mkdirSync(dirname(registry), { recursive: true });
-		// Version-2 session headers prove the old registry key shape, where a
-		// record was keyed by the persisted session id while its directory retained
-		// a sub-* run id.
+		// Reader compatibility for v2 headers does not relax registry provenance:
+		// childId remains the writer's direct sub-* directory name.
 		for (const child of [first, second]) {
 			const file = child.getSessionFile()!;
 			const [header, ...entries] = readFileSync(file, "utf8").trimEnd().split(/\r?\n/);
@@ -113,13 +113,13 @@ describe("daemon catalog selector resolution", () => {
 			[
 				{
 					type: "rlm_subagent",
-					childId: first.getSessionId(),
+					childId: "sub-first",
 					sessionFile: first.getSessionFile(),
 					status: "completed",
 				},
 				{
 					type: "rlm_subagent",
-					childId: second.getSessionId(),
+					childId: "sub-second",
 					sessionFile: second.getSessionFile(),
 					status: "completed",
 				},
@@ -698,6 +698,83 @@ describe("daemon catalog selector resolution", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
+	});
+
+	it("rejects promptly and releases authority FDs when the helper executable cannot spawn", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-helper-spawn-error-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		const baseline = getOpenCatalogAuthorityFdCountForTest();
+		setCatalogHelperLaunchForTest({ command: join(root, "does-not-exist"), args: [] });
+		try {
+			await expect(
+				Promise.race([
+					listCatalogFamilySessions(sessionDir),
+					new Promise<never>((_, reject) => setTimeout(() => reject(new Error("helper spawn hung")), 1_000)),
+				]),
+			).rejects.toThrow("Invalid RLM artifact family topology");
+		} finally {
+			setCatalogHelperLaunchForTest(undefined);
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(baseline);
+	});
+
+	it("rejects the family when the helper writes delayed unsolicited stdout after its final response", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-helper-delayed-stdout-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		const header = readFileSync(parent.getSessionFile()!, "utf8").split(/\r?\n/, 1)[0]!;
+		const helper = String.raw`let input="";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => {
+ input += chunk;
+ while (true) {
+  const end=input.indexOf("\n"); if (end<0) break;
+  const request=JSON.parse(input.slice(0,end)); input=input.slice(end+1);
+  const payload=request.mode === "header" ? { id:request.id, data:${JSON.stringify(Buffer.from(header).toString("base64"))}, mtimeMs:0, dev:"1", ino:"1" } : { id:request.id, mtimeMs:0, dev:"1", ino:"1" };
+  process.stdout.write(JSON.stringify(payload)+"\n");
+  if (request.mode === "stat") setTimeout(() => process.stdout.write("{\"unsolicited\":true}\n"), 25);
+ }
+});`;
+		const baseline = getOpenCatalogAuthorityFdCountForTest();
+		setCatalogHelperLaunchForTest({ command: process.execPath, args: ["-e", helper] });
+		try {
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+		} finally {
+			setCatalogHelperLaunchForTest(undefined);
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(baseline);
+	});
+
+	it("rejects a v2 header whose registry rekeys the child by session id", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-v2-rekey-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		const child = SessionManager.create(root, join(root, "session-artifacts", "parent", "sub-real"));
+		child.newSession({ id: "child", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		child.appendSessionInfo("child");
+		const childFile = child.getSessionFile()!;
+		const [header, ...entries] = readFileSync(childFile, "utf8").trimEnd().split(/\r?\n/);
+		writeFileSync(childFile, `${JSON.stringify({ ...JSON.parse(header!), version: 2 })}\n${entries.join("\n")}\n`);
+		const registry = join(root, "session-artifacts", "parent", "rlm-subagents.jsonl");
+		mkdirSync(dirname(registry), { recursive: true });
+		writeFileSync(
+			registry,
+			JSON.stringify({ type: "rlm_subagent", childId: "child", sessionFile: childFile, status: "completed" }),
+		);
+		try {
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("writer artifact layout");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("walks a realistic profile: fork seeds, sub-* registry ids, two nested levels", async () => {

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -884,6 +884,12 @@ describe("daemon catalog selector resolution", () => {
 			trustedOpens++;
 		});
 		try {
+			expect(() => listCatalogFamilySessionsWithLimitForTest(sessionDir, 0)).toThrow(
+				"Invalid catalog family node limit",
+			);
+			expect(() => listCatalogFamilySessionsWithLimitForTest(sessionDir, Number.MAX_SAFE_INTEGER)).toThrow(
+				"Invalid catalog family node limit",
+			);
 			// The per-call helper proves exact/over behavior without mutable global
 			// security state or creating 10,001 filesystem entries.
 			await expect(listCatalogFamilySessionsWithLimitForTest(sessionDir, 1)).resolves.toEqual([
@@ -898,6 +904,41 @@ describe("daemon catalog selector resolution", () => {
 			// No candidate descriptor may be opened, classified, or metadata-scanned
 			// after discovery proves the family is over the hard bound.
 			expect(trustedOpens).toBe(0);
+		} finally {
+			setCatalogBeforeTrustedOpenForTest(undefined);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("counts registry children in the exact family-node limit before descriptor reads", async () => {
+		const { root, sessionDir, parent } = createCatalogFamilyFixture();
+		try {
+			await expect(listCatalogFamilySessionsWithLimitForTest(sessionDir, 3)).resolves.toHaveLength(3);
+
+			const third = SessionManager.create(
+				root,
+				join(root, "session-artifacts", parent.getSessionId(), "sub-33333333"),
+			);
+			third.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
+			third.appendSessionInfo("third");
+			const registry = join(root, "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
+			appendFileSync(
+				registry,
+				`\n${JSON.stringify({
+					type: "rlm_subagent",
+					childId: "sub-33333333",
+					sessionFile: third.getSessionFile(),
+					status: "completed",
+				})}`,
+			);
+			let thirdOpened = false;
+			setCatalogBeforeTrustedOpenForTest((path) => {
+				if (path === third.getSessionFile()) thirdOpened = true;
+			});
+			await expect(listCatalogFamilySessionsWithLimitForTest(sessionDir, 3)).rejects.toThrow(
+				"family node limit exhausted",
+			);
+			expect(thirdOpened).toBe(false);
 		} finally {
 			setCatalogBeforeTrustedOpenForTest(undefined);
 			rmSync(root, { recursive: true, force: true });
@@ -943,13 +984,18 @@ describe("daemon catalog selector resolution", () => {
 		);
 		rmSync(boundaryType);
 
-		const boundaryId = join(sessionDir, "boundary-id-no-value.jsonl");
-		const idPrefix = `{"junk":0,"id"${" ".repeat(64 * 1024 - Buffer.byteLength('{"junk":0,"id"', "utf8"))}`;
-		writeFileSync(boundaryId, `${idPrefix}:"claimed","padding":"${"x".repeat(200 * 1024)}"}`);
-		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
-			"session header exceeds the trusted read limit",
-		);
-		rmSync(boundaryId);
+		for (const [name, beforeBoundary, suffix] of [
+			["boundary-id-no-colon", '{"junk":0,"id"', ':"claimed","padding":"'],
+			["boundary-id-colon-no-value", '{"junk":0,"id":', '"claimed","padding":"'],
+		] as const) {
+			const boundaryId = join(sessionDir, `${name}.jsonl`);
+			const idPrefix = `${beforeBoundary}${" ".repeat(64 * 1024 - Buffer.byteLength(beforeBoundary, "utf8"))}`;
+			writeFileSync(boundaryId, `${idPrefix}${suffix}${"x".repeat(200 * 1024)}"}`);
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
+				"session header exceeds the trusted read limit",
+			);
+			rmSync(boundaryId);
+		}
 
 		// A complete demonstrably non-string type value remains unrelated; the
 		// following outer id is still scanned and cannot be hidden by that skip.

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -13,6 +13,7 @@ import { dirname, join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 import { type SessionInfo, SessionManager } from "../src/core/session-manager.js";
 import {
+	getCatalogHelperSpawnCountForTest,
 	getOpenCatalogAuthorityFdCountForTest,
 	listCatalogFamilySessions,
 	listSavedSessionSiblings,
@@ -664,6 +665,18 @@ describe("daemon catalog selector resolution", () => {
 		);
 		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
 		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("serves an entire family walk from a single helper process", async () => {
+		const { root, sessionDir } = createCatalogFamilyFixture();
+		try {
+			const spawnsBefore = getCatalogHelperSpawnCountForTest();
+			await expect(listCatalogFamilySessions(sessionDir)).resolves.toHaveLength(3);
+			expect(getCatalogHelperSpawnCountForTest()).toBe(spawnsBefore + 1);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
 	});
 
 	it("treats an exact name colliding with another session id prefix as ambiguous", () => {

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -44,10 +44,10 @@ function createCatalogFamilyFixture() {
 	const parent = SessionManager.create(root, sessionDir);
 	parent.newSession({ rlmDepth: 0 });
 	parent.appendSessionInfo("parent");
-	const first = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-first"));
+	const first = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-11111111"));
 	first.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
 	first.appendSessionInfo("first");
-	const second = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-second"));
+	const second = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-22222222"));
 	second.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
 	second.appendSessionInfo("second");
 	const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
@@ -58,13 +58,13 @@ function createCatalogFamilyFixture() {
 		[
 			{
 				type: "rlm_subagent",
-				childId: "sub-first",
+				childId: "sub-11111111",
 				sessionFile: first.getSessionFile(),
 				status: "completed",
 			},
 			{
 				type: "rlm_subagent",
-				childId: "sub-second",
+				childId: "sub-22222222",
 				sessionFile: second.getSessionFile(),
 				status: "completed",
 			},
@@ -93,12 +93,17 @@ describe("daemon catalog selector resolution", () => {
 		const parent = SessionManager.create(root, sessionDir);
 		parent.newSession({ rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
-		const first = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-first"));
+		const first = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-11111111"));
 		first.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
 		first.appendSessionInfo("first");
-		const second = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-second"));
+		first.appendSessionState({ status: "archived" });
+		const second = SessionManager.create(
+			root,
+			join(root, "session-artifacts", parent.getSessionId(), "sub-22222222"),
+		);
 		second.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
 		second.appendSessionInfo("second");
+		second.appendSessionState({ status: "active" });
 		const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
 		mkdirSync(dirname(registry), { recursive: true });
 		// Reader compatibility for v2 headers does not relax registry provenance:
@@ -113,13 +118,13 @@ describe("daemon catalog selector resolution", () => {
 			[
 				{
 					type: "rlm_subagent",
-					childId: "sub-first",
+					childId: "sub-11111111",
 					sessionFile: first.getSessionFile(),
 					status: "completed",
 				},
 				{
 					type: "rlm_subagent",
-					childId: "sub-second",
+					childId: "sub-22222222",
 					sessionFile: second.getSessionFile(),
 					status: "completed",
 				},
@@ -129,8 +134,8 @@ describe("daemon catalog selector resolution", () => {
 		);
 
 		await expect(listSavedSessionSiblings(first.getSessionFile()!, sessionDir)).resolves.toEqual([
-			expect.objectContaining({ id: first.getSessionId() }),
-			expect.objectContaining({ id: second.getSessionId() }),
+			expect.objectContaining({ id: first.getSessionId(), name: "first", state: { status: "archived" } }),
+			expect.objectContaining({ id: second.getSessionId(), name: "second", state: { status: "active" } }),
 		]);
 	});
 
@@ -140,9 +145,9 @@ describe("daemon catalog selector resolution", () => {
 			await withDefaultSessionDir(sessionDir, async () => {
 				await expect(listCatalogFamilySessions()).resolves.toEqual(
 					expect.arrayContaining([
-						expect.objectContaining({ id: parent.getSessionId() }),
-						expect.objectContaining({ id: first.getSessionId() }),
-						expect.objectContaining({ id: second.getSessionId() }),
+						expect.objectContaining({ id: parent.getSessionId(), name: "parent" }),
+						expect.objectContaining({ id: first.getSessionId(), name: "first" }),
+						expect.objectContaining({ id: second.getSessionId(), name: "second" }),
 					]),
 				);
 			});
@@ -174,11 +179,11 @@ describe("daemon catalog selector resolution", () => {
 		parent.newSession({ rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
 		const parentFile = parent.getSessionFile()!;
-		const firstDir = join(root, "session-artifacts", parent.getSessionId(), "sub-first");
+		const firstDir = join(root, "session-artifacts", parent.getSessionId(), "sub-11111111");
 		const first = SessionManager.create(root, firstDir);
 		first.newSession({ parentSession: relative(firstDir, parentFile), rlmDepth: 1 });
 		first.appendSessionInfo("first");
-		const secondDir = join(root, "session-artifacts", parent.getSessionId(), "sub-second");
+		const secondDir = join(root, "session-artifacts", parent.getSessionId(), "sub-22222222");
 		const second = SessionManager.create(root, secondDir);
 		second.newSession({ parentSession: relative(secondDir, parentFile), rlmDepth: 1 });
 		second.appendSessionInfo("second");
@@ -189,13 +194,13 @@ describe("daemon catalog selector resolution", () => {
 			[
 				{
 					type: "rlm_subagent",
-					childId: "sub-first",
+					childId: "sub-11111111",
 					sessionFile: first.getSessionFile(),
 					status: "completed",
 				},
 				{
 					type: "rlm_subagent",
-					childId: "sub-second",
+					childId: "sub-22222222",
 					sessionFile: second.getSessionFile(),
 					status: "completed",
 				},
@@ -261,28 +266,38 @@ describe("daemon catalog selector resolution", () => {
 			}
 			const parent = create(
 				"parent",
-				join(root, "session-artifacts", "root", "sub-parent"),
+				join(root, "session-artifacts", "root", "sub-33333333"),
 				rootSession.getSessionFile(),
 				1,
 			);
 			const first = create(
 				"first",
-				join(root, "session-artifacts", "root", "sub-parent", "sub-first"),
+				join(root, "session-artifacts", "root", "sub-33333333", "sub-11111111"),
 				parent.getSessionFile(),
 				2,
 			);
 			const second = create(
 				"second",
-				join(root, "session-artifacts", "root", "sub-parent", "sub-second"),
+				join(root, "session-artifacts", "root", "sub-33333333", "sub-22222222"),
 				parent.getSessionFile(),
 				2,
 			);
 			writeRegistry("root", [
-				{ type: "rlm_subagent", childId: "sub-parent", sessionFile: parent.getSessionFile(), status: "completed" },
+				{
+					type: "rlm_subagent",
+					childId: "sub-33333333",
+					sessionFile: parent.getSessionFile(),
+					status: "completed",
+				},
 			]);
 			writeRegistry("parent", [
-				{ type: "rlm_subagent", childId: "sub-first", sessionFile: first.getSessionFile(), status: "completed" },
-				{ type: "rlm_subagent", childId: "sub-second", sessionFile: second.getSessionFile(), status: "completed" },
+				{ type: "rlm_subagent", childId: "sub-11111111", sessionFile: first.getSessionFile(), status: "completed" },
+				{
+					type: "rlm_subagent",
+					childId: "sub-22222222",
+					sessionFile: second.getSessionFile(),
+					status: "completed",
+				},
 			]);
 			return { root, sessionDir, rootSession, parent, first, second, registryPath, writeRegistry };
 		};
@@ -308,7 +323,7 @@ describe("daemon catalog selector resolution", () => {
 					const alias = join(dirname(fixture.first.getSessionFile()!), "impostor.jsonl");
 					writeFileSync(alias, readFileSync(fixture.first.getSessionFile()!));
 					fixture.writeRegistry("parent", [
-						{ type: "rlm_subagent", childId: "sub-first", sessionFile: alias, status: "completed" },
+						{ type: "rlm_subagent", childId: "sub-11111111", sessionFile: alias, status: "completed" },
 					]);
 				},
 			],
@@ -317,12 +332,17 @@ describe("daemon catalog selector resolution", () => {
 				(fixture) => {
 					const evil = SessionManager.create(
 						fixture.root,
-						join(fixture.root, "session-artifacts", "parent", "sub-evil"),
+						join(fixture.root, "session-artifacts", "parent", "sub-66666666"),
 					);
 					evil.newSession({ id: "evil", parentSession: fixture.rootSession.getSessionFile(), rlmDepth: 2 });
 					evil.appendSessionInfo("evil");
 					fixture.writeRegistry("parent", [
-						{ type: "rlm_subagent", childId: "evil", sessionFile: evil.getSessionFile(), status: "completed" },
+						{
+							type: "rlm_subagent",
+							childId: "sub-66666666",
+							sessionFile: evil.getSessionFile(),
+							status: "completed",
+						},
 					]);
 				},
 			],
@@ -331,12 +351,17 @@ describe("daemon catalog selector resolution", () => {
 				(fixture) => {
 					const evil = SessionManager.create(
 						fixture.root,
-						join(fixture.root, "session-artifacts", "parent", "sub-evil"),
+						join(fixture.root, "session-artifacts", "parent", "sub-66666666"),
 					);
 					evil.newSession({ id: "evil", parentSession: fixture.parent.getSessionFile(), rlmDepth: 7 });
 					evil.appendSessionInfo("evil");
 					fixture.writeRegistry("parent", [
-						{ type: "rlm_subagent", childId: "evil", sessionFile: evil.getSessionFile(), status: "completed" },
+						{
+							type: "rlm_subagent",
+							childId: "sub-66666666",
+							sessionFile: evil.getSessionFile(),
+							status: "completed",
+						},
 					]);
 				},
 			],
@@ -346,7 +371,7 @@ describe("daemon catalog selector resolution", () => {
 					fixture.writeRegistry("parent", [
 						{
 							type: "rlm_subagent",
-							childId: "evil",
+							childId: "sub-66666666",
 							sessionFile: join(tmpdir(), "outside.jsonl"),
 							status: "completed",
 						},
@@ -358,8 +383,8 @@ describe("daemon catalog selector resolution", () => {
 					fixture.writeRegistry("parent", [
 						{
 							type: "rlm_subagent",
-							childId: "first",
-							sessionFile: `${dirname(fixture.first.getSessionFile()!)}/../sub-first/first.jsonl`,
+							childId: "sub-11111111",
+							sessionFile: `${dirname(fixture.first.getSessionFile()!)}/../sub-11111111/first.jsonl`,
 							status: "completed",
 						},
 					]),
@@ -370,7 +395,7 @@ describe("daemon catalog selector resolution", () => {
 					fixture.writeRegistry("parent", [
 						{
 							type: "rlm_subagent",
-							childId: "root",
+							childId: "sub-33333333",
 							sessionFile: fixture.rootSession.getSessionFile(),
 							status: "completed",
 						},
@@ -378,13 +403,25 @@ describe("daemon catalog selector resolution", () => {
 			],
 			["malformed", (fixture) => fixture.writeRegistry("parent", ["{not json"])],
 			[
+				"malformed child id",
+				(fixture) =>
+					fixture.writeRegistry("parent", [
+						{
+							type: "rlm_subagent",
+							childId: "sub-ABCDEF12",
+							sessionFile: fixture.first.getSessionFile(),
+							status: "completed",
+						},
+					]),
+			],
+			[
 				"record limit",
 				(fixture) =>
 					fixture.writeRegistry(
 						"parent",
 						Array.from({ length: 10_001 }, (_, index) => ({
 							type: "rlm_subagent",
-							childId: `bad-${index}`,
+							childId: `sub-${index.toString(16).padStart(8, "0")}`,
 							sessionFile: fixture.first.getSessionFile(),
 							status: "completed",
 						})),
@@ -399,11 +436,11 @@ describe("daemon catalog selector resolution", () => {
 			);
 		}
 		const symlink = makeFixture("prime-catalog-family-symlink-");
-		const alias = join(symlink.root, "session-artifacts", "parent", "sub-alias", "first.jsonl");
+		const alias = join(symlink.root, "session-artifacts", "parent", "sub-77777777", "first.jsonl");
 		mkdirSync(dirname(alias), { recursive: true });
 		symlinkSync(symlink.first.getSessionFile()!, alias);
 		symlink.writeRegistry("parent", [
-			{ type: "rlm_subagent", childId: "first", sessionFile: alias, status: "completed" },
+			{ type: "rlm_subagent", childId: "sub-11111111", sessionFile: alias, status: "completed" },
 		]);
 		await expect(listCatalogFamilySessions(symlink.sessionDir)).rejects.toThrow(
 			"Invalid RLM artifact family topology",
@@ -417,7 +454,7 @@ describe("daemon catalog selector resolution", () => {
 			const parent = SessionManager.create(root, sessionDir);
 			parent.newSession({ id: "parent", rlmDepth: 0 });
 			parent.appendSessionInfo("parent");
-			const childDir = join(root, "session-artifacts", "parent", "sub-child");
+			const childDir = join(root, "session-artifacts", "parent", "sub-44444444");
 			const child = SessionManager.create(root, childDir);
 			child.newSession({ id: "child", parentSession: parent.getSessionFile(), rlmDepth: 1 });
 			child.appendSessionInfo("child");
@@ -427,7 +464,7 @@ describe("daemon catalog selector resolution", () => {
 				registry,
 				JSON.stringify({
 					type: "rlm_subagent",
-					childId: "sub-child",
+					childId: "sub-44444444",
 					sessionFile: child.getSessionFile(),
 					status: "completed",
 				}),
@@ -554,7 +591,7 @@ describe("daemon catalog selector resolution", () => {
 			const parent = SessionManager.create(root, sessionDir);
 			parent.newSession({ id: "parent", rlmDepth: 0 });
 			parent.appendSessionInfo("parent");
-			const child = SessionManager.create(root, join(root, "session-artifacts", "parent", "sub-child"));
+			const child = SessionManager.create(root, join(root, "session-artifacts", "parent", "sub-44444444"));
 			child.newSession({ id: "child", parentSession: parent.getSessionFile(), rlmDepth: 1 });
 			child.appendSessionInfo("child");
 			const childFile = child.getSessionFile()!;
@@ -566,7 +603,12 @@ describe("daemon catalog selector resolution", () => {
 			mkdirSync(dirname(registry), { recursive: true });
 			writeFileSync(
 				registry,
-				JSON.stringify({ type: "rlm_subagent", childId: "sub-child", sessionFile: childFile, status: "completed" }),
+				JSON.stringify({
+					type: "rlm_subagent",
+					childId: "sub-44444444",
+					sessionFile: childFile,
+					status: "completed",
+				}),
 			);
 			return sessionDir;
 		};
@@ -631,6 +673,50 @@ describe("daemon catalog selector resolution", () => {
 		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(baseline);
 	});
 
+	it("returns descriptor-bound metadata after a multi-megabyte entry without reopening the pathname", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-compact-metadata-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("initial name");
+		const file = parent.getSessionFile()!;
+		appendFileSync(
+			file,
+			`${[
+				JSON.stringify({
+					type: "message",
+					id: "first-message",
+					parentId: null,
+					timestamp: "2026-01-02T03:04:05.000Z",
+					message: {
+						role: "user",
+						content: "first searchable prompt",
+						timestamp: Date.parse("2026-01-02T03:04:05.000Z"),
+					},
+				}),
+				JSON.stringify({ type: "custom_message", body: "x".repeat(3 * 1024 * 1024) }),
+				JSON.stringify({ type: "session_info", name: "trailing name" }),
+				JSON.stringify({ type: "session_state", state: { status: "archived" } }),
+				JSON.stringify({
+					type: "agent_status",
+					status: { summary: "trailing recap", taskState: "completed", basedOnMessageCount: 1 },
+				}),
+			].join("\n")}\n`,
+		);
+		const [info] = await listCatalogFamilySessions(sessionDir);
+		expect(info).toMatchObject({
+			id: "parent",
+			name: "trailing name",
+			state: { status: "archived" },
+			messageCount: 1,
+			firstMessage: "first searchable prompt",
+			allMessagesText: "first searchable prompt",
+			agentStatus: { summary: "trailing recap", taskState: "completed", basedOnMessageCount: 1 },
+		});
+		expect(info?.modified.toISOString()).toBe("2026-01-02T03:04:05.000Z");
+		rmSync(root, { recursive: true, force: true });
+	});
+
 	it("reads only the session header line even when the body is huge", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-header-only-"));
 		const sessionDir = join(root, "sessions");
@@ -670,7 +756,7 @@ describe("daemon catalog selector resolution", () => {
 		const parent = SessionManager.create(root, sessionDir);
 		parent.newSession({ id: "parent", rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
-		const child = SessionManager.create(root, join(root, "session-artifacts", "parent", "sub-child"));
+		const child = SessionManager.create(root, join(root, "session-artifacts", "parent", "sub-44444444"));
 		child.newSession({ id: "child", parentSession: join(sessionDir, "gone.jsonl"), rlmDepth: 1 });
 		child.appendSessionInfo("child");
 		const registry = join(root, "session-artifacts", "parent", "rlm-subagents.jsonl");
@@ -679,7 +765,7 @@ describe("daemon catalog selector resolution", () => {
 			registry,
 			JSON.stringify({
 				type: "rlm_subagent",
-				childId: "sub-child",
+				childId: "sub-44444444",
 				sessionFile: child.getSessionFile(),
 				status: "completed",
 			}),
@@ -736,9 +822,9 @@ process.stdin.on("data", chunk => {
  while (true) {
   const end=input.indexOf("\n"); if (end<0) break;
   const request=JSON.parse(input.slice(0,end)); input=input.slice(end+1);
-  const payload=request.mode === "header" ? { id:request.id, data:${JSON.stringify(Buffer.from(header).toString("base64"))}, mtimeMs:0, dev:"1", ino:"1" } : { id:request.id, mtimeMs:0, dev:"1", ino:"1" };
+  const payload=request.mode === "header" ? { id:request.id, data:${JSON.stringify(Buffer.from(header).toString("base64"))}, mtimeMs:0, dev:"1", ino:"1" } : request.mode === "metadata" ? { id:request.id, data:{valid:true,messageCount:0,firstMessage:"(no messages)",allMessagesText:"",modifiedMs:0}, mtimeMs:0, dev:"1", ino:"1" } : { id:request.id, mtimeMs:0, dev:"1", ino:"1" };
   process.stdout.write(JSON.stringify(payload)+"\n");
-  if (request.mode === "stat") setTimeout(() => process.stdout.write("{\"unsolicited\":true}\n"), 25);
+  if (request.mode === "metadata") setTimeout(() => process.stdout.write("{\"unsolicited\":true}\n"), 25);
  }
 });`;
 		const baseline = getOpenCatalogAuthorityFdCountForTest();
@@ -758,7 +844,7 @@ process.stdin.on("data", chunk => {
 		const parent = SessionManager.create(root, sessionDir);
 		parent.newSession({ id: "parent", rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
-		const child = SessionManager.create(root, join(root, "session-artifacts", "parent", "sub-real"));
+		const child = SessionManager.create(root, join(root, "session-artifacts", "parent", "sub-55555555"));
 		child.newSession({ id: "child", parentSession: parent.getSessionFile(), rlmDepth: 1 });
 		child.appendSessionInfo("child");
 		const childFile = child.getSessionFile()!;
@@ -768,7 +854,7 @@ process.stdin.on("data", chunk => {
 		mkdirSync(dirname(registry), { recursive: true });
 		writeFileSync(
 			registry,
-			JSON.stringify({ type: "rlm_subagent", childId: "child", sessionFile: childFile, status: "completed" }),
+			JSON.stringify({ type: "rlm_subagent", childId: "sub-66666666", sessionFile: childFile, status: "completed" }),
 		);
 		try {
 			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("writer artifact layout");
@@ -844,7 +930,7 @@ process.stdin.on("data", chunk => {
 			const parent = SessionManager.create(root, sessionDir);
 			parent.newSession({ id: "parent", rlmDepth: 0 });
 			parent.appendSessionInfo("parent");
-			const childDir = join(root, "session-artifacts", "parent", "sub-real");
+			const childDir = join(root, "session-artifacts", "parent", "sub-55555555");
 			const child = SessionManager.create(root, childDir);
 			child.newSession({ id: "child", parentSession: parent.getSessionFile(), rlmDepth: 1 });
 			child.appendSessionInfo("child");
@@ -855,19 +941,19 @@ process.stdin.on("data", chunk => {
 					registry,
 					JSON.stringify({ type: "rlm_subagent", childId, sessionFile, status: "completed" }),
 				);
-			writeRegistry("sub-real");
+			writeRegistry("sub-55555555");
 			return { root, sessionDir, child, childDir, writeRegistry };
 		};
 		const spoofed = make();
-		spoofed.writeRegistry("sub-spoofed");
+		spoofed.writeRegistry("sub-66666666");
 		await expect(listCatalogFamilySessions(spoofed.sessionDir)).rejects.toThrow("writer artifact layout");
 		rmSync(spoofed.root, { recursive: true, force: true });
 
 		const nested = make();
-		const nestedPath = join(nested.sessionDir, "sub-real", "child.jsonl");
+		const nestedPath = join(nested.sessionDir, "sub-55555555", "child.jsonl");
 		mkdirSync(dirname(nestedPath), { recursive: true });
 		writeFileSync(nestedPath, readFileSync(nested.child.getSessionFile()!));
-		nested.writeRegistry("sub-real", nestedPath);
+		nested.writeRegistry("sub-55555555", nestedPath);
 		await expect(listCatalogFamilySessions(nested.sessionDir)).rejects.toThrow("writer artifact layout");
 		rmSync(nested.root, { recursive: true, force: true });
 

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -16,13 +16,13 @@ import {
 	getCatalogHelperSpawnCountForTest,
 	getOpenCatalogAuthorityFdCountForTest,
 	listCatalogFamilySessions,
+	listCatalogFamilySessionsWithLimitForTest,
 	listSavedSessionSiblings,
 	resolveCatalogSessionMatch,
 	setCatalogAfterHelperResponseForTest,
 	setCatalogAfterTrustedHeaderForTest,
 	setCatalogBeforeTrustedOpenForTest,
 	setCatalogHelperLaunchForTest,
-	setCatalogMaxRlmFamilyNodesForTest,
 } from "../src/modes/daemon/daemon-catalog-process.js";
 
 function session(id: string, name: string | undefined, path: string): SessionInfo {
@@ -884,21 +884,21 @@ describe("daemon catalog selector resolution", () => {
 			trustedOpens++;
 		});
 		try {
-			// The narrow limit hook proves both the exact-limit success case and
-			// over-limit failure without creating 10,001 filesystem entries.
-			setCatalogMaxRlmFamilyNodesForTest(1);
-			await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([
+			// The per-call helper proves exact/over behavior without mutable global
+			// security state or creating 10,001 filesystem entries.
+			await expect(listCatalogFamilySessionsWithLimitForTest(sessionDir, 1)).resolves.toEqual([
 				expect.objectContaining({ id: "parent" }),
 			]);
 			expect(trustedOpens).toBeGreaterThan(0);
 			trustedOpens = 0;
 			writeFileSync(join(sessionDir, "unrelated.jsonl"), "not json\n");
-			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("family node limit exhausted");
+			await expect(listCatalogFamilySessionsWithLimitForTest(sessionDir, 1)).rejects.toThrow(
+				"family node limit exhausted during root discovery",
+			);
 			// No candidate descriptor may be opened, classified, or metadata-scanned
 			// after discovery proves the family is over the hard bound.
 			expect(trustedOpens).toBe(0);
 		} finally {
-			setCatalogMaxRlmFamilyNodesForTest(undefined);
 			setCatalogBeforeTrustedOpenForTest(undefined);
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -506,6 +506,21 @@ describe("daemon catalog selector resolution", () => {
 		await expect(listCatalogFamilySessions(duplicateDir)).rejects.toThrow("duplicate session id");
 	});
 
+	it("releases the session authority descriptor when the artifacts root open fails", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-artifacts-open-fail-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		// A symlinked artifacts root fails the O_NOFOLLOW open with a non-ENOENT error.
+		const realArtifacts = join(root, "session-artifacts-real");
+		mkdirSync(realArtifacts);
+		symlinkSync(realArtifacts, join(root, "session-artifacts"));
+		const baseline = getOpenCatalogAuthorityFdCountForTest();
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(baseline);
+	});
+
 	it("treats an exact name colliding with another session id prefix as ambiguous", () => {
 		const sessions = [
 			session("named-session-id", "target", "/tmp/by-name.jsonl"),

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -18,6 +18,7 @@ import {
 	listCatalogFamilySessions,
 	listSavedSessionSiblings,
 	resolveCatalogSessionMatch,
+	setCatalogAfterTrustedHeaderForTest,
 	setCatalogBeforeTrustedOpenForTest,
 } from "../src/modes/daemon/daemon-catalog-process.js";
 
@@ -99,7 +100,14 @@ describe("daemon catalog selector resolution", () => {
 		second.appendSessionInfo("second");
 		const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
 		mkdirSync(dirname(registry), { recursive: true });
-		// Legacy registry variant where childId happens to equal the session id.
+		// Version-2 session headers prove the old registry key shape, where a
+		// record was keyed by the persisted session id while its directory retained
+		// a sub-* run id.
+		for (const child of [first, second]) {
+			const file = child.getSessionFile()!;
+			const [header, ...entries] = readFileSync(file, "utf8").trimEnd().split(/\r?\n/);
+			writeFileSync(file, `${JSON.stringify({ ...JSON.parse(header!), version: 2 })}\n${entries.join("\n")}\n`);
+		}
 		writeFileSync(
 			registry,
 			[
@@ -121,8 +129,8 @@ describe("daemon catalog selector resolution", () => {
 		);
 
 		await expect(listSavedSessionSiblings(first.getSessionFile()!, sessionDir)).resolves.toEqual([
-			expect.objectContaining({ id: first.getSessionId(), name: "first" }),
-			expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+			expect.objectContaining({ id: first.getSessionId() }),
+			expect.objectContaining({ id: second.getSessionId() }),
 		]);
 	});
 
@@ -132,9 +140,9 @@ describe("daemon catalog selector resolution", () => {
 			await withDefaultSessionDir(sessionDir, async () => {
 				await expect(listCatalogFamilySessions()).resolves.toEqual(
 					expect.arrayContaining([
-						expect.objectContaining({ id: parent.getSessionId(), name: "parent" }),
-						expect.objectContaining({ id: first.getSessionId(), name: "first" }),
-						expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+						expect.objectContaining({ id: parent.getSessionId() }),
+						expect.objectContaining({ id: first.getSessionId() }),
+						expect.objectContaining({ id: second.getSessionId() }),
 					]),
 				);
 			});
@@ -149,8 +157,8 @@ describe("daemon catalog selector resolution", () => {
 		try {
 			await withDefaultSessionDir(sessionDir, async () => {
 				await expect(listSavedSessionSiblings(first.getSessionFile()!)).resolves.toEqual([
-					expect.objectContaining({ id: first.getSessionId(), name: "first" }),
-					expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+					expect.objectContaining({ id: first.getSessionId() }),
+					expect.objectContaining({ id: second.getSessionId() }),
 				]);
 			});
 		} finally {
@@ -197,8 +205,8 @@ describe("daemon catalog selector resolution", () => {
 		);
 
 		await expect(listSavedSessionSiblings(first.getSessionFile()!, sessionDir)).resolves.toEqual([
-			expect.objectContaining({ id: first.getSessionId(), name: "first" }),
-			expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+			expect.objectContaining({ id: first.getSessionId() }),
+			expect.objectContaining({ id: second.getSessionId() }),
 		]);
 	});
 
@@ -750,6 +758,57 @@ describe("daemon catalog selector resolution", () => {
 		}
 		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
 		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("binds registry child ids to direct writer directories and detects post-header replacement", async () => {
+		const make = () => {
+			const root = mkdtempSync(join(tmpdir(), "prime-catalog-identity-binding-"));
+			const sessionDir = join(root, "sessions");
+			const parent = SessionManager.create(root, sessionDir);
+			parent.newSession({ id: "parent", rlmDepth: 0 });
+			parent.appendSessionInfo("parent");
+			const childDir = join(root, "session-artifacts", "parent", "sub-real");
+			const child = SessionManager.create(root, childDir);
+			child.newSession({ id: "child", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+			child.appendSessionInfo("child");
+			const registry = join(root, "session-artifacts", "parent", "rlm-subagents.jsonl");
+			mkdirSync(dirname(registry), { recursive: true });
+			const writeRegistry = (childId: string, sessionFile = child.getSessionFile()!) =>
+				writeFileSync(
+					registry,
+					JSON.stringify({ type: "rlm_subagent", childId, sessionFile, status: "completed" }),
+				);
+			writeRegistry("sub-real");
+			return { root, sessionDir, child, childDir, writeRegistry };
+		};
+		const spoofed = make();
+		spoofed.writeRegistry("sub-spoofed");
+		await expect(listCatalogFamilySessions(spoofed.sessionDir)).rejects.toThrow("writer artifact layout");
+		rmSync(spoofed.root, { recursive: true, force: true });
+
+		const nested = make();
+		const nestedPath = join(nested.sessionDir, "sub-real", "child.jsonl");
+		mkdirSync(dirname(nestedPath), { recursive: true });
+		writeFileSync(nestedPath, readFileSync(nested.child.getSessionFile()!));
+		nested.writeRegistry("sub-real", nestedPath);
+		await expect(listCatalogFamilySessions(nested.sessionDir)).rejects.toThrow("writer artifact layout");
+		rmSync(nested.root, { recursive: true, force: true });
+
+		const replacement = make();
+		let swapped = false;
+		setCatalogAfterTrustedHeaderForTest((path) => {
+			if (swapped || path !== replacement.child.getSessionFile()) return;
+			swapped = true;
+			const moved = `${path}.old`;
+			renameSync(path, moved);
+			writeFileSync(path, `${readFileSync(moved, "utf8").split(/\r?\n/, 1)[0]}\n${"x".repeat(2 * 1024 * 1024)}\n`);
+		});
+		await expect(listCatalogFamilySessions(replacement.sessionDir)).rejects.toThrow(
+			"session changed after its trusted header read",
+		);
+		setCatalogAfterTrustedHeaderForTest(undefined);
+		rmSync(replacement.root, { recursive: true, force: true });
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
 	});
 
 	it("treats an exact name colliding with another session id prefix as ambiguous", () => {

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -1,9 +1,15 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 import { type SessionInfo, SessionManager } from "../src/core/session-manager.js";
-import { listSavedSessionSiblings, resolveCatalogSessionMatch } from "../src/modes/daemon/daemon-catalog-process.js";
+import {
+	getOpenCatalogAuthorityFdCountForTest,
+	listCatalogFamilySessions,
+	listSavedSessionSiblings,
+	resolveCatalogSessionMatch,
+	setCatalogBeforeTrustedOpenForTest,
+} from "../src/modes/daemon/daemon-catalog-process.js";
 
 function session(id: string, name: string | undefined, path: string): SessionInfo {
 	return {
@@ -20,17 +26,64 @@ function session(id: string, name: string | undefined, path: string): SessionInf
 	};
 }
 
+function createCatalogFamilyFixture() {
+	const root = mkdtempSync(join(tmpdir(), "prime-catalog-default-session-dir-"));
+	const sessionDir = join(root, "sessions");
+	const parent = SessionManager.create(root, sessionDir);
+	parent.newSession({ rlmDepth: 0 });
+	parent.appendSessionInfo("parent");
+	const first = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-first"));
+	first.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
+	first.appendSessionInfo("first");
+	const second = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-second"));
+	second.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
+	second.appendSessionInfo("second");
+	const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
+	mkdirSync(dirname(registry), { recursive: true });
+	writeFileSync(
+		registry,
+		[
+			{
+				type: "rlm_subagent",
+				childId: first.getSessionId(),
+				sessionFile: first.getSessionFile(),
+				status: "completed",
+			},
+			{
+				type: "rlm_subagent",
+				childId: second.getSessionId(),
+				sessionFile: second.getSessionFile(),
+				status: "completed",
+			},
+		]
+			.map((entry) => JSON.stringify(entry))
+			.join("\n"),
+	);
+	return { root, sessionDir, parent, first, second };
+}
+
+async function withDefaultSessionDir<T>(sessionDir: string, callback: () => Promise<T>): Promise<T> {
+	const previousSessionDir = process.env.PRIME_AGENT_SESSION_DIR;
+	process.env.PRIME_AGENT_SESSION_DIR = sessionDir;
+	try {
+		return await callback();
+	} finally {
+		if (previousSessionDir === undefined) delete process.env.PRIME_AGENT_SESSION_DIR;
+		else process.env.PRIME_AGENT_SESSION_DIR = previousSessionDir;
+	}
+}
+
 describe("daemon catalog selector resolution", () => {
 	it("reads only a saved child's persisted sibling set", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-siblings-"));
 		const sessionDir = join(root, "sessions");
 		const parent = SessionManager.create(root, sessionDir);
-		parent.newSession();
+		parent.newSession({ rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
-		const first = SessionManager.create(root, join(root, "first"));
+		const first = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-first"));
 		first.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
 		first.appendSessionInfo("first");
-		const second = SessionManager.create(root, join(root, "second"));
+		const second = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-second"));
 		second.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
 		second.appendSessionInfo("second");
 		const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
@@ -38,31 +91,74 @@ describe("daemon catalog selector resolution", () => {
 		writeFileSync(
 			registry,
 			[
-				{ type: "rlm_subagent", childId: "first", sessionFile: first.getSessionFile(), status: "completed" },
-				{ type: "rlm_subagent", childId: "second", sessionFile: second.getSessionFile(), status: "completed" },
+				{
+					type: "rlm_subagent",
+					childId: first.getSessionId(),
+					sessionFile: first.getSessionFile(),
+					status: "completed",
+				},
+				{
+					type: "rlm_subagent",
+					childId: second.getSessionId(),
+					sessionFile: second.getSessionFile(),
+					status: "completed",
+				},
 			]
 				.map((entry) => JSON.stringify(entry))
 				.join("\n"),
 		);
 
-		await expect(listSavedSessionSiblings(first.getSessionFile()!)).resolves.toEqual([
+		await expect(listSavedSessionSiblings(first.getSessionFile()!, sessionDir)).resolves.toEqual([
 			expect.objectContaining({ id: first.getSessionId(), name: "first" }),
 			expect.objectContaining({ id: second.getSessionId(), name: "second" }),
 		]);
+	});
+
+	it("uses the configured default session directory for family catalogs", async () => {
+		const { root, sessionDir, parent, first, second } = createCatalogFamilyFixture();
+		try {
+			await withDefaultSessionDir(sessionDir, async () => {
+				await expect(listCatalogFamilySessions()).resolves.toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ id: parent.getSessionId(), name: "parent" }),
+						expect.objectContaining({ id: first.getSessionId(), name: "first" }),
+						expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+					]),
+				);
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
+	});
+
+	it("uses the configured default session directory for saved siblings", async () => {
+		const { root, sessionDir, first, second } = createCatalogFamilyFixture();
+		try {
+			await withDefaultSessionDir(sessionDir, async () => {
+				await expect(listSavedSessionSiblings(first.getSessionFile()!)).resolves.toEqual([
+					expect.objectContaining({ id: first.getSessionId(), name: "first" }),
+					expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+				]);
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
 	});
 
 	it("resolves relative parent headers from each child session directory", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-relative-siblings-"));
 		const sessionDir = join(root, "sessions");
 		const parent = SessionManager.create(root, sessionDir);
-		parent.newSession();
+		parent.newSession({ rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
 		const parentFile = parent.getSessionFile()!;
-		const firstDir = join(root, "first");
+		const firstDir = join(root, "session-artifacts", parent.getSessionId(), "sub-first");
 		const first = SessionManager.create(root, firstDir);
 		first.newSession({ parentSession: relative(firstDir, parentFile), rlmDepth: 1 });
 		first.appendSessionInfo("first");
-		const secondDir = join(root, "second");
+		const secondDir = join(root, "session-artifacts", parent.getSessionId(), "sub-second");
 		const second = SessionManager.create(root, secondDir);
 		second.newSession({ parentSession: relative(secondDir, parentFile), rlmDepth: 1 });
 		second.appendSessionInfo("second");
@@ -71,17 +167,343 @@ describe("daemon catalog selector resolution", () => {
 		writeFileSync(
 			registry,
 			[
-				{ type: "rlm_subagent", childId: "first", sessionFile: first.getSessionFile(), status: "completed" },
-				{ type: "rlm_subagent", childId: "second", sessionFile: second.getSessionFile(), status: "completed" },
+				{
+					type: "rlm_subagent",
+					childId: first.getSessionId(),
+					sessionFile: first.getSessionFile(),
+					status: "completed",
+				},
+				{
+					type: "rlm_subagent",
+					childId: second.getSessionId(),
+					sessionFile: second.getSessionFile(),
+					status: "completed",
+				},
 			]
 				.map((entry) => JSON.stringify(entry))
 				.join("\n"),
 		);
 
-		await expect(listSavedSessionSiblings(first.getSessionFile()!)).resolves.toEqual([
+		await expect(listSavedSessionSiblings(first.getSessionFile()!, sessionDir)).resolves.toEqual([
 			expect.objectContaining({ id: first.getSessionId(), name: "first" }),
 			expect.objectContaining({ id: second.getSessionId(), name: "second" }),
 		]);
+	});
+
+	it("treats an absent session-artifacts directory as an empty family registry", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-no-artifacts-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+
+		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([
+			expect.objectContaining({ id: "parent", rlmDepth: 0 }),
+		]);
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
+	});
+
+	it("walks a trusted depth-two artifact family and fails closed for hostile artifacts", async () => {
+		const makeFixture = (name: string, omitRootDepth = false) => {
+			const root = mkdtempSync(join(tmpdir(), name));
+			const sessionDir = join(root, "sessions");
+			const registryPath = (parentId: string) => {
+				const parentFile = [rootSession, parent, first, second]
+					.find((manager) => manager.getSessionId() === parentId)
+					?.getSessionFile();
+				return parentFile && dirname(parentFile) !== sessionDir
+					? join(dirname(parentFile), "session-artifacts", parentId, "rlm-subagents.jsonl")
+					: join(root, "session-artifacts", parentId, "rlm-subagents.jsonl");
+			};
+			const writeRegistry = (parentId: string, entries: unknown[]) => {
+				const path = registryPath(parentId);
+				mkdirSync(dirname(path), { recursive: true });
+				writeFileSync(
+					path,
+					entries.map((entry) => (typeof entry === "string" ? entry : JSON.stringify(entry))).join("\n"),
+				);
+			};
+			const create = (id: string, dir: string, parentSession?: string, depth = 0) => {
+				const manager = SessionManager.create(root, dir);
+				manager.newSession({ id, parentSession, rlmDepth: depth });
+				manager.appendSessionInfo(id);
+				return manager;
+			};
+			const rootSession = create("root", sessionDir);
+			if (omitRootDepth) {
+				const rootFile = rootSession.getSessionFile()!;
+				const [header, ...entries] = readFileSync(rootFile, "utf8").trimEnd().split(/\r?\n/);
+				const persistedHeader = JSON.parse(header!) as Record<string, unknown>;
+				delete persistedHeader.rlmDepth;
+				writeFileSync(rootFile, `${[JSON.stringify(persistedHeader), ...entries].join("\n")}\n`);
+			}
+			const parent = create(
+				"parent",
+				join(root, "session-artifacts", "root", "sub-parent"),
+				rootSession.getSessionFile(),
+				1,
+			);
+			const first = create(
+				"first",
+				join(root, "session-artifacts", "parent", "sub-first"),
+				parent.getSessionFile(),
+				2,
+			);
+			const second = create(
+				"second",
+				join(root, "session-artifacts", "parent", "sub-second"),
+				parent.getSessionFile(),
+				2,
+			);
+			writeRegistry("root", [
+				{ type: "rlm_subagent", childId: "parent", sessionFile: parent.getSessionFile(), status: "completed" },
+			]);
+			writeRegistry("parent", [
+				{ type: "rlm_subagent", childId: "first", sessionFile: first.getSessionFile(), status: "completed" },
+				{ type: "rlm_subagent", childId: "second", sessionFile: second.getSessionFile(), status: "completed" },
+			]);
+			return { root, sessionDir, rootSession, parent, first, second, registryPath, writeRegistry };
+		};
+		const valid = makeFixture("prime-catalog-family-valid-", true);
+		await expect(listCatalogFamilySessions(valid.sessionDir)).resolves.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "root", rlmDepth: 0 }),
+				expect.objectContaining({ id: "parent", rlmDepth: 1 }),
+				expect.objectContaining({ id: "first", rlmDepth: 2 }),
+				expect.objectContaining({ id: "second", rlmDepth: 2 }),
+			]),
+		);
+		await expect(listSavedSessionSiblings(valid.first.getSessionFile()!, valid.sessionDir)).resolves.toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: "first" }), expect.objectContaining({ id: "second" })]),
+		);
+
+		const cases: Array<[string, (fixture: ReturnType<typeof makeFixture>) => void]> = [
+			[
+				"id mismatch",
+				(fixture) =>
+					fixture.writeRegistry("parent", [
+						{
+							type: "rlm_subagent",
+							childId: "wrong",
+							sessionFile: fixture.first.getSessionFile(),
+							status: "completed",
+						},
+					]),
+			],
+			[
+				"parent mismatch",
+				(fixture) => {
+					const evil = SessionManager.create(
+						fixture.root,
+						join(fixture.root, "session-artifacts", "parent", "sub-evil"),
+					);
+					evil.newSession({ id: "evil", parentSession: fixture.rootSession.getSessionFile(), rlmDepth: 2 });
+					evil.appendSessionInfo("evil");
+					fixture.writeRegistry("parent", [
+						{ type: "rlm_subagent", childId: "evil", sessionFile: evil.getSessionFile(), status: "completed" },
+					]);
+				},
+			],
+			[
+				"depth mismatch",
+				(fixture) => {
+					const evil = SessionManager.create(
+						fixture.root,
+						join(fixture.root, "session-artifacts", "parent", "sub-evil"),
+					);
+					evil.newSession({ id: "evil", parentSession: fixture.parent.getSessionFile(), rlmDepth: 7 });
+					evil.appendSessionInfo("evil");
+					fixture.writeRegistry("parent", [
+						{ type: "rlm_subagent", childId: "evil", sessionFile: evil.getSessionFile(), status: "completed" },
+					]);
+				},
+			],
+			[
+				"external path",
+				(fixture) =>
+					fixture.writeRegistry("parent", [
+						{
+							type: "rlm_subagent",
+							childId: "evil",
+							sessionFile: join(tmpdir(), "outside.jsonl"),
+							status: "completed",
+						},
+					]),
+			],
+			[
+				"path alias",
+				(fixture) =>
+					fixture.writeRegistry("parent", [
+						{
+							type: "rlm_subagent",
+							childId: "first",
+							sessionFile: `${dirname(fixture.first.getSessionFile()!)}/../sub-first/first.jsonl`,
+							status: "completed",
+						},
+					]),
+			],
+			[
+				"cycle",
+				(fixture) =>
+					fixture.writeRegistry("parent", [
+						{
+							type: "rlm_subagent",
+							childId: "root",
+							sessionFile: fixture.rootSession.getSessionFile(),
+							status: "completed",
+						},
+					]),
+			],
+			["malformed", (fixture) => fixture.writeRegistry("parent", ["{not json"])],
+			[
+				"record limit",
+				(fixture) =>
+					fixture.writeRegistry(
+						"parent",
+						Array.from({ length: 10_001 }, (_, index) => ({
+							type: "rlm_subagent",
+							childId: `bad-${index}`,
+							sessionFile: fixture.first.getSessionFile(),
+							status: "completed",
+						})),
+					),
+			],
+		];
+		for (const [label, mutate] of cases) {
+			const fixture = makeFixture(`prime-catalog-family-${label.replace(/\s/g, "-")}-`);
+			mutate(fixture);
+			await expect(listCatalogFamilySessions(fixture.sessionDir), label).rejects.toThrow(
+				"Invalid RLM artifact family topology",
+			);
+		}
+		const symlink = makeFixture("prime-catalog-family-symlink-");
+		const alias = join(symlink.root, "session-artifacts", "parent", "sub-alias", "first.jsonl");
+		mkdirSync(dirname(alias), { recursive: true });
+		symlinkSync(symlink.first.getSessionFile()!, alias);
+		symlink.writeRegistry("parent", [
+			{ type: "rlm_subagent", childId: "first", sessionFile: alias, status: "completed" },
+		]);
+		await expect(listCatalogFamilySessions(symlink.sessionDir)).rejects.toThrow(
+			"Invalid RLM artifact family topology",
+		);
+	});
+
+	it("rejects symlinked roots and deterministic intermediate/final replacement races", async () => {
+		const make = (name: string) => {
+			const root = mkdtempSync(join(tmpdir(), name));
+			const sessionDir = join(root, "sessions");
+			const parent = SessionManager.create(root, sessionDir);
+			parent.newSession({ id: "parent", rlmDepth: 0 });
+			parent.appendSessionInfo("parent");
+			const childDir = join(root, "session-artifacts", "parent", "sub-child");
+			const child = SessionManager.create(root, childDir);
+			child.newSession({ id: "child", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+			child.appendSessionInfo("child");
+			const registry = join(root, "session-artifacts", "parent", "rlm-subagents.jsonl");
+			mkdirSync(dirname(registry), { recursive: true });
+			writeFileSync(
+				registry,
+				JSON.stringify({
+					type: "rlm_subagent",
+					childId: "child",
+					sessionFile: child.getSessionFile(),
+					status: "completed",
+				}),
+			);
+			return { root, sessionDir, parent, child, childDir, registry };
+		};
+
+		const rootLink = make("prime-catalog-root-link-");
+		const movedSessions = `${rootLink.sessionDir}-real`;
+		renameSync(rootLink.sessionDir, movedSessions);
+		symlinkSync(movedSessions, rootLink.sessionDir);
+		await expect(listCatalogFamilySessions(rootLink.sessionDir)).rejects.toThrow(
+			"Invalid RLM artifact family topology",
+		);
+
+		const intermediate = make("prime-catalog-intermediate-swap-");
+		let swappedIntermediate = false;
+		setCatalogBeforeTrustedOpenForTest((path) => {
+			if (swappedIntermediate || path !== intermediate.child.getSessionFile()) return;
+			swappedIntermediate = true;
+			const moved = `${intermediate.childDir}-real`;
+			renameSync(intermediate.childDir, moved);
+			symlinkSync(moved, intermediate.childDir);
+		});
+		await expect(listCatalogFamilySessions(intermediate.sessionDir)).rejects.toThrow(
+			"Invalid RLM artifact family topology",
+		);
+
+		const finalSwap = make("prime-catalog-final-swap-");
+		let swappedFinal = false;
+		setCatalogBeforeTrustedOpenForTest((path) => {
+			if (swappedFinal || path !== finalSwap.child.getSessionFile()) return;
+			swappedFinal = true;
+			const moved = `${path}.real`;
+			renameSync(path, moved);
+			symlinkSync(moved, path);
+		});
+		await expect(listCatalogFamilySessions(finalSwap.sessionDir)).rejects.toThrow(
+			"Invalid RLM artifact family topology",
+		);
+		setCatalogBeforeTrustedOpenForTest(undefined);
+	});
+
+	it("parses session metadata from the same descriptor-bound bytes without a pathname reopen", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-no-reopen-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("bound-name");
+		let removed = false;
+		setCatalogBeforeTrustedOpenForTest((path) => {
+			if (removed || path !== parent.getSessionFile()) return;
+			removed = true;
+			const original = `${path}.opened`;
+			renameSync(path, original);
+			writeFileSync(path, "not a session\n");
+		});
+		// The helper opens after the hook, so it must reject the replacement instead of
+		// authorizing stale bytes. This pins the absence of a later readSessionInfo reopen.
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+		setCatalogBeforeTrustedOpenForTest(undefined);
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("closes authority descriptors after repeated hostile seed failures", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-fd-release-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		const hostile = SessionManager.create(root, sessionDir);
+		hostile.newSession({ id: "hostile", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		hostile.appendSessionInfo("hostile");
+		const baseline = getOpenCatalogAuthorityFdCountForTest();
+		for (let attempt = 0; attempt < 64; attempt++) {
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+			expect(getOpenCatalogAuthorityFdCountForTest()).toBe(baseline);
+		}
+	});
+
+	it("rejects an unregistered parent-claiming seed and conflicting duplicate identity", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-orphan-seed-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		const orphan = SessionManager.create(root, sessionDir);
+		orphan.newSession({ id: "evil", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		orphan.appendSessionInfo("evil");
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("managed session seed claims a parent");
+
+		const duplicateRoot = mkdtempSync(join(tmpdir(), "prime-catalog-duplicate-id-"));
+		const duplicateDir = join(duplicateRoot, "sessions");
+		const duplicate = SessionManager.create(duplicateRoot, duplicateDir);
+		duplicate.newSession({ id: "duplicate", rlmDepth: 0 });
+		duplicate.appendSessionInfo("one");
+		writeFileSync(join(duplicateDir, "alias.jsonl"), readFileSync(duplicate.getSessionFile()!));
+		await expect(listCatalogFamilySessions(duplicateDir)).rejects.toThrow("duplicate session id");
 	});
 
 	it("treats an exact name colliding with another session id prefix as ambiguous", () => {

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -18,6 +18,7 @@ import {
 	listCatalogFamilySessions,
 	listSavedSessionSiblings,
 	resolveCatalogSessionMatch,
+	setCatalogAfterHelperResponseForTest,
 	setCatalogAfterTrustedHeaderForTest,
 	setCatalogBeforeTrustedOpenForTest,
 	setCatalogHelperLaunchForTest,
@@ -717,11 +718,20 @@ describe("daemon catalog selector resolution", () => {
 		rmSync(root, { recursive: true, force: true });
 	});
 
-	it("caps the exact escaped metadata response while preserving a usable family", async () => {
+	it("caps exact escaped metadata envelopes without changing request ids", async () => {
 		// Keep each JSONL record below the parser's 1 MiB record bound while its
 		// combined escaped metadata response still greatly exceeds 256 KiB.
-		const payloads = ["a".repeat(500_000), "漢😀".repeat(50_000), '"\\\b\f\n\r\t\u0000'.repeat(25_000)];
+		const payloads = [
+			"a".repeat(500_000),
+			"漢".repeat(100_000),
+			"😀".repeat(75_000),
+			'"\\\b\f\n\r\t\u0000'.repeat(25_000),
+		];
 		for (const [index, payload] of payloads.entries()) {
+			const responses: Array<{ id: string; line: string }> = [];
+			setCatalogAfterHelperResponseForTest((mode, id, line) => {
+				if (mode === "metadata") responses.push({ id, line });
+			});
 			const root = mkdtempSync(join(tmpdir(), `prime-catalog-escaped-cap-${index}-`));
 			const sessionDir = join(root, "sessions");
 			const parent = SessionManager.create(root, sessionDir);
@@ -732,59 +742,36 @@ describe("daemon catalog selector resolution", () => {
 				`${[
 					JSON.stringify({ type: "message", message: { role: "user", content: payload } }),
 					JSON.stringify({ type: "session_info", name: payload }),
-					// Hostile taskState must be dropped rather than treated as a free-text
-					// field. The allowed wire enum is tested below.
 					JSON.stringify({
 						type: "agent_status",
 						status: { summary: payload, taskState: payload, basedOnMessageCount: 1 },
 					}),
 				].join("\n")}\n`,
 			);
-			const family = await listCatalogFamilySessions(sessionDir);
-			expect(family).toHaveLength(1);
-			const [session] = family;
-			// A successful descriptor helper exchange proves the exact ASCII-escaped
-			// response stayed inside its 256 KiB wire cap. The compact response still
-			// has every catalog field consumers require.
-			expect(session).toEqual(
-				expect.objectContaining({
-					id: `parent-${index}`,
-					firstMessage: expect.any(String),
-					allMessagesText: expect.any(String),
-					name: expect.any(String),
-					agentStatus: expect.objectContaining({
-						summary: expect.any(String),
-						basedOnMessageCount: 1,
+			try {
+				const family = await listCatalogFamilySessions(sessionDir);
+				expect(family).toHaveLength(1);
+				const [session] = family;
+				expect(session).toEqual(
+					expect.objectContaining({
+						id: `parent-${index}`,
+						firstMessage: expect.any(String),
+						allMessagesText: expect.any(String),
+						name: expect.any(String),
+						agentStatus: expect.objectContaining({ summary: expect.any(String), basedOnMessageCount: 1 }),
 					}),
-				}),
-			);
-			expect(session?.agentStatus?.taskState).toBeUndefined();
-			const serialized = JSON.stringify({
-				id: "metadata-response",
-				data: {
-					valid: true,
-					messageCount: session.messageCount,
-					firstMessage: session.firstMessage,
-					allMessagesText: session.allMessagesText,
-					modifiedMs: session.modified.getTime(),
-					name: session.name,
-					agentStatus: session.agentStatus,
-				},
-			});
-			// The helper uses Python json.dumps(..., ensure_ascii=True), including
-			// surrogate-pair escaping for astral code points. Assert that exact
-			// envelope representation, not a UTF-8 or lossy Node "ascii" estimate.
-			const ensureAscii = serialized.replace(/[\u0080-\u{10ffff}]/gu, (character) => {
-				const codePoint = character.codePointAt(0)!;
-				if (codePoint <= 0xffff) return `\\u${codePoint.toString(16).padStart(4, "0")}`;
-				const offset = codePoint - 0x10000;
-				return `\\u${(0xd800 + (offset >> 10)).toString(16)}\\u${(0xdc00 + (offset & 0x3ff)).toString(16)}`;
-			});
-			expect(Buffer.byteLength(ensureAscii, "ascii")).toBeLessThanOrEqual(256 * 1024);
-			rmSync(root, { recursive: true, force: true });
+				);
+				expect(session?.agentStatus?.taskState).toBeUndefined();
+				expect(responses).toHaveLength(1);
+				const response = responses[0]!;
+				expect(JSON.parse(response.line).id).toBe(response.id);
+				expect(Buffer.byteLength(response.line, "ascii")).toBeLessThanOrEqual(256 * 1024);
+			} finally {
+				setCatalogAfterHelperResponseForTest(undefined);
+				rmSync(root, { recursive: true, force: true });
+			}
 		}
 	});
-
 	it("retains only allowed typed agent task states", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-agent-status-schema-"));
 		const sessionDir = join(root, "sessions");
@@ -817,24 +804,33 @@ describe("daemon catalog selector resolution", () => {
 		writeFileSync(join(sessionDir, "blank.jsonl"), "\n");
 		writeFileSync(join(sessionDir, "junk.jsonl"), "not json\n");
 		writeFileSync(join(sessionDir, "event.jsonl"), '{"type":"message","id":"junk"}\n');
+		writeFileSync(join(sessionDir, "session-no-id.jsonl"), '{"type":"session","cwd":"/tmp"}\n');
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("trustworthy topology claims");
+		rmSync(join(sessionDir, "session-no-id.jsonl"));
 		// An oversized root is skippable only when its bounded prefix is
 		// demonstrably unrelated, including incomplete unrelated junk. A purported
 		// session or identifier claim remains topology-relevant and fails closed.
-		writeFileSync(join(sessionDir, "oversized-junk.jsonl"), `not-json-${"x".repeat(300 * 1024)}`);
+		const classificationResponses: string[] = [];
+		setCatalogAfterHelperResponseForTest((mode, _id, line) => {
+			if (mode === "classify") classificationResponses.push(line);
+		});
+		writeFileSync(join(sessionDir, "oversized-junk.jsonl"), `not-json-${"x".repeat(200 * 1024)}`);
 		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([expect.objectContaining({ id: "parent" })]);
+		expect(classificationResponses.every((line) => Buffer.byteLength(line, "ascii") <= 256 * 1024)).toBe(true);
+		setCatalogAfterHelperResponseForTest(undefined);
 		rmSync(join(sessionDir, "oversized-junk.jsonl"));
-		writeFileSync(join(sessionDir, "oversized-event.jsonl"), `{"type":"message","body":"${"x".repeat(300 * 1024)}`);
+		writeFileSync(join(sessionDir, "oversized-event.jsonl"), `{"type":"message","body":"${"x".repeat(200 * 1024)}`);
 		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([expect.objectContaining({ id: "parent" })]);
 		rmSync(join(sessionDir, "oversized-event.jsonl"));
 		writeFileSync(
 			join(sessionDir, "oversized-session.jsonl"),
-			`{"type":"session","id":"claimed","padding":"${"x".repeat(300 * 1024)}`,
+			`{"type":"session","id":"claimed","padding":"${"x".repeat(200 * 1024)}`,
 		);
 		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
 			"session header exceeds the trusted read limit",
 		);
 		rmSync(join(sessionDir, "oversized-session.jsonl"));
-		writeFileSync(join(sessionDir, "oversized-id.jsonl"), `{"id":"claimed","padding":"${"x".repeat(300 * 1024)}`);
+		writeFileSync(join(sessionDir, "oversized-id.jsonl"), `{"id":"claimed","padding":"${"x".repeat(200 * 1024)}`);
 		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow(
 			"session header exceeds the trusted read limit",
 		);
@@ -845,6 +841,20 @@ describe("daemon catalog selector resolution", () => {
 		writeFileSync(join(sessionDir, "duplicate.jsonl"), readFileSync(parent.getSessionFile()!));
 		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("duplicate session id");
 		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("keeps registry-reached child headers strict when classification would truncate", async () => {
+		const { root, sessionDir, first } = createCatalogFamilyFixture();
+		try {
+			const file = first.getSessionFile()!;
+			const entries = readFileSync(file, "utf8").trimEnd().split(/\r?\n/);
+			const header = JSON.parse(entries[0]!) as Record<string, unknown>;
+			header.padding = "x".repeat(200 * 1024);
+			writeFileSync(file, `${[JSON.stringify(header), ...entries.slice(1)].join("\n")}\n`);
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("reads only the session header line even when the body is huge", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -875,79 +875,127 @@ describe("daemon mode helpers", () => {
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
 
-	it("fences stale same-id same-directory daemon release and delete by runtime identity", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-daemon-incarnation-test.sock", {
+	it("reports a stale old release after a same-id daemon republish without touching the replacement", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-daemon-stale-release-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
 			createRuntime: vi.fn(),
 		});
-		const parentState = makeState("parent-incarnation");
-		const oldState = makeState("old-incarnation", parentState.activeSessionId);
-		const newState = makeState("new-incarnation", parentState.activeSessionId);
-		const sessionDir = "/tmp/recycled-child-directory";
-		const oldSession = {
-			sessionFile: `${sessionDir}/old.jsonl`,
-			disposeAsync: vi.fn(async () => {}),
+		const parentState = makeState("parent-stale-release");
+		const replacementState = makeState("replacement-stale-release", parentState.activeSessionId);
+		const sessionDir = "/tmp/recycled-release-child-directory";
+		const oldSession = { sessionFile: `${sessionDir}/old.jsonl`, sessionId: "old-release-session" };
+		const replacementSession = {
+			sessionFile: `${sessionDir}/replacement.jsonl`,
+			sessionId: "replacement-release-session",
 		};
-		const newSession = {
-			sessionFile: `${sessionDir}/new.jsonl`,
-			disposeAsync: vi.fn(async () => {}),
+		replacementState.runtime = {
+			...replacementState.runtime,
+			metadata: {
+				kind: "subagent",
+				createdAt: 1,
+				parentActiveSessionId: parentState.activeSessionId,
+				rlmChildId: "recycled-release-child",
+				sessionDir,
+			},
+			session: replacementSession,
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closeSession: ReturnType<typeof vi.fn>;
+			recordRlmSubagentDeletion: ReturnType<typeof vi.fn>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
 		};
-		for (const [state, session] of [
-			[oldState, oldSession],
-			[newState, newSession],
-		] as const) {
-			state.runtime = {
-				...state.runtime,
-				metadata: {
-					kind: "subagent",
-					createdAt: 1,
-					parentActiveSessionId: parentState.activeSessionId,
-					rlmChildId: "recycled-child",
-					sessionDir,
-				},
-				session,
-			} as never;
-		}
+		internals.sessions.set(parentState.activeSessionId, parentState);
+		internals.sessions.set(replacementState.activeSessionId, replacementState);
+		internals.closeSession = vi.fn(async () => {});
+		internals.recordRlmSubagentDeletion = vi.fn(async () => "tombstoned" as const);
+
+		await expect(
+			internals
+				.createSubagentRuntimeHost(parentState)
+				.releaseRlmSubagentRuntime?.(
+					{ session: oldSession } as never,
+					{ id: "recycled-release-child", sessionDir } as CreateRlmSubagentRuntimeOptions,
+					"cancelled",
+				),
+		).resolves.toEqual({ deletionDurability: "stale" });
+		expect(internals.recordRlmSubagentDeletion).not.toHaveBeenCalled();
+		expect(internals.closeSession).not.toHaveBeenCalled();
+		expect(internals.sessions.get(replacementState.activeSessionId)).toBe(replacementState);
+	});
+
+	it("reports a stale old delete before registry or job mutation, then deletes the exact replacement", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-daemon-stale-delete-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parentState = makeState("parent-stale-delete");
+		const replacementState = makeState("replacement-stale-delete", parentState.activeSessionId);
+		const sessionDir = "/tmp/recycled-delete-child-directory";
+		const oldSession = { sessionFile: `${sessionDir}/old.jsonl`, sessionId: "old-delete-session" };
+		const replacementSession = {
+			sessionFile: `${sessionDir}/replacement.jsonl`,
+			sessionId: "replacement-delete-session",
+		};
+		replacementState.runtime = {
+			...replacementState.runtime,
+			metadata: {
+				kind: "subagent",
+				createdAt: 1,
+				parentActiveSessionId: parentState.activeSessionId,
+				rlmChildId: "recycled-delete-child",
+				sessionDir,
+			},
+			session: replacementSession,
+		} as never;
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
 			closeSession: ReturnType<typeof vi.fn>;
 			recordRlmSubagentDeletion: ReturnType<typeof vi.fn>;
 			readLatestRlmSubagentRegistry: ReturnType<typeof vi.fn>;
+			cancelScheduledJobsForSessionFile: ReturnType<typeof vi.fn>;
 			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
 		};
 		internals.sessions.set(parentState.activeSessionId, parentState);
-		// Model recreation: the old object is no longer resident, while the new
-		// object has exactly the same child id and directory.
-		internals.sessions.set(newState.activeSessionId, newState);
+		internals.sessions.set(replacementState.activeSessionId, replacementState);
 		internals.closeSession = vi.fn(async (state: ActiveSessionState) => {
 			internals.sessions.delete(state.activeSessionId);
 		});
 		internals.recordRlmSubagentDeletion = vi.fn(async () => "tombstoned" as const);
 		internals.readLatestRlmSubagentRegistry = vi.fn(async () => [
-			{ childId: "recycled-child", sessionDir, sessionFile: newSession.sessionFile },
+			{
+				childId: "recycled-delete-child",
+				sessionDir,
+				sessionFile: replacementSession.sessionFile,
+				sessionId: replacementSession.sessionId,
+			},
 		]);
+		internals.cancelScheduledJobsForSessionFile = vi.fn();
 		const host = internals.createSubagentRuntimeHost(parentState);
-		const options = { id: "recycled-child", sessionDir } as CreateRlmSubagentRuntimeOptions;
 
-		await expect(
-			host.releaseRlmSubagentRuntime?.({ session: oldSession } as never, options, "cancelled"),
-		).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
-		await expect(host.deleteRlmSubagentRuntime("recycled-child", oldSession as never)).rejects.toMatchObject({
-			name: "RlmSubagentHostDeletionError",
-			phase: "precommit",
+		await expect(host.deleteRlmSubagentRuntime("recycled-delete-child", oldSession as never)).resolves.toEqual({
+			deletionDurability: "stale",
 		});
+		expect(internals.readLatestRlmSubagentRegistry).not.toHaveBeenCalled();
 		expect(internals.recordRlmSubagentDeletion).not.toHaveBeenCalled();
 		expect(internals.closeSession).not.toHaveBeenCalled();
-		expect(oldSession.disposeAsync).not.toHaveBeenCalled();
-		expect(newSession.disposeAsync).not.toHaveBeenCalled();
-		expect(internals.sessions.get(newState.activeSessionId)).toBe(newState);
+		expect(internals.cancelScheduledJobsForSessionFile).not.toHaveBeenCalled();
+		expect(internals.sessions.get(replacementState.activeSessionId)).toBe(replacementState);
 
 		await expect(
-			host.releaseRlmSubagentRuntime?.({ session: newSession } as never, options, "cancelled"),
+			host.deleteRlmSubagentRuntime("recycled-delete-child", replacementSession as never, {
+				childId: "recycled-delete-child",
+				sessionDir,
+				sessionFile: replacementSession.sessionFile,
+				sessionId: replacementSession.sessionId,
+				generation: 1,
+				assertCurrent: vi.fn(),
+			}),
 		).resolves.toEqual({ deletionDurability: "tombstoned" });
 		expect(internals.recordRlmSubagentDeletion).toHaveBeenCalledOnce();
-		expect(internals.closeSession).toHaveBeenCalledOnce();
-		expect(internals.closeSession).toHaveBeenCalledWith(newState, "killed");
+		expect(internals.closeSession).toHaveBeenCalledWith(replacementState, "killed", false);
+		expect(internals.cancelScheduledJobsForSessionFile).toHaveBeenCalledWith(replacementSession.sessionFile);
+		expect(internals.sessions.has(replacementState.activeSessionId)).toBe(false);
 	});
 
 	it("classifies scheduler failure after a daemon tombstone as postcommit", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -836,7 +836,7 @@ describe("daemon mode helpers", () => {
 			);
 		expect(recordDeletion).toHaveBeenCalledWith(parentState, "child-1", undefined, childState.runtime.session);
 		expect(recordDeletion.mock.invocationCallOrder[0]).toBeLessThan(closeSession.mock.invocationCallOrder[1]!);
-		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
+		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed", false);
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
 		// A registry failure is precommit: keep the live incarnation resident and
@@ -871,7 +871,7 @@ describe("daemon mode helpers", () => {
 		).resolves.toEqual({ deletionDurability: "tombstoned" });
 		expect(retryDeletion).toHaveBeenCalledOnce();
 		expect(closeSession).toHaveBeenCalledTimes(closeCountBeforeFailure + 1);
-		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
+		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed", false);
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
 
@@ -1597,7 +1597,7 @@ describe("daemon mode helpers", () => {
 			expect(readFileSync(join(after.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")).toContain(
 				'"status":"deleted"',
 			);
-			expect(afterInternals.sessions.has(afterChild.activeSessionId)).toBe(false);
+			await vi.waitFor(() => expect(afterInternals.sessions.has(afterChild.activeSessionId)).toBe(false));
 		} finally {
 			rmSync(beforeTempDir, { recursive: true, force: true });
 			rmSync(afterTempDir, { recursive: true, force: true });
@@ -11390,6 +11390,90 @@ function makeAgentFamilyState(
 	} as never;
 	return { state, acceptAgentMessagePrompt };
 }
+
+describe("daemon tombstoned retirement", () => {
+	it("returns from host deletion while an exact tombstoned close remains gated and hidden", async () => {
+		const daemon = new AgentDaemon("/tmp/gated-retirement.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parent = makeState("gated-parent");
+		const child = makeState("gated-child", parent.activeSessionId);
+		child.runtime = {
+			...child.runtime,
+			session: { sessionId: "gated-session", sessionFile: "/tmp/child-1.jsonl" },
+		} as ActiveSessionState["runtime"];
+		Object.assign(child.runtime.metadata, { kind: "subagent", rlmChildId: "child-1", sessionDir: "/tmp/child-1" });
+		let release!: () => void;
+		let closed = false;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		}).then(() => {
+			closed = true;
+		});
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closingSessions: Map<string, unknown>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+			isPublicRlmState(state: ActiveSessionState): boolean;
+			recordRlmSubagentDeletion: ReturnType<typeof vi.fn>;
+			readLatestRlmSubagentRegistry: ReturnType<typeof vi.fn>;
+			closeSession: ReturnType<typeof vi.fn>;
+		};
+		internals.sessions.set(parent.activeSessionId, parent);
+		internals.sessions.set(child.activeSessionId, child);
+		internals.readLatestRlmSubagentRegistry = vi.fn(async () => [
+			{ childId: "child-1", sessionDir: "/tmp/child-1", sessionFile: child.runtime.session.sessionFile },
+		]);
+		internals.recordRlmSubagentDeletion = vi.fn(async () => "tombstoned" as const);
+		internals.closeSession = vi.fn(() => {
+			internals.closingSessions.set(child.activeSessionId, {});
+			return gate;
+		});
+		const result = await internals
+			.createSubagentRuntimeHost(parent)
+			.deleteRlmSubagentRuntime("child-1", child.runtime.session);
+		expect(result).toEqual({ deletionDurability: "tombstoned" });
+		expect(internals.recordRlmSubagentDeletion).toHaveBeenCalledOnce();
+		expect(internals.closeSession).toHaveBeenCalledWith(child, "killed", false);
+		expect(internals.recordRlmSubagentDeletion.mock.invocationCallOrder[0]).toBeLessThan(
+			internals.closeSession.mock.invocationCallOrder[0]!,
+		);
+		expect(closed).toBe(false);
+		expect(internals.isPublicRlmState(child)).toBe(false);
+		release();
+		await gate;
+	});
+
+	it("retains a failed physical disposal and retries the exact runtime", async () => {
+		const daemon = new AgentDaemon("/tmp/retry-retirement.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parent = makeState("retry-parent");
+		const child = makeState("retry-child", parent.activeSessionId);
+		const dispose = vi.fn(async () => {});
+		child.runtime.dispose = dispose;
+		const disposeFailure = new Error("dispose failed");
+		const internals = daemon as unknown as {
+			closeDisposeErrors: WeakMap<ActiveSessionState, unknown>;
+			failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+			detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+			closeSession: ReturnType<typeof vi.fn>;
+		};
+		internals.closeSession = vi.fn(async () => {
+			internals.closeDisposeErrors.set(child, disposeFailure);
+			throw disposeFailure;
+		});
+		internals.detachTombstonedClose(parent, child, "child-1");
+		await vi.waitFor(() =>
+			expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(disposeFailure),
+		);
+		internals.detachTombstonedClose(parent, child, "child-1");
+		await vi.waitFor(() => expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false));
+		expect(dispose).toHaveBeenCalledOnce();
+	});
+});
 
 function makeState(activeSessionId: string, parentActiveSessionId?: string): ActiveSessionState {
 	return {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -978,6 +978,47 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("rechecks retry authority before appending a daemon deletion tombstone", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-deletion-authority-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				recordRlmSubagentDeletion(
+					parentState: ActiveSessionState,
+					childId: string,
+					authority?: { assertCurrent(): void },
+				): Promise<"absent" | "tombstoned" | "unknown">;
+			};
+			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const before = readFileSync(registryPath, "utf8");
+			const revoked = new Error("host request authority was revoked");
+
+			// The complete asynchronous registry read must not become authority to
+			// append after the caller has been revoked.
+			await expect(
+				internals.recordRlmSubagentDeletion(parentState, fixture.childId, {
+					assertCurrent: () => {
+						throw revoked;
+					},
+				}),
+			).rejects.toBe(revoked);
+			expect(readFileSync(registryPath, "utf8")).toBe(before);
+
+			await expect(
+				internals.recordRlmSubagentDeletion(parentState, fixture.childId, { assertCurrent: () => {} }),
+			).resolves.toBe("tombstoned");
+			expect(readFileSync(registryPath, "utf8").match(/"childId":"child-1"/g)).toHaveLength(2);
+			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
+			await expect(
+				internals.recordRlmSubagentDeletion(parentState, "unknown", { assertCurrent: () => {} }),
+			).resolves.toBe("absent");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("persists a real child completion for passive discovery, roster, and listing", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-real-completion-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -818,9 +818,10 @@ describe("daemon mode helpers", () => {
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
-		// A registry failure must not strand the cancelled child as a stale resident session,
-		// but must retain the artifact because durability is unknown.
+		// A registry failure is precommit: keep the live incarnation resident and
+		// addressable so a later owner can retry the durable tombstone and close once.
 		internals.sessions.set(childState.activeSessionId, childState);
+		const closeCountBeforeFailure = closeSession.mock.calls.length;
 		internals.recordRlmSubagentDeletion = vi.fn(async () => {
 			throw new Error("registry write failed");
 		});
@@ -832,7 +833,23 @@ describe("daemon mode helpers", () => {
 					{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
 					"cancelled",
 				),
-		).resolves.toEqual({ deletionDurability: "unknown" });
+		).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+		expect(closeSession).toHaveBeenCalledTimes(closeCountBeforeFailure);
+		expect(internals.sessions.get(childState.activeSessionId)).toBe(childState);
+
+		const retryDeletion = vi.fn(async () => "tombstoned" as const);
+		internals.recordRlmSubagentDeletion = retryDeletion;
+		await expect(
+			internals
+				.createSubagentRuntimeHost(parentState)
+				.releaseRlmSubagentRuntime?.(
+					{ session: childState.runtime.session },
+					{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
+					"cancelled",
+				),
+		).resolves.toEqual({ deletionDurability: "tombstoned" });
+		expect(retryDeletion).toHaveBeenCalledOnce();
+		expect(closeSession).toHaveBeenCalledTimes(closeCountBeforeFailure + 1);
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	AGENT_FAMILY_REACH_ERROR,
 	type AgentSessionMessageController,
+	assertAgentFamilyReach,
 	DEFAULT_AGENT_MESSAGE_MAX_CHARS,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
@@ -46,6 +47,53 @@ import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js"
 import { DAEMON_WORKER_SUPERVISOR_SOCKET_ENV } from "../src/modes/daemon/daemon-worker-protocol.js";
 
 describe("daemon mode helpers", () => {
+	const useResidentCatalog = (daemon: AgentDaemon) => {
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries?: () => Promise<
+				readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+			>;
+		};
+		internals.agentFamilyCatalogEntries = async () =>
+			Object.freeze(
+				[...internals.sessions.values()].map((state) => {
+					const session = state.runtime.session;
+					const metadata = state.runtime.metadata;
+					const parentSessionId =
+						metadata.parentSessionId ??
+						(metadata.parentActiveSessionId
+							? internals.sessions.get(metadata.parentActiveSessionId)?.runtime.session.sessionId
+							: undefined);
+					return {
+						id: session.sessionId,
+						depth: session.rlmDepth ?? 0,
+						status: "running" as const,
+						...(parentSessionId ? { parentSessionId } : {}),
+						...(session.sessionFile ? { sessionPath: session.sessionFile } : {}),
+					};
+				}),
+			);
+	};
+
+	const installDeterministicAgentFamilyCatalog = (internals: object, states: readonly ActiveSessionState[]) => {
+		const catalogTarget = internals as {
+			agentFamilyCatalogEntries?: () => Promise<
+				readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+			>;
+		};
+		catalogTarget.agentFamilyCatalogEntries = vi.fn(async () =>
+			Object.freeze(
+				states.map((state) => ({
+					id: state.runtime.session.sessionId,
+					depth: state.runtime.session.rlmDepth ?? 0,
+					status: "running" as const,
+					...(state.runtime.metadata.parentSessionId
+						? { parentSessionId: state.runtime.metadata.parentSessionId }
+						: {}),
+				})),
+			),
+		);
+	};
 	it("preserves envelope client identity while registering prompt admission", () => {
 		const daemon = new AgentDaemon("/tmp/unused-daemon.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
@@ -241,6 +289,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const send = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -248,8 +297,9 @@ describe("daemon mode helpers", () => {
 			fromState,
 			origin: "agent",
 		});
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && acceptAgentMessagePrompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
 		resolvePrompt();
@@ -485,6 +535,69 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("fails closed for malformed remote peer topology on daemon ACL surfaces", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-malformed-remote-family.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const root = makeState("root");
+		root.runtime = {
+			...root.runtime,
+			cwd: "/tmp",
+			metadata: { kind: "top-level", createdAt: 1 },
+			session: {
+				sessionId: "session-root",
+				sessionName: "root",
+				rlmDepth: 0,
+				isStreaming: false,
+				isSessionActive: false,
+				unfinishedActionCount: 0,
+				messages: [],
+				sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+				hasRunningRlmChildren: () => false,
+				sessionManager: { getSessionArtifactDir: () => undefined },
+			},
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			remoteAgentPeers: Map<string, Record<string, unknown>>;
+			createAgentMessageController(
+				getCurrentState: () => ActiveSessionState | undefined,
+			): AgentSessionMessageController;
+			createAgentObserveController(getCurrentState: () => ActiveSessionState): AgentObserveController;
+		};
+		internals.sessions.set(root.activeSessionId, root);
+		const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
+		try {
+			for (const malformed of [
+				{ rlmDepth: 0, parentSessionId: "session-root" },
+				{ rlmDepth: -1 },
+				{ rlmDepth: 1 },
+			]) {
+				internals.remoteAgentPeers.clear();
+				internals.remoteAgentPeers.set("malformed-peer", {
+					activeSessionId: "malformed-peer",
+					sessionId: "session-malformed-peer",
+					sessionName: "malformed-peer",
+					runtimeKind: "subagent",
+					cwd: "/tmp/remote",
+					isStreaming: false,
+					unfinishedActionCount: 0,
+					...malformed,
+				});
+				const messaging = internals.createAgentMessageController(() => root);
+				const observe = internals.createAgentObserveController(() => root);
+				await expect(messaging.roster!()).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+				await expect(messaging.sendAgentMessage({ target: "malformed-peer", message: "no" })).rejects.toThrow(
+					AGENT_FAMILY_REACH_ERROR,
+				);
+				await expect(observe.listAgents()).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			}
+		} finally {
+			listAll.mockRestore();
+		}
+	});
+
 	it("canonicalizes symlinked paths in the family catalog and name reservations", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-family-catalog-paths-"));
 		try {
@@ -621,6 +734,7 @@ describe("daemon mode helpers", () => {
 		internals.sessions.set(parentState.activeSessionId, parentState);
 		// A successfully completed RLM child remains idle in this daemon registry.
 		internals.sessions.set(subagentState.activeSessionId, subagentState);
+		installDeterministicAgentFamilyCatalog(internals, [parentState, subagentState]);
 
 		const controller = internals.createAgentMessageController(() => parentState);
 		const subagentSummary = (await controller.listAgents()).agents.find(
@@ -1204,6 +1318,7 @@ describe("daemon mode helpers", () => {
 			},
 			worker: { authenticationToken: "worker-token" },
 		});
+		useResidentCatalog(daemon);
 		const parentState = makeState("parent");
 		const childState = makeState("child", parentState.activeSessionId);
 		const sessionPrompt = vi.fn(async () => {});
@@ -1333,6 +1448,9 @@ describe("daemon mode helpers", () => {
 			session: {
 				sessionId: "session-source",
 				sessionName: "Source",
+				sessionFile: "/tmp/source.jsonl",
+				rlmDepth: 0,
+				sessionManager: { getSessionArtifactDir: () => undefined },
 				isStreaming: false,
 				sessionActions: { queuedCount: 0, steering: [], followUps: [] },
 			},
@@ -1371,6 +1489,9 @@ describe("daemon mode helpers", () => {
 			cwd: "/tmp/remote",
 			isStreaming: false,
 			sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+			rlmDepth: 1,
+			parentSessionId: "session-source",
+			parentSessionPath: "/tmp/source.jsonl",
 		});
 		internals.sendRemoteAgentSessionMessage = sendRemoteAgentSessionMessage;
 
@@ -1833,6 +1954,7 @@ describe("daemon mode helpers", () => {
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetA.activeSessionId, targetA);
 		internals.sessions.set(targetB.activeSessionId, targetB);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetA, targetB]);
 
 		for (let i = 0; i < 3; i++) {
 			await expect(
@@ -2057,6 +2179,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		for (let i = 0; i < 3; i++) {
 			await expect(
@@ -2124,6 +2247,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const first = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -2201,18 +2325,22 @@ describe("daemon mode helpers", () => {
 			return fromState;
 		});
 
+		installDeterministicAgentFamilyCatalog(internals, [...senders, targetState]);
+		const sends: Promise<unknown>[] = [];
 		const errors: unknown[] = [];
 		for (const [i, fromState] of senders.entries()) {
-			void internals
-				.sendAgentSessionMessage({
-					targetSelector: targetState.activeSessionId,
-					message: `message ${i}`,
-					fromState,
-					origin: "agent",
-				})
-				.catch((error) => {
-					errors.push(error);
-				});
+			sends.push(
+				internals
+					.sendAgentSessionMessage({
+						targetSelector: targetState.activeSessionId,
+						message: `message ${i}`,
+						fromState,
+						origin: "agent",
+					})
+					.catch((error) => {
+						errors.push(error);
+					}),
+			);
 		}
 		for (let attempt = 0; attempt < 200 && queueAgentMessagePrompt.mock.calls.length < 12; attempt++) {
 			await Promise.resolve();
@@ -2220,6 +2348,7 @@ describe("daemon mode helpers", () => {
 
 		// With reservations held past queue time, 12 concurrent senders would
 		// count as 24 against the 20-slot cap and the tail would reject.
+		await Promise.all(sends);
 		expect(errors).toEqual([]);
 		expect(queueAgentMessagePrompt).toHaveBeenCalledTimes(12);
 	});
@@ -2264,6 +2393,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		await expect(
 			internals.sendAgentSessionMessage({
@@ -2287,6 +2417,7 @@ describe("daemon mode helpers", () => {
 				throw new Error("unexpected runtime creation");
 			},
 		});
+		useResidentCatalog(daemon);
 		const makeBusyState = (name: string) => {
 			const state = makeState(name);
 			state.runtime = {
@@ -2633,6 +2764,7 @@ describe("daemon mode helpers", () => {
 				throw new Error("unexpected runtime creation");
 			},
 		});
+		useResidentCatalog(daemon);
 		const states = [
 			makeState("root"),
 			makeState("child", "root"),
@@ -2714,11 +2846,169 @@ describe("daemon mode helpers", () => {
 		);
 	});
 
+	it("authorizes depth-two passive siblings only from the persisted daemon topology", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-deep-passive-acl-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const secondGrandchildDir = join(fixture.childSessionDir, "sibling-grandchild");
+			const secondGrandchild = SessionManager.create(tempDir, secondGrandchildDir);
+			secondGrandchild.newSession({ parentSession: fixture.childSessionFile, rlmDepth: 2 });
+			secondGrandchild.flushNow();
+			const secondGrandchildFile = secondGrandchild.getSessionFile();
+			if (!secondGrandchildFile) throw new Error("Missing sibling grandchild session");
+			const childRegistry = join(fixture.childArtifactDir, "rlm-subagents.jsonl");
+			writeFileSync(
+				childRegistry,
+				`${readFileSync(childRegistry, "utf8")}${JSON.stringify({
+					type: "rlm_subagent",
+					childId: "sibling-grandchild",
+					sessionName: "sibling-grandchild",
+					sessionDir: secondGrandchildDir,
+					sessionFile: secondGrandchildFile,
+					parentSessionId: fixture.childSessionId,
+					parentSessionFile: fixture.childSessionFile,
+					rlmDepth: 2,
+					status: "completed",
+					createdAt: 2,
+					updatedAt: "2026-01-01T00:00:02.000Z",
+				})}\n`,
+			);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				agentFamilyCatalogEntries(): Promise<
+					readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+				>;
+			};
+			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const catalog = await internals.agentFamilyCatalogEntries();
+			const first = catalog.find((entry) => entry.id === fixture.grandchildSessionId);
+			const second = catalog.find((entry) => entry.id === secondGrandchild.getSessionId());
+			expect(first).toBeDefined();
+			expect(second).toBeDefined();
+			expect(catalog).toContainEqual(expect.objectContaining({ id: fixture.childSessionId, depth: 1 }));
+			expect(assertAgentFamilyReach(first!, second!, catalog)).toBe("sibling");
+
+			// A depth-two pair claiming the root cannot manufacture the missing depth-one edge.
+			expect(() =>
+				assertAgentFamilyReach(
+					{ ...first!, parentSessionId: fixture.parentSessionId, parentSessionPath: fixture.parentSessionFile },
+					{ ...second!, parentSessionId: fixture.parentSessionId, parentSessionPath: fixture.parentSessionFile },
+					catalog,
+				),
+			).toThrow(AGENT_FAMILY_REACH_ERROR);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("observes residents from the captured family catalog rather than live endpoint fields", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-observe-captured-family.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const source = makeState("source");
+		const target = makeState("target");
+		for (const state of [source, target]) {
+			state.runtime = {
+				...state.runtime,
+				metadata: { kind: "top-level", createdAt: 1 },
+				diagnostics: [],
+				session: {
+					...state.runtime.session,
+					messages: [],
+					hasRunningRlmChildren: vi.fn(() => false),
+					sessionManager: {
+						getHeader: vi.fn(() => ({})),
+						getCwd: vi.fn(() => "/tmp"),
+						getSessionArtifactDir: vi.fn(() => undefined),
+					},
+					getSessionActionSnapshot: vi.fn(() => ({ queuedCount: 0, steering: [], followUps: [] })),
+					state: { streamingMessage: undefined, pendingToolCalls: new Map() },
+					sessionId: `session-${state.activeSessionId}`,
+					sessionFile: `/tmp/${state.activeSessionId}.jsonl`,
+					rlmDepth: 0,
+				},
+			} as never;
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries(): Promise<
+				readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+			>;
+			createAgentObserveController(getCurrentState: () => ActiveSessionState): AgentObserveController;
+		};
+		internals.sessions.set(source.activeSessionId, source);
+		internals.sessions.set(target.activeSessionId, target);
+		Object.assign(internals, {
+			agentFamilyCatalogEntries: vi.fn(async () =>
+				Object.freeze([
+					{ id: "left-parent", depth: 0, status: "inactive", sessionPath: "/tmp/left.jsonl" },
+					{ id: "right-parent", depth: 0, status: "inactive", sessionPath: "/tmp/right.jsonl" },
+					{ id: "session-source", depth: 1, status: "running", parentSessionId: "left-parent" },
+					{ id: "session-target", depth: 1, status: "running", parentSessionId: "right-parent" },
+				]),
+			),
+		});
+
+		// The live root summaries would otherwise be sibling roots. Their conflicting
+		// topology cannot override the captured snapshot's unrelated parent edges.
+		const observed = await internals.createAgentObserveController(() => source).listAgents();
+		expect(observed.agents.map((agent) => agent.activeSessionId)).toEqual(["source"]);
+	});
+
+	it("fails closed for every agent ACL surface when the captured catalog duplicates a stable session ID", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-duplicate-captured-family.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parent = makeAgentFamilyState("parent", "parent");
+		const source = makeAgentFamilyState("source", "source", parent.state);
+		const target = makeAgentFamilyState("target", "target", parent.state);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries(): Promise<
+				readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+			>;
+			createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
+			createAgentObserveController(getCurrentState: () => ActiveSessionState): AgentObserveController;
+		};
+		for (const fixture of [parent, source, target])
+			internals.sessions.set(fixture.state.activeSessionId, fixture.state);
+		const sourceId = source.state.runtime.session.sessionId;
+		const parentId = parent.state.runtime.session.sessionId;
+		const targetId = target.state.runtime.session.sessionId;
+		const entries = [
+			{ id: parentId, depth: 0, status: "running" as const },
+			{ id: sourceId, depth: 1, status: "running" as const, parentSessionId: parentId },
+			{ id: sourceId, depth: 1, status: "running" as const, parentSessionId: "forged-parent" },
+			{ id: targetId, depth: 1, status: "running" as const, parentSessionId: parentId },
+		];
+
+		// The current observer must be resolved from the immutable catalog before
+		// self inclusion. Either duplicate ordering is ambiguous and must fail closed.
+		for (const catalog of [entries, [...entries.slice(0, 1), entries[2]!, entries[1]!, entries[3]!]]) {
+			internals.agentFamilyCatalogEntries = vi.fn(async () => Object.freeze(catalog));
+			const observe = internals.createAgentObserveController(() => source.state);
+			await expect(observe.listAgents()).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			await expect(observe.getAgent(target.state.activeSessionId)).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			await expect(observe.recentMessages({ target: target.state.activeSessionId })).rejects.toThrow(
+				AGENT_FAMILY_REACH_ERROR,
+			);
+			await expect(
+				internals
+					.createAgentMessageController(() => source.state)
+					.sendAgentMessage({ target: target.state.activeSessionId, message: "must not deliver" }),
+			).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+		}
+		expect(target.acceptAgentMessagePrompt).not.toHaveBeenCalled();
+	});
+
 	it("resolves a duplicate session name to the only family-reachable agent", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-family-name-resolution.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
 			createRuntime: vi.fn(),
 		});
+		useResidentCatalog(daemon);
 		const observer = makeAgentFamilyState("observer", "observer");
 		const familyHelper = makeAgentFamilyState("family-helper", "helper", observer.state);
 		const otherRoot = makeAgentFamilyState("other-root", "other-root");
@@ -2858,6 +3148,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const first = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -2871,15 +3162,17 @@ describe("daemon mode helpers", () => {
 			fromState,
 			origin: "agent",
 		});
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && prompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(prompt).toHaveBeenCalledTimes(1);
 
 		promptResolves[0]?.();
 		await expect(first).resolves.toMatchObject({ message: "first" });
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && prompt.mock.calls.length < 2; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(prompt).toHaveBeenCalledTimes(2);
 		expect(followUp).not.toHaveBeenCalled();
@@ -3213,6 +3506,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const first = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -3226,15 +3520,17 @@ describe("daemon mode helpers", () => {
 			fromState,
 			origin: "agent",
 		});
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && prompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(prompt).toHaveBeenCalledTimes(1);
 		(targetState.runtime.session as { isStreaming: boolean }).isStreaming = true;
 		promptResolves[0]?.();
 		await expect(first).resolves.toMatchObject({ message: "first" });
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && queueAgentMessagePrompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(prompt).toHaveBeenCalledTimes(1);
 		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
@@ -3667,6 +3963,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const first = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -3680,8 +3977,9 @@ describe("daemon mode helpers", () => {
 			fromState,
 			origin: "agent",
 		});
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && acceptAgentMessagePrompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 		(targetState.runtime.session as { unfinishedActionCount: number }).unfinishedActionCount = 20;
 
 		resolveFirstPrompt();
@@ -4024,6 +4322,7 @@ describe("daemon mode helpers", () => {
 			}): Promise<unknown>;
 		};
 		internals.sessions.set(state.activeSessionId, state);
+		installDeterministicAgentFamilyCatalog(internals, [state]);
 
 		await expect(
 			internals.sendAgentSessionMessage({
@@ -5745,13 +6044,15 @@ describe("daemon mode helpers", () => {
 				sessionPath: fixture.parentSessionFile,
 			});
 
-			await internals
-				.createAgentMessageController(() => parentState)
-				.sendAgentMessage({ target: "renamed-worker", message: "report progress" });
-
-			// The nested header depth must win over the legacy depth-1 default so the
-			// woken child does not come up shallower than persisted.
-			expect(fixture.createRuntime.mock.calls[1]?.[0].sessionOptions?.rlmDepth).toBe(2);
+			// A root may not directly reach a depth-two child. The persisted header
+			// is authoritative even when legacy registry metadata omits depth, and denial
+			// must happen before hydration.
+			await expect(
+				internals
+					.createAgentMessageController(() => parentState)
+					.sendAgentMessage({ target: "renamed-worker", message: "report progress" }),
+			).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			expect(fixture.createRuntime).toHaveBeenCalledOnce();
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -9566,6 +9867,301 @@ describe("daemon mode helpers", () => {
 			}),
 		).rejects.toThrow("Unknown active session: missing");
 	});
+
+	it("delivers disjoint CLI sends while preserving agent-origin catalog ACLs", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-cli-from-state.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const { state: fromState } = makeAgentFamilyState("source", "Source");
+		const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target");
+		const agentFamilyCatalogEntries = vi.fn(async () =>
+			Object.freeze([
+				{
+					id: fromState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: "source-parent",
+				},
+				{
+					id: targetState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: "target-parent",
+				},
+			]),
+		);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				fromState?: ActiveSessionState;
+				origin: "agent" | "cli";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(fromState.activeSessionId, fromState);
+		internals.sessions.set(targetState.activeSessionId, targetState);
+		internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "CLI delivery ignores the family reach ACL",
+				fromState,
+				origin: "cli",
+			}),
+		).resolves.toMatchObject({
+			deliveryStatus: "delivered",
+			target: { activeSessionId: targetState.activeSessionId },
+		});
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+			customMessage: { details: { fromRelationship: undefined } },
+		});
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "agent ACL must reject this",
+				fromState,
+				origin: "agent",
+			}),
+		).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
+	});
+
+	it("labels CLI sibling sends from an authoritative depth-1 catalog", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-cli-sibling-label.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const { state: parentState } = makeAgentFamilyState("parent", "Parent");
+		const { state: fromState } = makeAgentFamilyState("source", "Source", parentState);
+		const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target", parentState);
+		const agentFamilyCatalogEntries = vi.fn(async () =>
+			Object.freeze([
+				{
+					id: parentState.runtime.session.sessionId,
+					depth: 0,
+					status: "running" as const,
+				},
+				{
+					id: fromState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: parentState.runtime.session.sessionId,
+				},
+				{
+					id: targetState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: parentState.runtime.session.sessionId,
+				},
+			]),
+		);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				fromState?: ActiveSessionState;
+				origin: "agent" | "cli";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(parentState.activeSessionId, parentState);
+		internals.sessions.set(fromState.activeSessionId, fromState);
+		internals.sessions.set(targetState.activeSessionId, targetState);
+		internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "sent by the CLI sibling",
+				fromState,
+				origin: "cli",
+			}),
+		).resolves.toMatchObject({ deliveryStatus: "delivered" });
+		expect(agentFamilyCatalogEntries).toHaveBeenCalledOnce();
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+			customMessage: { details: { fromRelationship: "sibling" } },
+		});
+	});
+
+	it("omits a CLI sibling label when the catalog has ambiguous parents", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-cli-ambiguous-sibling.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const { state: firstParent } = makeAgentFamilyState("first-parent", "First parent");
+		const { state: fromState } = makeAgentFamilyState("source", "Source", firstParent);
+		const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target", firstParent);
+		const agentFamilyCatalogEntries = vi.fn(async () =>
+			Object.freeze([
+				{
+					id: firstParent.runtime.session.sessionId,
+					depth: 0,
+					status: "running" as const,
+				},
+				{
+					id: firstParent.runtime.session.sessionId,
+					depth: 0,
+					status: "running" as const,
+				},
+				{
+					id: fromState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: firstParent.runtime.session.sessionId,
+				},
+				{
+					id: targetState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: firstParent.runtime.session.sessionId,
+				},
+			]),
+		);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				fromState?: ActiveSessionState;
+				origin: "agent" | "cli";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(fromState.activeSessionId, fromState);
+		internals.sessions.set(targetState.activeSessionId, targetState);
+		internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "sent with ambiguous parent evidence",
+				fromState,
+				origin: "cli",
+			}),
+		).resolves.toMatchObject({ deliveryStatus: "delivered" });
+		expect(agentFamilyCatalogEntries).toHaveBeenCalledOnce();
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+			customMessage: { details: { fromRelationship: undefined } },
+		});
+	});
+
+	it.each(["sender", "target"] as const)(
+		"delivers an unlabeled CLI message with a duplicate %s endpoint while agent origin rejects it",
+		async (duplicate) => {
+			const daemon = new AgentDaemon(`/tmp/prime-agent-cli-duplicate-${duplicate}.sock`, {
+				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			const { state: fromState } = makeAgentFamilyState("source", "Source");
+			const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target");
+			const fromEntry = {
+				id: fromState.runtime.session.sessionId,
+				depth: 0,
+				status: "running" as const,
+			};
+			const targetEntry = {
+				id: targetState.runtime.session.sessionId,
+				depth: 0,
+				status: "running" as const,
+			};
+			const duplicateEntry = duplicate === "sender" ? fromEntry : targetEntry;
+			const agentFamilyCatalogEntries = vi.fn(async () =>
+				Object.freeze([fromEntry, targetEntry, { ...duplicateEntry }]),
+			);
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+				sendAgentSessionMessage(options: {
+					targetSelector: string;
+					message: string;
+					fromState?: ActiveSessionState;
+					origin: "agent" | "cli";
+				}): Promise<unknown>;
+			};
+			internals.sessions.set(fromState.activeSessionId, fromState);
+			internals.sessions.set(targetState.activeSessionId, targetState);
+			internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+
+			await expect(
+				internals.sendAgentSessionMessage({
+					targetSelector: targetState.activeSessionId,
+					message: "CLI delivery treats topology as advisory",
+					fromState,
+					origin: "cli",
+				}),
+			).resolves.toMatchObject({ deliveryStatus: "delivered" });
+			expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+				customMessage: { details: { fromRelationship: undefined } },
+			});
+			await expect(
+				internals.sendAgentSessionMessage({
+					targetSelector: targetState.activeSessionId,
+					message: "agent origin rejects ambiguous authority",
+					fromState,
+					origin: "agent",
+				}),
+			).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
+		},
+	);
+
+	it("delivers an unlabeled CLI message when catalog acquisition fails while agent origin rejects it", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-cli-catalog-failure.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const { state: fromState } = makeAgentFamilyState("source", "Source");
+		const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target");
+		const catalogError = new Error("catalog unavailable");
+		const agentFamilyCatalogEntries = vi.fn(async () => {
+			throw catalogError;
+		});
+		const log = vi.fn();
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+			log: typeof log;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				fromState?: ActiveSessionState;
+				origin: "agent" | "cli";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(fromState.activeSessionId, fromState);
+		internals.sessions.set(targetState.activeSessionId, targetState);
+		internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+		internals.log = log;
+
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "CLI delivery survives catalog failure",
+				fromState,
+				origin: "cli",
+			}),
+		).resolves.toMatchObject({ deliveryStatus: "delivered" });
+		expect(log).toHaveBeenCalledWith(
+			"Agent family catalog unavailable for CLI message relationship: catalog unavailable",
+		);
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+			customMessage: { details: { fromRelationship: undefined } },
+		});
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "agent origin rejects catalog failure",
+				fromState,
+				origin: "agent",
+			}),
+		).rejects.toBe(catalogError);
+		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
+	});
 });
 
 type CronAdmissionActivity = Partial<{
@@ -9694,7 +10290,7 @@ function makePersistedRlmDaemonFixture(
 	const childId = "child-1";
 	const childSessionDir = join(parentArtifactDir, "sub-1234abcd");
 	const childManager = SessionManager.create(tempDir, childSessionDir);
-	childManager.newSession({ parentSession: parentSessionFile });
+	childManager.newSession({ parentSession: parentSessionFile, rlmDepth: 1 });
 	childManager.appendSessionInfo("spawn-worker");
 	childManager.appendSessionInfo("renamed-worker");
 	childManager.appendMessage({ role: "user", content: "complete this task", timestamp: 1 });
@@ -9708,7 +10304,7 @@ function makePersistedRlmDaemonFixture(
 	mkdirSync(childArtifactDir, { recursive: true });
 	const grandchildSessionDir = join(childSessionDir, "sub-deadbeef");
 	const grandchildManager = SessionManager.create(tempDir, grandchildSessionDir);
-	grandchildManager.newSession({ parentSession: childSessionFile });
+	grandchildManager.newSession({ parentSession: childSessionFile, rlmDepth: 2 });
 	grandchildManager.appendSessionInfo("nested-worker");
 	grandchildManager.appendMessage({ role: "user", content: "complete the nested task", timestamp: 2 });
 	grandchildManager.flushNow();
@@ -9824,9 +10420,12 @@ function makePersistedRlmDaemonFixture(
 		parentArtifactDir,
 		parentSessionId: parentManager.getSessionId(),
 		childId,
+		childSessionId: childManager.getSessionId(),
 		childSessionFile,
 		childSessionDir,
+		childArtifactDir,
 		grandchildId,
+		grandchildSessionId: grandchildManager.getSessionId(),
 		grandchildSessionFile,
 	};
 }

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11967,7 +11967,7 @@ describe("daemon tombstoned retirement", () => {
 			} as never;
 			const internals = daemon as unknown as {
 				sessions: Map<string, ActiveSessionState>;
-				closeSession(state: ActiveSessionState, reason: typeof reason): Promise<void>;
+				closeSession(state: ActiveSessionState, reason: "completed" | "killed"): Promise<void>;
 				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
 				createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
 			};

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1195,6 +1195,11 @@ describe("daemon mode helpers", () => {
 			const original = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
 			const oldSessionId = original.sessionId as string;
 			const replacementSessionId = "replacement-session-id";
+			const replacementEntries = readFileSync(fixture.childSessionFile, "utf8").split(/\r?\n/u);
+			const replacementHeader = JSON.parse(replacementEntries[0]!) as Record<string, unknown>;
+			replacementHeader.id = replacementSessionId;
+			replacementEntries[0] = JSON.stringify(replacementHeader);
+			writeFileSync(fixture.childSessionFile, replacementEntries.join("\n"));
 			writeFileSync(
 				registryPath,
 				`${JSON.stringify(original)}\n${JSON.stringify({

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -47,6 +47,7 @@ import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js"
 import { DAEMON_WORKER_SUPERVISOR_SOCKET_ENV } from "../src/modes/daemon/daemon-worker-protocol.js";
 
 describe("daemon mode helpers", () => {
+	const emptySavedSessionsDir = join(tmpdir(), `prime-agent-daemon-tests-no-saved-sessions-${process.pid}`);
 	const useResidentCatalog = (daemon: AgentDaemon) => {
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
@@ -2011,6 +2012,7 @@ describe("daemon mode helpers", () => {
 			...state.runtime,
 			dispose,
 			session: {
+				beginClosing: vi.fn(),
 				sessionId: "session-child",
 				sessionFile: undefined,
 				abort: vi.fn(() => new Promise<void>(() => {})),
@@ -2046,7 +2048,11 @@ describe("daemon mode helpers", () => {
 
 	it("lists and routes agent messages to peers hosted by another worker", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -2122,7 +2128,11 @@ describe("daemon mode helpers", () => {
 
 	it("routes nonresident agent-message targets through the supervisor wake path", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -2424,7 +2434,11 @@ describe("daemon mode helpers", () => {
 
 	it("reports queued status when a direct accept races into the queue", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -3081,7 +3095,11 @@ describe("daemon mode helpers", () => {
 
 	it("counts accepted in-flight agent messages against the target queue cap", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -3161,7 +3179,11 @@ describe("daemon mode helpers", () => {
 
 	it("reports non-streaming busy sessions as active in agent-observe summaries", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -3473,6 +3495,7 @@ describe("daemon mode helpers", () => {
 				`${readFileSync(childRegistry, "utf8")}${JSON.stringify({
 					type: "rlm_subagent",
 					childId: "sibling-grandchild",
+					sessionId: secondGrandchild.getSessionId(),
 					sessionName: "sibling-grandchild",
 					sessionDir: secondGrandchildDir,
 					sessionFile: secondGrandchildFile,
@@ -3653,7 +3676,11 @@ describe("daemon mode helpers", () => {
 
 	it("keeps a session ID ambiguous when a reachable agent uses it as its name", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-family-id-ambiguity.sock", {
-			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: vi.fn(),
 		});
 		const parent = makeAgentFamilyState("parent", "parent");
@@ -3685,7 +3712,11 @@ describe("daemon mode helpers", () => {
 
 	it("keeps a duplicate session name ambiguous when two family agents are reachable", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-family-name-ambiguity.sock", {
-			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: vi.fn(),
 		});
 		const parent = makeAgentFamilyState("parent", "helper");
@@ -3793,7 +3824,11 @@ describe("daemon mode helpers", () => {
 
 	it("queues agent messages behind an idle target with a pending retry", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -3850,7 +3885,11 @@ describe("daemon mode helpers", () => {
 
 	it("queues agent messages behind existing pending work on an idle target", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -3906,7 +3945,11 @@ describe("daemon mode helpers", () => {
 
 	it("queues agent messages while the target is compacting", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -3960,7 +4003,11 @@ describe("daemon mode helpers", () => {
 
 	it("queues agent messages while target bash is running", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -4014,7 +4061,11 @@ describe("daemon mode helpers", () => {
 
 	it("acknowledges queued agent messages after queue insertion", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -4152,7 +4203,11 @@ describe("daemon mode helpers", () => {
 
 	it("rejects agent messages when queued delivery is coalesced", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -4200,7 +4255,11 @@ describe("daemon mode helpers", () => {
 
 	it("rejects agent messages when direct delivery preflight fails", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp/prime-agent-test-agent",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: async () => {
 				throw new Error("unexpected runtime creation");
 			},
@@ -4852,6 +4911,7 @@ describe("daemon mode helpers", () => {
 			cwd: "/tmp",
 			metadata: { kind: "subagent", createdAt: 1 },
 			session: {
+				beginClosing: vi.fn(),
 				sessionId: "session-target",
 				sessionName: "Target",
 				isStreaming: false,
@@ -5450,6 +5510,7 @@ describe("daemon mode helpers", () => {
 				...state.runtime,
 				dispose: vi.fn(async () => {}),
 				session: {
+					beginClosing: vi.fn(),
 					sessionId: "session-active",
 					sessionFile: undefined,
 					isBashRunning: false,
@@ -8583,6 +8644,7 @@ describe("daemon mode helpers", () => {
 				cwd: tempDir,
 				dispose,
 				session: {
+					beginClosing: vi.fn(),
 					sessionId: "session-1",
 					sessionFile,
 					messages: ["user message"],
@@ -8679,6 +8741,7 @@ describe("daemon mode helpers", () => {
 					await disposeGate;
 				}),
 				session: {
+					beginClosing: vi.fn(),
 					sessionId: "session-1",
 					sessionFile,
 					messages: ["user message"],
@@ -8747,6 +8810,7 @@ describe("daemon mode helpers", () => {
 				...state.runtime,
 				cwd: tempDir,
 				session: {
+					beginClosing: vi.fn(),
 					sessionId: "session-1",
 					sessionFile: join(tempDir, "session.jsonl"),
 					sessionManager: { appendSessionState },
@@ -8807,6 +8871,7 @@ describe("daemon mode helpers", () => {
 					...state.runtime,
 					cwd: tempDir,
 					session: {
+						beginClosing: vi.fn(),
 						sessionId,
 						sessionFile: join(tempDir, `${sessionId}.jsonl`),
 						sessionManager: { appendSessionState },
@@ -8934,6 +8999,7 @@ describe("daemon mode helpers", () => {
 					await disposeGate;
 				}),
 				session: {
+					beginClosing: vi.fn(),
 					sessionId: "session-1",
 					sessionFile: join(tempDir, "session.jsonl"),
 					messages: ["user message"],
@@ -11072,6 +11138,7 @@ function makeRuntimeSession(
 			return sessionManager.getSessionName();
 		},
 		setSubagentRuntimeHost: vi.fn(),
+		beginClosing: vi.fn(),
 		getRlmChildRunStatus: vi.fn(() => "running"),
 		registerRlmChildSession: vi.fn(() => true),
 		releaseRlmChildSession: vi.fn(() => vi.fn()),
@@ -11123,6 +11190,7 @@ function makeAgentFamilyState(
 			isSessionActive: false,
 			hasAcceptedPromptInFlight: false,
 			unfinishedActionCount: 0,
+			beginClosing: vi.fn(),
 			messages: [],
 			state: { pendingToolCalls: new Set(), streamingMessage: undefined },
 			sessionManager: {
@@ -11149,6 +11217,7 @@ function makeState(activeSessionId: string, parentActiveSessionId?: string): Act
 				createdAt: 1,
 				parentActiveSessionId,
 			},
+			session: { beginClosing: vi.fn() },
 		},
 	} as unknown as ActiveSessionState;
 }

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -834,6 +834,99 @@ describe("daemon mode helpers", () => {
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
 
+	it("reports durable retention only for actual daemon deletion tombstones", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-release-ownership-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createRlmSubagentRuntime(
+					parentState: ActiveSessionState,
+					options: CreateRlmSubagentRuntimeOptions,
+				): Promise<ActiveSessionState["runtime"]>;
+				createSubagentRuntimeHost(parentState: ActiveSessionState): SubagentRuntimeHost;
+				appendRlmSubagentRegistryEntry(parentState: ActiveSessionState, entry: { status: string }): boolean;
+			};
+			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			Object.assign(parentState.runtime.session, {
+				isSessionActive: false,
+				isStreaming: false,
+				isCompacting: false,
+				isBashRunning: false,
+				state: { pendingToolCalls: new Set(), streamingMessage: undefined },
+				thinkingLevel: "off",
+				hasRunningRlmChildren: () => false,
+				getSessionActionSnapshot: () => ({ queuedCount: 0, steering: [], followUps: [] }),
+			});
+			const optionsFor = (id: string): CreateRlmSubagentRuntimeOptions => ({
+				parentSession: parentState.runtime.session,
+				id,
+				prompt: `release ${id}`,
+				sessionName: id,
+				sessionDir: join(fixture.parentArtifactDir, id),
+				model: { provider: "test", id: "model" } as Model<Api>,
+				thinkingLevel: "off",
+				serviceTier: null,
+				scopedModels: [],
+				activeToolNames: [],
+				customTools: [],
+				includeGoals: false,
+				includeCompactSkill: false,
+				rlmDepth: 1,
+				rlmMaxDepth: 4,
+				rlmParentNodeId: id,
+			});
+			const host = internals.createSubagentRuntimeHost(parentState);
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+
+			// A real resident child with its row removed has no durable owner. The host
+			// still closes it, and explicitly returns retained:false.
+			const noRowOptions = optionsFor("release-no-row");
+			const noRowRuntime = await internals.createRlmSubagentRuntime(parentState, noRowOptions);
+			writeFileSync(
+				registryPath,
+				`${readFileSync(registryPath, "utf8")
+					.split("\n")
+					.filter((line) => !line.includes('"childId":"release-no-row"'))
+					.filter(Boolean)
+					.join("\n")}\n`,
+			);
+			await expect(host.releaseRlmSubagentRuntime?.(noRowRuntime, noRowOptions, "cancelled")).resolves.toEqual({
+				retained: false,
+			});
+			expect([...internals.sessions.values()].some((state) => state.runtime.session === noRowRuntime.session)).toBe(
+				false,
+			);
+
+			// The ordinary daemon append/fsync path records the tombstone before close.
+			const retainedOptions = optionsFor("release-tombstoned");
+			const retainedRuntime = await internals.createRlmSubagentRuntime(parentState, retainedOptions);
+			await expect(host.releaseRlmSubagentRuntime?.(retainedRuntime, retainedOptions, "cancelled")).resolves.toEqual(
+				{
+					retained: true,
+				},
+			);
+			expect(readFileSync(registryPath, "utf8")).toContain('"childId":"release-tombstoned"');
+			expect(readFileSync(registryPath, "utf8")).toContain('"status":"deleted"');
+
+			// A deterministic append/fsync failure likewise closes the real resident
+			// runtime but cannot claim durable ownership of its artifact directory.
+			const failedOptions = optionsFor("release-write-failed");
+			const failedRuntime = await internals.createRlmSubagentRuntime(parentState, failedOptions);
+			const append = vi.spyOn(internals, "appendRlmSubagentRegistryEntry").mockReturnValue(false);
+			await expect(host.releaseRlmSubagentRuntime?.(failedRuntime, failedOptions, "cancelled")).resolves.toEqual({
+				retained: false,
+			});
+			expect(append).toHaveBeenCalledWith(parentState, expect.objectContaining({ status: "deleted" }));
+			expect([...internals.sessions.values()].some((state) => state.runtime.session === failedRuntime.session)).toBe(
+				false,
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("persists a real child completion for passive discovery, roster, and listing", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-real-completion-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1019,6 +1019,84 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("honors daemon deletion authority on both sides of the append boundary", async () => {
+		const beforeTempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-before-append-"));
+		const afterTempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-after-append-"));
+		try {
+			const before = makePersistedRlmDaemonFixture(beforeTempDir);
+			const beforeInternals = before.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				sessions: Map<string, ActiveSessionState>;
+			};
+			const beforeParent = await beforeInternals.createRuntime({
+				type: "create",
+				sessionPath: before.parentSessionFile,
+			});
+			const beforeChild = await beforeInternals.createRuntime({
+				type: "create",
+				sessionPath: before.childSessionFile,
+			});
+			const beforeRegistryPath = join(before.parentArtifactDir, "rlm-subagents.jsonl");
+			const beforeRegistry = readFileSync(beforeRegistryPath, "utf8");
+			const revokedBeforeAppend = new Error("host request authority was revoked");
+			let beforeBoundaryChecks = 0;
+			await expect(
+				beforeInternals
+					.createSubagentRuntimeHost(beforeParent)
+					.deleteRlmSubagentRuntime(before.childId, beforeChild.runtime.session, {
+						childId: before.childId,
+						sessionDir: before.childSessionDir,
+						generation: 1,
+						assertCurrent: () => {
+							if (++beforeBoundaryChecks === 2) throw revokedBeforeAppend;
+						},
+					}),
+			).rejects.toBe(revokedBeforeAppend);
+			expect(readFileSync(beforeRegistryPath, "utf8")).toBe(beforeRegistry);
+			expect(beforeInternals.sessions.get(beforeChild.activeSessionId)).toBe(beforeChild);
+
+			const after = makePersistedRlmDaemonFixture(afterTempDir);
+			const afterInternals = after.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				appendRlmSubagentRegistryEntry(parent: ActiveSessionState, entry: { status: string }): boolean;
+				sessions: Map<string, ActiveSessionState>;
+			};
+			const afterParent = await afterInternals.createRuntime({
+				type: "create",
+				sessionPath: after.parentSessionFile,
+			});
+			const afterChild = await afterInternals.createRuntime({ type: "create", sessionPath: after.childSessionFile });
+			const afterAbort = new AbortController();
+			const appendEntry = afterInternals.appendRlmSubagentRegistryEntry;
+			vi.spyOn(afterInternals, "appendRlmSubagentRegistryEntry").mockImplementation((parentState, entry) => {
+				const result = appendEntry.call(afterInternals, parentState, entry);
+				afterAbort.abort();
+				return result;
+			});
+			await expect(
+				afterInternals
+					.createSubagentRuntimeHost(afterParent)
+					.deleteRlmSubagentRuntime(after.childId, afterChild.runtime.session, {
+						childId: after.childId,
+						sessionDir: after.childSessionDir,
+						generation: 1,
+						assertCurrent: () => {
+							if (afterAbort.signal.aborted) throw new Error("host request authority was revoked");
+						},
+					}),
+			).resolves.toBeUndefined();
+			expect(readFileSync(join(after.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")).toContain(
+				'"status":"deleted"',
+			);
+			expect(afterInternals.sessions.has(afterChild.activeSessionId)).toBe(false);
+		} finally {
+			rmSync(beforeTempDir, { recursive: true, force: true });
+			rmSync(afterTempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("persists a real child completion for passive discovery, roster, and listing", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-real-completion-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -779,7 +779,10 @@ describe("daemon mode helpers", () => {
 		let internals: {
 			sessions: Map<string, ActiveSessionState>;
 			closeSession: (state: ActiveSessionState, reason: "completed" | "killed") => Promise<void>;
-			recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<boolean>;
+			recordRlmSubagentDeletion(
+				parentState: ActiveSessionState,
+				childId: string,
+			): Promise<"absent" | "tombstoned" | "unknown">;
 			createSubagentRuntimeHost(parentState: ActiveSessionState): SubagentRuntimeHost;
 		};
 		const closeSession = vi.fn(async (state: ActiveSessionState) => {
@@ -789,7 +792,7 @@ describe("daemon mode helpers", () => {
 		internals.sessions.set(parentState.activeSessionId, parentState);
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.closeSession = closeSession;
-		const recordDeletion = vi.fn(async () => true);
+		const recordDeletion = vi.fn(async () => "tombstoned" as const);
 		internals.recordRlmSubagentDeletion = recordDeletion;
 
 		await internals
@@ -816,7 +819,7 @@ describe("daemon mode helpers", () => {
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
 		// A registry failure must not strand the cancelled child as a stale resident session,
-		// and must tell the caller to remove its never-admitted artifact dir.
+		// but must retain the artifact because durability is unknown.
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.recordRlmSubagentDeletion = vi.fn(async () => {
 			throw new Error("registry write failed");
@@ -829,7 +832,7 @@ describe("daemon mode helpers", () => {
 					{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
 					"cancelled",
 				),
-		).resolves.toEqual({ retained: false });
+		).resolves.toEqual({ deletionDurability: "unknown" });
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
@@ -881,7 +884,7 @@ describe("daemon mode helpers", () => {
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
 
 			// A real resident child with its row removed has no durable owner. The host
-			// still closes it, and explicitly returns retained:false.
+			// still closes it, and explicitly proves the artifact is absent.
 			const noRowOptions = optionsFor("release-no-row");
 			const noRowRuntime = await internals.createRlmSubagentRuntime(parentState, noRowOptions);
 			writeFileSync(
@@ -893,7 +896,7 @@ describe("daemon mode helpers", () => {
 					.join("\n")}\n`,
 			);
 			await expect(host.releaseRlmSubagentRuntime?.(noRowRuntime, noRowOptions, "cancelled")).resolves.toEqual({
-				retained: false,
+				deletionDurability: "absent",
 			});
 			expect([...internals.sessions.values()].some((state) => state.runtime.session === noRowRuntime.session)).toBe(
 				false,
@@ -904,24 +907,43 @@ describe("daemon mode helpers", () => {
 			const retainedRuntime = await internals.createRlmSubagentRuntime(parentState, retainedOptions);
 			await expect(host.releaseRlmSubagentRuntime?.(retainedRuntime, retainedOptions, "cancelled")).resolves.toEqual(
 				{
-					retained: true,
+					deletionDurability: "tombstoned",
 				},
 			);
 			expect(readFileSync(registryPath, "utf8")).toContain('"childId":"release-tombstoned"');
 			expect(readFileSync(registryPath, "utf8")).toContain('"status":"deleted"');
 
 			// A deterministic append/fsync failure likewise closes the real resident
-			// runtime but cannot claim durable ownership of its artifact directory.
+			// runtime but leaves durable ownership unknown, so the caller retains it.
 			const failedOptions = optionsFor("release-write-failed");
 			const failedRuntime = await internals.createRlmSubagentRuntime(parentState, failedOptions);
 			const append = vi.spyOn(internals, "appendRlmSubagentRegistryEntry").mockReturnValue(false);
 			await expect(host.releaseRlmSubagentRuntime?.(failedRuntime, failedOptions, "cancelled")).resolves.toEqual({
-				retained: false,
+				deletionDurability: "unknown",
 			});
 			expect(append).toHaveBeenCalledWith(parentState, expect.objectContaining({ status: "deleted" }));
 			expect([...internals.sessions.values()].some((state) => state.runtime.session === failedRuntime.session)).toBe(
 				false,
 			);
+
+			// A malformed registry history cannot prove that a child is absent.
+			const malformedOptions = optionsFor("release-malformed");
+			const malformedRuntime = await internals.createRlmSubagentRuntime(parentState, malformedOptions);
+			writeFileSync(registryPath, `${readFileSync(registryPath, "utf8")}not-json\n`);
+			await expect(
+				host.releaseRlmSubagentRuntime?.(malformedRuntime, malformedOptions, "cancelled"),
+			).resolves.toEqual({ deletionDurability: "unknown" });
+
+			// An unreadable registry has the same fail-closed result, rather than
+			// treating the missing child row as authority to remove artifacts.
+			append.mockRestore();
+			const readFaultOptions = optionsFor("release-read-fault");
+			const readFaultRuntime = await internals.createRlmSubagentRuntime(parentState, readFaultOptions);
+			rmSync(registryPath);
+			mkdirSync(registryPath);
+			await expect(
+				host.releaseRlmSubagentRuntime?.(readFaultRuntime, readFaultOptions, "cancelled"),
+			).resolves.toEqual({ deletionDurability: "unknown" });
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -813,7 +813,7 @@ describe("daemon mode helpers", () => {
 				{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
 				"cancelled",
 			);
-		expect(recordDeletion).toHaveBeenCalledWith(parentState, "child-1");
+		expect(recordDeletion).toHaveBeenCalledWith(parentState, "child-1", undefined, childState.runtime.session);
 		expect(recordDeletion.mock.invocationCallOrder[0]).toBeLessThan(closeSession.mock.invocationCallOrder[1]!);
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
@@ -1233,7 +1233,13 @@ describe("daemon mode helpers", () => {
 				recordRlmSubagentDeletion(
 					parentState: ActiveSessionState,
 					childId: string,
-					authority?: { assertCurrent(): void },
+					authority?: {
+						childId?: string;
+						sessionDir?: string;
+						sessionFile?: string;
+						sessionId?: string;
+						assertCurrent(): void;
+					},
 				): Promise<"absent" | "tombstoned" | "unknown">;
 			};
 			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
@@ -1381,12 +1387,18 @@ describe("daemon mode helpers", () => {
 					.deleteRlmSubagentRuntime(before.childId, beforeChild.runtime.session, {
 						childId: before.childId,
 						sessionDir: before.childSessionDir,
+						sessionFile: before.childSessionFile,
+						sessionId: beforeChild.runtime.session.sessionId,
 						generation: 1,
 						assertCurrent: () => {
 							if (++beforeBoundaryChecks === 2) throw revokedBeforeAppend;
 						},
 					}),
-			).rejects.toBe(revokedBeforeAppend);
+			).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
+				cause: revokedBeforeAppend,
+			});
 			expect(readFileSync(beforeRegistryPath, "utf8")).toBe(beforeRegistry);
 			expect(beforeInternals.sessions.get(beforeChild.activeSessionId)).toBe(beforeChild);
 
@@ -1415,6 +1427,8 @@ describe("daemon mode helpers", () => {
 					.deleteRlmSubagentRuntime(after.childId, afterChild.runtime.session, {
 						childId: after.childId,
 						sessionDir: after.childSessionDir,
+						sessionFile: after.childSessionFile,
+						sessionId: afterChild.runtime.session.sessionId,
 						generation: 1,
 						assertCurrent: () => {
 							if (afterAbort.signal.aborted) throw new Error("host request authority was revoked");
@@ -1741,7 +1755,7 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("closes the exact parent-scoped daemon runtime when a retained subagent is deleted", async () => {
+	it("rejects stale or missing daemon runtime objects without destructive authority", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -1751,9 +1765,7 @@ describe("daemon mode helpers", () => {
 		const parentState = makeState("parent");
 		parentState.runtime = {
 			...parentState.runtime,
-			session: {
-				sessionManager: { getSessionArtifactDir: () => undefined },
-			},
+			session: { sessionManager: { getSessionArtifactDir: () => undefined } },
 		} as ActiveSessionState["runtime"];
 		const childState = makeState("child", parentState.activeSessionId);
 		const foreignChildState = makeState("foreign-child", "other-parent");
@@ -1777,31 +1789,32 @@ describe("daemon mode helpers", () => {
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
 			closeSession: typeof closeSession;
-			createSubagentRuntimeHost(parent: ActiveSessionState): {
-				deleteRlmSubagentRuntime(childId: string, session: ActiveSessionState["runtime"]["session"]): Promise<void>;
-			};
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
 		};
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.sessions.set(foreignChildState.activeSessionId, foreignChildState);
 		internals.closeSession = closeSession;
-
+		const host = internals.createSubagentRuntimeHost(parentState);
 		const staleParentReference = {
 			disposeAsync: vi.fn(async () => {}),
 		} as unknown as ActiveSessionState["runtime"]["session"];
-		const host = internals.createSubagentRuntimeHost(parentState);
-		await host.deleteRlmSubagentRuntime("child-1", staleParentReference);
 
-		expect(closeSession).toHaveBeenCalledOnce();
-		expect(closeSession).toHaveBeenCalledWith(childState, "killed", false);
-		expect(closeSession).not.toHaveBeenCalledWith(foreignChildState, expect.anything());
+		await expect(host.deleteRlmSubagentRuntime("child-1", staleParentReference)).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "precommit",
+		});
+		expect(closeSession).not.toHaveBeenCalled();
 		expect(childSession.disposeAsync).not.toHaveBeenCalled();
-		expect(staleParentReference.disposeAsync).toHaveBeenCalledOnce();
+		expect(staleParentReference.disposeAsync).not.toHaveBeenCalled();
 
 		const missingSession = {
 			disposeAsync: vi.fn(async () => {}),
 		} as unknown as ActiveSessionState["runtime"]["session"];
-		await host.deleteRlmSubagentRuntime("missing-child", missingSession);
-		expect(missingSession.disposeAsync).toHaveBeenCalledOnce();
+		await expect(host.deleteRlmSubagentRuntime("missing-child", missingSession)).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "precommit",
+		});
+		expect(missingSession.disposeAsync).not.toHaveBeenCalled();
 	});
 
 	it("cancels child jobs when deletion joins an in-flight passivation close", async () => {
@@ -8127,13 +8140,23 @@ describe("daemon mode helpers", () => {
 			};
 			parentSession.deleteInactiveRlmSubagent = async (childId) => {
 				if (childId !== fixture.childId) return "not_found";
+				const persisted = JSON.parse(
+					readFileSync(join(fixture.parentArtifactDir, "rlm-subagents.jsonl"), "utf8"),
+				) as { sessionId: string };
 				await (
 					fixture.daemon as unknown as {
 						createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
 					}
 				)
 					.createSubagentRuntimeHost(parentState)
-					.deleteRlmSubagentRuntime(childId);
+					.deleteRlmSubagentRuntime(childId, undefined, {
+						childId,
+						sessionDir: fixture.childSessionDir,
+						sessionFile: fixture.childSessionFile,
+						sessionId: persisted.sessionId,
+						generation: 1,
+						assertCurrent: () => {},
+					});
 				return "deleted";
 			};
 			const client = makeClient("client-1", parentState.activeSessionId);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1207,6 +1207,22 @@ describe("daemon mode helpers", () => {
 			await expect(internals.recordRlmSubagentDeletion(parent, fixture.childId)).resolves.toBe("unknown");
 			expect(readFileSync(registryPath, "utf8")).toBe(modern);
 
+			// In contrast, a complete registry read can prove a no-row request is
+			// already absent without inventing an incarnation authority. Existing
+			// rows above remain fail-closed.
+			await expect(host.deleteRlmSubagentRuntime("missing-child")).resolves.toEqual({
+				deletionDurability: "absent",
+			});
+			await expect(
+				host.deleteRlmSubagentRuntime("missing-child", undefined, {
+					childId: "missing-child",
+					sessionDir: join(tempDir, "stale-missing-child"),
+					generation: 1,
+					assertCurrent: () => {},
+				}),
+			).resolves.toEqual({ deletionDurability: "absent" });
+			expect(readFileSync(registryPath, "utf8")).toBe(modern);
+
 			const legacy = JSON.parse(modern) as Record<string, unknown>;
 			delete legacy.sessionId;
 			writeFileSync(registryPath, `${JSON.stringify(legacy)}\n`);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11445,6 +11445,91 @@ describe("daemon tombstoned retirement", () => {
 		await gate;
 	});
 
+	it("hides a closing child subtree from daemon lists, targets, and cron jobs", async () => {
+		const daemon = new AgentDaemon("/tmp/closing-subtree.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const root = makeState("closing-root");
+		const child = makeState("closing-child", root.activeSessionId);
+		const grandchild = makeState("closing-grandchild", child.activeSessionId);
+		const sibling = makeState("closing-sibling", root.activeSessionId);
+		for (const [state, rlmChildId] of [
+			[root, undefined],
+			[child, "child"],
+			[grandchild, "grandchild"],
+			[sibling, "sibling"],
+		] as const) {
+			state.runtime = {
+				...state.runtime,
+				cwd: "/tmp",
+				diagnostics: [],
+				metadata: {
+					...state.runtime.metadata,
+					kind: state === root ? "top-level" : "subagent",
+					...(rlmChildId ? { rlmChildId } : {}),
+				},
+				session: {
+					sessionId: `session-${state.activeSessionId}`,
+					sessionName: state.activeSessionId,
+					isSessionActive: false,
+					isStreaming: false,
+					isCompacting: false,
+					isBashRunning: false,
+					hasRunningRlmChildren: () => false,
+					messages: [],
+					state: { pendingToolCalls: new Set(), streamingMessage: undefined },
+					unfinishedActionCount: 0,
+					sessionManager: { getCwd: () => "/tmp" },
+					getSessionActionSnapshot: () => ({ queuedCount: 0, steering: [], followUps: [] }),
+				},
+			} as never;
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closingSessions: Map<string, unknown>;
+			failedTombstonedRlmCloses: Map<string, { state: ActiveSessionState }>;
+			createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			getOrHydrateBoundSessionState(id: string): Promise<ActiveSessionState>;
+			isCronJobRunnableForState(job: AgentCronJob, state: ActiveSessionState, requirePersistedJob: boolean): boolean;
+			isPublicRlmState(state: ActiveSessionState): boolean;
+		};
+		for (const state of [root, child, grandchild, sibling]) internals.sessions.set(state.activeSessionId, state);
+		internals.closingSessions.set(child.activeSessionId, {});
+
+		expect(internals.isPublicRlmState(child)).toBe(false);
+		expect(internals.isPublicRlmState(grandchild)).toBe(false);
+		expect(internals.isPublicRlmState(sibling)).toBe(true);
+		const listed = (await internals.handleCommand(makeClient("list-client", root.activeSessionId), {
+			type: "list",
+		})) as { data: { sessions: SessionSummary[] } };
+		expect(listed.data.sessions.map((session) => session.activeSessionId)).toEqual(
+			expect.arrayContaining([root.activeSessionId, sibling.activeSessionId]),
+		);
+		expect(listed.data.sessions.map((session) => session.activeSessionId)).not.toEqual(
+			expect.arrayContaining([child.activeSessionId, grandchild.activeSessionId]),
+		);
+		const targets = await internals.createAgentMessageController(() => root).listAgents();
+		expect(targets.agents.map((agent) => agent.activeSessionId)).toEqual(
+			expect.arrayContaining([sibling.activeSessionId]),
+		);
+		expect(targets.agents.map((agent) => agent.activeSessionId)).not.toEqual(
+			expect.arrayContaining([child.activeSessionId, grandchild.activeSessionId]),
+		);
+		await expect(internals.getOrHydrateBoundSessionState(grandchild.activeSessionId)).rejects.toThrow("unavailable");
+		const job = { status: "active", activeSessionId: grandchild.activeSessionId } as AgentCronJob;
+		expect(internals.isCronJobRunnableForState(job, grandchild, false)).toBe(false);
+		expect(
+			internals.isCronJobRunnableForState({ ...job, activeSessionId: sibling.activeSessionId }, sibling, false),
+		).toBe(true);
+
+		internals.closingSessions.delete(child.activeSessionId);
+		internals.sessions.delete(child.activeSessionId);
+		internals.failedTombstonedRlmCloses.set(child.activeSessionId, { state: child });
+		expect(internals.isPublicRlmState(grandchild)).toBe(false);
+	});
+
 	it("retains a failed physical disposal and retries the exact runtime", async () => {
 		const daemon = new AgentDaemon("/tmp/retry-retirement.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1202,6 +1202,23 @@ describe("daemon mode helpers", () => {
 				status: "deleted",
 				sessionId: child.runtime.session.sessionId,
 			});
+
+			// An already-deleted legacy row still needs one identity-upgrade append so
+			// retained cleanup retries can later prove the exact tombstoned incarnation.
+			writeFileSync(registryPath, `${JSON.stringify({ ...legacy, status: "deleted" })}\n`);
+			await expect(
+				internals.recordRlmSubagentDeletion(parent, fixture.childId, undefined, child.runtime.session),
+			).resolves.toBe("tombstoned");
+			const deletedEntries = readFileSync(registryPath, "utf8")
+				.trim()
+				.split(/\r?\n/u)
+				.map((line) => JSON.parse(line) as Record<string, unknown>);
+			expect(deletedEntries).toHaveLength(2);
+			expect(deletedEntries[1]).toMatchObject({
+				childId: fixture.childId,
+				status: "deleted",
+				sessionId: child.runtime.session.sessionId,
+			});
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1159,12 +1159,22 @@ describe("daemon mode helpers", () => {
 			expect(readFileSync(registryPath, "utf8")).toBe(before);
 
 			await expect(
-				internals.recordRlmSubagentDeletion(parentState, fixture.childId, { assertCurrent: () => {} }),
+				internals.recordRlmSubagentDeletion(parentState, fixture.childId, {
+					childId: fixture.childId,
+					sessionDir: fixture.childSessionDir,
+					sessionFile: fixture.childSessionFile,
+					sessionId: JSON.parse(before).sessionId as string,
+					assertCurrent: () => {},
+				}),
 			).resolves.toBe("tombstoned");
 			expect(readFileSync(registryPath, "utf8").match(/"childId":"child-1"/g)).toHaveLength(2);
 			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
 			await expect(
-				internals.recordRlmSubagentDeletion(parentState, "unknown", { assertCurrent: () => {} }),
+				internals.recordRlmSubagentDeletion(parentState, "unknown", {
+					childId: "unknown",
+					sessionDir: "/tmp/unknown",
+					assertCurrent: () => {},
+				}),
 			).resolves.toBe("absent");
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
@@ -1183,13 +1193,13 @@ describe("daemon mode helpers", () => {
 			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
 			const original = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
-			const replacementFile = join(fixture.childSessionDir, "replacement.jsonl");
-			writeFileSync(replacementFile, "replacement");
+			const oldSessionId = original.sessionId as string;
+			const replacementSessionId = "replacement-session-id";
 			writeFileSync(
 				registryPath,
-				`${JSON.stringify({
+				`${JSON.stringify(original)}\n${JSON.stringify({
 					...original,
-					sessionFile: replacementFile,
+					sessionId: replacementSessionId,
 					updatedAt: "2026-01-01T00:00:02.000Z",
 				})}\n`,
 			);
@@ -1198,7 +1208,7 @@ describe("daemon mode helpers", () => {
 				childId: fixture.childId,
 				sessionDir: fixture.childSessionDir,
 				sessionFile: fixture.childSessionFile,
-				sessionId: "old-session-id",
+				sessionId: oldSessionId,
 				generation: 1,
 				assertCurrent: () => {},
 			};
@@ -1214,8 +1224,7 @@ describe("daemon mode helpers", () => {
 			});
 			const currentAuthority = {
 				...oldAuthority,
-				sessionFile: replacementFile,
-				sessionId: "replacement-session-id",
+				sessionId: replacementSessionId,
 				generation: 2,
 			};
 			await expect(
@@ -5617,6 +5626,7 @@ describe("daemon mode helpers", () => {
 					sessionName: "heartbeat-child",
 					sessionDir: childSessionDir,
 					sessionFile: childSessionFile,
+					sessionId: childManager.getSessionId(),
 					parentSessionId: parentManager.getSessionId(),
 					parentSessionFile,
 					rlmDepth: 1,
@@ -6172,6 +6182,7 @@ describe("daemon mode helpers", () => {
 					sessionName: "cycle-to-root",
 					sessionDir: join(tempDir, "sessions"),
 					sessionFile: fixture.parentSessionFile,
+					sessionId: fixture.parentSessionId,
 					parentSessionId: childInfo.id,
 					parentSessionFile: fixture.childSessionFile,
 					status: "completed",
@@ -6400,6 +6411,7 @@ describe("daemon mode helpers", () => {
 					sessionName: "spawn-worker",
 					sessionDir: siblingSessionDir,
 					sessionFile: siblingSessionFile,
+					sessionId: siblingManager.getSessionId(),
 					parentSessionId: fixture.parentSessionId,
 					parentSessionFile: fixture.parentSessionFile,
 					status: "completed",
@@ -10798,6 +10810,7 @@ function makePersistedRlmDaemonFixture(
 			sessionName: "nested-worker",
 			sessionDir: grandchildSessionDir,
 			sessionFile: grandchildSessionFile,
+			sessionId: grandchildManager.getSessionId(),
 			parentSessionId: childManager.getSessionId(),
 			parentSessionFile: childSessionFile,
 			rlmDepth: 2,
@@ -10817,6 +10830,7 @@ function makePersistedRlmDaemonFixture(
 			sessionName: "spawn-worker",
 			sessionDir: childSessionDir,
 			sessionFile: childSessionFile,
+			sessionId: childManager.getSessionId(),
 			parentSessionId: parentManager.getSessionId(),
 			parentSessionFile,
 			rlmDepth: 1,

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -20,7 +20,7 @@ import {
 	createDefaultRlmSubagentSessionName,
 	type SubagentRuntimeHost,
 } from "../src/core/rlm-runtime.js";
-import { canonicalSessionPath } from "../src/core/session-lease.js";
+import { acquireSessionLease, canonicalSessionPath } from "../src/core/session-lease.js";
 import { readSessionInfo, type SessionInfo, SessionManager } from "../src/core/session-manager.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import {
@@ -11931,6 +11931,96 @@ describe("daemon tombstoned retirement", () => {
 			expect(cancelScheduledJobsForSession).toHaveBeenCalledTimes(2);
 			expect(fixture.runtimeSessions[1]!.disposeAsync).toHaveBeenCalledOnce();
 		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it.each(["completed", "killed"] as const)(
+		"irrevocably retires a non-tombstoned %s close after cleanup failure",
+		async (reason) => {
+			const daemon = new AgentDaemon(`/tmp/retire-${reason}.sock`, {
+				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			const state = makeState(`retire-${reason}`);
+			const client = makeClient(`retire-client-${reason}`, state.activeSessionId);
+			state.clients.add(client);
+			const cleanupFailure = new Error(`${reason} archive failed`);
+			state.extensionUiRequests = new Map();
+			state.runtime = {
+				...state.runtime,
+				dispose: vi.fn(async () => {}),
+				releaseSessionLease: vi.fn(),
+				session: {
+					sessionId: `retire-session-${reason}`,
+					sessionFile: `/tmp/retire-${reason}.jsonl`,
+					messages: ["content"],
+					isBashRunning: false,
+					abort: vi.fn(async () => {}),
+					sessionManager: {
+						appendSessionState: vi.fn(() => {
+							throw cleanupFailure;
+						}),
+						hasUserContent: () => true,
+					},
+				},
+			} as never;
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				closeSession(state: ActiveSessionState, reason: typeof reason): Promise<void>;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+				createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
+			};
+			internals.sessions.set(state.activeSessionId, state);
+
+			await expect(internals.closeSession(state, reason)).rejects.toBe(cleanupFailure);
+			expect(internals.sessions.has(state.activeSessionId)).toBe(false);
+			expect(state.clients.size).toBe(0);
+			expect(client.attachedActiveSessionIds.has(state.activeSessionId)).toBe(false);
+			const listed = (await internals.handleCommand(makeClient(`list-${reason}`, "other"), {
+				type: "list",
+			})) as { data: { sessions: SessionSummary[] } };
+			expect(listed.data.sessions.map((session) => session.activeSessionId)).not.toContain(state.activeSessionId);
+			const targets = await internals.createAgentMessageController(() => makeState("other")).listAgents();
+			expect(targets.agents.map((agent) => agent.activeSessionId)).not.toContain(state.activeSessionId);
+		},
+	);
+
+	it("keeps a tombstoned close lease until its full cleanup retry succeeds", async () => {
+		vi.useFakeTimers();
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-tombstone-lease-"));
+		try {
+			vi.stubEnv("PRIME_AGENT_INTERNAL_SESSION_LEASES", "1");
+			vi.stubEnv("PRIME_AGENT_INTERNAL_SESSION_LEASE_OWNER_ID", "tombstone-lease");
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const archiveFailure = new Error("archive failed");
+			vi.spyOn(child.runtime.session.sessionManager, "appendSessionState")
+				.mockImplementationOnce(() => {
+					throw archiveFailure;
+				})
+				.mockImplementation(() => undefined as never);
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() =>
+				expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(archiveFailure),
+			);
+			expect(() => acquireSessionLease(fixture.childSessionFile, tempDir)).toThrow();
+			await vi.advanceTimersByTimeAsync(250);
+			await vi.waitFor(() => expect(internals.sessions.has(child.activeSessionId)).toBe(false));
+			const reopened = acquireSessionLease(fixture.childSessionFile, tempDir);
+			expect(reopened).toBeDefined();
+			reopened?.release();
+		} finally {
+			vi.unstubAllEnvs();
+			vi.useRealTimers();
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1130,6 +1130,66 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("fails closed for incomplete or passive deletion and upgrades only an exact resident legacy row", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-resident-deletion-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				recordRlmSubagentDeletion(
+					parentState: ActiveSessionState,
+					childId: string,
+					authority?: { assertCurrent(): void; childId?: string; sessionDir?: string },
+					residentSession?: ActiveSessionState["runtime"]["session"],
+				): Promise<"absent" | "tombstoned" | "unknown">;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const modern = readFileSync(registryPath, "utf8");
+
+			// A coordinator-shaped request that omits either incarnation fence must
+			// not use a matching resident object as a fallback authorization.
+			await expect(
+				internals.recordRlmSubagentDeletion(
+					parent,
+					fixture.childId,
+					{
+						childId: fixture.childId,
+						sessionDir: fixture.childSessionDir,
+						assertCurrent: () => {},
+					},
+					child.runtime.session,
+				),
+			).resolves.toBe("unknown");
+			expect(readFileSync(registryPath, "utf8")).toBe(modern);
+
+			// A passive authority-free request has no incarnation proof and cannot
+			// turn a valid current registry record into a destructive append.
+			await expect(internals.recordRlmSubagentDeletion(parent, fixture.childId)).resolves.toBe("unknown");
+			expect(readFileSync(registryPath, "utf8")).toBe(modern);
+
+			const legacy = JSON.parse(modern) as Record<string, unknown>;
+			delete legacy.sessionId;
+			writeFileSync(registryPath, `${JSON.stringify(legacy)}\n`);
+			await expect(
+				internals.recordRlmSubagentDeletion(parent, fixture.childId, undefined, child.runtime.session),
+			).resolves.toBe("tombstoned");
+			const entries = readFileSync(registryPath, "utf8")
+				.trim()
+				.split(/\r?\n/u)
+				.map((line) => JSON.parse(line) as Record<string, unknown>);
+			expect(entries).toHaveLength(2);
+			expect(entries[1]).toMatchObject({
+				childId: fixture.childId,
+				status: "deleted",
+				sessionId: child.runtime.session.sessionId,
+			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("rechecks retry authority before appending a daemon deletion tombstone", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-deletion-authority-"));
 		try {
@@ -1175,7 +1235,7 @@ describe("daemon mode helpers", () => {
 					sessionDir: "/tmp/unknown",
 					assertCurrent: () => {},
 				}),
-			).resolves.toBe("absent");
+			).resolves.toBe("unknown");
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1188,6 +1188,7 @@ describe("daemon mode helpers", () => {
 			const internals = fixture.daemon as unknown as {
 				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
 				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				closeSession(state: ActiveSessionState, reason: "killed", allowPassivation: false): Promise<void>;
 				cancelScheduledJobsForSessionFile(sessionFile: string): void;
 			};
 			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
@@ -1232,16 +1233,25 @@ describe("daemon mode helpers", () => {
 				sessionId: replacementSessionId,
 				generation: 2,
 			};
+			const replacement = await internals.createRuntime({
+				type: "create",
+				sessionPath: fixture.childSessionFile,
+			});
+			const close = vi.spyOn(internals, "closeSession");
 			await expect(
-				host.deleteRlmSubagentRuntime(fixture.childId, undefined, currentAuthority),
+				host.deleteRlmSubagentRuntime(fixture.childId, replacement.runtime.session, currentAuthority),
 			).rejects.toMatchObject({
 				name: "RlmSubagentHostDeletionError",
 				phase: "tombstoned",
 			});
+			expect(close).toHaveBeenCalledOnce();
 			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
-			await expect(host.deleteRlmSubagentRuntime(fixture.childId, undefined, currentAuthority)).resolves.toEqual({
-				deletionDurability: "tombstoned",
-			});
+			// The coordinator retains the session object after postcommit failure, but
+			// daemon state is already absent. Retry only the remaining scheduler work.
+			await expect(
+				host.deleteRlmSubagentRuntime(fixture.childId, replacement.runtime.session, currentAuthority),
+			).resolves.toEqual({ deletionDurability: "tombstoned" });
+			expect(close).toHaveBeenCalledOnce();
 			expect(cleanup).toHaveBeenCalledTimes(2);
 			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
 		} finally {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -5780,7 +5780,10 @@ describe("daemon mode helpers", () => {
 			messages: [],
 		} as unknown as DaemonOutbound);
 		client.catchupActiveSessionIds = new Set([otherState.activeSessionId]);
-		internals.sessions.delete(state.activeSessionId);
+		(internals as unknown as { closingSessions: Map<string, unknown> }).closingSessions.set(
+			state.activeSessionId,
+			{},
+		);
 		resolveAttach({
 			activeSessionId: state.activeSessionId,
 			snapshot: { summary: {}, state: {}, messages: [] },
@@ -11542,6 +11545,237 @@ describe("daemon tombstoned retirement", () => {
 				activeSessionId: child.activeSessionId,
 			}),
 		).rejects.toThrow("unavailable");
+	});
+
+	it("keeps private session reads and scheduled-job catalogs unpublished", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-private-publications-"));
+		try {
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
+				createRuntime: vi.fn(),
+			});
+			const privateState = makeState("private-session");
+			privateState.runtime = {
+				...privateState.runtime,
+				metadata: { kind: "top-level", createdAt: 1 },
+				session: {
+					sessionId: "private-stable-id",
+					sessionFile: join(tempDir, "private.jsonl"),
+					sessionManager: {
+						getCwd: () => tempDir,
+						getSessionDir: () => tempDir,
+					},
+				},
+			} as never;
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				closingSessions: Map<string, unknown>;
+				cronStore: AgentCronJobStore;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+				buildSessionListWithPassiveRlmSubagents(
+					activeSessions: ActiveSessionState[],
+					savedSessions: SessionInfo[],
+					scheduledJobs: AgentCronJob[],
+				): Promise<SessionSummary[]>;
+			};
+			internals.sessions.set(privateState.activeSessionId, privateState);
+			internals.closingSessions.set(privateState.activeSessionId, {});
+			const savedInfo = (path: string, id: string, parentSessionPath?: string): SessionInfo => ({
+				path,
+				id,
+				cwd: tempDir,
+				parentSessionPath,
+				rlmDepth: parentSessionPath ? 1 : 0,
+				created: new Date(0),
+				modified: new Date(0),
+				messageCount: 1,
+				firstMessage: id,
+				allMessagesText: id,
+			});
+			const privateSaved = savedInfo(join(tempDir, "private.jsonl"), "private-stable-id");
+			const privateDescendant = savedInfo(
+				join(tempDir, "private-descendant.jsonl"),
+				"private-descendant",
+				privateSaved.path,
+			);
+			const publicSaved = savedInfo(join(tempDir, "public.jsonl"), "public-stable-id");
+			const savedList = await internals.buildSessionListWithPassiveRlmSubagents(
+				[],
+				[privateSaved, privateDescendant, publicSaved],
+				[],
+			);
+			expect(savedList.map((session) => session.sessionId)).toEqual([publicSaved.id]);
+
+			const privateCron = internals.cronStore.create({
+				activeSessionId: privateState.activeSessionId,
+				sessionId: "private-stable-id",
+				sessionFile: join(tempDir, "private.jsonl"),
+				cwd: tempDir,
+				scheduleText: "in 1m",
+				prompt: "private cron",
+				now: new Date("2026-01-01T12:00:00.000Z"),
+			});
+			internals.cronStore.cancel(privateCron.id, new Date("2026-01-01T12:00:01.000Z"));
+			const privateHeartbeat = internals.cronStore.createHeartbeat({
+				activeSessionId: privateState.activeSessionId,
+				sessionId: "private-stable-id",
+				sessionFile: join(tempDir, "private.jsonl"),
+				cwd: tempDir,
+				scheduleText: "every 5m",
+				prompt: "private heartbeat",
+				now: new Date("2026-01-01T12:00:02.000Z"),
+			});
+			const globalCron = internals.cronStore.create({
+				activeSessionId: "unloaded-session",
+				sessionId: "unloaded-stable-id",
+				sessionFile: join(tempDir, "unloaded.jsonl"),
+				cwd: tempDir,
+				scheduleText: "in 2m",
+				prompt: "unloaded cron",
+				now: new Date("2026-01-01T12:00:03.000Z"),
+			});
+
+			const guardedMutations = [
+				{ type: "restore_next_turn", messages: [] },
+				{ type: "append_custom_message", message: { customType: "test", content: "private" } },
+				{ type: "resume_queue" },
+				{ type: "agent_messages_clear" },
+				{ type: "abort" },
+				{ type: "abort_side_question", sideQuestionId: "side" },
+				{ type: "execute_bash", command: "echo private" },
+				{ type: "execute_bash_and_wait", command: "echo private" },
+				{ type: "abort_bash" },
+				{ type: "cancel_rlm_child", childId: "child" },
+				{ type: "delete_rlm_subagent", childId: "child" },
+				{ type: "clear_queue" },
+				{ type: "abort_and_clear_queue" },
+				{ type: "cron_add", schedule: "in 1m", prompt: "private" },
+				{ type: "cron_cancel", jobId: privateCron.id },
+				{ type: "heartbeat_set", schedule: "every 5m", prompt: "private" },
+				{ type: "set_thinking_level", level: "medium" },
+				{ type: "set_auto_compaction", enabled: true },
+				{ type: "set_auto_retry", enabled: true },
+				{ type: "abort_compaction" },
+				{ type: "abort_branch_summary" },
+				{ type: "abort_retry" },
+				{ type: "reload" },
+				{ type: "export_html" },
+				{ type: "export_jsonl" },
+				{ type: "set_session_name", name: "private" },
+				{ type: "set_session_entry_label", entryId: "entry", label: "private" },
+			] as const;
+			for (const command of guardedMutations) {
+				await expect(
+					internals.handleCommand(makeClient(`private-${command.type}`, "unloaded-session"), {
+						...command,
+						activeSessionId: privateState.activeSessionId,
+					} as DaemonCommand),
+				).rejects.toThrow("unavailable");
+			}
+
+			const reads = [
+				"get_session_header",
+				"get_state",
+				"get_connection_state",
+				"get_messages",
+				"get_session_stats",
+				"get_context_tree",
+				"get_commands",
+				"get_resource_snapshot",
+				"get_model_catalog",
+				"get_available_models",
+				"get_queue",
+				"heartbeat_get",
+				"get_session_context",
+				"get_session_tree",
+				"get_user_messages_for_forking",
+				"get_last_assistant_text",
+				"get_system_prompt",
+				"get_rlm_max_depth_status",
+			] as const;
+			for (const type of reads) {
+				await expect(
+					internals.handleCommand(makeClient(`private-${type}`, "unloaded-session"), {
+						type,
+						activeSessionId: privateState.activeSessionId,
+					} as DaemonCommand),
+				).rejects.toThrow("unavailable");
+			}
+			await expect(
+				internals.handleCommand(makeClient("private-tool", "unloaded-session"), {
+					type: "get_tool_definition",
+					activeSessionId: privateState.activeSessionId,
+					name: "bash",
+				}),
+			).rejects.toThrow("unavailable");
+			await expect(
+				internals.handleCommand(makeClient("private-saved", "unloaded-session"), {
+					type: "list_saved_sessions",
+					activeSessionId: privateState.activeSessionId,
+					scope: "current",
+				}),
+			).rejects.toThrow("unavailable");
+
+			for (const type of ["cron_list", "heartbeats_list"] as const) {
+				await expect(
+					internals.handleCommand(makeClient(`private-${type}`, "unloaded-session"), {
+						type,
+						activeSessionId: privateState.activeSessionId,
+					}),
+				).rejects.toThrow("unavailable");
+			}
+
+			const cronList = (await internals.handleCommand(makeClient("cron-list", "unloaded-session"), {
+				type: "cron_list",
+				includeInactive: true,
+			})) as { data: { jobs: AgentCronJob[] } };
+			expect(cronList.data.jobs.map((job) => job.id)).toEqual([globalCron.id]);
+			const heartbeatList = (await internals.handleCommand(makeClient("heartbeat-list", "unloaded-session"), {
+				type: "heartbeats_list",
+			})) as { data: { heartbeats: Array<{ job: AgentCronJob }> } };
+			expect(heartbeatList.data.heartbeats.map(({ job }) => job.id)).not.toContain(privateHeartbeat.id);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("reconciles a detached tombstoned close on bounded timer backoff", async () => {
+		vi.useFakeTimers();
+		try {
+			const daemon = new AgentDaemon("/tmp/tombstoned-close-reconcile.sock", {
+				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			const parent = makeState("retry-parent");
+			const child = makeState("retry-child", parent.activeSessionId);
+			Object.assign(child.runtime.metadata, { kind: "subagent", rlmChildId: "child" });
+			const closeSession = vi
+				.fn<(state: ActiveSessionState, reason: "killed", notify: false) => Promise<void>>()
+				.mockRejectedValueOnce(new Error("one-shot close failure"))
+				.mockResolvedValue(undefined);
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+				detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+				closeSession: typeof closeSession;
+			};
+			internals.sessions.set(parent.activeSessionId, parent);
+			internals.sessions.set(child.activeSessionId, child);
+			internals.closeSession = closeSession;
+
+			internals.detachTombstonedClose(parent, child, "child");
+			await vi.runAllTicks();
+			await Promise.resolve();
+			expect(closeSession).toHaveBeenCalledOnce();
+			expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(true);
+			await vi.advanceTimersByTimeAsync(249);
+			expect(closeSession).toHaveBeenCalledOnce();
+			await vi.advanceTimersByTimeAsync(1);
+			expect(closeSession).toHaveBeenCalledTimes(2);
+			expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("retries a rejected runtime disposal through the exact full tombstoned close", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -779,7 +779,7 @@ describe("daemon mode helpers", () => {
 		let internals: {
 			sessions: Map<string, ActiveSessionState>;
 			closeSession: (state: ActiveSessionState, reason: "completed" | "killed") => Promise<void>;
-			recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<void>;
+			recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<boolean>;
 			createSubagentRuntimeHost(parentState: ActiveSessionState): SubagentRuntimeHost;
 		};
 		const closeSession = vi.fn(async (state: ActiveSessionState) => {
@@ -789,7 +789,7 @@ describe("daemon mode helpers", () => {
 		internals.sessions.set(parentState.activeSessionId, parentState);
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.closeSession = closeSession;
-		const recordDeletion = vi.fn(async () => undefined);
+		const recordDeletion = vi.fn(async () => true);
 		internals.recordRlmSubagentDeletion = recordDeletion;
 
 		await internals
@@ -815,7 +815,8 @@ describe("daemon mode helpers", () => {
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
-		// A registry failure must not strand the cancelled child as a stale resident session.
+		// A registry failure must not strand the cancelled child as a stale resident session,
+		// and must tell the caller to remove its never-admitted artifact dir.
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.recordRlmSubagentDeletion = vi.fn(async () => {
 			throw new Error("registry write failed");
@@ -828,7 +829,7 @@ describe("daemon mode helpers", () => {
 					{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
 					"cancelled",
 				),
-		).rejects.toThrow("registry write failed");
+		).resolves.toEqual({ retained: false });
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -854,6 +854,128 @@ describe("daemon mode helpers", () => {
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
 
+	it("fences stale same-id same-directory daemon release and delete by runtime identity", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-daemon-incarnation-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parentState = makeState("parent-incarnation");
+		const oldState = makeState("old-incarnation", parentState.activeSessionId);
+		const newState = makeState("new-incarnation", parentState.activeSessionId);
+		const sessionDir = "/tmp/recycled-child-directory";
+		const oldSession = {
+			sessionFile: `${sessionDir}/old.jsonl`,
+			disposeAsync: vi.fn(async () => {}),
+		};
+		const newSession = {
+			sessionFile: `${sessionDir}/new.jsonl`,
+			disposeAsync: vi.fn(async () => {}),
+		};
+		for (const [state, session] of [
+			[oldState, oldSession],
+			[newState, newSession],
+		] as const) {
+			state.runtime = {
+				...state.runtime,
+				metadata: {
+					kind: "subagent",
+					createdAt: 1,
+					parentActiveSessionId: parentState.activeSessionId,
+					rlmChildId: "recycled-child",
+					sessionDir,
+				},
+				session,
+			} as never;
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closeSession: ReturnType<typeof vi.fn>;
+			recordRlmSubagentDeletion: ReturnType<typeof vi.fn>;
+			readLatestRlmSubagentRegistry: ReturnType<typeof vi.fn>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+		};
+		internals.sessions.set(parentState.activeSessionId, parentState);
+		// Model recreation: the old object is no longer resident, while the new
+		// object has exactly the same child id and directory.
+		internals.sessions.set(newState.activeSessionId, newState);
+		internals.closeSession = vi.fn(async (state: ActiveSessionState) => {
+			internals.sessions.delete(state.activeSessionId);
+		});
+		internals.recordRlmSubagentDeletion = vi.fn(async () => "tombstoned" as const);
+		internals.readLatestRlmSubagentRegistry = vi.fn(async () => [
+			{ childId: "recycled-child", sessionDir, sessionFile: newSession.sessionFile },
+		]);
+		const host = internals.createSubagentRuntimeHost(parentState);
+		const options = { id: "recycled-child", sessionDir } as CreateRlmSubagentRuntimeOptions;
+
+		await expect(
+			host.releaseRlmSubagentRuntime?.({ session: oldSession } as never, options, "cancelled"),
+		).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+		await expect(host.deleteRlmSubagentRuntime("recycled-child", oldSession as never)).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "precommit",
+		});
+		expect(internals.recordRlmSubagentDeletion).not.toHaveBeenCalled();
+		expect(internals.closeSession).not.toHaveBeenCalled();
+		expect(oldSession.disposeAsync).not.toHaveBeenCalled();
+		expect(newSession.disposeAsync).not.toHaveBeenCalled();
+		expect(internals.sessions.get(newState.activeSessionId)).toBe(newState);
+
+		await expect(
+			host.releaseRlmSubagentRuntime?.({ session: newSession } as never, options, "cancelled"),
+		).resolves.toEqual({ deletionDurability: "tombstoned" });
+		expect(internals.recordRlmSubagentDeletion).toHaveBeenCalledOnce();
+		expect(internals.closeSession).toHaveBeenCalledOnce();
+		expect(internals.closeSession).toHaveBeenCalledWith(newState, "killed");
+	});
+
+	it("classifies scheduler failure after a daemon tombstone as postcommit", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-daemon-postcommit-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parentState = makeState("parent-postcommit");
+		const childState = makeState("child-postcommit", parentState.activeSessionId);
+		const sessionDir = "/tmp/postcommit-child";
+		const session = { sessionFile: `${sessionDir}/child.jsonl` };
+		childState.runtime = {
+			...childState.runtime,
+			metadata: {
+				kind: "subagent",
+				createdAt: 1,
+				parentActiveSessionId: parentState.activeSessionId,
+				rlmChildId: "postcommit-child",
+				sessionDir,
+			},
+			session,
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closeSession: ReturnType<typeof vi.fn>;
+			recordRlmSubagentDeletion: ReturnType<typeof vi.fn>;
+			readLatestRlmSubagentRegistry: ReturnType<typeof vi.fn>;
+			cancelScheduledJobsForSessionFile: ReturnType<typeof vi.fn>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+		};
+		internals.sessions.set(childState.activeSessionId, childState);
+		internals.closeSession = vi.fn(async () => {});
+		internals.recordRlmSubagentDeletion = vi.fn(async () => "tombstoned" as const);
+		internals.readLatestRlmSubagentRegistry = vi.fn(async () => [
+			{ childId: "postcommit-child", sessionDir, sessionFile: session.sessionFile },
+		]);
+		internals.cancelScheduledJobsForSessionFile = vi.fn(() => {
+			throw new Error("scheduler cleanup failed");
+		});
+
+		await expect(
+			internals
+				.createSubagentRuntimeHost(parentState)
+				.deleteRlmSubagentRuntime("postcommit-child", session as never),
+		).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "tombstoned" });
+		expect(internals.recordRlmSubagentDeletion).toHaveBeenCalledOnce();
+		expect(internals.closeSession).toHaveBeenCalledOnce();
+	});
+
 	it("reports durable retention only for actual daemon deletion tombstones", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-release-ownership-"));
 		try {
@@ -950,9 +1072,13 @@ describe("daemon mode helpers", () => {
 						...patch,
 					})}\n`,
 				);
-				await expect(host.releaseRlmSubagentRuntime?.(runtime, options, "cancelled")).resolves.toEqual({
-					deletionDurability: "unknown",
+				await expect(host.releaseRlmSubagentRuntime?.(runtime, options, "cancelled")).rejects.toMatchObject({
+					name: "RlmSubagentHostDeletionError",
+					phase: "precommit",
 				});
+				expect([...internals.sessions.values()].some((state) => state.runtime.session === runtime.session)).toBe(
+					true,
+				);
 				expect(existsSync(options.sessionDir)).toBe(true);
 			}
 
@@ -964,12 +1090,15 @@ describe("daemon mode helpers", () => {
 			const failedOptions = optionsFor("release-write-failed");
 			const failedRuntime = await internals.createRlmSubagentRuntime(parentState, failedOptions);
 			const append = vi.spyOn(internals, "appendRlmSubagentRegistryEntry").mockReturnValue(false);
-			await expect(host.releaseRlmSubagentRuntime?.(failedRuntime, failedOptions, "cancelled")).resolves.toEqual({
-				deletionDurability: "unknown",
+			await expect(
+				host.releaseRlmSubagentRuntime?.(failedRuntime, failedOptions, "cancelled"),
+			).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
 			});
 			expect(append).toHaveBeenCalledWith(parentState, expect.objectContaining({ status: "deleted" }));
 			expect([...internals.sessions.values()].some((state) => state.runtime.session === failedRuntime.session)).toBe(
-				false,
+				true,
 			);
 
 			// A malformed registry history cannot prove that a child is absent.
@@ -978,7 +1107,10 @@ describe("daemon mode helpers", () => {
 			writeFileSync(registryPath, `${readFileSync(registryPath, "utf8")}not-json\n`);
 			await expect(
 				host.releaseRlmSubagentRuntime?.(malformedRuntime, malformedOptions, "cancelled"),
-			).resolves.toEqual({ deletionDurability: "unknown" });
+			).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+			expect(
+				[...internals.sessions.values()].some((state) => state.runtime.session === malformedRuntime.session),
+			).toBe(true);
 
 			// An unreadable registry has the same fail-closed result, rather than
 			// treating the missing child row as authority to remove artifacts.
@@ -989,7 +1121,10 @@ describe("daemon mode helpers", () => {
 			mkdirSync(registryPath);
 			await expect(
 				host.releaseRlmSubagentRuntime?.(readFaultRuntime, readFaultOptions, "cancelled"),
-			).resolves.toEqual({ deletionDurability: "unknown" });
+			).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+			expect(
+				[...internals.sessions.values()].some((state) => state.runtime.session === readFaultRuntime.session),
+			).toBe(true);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1136,6 +1136,8 @@ describe("daemon mode helpers", () => {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
 			const internals = fixture.daemon as unknown as {
 				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				closeSession(state: ActiveSessionState, reason: "killed", allowPassivation: false): Promise<void>;
 				recordRlmSubagentDeletion(
 					parentState: ActiveSessionState,
 					childId: string,
@@ -1147,6 +1149,21 @@ describe("daemon mode helpers", () => {
 			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
 			const modern = readFileSync(registryPath, "utf8");
+			const host = internals.createSubagentRuntimeHost(parent);
+			const close = vi.spyOn(internals, "closeSession");
+			const incompleteAuthority = {
+				childId: fixture.childId,
+				sessionDir: fixture.childSessionDir,
+				generation: 1,
+				assertCurrent: () => {},
+			};
+
+			// The public host path must fail before both tombstone append and resident close.
+			await expect(
+				host.deleteRlmSubagentRuntime(fixture.childId, child.runtime.session, incompleteAuthority),
+			).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+			expect(close).not.toHaveBeenCalled();
+			expect(readFileSync(registryPath, "utf8")).toBe(modern);
 
 			// A coordinator-shaped request that omits either incarnation fence must
 			// not use a matching resident object as a fallback authorization.

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -8414,19 +8414,20 @@ describe("daemon mode helpers", () => {
 			})) as { data: { deleted: boolean } };
 			expect(unknown.data).toEqual({ deleted: false });
 
-			const result = (await internals.handleCommand(client, {
-				type: "delete_rlm_subagent",
-				activeSessionId: parentState.activeSessionId,
-				childId: fixture.childId,
-			})) as { data: { deleted: boolean } };
-			expect(result.data).toEqual({ deleted: true });
+			await expect(
+				internals.handleCommand(client, {
+					type: "delete_rlm_subagent",
+					activeSessionId: parentState.activeSessionId,
+					childId: fixture.childId,
+				}),
+			).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
 			expect(fixture.createRuntime).toHaveBeenCalledOnce();
 			expect(existsSync(fixture.childSessionFile)).toBe(true);
 			const persisted = readFileSync(join(fixture.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")
 				.trim()
 				.split(/\r?\n/)
 				.map((line) => JSON.parse(line) as { childId: string; status: string });
-			expect(persisted.at(-1)).toMatchObject({ childId: fixture.childId, status: "deleted" });
+			expect(persisted.at(-1)).toMatchObject({ childId: fixture.childId, status: "completed" });
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1236,6 +1236,11 @@ describe("daemon mode helpers", () => {
 			const legacy = JSON.parse(modern) as Record<string, unknown>;
 			delete legacy.sessionId;
 			writeFileSync(registryPath, `${JSON.stringify(legacy)}\n`);
+			await expect(host.deleteRlmSubagentRuntime(fixture.childId)).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
+			});
+			expect(close).not.toHaveBeenCalled();
 			await expect(
 				internals.recordRlmSubagentDeletion(parent, fixture.childId, undefined, child.runtime.session),
 			).resolves.toBe("tombstoned");

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11986,6 +11986,57 @@ describe("daemon tombstoned retirement", () => {
 		},
 	);
 
+	it("retains a failed close only for its exact tombstoned record", async () => {
+		const daemon = new AgentDaemon("/tmp/exact-tombstoned-close.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const cleanupFailure = new Error("archive failed");
+		const ordinary = makeState("ordinary-subagent-close");
+		const tombstoned = makeState("tombstoned-subagent-close");
+		const releases = new Map<ActiveSessionState, ReturnType<typeof vi.fn>>();
+		for (const state of [ordinary, tombstoned]) {
+			const releaseSessionLease = vi.fn();
+			releases.set(state, releaseSessionLease);
+			state.extensionUiRequests = new Map();
+			state.runtime = {
+				...state.runtime,
+				claimSessionLeaseReleaseForDaemon: () => true,
+				dispose: vi.fn(async () => {}),
+				releaseSessionLease,
+				session: {
+					sessionId: `session-${state.activeSessionId}`,
+					sessionFile: `/tmp/${state.activeSessionId}.jsonl`,
+					messages: ["content"],
+					isBashRunning: false,
+					abort: vi.fn(async () => {}),
+					sessionManager: {
+						appendSessionState: vi.fn(() => {
+							throw cleanupFailure;
+						}),
+						hasUserContent: () => true,
+					},
+				},
+			} as never;
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			failedTombstonedRlmCloses: Map<string, { state: ActiveSessionState }>;
+			closeSession(state: ActiveSessionState, reason: "killed"): Promise<void>;
+		};
+		internals.sessions.set(ordinary.activeSessionId, ordinary);
+		internals.sessions.set(tombstoned.activeSessionId, tombstoned);
+		internals.failedTombstonedRlmCloses.set(tombstoned.activeSessionId, { state: tombstoned });
+
+		await expect(internals.closeSession(ordinary, "killed")).rejects.toBe(cleanupFailure);
+		expect(internals.sessions.has(ordinary.activeSessionId)).toBe(false);
+		expect(releases.get(ordinary)).toHaveBeenCalledOnce();
+
+		await expect(internals.closeSession(tombstoned, "killed")).rejects.toBe(cleanupFailure);
+		expect(internals.sessions.get(tombstoned.activeSessionId)).toBe(tombstoned);
+		expect(releases.get(tombstoned)).not.toHaveBeenCalled();
+	});
+
 	it("keeps a tombstoned close lease until its full cleanup retry succeeds", async () => {
 		vi.useFakeTimers();
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-tombstone-lease-"));

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11635,6 +11635,21 @@ describe("daemon tombstoned retirement", () => {
 				now: new Date("2026-01-01T12:00:03.000Z"),
 			});
 
+			const cancel = vi.spyOn(internals.cronStore, "cancel");
+			await expect(
+				internals.handleCommand(makeClient("unscoped-private-cron-cancel", "unloaded-session"), {
+					type: "cron_cancel",
+					jobId: privateCron.id,
+				}),
+			).rejects.toThrow(`No cron job found: ${privateCron.id}`);
+			expect(cancel).not.toHaveBeenCalled();
+			const cancelledGlobalCron = (await internals.handleCommand(
+				makeClient("unscoped-global-cron-cancel", "unloaded-session"),
+				{ type: "cron_cancel", jobId: globalCron.id },
+			)) as { data: { job: AgentCronJob } };
+			expect(cancelledGlobalCron.data.job).toMatchObject({ id: globalCron.id, status: "cancelled" });
+			expect(cancel).toHaveBeenCalledWith(globalCron.id);
+
 			const guardedMutations = [
 				{ type: "restore_next_turn", messages: [] },
 				{ type: "append_custom_message", message: { customType: "test", content: "private" } },

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1223,6 +1223,16 @@ describe("daemon mode helpers", () => {
 			).resolves.toEqual({ deletionDurability: "absent" });
 			expect(readFileSync(registryPath, "utf8")).toBe(modern);
 
+			// The lenient lookup above skips malformed lines. It must not turn that
+			// omission into absence proof for a passive no-row deletion request.
+			writeFileSync(registryPath, `${modern}not-json\n`);
+			await expect(host.deleteRlmSubagentRuntime("missing-child")).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
+			});
+			expect(readFileSync(registryPath, "utf8")).toBe(`${modern}not-json\n`);
+			writeFileSync(registryPath, modern);
+
 			const legacy = JSON.parse(modern) as Record<string, unknown>;
 			delete legacy.sessionId;
 			writeFileSync(registryPath, `${JSON.stringify(legacy)}\n`);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1235,7 +1235,13 @@ describe("daemon mode helpers", () => {
 
 			const legacy = JSON.parse(modern) as Record<string, unknown>;
 			delete legacy.sessionId;
-			writeFileSync(registryPath, `${JSON.stringify(legacy)}\n`);
+			const legacyRegistry = `${JSON.stringify(legacy)}\n`;
+			writeFileSync(registryPath, legacyRegistry);
+			await expect(host.deleteRlmSubagentRuntime("missing-child")).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
+			});
+			expect(readFileSync(registryPath, "utf8")).toBe(legacyRegistry);
 			await expect(host.deleteRlmSubagentRuntime(fixture.childId)).rejects.toMatchObject({
 				name: "RlmSubagentHostDeletionError",
 				phase: "precommit",
@@ -1271,6 +1277,59 @@ describe("daemon mode helpers", () => {
 				status: "deleted",
 				sessionId: child.runtime.session.sessionId,
 			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rechecks authority after strict registry absence proof", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-absence-authority-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				readCompleteRlmSubagentRegistryForDeletion(parent: ActiveSessionState): Promise<unknown>;
+				closeSession: ReturnType<typeof vi.fn>;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const before = readFileSync(join(fixture.parentArtifactDir, "rlm-subagents.jsonl"), "utf8");
+			const originalRead = internals.readCompleteRlmSubagentRegistryForDeletion.bind(internals);
+			let beginStrictRead!: () => void;
+			const strictReadStarted = new Promise<void>((resolve) => {
+				beginStrictRead = resolve;
+			});
+			let releaseStrictRead!: () => void;
+			const strictReadGate = new Promise<void>((resolve) => {
+				releaseStrictRead = resolve;
+			});
+			vi.spyOn(internals, "readCompleteRlmSubagentRegistryForDeletion").mockImplementation(async (state) => {
+				beginStrictRead();
+				await strictReadGate;
+				return originalRead(state);
+			});
+			const close = vi.spyOn(internals, "closeSession");
+			let revoked = false;
+			const deletion = internals
+				.createSubagentRuntimeHost(parent)
+				.deleteRlmSubagentRuntime("missing-child", undefined, {
+					childId: "missing-child",
+					sessionDir: join(tempDir, "missing-child"),
+					generation: 1,
+					assertCurrent: () => {
+						if (revoked) throw new Error("host request authority was revoked");
+					},
+				});
+
+			await strictReadStarted;
+			revoked = true;
+			releaseStrictRead();
+			await expect(deletion).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
+			});
+			expect(readFileSync(join(fixture.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")).toBe(before);
+			expect(close).not.toHaveBeenCalled();
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -8233,6 +8292,33 @@ describe("daemon mode helpers", () => {
 			expect(result.data).toEqual({ deleted: false, reason: "running" });
 			expect(deleteSpy).not.toHaveBeenCalled();
 			expect(internals.sessions.get(nestedState.activeSessionId)).toBe(nestedState);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("reports stale when inactive cleanup preserves a newer child", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-stale-rlm-delete-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const parentSession = parent.runtime.session as unknown as {
+				deleteInactiveRlmSubagent: ReturnType<typeof vi.fn>;
+			};
+			parentSession.deleteInactiveRlmSubagent = vi.fn(async () => "preserved_newer" as const);
+
+			const result = (await internals.handleCommand(makeClient("client-1", parent.activeSessionId), {
+				type: "delete_rlm_subagent",
+				activeSessionId: parent.activeSessionId,
+				childId: fixture.childId,
+			})) as { data: { deleted: boolean; reason?: string } };
+
+			expect(result.data).toEqual({ deleted: false, reason: "stale" });
+			expect(parentSession.deleteInactiveRlmSubagent).toHaveBeenCalledOnce();
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -134,9 +134,13 @@ describe("daemon mode helpers", () => {
 		expect(setSessionName).toHaveBeenCalledOnce();
 	});
 
-	it("treats a depth-zero fork as a sibling of another root", () => {
+	it("treats a depth-zero fork as a sibling of another root", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-fork-family.sock", {
-			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			defaultSessionConfig: {
+				agentDir: "/tmp",
+				cwd: "/tmp",
+				sessionDir: emptySavedSessionsDir,
+			},
 			createRuntime: vi.fn(),
 		});
 		const fork = makeState("fork");
@@ -152,7 +156,10 @@ describe("daemon mode helpers", () => {
 				sessionId: "session-fork",
 				sessionFile: "/tmp/fork.jsonl",
 				rlmDepth: 0,
-				sessionManager: { getHeader: () => ({ parentSession: "/tmp/fork-origin.jsonl" }) },
+				sessionManager: {
+					getHeader: () => ({ parentSession: "/tmp/fork-origin.jsonl" }),
+					getSessionArtifactDir: () => undefined,
+				},
 			},
 		} as never;
 		const root = makeState("root");
@@ -163,20 +170,33 @@ describe("daemon mode helpers", () => {
 				sessionId: "session-root",
 				sessionFile: "/tmp/root.jsonl",
 				rlmDepth: 0,
+				sessionManager: { getSessionArtifactDir: () => undefined },
 			},
 		} as never;
 		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
 			agentFamilyEntry(state: ActiveSessionState): {
 				parentSessionId?: string;
 				parentSessionPath?: string;
 			};
+			agentFamilyCatalogEntries(): Promise<
+				readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+			>;
 			isAgentFamilyReachable(current: ActiveSessionState, target: ActiveSessionState): boolean;
 		};
+		internals.sessions.set(fork.activeSessionId, fork);
+		internals.sessions.set(root.activeSessionId, root);
 
 		expect(internals.agentFamilyEntry(fork)).not.toHaveProperty("parentSessionId");
 		expect(internals.agentFamilyEntry(fork)).not.toHaveProperty("parentSessionPath");
 		expect(internals.isAgentFamilyReachable(root, fork)).toBe(true);
 		expect(internals.isAgentFamilyReachable(fork, root)).toBe(true);
+		const catalog = await internals.agentFamilyCatalogEntries();
+		const forkEntry = catalog.find((entry) => entry.id === "session-fork");
+		const rootEntry = catalog.find((entry) => entry.id === "session-root");
+		expect(forkEntry).toEqual(expect.objectContaining({ depth: 0 }));
+		expect(forkEntry).not.toHaveProperty("parentSessionPath");
+		expect(assertAgentFamilyReach(rootEntry!, forkEntry!, catalog)).toBe("sibling");
 	});
 
 	it("finds only direct child active sessions", () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -882,6 +882,7 @@ describe("daemon mode helpers", () => {
 			});
 			const host = internals.createSubagentRuntimeHost(parentState);
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const validHistoryEntry = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
 
 			// A real resident child with its row removed has no durable owner. The host
 			// still closes it, and explicitly proves the artifact is absent.
@@ -912,6 +913,34 @@ describe("daemon mode helpers", () => {
 			);
 			expect(readFileSync(registryPath, "utf8")).toContain('"childId":"release-tombstoned"');
 			expect(readFileSync(registryPath, "utf8")).toContain('"status":"deleted"');
+
+			// Every historical line is authority-sensitive: an unrelated syntactically
+			// valid but schema-truncated row makes release durability unknown rather
+			// than authorizing artifact removal as if the child were absent.
+			for (const [label, patch] of [
+				["missing-parent-session-id", { parentSessionId: undefined }],
+				["missing-created-at", { createdAt: undefined }],
+				["missing-updated-at", { updatedAt: undefined }],
+				["malformed-model", { model: { provider: "test" } }],
+			] as const) {
+				const options = optionsFor(`release-${label}`);
+				const runtime = await internals.createRlmSubagentRuntime(parentState, options);
+				writeFileSync(
+					registryPath,
+					`${JSON.stringify(validHistoryEntry)}\n${JSON.stringify({
+						...validHistoryEntry,
+						childId: `unrelated-${label}`,
+						...patch,
+					})}\n`,
+				);
+				await expect(host.releaseRlmSubagentRuntime?.(runtime, options, "cancelled")).resolves.toEqual({
+					deletionDurability: "unknown",
+				});
+				expect(existsSync(options.sessionDir)).toBe(true);
+			}
+
+			// Restore complete history so this control reaches the append boundary.
+			writeFileSync(registryPath, `${JSON.stringify(validHistoryEntry)}\n`);
 
 			// A deterministic append/fsync failure likewise closes the real resident
 			// runtime but leaves durable ownership unknown, so the caller retains it.

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1510,7 +1510,7 @@ describe("daemon mode helpers", () => {
 			await expect(
 				host.deleteRlmSubagentRuntime(fixture.childId, replacement.runtime.session, currentAuthority),
 			).resolves.toEqual({ deletionDurability: "tombstoned" });
-			expect(close).toHaveBeenCalledOnce();
+			expect(close).toHaveBeenCalledTimes(2);
 			expect(cleanup).toHaveBeenCalledTimes(2);
 			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
 		} finally {
@@ -2128,17 +2128,17 @@ describe("daemon mode helpers", () => {
 		expect(listed.agents).not.toContainEqual(
 			expect.objectContaining({ activeSessionId: childState.activeSessionId }),
 		);
-		expect(() => internals.getBoundSessionState(childState.activeSessionId)).toThrow("is closing");
+		expect(() => internals.getBoundSessionState(childState.activeSessionId)).toThrow("unavailable");
 		await expect(
 			controller.sendAgentMessage({ target: childState.activeSessionId, message: "continue" }),
-		).rejects.toThrow("is closing");
+		).rejects.toThrow("unavailable");
 		const client = makeClient("client-1", childState.activeSessionId);
 		for (const command of [
 			{ id: "prompt", type: "prompt", activeSessionId: childState.activeSessionId, message: "continue" },
 			{ id: "steer", type: "steer", activeSessionId: childState.activeSessionId, message: "continue" },
 			{ id: "follow-up", type: "follow_up", activeSessionId: childState.activeSessionId, message: "continue" },
 		] as const) {
-			await expect(internals.handleCommand(client, command)).rejects.toThrow("is closing");
+			await expect(internals.handleCommand(client, command)).rejects.toThrow("unavailable");
 		}
 
 		internals.closingSessions.delete(childState.activeSessionId);
@@ -2155,7 +2155,7 @@ describe("daemon mode helpers", () => {
 		expect(sessionPrompt).not.toHaveBeenCalled();
 	});
 
-	it("removes a closing daemon session even when runtime disposal fails", async () => {
+	it("retains a closing daemon session when runtime disposal fails", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -2200,7 +2200,7 @@ describe("daemon mode helpers", () => {
 		await expect(internals.closeSession(state, "killed", false)).rejects.toThrow("dispose failed");
 
 		expect(dispose).toHaveBeenCalledOnce();
-		expect(internals.sessions.has(state.activeSessionId)).toBe(false);
+		expect(internals.sessions.get(state.activeSessionId)).toBe(state);
 		expect(internals.closingSessions.has(state.activeSessionId)).toBe(false);
 	});
 
@@ -8297,7 +8297,7 @@ describe("daemon mode helpers", () => {
 				childId: fixture.childId,
 			})) as { data: { deleted: boolean } };
 			expect(idle.data).toEqual({ deleted: true });
-			expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
+			await vi.waitFor(() => expect(internals.sessions.has(childState.activeSessionId)).toBe(false));
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -11501,6 +11501,15 @@ describe("daemon tombstoned retirement", () => {
 		expect(internals.isPublicRlmState(child)).toBe(false);
 		expect(internals.isPublicRlmState(grandchild)).toBe(false);
 		expect(internals.isPublicRlmState(sibling)).toBe(true);
+		for (const command of [
+			{ type: "get_state", activeSessionId: child.activeSessionId },
+			{ type: "get_connection_state", activeSessionId: child.activeSessionId },
+			{ type: "get_messages", activeSessionId: child.activeSessionId },
+		] as const) {
+			await expect(
+				internals.handleCommand(makeClient("private-read-client", root.activeSessionId), command),
+			).rejects.toThrow("unavailable");
+		}
 		const listed = (await internals.handleCommand(makeClient("list-client", root.activeSessionId), {
 			type: "list",
 		})) as { data: { sessions: SessionSummary[] } };
@@ -11525,38 +11534,156 @@ describe("daemon tombstoned retirement", () => {
 		).toBe(true);
 
 		internals.closingSessions.delete(child.activeSessionId);
-		internals.sessions.delete(child.activeSessionId);
 		internals.failedTombstonedRlmCloses.set(child.activeSessionId, { state: child });
 		expect(internals.isPublicRlmState(grandchild)).toBe(false);
+		await expect(
+			internals.handleCommand(makeClient("failed-private-read-client", root.activeSessionId), {
+				type: "get_messages",
+				activeSessionId: child.activeSessionId,
+			}),
+		).rejects.toThrow("unavailable");
 	});
 
-	it("retains a failed physical disposal and retries the exact runtime", async () => {
-		const daemon = new AgentDaemon("/tmp/retry-retirement.sock", {
+	it("retries a rejected runtime disposal through the exact full tombstoned close", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-retry-tombstoned-dispose-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const disposeFailure = new Error("dispose failed");
+			fixture.runtimeSessions[1]!.disposeAsync = vi
+				.fn<() => Promise<void>>()
+				.mockRejectedValueOnce(disposeFailure)
+				.mockResolvedValue(undefined);
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() =>
+				expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(disposeFailure),
+			);
+			expect(internals.sessions.get(child.activeSessionId)).toBe(child);
+			expect(fixture.runtimeSessions[1]!.disposeAsync).toHaveBeenCalledOnce();
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() => {
+				expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false);
+				expect(internals.sessions.has(child.activeSessionId)).toBe(false);
+			});
+			expect(fixture.runtimeSessions[1]!.disposeAsync).toHaveBeenCalledTimes(2);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a failed tombstoned cascade private and retries its resident subtree", async () => {
+		const daemon = new AgentDaemon("/tmp/retry-tombstoned-cascade.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
 			createRuntime: vi.fn(),
 		});
-		const parent = makeState("retry-parent");
-		const child = makeState("retry-child", parent.activeSessionId);
-		const dispose = vi.fn(async () => {});
-		child.runtime.dispose = dispose;
-		const disposeFailure = new Error("dispose failed");
+		const root = makeState("cascade-root");
+		const parent = makeState("cascade-parent", root.activeSessionId);
+		const descendant = makeState("cascade-descendant", parent.activeSessionId);
+		Object.assign(parent.runtime.metadata, { kind: "subagent", rlmChildId: "parent" });
+		Object.assign(descendant.runtime.metadata, { kind: "subagent", rlmChildId: "descendant" });
+		const cascadeFailure = new Error("descendant dispose failed");
+		const descendantDispose = vi
+			.fn<() => Promise<void>>()
+			.mockRejectedValueOnce(cascadeFailure)
+			.mockResolvedValue(undefined);
+		for (const [state, dispose] of [
+			[parent, vi.fn(async () => {})],
+			[descendant, descendantDispose],
+		] as const) {
+			state.extensionUiRequests = new Map();
+			state.runtime = {
+				...state.runtime,
+				dispose,
+				session: {
+					sessionId: `session-${state.activeSessionId}`,
+					sessionFile: undefined,
+					isBashRunning: false,
+					abort: vi.fn(async () => {}),
+				},
+			} as unknown as ActiveSessionState["runtime"];
+		}
 		const internals = daemon as unknown as {
-			closeDisposeErrors: WeakMap<ActiveSessionState, unknown>;
+			sessions: Map<string, ActiveSessionState>;
 			failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
-			detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
-			closeSession: ReturnType<typeof vi.fn>;
+			detachTombstonedClose(root: ActiveSessionState, child: ActiveSessionState, id: string): void;
+			isPublicRlmState(state: ActiveSessionState): boolean;
+			cancelScheduledJobsForSession: ReturnType<typeof vi.fn>;
+			isEmptyDraftContent: ReturnType<typeof vi.fn>;
+			abortBashForClose: ReturnType<typeof vi.fn>;
+			recordWorkerRecoveryState: ReturnType<typeof vi.fn>;
+			broadcastToSession: ReturnType<typeof vi.fn>;
 		};
-		internals.closeSession = vi.fn(async () => {
-			internals.closeDisposeErrors.set(child, disposeFailure);
-			throw disposeFailure;
-		});
-		internals.detachTombstonedClose(parent, child, "child-1");
+		for (const state of [root, parent, descendant]) internals.sessions.set(state.activeSessionId, state);
+		internals.cancelScheduledJobsForSession = vi.fn();
+		internals.isEmptyDraftContent = vi.fn(() => true);
+		internals.abortBashForClose = vi.fn(async () => {});
+		internals.recordWorkerRecoveryState = vi.fn();
+		internals.broadcastToSession = vi.fn();
+
+		internals.detachTombstonedClose(root, parent, "parent");
 		await vi.waitFor(() =>
-			expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(disposeFailure),
+			expect(internals.failedTombstonedRlmCloses.get(parent.activeSessionId)?.error).toBe(cascadeFailure),
 		);
-		internals.detachTombstonedClose(parent, child, "child-1");
-		await vi.waitFor(() => expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false));
-		expect(dispose).toHaveBeenCalledOnce();
+		expect(internals.sessions.get(parent.activeSessionId)).toBe(parent);
+		expect(internals.sessions.get(descendant.activeSessionId)).toBe(descendant);
+		expect(internals.isPublicRlmState(parent)).toBe(false);
+		expect(internals.isPublicRlmState(descendant)).toBe(false);
+
+		internals.detachTombstonedClose(root, parent, "parent");
+		await vi.waitFor(() => {
+			expect(internals.failedTombstonedRlmCloses.has(parent.activeSessionId)).toBe(false);
+			expect(internals.sessions.has(parent.activeSessionId)).toBe(false);
+			expect(internals.sessions.has(descendant.activeSessionId)).toBe(false);
+		});
+		expect(descendantDispose).toHaveBeenCalledTimes(2);
+	});
+
+	it("retries a tombstoned close that failed before disposal", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-retry-tombstoned-pre-dispose-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+				cancelScheduledJobsForSession: ReturnType<typeof vi.fn>;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const preDisposeFailure = new Error("pre-dispose close failed");
+			const cancelScheduledJobsForSession = vi.fn().mockImplementationOnce(() => {
+				throw preDisposeFailure;
+			});
+			internals.cancelScheduledJobsForSession = cancelScheduledJobsForSession;
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() =>
+				expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(preDisposeFailure),
+			);
+			expect(internals.sessions.get(child.activeSessionId)).toBe(child);
+			expect(fixture.runtimeSessions[1]!.disposeAsync).not.toHaveBeenCalled();
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() => {
+				expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false);
+				expect(internals.sessions.has(child.activeSessionId)).toBe(false);
+			});
+			expect(cancelScheduledJobsForSession).toHaveBeenCalledTimes(2);
+			expect(fixture.runtimeSessions[1]!.disposeAsync).toHaveBeenCalledOnce();
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1171,6 +1171,70 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("fences passive deletion by its persisted incarnation and retries only post-tombstone cleanup", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-delete-incarnation-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				cancelScheduledJobsForSessionFile(sessionFile: string): void;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const original = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
+			const replacementFile = join(fixture.childSessionDir, "replacement.jsonl");
+			writeFileSync(replacementFile, "replacement");
+			writeFileSync(
+				registryPath,
+				`${JSON.stringify({
+					...original,
+					sessionFile: replacementFile,
+					updatedAt: "2026-01-01T00:00:02.000Z",
+				})}\n`,
+			);
+			const host = internals.createSubagentRuntimeHost(parent);
+			const oldAuthority = {
+				childId: fixture.childId,
+				sessionDir: fixture.childSessionDir,
+				sessionFile: fixture.childSessionFile,
+				sessionId: "old-session-id",
+				generation: 1,
+				assertCurrent: () => {},
+			};
+			await expect(host.deleteRlmSubagentRuntime(fixture.childId, undefined, oldAuthority)).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
+			});
+			expect(readFileSync(registryPath, "utf8")).not.toContain('"status":"deleted"');
+
+			let cleanupAttempts = 0;
+			const cleanup = vi.spyOn(internals, "cancelScheduledJobsForSessionFile").mockImplementation(() => {
+				if (++cleanupAttempts === 1) throw new Error("scheduler cleanup failed once");
+			});
+			const currentAuthority = {
+				...oldAuthority,
+				sessionFile: replacementFile,
+				sessionId: "replacement-session-id",
+				generation: 2,
+			};
+			await expect(
+				host.deleteRlmSubagentRuntime(fixture.childId, undefined, currentAuthority),
+			).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "tombstoned",
+			});
+			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
+			await expect(host.deleteRlmSubagentRuntime(fixture.childId, undefined, currentAuthority)).resolves.toEqual({
+				deletionDurability: "tombstoned",
+			});
+			expect(cleanup).toHaveBeenCalledTimes(2);
+			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("honors daemon deletion authority on both sides of the append boundary", async () => {
 		const beforeTempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-before-append-"));
 		const afterTempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-after-append-"));
@@ -1238,7 +1302,7 @@ describe("daemon mode helpers", () => {
 							if (afterAbort.signal.aborted) throw new Error("host request authority was revoked");
 						},
 					}),
-			).resolves.toBeUndefined();
+			).resolves.toEqual({ deletionDurability: "tombstoned" });
 			expect(readFileSync(join(after.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")).toContain(
 				'"status":"deleted"',
 			);

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -93,6 +93,23 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("queue_message_mutation");
 	});
 
+	it("schema-gates only authority-aware saved-session renames", () => {
+		const detachedLegacy: DaemonCommand = {
+			type: "rename_saved_session",
+			sessionPath: "/tmp/session.jsonl",
+			name: "renamed",
+		};
+		const activeLegacy: DaemonCommand = { ...detachedLegacy, activeSessionId: "active" };
+		const authorityAware: DaemonCommand = { ...detachedLegacy, sessionDir: "/tmp/sessions" };
+		expect(getDaemonCommandCompatibilities(detachedLegacy)).toEqual([{ minProtocol: 7 }]);
+		expect(getDaemonCommandCompatibilities(activeLegacy)).toEqual([{ minProtocol: 7 }]);
+		expect(getDaemonCommandCompatibilities(authorityAware)).toEqual([{ minProtocol: 7, minSchemaRevision: 17 }]);
+		expect(DAEMON_COMMAND_COMPATIBILITY.rename_saved_session).toEqual({
+			minProtocol: 7,
+			minSchemaRevision: 17,
+		});
+	});
+
 	it("schema-gates the RLM max depth commands at their introducing revision", () => {
 		expect(DAEMON_COMMAND_COMPATIBILITY.get_rlm_max_depth_status).toEqual({ minProtocol: 7, minSchemaRevision: 11 });
 		expect(DAEMON_COMMAND_COMPATIBILITY.set_rlm_max_depth).toEqual({ minProtocol: 7, minSchemaRevision: 11 });

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -589,6 +589,22 @@ describe("buildRlmChildSnapshots", () => {
 		expect(snapshots.map((snapshot) => [snapshot.id, snapshot.status])).toEqual([["sub-aaa", "running"]]);
 	});
 
+	it("omits a precommit-quarantined resident child from attach snapshots", () => {
+		const parent = makeState({ activeSessionId: "parent", quarantinedRlmChildren: ["sub-private"] });
+		const privateChild = makeState({
+			activeSessionId: "private-child",
+			metadata: { kind: "subagent", createdAt: 1, parentActiveSessionId: "parent", rlmChildId: "sub-private" },
+		});
+		const visibleChild = makeState({
+			activeSessionId: "visible-child",
+			metadata: { kind: "subagent", createdAt: 1, parentActiveSessionId: "parent", rlmChildId: "sub-visible" },
+		});
+
+		expect(buildRlmChildSnapshots("parent", [parent, privateChild, visibleChild])).toMatchObject([
+			{ id: "sub-visible" },
+		]);
+	});
+
 	it("keeps terminal run status while projecting a retained child's active follow-up", () => {
 		const parent = makeState({
 			activeSessionId: "parent",
@@ -692,6 +708,7 @@ interface StateOptions {
 	hasUserContent?: boolean;
 	summaryState?: ActiveSessionState["summaryState"];
 	childRunStatuses?: Record<string, "queued" | "running" | "done" | "error" | "cancelled">;
+	quarantinedRlmChildren?: string[];
 	hasRunningRlmChildren?: boolean;
 	hasAcceptedPromptInFlight?: boolean;
 	unfinishedActionCount?: number;
@@ -742,6 +759,8 @@ function makeState(options: StateOptions): ActiveSessionState {
 				},
 				messages: options.messages ?? ([] as AgentMessage[]),
 				getRlmChildRunStatus: (childId: string) => options.childRunStatuses?.[childId],
+				isRlmChildDeletionQuarantined: (childId: string) =>
+					options.quarantinedRlmChildren?.includes(childId) ?? false,
 				hasRunningRlmChildren: () => options.hasRunningRlmChildren ?? false,
 				hasAcceptedPromptInFlight: options.hasAcceptedPromptInFlight ?? false,
 				unfinishedActionCount: options.unfinishedActionCount ?? (options.hasAcceptedPromptInFlight ? 1 : 0),

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -111,6 +111,7 @@ function makeSupervisor(idleEvictionMinutes: number | "off" = 90): SupervisorInt
 	supervisor.stopWorker = vi.fn(async (worker: WorkerFixture) => {
 		supervisor.workers.delete(worker.descriptor.workerId);
 	});
+	supervisor.catalog.list = vi.fn(async () => []);
 	supervisor.log = vi.fn();
 	supervisors.push(supervisor);
 	return supervisor;

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../src/core/session-manager.js";
 import { success } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DaemonSupervisor, idleEvictionSweepIntervalMs } from "../src/modes/daemon/daemon-supervisor.js";
@@ -31,8 +32,17 @@ interface SupervisorInternals {
 	workers: Map<string, WorkerFixture>;
 	clients: Set<{ id: string; attachedActiveSessionIds: Set<string> }>;
 	idleEvictionFence?: Promise<void>;
-	catalog: { resolve: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> };
+	catalog: {
+		resolve: ReturnType<typeof vi.fn>;
+		stop: ReturnType<typeof vi.fn>;
+		list?: ReturnType<typeof vi.fn>;
+		family?: ReturnType<typeof vi.fn>;
+		siblings?: ReturnType<typeof vi.fn>;
+	};
 	createOrReuseWorker: ReturnType<typeof vi.fn>;
+	familyCatalogEntries(
+		sessionDir?: string,
+	): Promise<readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]>;
 	stopWorker: ReturnType<typeof vi.fn>;
 	log: ReturnType<typeof vi.fn>;
 	scheduleIdleEvictionSweep(): void;
@@ -304,6 +314,50 @@ describe("daemon supervisor whole-tree eviction", () => {
 		});
 	});
 
+	it("uses the merged custom session directory for named saved-session siblings", async () => {
+		const supervisor = makeSupervisor();
+		const sessionPath = "/tmp/custom-sessions/saved.jsonl";
+		const target = {
+			id: "saved",
+			path: sessionPath,
+			cwd: "/tmp/project",
+			parentSessionPath: "/tmp/custom-sessions/parent.jsonl",
+			rlmDepth: 1,
+			created: new Date("2026-08-01T12:00:00.000Z"),
+			modified: new Date("2026-08-01T12:00:00.000Z"),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+		};
+		supervisor.catalog.resolve = vi.fn(async () => sessionPath);
+		supervisor.catalog.siblings = vi.fn(async () => [target]);
+		const launched = makeWorker("launched", [makeSummary("launched-active", Date.now())]);
+		const launchWorker = vi.fn(async () => launched);
+		Object.assign(supervisor, { launchWorker });
+		const createOrReuseWorker = (
+			supervisor as unknown as {
+				createOrReuseWorker(clientId: string, command: object): Promise<WorkerFixture>;
+			}
+		).createOrReuseWorker.bind(supervisor);
+
+		await expect(
+			createOrReuseWorker("client", {
+				id: "named-custom",
+				type: "create",
+				sessionPath: "saved",
+				name: "renamed",
+				config: { sessionDir: "/tmp/custom-sessions" },
+			}),
+		).resolves.toBe(launched);
+		expect(supervisor.catalog.resolve).toHaveBeenCalledWith("saved", expect.any(String), "/tmp/custom-sessions");
+		expect(supervisor.catalog.siblings).toHaveBeenCalledWith(sessionPath, "/tmp/custom-sessions");
+		expect(launchWorker).toHaveBeenCalledWith(
+			expect.objectContaining({ sessionPath, config: { sessionDir: "/tmp/custom-sessions" } }),
+			undefined,
+			undefined,
+		);
+	});
+
 	it("resolves a saved target in the source worker's create-time session directory", async () => {
 		const now = Date.parse("2026-08-01T12:00:00.000Z");
 		const supervisor = makeSupervisor();
@@ -311,9 +365,19 @@ describe("daemon supervisor whole-tree eviction", () => {
 		const source = makeWorker("source", [sourceSummary]);
 		source.descriptor.createCommand.config = { sessionDir: "/tmp/custom-sessions" };
 		source.summaries = new Map([["source-active", sourceSummary]]);
+		// The wake path reads this row before authorizing it, so model an actual
+		// saved session rather than a summary whose sessionFile is not readable.
+		const targetDirectory = mkdtempSync(join(tmpdir(), "prime-supervisor-saved-target-"));
+		tempDirs.push(targetDirectory);
+		const targetManager = SessionManager.create(targetDirectory, join(targetDirectory, "sessions"));
+		targetManager.newSession();
+		targetManager.appendSessionInfo("saved target");
+		targetManager.flushNow();
+		const targetPath = targetManager.getSessionFile();
+		if (!targetPath) throw new Error("Missing saved target session path");
 		const targetSummary = makeSummary("target-active", now, {
-			sessionId: "target-session",
-			sessionFile: "/tmp/target.jsonl",
+			sessionId: targetManager.getSessionId(),
+			sessionFile: targetPath,
 		});
 		const target = makeWorker("target", [targetSummary]);
 		target.descriptor.rootActiveSessionId = "target-active";
@@ -324,7 +388,7 @@ describe("daemon supervisor whole-tree eviction", () => {
 			data: { deliveryStatus: "delivered" },
 		});
 		supervisor.workers.set("source", source);
-		supervisor.catalog.resolve = vi.fn(async () => "/tmp/target.jsonl");
+		supervisor.catalog.resolve = vi.fn(async () => targetPath);
 		supervisor.createOrReuseWorker = vi.fn(async () => target);
 		const client = { id: "sender", attachedActiveSessionIds: new Set<string>() };
 
@@ -339,7 +403,12 @@ describe("daemon supervisor whole-tree eviction", () => {
 		expect(supervisor.catalog.resolve).toHaveBeenCalledWith("target-session", "/tmp/project", "/tmp/custom-sessions");
 		expect(supervisor.createOrReuseWorker).toHaveBeenCalledWith(
 			"sender",
-			expect.objectContaining({ type: "create", sessionPath: "/tmp/target.jsonl", continueRecent: false }),
+			expect.objectContaining({
+				type: "create",
+				sessionPath: targetPath,
+				continueRecent: false,
+				config: { sessionDir: "/tmp/custom-sessions" },
+			}),
 		);
 		expect(target.client?.requestWorker).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -440,5 +509,364 @@ describe("daemon supervisor whole-tree eviction", () => {
 			}),
 		).rejects.toThrow('Ambiguous session selector "target"');
 		expect(supervisor.createOrReuseWorker).not.toHaveBeenCalled();
+	});
+
+	it("captures every inactive descendant for cross-worker sibling authorization", async () => {
+		const supervisor = makeSupervisor();
+		const timestamp = new Date("2026-08-01T12:00:00.000Z");
+		const catalog = [
+			{
+				id: "root",
+				path: "/tmp/root.jsonl",
+				cwd: "/tmp",
+				rlmDepth: 0,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+			{
+				id: "middle",
+				path: "/tmp/middle.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/root.jsonl",
+				rlmDepth: 1,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+			{
+				id: "first",
+				path: "/tmp/first.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/middle.jsonl",
+				rlmDepth: 2,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+			{
+				id: "second",
+				path: "/tmp/second.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/middle.jsonl",
+				rlmDepth: 2,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+		];
+		supervisor.catalog.list = vi.fn(async () => catalog);
+		Object.assign(supervisor.catalog, { family: vi.fn(async () => catalog) });
+		const entries = await supervisor.familyCatalogEntries("/tmp/custom-sessions");
+		expect(supervisor.catalog.list).toHaveBeenCalledWith(undefined, "/tmp/custom-sessions");
+		expect(supervisor.catalog.family).toHaveBeenCalledWith("/tmp/custom-sessions");
+		expect(entries.map((entry) => entry.id)).toEqual(["root", "middle", "first", "second"]);
+		const { assertAgentFamilyReach } = await import("../src/core/agent-messages.js");
+		expect(
+			assertAgentFamilyReach(
+				entries.find((entry) => entry.id === "first")!,
+				entries.find((entry) => entry.id === "second")!,
+				entries,
+			),
+		).toBe("sibling");
+	});
+
+	it("scopes live family rows to the requested configured session directory", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const source = makeWorker("source", [makeSummary("source", now)]);
+		source.descriptor.createCommand.config = { sessionDir: "/tmp/sessions-a" };
+		const foreign = makeWorker("foreign", [makeSummary("foreign", now)]);
+		foreign.descriptor.createCommand.config = { sessionDir: "/tmp/sessions-b" };
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("foreign", foreign);
+		supervisor.catalog.list = vi.fn(async () => []);
+		Object.assign(supervisor.catalog, { family: vi.fn(async () => []) });
+
+		const entries = await supervisor.familyCatalogEntries("/tmp/sessions-a");
+		expect(entries.map((entry) => entry.id)).toEqual(["source-session"]);
+	});
+
+	it("anchors relative live parent paths to the child session file", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const worker = makeWorker("family", [
+			makeSummary("root", now, { sessionId: "root", sessionFile: "/tmp/family/root.jsonl", rlmDepth: 0 }),
+			makeSummary("child", now, {
+				sessionId: "child",
+				sessionFile: "/tmp/family/children/child.jsonl",
+				rlmDepth: 1,
+				parentSessionId: "root",
+				parentSessionPath: "../root.jsonl",
+			}),
+		]);
+		worker.descriptor.createCommand.config = { sessionDir: "/tmp/sessions" };
+		supervisor.workers.set("family", worker);
+		supervisor.catalog.list = vi.fn(async () => []);
+		Object.assign(supervisor.catalog, { family: vi.fn(async () => []) });
+
+		const entries = await supervisor.familyCatalogEntries("/tmp/sessions");
+		const { assertAgentFamilyReach } = await import("../src/core/agent-messages.js");
+		expect(assertAgentFamilyReach(entries[0]!, entries[1]!, entries)).toBe("child");
+	});
+
+	it("uses the source worker session directory for agent-origin family snapshots", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const source = makeWorker("source", [makeSummary("source-active", now, { sessionId: "source" })]);
+		source.descriptor.createCommand.config = { sessionDir: "/tmp/custom-sessions" };
+		const target = makeWorker("target", [makeSummary("target-active", now, { sessionId: "target" })]);
+		target.client!.requestWorker.mockResolvedValue({
+			type: "response",
+			command: "worker_deliver_message",
+			success: true,
+			data: { deliveryStatus: "delivered" },
+		});
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("target", target);
+		const familyCatalogEntries = vi.fn(async () =>
+			Object.freeze([
+				{ id: "root", depth: 0, status: "inactive" as const },
+				{ id: "source", depth: 1, status: "running" as const, parentSessionId: "root" },
+				{ id: "target", depth: 1, status: "running" as const, parentSessionId: "root" },
+			]),
+		);
+		Object.assign(supervisor, { familyCatalogEntries });
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "custom-root",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: "target-active",
+					message: "deliver",
+				},
+			),
+		).resolves.toMatchObject({ success: true });
+		expect(familyCatalogEntries).toHaveBeenCalledWith("/tmp/custom-sessions");
+	});
+
+	it("rejects active topology that conflicts with the persisted row before remote delivery", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const sourceSummary = makeSummary("source-active", now, {
+			sessionId: "source",
+			rlmDepth: 1,
+			parentSessionPath: "/tmp/root.jsonl",
+		});
+		const targetSummary = makeSummary("target-active", now, {
+			sessionId: "target",
+			sessionFile: "/tmp/target.jsonl",
+			rlmDepth: 1,
+			parentSessionPath: "/tmp/forged-parent.jsonl",
+		});
+		const source = makeWorker("source", [sourceSummary]);
+		const target = makeWorker("target", [targetSummary]);
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("target", target);
+		const timestamp = new Date(now);
+		const catalog = [
+			{
+				id: "root",
+				path: "/tmp/root.jsonl",
+				cwd: "/tmp",
+				rlmDepth: 0,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+			{
+				id: "target",
+				path: "/tmp/target.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/root.jsonl",
+				rlmDepth: 1,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+		];
+		supervisor.catalog.list = vi.fn(async () => catalog);
+		Object.assign(supervisor.catalog, { family: vi.fn(async () => catalog) });
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "persisted-conflict",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: "target-active",
+					message: "deny",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(target.client?.requestWorker).not.toHaveBeenCalled();
+	});
+
+	it("uses only the source custom directory when denying a conflicting family topology", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const sourceSummary = makeSummary("source-active", now, {
+			sessionId: "source",
+			rlmDepth: 1,
+			parentSessionPath: "/tmp/custom-sessions/root.jsonl",
+		});
+		const targetSummary = makeSummary("target-active", now, {
+			sessionId: "target",
+			sessionFile: "/tmp/custom-sessions/target.jsonl",
+			rlmDepth: 1,
+			parentSessionPath: "/tmp/custom-sessions/forged-parent.jsonl",
+		});
+		const source = makeWorker("source", [sourceSummary]);
+		source.descriptor.createCommand.config = { sessionDir: "/tmp/custom-sessions" };
+		const target = makeWorker("target", [targetSummary]);
+		target.descriptor.createCommand.config = { sessionDir: "/tmp/custom-sessions" };
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("target", target);
+		const timestamp = new Date(now);
+		const catalog = [
+			{
+				id: "root",
+				path: "/tmp/custom-sessions/root.jsonl",
+				cwd: "/tmp",
+				rlmDepth: 0,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+				allMessagesText: "",
+			},
+			{
+				id: "target",
+				path: "/tmp/custom-sessions/target.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/custom-sessions/root.jsonl",
+				rlmDepth: 1,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+				allMessagesText: "",
+			},
+		];
+		supervisor.catalog.list = vi.fn(async () => catalog);
+		supervisor.catalog.family = vi.fn(async () => catalog);
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "custom-persisted-conflict",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: "target-active",
+					message: "deny",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(supervisor.catalog.list).toHaveBeenCalledWith(undefined, "/tmp/custom-sessions");
+		expect(supervisor.catalog.family).toHaveBeenCalledWith("/tmp/custom-sessions");
+		expect(target.client?.requestWorker).not.toHaveBeenCalled();
+	});
+
+	it("rejects duplicate snapshot identities before cross-worker delivery", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const sourceSummary = makeSummary("source-active", now, { sessionId: "source" });
+		const targetSummary = makeSummary("target-active", now, { sessionId: "target" });
+		const source = makeWorker("source", [sourceSummary]);
+		const target = makeWorker("target", [targetSummary]);
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("target", target);
+		Object.assign(supervisor, {
+			familyCatalogEntries: vi.fn(async () =>
+				Object.freeze([
+					{ id: "root", depth: 0, status: "inactive" as const },
+					{ id: "source", depth: 1, status: "running" as const, parentSessionId: "root" },
+					{ id: "target", depth: 1, status: "running" as const, parentSessionId: "root" },
+					{ id: "target", depth: 1, status: "running" as const, parentSessionId: "forged" },
+				]),
+			),
+		});
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "duplicate",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: "target-active",
+					message: "deny",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(target.client?.requestWorker).not.toHaveBeenCalled();
+	});
+
+	it("rejects a postwake session substitution without delivery", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-postwake-substitution-"));
+		tempDirs.push(directory);
+		const parentManager = SessionManager.create(directory, join(directory, "sessions"));
+		parentManager.newSession({ rlmDepth: 0 });
+		parentManager.flushNow();
+		const parentPath = parentManager.getSessionFile();
+		if (!parentPath) throw new Error("Missing parent session path");
+		const targetManager = SessionManager.create(directory, join(directory, "sessions"));
+		targetManager.newSession({ parentSession: parentPath, rlmDepth: 1 });
+		targetManager.flushNow();
+		const targetPath = targetManager.getSessionFile();
+		if (!targetPath) throw new Error("Missing target session path");
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const sourceSummary = makeSummary("source-active", now, { sessionId: "source" });
+		const source = makeWorker("source", [sourceSummary]);
+		const substituted = makeSummary("woken-active", now, { sessionId: "substitute", sessionFile: targetPath });
+		const woken = makeWorker("woken", [substituted]);
+		const supervisor = makeSupervisor();
+		supervisor.workers.set("source", source);
+		supervisor.catalog.resolve = vi.fn(async () => targetPath);
+		supervisor.createOrReuseWorker = vi.fn(async () => woken);
+		Object.assign(supervisor, {
+			familyCatalogEntries: vi.fn(async () =>
+				Object.freeze([
+					{ id: parentManager.getSessionId(), depth: 0, status: "inactive" as const, sessionPath: parentPath },
+					{ id: "source", depth: 1, status: "running" as const, parentSessionId: parentManager.getSessionId() },
+					{
+						id: targetManager.getSessionId(),
+						depth: 1,
+						status: "inactive" as const,
+						parentSessionPath: parentPath,
+						sessionPath: targetPath,
+					},
+				]),
+			),
+		});
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "substitution",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: targetManager.getSessionId(),
+					message: "deny",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(supervisor.createOrReuseWorker).toHaveBeenCalledOnce();
+		expect(woken.client?.requestWorker).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -52,8 +52,10 @@ interface SupervisorInternals {
 }
 
 const tempDirs: string[] = [];
+const supervisors: SupervisorInternals[] = [];
 
-afterEach(() => {
+afterEach(async () => {
+	for (const supervisor of supervisors.splice(0)) await (supervisor.catalog.stop as () => Promise<void>)();
 	for (const directory of tempDirs.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
 
@@ -110,6 +112,7 @@ function makeSupervisor(idleEvictionMinutes: number | "off" = 90): SupervisorInt
 		supervisor.workers.delete(worker.descriptor.workerId);
 	});
 	supervisor.log = vi.fn();
+	supervisors.push(supervisor);
 	return supervisor;
 }
 

--- a/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
@@ -22,13 +22,14 @@ interface SupervisorInternals {
 		clientId: string,
 		command: { type: "create"; name?: string; sessionPath?: string },
 	): Promise<WorkerFixture>;
-	assertSupervisorSavedSessionNameAvailable(sessionPath: string, name: string): Promise<void>;
+	assertSupervisorSavedSessionNameAvailable(sessionPath: string, name: string, sessionDir?: string): Promise<void>;
 	assertSavedSiblingNameAvailable(
 		siblings: Array<Record<string, unknown>>,
 		target: Record<string, unknown>,
 		name: string,
 	): void;
 	familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry;
+	familyCatalogEntries(): Promise<readonly AgentFamilyCatalogEntry[]>;
 	handleCommand(client: object, command: Record<string, unknown>): Promise<unknown>;
 }
 
@@ -41,7 +42,7 @@ interface WorkerFixture {
 		pid: number;
 		authenticationToken: string;
 		ownerClientId?: string;
-		createCommand: { config: { cwd: string } };
+		createCommand: { config: { cwd: string; sessionDir?: string } };
 	};
 	client: {
 		request: ReturnType<typeof vi.fn>;
@@ -491,6 +492,7 @@ describe("daemon supervisor passive subagent topology", () => {
 			releaseRename = resolve;
 		});
 		const firstWorker = worker("first", [firstSummary]);
+		firstWorker.descriptor.createCommand.config.sessionDir = join(directory, "custom-sessions");
 		firstWorker.client.request.mockImplementation(async () => {
 			await renameGate;
 			return success(undefined, "rename_saved_session", firstSummary);
@@ -503,10 +505,12 @@ describe("daemon supervisor passive subagent topology", () => {
 		}) as unknown as SupervisorInternals;
 		supervisor.workers.set("first", firstWorker);
 		supervisor.workers.set("second", secondWorker);
+		const siblings = vi.fn(async () => []);
+		const list = vi.fn(async () => []);
 		Object.assign(supervisor, {
 			catalog: {
-				siblings: vi.fn(async () => []),
-				list: vi.fn(async () => []),
+				siblings,
+				list,
 			},
 		});
 		const client = { id: "client", attachedActiveSessionIds: new Set<string>() };
@@ -534,6 +538,8 @@ describe("daemon supervisor passive subagent topology", () => {
 		expect(secondWorker.client.request).not.toHaveBeenCalled();
 		releaseRename();
 		await expect(first).resolves.toMatchObject({ success: true });
+		expect(siblings).not.toHaveBeenCalled();
+		expect(list).toHaveBeenCalledWith(undefined, join(directory, "custom-sessions"));
 	});
 
 	it("serializes same-scope inactive renames across catalog validation and commit", async () => {
@@ -563,9 +569,10 @@ describe("daemon supervisor passive subagent topology", () => {
 			defaultSessionConfig: { agentDir: directory, cwd: directory },
 			descriptorDir: join(directory, "workers"),
 		}) as unknown as SupervisorInternals;
+		const siblings = vi.fn(async () => saved);
 		Object.assign(supervisor, {
 			catalog: {
-				siblings: vi.fn(async () => saved),
+				siblings,
 				rename,
 			},
 		});
@@ -575,6 +582,7 @@ describe("daemon supervisor passive subagent topology", () => {
 			type: "rename_saved_session",
 			sessionPath: firstPath,
 			name: "shared",
+			sessionDir: join(directory, "custom-sessions"),
 		});
 		await vi.waitFor(() => expect(rename).toHaveBeenCalledOnce());
 		await expect(
@@ -582,10 +590,12 @@ describe("daemon supervisor passive subagent topology", () => {
 				type: "rename_saved_session",
 				sessionPath: secondPath,
 				name: "shared",
+				sessionDir: join(directory, "custom-sessions"),
 			}),
 		).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
 		releaseRename();
 		await expect(first).resolves.toMatchObject({ success: true });
+		expect(siblings).toHaveBeenCalledWith(firstPath, join(directory, "custom-sessions"));
 	});
 
 	it("reserves named child creates by parent scope until worker launch completes", async () => {
@@ -642,6 +652,156 @@ describe("daemon supervisor passive subagent topology", () => {
 		).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
 		releaseLaunch();
 		await expect(first).resolves.toBe(launched);
+	});
+
+	it("authorizes live depth-two siblings through an artifact-resident parent across workers", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-artifact-family-reach-"));
+		tempDirs.push(directory);
+		const parentPath = join(directory, "parent.jsonl");
+		const parent = {
+			id: "artifact-parent",
+			path: parentPath,
+			cwd: directory,
+			created: new Date(0),
+			modified: new Date(0),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+			rlmDepth: 1,
+		};
+		const source = summary({
+			id: "source-active",
+			activeSessionId: "source-active",
+			sessionId: "source-session",
+			runtimeKind: "subagent",
+			rlmDepth: 2,
+			parentSessionId: parent.id,
+		});
+		const target = summary({
+			id: "target-active",
+			activeSessionId: "target-active",
+			sessionId: "target-session",
+			runtimeKind: "subagent",
+			rlmDepth: 2,
+			parentSessionId: parent.id,
+		});
+		const sourceWorker = worker("source", [source]);
+		const targetWorker = worker("target", [target]);
+		targetWorker.client.requestWorker.mockResolvedValue({
+			type: "response",
+			command: "worker_deliver_message",
+			success: true,
+		} as never);
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		supervisor.workers.set("source", sourceWorker);
+		supervisor.workers.set("target", targetWorker);
+		Object.assign(supervisor, { catalog: { list: vi.fn(async () => []), family: vi.fn(async () => [parent]) } });
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "client", attachedActiveSessionIds: new Set<string>() },
+				{
+					id: "message",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: source.activeSessionId,
+					targetActiveSessionId: target.activeSessionId,
+					message: "hello sibling",
+				},
+			),
+		).resolves.toMatchObject({ success: true });
+		expect(targetWorker.client.requestWorker).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "worker_deliver_message", targetActiveSessionId: target.activeSessionId }),
+			expect.any(Number),
+		);
+	});
+
+	it.each([
+		["missing", []],
+		[
+			"malformed",
+			[
+				{
+					id: "artifact-parent",
+					path: join(tmpdir(), "malformed.jsonl"),
+					cwd: "",
+					created: new Date(0),
+					modified: new Date(0),
+					messageCount: 0,
+					firstMessage: "",
+					allMessagesText: "",
+					rlmDepth: 0,
+				},
+			],
+		],
+		[
+			"conflicting",
+			[
+				{
+					id: "artifact-parent",
+					path: join(tmpdir(), "first-parent.jsonl"),
+					cwd: "",
+					created: new Date(0),
+					modified: new Date(0),
+					messageCount: 0,
+					firstMessage: "",
+					allMessagesText: "",
+					rlmDepth: 1,
+				},
+				{
+					id: "artifact-parent",
+					path: join(tmpdir(), "second-parent.jsonl"),
+					cwd: "",
+					created: new Date(0),
+					modified: new Date(0),
+					messageCount: 0,
+					firstMessage: "",
+					allMessagesText: "",
+					rlmDepth: 1,
+				},
+			],
+		],
+	] as const)("denies live depth-two siblings when the artifact parent is %s", async (_kind, parents) => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-artifact-family-deny-"));
+		tempDirs.push(directory);
+		const child = (id: string) =>
+			summary({
+				id: `${id}-active`,
+				activeSessionId: `${id}-active`,
+				sessionId: `${id}-session`,
+				runtimeKind: "subagent",
+				rlmDepth: 2,
+				parentSessionId: "artifact-parent",
+			});
+		const source = child("source");
+		const target = child("target");
+		const sourceWorker = worker("source", [source]);
+		const targetWorker = worker("target", [target]);
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		supervisor.workers.set("source", sourceWorker);
+		supervisor.workers.set("target", targetWorker);
+		Object.assign(supervisor, { catalog: { list: vi.fn(async () => []), family: vi.fn(async () => parents) } });
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "client", attachedActiveSessionIds: new Set<string>() },
+				{
+					id: "message",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: source.activeSessionId,
+					targetActiveSessionId: target.activeSessionId,
+					message: "hello sibling",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(targetWorker.client.requestWorker).not.toHaveBeenCalled();
 	});
 
 	it("retains passive worker summaries but syncs only roots to cross-worker peer maps", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
@@ -314,6 +314,180 @@ describe("daemon supervisor passive subagent topology", () => {
 		);
 	});
 
+	it("fails closed when a saved sibling catalog has conflicting identity or topology", () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-saved-sibling-conflict-"));
+		tempDirs.push(directory);
+		const parentSessionPath = join(directory, "parent.jsonl");
+		const base = {
+			cwd: directory,
+			created: new Date(0),
+			modified: new Date(0),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+			parentSessionPath,
+			rlmDepth: 1,
+		};
+		const target = { ...base, id: "target", path: join(directory, "target.jsonl") };
+		const sibling = { ...base, id: "sibling", path: join(directory, "sibling.jsonl"), name: "taken" };
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+
+		for (const conflictingSiblings of [
+			[target, { ...sibling, id: target.id }],
+			[target, { ...sibling, path: target.path }],
+			[target, { ...sibling, parentSessionPath: join(directory, "other-parent.jsonl") }],
+			[target, { ...sibling, rlmDepth: 2 }],
+		]) {
+			expect(() => supervisor.assertSavedSiblingNameAvailable(conflictingSiblings, target, "taken")).toThrow(
+				"Saved sibling catalog is structurally ambiguous",
+			);
+		}
+		expect(() => supervisor.assertSavedSiblingNameAvailable([sibling], target, "taken")).toThrow(
+			"Saved sibling catalog does not contain its target",
+		);
+	});
+
+	it("anchors saved sibling relative parents at their own session files", () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-relative-saved-siblings-"));
+		tempDirs.push(directory);
+		const base = {
+			cwd: directory,
+			created: new Date(0),
+			modified: new Date(0),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+			rlmDepth: 1,
+		};
+		const target = {
+			...base,
+			id: "target",
+			path: join(directory, "children", "target.jsonl"),
+			parentSessionPath: "../parent.jsonl",
+		};
+		const sibling = {
+			...base,
+			id: "sibling",
+			path: join(directory, "children", "nested", "sibling.jsonl"),
+			parentSessionPath: "../../parent.jsonl",
+			name: "taken",
+		};
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+
+		expect(() => supervisor.assertSavedSiblingNameAvailable([target, sibling], target, "available")).not.toThrow();
+		expect(() =>
+			supervisor.assertSavedSiblingNameAvailable(
+				[target, { ...sibling, parentSessionPath: "../other-parent.jsonl" }],
+				target,
+				"available",
+			),
+		).toThrow("Saved sibling catalog is structurally ambiguous");
+	});
+
+	it("uses one canonical saved-sibling reservation for equivalent relative parents during create", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-relative-saved-create-reservation-"));
+		tempDirs.push(directory);
+		const base = {
+			cwd: directory,
+			created: new Date(0),
+			modified: new Date(0),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+			rlmDepth: 1,
+		};
+		const firstPath = join(directory, "children", "first.jsonl");
+		const secondPath = join(directory, "children", "nested", "second.jsonl");
+		const siblings = [
+			{ ...base, id: "first", path: firstPath, parentSessionPath: "../parent.jsonl" },
+			{ ...base, id: "second", path: secondPath, parentSessionPath: "../../parent.jsonl" },
+		];
+		let releaseLaunch!: () => void;
+		const launchGate = new Promise<void>((resolve) => {
+			releaseLaunch = resolve;
+		});
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		const resident = worker("opened");
+		const launchWorker = vi.fn(async () => {
+			await launchGate;
+			return resident;
+		});
+		Object.assign(supervisor, {
+			catalog: { siblings: vi.fn(async () => siblings) },
+			launchWorker,
+		});
+
+		const first = supervisor.createOrReuseWorker("client", {
+			type: "create",
+			name: "shared",
+			sessionPath: firstPath,
+		});
+		await vi.waitFor(() => expect(launchWorker).toHaveBeenCalledOnce());
+		await expect(
+			supervisor.createOrReuseWorker("client", { type: "create", name: "shared", sessionPath: secondPath }),
+		).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
+		releaseLaunch();
+		await expect(first).resolves.toBe(resident);
+	});
+
+	it("uses one canonical saved-sibling reservation for equivalent relative parents during rename", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-relative-saved-rename-reservation-"));
+		tempDirs.push(directory);
+		const base = {
+			cwd: directory,
+			created: new Date(0),
+			modified: new Date(0),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+			rlmDepth: 1,
+		};
+		const firstPath = join(directory, "children", "first.jsonl");
+		const secondPath = join(directory, "children", "nested", "second.jsonl");
+		const siblings = [
+			{ ...base, id: "first", path: firstPath, parentSessionPath: "../parent.jsonl" },
+			{ ...base, id: "second", path: secondPath, parentSessionPath: "../../parent.jsonl" },
+		];
+		let releaseRename!: () => void;
+		const renameGate = new Promise<void>((resolve) => {
+			releaseRename = resolve;
+		});
+		const rename = vi.fn(async () => {
+			await renameGate;
+		});
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		Object.assign(supervisor, { catalog: { siblings: vi.fn(async () => siblings), rename } });
+		const client = { id: "client", attachedActiveSessionIds: new Set<string>() };
+
+		const first = supervisor.handleCommand(client, {
+			type: "rename_saved_session",
+			sessionPath: firstPath,
+			name: "shared",
+		});
+		await vi.waitFor(() => expect(rename).toHaveBeenCalledOnce());
+		await expect(
+			supervisor.handleCommand(client, {
+				type: "rename_saved_session",
+				sessionPath: secondPath,
+				name: "shared",
+			}),
+		).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
+		releaseRename();
+		await expect(first).resolves.toMatchObject({ success: true });
+	});
+
 	it("publishes an opening reservation before named create validation awaits", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-named-create-race-"));
 		tempDirs.push(directory);

--- a/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
@@ -488,6 +488,105 @@ describe("daemon supervisor passive subagent topology", () => {
 		await expect(first).resolves.toMatchObject({ success: true });
 	});
 
+	it("shares the active and saved sibling scope reservation across differently located children", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-active-saved-scope-reservation-"));
+		tempDirs.push(directory);
+		const activePath = join(directory, "children", "active.jsonl");
+		const savedPath = join(directory, "children", "nested", "saved.jsonl");
+		const active = summary({
+			id: "active-id",
+			sessionId: "active-id",
+			sessionFile: activePath,
+			parentSessionPath: "../parent.jsonl",
+			rlmDepth: 1,
+		});
+		const base = {
+			cwd: directory,
+			created: new Date(0),
+			modified: new Date(0),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+			rlmDepth: 1,
+		};
+		const saved = { ...base, id: "saved-id", path: savedPath, parentSessionPath: "../../parent.jsonl" };
+		let releaseRename!: () => void;
+		let signalRename!: () => void;
+		const renameGate = new Promise<void>((resolve) => {
+			releaseRename = resolve;
+		});
+		const renameStarted = new Promise<void>((resolve) => {
+			signalRename = resolve;
+		});
+		const rename = vi.fn(async () => {
+			signalRename();
+			await renameGate;
+		});
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		Object.assign(supervisor, {
+			workers: new Map([["active", worker("active", [active])]]),
+			catalog: { siblings: vi.fn(async () => [saved]), list: vi.fn(async () => [saved]), rename },
+		});
+		const client = { id: "client", attachedActiveSessionIds: new Set<string>() };
+
+		const activeRename = supervisor.handleCommand(client, {
+			type: "rename_saved_session",
+			sessionPath: activePath,
+			name: "shared",
+		});
+		await renameStarted;
+		await expect(
+			supervisor.handleCommand(client, { type: "rename_saved_session", sessionPath: savedPath, name: "shared" }),
+		).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
+		expect(rename).toHaveBeenCalledOnce();
+		releaseRename();
+		await expect(activeRename).resolves.toMatchObject({ success: true });
+	});
+
+	it("fails closed before mutation for an active nonroot relative parent without a session file", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-unanchored-active-parent-"));
+		tempDirs.push(directory);
+		const sessionPath = join(directory, "child.jsonl");
+		const unanchored = summary({
+			id: "unanchored-id",
+			sessionId: "unanchored-id",
+			parentSessionPath: "../parent.jsonl",
+			rlmDepth: 1,
+		});
+		const saved = {
+			id: "saved-id",
+			path: sessionPath,
+			cwd: directory,
+			created: new Date(0),
+			modified: new Date(0),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+			rlmDepth: 0,
+		};
+		const rename = vi.fn();
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		Object.assign(supervisor, {
+			workers: new Map([["unanchored", worker("unanchored", [unanchored])]]),
+			catalog: { siblings: vi.fn(async () => [saved]), list: vi.fn(async () => [saved]), rename },
+		});
+		const client = { id: "client", attachedActiveSessionIds: new Set<string>() };
+
+		await expect(
+			supervisor.handleCommand(client, { type: "rename_saved_session", sessionPath, name: "blocked" }),
+		).rejects.toThrow("Non-root session has an unanchored relative parent path");
+		expect(rename).not.toHaveBeenCalled();
+		expect(() => supervisor.familyCatalogEntry(unanchored)).toThrow(
+			"Non-root session has an unanchored relative parent path",
+		);
+	});
+
 	it("publishes an opening reservation before named create validation awaits", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-named-create-race-"));
 		tempDirs.push(directory);

--- a/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
@@ -546,6 +546,48 @@ describe("daemon supervisor passive subagent topology", () => {
 		await expect(activeRename).resolves.toMatchObject({ success: true });
 	});
 
+	it("blocks a saved-child launch when an active sibling occupies its canonical scope", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-active-saved-create-availability-"));
+		tempDirs.push(directory);
+		const activePath = join(directory, "children", "active.jsonl");
+		const savedPath = join(directory, "children", "nested", "saved.jsonl");
+		const active = summary({
+			id: "active-id",
+			sessionId: "active-id",
+			sessionName: "shared",
+			sessionFile: activePath,
+			parentSessionPath: "../parent.jsonl",
+			rlmDepth: 1,
+		});
+		const saved = {
+			id: "saved-id",
+			path: savedPath,
+			cwd: directory,
+			created: new Date(0),
+			modified: new Date(0),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+			rlmDepth: 1,
+			parentSessionPath: "../../parent.jsonl",
+		};
+		const launchWorker = vi.fn();
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		Object.assign(supervisor, {
+			workers: new Map([["active", worker("active", [active])]]),
+			catalog: { siblings: vi.fn(async () => [saved]), list: vi.fn(async () => [saved]) },
+			launchWorker,
+		});
+
+		await expect(
+			supervisor.createOrReuseWorker("client", { type: "create", name: "shared", sessionPath: savedPath }),
+		).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
+		expect(launchWorker).not.toHaveBeenCalled();
+	});
+
 	it("fails closed before mutation for an active nonroot relative parent without a session file", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-unanchored-active-parent-"));
 		tempDirs.push(directory);

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1464,10 +1464,7 @@ describe("daemon worker supervisor monitoring", () => {
 				lifecycle: "ready" as const,
 			},
 			summaries: new Map<string, SessionSummary>([
-				[
-					"root-active",
-					{ id: "root-active", sessionId: "root-session", activeSessionId: "root-active" } as SessionSummary,
-				],
+				["root-active", { id: "root-active", sessionId: "root-session", activeSessionId: "root-active" } as SessionSummary],
 			]),
 			snapshotCache: new Map(),
 			transcriptCaches: new Map(),
@@ -1515,16 +1512,13 @@ describe("daemon worker supervisor monitoring", () => {
 		}) as {
 			workers: typeof workers;
 			workerStopCounts: Map<typeof worker, number>;
-			handleCommand(
-				client: DaemonSocketClient,
-				command: { type: "kill"; activeSessionId: string },
-			): Promise<unknown>;
+			handleCommand(client: DaemonSocketClient, command: { type: "kill"; activeSessionId: string }): Promise<unknown>;
 			handleWorkerFrame(target: typeof worker, frame: PrivateFrame<DaemonWorkerFrameHeader>): void;
 		};
 
-		await expect(
-			supervisor.handleCommand({} as DaemonSocketClient, { type: "kill", activeSessionId: "root-active" }),
-		).resolves.toEqual(success(undefined, "kill"));
+		await expect(supervisor.handleCommand({} as DaemonSocketClient, { type: "kill", activeSessionId: "root-active" })).resolves.toEqual(
+			success(undefined, "kill"),
+		);
 		expect(stopWorkerUntracked).toHaveBeenCalledWith(worker, true, false, true, false, undefined);
 		expect(workers.has(worker.descriptor.workerId)).toBe(false);
 		expect(deleteWorkerDescriptor).toHaveBeenCalledWith(worker);

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+import { DAEMON_SUPERVISOR_REGISTRY_DIR_ENV } from "../src/modes/daemon/daemon-supervisor-ownership.js";
 import {
 	DAEMON_WORKER_STARTUP_GATE_COMMIT,
 	DAEMON_WORKER_SUPERVISOR_SOCKET_ENV,
@@ -38,7 +39,7 @@ const workerLaunchTestState = vi.hoisted(() => ({
 	gateMarkerPath: "",
 	tsxCliPath: "",
 	cliEntrypoint: "",
-	spawned: [] as Array<{ child: ChildProcess; args: readonly string[] }>,
+	spawned: [] as Array<{ child: ChildProcess; args: readonly string[]; env: NodeJS.ProcessEnv | undefined }>,
 }));
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -50,7 +51,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 		spawn(command: string, args: readonly string[], options: SpawnOptions): ChildProcess {
 			const child = actual.spawn(command, args, options);
 			if (workerLaunchTestState.capture) {
-				workerLaunchTestState.spawned.push({ child, args });
+				workerLaunchTestState.spawned.push({ child, args, env: options.env });
 			}
 			return child;
 		},
@@ -114,7 +115,7 @@ vi.mock("../src/core/session-lease.js", async (importOriginal) => {
 	};
 });
 
-const supervisorRegistryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+const supervisorRegistryDirEnv = DAEMON_SUPERVISOR_REGISTRY_DIR_ENV;
 const previousSupervisorRegistryDir = process.env[supervisorRegistryDirEnv];
 const supervisorRegistryDirs = new Set<string>();
 
@@ -640,7 +641,9 @@ describe("daemon worker supervisor monitoring", () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-committed-gate-test-"));
 		const descriptorDir = join(root, "descriptors");
 		const markerPath = join(root, "startup-marker");
+		const registryDir = join(root, "isolated-supervisor-registry");
 		mkdirSync(descriptorDir, { recursive: true });
+		mkdirSync(registryDir, { recursive: true });
 		supervisorRegistryDirs.add(root);
 		workerLaunchTestState.capture = true;
 		workerLaunchTestState.forceMissingProcessStartId = true;
@@ -665,6 +668,7 @@ describe("daemon worker supervisor monitoring", () => {
 			...createSupervisorSnapshotState(),
 			defaultSessionConfig: { cwd: root, agentDir: root },
 			descriptorDir,
+			supervisorRegistryDir: registryDir,
 			socketPath: join(root, "supervisor.sock"),
 			workers,
 			shuttingDown: false,
@@ -675,16 +679,37 @@ describe("daemon worker supervisor monitoring", () => {
 			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
-			launchWorker(command: {
-				type: "create";
-				config: { cwd: string; agentDir: string };
-			}): Promise<{ descriptor: { lifecycle: string } }>;
+			launchWorker(
+				command: { type: "create"; config: { cwd: string; agentDir: string }; launchEnv?: Record<string, string> },
+				existing?: {
+					descriptor: {
+						lifecycle: string;
+						createCommand: { type: "create"; config: { cwd: string; agentDir: string } };
+						launchEnv?: Record<string, string>;
+					};
+				},
+			): Promise<{
+				descriptor: {
+					lifecycle: string;
+					createCommand: { type: "create"; config: { cwd: string; agentDir: string } };
+					launchEnv?: Record<string, string>;
+				};
+			}>;
 		};
 
-		const worker = await supervisor.launchWorker({ type: "create", config: { cwd: root, agentDir: root } });
+		const worker = await supervisor.launchWorker({
+			type: "create",
+			config: { cwd: root, agentDir: root },
+			launchEnv: { [DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]: join(root, "untrusted-registry") },
+		});
+		await supervisor.launchWorker(worker.descriptor.createCommand, worker);
 
+		expect(
+			workerLaunchTestState.spawned.slice(-2).map(({ env }) => env?.[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]),
+		).toEqual([registryDir, registryDir]);
 		expect(readFileSync(markerPath, "utf8")).toBe("start\n");
-		expect(connectWorker).toHaveBeenCalledOnce();
+		expect(worker.descriptor.launchEnv?.[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]).toBeUndefined();
+		expect(connectWorker).toHaveBeenCalledTimes(2);
 		expect(worker.descriptor.lifecycle).toBe("ready");
 		expect(workers.size).toBe(1);
 		expect(readdirSync(descriptorDir).filter((name) => name.endsWith(".json"))).toHaveLength(1);

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -1464,7 +1464,10 @@ describe("daemon worker supervisor monitoring", () => {
 				lifecycle: "ready" as const,
 			},
 			summaries: new Map<string, SessionSummary>([
-				["root-active", { id: "root-active", sessionId: "root-session", activeSessionId: "root-active" } as SessionSummary],
+				[
+					"root-active",
+					{ id: "root-active", sessionId: "root-session", activeSessionId: "root-active" } as SessionSummary,
+				],
 			]),
 			snapshotCache: new Map(),
 			transcriptCaches: new Map(),
@@ -1512,13 +1515,16 @@ describe("daemon worker supervisor monitoring", () => {
 		}) as {
 			workers: typeof workers;
 			workerStopCounts: Map<typeof worker, number>;
-			handleCommand(client: DaemonSocketClient, command: { type: "kill"; activeSessionId: string }): Promise<unknown>;
+			handleCommand(
+				client: DaemonSocketClient,
+				command: { type: "kill"; activeSessionId: string },
+			): Promise<unknown>;
 			handleWorkerFrame(target: typeof worker, frame: PrivateFrame<DaemonWorkerFrameHeader>): void;
 		};
 
-		await expect(supervisor.handleCommand({} as DaemonSocketClient, { type: "kill", activeSessionId: "root-active" })).resolves.toEqual(
-			success(undefined, "kill"),
-		);
+		await expect(
+			supervisor.handleCommand({} as DaemonSocketClient, { type: "kill", activeSessionId: "root-active" }),
+		).resolves.toEqual(success(undefined, "kill"));
 		expect(stopWorkerUntracked).toHaveBeenCalledWith(worker, true, false, true, false, undefined);
 		expect(workers.has(worker.descriptor.workerId)).toBe(false);
 		expect(deleteWorkerDescriptor).toHaveBeenCalledWith(worker);

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -312,8 +312,8 @@ describe("daemon supervisor resident workers", () => {
 			if (!sessionFile) throw new Error("Missing child fixture path");
 			return { childId, sessionName, childSessionDir, manager, sessionFile };
 		};
-		const child = makeChild("passive-child", "passive-child-worker", 2);
-		const createChild = makeChild("passive-create-child", "passive-create-worker", 3);
+		const child = makeChild("sub-a1b2c3d4", "passive-child-worker", 2);
+		const createChild = makeChild("sub-e5f6a7b8", "passive-create-worker", 3);
 		writeFileSync(
 			join(parentArtifactDir, "rlm-subagents.jsonl"),
 			`${[child, createChild]

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -324,6 +324,7 @@ describe("daemon supervisor resident workers", () => {
 						sessionName: fixture.sessionName,
 						sessionDir: fixture.childSessionDir,
 						sessionFile: fixture.sessionFile,
+						sessionId: fixture.manager.getSessionId(),
 						parentSessionId: parentManager.getSessionId(),
 						parentSessionFile,
 						rlmDepth: 1,

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import {
-	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
 	type HostRequestHandler,
@@ -72,7 +71,7 @@ export function createTestHostHandlers<
 >(handlers: T): Record<keyof T, HostRequestHandler> {
 	return Object.fromEntries(
 		Object.entries(handlers).map(([type, implementation]) => {
-			const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+			const handler = createHostRequestHandler(implementation);
 			testHostHandlerImplementations.set(handler, implementation);
 			return [type, handler];
 		}),

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
 	createHostRequestHandler,
 	type HostRequestContext,
@@ -23,8 +22,6 @@ export async function invokeHostRequestHandlerForTest(
 	}
 	const controller = new AbortController();
 	const context: HostRequestContext = {
-		requestId: randomUUID(),
-		generation: 0,
 		signal: controller.signal,
 		isCurrent: () => !controller.signal.aborted,
 	};

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -1,20 +1,72 @@
+import { randomUUID } from "node:crypto";
 import {
 	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
 	type HostRequestHandlerImplementation,
-	invokeHostRequestHandlerForTest,
+	KernelManager,
 } from "../src/core/kernel/index.js";
 
-/** Invoke only through a dispatcher-minted context; fixtures cannot fabricate one. */
-export function invokeHostRequest(
+/** Raw implementations are retained only for test-created business-unit fixtures. */
+const testHostHandlerImplementations = new WeakMap<
+	HostRequestHandlerImplementation,
+	HostRequestHandlerImplementation
+>();
+
+/**
+ * Calls a raw test fixture with synthetic context. This deliberately bypasses the
+ * production wrapper and never registers context identity with production authority.
+ */
+export async function invokeHostRequestHandlerForTest(
 	handler: HostRequestHandlerImplementation,
 	payload: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-	return invokeHostRequestHandlerForTest(handler, payload);
+	const implementation = testHostHandlerImplementations.get(handler);
+	if (!implementation) {
+		throw new Error("host request handler has no test-local raw implementation");
+	}
+	const controller = new AbortController();
+	const context: HostRequestContext = {
+		requestId: randomUUID(),
+		generation: 0,
+		signal: controller.signal,
+		isCurrent: () => !controller.signal.aborted,
+	};
+	try {
+		return await implementation(payload, context);
+	} finally {
+		controller.abort();
+	}
 }
 
-/** Build factory-minted handlers for integration tests. Context identity is host-private. */
+/**
+ * Exercises a production capability only through the KernelManager's private
+ * dispatcher, preserving its authority and revocation boundary in integration tests.
+ */
+export async function invokeHostRequestThroughKernelForTest(
+	handler: HostRequestHandlerImplementation,
+	payload: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+	const replies: Record<string, unknown>[] = [];
+	const internals = manager as unknown as {
+		startHostRequestFromComm: (commId: string, data: unknown) => void;
+		sendCommMessage: (commId: string, data: Record<string, unknown>) => Promise<void>;
+		inFlightHostRequests: Set<Promise<void>>;
+	};
+	internals.sendCommMessage = async (_commId, data) => {
+		replies.push(data);
+	};
+	internals.startHostRequestFromComm("test-host-request", { type: "test", ...payload });
+	await Promise.allSettled([...internals.inFlightHostRequests]);
+	const reply = replies[0];
+	if (!reply) throw new Error("test host request did not produce a reply");
+	if (reply.status === "error") throw new Error(String(reply.error));
+	const { status: _status, ...result } = reply;
+	return result;
+}
+
+/** Build factory-minted handlers for test fixtures while retaining raw implementations locally. */
 export function createTestHostHandlers<
 	T extends Record<
 		string,
@@ -22,9 +74,10 @@ export function createTestHostHandlers<
 	>,
 >(handlers: T): Record<keyof T, HostRequestHandlerImplementation> {
 	return Object.fromEntries(
-		Object.entries(handlers).map(([type, handler]) => [
-			type,
-			createHostRequestHandler(handler, contextAwareHostRequestHandler),
-		]),
+		Object.entries(handlers).map(([type, implementation]) => {
+			const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+			testHostHandlerImplementations.set(handler, implementation);
+			return [type, handler];
+		}),
 	) as unknown as Record<keyof T, HostRequestHandlerImplementation>;
 }

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -1,32 +1,20 @@
 import {
+	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
 	type HostRequestHandlerImplementation,
+	invokeHostRequestHandlerForTest,
 } from "../src/core/kernel/index.js";
 
-let nextSyntheticHostRequestId = 0;
-
-/** Create a distinct, current dispatcher context for direct host-handler tests. */
-export function createSyntheticHostRequestContext(): HostRequestContext {
-	const requestNumber = ++nextSyntheticHostRequestId;
-	const controller = new AbortController();
-	return {
-		requestId: `test-host-request-${requestNumber}`,
-		generation: requestNumber,
-		signal: controller.signal,
-		isCurrent: () => !controller.signal.aborted,
-	};
-}
-
-/** Invoke a production-shaped handler with a synthetic dispatcher context. */
+/** Invoke only through a dispatcher-minted context; fixtures cannot fabricate one. */
 export function invokeHostRequest(
 	handler: HostRequestHandlerImplementation,
 	payload: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-	return handler(payload, createSyntheticHostRequestContext());
+	return invokeHostRequestHandlerForTest(handler, payload);
 }
 
-/** Build staged context-aware fixture handlers through the production factory. */
+/** Build factory-minted handlers for integration tests. Context identity is host-private. */
 export function createTestHostHandlers<
 	T extends Record<
 		string,
@@ -34,6 +22,9 @@ export function createTestHostHandlers<
 	>,
 >(handlers: T): Record<keyof T, HostRequestHandlerImplementation> {
 	return Object.fromEntries(
-		Object.entries(handlers).map(([type, handler]) => [type, createHostRequestHandler(handler)]),
+		Object.entries(handlers).map(([type, handler]) => [
+			type,
+			createHostRequestHandler(handler, contextAwareHostRequestHandler),
+		]),
 	) as unknown as Record<keyof T, HostRequestHandlerImplementation>;
 }

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -3,22 +3,19 @@ import {
 	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
-	type HostRequestHandlerImplementation,
+	type HostRequestHandler,
 	KernelManager,
 } from "../src/core/kernel/index.js";
 
 /** Raw implementations are retained only for test-created business-unit fixtures. */
-const testHostHandlerImplementations = new WeakMap<
-	HostRequestHandlerImplementation,
-	HostRequestHandlerImplementation
->();
+const testHostHandlerImplementations = new WeakMap<HostRequestHandler, HostRequestHandler>();
 
 /**
  * Calls a raw test fixture with synthetic context. This deliberately bypasses the
  * production wrapper and never registers context identity with production authority.
  */
 export async function invokeHostRequestHandlerForTest(
-	handler: HostRequestHandlerImplementation,
+	handler: HostRequestHandler,
 	payload: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
 	const implementation = testHostHandlerImplementations.get(handler);
@@ -44,7 +41,7 @@ export async function invokeHostRequestHandlerForTest(
  * dispatcher, preserving its authority and revocation boundary in integration tests.
  */
 export async function invokeHostRequestThroughKernelForTest(
-	handler: HostRequestHandlerImplementation,
+	handler: HostRequestHandler,
 	payload: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
 	const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
@@ -72,12 +69,12 @@ export function createTestHostHandlers<
 		string,
 		(payload: Record<string, unknown>, context: HostRequestContext) => Promise<Record<string, unknown>>
 	>,
->(handlers: T): Record<keyof T, HostRequestHandlerImplementation> {
+>(handlers: T): Record<keyof T, HostRequestHandler> {
 	return Object.fromEntries(
 		Object.entries(handlers).map(([type, implementation]) => {
 			const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
 			testHostHandlerImplementations.set(handler, implementation);
 			return [type, handler];
 		}),
-	) as unknown as Record<keyof T, HostRequestHandlerImplementation>;
+	) as unknown as Record<keyof T, HostRequestHandler>;
 }

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -5,7 +5,7 @@ import {
 	KernelManager,
 } from "../src/core/kernel/index.js";
 
-/** Raw implementations are retained only for test-created business-unit fixtures. */
+/** Raw implementations retained per fixture so tests can call them without dispatcher authority. */
 const testHostHandlerImplementations = new WeakMap<HostRequestHandler, HostRequestHandler>();
 
 /**

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -21,10 +21,7 @@ export async function invokeHostRequestHandlerForTest(
 		throw new Error("host request handler has no test-local raw implementation");
 	}
 	const controller = new AbortController();
-	const context: HostRequestContext = {
-		signal: controller.signal,
-		isCurrent: () => !controller.signal.aborted,
-	};
+	const context: HostRequestContext = { signal: controller.signal };
 	try {
 		return await implementation(payload, context);
 	} finally {

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -55,10 +55,7 @@ describe("staged host-request handler authority", () => {
 			calls += 1;
 			return {};
 		});
-		const fabricated = {
-			signal: new AbortController().signal,
-			isCurrent: () => true,
-		};
+		const fabricated = { signal: new AbortController().signal };
 		await expect(handler({ context: fabricated }, fabricated)).rejects.toThrow("host request context is invalid");
 		expect(calls).toBe(0);
 	});

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -23,15 +23,12 @@ describe("staged host-request handler authority", () => {
 		expect(calls).toBe(1);
 	});
 
-	it("rejects copied-symbol forgeries through WeakSet provenance before they run", () => {
-		const genuine = createHostRequestHandler(async (_payload, _context) => ({}));
+	it("rejects handlers that were not minted by the factory", () => {
 		let calls = 0;
 		const forged = async (): Promise<Record<string, unknown>> => {
 			calls += 1;
 			return {};
 		};
-		const brand = Object.getOwnPropertySymbols(genuine)[0];
-		Object.defineProperty(forged, brand, Object.getOwnPropertyDescriptor(genuine, brand)!);
 
 		expect(() => assertHostRequestHandler(forged)).toThrow(
 			"host request handler is not a dispatcher-created capability",

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
 	assertHostRequestHandler,
+	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
+	invokeHostRequestHandlerForTest,
 } from "../src/core/kernel/index.js";
 
 describe("staged host-request handler authority", () => {
@@ -14,9 +16,9 @@ describe("staged host-request handler authority", () => {
 		};
 
 		expect(() => {
-			// @ts-expect-error Staged handlers must accept dispatcher context as their second argument.
+			// @ts-expect-error Context-aware registration needs an explicit marker.
 			createHostRequestHandler(unary);
-		}).toThrow("host request handlers must accept payload and context");
+		}).toThrow("host request handlers require the context-aware marker");
 		expect(calls).toBe(0);
 	});
 
@@ -25,17 +27,17 @@ describe("staged host-request handler authority", () => {
 		const handler = createHostRequestHandler(async (_payload, _context) => {
 			calls += 1;
 			return {};
-		});
+		}, contextAwareHostRequestHandler);
 
 		assertHostRequestHandler(handler);
-		// @ts-expect-error A staged handler cannot be invoked without dispatcher context.
 		await expect(handler({})).rejects.toThrow("host request context is invalid");
 		await expect(handler({}, {} as HostRequestContext)).rejects.toThrow("host request context is invalid");
-		expect(calls).toBe(0);
+		await expect(invokeHostRequestHandlerForTest(handler, {})).resolves.toEqual({});
+		expect(calls).toBe(1);
 	});
 
 	it("rejects copied-symbol forgeries through WeakSet provenance before they run", () => {
-		const genuine = createHostRequestHandler(async (_payload, _context) => ({}));
+		const genuine = createHostRequestHandler(async (_payload, _context) => ({}), contextAwareHostRequestHandler);
 		let calls = 0;
 		const forged = async (): Promise<Record<string, unknown>> => {
 			calls += 1;
@@ -47,6 +49,39 @@ describe("staged host-request handler authority", () => {
 		expect(() => assertHostRequestHandler(forged)).toThrow(
 			"host request handler is not a dispatcher-created capability",
 		);
+		expect(calls).toBe(0);
+	});
+
+	it("uses explicit marker rather than implementation length for rest and default handlers", async () => {
+		const rest = createHostRequestHandler(
+			async (...args: [Record<string, unknown>, HostRequestContext]) => ({
+				requestId: args[1].requestId,
+			}),
+			contextAwareHostRequestHandler,
+		);
+		const defaulted = createHostRequestHandler(
+			async (_payload, context = undefined as unknown as HostRequestContext) => ({
+				generation: context.generation,
+			}),
+			contextAwareHostRequestHandler,
+		);
+		expect((await invokeHostRequestHandlerForTest(rest, {})).requestId).toEqual(expect.any(String));
+		expect((await invokeHostRequestHandlerForTest(defaulted, {})).generation).toBe(0);
+	});
+
+	it("does not accept a structural or payload-supplied context", async () => {
+		let calls = 0;
+		const handler = createHostRequestHandler(async (_payload, _context) => {
+			calls += 1;
+			return {};
+		}, contextAwareHostRequestHandler);
+		const fabricated = {
+			requestId: "python",
+			generation: 1,
+			signal: new AbortController().signal,
+			isCurrent: () => true,
+		};
+		await expect(handler({ context: fabricated }, fabricated)).rejects.toThrow("host request context is invalid");
 		expect(calls).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -4,8 +4,8 @@ import {
 	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
-	invokeHostRequestHandlerForTest,
 } from "../src/core/kernel/index.js";
+import { invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest } from "./host-request-context.js";
 
 describe("staged host-request handler authority", () => {
 	it("rejects unary factory inputs before they run", () => {
@@ -30,7 +30,9 @@ describe("staged host-request handler authority", () => {
 		}, contextAwareHostRequestHandler);
 
 		assertHostRequestHandler(handler);
-		await expect(handler({})).rejects.toThrow("host request context is invalid");
+		await expect(handler({}, undefined as unknown as HostRequestContext)).rejects.toThrow(
+			"host request context is invalid",
+		);
 		await expect(handler({}, {} as HostRequestContext)).rejects.toThrow("host request context is invalid");
 		await expect(invokeHostRequestHandlerForTest(handler, {})).resolves.toEqual({});
 		expect(calls).toBe(1);
@@ -66,7 +68,7 @@ describe("staged host-request handler authority", () => {
 			contextAwareHostRequestHandler,
 		);
 		expect((await invokeHostRequestHandlerForTest(rest, {})).requestId).toEqual(expect.any(String));
-		expect((await invokeHostRequestHandlerForTest(defaulted, {})).generation).toBe(0);
+		expect((await invokeHostRequestHandlerForTest(defaulted, {})).generation).toBe(1);
 	});
 
 	it("does not accept a structural or payload-supplied context", async () => {

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -1,33 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
 	assertHostRequestHandler,
-	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
 } from "../src/core/kernel/index.js";
 import { invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest } from "./host-request-context.js";
 
 describe("staged host-request handler authority", () => {
-	it("rejects unary factory inputs before they run", () => {
-		let calls = 0;
-		const unary = async (_payload: Record<string, unknown>): Promise<Record<string, unknown>> => {
-			calls += 1;
-			return {};
-		};
-
-		expect(() => {
-			// @ts-expect-error Context-aware registration needs an explicit marker.
-			createHostRequestHandler(unary);
-		}).toThrow("host request handlers require the context-aware marker");
-		expect(calls).toBe(0);
-	});
-
 	it("rejects missing or invalid context before a genuine handler runs", async () => {
 		let calls = 0;
 		const handler = createHostRequestHandler(async (_payload, _context) => {
 			calls += 1;
 			return {};
-		}, contextAwareHostRequestHandler);
+		});
 
 		assertHostRequestHandler(handler);
 		await expect(handler({}, undefined as unknown as HostRequestContext)).rejects.toThrow(
@@ -39,7 +24,7 @@ describe("staged host-request handler authority", () => {
 	});
 
 	it("rejects copied-symbol forgeries through WeakSet provenance before they run", () => {
-		const genuine = createHostRequestHandler(async (_payload, _context) => ({}), contextAwareHostRequestHandler);
+		const genuine = createHostRequestHandler(async (_payload, _context) => ({}));
 		let calls = 0;
 		const forged = async (): Promise<Record<string, unknown>> => {
 			calls += 1;
@@ -54,18 +39,14 @@ describe("staged host-request handler authority", () => {
 		expect(calls).toBe(0);
 	});
 
-	it("uses explicit marker rather than implementation length for rest and default handlers", async () => {
-		const rest = createHostRequestHandler(
-			async (...args: [Record<string, unknown>, HostRequestContext]) => ({
-				requestId: args[1].requestId,
-			}),
-			contextAwareHostRequestHandler,
-		);
+	it("passes dispatcher context to rest and default-parameter handlers", async () => {
+		const rest = createHostRequestHandler(async (...args: [Record<string, unknown>, HostRequestContext]) => ({
+			requestId: args[1].requestId,
+		}));
 		const defaulted = createHostRequestHandler(
 			async (_payload, context = undefined as unknown as HostRequestContext) => ({
 				generation: context.generation,
 			}),
-			contextAwareHostRequestHandler,
 		);
 		expect((await invokeHostRequestHandlerForTest(rest, {})).requestId).toEqual(expect.any(String));
 		expect((await invokeHostRequestHandlerForTest(defaulted, {})).generation).toBe(1);
@@ -76,7 +57,7 @@ describe("staged host-request handler authority", () => {
 		const handler = createHostRequestHandler(async (_payload, _context) => {
 			calls += 1;
 			return {};
-		}, contextAwareHostRequestHandler);
+		});
 		const fabricated = {
 			requestId: "python",
 			generation: 1,

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../src/core/kernel/index.js";
 import { invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest } from "./host-request-context.js";
 
-describe("staged host-request handler authority", () => {
+describe("host-request handler authority", () => {
 	it("rejects missing or invalid context before a genuine handler runs", async () => {
 		let calls = 0;
 		const handler = createHostRequestHandler(async (_payload, _context) => {

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -41,15 +41,15 @@ describe("staged host-request handler authority", () => {
 
 	it("passes dispatcher context to rest and default-parameter handlers", async () => {
 		const rest = createHostRequestHandler(async (...args: [Record<string, unknown>, HostRequestContext]) => ({
-			requestId: args[1].requestId,
+			aborted: args[1].signal.aborted,
 		}));
 		const defaulted = createHostRequestHandler(
 			async (_payload, context = undefined as unknown as HostRequestContext) => ({
-				generation: context.generation,
+				aborted: context.signal.aborted,
 			}),
 		);
-		expect((await invokeHostRequestHandlerForTest(rest, {})).requestId).toEqual(expect.any(String));
-		expect((await invokeHostRequestHandlerForTest(defaulted, {})).generation).toBe(1);
+		expect((await invokeHostRequestHandlerForTest(rest, {})).aborted).toBe(false);
+		expect((await invokeHostRequestHandlerForTest(defaulted, {})).aborted).toBe(false);
 	});
 
 	it("does not accept a structural or payload-supplied context", async () => {
@@ -59,8 +59,6 @@ describe("staged host-request handler authority", () => {
 			return {};
 		});
 		const fabricated = {
-			requestId: "python",
-			generation: 1,
 			signal: new AbortController().signal,
 			isCurrent: () => true,
 		};

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	AGENT_MESSAGE_DISPLAY_MIME,
-	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
 	KernelManager,
@@ -263,7 +262,7 @@ describe("KernelManager abort handling", () => {
 			capturedContext = context;
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			state: "running";
@@ -300,7 +299,7 @@ describe("KernelManager abort handling", () => {
 			});
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			state: "running";
@@ -338,7 +337,7 @@ describe("KernelManager abort handling", () => {
 				resolveHandler = resolve;
 			});
 			return { current: context.isCurrent() };
-		}, contextAwareHostRequestHandler);
+		});
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sent: Record<string, unknown>[] = [];
 		const internals = manager as unknown as {
@@ -386,7 +385,7 @@ describe("KernelManager abort handling", () => {
 				throw new Error("first request failed after close");
 			}
 			return { request: "second" };
-		}, contextAwareHostRequestHandler);
+		});
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sent: Record<string, unknown>[] = [];
 		const internals = manager as unknown as {
@@ -423,7 +422,7 @@ describe("KernelManager abort handling", () => {
 	it("sends one error reply when a current host request throws", async () => {
 		const handler = createHostRequestHandler(async () => {
 			throw new Error("handler failed");
-		}, contextAwareHostRequestHandler);
+		});
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sent: Record<string, unknown>[] = [];
 		const internals = manager as unknown as {
@@ -451,7 +450,7 @@ describe("KernelManager abort handling", () => {
 
 	it("does not report handler failure or send an error reply when the ok reply fails", async () => {
 		const implementation = vi.fn(async () => ({ completed: true }));
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sendCommMessage = vi.fn(async () => {
 			throw new Error("reply send failed");
@@ -499,7 +498,7 @@ describe("KernelManager abort handling", () => {
 			});
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			state: "running";
@@ -560,7 +559,7 @@ describe("KernelManager abort handling", () => {
 			});
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			state: "running";
@@ -615,7 +614,7 @@ describe("KernelManager abort handling", () => {
 			capturedContext = context;
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			hostRequestsClosed: boolean;

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -3,6 +3,7 @@ import {
 	AGENT_MESSAGE_DISPLAY_MIME,
 	contextAwareHostRequestHandler,
 	createHostRequestHandler,
+	type HostRequestContext,
 	KernelManager,
 	type KernelSentAgentMessage,
 } from "../src/core/kernel/index.js";
@@ -254,6 +255,78 @@ describe("KernelManager abort handling", () => {
 
 		await expect(executePromise).resolves.toMatchObject({ status: "aborted" });
 		expect(controlSend).toHaveBeenCalled();
+	});
+
+	it("revokes a settled host-request context before a retained wrapper can replay it", async () => {
+		let capturedContext: HostRequestContext | undefined;
+		const implementation = vi.fn(async (_payload: Record<string, unknown>, context: HostRequestContext) => {
+			capturedContext = context;
+			return { ok: true };
+		});
+		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const internals = manager as unknown as {
+			state: "running";
+			connection: { key: string };
+			shell: { send: () => Promise<void>; close: () => void };
+			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
+			sendCommMessage: (_commId: string, data: Record<string, unknown>) => Promise<void>;
+			inFlightHostRequests: Set<Promise<void>>;
+		};
+		internals.state = "running";
+		internals.connection = { key: "test" };
+		internals.shell = { send: async () => {}, close: () => {} };
+		internals.sendCommMessage = async () => {};
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "request", target_name: "host.request", data: { type: "test" } },
+		});
+		await vi.waitFor(() => expect(capturedContext).toBeDefined());
+		await Promise.allSettled([...internals.inFlightHostRequests]);
+		expect(capturedContext?.signal.aborted).toBe(true);
+		if (!capturedContext) throw new Error("Expected genuine host request context");
+		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request context is invalid");
+		expect(implementation).toHaveBeenCalledTimes(1);
+		manager.disposeSync();
+	});
+
+	it("revokes a comm-closed host-request context before a retained wrapper can replay it", async () => {
+		let capturedContext: HostRequestContext | undefined;
+		let resolveHandler: (() => void) | undefined;
+		const implementation = vi.fn(async (_payload: Record<string, unknown>, context: HostRequestContext) => {
+			capturedContext = context;
+			await new Promise<void>((resolve) => {
+				resolveHandler = resolve;
+			});
+			return { ok: true };
+		});
+		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const internals = manager as unknown as {
+			state: "running";
+			connection: { key: string };
+			shell: { send: () => Promise<void>; close: () => void };
+			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
+			sendCommMessage: (_commId: string, data: Record<string, unknown>) => Promise<void>;
+			inFlightHostRequests: Set<Promise<void>>;
+		};
+		internals.state = "running";
+		internals.connection = { key: "test" };
+		internals.shell = { send: async () => {}, close: () => {} };
+		internals.sendCommMessage = async () => {};
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "request", target_name: "host.request", data: { type: "test" } },
+		});
+		await vi.waitFor(() => expect(capturedContext).toBeDefined());
+		internals.handleCommMessage({ header: { msg_type: "comm_close" }, content: { comm_id: "request" } });
+		expect(capturedContext?.signal.aborted).toBe(true);
+		if (!capturedContext) throw new Error("Expected genuine host request context");
+		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request context is invalid");
+		expect(implementation).toHaveBeenCalledTimes(1);
+		resolveHandler?.();
+		await Promise.allSettled([...internals.inFlightHostRequests]);
+		manager.disposeSync();
 	});
 
 	it("revokes host-request authority on comm close and never reads context from payload", async () => {

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -495,6 +495,60 @@ describe("KernelManager abort handling", () => {
 		await disposePromise;
 	});
 
+	it("restart reopens host-request admission only after shutdown settles", async () => {
+		let capturedContext: HostRequestContext | undefined;
+		let releaseShutdown: (() => void) | undefined;
+		const shutdownSettled = new Promise<void>((resolve) => {
+			releaseShutdown = resolve;
+		});
+		const implementation = vi.fn(async (_payload: Record<string, unknown>, context: HostRequestContext) => {
+			capturedContext = context;
+			return { ok: true };
+		});
+		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const internals = manager as unknown as {
+			hostRequestsClosed: boolean;
+			state: "idle" | "running" | "shutdown";
+			connection: { key: string };
+			shell: { send: () => Promise<void>; close: () => void };
+			shutdown: () => Promise<void>;
+			start: () => Promise<void>;
+			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
+			sendCommMessage: (_commId: string, data: Record<string, unknown>) => Promise<void>;
+			activeHostRequestControllers: Map<string, AbortController>;
+			inFlightHostRequests: Set<Promise<void>>;
+		};
+		internals.hostRequestsClosed = true;
+		internals.shutdown = async () => {
+			expect(internals.hostRequestsClosed).toBe(true);
+			internals.state = "shutdown";
+			await shutdownSettled;
+		};
+		internals.start = async () => {
+			expect(internals.hostRequestsClosed).toBe(false);
+			internals.state = "running";
+			internals.connection = { key: "test" };
+			internals.shell = { send: async () => {}, close: () => {} };
+			internals.sendCommMessage = async () => {};
+			internals.handleCommMessage({
+				header: { msg_type: "comm_open" },
+				content: { comm_id: "restarted-request", target_name: "host.request", data: { type: "test" } },
+			});
+		};
+
+		const restartPromise = manager.restart();
+		await Promise.resolve();
+		expect(internals.hostRequestsClosed).toBe(true);
+		releaseShutdown?.();
+		await restartPromise;
+		await Promise.allSettled([...internals.inFlightHostRequests]);
+
+		expect(implementation).toHaveBeenCalledTimes(1);
+		expect(capturedContext?.signal.aborted).toBe(true);
+		expect(internals.activeHostRequestControllers.has("restarted-request")).toBe(false);
+	});
+
 	it("fails a later execution fast when the interrupted cell never idles", async () => {
 		vi.useFakeTimers();
 		const manager = new KernelManager({ cwd: process.cwd() });

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -374,6 +374,127 @@ describe("KernelManager abort handling", () => {
 		manager.disposeSync();
 	});
 
+	it("closes host-request admission before snapshot shutdown flushes", async () => {
+		let capturedContext: HostRequestContext | undefined;
+		let releaseHandler: (() => void) | undefined;
+		let releaseFlush: (() => void) | undefined;
+		let markFlushEntered: (() => void) | undefined;
+		const flushEntered = new Promise<void>((resolve) => {
+			markFlushEntered = resolve;
+		});
+		const implementation = vi.fn(async (_payload: Record<string, unknown>, context: HostRequestContext) => {
+			capturedContext = context;
+			await new Promise<void>((resolve) => {
+				releaseHandler = resolve;
+			});
+			return { ok: true };
+		});
+		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const internals = manager as unknown as {
+			state: "running";
+			connection: { key: string };
+			shell: { send: () => Promise<void>; close: () => void };
+			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
+			flushSnapshotForDispose: () => Promise<void>;
+			activeHostRequestControllers: Map<string, AbortController>;
+			handledHostRequestCommIds: Set<string>;
+			inFlightHostRequests: Set<Promise<void>>;
+		};
+		Object.assign(internals, {
+			state: "running",
+			connection: { key: "test" },
+			shell: { send: async () => {}, close: () => {} },
+			flushSnapshotForDispose: async () => {
+				markFlushEntered?.();
+				await new Promise<void>((resolve) => {
+					releaseFlush = resolve;
+				});
+			},
+		});
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "existing", target_name: "host.request", data: { type: "test" } },
+		});
+		await vi.waitFor(() => expect(capturedContext).toBeDefined());
+
+		const shutdownPromise = manager.shutdown({ snapshot: true });
+		await flushEntered;
+		expect(capturedContext?.signal.aborted).toBe(true);
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "late", target_name: "host.request", data: { type: "test" } },
+		});
+		expect(implementation).toHaveBeenCalledTimes(1);
+		expect(internals.activeHostRequestControllers.has("late")).toBe(false);
+		expect(internals.handledHostRequestCommIds.has("late")).toBe(false);
+
+		releaseFlush?.();
+		await shutdownPromise;
+		releaseHandler?.();
+		await Promise.allSettled([...internals.inFlightHostRequests]);
+	});
+
+	it("closes host-request admission before dispose flushes", async () => {
+		let capturedContext: HostRequestContext | undefined;
+		let releaseHandler: (() => void) | undefined;
+		let releaseFlush: (() => void) | undefined;
+		let markFlushEntered: (() => void) | undefined;
+		const flushEntered = new Promise<void>((resolve) => {
+			markFlushEntered = resolve;
+		});
+		const implementation = vi.fn(async (_payload: Record<string, unknown>, context: HostRequestContext) => {
+			capturedContext = context;
+			await new Promise<void>((resolve) => {
+				releaseHandler = resolve;
+			});
+			return { ok: true };
+		});
+		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const internals = manager as unknown as {
+			state: "running";
+			connection: { key: string };
+			shell: { send: () => Promise<void>; close: () => void };
+			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
+			flushSnapshotForDispose: () => Promise<void>;
+			activeHostRequestControllers: Map<string, AbortController>;
+			handledHostRequestCommIds: Set<string>;
+			inFlightHostRequests: Set<Promise<void>>;
+		};
+		Object.assign(internals, {
+			state: "running",
+			connection: { key: "test" },
+			shell: { send: async () => {}, close: () => {} },
+			flushSnapshotForDispose: async () => {
+				markFlushEntered?.();
+				await new Promise<void>((resolve) => {
+					releaseFlush = resolve;
+				});
+			},
+		});
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "existing", target_name: "host.request", data: { type: "test" } },
+		});
+		await vi.waitFor(() => expect(capturedContext).toBeDefined());
+
+		const disposePromise = manager.dispose();
+		await flushEntered;
+		expect(capturedContext?.signal.aborted).toBe(true);
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "late", target_name: "host.request", data: { type: "test" } },
+		});
+		expect(implementation).toHaveBeenCalledTimes(1);
+		expect(internals.activeHostRequestControllers.has("late")).toBe(false);
+		expect(internals.handledHostRequestCommIds.has("late")).toBe(false);
+
+		releaseFlush?.();
+		releaseHandler?.();
+		await disposePromise;
+	});
+
 	it("fails a later execution fast when the interrupted cell never idles", async () => {
 		vi.useFakeTimers();
 		const manager = new KernelManager({ cwd: process.cwd() });

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -512,7 +512,7 @@ describe("KernelManager abort handling", () => {
 			state: "idle" | "running" | "shutdown";
 			connection: { key: string };
 			shell: { send: () => Promise<void>; close: () => void };
-			shutdown: () => Promise<void>;
+			shutdownInternal: () => Promise<void>;
 			start: () => Promise<void>;
 			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
 			sendCommMessage: (_commId: string, data: Record<string, unknown>) => Promise<void>;
@@ -520,7 +520,7 @@ describe("KernelManager abort handling", () => {
 			inFlightHostRequests: Set<Promise<void>>;
 		};
 		internals.hostRequestsClosed = true;
-		internals.shutdown = async () => {
+		internals.shutdownInternal = async () => {
 			expect(internals.hostRequestsClosed).toBe(true);
 			internals.state = "shutdown";
 			await shutdownSettled;
@@ -611,5 +611,39 @@ describe("KernelManager abort handling", () => {
 		expect(shellSend).toHaveBeenCalledTimes(1);
 		expect(controlSend).toHaveBeenCalled();
 		manager.disposeSync();
+	});
+
+	it("does not restart or reopen host-request admission when disposal races shutdown", async () => {
+		let releaseShutdown: (() => void) | undefined;
+		let markShutdownEntered: (() => void) | undefined;
+		const shutdownEntered = new Promise<void>((resolve) => {
+			markShutdownEntered = resolve;
+		});
+		const shutdownBlocked = new Promise<void>((resolve) => {
+			releaseShutdown = resolve;
+		});
+		const manager = new KernelManager({ cwd: process.cwd() });
+		const start = vi.fn(async () => {});
+		const internals = manager as unknown as {
+			hostRequestsClosed: boolean;
+			state: "idle" | "running" | "shutdown";
+			shutdownInternal: () => Promise<void>;
+			start: () => Promise<void>;
+		};
+		internals.shutdownInternal = async () => {
+			markShutdownEntered?.();
+			await shutdownBlocked;
+		};
+		internals.start = start;
+
+		const restartPromise = manager.restart();
+		await shutdownEntered;
+		manager.disposeSync();
+		expect(internals.hostRequestsClosed).toBe(true);
+		releaseShutdown?.();
+
+		await expect(restartPromise).rejects.toThrow("Kernel terminated during restart");
+		expect(start).not.toHaveBeenCalled();
+		expect(internals.hostRequestsClosed).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AGENT_MESSAGE_DISPLAY_MIME, KernelManager, type KernelSentAgentMessage } from "../src/core/kernel/index.js";
+import {
+	AGENT_MESSAGE_DISPLAY_MIME,
+	contextAwareHostRequestHandler,
+	createHostRequestHandler,
+	KernelManager,
+	type KernelSentAgentMessage,
+} from "../src/core/kernel/index.js";
 
 async function waitForCalls(mock: { mock: { calls: unknown[][] } }, count: number): Promise<void> {
 	for (let i = 0; i < 20; i++) {
@@ -248,6 +254,51 @@ describe("KernelManager abort handling", () => {
 
 		await expect(executePromise).resolves.toMatchObject({ status: "aborted" });
 		expect(controlSend).toHaveBeenCalled();
+	});
+
+	it("revokes host-request authority on comm close and never reads context from payload", async () => {
+		let contextSignal: AbortSignal | undefined;
+		let resolveHandler: (() => void) | undefined;
+		const handler = createHostRequestHandler(async (_payload, context) => {
+			contextSignal = context.signal;
+			await new Promise<void>((resolve) => {
+				resolveHandler = resolve;
+			});
+			return { current: context.isCurrent() };
+		}, contextAwareHostRequestHandler);
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const sent: Record<string, unknown>[] = [];
+		const internals = manager as unknown as {
+			state: "running";
+			connection: { key: string };
+			shell: { send: () => Promise<void>; close: () => void };
+			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
+			sendCommMessage: (_commId: string, data: Record<string, unknown>) => Promise<void>;
+			inFlightHostRequests: Set<Promise<void>>;
+		};
+		internals.state = "running";
+		internals.connection = { key: "test" };
+		internals.shell = { send: async () => {}, close: () => {} };
+		internals.sendCommMessage = async (_commId, data) => {
+			sent.push(data);
+		};
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: {
+				comm_id: "request",
+				target_name: "host.request",
+				data: { type: "test", context: { forged: true } },
+			},
+		});
+		await vi.waitFor(() => expect(contextSignal).toBeDefined());
+		expect(contextSignal).toBeDefined();
+		expect(contextSignal?.aborted).toBe(false);
+		internals.handleCommMessage({ header: { msg_type: "comm_close" }, content: { comm_id: "request" } });
+		expect(contextSignal?.aborted).toBe(true);
+		resolveHandler?.();
+		await Promise.allSettled([...internals.inFlightHostRequests]);
+		expect(sent).toContainEqual(expect.objectContaining({ status: "error" }));
+		manager.disposeSync();
 	});
 
 	it("fails a later execution fast when the interrupted cell never idles", async () => {

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -284,7 +284,7 @@ describe("KernelManager abort handling", () => {
 		await Promise.allSettled([...internals.inFlightHostRequests]);
 		expect(capturedContext?.signal.aborted).toBe(true);
 		if (!capturedContext) throw new Error("Expected genuine host request context");
-		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request context is invalid");
+		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request authority was revoked");
 		expect(implementation).toHaveBeenCalledTimes(1);
 		manager.disposeSync();
 	});
@@ -321,7 +321,7 @@ describe("KernelManager abort handling", () => {
 		internals.handleCommMessage({ header: { msg_type: "comm_close" }, content: { comm_id: "request" } });
 		expect(capturedContext?.signal.aborted).toBe(true);
 		if (!capturedContext) throw new Error("Expected genuine host request context");
-		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request context is invalid");
+		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request authority was revoked");
 		expect(implementation).toHaveBeenCalledTimes(1);
 		resolveHandler?.();
 		await Promise.allSettled([...internals.inFlightHostRequests]);
@@ -336,7 +336,7 @@ describe("KernelManager abort handling", () => {
 			await new Promise<void>((resolve) => {
 				resolveHandler = resolve;
 			});
-			return { current: context.isCurrent() };
+			return { current: !context.signal.aborted };
 		});
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sent: Record<string, unknown>[] = [];

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -449,6 +449,41 @@ describe("KernelManager abort handling", () => {
 		manager.disposeSync();
 	});
 
+	it("does not report handler failure or send an error reply when the ok reply fails", async () => {
+		const implementation = vi.fn(async () => ({ completed: true }));
+		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const sendCommMessage = vi.fn(async () => {
+			throw new Error("reply send failed");
+		});
+		const internals = manager as unknown as {
+			state: "running";
+			connection: { key: string };
+			shell: { send: () => Promise<void>; close: () => void };
+			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
+			sendCommMessage: typeof sendCommMessage;
+			inFlightHostRequests: Set<Promise<void>>;
+			kernelStderr: string;
+		};
+		internals.state = "running";
+		internals.connection = { key: "test" };
+		internals.shell = { send: async () => {}, close: () => {} };
+		internals.sendCommMessage = sendCommMessage;
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "ok-reply-fails", target_name: "host.request", data: { type: "test" } },
+		});
+		await Promise.allSettled([...internals.inFlightHostRequests]);
+		expect(implementation).toHaveBeenCalledTimes(1);
+		expect(sendCommMessage).toHaveBeenCalledTimes(1);
+		expect(sendCommMessage).toHaveBeenCalledWith("ok-reply-fails", { status: "ok", completed: true });
+		expect(internals.kernelStderr).toContain(
+			"failed to send host request ok reply for comm ok-reply-fails: reply send failed",
+		);
+		expect(internals.kernelStderr).not.toContain("host request failed for comm ok-reply-fails");
+		manager.disposeSync();
+	});
+
 	it("closes host-request admission before snapshot shutdown flushes", async () => {
 		let capturedContext: HostRequestContext | undefined;
 		let releaseHandler: (() => void) | undefined;

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -370,7 +370,82 @@ describe("KernelManager abort handling", () => {
 		expect(contextSignal?.aborted).toBe(true);
 		resolveHandler?.();
 		await Promise.allSettled([...internals.inFlightHostRequests]);
-		expect(sent).toContainEqual(expect.objectContaining({ status: "error" }));
+		expect(sent).toEqual([]);
+		manager.disposeSync();
+	});
+
+	it("does not send a stale error to a reopened comm with the same id", async () => {
+		let firstContext: HostRequestContext | undefined;
+		let releaseFirst: (() => void) | undefined;
+		const handler = createHostRequestHandler(async (_payload, context) => {
+			if (!firstContext) {
+				firstContext = context;
+				await new Promise<void>((resolve) => {
+					releaseFirst = resolve;
+				});
+				throw new Error("first request failed after close");
+			}
+			return { request: "second" };
+		}, contextAwareHostRequestHandler);
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const sent: Record<string, unknown>[] = [];
+		const internals = manager as unknown as {
+			state: "running";
+			connection: { key: string };
+			shell: { send: () => Promise<void>; close: () => void };
+			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
+			sendCommMessage: (_commId: string, data: Record<string, unknown>) => Promise<void>;
+			inFlightHostRequests: Set<Promise<void>>;
+		};
+		internals.state = "running";
+		internals.connection = { key: "test" };
+		internals.shell = { send: async () => {}, close: () => {} };
+		internals.sendCommMessage = async (_commId, data) => {
+			sent.push(data);
+		};
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "reused", target_name: "host.request", data: { type: "test" } },
+		});
+		await vi.waitFor(() => expect(firstContext).toBeDefined());
+		internals.handleCommMessage({ header: { msg_type: "comm_close" }, content: { comm_id: "reused" } });
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "reused", target_name: "host.request", data: { type: "test" } },
+		});
+		await vi.waitFor(() => expect(sent).toContainEqual({ status: "ok", request: "second" }));
+		releaseFirst?.();
+		await Promise.allSettled([...internals.inFlightHostRequests]);
+		expect(sent).toEqual([{ status: "ok", request: "second" }]);
+		manager.disposeSync();
+	});
+
+	it("sends one error reply when a current host request throws", async () => {
+		const handler = createHostRequestHandler(async () => {
+			throw new Error("handler failed");
+		}, contextAwareHostRequestHandler);
+		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
+		const sent: Record<string, unknown>[] = [];
+		const internals = manager as unknown as {
+			state: "running";
+			connection: { key: string };
+			shell: { send: () => Promise<void>; close: () => void };
+			handleCommMessage: (message: { header: { msg_type: string }; content: Record<string, unknown> }) => void;
+			sendCommMessage: (_commId: string, data: Record<string, unknown>) => Promise<void>;
+			inFlightHostRequests: Set<Promise<void>>;
+		};
+		internals.state = "running";
+		internals.connection = { key: "test" };
+		internals.shell = { send: async () => {}, close: () => {} };
+		internals.sendCommMessage = async (_commId, data) => {
+			sent.push(data);
+		};
+		internals.handleCommMessage({
+			header: { msg_type: "comm_open" },
+			content: { comm_id: "current", target_name: "host.request", data: { type: "test" } },
+		});
+		await Promise.allSettled([...internals.inFlightHostRequests]);
+		expect(sent).toEqual([{ status: "error", error: "handler failed" }]);
 		manager.disposeSync();
 	});
 

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -7,6 +7,8 @@ import { KernelManager, type KernelSentAgentMessage } from "../src/core/kernel/i
 import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
 import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
+import { createTestHostHandlers } from "./host-request-context.js";
+
 function bundledAgentMessageSkill(): PythonSkillRuntimeInfo {
 	const packagePath = join(getBundledSkillsDir(), "agent-message");
 	return {
@@ -44,7 +46,7 @@ describe("agent-message skill over the kernel host bridge", () => {
 		const requests: Array<{ type: string; payload: Record<string, unknown> }> = [];
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentMessageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"agent_message.list_agents": async (payload) => {
 					requests.push({ type: "agent_message.list_agents", payload });
 					return {
@@ -64,7 +66,7 @@ describe("agent-message skill over the kernel host bridge", () => {
 						queuedAt: "2026-06-16T00:00:00.000Z",
 					};
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -117,7 +119,7 @@ print(json.dumps({"agents": agents, "receipt": receipt}, sort_keys=True))
 	it("emits successful broadcast receipts and leaves short errors in the result", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentMessageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"agent_message.send": async (payload) => ({
 					receipts: [
 						{
@@ -132,7 +134,7 @@ print(json.dumps({"agents": agents, "receipt": receipt}, sort_keys=True))
 						{ target: "sibling", error: "rate limited" },
 					],
 				}),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -162,11 +164,11 @@ print(json.dumps(receipt, sort_keys=True))
 	it("rejects broadcast combined with role selectors before reaching the host", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentMessageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"agent_message.send": async () => {
 					throw new Error("should not reach host");
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -183,11 +185,11 @@ except TypeError as error:
 	it("rejects a positional name target before reaching the host", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentMessageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"agent_message.send": async () => {
 					throw new Error("should not reach host");
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -206,11 +208,11 @@ except TypeError as error:
 	it("does not expose a queueable delivery mode", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentMessageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"agent_message.send": async () => {
 					throw new Error("should not reach host");
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -227,7 +229,7 @@ except TypeError as error:
 	it("captures sent messages from detached tasks after the cell is idle", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentMessageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"agent_message.send": async (payload) => ({
 					id: "agentmsg-background",
 					source: "agent_message",
@@ -237,7 +239,7 @@ except TypeError as error:
 					deliveredAt: "2026-07-10T00:00:00.000Z",
 					deliveryMode: payload.mode,
 				}),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();

--- a/packages/coding-agent/test/kernel-agent-observe-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-observe-skill.test.ts
@@ -6,6 +6,8 @@ import { getBundledSkillsDir } from "../src/config.js";
 import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
 import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
+import { createTestHostHandlers } from "./host-request-context.js";
+
 function bundledAgentObserveSkill(): PythonSkillRuntimeInfo {
 	const packagePath = join(getBundledSkillsDir(), "agent-observe");
 	return {
@@ -35,7 +37,7 @@ describe("agent-observe skill over the kernel host bridge", () => {
 		const requests: Array<{ type: string; payload: Record<string, unknown> }> = [];
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentObserveSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"agent_observe.list": async (payload) => {
 					requests.push({ type: "agent_observe.list", payload });
 					return {
@@ -60,7 +62,7 @@ describe("agent-observe skill over the kernel host bridge", () => {
 						truncated: false,
 					};
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -93,11 +95,11 @@ print(json.dumps({"agents": agents, "agent": agent, "recent": recent}, sort_keys
 	it("validates argument types before sending to the host", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAgentObserveSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"agent_observe.get": async () => {
 					throw new Error("should not reach host");
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();

--- a/packages/coding-agent/test/kernel-attach-image-skill.test.ts
+++ b/packages/coding-agent/test/kernel-attach-image-skill.test.ts
@@ -6,6 +6,8 @@ import { getBundledSkillsDir } from "../src/config.js";
 import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
 import { IpythonKernelProvisioner, imageBlocksFromAttachments } from "../src/core/tools/ipython.js";
 
+import { createTestHostHandlers } from "./host-request-context.js";
+
 // 1x1 transparent PNG.
 const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
 
@@ -40,9 +42,9 @@ describe("attach-image skill over the kernel host bridge", () => {
 
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAttachImageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"model.info": async () => ({ id: "anthropic/claude-haiku-4.5", input: ["text", "image"] }),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -63,9 +65,9 @@ describe("attach-image skill over the kernel host bridge", () => {
 
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAttachImageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"model.info": async () => ({ id: "anthropic/claude-haiku-4.5", input: ["text", "image"] }),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -88,9 +90,9 @@ print(await attach_image(${JSON.stringify(imagePath)}))
 
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAttachImageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"model.info": async () => ({ id: "anthropic/claude-haiku-4.5", input: ["text", "image"] }),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -113,9 +115,9 @@ print(await attach_image(${JSON.stringify(imagePath)}))
 
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAttachImageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"model.info": async () => ({ id: "anthropic/claude-haiku-4.5", input: ["text", "image"] }),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -140,9 +142,9 @@ print(await attach_image(${JSON.stringify(imagePath)}))
 
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAttachImageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"model.info": async () => ({ id: "anthropic/claude-haiku-4.5", input: ["text", "image"] }),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -178,9 +180,9 @@ except ValueError as error:
 
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAttachImageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"model.info": async () => ({ id: "anthropic/claude-haiku-4.5", input: ["text", "image"] }),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -215,9 +217,9 @@ except ValueError as error:
 
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAttachImageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"model.info": async () => ({ id: "openai/gpt-oss-120b", input: ["text"] }),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -242,9 +244,9 @@ except RuntimeError as error:
 
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledAttachImageSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"model.info": async () => ({ id: "anthropic/claude-haiku-4.5", input: ["text", "image"] }),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();

--- a/packages/coding-agent/test/kernel-goal-skill.test.ts
+++ b/packages/coding-agent/test/kernel-goal-skill.test.ts
@@ -6,6 +6,8 @@ import { getBundledSkillsDir } from "../src/config.js";
 import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
 import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
+import { createTestHostHandlers } from "./host-request-context.js";
+
 function bundledGoalSkill(): PythonSkillRuntimeInfo {
 	const packagePath = join(getBundledSkillsDir(), "goal");
 	return {
@@ -35,7 +37,7 @@ describe("goal skill over the kernel host bridge", { tags: ["kernel-heavy"] }, (
 		const requests: Array<{ type: string; payload: Record<string, unknown> }> = [];
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledGoalSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"goal.create": async (payload) => {
 					requests.push({ type: "goal.create", payload });
 					return {
@@ -53,7 +55,7 @@ describe("goal skill over the kernel host bridge", { tags: ["kernel-heavy"] }, (
 							"Goal achieved. Report final budget usage to the user: tokens used: 7 of 10.",
 					};
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -85,11 +87,11 @@ print(_completed["goal"]["status"], _completed["completion_budget_report"])
 	it("surfaces host errors and missing handlers as Python exceptions", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledGoalSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"goal.complete": async () => {
 					throw new Error("cannot complete goal because this thread has no goal");
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -128,9 +130,9 @@ except RuntimeError as error:
 	it("rejects replies with an unexpected status instead of hanging", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledGoalSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"goal.get": async () => ({ status: "partial" }),
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();

--- a/packages/coding-agent/test/kernel-goal-skill.test.ts
+++ b/packages/coding-agent/test/kernel-goal-skill.test.ts
@@ -127,22 +127,30 @@ except RuntimeError as error:
 		expect(reroute.stdout.trim()).toBe('RuntimeError: host request type "goal.get" is not available in this session');
 	});
 
-	it("rejects replies with an unexpected status instead of hanging", async () => {
+	it("keeps the protocol status authoritative over handler payload keys", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledGoalSkill()],
 			hostHandlers: createTestHostHandlers({
-				"goal.get": async () => ({ status: "partial" }),
+				"goal.get": async () => ({
+					status: "partial",
+					value: "kept",
+					error: "payload error",
+					id: "payload-id",
+				}),
 			}),
 		});
 
 		const manager = await provisioner.ensure();
 		const result = await manager.execute(`
-try:
-    await goal.get()
-except RuntimeError as error:
-    print(f"RuntimeError: {error}")
+import json
+_reply = await goal.get()
+print(json.dumps(_reply, sort_keys=True))
 `);
 		expect(result.status).toBe("ok");
-		expect(result.stdout.trim()).toBe("RuntimeError: host request goal.get returned unexpected status: 'partial'");
+		expect(JSON.parse(result.stdout.trim())).toEqual({
+			error: "payload error",
+			id: "payload-id",
+			value: "kept",
+		});
 	});
 });

--- a/packages/coding-agent/test/kernel-rlm-heartbeat-skill.test.ts
+++ b/packages/coding-agent/test/kernel-rlm-heartbeat-skill.test.ts
@@ -6,6 +6,8 @@ import { getBundledSkillsDir } from "../src/config.js";
 import type { PythonSkillRuntimeInfo } from "../src/core/skills.js";
 import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
 
+import { createTestHostHandlers } from "./host-request-context.js";
+
 function bundledRlmHeartbeatSkill(): PythonSkillRuntimeInfo {
 	const packagePath = join(getBundledSkillsDir(), "rlm-heartbeat");
 	return {
@@ -35,7 +37,7 @@ describe("RLM heartbeat skill over the kernel host bridge", () => {
 		const requests: Array<{ type: string; payload: Record<string, unknown> }> = [];
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledRlmHeartbeatSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"rlm_heartbeat.create": async (payload) => {
 					requests.push({ type: "rlm_heartbeat.create", payload });
 					return {
@@ -85,7 +87,7 @@ describe("RLM heartbeat skill over the kernel host bridge", () => {
 						},
 					};
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -131,7 +133,7 @@ print(json.dumps({
 	it("surfaces missing host handlers as Python exceptions", async () => {
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledRlmHeartbeatSkill()],
-			hostHandlers: {},
+			hostHandlers: createTestHostHandlers({}),
 		});
 
 		const manager = await provisioner.ensure();
@@ -151,12 +153,12 @@ except RuntimeError as error:
 		let hostRequestCount = 0;
 		provisioner = new IpythonKernelProvisioner(tempDir, {
 			pythonSkills: [bundledRlmHeartbeatSkill()],
-			hostHandlers: {
+			hostHandlers: createTestHostHandlers({
 				"rlm_heartbeat.create": async () => {
 					hostRequestCount++;
 					return {};
 				},
-			},
+			}),
 		});
 
 		const manager = await provisioner.ensure();

--- a/packages/coding-agent/test/kernel-startup.test.ts
+++ b/packages/coding-agent/test/kernel-startup.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { KernelManager } from "../src/core/kernel/index.js";
 
 let tempDir = "";
+let originalForkserver: string | undefined;
 
 function writeExecutable(filePath: string, content: string): void {
 	writeFileSync(filePath, content);
@@ -13,10 +14,14 @@ function writeExecutable(filePath: string, content: string): void {
 
 describe("KernelManager startup", () => {
 	beforeEach(() => {
+		originalForkserver = process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+		process.env.PRIME_AGENT_KERNEL_FORKSERVER = "0";
 		tempDir = mkdtempSync(join(tmpdir(), "prime-agent-kernel-startup-"));
 	});
 
 	afterEach(() => {
+		if (originalForkserver === undefined) delete process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+		else process.env.PRIME_AGENT_KERNEL_FORKSERVER = originalForkserver;
 		if (tempDir) {
 			rmSync(tempDir, { recursive: true, force: true });
 			tempDir = "";

--- a/packages/coding-agent/test/kernel-startup.test.ts
+++ b/packages/coding-agent/test/kernel-startup.test.ts
@@ -81,6 +81,63 @@ describe("KernelManager startup", () => {
 		await expect(retry).rejects.toThrow("connection unavailable");
 	});
 
+	it.each(["connection", "probe"] as const)(
+		"does not make a %s failure retryable after concurrent disposal during cleanup",
+		async (failurePoint) => {
+			const python = join(tempDir, "python");
+			writeExecutable(python, ["#!/bin/sh", "sleep 30", ""].join("\n"));
+			const manager = new KernelManager({ python, cwd: tempDir });
+			const failure = new Error(`${failurePoint} unavailable`);
+			let releaseCleanup: () => void = () => {};
+			const cleanupGate = new Promise<void>((resolve) => {
+				releaseCleanup = resolve;
+			});
+			let cleanupStarted: () => void = () => {};
+			const cleanupStartedGate = new Promise<void>((resolve) => {
+				cleanupStarted = resolve;
+			});
+			const internals = manager as unknown as {
+				state: "idle" | "starting" | "running" | "shutdown";
+				terminal: boolean;
+				waitForResolvedConnection: () => Promise<never>;
+				probeReady: () => Promise<void>;
+				shutdownInternal: () => Promise<void>;
+			};
+			if (failurePoint === "connection") {
+				internals.waitForResolvedConnection = () => Promise.reject(failure);
+			} else {
+				internals.waitForResolvedConnection = async () =>
+					({
+						ip: "127.0.0.1",
+						transport: "tcp" as const,
+						shell_port: 1,
+						iopub_port: 2,
+						stdin_port: 3,
+						control_port: 4,
+						hb_port: 5,
+						signature_scheme: "hmac-sha256" as const,
+						key: "",
+						kernel_name: "python3",
+					}) as never;
+				internals.probeReady = () => Promise.reject(failure);
+			}
+			internals.shutdownInternal = async () => {
+				internals.state = "shutdown";
+				cleanupStarted();
+				await cleanupGate;
+			};
+
+			const start = manager.start();
+			await cleanupStartedGate;
+			manager.disposeSync();
+			releaseCleanup();
+			await expect(start).rejects.toBe(failure);
+			expect(internals.terminal).toBe(true);
+			expect(internals.state).toBe("shutdown");
+			await expect(manager.start()).rejects.toThrow("Kernel was disposed");
+		},
+	);
+
 	it("keeps disposal during startup terminal", async () => {
 		const python = join(tempDir, "python");
 		writeExecutable(python, ["#!/bin/sh", "sleep 30", ""].join("\n"));

--- a/packages/coding-agent/test/kernel-startup.test.ts
+++ b/packages/coding-agent/test/kernel-startup.test.ts
@@ -168,4 +168,39 @@ describe("KernelManager startup", () => {
 		expect(internals.hostRequestsClosed).toBe(true);
 		await expect(manager.start()).rejects.toThrow("Kernel was disposed");
 	});
+
+	it("rejects an external cell queued before terminal entry without dispatching it", async () => {
+		const manager = new KernelManager({ cwd: tempDir });
+		const firstEntered = vi.fn();
+		let releaseFirst = () => {};
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const executeInner = vi.fn(async (code: string) => {
+			if (code === "first") {
+				firstEntered();
+				await firstGate;
+			}
+			return { stdout: "", stderr: "", status: "ok" as const, durationMs: 0 };
+		});
+		const internals = manager as unknown as {
+			state: "idle" | "starting" | "running" | "shutdown";
+			start(): Promise<void>;
+			executeInner: typeof executeInner;
+		};
+		internals.state = "running";
+		internals.start = async () => {};
+		internals.executeInner = executeInner;
+
+		const first = manager.execute("first");
+		await vi.waitFor(() => expect(firstEntered).toHaveBeenCalledOnce());
+		const secondRejection = expect(manager.execute("second")).rejects.toThrow("Kernel was disposed");
+		const disposal = manager.dispose();
+		releaseFirst();
+
+		await expect(first).resolves.toMatchObject({ status: "ok" });
+		await secondRejection;
+		await disposal;
+		expect(executeInner).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/coding-agent/test/kernel-startup.test.ts
+++ b/packages/coding-agent/test/kernel-startup.test.ts
@@ -43,25 +43,37 @@ describe("KernelManager startup", () => {
 		const python = join(tempDir, "python");
 		writeExecutable(python, ["#!/bin/sh", "sleep 30", ""].join("\n"));
 		const manager = new KernelManager({ python, cwd: tempDir });
+		let rejectRetry: (error: Error) => void = () => {};
+		let markRetryEntered: () => void = () => {};
+		const retryEntered = new Promise<void>((resolve) => {
+			markRetryEntered = resolve;
+		});
+		let connectionAttempts = 0;
 		const internals = manager as unknown as {
-			doStart: () => Promise<void>;
 			state: "idle" | "starting" | "running" | "shutdown";
 			terminal: boolean;
+			hostRequestsClosed: boolean;
 			waitForResolvedConnection: () => Promise<never>;
 		};
-		internals.waitForResolvedConnection = async () => {
-			throw new Error("connection unavailable");
+		internals.waitForResolvedConnection = () => {
+			connectionAttempts++;
+			if (connectionAttempts === 1) return Promise.reject(new Error("connection unavailable"));
+			return new Promise<never>((_resolve, reject) => {
+				rejectRetry = reject;
+				markRetryEntered();
+			});
 		};
 
 		await expect(manager.start()).rejects.toThrow("connection unavailable");
 		expect(internals.terminal).toBe(false);
 		expect(internals.state).toBe("idle");
 
-		const retryStart = vi.fn(async () => {});
-		internals.doStart = retryStart;
-		await expect(manager.start()).resolves.toBeUndefined();
-		expect(retryStart).toHaveBeenCalledOnce();
+		const retry = manager.start();
+		await retryEntered;
+		expect(internals.hostRequestsClosed).toBe(false);
 		manager.disposeSync();
+		rejectRetry(new Error("connection unavailable"));
+		await expect(retry).rejects.toThrow("connection unavailable");
 	});
 
 	it("keeps disposal during startup terminal", async () => {
@@ -75,6 +87,7 @@ describe("KernelManager startup", () => {
 		});
 		const internals = manager as unknown as {
 			terminal: boolean;
+			hostRequestsClosed: boolean;
 			waitForResolvedConnection: () => Promise<never>;
 		};
 		internals.waitForResolvedConnection = () =>
@@ -90,6 +103,7 @@ describe("KernelManager startup", () => {
 
 		await expect(start).rejects.toThrow("connection unavailable");
 		expect(internals.terminal).toBe(true);
+		expect(internals.hostRequestsClosed).toBe(true);
 		await expect(manager.start()).rejects.toThrow("Kernel was disposed");
 	});
 });

--- a/packages/coding-agent/test/kernel-startup.test.ts
+++ b/packages/coding-agent/test/kernel-startup.test.ts
@@ -38,4 +38,58 @@ describe("KernelManager startup", () => {
 			await manager.dispose();
 		}
 	});
+
+	it("keeps a connection-resolution startup failure retryable", async () => {
+		const python = join(tempDir, "python");
+		writeExecutable(python, ["#!/bin/sh", "sleep 30", ""].join("\n"));
+		const manager = new KernelManager({ python, cwd: tempDir });
+		const internals = manager as unknown as {
+			doStart: () => Promise<void>;
+			state: "idle" | "starting" | "running" | "shutdown";
+			terminal: boolean;
+			waitForResolvedConnection: () => Promise<never>;
+		};
+		internals.waitForResolvedConnection = async () => {
+			throw new Error("connection unavailable");
+		};
+
+		await expect(manager.start()).rejects.toThrow("connection unavailable");
+		expect(internals.terminal).toBe(false);
+		expect(internals.state).toBe("idle");
+
+		const retryStart = vi.fn(async () => {});
+		internals.doStart = retryStart;
+		await expect(manager.start()).resolves.toBeUndefined();
+		expect(retryStart).toHaveBeenCalledOnce();
+		manager.disposeSync();
+	});
+
+	it("keeps disposal during startup terminal", async () => {
+		const python = join(tempDir, "python");
+		writeExecutable(python, ["#!/bin/sh", "sleep 30", ""].join("\n"));
+		const manager = new KernelManager({ python, cwd: tempDir });
+		let rejectConnection: (error: Error) => void = () => {};
+		let markConnectionWaitEntered: () => void = () => {};
+		const connectionWaitEntered = new Promise<void>((resolve) => {
+			markConnectionWaitEntered = resolve;
+		});
+		const internals = manager as unknown as {
+			terminal: boolean;
+			waitForResolvedConnection: () => Promise<never>;
+		};
+		internals.waitForResolvedConnection = () =>
+			new Promise<never>((_resolve, reject) => {
+				rejectConnection = reject;
+				markConnectionWaitEntered();
+			});
+
+		const start = manager.start();
+		await connectionWaitEntered;
+		manager.disposeSync();
+		rejectConnection(new Error("connection unavailable"));
+
+		await expect(start).rejects.toThrow("connection unavailable");
+		expect(internals.terminal).toBe(true);
+		await expect(manager.start()).rejects.toThrow("Kernel was disposed");
+	});
 });

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -174,4 +174,30 @@ describeIfKernel("kernel state snapshot round-trip (real kernel)", { tags: ["ker
 			rmSync(autoDir, { recursive: true, force: true });
 		}
 	}, 60_000);
+
+	it.each([
+		["dispose", async (manager: KernelManager) => manager.dispose()],
+		["shutdown(snapshot:true)", async (manager: KernelManager) => manager.shutdown({ snapshot: true })],
+	] as const)("persists the final namespace through %s after the terminal fence", async (_label, terminate) => {
+		const finalDir = mkdtempSync(join(tmpdir(), "prime-agent-state-final-"));
+		const finalPath = join(finalDir, "final.dill");
+		const cfg = { path: finalPath, manifestPath: join(finalDir, "final.json"), debounceMs: 60_000 };
+		const writer = new KernelManager({ python: python as string, cwd: finalDir, snapshot: cfg });
+		await writer.execute("final_only = 42");
+		await terminate(writer);
+		await expect(writer.execute("late = 1")).rejects.toThrow("Kernel was disposed");
+		expect(existsSync(finalPath)).toBe(true);
+
+		const reader = new KernelManager({ python: python as string, cwd: finalDir, snapshot: cfg });
+		try {
+			const restore = await reader.restoreState();
+			expect(restore?.restored).toContain("final_only");
+			const result = await reader.execute("print(final_only)");
+			expect(result.stdout.trim()).toBe("42");
+		} finally {
+			await reader.dispose();
+			rmSync(finalDir, { recursive: true, force: true });
+		}
+	}, 60_000);
+
 });

--- a/packages/coding-agent/test/legacy-rlm-host-types.d.ts
+++ b/packages/coding-agent/test/legacy-rlm-host-types.d.ts
@@ -7,6 +7,6 @@ declare module "../src/core/rlm-runtime.js" {
 			runtime: RlmSubagentRuntime,
 			options: CreateRlmSubagentRuntimeOptions,
 			status: "done" | "error" | "cancelled",
-		) => Promise<{ retained: boolean }>;
+		) => Promise<{ deletionDurability: "absent" | "tombstoned" | "unknown" }>;
 	}
 }

--- a/packages/coding-agent/test/legacy-rlm-host-types.d.ts
+++ b/packages/coding-agent/test/legacy-rlm-host-types.d.ts
@@ -7,6 +7,6 @@ declare module "../src/core/rlm-runtime.js" {
 			runtime: RlmSubagentRuntime,
 			options: CreateRlmSubagentRuntimeOptions,
 			status: "done" | "error" | "cancelled",
-		) => Promise<void>;
+		) => Promise<{ retained: boolean }>;
 	}
 }

--- a/packages/coding-agent/test/mcp-manager.test.ts
+++ b/packages/coding-agent/test/mcp-manager.test.ts
@@ -4,10 +4,10 @@ import { join } from "node:path";
 import { getOAuthProvider, resetOAuthProviders } from "@earendil-works/pi-ai/oauth";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
-import { invokeHostRequestHandlerForTest } from "../src/core/kernel/index.js";
 import { McpManager } from "../src/core/mcp/mcp-manager.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import type { McpServerConfig } from "../src/core/settings-manager.js";
+import { invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest } from "./host-request-context.js";
 
 describe("McpManager", () => {
 	let tempDir: string;

--- a/packages/coding-agent/test/mcp-manager.test.ts
+++ b/packages/coding-agent/test/mcp-manager.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { getOAuthProvider, resetOAuthProviders } from "@earendil-works/pi-ai/oauth";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
+import { invokeHostRequestHandlerForTest } from "../src/core/kernel/index.js";
 import { McpManager } from "../src/core/mcp/mcp-manager.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import type { McpServerConfig } from "../src/core/settings-manager.js";
@@ -79,8 +80,10 @@ describe("McpManager", () => {
 
 		// refresh with no credentials fails (so the kernel reports a refresh error,
 		// not a false success), and a missing server arg is rejected.
-		await expect(handlers["mcp.refresh"]({ server: "linear" })).rejects.toThrow("Could not refresh");
-		await expect(handlers["mcp.refresh"]({})).rejects.toThrow("requires a server");
+		await expect(invokeHostRequestHandlerForTest(handlers["mcp.refresh"]!, { server: "linear" })).rejects.toThrow(
+			"Could not refresh",
+		);
+		await expect(invokeHostRequestHandlerForTest(handlers["mcp.refresh"]!, {})).rejects.toThrow("requires a server");
 	});
 
 	it("exposes mcp.begin_login only when beginLogin is provided", async () => {
@@ -93,7 +96,7 @@ describe("McpManager", () => {
 		});
 		const handlers = manager.hostHandlers();
 		expect(Object.keys(handlers).sort()).toEqual(["mcp.begin_login", "mcp.config", "mcp.refresh"]);
-		await handlers["mcp.begin_login"]({ server: "linear" });
+		await invokeHostRequestHandlerForTest(handlers["mcp.begin_login"]!, { server: "linear" });
 		expect(called).toBe("linear");
 	});
 
@@ -105,11 +108,13 @@ describe("McpManager", () => {
 			}),
 		});
 		const handlers = manager.hostHandlers();
-		expect(await handlers["mcp.config"]({ server: "linear" })).toEqual({
+		expect(await invokeHostRequestHandlerForTest(handlers["mcp.config"]!, { server: "linear" })).toEqual({
 			url: "https://proxy.test/mcp",
 			headers: { "X-Extra": "1" },
 		});
-		expect(await handlers["mcp.config"]({ server: "notion" })).toEqual({ url: "https://mcp.notion.com/mcp" });
+		expect(await invokeHostRequestHandlerForTest(handlers["mcp.config"]!, { server: "notion" })).toEqual({
+			url: "https://mcp.notion.com/mcp",
+		});
 	});
 
 	it("does not treat an oauth override of a catalog name as authed via the official stored cred", () => {

--- a/packages/coding-agent/test/saved-session-catalog.test.ts
+++ b/packages/coding-agent/test/saved-session-catalog.test.ts
@@ -145,7 +145,12 @@ describe("saved session catalog", () => {
 		});
 
 		expect(fakeClient.commands).toEqual([
-			{ type: "rename_saved_session", sessionPath: "/tmp/sessions/one.jsonl", name: "One" },
+			{
+				type: "rename_saved_session",
+				sessionPath: "/tmp/sessions/one.jsonl",
+				sessionDir: "/tmp/sessions",
+				name: "One",
+			},
 			{ type: "delete_saved_session", sessionPath: "/tmp/sessions/one.jsonl" },
 		]);
 	});

--- a/packages/coding-agent/test/suite/agent-session-action-races.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-action-races.test.ts
@@ -14,6 +14,7 @@ interface CommitFenceInternals {
 	_scheduleSessionInputPump(): void;
 	_acquireDirectTurnAdmissionFence(signal?: AbortSignal): Promise<{ release(): void }>;
 	_acquireSessionActionCommitFence(signal?: AbortSignal): Promise<{ release(): void }>;
+	_drainPendingRefinementForDisposal(): Promise<void>;
 	_promptInjectedMessage(
 		text: string,
 		message: {
@@ -124,6 +125,31 @@ describe("AgentSession action commit-fence races", () => {
 		}
 		await Promise.resolve();
 		expect(settlementCount).toBe(1);
+	});
+
+	it("fences prompt admission synchronously while orderly async disposal drains", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("must not start")]);
+		const internals = harness.session as unknown as CommitFenceInternals;
+		const drainEntered = createDeferred();
+		const drainGate = createDeferred();
+		internals._drainPendingRefinementForDisposal = async () => {
+			drainEntered.resolve();
+			await drainGate.promise;
+		};
+
+		const disposal = harness.session.disposeAsync();
+		await drainEntered.promise;
+		await expect(harness.session.prompt("late prompt")).rejects.toThrow(
+			"Cannot admit a session action because the session is disposing or disposed.",
+		);
+		expect(internals._actionStore.unfinishedActions()).toEqual([]);
+		expect(getUserTexts(harness)).not.toContain("late prompt");
+		expect(harness.getPendingResponseCount()).toBe(1);
+
+		drainGate.resolve();
+		await disposal;
 	});
 
 	it("reports a queued commit-fence waiter while its predecessor releases", async () => {

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -381,6 +381,50 @@ describe("AgentSession prompt characterization", () => {
 		expect(expandedPrompt).toBe("Review this code: src/index.ts");
 	});
 
+	it.each(["beginClosing", "dispose"] as const)(
+		"rejects extension commands and input handler prompts after $closeEntry during streaming without extension side effects",
+		async (closeEntry) => {
+			const commandRuns: string[] = [];
+			const inputRuns: string[] = [];
+			const { harness, waitForToolStart, promptPromise, releaseToolExecution } = await createWaitingHarness({
+				extensionFactories: [
+					(pi) => {
+						pi.registerCommand("testcmd", {
+							description: "Test command",
+							handler: async (args) => {
+								commandRuns.push(args);
+							},
+						});
+						pi.on("input", (event) => {
+							inputRuns.push(event.text);
+						});
+					},
+				],
+			});
+			harnesses.push(harness);
+			harness.setResponses([
+				fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+				fauxAssistantMessage("done"),
+			]);
+			await waitForToolStart;
+			inputRuns.length = 0;
+			if (closeEntry === "beginClosing") harness.session.beginClosing();
+			else harness.session.dispose();
+
+			await expect(harness.session.prompt("/testcmd must-not-run")).rejects.toThrow(
+				"Cannot admit a session action because the session is disposing or disposed.",
+			);
+			await expect(harness.session.prompt("must-not-reach-input-handler", { streamingBehavior: "followUp" })).rejects.toThrow(
+				"Cannot admit a session action because the session is disposing or disposed.",
+			);
+			expect(commandRuns).toEqual([]);
+			expect(inputRuns).toEqual([]);
+
+			releaseToolExecution();
+			await promptPromise.catch(() => undefined);
+		},
+	);
+
 	it("dispatches extension commands without consuming a provider response", async () => {
 		const commandRuns: string[] = [];
 		const harness = await createHarness({

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -414,9 +414,9 @@ describe("AgentSession prompt characterization", () => {
 			await expect(harness.session.prompt("/testcmd must-not-run")).rejects.toThrow(
 				"Cannot admit a session action because the session is disposing or disposed.",
 			);
-			await expect(harness.session.prompt("must-not-reach-input-handler", { streamingBehavior: "followUp" })).rejects.toThrow(
-				"Cannot admit a session action because the session is disposing or disposed.",
-			);
+			await expect(
+				harness.session.prompt("must-not-reach-input-handler", { streamingBehavior: "followUp" }),
+			).rejects.toThrow("Cannot admit a session action because the session is disposing or disposed.");
 			expect(commandRuns).toEqual([]);
 			expect(inputRuns).toEqual([]);
 

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -2644,6 +2644,27 @@ describe("AgentSession queue characterization", () => {
 		expect(getUserTexts(harness)).toEqual(["queued before abort", "wake after abort"]);
 	});
 
+	it("preserves agent mail admitted during update-restart suspension", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("mail handled after restart")]);
+		const prompt = agentPromptText("agentmsg_update_restart", "hold for recovery");
+		harness.session.abortForUpdateRestart();
+
+		await expect(harness.session.queueAgentMessagePrompt(prompt, "followUp")).resolves.toBe(true);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		expect(getUserTexts(harness)).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual([prompt]);
+		expect(harness.session.getSessionActionRecoverySnapshot().actions).toEqual([
+			expect.objectContaining({ payload: expect.objectContaining({ text: prompt }) }),
+		]);
+
+		expect(harness.session.resumeQueuedWork()).toBe(true);
+		await harness.session.waitForIdle();
+		expect(getUserTexts(harness)).toEqual([prompt]);
+	});
+
 	it("waitForIdle resolves when the queue is cleared while the pump is suspended", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -166,6 +166,7 @@ describe("AgentSessionRuntime characterization", () => {
 				},
 			},
 			setSubagentRuntimeHost: vi.fn(),
+			beginClosing: vi.fn(),
 			dispose: disposeSession,
 			disposeAsync: disposeSession,
 		} as unknown as AgentSession;

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -265,22 +265,26 @@ describe("AgentSessionRuntime characterization", () => {
 		expect(beforeInvalidate).toHaveBeenCalledTimes(1);
 	});
 
-	it("does not replay shutdown events when runtime disposal throws", async () => {
+	it("deduplicates concurrent disposal attempts and retries after rejection", async () => {
 		let shutdownCount = 0;
 		const { runtime, disposeSession } = createRuntimeWithFakeSession({
 			onShutdown: () => {
 				shutdownCount += 1;
 			},
 		});
+		let invalidateCount = 0;
 		runtime.setBeforeSessionInvalidate(() => {
-			throw new Error("invalidate failed");
+			invalidateCount += 1;
+			if (invalidateCount === 1) throw new Error("invalidate failed");
 		});
 
-		await expect(runtime.dispose()).rejects.toThrow("invalidate failed");
-		await expect(runtime.dispose()).rejects.toThrow("invalidate failed");
+		const firstAttempt = runtime.dispose();
+		await expect(Promise.all([firstAttempt, runtime.dispose()])).rejects.toThrow("invalidate failed");
+		await expect(runtime.dispose()).resolves.toBeUndefined();
+		await runtime.dispose();
 
-		expect(shutdownCount).toBe(1);
-		expect(disposeSession).toHaveBeenCalledTimes(1);
+		expect(shutdownCount).toBe(2);
+		expect(disposeSession).toHaveBeenCalledTimes(2);
 	});
 
 	it("continues disposing tracked subagents after one child dispose fails", async () => {

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -343,7 +343,9 @@ describe("AgentSessionRuntime characterization", () => {
 			generation: 1,
 			assertCurrent: vi.fn(),
 		};
-		await runtime.deleteRlmSubagentRuntime("replaced-child", staleSession, staleAuthority);
+		await expect(runtime.deleteRlmSubagentRuntime("replaced-child", staleSession, staleAuthority)).resolves.toEqual({
+			deletionDurability: "stale",
+		});
 		expect(disposeStaleSession).toHaveBeenCalledOnce();
 		expect(disposeReplacedRuntime).not.toHaveBeenCalled();
 		expect(runtimeWithSubagents.subagentRuntimes.get("replaced-child")).toBe(replacedRuntime);

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -35,6 +35,13 @@ type RuntimeSubagentMapAccess = {
 	subagentRuntimes: Map<string, AgentSessionRuntime>;
 };
 
+type StrictDeletionAuthority = {
+	childId: string;
+	sessionDir: string;
+	generation: number;
+	assertCurrent: ReturnType<typeof vi.fn>;
+};
+
 describe("AgentSessionRuntime characterization", () => {
 	const cleanups: Array<() => Promise<void> | void> = [];
 
@@ -324,6 +331,61 @@ describe("AgentSessionRuntime characterization", () => {
 		const retainedSession = { disposeAsync: disposeRetained } as unknown as AgentSession;
 		await runtime.deleteRlmSubagentRuntime("retained-child", retainedSession);
 		expect(disposeRetained).toHaveBeenCalledOnce();
+	});
+
+	it("rejects stale inline deletion authority for a recycled child id without mutating the current runtime", async () => {
+		const { runtime, tempDir } = await createRuntimeForTest(() => {});
+		const oldSession = { disposeAsync: vi.fn(async () => {}) } as unknown as AgentSession;
+		const currentSession = {} as AgentSession;
+		const disposeCurrent = vi.fn(async () => {});
+		const currentRuntime = {
+			session: currentSession,
+			dispose: disposeCurrent,
+			metadata: { rlmChildId: "recycled-child", sessionDir: join(tempDir, "current-incarnation") },
+		} as unknown as AgentSessionRuntime;
+		const runtimeWithSubagents = runtime as unknown as RuntimeSubagentMapAccess;
+		runtimeWithSubagents.subagentRuntimes.set("recycled-child", currentRuntime);
+		const authority: StrictDeletionAuthority = {
+			childId: "recycled-child",
+			sessionDir: join(tempDir, "old-incarnation"),
+			generation: 1,
+			assertCurrent: vi.fn(),
+		};
+
+		await expect(runtime.deleteRlmSubagentRuntime("recycled-child", oldSession, authority)).rejects.toThrow(
+			"RLM subagent deletion authority does not match runtime incarnation",
+		);
+
+		expect(authority.assertCurrent).toHaveBeenCalledTimes(2);
+		expect(disposeCurrent).not.toHaveBeenCalled();
+		expect(oldSession.disposeAsync).not.toHaveBeenCalled();
+		expect(runtimeWithSubagents.subagentRuntimes.get("recycled-child")).toBe(currentRuntime);
+	});
+
+	it("deletes an inline runtime only when its authority matches the current incarnation", async () => {
+		const { runtime, tempDir } = await createRuntimeForTest(() => {});
+		const childSession = {} as AgentSession;
+		const disposeChild = vi.fn(async () => {});
+		const sessionDir = join(tempDir, "matching-incarnation");
+		const childRuntime = {
+			session: childSession,
+			dispose: disposeChild,
+			metadata: { rlmChildId: "matching-child", sessionDir },
+		} as unknown as AgentSessionRuntime;
+		const runtimeWithSubagents = runtime as unknown as RuntimeSubagentMapAccess;
+		runtimeWithSubagents.subagentRuntimes.set("matching-child", childRuntime);
+		const authority: StrictDeletionAuthority = {
+			childId: "matching-child",
+			sessionDir,
+			generation: 2,
+			assertCurrent: vi.fn(),
+		};
+
+		await runtime.deleteRlmSubagentRuntime("matching-child", childSession, authority);
+
+		expect(authority.assertCurrent).toHaveBeenCalledTimes(2);
+		expect(disposeChild).toHaveBeenCalledOnce();
+		expect(runtimeWithSubagents.subagentRuntimes.has("matching-child")).toBe(false);
 	});
 
 	it("publishes in-process RLM sessions before create resolves and rejects cancelled startup", async () => {

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -41,7 +41,7 @@ type StrictDeletionAuthority = {
 	sessionFile: string;
 	sessionId: string;
 	generation: number;
-	assertCurrent: ReturnType<typeof vi.fn>;
+	assertCurrent: () => void;
 };
 
 describe("AgentSessionRuntime characterization", () => {
@@ -382,7 +382,7 @@ describe("AgentSessionRuntime characterization", () => {
 		};
 
 		await expect(runtime.deleteRlmSubagentRuntime("recycled-child", oldSession, authority)).rejects.toThrow(
-			"RLM subagent deletion authority does not match runtime incarnation",
+			"RLM subagent deletion does not match runtime incarnation",
 		);
 
 		expect(authority.assertCurrent).toHaveBeenCalledTimes(2);
@@ -424,7 +424,7 @@ describe("AgentSessionRuntime characterization", () => {
 		const authority: StrictDeletionAuthority = {
 			childId: "matching-child",
 			sessionDir,
-			sessionFile: childSession.sessionFile,
+			sessionFile: childSession.sessionFile!,
 			sessionId: childSession.sessionId,
 			generation: 2,
 			assertCurrent: vi.fn(),
@@ -502,7 +502,7 @@ describe("AgentSessionRuntime characterization", () => {
 		await runtime.session.runRlmChild("fail after startup");
 
 		await vi.waitFor(() => expect(deleteRlmSubagentRuntime).toHaveBeenCalledOnce());
-		expect(runtime.listSubagentRuntimes()).toEqual([]);
+		await vi.waitFor(() => expect(runtime.listSubagentRuntimes()).toEqual([]));
 	});
 
 	it("plumbs the parent agent identity into runtime-created child prompts", async () => {
@@ -537,7 +537,7 @@ describe("AgentSessionRuntime characterization", () => {
 			createRlmSubagentRuntime: async () => {
 				throw new Error("unexpected child creation");
 			},
-			deleteRlmSubagentRuntime: async () => {},
+			deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			disposeRlmSubagentRuntimes,
 		};
 		const { runtime } = await createRuntimeForTest(() => {});

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -38,6 +38,8 @@ type RuntimeSubagentMapAccess = {
 type StrictDeletionAuthority = {
 	childId: string;
 	sessionDir: string;
+	sessionFile: string;
+	sessionId: string;
 	generation: number;
 	assertCurrent: ReturnType<typeof vi.fn>;
 };
@@ -298,8 +300,8 @@ describe("AgentSessionRuntime characterization", () => {
 		expect(secondDispose).toHaveBeenCalledTimes(1);
 	});
 
-	it("deletes exact and replaced in-process RLM child runtimes and retained sessions", async () => {
-		const { runtime } = await createRuntimeForTest(() => {});
+	it("deletes exact inline runtimes and fences stale or unowned retained sessions", async () => {
+		const { runtime, tempDir } = await createRuntimeForTest(() => {});
 		const childSession = {} as AgentSession;
 		const disposeRuntime = vi.fn(async () => {});
 		const childRuntime = { session: childSession, dispose: disposeRuntime } as unknown as AgentSessionRuntime;
@@ -316,26 +318,51 @@ describe("AgentSessionRuntime characterization", () => {
 		const replacedRuntime = {
 			session: currentSession,
 			dispose: disposeReplacedRuntime,
+			metadata: { rlmChildId: "replaced-child", sessionDir: join(tempDir, "current-incarnation") },
 		} as unknown as AgentSessionRuntime;
 		const disposeStaleSession = vi.fn(async () => {});
-		const staleSession = { disposeAsync: disposeStaleSession } as unknown as AgentSession;
+		const staleSessionDir = join(tempDir, "stale-incarnation");
+		const staleSessionFile = join(staleSessionDir, "stale.jsonl");
+		const staleSession = {
+			sessionFile: staleSessionFile,
+			sessionId: "stale-session",
+			disposeAsync: disposeStaleSession,
+		} as unknown as AgentSession;
 		runtimeWithSubagents.subagentRuntimes.set("replaced-child", replacedRuntime);
 
-		await runtime.deleteRlmSubagentRuntime("replaced-child", staleSession);
-
-		expect(disposeReplacedRuntime).toHaveBeenCalledOnce();
+		await expect(runtime.deleteRlmSubagentRuntime("replaced-child", staleSession)).rejects.toThrow(
+			"RLM subagent deletion does not match runtime incarnation",
+		);
+		expect(disposeStaleSession).not.toHaveBeenCalled();
+		const staleAuthority: StrictDeletionAuthority = {
+			childId: "replaced-child",
+			sessionDir: staleSessionDir,
+			sessionFile: staleSessionFile,
+			sessionId: staleSession.sessionId,
+			generation: 1,
+			assertCurrent: vi.fn(),
+		};
+		await runtime.deleteRlmSubagentRuntime("replaced-child", staleSession, staleAuthority);
 		expect(disposeStaleSession).toHaveBeenCalledOnce();
-		expect(runtimeWithSubagents.subagentRuntimes.has("replaced-child")).toBe(false);
+		expect(disposeReplacedRuntime).not.toHaveBeenCalled();
+		expect(runtimeWithSubagents.subagentRuntimes.get("replaced-child")).toBe(replacedRuntime);
 
 		const disposeRetained = vi.fn(async () => {});
 		const retainedSession = { disposeAsync: disposeRetained } as unknown as AgentSession;
-		await runtime.deleteRlmSubagentRuntime("retained-child", retainedSession);
-		expect(disposeRetained).toHaveBeenCalledOnce();
+		await expect(runtime.deleteRlmSubagentRuntime("retained-child", retainedSession)).rejects.toThrow(
+			"RLM subagent runtime incarnation is no longer resident",
+		);
+		expect(disposeRetained).not.toHaveBeenCalled();
 	});
 
 	it("rejects stale inline deletion authority for a recycled child id without mutating the current runtime", async () => {
 		const { runtime, tempDir } = await createRuntimeForTest(() => {});
-		const oldSession = { disposeAsync: vi.fn(async () => {}) } as unknown as AgentSession;
+		const oldSessionDir = join(tempDir, "old-incarnation");
+		const oldSession = {
+			sessionFile: join(oldSessionDir, "old.jsonl"),
+			sessionId: "old-session",
+			disposeAsync: vi.fn(async () => {}),
+		} as unknown as AgentSession;
 		const currentSession = {} as AgentSession;
 		const disposeCurrent = vi.fn(async () => {});
 		const currentRuntime = {
@@ -347,7 +374,9 @@ describe("AgentSessionRuntime characterization", () => {
 		runtimeWithSubagents.subagentRuntimes.set("recycled-child", currentRuntime);
 		const authority: StrictDeletionAuthority = {
 			childId: "recycled-child",
-			sessionDir: join(tempDir, "old-incarnation"),
+			sessionDir: oldSessionDir,
+			sessionFile: join(oldSessionDir, "wrong.jsonl"),
+			sessionId: oldSession.sessionId,
 			generation: 1,
 			assertCurrent: vi.fn(),
 		};
@@ -364,9 +393,15 @@ describe("AgentSessionRuntime characterization", () => {
 
 	it("deletes an inline runtime only when its authority matches the current incarnation", async () => {
 		const { runtime, tempDir } = await createRuntimeForTest(() => {});
-		const childSession = {} as AgentSession;
-		const disposeChild = vi.fn(async () => {});
 		const sessionDir = join(tempDir, "matching-incarnation");
+		const childSession = {
+			sessionFile: join(sessionDir, "child.jsonl"),
+			sessionId: "matching-session",
+		} as AgentSession;
+		const disposeChild = vi
+			.fn<() => Promise<void>>()
+			.mockRejectedValueOnce(new Error("inline close failed once"))
+			.mockResolvedValueOnce(undefined);
 		const childRuntime = {
 			session: childSession,
 			dispose: disposeChild,
@@ -374,17 +409,35 @@ describe("AgentSessionRuntime characterization", () => {
 		} as unknown as AgentSessionRuntime;
 		const runtimeWithSubagents = runtime as unknown as RuntimeSubagentMapAccess;
 		runtimeWithSubagents.subagentRuntimes.set("matching-child", childRuntime);
+		const incompleteAuthority = {
+			childId: "matching-child",
+			sessionDir,
+			generation: 1,
+			assertCurrent: vi.fn(),
+		};
+		await expect(
+			runtime.deleteRlmSubagentRuntime("matching-child", childSession, incompleteAuthority),
+		).rejects.toThrow("RLM subagent deletion authority does not match runtime incarnation");
+		expect(disposeChild).not.toHaveBeenCalled();
+		expect(runtimeWithSubagents.subagentRuntimes.get("matching-child")).toBe(childRuntime);
+
 		const authority: StrictDeletionAuthority = {
 			childId: "matching-child",
 			sessionDir,
+			sessionFile: childSession.sessionFile,
+			sessionId: childSession.sessionId,
 			generation: 2,
 			assertCurrent: vi.fn(),
 		};
+		await expect(runtime.deleteRlmSubagentRuntime("matching-child", childSession, authority)).rejects.toThrow(
+			"inline close failed once",
+		);
+		expect(runtimeWithSubagents.subagentRuntimes.get("matching-child")).toBe(childRuntime);
 
 		await runtime.deleteRlmSubagentRuntime("matching-child", childSession, authority);
 
-		expect(authority.assertCurrent).toHaveBeenCalledTimes(2);
-		expect(disposeChild).toHaveBeenCalledOnce();
+		expect(authority.assertCurrent).toHaveBeenCalledTimes(4);
+		expect(disposeChild).toHaveBeenCalledTimes(2);
 		expect(runtimeWithSubagents.subagentRuntimes.has("matching-child")).toBe(false);
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -35,6 +35,10 @@ type RuntimeSubagentMapAccess = {
 	subagentRuntimes: Map<string, AgentSessionRuntime>;
 };
 
+type RuntimeSessionLeaseAccess = {
+	_sessionLease?: { release(): void };
+};
+
 type StrictDeletionAuthority = {
 	childId: string;
 	sessionDir: string;
@@ -285,6 +289,47 @@ describe("AgentSessionRuntime characterization", () => {
 
 		expect(shutdownCount).toBe(2);
 		expect(disposeSession).toHaveBeenCalledTimes(2);
+	});
+
+	it("defers lease release when the daemon claims before direct disposal", async () => {
+		const { runtime } = createRuntimeWithFakeSession();
+		const release = vi.fn();
+		let finishShutdown: () => void;
+		const shutdown = new Promise<void>((resolve) => {
+			finishShutdown = resolve;
+		});
+		(runtime as unknown as RuntimeSessionLeaseAccess)._sessionLease = { release };
+		(runtime.session.extensionRunner as unknown as { emit(): Promise<void> }).emit = async () => shutdown;
+
+		expect(runtime.claimSessionLeaseReleaseForDaemon()).toBe(true);
+		const directDispose = runtime.dispose();
+		await vi.waitFor(() => expect(release).not.toHaveBeenCalled());
+		finishShutdown!();
+		await directDispose;
+		expect(release).not.toHaveBeenCalled();
+
+		runtime.releaseSessionLease();
+		runtime.releaseSessionLease();
+		expect(release).toHaveBeenCalledOnce();
+	});
+
+	it("fails closed when direct disposal starts before a daemon lease claim", async () => {
+		const { runtime } = createRuntimeWithFakeSession();
+		const release = vi.fn();
+		let finishShutdown: () => void;
+		const shutdown = new Promise<void>((resolve) => {
+			finishShutdown = resolve;
+		});
+		(runtime as unknown as RuntimeSessionLeaseAccess)._sessionLease = { release };
+		(runtime.session.extensionRunner as unknown as { emit(): Promise<void> }).emit = async () => shutdown;
+
+		const directDispose = runtime.dispose();
+		expect(runtime.claimSessionLeaseReleaseForDaemon()).toBe(false);
+		expect(release).not.toHaveBeenCalled();
+		finishShutdown!();
+		await directDispose;
+
+		expect(release).toHaveBeenCalledOnce();
 	});
 
 	it("continues disposing tracked subagents after one child dispose fails", async () => {

--- a/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
@@ -183,7 +183,12 @@ describe("ENG-4602 snapshot transfer containment", () => {
 			clients: new Set<DaemonSocketClient>(),
 			eventGeneration: "generation-4602",
 			lastEventSequence: 1,
-			runtime: { metadata: { kind: "top-level", createdAt: 1 } },
+			runtime: {
+				metadata: { kind: "top-level", createdAt: 1 },
+				// Resident daemon states always carry a runtime session. A persisted
+				// path lets passive discovery inspect its (empty) registry normally.
+				session: { sessionFile: "/tmp/eng-4602-session.jsonl" },
+			},
 		} as unknown as ActiveSessionState;
 		const socket = new PassThrough();
 		const client = {

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -1,6 +1,6 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
-import type { HostRequestHandlers } from "../../../src/core/kernel/index.js";
+import { type HostRequestHandlers, invokeHostRequestHandlerForTest } from "../../../src/core/kernel/index.js";
 import { SessionManager } from "../../../src/core/session-manager.js";
 import { createHarness } from "../harness.js";
 
@@ -27,7 +27,7 @@ describe("ENG-4649 subagent model selection", () => {
 			)._createKernelHostHandlers();
 			const findModels = handlers["rlm.find_models"];
 			if (!findModels) throw new Error("Missing rlm.find_models host handler");
-			await expect(findModels({ query: "model 319", limit: 5 })).resolves.toEqual({
+			await expect(invokeHostRequestHandlerForTest(findModels!, { query: "model 319", limit: 5 })).resolves.toEqual({
 				models: [
 					{
 						provider,
@@ -37,7 +37,9 @@ describe("ENG-4649 subagent model selection", () => {
 					},
 				],
 			});
-			await expect(findModels({ query: "model", limit: 21 })).rejects.toThrow("integer from 1 to 20");
+			await expect(invokeHostRequestHandlerForTest(findModels!, { query: "model", limit: 21 })).rejects.toThrow(
+				"integer from 1 to 20",
+			);
 			harness.setResponses([fauxAssistantMessage("resolved child answer")]);
 
 			const result = await harness.session.runRlmChild("use the requested model", {

--- a/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4649-subagent-model-selection.test.ts
@@ -1,7 +1,8 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
-import { type HostRequestHandlers, invokeHostRequestHandlerForTest } from "../../../src/core/kernel/index.js";
+import type { HostRequestHandlers } from "../../../src/core/kernel/index.js";
 import { SessionManager } from "../../../src/core/session-manager.js";
+import { invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest } from "../../host-request-context.js";
 import { createHarness } from "../harness.js";
 
 const provider = "faux-eng-4649";

--- a/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
@@ -68,7 +68,7 @@ describe("#617 subagent terminal agent messages", () => {
 			rlmMaxDepth: 1,
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child!.session }),
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 		child.setResponses([fauxAssistantMessage("child completed")]);
@@ -105,7 +105,7 @@ describe("#617 subagent terminal agent messages", () => {
 		parent = await createHarness({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child!.session }),
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			} as never,
 		});
 		child.setResponses([fauxAssistantMessage("done, no reply to parent")]);


### PR DESCRIPTION
## Summary
- replace advisory host request handler registration with factory-minted capabilities and opaque dispatcher contexts
- revoke in-flight authority on comm close, settlement, cleanup, disposal, and restart paths
- migrate kernel host registrations and focused fixtures to explicit context-aware handlers

## Validation
- `biome check` on all changed paths
- `tsgo --noEmit`
- explicit kernel/host-request Vitest suite (167 passed, 7 skipped)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dispatch host requests as capability-branded handlers with abortable, provenance-checked contexts
> - `KernelManager` now mints a per-comm `HostRequestContext` (via `mintHostRequestContext`) with an `AbortController`-backed signal that is revoked on `comm_close`, during shutdown, and after settlement, preventing stale or replayed handler invocations.
> - `createHostRequestHandler` now requires an explicit `contextAwareHostRequestHandler` marker; unary or unmarked handlers are rejected at registration time rather than via `Function.length` heuristics.
> - `assertGenuineHostRequestContext` validates context objects by WeakSet provenance instead of structural checks, blocking payload-injected or fabricated contexts.
> - `KernelManager` gains a terminal state: once entered, `start()` rejects, host-request admission is closed, and restart waits for non-terminal shutdown to complete before reopening admission.
> - All production host handlers (`agent-messages`, `agent-observe`, `agent-session`, `rlm-runtime`, `mcp-manager`) are wrapped with `createHostRequestHandler` and `contextAwareHostRequestHandler`.
> - Test helpers in [host-request-context.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1243/files#diff-74ed9f303a03d8b98fbace8f9d1c7767624c986b0842b46402ebb36a58ff470a) are updated to produce branded handlers and provide `invokeHostRequestHandlerForTest` / `invokeHostRequestThroughKernelForTest` for exercising dispatch semantics without a real kernel.
> - Risk: any externally registered host handler not wrapped with `createHostRequestHandler` + `contextAwareHostRequestHandler` will be rejected at dispatch time.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1243 opened
>
> - Implemented request authority propagation for RLM child runs using abort signals and currency checks [77b188b]
> - Unified kernel startup failure cleanup to conditionally return to idle state [77b188b]
> - Added test coverage for request authority revocation in RLM child runs and kernel startup race conditions [77b188b]
> - Implemented immutable family catalog snapshots with multi-source reconciliation [0ff02b3]
> - Replaced live-derived relationships with catalog-based authorization for all agent family reach assertions [0ff02b3]
> - Plumbed sessionDir scoping through all catalog queries, name reservations, and worker launches [0ff02b3]
> - Hardened registry parsing with descriptor-relative reads and hostile artifact validation [0ff02b3]
> - Refactored session disposal to parallelize kernel shutdown and refinement drain with aggregated error handling [0ff02b3]
> - Bumped daemon protocol schema revision to 17 for authority-aware saved-session renames [0ff02b3]
> - Exported supervisor registry directory resolution and refactored ownership utilities [0ff02b3]
> - Strengthened sibling name reservation with canonical parent path resolution [0ff02b3]
> - Replaced host request authority from ID/generation/isCurrent() model to AbortSignal-based revocation [7dcf7fe]
> - Implemented RLM subagent deletion durability tracking with strict authority fencing and coordination [7dcf7fe]
> - Rewrote catalog family session traversal with descriptor-bound reads through persistent helper process [7dcf7fe]
> - Added session closing lifecycle with synchronous admission fencing and orderly async disposal [7dcf7fe]
> - Refactored sibling scope calculation and saved session name reservation to normalize depth and parent path uniformly [7dcf7fe]
> - Changed kernel host request dispatch to assign protocol status last in comm message payload [7dcf7fe]
> - Added readSessionHeaderInfoFromBuffer utility for bounded header parsing without body scan [7dcf7fe]
> - Changed deleteRlmSubagentRuntime return type to include deletionDurability result [7dcf7fe]
> - Modified `AgentDaemon.persistedTopologyClaims` and `AgentDaemon.residentAgentFamilyCandidate` utilities to gate parent session derivation based on depth values [2694177]
> - Expanded test coverage for depth-0 session fork handling in daemon mode [2694177]
> - Introduced stale incarnation detection and newer child preservation across the subagent deletion lifecycle [5dc3453]
> - Enhanced daemon subagent registry deletion with strict absence proof capability [5dc3453]
> - Fixed daemon catalog session listing to validate child artifact paths against parent session artifact directory structure [5dc3453]
> - Modified session closing to accept custom delivery and completion errors [5dc3453]
> - Added explicit pump suspension clearing before non-streaming prompts after abort [5dc3453]
> - Introduced tombstoned RLM subagent close retry infrastructure with exponential backoff [f7d3652]
> - Refactored `AgentDaemon.closeSessionOnce()` to support tombstoned retry context and resilient error handling [f7d3652]
> - Enforced session quarantine and privacy filtering across all daemon commands and listings [f7d3652]
> - Implemented session quarantine detection and public state filtering in daemon [f7d3652]
> - Introduced `PrivateSessionUnavailableError` and modified session state retrieval to enforce quarantine checks [f7d3652]
> - Modified RLM subagent release and deletion callbacks to support tombstoned durability with deferred cleanup [f7d3652]
> - Added `AgentDaemon.findExactRlmState()` helper for precise subagent state lookup [f7d3652]
> - Filtered heartbeats and cron jobs by session quarantine status [f7d3652]
> - Implemented session lease claiming and deferred release in `AgentSessionRuntime` [f7d3652]
> - Modified `AgentSessionRuntime.dispose()` and `AgentSession.disposeAsync()` to reset disposal promises on failure for retry support [f7d3652]
> - Tracked suspension reason in `AgentSession` to prevent direct prompts during update-restart preparation [f7d3652]
> - Implemented RLM child deletion quarantine and newer incarnation preservation in `AgentSession` [f7d3652]
> - Changed `AgentSessionRuntime` RLM subagent deletion to report `deletionDurability='absent'` for old incarnations [f7d3652]
> - Modified catalog session enumeration to use BigInt file stats for inode precision [f7d3652]
> - Filtered RLM child snapshots by deletion quarantine status [f7d3652]
> - Added comprehensive test coverage for tombstoned retirement, disposal retry, quarantine behavior, and inode precision [f7d3652]
> - Added `sessionId` to RLM subagent records in daemon supervisor tests [f7d3652]
> - Added catalog list mock to supervisor eviction tests [f7d3652]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cce55b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches kernel request authority, multi-phase RLM subagent deletion with durable host boundaries, and security-sensitive catalog traversal; regressions could revoke live work, delete wrong child incarnations, or mis-resolve agent families.
> 
> **Overview**
> This PR turns IPython **host requests** into factory-minted handlers that only run with dispatcher-minted `HostRequestContext` (WeakSet-proven `AbortSignal`). Authority is revoked on comm close, settlement, shutdown, and dispose; the kernel has a one-way **terminal** state that blocks new admission. Production handlers (`rlm.*`, goals, compact, MCP, agent messaging/observe) are migrated to `createHostRequestHandler`, and `rlm.run` / `rlm.delete_subagent` propagate the signal into spawn and delete paths.
> 
> **RLM subagent lifecycle** gets a per-child deletion coordinator (generation + exact lease/incarnation) so explicit deletes, compaction reapers, spawn finalizers, and cancelled never-admitted children share one transaction. Deletes can return `preserved_newer` or land in private **quarantine** when durability is unknown; runtime/host APIs gain `RlmSubagentDeletionAuthority`, typed host deletion errors, and stricter `deleteRlmSubagentRuntime` matching on `sessionFile` / `sessionId`. Spawn admission can abort before publication; session disposal adds synchronous **closing** (`beginClosing` / `isClosing`), blocks reload/runtime rebuild during async teardown, and defers session lease release when the daemon owns retirement.
> 
> **Agent family** naming and reach now resolve siblings via catalog-filtered parents (with a direct parent-id/path fallback for passive children) and stricter `isAgentFamilyParent` when both id and path are present. The daemon **catalog** adds a `family` command and replaces sibling listing with a bounded walk: O_NOFOLLOW roots, a persistent Python openat helper for header/metadata/registry reads, registry layout validation, and fail-closed limits on nodes/edges/depth. Session listing gains buffer-based header parsing helpers for that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d36520bba57692bf11662c0b1601348496f11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->