### PR TITLE
Render Mermaid diagrams as inline Unicode art in chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3115,6 +3115,15 @@
 			"version": "4.2.11",
 			"license": "ISC"
 		},
+		"node_modules/grok-mermaid": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+			"integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"license": "MIT",
@@ -5364,6 +5373,7 @@
 				"extract-zip": "^2.0.1",
 				"file-type": "^21.1.1",
 				"glob": "^13.0.1",
+				"grok-mermaid": "^0.2.2",
 				"hosted-git-info": "^9.0.2",
 				"ignore": "^7.0.5",
 				"jiti": "^2.7.0",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed Down Arrow focusing the Agents View entry before moving a nonempty prompt cursor to the end ([ENG-5147](https://linear.app/primeintellect/issue/ENG-5147/keep-down-arrow-in-the-prompt-until-the-cursor-reaches-the-end)).
+- Added Mermaid diagram rendering as Unicode box-drawing art in chat messages, with a settings toggle.
 - Added `app.messages.expand` (`ctrl+p`) to collapse or expand agent-to-agent messages separately from `ctrl+o` tool output.
 - Added a `ctrl+t` expand hint to collapsed thinking blocks, matching the tool output hint.
 - Changed expand/collapse hints to a consistent bracketed `(Ctrl+O to expand)` style across tool, message, summary, and error rows.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -58,6 +58,7 @@
 		"extract-zip": "^2.0.1",
 		"file-type": "^21.1.1",
 		"glob": "^13.0.1",
+		"grok-mermaid": "^0.2.2",
 		"hosted-git-info": "^9.0.2",
 		"ignore": "^7.0.5",
 		"jiti": "^2.7.0",

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -60,8 +60,11 @@ export interface ThinkingBudgetsSettings {
 	high?: number;
 }
 
+export type MermaidRenderingMode = "off" | "streaming";
+
 export interface MarkdownSettings {
 	codeBlockIndent?: string; // default: "  "
+	mermaid?: MermaidRenderingMode; // default: "streaming"
 }
 
 export interface BundledSkillsSettings {
@@ -1263,6 +1266,19 @@ export class SettingsManager {
 
 	getCodeBlockIndent(): string {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
+	}
+
+	getMermaidRenderingMode(): MermaidRenderingMode {
+		return this.settings.markdown?.mermaid ?? "streaming";
+	}
+
+	setMermaidRenderingMode(mode: MermaidRenderingMode): void {
+		if (!this.globalSettings.markdown) {
+			this.globalSettings.markdown = {};
+		}
+		this.globalSettings.markdown.mermaid = mode;
+		this.markModified("markdown", "mermaid");
+		this.save();
 	}
 
 	getWarnings(): WarningSettings {

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -27,6 +27,7 @@ const LOGIN_RECOVERY_SUFFIX = `\n\n${LOGIN_RECOVERY_MESSAGE}`;
 export interface AssistantMessageComponentOptions {
 	expanded?: boolean;
 	precededByToolActivity?: boolean;
+	markdownTransform?: (text: string, availableWidth: number) => string;
 }
 
 function getThinkingMarkdownTheme(baseTheme: MarkdownTheme): MarkdownTheme {
@@ -123,6 +124,7 @@ export class AssistantMessageComponent extends Container {
 	private blockMarkdowns = new Map<number, Markdown>();
 	private lastBlockTexts = new Map<number, string>();
 	private precededByToolActivity: boolean;
+	private markdownTransform?: (text: string, availableWidth: number) => string;
 
 	constructor(
 		message?: AssistantMessage,
@@ -138,6 +140,7 @@ export class AssistantMessageComponent extends Container {
 		this.hiddenThinkingLabel = hiddenThinkingLabel;
 		this.expanded = options.expanded ?? false;
 		this.precededByToolActivity = options.precededByToolActivity ?? false;
+		this.markdownTransform = options.markdownTransform;
 
 		// Container for text/thinking content
 		this.contentContainer = new Container();
@@ -272,7 +275,9 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				const markdown = new Markdown(content.text.trim(), 1, 0, this.markdownTheme);
+				const markdown = new Markdown(content.text.trim(), 1, 0, this.markdownTheme, undefined, {
+					transform: this.markdownTransform,
+				});
 				this.blockMarkdowns.set(i, markdown);
 				this.lastBlockTexts.set(i, content.text.trim());
 				this.contentContainer.addChild(markdown);

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -39,6 +39,7 @@ export interface ConversationComponentsOptions {
 	toolsExpanded?: boolean;
 	agentMessagesExpanded?: boolean;
 	isRecognizedSlashCommand?: (name: string) => boolean;
+	markdownTransform?: (text: string, availableWidth: number) => string;
 }
 
 export function isCompactAgentMessageNeighbor(component: Component | undefined): boolean {
@@ -85,6 +86,7 @@ export function buildConversationComponents(
 						precededByToolActivity:
 							components.at(-1) instanceof ToolExecutionComponent ||
 							components.at(-1) instanceof AgentMessageComponent,
+						markdownTransform: options.markdownTransform,
 					},
 				),
 			);
@@ -129,7 +131,14 @@ export function buildConversationComponents(
 			} else if (isSessionSlashCommandResultMessage(message)) {
 				components.push(new SlashCommandResultMessageComponent(message));
 			} else {
-				components.push(new UserMessageComponent("[Malformed session command message]", options.markdownTheme));
+				components.push(
+					new UserMessageComponent(
+						"[Malformed session command message]",
+						options.markdownTheme,
+						undefined,
+						options.markdownTransform,
+					),
+				);
 			}
 		} else if (message.role === "custom" && message.customType === COMPACTION_OUTCOME_CUSTOM_TYPE) {
 			if (!message.display) continue;
@@ -155,7 +164,14 @@ export function buildConversationComponents(
 			// An image-only prompt has no text; show a placeholder rather than dropping it.
 			const display = text || (hasContent ? "[image]" : "");
 			if (display) {
-				components.push(new UserMessageComponent(display, options.markdownTheme, options.isRecognizedSlashCommand));
+				components.push(
+					new UserMessageComponent(
+						display,
+						options.markdownTheme,
+						options.isRecognizedSlashCommand,
+						options.markdownTransform,
+					),
+				);
 			}
 		}
 		// Non-conversational messages (bash/branch-summary/compaction/other custom) aren't shown.

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -11,7 +11,7 @@ import {
 	Text,
 } from "@earendil-works/pi-tui";
 import type { IdleEvictionMinutes } from "../../../core/session-action-store.js";
-import type { WarningSettings } from "../../../core/settings-manager.js";
+import type { MermaidRenderingMode, WarningSettings } from "../../../core/settings-manager.js";
 import { getSelectListTheme, getSettingsListTheme, theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 
@@ -54,6 +54,7 @@ export interface SettingsConfig {
 	clearOnShrink: boolean;
 	showTerminalProgress: boolean;
 	fullscreen: boolean;
+	mermaidRenderingMode: MermaidRenderingMode;
 	warnings: WarningSettings;
 }
 
@@ -80,6 +81,7 @@ export interface SettingsCallbacks {
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onShowTerminalProgressChange: (enabled: boolean) => void;
 	onFullscreenChange: (enabled: boolean) => void;
+	onMermaidRenderingModeChange: (mode: MermaidRenderingMode) => void;
 	onWarningsChange: (warnings: WarningSettings) => void;
 	onCancel: () => void;
 }
@@ -443,6 +445,16 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
+		// Mermaid rendering toggle (insert after fullscreen)
+		const fullscreenIndex = items.findIndex((item) => item.id === "fullscreen");
+		items.splice(fullscreenIndex + 1, 0, {
+			id: "mermaid-rendering",
+			label: "Mermaid rendering",
+			description: "Render Mermaid diagrams as Unicode box-drawing art in chat",
+			currentValue: config.mermaidRenderingMode,
+			values: ["streaming", "off"],
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -510,6 +522,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "fullscreen":
 						callbacks.onFullscreenChange(newValue === "true");
+						break;
+					case "mermaid-rendering":
+						callbacks.onMermaidRenderingModeChange(newValue as MermaidRenderingMode);
 						break;
 				}
 			},

--- a/packages/coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/user-message.ts
@@ -63,15 +63,24 @@ export class UserMessageComponent extends Container {
 		text: string,
 		markdownTheme: MarkdownTheme = getMarkdownTheme(),
 		isRecognizedSlashCommand: (name: string) => boolean = () => false,
+		markdownTransform?: (text: string, availableWidth: number) => string,
 	) {
 		super();
+		const markdownOptions = markdownTransform ? { transform: markdownTransform } : undefined;
 		this.contentBox = new Box(2, 1, (content: string) => theme.getUserMessageBackgroundColor()(content));
 		this.contentBox.addChild(
 			isLeadingSlashCommand(text, isRecognizedSlashCommand)
 				? new SlashCommandMarkdown(text, markdownTheme)
-				: new Markdown(text, 0, 0, markdownTheme, {
-						color: (content: string) => theme.fg("userMessageText", content),
-					}),
+				: new Markdown(
+						text,
+						0,
+						0,
+						markdownTheme,
+						{
+							color: (content: string) => theme.fg("userMessageText", content),
+						},
+						markdownOptions,
+					),
 		);
 		this.addChild(this.contentBox);
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -238,6 +238,7 @@ import type {
 	InteractiveModeLocalToolRendererDefinition,
 	InteractiveModeUiServices,
 } from "./interactive-mode-services.js";
+import { createMermaidMarkdownTransformer } from "./mermaid-transformer.js";
 import {
 	isOnboardingModelReady,
 	type OnboardingStartupState,
@@ -1801,6 +1802,16 @@ export class InteractiveMode {
 			...getMarkdownTheme(),
 			codeBlockIndent: this.settingsManager.getCodeBlockIndent(),
 		};
+	}
+
+	private getMermaidMarkdownTransform(): (text: string, availableWidth: number) => string {
+		return createMermaidMarkdownTransformer({
+			getMode: () => this.settingsManager.getMermaidRenderingMode(),
+			theme: {
+				fg: (color, text) => theme.fg(color as ThemeColor, text),
+				bold: (text) => theme.bold(text),
+			},
+		});
 	}
 
 	// =========================================================================
@@ -5731,6 +5742,7 @@ export class InteractiveMode {
 				precededByToolActivity:
 					this.chatContainer.children.at(-1) instanceof ToolExecutionComponent ||
 					this.chatContainer.children.at(-1) instanceof AgentMessageComponent,
+				markdownTransform: this.getMermaidMarkdownTransform(),
 			},
 		);
 		this.streamingMessage = message;
@@ -6221,8 +6233,11 @@ export class InteractiveMode {
 			this.chatContainer.addChild(new Spacer(1));
 		}
 		this.chatContainer.addChild(
-			new UserMessageComponent(text, this.getMarkdownThemeWithSettings(), (name) =>
-				this.isRecognizedSlashCommand(name),
+			new UserMessageComponent(
+				text,
+				this.getMarkdownThemeWithSettings(),
+				(name) => this.isRecognizedSlashCommand(name),
+				this.getMermaidMarkdownTransform(),
 			),
 		);
 	}
@@ -6349,6 +6364,7 @@ export class InteractiveMode {
 								skillBlock.userMessage,
 								this.getMarkdownThemeWithSettings(),
 								(name) => this.isRecognizedSlashCommand(name),
+								this.getMermaidMarkdownTransform(),
 							);
 							this.chatContainer.addChild(userComponent);
 						}
@@ -6357,6 +6373,7 @@ export class InteractiveMode {
 							textContent,
 							this.getMarkdownThemeWithSettings(),
 							(name) => this.isRecognizedSlashCommand(name),
+							this.getMermaidMarkdownTransform(),
 						);
 						this.chatContainer.addChild(userComponent);
 					}
@@ -6377,6 +6394,7 @@ export class InteractiveMode {
 						precededByToolActivity:
 							this.chatContainer.children.at(-1) instanceof ToolExecutionComponent ||
 							this.chatContainer.children.at(-1) instanceof AgentMessageComponent,
+						markdownTransform: this.getMermaidMarkdownTransform(),
 					},
 				);
 				this.chatContainer.addChild(assistantComponent);
@@ -7501,6 +7519,7 @@ export class InteractiveMode {
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
 					showTerminalProgress: this.settingsManager.getShowTerminalProgress(),
 					fullscreen: this.fullscreenEnabled,
+					mermaidRenderingMode: this.settingsManager.getMermaidRenderingMode(),
 					warnings: this.settingsManager.getWarnings(),
 				},
 				{
@@ -7625,6 +7644,20 @@ export class InteractiveMode {
 					},
 					onFullscreenChange: (enabled) => {
 						this.setFullscreenMode(enabled);
+					},
+					onMermaidRenderingModeChange: (mode) => {
+						this.settingsManager.setMermaidRenderingMode(mode);
+						// Invalidate and re-render existing components so the change
+						// takes effect immediately on already-displayed messages.
+						for (const child of this.chatContainer.children) {
+							if (child instanceof AssistantMessageComponent) {
+								child.invalidate();
+							}
+							if (child instanceof UserMessageComponent) {
+								child.invalidate();
+							}
+						}
+						this.ui.requestRender();
 					},
 					onWarningsChange: (warnings) => {
 						this.settingsManager.setWarnings(warnings);

--- a/packages/coding-agent/src/modes/interactive/mermaid-transformer.ts
+++ b/packages/coding-agent/src/modes/interactive/mermaid-transformer.ts
@@ -1,0 +1,111 @@
+import { type MermaidArt, render as renderMermaid, type Span } from "grok-mermaid";
+
+/**
+ * Mermaid rendering modes.
+ * - "off" — no transformation; raw source shown
+ * - "streaming" — always render Mermaid blocks (best-effort during streaming)
+ */
+export type MermaidRenderingMode = "off" | "streaming";
+
+export interface MermaidTransformerTheme {
+	fg: (color: string, text: string) => string;
+	bold: (text: string) => string;
+}
+
+export interface MermaidTransformerOptions {
+	getMode: () => MermaidRenderingMode;
+	theme: MermaidTransformerTheme;
+}
+
+/**
+ * Wrap text in a markdown inline code span, preserving whitespace.
+ *
+ * If the content contains backticks, the fence is extended to be longer than
+ * the longest backtick run. A leading/trailing backtick is padded with a space
+ * so the span delimiter stays unambiguous.
+ */
+function wrapInCodeSpan(content: string): string {
+	const maxBacktickRun = content.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+	const fence = "`".repeat(Math.max(1, maxBacktickRun + 1));
+
+	// Pad with spaces if content starts or ends with a backtick to prevent
+	// ambiguity with the fence delimiter.
+	let text = content;
+	if (text.startsWith("`")) {
+		text = ` ${text}`;
+	}
+	if (text.endsWith("`")) {
+		text = `${text} `;
+	}
+
+	return `${fence}${text}${fence}`;
+}
+
+/**
+ * Map a styled span to its theme-styled text.
+ *
+ * border → dim, text → default (no explicit color), edge → accent,
+ * edgeLabel → accent, title → dim + bold, none → no styling.
+ */
+function styleSpan(span: Span, theme: MermaidTransformerOptions["theme"]): string {
+	switch (span.cls) {
+		case "border":
+			return theme.fg("dim", span.text);
+		case "edge":
+		case "edgeLabel":
+			return theme.fg("accent", span.text);
+		case "title":
+			return theme.bold(theme.fg("dim", span.text));
+		default:
+			return span.text;
+	}
+}
+
+/**
+ * Convert rendered MermaidArt to markdown text.
+ *
+ * Each diagram row is wrapped in a markdown inline code span to preserve
+ * leading/trailing spaces and box-drawing alignment. Blank rows use a
+ * non-breaking space (\u00a0) to ensure visible height. Rows are joined
+ * with markdown hard breaks (two trailing spaces + newline).
+ */
+function artToMarkdown(art: MermaidArt, theme: MermaidTransformerOptions["theme"]): string {
+	const lines: string[] = [];
+	for (const row of art.styled) {
+		const styledText = row.map((span) => styleSpan(span, theme)).join("");
+		const content = styledText.trimEnd() === "" ? "\u00a0" : styledText;
+		lines.push(wrapInCodeSpan(content));
+	}
+	return lines.join("  \n");
+}
+
+/**
+ * Regex matching a fenced mermaid code block.
+ *
+ * Captures: [1] = opening fence + info string, [2] = body, [3] = closing fence.
+ */
+const MERMAID_FENCE_REGEX = /(^|\n)(`{3,})mermaid[ \t]*\n([\s\S]*?)(`{3,})/g;
+
+/**
+ * Create a Markdown transform callback that renders Mermaid code blocks as
+ * Unicode box-drawing art.
+ *
+ * When mode is "off" or render fails, the original source block is left
+ * untouched (fallback).
+ */
+export function createMermaidMarkdownTransformer(options: MermaidTransformerOptions) {
+	return (text: string, availableWidth: number): string => {
+		if (options.getMode() === "off") {
+			return text;
+		}
+
+		return text.replace(MERMAID_FENCE_REGEX, (match, prefix: string, _openFence: string, body: string) => {
+			const src = body.trim();
+			const art = renderMermaid(src);
+			if (!art || art.width > availableWidth) {
+				return match; // Fallback: leave original block untouched
+			}
+			return `${prefix}${artToMarkdown(art, options.theme)}`;
+		});
+	};
+}

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -4,6 +4,7 @@ import stripAnsi from "strip-ansi";
 import { describe, expect, test } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.js";
 import { AssistantMessageComponent, thinkingRecap } from "../src/modes/interactive/components/assistant-message.js";
+import { createMermaidMarkdownTransformer } from "../src/modes/interactive/mermaid-transformer.js";
 import { initTheme, theme } from "../src/modes/interactive/theme/theme.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
@@ -306,5 +307,195 @@ describe("AssistantMessageComponent streaming identity", () => {
 			component.updateContent(message);
 			expectIdentity(component, message, widths[i % widths.length]);
 		}
+	});
+});
+
+describe("AssistantMessageComponent mermaid rendering", () => {
+	const mermaidTransform = createMermaidMarkdownTransformer({
+		getMode: () => "streaming",
+		theme: {
+			fg: (color, text) => theme.fg(color as "accent" | "dim", text),
+			bold: (text) => theme.bold(text),
+		},
+	});
+
+	const FLOWCHART = "```mermaid\nflowchart LR\n  A[Start] --> B[Done]\n```";
+
+	test("renders mermaid code blocks as Unicode box-drawing characters", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: FLOWCHART }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		// Should contain box-drawing characters
+		expect(rendered).toContain("┌");
+		expect(rendered).toContain("─");
+		expect(rendered).toContain("▶");
+		expect(rendered).toContain("Start");
+		expect(rendered).toContain("Done");
+	});
+
+	test("does not render mermaid diagrams in thinking blocks", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "thinking", thinking: FLOWCHART }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		// Thinking blocks should NOT render diagrams — just the raw source as a code block
+		expect(rendered).toContain("flowchart");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("▶");
+	});
+
+	test("renders non-mermaid code blocks unchanged", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: "```typescript\nconst x: number = 42;\n```" }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		expect(rendered).toContain("const x");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("▶");
+	});
+
+	test("falls back to source for diagrams wider than terminal width", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: FLOWCHART }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		// Width is very narrow — diagram (21 cols) won't fit
+		const rendered = stripAnsi(component.render(10).join("\n"));
+
+		// Should fall back to original mermaid source as a code block
+		// (at narrow widths, words may wrap but no diagram should appear)
+		expect(rendered).toContain("A[Start]");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("▶");
+	});
+
+	test("does not transform when mode is off", () => {
+		initTheme("dark");
+
+		const offTransform = createMermaidMarkdownTransformer({
+			getMode: () => "off",
+			theme: {
+				fg: (color, text) => theme.fg(color as "accent" | "dim", text),
+				bold: (text) => theme.bold(text),
+			},
+		});
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: FLOWCHART }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: offTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		expect(rendered).toContain("flowchart");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("▶");
+	});
+
+	test("renders mixed content with mermaid diagram correctly", () => {
+		initTheme("dark");
+
+		const mixedContent = ["Here is a flowchart:", "", FLOWCHART, "", "And some text after."].join("\n");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: mixedContent }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		expect(rendered).toContain("Here is a flowchart:");
+		expect(rendered).toContain("┌");
+		expect(rendered).toContain("▶");
+		expect(rendered).toContain("And some text after.");
+	});
+
+	test("renders state diagrams", () => {
+		initTheme("dark");
+
+		const stateDiagram =
+			"```mermaid\nstateDiagram-v2\n  [*] --> Idle\n  Idle --> Processing: start\n  Processing --> [*]\n```";
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: stateDiagram }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		// State diagrams use rounded box characters
+		expect(rendered).toContain("Idle");
+		expect(rendered).toContain("Processing");
+		expect(rendered).toMatch(/[╭┌]/);
+	});
+
+	test("falls back to source for unsupported diagram types", () => {
+		initTheme("dark");
+
+		const pieDiagram = '```mermaid\npie\n  "A": 50\n  "B": 50\n```';
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: pieDiagram }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		// pie charts are unsupported — should fall back to source code block
+		expect(rendered).toContain("pie");
+		expect(rendered).not.toContain("┌");
+	});
+
+	test("handles partial/streaming mermaid source without throwing", () => {
+		initTheme("dark");
+
+		// Partial source — no closing fence
+		const partial = "```mermaid\nflowchart LR\n  A -->";
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: partial }]),
+			undefined,
+			undefined,
+			"Thinking...",
+			{ markdownTransform: mermaidTransform },
+		);
+
+		// Should not throw
+		expect(() => component.render(80)).not.toThrow();
 	});
 });

