### PR TITLE
fix(coding-agent): allow the self-update tarball install on npm 12

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed `prime-agent update` failing with `EALLOWREMOTE` on npm 12 when the release is installed from its tarball URL ([#1272](https://github.com/PrimeIntellect-ai/prime-agent/pull/1272) by [@smwbev](https://github.com/smwbev)).
+
 ## [0.7.2] - 2026-08-11
 
 - Fixed Down Arrow focusing the Agents View entry before moving a nonempty prompt cursor to the end ([ENG-5147](https://linear.app/primeintellect/issue/ENG-5147/keep-down-arrow-in-the-prompt-until-the-cursor-reaches-the-end)).

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -47,6 +47,8 @@ interface SelfUpdateCommandStep {
 	command: string;
 	args: string[];
 	display: string;
+	/** Extra environment for this step only; merged over the current environment when it runs. */
+	env?: Record<string, string>;
 }
 
 export interface SelfUpdateCommand extends SelfUpdateCommandStep {
@@ -73,11 +75,21 @@ function makeSelfUpdateCommand(
 	};
 }
 
-function makeSelfUpdateCommandStep(command: string, args: string[]): SelfUpdateCommandStep {
+function makeSelfUpdateCommandStep(
+	command: string,
+	args: string[],
+	env?: Record<string, string>,
+): SelfUpdateCommandStep {
+	const quote = (value: string) => (/\s/.test(value) ? `"${value}"` : value);
+	// Render the environment into the display so the update log and the
+	// copy-paste fallback describe what actually runs, rather than a command
+	// that fails without the assignment.
+	const envPrefix = Object.entries(env ?? {}).map(([name, value]) => `${name}=${quote(value)}`);
 	return {
 		command,
 		args,
-		display: [command, ...args].map((arg) => (/\s/.test(arg) ? `"${arg}"` : arg)).join(" "),
+		...(env ? { env } : {}),
+		display: [...envPrefix, ...[command, ...args].map(quote)].join(" "),
 	};
 }
 
@@ -189,7 +201,18 @@ function getSelfUpdateCommandForMethod(
 			const [command = "npm", ...npmArgs] = npmCommand ?? [];
 			const inferred = npmCommand?.length ? undefined : getInferredNpmInstall();
 			const prefixArgs = [...npmArgs, ...(inferred ? ["--prefix", inferred.prefix] : [])];
-			const installStep = makeSelfUpdateCommandStep(command, [...prefixArgs, "install", "-g", updateSpec]);
+			// npm >= 12 defaults allow-remote to none, so installing a release
+			// artifact by URL fails with EALLOWREMOTE. Grant it for this install
+			// only — never through the user's npmrc — and only when the spec is
+			// such an artifact; registry specs must keep the stricter default.
+			// "root" is not enough: the released tarball itself depends on
+			// further tarball URLs, which npm treats as non-root.
+			const installEnv = isDirectPackageArtifactSpec(updateSpec) ? { npm_config_allow_remote: "all" } : undefined;
+			const installStep = makeSelfUpdateCommandStep(
+				command,
+				[...prefixArgs, "install", "-g", updateSpec],
+				installEnv,
+			);
 			const uninstallStep =
 				updatePackageName === installedPackageName
 					? undefined

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -466,6 +466,7 @@ async function runSelfUpdate(command: SelfUpdateCommand): Promise<void> {
 			const child = spawn(step.command, step.args, {
 				stdio: "inherit",
 				shell: shouldUseWindowsShell(step.command),
+				env: step.env ? { ...process.env, ...step.env } : undefined,
 			});
 			child.on("error", (error) => {
 				reject(error);

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -242,7 +242,8 @@ describe("detectInstallMethod", () => {
 		expect(command).toEqual({
 			command: "npm",
 			args: ["--prefix", prefix, "install", "-g", tarballUrl],
-			display: `npm --prefix ${prefix} install -g ${tarballUrl}`,
+			env: { npm_config_allow_remote: "all" },
+			display: `npm_config_allow_remote=all npm --prefix ${prefix} install -g ${tarballUrl}`,
 		});
 	});
 
@@ -255,12 +256,14 @@ describe("detectInstallMethod", () => {
 		expect(command).toEqual({
 			command: "npm",
 			args: ["--prefix", prefix, "install", "-g", tarballUrl],
-			display: `npm --prefix ${prefix} install -g ${tarballUrl} && npm --prefix ${prefix} uninstall -g @earendil-works/pi-coding-agent`,
+			env: { npm_config_allow_remote: "all" },
+			display: `npm_config_allow_remote=all npm --prefix ${prefix} install -g ${tarballUrl} && npm --prefix ${prefix} uninstall -g @earendil-works/pi-coding-agent`,
 			steps: [
 				{
 					command: "npm",
 					args: ["--prefix", prefix, "install", "-g", tarballUrl],
-					display: `npm --prefix ${prefix} install -g ${tarballUrl}`,
+					env: { npm_config_allow_remote: "all" },
+					display: `npm_config_allow_remote=all npm --prefix ${prefix} install -g ${tarballUrl}`,
 				},
 				{
 					command: "npm",

--- a/packages/coding-agent/test/suite/regressions/741-npm-self-update-allow-remote.test.ts
+++ b/packages/coding-agent/test/suite/regressions/741-npm-self-update-allow-remote.test.ts
@@ -1,0 +1,75 @@
+import { mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getSelfUpdateCommand } from "../../../src/config.js";
+
+const TARBALL_URL = "https://downloads.example.test/releases/v0.7.2/prime-agent-0.7.2.tgz";
+const PACKAGE_NAME = "@earendil-works/pi-coding-agent";
+
+const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
+const originalPiPackageDir = process.env.PI_PACKAGE_DIR;
+let tempDir: string | undefined;
+
+// Fake a global npm install under a custom prefix so self-update resolves to npm.
+function createNpmPrefixInstall(): string {
+	const prefix = mkdtempSync(join(tmpdir(), "pi-741-"));
+	const packageDir = join(prefix, "lib", "node_modules", "@earendil-works", "pi-coding-agent");
+	mkdirSync(packageDir, { recursive: true });
+	tempDir = prefix;
+	process.env.PI_PACKAGE_DIR = packageDir;
+	Object.defineProperty(process, "execPath", { value: join(packageDir, "dist", "cli.js"), configurable: true });
+	return prefix;
+}
+
+afterEach(() => {
+	if (execPathDescriptor) {
+		Object.defineProperty(process, "execPath", execPathDescriptor);
+	}
+	if (originalPiPackageDir === undefined) {
+		delete process.env.PI_PACKAGE_DIR;
+	} else {
+		process.env.PI_PACKAGE_DIR = originalPiPackageDir;
+	}
+	if (tempDir) {
+		rmSync(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+});
+
+describe("issue #741: npm 12 refuses the self-update release tarball", () => {
+	it("grants allow-remote to the install step when updating from a release artifact", () => {
+		const prefix = createNpmPrefixInstall();
+
+		const command = getSelfUpdateCommand(PACKAGE_NAME, undefined, TARBALL_URL);
+
+		expect(command?.env).toEqual({ npm_config_allow_remote: "all" });
+		expect(command?.args).toEqual(["--prefix", prefix, "install", "-g", TARBALL_URL]);
+		expect(command?.display).toBe(`npm_config_allow_remote=all npm --prefix ${prefix} install -g ${TARBALL_URL}`);
+	});
+
+	it("keeps registry updates on the npm 12 default", () => {
+		createNpmPrefixInstall();
+
+		const command = getSelfUpdateCommand(PACKAGE_NAME);
+
+		expect(command?.env).toBeUndefined();
+		expect(command?.display).not.toContain("allow_remote");
+	});
+
+	it("grants allow-remote to the install step only, not the follow-up uninstall", () => {
+		createNpmPrefixInstall();
+
+		const command = getSelfUpdateCommand(PACKAGE_NAME, undefined, TARBALL_URL, "prime-agent");
+
+		expect(command?.steps?.map((step) => step.env)).toEqual([{ npm_config_allow_remote: "all" }, undefined]);
+	});
+
+	it("grants allow-remote to local artifacts too, whose transitive dependencies are remote", () => {
+		createNpmPrefixInstall();
+
+		const command = getSelfUpdateCommand(PACKAGE_NAME, undefined, "file:/tmp/prime-agent-0.7.2.tgz");
+
+		expect(command?.env).toEqual({ npm_config_allow_remote: "all" });
+	});
+});


### PR DESCRIPTION
## Problem

`prime-agent update` cannot update an npm-managed install on npm 12:

```
Updating prime-agent with npm --prefix /opt/homebrew install -g https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/releases/v0.7.2/prime-agent-0.7.2.tgz...
npm error code EALLOWREMOTE
npm error Fetching packages of type "remote" have been disabled
npm error Refusing to fetch "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/releases/v0.7.2/prime-agent-0.7.2.tgz"
Error: npm --prefix /opt/homebrew install -g https://... exited with code 1
```

Reproduced on macOS (Apple Silicon), Node v26.5.0, npm 12.0.1, global npm install with prefix `/opt/homebrew`, updating 0.7.1 -> 0.7.2.

npm 12 defaults `allow-remote` to `none`. The self-update installs the release artifact by URL, which is a remote fetch, and the released package declares further tarball URLs (`@earendil-works/pi-agent-core`, `pi-ai`, `pi-tui`), which npm classifies as non-root — so `root` is not enough either, matching what @felipecsl measured in #741.

## Change

- `SelfUpdateCommandStep` carries an optional `env`, merged over the current environment when that step runs.
- The npm branch of `getSelfUpdateCommandForMethod` sets `npm_config_allow_remote=all` on the install step, and only when `isDirectPackageArtifactSpec(updateSpec)` holds. Registry specs keep the stricter npm 12 default, and the follow-up uninstall step never gets the grant.
- `runSelfUpdate` passes the step environment to `spawn`; steps without `env` keep inheriting `process.env` unchanged.

The grant is scoped to the one process that needs it. Nothing is written to the user's `~/.npmrc`, which is the same approach #773 took for the installer.

`isDirectPackageArtifactSpec` rather than an npm version gate: the predicate already distinguishes the case that needs the config (a release artifact fetched by URL or path) from the case that must not get it (a registry spec), and it is the same condition that already decides the install/uninstall ordering. A version gate would grant `allow-remote` to registry updates as well on npm 12, which is strictly weaker; on npm < 12 the extra environment variable is ignored, so gating on the version buys nothing.

pnpm, yarn and bun install remote tarballs without an equivalent opt-in — pnpm's nearest setting, `blockExoticSubdeps`, is off by default and is not an env-scoped grant — so their branches are unchanged.

The step environment is rendered into `display`, so the "Updating ..." line and the copy-paste fallback describe the command that actually runs instead of one that fails without the assignment. The assignment is rendered in POSIX form; on Windows it reads as a description rather than a paste-ready line.

## Verification

- `npm run check` clean.
- New regression test `packages/coding-agent/test/suite/regressions/741-npm-self-update-allow-remote.test.ts`; it fails on `main` and passes with this change. Existing `test/config.test.ts` expectations updated for the new field.
- Real npm 12.0.1 check against the published 0.7.2 artifact, in a throwaway prefix:

```
$ npm --prefix "$tmp" install -g --dry-run https://pub-...r2.dev/releases/v0.7.2/prime-agent-0.7.2.tgz
npm error code EALLOWREMOTE

$ npm_config_allow_remote=all npm --prefix "$tmp" install -g --dry-run https://pub-...r2.dev/releases/v0.7.2/prime-agent-0.7.2.tgz
(resolves)
```

The `spawn` wiring itself is covered only by that manual run; the test asserts the command that `runSelfUpdate` receives.

## Scope

Complementary to #773, which fixes the same npm 12 default on the `install.sh` side; there is no file overlap with it. Its author noted in #741 that the self-update path was deliberately left out, which is what this PR closes.

Two things stay out of scope:

- npm 12 also blocks the `postinstall` that prepares uv and the IPython runtime unless `allow-scripts` covers it (reported by @felipecsl in #741). That is a separate default with a different trade-off, so it is not silently granted here.
- The deeper fix is publishing without transitive URL dependencies, which is a release-pipeline call for maintainers.

Refs #741 — deliberately not `Fixes`, since the issue also covers the installer surface handled in #773.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `prime-agent update` failing with EALLOWREMOTE on npm 12 when installing from a tarball URL
> - Adds an optional `env` field to `SelfUpdateCommandStep` and passes per-step environment overrides to child processes in `runSelfUpdate`.
> - When the npm update spec is a direct artifact (tarball URL or local file), the install step now runs with `npm_config_allow_remote=all`; registry-based updates and the uninstall step are unaffected.
> - The displayed command string now includes the env var prefix so logs and copy-paste output reflect the actual executed command.
> - Adds a regression test suite in [741-npm-self-update-allow-remote.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1272/files#diff-167f4e9cfd98714c94ea2aaa102e3ff88c91aa09c5e40c144dabdf9de73b2c96) covering tarball, local file, registry, and stepped uninstall cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3855bc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->