### PR TITLE
fix(coding-agent): report session id alongside path to herdr

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed the builtin herdr reporter never registering a resumable session ref: reports now carry both `agent_session_id` and `agent_session_path`, since herdr only accepts the id for the `prime-agent` label ([#1260](https://github.com/PrimeIntellect-ai/prime-agent/issues/1260)).
+
 ## [0.7.2] - 2026-08-11
 
 - Fixed Down Arrow focusing the Agents View entry before moving a nonempty prompt cursor to the end ([ENG-5147](https://linear.app/primeintellect/issue/ENG-5147/keep-down-arrow-in-the-prompt-until-the-cursor-reaches-the-end)).

--- a/packages/coding-agent/src/core/extensions/builtin/herdr-agent-state.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/herdr-agent-state.ts
@@ -205,13 +205,14 @@ function herdrAgentStateExtensionImpl(pi: ExtensionAPI, getLoadedExtensionPaths:
 	}
 
 	function withSessionRef(params: Record<string, unknown>): Record<string, unknown> {
-		if (currentAgentSessionPath) {
-			return { ...params, agent_session_path: currentAgentSessionPath };
-		}
-		if (currentAgentSessionId) {
-			return { ...params, agent_session_id: currentAgentSessionId };
-		}
-		return params;
+		// Report both identity forms. Herdr's report handler only accepts
+		// agent_session_id for the prime-agent label (path acceptance is
+		// pi/omp-only), so a path-only report never registered the session.
+		return {
+			...params,
+			...(currentAgentSessionId ? { agent_session_id: currentAgentSessionId } : {}),
+			...(currentAgentSessionPath ? { agent_session_path: currentAgentSessionPath } : {}),
+		};
 	}
 
 	function sendState(state: AgentState, message?: string, seq = nextReportSeq()): Promise<void> {

--- a/packages/coding-agent/test/herdr-agent-state.test.ts
+++ b/packages/coding-agent/test/herdr-agent-state.test.ts
@@ -203,6 +203,7 @@ describe("herdrAgentStateExtension", () => {
 		handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, parentCtx);
 		await waitForRequests(1);
 		expect(requests[0]?.params.agent_session_path).toBe("/tmp/parent.jsonl");
+		expect(requests[0]?.params.agent_session_id).toBe("parent");
 
 		// Inline RLM children rebind the same handlers with their own ctx; their
 		// events must not flip the pane state or release the parent's pane.
@@ -256,6 +257,7 @@ describe("herdrAgentStateExtension", () => {
 		expect(requests[0]?.params.pane_id).toBe("w1:p1");
 		expect(requests[0]?.params.state).toBe("idle");
 		expect(requests[0]?.params.agent_session_path).toBe("/tmp/session.jsonl");
+		expect(requests[0]?.params.agent_session_id).toBe("session-1");
 
 		handlers.get("agent_start")?.[0]?.({ type: "agent_start" }, ctx);
 		await waitForRequests(2);

--- a/packages/coding-agent/test/suite/regressions/1260-herdr-session-ref.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1260-herdr-session-ref.test.ts
@@ -1,0 +1,137 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { herdrAgentStateExtension } from "../../../src/core/extensions/builtin/herdr-agent-state.js";
+import { createHarness, type Harness } from "../harness.js";
+
+interface RecordedRequest {
+	method: string;
+	params: Record<string, unknown>;
+}
+
+async function startFakeHerdrServer(socketPath: string): Promise<{
+	server: Server;
+	requests: RecordedRequest[];
+	waitForRequests: (count: number, timeoutMs?: number) => Promise<void>;
+}> {
+	const requests: RecordedRequest[] = [];
+	const waiters: Array<{ count: number; resolve: () => void }> = [];
+
+	const server = createServer((socket) => {
+		let buffer = "";
+		socket.on("data", (chunk) => {
+			buffer += chunk.toString();
+			let newlineIndex = buffer.indexOf("\n");
+			while (newlineIndex >= 0) {
+				const line = buffer.slice(0, newlineIndex);
+				buffer = buffer.slice(newlineIndex + 1);
+				if (line.trim()) {
+					const parsed = JSON.parse(line);
+					requests.push({ method: parsed.method, params: parsed.params });
+					socket.write(`${JSON.stringify({ id: parsed.id, result: { type: "ok" } })}\n`);
+					for (const waiter of [...waiters]) {
+						if (requests.length >= waiter.count) {
+							waiters.splice(waiters.indexOf(waiter), 1);
+							waiter.resolve();
+						}
+					}
+				}
+				newlineIndex = buffer.indexOf("\n");
+			}
+		});
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.on("error", reject);
+		server.listen(socketPath, resolve);
+	});
+
+	const waitForRequests = (count: number, timeoutMs = 3000): Promise<void> => {
+		if (requests.length >= count) {
+			return Promise.resolve();
+		}
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => reject(new Error(`timed out waiting for ${count} herdr requests`)), timeoutMs);
+			waiters.push({
+				count,
+				resolve: () => {
+					clearTimeout(timer);
+					resolve();
+				},
+			});
+		});
+	};
+
+	return { server, requests, waitForRequests };
+}
+
+describe("regression #1260: builtin herdr reporter registers a resumable session ref", () => {
+	const savedEnv: Record<string, string | undefined> = {};
+	const envKeys = ["HERDR_ENV", "HERDR_SOCKET_PATH", "HERDR_PANE_ID", "HERDR_PI_IDLE_DEBOUNCE_MS"];
+	for (const key of envKeys) {
+		savedEnv[key] = process.env[key];
+	}
+
+	const cleanupServers: Server[] = [];
+	const cleanupHarnesses: Harness[] = [];
+	const cleanupPaths: string[] = [];
+
+	afterEach(async () => {
+		for (const key of envKeys) {
+			if (savedEnv[key] === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = savedEnv[key];
+			}
+		}
+		while (cleanupHarnesses.length > 0) {
+			cleanupHarnesses.pop()?.cleanup();
+		}
+		while (cleanupServers.length > 0) {
+			const server = cleanupServers.pop();
+			await new Promise<void>((resolve) => server?.close(() => resolve()));
+		}
+		while (cleanupPaths.length > 0) {
+			const path = cleanupPaths.pop();
+			if (path) {
+				rmSync(path, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("reports both session id and session path from the live session manager", async () => {
+		// The extension factory captures HERDR_* env at load, so the socket and
+		// env must exist before the harness loads extensions.
+		const socketDir = join(tmpdir(), `hrd-1260-${Math.random().toString(36).slice(2, 8)}`);
+		mkdirSync(socketDir, { recursive: true });
+		cleanupPaths.push(socketDir);
+		const socketPath = join(socketDir, "h.sock");
+		const { server, requests, waitForRequests } = await startFakeHerdrServer(socketPath);
+		cleanupServers.push(server);
+
+		process.env.HERDR_ENV = "1";
+		process.env.HERDR_SOCKET_PATH = socketPath;
+		process.env.HERDR_PANE_ID = "w1:p1";
+		process.env.HERDR_PI_IDLE_DEBOUNCE_MS = "10";
+
+		const harness = await createHarness({
+			persistSession: true,
+			extensionFactories: [herdrAgentStateExtension],
+		});
+		cleanupHarnesses.push(harness);
+
+		await harness.session.bindExtensions({});
+		await waitForRequests(1);
+
+		// Herdr accepts agent_session_id for the prime-agent label but dropped
+		// path-only reports, so the session never became resumable. Both forms
+		// must ride every report.
+		const report = requests[0];
+		expect(report?.method).toBe("pane.report_agent");
+		expect(report?.params.agent).toBe("prime-agent");
+		expect(report?.params.agent_session_id).toBe(harness.sessionManager.getSessionId());
+		expect(report?.params.agent_session_path).toBe(harness.sessionManager.getSessionFile());
+	});
+});


### PR DESCRIPTION
## Summary

The builtin herdr reporter captured the resumable session ref correctly but sent only `agent_session_path` when the session was persisted. Herdr's report handler accepts paths only for the `pi`/`omp` labels; for the `prime-agent` label it reads `agent_session_id`, so the ref was silently dropped and panes never became resumable (`agent_session` stayed null, no `prime-agent --resume` on herdr-server restart).

The reporter now sends both `agent_session_id` and `agent_session_path` on every report, so the session registers on current herdr (via id) and on path-accepting herdr (via path).

Fixes #1260.

## Root cause notes

- The ref itself resolves fine: daemon-created sessions are persisted via `SessionManager.create`, which assigns the session file at construction, before `session_start` fires. A socket tap on `HERDR_SOCKET_PATH` shows the first `pane.report_agent` already carrying `agent_session_path`. The drop happens herdr-side, in `session_ref_from_report`.
- prime-agent support in herdr currently lives on a fork (witt3rd/herdr); upstream herdr has no `("herdr:pi","prime-agent")` official source. The companion herdr-side fix (accept prime-agent paths, matching the snapshot/planner handling) is witt3rd/herdr@d524e4f1. This change stands alone: sending the id makes registration work regardless.

## Test plan

- New regression test `packages/coding-agent/test/suite/regressions/1260-herdr-session-ref.test.ts` drives the builtin extension against a real persisted `SessionManager` and a fake herdr socket, asserting both identity forms on the report (fails without the fix).
- Extended `test/herdr-agent-state.test.ts` assertions for both forms.
- `npm run check` clean.
- Verified end-to-end on an isolated herdr session: agent start → prompt → `agent_session` registered → herdr-server restart → pane relaunches `prime-agent --resume <ref>` with session content intact.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix herdr reporter to include session id alongside session path in reports
> Previously, `withSessionRef` in [herdr-agent-state.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1269/files#diff-70837eb42752c61bc0c74d4ac79ed6c43a9d5c1cd8f2d90ea742d729f7dbbaa0) sent either `agent_session_path` or `agent_session_id`, but not both. Now both fields are included in `pane.report_agent` requests when available, allowing herdr to register a resumable session correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dafafe8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->