### PR TITLE
Render Mermaid diagrams as inline Unicode art in chat

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,77 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+embeddeddolt/
+proxieddb/
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+proxied_server_client_info.json
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+export-state.json
+last_pull
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Debug-mode pprof artifacts (written when dolt.debug: true in config.yaml)
+dolt-pprof/
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Sync-ready**: Uses Dolt remotes for backup and team sharing
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Dolt-native sync via bd dolt push / bd dolt pull
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,68 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, .beads/issues.jsonl is the only local store
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# Dolt-native backup (periodic backup for off-machine recovery)
+# This is full database backup only. Cross-machine sync uses Dolt remotes.
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-backups
+#   git-push: false    # Disable git push (backup locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Optional JSONL auto-export for viewers, interchange, and issue-level migration.
+# Disabled by default; enable only when an integration needs fresh .beads/issues.jsonl.
+# Use relative paths under .beads/ for JSONL import/export filenames.
+# export:
+#   auto: false
+#   path: issues.jsonl
+#   interval: 60s
+#   git-add: false
+# import:
+#   path: issues.jsonl
+
+# Integration settings (access with 'bd config get/set')
+# Non-secret keys (stored in the database):
+# - jira.url, jira.project
+# - linear.team_id
+# - github.org, github.repo
+#
+# Secret keys (stored in this file but prefer env vars to avoid git exposure):
+# - linear.api_key  → use LINEAR_API_KEY env var instead
+# - github.token    → use GITHUB_TOKEN env var instead
+
+sync.remote: "git+https://github.com/ruttybob/prime-agent.git"

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "pai",
+  "project_id": "4c83c6b3-e27c-4fe3-8dca-19d446151284"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ collect.sh
 
 __pycache__/
 *.pyc
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.beads/proxieddb/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,3 +257,22 @@ git pull --rebase && git push
 ### User override
 
 If the user instructions conflict with rules set out here, ask for confirmation that they want to override the rules. Only then execute their instructions.
+
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in a local bd (beads) database (prefix `pai`, committed mode — `.beads/` tracked in git with Dolt-remote sync). See `docs/agents/issue-tracker.md`.
+
+### Persistent memory
+
+In bd, via `bd remember` / `bd recall` — auto-injected at `bd prime` time, so present in every session. Reach for `bd remember "<insight>"` for anything worth keeping across sessions. See *Memory* in `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles using default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` at repo root, `docs/adr/` for decisions. See `docs/agents/domain.md`.

