### PR TITLE
Fix transcript scrolling twice per PageUp/PageDown press

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed hyperlinks not being clickable in fullscreen mode on terminals that gate native link handling while mouse reporting is active (e.g. Ghostty); left-clicking a link now opens it directly.
+- Fixed the transcript scrolling twice for a single PageUp or PageDown press on terminals using the Kitty keyboard protocol.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -994,6 +994,10 @@ export class TUI extends Container {
 
 		if (overlayFocused || !fullscreen.viewportControls) return false;
 
+		// A key release repeats the same binding under the Kitty protocol and would
+		// scroll a second time for one keypress.
+		if (isKeyRelease(data)) return false;
+
 		const keybindings = getKeybindings();
 		if (keybindings.matches(data, "tui.viewport.pageUp")) {
 			this.scrollBy(-fullscreen.viewport.pageSize());

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -65,6 +65,7 @@ class LoggingVirtualTerminal extends VirtualTerminal {
 const WHEEL_UP = "\x1b[<64;5;5M";
 const WHEEL_DOWN = "\x1b[<65;5;5M";
 const PAGE_UP = "\x1b[5~";
+const PAGE_UP_RELEASE = "\x1b[5;1:3~";
 const VIEWPORT_TOP = "\x1b[1;4A"; // shift+alt+up
 const FOLLOW = "\x1b[1;6B"; // ctrl+shift+down
 
@@ -289,6 +290,25 @@ describe("TUI fullscreen mode", () => {
 		tui.requestRender();
 		await terminal.waitForRender();
 		assert.strictEqual(terminal.getViewport()[7], "Line 21");
+
+		tui.stop();
+	});
+
+	it("scrolls once per keypress, ignoring the kitty release event", async () => {
+		const { terminal, tui, chat, dock } = setup(lines(30));
+		const editor = new TestComponent();
+		tui.setFocus(editor);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput(PAGE_UP);
+		await terminal.waitForRender();
+		assert.strictEqual(terminal.getViewport()[0], "Line 15");
+
+		// Releasing the key must not scroll a second time.
+		terminal.sendInput(PAGE_UP_RELEASE);
+		await terminal.waitForRender();
+		assert.strictEqual(terminal.getViewport()[0], "Line 15");
 
 		tui.stop();
 	});


### PR DESCRIPTION
Pressing PageUp scrolls the transcript up, and releasing the key scrolls it up again, so one keypress moves two pages. Same for PageDown.

Key release events are filtered only on the path to the focused component:

```ts
if (isKeyRelease(data) && !this.focusedComponent.wantsKeyRelease) return;
```

`handleFullscreenInput`, which evaluates `tui.viewport.pageUp`, `tui.viewport.pageDown`, `tui.viewport.top` and `tui.viewport.follow`, had no such guard. With the Kitty keyboard protocol enabled the terminal also sends a release event, it matches the same binding, and the viewport scrolls a second time. Terminals without the protocol are unaffected, which is why this is easy to miss. Reproduced on Alacritty.

The guard is placed after the mouse handling so mouse reports keep being consumed as before.

The regression test in `packages/tui/test/fullscreen.test.ts` was verified against the unpatched code: it fails without the fix and passes with it.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix transcript scrolling twice per PageUp/PageDown press on Kitty protocol terminals
> Terminals using the Kitty keyboard protocol send both key press and key release events, causing PageUp/PageDown to scroll the transcript twice. A guard in the [TUI fullscreen input handler](https://github.com/PrimeIntellect-ai/prime-agent/pull/1303/files#diff-0aed3a4b69095fa2ae0cffa8689c7dad409e8b36ab77544b0defb1474fde7311) now calls `isKeyRelease()` and returns early for release events, so each keypress scrolls exactly once.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0bff26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->