### PR TITLE
fix: tolerate null assistant content blocks

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -203,9 +203,9 @@ export class AssistantMessageComponent extends Container {
 		const parts: string[] = [];
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
-			if (content.type === "text") {
+			if (content?.type === "text") {
 				parts.push(`${i}:text:${content.text.trim() ? 1 : 0}`);
-			} else if (content.type === "thinking") {
+			} else if (content?.type === "thinking") {
 				parts.push(`${i}:thinking:${content.thinking.trim() ? 1 : 0}`);
 				if (this.hideThinkingBlock && content.thinking.trim()) {
 					// The collapsed row bakes the recap into a static line, so a recap
@@ -214,7 +214,7 @@ export class AssistantMessageComponent extends Container {
 					parts.push(`${i}:recap:${JSON.stringify(thinkingRecap(content.thinking, this.hiddenThinkingLabel))}`);
 				}
 			} else {
-				parts.push(`${i}:${content.type}`);
+				parts.push(`${i}:${content?.type ?? "invalid"}`);
 			}
 		}
 		parts.push(
@@ -244,7 +244,11 @@ export class AssistantMessageComponent extends Container {
 			}
 			const content = message.content[i];
 			const text =
-				content.type === "text" ? content.text.trim() : content.type === "thinking" ? content.thinking.trim() : "";
+				content?.type === "text"
+					? content.text.trim()
+					: content?.type === "thinking"
+						? content.thinking.trim()
+						: "";
 			if (this.lastBlockTexts.get(i) !== text) {
 				markdown.setText(text);
 				this.lastBlockTexts.set(i, text);
@@ -259,7 +263,7 @@ export class AssistantMessageComponent extends Container {
 		this.lastBlockTexts.clear();
 
 		const hasVisibleContent = message.content.some(
-			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
+			(c) => (c?.type === "text" && c.text.trim()) || (c?.type === "thinking" && c.thinking.trim()),
 		);
 
 		if (hasVisibleContent) {
@@ -269,19 +273,19 @@ export class AssistantMessageComponent extends Container {
 		// Render content in order
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
-			if (content.type === "text" && content.text.trim()) {
+			if (content?.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
 				const markdown = new Markdown(content.text.trim(), 1, 0, this.markdownTheme);
 				this.blockMarkdowns.set(i, markdown);
 				this.lastBlockTexts.set(i, content.text.trim());
 				this.contentContainer.addChild(markdown);
-			} else if (content.type === "thinking" && content.thinking.trim()) {
+			} else if (content?.type === "thinking" && content.thinking.trim()) {
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
 				const hasVisibleContentAfter = message.content
 					.slice(i + 1)
-					.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
+					.some((c) => (c?.type === "text" && c.text.trim()) || (c?.type === "thinking" && c.thinking.trim()));
 
 				const thinkingLabel = theme.bold(theme.fg("thinkingText", this.hiddenThinkingLabel));
 				if (this.hideThinkingBlock) {
@@ -320,7 +324,7 @@ export class AssistantMessageComponent extends Container {
 			}
 		}
 
-		const hasToolCalls = message.content.some((c) => c.type === "toolCall");
+		const hasToolCalls = message.content.some((c) => c?.type === "toolCall");
 		this.hasToolCalls = hasToolCalls;
 		if (message.stopReason === "aborted") {
 			const abortMessage =

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -42,6 +42,18 @@ describe("AssistantMessageComponent", () => {
 		expect(lines[lines.length - 1].startsWith(OSC133_ZONE_END + OSC133_ZONE_FINAL)).toBe(true);
 	});
 
+	test("ignores null content blocks from malformed provider responses", () => {
+		initTheme("dark");
+
+		const malformedContent = [null, { type: "text", text: "hello" }] as unknown as AssistantMessage["content"];
+		const component = new AssistantMessageComponent(createAssistantMessage(malformedContent));
+		expect(stripAnsi(component.render(40).join("\n"))).toContain("hello");
+
+		const updatedContent = [null, { type: "text", text: "hello again" }] as unknown as AssistantMessage["content"];
+		component.updateContent(createAssistantMessage(updatedContent));
+		expect(stripAnsi(component.render(40).join("\n"))).toContain("hello again");
+	});
+
 	test("does not add OSC 133 zone markers when assistant message contains tool calls", () => {
 		initTheme("dark");
 


### PR DESCRIPTION
## Summary
- guard assistant message rendering against `null`/sparse content blocks received at runtime
- preserve invalid block positions in the streaming structure signature so later valid updates still trigger reconciliation correctly
- add regression coverage for initial and incremental rendering with a null content entry

## Why
Assistant content is statically typed as valid blocks, but compact streaming or malformed provider payloads can produce a null entry at runtime. `AssistantMessageComponent.computeSignature()` dereferenced `content.type` unconditionally, crashing the entire TUI.

## Testing
- `npm test --workspace packages/coding-agent -- test/assistant-message.test.ts`
- `npx biome check packages/coding-agent/src/modes/interactive/components/assistant-message.ts packages/coding-agent/test/assistant-message.test.ts`
- `npx tsgo --noEmit`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive UI rendering only; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a crash when malformed or sparse streaming payloads include **`null`** entries in assistant **`message.content`**.
> 
> **`AssistantMessageComponent`** now uses optional chaining when reading each block’s **`type`** and text across **`computeSignature`**, **`reconcile`**, and **`rebuild`**. Invalid slots are treated as **`invalid`** in the structure signature so index positions stay stable and later valid updates still reconcile correctly during streaming.
> 
> Adds a regression test that renders and **`updateContent`**’s messages with a leading **`null`** block while still showing adjacent text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e87bcb9492b8d55b9b6db00b03985bfdd6be75c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix null content block handling in `AssistantMessageComponent`
> Adds null-safe checks throughout `AssistantMessageComponent` in [assistant-message.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1256/files#diff-034b364bcedb4e7d875ce45bc6ef8008c82444b43240cfd89c106db6ebb0d8e5) to tolerate null or undefined entries in assistant message content arrays. Null entries are now skipped during rendering and encoded as `'invalid'` in the structural signature instead of throwing a runtime error. A new test covers streaming updates with leading null content blocks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e87bcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->