### PR TITLE
fix(goals): park after empty continuation turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed active goals repeatedly waking after an empty assistant turn; goals now remain active until new input arrives, with continuation wakes coalesced into the lower-tray counter.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3195,11 +3195,23 @@ export class AgentSession {
 		}
 	}
 
+	private _isQuiescentGoalBoundary(message: AssistantMessage): boolean {
+		if (message.stopReason === "error" || message.stopReason === "aborted") {
+			return false;
+		}
+		return !message.content.some(
+			(content) => (content.type === "text" && content.text.trim().length > 0) || content.type === "toolCall",
+		);
+	}
+
 	private async _getContinuationMessages(
 		context: GetContinuationMessagesContext,
 		signal?: AbortSignal,
 	): Promise<AgentMessage[]> {
 		if (this.queuedActionCount > 0) {
+			return [];
+		}
+		if (this._goalState.status === "active" && this._isQuiescentGoalBoundary(context.message)) {
 			return [];
 		}
 		const arrivalEpoch = this._sessionInputArrivalEpoch;

--- a/packages/coding-agent/src/core/goals.ts
+++ b/packages/coding-agent/src/core/goals.ts
@@ -167,7 +167,7 @@ export function createGoalContextMessage(
 		role: "custom",
 		customType: GOAL_CONTEXT_CUSTOM_TYPE,
 		content,
-		display: true,
+		display: kind !== "continuation",
 		details: {
 			kind,
 			goalId: goal.goalId,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6085,8 +6085,10 @@ export class InteractiveMode {
 	private getTrayGoalLabel(): string | undefined {
 		const goal = this.getGoalState();
 		switch (goal.status) {
-			case "active":
-				return `Pursuing goal (${this.formatGoalElapsed(goal.timeUsedSeconds)})`;
+			case "active": {
+				const wakeLabel = `${goal.continuationsUsed} wake${goal.continuationsUsed === 1 ? "" : "s"}`;
+				return `Pursuing goal (${this.formatGoalElapsed(goal.timeUsedSeconds)} · ${wakeLabel})`;
+			}
 			case "paused":
 				return `Goal paused (${this.formatGoalElapsed(goal.timeUsedSeconds)})`;
 			case "budget_limited":

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -3980,7 +3980,7 @@ describe("InteractiveMode tray goal label", () => {
 		};
 		fakeThis.uiServices = { getContextUsage: () => undefined };
 
-		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s)");
+		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s · 1 wake)");
 	});
 
 	test("combines active goals with token/context usage in one lower-tray label", () => {
@@ -3993,13 +3993,13 @@ describe("InteractiveMode tray goal label", () => {
 				objective: "finish the task",
 				tokensUsed: 0,
 				timeUsedSeconds: 65,
-				continuationsUsed: 1,
+				continuationsUsed: 2,
 			} satisfies GoalState,
 			contextUsage: { contextWindow: 100_000, tokens: 75_000, percent: 75 },
 		};
 		fakeThis.uiServices = { getContextUsage: () => undefined };
 
-		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s) · 75k (75%)");
+		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s · 2 wakes) · 75k (75%)");
 	});
 
 	test("combines active goals, active heartbeats, and context usage in one lower-tray label", () => {
@@ -4019,7 +4019,7 @@ describe("InteractiveMode tray goal label", () => {
 		};
 		fakeThis.uiServices = { getContextUsage: () => undefined };
 
-		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s) · 1 heartbeat · 75k (75%)");
+		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s · 1 wake) · 1 heartbeat · 75k (75%)");
 	});
 
 	test("omits the usage segment when token count is unknown", () => {
@@ -4038,7 +4038,7 @@ describe("InteractiveMode tray goal label", () => {
 		};
 		fakeThis.uiServices = { getContextUsage: () => undefined };
 
-		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s)");
+		expect(getTrayContextLabel.call(fakeThis)).toBe("Pursuing goal (1m 05s · 1 wake)");
 	});
 });
 

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -237,6 +237,65 @@ describe("AgentSession goals", () => {
 		expect(harness.getPendingResponseCount()).toBe(0);
 	});
 
