### PR TITLE
fix(ai): reject invalid OAuth provider selections

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed interactive OAuth provider selection crashing on non-numeric input ([#1271](https://github.com/PrimeIntellect-ai/prime-agent/issues/1271)).
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -103,8 +103,8 @@ Examples:
 			const choice = await prompt(rl, `Enter number (1-${PROVIDERS.length}): `);
 			rl.close();
 
-			const index = parseInt(choice, 10) - 1;
-			if (index < 0 || index >= PROVIDERS.length) {
+			const index = Number(choice) - 1;
+			if (!Number.isInteger(index) || index < 0 || index >= PROVIDERS.length) {
 				console.error("Invalid selection");
 				process.exit(1);
 			}

--- a/packages/ai/test/cli.test.ts
+++ b/packages/ai/test/cli.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const tsxLoader = require.resolve("tsx/esm");
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cliPath = resolve(packageRoot, "src/cli.ts");
+
+describe("OAuth CLI", () => {
+	it("rejects a non-numeric interactive provider selection", () => {
+		const testDir = mkdtempSync(join(tmpdir(), "pi-ai-cli-"));
+		try {
+			const result = spawnSync(process.execPath, ["--import", tsxLoader, cliPath, "login"], {
+				cwd: testDir,
+				encoding: "utf8",
+				input: "abc\n",
+				timeout: 5_000,
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.signal).toBeNull();
+			expect(result.status).toBe(1);
+			expect(result.stdout).toContain("Select a provider:");
+			expect(result.stdout).not.toContain("Logging in to");
+			expect(result.stderr.trim()).toBe("Invalid selection");
+			expect(result.stderr).not.toContain("TypeError");
+			expect(result.stderr).not.toContain("Cannot read properties");
+			expect(existsSync(join(testDir, "auth.json"))).toBe(false);
+		} finally {
+			rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Reject non-numeric interactive OAuth provider selections before indexing the provider list.
- Report `Invalid selection` instead of throwing a property access error.
- Add an isolated CLI regression test and changelog entry.

## Root cause

`parseInt()` returned `NaN` for non-numeric input. Because comparisons with `NaN` are false, the existing range check was bypassed and the CLI attempted to read `PROVIDERS[index].id`.

## Behavior

```text
Before: Error: Cannot read properties of undefined (reading 'id')
After:  Invalid selection
Exit code: 1
```

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/cli.test.ts`
- `npm run check`
- Manually ran the built CLI, entered `abc`, and verified `Invalid selection` with exit code 1.

## Related

PR #1282 was opened while this fix was being prepared and also touches #1271 as part of a multi-issue change. This PR is intentionally limited to #1271 and includes focused regression coverage.

Fixes #1271


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `login` command to reject non-numeric OAuth provider selections
> Replaces `parseInt` with `Number()` and adds a `Number.isInteger` guard in [cli.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1287/files#diff-d407c2a03328fecec709113b81652fbf80f40a7b49ea75e3fa78c8cd0be2d320) to validate provider selection input. Out-of-range or non-integer input now exits with code 1 and prints 'Invalid selection' to stderr instead of throwing a TypeError.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6e37ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->