### PR TITLE
docs(ai): record that MLX context overflow is undetectable

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Documented that MLX (`mlx_lm.server`) aborts instead of reporting context overflow, so overflow cannot be detected for that backend.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -27,6 +27,9 @@ import type { AssistantMessage } from "../types.js";
  *   with output=0 (no room left to generate). Detected via stopReason "length" + zero output +
  *   input filling the context window.
  * - Ollama: Some deployments truncate silently, others return errors like "prompt too long; exceeded max context length by X tokens"
+ * - MLX (mlx_lm.server): Does NOT reject, error, or truncate. It prefills the entire prompt past
+ *   the model's max_position_embeddings until the GPU runs out of memory, then the server process
+ *   aborts. There is no error message to match - see the note below.
  */
 const OVERFLOW_PATTERNS = [
 	/prompt is too long/i, // Anthropic token overflow
@@ -98,6 +101,20 @@ const NON_OVERFLOW_PATTERNS = [
  * - Ollama: May truncate input silently for some setups, but may also return explicit
  *   overflow errors that match the patterns above. Silent truncation still cannot be
  *   detected here because we do not know the expected token count.
+ * - MLX (mlx_lm.server): Not detectable at all. An oversized prompt is prefilled in full,
+ *   past the model's own position limit, until Metal reports insufficient memory and the
+ *   server aborts mid-request:
+ *
+ *     Prompt processing progress: 40960/50013
+ *     libc++abi: terminating due to uncaught exception of type std::runtime_error:
+ *     [METAL] Command buffer execution failed: Insufficient Memory
+ *
+ *   The client observes a dropped connection, so none of the three cases below apply: there
+ *   is no errorMessage to match, no usage to compare against the context window, and no
+ *   length stop. Do not add a transport-error pattern to work around this - a dropped socket
+ *   is not evidence of overflow, and matching one would misclassify every server crash and
+ *   network fault. The mitigation belongs in configuration: declare a contextWindow the host
+ *   can actually hold so compaction runs before the limit is reached.
  *
  * ## Custom Providers
  *

--- a/packages/ai/test/overflow.test.ts
+++ b/packages/ai/test/overflow.test.ts
@@ -96,4 +96,18 @@ describe("isContextOverflow", () => {
 		const message = createLengthStopMessage(100, 0, 0);
 		expect(isContextOverflow(message, 200000)).toBe(false);
 	});
+
+	// mlx_lm.server aborts the whole process when a prompt exhausts GPU memory, so an
+	// oversized request surfaces as a dropped connection rather than a provider error.
+	// A transport failure is not evidence of overflow - it is equally consistent with a
+	// crash or a network fault - so these must stay unclassified.
+	it.each([
+		"fetch failed",
+		"terminated",
+		"socket hang up",
+		"read ECONNRESET",
+		"Error: connect ECONNREFUSED 127.0.0.1:8080",
+	])("does not treat transport failure %j as overflow", (errorMessage) => {
+		expect(isContextOverflow(createErrorMessage(errorMessage), 32768)).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary

`mlx_lm.server` cannot have a context-overflow pattern, and this documents why so nobody tries to add one.

Given a prompt beyond the model's context it does not reject, error, or truncate. It prefills the entire prompt past the model's own `max_position_embeddings` until the GPU runs out of memory, then the server process aborts mid-request:

```
Prompt processing progress: 38912/50013
Prompt processing progress: 40960/50013
"POST /v1/chat/completions HTTP/1.1" 200
libc++abi: terminating due to uncaught exception of type std::runtime_error:
[METAL] Command buffer execution failed: Insufficient Memory
(00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory)
```

The client observes a dropped connection, so none of the three cases in `isContextOverflow` apply: there is no `errorMessage` to match, no `usage` to compare against the context window, and no length stop.

## Changes

- Document the behaviour in `overflow.ts` alongside the other backends, in both the provider list and the "Unreliable detection" section.
- Add regression tests asserting that transport failures (`fetch failed`, `terminated`, `socket hang up`, `ECONNRESET`, `ECONNREFUSED`) stay unclassified.
- Changelog entry under `[Unreleased]`.

The tests are the point. A dropped socket is not evidence of overflow — it is equally consistent with a server crash or a network fault — so matching one to "support MLX" would misclassify every such failure. The tests make that regression fail loudly.

No behaviour changes; `isContextOverflow` is untouched.

## Reproduction

Measured against `mlx_lm.server` 0.31.3 serving `mlx-community/Qwen3-14B-4bit` (`max_position_embeddings` 40960) on an M4 / 24 GB, sending a ~50k-token prompt. The crash is memory-bound, so the exact threshold varies with host memory, but the failure mode does not: MLX never reports overflow.

The practical mitigation is configuration rather than detection — declare a `contextWindow` the host can actually hold so compaction runs before the limit is reached. Note that a `KeepAlive` launchd agent restarts the server after such a crash, which makes it easy to miss.

## Testing

- `packages/ai`: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/overflow.test.ts` — 14 passed
- `npm run check` from the repo root — clean


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document that MLX context overflow is undetectable in `isContextOverflow`
> - Documents in [overflow.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1277/files#diff-30f350598d8206d5cab80b09f21240a7cdb6b646e81506389f7884f7d0013680) that `mlx_lm.server` aborts the process on context overflow rather than returning an error, making overflow undetectable via response inspection.
> - Adds tests in [overflow.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1277/files#diff-272681e52108eeedd8e703d382ed7ebef05ebd883e7328f2402c8eb5da361c20) asserting that transport-level errors (`fetch failed`, `socket hang up`, `ECONNRESET`, etc.) are not classified as context overflow.
> - Warns explicitly in JSDoc not to treat dropped connections as overflow and suggests configuration-based mitigation for MLX users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cea8555.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->