+	it("processes queued input before parking an empty goal boundary", async () => {
+		let releaseMessageEnd: (() => void) | undefined;
+		const blockedMessageEnd = new Promise<void>((resolve) => {
+			releaseMessageEnd = resolve;
+		});
+		let didBlock = false;
+		const extension: ExtensionFactory = (pi) => {
+			pi.on("message_end", async (event) => {
+				if (event.message.role === "assistant" && !didBlock) {
+					didBlock = true;
+					await blockedMessageEnd;
+				}
+			});
+		};
+		const sessionRef: { current?: AgentSession } = {};
+		const harness = await createHarness({
+			tools: [createFauxIpythonTool(sessionRef)],
+			extensionFactories: [extension],
+		});
+		sessionRef.current = harness.session;
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(""),
+			fauxAssistantMessage("Answered the follow-up."),
+			fauxAssistantMessage(fauxToolCall("ipython", COMPLETE_GOAL_CELL), { stopReason: "toolUse" }),
+			fauxAssistantMessage("Goal complete."),
+		]);
+
+		const promptPromise = harness.session.prompt("/goal finish the task");
+		await waitForCondition(() => didBlock);
+		const followUpPromise = harness.session.prompt("Use this new information.", { streamingBehavior: "followUp" });
+		releaseMessageEnd?.();
+		await Promise.all([promptPromise, followUpPromise]);
+
+		expect(visibleAssistantTexts(harness)).toEqual(["Answered the follow-up.", "Goal complete."]);
+		expect(harness.session.goalState).toMatchObject({ active: false, status: "complete", continuationsUsed: 1 });
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("parks thinking-only goal output without falling through to autonomous continuation", async () => {
+		const sessionRef: { current?: AgentSession } = {};
+		const harness = await createHarness({
+			tools: [createFauxIpythonTool(sessionRef)],
+			autonomous: { enabled: true, maxContinuations: 1 },
+		});
+		sessionRef.current = harness.session;
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage([{ type: "thinking", thinking: "Waiting for external input." }]),
+			fauxAssistantMessage("Should remain unused."),
+		]);
+
+		await harness.session.prompt("/goal finish the task");
+
+		expect(harness.session.goalState).toMatchObject({ active: true, status: "active", continuationsUsed: 0 });
+		expect(harness.session.getAutonomousStatus()).toMatchObject({ continuationsUsed: 0 });
+		expect(harness.getPendingResponseCount()).toBe(1);
+	});
+
 	it("counts tokens from the goal completion turn", async () => {
 		const harness = await createGoalHarness();
 		harness.setResponses([

--- a/packages/coding-agent/test/suite/agent-session-goal.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-goal.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentSession } from "../../src/core/agent-session.js";
 import { AuthStorage } from "../../src/core/auth-storage.js";
 import type { ExtensionFactory } from "../../src/core/extensions/types.js";
-import type { GoalHostResponse } from "../../src/core/goals.js";
+import { createGoalContextMessage, type GoalHostResponse, type GoalState } from "../../src/core/goals.js";
 import { ModelRegistry } from "../../src/core/model-registry.js";
 import { SessionManager } from "../../src/core/session-manager.js";
 import { SettingsManager } from "../../src/core/settings-manager.js";
@@ -185,6 +185,55 @@ describe("AgentSession goals", () => {
 			continuationsUsed: 2,
 			lastReason: "Goal achieved",
 		});
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("hides continuation contexts but keeps actionable goal contexts visible", () => {
+		const goal = {
+			active: true,
+			status: "active",
+			goalId: "goal-1",
+			objective: "finish the task",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			continuationsUsed: 1,
+		} satisfies GoalState;
+
+		expect(createGoalContextMessage(goal, "continuation").display).toBe(false);
+		expect(
+			createGoalContextMessage({ ...goal, status: "budget_limited", active: false }, "budget_limit").display,
+		).toBe(true);
+		expect(createGoalContextMessage(goal, "objective_updated").display).toBe(true);
+	});
+
+	it("parks an active goal after an empty assistant turn and resumes on new input", async () => {
+		const harness = await createGoalHarness();
+		harness.setResponses([
+			fauxAssistantMessage("Made progress."),
+			fauxAssistantMessage(""),
+			fauxAssistantMessage(fauxToolCall("ipython", COMPLETE_GOAL_CELL), { stopReason: "toolUse" }),
+			fauxAssistantMessage("Goal complete."),
+		]);
+
+		await harness.session.prompt("/goal finish the task");
+
+		expect(visibleAssistantTexts(harness)).toEqual(["Made progress."]);
+		expect(harness.session.goalState).toMatchObject({
+			active: true,
+			status: "active",
+			continuationsUsed: 1,
+		});
+		expect(harness.getPendingResponseCount()).toBe(2);
+		const contextsBeforeResume = goalContextMessages(harness);
+		expect(contextsBeforeResume).toHaveLength(2);
+		expect(contextsBeforeResume.every((message) => message.role === "custom" && message.display === false)).toBe(
+			true,
+		);
+
+		await harness.session.prompt("Continue now.");
+
+		expect(visibleAssistantTexts(harness)).toEqual(["Made progress.", "Goal complete."]);
+		expect(harness.session.goalState).toMatchObject({ active: false, status: "complete" });
 		expect(harness.getPendingResponseCount()).toBe(0);
 	});
 


### PR DESCRIPTION
## Summary

- park an active goal when an assistant turn has no non-whitespace text or tool call
- keep the goal active so later external input resumes it normally
- hide repeated continuation prompt panels and show the existing continuation count in the fixed lower tray

## Why

An active goal currently requests another model turn after every natural stop. If the model returns an empty/whitespace-only assistant message while waiting for input, Prime Agent immediately injects another visible `<goal_context>`. This creates a visible wake loop and advances the transcript despite no actionable result.

This change treats that empty result as a quiescent boundary. It does not pause, clear, complete, or error the goal, and it does not change persisted or wire schemas.

## Semantics

- Quiescent: no trimmed text and no tool call (thinking-only is also quiescent).
- Terminal error/abort behavior is unchanged.
- `continuationsUsed` increments only when an actual continuation prompt is issued.
- Continuation contexts remain in model/session history with `display: false`.
- Budget-limit and objective-update contexts remain visible.
- Later user/agent input starts a normal run against the still-active goal.

## Tests

- focused Vitest: 196 passed
- TypeScript: `tsgo --noEmit`
- Biome 2.5.5 on all changed TS files
- installer render check
- browser smoke check

`npm run check` initially resolved a stale hoisted Biome 2.3.5 from the parent checkout, which cannot parse this branch's 2.5.5 config. Running the pinned 2.5.5 CLI directly passed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Park active goals after empty assistant continuation turns
> - `AgentSession._getContinuationMessages` now returns `[]` when the latest assistant message has no tool calls and no non-empty text (detected via new `_isQuiescentGoalBoundary` helper), preventing active goals from looping on empty turns.
> - Continuation goal context messages are hidden from display; only actionable goal contexts remain visible.
> - The lower-tray goal label now shows a wake count (e.g. `· 2 wakes`) for active goals using `continuationsUsed`.
> - Behavioral Change: active goals that previously auto-continued after empty or thinking-only assistant turns will now park until new input arrives.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5a2b1c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->