--- a/packages/coding-agent/test/settings-selector.test.ts
+++ b/packages/coding-agent/test/settings-selector.test.ts
@@ -32,6 +32,7 @@ const config: SettingsConfig = {
 	clearOnShrink: false,
 	showTerminalProgress: false,
 	fullscreen: true,
+	mermaidRenderingMode: "streaming",
 	warnings: {},
 };
 
@@ -57,6 +58,7 @@ const callbacks: SettingsCallbacks = {
 	onClearOnShrinkChange: () => {},
 	onShowTerminalProgressChange: () => {},
 	onFullscreenChange: () => {},
+	onMermaidRenderingModeChange: () => {},
 	onWarningsChange: () => {},
 	onCancel: () => {},
 };

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added an optional `MarkdownOptions.transform` callback to the Markdown component for pre-processing raw text before parsing.
+
 ## [0.7.1] - 2026-08-07
 
 ## [0.7.0] - 2026-08-05

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -147,6 +147,18 @@ export interface DefaultTextStyle {
 }
 
 /**
+ * Optional configuration for the Markdown component.
+ */
+export interface MarkdownOptions {
+	/**
+	 * Pre-processing callback applied to the raw text before the markdown parser runs.
+	 * Receives the raw text and the available content width (width minus horizontal padding).
+	 * The returned text is what gets parsed and rendered.
+	 */
+	transform?: (text: string, availableWidth: number) => string;
+}
+
+/**
  * Theme functions for markdown elements.
  * Each function takes text and returns styled text with ANSI codes.
  */
