### PR TITLE
Make Ctrl+P toggle sent agent messages too

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Fixed ctrl+p ("Toggle agent message expansion") only toggling received agent messages; it now expands and collapses sent agent messages together with received ones.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
+++ b/packages/coding-agent/src/modes/interactive/components/conversation-components.ts
@@ -102,6 +102,7 @@ export function buildConversationComponents(
 					options.cwd,
 				);
 				tool.setExpanded(expanded);
+				tool.setAgentMessagesExpanded(agentMessagesExpanded);
 				tool.markExecutionStarted();
 				tool.setArgsComplete();
 				selectLatestToolExpandHint(components, tool);

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -32,7 +32,6 @@ export interface IPythonCellState {
 	isPartial?: boolean;
 	isError?: boolean;
 	expanded?: boolean;
-	/** Agent-message expansion (app.messages.expand / ctrl+p) — independent of tool-output `expanded`. */
 	agentMessagesExpanded?: boolean;
 	showExpandHint?: boolean;
 	executionStarted?: boolean;

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -32,6 +32,8 @@ export interface IPythonCellState {
 	isPartial?: boolean;
 	isError?: boolean;
 	expanded?: boolean;
+	/** Agent-message expansion (app.messages.expand / ctrl+p) — independent of tool-output `expanded`. */
+	agentMessagesExpanded?: boolean;
 	showExpandHint?: boolean;
 	executionStarted?: boolean;
 	argsComplete?: boolean;
@@ -643,7 +645,7 @@ export class IPythonCellComponent implements Component {
 		for (const message of messages) {
 			const label = message.deliveryStatus === "delivered" ? "Agent message sent" : "Agent message queued";
 			const recipient = formatAgentMessageParticipant("sent", message.receiverRole, message.target);
-			if (this.state.expanded) {
+			if (this.state.agentMessagesExpanded) {
 				this.addBlank(lines, width);
 				this.addPlain(
 					lines,

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -79,6 +79,7 @@ export class ToolExecutionComponent extends Container {
 	private toolCallId: string;
 	private args: any;
 	private expanded = false;
+	private agentMessagesExpanded = false;
 	private showExpandHint = true;
 	private showImages: boolean;
 	private includeImageDimensions: boolean;
@@ -267,6 +268,14 @@ export class ToolExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
+	setAgentMessagesExpanded(expanded: boolean): void {
+		if (this.agentMessagesExpanded === expanded) {
+			return;
+		}
+		this.agentMessagesExpanded = expanded;
+		this.updateDisplay();
+	}
+
 	setShowExpandHint(show: boolean): void {
 		if (this.showExpandHint === show) {
 			return;
@@ -331,6 +340,7 @@ export class ToolExecutionComponent extends Container {
 					isPartial: this.isPartial,
 					isError: this.result?.isError ?? false,
 					expanded: this.expanded,
+					agentMessagesExpanded: this.agentMessagesExpanded,
 					executionStarted: this.executionStarted,
 					argsComplete: this.argsComplete,
 					showExpandHint: this.showExpandHint,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -320,6 +320,19 @@ function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
 
+interface AgentMessagesExpandable {
+	setAgentMessagesExpanded(expanded: boolean): void;
+}
+
+function hasAgentMessagesExpansion(obj: unknown): obj is AgentMessagesExpandable {
+	return (
+		typeof obj === "object" &&
+		obj !== null &&
+		"setAgentMessagesExpanded" in obj &&
+		typeof (obj as AgentMessagesExpandable).setAgentMessagesExpanded === "function"
+	);
+}
+
 class ExpandableText extends Text implements Expandable {
 	constructor(
 		private readonly getCollapsedText: () => string,
@@ -3018,6 +3031,7 @@ export class InteractiveMode {
 				this.getCurrentCwd(),
 			);
 			component.setExpanded(this.toolOutputExpanded);
+			component.setAgentMessagesExpanded(this.agentMessagesExpanded);
 			if (this.startedToolCalls.has(latestToolCall.id)) {
 				component.markExecutionStarted();
 			}
@@ -6499,6 +6513,7 @@ export class InteractiveMode {
 							this.getCurrentCwd(),
 						);
 						component.setExpanded(this.toolOutputExpanded);
+						component.setAgentMessagesExpanded(this.agentMessagesExpanded);
 						selectLatestToolExpandHint(this.chatContainer.children, component);
 						this.chatContainer.addChild(component);
 						this.registerIpythonToolComponent(content.name, content.id, component);
@@ -7267,6 +7282,9 @@ export class InteractiveMode {
 		for (const child of this.chatContainer.children) {
 			if (isExpandable(child)) {
 				child.setExpanded(this.expansionStateFor(child));
+			}
+			if (hasAgentMessagesExpansion(child)) {
+				child.setAgentMessagesExpanded(this.agentMessagesExpanded);
 			}
 		}
 		// Expanding/collapsing changes blocks above the viewport, which would

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -4234,6 +4234,7 @@ describe("InteractiveMode.setToolsExpanded", () => {
 
 	test("toggles agent messages separately from tools", () => {
 		const toolChild = { setExpanded: vi.fn() };
+		const ipythonChild = { setExpanded: vi.fn(), setAgentMessagesExpanded: vi.fn() };
 		const messageChild = new AgentMessageComponent({
 			role: "custom",
 			customType: "agent_message",
@@ -4243,7 +4244,7 @@ describe("InteractiveMode.setToolsExpanded", () => {
 			timestamp: 123,
 		} as any);
 		const messageSetExpanded = vi.spyOn(messageChild, "setExpanded");
-		const fakeThis = createExpansionFakeThis([toolChild, messageChild]);
+		const fakeThis = createExpansionFakeThis([toolChild, ipythonChild, messageChild]);
 
 		fakeThis.toggleAgentMessageExpansion();
 
@@ -4251,11 +4252,15 @@ describe("InteractiveMode.setToolsExpanded", () => {
 		expect(fakeThis.toolOutputExpanded).toBe(false);
 		expect(messageSetExpanded).toHaveBeenCalledWith(true);
 		expect(toolChild.setExpanded).toHaveBeenCalledWith(false);
+		expect(ipythonChild.setExpanded).toHaveBeenCalledWith(false);
+		expect(ipythonChild.setAgentMessagesExpanded).toHaveBeenCalledWith(true);
 
 		fakeThis.setToolsExpanded(true);
 
 		expect(toolChild.setExpanded).toHaveBeenCalledWith(true);
 		expect(messageSetExpanded).toHaveBeenLastCalledWith(true);
+		expect(ipythonChild.setExpanded).toHaveBeenCalledWith(true);
+		expect(ipythonChild.setAgentMessagesExpanded).toHaveBeenLastCalledWith(true);
 		expect(fakeThis.agentMessagesExpanded).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -549,6 +549,7 @@ describe("ENG-4531 agent message UI", () => {
 			executionStarted: true,
 			argsComplete: true,
 			expanded: true,
+			agentMessagesExpanded: true,
 			details: {
 				status: "ok",
 				result: receipt,
@@ -593,6 +594,7 @@ describe("ENG-4531 agent message UI", () => {
 			executionStarted: true,
 			argsComplete: true,
 			expanded: true,
+			agentMessagesExpanded: true,
 			details: {
 				status: "ok",
 				result: receipts,
@@ -623,6 +625,7 @@ describe("ENG-4531 agent message UI", () => {
 			executionStarted: true,
 			argsComplete: true,
 			expanded: true,
+			agentMessagesExpanded: true,
 			details: {
 				status: "ok",
 				result: "{'referenced_message': 'agentmsg_4531_ref', 'answer': 42}",
@@ -652,6 +655,7 @@ describe("ENG-4531 agent message UI", () => {
 			executionStarted: true,
 			argsComplete: true,
 			expanded: true,
+			agentMessagesExpanded: true,
 			details: {
 				status: "ok",
 				result: "'done'",
@@ -675,5 +679,42 @@ describe("ENG-4531 agent message UI", () => {
 		expect(rendered).toContain(" ◆ Agent message sent · to parent Worker");
 		expect(rendered).toContain(" ╰─ Ping.");
 		expect(rendered).toContain("done");
+	});
+
+	it("decouples sent-message expansion from tool-output expansion", () => {
+		const sentAgentMessage = {
+			id: "agentmsg_4531_decoupled",
+			message: "Decouple me.",
+			deliveryStatus: "delivered",
+			receiverRole: "parent",
+			target: {
+				activeSessionId: "worker-active",
+				sessionId: "worker-session",
+				sessionName: "Worker",
+			},
+		};
+		const baseState = {
+			code: 'await agent_message.send("Decouple me.", receiver_role="parent")',
+			executionStarted: true,
+			argsComplete: true,
+			details: { status: "ok", sentAgentMessages: [sentAgentMessage] },
+		};
+
+		const agentExpanded = stripAnsi(
+			new IPythonCellComponent({ ...baseState, expanded: false, agentMessagesExpanded: true })
+				.render(120)
+				.join("\n"),
+		);
+		expect(agentExpanded).toContain(" ◆ Agent message sent · to parent Worker");
+		expect(agentExpanded).toContain(" ╰─ Decouple me.");
+		expect(agentExpanded).not.toContain("· Decouple me.");
+
+		const toolExpanded = stripAnsi(
+			new IPythonCellComponent({ ...baseState, expanded: true, agentMessagesExpanded: false })
+				.render(120)
+				.join("\n"),
+		);
+		expect(toolExpanded).toContain(" ◆ Agent message sent · to parent Worker · Decouple me.");
+		expect(toolExpanded).not.toContain("╰─");
 	});
 });


### PR DESCRIPTION
## What this does

`Ctrl+P` toggles agent-to-agent messages open and closed. Until now it only worked on messages the agent *received* — messages it *sent* stayed collapsed (they only opened together with the whole tool output via `Ctrl+O`). Now `Ctrl+P` expands and collapses both sent and received messages together.

## Why

Sent and received messages are two halves of the same conversation. Having one key expand one half, and a different key (meant for tool output) expand the other, was confusing and inconsistent.

## How it works

There was already a single "are agent messages expanded" switch behind `Ctrl+P`. The sent-message display just wasn't connected to it — it was wired to the tool-output switch instead. The fix connects the sent-message display to the same switch the received messages use, and disconnects it from the tool-output one. So:

- `Ctrl+P` opens and closes all agent messages, sent and received.
- `Ctrl+O` goes back to meaning tool output only.
- No new keybinding, no second switch to keep in sync.

## Changes

- The sent-message part of the code cell display now reads the shared message-expansion switch (+32/−1 across four files).
- Tests covering the new toggle behavior (+47/−1).
- One changelog entry.

Lines changed: source +32/−1, tests +47/−1, changelog +1/−0.

## Checks

- `npm run check` clean.
- 184 tests across the touched areas pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive UI rendering and expansion state only; no auth, persistence, or execution behavior changes.
> 
> **Overview**
> **Ctrl+P** (`app.messages.expand`) now expands and collapses **sent** agent messages in IPython/`agent_message.send` tool rows, not only received `AgentMessageComponent` rows.
> 
> Sent-message bodies in `IPythonCellComponent` were tied to **tool output** expansion (`expanded` / **Ctrl+O**). They now use a separate **`agentMessagesExpanded`** flag that follows the same global toggle as received messages. `ToolExecutionComponent` stores that flag, passes it into nested IPython cells, and `InteractiveMode.applyChatExpansion` pushes `agentMessagesExpanded` to chat children (with a small type guard). New and rehydrated tool rows get the current setting at creation time.
> 
> **Ctrl+O** stays for tool/code/output expansion; **Ctrl+P** controls all agent-to-agent message text (sent and received) together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d6bb6d810b85695bdf8dff901b375f90dafff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Ctrl+P to toggle sent agent messages in addition to received messages
> - Adds a separate `agentMessagesExpanded` flag to `ToolExecutionComponent` and `IPythonCellComponent` so sent agent messages expand/collapse independently of tool output expansion.
> - `InteractiveMode.applyChatExpansion` now calls `setAgentMessagesExpanded` on children that support it, propagating the Ctrl+P toggle to both sent and received agent messages.
> - Newly created tool blocks inherit the current `agentMessagesExpanded` state at construction time via a new `AgentMessagesExpandable` interface and `hasAgentMessagesExpansion` type guard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36d6bb6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->