### PR TITLE
Add line move and word swap to the editor

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed hyperlinks not being clickable in fullscreen mode on terminals that gate native link handling while mouse reporting is active (e.g. Ghostty); left-clicking a link now opens it directly.
+- Added editor motions to reorder text without retyping it: `ctrl+up`/`ctrl+down` move the current line, and `alt+shift+left`/`alt+shift+right` swap the word under the cursor with its neighbor ([#1295](https://github.com/PrimeIntellect-ai/prime-agent/pull/1295) by [@porky11](https://github.com/porky11)).
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -32,6 +32,10 @@ function isAtomicMarker(segment: string): boolean {
 	return segment.length >= 10 && (PASTE_MARKER_SINGLE.test(segment) || IMAGE_MARKER_SINGLE.test(segment));
 }
 
+function isWordSegment(segment: string): boolean {
+	return !isWhitespaceChar(segment) && !isPunctuationChar(segment) && !isAtomicMarker(segment);
+}
+
 /**
  * A segmenter that wraps Intl.Segmenter and merges graphemes that fall
  * within paste or image markers into single atomic segments. This makes cursor
@@ -892,6 +896,23 @@ export class Editor implements Component, Focusable {
 		}
 		if (kb.matches(data, "tui.editor.cursorWordRight")) {
 			this.moveWordForwards();
+			return;
+		}
+
+		if (kb.matches(data, "tui.editor.moveLineUp")) {
+			this.moveLineUp();
+			return;
+		}
+		if (kb.matches(data, "tui.editor.moveLineDown")) {
+			this.moveLineDown();
+			return;
+		}
+		if (kb.matches(data, "tui.editor.swapWordBackward")) {
+			this.swapWordBackward();
+			return;
+		}
+		if (kb.matches(data, "tui.editor.swapWordForward")) {
+			this.swapWordForward();
 			return;
 		}
 
@@ -1774,6 +1795,128 @@ export class Editor implements Component, Focusable {
 		}
 		this.refreshAutocompleteAfterEdit();
 	}
+
+	private moveLineUp(): void {
+		if (this.state.cursorLine <= 0) return;
+		this.pushUndoSnapshot();
+		const line = this.state.lines[this.state.cursorLine];
+		const above = this.state.lines[this.state.cursorLine - 1];
+		if (line === undefined || above === undefined) return;
+		this.state.lines[this.state.cursorLine - 1] = line;
+		this.state.lines[this.state.cursorLine] = above;
+		this.state.cursorLine--;
+		this.setCursorCol(Math.min(this.state.cursorCol, (this.state.lines[this.state.cursorLine] || "").length));
+		if (this.onChange) this.onChange(this.getText());
+		this.refreshAutocompleteAfterEdit();
+	}
+
+	private moveLineDown(): void {
+		if (this.state.cursorLine >= this.state.lines.length - 1) return;
+		this.pushUndoSnapshot();
+		const line = this.state.lines[this.state.cursorLine];
+		const below = this.state.lines[this.state.cursorLine + 1];
+		if (line === undefined || below === undefined) return;
+		this.state.lines[this.state.cursorLine + 1] = line;
+		this.state.lines[this.state.cursorLine] = below;
+		this.state.cursorLine++;
+		this.setCursorCol(Math.min(this.state.cursorCol, (this.state.lines[this.state.cursorLine] || "").length));
+		if (this.onChange) this.onChange(this.getText());
+		this.refreshAutocompleteAfterEdit();
+	}
+
+	private wordRangeAt(line: string, col: number): { start: number; end: number } | null {
+		if (col < 0 || col > line.length) return null;
+		const graphemes = [...this.segment(line)];
+		const starts: number[] = [];
+		let acc = 0;
+		for (const g of graphemes) {
+			starts.push(acc);
+			acc += g.segment.length;
+		}
+		const indexAt = (offset: number): number =>
+			graphemes.findIndex((g, i) => offset >= (starts[i] ?? 0) && offset < (starts[i] ?? 0) + g.segment.length);
+
+		let idx = indexAt(col);
+		if (idx === -1 || !isWordSegment(graphemes[idx]?.segment || "")) {
+			const before = indexAt(col - 1);
+			if (before === -1 || !isWordSegment(graphemes[before]?.segment || "")) return null;
+			idx = before;
+		}
+
+		let start = idx;
+		while (start > 0 && isWordSegment(graphemes[start - 1]?.segment || "")) {
+			start--;
+		}
+		let end = idx;
+		while (end < graphemes.length - 1 && isWordSegment(graphemes[end + 1]?.segment || "")) {
+			end++;
+		}
+		const offset = starts[start] ?? 0;
+		const len = (starts[end] ?? 0) + (graphemes[end]?.segment.length ?? 0) - offset;
+		return { start: offset, end: offset + len };
+	}
+
+	private swapWordBackward(): void {
+		const currentLine = this.state.lines[this.state.cursorLine];
+		if (currentLine === undefined) return;
+		const col = Math.min(this.state.cursorCol, currentLine.length);
+		const word = this.wordRangeAt(currentLine, col);
+		if (!word) return;
+		const beforeGraphemes = [...this.segment(currentLine.slice(0, word.start))];
+		let prevWordEnd = word.start;
+		while (beforeGraphemes.length > 0) {
+			const seg = beforeGraphemes[beforeGraphemes.length - 1]?.segment || "";
+			if (isWordSegment(seg)) break;
+			if (isAtomicMarker(seg)) return;
+			prevWordEnd -= beforeGraphemes.pop()!.segment.length;
+		}
+		const prev = prevWordEnd > 0 ? this.wordRangeAt(currentLine, prevWordEnd - 1) : null;
+		if (!prev) return;
+		const gap = currentLine.slice(prev.end, word.start);
+		const movedWord = currentLine.slice(word.start, word.end);
+		const displacedWord = currentLine.slice(prev.start, prev.end);
+		this.pushUndoSnapshot();
+		this.state.lines[this.state.cursorLine] =
+			currentLine.slice(0, prev.start) + movedWord + gap + displacedWord + currentLine.slice(word.end);
+		this.setCursorCol(prev.start + (col - word.start));
+		if (this.onChange) this.onChange(this.getText());
+		this.refreshAutocompleteAfterEdit();
+	}
+
+	private swapWordForward(): void {
+		const currentLine = this.state.lines[this.state.cursorLine];
+		if (currentLine === undefined) return;
+		const col = Math.min(this.state.cursorCol, currentLine.length);
+		const word = this.wordRangeAt(currentLine, col);
+		if (!word) return;
+		const afterGraphemes = [...this.segment(currentLine.slice(word.end))];
+		let gapLength = 0;
+		let idx = 0;
+		while (idx < afterGraphemes.length) {
+			const seg = afterGraphemes[idx]?.segment || "";
+			if (isWordSegment(seg)) break;
+			if (isAtomicMarker(seg)) return;
+			gapLength += seg.length;
+			idx++;
+		}
+		if (idx >= afterGraphemes.length) return;
+		const nextStart = word.end + gapLength;
+		let nextEnd = nextStart;
+		while (idx < afterGraphemes.length && isWordSegment(afterGraphemes[idx]?.segment || "")) {
+			nextEnd += (afterGraphemes[idx]?.segment || "").length;
+			idx++;
+		}
+		const gap = currentLine.slice(word.end, nextStart);
+		const movedWord = currentLine.slice(word.start, word.end);
+		const displacedWord = currentLine.slice(nextStart, nextEnd);
+		this.pushUndoSnapshot();
+		this.state.lines[this.state.cursorLine] =
+			currentLine.slice(0, word.start) + displacedWord + gap + movedWord + currentLine.slice(nextEnd);
+		this.setCursorCol(col + (nextEnd - word.end));
+		if (this.onChange) this.onChange(this.getText());
+		this.refreshAutocompleteAfterEdit();
+	}
+
 
 	private handleForwardDelete(): void {
 		this.historyIndex = -1; // Exit history browsing mode

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -27,6 +27,10 @@ export interface Keybindings {
 	"tui.editor.yank": true;
 	"tui.editor.yankPop": true;
 	"tui.editor.undo": true;
+	"tui.editor.moveLineUp": true;
+	"tui.editor.moveLineDown": true;
+	"tui.editor.swapWordBackward": true;
+	"tui.editor.swapWordForward": true;
 	// Generic input actions
 	"tui.input.newLine": true;
 	"tui.input.submit": true;
@@ -135,6 +139,26 @@ export const TUI_KEYBINDINGS = {
 	"tui.editor.yank": { defaultKeys: "ctrl+y", description: "Yank", defaultKeyScope: "editor" },
 	"tui.editor.yankPop": { defaultKeys: "alt+y", description: "Yank pop", defaultKeyScope: "editor" },
 	"tui.editor.undo": { defaultKeys: "ctrl+-", description: "Undo", defaultKeyScope: "editor" },
+	"tui.editor.moveLineUp": {
+		defaultKeys: "ctrl+up",
+		description: "Move line up",
+		defaultKeyScope: "editor",
+	},
+	"tui.editor.moveLineDown": {
+		defaultKeys: "ctrl+down",
+		description: "Move line down",
+		defaultKeyScope: "editor",
+	},
+	"tui.editor.swapWordBackward": {
+		defaultKeys: "alt+shift+left",
+		description: "Swap word backward",
+		defaultKeyScope: "editor",
+	},
+	"tui.editor.swapWordForward": {
+		defaultKeys: "alt+shift+right",
+		description: "Swap word forward",
+		defaultKeyScope: "editor",
+	},
 	"tui.input.newLine": {
 		defaultKeys: "shift+enter",
 		description: "Insert newline",

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -4085,4 +4085,76 @@ describe("Editor component", () => {
 			assert.strictEqual(submitted, pastedText);
 		});
 	});
+
+	describe("Line, word and segment moves", () => {
+		function editorWithCursorBefore(text: string, stepsFromEnd: number): Editor {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setText(text);
+			for (let i = 0; i < stepsFromEnd; i++) {
+				editor.handleInput("\x1b[D");
+			}
+			return editor;
+		}
+
+		it("swaps a word backward across whitespace", () => {
+			const editor = editorWithCursorBefore("foo bar", 2);
+			editor.handleInput("\x1b[1;4D");
+			assert.strictEqual(editor.getText(), "bar foo");
+		});
+
+		it("swaps a word forward across whitespace", () => {
+			const editor = editorWithCursorBefore("foo bar", 6);
+			editor.handleInput("\x1b[1;4C");
+			assert.strictEqual(editor.getText(), "bar foo");
+		});
+
+		it("swaps words separated by punctuation instead of freezing", () => {
+			const editor = editorWithCursorBefore("std::vec", 2);
+			editor.handleInput("\x1b[1;4D");
+			assert.strictEqual(editor.getText(), "vec::std");
+		});
+
+		it("swaps words separated by an arrow instead of freezing", () => {
+			const editor = editorWithCursorBefore("foo->bar", 2);
+			editor.handleInput("\x1b[1;4D");
+			assert.strictEqual(editor.getText(), "bar->foo");
+		});
+
+		it("keeps the cursor on the moved word so repeated swaps drag it", () => {
+			const editor = editorWithCursorBefore("one two three", 3);
+			editor.handleInput("\x1b[1;4D");
+			assert.strictEqual(editor.getText(), "one three two");
+			editor.handleInput("\x1b[1;4D");
+			assert.strictEqual(editor.getText(), "three one two");
+		});
+
+		it("drags a word forward with repeated swaps", () => {
+			const editor = editorWithCursorBefore("one two three", 11);
+			editor.handleInput("\x1b[1;4C");
+			assert.strictEqual(editor.getText(), "two one three");
+			editor.handleInput("\x1b[1;4C");
+			assert.strictEqual(editor.getText(), "two three one");
+		});
+
+		it("swaps the word the cursor sits in front of", () => {
+			const editor = editorWithCursorBefore("foo bar", 3);
+			editor.handleInput("\x1b[1;4D");
+			assert.strictEqual(editor.getText(), "bar foo");
+		});
+
+		it("swaps the word the cursor sits behind", () => {
+			const editor = editorWithCursorBefore("foo bar", 4);
+			editor.handleInput("\x1b[1;4C");
+			assert.strictEqual(editor.getText(), "bar foo");
+		});
+
+		it("moves a line up and down", () => {
+			const editor = editorWithCursorBefore("first\nsecond", 3);
+			editor.handleInput("\x1b[1;5A");
+			assert.strictEqual(editor.getText(), "second\nfirst");
+			editor.handleInput("\x1b[1;5B");
+			assert.strictEqual(editor.getText(), "first\nsecond");
+		});
+
+	});
 });


### PR DESCRIPTION
Adds two editor motions for reordering text without retyping it:

- `ctrl+up` / `ctrl+down` move the current line
- `alt+shift+left` / `alt+shift+right` swap the word under the cursor with its neighbor

The word swap keeps the cursor on the moved word, so repeated presses drag it through the line. Separators stay in place: `std::vec` becomes `vec::std`, `foo->bar` becomes `bar->foo`. The word next to the cursor counts too, so the swap works with the cursor sitting directly before or after a word. Paste markers are treated as atomic and stop the swap instead of being torn apart.

Both defaults use chords that are unbound in `packages/tui/src/keybindings.ts` and in `packages/coding-agent/src/core/keybindings.ts`; no existing binding is changed or removed. `alt+up` / `alt+down` would be the more familiar choice for line moves, but they belong to `app.message.navigateOlder` / `app.message.navigateNewer`, which are matched before editor bindings. Happy to switch if you would rather move those.

Tests: nine cases in `packages/tui/test/editor.test.ts` covering both directions, separators, cursor tracking, and the cursor sitting next to a word.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add line move and word swap keybindings to the editor
> - Adds `ctrl+up`/`ctrl+down` to move the current line up or down, swapping it with the adjacent line and keeping the cursor on the moved line.
> - Adds `alt+shift+left`/`alt+shift+right` to swap the word under the cursor with the preceding or following word, preserving intervening whitespace and punctuation.
> - Introduces `wordRangeAt` to locate word boundaries using the existing segmenter, and `isWordSegment` to distinguish word segments from whitespace, punctuation, and atomic markers.
> - All four actions push an undo snapshot, update the line, reposition the cursor, and refresh autocomplete.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98dc5c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->