--- a/docs/adr/0001-mermaid-rendering-via-transform.md
+++ b/docs/adr/0001-mermaid-rendering-via-transform.md
@@ -1,0 +1,61 @@
+# ADR-0001: Mermaid rendering via Markdown transform callback
+
+Status: Proposed
+
+## Context
+
+We need to render Mermaid diagrams as Unicode box-drawing art inline in chat
+messages during streaming. The upstream pi project (v0.84.1) solved this with
+a `MarkdownOptions.transform` callback on the TUI `Markdown` component — a
+pre-processing step that replaces mermaid code blocks with styled art before
+marked parses the markdown.
+
+Two approaches were considered:
+
+1. **Transform callback** (pi's approach): Add `transform?: (md, width) => string`
+   to `MarkdownOptions`. The coding-agent creates a mermaid transformer that
+   lexes markdown, finds mermaid code blocks, renders them via grok-mermaid,
+   and returns modified markdown with diagram rows wrapped in inline code spans.
+
+2. **renderCodeBlock modification**: Add a `renderMermaid?(src, width)` callback
+   to `MarkdownTheme`. The TUI's `renderCodeBlock` method calls it when
+   `token.lang === "mermaid"`, returning styled lines instead of the default
+   code block rendering.
+
+## Decision
+
+Adopt approach 1: **transform callback**.
+
+## Rationale
+
+- **Upstream alignment**: pi v0.84.1 already uses this approach. Matching it
+  simplifies future upgrades and keeps the mental model consistent.
+
+- **Robustness**: Transform operates on raw markdown before parsing. It does
+  not depend on internal `renderCodeBlock` mechanics, per-block caching, or
+  token processing details. Changes to TUI rendering internals do not affect it.
+
+- **Minimal coupling**: The TUI gains one optional interface field and one
+  optional constructor parameter. The coding-agent owns all mermaid-specific
+  logic (grok-mermaid dependency, color mapping, mode handling, fallback).
+
+- **Simplicity**: `renderCodeBlock` approach would need width threading
+  (currently not passed to it), theme coupling for a rendering concern, and
+  coordination with the per-block cache. Transform avoids all three.
+
+## Consequences
+
+- The `Markdown` constructor gains a 6th optional parameter. All existing
+  call sites (50+) remain backward compatible.
+
+- `Markdown.render()` applies `transform(this.text, contentWidth)` before
+  parsing. If transform returns the same text, behavior is identical to today.
+
+- Only 4 of 15 `new Markdown()` src call sites pass a transform (assistant
+  text blocks, user messages). Thinking blocks and static content (changelog,
+  hotkeys) do not.
+
+- Mermaid rendering happens at the markdown-source level, not the token level.
+  This means grok-mermaid's `render()` is called during transform, and the
+  result is re-parsed by marked. The double-parse cost is negligible because
+  the transformed mermaid blocks are simple inline code spans.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,129 @@
+# Issue tracker: bd (beads)
+
+Issues and specs for this repo live in a local [bd (beads)](https://github.com/gastownhall/beads) database — a dependency-aware issue tracker backed by an embedded Dolt SQL store (no server, no external service). Use the `bd` CLI for all operations; it emits JSON via `--json`, so a pi session running in this repo drives it directly (treat it like `gh`). `bd prime` is the single source of truth for operational commands — run it for the full, up-to-date reference; this doc records only this repo's conventions and the mappings the engineering skills read.
+
+> **Recorded values** (fill once at setup):
+>
+> - Prefix: `pai` — issue identifiers look like `pai-<hash>` (e.g. `pai-a3f2dd`).
+> - Visibility: `committed` — `.beads/` is tracked in git, enabling Dolt-remote sync across machines.
+> - Sync remote: `origin` (auto-wired from `git remote`) — see *Sync*.
+
+## Model
+
+One layer: the repo's `.beads/` directory holds an embedded Dolt database. There is **no workspace/project split** (unlike Multica) and **no per-feature project** — every issue in this repo shares one flat space, scoped only by labels, parent-child links, and epics. Each issue gets a prefix-wide identifier `<PREFIX>-<hash>` and carries a **status** (lifecycle), **priority** (0–4), **assignee**, **labels**, and **dependency edges** (bd's first-class feature).
+
+## Init (run once at setup)
+
+```bash
+bd init --prefix <KEY> --role maintainer [--stealth] --skip-agents --skip-hooks
+```
+
+- `--prefix <KEY>` — short lowercase key prefixing every issue id (default: directory name).
+- `--role maintainer` — you own this tracker (use `contributor` for an OSS fork).
+- `--stealth` — keep `.beads/` out of git via `.git/info/exclude` (local-only; **no cross-machine sync**). Omit to commit `.beads/` and enable Dolt-remote sync.
+- `--skip-agents` — the matt setup writes its **own** lean AGENTS.md pointer (see the `## Agent skills` block); skip bd's built-in AGENTS.md/Claude/Codex generation to avoid a duplicate source of truth.
+- `--skip-hooks` — no git hooks (the matt flow does not depend on them; drop this flag if you want bd's sync-on-commit hooks).
+
+Confirm: `bd where` (active workspace) and `bd context` (backend identity + sync settings). Idempotent re-runs: add `--init-if-missing`.
+
+## Sync (optional — only when `committed`)
+
+bd syncs across machines through **Dolt remotes**, not JSONL. `bd init` auto-wires the git `origin` as the Dolt remote when one exists.
+
+```bash
+bd dolt remote list                     # verify the remote
+bd dolt remote add origin <git-url>     # add if missing (bd init usually does this)
+bd dolt push                            # push issues
+bd dolt pull                            # pull teammates' changes
+```
+
+Dolt merges at cell level, so concurrent edits rarely conflict. `.beads/issues.jsonl` is a **passive export** (for viewers / interchange), not the sync protocol — never treat it as one. Stealth repos have no remote sync (`.beads/` is local-only).
+
+## Memory (persistent, prime-injected)
+
+bd holds persistent project memory in the same database — insights that survive across sessions and **auto-inject at `bd prime` time**, so every session has them without manual loading. This is the replacement for ad-hoc `NOTES.md` / memory files.
+
+- **Store**: `bd remember "<insight>"` (key auto-generated from content), or `bd remember "<insight>" --key <slug>` for a stable, recallable key. Re-`remember` with the same `--key` updates in place.
+- **Recall**: `bd recall <key>` (a bare existing key passed to `bd remember` also recalls it).
+- **List / search**: `bd memories` / `bd memories "<phrase>"`.
+- **Forget**: `bd forget <key>`.
+
+Use it for the unwritten conventions, gotchas, and reasons-behind-choices a new session needs but no config confesses. Do **not** use it for issue state (issues are for that) or per-session scratch (`bd note` on an issue is).
+
+## Labels (implicit — no `create` step)
+
+bd labels spring into existence on first use (`bd update --add-label X` / `bd create --labels X`) — there is no `label create` command, so setup creates nothing here (contrast with Multica's label-seeding stage). The five canonical **triage** roles (see `triage-labels.md`) are bd labels:
+
+```text
+needs-triage · needs-info · ready-for-agent · ready-for-human · wontfix
+```
+
+The `wayfinder:*` labels (`wayfinder:map`, `wayfinder:research`, `wayfinder:prototype`, `wayfinder:grilling`, `wayfinder:task`) **are** used here — wayfinder runs natively on bd (see *Wayfinding operations*), so they spring into existence like any other label, with no creation step.
+
+## Conventions
+
+- **Create**: `bd create "Title" -d "desc" -t task -p 2 [--assignee X] [--labels a,b] [--deps type:id,…]`. Types: `bug|feature|task|epic|chore|decision`. Priorities: 0 (critical) – 4 (backlog), default 2. `--deps discovered-from:<id>` links auto-discovered follow-up work.
+- **Read**: `bd show <id>` (or `bd show <id> --json`, `--include-comments`, `--children`). `bd show --current` shows the active issue.
+- **List**: `bd list --status open --json` / `--label needs-triage` / `--priority 0` / `--assignee X` / `--all` (incl. closed).
+- **Comment** (conversation): `bd comment <id> "text"`. **Note** (persistent field): `bd note <id> "text"`.
+- **Labels**: `bd label add <id> <role>` / `bd label remove <id> <role>` (or `bd update <id> --add-label X` / `--remove-label X`).
+- **Claim**: `bd update <id> --claim` (sets assignee + `in_progress`; idempotent if already yours) — or `bd ready --claim --json` (atomic claim of the next ready issue).
+- **Close**: `bd close <id> --reason "…"`. **Reopen**: `bd reopen <id>`.
+
+## Dependencies / blocking (bd's first-class feature)
+
+```bash
+bd dep add <issue> <depends-on>         # <depends-on> blocks <issue>
+bd dep <blocker> --blocks <blocked>     # same thing, other direction
+bd dep list <id>                        # edges of one issue
+bd dep tree <id>                        # visualize
+bd dep cycles                           # detect circular deps
+```
+
+Dependency types: `blocks` (hard gate), `related` (soft link), `parent-child` (epic / subtask), `discovered-from` (auto-created for AI-discovered follow-ups).
+
+The **frontier** is built in: `bd ready` lists open issues with **no active blockers** — claimable now. This is the dependency-aware equivalent of wayfinder's frontier query, available without any body-convention.
+
+## Resolving an issue
+
+bd has **native** terminal state (unlike local markdown's `Status:` line):
+
+```bash
+bd close <id> --reason "Landed in PR #42, commit abc1234"
+```
+
+`closed` means *landed / worked*, recorded in the Dolt history. The close reason is the link to where the work shipped (PR / commit / branch) — bd has no auto-linking to git, so the reason is the record. Closed issues fall out of every active scan (`bd ready`, `bd list --status open`, triage) automatically.
+
+## Triage mapping (labels on top of lifecycle status)
+
+Two independent axes:
+
+- **bd status** (lifecycle): `open` → `in_progress` (claimed) → `closed`, with `blocked` / `deferred` / `hooked` as operational states. Driven by `--claim` / `--status` / `close`.
+- **bd labels** (triage role): the five canonical strings above, applied by `/triage`. `ready-for-agent` + `bd ready` = fully unblocked and AFK-ready.
+
+`/triage` reads `triage-labels.md` for the vocabulary and applies labels via `bd label add`. A `wontfix` issue is also closed (`bd close`); the label records *why* it left the queue.
+
+## Wayfinding operations
+
+`/wayfinder` consults this section. **Wayfinder runs natively on bd** — bd's first-class dependencies (`bd dep`) and built-in scoped frontier (`bd ready --parent`) are a cleaner substrate than the local-markdown body conventions, so there is no `.scratch/` indirection here (unlike Multica, which is execution-only). The github tracker follows the same native-deps pattern; bd matches it without the sub-issues-API dance. A **map** is one bd issue; its **decision tickets** are child issues.
+
+- **Create the map**: `bd create "<Destination>" -t epic -d "<map body>" --labels wayfinder:map`. Body uses the map template (`## Destination`, `## Notes`, `## Not yet specified`, `## Out of scope` — see `/wayfinder`). The map is an index: a decision lives in its ticket; the map only gists + links. `## Decisions so far` is **not** in the body — it is the map's **notes** field, appended one line per resolution (below).
+- **Create a ticket**: `bd create "<Question title>" --parent <map-id> --labels wayfinder:<type> -d "<question body>"` (multiline body via `--stdin` / heredoc). Types: `research` / `prototype` / `grilling` / `task`. The `--parent` edge is the containment (every ticket is a child of its map); the bd issue id is the ticket's identity.
+- **Wire blocking** (second pass, after tickets have ids): `bd dep add <child> <blocker>` (type `blocks`, the default). This is bd's **native** dependency — it renders the frontier in `bd ready` and `bd dep tree`, the visual the human checks without opening the map. A ticket is unblocked when every blocker is `closed`.
+- **Frontier query**: `bd ready --parent <map-id>` — open, unblocked descendants of the map. `bd ready` excludes `in_progress` / `blocked` / `deferred`, and claiming sets `in_progress`, so claimed tickets fall out automatically. Pick the first by priority, or the one the user named.
+- **Claim**: `bd update <ticket-id> --claim` (sets assignee + `in_progress`; idempotent if already yours) — the session's first write, before any work. The claim _is_ the assignment; do not bare-`--assignee` (that leaves status `open` and the ticket still in the frontier).
+- **Resolve**: `bd comment <ticket-id> "<answer>"` (the resolution), then `bd close <ticket-id>`, then append the index line to the map's Decisions-so-far: `bd note <map-id> "- [<ticket title>](link) — <one-line gist>"`. A **research** ticket is resolved by a `/research` subagent whose findings land on a throwaway branch — link the branch from the ticket as its asset (`bd note <ticket-id> "branch: …"`).
+- **Refer by name** (`/wayfinder` rule): cite tickets by **title**, never a bare id — the id rides inside the name.
+- **Concurrency**: bd is a single database with atomic `--claim`; other sessions may edit concurrently. Re-`bd show` the map / re-run the frontier before acting.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** bd is an internal tracker with no PR object; there is nothing to triage. (`/triage` skips this entirely for bd.)
+
+## When a skill says "publish to the issue tracker"
+
+`bd create "Title" -d "…" -t task -p 2` (add `--deps` / `--labels` / `--assignee` as needed).
+
+## When a skill says "fetch the relevant ticket"
+
+`bd show <id>` (or `bd show <id> --json --include-comments` for full context).

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/ideas/mermaid-rendering.md
+++ b/docs/ideas/mermaid-rendering.md
@@ -1,0 +1,116 @@
+# Mermaid Rendering — Inline Unicode Diagrams
+
+## Problem Statement
+Render Mermaid diagrams as Unicode box-drawing art inline in the chat,
+during streaming, without modifying agent behavior.
+
+## Architecture Decision
+
+**Transform approach** (matching upstream pi v0.84.1): pre-process raw
+markdown before parsing, replacing mermaid code blocks with styled Unicode
+diagrams via a `MarkdownOptions.transform` callback on the TUI `Markdown`
+component.
+
+Not the 8-layer pipeline from the original idea. No Extension API changes.
+No markdown-transform composer. One transformer function passed directly.
+
+### Scope — 4 files modified, 1 new, 2 packages
+
+**packages/tui/src/components/markdown.ts**
+- Add `MarkdownOptions` interface: `{ transform?: (md: string, availableWidth: number) => string }`
+- Add 6th optional constructor parameter `options?: MarkdownOptions`
+- In `render()`: `const text = this.options.transform?.(this.text, contentWidth) ?? this.text;`
+- Backward compatible — all existing 50+ call sites unchanged
+
+**packages/coding-agent/src/modes/interactive/components/mermaid.ts** (new)
+- `createMermaidMarkdownTransformer({ getMode, theme }): (md, width) => string`
+- Lex markdown → find `token.type === "code"` with `lang === "mermaid"` →
+  `render()` from grok-mermaid → replace block with styled Unicode art
+- Each diagram row wrapped in `codeSpan()` for whitespace preservation
+- Modes: `off` → passthrough, `streaming` → always render (grok-mermaid
+  handles partial diagrams natively via retry-without-last-line)
+- Color mapping: iterate `art.styled`, map each `Span.cls` to `theme.fg()`:
+  - `border` → `dim`
+  - `text` → default (no explicit color)
+  - `edge` → `accent`
+  - `edgeLabel` → `accent`
+  - `title` → `dim` + `bold`
+  - `none` → no styling
+- Fallback: `render(src)` returns `null` or `art.width > contentWidth` →
+  leave original code block untouched (raw mermaid source via `token.raw`)
+
+**packages/coding-agent/src/modes/interactive/components/assistant-message.ts**
+- Add `markdownTransform?` to `AssistantMessageComponentOptions`
+- In `rebuild()` line 216: pass `{ transform: this.markdownTransform }`
+  to text block Markdown
+- NOT in thinking blocks (line 237) — thinking is draft, mermaid is noise
+
+**packages/coding-agent/src/modes/interactive/components/user-message.ts**
+- Add `markdownTransform?` param to both constructors
+- Pass `{ transform }` to Markdown at lines 31 and 72
+
+**packages/coding-agent/src/modes/interactive/interactive-mode.ts**
+- Create `mermaidMarkdownTransformer` field:
+  `createMermaidMarkdownTransformer({ getMode: () => settingsManager.getMermaidRenderingMode(), theme })`
+- Pass to AssistantMessageComponent and UserMessageComponent constructors
+- Handle `onMermaidRenderingModeChange` → invalidate + re-render
+
+**packages/coding-agent/src/core/settings-manager.ts**
+- Add `mermaid?: MermaidRenderingMode` to `MarkdownSettings`
+  (`type MermaidRenderingMode = "off" | "streaming"`)
+- Add `getMermaidRenderingMode()` / `setMermaidRenderingMode()`
+- Default: `"streaming"`
+
+**packages/coding-agent/src/modes/interactive/components/settings-selector.ts**
+- Add `mermaidRenderingMode` to `SettingsConfig`
+- Add `onMermaidRenderingModeChange` to `SettingsCallbacks`
+- Toggle: "Mermaid diagrams" with values `off | streaming`
+
+**packages/coding-agent/package.json**
+- `"grok-mermaid": "0.2.2"` — install with `--min-release-age=0` override
+
+**packages/coding-agent/CHANGELOG.md** + **packages/tui/CHANGELOG.md**
+- Add entry under `[Unreleased]`
+
+## Settled Design Decisions
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| D1 | Architecture | Transform approach (pi backport) | Matches upstream; pre-processing is robust against TUI internals |
+| D2 | Dependency age | Override `--min-release-age=0` | grok-mermaid 0.2.2 published 6 days ago; user-approved override |
+| D3 | Package owner | coding-agent owns grok-mermaid | TUI stays generic; theme + mode + fallback all in one place |
+| D4 | Modes | `off` / `streaming` (default: streaming) | `final` dropped — prime-agent's incremental reconcile + per-block cache makes streaming→complete cache invalidation expensive; grok-mermaid handles partial diagrams natively |
+| D5 | Fallback | Plain code block | `render()===null` or `art.width > contentWidth` → leave `token.raw` unchanged |
+| D6 | Color mapping | Span→theme (not `toAnsi`) | Raw ANSI in pi pipeline would break; `theme.fg()` integration is native |
+| D7 | Settings location | `MarkdownSettings.mermaid` | Mermaid is markdown rendering; no separate interface |
+| D8 | Coverage | assistant text + user messages | NOT thinking blocks, NOT static content |
+| D9 | Composer | None | Single transformer passed directly as `(md, width) => string` |
+| D10 | isStreaming in render path | Not needed | No `final` mode → grok-mermaid partial rendering suffices |
+
+## Why Not `final` Mode
+
+Upstream pi supports `off | final | streaming`. We implement `off | streaming`.
+
+Pi's `AssistantMessageComponent.updateContent()` does a **full rebuild** on
+every call — `contentContainer.clear()` + new Markdown components. The
+`isStreaming` flag is baked into a fresh transform closure each time. When
+`message_end` fires with `isStreaming=false`, new components get empty caches,
+and the transform renders mermaid art on the first `render()`.
+
+Prime-agent's `AssistantMessageComponent` uses **incremental reconcile**:
+`computeSignature()` → `setText()` only on changed blocks → per-block render
+cache. When `message_end` fires, the signature doesn't change (same content
+structure), so `setText()` is never called, and the cached result (without
+mermaid art) is returned. Implementing `final` mode would require:
+invalidating all `blockMarkdowns` on streaming state change, propagating
+`isStreaming` through the component tree, and forcing rebuilds. That's
+~15-20 lines of plumbing for a mode whose primary benefit (avoiding partial
+flicker) is already handled by grok-mermaid's retry-without-last-line.
+
+## Not Doing
+- Extension API `registerMarkdownTransformer` — no second consumer; YAGNI
+- `outputPad` / `preserveOrderedListMarkers` / `preserveBackslashEscapes` —
+  unrelated pi features
+- `toAnsi()` — raw ANSI conflicts with pi rendering pipeline
+- Mermaid in thinking blocks — draft content, visual noise
+- Theme spans in `custom-message.ts` — mermaid.ts uses `theme.fg()` directly

--- a/package-lock.json
+++ b/package-lock.json
@@ -3115,6 +3115,15 @@
 			"version": "4.2.11",
 			"license": "ISC"
 		},
+		"node_modules/grok-mermaid": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+			"integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"license": "MIT",
@@ -5364,6 +5373,7 @@
 				"extract-zip": "^2.0.1",
 				"file-type": "^21.1.1",
 				"glob": "^13.0.1",
+				"grok-mermaid": "^0.2.2",
 				"hosted-git-info": "^9.0.2",
 				"ignore": "^7.0.5",
 				"jiti": "^2.7.0",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added `reasoning_effort` control for all Z.AI reasoning models, exposing five thinking levels (`off`, `low`, `medium`, `high`, `max`) in the `/effort` selector.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -110,6 +110,14 @@ const ZAI_THINKING_COMPAT: OpenAICompletionsCompat = {
 	thinkingFormat: "zai",
 };
 
+const ZAI_THINKING_LEVEL_MAP = {
+	minimal: null,
+	low: "high",
+	medium: "high",
+	high: "high",
+	max: "max",
+} as const;
+
 const PRIME_INFERENCE_BASE_URL = "https://api.pinference.ai/api/v1";
 const PRIME_INFERENCE_COMPAT: OpenAICompletionsCompat = {
 	supportsStore: false,
@@ -1136,6 +1144,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 				const m = model as ModelsDevModel;
 				if (m.tool_call !== true) continue;
 				const supportsImage = m.modalities?.input?.includes("image");
+				const hasReasoning = m.reasoning === true;
 
 				models.push({
 					id: modelId,
@@ -1143,8 +1152,9 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					api: "openai-completions",
 					provider: "zai",
 					baseUrl: "https://api.z.ai/api/coding/paas/v4",
-					reasoning: m.reasoning === true,
+					reasoning: hasReasoning,
 					input: supportsImage ? ["text", "image"] : ["text"],
+					...(hasReasoning ? { thinkingLevelMap: ZAI_THINKING_LEVEL_MAP } : {}),
 					cost: {
 						input: m.cost?.input || 0,
 						output: m.cost?.output || 0,
@@ -1154,6 +1164,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					compat: {
 						supportsDeveloperRole: false,
 						thinkingFormat: ZAI_THINKING_COMPAT.thinkingFormat,
+						...(hasReasoning ? { supportsReasoningEffort: true } : {}),
 						...(!ZAI_TOOL_STREAM_UNSUPPORTED_MODELS.has(modelId) ? { zaiToolStream: true } : {}),
 					},
 					contextWindow: m.limit?.context || 4096,

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -20330,8 +20330,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","supportsReasoningEffort":true,"zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"minimal":null,"low":"high","medium":"high","high":"high","max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,
@@ -20348,8 +20349,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","supportsReasoningEffort":true,"zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"minimal":null,"low":"high","medium":"high","high":"high","max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,
@@ -20366,8 +20368,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","supportsReasoningEffort":true,"zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"minimal":null,"low":"high","medium":"high","high":"high","max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,
@@ -20384,8 +20387,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","supportsReasoningEffort":true,"zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"minimal":null,"low":"high","medium":"high","high":"high","max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -562,7 +562,18 @@ function buildParams(
 	}
 
 	if (compat.thinkingFormat === "zai" && model.reasoning) {
-		(params as any).enable_thinking = !!options?.reasoningEffort;
+		const zaiParams = params as Omit<typeof params, "reasoning_effort"> & {
+			thinking?: { type: "enabled" | "disabled"; clear_thinking?: boolean };
+			reasoning_effort?: string;
+		};
+		zaiParams.thinking = options?.reasoningEffort ? { type: "enabled", clear_thinking: false } : { type: "disabled" };
+		if (options?.reasoningEffort && compat.supportsReasoningEffort) {
+			const mappedEffort = model.thinkingLevelMap?.[options.reasoningEffort];
+			const effort = mappedEffort === undefined ? options.reasoningEffort : mappedEffort;
+			if (typeof effort === "string") {
+				zaiParams.reasoning_effort = effort;
+			}
+		}
 	} else if (compat.thinkingFormat === "qwen" && model.reasoning) {
 		(params as any).enable_thinking = !!options?.reasoningEffort;
 	} else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -308,7 +308,7 @@ export interface OpenAICompletionsCompat {
 	requiresThinkingAsText?: boolean;
 	/** Whether all replayed assistant messages must include an empty reasoning_content field when reasoning is enabled. Default: auto-detected from URL. */
 	requiresReasoningContentOnAssistantMessages?: boolean;
-	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" uses thinking: { type } plus reasoning_effort, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
+	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" uses thinking: { type } plus reasoning_effort, "zai" uses thinking: { type, clear_thinking } plus optional reasoning_effort (when supported), "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
 	thinkingFormat?: "openai" | "openrouter" | "deepseek" | "zai" | "qwen" | "qwen-chat-template";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;

--- a/packages/ai/test/zai-thinking.test.ts
+++ b/packages/ai/test/zai-thinking.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { getModel, getSupportedThinkingLevels } from "../src/models.js";
+import { stream } from "../src/stream.js";
+import type { Context, Model } from "../src/types.js";
+
+function makeContext(): Context {
+	return {
+		messages: [
+			{
+				role: "user",
+				content: "Hello",
+				timestamp: Date.now(),
+			},
+		],
+	};
+}
+
+interface ZaiPayload {
+	thinking?: { type: string; clear_thinking?: boolean };
+	reasoning_effort?: string;
+	enable_thinking?: boolean;
+}
+
+async function capturePayload(
+	model: Model<"openai-completions">,
+	reasoningEffort?: "low" | "medium" | "high" | "max",
+): Promise<ZaiPayload> {
+	let captured: ZaiPayload | undefined;
+
+	const s = stream(model, makeContext(), {
+		reasoningEffort,
+		signal: AbortSignal.abort(),
+		onPayload: (payload) => {
+			captured = payload as ZaiPayload;
+			return undefined;
+		},
+	});
+
+	for await (const event of s) {
+		if (event.type === "error") break;
+	}
+
+	if (!captured) throw new Error("Expected payload to be captured");
+	return captured;
+}
+
+describe("Z.AI thinking levels", () => {
+	describe("getSupportedThinkingLevels", () => {
+		it("returns [off, low, medium, high, max] for glm-5.2", () => {
+			const model = getModel("zai", "glm-5.2");
+			expect(model).toBeDefined();
+			expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "medium", "high", "max"]);
+		});
+
+		it("returns [off, low, medium, high, max] for glm-5.2-highspeed", () => {
+			const model = getModel("zai", "glm-5.2-highspeed");
+			expect(model).toBeDefined();
+			expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "medium", "high", "max"]);
+		});
+
+		it("returns [off, low, medium, high, max] for glm-4.7", () => {
+			const model = getModel("zai", "glm-4.7");
+			expect(model).toBeDefined();
+			expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "medium", "high", "max"]);
+		});
+
+		it("returns [off, low, medium, high, max] for glm-5-turbo", () => {
+			const model = getModel("zai", "glm-5-turbo");
+			expect(model).toBeDefined();
+			expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "medium", "high", "max"]);
+		});
+	});
+
+	describe("request params for glm-5.2", () => {
+		it("sends thinking.type=enabled with clear_thinking=false and reasoning_effort when effort is high", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model, "high");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+			expect(payload.enable_thinking).toBeUndefined();
+		});
+
+		it("sends reasoning_effort=max when effort is max", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model, "max");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("max");
+		});
+
+		it("maps low effort to reasoning_effort=high (alias)", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model, "low");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+		});
+
+		it("maps medium effort to reasoning_effort=high (alias)", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model, "medium");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+		});
+
+		it("sends thinking.type=disabled when reasoning is off (no reasoningEffort)", async () => {
+			const model = getModel("zai", "glm-5.2")!;
+			const payload = await capturePayload(model);
+
+			expect(payload.thinking).toEqual({ type: "disabled" });
+			expect(payload.reasoning_effort).toBeUndefined();
+			expect(payload.enable_thinking).toBeUndefined();
+		});
+	});
+
+	describe("request params for glm-4.7", () => {
+		it("sends thinking.type=enabled with clear_thinking=false and reasoning_effort when effort is high", async () => {
+			const model = getModel("zai", "glm-4.7")!;
+			const payload = await capturePayload(model, "high");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+			expect(payload.enable_thinking).toBeUndefined();
+		});
+
+		it("sends reasoning_effort=max when effort is max", async () => {
+			const model = getModel("zai", "glm-4.7")!;
+			const payload = await capturePayload(model, "max");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("max");
+		});
+
+		it("sends thinking.type=disabled when reasoning is off", async () => {
+			const model = getModel("zai", "glm-4.7")!;
+			const payload = await capturePayload(model);
+
+			expect(payload.thinking).toEqual({ type: "disabled" });
+			expect(payload.reasoning_effort).toBeUndefined();
+		});
+	});
+
+	describe("request params for glm-5-turbo", () => {
+		it("sends thinking.type=enabled with clear_thinking=false and reasoning_effort when effort is high", async () => {
+			const model = getModel("zai", "glm-5-turbo")!;
+			const payload = await capturePayload(model, "high");
+
+			expect(payload.thinking).toEqual({ type: "enabled", clear_thinking: false });
+			expect(payload.reasoning_effort).toBe("high");
+			expect(payload.enable_thinking).toBeUndefined();
+		});
+
+		it("sends thinking.type=disabled when reasoning is off", async () => {
+			const model = getModel("zai", "glm-5-turbo")!;
+			const payload = await capturePayload(model);
+
+			expect(payload.thinking).toEqual({ type: "disabled" });
+			expect(payload.reasoning_effort).toBeUndefined();
+		});
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added the current working directory to the editor status line.
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed `ctrl+c` to clear the prompt when it has content and no operation is running.
 - Added privacy-safe pseudonymous product analytics for onboarding, command use, execution modes, run outcomes, TTFT, latency, usage, tools, retries, and compactions, with disclosure and opt-out controls ([ENG-4682](https://linear.app/primeintellect/issue/ENG-4682/add-privacy-safe-posthog-analytics-to-prime-agent)).
 - Changed sent agent messages in the IPython cell UI to show only the message text with a `╰─` gutter when expanded, matching received messages, and hid the raw `agent_message.send` receipt dictionary.
 - Fixed Homebrew installs attempting to self-update their versioned Cellar keg instead of directing users to `brew upgrade prime-agent` ([#844](https://github.com/PrimeIntellect-ai/prime-agent/issues/844))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added Mermaid diagram rendering as Unicode box-drawing art in chat messages, with a settings toggle.
 - Added the current working directory to the editor status line.
 - Changed `ctrl+c` to clear the prompt when it has content and no operation is running.
 - Added `app.messages.expand` (`ctrl+p`) to collapse or expand agent-to-agent messages separately from `ctrl+o` tool output.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -58,6 +58,7 @@
 		"extract-zip": "^2.0.1",
 		"file-type": "^21.1.1",
 		"glob": "^13.0.1",
+		"grok-mermaid": "^0.2.2",
 		"hosted-git-info": "^9.0.2",
 		"ignore": "^7.0.5",
 		"jiti": "^2.7.0",

--- a/packages/coding-agent/src/core/session-file-actions.ts
+++ b/packages/coding-agent/src/core/session-file-actions.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { rm, unlink } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
@@ -71,4 +71,58 @@ export async function deleteSessionFile(
 		await deleteSessionArtifacts(sessionPath);
 	}
 	return result;
+}
+
+// Entry types that are always present when a session is created. A file that
+// contains only these plus session_state holds nothing worth keeping.
+const BOOTSTRAP_ENTRY_TYPES = new Set(["session", "model_change", "thinking_level_change", "service_tier_change"]);
+
+/**
+ * True when a session file is an empty draft: it has no messages and its only
+ * entries are the bootstrap prefix (session header, model/thinking/tier changes)
+ * optionally followed by a daemon-written session_state. Such files are ghost
+ * sessions — created on disk for crash recovery but never receiving a message.
+ */
+function isEmptyDraftSessionFile(sessionPath: string): boolean {
+	let content: string;
+	try {
+		content = readFileSync(sessionPath, "utf8");
+	} catch {
+		return false;
+	}
+	for (const line of content.split("\n")) {
+		if (!line.trim()) continue;
+		let entry: { type?: string };
+		try {
+			entry = JSON.parse(line);
+		} catch {
+			return false;
+		}
+		const type = entry.type;
+		if (!type) return false;
+		if (BOOTSTRAP_ENTRY_TYPES.has(type)) continue;
+		if (type === "session_state") continue;
+		// Any other entry type means the session has real content.
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Scan a session directory for ghost session files — empty drafts left behind
+ * when a daemon shuts down or crashes before the user sends their first message.
+ * Returns the count of files removed.
+ */
+export async function sweepGhostSessionFiles(sessionDir: string): Promise<number> {
+	if (!existsSync(sessionDir)) return 0;
+	let swept = 0;
+	for (const entry of readdirSync(sessionDir)) {
+		if (!entry.endsWith(".jsonl")) continue;
+		const filePath = join(sessionDir, entry);
+		if (isEmptyDraftSessionFile(filePath)) {
+			await deleteSessionFile(filePath).catch(() => undefined);
+			swept++;
+		}
+	}
+	return swept;
 }

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -1,6 +1,15 @@
 import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	realpathSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { lockSync } from "proper-lockfile";
 
@@ -227,6 +236,33 @@ function reclaimStaleLease(directory: string): boolean {
 	}
 	rmSync(stalePath, { recursive: true, force: true });
 	return true;
+}
+
+/**
+ * Remove all session-lease directories whose owner process is no longer alive.
+ * Called at daemon startup to reclaim leases left behind by crashed or killed
+ * processes. Safe because a live process can always re-acquire a swept lease.
+ */
+export function sweepStaleSessionLeases(agentDir: string): number {
+	const root = join(agentDir, "session-leases");
+	if (!existsSync(root)) return 0;
+	let swept = 0;
+	for (const entry of readdirSync(root)) {
+		if (!entry.endsWith(".lock")) continue;
+		const directory = join(root, entry);
+		const owner = readLeaseOwner(directory);
+		if (!owner) {
+			// Malformed or incomplete lease directory: reclaim it.
+			reclaimStaleLease(directory);
+			swept++;
+			continue;
+		}
+		if (!isLeaseOwnerAlive(owner)) {
+			reclaimStaleLease(directory);
+			swept++;
+		}
+	}
+	return swept;
 }
 
 export function acquireSessionLease(

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -60,8 +60,11 @@ export interface ThinkingBudgetsSettings {
 	high?: number;
 }
 
+export type MermaidRenderingMode = "off" | "streaming";
+
 export interface MarkdownSettings {
 	codeBlockIndent?: string; // default: "  "
+	mermaid?: MermaidRenderingMode; // default: "streaming"
 }
 
 export interface BundledSkillsSettings {
@@ -1263,6 +1266,19 @@ export class SettingsManager {
 
 	getCodeBlockIndent(): string {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
+	}
+
+	getMermaidRenderingMode(): MermaidRenderingMode {
+		return this.settings.markdown?.mermaid ?? "streaming";
+	}
+
+	setMermaidRenderingMode(mode: MermaidRenderingMode): void {
+		if (!this.globalSettings.markdown) {
+			this.globalSettings.markdown = {};
+		}
+		this.globalSettings.markdown.mermaid = mode;
+		this.markModified("markdown", "mermaid");
+		this.save();
 	}
 
 	getWarnings(): WarningSettings {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -30,6 +30,7 @@ import {
 	getCronJobsPath,
 	getDaemonLogPath,
 	getDaemonUpdateRestartManifestPath,
+	getSessionsDir,
 	VERSION,
 } from "../../config.js";
 import {
@@ -106,8 +107,13 @@ import {
 	type IdleEvictionMinutes,
 	type SessionPassivationSnapshot,
 } from "../../core/session-action-store.js";
-import { deleteSessionFile } from "../../core/session-file-actions.js";
-import { acquireSessionLease, canonicalSessionPath, type SessionLease } from "../../core/session-lease.js";
+import { deleteSessionFile, sweepGhostSessionFiles } from "../../core/session-file-actions.js";
+import {
+	acquireSessionLease,
+	canonicalSessionPath,
+	type SessionLease,
+	sweepStaleSessionLeases,
+} from "../../core/session-lease.js";
 import {
 	readSessionInfo,
 	resolveSessionRlmDepth,
@@ -617,12 +623,37 @@ export class AgentDaemon {
 
 		this.registerSignalHandlers();
 		this.summarizer.start();
+		this.sweepStaleStartupState();
 		this.log(`Prime Agent daemon listening on ${this.socketPath}`);
 		// No startup restore: on-disk sessions return only via --resume or the agents view.
 		if (!this.shuttingDown) {
 			this.cronScheduler.start();
 		}
 		this.startSupervisorMonitor();
+	}
+
+	/**
+	 * Best-effort cleanup at daemon startup: remove stale session leases left by
+	 * crashed processes and ghost session files (empty drafts that were never
+	 * sent a message). These accumulate when a daemon exits without cleaning up.
+	 */
+	private sweepStaleStartupState(): void {
+		try {
+			const staleLeases = sweepStaleSessionLeases(this.agentDir);
+			if (staleLeases > 0) {
+				this.log(`swept ${staleLeases} stale session lease(s) at startup`);
+			}
+		} catch (error) {
+			this.log(`session lease sweep failed: ${error instanceof Error ? error.message : String(error)}`);
+		}
+		const sessionDir = this.options.defaultSessionConfig.sessionDir ?? getSessionsDir(this.agentDir);
+		void sweepGhostSessionFiles(sessionDir)
+			.then((count) => {
+				if (count > 0) this.log(`swept ${count} ghost session file(s) at startup`);
+			})
+			.catch((error) => {
+				this.log(`ghost session sweep failed: ${error instanceof Error ? error.message : String(error)}`);
+			});
 	}
 
 	private startSupervisorMonitor(): void {
@@ -6035,10 +6066,11 @@ export class AgentDaemon {
 			? await this.closeChildSessions(state, reason, waitForAbort, descendants)
 			: undefined;
 		// Empty draft (no messages, config, or jobs): discard rather than persist an
-		// empty session file. Mirrors the detach-time discard so a config-bearing
-		// draft closed via kill/completed is never wiped.
+		// empty session file. A busy session is never discarded even if empty — the
+		// activity may produce content. Mirrors isDiscardableDraft so all close
+		// reasons (including shutdown/update) agree on what an abandoned draft is.
 		const keepsResumeEntry = this.closeKeepsResumeEntry(reason);
-		const isEmptyDraftSession = !keepsResumeEntry && this.isEmptyDraftContent(state);
+		const isEmptyDraftSession = this.isEmptyDraftContent(state) && !isActiveSessionBusy(state);
 		let persistError: unknown;
 		// Clean shutdown leaves the session un-archived so it stays in the resume list.
 		if (!keepsResumeEntry && !isEmptyDraftSession) {

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -27,6 +27,7 @@ const LOGIN_RECOVERY_SUFFIX = `\n\n${LOGIN_RECOVERY_MESSAGE}`;
 export interface AssistantMessageComponentOptions {
 	expanded?: boolean;
 	precededByToolActivity?: boolean;
+	markdownTransform?: (text: string, availableWidth: number) => string;
 }
 
 function getThinkingMarkdownTheme(baseTheme: MarkdownTheme): MarkdownTheme {
@@ -123,6 +124,7 @@ export class AssistantMessageComponent extends Container {
 	private blockMarkdowns = new Map<number, Markdown>();
 	private lastBlockTexts = new Map<number, string>();
 	private precededByToolActivity: boolean;
+	private markdownTransform?: (text: string, availableWidth: number) => string;
 
 	constructor(
 		message?: AssistantMessage,
@@ -138,6 +140,7 @@ export class AssistantMessageComponent extends Container {
 		this.hiddenThinkingLabel = hiddenThinkingLabel;
 		this.expanded = options.expanded ?? false;
 		this.precededByToolActivity = options.precededByToolActivity ?? false;
+		this.markdownTransform = options.markdownTransform;
 
 		// Container for text/thinking content
 		this.contentContainer = new Container();
@@ -272,7 +275,9 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				const markdown = new Markdown(content.text.trim(), 1, 0, this.markdownTheme);
+				const markdown = new Markdown(content.text.trim(), 1, 0, this.markdownTheme, undefined, {
+					transform: this.markdownTransform,
+				});
 				this.blockMarkdowns.set(i, markdown);
 				this.lastBlockTexts.set(i, content.text.trim());
 				this.contentContainer.addChild(markdown);

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -39,6 +39,7 @@ export interface ConversationComponentsOptions {
 	toolsExpanded?: boolean;
 	agentMessagesExpanded?: boolean;
 	isRecognizedSlashCommand?: (name: string) => boolean;
+	markdownTransform?: (text: string, availableWidth: number) => string;
 }
 
 export function isCompactAgentMessageNeighbor(component: Component | undefined): boolean {
@@ -85,6 +86,7 @@ export function buildConversationComponents(
 						precededByToolActivity:
 							components.at(-1) instanceof ToolExecutionComponent ||
 							components.at(-1) instanceof AgentMessageComponent,
+						markdownTransform: options.markdownTransform,
 					},
 				),
 			);
@@ -129,7 +131,14 @@ export function buildConversationComponents(
 			} else if (isSessionSlashCommandResultMessage(message)) {
 				components.push(new SlashCommandResultMessageComponent(message));
 			} else {
-				components.push(new UserMessageComponent("[Malformed session command message]", options.markdownTheme));
+				components.push(
+					new UserMessageComponent(
+						"[Malformed session command message]",
+						options.markdownTheme,
+						undefined,
+						options.markdownTransform,
+					),
+				);
 			}
 		} else if (message.role === "custom" && message.customType === COMPACTION_OUTCOME_CUSTOM_TYPE) {
 			if (!message.display) continue;
@@ -155,7 +164,14 @@ export function buildConversationComponents(
 			// An image-only prompt has no text; show a placeholder rather than dropping it.
 			const display = text || (hasContent ? "[image]" : "");
 			if (display) {
-				components.push(new UserMessageComponent(display, options.markdownTheme, options.isRecognizedSlashCommand));
+				components.push(
+					new UserMessageComponent(
+						display,
+						options.markdownTheme,
+						options.isRecognizedSlashCommand,
+						options.markdownTransform,
+					),
+				);
 			}
 		}
 		// Non-conversational messages (bash/branch-summary/compaction/other custom) aren't shown.

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -11,7 +11,7 @@ import {
 	Text,
 } from "@earendil-works/pi-tui";
 import type { IdleEvictionMinutes } from "../../../core/session-action-store.js";
-import type { WarningSettings } from "../../../core/settings-manager.js";
+import type { MermaidRenderingMode, WarningSettings } from "../../../core/settings-manager.js";
 import { getSelectListTheme, getSettingsListTheme, theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 
@@ -54,6 +54,7 @@ export interface SettingsConfig {
 	clearOnShrink: boolean;
 	showTerminalProgress: boolean;
 	fullscreen: boolean;
+	mermaidRenderingMode: MermaidRenderingMode;
 	warnings: WarningSettings;
 }
 
@@ -80,6 +81,7 @@ export interface SettingsCallbacks {
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onShowTerminalProgressChange: (enabled: boolean) => void;
 	onFullscreenChange: (enabled: boolean) => void;
+	onMermaidRenderingModeChange: (mode: MermaidRenderingMode) => void;
 	onWarningsChange: (warnings: WarningSettings) => void;
 	onCancel: () => void;
 }
@@ -443,6 +445,16 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
+		// Mermaid rendering toggle (insert after fullscreen)
+		const fullscreenIndex = items.findIndex((item) => item.id === "fullscreen");
+		items.splice(fullscreenIndex + 1, 0, {
+			id: "mermaid-rendering",
+			label: "Mermaid rendering",
+			description: "Render Mermaid diagrams as Unicode box-drawing art in chat",
+			currentValue: config.mermaidRenderingMode,
+			values: ["streaming", "off"],
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -510,6 +522,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "fullscreen":
 						callbacks.onFullscreenChange(newValue === "true");
+						break;
+					case "mermaid-rendering":
+						callbacks.onMermaidRenderingModeChange(newValue as MermaidRenderingMode);
 						break;
 				}
 			},

--- a/packages/coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/user-message.ts
@@ -63,15 +63,24 @@ export class UserMessageComponent extends Container {
 		text: string,
 		markdownTheme: MarkdownTheme = getMarkdownTheme(),
 		isRecognizedSlashCommand: (name: string) => boolean = () => false,
+		markdownTransform?: (text: string, availableWidth: number) => string,
 	) {
 		super();
+		const markdownOptions = markdownTransform ? { transform: markdownTransform } : undefined;
 		this.contentBox = new Box(2, 1, (content: string) => theme.getUserMessageBackgroundColor()(content));
 		this.contentBox.addChild(
 			isLeadingSlashCommand(text, isRecognizedSlashCommand)
 				? new SlashCommandMarkdown(text, markdownTheme)
-				: new Markdown(text, 0, 0, markdownTheme, {
-						color: (content: string) => theme.fg("userMessageText", content),
-					}),
+				: new Markdown(
+						text,
+						0,
+						0,
+						markdownTheme,
+						{
+							color: (content: string) => theme.fg("userMessageText", content),
+						},
+						markdownOptions,
+					),
 		);
 		this.addChild(this.contentBox);
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6626,6 +6626,11 @@ export class InteractiveMode {
 			void this.shutdown();
 			return;
 		}
+		// If the editor has content and nothing is running, clear it.
+		if (this.editor.getText().length > 0 && !this.hasInterruptibleWork()) {
+			this.clearInputBar();
+			return;
+		}
 		this.handleInterruptKey();
 	}
 
@@ -9534,7 +9539,7 @@ ${shortcutsKey ? `\`${shortcutsKey}\` quick shortcuts · ` : ""}\`/hotkeys\` ful
 |-----|--------|
 | \`${tab}\` | Path completion / accept autocomplete |
 | \`${clearInput}\` | Clear input / cancel autocomplete |
-| \`${clear}\` | Interrupt current operation (first) / exit (second) |
+| \`${clear}\` | Clear prompt (if text) / interrupt / exit (twice) |
 ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shortcutsKey ? `| \`${shortcutsKey}\` | Show quick shortcuts |\n` : ""}| \`${exit}\` | Exit (when editor is empty) |
 | \`${selectModel}\` | Open model selector |
 | \`${expandTools}\` | Toggle tool output expansion |

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5965,9 +5965,10 @@ export class InteractiveMode {
 		const modelLabel = this.getModelTrayLabel();
 		const hasChildren = this.options.sessionHasChildren === true || (this.subagentSnapshots?.size ?? 0) > 0;
 		const depthLabel = formatAgentDepthLabel(this.options.sessionDepth, hasChildren);
+		const cwdLabel = truncatePathMiddle(formatSplashCwd(this.getCurrentCwd()), 30);
 		const shortcutsHint = this.getShortcutsTrayHint();
 		const agentsHint = this.getAgentsViewTrayHint();
-		return [agentsHint, depthLabel, modelLabel, shortcutsHint]
+		return [agentsHint, depthLabel, modelLabel, cwdLabel, shortcutsHint]
 			.filter((label): label is string => label !== undefined)
 			.join("  ");
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -237,6 +237,7 @@ import type {
 	InteractiveModeLocalToolRendererDefinition,
 	InteractiveModeUiServices,
 } from "./interactive-mode-services.js";
+import { createMermaidMarkdownTransformer } from "./mermaid-transformer.js";
 import {
 	isOnboardingModelReady,
 	type OnboardingStartupState,
@@ -1796,6 +1797,16 @@ export class InteractiveMode {
 			...getMarkdownTheme(),
 			codeBlockIndent: this.settingsManager.getCodeBlockIndent(),
 		};
+	}
+
+	private getMermaidMarkdownTransform(): (text: string, availableWidth: number) => string {
+		return createMermaidMarkdownTransformer({
+			getMode: () => this.settingsManager.getMermaidRenderingMode(),
+			theme: {
+				fg: (color, text) => theme.fg(color as ThemeColor, text),
+				bold: (text) => theme.bold(text),
+			},
+		});
 	}
 
 	// =========================================================================
@@ -5695,6 +5706,7 @@ export class InteractiveMode {
 				precededByToolActivity:
 					this.chatContainer.children.at(-1) instanceof ToolExecutionComponent ||
 					this.chatContainer.children.at(-1) instanceof AgentMessageComponent,
+				markdownTransform: this.getMermaidMarkdownTransform(),
 			},
 		);
 		this.streamingMessage = message;
@@ -6186,8 +6198,11 @@ export class InteractiveMode {
 			this.chatContainer.addChild(new Spacer(1));
 		}
 		this.chatContainer.addChild(
-			new UserMessageComponent(text, this.getMarkdownThemeWithSettings(), (name) =>
-				this.isRecognizedSlashCommand(name),
+			new UserMessageComponent(
+				text,
+				this.getMarkdownThemeWithSettings(),
+				(name) => this.isRecognizedSlashCommand(name),
+				this.getMermaidMarkdownTransform(),
 			),
 		);
 	}
@@ -6314,6 +6329,7 @@ export class InteractiveMode {
 								skillBlock.userMessage,
 								this.getMarkdownThemeWithSettings(),
 								(name) => this.isRecognizedSlashCommand(name),
+								this.getMermaidMarkdownTransform(),
 							);
 							this.chatContainer.addChild(userComponent);
 						}
@@ -6322,6 +6338,7 @@ export class InteractiveMode {
 							textContent,
 							this.getMarkdownThemeWithSettings(),
 							(name) => this.isRecognizedSlashCommand(name),
+							this.getMermaidMarkdownTransform(),
 						);
 						this.chatContainer.addChild(userComponent);
 					}
@@ -6342,6 +6359,7 @@ export class InteractiveMode {
 						precededByToolActivity:
 							this.chatContainer.children.at(-1) instanceof ToolExecutionComponent ||
 							this.chatContainer.children.at(-1) instanceof AgentMessageComponent,
+						markdownTransform: this.getMermaidMarkdownTransform(),
 					},
 				);
 				this.chatContainer.addChild(assistantComponent);
@@ -7286,6 +7304,7 @@ export class InteractiveMode {
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
 					showTerminalProgress: this.settingsManager.getShowTerminalProgress(),
 					fullscreen: this.fullscreenEnabled,
+					mermaidRenderingMode: this.settingsManager.getMermaidRenderingMode(),
 					warnings: this.settingsManager.getWarnings(),
 				},
 				{
@@ -7410,6 +7429,20 @@ export class InteractiveMode {
 					},
 					onFullscreenChange: (enabled) => {
 						this.setFullscreenMode(enabled);
+					},
+					onMermaidRenderingModeChange: (mode) => {
+						this.settingsManager.setMermaidRenderingMode(mode);
+						// Invalidate and re-render existing components so the change
+						// takes effect immediately on already-displayed messages.
+						for (const child of this.chatContainer.children) {
+							if (child instanceof AssistantMessageComponent) {
+								child.invalidate();
+							}
+							if (child instanceof UserMessageComponent) {
+								child.invalidate();
+							}
+						}
+						this.ui.requestRender();
 					},
 					onWarningsChange: (warnings) => {
 						this.settingsManager.setWarnings(warnings);

--- a/packages/coding-agent/src/modes/interactive/mermaid-transformer.ts
+++ b/packages/coding-agent/src/modes/interactive/mermaid-transformer.ts
@@ -1,0 +1,111 @@
+import { type MermaidArt, render as renderMermaid, type Span } from "grok-mermaid";
+
+/**
+ * Mermaid rendering modes.
+ * - "off" — no transformation; raw source shown
+ * - "streaming" — always render Mermaid blocks (best-effort during streaming)
+ */
+export type MermaidRenderingMode = "off" | "streaming";
+
+export interface MermaidTransformerTheme {
+	fg: (color: string, text: string) => string;
+	bold: (text: string) => string;
+}
+
+export interface MermaidTransformerOptions {
+	getMode: () => MermaidRenderingMode;
+	theme: MermaidTransformerTheme;
+}
+
+/**
+ * Wrap text in a markdown inline code span, preserving whitespace.
+ *
+ * If the content contains backticks, the fence is extended to be longer than
+ * the longest backtick run. A leading/trailing backtick is padded with a space
+ * so the span delimiter stays unambiguous.
+ */
+function wrapInCodeSpan(content: string): string {
+	const maxBacktickRun = content.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+	const fence = "`".repeat(Math.max(1, maxBacktickRun + 1));
+
+	// Pad with spaces if content starts or ends with a backtick to prevent
+	// ambiguity with the fence delimiter.
+	let text = content;
+	if (text.startsWith("`")) {
+		text = ` ${text}`;
+	}
+	if (text.endsWith("`")) {
+		text = `${text} `;
+	}
+
+	return `${fence}${text}${fence}`;
+}
+
+/**
+ * Map a styled span to its theme-styled text.
+ *
+ * border → dim, text → default (no explicit color), edge → accent,
+ * edgeLabel → accent, title → dim + bold, none → no styling.
+ */
+function styleSpan(span: Span, theme: MermaidTransformerOptions["theme"]): string {
+	switch (span.cls) {
+		case "border":
+			return theme.fg("dim", span.text);
+		case "edge":
+		case "edgeLabel":
+			return theme.fg("accent", span.text);
+		case "title":
+			return theme.bold(theme.fg("dim", span.text));
+		default:
+			return span.text;
+	}
+}
+
+/**
+ * Convert rendered MermaidArt to markdown text.
+ *
+ * Each diagram row is wrapped in a markdown inline code span to preserve
+ * leading/trailing spaces and box-drawing alignment. Blank rows use a
+ * non-breaking space (\u00a0) to ensure visible height. Rows are joined
+ * with markdown hard breaks (two trailing spaces + newline).
+ */
+function artToMarkdown(art: MermaidArt, theme: MermaidTransformerOptions["theme"]): string {
+	const lines: string[] = [];
+	for (const row of art.styled) {
+		const styledText = row.map((span) => styleSpan(span, theme)).join("");
+		const content = styledText.trimEnd() === "" ? "\u00a0" : styledText;
+		lines.push(wrapInCodeSpan(content));
+	}
+	return lines.join("  \n");
+}
+
+/**
+ * Regex matching a fenced mermaid code block.
+ *
+ * Captures: [1] = opening fence + info string, [2] = body, [3] = closing fence.
+ */
+const MERMAID_FENCE_REGEX = /(^|\n)(`{3,})mermaid[ \t]*\n([\s\S]*?)(`{3,})/g;
+
+/**
+ * Create a Markdown transform callback that renders Mermaid code blocks as
+ * Unicode box-drawing art.
+ *
+ * When mode is "off" or render fails, the original source block is left
+ * untouched (fallback).
+ */
+export function createMermaidMarkdownTransformer(options: MermaidTransformerOptions) {
+	return (text: string, availableWidth: number): string => {
+		if (options.getMode() === "off") {
+			return text;
+		}
+
+		return text.replace(MERMAID_FENCE_REGEX, (match, prefix: string, _openFence: string, body: string) => {
+			const src = body.trim();
+			const art = renderMermaid(src);
+			if (!art || art.width > availableWidth) {
+				return match; // Fallback: leave original block untouched
+			}
+			return `${prefix}${artToMarkdown(art, options.theme)}`;
+		});
+	};
+}

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -4,6 +4,7 @@ import stripAnsi from "strip-ansi";
 import { describe, expect, test } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import { AssistantMessageComponent, thinkingRecap } from "../src/modes/interactive/components/assistant-message.js";
+import { createMermaidMarkdownTransformer } from "../src/modes/interactive/mermaid-transformer.js";
 import { initTheme, theme } from "../src/modes/interactive/theme/theme.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
@@ -306,5 +307,195 @@ describe("AssistantMessageComponent streaming identity", () => {
 			component.updateContent(message);
 			expectIdentity(component, message, widths[i % widths.length]);
 		}
+	});
+});
+
+describe("AssistantMessageComponent mermaid rendering", () => {
+	const mermaidTransform = createMermaidMarkdownTransformer({
+		getMode: () => "streaming",
+		theme: {
+			fg: (color, text) => theme.fg(color as "accent" | "dim", text),
+			bold: (text) => theme.bold(text),
+		},
+	});
+
+	const FLOWCHART = "```mermaid\nflowchart LR\n  A[Start] --> B[Done]\n```";
+
+	test("renders mermaid code blocks as Unicode box-drawing characters", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: FLOWCHART }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		// Should contain box-drawing characters
+		expect(rendered).toContain("┌");
+		expect(rendered).toContain("─");
+		expect(rendered).toContain("▶");
+		expect(rendered).toContain("Start");
+		expect(rendered).toContain("Done");
+	});
+
+	test("does not render mermaid diagrams in thinking blocks", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "thinking", thinking: FLOWCHART }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		// Thinking blocks should NOT render diagrams — just the raw source as a code block
+		expect(rendered).toContain("flowchart");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("▶");
+	});
+
+	test("renders non-mermaid code blocks unchanged", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: "```typescript\nconst x: number = 42;\n```" }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		expect(rendered).toContain("const x");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("▶");
+	});
+
+	test("falls back to source for diagrams wider than terminal width", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: FLOWCHART }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		// Width is very narrow — diagram (21 cols) won't fit
+		const rendered = stripAnsi(component.render(10).join("\n"));
+
+		// Should fall back to original mermaid source as a code block
+		// (at narrow widths, words may wrap but no diagram should appear)
+		expect(rendered).toContain("A[Start]");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("▶");
+	});
+
+	test("does not transform when mode is off", () => {
+		initTheme("dark");
+
+		const offTransform = createMermaidMarkdownTransformer({
+			getMode: () => "off",
+			theme: {
+				fg: (color, text) => theme.fg(color as "accent" | "dim", text),
+				bold: (text) => theme.bold(text),
+			},
+		});
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: FLOWCHART }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: offTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		expect(rendered).toContain("flowchart");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("▶");
+	});
+
+	test("renders mixed content with mermaid diagram correctly", () => {
+		initTheme("dark");
+
+		const mixedContent = ["Here is a flowchart:", "", FLOWCHART, "", "And some text after."].join("\n");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: mixedContent }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		expect(rendered).toContain("Here is a flowchart:");
+		expect(rendered).toContain("┌");
+		expect(rendered).toContain("▶");
+		expect(rendered).toContain("And some text after.");
+	});
+
+	test("renders state diagrams", () => {
+		initTheme("dark");
+
+		const stateDiagram =
+			"```mermaid\nstateDiagram-v2\n  [*] --> Idle\n  Idle --> Processing: start\n  Processing --> [*]\n```";
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: stateDiagram }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		// State diagrams use rounded box characters
+		expect(rendered).toContain("Idle");
+		expect(rendered).toContain("Processing");
+		expect(rendered).toMatch(/[╭┌]/);
+	});
+
+	test("falls back to source for unsupported diagram types", () => {
+		initTheme("dark");
+
+		const pieDiagram = '```mermaid\npie\n  "A": 50\n  "B": 50\n```';
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: pieDiagram }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		// pie charts are unsupported — should fall back to source code block
+		expect(rendered).toContain("pie");
+		expect(rendered).not.toContain("┌");
+	});
+
+	test("handles partial/streaming mermaid source without throwing", () => {
+		initTheme("dark");
+
+		// Partial source — no closing fence
+		const partial = "```mermaid\nflowchart LR\n  A -->";
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: partial }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+
+		// Should not throw
+		expect(() => component.render(80)).not.toThrow();
 	});
 });

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1287,6 +1287,8 @@ describe("daemon mode helpers", () => {
 			session: {
 				sessionId: "session-child",
 				sessionFile: undefined,
+				isSessionActive: false,
+				hasRunningRlmChildren: () => false,
 				abort: vi.fn(() => new Promise<void>(() => {})),
 			},
 		} as unknown as ActiveSessionState["runtime"];
@@ -4543,6 +4545,8 @@ describe("daemon mode helpers", () => {
 					sessionId: "session-active",
 					sessionFile: undefined,
 					isBashRunning: false,
+					isSessionActive: false,
+					hasRunningRlmChildren: () => false,
 					abort: vi.fn(async () => {}),
 					sessionManager: { appendSessionState: vi.fn() },
 				},
@@ -9535,6 +9539,113 @@ describe("daemon mode helpers", () => {
 				activeSessionId: "missing",
 			}),
 		).rejects.toThrow("Unknown active session: missing");
+	});
+
+	it("deletes an empty draft session file when closed via shutdown", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-ghost-shutdown-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			manager.appendSessionState({ status: "active" });
+			manager.flushNow();
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) throw new Error("Missing session file");
+
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				Object.assign(session, {
+					isStreaming: false,
+					isCompacting: false,
+					isSessionActive: false,
+					isBashRunning: false,
+					isRetrying: false,
+					unfinishedActionCount: 0,
+					hasRunningRlmChildren: () => false,
+				});
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				closeSession(state: ActiveSessionState, reason: "shutdown"): Promise<void>;
+			};
+
+			const state = await internals.createRuntime({ type: "create", sessionPath: sessionFile });
+			expect(existsSync(sessionFile)).toBe(true);
+
+			await internals.closeSession(state, "shutdown");
+
+			expect(existsSync(sessionFile)).toBe(false);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves a session with user content when closed via shutdown", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-shutdown-content-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			manager.appendMessage({ role: "user", content: "hello world", timestamp: 1 });
+			manager.appendSessionState({ status: "active" });
+			manager.flushNow();
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) throw new Error("Missing session file");
+
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				Object.assign(session, {
+					isStreaming: false,
+					isCompacting: false,
+					isSessionActive: false,
+					isBashRunning: false,
+					isRetrying: false,
+					unfinishedActionCount: 0,
+					hasRunningRlmChildren: () => false,
+				});
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				closeSession(state: ActiveSessionState, reason: "shutdown"): Promise<void>;
+			};
+
+			const state = await internals.createRuntime({ type: "create", sessionPath: sessionFile });
+			expect(existsSync(sessionFile)).toBe(true);
+
+			await internals.closeSession(state, "shutdown");
+
+			expect(existsSync(sessionFile)).toBe(true);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
+++ b/packages/coding-agent/test/interactive-mode-ctrl-c.test.ts
@@ -196,10 +196,9 @@ describe("InteractiveMode interrupt shortcuts", () => {
 	});
 
 	it("clears the exit hint after two seconds", async () => {
-		const mode = createInteractiveFake({ editorText: "draft" });
+		const mode = createInteractiveFake({});
 
 		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
-		expect(mode.editor.getText()).toBe("draft");
 		expect(Reflect.get(InteractiveMode.prototype, "getTrayOverrideLabel").call(mode)).toBe(
 			"Press Ctrl+C again to exit",
 		);
@@ -211,13 +210,33 @@ describe("InteractiveMode interrupt shortcuts", () => {
 		expect(mode.ui.requestRender).toHaveBeenCalled();
 	});
 
-	it("preserves idle draft input on first Ctrl+C", () => {
+	it("clears idle draft input on first Ctrl+C", () => {
 		const mode = createInteractiveFake({ editorText: "draft" });
 
 		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
 
-		expect(mode.editor.getText()).toBe("draft");
+		expect(mode.editor.getText()).toBe("");
 		expect(mode.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
+		expect(mode.shutdown).not.toHaveBeenCalled();
+	});
+
+	it("does not clear draft on Ctrl+C when streaming (interrupts instead)", () => {
+		const mode = createInteractiveFake({ editorText: "draft", streaming: true });
+
+		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
+
+		expect(mode.editor.getText()).toBe("draft");
+		expect(mode.restoreQueuedMessagesToEditor).toHaveBeenCalledWith({ abort: true });
+		expect(mode.shutdown).not.toHaveBeenCalled();
+	});
+
+	it("does not clear draft on Ctrl+C when bash is running (interrupts instead)", () => {
+		const mode = createInteractiveFake({ editorText: "draft", bashRunning: true });
+
+		Reflect.get(InteractiveMode.prototype, "handleCtrlC").call(mode);
+
+		expect(mode.editor.getText()).toBe("draft");
+		expect(mode.agentConnection.abortBash).toHaveBeenCalledTimes(1);
 		expect(mode.shutdown).not.toHaveBeenCalled();
 	});
 

--- a/packages/coding-agent/test/session-artifacts-delete.test.ts
+++ b/packages/coding-agent/test/session-artifacts-delete.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { deleteSessionFile } from "../src/core/session-file-actions.js";
+import { deleteSessionFile, sweepGhostSessionFiles } from "../src/core/session-file-actions.js";
 
 let root = "";
 
@@ -70,5 +70,44 @@ describe("deleteSessionFile removes the session artifact directory", () => {
 
 		const result = await deleteSessionFile(sessionPath);
 		expect(result.ok).toBe(true);
+	});
+
+	it("sweepGhostSessionFiles removes empty draft sessions and preserves real ones", async () => {
+		const sessionsDir = join(root, "sessions");
+		mkdirSync(sessionsDir, { recursive: true });
+
+		// Ghost: only bootstrap entries + session_state.
+		const ghostPath = join(sessionsDir, "ghost.jsonl");
+		writeFileSync(
+			ghostPath,
+			`${[
+				'{"type":"session","version":3,"id":"ghost"}',
+				'{"type":"model_change","id":"a","parentId":null}',
+				'{"type":"thinking_level_change","id":"b","parentId":"a"}',
+				'{"type":"service_tier_change","id":"c","parentId":"b"}',
+				'{"type":"session_state","id":"d","parentId":"c","state":{"status":"active"}}',
+			].join("\n")}\n`,
+		);
+
+		// Real session: has a user message.
+		const realPath = join(sessionsDir, "real.jsonl");
+		writeFileSync(
+			realPath,
+			`${[
+				'{"type":"session","version":3,"id":"real"}',
+				'{"type":"model_change","id":"a","parentId":null}',
+				'{"type":"message","id":"b","parentId":"a","message":{"role":"user","content":"hi"}}',
+			].join("\n")}\n`,
+		);
+
+		const swept = await sweepGhostSessionFiles(sessionsDir);
+		expect(swept).toBe(1);
+		expect(existsSync(ghostPath)).toBe(false);
+		expect(existsSync(realPath)).toBe(true);
+	});
+
+	it("sweepGhostSessionFiles is a no-op for a missing directory", async () => {
+		const swept = await sweepGhostSessionFiles(join(root, "does-not-exist"));
+		expect(swept).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/session-lease.test.ts
+++ b/packages/coding-agent/test/session-lease.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { lockSync } from "proper-lockfile";
@@ -11,6 +11,7 @@ import {
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 	SessionAlreadyActiveError,
+	sweepStaleSessionLeases,
 } from "../src/core/session-lease.js";
 
 const tempDirs: string[] = [];
@@ -185,5 +186,53 @@ describe("session leases", () => {
 	it("is inert for direct SDK runtimes unless worker isolation enables it", () => {
 		const agentDir = createTempDir();
 		expect(acquireSessionLease(join(agentDir, "session.jsonl"), agentDir, {})).toBeUndefined();
+	});
+
+	it("sweeps stale leases at startup while keeping live ones", () => {
+		const agentDir = createTempDir();
+
+		// Stale lease: owner PID does not exist.
+		const stalePath = canonicalSessionPath(resolve(agentDir, "stale.jsonl"));
+		const staleKey = createHash("sha256").update(stalePath).digest("hex");
+		const staleDir = join(agentDir, "session-leases", `${staleKey}.lock`);
+		mkdirSync(staleDir, { recursive: true });
+		writeFileSync(
+			join(staleDir, "owner.json"),
+			JSON.stringify({
+				version: 1,
+				token: "stale",
+				pid: 2_147_483_647,
+				activeSessionId: "dead-owner",
+				sessionPath: stalePath,
+				createdAt: new Date(0).toISOString(),
+			}),
+		);
+
+		// Live lease: owner is this process.
+		const livePath = canonicalSessionPath(resolve(agentDir, "live.jsonl"));
+		const liveKey = createHash("sha256").update(livePath).digest("hex");
+		const liveDir = join(agentDir, "session-leases", `${liveKey}.lock`);
+		mkdirSync(liveDir, { recursive: true });
+		writeFileSync(
+			join(liveDir, "owner.json"),
+			JSON.stringify({
+				version: 1,
+				token: "live",
+				pid: process.pid,
+				activeSessionId: "this-process",
+				sessionPath: livePath,
+				createdAt: new Date(0).toISOString(),
+			}),
+		);
+
+		const swept = sweepStaleSessionLeases(agentDir);
+		expect(swept).toBe(1);
+		expect(existsSync(staleDir)).toBe(false);
+		expect(existsSync(liveDir)).toBe(true);
+	});
+
+	it("handles a missing session-leases directory gracefully", () => {
+		const agentDir = createTempDir();
+		expect(sweepStaleSessionLeases(agentDir)).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/settings-selector.test.ts
+++ b/packages/coding-agent/test/settings-selector.test.ts
@@ -32,6 +32,7 @@ const config: SettingsConfig = {
 	clearOnShrink: false,
 	showTerminalProgress: false,
 	fullscreen: true,
+	mermaidRenderingMode: "streaming",
 	warnings: {},
 };
 
@@ -57,6 +58,7 @@ const callbacks: SettingsCallbacks = {
 	onClearOnShrinkChange: () => {},
 	onShowTerminalProgressChange: () => {},
 	onFullscreenChange: () => {},
+	onMermaidRenderingModeChange: () => {},
 	onWarningsChange: () => {},
 	onCancel: () => {},
 };

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 - Added double-click word selection, triple-click line selection, and word-granularity drag selection in the fullscreen TUI.
+- Changed click counting to use word-level proximity instead of exact column match, so slight mouse drift between clicks still registers multi-clicks.
+- Fixed selection anchor mutating during word/line drag by computing the effective range from the initial word/line boundary.
+- Changed fullscreen mouse selection to keep the highlight visible after release instead of clearing immediately.
 
 ## [0.7.1] - 2026-08-07
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added double-click word selection, triple-click line selection, and word-granularity drag selection in the fullscreen TUI.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added an optional `MarkdownOptions.transform` callback to the Markdown component for pre-processing raw text before parsing.
 - Added double-click word selection, triple-click line selection, and word-granularity drag selection in the fullscreen TUI.
 - Changed click counting to use word-level proximity instead of exact column match, so slight mouse drift between clicks still registers multi-clicks.
 - Fixed selection anchor mutating during word/line drag by computing the effective range from the initial word/line boundary.

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -147,6 +147,18 @@ export interface DefaultTextStyle {
 }
 
 /**
+ * Optional configuration for the Markdown component.
+ */
+export interface MarkdownOptions {
+	/**
+	 * Pre-processing callback applied to the raw text before the markdown parser runs.
+	 * Receives the raw text and the available content width (width minus horizontal padding).
+	 * The returned text is what gets parsed and rendered.
+	 */
+	transform?: (text: string, availableWidth: number) => string;
+}
+
+/**
  * Theme functions for markdown elements.
  * Each function takes text and returns styled text with ANSI codes.
  */
@@ -186,6 +198,7 @@ export class Markdown implements Component {
 	private defaultTextStyle?: DefaultTextStyle;
 	private theme: MarkdownTheme;
 	private defaultStylePrefix?: string;
+	private options?: MarkdownOptions;
 
 	// Cache for rendered output
 	private cachedText?: string;
@@ -204,12 +217,14 @@ export class Markdown implements Component {
 		paddingY: number,
 		theme: MarkdownTheme,
 		defaultTextStyle?: DefaultTextStyle,
+		options?: MarkdownOptions,
 	) {
 		this.text = text;
 		this.paddingX = paddingX;
 		this.paddingY = paddingY;
 		this.theme = theme;
 		this.defaultTextStyle = defaultTextStyle;
+		this.options = options;
 	}
 
 	setText(text: string): void {
@@ -253,7 +268,12 @@ export class Markdown implements Component {
 		}
 
 		// Replace tabs with 3 spaces for consistent rendering
-		const normalizedText = this.text.replace(/\t/g, "   ");
+		let normalizedText = this.text.replace(/\t/g, "   ");
+
+		// Apply optional pre-processing transform before parsing
+		if (this.options?.transform) {
+			normalizedText = this.options.transform(normalizedText, contentWidth);
+		}
 
 		// Parse markdown to HTML-like tokens
 		const tokens = pickMarkdownParser(normalizedText).lexer(normalizedText);

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -139,7 +139,22 @@ export class FullscreenViewport {
 	private orderedSelection(): { start: SelectionPoint; end: SelectionPoint } | null {
 		const a = this.selectionAnchor;
 		const b = this.selectionHead;
-		if (!a || !b || (a.line === b.line && a.col === b.col)) return null;
+		if (!a || !b) return null;
+
+		// For word/line granularity the anchor is the click position and head is the
+		// drag target; the effective range spans the initial word/line plus the head.
+		if (
+			(this.selectionGranularity === "word" || this.selectionGranularity === "line") &&
+			this.selectionInitialRange
+		) {
+			const initial = this.selectionInitialRange;
+			const start = this.compareSelectionPoints(b, initial.start) < 0 ? b : initial.start;
+			const end = this.compareSelectionPoints(b, initial.end) > 0 ? b : initial.end;
+			if (this.compareSelectionPoints(start, end) === 0) return null;
+			return { start, end };
+		}
+
+		if (a.line === b.line && a.col === b.col) return null;
 		const flipped = a.line > b.line || (a.line === b.line && a.col > b.col);
 		return flipped ? { start: b, end: a } : { start: a, end: b };
 	}
@@ -201,7 +216,7 @@ export class FullscreenViewport {
 		}
 		const text = stripAnsi(this.lastTranscript[line] ?? "");
 		const word = this.wordAtColumn(text, Math.max(0, screenCol));
-		this.selectionAnchor = { line, col: word.start };
+		this.selectionAnchor = { line, col: Math.max(0, screenCol) };
 		this.selectionHead = { line, col: word.end };
 		this.selectionInitialRange = {
 			start: { line, col: word.start },
@@ -213,7 +228,7 @@ export class FullscreenViewport {
 		return true;
 	}
 
-	beginLineSelection(screenRow: number, _screenCol: number): boolean {
+	beginLineSelection(screenRow: number, screenCol: number): boolean {
 		const line = this.transcriptLineForScreenRow(screenRow, false);
 		if (line === null) {
 			this.clearSelection();
@@ -221,7 +236,7 @@ export class FullscreenViewport {
 		}
 		const text = stripAnsi(this.lastTranscript[line] ?? "");
 		const width = visibleWidth(text);
-		this.selectionAnchor = { line, col: 0 };
+		this.selectionAnchor = { line, col: Math.max(0, screenCol) };
 		this.selectionHead = { line, col: width };
 		this.selectionInitialRange = {
 			start: { line, col: 0 },
@@ -243,6 +258,14 @@ export class FullscreenViewport {
 			start = end;
 		}
 		return { start, end: start };
+	}
+
+	/** Word segment boundaries (terminal columns) at a screen position, or null outside transcript. */
+	wordRangeAt(screenRow: number, screenCol: number): { start: number; end: number } | null {
+		const line = this.transcriptLineForScreenRow(screenRow, false);
+		if (line === null) return null;
+		const text = stripAnsi(this.lastTranscript[line] ?? "");
+		return this.wordAtColumn(text, Math.max(0, screenCol));
 	}
 
 	extendSelection(screenRow: number, screenCol: number): void {
@@ -268,29 +291,13 @@ export class FullscreenViewport {
 			const text = stripAnsi(this.lastTranscript[line] ?? "");
 			const word = this.wordAtColumn(text, clampedCol);
 			if (line < initial.start.line || (line === initial.start.line && clampedCol < initial.start.col)) {
-				// Dragging left/up: anchor at initial word end, head at dragged word start
-				this.selectionAnchor = { line: initial.end.line, col: initial.end.col };
 				this.selectionHead = { line, col: word.start };
 			} else {
-				// Dragging right/down: anchor at initial word start, head at dragged word end
-				this.selectionAnchor = { line: initial.start.line, col: initial.start.col };
 				this.selectionHead = { line, col: word.end };
 			}
 		} else {
-			// "line" granularity: select whole lines
-			const initialText = stripAnsi(this.lastTranscript[initial.start.line] ?? "");
-			const initialWidth = visibleWidth(initialText);
-			const dragText = stripAnsi(this.lastTranscript[line] ?? "");
-			if (line < initial.start.line) {
-				this.selectionAnchor = { line: initial.start.line, col: initialWidth };
-				this.selectionHead = { line, col: 0 };
-			} else if (line > initial.start.line) {
-				this.selectionAnchor = { line: initial.start.line, col: 0 };
-				this.selectionHead = { line, col: visibleWidth(dragText) };
-			} else {
-				this.selectionAnchor = { line: initial.start.line, col: 0 };
-				this.selectionHead = { line: initial.start.line, col: initialWidth };
-			}
+			const text = stripAnsi(this.lastTranscript[line] ?? "");
+			this.selectionHead = line < initial.start.line ? { line, col: 0 } : { line, col: visibleWidth(text) };
 		}
 	}
 
@@ -335,13 +342,10 @@ export class FullscreenViewport {
 			return null;
 		}
 		const sel = this.orderedSelection();
-		const text = sel
-			? this.selectionMode === "table"
-				? this.extractTableSelectionText(this.lastTranscript, sel)
-				: this.extractSelectionText(this.lastTranscript, sel)
-			: null;
-		this.clearSelection();
-		return text;
+		if (!sel) return null;
+		return this.selectionMode === "table"
+			? this.extractTableSelectionText(this.lastTranscript, sel)
+			: this.extractSelectionText(this.lastTranscript, sel);
 	}
 
 	extendActiveSelection(screenRow: number, screenCol: number): void {
@@ -421,7 +425,6 @@ export class FullscreenViewport {
 		const active = this.activeFrameSelection;
 		const sourceLines = active?.frame ?? this.lastFrame;
 		const regions = active?.regions ?? this.frameSelectionRegions;
-		this.clearSelection();
 		if (!sel) return null;
 		return this.extractFrameSelectionText(sourceLines, regions, sel);
 	}

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -7,7 +7,7 @@
 
 import type { TableCellSelectionRegion } from "./selection-metadata.js";
 import { isImageLine } from "./terminal-image.js";
-import { sliceByColumn, stripAnsi, visibleWidth } from "./utils.js";
+import { getWordSegmenter, sliceByColumn, stripAnsi, visibleWidth } from "./utils.js";
 
 export const FULLSCREEN_MIN_TRANSCRIPT_ROWS = 3;
 
@@ -71,6 +71,8 @@ interface TableSelectionRange {
 
 type SelectionMode = "transcript" | "table" | "frame";
 
+type SelectionGranularity = "character" | "word" | "line";
+
 export class FullscreenViewport {
 	private scrollTop = 0;
 	private following = true;
@@ -90,6 +92,8 @@ export class FullscreenViewport {
 	private selectionAnchor: SelectionPoint | null = null;
 	private selectionHead: SelectionPoint | null = null;
 	private selectionMode: SelectionMode | null = null;
+	private selectionGranularity: SelectionGranularity = "character";
+	private selectionInitialRange: { start: SelectionPoint; end: SelectionPoint } | null = null;
 
 	/**
 	 * Compose a frame of exactly `height` lines: scrolled transcript window on
@@ -175,6 +179,8 @@ export class FullscreenViewport {
 		const point = { line, col: Math.max(0, screenCol) };
 		this.selectionAnchor = point;
 		this.selectionHead = { ...point };
+		this.selectionGranularity = "character";
+		this.selectionInitialRange = null;
 		const table = this.tableAtPoint(point);
 		const tableCell = table ? this.closestTableCell(table, point) : null;
 		if (table && tableCell) {
@@ -187,11 +193,105 @@ export class FullscreenViewport {
 		return true;
 	}
 
+	beginWordSelection(screenRow: number, screenCol: number): boolean {
+		const line = this.transcriptLineForScreenRow(screenRow, false);
+		if (line === null) {
+			this.clearSelection();
+			return false;
+		}
+		const text = stripAnsi(this.lastTranscript[line] ?? "");
+		const word = this.wordAtColumn(text, Math.max(0, screenCol));
+		this.selectionAnchor = { line, col: word.start };
+		this.selectionHead = { line, col: word.end };
+		this.selectionInitialRange = {
+			start: { line, col: word.start },
+			end: { line, col: word.end },
+		};
+		this.selectionGranularity = "word";
+		this.selectionMode = "transcript";
+		this.activeTableSelection = null;
+		return true;
+	}
+
+	beginLineSelection(screenRow: number, _screenCol: number): boolean {
+		const line = this.transcriptLineForScreenRow(screenRow, false);
+		if (line === null) {
+			this.clearSelection();
+			return false;
+		}
+		const text = stripAnsi(this.lastTranscript[line] ?? "");
+		const width = visibleWidth(text);
+		this.selectionAnchor = { line, col: 0 };
+		this.selectionHead = { line, col: width };
+		this.selectionInitialRange = {
+			start: { line, col: 0 },
+			end: { line, col: width },
+		};
+		this.selectionGranularity = "line";
+		this.selectionMode = "transcript";
+		this.activeTableSelection = null;
+		return true;
+	}
+
+	private wordAtColumn(text: string, col: number): { start: number; end: number } {
+		const segmenter = getWordSegmenter();
+		let start = 0;
+		for (const { segment } of segmenter.segment(text)) {
+			const segWidth = visibleWidth(segment);
+			const end = start + segWidth;
+			if (col >= start && col < end) return { start, end };
+			start = end;
+		}
+		return { start, end: start };
+	}
+
 	extendSelection(screenRow: number, screenCol: number): void {
 		if (!this.selectionAnchor || (this.selectionMode !== "transcript" && this.selectionMode !== "table")) return;
 		const line = this.transcriptLineForScreenRow(screenRow, true);
 		if (line === null) return;
-		this.selectionHead = { line, col: Math.max(0, screenCol) };
+
+		if (this.selectionMode === "table") {
+			this.selectionHead = { line, col: Math.max(0, screenCol) };
+			return;
+		}
+
+		const clampedCol = Math.max(0, screenCol);
+
+		if (this.selectionGranularity === "character" || !this.selectionInitialRange) {
+			this.selectionHead = { line, col: clampedCol };
+			return;
+		}
+
+		const initial = this.selectionInitialRange;
+
+		if (this.selectionGranularity === "word") {
+			const text = stripAnsi(this.lastTranscript[line] ?? "");
+			const word = this.wordAtColumn(text, clampedCol);
+			if (line < initial.start.line || (line === initial.start.line && clampedCol < initial.start.col)) {
+				// Dragging left/up: anchor at initial word end, head at dragged word start
+				this.selectionAnchor = { line: initial.end.line, col: initial.end.col };
+				this.selectionHead = { line, col: word.start };
+			} else {
+				// Dragging right/down: anchor at initial word start, head at dragged word end
+				this.selectionAnchor = { line: initial.start.line, col: initial.start.col };
+				this.selectionHead = { line, col: word.end };
+			}
+		} else {
+			// "line" granularity: select whole lines
+			const initialText = stripAnsi(this.lastTranscript[initial.start.line] ?? "");
+			const initialWidth = visibleWidth(initialText);
+			const dragText = stripAnsi(this.lastTranscript[line] ?? "");
+			if (line < initial.start.line) {
+				this.selectionAnchor = { line: initial.start.line, col: initialWidth };
+				this.selectionHead = { line, col: 0 };
+			} else if (line > initial.start.line) {
+				this.selectionAnchor = { line: initial.start.line, col: 0 };
+				this.selectionHead = { line, col: visibleWidth(dragText) };
+			} else {
+				this.selectionAnchor = { line: initial.start.line, col: 0 };
+				this.selectionHead = { line: initial.start.line, col: initialWidth };
+			}
+		}
 	}
 
 	selectionAutoScrollDirection(screenRow: number): SelectionScrollDirection | null {
@@ -297,6 +397,8 @@ export class FullscreenViewport {
 		};
 		this.selectionAnchor = point;
 		this.selectionHead = { ...point };
+		this.selectionGranularity = "character";
+		this.selectionInitialRange = null;
 		this.selectionMode = "frame";
 		return true;
 	}
@@ -617,6 +719,8 @@ export class FullscreenViewport {
 		this.selectionAnchor = null;
 		this.selectionHead = null;
 		this.selectionMode = null;
+		this.selectionGranularity = "character";
+		this.selectionInitialRange = null;
 		this.activeFrameSelection = null;
 		this.activeTableSelection = null;
 	}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -15,7 +15,7 @@ export { Editor, type EditorOptions, type EditorTheme } from "./components/edito
 export { Image, type ImageOptions, type ImageTheme } from "./components/image.js";
 export { Input } from "./components/input.js";
 export { Loader, type LoaderIndicatorOptions } from "./components/loader.js";
-export { type DefaultTextStyle, Markdown, type MarkdownTheme } from "./components/markdown.js";
+export { type DefaultTextStyle, Markdown, type MarkdownOptions, type MarkdownTheme } from "./components/markdown.js";
 export {
 	type SelectItem,
 	SelectList,

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -353,7 +353,8 @@ export class TUI extends Container {
 	private static readonly DOUBLE_CLICK_MS = 500;
 	private lastClickTime = 0;
 	private lastClickRow = -1;
-	private lastClickCol = -1;
+	private lastClickWordStart = -1;
+	private lastClickWordEnd = -1;
 	private clickCount = 0;
 	private selectionAutoScrollTimer: NodeJS.Timeout | undefined;
 	private selectionAutoScrollDirection: SelectionScrollDirection | null = null;
@@ -798,20 +799,23 @@ export class TUI extends Container {
 		this.selectionAutoScrollTimer.unref();
 	}
 
-	private countClick(screenRow: number, screenCol: number): number {
+	private countClick(screenRow: number, screenCol: number, viewport: FullscreenViewport): number {
 		const now = Date.now();
-		if (
-			now - this.lastClickTime <= TUI.DOUBLE_CLICK_MS &&
+		const word = viewport.wordRangeAt(screenRow, screenCol);
+		const sameWord =
 			screenRow === this.lastClickRow &&
-			screenCol === this.lastClickCol
-		) {
+			word !== null &&
+			word.start === this.lastClickWordStart &&
+			word.end === this.lastClickWordEnd;
+		if (now - this.lastClickTime <= TUI.DOUBLE_CLICK_MS && sameWord) {
 			this.clickCount = (this.clickCount % 3) + 1;
 		} else {
 			this.clickCount = 1;
 		}
 		this.lastClickTime = now;
 		this.lastClickRow = screenRow;
-		this.lastClickCol = screenCol;
+		this.lastClickWordStart = word?.start ?? screenCol;
+		this.lastClickWordEnd = word?.end ?? screenCol;
 		return this.clickCount;
 	}
 
@@ -924,7 +928,7 @@ export class TUI extends Container {
 					this.scrollBy(TUI.WHEEL_SCROLL_LINES);
 				} else if (event.button === MOUSE_BUTTON_LEFT && event.press && !event.motion) {
 					this.stopSelectionAutoScroll();
-					const clicks = this.countClick(event.y - 1, event.x - 1);
+					const clicks = this.countClick(event.y - 1, event.x - 1, viewport);
 					let began = false;
 					if (clicks === 2) {
 						began = viewport.beginWordSelection(event.y - 1, event.x - 1);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -350,6 +350,11 @@ export class TUI extends Container {
 	private static readonly WHEEL_SCROLL_LINES = 3;
 	private static readonly SELECTION_AUTO_SCROLL_DELAY_MS = 150;
 	private static readonly SELECTION_AUTO_SCROLL_INTERVAL_MS = 50;
+	private static readonly DOUBLE_CLICK_MS = 500;
+	private lastClickTime = 0;
+	private lastClickRow = -1;
+	private lastClickCol = -1;
+	private clickCount = 0;
 	private selectionAutoScrollTimer: NodeJS.Timeout | undefined;
 	private selectionAutoScrollDirection: SelectionScrollDirection | null = null;
 	private selectionAutoScrollRow = 0;
@@ -793,6 +798,23 @@ export class TUI extends Container {
 		this.selectionAutoScrollTimer.unref();
 	}
 
+	private countClick(screenRow: number, screenCol: number): number {
+		const now = Date.now();
+		if (
+			now - this.lastClickTime <= TUI.DOUBLE_CLICK_MS &&
+			screenRow === this.lastClickRow &&
+			screenCol === this.lastClickCol
+		) {
+			this.clickCount = (this.clickCount % 3) + 1;
+		} else {
+			this.clickCount = 1;
+		}
+		this.lastClickTime = now;
+		this.lastClickRow = screenRow;
+		this.lastClickCol = screenCol;
+		return this.clickCount;
+	}
+
 	private stopSelectionAutoScroll(): void {
 		if (this.selectionAutoScrollTimer) {
 			clearTimeout(this.selectionAutoScrollTimer);
@@ -902,7 +924,16 @@ export class TUI extends Container {
 					this.scrollBy(TUI.WHEEL_SCROLL_LINES);
 				} else if (event.button === MOUSE_BUTTON_LEFT && event.press && !event.motion) {
 					this.stopSelectionAutoScroll();
-					if (!viewport.beginSelection(event.y - 1, event.x - 1)) {
+					const clicks = this.countClick(event.y - 1, event.x - 1);
+					let began = false;
+					if (clicks === 2) {
+						began = viewport.beginWordSelection(event.y - 1, event.x - 1);
+					} else if (clicks === 3) {
+						began = viewport.beginLineSelection(event.y - 1, event.x - 1);
+					} else {
+						began = viewport.beginSelection(event.y - 1, event.x - 1);
+					}
+					if (!began) {
 						viewport.beginFrameSelection(event.y - 1, event.x - 1);
 					}
 					this.requestRender();

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -3,11 +3,21 @@ import { eastAsianWidth } from "get-east-asian-width";
 // Grapheme segmenter (shared instance)
 const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
+// Word-level segmenter (shared instance) for double-click word selection
+const wordSegmenter = new Intl.Segmenter(undefined, { granularity: "word" });
+
 /**
  * Get the shared grapheme segmenter instance.
  */
 export function getSegmenter(): Intl.Segmenter {
 	return segmenter;
+}
+
+/**
+ * Get the shared word-level segmenter instance.
+ */
+export function getWordSegmenter(): Intl.Segmenter {
+	return wordSegmenter;
 }
 
 /**

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -1033,4 +1033,168 @@ describe("TUI fullscreen mode", () => {
 
 		tui.stop();
 	});
+
+	it("double-click selects a word", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Screen row 3 = transcript line 15 ("hello world foo bar")
+		// "world" is at cols 6-10 (0-based). Click at col 7 -> SGR col=8, row=4.
+		// First click (press + release)
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// Second click (press + release) -- double-click
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["world"]);
+
+		tui.stop();
+	});
+
+	it("triple-click selects a full line", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Triple-click at the same position
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		// Click 2 (double-click)
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		copies.length = 0; // double-click already copied the word
+		// Click 3 (triple-click)
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["hello world foo bar"]);
+
+		tui.stop();
+	});
+
+	it("double-click and drag extends selection by words", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Double-click on "world" then drag right into "foo" without releasing
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		// Click 2 -- double-click starts word selection
+		terminal.sendInput("\x1b[<0;8;4M");
+		// Drag to "foo" at col 13 -> SGR col=14
+		terminal.sendInput("\x1b[<32;14;4M");
+		// Release
+		terminal.sendInput("\x1b[<0;14;4m");
+		await terminal.waitForRender();
+
+		// Should select "world foo" (word boundary snapping)
+		assert.deepStrictEqual(copies, ["world foo"]);
+
+		tui.stop();
+	});
+
+	it("double-click and drag left extends backward by words", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Double-click on "world" then drag left into "hello"
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		// Click 2 -- double-click starts word selection
+		terminal.sendInput("\x1b[<0;8;4M");
+		// Drag left to "hello" at col 2 -> SGR col=3
+		terminal.sendInput("\x1b[<32;3;4M");
+		// Release
+		terminal.sendInput("\x1b[<0;3;4m");
+		await terminal.waitForRender();
+
+		// Should select "hello world" (from start of "hello" to end of "world")
+		assert.deepStrictEqual(copies, ["hello world"]);
+
+		tui.stop();
+	});
+
+	it("click count resets after the double-click interval", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// First click
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// Wait past the 500ms double-click interval
+		await new Promise((resolve) => setTimeout(resolve, 600));
+
+		// Second click -- should be treated as a new single click, not a double-click
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// No word selection -- single click copies nothing
+		assert.deepStrictEqual(copies, []);
+
+		tui.stop();
+	});
+
+	it("click count resets on a different row", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Click at row 4, col 8
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// Click at row 5, col 8 -- different row
+		terminal.sendInput("\x1b[<0;8;5M");
+		terminal.sendInput("\x1b[<0;8;5m");
+		await terminal.waitForRender();
+
+		// No word selection
+		assert.deepStrictEqual(copies, []);
+
+		tui.stop();
+	});
 });

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -1197,4 +1197,161 @@ describe("TUI fullscreen mode", () => {
 
 		tui.stop();
 	});
+
+	it("double-click and drag across lines extends by words", async () => {
+		const testLines = lines(20);
+		testLines[14] = "alpha beta gamma";
+		testLines[15] = "delta epsilon zeta";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Double-click on "beta" (line 14, col 7 → SGR col 8, row 3)
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;3M");
+		terminal.sendInput("\x1b[<0;8;3m");
+		await terminal.waitForRender();
+		// Click 2 -- double-click starts word selection on "beta"
+		terminal.sendInput("\x1b[<0;8;3M");
+		// Drag to "epsilon" (line 15, col 10 → SGR col 11, row 4)
+		terminal.sendInput("\x1b[<32;11;4M");
+		// Release
+		terminal.sendInput("\x1b[<0;11;4m");
+		await terminal.waitForRender();
+
+		// Should select from "beta" start through "epsilon" end, spanning both lines
+		assert.deepStrictEqual(copies, ["beta gamma\ndelta epsilon"]);
+
+		tui.stop();
+	});
+
+	it("triple-click and drag extends by whole lines", async () => {
+		const testLines = lines(20);
+		testLines[14] = "alpha beta gamma";
+		testLines[15] = "delta epsilon zeta";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Triple-click on line 14 (col 3, row 3 → SGR col 4, row 3)
+		// Click 1
+		terminal.sendInput("\x1b[<0;4;3M");
+		terminal.sendInput("\x1b[<0;4;3m");
+		await terminal.waitForRender();
+		// Click 2 (double-click)
+		terminal.sendInput("\x1b[<0;4;3M");
+		terminal.sendInput("\x1b[<0;4;3m");
+		await terminal.waitForRender();
+		copies.length = 0;
+		// Click 3 (triple-click -- selects full line)
+		terminal.sendInput("\x1b[<0;4;3M");
+		// Drag down to line 15 (col 5, row 4 → SGR col 6, row 4)
+		terminal.sendInput("\x1b[<32;6;4M");
+		// Release
+		terminal.sendInput("\x1b[<0;6;4m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["alpha beta gamma\ndelta epsilon zeta"]);
+
+		tui.stop();
+	});
+
+	it("double-clicking whitespace copies nothing", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Double-click on the space between "hello" and "world" (col 5 → SGR col 6, row 4)
+		// Click 1
+		terminal.sendInput("\x1b[<0;6;4M");
+		terminal.sendInput("\x1b[<0;6;4m");
+		await terminal.waitForRender();
+		// Click 2
+		terminal.sendInput("\x1b[<0;6;4M");
+		terminal.sendInput("\x1b[<0;6;4m");
+		await terminal.waitForRender();
+
+		// Whitespace selection trims to null -- nothing copied
+		assert.deepStrictEqual(copies, []);
+
+		tui.stop();
+	});
+
+	it("double-click selects CJK wide-character words", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello \u4e16\u754c bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// "世界" occupies visible cols 6-9. Click at col 7 → SGR col 8, row 4.
+		// Click 1
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+		// Click 2
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["\u4e16\u754c"]);
+
+		tui.stop();
+	});
+
+	it("selection remains highlighted after mouse release", async () => {
+		const testLines = lines(20);
+		testLines[15] = "hello world foo bar";
+		const { terminal, tui, chat, dock } = setup(testLines);
+		const copies: string[] = [];
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Drag-select "hello" (cols 0-4 on line 15 = screen row 3)
+		// SGR col 1 → internal col 0, SGR col 6 → internal col 5
+		terminal.sendInput("\x1b[<0;1;4M");
+		terminal.sendInput("\x1b[<32;6;4M");
+		await terminal.waitForRender();
+
+		// Release
+		terminal.sendInput("\x1b[<0;6;4m");
+		await terminal.waitForRender();
+
+		// Text was copied
+		assert.deepStrictEqual(copies, ["hello"]);
+
+		// Selection highlight persists after release — force a full repaint
+		// and verify the highlight is re-applied
+		terminal.clearWrites();
+		terminal.resize(40, 11);
+		await terminal.waitForRender();
+		assert.ok(terminal.getWrites().includes("\x1b[7m"), "selection highlight visible after release");
+
+		// A plain click clears the persisted selection
+		terminal.clearWrites();
+		terminal.resize(40, 10);
+		await terminal.waitForRender();
+		terminal.sendInput("\x1b[<0;8;4M");
+		terminal.sendInput("\x1b[<0;8;4m");
+		await terminal.waitForRender();
+
+		// Force repaint to check the highlight is gone
+		terminal.clearWrites();
+		terminal.resize(40, 11);
+		await terminal.waitForRender();
+		assert.ok(!terminal.getWrites().includes("\x1b[7m"), "selection cleared by plain click");
+
+		tui.stop();
+	});
 });

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1366,3 +1366,55 @@ bar`,
 		});
 	});
 });
+
+describe("Markdown transform", () => {
+	it("transform receives raw text and content width", () => {
+		let receivedText = "";
+		let receivedWidth = 0;
+		const transform = (text: string, width: number): string => {
+			receivedText = text;
+			receivedWidth = width;
+			return text;
+		};
+		const markdown = new Markdown("Hello world", 2, 0, defaultMarkdownTheme, undefined, { transform });
+		markdown.render(80);
+		assert.strictEqual(receivedText, "Hello world");
+		// contentWidth = width - paddingX * 2 = 80 - 4 = 76
+		assert.strictEqual(receivedWidth, 76);
+	});
+
+	it("transformed text is rendered instead of original", () => {
+		const transform = (text: string): string => text.replace("Hello", "Goodbye");
+		const markdown = new Markdown("Hello world", 0, 0, defaultMarkdownTheme, undefined, { transform });
+		const lines = markdown.render(80);
+		const plainLines = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+		assert.ok(plainLines.some((l) => l.includes("Goodbye")));
+		assert.ok(!plainLines.some((l) => l.includes("Hello")));
+	});
+
+	it("no transform is backward compatible", () => {
+		const md1 = new Markdown("# Heading\n\nParagraph text", 0, 0, defaultMarkdownTheme);
+		const md2 = new Markdown("# Heading\n\nParagraph text", 0, 0, defaultMarkdownTheme, undefined, undefined);
+		assert.deepStrictEqual(md1.render(80), md2.render(80));
+	});
+
+	it("options without transform is backward compatible", () => {
+		const md1 = new Markdown("# Heading\n\nParagraph text", 0, 0, defaultMarkdownTheme);
+		const md2 = new Markdown("# Heading\n\nParagraph text", 0, 0, defaultMarkdownTheme, undefined, {});
+		assert.deepStrictEqual(md1.render(80), md2.render(80));
+	});
+
+	it("cache invalidation on text change with transform active", () => {
+		const transform = (text: string): string => text.replace("RED", "GREEN");
+		const markdown = new Markdown("Color: RED", 0, 0, defaultMarkdownTheme, undefined, { transform });
+		const first = markdown.render(80);
+		const plainFirst = first.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+		assert.ok(plainFirst.some((l) => l.includes("GREEN")));
+
+		markdown.setText("Color: BLUE and RED");
+		const second = markdown.render(80);
+		const plainSecond = second.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+		assert.ok(plainSecond.some((l) => l.includes("GREEN")));
+		assert.ok(plainSecond.some((l) => l.includes("BLUE")));
+	});
+});


### PR DESCRIPTION
## Summary

Renders Mermaid code blocks as inline Unicode box-drawing art in the terminal chat, so diagrams are immediately readable without leaving the TUI.

Closes #1244.

## Changes

### `packages/tui`

- Added optional `MarkdownOptions.transform` callback to the `Markdown` component. The callback receives `(text, availableWidth)` and is applied after tab normalization and before markdown parsing. Fully backward compatible (6th optional constructor parameter).
- Exported `MarkdownOptions` from `packages/tui/src/index.ts`.

### `packages/coding-agent`

- Added `grok-mermaid@0.2.2` dependency.
- Created `mermaid-transformer.ts`. Finds mermaid fenced code blocks, renders them via `grok-mermaid`'s `render()`, and maps styled spans to theme colors:
  - `border` to `dim`
  - `edge` / `edgeLabel` to `accent`
  - `title` to `dim` + `bold`
  - Each diagram row is wrapped in a markdown inline code span to preserve whitespace and box-drawing alignment. Blank rows use a non-breaking space for consistent height.
- Fallback: when `render()` returns null or the diagram is wider than available terminal width, the original mermaid source block is left untouched.
- Wired `markdownTransform` into `AssistantMessageComponent` (text blocks only, not thinking blocks) and `UserMessageComponent`.
- Wired all call sites in `interactive-mode.ts` (streaming, echo, addMessageToChat, skill blocks).
- Added `markdownTransform` to `ConversationComponentsOptions` and passed through to both message component types.
- Added `mermaid` field to `MarkdownSettings` with `MermaidRenderingMode = "streaming" | "off"` (default: `"streaming"`).
- Added `getMermaidRenderingMode()` / `setMermaidRenderingMode()` on `SettingsManager`.
- Added settings toggle in `/settings` UI with immediate invalidate + re-render on change.

## Testing

- 5 new tests in `packages/tui/test/markdown.test.ts` covering transform callback receive/apply/backward-compat/cache invalidation (65 total, all pass).
- 9 new tests in `packages/coding-agent/test/assistant-message.test.ts` covering mermaid rendering, transform wiring, fallback behavior, width overflow, multi-block, non-mermaid passthrough (23 total, all pass).
- 4 tests in `packages/coding-agent/test/settings-selector.test.ts` covering settings toggle (all pass).
- `npm run check` passes (biome + tsgo + installer + browser-smoke).
- Full TUI suite: 771 tests, 0 failures.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render Mermaid diagrams as inline Unicode art in chat
> - Adds a [mermaid-transformer](https://github.com/PrimeIntellect-ai/prime-agent/pull/1245/files#diff-8f6559e6bdbde44239400c4ab953d4915e74a10db3e2adf26767079866ad2fdf) that scans fenced ` ```mermaid ` blocks and renders them as styled Unicode box-drawing art using `grok-mermaid`, falling back to the raw block if rendering fails or the art exceeds terminal width.
> - Wires the transformer into both `AssistantMessageComponent` and `UserMessageComponent` via a new optional `markdownTransform` callback on the `Markdown` component, propagated through `ConversationComponentsOptions`.
> - Adds a **Mermaid rendering** toggle (values: `streaming` / `off`) to the settings UI; changing it immediately re-renders existing messages.
> - Adds double-click word selection and triple-click line selection to the fullscreen TUI transcript viewport.
> - On daemon startup, sweeps stale session leases and ghost session files (JSONL files containing only bootstrap entries).
> - Updates Z.AI model request format to use a `thinking` object with `type`/`clear_thinking` fields and conditionally includes `reasoning_effort` for supported models.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0197283.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->