### PR TITLE
feat(acp): advertise executable commands to ACP clients

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added an ACP `available_commands_update` after `session/new`, so ACP clients can complete the session commands, skills, prompt templates, and extension commands a prompt turn actually executes.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added an ACP `available_commands_update` after `session/new`, so ACP clients can complete the session commands, skills, prompt templates, and extension commands a prompt turn actually executes.
+- Added an ACP `available_commands_update` after `session/new`, so ACP clients can complete the session commands, skills, prompt templates, and extension commands a prompt turn actually executes ([#1308](https://github.com/PrimeIntellect-ai/prime-agent/pull/1308) by [@AndriyPytel](https://github.com/AndriyPytel)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/docs/acp.md
+++ b/packages/coding-agent/docs/acp.md
@@ -42,6 +42,8 @@ Session activity arrives as `session/update` notifications:
 
 After `session/new`, one `available_commands_update` lists the commands a prompt turn executes: the session commands (`compact`, `refine`, `goal`, `autonomous`), skills as `skill:<name>`, prompt templates, and extension commands. Commands that open a TUI selector, such as `/model` and `/settings`, are not advertised — outside the TUI they are ordinary prompt text.
 
+Each name appears once, resolved the way a submitted command is: a session builtin first, then an extension command, then a skill, then a prompt template. The list is an initial snapshot; ACP has no method to reload resources, and a reload from elsewhere raises no session event, so nothing can invalidate it for the life of the connection.
+
 IPython is Prime Agent's model-facing tool, so a cell is a `tool_call` of kind `execute` whose `rawInput` carries the cell source.
 
 ## Prime Agent extensions

--- a/packages/coding-agent/docs/acp.md
+++ b/packages/coding-agent/docs/acp.md
@@ -40,6 +40,8 @@ Session activity arrives as `session/update` notifications:
 | tool finishes | `tool_call_update` (`completed` / `failed`) |
 | shell output | `tool_call` plus incremental `tool_call_update` |
 
+After `session/new`, one `available_commands_update` lists the commands a prompt turn executes: the session commands (`compact`, `refine`, `goal`, `autonomous`), skills as `skill:<name>`, prompt templates, and extension commands. Commands that open a TUI selector, such as `/model` and `/settings`, are not advertised — outside the TUI they are ordinary prompt text.
+
 IPython is Prime Agent's model-facing tool, so a cell is a `tool_call` of kind `execute` whose `rawInput` carries the cell source.
 
 ## Prime Agent extensions

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -11,7 +11,7 @@ import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
 import { InProcessAgentConnection } from "../agent-connection/in-process-agent-connection.js";
-import type { AgentConnection } from "../agent-connection/types.js";
+import type { AgentConnection, AgentConnectionSlashCommand } from "../agent-connection/types.js";
 import { latestAutonomousGateAttempt } from "../headless-completion.js";
 import { type AcpEventMappingState, acpUpdatesForSessionEvent } from "./acp-events.js";
 import { primeAgentMeta } from "./acp-meta.js";
@@ -101,6 +101,7 @@ interface AcpSessionEntry {
 	id: string;
 	abort: AbortController | undefined;
 	unsubscribe: (() => void) | undefined;
+	commandsTimer: ReturnType<typeof setTimeout> | undefined;
 }
 
 /**
@@ -229,11 +230,27 @@ async function turnFailure(connection: AgentConnection, boundary: TurnBoundary):
 }
 
 /**
+ * The order a submitted command is resolved in, mirroring `_normalizeSubmission`:
+ * a session builtin first, then an extension command, then a skill, then a
+ * prompt template. Extension names are already disambiguated upstream, so only
+ * collisions across these sources have to be resolved here.
+ */
+const CONNECTION_COMMAND_PRECEDENCE: Record<AgentConnectionSlashCommand["source"], number> = {
+	extension: 0,
+	skill: 1,
+	prompt: 2,
+};
+
+/**
  * Commands an ACP client can offer for completion.
  *
  * Only commands a prompt actually executes are advertised. The rest of
  * `BUILTIN_SLASH_COMMANDS` opens a TUI selector (`/model`, `/settings`) and has
  * no headless behavior, so listing it would complete to plain prompt text.
+ *
+ * One entry per name, resolved the way a submission is: a client cannot know
+ * which route wins, so advertising both sides of a collision is worse than
+ * advertising the loser not at all.
  */
 async function acpAvailableCommands(connection: AgentConnection): Promise<acp.AvailableCommand[]> {
 	const sessionCommands = BUILTIN_SLASH_COMMANDS.filter((command) => command.execution === "session").map(
@@ -246,14 +263,25 @@ async function acpAvailableCommands(connection: AgentConnection): Promise<acp.Av
 	// Skills, prompt templates, and extension commands. A failure here costs
 	// completion, not the session, so it must not reject session/new.
 	const connectionCommands = await connection.getCommands().catch(() => []);
-	return [
+	const advertised = [
 		...sessionCommands,
-		...connectionCommands.map((command) => ({
-			name: command.name,
-			description: command.description ?? "",
-			...(command.argumentHint ? { input: { hint: command.argumentHint } } : {}),
-		})),
+		...[...connectionCommands]
+			.sort(
+				(left, right) => CONNECTION_COMMAND_PRECEDENCE[left.source] - CONNECTION_COMMAND_PRECEDENCE[right.source],
+			)
+			.map((command) => ({
+				name: command.name,
+				description: command.description ?? "",
+				...(command.argumentHint ? { input: { hint: command.argumentHint } } : {}),
+			})),
 	];
+	// A name that resolves to one route must be advertised once, or a client
+	// completes to an entry whose description belongs to a route that will not run.
+	const byName = new Map<string, acp.AvailableCommand>();
+	for (const command of advertised) {
+		if (!byName.has(command.name)) byName.set(command.name, command);
+	}
+	return [...byName.values()];
 }
 
 export async function runAcpMode(runtimeHost: AgentSessionRuntime): Promise<never> {
@@ -327,7 +355,12 @@ export async function runAcpModeWithConnection(
 				}
 			}
 			const sessionId = randomUUID();
-			const entry: AcpSessionEntry = { id: sessionId, abort: undefined, unsubscribe: undefined };
+			const entry: AcpSessionEntry = {
+				id: sessionId,
+				abort: undefined,
+				unsubscribe: undefined,
+				commandsTimer: undefined,
+			};
 			// Subscribe for the session lifetime, not per prompt turn: prime-agent
 			// subagents are fire-and-forget and keep reporting after the spawning turn
 			// ends, so a turn-scoped subscription would drop their updates. One
@@ -354,16 +387,21 @@ export async function runAcpModeWithConnection(
 			entry.unsubscribe = unsubscribe;
 			session = entry;
 			// Sent after this handler returns: a client cannot route a session
-			// update for a session id it has not been told about yet.
-			setTimeout(() => {
-				void acpAvailableCommands(connection).then((availableCommands) =>
+			// update for a session id it has not been told about yet. The session can
+			// be closed in that gap, so the callback reads resources and notifies only
+			// while it still owns the slot it was scheduled for.
+			entry.commandsTimer = setTimeout(() => {
+				entry.commandsTimer = undefined;
+				if (session !== entry) return;
+				void acpAvailableCommands(connection).then((availableCommands) => {
+					if (session !== entry) return;
 					ctx.client
 						.notify(acp.methods.client.session.update, {
 							sessionId,
 							update: { sessionUpdate: "available_commands_update", availableCommands },
 						})
-						.catch(() => undefined),
-				);
+						.catch(() => undefined);
+				});
 			}, 0);
 			return {
 				sessionId,
@@ -435,6 +473,7 @@ export async function runAcpModeWithConnection(
 			// must abort the connection the same way session/cancel does.
 			const closing = session;
 			session = undefined;
+			if (closing.commandsTimer) clearTimeout(closing.commandsTimer);
 			closing.unsubscribe?.();
 			if (closing.abort) {
 				closing.abort.abort();
@@ -458,6 +497,7 @@ export async function runAcpModeWithConnection(
 	// harness that spawns many short-lived sessions.
 	await handle.closed.catch(() => undefined);
 	session?.abort?.abort();
+	if (session?.commandsTimer) clearTimeout(session.commandsTimer);
 	session?.unsubscribe?.();
 	session = undefined;
 	await connection.dispose().catch(() => undefined);

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -9,6 +9,7 @@ import { VERSION } from "../../config.js";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
+import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
 import { InProcessAgentConnection } from "../agent-connection/in-process-agent-connection.js";
 import type { AgentConnection } from "../agent-connection/types.js";
 import { latestAutonomousGateAttempt } from "../headless-completion.js";
@@ -227,6 +228,34 @@ async function turnFailure(connection: AgentConnection, boundary: TurnBoundary):
 	return undefined;
 }
 
+/**
+ * Commands an ACP client can offer for completion.
+ *
+ * Only commands a prompt actually executes are advertised. The rest of
+ * `BUILTIN_SLASH_COMMANDS` opens a TUI selector (`/model`, `/settings`) and has
+ * no headless behavior, so listing it would complete to plain prompt text.
+ */
+async function acpAvailableCommands(connection: AgentConnection): Promise<acp.AvailableCommand[]> {
+	const sessionCommands = BUILTIN_SLASH_COMMANDS.filter((command) => command.execution === "session").map(
+		(command) => ({
+			name: command.name,
+			description: command.description,
+			...(command.argumentHint ? { input: { hint: command.argumentHint } } : {}),
+		}),
+	);
+	// Skills, prompt templates, and extension commands. A failure here costs
+	// completion, not the session, so it must not reject session/new.
+	const connectionCommands = await connection.getCommands().catch(() => []);
+	return [
+		...sessionCommands,
+		...connectionCommands.map((command) => ({
+			name: command.name,
+			description: command.description ?? "",
+			...(command.argumentHint ? { input: { hint: command.argumentHint } } : {}),
+		})),
+	];
+}
+
 export async function runAcpMode(runtimeHost: AgentSessionRuntime): Promise<never> {
 	const connection = new InProcessAgentConnection(runtimeHost);
 	return runAcpModeWithConnection(connection, {
@@ -324,6 +353,18 @@ export async function runAcpModeWithConnection(
 			// failed subscribe cannot leave the slot occupied and unusable.
 			entry.unsubscribe = unsubscribe;
 			session = entry;
+			// Sent after this handler returns: a client cannot route a session
+			// update for a session id it has not been told about yet.
+			setTimeout(() => {
+				void acpAvailableCommands(connection).then((availableCommands) =>
+					ctx.client
+						.notify(acp.methods.client.session.update, {
+							sessionId,
+							update: { sessionUpdate: "available_commands_update", availableCommands },
+						})
+						.catch(() => undefined),
+				);
+			}, 0);
 			return {
 				sessionId,
 				...(cwdMismatch ? { _meta: primeAgentMeta({ cwd: cwdMismatch }) } : {}),

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -1,3 +1,4 @@
+import { tmpdir } from "node:os";
 import * as acp from "@agentclientprotocol/sdk";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
@@ -5,7 +6,7 @@ import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.j
 import { PRIME_AGENT_META_NAMESPACE } from "../../src/modes/acp/acp-meta.js";
 import { runAcpModeWithConnection } from "../../src/modes/acp/index.js";
 import { InProcessAgentConnection } from "../../src/modes/agent-connection/in-process-agent-connection.js";
-import { createTestResourceLoader } from "../utilities.js";
+import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.js";
 import { createHarness } from "./harness.js";
 
 /** Minimal AgentSessionRuntime host over a real faux-backed AgentSession. */
@@ -131,6 +132,85 @@ describe("ACP mode end to end", () => {
 		expect(
 			update.availableCommands.find((command: acp.AvailableCommand) => command.name === "compact"),
 		).toMatchObject({ input: { hint: "[instructions]" } });
+
+		harness.cleanup();
+	}, 30_000);
+
+	it("advertises one entry per name, resolved the way a submission is", async () => {
+		const sourceInfo = { path: "/x", source: "user", scope: "user", origin: "top-level" } as const;
+		const extensionsResult = await createTestExtensionsResult(
+			[
+				(pi: any) => {
+					// Collides with the builtin session command, which wins at submission.
+					pi.registerCommand("compact", { description: "extension compact", handler: async () => {} });
+					// Collides with the skill below, and an extension command is resolved first.
+					pi.registerCommand("skill:code-review", { description: "extension review", handler: async () => {} });
+				},
+			],
+			tmpdir(),
+		);
+		const harness = await createHarness({
+			resourceLoader: createTestResourceLoader({
+				extensionsResult,
+				skills: [
+					{
+						kind: "markdown",
+						name: "code-review",
+						description: "skill review",
+						filePath: "/skills/code-review/SKILL.md",
+						baseDir: "/skills/code-review",
+						sourceInfo,
+						disableModelInvocation: false,
+					},
+				],
+				prompts: [
+					{
+						name: "skill:code-review",
+						description: "template review",
+						content: "",
+						filePath: "/prompts/review.md",
+						sourceInfo,
+					},
+				],
+			}),
+		});
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const { client, updates } = connectAcpClient(connection);
+
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+
+		const update = await vi.waitFor(() => {
+			const found = updates.find((u) => u.update?.sessionUpdate === "available_commands_update");
+			if (!found) throw new Error("no available_commands_update yet");
+			return found.update;
+		});
+
+		const names = update.availableCommands.map((command: acp.AvailableCommand) => command.name);
+		expect(names.length).toBe(new Set(names).size);
+		const describe = (name: string) =>
+			update.availableCommands.find((command: acp.AvailableCommand) => command.name === name)?.description;
+		// A session builtin is parsed before any extension command.
+		expect(describe("compact")).not.toBe("extension compact");
+		// An extension command is executed before a skill or a prompt template.
+		expect(describe("skill:code-review")).toBe("extension review");
+
+		harness.cleanup();
+	}, 30_000);
+
+	it("does not advertise commands to a session that was closed first", async () => {
+		const harness = await createHarness();
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const { client, updates } = connectAcpClient(connection);
+
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+		// Closing before the deferred callback runs must cancel it: the resources it
+		// would read belong to a session the client has already released.
+		await client.request("session/close", { sessionId: session.sessionId });
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(updates.some((u) => u.update?.sessionUpdate === "available_commands_update")).toBe(false);
 
 		harness.cleanup();
 	}, 30_000);

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -1,10 +1,11 @@
 import * as acp from "@agentclientprotocol/sdk";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.js";
 import { PRIME_AGENT_META_NAMESPACE } from "../../src/modes/acp/acp-meta.js";
 import { runAcpModeWithConnection } from "../../src/modes/acp/index.js";
 import { InProcessAgentConnection } from "../../src/modes/agent-connection/in-process-agent-connection.js";
+import { createTestResourceLoader } from "../utilities.js";
 import { createHarness } from "./harness.js";
 
 /** Minimal AgentSessionRuntime host over a real faux-backed AgentSession. */
@@ -81,6 +82,55 @@ describe("ACP mode end to end", () => {
 			.map((u) => u.update.content.text)
 			.join("");
 		expect(text).toContain("Hello from prime-agent");
+
+		harness.cleanup();
+	}, 30_000);
+
+	it("advertises executable commands after session/new", async () => {
+		const harness = await createHarness({
+			resourceLoader: createTestResourceLoader({
+				skills: [
+					{
+						kind: "markdown",
+						name: "code-review",
+						description: "Review a diff",
+						filePath: "/skills/code-review/SKILL.md",
+						baseDir: "/skills/code-review",
+						sourceInfo: {
+							path: "/skills/code-review/SKILL.md",
+							source: "user",
+							scope: "user",
+							origin: "top-level",
+						},
+						disableModelInvocation: false,
+					},
+				],
+			}),
+		});
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+
+		const { client, updates } = connectAcpClient(connection);
+
+		await client.request("initialize", {
+			protocolVersion: acp.PROTOCOL_VERSION,
+			clientCapabilities: {},
+		});
+		await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+
+		const update = await vi.waitFor(() => {
+			const found = updates.find((u) => u.update?.sessionUpdate === "available_commands_update");
+			if (!found) throw new Error("no available_commands_update yet");
+			return found.update;
+		});
+
+		const names = update.availableCommands.map((command: acp.AvailableCommand) => command.name);
+		expect(names).toContain("compact");
+		expect(names).toContain("skill:code-review");
+		// TUI-only selectors have no headless behavior and must not be offered.
+		expect(names).not.toContain("model");
+		expect(
+			update.availableCommands.find((command: acp.AvailableCommand) => command.name === "compact"),
+		).toMatchObject({ input: { hint: "[instructions]" } });
 
 		harness.cleanup();
 	}, 30_000);

--- a/packages/coding-agent/test/utilities.ts
+++ b/packages/coding-agent/test/utilities.ts
@@ -14,6 +14,7 @@ import { createEventBus } from "../src/core/event-bus.js";
 import type { Extension, ExtensionFactory, LoadExtensionsResult } from "../src/core/extensions/index.js";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../src/core/extensions/loader.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
+import type { PromptTemplate } from "../src/core/prompt-templates.js";
 import type { ResourceLoader } from "../src/core/resource-loader.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
@@ -207,6 +208,7 @@ export async function createTestExtensionsResult(
 export interface CreateTestResourceLoaderOptions {
 	extensionsResult?: LoadExtensionsResult;
 	skills?: Skill[];
+	prompts?: PromptTemplate[];
 }
 
 export function createTestResourceLoader(options: CreateTestResourceLoaderOptions = {}): ResourceLoader {
@@ -219,7 +221,7 @@ export function createTestResourceLoader(options: CreateTestResourceLoaderOption
 	return {
 		getExtensions: () => extensionsResult,
 		getSkills: () => ({ skills: options.skills ?? [], diagnostics: [] }),
-		getPrompts: () => ({ prompts: [], diagnostics: [] }),
+		getPrompts: () => ({ prompts: options.prompts ?? [], diagnostics: [] }),
 		getThemes: () => ({ themes: [], diagnostics: [] }),
 		getAgentsFiles: () => ({ agentsFiles: [] }),
 		getSystemPrompt: () => undefined,


### PR DESCRIPTION
## Context

Discussion: #1354. Issue: #1306.

ACP mode never sends `available_commands_update`, so a client receives no command list for the session and a user has to type `/skill:<name>` blind, while the same session in the TUI completes every one of them.

## Changes

- Send one `available_commands_update` after `session/new`, carrying the session slash commands (`compact`, `refine`, `goal`, `autonomous`) plus everything `connection.getCommands()` returns: skills as `skill:<name>`, prompt templates, and extension commands. `argumentHint` becomes the ACP `input.hint`.
- Leave out builtins whose `execution` is not `"session"`. `/model`, `/settings`, and `/export` open a TUI selector and have no headless behavior, so completing to them would only insert prompt text.
- Schedule the notification with `setTimeout(..., 0)` so it leaves after the `session/new` response: a client cannot route a session update for a session id it has not been told about yet. A `getCommands()` rejection is swallowed, since losing completion must not fail session creation.

## Validation

- `test/suite/acp-mode.test.ts` drives a real `@agentclientprotocol/sdk` client over the in-memory duplex pair, asserts `compact` and `skill:code-review` are present and `model` is absent, and checks the `[instructions]` hint. It fails on `main` with `no available_commands_update yet`.
- `npm run check` passes.
- Verified by hand over stdio against a live ACP client: `session/new` now produces `available_commands_update` with the session commands followed by every loaded skill.

fixes #1306

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Advertise executable commands to ACP clients after session creation
> - After `session/new`, the agent schedules an async `available_commands_update` containing all executable commands: session built-ins (`compact`, `refine`, `goal`, `autonomous`), skills (`skill:<name>`), prompt templates, and extension commands.
> - Commands are deduplicated and precedence-resolved (extension > skill > prompt) in [acp-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1308/files#diff-473a1e95bcc808978b4a7a178715a63a4641e6fd423612a47c6ecdcdb5d111ae), matching the same resolution order used for command submission.
> - TUI-only commands like `/model` and `/settings` are excluded; the list is a snapshot for the connection's lifetime with no reload mechanism.
> - The update is suppressed if the session is closed before the scheduled callback fires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3258e9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
