### PR TITLE
fix(tui): open bare URLs in fullscreen mode

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1161,7 +1161,7 @@ export class SettingsManager {
 		// the application to reproduce that gesture. Preserve native link clicks
 		// by default; users can explicitly enable fullscreen mouse capture.
 		const termProgram = process.env.TERM_PROGRAM?.toLowerCase();
-		const isGhostty = termProgram === "ghostty" || !!process.env.GHOSTTY_RESOURCES_DIR;
+		const isGhostty = termProgram === "ghostty" || (termProgram === undefined && !!process.env.GHOSTTY_RESOURCES_DIR);
 		return !isGhostty;
 	}
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1155,7 +1155,7 @@ export class SettingsManager {
 
 	getFullscreenMouse(): boolean {
 		const configured = this.settings.terminal?.fullscreenMouse;
-		if (configured !== undefined) return configured;
+		if (typeof configured === "boolean") return configured;
 		// Ghostty's native Cmd-click URL handling is suppressed while an
 		// application enables mouse reporting, and SGR cannot encode Command for
 		// the application to reproduce that gesture. Preserve native link clicks

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -45,7 +45,7 @@ export interface TerminalSettings {
 	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
 	showTerminalProgress?: boolean; // default: false (OSC 9;4 terminal progress indicators)
 	fullscreen?: boolean; // default: true (alternate-screen rendering with scrollable transcript)
-	fullscreenMouse?: boolean; // default: true (wheel scrolling in fullscreen; disable if it breaks selection)
+	fullscreenMouse?: boolean; // default: true, except false in Ghostty to preserve native Cmd-click links
 }
 
 export interface ImageSettings {
@@ -1154,7 +1154,15 @@ export class SettingsManager {
 	}
 
 	getFullscreenMouse(): boolean {
-		return this.settings.terminal?.fullscreenMouse ?? true;
+		const configured = this.settings.terminal?.fullscreenMouse;
+		if (configured !== undefined) return configured;
+		// Ghostty's native Cmd-click URL handling is suppressed while an
+		// application enables mouse reporting, and SGR cannot encode Command for
+		// the application to reproduce that gesture. Preserve native link clicks
+		// by default; users can explicitly enable fullscreen mouse capture.
+		const termProgram = process.env.TERM_PROGRAM?.toLowerCase();
+		const isGhostty = termProgram === "ghostty" || !!process.env.GHOSTTY_RESOURCES_DIR;
+		return !isGhostty;
 	}
 
 	setFullscreenMouse(enabled: boolean): void {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1161,7 +1161,11 @@ export class SettingsManager {
 		// the application to reproduce that gesture. Preserve native link clicks
 		// by default; users can explicitly enable fullscreen mouse capture.
 		const termProgram = process.env.TERM_PROGRAM?.toLowerCase();
-		const isGhostty = termProgram === "ghostty" || (termProgram === undefined && !!process.env.GHOSTTY_RESOURCES_DIR);
+		const term = process.env.TERM?.toLowerCase();
+		const isGhostty =
+			termProgram === "ghostty" ||
+			term?.includes("ghostty") === true ||
+			(termProgram === undefined && !!process.env.GHOSTTY_RESOURCES_DIR);
 		return !isGhostty;
 	}
 

--- a/packages/coding-agent/test/fullscreen-mode.test.ts
+++ b/packages/coding-agent/test/fullscreen-mode.test.ts
@@ -9,6 +9,8 @@ describe("fullscreen mode settings", () => {
 	const agentDir = join(testDir, "agent");
 	const projectDir = join(testDir, "project");
 	let savedEnv: string | undefined;
+	let savedTermProgram: string | undefined;
+	let savedGhosttyResourcesDir: string | undefined;
 
 	beforeEach(() => {
 		if (existsSync(testDir)) {
@@ -17,7 +19,11 @@ describe("fullscreen mode settings", () => {
 		mkdirSync(agentDir, { recursive: true });
 		mkdirSync(join(projectDir, ".prime", "agent"), { recursive: true });
 		savedEnv = process.env.PI_FULLSCREEN;
+		savedTermProgram = process.env.TERM_PROGRAM;
+		savedGhosttyResourcesDir = process.env.GHOSTTY_RESOURCES_DIR;
 		delete process.env.PI_FULLSCREEN;
+		delete process.env.TERM_PROGRAM;
+		delete process.env.GHOSTTY_RESOURCES_DIR;
 	});
 
 	afterEach(() => {
@@ -29,11 +35,28 @@ describe("fullscreen mode settings", () => {
 		} else {
 			process.env.PI_FULLSCREEN = savedEnv;
 		}
+		if (savedTermProgram === undefined) delete process.env.TERM_PROGRAM;
+		else process.env.TERM_PROGRAM = savedTermProgram;
+		if (savedGhosttyResourcesDir === undefined) delete process.env.GHOSTTY_RESOURCES_DIR;
+		else process.env.GHOSTTY_RESOURCES_DIR = savedGhosttyResourcesDir;
 	});
 
 	it("defaults to on with mouse enabled", () => {
 		const manager = SettingsManager.create(projectDir, agentDir);
 		expect(manager.getFullscreen()).toBe(true);
+		expect(manager.getFullscreenMouse()).toBe(true);
+	});
+
+	it("preserves native Ghostty link clicks by disabling mouse capture by default", () => {
+		process.env.TERM_PROGRAM = "ghostty";
+		const manager = SettingsManager.create(projectDir, agentDir);
+		expect(manager.getFullscreenMouse()).toBe(false);
+	});
+
+	it("honors an explicit fullscreen mouse setting in Ghostty", () => {
+		process.env.GHOSTTY_RESOURCES_DIR = "/Applications/Ghostty.app/Contents/Resources/ghostty";
+		const manager = SettingsManager.create(projectDir, agentDir);
+		manager.setFullscreenMouse(true);
 		expect(manager.getFullscreenMouse()).toBe(true);
 	});
 

--- a/packages/coding-agent/test/fullscreen-mode.test.ts
+++ b/packages/coding-agent/test/fullscreen-mode.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SettingsManager } from "../src/core/settings-manager.js";
@@ -57,6 +57,14 @@ describe("fullscreen mode settings", () => {
 		process.env.GHOSTTY_RESOURCES_DIR = "/Applications/Ghostty.app/Contents/Resources/ghostty";
 		const manager = SettingsManager.create(projectDir, agentDir);
 		manager.setFullscreenMouse(true);
+		expect(manager.getFullscreenMouse()).toBe(true);
+	});
+
+	it("ignores a malformed null fullscreen mouse setting", () => {
+		process.env.TERM_PROGRAM = "xterm";
+		const settingsPath = join(agentDir, "settings.json");
+		writeFileSync(settingsPath, JSON.stringify({ terminal: { fullscreenMouse: null } }));
+		const manager = SettingsManager.create(projectDir, agentDir);
 		expect(manager.getFullscreenMouse()).toBe(true);
 	});
 

--- a/packages/coding-agent/test/fullscreen-mode.test.ts
+++ b/packages/coding-agent/test/fullscreen-mode.test.ts
@@ -10,6 +10,7 @@ describe("fullscreen mode settings", () => {
 	const projectDir = join(testDir, "project");
 	let savedEnv: string | undefined;
 	let savedTermProgram: string | undefined;
+	let savedTerm: string | undefined;
 	let savedGhosttyResourcesDir: string | undefined;
 
 	beforeEach(() => {
@@ -20,9 +21,11 @@ describe("fullscreen mode settings", () => {
 		mkdirSync(join(projectDir, ".prime", "agent"), { recursive: true });
 		savedEnv = process.env.PI_FULLSCREEN;
 		savedTermProgram = process.env.TERM_PROGRAM;
+		savedTerm = process.env.TERM;
 		savedGhosttyResourcesDir = process.env.GHOSTTY_RESOURCES_DIR;
 		delete process.env.PI_FULLSCREEN;
 		delete process.env.TERM_PROGRAM;
+		delete process.env.TERM;
 		delete process.env.GHOSTTY_RESOURCES_DIR;
 	});
 
@@ -37,6 +40,8 @@ describe("fullscreen mode settings", () => {
 		}
 		if (savedTermProgram === undefined) delete process.env.TERM_PROGRAM;
 		else process.env.TERM_PROGRAM = savedTermProgram;
+		if (savedTerm === undefined) delete process.env.TERM;
+		else process.env.TERM = savedTerm;
 		if (savedGhosttyResourcesDir === undefined) delete process.env.GHOSTTY_RESOURCES_DIR;
 		else process.env.GHOSTTY_RESOURCES_DIR = savedGhosttyResourcesDir;
 	});
@@ -51,6 +56,19 @@ describe("fullscreen mode settings", () => {
 		process.env.TERM_PROGRAM = "ghostty";
 		const manager = SettingsManager.create(projectDir, agentDir);
 		expect(manager.getFullscreenMouse()).toBe(false);
+	});
+
+	it("detects Ghostty through TERM in SSH sessions", () => {
+		process.env.TERM = "xterm-ghostty";
+		const manager = SettingsManager.create(projectDir, agentDir);
+		expect(manager.getFullscreenMouse()).toBe(false);
+	});
+
+	it("honors explicit mouse capture when TERM identifies Ghostty", () => {
+		process.env.TERM = "xterm-ghostty";
+		const manager = SettingsManager.create(projectDir, agentDir);
+		manager.setFullscreenMouse(true);
+		expect(manager.getFullscreenMouse()).toBe(true);
 	});
 
 	it("does not mistake an integrated terminal inheriting Ghostty variables for Ghostty", () => {

--- a/packages/coding-agent/test/fullscreen-mode.test.ts
+++ b/packages/coding-agent/test/fullscreen-mode.test.ts
@@ -53,6 +53,13 @@ describe("fullscreen mode settings", () => {
 		expect(manager.getFullscreenMouse()).toBe(false);
 	});
 
+	it("does not mistake an integrated terminal inheriting Ghostty variables for Ghostty", () => {
+		process.env.TERM_PROGRAM = "vscode";
+		process.env.GHOSTTY_RESOURCES_DIR = "/Applications/Ghostty.app/Contents/Resources/ghostty";
+		const manager = SettingsManager.create(projectDir, agentDir);
+		expect(manager.getFullscreenMouse()).toBe(true);
+	});
+
 	it("honors an explicit fullscreen mouse setting in Ghostty", () => {
 		process.env.GHOSTTY_RESOURCES_DIR = "/Applications/Ghostty.app/Contents/Resources/ghostty";
 		const manager = SettingsManager.create(projectDir, agentDir);

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -7,7 +7,7 @@
 
 import type { TableCellSelectionRegion } from "./selection-metadata.js";
 import { isImageLine } from "./terminal-image.js";
-import { hyperlinkAtColumn, sliceByColumn, stripAnsi, visibleWidth } from "./utils.js";
+import { sliceByColumn, stripAnsi, urlAtColumn, visibleWidth } from "./utils.js";
 
 export const FULLSCREEN_MIN_TRANSCRIPT_ROWS = 3;
 
@@ -635,7 +635,7 @@ export class FullscreenViewport {
 		if (screenRow >= this.lastFrameVisibleHeight) return null;
 		const line = this.lastFrame[this.lastFrameVisibleStart + screenRow];
 		if (line === undefined || isImageLine(line)) return null;
-		return hyperlinkAtColumn(line, screenCol);
+		return urlAtColumn(line, screenCol);
 	}
 
 	/** Row-diff a composed frame against the previous one with absolute addressing. */

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -330,6 +330,7 @@ export class TUI extends Container {
 	private preserveViewportOnNextRender = false; // One-shot: repaint visible viewport in place instead of replaying scrollback
 	private stopped = false;
 	private fullscreenLeftMouseDragged = false;
+	private fullscreenPressedHyperlink: string | null = null;
 	private overlaySelectionRegions: FrameSelectionRegion[] = [];
 
 	// While set, doRender paints fixed frames via the viewport; the inline
@@ -553,6 +554,8 @@ export class TUI extends Container {
 		const enabled = this.shouldEnableFullscreenMouseTracking();
 		if (!enabled) {
 			this.stopSelectionAutoScroll();
+			this.fullscreenLeftMouseDragged = false;
+			this.fullscreenPressedHyperlink = null;
 			this.fullscreen?.viewport.clearSelection();
 		} else if (this.isFullscreenOverlayFocused()) {
 			this.stopSelectionAutoScroll();
@@ -677,6 +680,8 @@ export class TUI extends Container {
 	 */
 	enterFullscreen(options: FullscreenOptions): void {
 		if (this.fullscreen) return;
+		this.fullscreenLeftMouseDragged = false;
+		this.fullscreenPressedHyperlink = null;
 		this.fullscreen = {
 			viewport: new FullscreenViewport(),
 			scroll: options.scroll,
@@ -930,6 +935,9 @@ export class TUI extends Container {
 				event?.button === MOUSE_BUTTON_LEFT && !event.press ? this.fullscreenLeftMouseDragged : false;
 			if (event?.button === MOUSE_BUTTON_LEFT && event.press) {
 				this.fullscreenLeftMouseDragged = event.motion;
+				if (!event.motion) {
+					this.fullscreenPressedHyperlink = fullscreen.viewport.hyperlinkAt(event.y - 1, event.x - 1);
+				}
 			}
 			if (event && !overlayFocused) {
 				const viewport = fullscreen.viewport;
@@ -958,7 +966,7 @@ export class TUI extends Container {
 					this.stopSelectionAutoScroll();
 					viewport.clearSelection();
 					if (event.button === MOUSE_BUTTON_LEFT && !event.motion && !leftReleaseWasDrag) {
-						const url = viewport.hyperlinkAt(event.y - 1, event.x - 1);
+						const url = this.fullscreenPressedHyperlink ?? viewport.hyperlinkAt(event.y - 1, event.x - 1);
 						if (url) this.openHyperlink(url);
 					}
 				}
@@ -980,13 +988,14 @@ export class TUI extends Container {
 				} else if (!event.press) {
 					viewport.clearSelection();
 					if (event.button === MOUSE_BUTTON_LEFT && !event.motion && !leftReleaseWasDrag) {
-						const url = viewport.hyperlinkAt(event.y - 1, event.x - 1);
+						const url = this.fullscreenPressedHyperlink ?? viewport.hyperlinkAt(event.y - 1, event.x - 1);
 						if (url) this.openHyperlink(url);
 					}
 				}
 			}
 			if (event?.button === MOUSE_BUTTON_LEFT && !event.press) {
 				this.fullscreenLeftMouseDragged = false;
+				this.fullscreenPressedHyperlink = null;
 			}
 			return true;
 		}

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -1269,6 +1269,36 @@ export function hyperlinkAtColumn(line: string, column: number): string | null {
 	return null;
 }
 
+/**
+ * Return an explicit OSC 8 URL or terminal-style bare HTTP(S) URL covering a
+ * visible column. OSC 8 remains authoritative when its label resembles a URL.
+ */
+export function urlAtColumn(line: string, column: number): string | null {
+	const explicitUrl = hyperlinkAtColumn(line, column);
+	if (explicitUrl || column < 0) return explicitUrl;
+
+	// Fullscreen normalizes tabs before painting, and strips ANSI without
+	// changing visible columns. Mirror that representation for bare URL spans.
+	const plainText = stripAnsi(line).replace(/\t/g, "   ");
+	const urlPattern = /https?:\/\/[^\s<>"'`]+/giu;
+	for (const match of plainText.matchAll(urlPattern)) {
+		let url = match[0].replace(/[.,;:!?]+$/u, "");
+		for (const [open, close] of [
+			["(", ")"],
+			["[", "]"],
+			["{", "}"],
+		] as const) {
+			while (url.endsWith(close) && url.split(close).length > url.split(open).length) {
+				url = url.slice(0, -1);
+			}
+		}
+		const start = visibleWidth(plainText.slice(0, match.index));
+		const end = start + visibleWidth(url);
+		if (column >= start && column < end) return url;
+	}
+	return null;
+}
+
 // Pooled tracker instance for extractSegments (avoids allocation per call)
 const pooledStyleTracker = new AnsiCodeTracker();
 

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -961,6 +961,45 @@ describe("TUI fullscreen mode", () => {
 		tui.stop();
 	});
 
+	it("clicking a bare URL opens it when OSC 8 metadata is absent", async () => {
+		const transcript = lines(20);
+		transcript[12] = "see https://example.com/docs here";
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;6;1M");
+		// The target can repaint between physical press and release while output streams.
+		transcript[12] = "updated without the URL";
+		tui.requestRender();
+		await terminal.waitForRender();
+		terminal.sendInput("\x1b[<0;6;1m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(opened, ["https://example.com/docs"]);
+
+		tui.stop();
+	});
+
+	it("clicking a hyperlink after a tab opens the painted target", async () => {
+		const transcript = lines(20);
+		transcript[12] = "\t\x1b]8;;https://example.com/docs\x1b\\docs\x1b]8;;\x1b\\";
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// The tab is painted as three spaces, so the link starts at column 4.
+		terminal.sendInput("\x1b[<0;4;1M");
+		terminal.sendInput("\x1b[<0;4;1m");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(opened, ["https://example.com/docs"]);
+
+		tui.stop();
+	});
+
 	it("drag-selecting over a hyperlink copies text without opening it", async () => {
 		const transcript = lines(20);
 		transcript[12] = "see \x1b]8;;https://example.com/docs\x1b\\docs\x1b]8;;\x1b\\ here";

--- a/packages/tui/test/hyperlink-at-column.test.ts
+++ b/packages/tui/test/hyperlink-at-column.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { hyperlinkAtColumn } from "../src/utils.js";
+import { hyperlinkAtColumn, urlAtColumn } from "../src/utils.js";
 
 const ST = "\x1b\\";
 
@@ -30,6 +30,31 @@ describe("hyperlinkAtColumn", () => {
 		assert.strictEqual(hyperlinkAtColumn(line, 1), "https://a.example");
 		assert.strictEqual(hyperlinkAtColumn(line, 2), null);
 		assert.strictEqual(hyperlinkAtColumn(line, 3), "https://b.example");
+	});
+
+	it("detects bare http URLs when OSC 8 metadata is absent", () => {
+		const line = "visit https://example.com/docs, then continue";
+		assert.strictEqual(urlAtColumn(line, 6), "https://example.com/docs");
+		assert.strictEqual(urlAtColumn(line, 29), "https://example.com/docs");
+		assert.strictEqual(urlAtColumn(line, 30), null);
+	});
+
+	it("does not include trailing prose punctuation in bare URLs", () => {
+		const line = "open (https://example.com/path).";
+		assert.strictEqual(urlAtColumn(line, 7), "https://example.com/path");
+		assert.strictEqual(urlAtColumn(line, 30), null);
+	});
+
+	it("prefers an OSC 8 target over a URL-like label", () => {
+		const line = link("https://target.example", "https://label.example");
+		assert.strictEqual(urlAtColumn(line, 10), "https://target.example");
+	});
+
+	it("resolves a link after its painted tab expansion", () => {
+		const line = `   ${link("https://example.com", "docs")}`;
+		assert.strictEqual(hyperlinkAtColumn(line, 2), null);
+		assert.strictEqual(hyperlinkAtColumn(line, 3), "https://example.com");
+		assert.strictEqual(hyperlinkAtColumn(line, 6), "https://example.com");
 	});
 
 	it("counts wide graphemes as two columns", () => {


### PR DESCRIPTION
## Summary

- make fullscreen URL hit-testing recognize visible bare `http(s)` URLs in addition to OSC 8 metadata
- preserve OSC 8 as authoritative when its label differs from its target
- capture the clicked URL on mouse press so streaming/repaints between press and release cannot lose the target
- reset click gesture state across fullscreen/mouse-tracking lifecycle transitions

## Why

#1270 fixed OSC 8 links, but Ghostty's normal plaintext URL detection is also suppressed while fullscreen SGR mouse reporting is active. Plain URLs from tool output, code, or non-OSC rendering therefore still looked like links but could not be opened. Release-time-only lookup was also vulnerable to a frame repaint between physical press and release.

## Real Ghostty behavior

A real-session retest exposed a gap in the initial synthetic-mouse solution: Ghostty's native link gesture is Cmd-click, but fullscreen SGR mouse capture suppresses that native path and the SGR protocol cannot encode macOS Command for Prime Agent to reproduce it. Ghostty now defaults `terminal.fullscreenMouse` to `false`, restoring native Cmd-click in fullscreen. An explicit `terminal.fullscreenMouse: true` still opts into application wheel/drag capture and the app-side URL fallback above.

When testing from a source checkout, rebuild first: `npm run build`. The launcher resolves workspace TUI imports through `packages/tui/dist`, and `./prime-agent.sh --dist` uses the bundled coding-agent build.

## Validation

- full `packages/tui` test suite passed
- focused fullscreen and URL hit-testing tests: **56 passed**
- `npx tsgo --noEmit`
- `npm run build --workspace packages/tui`
- browser smoke and installer checks
- agent tests
- fullscreen settings tests: **7 passed**
- root/package builds including the bundled CLI
- Biome and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UX and input-handling only; no auth, data, or API surface changes, with broad test coverage for URL hit-testing and Ghostty defaults.
> 
> **Overview**
> Improves **link opening in fullscreen** when SGR mouse capture is on, and **changes the default for Ghostty** so native Cmd-click links still work.
> 
> **TUI:** Adds `urlAtColumn` so hit-testing finds visible bare `http(s)` URLs (with tab expansion and punctuation trimming) as well as OSC 8 links, with OSC 8 still winning when both apply. Fullscreen clicks **record the URL on mouse press** and use that on release so streaming repaints between press and release cannot drop the target; click gesture state is cleared when mouse tracking toggles or fullscreen starts.
> 
> **Settings:** When `terminal.fullscreenMouse` is unset, it now defaults to **false in Ghostty** (via `TERM_PROGRAM`, `TERM`, or `GHOSTTY_RESOURCES_DIR` without another `TERM_PROGRAM`), so fullscreen does not enable mouse reporting and block Ghostty’s Cmd-click handling; explicit `true`/`false` in settings still override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8581f9477cf9a8c74f3313ae25cf593cdcbfad7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fullscreen mode to open bare HTTP(S) URLs on click
> - Adds `urlAtColumn()` in [`packages/tui/src/utils.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1299/files#diff-4c3f9017cf74053e3b6aca505c66afe64a6bb0e33edf0348d2f7dc436e594a93) to detect bare HTTP(S) URLs (not just OSC 8 hyperlinks) at a given visible column, trimming trailing punctuation and unmatched brackets.
> - Updates `FullscreenViewport.hyperlinkAt()` in [`packages/tui/src/fullscreen.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1299/files#diff-42a86b3d48ccefac8f35350cb99ab3ee2b645118e506afdecfa086d9aa48e177) to use `urlAtColumn()` instead of `hyperlinkAtColumn()`, enabling clicks on plain URLs.
> - Stores the hyperlink at mouse-down so the correct URL is opened even if the terminal re-renders before mouse-up.
> - Defaults `fullscreenMouse` to `false` in Ghostty terminals (detected via `TERM_PROGRAM`, `TERM`, or `GHOSTTY_RESOURCES_DIR`) to preserve native Cmd-click link handling, while remaining `true` elsewhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8581f94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->