### PR TITLE
Add ctrl+backspace and ctrl+delete as word delete shortcuts

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed hyperlinks not being clickable in fullscreen mode on terminals that gate native link handling while mouse reporting is active (e.g. Ghostty); left-clicking a link now opens it directly.
+- Added `ctrl+backspace` and `ctrl+delete` as word delete shortcuts, alongside the existing `ctrl+w`, `alt+backspace`, `alt+d` and `alt+delete`.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -113,12 +113,12 @@ export const TUI_KEYBINDINGS = {
 		defaultKeyScope: "editor",
 	},
 	"tui.editor.deleteWordBackward": {
-		defaultKeys: ["ctrl+w", "alt+backspace"],
+		defaultKeys: ["ctrl+w", "ctrl+backspace", "alt+backspace"],
 		description: "Delete word backward",
 		defaultKeyScope: "editor",
 	},
 	"tui.editor.deleteWordForward": {
-		defaultKeys: ["alt+d", "alt+delete"],
+		defaultKeys: ["alt+d", "ctrl+delete", "alt+delete"],
 		description: "Delete word forward",
 		defaultKeyScope: "editor",
 	},

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1445,6 +1445,23 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.getText(), "hello SINGLEworld");
 		});
 
+		it("Ctrl+Backspace deletes the word before the cursor", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setText("hello world");
+
+			editor.handleInput("\x1b[127;5u"); // ctrl+backspace, kitty encoding
+			assert.strictEqual(editor.getText(), "hello ");
+		});
+
+		it("Ctrl+Delete deletes the word after the cursor", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setText("hello world");
+			editor.handleInput("\x01"); // Ctrl+A - go to start
+
+			editor.handleInput("\x1b[3;5~"); // ctrl+delete
+			assert.strictEqual(editor.getText(), " world");
+		});
+
 		it("Alt+D deletes word forward and saves to kill ring", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 


### PR DESCRIPTION
Adds `ctrl+backspace` and `ctrl+delete` as word delete shortcuts. Both actions already exist; this only adds the chords most editors outside the terminal world use for them.

- `tui.editor.deleteWordBackward`: `ctrl+w`, `alt+backspace`, and now `ctrl+backspace`
- `tui.editor.deleteWordForward`: `alt+d`, `alt+delete`, and now `ctrl+delete`

Both chords are unbound in `packages/tui/src/keybindings.ts` and in `packages/coding-agent/src/core/keybindings.ts`, so no existing binding changes.

One caveat worth stating: `ctrl+backspace` only reaches the app on terminals that disambiguate it, meaning the Kitty keyboard protocol or modifyOtherKeys. Without either, the terminal sends a bare `\x08`, which `parseKey` deliberately treats as plain backspace outside Windows Terminal because it is indistinguishable from Ctrl+H. On those terminals the new binding is simply inert, and `ctrl+w` keeps working as before. Tested on Alacritty.

Tests: two cases in `packages/tui/test/editor.test.ts`, verified against the unpatched bindings so they fail without this change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ctrl+backspace` and `ctrl+delete` as word delete shortcuts in the TUI editor
> Extends `defaultKeys` in [keybindings.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1305/files#diff-37682caae521449d71ec7baf447af9ef6725c48fba2e43a93fbd9661814884be) to map `ctrl+backspace` to `deleteWordBackward` and `ctrl+delete` to `deleteWordForward`. Tests cover kitty-encoded sequences (`\x1b[127;5u` and `\x1b[3;5~`) for both operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 061fcac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->