### PR TITLE
fix(acp): title IPython tool calls by their cell and show the source

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Changed ACP IPython tool calls to be titled by their cell and to carry the cell source as content, so a client no longer shows a column of identical "IPython cell" rows with nothing in them.
+- Changed ACP IPython tool calls to be titled by their cell and to carry the cell source as content, so a client no longer shows a column of identical "IPython cell" rows with nothing in them ([#1309](https://github.com/PrimeIntellect-ai/prime-agent/pull/1309) by [@AndriyPytel](https://github.com/AndriyPytel)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Changed ACP IPython tool calls to be titled by their cell and to carry the cell source as content, so a client no longer shows a column of identical "IPython cell" rows with nothing in them.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/docs/acp.md
+++ b/packages/coding-agent/docs/acp.md
@@ -40,7 +40,7 @@ Session activity arrives as `session/update` notifications:
 | tool finishes | `tool_call_update` (`completed` / `failed`) |
 | shell output | `tool_call` plus incremental `tool_call_update` |
 
-IPython is Prime Agent's model-facing tool, so a cell is a `tool_call` of kind `execute` whose `rawInput` carries the cell source.
+IPython is Prime Agent's model-facing tool, so a cell is a `tool_call` of kind `execute` whose `rawInput` carries the cell source. The call is titled by the cell's first meaningful line, and the source also travels as a fenced content block for clients that render content rather than `rawInput`.
 
 ## Prime Agent extensions
 

--- a/packages/coding-agent/docs/acp.md
+++ b/packages/coding-agent/docs/acp.md
@@ -40,7 +40,7 @@ Session activity arrives as `session/update` notifications:
 | tool finishes | `tool_call_update` (`completed` / `failed`) |
 | shell output | `tool_call` plus incremental `tool_call_update` |
 
-IPython is Prime Agent's model-facing tool, so a cell is a `tool_call` of kind `execute` whose `rawInput` carries the cell source. The call is titled by the cell's first meaningful line, and the source also travels as a fenced content block for clients that render content rather than `rawInput`.
+IPython is Prime Agent's model-facing tool, so a cell is a `tool_call` of kind `execute` whose `rawInput` carries the cell source. The call is titled by the cell's first meaningful line, and the source also travels as a fenced content block for clients that render content rather than `rawInput`. Both treat the cell as untrusted text: the fence outruns the longest backtick run in the source, and control characters and bidi overrides are stripped from the title.
 
 ## Prime Agent extensions
 

--- a/packages/coding-agent/src/modes/acp/acp-events.ts
+++ b/packages/coding-agent/src/modes/acp/acp-events.ts
@@ -64,6 +64,32 @@ function assistantDeltaUpdates(event: AssistantMessageEvent): AcpSessionUpdate[]
 	return [];
 }
 
+const CELL_TITLE_MAX_LENGTH = 120;
+
+/**
+ * One-line label for an IPython cell.
+ *
+ * Every IPython call otherwise carries the same constant title, which leaves an
+ * ACP client rendering a column of identical rows with no way to tell one cell
+ * from the next.
+ */
+function ipythonCellTitle(code: string): string {
+	const lines = code.split("\n").filter((line) => line.trim().length > 0);
+	let title = lines[0]?.trim() ?? "";
+	// A cell magic names the interpreter, not the work, so it needs the first
+	// real line beside it to stay distinguishable from the next magic cell.
+	if (title.startsWith("%%") && lines[1]) title = `${title} \u00b7 ${lines[1].trim()}`;
+	if (!title) return "IPython cell";
+	if (title.length > CELL_TITLE_MAX_LENGTH) title = `${title.slice(0, CELL_TITLE_MAX_LENGTH - 1)}\u2026`;
+	const remaining = lines.length - 1;
+	return remaining > 0 ? `${title} \u00b7 +${remaining} lines` : title;
+}
+
+/** The cell source as a content block, for clients that render no `rawInput`. */
+function ipythonCellContent(code: string): { type: "content"; content: { type: "text"; text: string } } {
+	return { type: "content", content: textContent(["```python", code, "```"].join("\n")) };
+}
+
 /** Extract the IPython cell source so a client can show what is executing. */
 function ipythonCellSource(args: unknown): string | undefined {
 	if (!args || typeof args !== "object") return undefined;
@@ -130,6 +156,8 @@ function ipythonRichOutput(result: unknown): PrimeAgentIpythonMeta | undefined {
  */
 export interface AcpEventMappingState {
 	activeBashRunId?: string;
+	/** Cell source per in-flight IPython call, keyed by tool call id. */
+	ipythonCells?: Map<string, string>;
 }
 
 export function acpUpdatesForSessionEvent(
@@ -143,13 +171,18 @@ export function acpUpdatesForSessionEvent(
 
 		case "tool_execution_start": {
 			const cell = event.toolName === IPYTHON_TOOL_NAME ? ipythonCellSource(event.args) : undefined;
+			if (cell !== undefined) {
+				state.ipythonCells ??= new Map();
+				state.ipythonCells.set(event.toolCallId, cell);
+			}
 			return [
 				{
 					sessionUpdate: "tool_call",
 					toolCallId: event.toolCallId,
-					title: event.toolName === IPYTHON_TOOL_NAME ? "IPython cell" : event.toolName,
+					title: cell !== undefined ? ipythonCellTitle(cell) : event.toolName,
 					kind: acpToolKind(event.toolName),
 					status: "in_progress" satisfies AcpToolStatus,
+					...(cell !== undefined ? { content: [ipythonCellContent(cell)] } : {}),
 					rawInput: cell !== undefined ? { code: cell } : event.args,
 				},
 			];
@@ -158,12 +191,21 @@ export function acpUpdatesForSessionEvent(
 		case "tool_execution_end": {
 			const text = toolResultText(event.result);
 			const rich = event.toolName === IPYTHON_TOOL_NAME ? ipythonRichOutput(event.result) : undefined;
+			// A client replaces a tool call's content on update rather than
+			// appending to it, so the cell has to be repeated here or it vanishes
+			// the moment the call completes.
+			const cell = state.ipythonCells?.get(event.toolCallId);
+			state.ipythonCells?.delete(event.toolCallId);
+			const content = [
+				...(cell !== undefined ? [ipythonCellContent(cell)] : []),
+				...(text ? [{ type: "content", content: textContent(text) }] : []),
+			];
 			return [
 				{
 					sessionUpdate: "tool_call_update",
 					toolCallId: event.toolCallId,
 					status: (event.isError ? "failed" : "completed") satisfies AcpToolStatus,
-					...(text ? { content: [{ type: "content", content: textContent(text) }] } : {}),
+					...(content.length > 0 ? { content } : {}),
 					...(rich ? { _meta: primeAgentMeta({ ipython: rich }) } : {}),
 				},
 			];

--- a/packages/coding-agent/src/modes/acp/acp-events.ts
+++ b/packages/coding-agent/src/modes/acp/acp-events.ts
@@ -67,6 +67,14 @@ function assistantDeltaUpdates(event: AssistantMessageEvent): AcpSessionUpdate[]
 const CELL_TITLE_MAX_LENGTH = 120;
 
 /**
+ * Cell source is untrusted text, and a title is rendered as a single UI line.
+ *
+ * Control characters and bidi overrides survive the line split, so without this
+ * a cell can reorder or blank out the row that claims to describe it.
+ */
+const TITLE_UNSAFE = /[\u0000-\u0008\u000b-\u001f\u007f-\u009f\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
+
+/**
  * One-line label for an IPython cell.
  *
  * Every IPython call otherwise carries the same constant title, which leaves an
@@ -74,7 +82,10 @@ const CELL_TITLE_MAX_LENGTH = 120;
  * from the next.
  */
 function ipythonCellTitle(code: string): string {
-	const lines = code.split("\n").filter((line) => line.trim().length > 0);
+	const lines = code
+		.replace(TITLE_UNSAFE, "")
+		.split("\n")
+		.filter((line) => line.trim().length > 0);
 	let title = lines[0]?.trim() ?? "";
 	// A cell magic names the interpreter, not the work, so it needs the first
 	// real line beside it to stay distinguishable from the next magic cell.
@@ -85,9 +96,17 @@ function ipythonCellTitle(code: string): string {
 	return remaining > 0 ? `${title} \u00b7 +${remaining} lines` : title;
 }
 
-/** The cell source as a content block, for clients that render no `rawInput`. */
+/**
+ * The cell source as a content block, for clients that render no `rawInput`.
+ *
+ * A cell may legally contain a backtick fence of its own, so the fence has to
+ * outrun the longest run in the source: a fixed three would let the rest of the
+ * cell escape the code block and render as arbitrary Markdown.
+ */
 function ipythonCellContent(code: string): { type: "content"; content: { type: "text"; text: string } } {
-	return { type: "content", content: textContent(["```python", code, "```"].join("\n")) };
+	const longestRun = Math.max(0, ...[...code.matchAll(/`+/g)].map((match) => match[0].length));
+	const fence = "`".repeat(Math.max(3, longestRun + 1));
+	return { type: "content", content: textContent([`${fence}python`, code, fence].join("\n")) };
 }
 
 /** Extract the IPython cell source so a client can show what is executing. */
@@ -168,6 +187,12 @@ export function acpUpdatesForSessionEvent(
 		case "message_update":
 			if (event.message.role !== "assistant") return [];
 			return assistantDeltaUpdates(event.assistantMessageEvent);
+
+		// A cancelled or interrupted call never reports an end, so the run ending
+		// is the point at which a still-held cell is known to be unreachable.
+		case "agent_end":
+			state.ipythonCells?.clear();
+			return [];
 
 		case "tool_execution_start": {
 			const cell = event.toolName === IPYTHON_TOOL_NAME ? ipythonCellSource(event.args) : undefined;

--- a/packages/coding-agent/test/acp-events.test.ts
+++ b/packages/coding-agent/test/acp-events.test.ts
@@ -51,12 +51,58 @@ describe("ACP session event mapping", () => {
 			{
 				sessionUpdate: "tool_call",
 				toolCallId: "call-1",
-				title: "IPython cell",
+				title: "print(1)",
 				kind: "execute",
 				status: "in_progress",
+				content: [{ type: "content", content: { type: "text", text: "```python\nprint(1)\n```" } }],
 				rawInput: { code: "print(1)" },
 			},
 		]);
+	});
+
+	it("titles an IPython call by its cell so two calls are distinguishable", () => {
+		const title = (code: string) =>
+			acpUpdatesForSessionEvent({
+				type: "tool_execution_start",
+				toolCallId: "call-1",
+				toolName: "ipython",
+				args: { code },
+			} as AgentConnectionSessionEvent)[0]?.title;
+
+		expect(title("import os\nos.getcwd()")).toBe("import os \u00b7 +1 lines");
+		// A bare cell magic names the interpreter, not the work being done.
+		expect(title("%%bash\ngit status --short")).toBe("%%bash \u00b7 git status --short \u00b7 +1 lines");
+		expect(title("   ")).toBe("IPython cell");
+		expect(title(`${"x".repeat(200)}`)).toBe(`${"x".repeat(119)}\u2026`);
+	});
+
+	it("repeats the cell on completion, which replaces rather than appends content", () => {
+		const state: AcpEventMappingState = {};
+		acpUpdatesForSessionEvent(
+			{
+				type: "tool_execution_start",
+				toolCallId: "call-1",
+				toolName: "ipython",
+				args: { code: "print(1)" },
+			} as AgentConnectionSessionEvent,
+			state,
+		);
+		const updates = acpUpdatesForSessionEvent(
+			{
+				type: "tool_execution_end",
+				toolCallId: "call-1",
+				toolName: "ipython",
+				result: "1",
+				isError: false,
+			} as AgentConnectionSessionEvent,
+			state,
+		);
+		expect(updates[0]?.content).toEqual([
+			{ type: "content", content: { type: "text", text: "```python\nprint(1)\n```" } },
+			{ type: "content", content: { type: "text", text: "1" } },
+		]);
+		// The entry is dropped once the call ends, so state cannot grow unbounded.
+		expect(state.ipythonCells?.size).toBe(0);
 	});
 
 	it("carries rich IPython output from the fields the tool actually reports", () => {

--- a/packages/coding-agent/test/acp-events.test.ts
+++ b/packages/coding-agent/test/acp-events.test.ts
@@ -74,6 +74,28 @@ describe("ACP session event mapping", () => {
 		expect(title("%%bash\ngit status --short")).toBe("%%bash \u00b7 git status --short \u00b7 +1 lines");
 		expect(title("   ")).toBe("IPython cell");
 		expect(title(`${"x".repeat(200)}`)).toBe(`${"x".repeat(119)}\u2026`);
+		// Cell source is untrusted: a title is one rendered line, and these
+		// characters reorder or blank it out.
+		expect(title("\u202eprint(1)\u0007")).toBe("print(1)");
+	});
+
+	it("fences the cell so its own backticks cannot escape the code block", () => {
+		const content = (code: string) =>
+			(
+				acpUpdatesForSessionEvent({
+					type: "tool_execution_start",
+					toolCallId: "call-1",
+					toolName: "ipython",
+					args: { code },
+				} as AgentConnectionSessionEvent)[0]?.content as { content: { text: string } }[]
+			)[0]?.content.text;
+
+		const fenced = content('print("""```""")');
+		expect(fenced).toBe('````python\nprint("""```""")\n````');
+		// A cell carrying a longer run still has to be outrun, not matched.
+		expect(content("x = '`````'")).toBe("``````python\nx = '`````'\n``````");
+		// Tildes and markup are inert inside a backtick fence.
+		expect(content("~~~\n<script>alert(1)</script>")).toBe("```python\n~~~\n<script>alert(1)</script>\n```");
 	});
 
 	it("repeats the cell on completion, which replaces rather than appends content", () => {
@@ -102,6 +124,25 @@ describe("ACP session event mapping", () => {
 			{ type: "content", content: { type: "text", text: "1" } },
 		]);
 		// The entry is dropped once the call ends, so state cannot grow unbounded.
+		expect(state.ipythonCells?.size).toBe(0);
+	});
+
+	it("releases a cell whose call never reported an end", () => {
+		const state: AcpEventMappingState = {};
+		acpUpdatesForSessionEvent(
+			{
+				type: "tool_execution_start",
+				toolCallId: "cancelled-1",
+				toolName: "ipython",
+				args: { code: "print(1)" },
+			} as AgentConnectionSessionEvent,
+			state,
+		);
+		expect(state.ipythonCells?.size).toBe(1);
+		// A cancelled call reports no end, so the run ending is what releases it.
+		expect(
+			acpUpdatesForSessionEvent({ type: "agent_end", messages: [] } as AgentConnectionSessionEvent, state),
+		).toEqual([]);
 		expect(state.ipythonCells?.size).toBe(0);
 	});
 


### PR DESCRIPTION
## Context

Discussion: #1355. Issue: #1307.

Every IPython tool call reaches an ACP client titled `IPython cell`, with the source only in `rawInput`. Since IPython is the model-facing tool, that is the title of nearly every row in the session, and a client that renders content blocks rather than raw input shows those rows empty.

## Changes

- Title the call by the cell's first meaningful line, with `· +N lines` for the rest. A leading cell magic is paired with the following line, because `%%bash` on its own names the interpreter rather than the work.
- Send the source as a fenced content block on `tool_call`, and repeat it on `tool_call_update`: a client replaces a tool call's content on update instead of appending, so without the repeat the cell disappears the moment the call completes.
- Hold the in-flight cell in `AcpEventMappingState`, which already exists per session for bash correlation, and delete the entry when the call ends so the map cannot grow.

## Validation

- `test/acp-events.test.ts` covers the title for a plain cell, a `%%bash` cell, a blank cell, and a 200-character line, plus completion carrying both the cell and the result with the state entry released.
- `npm run check` passes.

fixes #1307

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Title IPython tool calls by their cell and include cell source as fenced content
> - Adds `ipythonCellTitle` to derive a sanitized, truncated title from the first meaningful line of a cell, with a `+N lines` suffix when additional lines exist.
> - Adds `ipythonCellContent` to wrap cell source in a fenced code block, using a backtick fence longer than any run in the source to prevent fence escapes.
> - Cell source is stored in mapper state on `tool_execution_start` and included as fenced content on both start and completion events; state is cleared on `agent_end`.
> - Behavioral Change: IPython `tool_call` updates now carry a derived title and fenced content block instead of generic defaults; clients that replace content on update (rather than append) will see cell source on completion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 086b88d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
