### PR TITLE
Bring back bare --resume and the /resume command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Useful commands:
 ```bash
 prime-agent agents                   # Browse running, idle, and saved sessions
 prime-agent attach <agent>           # Reattach to a running session
-prime-agent --resume <path|id>       # Resume a saved session
+prime-agent --resume [path|id]       # Browse sessions or resume one directly
 prime-agent status                   # Inspect background service state
 prime-agent doctor [--fix]           # Inspect or repair background services
 prime-agent update [--force]         # Update Prime Agent

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Restored bare `prime-agent --resume` opening the agents view and the `/resume [id|path]` slash command (bare opens the agents view; with an argument resumes that session in place) ([ENG-5173](https://linear.app/primeintellect/issue/ENG-5173/bring-back-raw-resume-commands-in-prime-agent)).
+
 ## [0.7.2] - 2026-08-11
 
 - Fixed Down Arrow focusing the Agents View entry before moving a nonempty prompt cursor to the end ([ENG-5147](https://linear.app/primeintellect/issue/ENG-5147/keep-down-arrow-in-the-prompt-until-the-cursor-reaches-the-end)).

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -150,7 +150,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/effort` | Set reasoning/thinking level |
 | `/scoped-models` | Enable/disable models for Ctrl+P cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
-| `/resume` | Open the searchable session view |
+| `/resume [id\|path]` | Open the agents view, or resume a session directly |
 | `/new`, `/clear` | Start a new session |
 | `/name <name>` | Set session display name |
 | `/session` | Show session info (file, ID, messages) |

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -42,7 +42,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/effort` | Set the reasoning/thinking level |
 | `/scoped-models` | Enable/disable models for Ctrl+P cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
-| `/resume` | Pick from previous sessions |
+| `/resume [id\|path]` | Open the agents view, or resume a session directly |
 | `/new` | Start a new session |
 | `/name <name>` | Set session display name |
 | `/session` | Show session file, ID, and message counts |

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -186,7 +186,7 @@ const TOP_LEVEL_OPTION_GROUPS: ReadonlyArray<{ heading: string; options: readonl
 		heading: "Session options",
 		options: [
 			["-c, --continue", "Continue the previous session"],
-			["-r, --resume <path|id>", "Resume a saved session"],
+			["-r, --resume [path|id]", "Open the agents view, or resume a saved session"],
 			["--fork <path|id>", "Fork a saved session into a new session"],
 			["--session-dir <dir>", "Use a custom session directory"],
 			["--no-session", "Do not save the session"],

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -186,6 +186,12 @@ const CANONICAL_BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 		takesArgument: true,
 	},
 	{ name: "heartbeats", description: "View and manage all user and agent heartbeats" },
+	{
+		name: "resume",
+		description: "Open the agents view, or resume a session by id or path",
+		argumentHint: "[id|path]",
+		takesArgument: true,
+	},
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
 	{
 		name: "fullscreen",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -166,8 +166,8 @@ export function shouldRejectNonInteractiveAttach(attachAgent: string | undefined
 	return attachAgent !== undefined && appMode !== "interactive";
 }
 
-export function shouldRejectBareResume(resume: true | string | undefined): boolean {
-	return resume === true;
+export function shouldRejectNonInteractiveBareResume(resume: true | string | undefined, appMode: AppMode): boolean {
+	return resume === true && appMode !== "interactive";
 }
 
 function resolveAppMode(parsed: Args, stdinIsTTY: boolean): AppMode {
@@ -253,13 +253,16 @@ export interface AgentsViewStartupDecision {
 }
 
 export function shouldOpenAgentsViewForDaemonInteractive(options: AgentsViewStartupDecision): boolean {
+	const bareResume = options.resume === true;
+	const requestsAgentsView = bareResume || (options.explicitAgentsView && !options.needsOnboarding);
 	return (
 		options.useDaemonInteractive &&
 		// `prime-agent` opens a new chat by default; the unified agents view is reached via
-		// left-arrow from a session or requested explicitly (`agents`).
-		!!options.explicitAgentsView &&
-		!options.needsOnboarding &&
-		// A resume selector resolves and opens its target directly.
+		// left-arrow from a session, requested explicitly (`agents`), or opened by bare `--resume`.
+		!!requestsAgentsView &&
+		// Onboarding still owns a normal/`agents` first run. Bare `--resume` is an explicit
+		// request for the unified session view and must not fall through to a new chat.
+		// A selector still resolves and opens its target directly.
 		typeof options.resume !== "string" &&
 		!options.continue &&
 		!options.fork
@@ -276,7 +279,12 @@ export interface DaemonInteractiveSessionManagerDecision {
 export function shouldUseEphemeralSessionManagerForDaemonInteractive(
 	options: DaemonInteractiveSessionManagerDecision,
 ): boolean {
-	return !options.hasActiveDaemonSession && options.resume === undefined && !options.continue && !options.fork;
+	return (
+		!options.hasActiveDaemonSession &&
+		(options.resume === undefined || options.resume === true) &&
+		!options.continue &&
+		!options.fork
+	);
 }
 
 export interface DaemonActiveSessionLookupDecision {
@@ -1077,10 +1085,8 @@ export async function main(args: string[], options?: MainOptions) {
 		console.error(chalk.red("Error: attach requires an interactive terminal"));
 		process.exit(1);
 	}
-	if (shouldRejectBareResume(parsed.resume)) {
-		console.error(
-			chalk.red("Error: --resume requires a session id or path; browse sessions with left-arrow from a chat"),
-		);
+	if (shouldRejectNonInteractiveBareResume(parsed.resume, appMode)) {
+		console.error(chalk.red("Error: --resume without a session selector requires an interactive terminal"));
 		process.exit(1);
 	}
 	setLogContext({ mode: appMode });
@@ -1640,7 +1646,7 @@ export async function main(args: string[], options?: MainOptions) {
 		printTimings();
 		await runAcpMode(runtime);
 	} else if (appMode === "interactive") {
-		if (explicitAgentsView) {
+		if (explicitAgentsView || parsed.resume === true) {
 			console.error(chalk.yellow("Warning: the agents view needs the daemon; opening a normal chat instead"));
 		}
 		if (scopedModels.length > 0 && (parsed.verbose || !settingsManager.getQuietStartup())) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -257,12 +257,8 @@ export function shouldOpenAgentsViewForDaemonInteractive(options: AgentsViewStar
 	const requestsAgentsView = bareResume || (options.explicitAgentsView && !options.needsOnboarding);
 	return (
 		options.useDaemonInteractive &&
-		// `prime-agent` opens a new chat by default; the unified agents view is reached via
-		// left-arrow from a session, requested explicitly (`agents`), or opened by bare `--resume`.
+		// A selector, continuation, or fork must open its target directly rather than the agents view.
 		!!requestsAgentsView &&
-		// Onboarding still owns a normal/`agents` first run. Bare `--resume` is an explicit
-		// request for the unified session view and must not fall through to a new chat.
-		// A selector still resolves and opens its target directly.
 		typeof options.resume !== "string" &&
 		!options.continue &&
 		!options.fork

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -116,6 +116,7 @@ import { resolvePrimeInferencePostLoginModelAction } from "../../core/prime-infe
 import { parseCommandArgs } from "../../core/prompt-templates.js";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.js";
 import { SessionImportFileNotFoundError } from "../../core/session-import-errors.js";
+import { resolveSessionPath, SessionSelectorError, SessionSelectorNotFoundError } from "../../core/session-resolver.js";
 import { parseSkillBlock } from "../../core/skill-blocks.js";
 import {
 	BUILTIN_SLASH_COMMANDS,
@@ -4835,6 +4836,11 @@ export class InteractiveMode {
 					await this.handleClearCommand(options);
 					return;
 				}
+				if (commandName === "resume") {
+					this.editor.setText("");
+					await this.handleResumeCommand(commandArgs);
+					return;
+				}
 				if (commandName === "reload" && !commandArgs) {
 					this.editor.setText("");
 					await this.handleReloadCommand();
@@ -8427,6 +8433,30 @@ export class InteractiveMode {
 			);
 			return { component: selector, focus: selector };
 		});
+	}
+
+	private async handleResumeCommand(args: string): Promise<void> {
+		const selector = args.trim();
+		if (!selector) {
+			await this.requestAgentsView();
+			return;
+		}
+		let sessionPath: string;
+		try {
+			sessionPath = (await resolveSessionPath(selector, this.getCurrentCwd(), this.connectionState?.sessionDir))
+				.path;
+		} catch (error) {
+			if (error instanceof SessionSelectorError) {
+				const suggestion =
+					error instanceof SessionSelectorNotFoundError && error.suggestion
+						? ` Did you mean '${error.suggestion}'?`
+						: "";
+				this.showError(`${error.message}.${suggestion}`);
+				return;
+			}
+			throw error;
+		}
+		await this.handleResumeSession(sessionPath);
 	}
 
 	private async handleResumeSession(

--- a/packages/coding-agent/test/interactive-mode-resume-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-resume-command.test.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+
+type InteractiveModePrototype = {
+	handleResumeCommand(this: ResumeCommandContext, args: string): Promise<void>;
+};
+
+type ResumeCommandContext = {
+	requestAgentsView: () => Promise<void>;
+	handleResumeSession: (sessionPath: string) => Promise<{ cancelled: boolean }>;
+	showError: (message: string) => void;
+	getCurrentCwd: () => string;
+	connectionState: { sessionDir?: string } | undefined;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
+
+const emptySessionDir = mkdtempSync(join(tmpdir(), "resume-command-test-"));
+
+afterAll(() => {
+	rmSync(emptySessionDir, { recursive: true, force: true });
+});
+
+function makeContext() {
+	return {
+		requestAgentsView: vi.fn<() => Promise<void>>(async () => undefined),
+		handleResumeSession: vi.fn<(sessionPath: string) => Promise<{ cancelled: boolean }>>(async () => ({
+			cancelled: false,
+		})),
+		showError: vi.fn<(message: string) => void>(),
+		getCurrentCwd: () => emptySessionDir,
+		connectionState: { sessionDir: emptySessionDir },
+	} satisfies ResumeCommandContext;
+}
+
+describe("InteractiveMode /resume command", () => {
+	it("opens the agents view for bare /resume", async () => {
+		const context = makeContext();
+
+		await interactiveModePrototype.handleResumeCommand.call(context, "  ");
+
+		expect(context.requestAgentsView).toHaveBeenCalledTimes(1);
+		expect(context.handleResumeSession).not.toHaveBeenCalled();
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+
+	it("resumes a session path argument in place", async () => {
+		const context = makeContext();
+
+		await interactiveModePrototype.handleResumeCommand.call(context, "/tmp/session.jsonl");
+
+		expect(context.handleResumeSession).toHaveBeenCalledWith("/tmp/session.jsonl");
+		expect(context.requestAgentsView).not.toHaveBeenCalled();
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+
+	it("shows a non-fatal error for an unknown session selector", async () => {
+		const context = makeContext();
+
+		await interactiveModePrototype.handleResumeCommand.call(context, "no-such-session");
+
+		expect(context.showError).toHaveBeenCalledWith(expect.stringContaining("No session found matching"));
+		expect(context.handleResumeSession).not.toHaveBeenCalled();
+		expect(context.requestAgentsView).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -623,6 +623,7 @@ type SubmitHandlerHarness = {
 	isBashRunning: () => boolean;
 	patchConnectionState: (patch: Record<string, unknown>) => void;
 	requestAgentsView: () => Promise<void>;
+	handleResumeCommand: (args: string) => Promise<void>;
 	agentConnection: {
 		prompt: (message: string) => Promise<void>;
 		executeBash: (command: string, options?: { excludeFromContext?: boolean }) => Promise<void>;
@@ -642,6 +643,7 @@ function createSubmitHandlerHarness(overrides: Partial<SubmitHandlerHarness> = {
 		patchConnectionState: vi.fn(),
 		promptStashState: {},
 		requestAgentsView: vi.fn(async () => {}),
+		handleResumeCommand: vi.fn(async () => {}),
 		promptStash: undefined,
 		pastedImages: new Map(),
 		getPromptStashImages: vi.fn(() => []),
@@ -1538,13 +1540,14 @@ describe("InteractiveMode connection events", () => {
 		expect(flushPendingBashComponents).toHaveBeenCalledOnce();
 	});
 
-	test("sends /resume as plain prompt text now that the command is retired", async () => {
+	test("routes /resume to the resume command handler", async () => {
 		const fakeThis = createSubmitHandlerHarness();
 
-		await fakeThis.defaultEditor.onSubmit?.("/resume unexpected");
+		await fakeThis.defaultEditor.onSubmit?.("/resume abc123");
 
+		expect(fakeThis.handleResumeCommand).toHaveBeenCalledWith("abc123");
 		expect(fakeThis.showError).not.toHaveBeenCalled();
-		expect(fakeThis.requestAgentsView).not.toHaveBeenCalled();
+		expect(fakeThis.agentConnection.prompt).not.toHaveBeenCalled();
 	});
 
 	test("renderCurrentSessionState waits for replacement handling before rendering", async () => {

--- a/packages/coding-agent/test/main-interactive-routing.test.ts
+++ b/packages/coding-agent/test/main-interactive-routing.test.ts
@@ -16,8 +16,8 @@ import {
 	shouldEnsureDaemonBeforeActiveSessionLookup,
 	shouldEnsureInteractiveDaemonForStartup,
 	shouldOpenAgentsViewForDaemonInteractive,
-	shouldRejectBareResume,
 	shouldRejectNonInteractiveAttach,
+	shouldRejectNonInteractiveBareResume,
 	shouldUseDaemonClient,
 	shouldUseDaemonClientRuntime,
 	shouldUseDaemonInteractive,
@@ -127,9 +127,10 @@ describe("interactive startup routing", () => {
 		expect(shouldRejectNonInteractiveAttach("worker", "print")).toBe(true);
 		expect(shouldRejectNonInteractiveAttach("worker", "interactive")).toBe(false);
 		expect(shouldRejectNonInteractiveAttach(undefined, "print")).toBe(false);
-		expect(shouldRejectBareResume(true)).toBe(true);
-		expect(shouldRejectBareResume("session-id")).toBe(false);
-		expect(shouldRejectBareResume(undefined)).toBe(false);
+		expect(shouldRejectNonInteractiveBareResume(true, "print")).toBe(true);
+		expect(shouldRejectNonInteractiveBareResume(true, "rpc")).toBe(true);
+		expect(shouldRejectNonInteractiveBareResume("session-id", "print")).toBe(false);
+		expect(shouldRejectNonInteractiveBareResume(true, "interactive")).toBe(false);
 	});
 
 	test("does not start the daemon for attach", () => {
@@ -183,14 +184,14 @@ describe("daemon-backed interactive session manager routing", () => {
 		expect(shouldOpenAgentsViewForDaemonInteractive(decision)).toBe(false);
 	});
 
-	test("bare --resume no longer routes to the agents view (it is rejected at startup)", () => {
+	test.each([false, true])("opens the agents view for bare --resume (onboarding=%s)", (needsOnboarding) => {
 		expect(
 			shouldOpenAgentsViewForDaemonInteractive({
 				useDaemonInteractive: true,
-				needsOnboarding: false,
+				needsOnboarding,
 				resume: true,
 			}),
-		).toBe(false);
+		).toBe(true);
 	});
 
 	test("ensures daemon is available before probing non-path session selectors", () => {
@@ -278,8 +279,8 @@ describe("daemon-backed interactive session manager routing", () => {
 		expect(shouldUseEphemeralSessionManagerForDaemonInteractive(decision)).toBe(false);
 	});
 
-	test("keeps bare --resume off the ephemeral local session manager", () => {
-		expect(shouldUseEphemeralSessionManagerForDaemonInteractive({ resume: true })).toBe(false);
+	test("uses an ephemeral local session manager for bare --resume", () => {
+		expect(shouldUseEphemeralSessionManagerForDaemonInteractive({ resume: true })).toBe(true);
 	});
 
 	test("finds an active daemon session by resolved session file", () => {

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -65,14 +65,6 @@ describe("built-in slash commands", () => {
 		});
 	});
 
-	test("exposes /resume with an optional session selector", () => {
-		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "resume")).toMatchObject({
-			description: "Open the agents view, or resume a session by id or path",
-			argumentHint: "[id|path]",
-			takesArgument: true,
-		});
-	});
-
 	test("exposes trace preview and backfill syntax", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "traces")).toMatchObject({
 			description: "Preview, upload, or configure Prime Agent traces",

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -65,6 +65,14 @@ describe("built-in slash commands", () => {
 		});
 	});
 
+	test("exposes /resume with an optional session selector", () => {
+		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "resume")).toMatchObject({
+			description: "Open the agents view, or resume a session by id or path",
+			argumentHint: "[id|path]",
+			takesArgument: true,
+		});
+	});
+
 	test("exposes trace preview and backfill syntax", () => {
 		expect(BUILTIN_SLASH_COMMANDS.find((command) => command.name === "traces")).toMatchObject({
 			description: "Preview, upload, or configure Prime Agent traces",


### PR DESCRIPTION
Fixes ENG-5173.

## What this does

Brings back the two resume commands that used to exist:

- `prime-agent --resume` with no argument opens the agents window, where you can pick the session you want to continue. (With an ID or path it still resumes that specific session, as before.)
- `/resume` inside a chat does the same: on its own it opens the agents window; with an ID or path it switches the current window to that session.

## Why

Both commands quietly disappeared when the agents view was unified some time ago. Since then, the only way to resume a session was the left-arrow agent menu, which several people did not find (one user asked "am I crazy or can't I resume anymore?"). The muscle memory for `--resume` and `/resume` is real, so they are back.

## How it works

- Bare `--resume` now routes to the same agents window that the `prime-agent agents` command opens, instead of printing an error. In modes without a terminal UI (like print or JSON mode) it still explains that resuming needs an ID there.
- `/resume` with an argument reuses the existing session-switching machinery, which already handles the case where the session is running somewhere else — it reattaches instead of opening it twice.
- No new wire protocol or daemon changes; everything reuses paths that already exist.

## Changes

- `main.ts`: route bare `--resume` to the agents view (+18/−12).
- `slash-commands.ts` + `interactive-mode.ts`: the restored `/resume` command (+36).
- Help text, READMEs, usage doc, and changelog updated.
- Tests: restored the routing assertions that existed before the removal, plus a new test file for the `/resume` command.

Lines changed: source +55/−13, tests +93/−12, docs and changelog +5/−3.

## Checks

- `npm run check` clean.
- 378 tests across the touched test files pass; the reviewer independently re-ran 224 of them.
- Newest main merged in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session-browsing UX restoration on existing resume and agents-view code paths; no new auth or protocol surface.
> 
> **Overview**
> Restores **bare `prime-agent --resume`** and **`/resume`** as ways to open the agents view, reversing the v0.4.0 removal that left session browsing mostly on left-arrow navigation.
> 
> **CLI:** `--resume` is optional (`[path|id]`). With no argument in an interactive terminal, startup routes to the same agents view as `prime-agent agents` instead of erroring; print/RPC/JSON still require a session id or path. Daemon interactive startup treats bare `--resume` like an explicit agents-view request and can use an ephemeral session manager when nothing is already active.
> 
> **TUI:** `/resume` is a built-in slash command again. No args calls `requestAgentsView()`; with an id or path it resolves via `resolveSessionPath` and switches in place through `handleResumeSession`, with friendly errors for unknown selectors.
> 
> Help text, README, usage docs, and the changelog are aligned with the restored behavior. Tests cover routing helpers and `/resume` handler branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d05b6d32a897529bee484f533dac0c28fd050c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore bare `--resume` flag and `/resume` slash command to open the agents view
> - Bare `--resume` (no argument) now routes to the agents view in interactive+daemon mode; passing an id/path resumes that session directly.
> - The `/resume [id|path]` slash command is added to the editor: no argument opens the agents view, a valid id/path resumes in place, and an unknown selector shows a user-friendly error.
> - `shouldRejectBareResume` is replaced by `shouldRejectNonInteractiveBareResume`, which only rejects bare `--resume` in non-interactive modes; interactive mode falls back to a normal chat with a warning when the daemon is unavailable.
> - CLI help text, docs, and README updated to reflect the optional argument syntax `[path|id]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50d05b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->