### PR TITLE
fix(tui): open OSC 8 hyperlinks on click in fullscreen mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+
 ## [0.7.2] - 2026-08-11
 
 - Fixed Down Arrow focusing the Agents View entry before moving a nonempty prompt cursor to the end ([ENG-5147](https://linear.app/primeintellect/issue/ENG-5147/keep-down-arrow-in-the-prompt-until-the-cursor-reaches-the-end)).

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -9803,6 +9803,7 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 | \`${viewportFollow}\` | Scroll to bottom and follow output |
 | mouse wheel | Scroll transcript |
 | mouse drag | Select and copy text |
+| mouse click on link | Open link in browser |
 `;
 
 		const shortcuts = this.bindLocalSessionExtensions

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed hyperlinks not being clickable in fullscreen mode on terminals that gate native link handling while mouse reporting is active (e.g. Ghostty); left-clicking a link now opens it directly.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -7,7 +7,7 @@
 
 import type { TableCellSelectionRegion } from "./selection-metadata.js";
 import { isImageLine } from "./terminal-image.js";
-import { sliceByColumn, stripAnsi, visibleWidth } from "./utils.js";
+import { hyperlinkAtColumn, sliceByColumn, stripAnsi, visibleWidth } from "./utils.js";
 
 export const FULLSCREEN_MIN_TRANSCRIPT_ROWS = 3;
 
@@ -623,6 +623,19 @@ export class FullscreenViewport {
 
 	hasSelection(): boolean {
 		return this.orderedSelection() !== null;
+	}
+
+	/**
+	 * OSC 8 hyperlink URL at a screen position in the last painted frame, or
+	 * null when the position is not over a hyperlink. Covers the transcript
+	 * window, the dock, and composited overlays.
+	 */
+	hyperlinkAt(screenRow: number, screenCol: number): string | null {
+		if (screenRow < 0 || screenCol < 0 || this.lastFrameVisibleHeight === 0) return null;
+		if (screenRow >= this.lastFrameVisibleHeight) return null;
+		const line = this.lastFrame[this.lastFrameVisibleStart + screenRow];
+		if (line === undefined || isImageLine(line)) return null;
+		return hyperlinkAtColumn(line, screenCol);
 	}
 
 	/** Row-diff a composed frame against the previous one with absolute addressing. */

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -759,7 +759,7 @@ export class TUI extends Container {
 	// (Ghostty only refreshes link hover when reporting is off or shift is held),
 	// so clicks the TUI consumes must open OSC 8 hyperlinks itself.
 	private openHyperlink(url: string): void {
-		if (/[\x00-\x1f\x7f]/.test(url)) return;
+		if (/\p{Cc}/u.test(url)) return;
 		let href: string;
 		try {
 			const parsed = new URL(url);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -329,6 +329,7 @@ export class TUI extends Container {
 	private fullRedrawCount = 0;
 	private preserveViewportOnNextRender = false; // One-shot: repaint visible viewport in place instead of replaying scrollback
 	private stopped = false;
+	private fullscreenLeftMouseDragged = false;
 	private overlaySelectionRegions: FrameSelectionRegion[] = [];
 
 	// While set, doRender paints fixed frames via the viewport; the inline
@@ -758,21 +759,29 @@ export class TUI extends Container {
 	// (Ghostty only refreshes link hover when reporting is off or shift is held),
 	// so clicks the TUI consumes must open OSC 8 hyperlinks itself.
 	private openHyperlink(url: string): void {
-		if (!/^https?:\/\//i.test(url)) return;
+		if (/[\x00-\x1f\x7f]/.test(url)) return;
+		let href: string;
+		try {
+			const parsed = new URL(url);
+			if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return;
+			href = parsed.href;
+		} catch {
+			return;
+		}
 		if (this.onOpenUrl) {
-			this.onOpenUrl(url);
+			this.onOpenUrl(href);
 			return;
 		}
 		const [command, ...args] =
 			process.platform === "darwin"
-				? ["open", url]
+				? ["open", href]
 				: process.platform === "win32"
 					? [
 							path.win32.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "rundll32.exe"),
 							"url.dll,FileProtocolHandler",
-							url,
+							href,
 						]
-					: ["xdg-open", url];
+					: ["xdg-open", href];
 		execFile(command, args, () => {});
 	}
 
@@ -917,6 +926,11 @@ export class TUI extends Container {
 		if (isMouseSequence(data)) {
 			// consumed even when disabled — mouse reports are garbage downstream
 			const event = this.terminal.mouseTrackingActive ? parseSgrMouseEvent(data) : null;
+			const leftReleaseWasDrag =
+				event?.button === MOUSE_BUTTON_LEFT && !event.press ? this.fullscreenLeftMouseDragged : false;
+			if (event?.button === MOUSE_BUTTON_LEFT && event.press) {
+				this.fullscreenLeftMouseDragged = event.motion;
+			}
 			if (event && !overlayFocused) {
 				const viewport = fullscreen.viewport;
 				if (isWheelUp(event)) {
@@ -943,7 +957,7 @@ export class TUI extends Container {
 				} else if (!event.press) {
 					this.stopSelectionAutoScroll();
 					viewport.clearSelection();
-					if (event.button === MOUSE_BUTTON_LEFT && !event.motion) {
+					if (event.button === MOUSE_BUTTON_LEFT && !event.motion && !leftReleaseWasDrag) {
 						const url = viewport.hyperlinkAt(event.y - 1, event.x - 1);
 						if (url) this.openHyperlink(url);
 					}
@@ -965,11 +979,14 @@ export class TUI extends Container {
 					this.requestRender();
 				} else if (!event.press) {
 					viewport.clearSelection();
-					if (event.button === MOUSE_BUTTON_LEFT && !event.motion) {
+					if (event.button === MOUSE_BUTTON_LEFT && !event.motion && !leftReleaseWasDrag) {
 						const url = viewport.hyperlinkAt(event.y - 1, event.x - 1);
 						if (url) this.openHyperlink(url);
 					}
 				}
+			}
+			if (event?.button === MOUSE_BUTTON_LEFT && !event.press) {
+				this.fullscreenLeftMouseDragged = false;
 			}
 			return true;
 		}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2,6 +2,7 @@
  * Minimal TUI implementation with differential rendering
  */
 
+import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -313,6 +314,8 @@ export class TUI extends Container {
 	public onDebug?: () => void;
 	/** Copies fullscreen mouse selections; when unset, OSC 52 is written directly. */
 	public onCopy?: (text: string) => void;
+	/** Opens hyperlinks clicked in the fullscreen viewport; when unset, the platform opener is used. */
+	public onOpenUrl?: (url: string) => void;
 	private renderRequested = false;
 	private renderTimer: NodeJS.Timeout | undefined;
 	private lastRenderAt = 0;
@@ -751,6 +754,28 @@ export class TUI extends Container {
 		return this.fullscreen?.viewport.scrollInfo() ?? null;
 	}
 
+	// Terminals gate their native link handling while mouse reporting is active
+	// (Ghostty only refreshes link hover when reporting is off or shift is held),
+	// so clicks the TUI consumes must open OSC 8 hyperlinks itself.
+	private openHyperlink(url: string): void {
+		if (!/^https?:\/\//i.test(url)) return;
+		if (this.onOpenUrl) {
+			this.onOpenUrl(url);
+			return;
+		}
+		const [command, ...args] =
+			process.platform === "darwin"
+				? ["open", url]
+				: process.platform === "win32"
+					? [
+							path.win32.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "rundll32.exe"),
+							"url.dll,FileProtocolHandler",
+							url,
+						]
+					: ["xdg-open", url];
+		execFile(command, args, () => {});
+	}
+
 	private copySelection(text: string): void {
 		if (this.onCopy) {
 			this.onCopy(text);
@@ -918,6 +943,10 @@ export class TUI extends Container {
 				} else if (!event.press) {
 					this.stopSelectionAutoScroll();
 					viewport.clearSelection();
+					if (event.button === MOUSE_BUTTON_LEFT && !event.motion) {
+						const url = viewport.hyperlinkAt(event.y - 1, event.x - 1);
+						if (url) this.openHyperlink(url);
+					}
 				}
 			} else if (event && overlayFocused) {
 				this.stopSelectionAutoScroll();
@@ -936,6 +965,10 @@ export class TUI extends Container {
 					this.requestRender();
 				} else if (!event.press) {
 					viewport.clearSelection();
+					if (event.button === MOUSE_BUTTON_LEFT && !event.motion) {
+						const url = viewport.hyperlinkAt(event.y - 1, event.x - 1);
+						if (url) this.openHyperlink(url);
+					}
 				}
 			}
 			return true;

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -1239,6 +1239,36 @@ export function sliceWithWidth(
 	return { text: result, width: resultWidth };
 }
 
+/**
+ * Return the OSC 8 hyperlink URL covering the given visible column, or null
+ * when the column is not inside a hyperlink (or is past the end of the line).
+ */
+export function hyperlinkAtColumn(line: string, column: number): string | null {
+	if (column < 0) return null;
+	const extractAnsi = createAnsiCodeExtractor(line);
+	let currentCol = 0;
+	let activeUrl: string | null = null;
+	let i = 0;
+	while (i < line.length) {
+		const ansi = extractAnsi(i);
+		if (ansi) {
+			const hyperlink = parseOsc8Hyperlink(ansi.code);
+			if (hyperlink !== undefined) activeUrl = hyperlink?.url ?? null;
+			i += ansi.length;
+			continue;
+		}
+		let textEnd = i;
+		while (textEnd < line.length && !extractAnsi(textEnd)) textEnd++;
+		for (const { segment } of segmenter.segment(line.slice(i, textEnd))) {
+			const w = graphemeWidth(segment);
+			if (column < currentCol + w) return activeUrl;
+			currentCol += w;
+		}
+		i = textEnd;
+	}
+	return null;
+}
+
 // Pooled tracker instance for extractSegments (avoids allocation per call)
 const pooledStyleTracker = new AnsiCodeTracker();
 

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -1059,7 +1059,8 @@ describe("TUI fullscreen mode", () => {
 		const transcript = lines(20);
 		transcript[12] =
 			"\x1b]8;;https://example.com/\x00bad\x1b\\nul\x1b]8;;\x1b\\ " +
-			"\x1b]8;;https://[invalid\x1b\\malformed\x1b]8;;\x1b\\";
+			"\x1b]8;;https://[invalid\x1b\\malformed\x1b]8;;\x1b\\ " +
+			"\x1b]8;;https://example.com/\u0085bad\x1b\\c1\x1b]8;;\x1b\\";
 		const { terminal, tui, chat, dock } = setup(transcript);
 		const opened: string[] = [];
 		tui.onOpenUrl = (url) => opened.push(url);
@@ -1070,6 +1071,8 @@ describe("TUI fullscreen mode", () => {
 		terminal.sendInput("\x1b[<0;1;1m");
 		terminal.sendInput("\x1b[<0;6;1M");
 		terminal.sendInput("\x1b[<0;6;1m");
+		terminal.sendInput("\x1b[<0;15;1M");
+		terminal.sendInput("\x1b[<0;15;1m");
 		await terminal.waitForRender();
 		assert.deepStrictEqual(opened, []);
 

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -983,6 +983,61 @@ describe("TUI fullscreen mode", () => {
 		tui.stop();
 	});
 
+	it("does not open a link when a drag returns to its press cell", async () => {
+		const transcript = lines(20);
+		transcript[12] = "see \x1b]8;;https://example.com/docs\x1b\\docs\x1b]8;;\x1b\\ here";
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		const copies: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;5;1M");
+		terminal.sendInput("\x1b[<32;9;1M");
+		terminal.sendInput("\x1b[<32;5;1M");
+		terminal.sendInput("\x1b[<0;5;1m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, []);
+		assert.deepStrictEqual(opened, []);
+
+		tui.stop();
+	});
+
+	it("does not open a link when a focused-overlay drag returns to its press cell", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20), 80, 10);
+		const opened: string[] = [];
+		const copies: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		const overlay = new InputComponent();
+		overlay.lines = ["\x1b]8;;https://example.com/docs\x1b\\docs\x1b]8;;\x1b\\"];
+		tui.showOverlay(overlay, { anchor: "center", width: 20 });
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		const row = viewport.findIndex((line) => line.includes("docs"));
+		assert.notStrictEqual(row, -1);
+		const x = viewport[row]!.indexOf("docs") + 1;
+		const y = row + 1;
+		terminal.sendInput(`\x1b[<0;${x};${y}M`);
+		terminal.sendInput(`\x1b[<32;${x + 4};${y}M`);
+		terminal.sendInput(`\x1b[<32;${x};${y}M`);
+		terminal.sendInput(`\x1b[<0;${x};${y}m`);
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, []);
+		assert.deepStrictEqual(opened, []);
+		assert.deepStrictEqual(overlay.inputs, []);
+
+		tui.stop();
+	});
+
 	it("ignores clicked hyperlinks with non-http schemes", async () => {
 		const transcript = lines(20);
 		transcript[12] = "\x1b]8;;file:///etc/passwd\x1b\\secrets\x1b]8;;\x1b\\";
@@ -994,6 +1049,27 @@ describe("TUI fullscreen mode", () => {
 
 		terminal.sendInput("\x1b[<0;3;1M");
 		terminal.sendInput("\x1b[<0;3;1m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(opened, []);
+
+		tui.stop();
+	});
+
+	it("rejects malformed or control-character hyperlink URLs", async () => {
+		const transcript = lines(20);
+		transcript[12] =
+			"\x1b]8;;https://example.com/\x00bad\x1b\\nul\x1b]8;;\x1b\\ " +
+			"\x1b]8;;https://[invalid\x1b\\malformed\x1b]8;;\x1b\\";
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<0;1;1m");
+		terminal.sendInput("\x1b[<0;6;1M");
+		terminal.sendInput("\x1b[<0;6;1m");
 		await terminal.waitForRender();
 		assert.deepStrictEqual(opened, []);
 

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -936,6 +936,87 @@ describe("TUI fullscreen mode", () => {
 		tui.stop();
 	});
 
+	it("clicking an OSC 8 hyperlink opens it through the URL handler", async () => {
+		const transcript = lines(20);
+		// window height is 8 (rows=10, dock=2), following shows lines 12..19
+		transcript[12] = "see \x1b]8;;https://example.com/docs\x1b\\\x1b[36mdocs\x1b[39m\x1b]8;;\x1b\\ here";
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// "docs" occupies columns 5-8 on screen row 1
+		terminal.sendInput("\x1b[<0;6;1M");
+		terminal.sendInput("\x1b[<0;6;1m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(opened, ["https://example.com/docs"]);
+
+		// clicking outside the link opens nothing
+		terminal.sendInput("\x1b[<0;2;1M");
+		terminal.sendInput("\x1b[<0;2;1m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(opened, ["https://example.com/docs"]);
+
+		tui.stop();
+	});
+
+	it("drag-selecting over a hyperlink copies text without opening it", async () => {
+		const transcript = lines(20);
+		transcript[12] = "see \x1b]8;;https://example.com/docs\x1b\\docs\x1b]8;;\x1b\\ here";
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		const copies: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.onCopy = (text) => copies.push(text);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;5;1M");
+		terminal.sendInput("\x1b[<32;9;1M");
+		terminal.sendInput("\x1b[<0;9;1m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copies, ["docs"]);
+		assert.deepStrictEqual(opened, []);
+
+		tui.stop();
+	});
+
+	it("ignores clicked hyperlinks with non-http schemes", async () => {
+		const transcript = lines(20);
+		transcript[12] = "\x1b]8;;file:///etc/passwd\x1b\\secrets\x1b]8;;\x1b\\";
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;3;1M");
+		terminal.sendInput("\x1b[<0;3;1m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(opened, []);
+
+		tui.stop();
+	});
+
+	it("clicking a hyperlink in the dock opens it", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(20));
+		dock.lines = ["\x1b]8;;https://example.com/login\x07sign in\x1b]8;;\x07", "footer"];
+		const opened: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// rows=10, dock=2 → dock starts at screen row 9
+		terminal.sendInput("\x1b[<0;3;9M");
+		terminal.sendInput("\x1b[<0;3;9m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(opened, ["https://example.com/login"]);
+
+		tui.stop();
+	});
+
 	it("a plain click copies nothing and clears any selection", async () => {
 		const { terminal, tui, chat, dock } = setup(lines(20));
 		const copies: string[] = [];

--- a/packages/tui/test/hyperlink-at-column.test.ts
+++ b/packages/tui/test/hyperlink-at-column.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { hyperlinkAtColumn } from "../src/utils.js";
+
+const ST = "\x1b\\";
+
+function link(url: string, text: string, terminator = ST): string {
+	return `\x1b]8;;${url}${terminator}${text}\x1b]8;;${terminator}`;
+}
+
+describe("hyperlinkAtColumn", () => {
+	it("returns the URL for columns inside the link and null outside", () => {
+		const line = `see ${link("https://example.com/docs", "docs")} here`;
+		assert.strictEqual(hyperlinkAtColumn(line, 0), null);
+		assert.strictEqual(hyperlinkAtColumn(line, 3), null);
+		assert.strictEqual(hyperlinkAtColumn(line, 4), "https://example.com/docs");
+		assert.strictEqual(hyperlinkAtColumn(line, 7), "https://example.com/docs");
+		assert.strictEqual(hyperlinkAtColumn(line, 8), null);
+	});
+
+	it("supports BEL-terminated links", () => {
+		const line = link("https://example.com/login", "https://example.com/login", "\x07");
+		assert.strictEqual(hyperlinkAtColumn(line, 0), "https://example.com/login");
+		assert.strictEqual(hyperlinkAtColumn(line, 24), "https://example.com/login");
+		assert.strictEqual(hyperlinkAtColumn(line, 25), null);
+	});
+
+	it("tracks multiple links on one line", () => {
+		const line = `${link("https://a.example", "aa")} ${link("https://b.example", "bb")}`;
+		assert.strictEqual(hyperlinkAtColumn(line, 1), "https://a.example");
+		assert.strictEqual(hyperlinkAtColumn(line, 2), null);
+		assert.strictEqual(hyperlinkAtColumn(line, 3), "https://b.example");
+	});
+
+	it("counts wide graphemes as two columns", () => {
+		const line = `\u4f60\u597d ${link("https://example.com", "docs")}`;
+		assert.strictEqual(hyperlinkAtColumn(line, 4), null);
+		assert.strictEqual(hyperlinkAtColumn(line, 5), "https://example.com");
+	});
+
+	it("ignores SGR styling inside the link", () => {
+		const line = `x ${link("https://example.com", "\x1b[36mdocs\x1b[39m")}`;
+		assert.strictEqual(hyperlinkAtColumn(line, 3), "https://example.com");
+	});
+
+	it("returns null past the end of the line and for negative columns", () => {
+		const line = link("https://example.com", "docs");
+		assert.strictEqual(hyperlinkAtColumn(line, 4), null);
+		assert.strictEqual(hyperlinkAtColumn(line, 100), null);
+		assert.strictEqual(hyperlinkAtColumn(line, -1), null);
+	});
+});


### PR DESCRIPTION
## Problem

In Ghostty on macOS, URLs rendered by the agent (OSC 8 hyperlinks in Markdown, login links, etc.) cannot be clicked, while the same links work in the VS Code terminal.

Root cause: the default fullscreen TUI enables SGR mouse tracking (`?1002h`/`?1006h`) for wheel scrolling and drag selection. Ghostty gates its native link handling while mouse reporting is active - `Surface.zig` only refreshes link hover when mouse reporting is off or shift is held, and a click only opens a link when the hover state is set. So with mouse reporting on, links are effectively unclickable there. VS Code is unaffected because its link detection runs at the UI layer before mouse reporting.

## Fix

Since the TUI consumes every mouse click anyway, it now handles link clicks itself:

- `utils.ts`: new `hyperlinkAtColumn(line, column)` resolves the OSC 8 URL covering a visible column (reuses the existing ANSI extractor and OSC 8 parser, handles BEL/ST terminators and wide graphemes).
- `fullscreen.ts`: `FullscreenViewport.hyperlinkAt(row, col)` maps a screen position to the last painted frame, covering the transcript window, dock, and composited overlays.
- `tui.ts`: a plain left click (press + release without drag) on a hyperlink opens it. Only `http(s)` URLs are opened. Default opener is `open`/`rundll32`/`xdg-open`; embedders can override via the new `TUI.onOpenUrl` hook. Drag selection and copy behavior are unchanged.

Inline (non-fullscreen) mode is unaffected: mouse tracking is off there, so terminals handle links natively.

## Tests

- `packages/tui/test/hyperlink-at-column.test.ts`: column resolution incl. BEL/ST terminators, multiple links, wide graphemes, SGR styling inside links.
- `packages/tui/test/fullscreen.test.ts`: click opens the URL through the handler, click outside a link does nothing, drag over a link copies without opening, non-http schemes are ignored, dock links open.

`npm run check` and the full tui test suite (768 tests) pass.

## Manual test in Ghostty

1. `git fetch && git checkout fix/ghostty-fullscreen-link-clicks && npm install`
2. Start from source in Ghostty: `./prime-agent.sh`
3. Ask the model: "print a markdown link to https://example.com and also the bare URL"
4. Left-click the link in the transcript - it should open in the browser. On `main`, clicking (or cmd+clicking) does nothing in Ghostty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fullscreen mouse handling and opens URLs via the system opener, which is security-sensitive, but only well-formed http(s) links are allowed and the behavior is covered by tests.
> 
> **Overview**
> **Fixes unclickable OSC 8 links in fullscreen** on terminals like Ghostty that disable native link handling while mouse reporting is active.
> 
> Plain left-clicks (press + release without drag) now resolve the hyperlink under the cursor from the last painted frame—including transcript, dock, and overlays—and open it. Only well-formed `http`/`https` URLs are opened; non-http schemes, control characters, and malformed URLs are ignored. Drag selection/copy is unchanged.
> 
> Adds `hyperlinkAtColumn` for column-aware OSC 8 lookup, `FullscreenViewport.hyperlinkAt`, and an optional `TUI.onOpenUrl` override (defaulting to `open` / `xdg-open` / `rundll32`). Help text and changelogs note the new click-to-open behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b842c73b8508cc72c8f6ee529ad1cc8288bfdae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OSC 8 hyperlink clicks in fullscreen mode when mouse reporting is active
> - Adds `FullscreenViewport.hyperlinkAt` in [fullscreen.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1270/files#diff-42a86b3d48ccefac8f35350cb99ab3ee2b645118e506afdecfa086d9aa48e177) to resolve the OSC 8 URL at a given screen position from the last painted frame.
> - Adds `hyperlinkAtColumn` in [utils.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1270/files#diff-4c3f9017cf74053e3b6aca505c66afe64a6bb0e33edf0348d2f7dc436e594a93) to parse ANSI sequences and return the active hyperlink URL at a visible column, accounting for wide graphemes.
> - On mouse button release without a selection, [tui.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1270/files#diff-0aed3a4b69095fa2ae0cffa8689c7dad409e8b36ab77544b0defb1474fde7311) queries the viewport for a hyperlink and opens it via a platform URL opener (`open`, `xdg-open`, or `rundll32`), or delegates to `onOpenUrl` if set. Only `http`/`https` schemes are opened.
> - Behavioral Change: left-clicks in fullscreen no longer pass through to the terminal's native link handler; instead the TUI intercepts and opens the link itself.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1270 opened
>
> - Prevented hyperlink activation when left mouse button is released after dragging and returning to the original cell in fullscreen mode [3e2b323]
> - Hardened URL validation in `TUI.openHyperlink` method to only accept well-formed http and https URLs [3e2b323]
> - Added test coverage for drag-to-click prevention and URL validation [3e2b323]
> - Replaced ASCII control character validation with Unicode control character validation in `TUI.openHyperlink` method and extended test coverage [b842c73]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52cd9fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->