### PR TITLE
fix: extension setStatus dropped when it races the client's own attach

### DIFF
--- a/packages/coding-agent/src/modes/daemon/active-session-state.ts
+++ b/packages/coding-agent/src/modes/daemon/active-session-state.ts
@@ -41,6 +41,16 @@ export interface ActiveSessionState {
 	eventGeneration: string;
 	lastEventSequence: DaemonEventSequence;
 	unsubscribe?: () => void;
+	/**
+	 * Last value an extension passed to ctx.ui.setStatus(key, text) for this
+	 * session, keyed by status key (undefined entries mark a cleared key so a
+	 * newly attaching client doesn't resurrect it). A setStatus call made
+	 * synchronously from session_start races the calling client's own attach —
+	 * broadcastToSession sees zero clients yet and the update is dropped with
+	 * no retry. Recording it here lets a newly attached client be caught up
+	 * immediately instead of waiting on the extension's next unrelated update.
+	 */
+	extensionStatusByKey?: Map<string, string | undefined>;
 	/** Latest background status summary, surfaced in the agents view. */
 	summaryState?: AgentStatus;
 	/**

--- a/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts
@@ -199,7 +199,13 @@ function createExtensionUIContext(
 			),
 		notify: (message, notifyType) => emitUiRequest("notify", { message, notifyType }),
 		onTerminalInput: () => () => {},
-		setStatus: (key, text) => emitUiRequest("setStatus", { statusKey: key, statusText: text }),
+		setStatus: (key, text) => {
+			if (!state.extensionStatusByKey) {
+				state.extensionStatusByKey = new Map();
+			}
+			state.extensionStatusByKey.set(key, text);
+			return emitUiRequest("setStatus", { statusKey: key, statusText: text });
+		},
 		setWorkingMessage: (message) => emitUiRequest("setWorkingMessage", { message }),
 		setWorkingVisible: (visible) => emitUiRequest("setWorkingVisible", { visible }),
 		setWorkingIndicator: (indicatorOptions?: WorkingIndicatorOptions) =>

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1279,6 +1279,11 @@ export class AgentDaemon {
 		}
 		this.summarizer.forget(state.activeSessionId);
 		state.summaryState = undefined;
+		// A rebind reloads extensions (bindActiveSessionState re-runs session_start),
+		// so a stale status key from the prior extension instance must not survive
+		// to be replayed to the next client that attaches — the new instance may
+		// never set that key again (renamed, removed, or simply hasn't ticked yet).
+		state.extensionStatusByKey = undefined;
 		state.runtime.session.setCurrentRecap(undefined);
 		this.summarizer.seed(state);
 		if (state.runtime.metadata.kind === "subagent") {
@@ -3344,6 +3349,7 @@ export class AgentDaemon {
 					);
 					state.clients.add(client);
 					client.attachedActiveSessionIds.add(state.activeSessionId);
+					this.replayExtensionStatusToClient(state, client);
 					this.write(client, success(command.id, "attach", summaryForActiveSession(state)));
 					return;
 				}
@@ -3587,6 +3593,7 @@ export class AgentDaemon {
 				}
 				state.clients.add(client);
 				client.attachedActiveSessionIds.add(state.activeSessionId);
+				this.replayExtensionStatusToClient(state, client);
 				if (deferClientEnv && clientEnv) {
 					this.updateRestart?.deferredClientEnv.push({
 						client,
@@ -6510,6 +6517,30 @@ export class AgentDaemon {
 		);
 		state.lastEventSequence = meta.sequence ?? state.lastEventSequence;
 		return { ...message, meta };
+	}
+
+	/**
+	 * Catches a newly attached client up on extension status segments set
+	 * before it connected. A setStatus call made synchronously from
+	 * session_start (the documented pattern — see examples/extensions/
+	 * status-line.ts) races the calling client's own attach and is dropped
+	 * by broadcastToSession's zero-clients fan-out with no retry, so without
+	 * this a status segment set at session start never reaches whichever
+	 * client happens to attach after it, including the one that caused it.
+	 */
+	private replayExtensionStatusToClient(state: ActiveSessionState, client: DaemonSocketClient): void {
+		if (!state.extensionStatusByKey?.size) {
+			return;
+		}
+		for (const [statusKey, statusText] of state.extensionStatusByKey) {
+			this.write(client, {
+				type: "extension_ui_request",
+				activeSessionId: state.activeSessionId,
+				id: randomUUID(),
+				method: "setStatus",
+				payload: { statusKey, statusText },
+			});
+		}
 	}
 
 	private write(client: DaemonSocketClient, message: DaemonOutbound): boolean {

--- a/packages/coding-agent/test/daemon-extension-binding.test.ts
+++ b/packages/coding-agent/test/daemon-extension-binding.test.ts
@@ -112,6 +112,53 @@ describe("daemon extension binding", () => {
 		return runtime;
 	}
 
+	it("records ctx.ui.setStatus values on ActiveSessionState for later replay", async () => {
+		const runtime = await createRuntimeForTest(
+			(pi: ExtensionAPI) => {
+				pi.registerCommand("set-status-cmd", {
+					description: "set status",
+					handler: async (_args, ctx) => {
+						ctx.ui.setStatus("tokspeed", "🤖 qwen-smart 42 tok/s");
+					},
+				});
+			},
+			["ack"],
+		);
+
+		const outbound: DaemonOutbound[] = [];
+		const state: ActiveSessionState = {
+			activeSessionId: "active-status",
+			runtime,
+			clients: new Set(),
+			pendingAttaches: 0,
+			extensionUiRequests: new Map(),
+			eventGeneration: "generation-status",
+			lastEventSequence: 0,
+		};
+		await bindActiveSessionState(state, {
+			broadcast: (_state, message) => {
+				outbound.push(message);
+			},
+			shutdown: () => {},
+		});
+
+		await runtime.session.prompt("/set-status-cmd");
+
+		// Recorded even though broadcast fired with zero attached clients — this
+		// is what replayExtensionStatusToClient (daemon-mode.ts) reads to catch
+		// up a client that attaches after the call, closing the session_start
+		// attach race (see daemon-mode.test.ts "replays the last extension
+		// setStatus...").
+		expect(state.extensionStatusByKey?.get("tokspeed")).toBe("🤖 qwen-smart 42 tok/s");
+		expect(outbound).toContainEqual(
+			expect.objectContaining({
+				type: "extension_ui_request",
+				method: "setStatus",
+				payload: { statusKey: "tokspeed", statusText: "🤖 qwen-smart 42 tok/s" },
+			}),
+		);
+	});
+
 	it("strips the duplicated partial message from broadcast message_update events", async () => {
 		const runtime = await createRuntimeForTest(() => {}, ["streamed reply"]);
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -4067,6 +4067,73 @@ describe("daemon mode helpers", () => {
 		).toBe(false);
 	});
 
+	it("replays the last extension setStatus to a client attaching after it was set", () => {
+		// Regression test: an extension's session_start handler calling
+		// ctx.ui.setStatus(...) synchronously races the calling client's own
+		// attach — broadcastToSession fans out to state.clients before that
+		// client has been added to it, so the update is dropped with no retry.
+		// replayExtensionStatusToClient (called right after state.clients.add)
+		// is what catches a newly attached client up on the current value.
+		const daemon = new AgentDaemon("/tmp/prime-agent-status-replay-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const state = makeState("active-status-replay");
+		state.extensionStatusByKey = new Map([
+			["tokspeed", "🤖 qwen-smart 42 tok/s"],
+			["cleared-key", undefined],
+		]);
+		const client = makeClient("late-client", state.activeSessionId, true);
+		const write = vi.fn((_data: unknown) => true);
+		client.socket = { destroyed: false, write } as unknown as Socket;
+
+		const replay = Reflect.get(daemon, "replayExtensionStatusToClient").bind(daemon);
+		replay(state, client);
+
+		expect(write).toHaveBeenCalledTimes(2);
+		const written = write.mock.calls.map(([line]) => JSON.parse(String(line)));
+		expect(written).toContainEqual(
+			expect.objectContaining({
+				type: "extension_ui_request",
+				activeSessionId: "active-status-replay",
+				method: "setStatus",
+				payload: { statusKey: "tokspeed", statusText: "🤖 qwen-smart 42 tok/s" },
+			}),
+		);
+		// A key an extension explicitly cleared (setStatus(key, undefined)) must
+		// replay as cleared too, not be silently skipped and left showing stale
+		// text to a client that never saw the original value.
+		expect(written).toContainEqual(
+			expect.objectContaining({
+				type: "extension_ui_request",
+				method: "setStatus",
+				payload: { statusKey: "cleared-key", statusText: undefined },
+			}),
+		);
+	});
+
+	it("does not replay status once a rebind (reload/replace) clears it", () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-status-rebind-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const state = makeState("active-status-rebind");
+		state.extensionStatusByKey = new Map([["tokspeed", "🤖 old-model 10 tok/s"]]);
+		state.runtime = {
+			...state.runtime,
+			session: {
+				setCurrentRecap: vi.fn(),
+				sessionManager: { getLatestAgentStatus: () => undefined },
+			},
+			metadata: { kind: "root" },
+		} as never;
+
+		const refresh = Reflect.get(daemon, "refreshReplacedSessionState").bind(daemon);
+		refresh(state);
+
+		expect(state.extensionStatusByKey).toBeUndefined();
+	});
+
 	it("delivers session closure while a client is snapshotting and backpressured", () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },


### PR DESCRIPTION
Ran into this while writing a status-bar extension that shows live tok/s in the footer. `ctx.ui.setStatus(...)` called from `session_start` — the pattern the docs and `examples/extensions/status-line.ts` both show — basically never showed up. Not "sometimes flaky," just never.

Added some trace logging to find out why, and it's a straight race: `session_start` fires inside the worker and the extension calls `setStatus` before the client that's causing all this has finished attaching. `broadcastToSession` fans the update out over `state.clients`, which is still empty at that exact moment, so it just gets dropped. No error, nothing queued, no retry — the next tick of whatever timer/interval is driving the extension is the only thing that saves you, and if the extension only calls `setStatus` once (also a documented pattern), it's gone for good.

Logged timestamps to confirm: the broadcast with `clients=0` and the client's `attach` finishing are about 30ms apart, broadcast always loses.

**Fix**: keep the last value passed to `setStatus` per key on `ActiveSessionState` (`extensionStatusByKey`), and replay it to a client right after it's added to `state.clients` — both places that happens (`worker_subscribe`, and the real `attach` handler). Cleared on rebind/reload too, so a stale value from a previous extension instance can't get replayed to someone after a `/reload` swaps it out.

Left `notify()` alone on purpose — a one-shot toast doesn't mean anything replayed to a client that wasn't there when it fired. `setStatus` is different, it's meant to represent current state, so replaying the last value on attach is just... correct, not a workaround.

**Tests**: added to `daemon-mode.test.ts` (replay-on-attach, and that a rebind clears the recorded value) and `daemon-extension-binding.test.ts` (setStatus actually records what it's given). All existing tests still pass, `npm run check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix extension `setStatus` being dropped when a client attaches after the call was made
> - When `ctx.ui.setStatus(key, text)` is called, the key/value pair is now recorded on `ActiveSessionState.extensionStatusByKey` before broadcasting.
> - When a client subscribes or attaches to an active session, `replayExtensionStatusToClient` sends all recorded `setStatus` values immediately, so the client sees current status without waiting for the next update.
> - On session rebind/reload, `extensionStatusByKey` is cleared so stale statuses are not replayed to future clients.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ea84d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->