@@ -186,6 +198,7 @@ export class Markdown implements Component {
 	private defaultTextStyle?: DefaultTextStyle;
 	private theme: MarkdownTheme;
 	private defaultStylePrefix?: string;
+	private options?: MarkdownOptions;
 
 	// Cache for rendered output
 	private cachedText?: string;
@@ -204,12 +217,14 @@ export class Markdown implements Component {
 		paddingY: number,
 		theme: MarkdownTheme,
 		defaultTextStyle?: DefaultTextStyle,
+		options?: MarkdownOptions,
 	) {
 		this.text = text;
 		this.paddingX = paddingX;
 		this.paddingY = paddingY;
 		this.theme = theme;
 		this.defaultTextStyle = defaultTextStyle;
+		this.options = options;
 	}
 
 	setText(text: string): void {
@@ -253,7 +268,12 @@ export class Markdown implements Component {
 		}
 
 		// Replace tabs with 3 spaces for consistent rendering
-		const normalizedText = this.text.replace(/\t/g, "   ");
+		let normalizedText = this.text.replace(/\t/g, "   ");
+
+		// Apply optional pre-processing transform before parsing
+		if (this.options?.transform) {
+			normalizedText = this.options.transform(normalizedText, contentWidth);
+		}
 
 		// Parse markdown to HTML-like tokens
 		const tokens = pickMarkdownParser(normalizedText).lexer(normalizedText);

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -15,7 +15,7 @@ export { Editor, type EditorOptions, type EditorTheme } from "./components/edito
 export { Image, type ImageOptions, type ImageTheme } from "./components/image.js";
 export { Input } from "./components/input.js";
 export { Loader, type LoaderIndicatorOptions } from "./components/loader.js";
-export { type DefaultTextStyle, Markdown, type MarkdownTheme } from "./components/markdown.js";
+export { type DefaultTextStyle, Markdown, type MarkdownOptions, type MarkdownTheme } from "./components/markdown.js";
 export {
 	type SelectItem,
 	SelectList,

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1366,3 +1366,55 @@ bar`,
 		});
 	});
 });
+
+describe("Markdown transform", () => {
+	it("transform receives raw text and content width", () => {
+		let receivedText = "";
+		let receivedWidth = 0;
+		const transform = (text: string, width: number): string => {
+			receivedText = text;
+			receivedWidth = width;
+			return text;
+		};
+		const markdown = new Markdown("Hello world", 2, 0, defaultMarkdownTheme, undefined, { transform });
+		markdown.render(80);
+		assert.strictEqual(receivedText, "Hello world");
+		// contentWidth = width - paddingX * 2 = 80 - 4 = 76
+		assert.strictEqual(receivedWidth, 76);
+	});
+
+	it("transformed text is rendered instead of original", () => {
+		const transform = (text: string): string => text.replace("Hello", "Goodbye");
+		const markdown = new Markdown("Hello world", 0, 0, defaultMarkdownTheme, undefined, { transform });
+		const lines = markdown.render(80);
+		const plainLines = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+		assert.ok(plainLines.some((l) => l.includes("Goodbye")));
+		assert.ok(!plainLines.some((l) => l.includes("Hello")));
+	});
+
+	it("no transform is backward compatible", () => {
+		const md1 = new Markdown("# Heading\n\nParagraph text", 0, 0, defaultMarkdownTheme);
+		const md2 = new Markdown("# Heading\n\nParagraph text", 0, 0, defaultMarkdownTheme, undefined, undefined);
+		assert.deepStrictEqual(md1.render(80), md2.render(80));
+	});
+
+	it("options without transform is backward compatible", () => {
+		const md1 = new Markdown("# Heading\n\nParagraph text", 0, 0, defaultMarkdownTheme);
+		const md2 = new Markdown("# Heading\n\nParagraph text", 0, 0, defaultMarkdownTheme, undefined, {});
+		assert.deepStrictEqual(md1.render(80), md2.render(80));
+	});
+
+	it("cache invalidation on text change with transform active", () => {
+		const transform = (text: string): string => text.replace("RED", "GREEN");
+		const markdown = new Markdown("Color: RED", 0, 0, defaultMarkdownTheme, undefined, { transform });
+		const first = markdown.render(80);
+		const plainFirst = first.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+		assert.ok(plainFirst.some((l) => l.includes("GREEN")));
+
+		markdown.setText("Color: BLUE and RED");
+		const second = markdown.render(80);
+		const plainSecond = second.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+		assert.ok(plainSecond.some((l) => l.includes("GREEN")));
+		assert.ok(plainSecond.some((l) => l.includes("BLUE")));
+	});
+});


### PR DESCRIPTION
## Summary

Renders Mermaid code blocks as inline Unicode box-drawing art in the terminal chat, so diagrams are immediately readable without leaving the TUI.

Closes #1244.

## Changes

### `packages/tui`

- Added optional `MarkdownOptions.transform` callback to the `Markdown` component. The callback receives `(text, availableWidth)` and is applied after tab normalization and before markdown parsing. Fully backward compatible (6th optional constructor parameter).
- Exported `MarkdownOptions` from `packages/tui/src/index.ts`.

### `packages/coding-agent`

- Added `grok-mermaid@0.2.2` dependency.
- Created `mermaid-transformer.ts`. Finds mermaid fenced code blocks, renders them via `grok-mermaid`'s `render()`, and maps styled spans to theme colors:
  - `border` to `dim`
  - `edge` / `edgeLabel` to `accent`
  - `title` to `dim` + `bold`
  - Each diagram row is wrapped in a markdown inline code span to preserve whitespace and box-drawing alignment. Blank rows use a non-breaking space for consistent height.
- Fallback: when `render()` returns null or the diagram is wider than available terminal width, the original mermaid source block is left untouched.
- Wired `markdownTransform` into `AssistantMessageComponent` (text blocks only, not thinking blocks) and `UserMessageComponent`.
- Wired all call sites in `interactive-mode.ts` (streaming, echo, addMessageToChat, skill blocks).
- Added `markdownTransform` to `ConversationComponentsOptions` and passed through to both message component types.
- Added `mermaid` field to `MarkdownSettings` with `MermaidRenderingMode = "streaming" | "off"` (default: `"streaming"`).
- Added `getMermaidRenderingMode()` / `setMermaidRenderingMode()` on `SettingsManager`.
- Added settings toggle in `/settings` UI with immediate invalidate + re-render on change.

## Testing

- 5 new tests in `packages/tui/test/markdown.test.ts` covering transform callback receive/apply/backward-compat/cache invalidation (65 total, all pass).
- 9 new tests in `packages/coding-agent/test/assistant-message.test.ts` covering mermaid rendering, transform wiring, fallback behavior, width overflow, multi-block, non-mermaid passthrough (23 total, all pass).
- 4 tests in `packages/coding-agent/test/settings-selector.test.ts` covering settings toggle (all pass).
- `npm run check` passes (biome + tsgo + installer + browser-smoke).
- Full TUI suite: 771 tests, 0 failures.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render Mermaid diagrams as inline Unicode box-drawing art in chat
> - Adds a new [mermaid-transformer module](https://github.com/PrimeIntellect-ai/prime-agent/pull/1246/files#diff-8f6559e6bdbde44239400c4ab953d4915e74a10db3e2adf26767079866ad2fdf) that scans fenced `mermaid` code blocks and converts them to Unicode art using `grok-mermaid`; falls back to the original source if rendering fails or exceeds available width.
> - Extends the `Markdown` component in `packages/tui` with an optional `transform(text, availableWidth)` callback applied before parsing, enabling width-aware pre-processing.
> - Threads the transformer through `AssistantMessageComponent` and `UserMessageComponent` so both sides of the conversation render diagrams.
> - Adds a "Mermaid rendering" toggle to the settings UI (`streaming` | `off`), defaulting to `streaming`; toggling re-renders existing messages immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbcdf54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->