### PR TITLE
fix(coding-agent): pickle callable Python skill modules by reference

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed the kernel state snapshot silently dropping every Python skill that exposes `run()`, and any user variable referencing one, with `cannot pickle '_PrimeAgentCallableSkillModule' object` ([#1211](https://github.com/PrimeIntellect-ai/prime-agent/issues/1211)).
+
 ## [0.7.2] - 2026-08-11
 
 - Fixed Down Arrow focusing the Agents View entry before moving a nonempty prompt cursor to the end ([ENG-5147](https://linear.app/primeintellect/issue/ENG-5147/keep-down-arrow-in-the-prompt-until-the-cursor-reaches-the-end)).

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -88,6 +88,13 @@ class _PrimeAgentCallableSkillModule(_prime_agent_types.ModuleType):
             return await result
         return result
 
+    # dill pickles modules by reference, but its dispatch is keyed on the exact
+    # type, so this subclass would otherwise fall through to the generic reduce
+    # path and raise TypeError - dropping the skill from the kernel state
+    # snapshot along with any user variable that references it.
+    def __reduce__(self):
+        return (_prime_agent_importlib.import_module, (self.__name__,))
+
 class _PrimeAgentUnavailableSkill:
     def __init__(self, name, error):
         self.__name__ = name

--- a/packages/coding-agent/test/kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/kernel-state-roundtrip.test.ts
@@ -1,9 +1,10 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { KernelManager } from "../src/core/kernel/index.js";
+import { buildRlmBootstrapCode } from "../src/core/tools/ipython.js";
 
 /** Find a python that can launch an ipykernel and has dill, or null to skip. */
 function resolveKernelPython(): string | null {
@@ -155,6 +156,61 @@ describeIfKernel("kernel state snapshot round-trip (real kernel)", { tags: ["ker
 		} finally {
 			await manager.dispose();
 			rmSync(listDir, { recursive: true, force: true });
+		}
+	}, 60_000);
+
+	// Python skills that expose run() are wrapped in a ModuleType subclass by the
+	// bootstrap. dill pickles modules by reference, but its dispatch is keyed on
+	// the exact type, so the subclass used to fall through to the generic reduce
+	// path and raise TypeError - dropping the skill and any user variable holding
+	// a reference to it.
+	it("snapshots callable Python skill modules and the user variables referencing them", async () => {
+		const skillDir = mkdtempSync(join(tmpdir(), "prime-agent-state-skill-"));
+		const srcDir = join(skillDir, "src");
+		mkdirSync(srcDir, { recursive: true });
+		writeFileSync(
+			join(srcDir, "demo_skill.py"),
+			'def run(value):\n    """Double a value."""\n    return value * 2\n',
+		);
+		const cfg = { path: join(skillDir, "skill.dill"), manifestPath: join(skillDir, "skill.json") };
+		const bootstrap = buildRlmBootstrapCode([
+			{
+				name: "demo-skill",
+				importName: "demo_skill",
+				packagePath: skillDir,
+				pyprojectPath: join(skillDir, "pyproject.toml"),
+			},
+		]);
+		const newSkillManager = () =>
+			new KernelManager({ python: python as string, cwd: skillDir, env: { PYTHONPATH: srcDir }, snapshot: cfg });
+
+		const writer = newSkillManager();
+		try {
+			expect((await writer.execute(bootstrap)).status).toBe("ok");
+			await writer.execute("tools = {'doubler': demo_skill}");
+
+			const snap = await writer.snapshotState();
+			expect(snap?.skipped.map((s) => s.name)).not.toContain("demo_skill");
+			expect(snap?.skipped.map((s) => s.name)).not.toContain("tools");
+			expect(snap?.saved).toEqual(expect.arrayContaining(["demo_skill", "tools"]));
+		} finally {
+			await writer.dispose();
+		}
+
+		const reader = newSkillManager();
+		try {
+			// Production order: restore revives the namespace, then the bootstrap
+			// overwrites the skill globals with freshly wrapped live handles.
+			const restore = await reader.restoreState();
+			expect(restore?.failed.map((f) => f.name) ?? []).not.toContain("tools");
+			expect(restore?.restored).toEqual(expect.arrayContaining(["demo_skill", "tools"]));
+			expect((await reader.execute(bootstrap)).status).toBe("ok");
+
+			const echo = await reader.execute("print(tools['doubler'].run(21), await demo_skill(3))");
+			expect(echo.stdout.trim()).toBe("42 6");
+		} finally {
+			await reader.dispose();
+			rmSync(skillDir, { recursive: true, force: true });
 		}
 	}, 60_000);
 

--- a/packages/coding-agent/test/suite/regressions/1211-callable-skill-module-pickle.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1211-callable-skill-module-pickle.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildRlmBootstrapCode } from "../../../src/core/tools/ipython.js";
+
+const SKILL = {
+	name: "demo-skill",
+	importName: "demo_skill",
+	packagePath: "/tmp/demo-skill",
+	pyprojectPath: "/tmp/demo-skill/pyproject.toml",
+};
+
+// The kernel state snapshot pickles each top-level name with dill. dill saves
+// modules by reference, but its dispatch is keyed on the exact type, so the
+// ModuleType subclass the bootstrap wraps callable skills in fell through to the
+// generic reduce path and raised TypeError. Every Python skill exposing run()
+// was dropped from the snapshot, and so was any user variable holding one.
+// The behavioural round-trip lives in test/kernel-state-roundtrip.test.ts.
+describe("regression #1211: callable Python skill modules survive the kernel state snapshot", () => {
+	const code = buildRlmBootstrapCode([SKILL]);
+
+	it("gives the callable skill module wrapper a pickle-by-reference reducer", () => {
+		expect(code).toContain("def __reduce__(self):");
+		expect(code).toContain("return (_prime_agent_importlib.import_module, (self.__name__,))");
+	});
+
+	it("reduces through importlib rather than a kernel-local helper", () => {
+		// A reducer naming a function defined in the kernel namespace would be
+		// pickled by value, dragging the wrapper class into the payload and
+		// reintroducing the failure it is meant to avoid.
+		const reducer = code.slice(code.indexOf("def __reduce__(self):"));
+		const returned = reducer.slice(0, reducer.indexOf("\n", reducer.indexOf("return ")));
+		expect(returned).toContain("_prime_agent_importlib.import_module");
+		expect(returned).not.toContain("_prime_agent_wrap_skill_module");
+	});
+
+	it("only defines the wrapper when the session has Python skills", () => {
+		expect(buildRlmBootstrapCode()).not.toContain("__reduce__");
+	});
+});


### PR DESCRIPTION
Fixes #1211.

## Root cause

The kernel bootstrap wraps every Python skill that exposes `run()` in `_PrimeAgentCallableSkillModule`, a `types.ModuleType` subclass (`packages/coding-agent/src/core/tools/ipython.ts`). dill saves modules by reference, but pickle's dispatch table is keyed on the exact type, so the subclass fell through to the generic reduce path and raised `TypeError: cannot pickle '_PrimeAgentCallableSkillModule' object`.

This predicts the reported split exactly: the five skills listed as skipped (`attach-image`, `compact`, `edit`, `refine`, `websearch`) are the ones defining `run`; the four listed as saved (`agent-message`, `agent-observe`, `goal`, `rlm-heartbeat`) do not, so they stayed plain modules and pickled by reference.

## The part that actually loses data

The skill globals themselves are rebuilt on resume regardless — `restoreState()` runs before the bootstrap specifically so the bootstrap overwrites them with fresh live handles.

The real loss is that an unpicklable wrapper also poisons any user variable holding a reference to it. Reproduced in a real kernel:

```python
tools = {'doubler': demo_skill}
```

`tools` was reported in `skipped` and dropped, with no bootstrap to rebuild it.

## Fix

Give the wrapper a `__reduce__` that restores through `importlib.import_module`. The reducer names a stdlib function, so it pickles by reference rather than dragging the wrapper class into the payload — which would reintroduce the same failure.

## Tests

- `test/kernel-state-roundtrip.test.ts`: real-kernel round-trip covering both the skill module and a user variable referencing it. Written first and confirmed failing against the unfixed code, with both `demo_skill` and `tools` in `skipped`.
- `test/suite/regressions/1211-callable-skill-module-pickle.test.ts`: contract test on the generated bootstrap, so the guarantee also holds in the default shards where `kernel-heavy` is filtered out.

## Verification

- `npm run test:kernel` scope: 7/7 in `kernel-state-roundtrip.test.ts`.
- 117 tests pass across 9 related kernel and skill test files.
- `npm run check` passes.

Four failures in `kernel-goal-skill.test.ts` and `acp-kernel-features.test.ts` are pre-existing in my environment, not from this change: the same four fail at `HEAD` with the patch reverted. My kernel venv's `rlm` lacks the host bridge.

## Known limitation

A variable restored before the bootstrap holds the unwrapped module, so `tools['doubler'].run(21)` works but calling `tools['doubler'](21)` directly does not. Closing that gap means switching the bootstrap from copy-wrapping to an in-place `__class__` upgrade, which makes every existing reference callable and drops the `__dict__` copy. I verified that works but left it out — it changes module-wrapping semantics for all users and is beyond this issue. Happy to send it separately if you want it.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pickling of callable Python skill modules in kernel state snapshots
> - Callable Python skill module wrappers (used to expose `run()` from Python skills) were silently dropped during kernel state snapshots due to a `TypeError` when `dill` tried to pickle them.
> - Adds a `__reduce__` method to the wrapper class in [ipython.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1278/files#diff-812e64dd0562a31155c537ae8f665280f5201d993eea105d5066d0e7d02ee36d) so instances are pickled by reference via `_prime_agent_importlib.import_module(self.__name__)` instead of via the generic reduce path.
> - Adds an integration test in [kernel-state-roundtrip.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1278/files#diff-0384e2afc0ba33cb48d0c8ec3a51a50c408444c4f9ae6418bf6ca83864801e68) covering snapshot/restore of callable skill modules and user variables referencing them.
> - Adds a regression test in [1211-callable-skill-module-pickle.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1278/files#diff-12d21b9112d5772b26d6c7d6ebcf0eb97bef6c27961102c7522e55886ec86bac) asserting the reducer emits correctly and is absent when no Python skills are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e026085.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->