### PR TITLE
Add named sessions with --name, --list-sessions and --delete-session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Added `--name` to open or resume a session by name within the current directory, plus `--list-sessions` to list that directory's sessions and `--delete-session` to delete a named session ([#1294](https://github.com/PrimeIntellect-ai/prime-agent/pull/1294) by [@porky11](https://github.com/porky11)).
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -22,6 +22,9 @@ export interface Args {
 	mode?: Mode;
 	daemonSocket?: string;
 	noSession?: boolean;
+	sessionName?: string;
+	listSessions?: boolean;
+	deleteSession?: string;
 	fork?: string;
 	sessionDir?: string;
 	models?: string[];
@@ -73,6 +76,9 @@ export function parseArgs(args: string[]): Args {
 	const result: Args = {
 		messages: [],
 		fileArgs: [],
+		sessionName: undefined,
+		listSessions: undefined,
+		deleteSession: undefined,
 		unknownFlags: new Map(),
 		diagnostics: [],
 	};
@@ -143,6 +149,12 @@ export function parseArgs(args: string[]): Args {
 			result.appendSystemPrompt.push(args[++i]);
 		} else if (arg === "--no-session") {
 			result.noSession = true;
+		} else if ((arg === "--name" || arg === "-n") && i + 1 < args.length) {
+			result.sessionName = args[++i];
+		} else if (arg === "--list-sessions") {
+			result.listSessions = true;
+		} else if (arg === "--delete-session" && i + 1 < args.length) {
+			result.deleteSession = args[++i];
 		} else if (arg === "--fork" && i + 1 < args.length) {
 			result.fork = args[++i];
 		} else if (arg === "--session-dir" && i + 1 < args.length) {

--- a/packages/coding-agent/src/core/named-sessions.ts
+++ b/packages/coding-agent/src/core/named-sessions.ts
@@ -1,0 +1,31 @@
+import type { SessionInfo } from "./session-manager.js";
+import { SessionManager } from "./session-manager.js";
+
+/** Thrown when several sessions in the same directory carry the same name. */
+export class AmbiguousSessionNameError extends Error {
+	constructor(
+		readonly name: string,
+		readonly matches: SessionInfo[],
+	) {
+		super(`Several sessions in this directory are named "${name}". Use --list-sessions and open one by id.`);
+		this.name = "AmbiguousSessionNameError";
+	}
+}
+
+/**
+ * Look up a session by its user-defined name within one working directory.
+ * Names live in the session's own `session_info` entries, so there is no second index
+ * to keep in sync and a name in one project can never resolve to another project's session.
+ */
+export async function findSessionByName(
+	name: string,
+	cwd: string,
+	sessionDir?: string,
+): Promise<SessionInfo | undefined> {
+	const sessions = await SessionManager.list(cwd, sessionDir);
+	const matches = sessions.filter((session) => session.name === name);
+	if (matches.length > 1) {
+		throw new AmbiguousSessionNameError(name, matches);
+	}
+	return matches[0];
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -5,6 +5,7 @@
  * createAgentSession() options. The SDK does the heavy lifting.
  */
 
+import { rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { type Api, type ImageContent, type Model, modelsAreEqual } from "@earendil-works/pi-ai";
@@ -59,6 +60,7 @@ import { KeybindingsManager } from "./core/keybindings.js";
 import { installFileLogSink, setLogContext } from "./core/logging.js";
 import type { ModelRegistry } from "./core/model-registry.js";
 import { findInitialModel, resolveCliModel, resolveModelScope, type ScopedModel } from "./core/model-resolver.js";
+import { findSessionByName } from "./core/named-sessions.js";
 import { restoreStdout, takeOverStdout } from "./core/output-guard.js";
 import type { CreateAgentSessionOptions } from "./core/sdk.js";
 import {
@@ -68,7 +70,7 @@ import {
 	type SessionCwdIssue,
 } from "./core/session-cwd.js";
 import { canonicalSessionPath, SessionAlreadyActiveError } from "./core/session-lease.js";
-import { SessionManager } from "./core/session-manager.js";
+import { type SessionInfo, SessionManager } from "./core/session-manager.js";
 import { SettingsManager } from "./core/settings-manager.js";
 import { isTelemetryEnabled } from "./core/telemetry.js";
 import { printTimings, resetTimings, time } from "./core/timings.js";
@@ -450,6 +452,17 @@ export async function createSessionManager(
 	sessionDir: string | undefined,
 ): Promise<SessionManager> {
 	const explicitCwdOverride = parsed.cwd ? cwd : undefined;
+
+	if (parsed.sessionName) {
+		const name = parsed.sessionName;
+		const sessionByName = await findSessionByName(name, cwd, sessionDir);
+		if (sessionByName) {
+			return SessionManager.open(sessionByName.path, sessionDir, explicitCwdOverride);
+		}
+		const manager = SessionManager.create(cwd, sessionDir);
+		manager.appendSessionInfo(name);
+		return manager;
+	}
 
 	if (parsed.noSession) {
 		return SessionManager.inMemory();
@@ -1095,6 +1108,42 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 	if (parsed.help) {
 		console.log(formatTopLevelHelp());
+		process.exit(0);
+	}
+
+	if (parsed.listSessions) {
+		const cwd = parsed.cwd ?? process.cwd();
+		const sessions = await SessionManager.list(cwd, parsed.sessionDir);
+		if (sessions.length === 0) {
+			console.log("No sessions in this directory.");
+		} else {
+			for (const s of sessions) {
+				const id = s.id.slice(0, 8);
+				const name = s.name ?? "";
+				const date = s.modified ? new Date(s.modified).toISOString().replace("T", " ").slice(0, 16) : "";
+				const path = s.path.replace(`${cwd}/`, "");
+				console.log(`${id}  ${date}  ${name.padEnd(20)} ${path}`);
+			}
+		}
+		process.exit(0);
+	}
+
+	if (parsed.deleteSession) {
+		const cwd = parsed.cwd ?? process.cwd();
+		const name = parsed.deleteSession;
+		let session: SessionInfo | undefined;
+		try {
+			session = await findSessionByName(name, cwd, parsed.sessionDir);
+		} catch (error: unknown) {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exit(1);
+		}
+		if (!session) {
+			console.log(`No session named "${name}" in this directory.`);
+			process.exit(0);
+		}
+		rmSync(session.path, { force: true });
+		console.log(`Deleted session "${name}".`);
 		process.exit(0);
 	}
 

--- a/packages/coding-agent/test/named-sessions.test.ts
+++ b/packages/coding-agent/test/named-sessions.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseArgs } from "../src/cli/args.js";
+import { ENV_SESSION_DIR } from "../src/config.js";
+import { AmbiguousSessionNameError, findSessionByName } from "../src/core/named-sessions.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { createSessionManager } from "../src/main.js";
+
+describe("named sessions", () => {
+	let tempDir: string;
+	let sessionDir: string;
+	let previousSessionDir: string | undefined;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "named-sessions-"));
+		sessionDir = join(tempDir, "sessions");
+		previousSessionDir = process.env[ENV_SESSION_DIR];
+		process.env[ENV_SESSION_DIR] = sessionDir;
+	});
+
+	afterEach(() => {
+		if (previousSessionDir === undefined) {
+			delete process.env[ENV_SESSION_DIR];
+		} else {
+			process.env[ENV_SESSION_DIR] = previousSessionDir;
+		}
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("stores the name inside the session it creates", async () => {
+		const created = await createSessionManager(parseArgs(["--name", "demo"]), tempDir, sessionDir);
+
+		const found = await findSessionByName("demo", tempDir, sessionDir);
+
+		expect(found?.id).toBe(created.getSessionId());
+	});
+
+	it("resumes the same session for a repeated name", async () => {
+		const first = await createSessionManager(parseArgs(["--name", "demo"]), tempDir, sessionDir);
+
+		const second = await createSessionManager(parseArgs(["--name", "demo"]), tempDir, sessionDir);
+
+		expect(second.getSessionId()).toBe(first.getSessionId());
+	});
+
+	it("creates separate sessions for different names", async () => {
+		const first = await createSessionManager(parseArgs(["--name", "one"]), tempDir, sessionDir);
+
+		const second = await createSessionManager(parseArgs(["--name", "two"]), tempDir, sessionDir);
+
+		expect(second.getSessionId()).not.toBe(first.getSessionId());
+	});
+
+	it("keeps the same name in two directories apart", async () => {
+		const otherDir = mkdtempSync(join(tmpdir(), "named-sessions-other-"));
+		try {
+			const here = await createSessionManager(parseArgs(["--name", "demo"]), tempDir, sessionDir);
+			const there = await createSessionManager(parseArgs(["--name", "demo"]), otherDir, sessionDir);
+
+			expect(there.getSessionId()).not.toBe(here.getSessionId());
+			expect((await findSessionByName("demo", tempDir, sessionDir))?.id).toBe(here.getSessionId());
+			expect((await findSessionByName("demo", otherDir, sessionDir))?.id).toBe(there.getSessionId());
+		} finally {
+			rmSync(otherDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not resolve a name from another directory", async () => {
+		const otherDir = mkdtempSync(join(tmpdir(), "named-sessions-other-"));
+		try {
+			await createSessionManager(parseArgs(["--name", "demo"]), otherDir, sessionDir);
+
+			expect(await findSessionByName("demo", tempDir, sessionDir)).toBeUndefined();
+		} finally {
+			rmSync(otherDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects an ambiguous name instead of picking one", async () => {
+		const first = SessionManager.create(tempDir, sessionDir);
+		first.appendSessionInfo("demo");
+		const second = SessionManager.create(tempDir, sessionDir);
+		second.appendSessionInfo("demo");
+
+		await expect(findSessionByName("demo", tempDir, sessionDir)).rejects.toThrow(AmbiguousSessionNameError);
+	});
+
+	it("leaves unnamed sessions unnamed", async () => {
+		const created = await createSessionManager(parseArgs([]), tempDir, sessionDir);
+		const sessions = await SessionManager.list(tempDir, sessionDir);
+
+		expect(sessions.find((s) => s.id === created.getSessionId())?.name).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Adds a way to open or resume a session by name instead of by id or path.

- `--name <name>` opens the session with that name, resuming it if it exists and creating it otherwise.
- `--list-sessions` lists the sessions of the current directory with id, date and name.
- `--delete-session <name>` drops a name mapping without touching the session file.

Name lookup first checks the mapping file in the session directory, then falls back to scanning the sessions of the current directory for a stored name, so sessions named through `/name` are found as well. A stale id in the mapping falls back to the scan instead of failing.

Tests: `packages/coding-agent/test/named-sessions.test.ts`, four cases covering resolve, set, delete and auto-naming, isolated through a temporary session directory.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add named sessions with `--name`, `--list-sessions`, and `--delete-session` CLI flags
> - `--name`/`-n` opens an existing session by name in the current directory, or creates a new one with that name if none exists.
> - `--list-sessions` prints all sessions for the working directory (id, modified date, name, path) and exits.
> - `--delete-session <name>` resolves a session by name and deletes it, reporting errors for ambiguous or missing names.
> - `findSessionByName` in [named-sessions.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1294/files#diff-e3fd319b69ac8918f16862348a3eeab51e814eb587495b893517b5570fc6e9cb) filters sessions by name and throws `AmbiguousSessionNameError` when multiple sessions share the same name in one directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bfe652.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->