### PR TITLE
ci(security): pin workflow actions by digest

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload production artifacts
         if: env.PUBLISH_PRODUCTION == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: prime-agent-production
           path: packages/coding-agent/release/production/artifacts/*
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload beta artifacts
         if: env.PUBLISH_BETA == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: prime-agent-beta
           path: packages/coding-agent/release/beta/artifacts/*
@@ -214,14 +214,14 @@ jobs:
 
       - name: Download production artifacts
         if: env.PUBLISH_PRODUCTION == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: prime-agent-production
           path: release-artifacts/production
 
       - name: Download beta artifacts
         if: env.PUBLISH_BETA == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: prime-agent-beta
           path: release-artifacts/beta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -85,10 +87,12 @@ jobs:
             install_uv: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/nightly-process-stress.yml
+++ b/.github/workflows/nightly-process-stress.yml
@@ -19,10 +19,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

- pin every GitHub Action used by the build, CI, and nightly workflows to an immutable commit digest
- disable persisted checkout credentials in every checkout step
- preserve the existing least-privilege workflow and job permissions, including the release job's required `contents: write`

Fixes #926.

## Risk

Low. This is limited to workflow references and checkout credential persistence. Action major versions and inputs are unchanged. The release job retains only the write permission required to create and update releases and tags.

## Provenance

Extracted directly onto current `main` from the independently authored security work in #1159. The commit preserves the original source SHA with a `cherry picked from` trailer. No changes were taken from the MCP/provider stack.

## Validation

- `npm run check`
- parsed all changed workflow YAML successfully
- verified all 14 `uses:` references are pinned to full 40-character SHA-1 values
- verified all 6 checkout steps use `persist-credentials: false`
- verified each pinned digest against its upstream action tag with `git ls-remote`
- `git diff --check origin/main...HEAD`

## Review focus

Please verify the pinned action identities, checkout credential handling, and the intentionally narrow `contents: write` permission on the publish job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f86d5be998987ba73f6898a1697c4f8454269579. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin CI workflow actions to specific commit digests
> - Pins all GitHub Actions in [build-binaries.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/1250/files#diff-e0c5149ab771083cacddbeaf3336656118f582f6311228e0b8652c3209a7dd2e), [ci.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/1250/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f), and [nightly-process-stress.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/1250/files#diff-d1175db99e1e2f68d172311e664dcf0f1f68a4d1746b80dd6b467fcb54e00faf) to immutable commit SHAs instead of mutable version tags.
> - Adds `persist-credentials: false` to all `actions/checkout` steps, preventing Git credentials from being stored in the local repository after checkout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f86d5be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->