### PR TITLE
Fetch the live OpenRouter model catalog

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added a shared OpenRouter catalog parser used by live discovery and model generation.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -5,6 +5,7 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { getAnthropicCacheCosts } from "../src/cache-pricing.js";
+import { parseOpenRouterModels } from "../src/openrouter-models.js";
 import { getOpenRouterReasoningCapabilities } from "../src/openrouter-reasoning.js";
 import {
 	CLOUDFLARE_AI_GATEWAY_ANTHROPIC_BASE_URL,
@@ -15,7 +16,6 @@ import {
 import {
 	Api,
 	type AnthropicMessagesCompat,
-	KnownProvider,
 	Model,
 	type OpenAICompletionsCompat,
 } from "../src/types.js";
@@ -747,60 +747,7 @@ function fetchOpenRouterCatalog(): Promise<any[]> {
 
 async function fetchOpenRouterModels(): Promise<Model<any>[]> {
 	try {
-		const models: Model<any>[] = [];
-
-		for (const model of await fetchOpenRouterCatalog()) {
-			// Only include models that support tools
-			if (!model.supported_parameters?.includes("tools")) continue;
-			// :batch routes are asynchronous batch variants, not streaming models
-			if (model.id.endsWith(":batch")) continue;
-
-			// Parse provider from model ID
-			let provider: KnownProvider = "openrouter";
-			let modelKey = model.id;
-
-			modelKey = model.id; // Keep full ID for OpenRouter
-
-			// Parse input modalities
-			const input: ("text" | "image")[] = ["text"];
-			if (model.architecture?.modality?.includes("image")) {
-				input.push("image");
-			}
-
-			// Convert pricing from $/token to $/million tokens. OpenRouter uses
-			// negative values as a placeholder for unknown pricing (e.g. auto-beta).
-			const inputCost = Math.max(0, parseFloat(model.pricing?.prompt || "0")) * 1_000_000;
-			const outputCost = Math.max(0, parseFloat(model.pricing?.completion || "0")) * 1_000_000;
-			const cacheReadCost = Math.max(0, parseFloat(model.pricing?.input_cache_read || "0")) * 1_000_000;
-			const cacheWriteCost = Math.max(0, parseFloat(model.pricing?.input_cache_write || "0")) * 1_000_000;
-			const reasoningCapabilities = getOpenRouterReasoningCapabilities(model);
-
-			const normalizedModel: Model<any> = {
-				id: modelKey,
-				name: model.name,
-				api: "openai-completions",
-				baseUrl: "https://openrouter.ai/api/v1",
-				provider,
-				reasoning: model.supported_parameters?.includes("reasoning") || false,
-				...(reasoningCapabilities?.thinkingLevelMap
-					? { thinkingLevelMap: reasoningCapabilities.thinkingLevelMap }
-					: {}),
-				...(reasoningCapabilities?.supportsReasoningEffort === false
-					? { compat: { supportsReasoningEffort: false } }
-					: {}),
-				input,
-				cost: {
-					input: inputCost,
-					output: outputCost,
-					cacheRead: cacheReadCost,
-					cacheWrite: cacheWriteCost,
-				},
-				contextWindow: model.context_length || 4096,
-				maxTokens: model.top_provider?.max_completion_tokens || 4096,
-			};
-			models.push(normalizedModel);
-		}
-
+		const models = parseOpenRouterModels(await fetchOpenRouterCatalog());
 		console.log(`Fetched ${models.length} tool-capable models from OpenRouter`);
 		return models;
 	} catch (error) {

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -5,6 +5,7 @@ export * from "./api-registry.js";
 export * from "./env-api-keys.js";
 export * from "./log.js";
 export * from "./models.js";
+export * from "./openrouter-models.js";
 export type { BedrockOptions, BedrockThinkingDisplay } from "./providers/amazon-bedrock.js";
 export type { AnthropicEffort, AnthropicOptions, AnthropicThinkingDisplay } from "./providers/anthropic.js";
 export type { AzureOpenAIResponsesOptions } from "./providers/azure-openai-responses.js";

--- a/packages/ai/src/openrouter-models.ts
+++ b/packages/ai/src/openrouter-models.ts
@@ -33,6 +33,7 @@ function parseOpenRouterModel(raw: unknown): Model<"openai-completions"> | undef
 	const id = typeof raw.id === "string" ? raw.id : undefined;
 	if (!id) return undefined;
 	const parameters = stringArray(raw.supported_parameters);
+	// :batch routes are asynchronous batch variants, not streaming models
 	if (!parameters.includes("tools") || id.endsWith(":batch")) return undefined;
 
 	const architecture = isRecord(raw.architecture) ? raw.architecture : {};
@@ -97,5 +98,7 @@ function finitePositive(value: unknown): number | undefined {
 
 function toCost(value: unknown): number {
 	const n = typeof value === "number" ? value : parseFloat(String(value ?? ""));
+	// Convert $/token to $/million tokens. OpenRouter uses negative values as a
+	// placeholder for unknown pricing (e.g. auto-beta).
 	return Number.isFinite(n) && n > 0 ? n * 1_000_000 : 0;
 }

--- a/packages/ai/src/openrouter-models.ts
+++ b/packages/ai/src/openrouter-models.ts
@@ -1,0 +1,108 @@
+import { getOpenRouterReasoningCapabilities } from "./openrouter-reasoning.js";
+import type { Model } from "./types.js";
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+/** Transport overlay matching `generate-models.ts` for DeepSeek V4 OpenRouter routes. */
+const DEEPSEEK_V4_THINKING_LEVEL_MAP = {
+	minimal: null,
+	low: null,
+	medium: null,
+	high: "high",
+	xhigh: "max",
+	max: null,
+} as const;
+
+/**
+ * Parse a page of the OpenRouter model catalog into normalized models.
+ * Skips malformed entries, drops `:batch` routes, and keeps tool-capable text
+ * routes. Throws on a malformed top-level payload. Reasoning levels come from
+ * {@link getOpenRouterReasoningCapabilities}.
+ */
+export function parseOpenRouterModels(payload: unknown): Model<"openai-completions">[] {
+	const data = catalogEntries(payload);
+	const models: Model<"openai-completions">[] = [];
+	for (const raw of data) {
+		const model = parseOpenRouterModel(raw);
+		if (model) models.push(model);
+	}
+	return models;
+}
+
+function catalogEntries(payload: unknown): unknown[] {
+	if (Array.isArray(payload)) return payload;
+	if (isRecord(payload) && Array.isArray(payload.data)) return payload.data;
+	throw new Error("Invalid OpenRouter model catalog payload");
+}
+
+function parseOpenRouterModel(raw: unknown): Model<"openai-completions"> | undefined {
+	if (!isRecord(raw)) return undefined;
+	const id = typeof raw.id === "string" ? raw.id : undefined;
+	if (!id) return undefined;
+	const parameters = stringArray(raw.supported_parameters);
+	if (!parameters.includes("tools") || id.endsWith(":batch")) return undefined;
+
+	const architecture = isRecord(raw.architecture) ? raw.architecture : {};
+	const output = stringArray(architecture.output_modalities);
+	if (output.length > 0 && !output.includes("text")) return undefined;
+
+	const contextWindow = finitePositive(raw.context_length) ?? 4096;
+	const topProvider = isRecord(raw.top_provider) ? raw.top_provider : {};
+	const pricing = isRecord(raw.pricing) ? raw.pricing : {};
+	const reasoningCapabilities = getOpenRouterReasoningCapabilities(raw);
+	const model: Model<"openai-completions"> = {
+		id,
+		name: typeof raw.name === "string" ? raw.name : id,
+		api: "openai-completions",
+		provider: "openrouter",
+		baseUrl: OPENROUTER_BASE_URL,
+		reasoning: parameters.includes("reasoning"),
+		input: hasImageInput(architecture) ? ["text", "image"] : ["text"],
+		cost: {
+			input: toCost(pricing.prompt),
+			output: toCost(pricing.completion),
+			cacheRead: toCost(pricing.input_cache_read),
+			cacheWrite: toCost(pricing.input_cache_write),
+		},
+		contextWindow,
+		maxTokens: Math.min(finitePositive(topProvider.max_completion_tokens) ?? 4096, contextWindow),
+		...(reasoningCapabilities?.thinkingLevelMap ? { thinkingLevelMap: reasoningCapabilities.thinkingLevelMap } : {}),
+		...(reasoningCapabilities?.supportsReasoningEffort === false
+			? { compat: { supportsReasoningEffort: false } }
+			: {}),
+	};
+	if (id.includes("deepseek-v4")) {
+		model.compat = {
+			...model.compat,
+			requiresReasoningContentOnAssistantMessages: true,
+			thinkingFormat: "deepseek",
+		};
+		model.thinkingLevelMap = { ...model.thinkingLevelMap, ...DEEPSEEK_V4_THINKING_LEVEL_MAP };
+	}
+	return model;
+}
+
+function hasImageInput(architecture: Record<string, unknown>): boolean {
+	const modalities = stringArray(architecture.input_modalities);
+	if (modalities.length > 0) return modalities.includes("image");
+	const modality = typeof architecture.modality === "string" ? architecture.modality : "";
+	return modality.split("->")[0].includes("image");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function finitePositive(value: unknown): number | undefined {
+	const n = typeof value === "number" ? value : parseFloat(String(value ?? ""));
+	return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function toCost(value: unknown): number {
+	const n = typeof value === "number" ? value : parseFloat(String(value ?? ""));
+	return Number.isFinite(n) && n > 0 ? n * 1_000_000 : 0;
+}

--- a/packages/ai/src/openrouter-models.ts
+++ b/packages/ai/src/openrouter-models.ts
@@ -3,7 +3,6 @@ import type { Model } from "./types.js";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
-/** Transport overlay matching `generate-models.ts` for DeepSeek V4 OpenRouter routes. */
 const DEEPSEEK_V4_THINKING_LEVEL_MAP = {
 	minimal: null,
 	low: null,
@@ -13,12 +12,6 @@ const DEEPSEEK_V4_THINKING_LEVEL_MAP = {
 	max: null,
 } as const;
 
-/**
- * Parse a page of the OpenRouter model catalog into normalized models.
- * Skips malformed entries, drops `:batch` routes, and keeps tool-capable text
- * routes. Throws on a malformed top-level payload. Reasoning levels come from
- * {@link getOpenRouterReasoningCapabilities}.
- */
 export function parseOpenRouterModels(payload: unknown): Model<"openai-completions">[] {
 	const data = catalogEntries(payload);
 	const models: Model<"openai-completions">[] = [];

--- a/packages/ai/test/openrouter-models.test.ts
+++ b/packages/ai/test/openrouter-models.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+import { getSupportedThinkingLevels } from "../src/models.js";
+import { parseOpenRouterModels } from "../src/openrouter-models.js";
+
+describe("parseOpenRouterModels", () => {
+	const entry = (overrides: Record<string, unknown> = {}) => ({
+		id: "vendor/model",
+		name: "Model",
+		supported_parameters: ["tools"],
+		architecture: { modality: "text->text", input_modalities: ["text"], output_modalities: ["text"] },
+		pricing: { prompt: "0.000001", completion: "0.000002", input_cache_read: "0.0000001" },
+		top_provider: { max_completion_tokens: 8192 },
+		context_length: 32768,
+		...overrides,
+	});
+
+	test("parses a normal entry with structured modalities and pricing", () => {
+		const [model] = parseOpenRouterModels({ data: [entry()] });
+		expect(model.id).toBe("vendor/model");
+		expect(model.api).toBe("openai-completions");
+		expect(model.provider).toBe("openrouter");
+		expect(model.input).toEqual(["text"]);
+		expect(model.cost.input).toBe(1);
+		expect(model.cost.output).toBe(2);
+		expect(Math.abs(model.cost.cacheRead - 0.1)).toBeLessThan(1e-9);
+		expect(model.cost.cacheWrite).toBe(0);
+		expect(model.contextWindow).toBe(32768);
+		expect(model.maxTokens).toBe(8192);
+		expect(model.reasoning).toBe(false);
+	});
+
+	test("accepts a bare data array, the same shape the generator already holds", () => {
+		expect(parseOpenRouterModels([entry()]).map((m) => m.id)).toEqual(["vendor/model"]);
+	});
+
+	test("detects image from structured input_modalities and legacy modality", () => {
+		expect(
+			parseOpenRouterModels({
+				data: [entry({ architecture: { input_modalities: ["text", "image"], output_modalities: ["text"] } })],
+			})[0].input,
+		).toEqual(["text", "image"]);
+		expect(
+			parseOpenRouterModels({
+				data: [entry({ architecture: { modality: "text+image->text", output_modalities: ["text"] } })],
+			})[0].input,
+		).toEqual(["text", "image"]);
+	});
+
+	test("skips non-tool, :batch, and non-text-output entries", () => {
+		const models = parseOpenRouterModels({
+			data: [
+				entry(),
+				entry({ id: "no/tools", supported_parameters: [] }),
+				entry({ id: "vendor/model:batch" }),
+				entry({ id: "vendor/audio", architecture: { output_modalities: ["audio"] } }),
+			],
+		});
+		expect(models.map((m) => m.id)).toEqual(["vendor/model"]);
+	});
+
+	test("uses provider reasoning metadata for mandatory sparse efforts", () => {
+		const [model] = parseOpenRouterModels({
+			data: [
+				entry({
+					supported_parameters: ["tools", "reasoning"],
+					reasoning: { mandatory: true, supported_efforts: ["xhigh", "high", "medium", "low", "minimal"] },
+				}),
+			],
+		});
+		expect(model.reasoning).toBe(true);
+		expect(getSupportedThinkingLevels(model)).toEqual(["minimal", "low", "medium", "high", "xhigh"]);
+	});
+
+	test("treats omitted supported_efforts as a toggle, matching catalog generation", () => {
+		const [model] = parseOpenRouterModels({
+			data: [entry({ supported_parameters: ["tools", "reasoning"], reasoning: { mandatory: false } })],
+		});
+		expect(model.compat?.supportsReasoningEffort).toBe(false);
+		expect(getSupportedThinkingLevels(model)).toEqual(["off", "high"]);
+	});
+
+	test("applies deepseek transport corrections", () => {
+		const [model] = parseOpenRouterModels({
+			data: [entry({ id: "deepseek/deepseek-v4-pro", supported_parameters: ["tools", "reasoning"] })],
+		});
+		expect(model.compat).toEqual({
+			requiresReasoningContentOnAssistantMessages: true,
+			thinkingFormat: "deepseek",
+		});
+		expect(model.thinkingLevelMap?.xhigh).toBe("max");
+	});
+
+	test("clamps maxTokens and treats invalid pricing as zero", () => {
+		const [model] = parseOpenRouterModels({
+			data: [
+				entry({
+					context_length: 10000,
+					top_provider: { max_completion_tokens: 999999 },
+					pricing: { prompt: null, completion: "NaN", input_cache_read: "-5" },
+				}),
+			],
+		});
+		expect(model.maxTokens).toBe(10000);
+		expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+	});
+
+	test("throws on a malformed payload but skips malformed entries", () => {
+		expect(() => parseOpenRouterModels({})).toThrow();
+		expect(parseOpenRouterModels({ data: [{}, 1, "x", entry({ id: 123 })] })).toEqual([]);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added live OpenRouter model discovery so the model browser reflects OpenRouter’s current catalog, with the generated snapshot retained as an offline/failure fallback.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## [Unreleased]
 
-- Added live OpenRouter model discovery so the model browser reflects OpenRouter’s current catalog, with the generated snapshot retained as an offline/failure fallback.
-- Fixed restoring a live-only OpenRouter model when a recent catalog cache omitted it, including saved defaults and `--model openrouter/...`.
+- Added live OpenRouter model discovery so the model browser, session restore, saved defaults, and `--model openrouter/...` use the current catalog, with the generated snapshot retained as an offline/failure fallback.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Added live OpenRouter model discovery so the model browser reflects OpenRouter’s current catalog, with the generated snapshot retained as an offline/failure fallback.
+- Fixed restoring a live-only OpenRouter model when a recent catalog cache omitted it, including saved defaults and `--model openrouter/...`.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/src/cli/list-models.ts
+++ b/packages/coding-agent/src/cli/list-models.ts
@@ -32,6 +32,7 @@ export async function listModels(modelRegistry: ModelRegistry, searchPattern?: s
 		console.error(chalk.yellow(`Warning: errors loading models.json:\n${loadError}`));
 	}
 
+	await modelRegistry.refreshOpenRouterModels();
 	const models = await modelRegistry.refreshAvailableModels();
 
 	if (models.length === 0) {

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -819,28 +819,23 @@ export class ModelRegistry {
 		return this.getAvailable();
 	}
 
-	/** Refresh the live OpenRouter catalog. Catalog queries and OpenRouter restore call this. */
-	async refreshOpenRouterModels(): Promise<void> {
+	async refreshOpenRouterModels(requireId?: string): Promise<void> {
 		if (isOfflineModeEnabled()) return;
 		try {
-			const models = await getOpenRouterModels();
+			const models = await getOpenRouterModels(globalThis.fetch, requireId);
 			if (!models) return;
 			this.liveOpenRouterModels = models;
 			this.loadModels();
 		} catch {
-			// Keep the previous live catalog (or none, falling back to the snapshot).
+			// Keep the previous live catalog, or the snapshot if none was loaded.
 		}
 	}
 
-	/**
-	 * Like find(), but fetches the live OpenRouter catalog when an OpenRouter id
-	 * is missing from the snapshot so session restore can resolve a model picked
-	 * from a previous live catalog.
-	 */
+	/** Resolve an OpenRouter id from the live catalog when it is missing from the snapshot. */
 	async findOrFetch(provider: string, modelId: string): Promise<Model<Api> | undefined> {
 		const existing = this.find(provider, modelId);
 		if (existing || provider !== "openrouter") return existing;
-		await this.refreshOpenRouterModels();
+		await this.refreshOpenRouterModels(modelId);
 		return this.find(provider, modelId);
 	}
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -437,6 +437,10 @@ function resolveOpenRouterCatalog(staticModels: Model<Api>[], live: Model<Api>[]
 			compat: mergeCompat(snapshot.compat, model.compat),
 			featured: snapshot.featured,
 			headers: snapshot.headers,
+			cost: snapshot.cost,
+			maxTokens: snapshot.maxTokens,
+			contextWindow: snapshot.contextWindow,
+			thinkingLevelMap: snapshot.thinkingLevelMap ?? model.thinkingLevelMap,
 		};
 	});
 	const liveIds = new Set(live.map((m) => m.id));
@@ -815,15 +819,29 @@ export class ModelRegistry {
 		return this.getAvailable();
 	}
 
-	/** Refresh the live OpenRouter catalog. Only explicit catalog queries call this. */
+	/** Refresh the live OpenRouter catalog. Catalog queries and OpenRouter restore call this. */
 	async refreshOpenRouterModels(): Promise<void> {
 		if (isOfflineModeEnabled()) return;
 		try {
 			const models = await getOpenRouterModels();
-			if (models) this.liveOpenRouterModels = models;
+			if (!models) return;
+			this.liveOpenRouterModels = models;
+			this.loadModels();
 		} catch {
 			// Keep the previous live catalog (or none, falling back to the snapshot).
 		}
+	}
+
+	/**
+	 * Like find(), but fetches the live OpenRouter catalog when an OpenRouter id
+	 * is missing from the snapshot so session restore can resolve a model picked
+	 * from a previous live catalog.
+	 */
+	async findOrFetch(provider: string, modelId: string): Promise<Model<Api> | undefined> {
+		const existing = this.find(provider, modelId);
+		if (existing || provider !== "openrouter") return existing;
+		await this.refreshOpenRouterModels();
+		return this.find(provider, modelId);
 	}
 
 	private async refreshPrivatePrimeInferenceAuthorization(

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -29,6 +29,7 @@ import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
 import { getAgentDir, VERSION } from "../config.js";
 import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
+import { getOpenRouterModels } from "./openrouter-model-catalog.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import {
 	fetchAuthorizedPrivatePrimeInferenceModelIds,
@@ -421,6 +422,30 @@ function isOfflineModeEnabled(): boolean {
 	return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
 }
 
+function isOpenRouterVirtualAlias(id: string): boolean {
+	return id === "auto" || id.startsWith("openrouter/") || id.startsWith("~");
+}
+
+function resolveOpenRouterCatalog(staticModels: Model<Api>[], live: Model<Api>[] | undefined): Model<Api>[] {
+	if (!live || live.length === 0) return staticModels;
+	const staticById = new Map(staticModels.map((m) => [m.id, m]));
+	const resolved = live.map((model) => {
+		const snapshot = staticById.get(model.id);
+		if (!snapshot) return model;
+		return {
+			...model,
+			compat: mergeCompat(snapshot.compat, model.compat),
+			featured: snapshot.featured,
+			headers: snapshot.headers,
+		};
+	});
+	const liveIds = new Set(live.map((m) => m.id));
+	for (const snapshot of staticModels) {
+		if (!liveIds.has(snapshot.id) && isOpenRouterVirtualAlias(snapshot.id)) resolved.push(snapshot);
+	}
+	return resolved;
+}
+
 /**
  * Model registry - loads and manages models, resolves API keys via AuthStorage.
  */
@@ -437,6 +462,7 @@ export class ModelRegistry {
 	private openAICodexModelsCache: { authFingerprint: string; modelIds: Set<string>; refreshedAt: number } | undefined;
 	private backgroundPrivatePrimeAuthorization: { fingerprint: string; promise: Promise<void> } | undefined;
 	private loadError: string | undefined = undefined;
+	private liveOpenRouterModels: Model<Api>[] | undefined;
 
 	/** Re-register dynamic OAuth providers (e.g. user MCP servers) after refresh() resets the registry. */
 	private onOAuthProvidersReset?: () => void;
@@ -540,7 +566,10 @@ export class ModelRegistry {
 		modelOverrides: Map<string, Map<string, ModelOverride>>,
 	): Model<Api>[] {
 		return getProviders().flatMap((provider) => {
-			const models = getModels(provider as KnownProvider) as Model<Api>[];
+			const models =
+				provider === "openrouter"
+					? resolveOpenRouterCatalog(getModels("openrouter") as Model<Api>[], this.liveOpenRouterModels)
+					: (getModels(provider as KnownProvider) as Model<Api>[]);
 			const providerOverride = overrides.get(provider);
 			const perModelOverrides = modelOverrides.get(provider);
 
@@ -786,6 +815,17 @@ export class ModelRegistry {
 		return this.getAvailable();
 	}
 
+	/** Refresh the live OpenRouter catalog. Only explicit catalog queries call this. */
+	async refreshOpenRouterModels(): Promise<void> {
+		if (isOfflineModeEnabled()) return;
+		try {
+			const models = await getOpenRouterModels();
+			if (models) this.liveOpenRouterModels = models;
+		} catch {
+			// Keep the previous live catalog (or none, falling back to the snapshot).
+		}
+	}
+
 	private async refreshPrivatePrimeInferenceAuthorization(
 		previousPrivateModelIds = new Set(this.authorizedPrivatePrimeInferenceModelIds),
 		previousTeamId = this.authorizedPrivatePrimeInferenceTeamId,
@@ -940,6 +980,7 @@ export class ModelRegistry {
 	}
 
 	async refreshModelCatalog(): Promise<ModelCatalogSnapshot> {
+		await this.refreshOpenRouterModels();
 		const availableModels = await this.refreshAvailableModels();
 		const availablePrivateModels = new Set(
 			availableModels.filter(isPrivatePrimeInferenceModel).map((model) => `${model.provider}/${model.id}`),

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -426,6 +426,14 @@ function isOpenRouterVirtualAlias(id: string): boolean {
 	return id === "auto" || id.startsWith("openrouter/") || id.startsWith("~");
 }
 
+/**
+ * Merge the live OpenRouter catalog with the generated snapshot. The live
+ * catalog is authoritative for membership and capabilities; for ids the
+ * snapshot already knows, the snapshot's curated cost/limit metadata is
+ * deliberately kept, so pricing or limit changes on OpenRouter apply only
+ * once the snapshot is regenerated. Virtual aliases (auto, openrouter/*, ~*)
+ * exist only in the snapshot and are always preserved.
+ */
 function resolveOpenRouterCatalog(staticModels: Model<Api>[], live: Model<Api>[] | undefined): Model<Api>[] {
 	if (!live || live.length === 0) return staticModels;
 	const staticById = new Map(staticModels.map((m) => [m.id, m]));

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -579,6 +579,9 @@ export async function findInitialModel(options: {
 			fallbackMessage: undefined,
 		};
 	}
+	if (defaultProvider === "openrouter" && defaultModelId) {
+		await modelRegistry.findOrFetch(defaultProvider, defaultModelId);
+	}
 	const availableModels = await getAvailableModels();
 
 	// 3. Try saved default from settings

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -626,6 +626,7 @@ export async function restoreModelFromSession(
 	shouldPrintMessages: boolean,
 	modelRegistry: ModelRegistry,
 ): Promise<{ model: Model<Api> | undefined; fallbackMessage: string | undefined }> {
+	await modelRegistry.findOrFetch(savedProvider, savedModelId);
 	const availableModels = await modelRegistry.refreshAvailableModels();
 	const restoredModel = availableModels.find(
 		(candidate) => candidate.provider === savedProvider && candidate.id === savedModelId,

--- a/packages/coding-agent/src/core/openrouter-model-catalog.ts
+++ b/packages/coding-agent/src/core/openrouter-model-catalog.ts
@@ -1,0 +1,57 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { parseOpenRouterModels } from "@earendil-works/pi-ai";
+
+const URL = "https://openrouter.ai/api/v1/models?output_modalities=text";
+const TTL_MS = 5 * 60_000;
+const TIMEOUT_MS = 3_000;
+const BACKOFF_MS = 30_000;
+
+let cached: { models: Model<Api>[]; fetchedAt: number } | undefined;
+let inFlight: Promise<Model<Api>[] | undefined> | undefined;
+let lastAttemptAt = 0;
+
+/** Reset the process-wide cache (exported for tests). */
+export function resetOpenRouterModelCache(): void {
+	cached = undefined;
+	inFlight = undefined;
+	lastAttemptAt = 0;
+}
+
+/**
+ * Fetch the live OpenRouter catalog with a bounded timeout. Returns the last
+ * known-good catalog on a failed or backed-off refresh, `undefined` on a cold
+ * miss, and deduplicates concurrent callers. Offline handling is left to the
+ * caller, which never makes a request in offline mode.
+ */
+export async function getOpenRouterModels(
+	fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<Model<Api>[] | undefined> {
+	const now = Date.now();
+	if (cached && now - cached.fetchedAt < TTL_MS) return cached.models;
+	if (inFlight) return inFlight;
+	if (now - lastAttemptAt < BACKOFF_MS) return cached?.models;
+	lastAttemptAt = now;
+
+	const run = async (): Promise<Model<Api>[] | undefined> => {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+		try {
+			const response = await fetchImpl(URL, { signal: controller.signal });
+			if (!response.ok) return cached?.models;
+			const models = parseOpenRouterModels(await response.json());
+			if (models.length === 0) return cached?.models;
+			cached = { models, fetchedAt: Date.now() };
+			return models;
+		} catch {
+			return cached?.models;
+		} finally {
+			clearTimeout(timer);
+		}
+	};
+	const promise = run();
+	inFlight = promise;
+	void promise.finally(() => {
+		if (inFlight === promise) inFlight = undefined;
+	});
+	return promise;
+}

--- a/packages/coding-agent/src/core/openrouter-model-catalog.ts
+++ b/packages/coding-agent/src/core/openrouter-model-catalog.ts
@@ -1,5 +1,4 @@
-import type { Api, Model } from "@earendil-works/pi-ai";
-import { parseOpenRouterModels } from "@earendil-works/pi-ai";
+import { type Api, type Model, parseOpenRouterModels } from "@earendil-works/pi-ai";
 
 const URL = "https://openrouter.ai/api/v1/models?output_modalities=text";
 const TTL_MS = 5 * 60_000;
@@ -10,26 +9,25 @@ let cached: { models: Model<Api>[]; fetchedAt: number } | undefined;
 let inFlight: Promise<Model<Api>[] | undefined> | undefined;
 let lastAttemptAt = 0;
 
-/** Reset the process-wide cache (exported for tests). */
 export function resetOpenRouterModelCache(): void {
 	cached = undefined;
 	inFlight = undefined;
 	lastAttemptAt = 0;
 }
 
-/**
- * Fetch the live OpenRouter catalog with a bounded timeout. Returns the last
- * known-good catalog on a failed or backed-off refresh, `undefined` on a cold
- * miss, and deduplicates concurrent callers. Offline handling is left to the
- * caller, which never makes a request in offline mode.
- */
+function catalogHasId(models: Model<Api>[] | undefined, id: string | undefined): boolean {
+	return !id || (models?.some((model) => model.id === id) ?? false);
+}
+
+/** Live OpenRouter catalog with TTL, in-flight dedupe, and failure backoff. */
 export async function getOpenRouterModels(
 	fetchImpl: typeof fetch = globalThis.fetch,
+	requireId?: string,
 ): Promise<Model<Api>[] | undefined> {
 	const now = Date.now();
-	if (cached && now - cached.fetchedAt < TTL_MS) return cached.models;
+	if (cached && now - cached.fetchedAt < TTL_MS && catalogHasId(cached.models, requireId)) return cached.models;
 	if (inFlight) return inFlight;
-	if (now - lastAttemptAt < BACKOFF_MS) return cached?.models;
+	if (now - lastAttemptAt < BACKOFF_MS && catalogHasId(cached?.models, requireId)) return cached?.models;
 	lastAttemptAt = now;
 
 	const run = async (): Promise<Model<Api>[] | undefined> => {

--- a/packages/coding-agent/src/core/openrouter-model-catalog.ts
+++ b/packages/coding-agent/src/core/openrouter-model-catalog.ts
@@ -8,11 +8,13 @@ const BACKOFF_MS = 30_000;
 let cached: { models: Model<Api>[]; fetchedAt: number } | undefined;
 let inFlight: Promise<Model<Api>[] | undefined> | undefined;
 let lastAttemptAt = 0;
+const recentlyMissingIds = new Map<string, number>();
 
 export function resetOpenRouterModelCache(): void {
 	cached = undefined;
 	inFlight = undefined;
 	lastAttemptAt = 0;
+	recentlyMissingIds.clear();
 }
 
 function catalogHasId(models: Model<Api>[] | undefined, id: string | undefined): boolean {
@@ -25,10 +27,21 @@ export async function getOpenRouterModels(
 	requireId?: string,
 ): Promise<Model<Api>[] | undefined> {
 	const now = Date.now();
-	if (cached && now - cached.fetchedAt < TTL_MS && catalogHasId(cached.models, requireId)) return cached.models;
-	if (inFlight) return inFlight;
-	if (now - lastAttemptAt < BACKOFF_MS && catalogHasId(cached?.models, requireId)) return cached?.models;
-	lastAttemptAt = now;
+	// A required id that a recent successful fetch did not contain stops forcing
+	// refetches until the TTL elapses; otherwise a session pinned to a delisted
+	// id would bypass the cache and backoff on every restore.
+	const missingSince = requireId ? recentlyMissingIds.get(requireId) : undefined;
+	const wantId = missingSince !== undefined && now - missingSince < TTL_MS ? undefined : requireId;
+
+	if (cached && now - cached.fetchedAt < TTL_MS && catalogHasId(cached.models, wantId)) return cached.models;
+	if (inFlight) {
+		// A concurrent refresh was started without knowledge of wantId; use its
+		// result when it suffices, otherwise fall through to a dedicated fetch.
+		const models = await inFlight;
+		if (catalogHasId(models, wantId)) return models;
+	}
+	if (now - lastAttemptAt < BACKOFF_MS && catalogHasId(cached?.models, wantId)) return cached?.models;
+	lastAttemptAt = Date.now();
 
 	const run = async (): Promise<Model<Api>[] | undefined> => {
 		const controller = new AbortController();
@@ -39,6 +52,7 @@ export async function getOpenRouterModels(
 			const models = parseOpenRouterModels(await response.json());
 			if (models.length === 0) return cached?.models;
 			cached = { models, fetchedAt: Date.now() };
+			if (requireId && !catalogHasId(models, requireId)) recentlyMissingIds.set(requireId, Date.now());
 			return models;
 		} catch {
 			return cached?.models;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -194,7 +194,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	// If session has data, try to restore model from it
 	if (!model && hasExistingSession && existingSession.model) {
-		const restoredModel = modelRegistry.find(existingSession.model.provider, existingSession.model.modelId);
+		const restoredModel = await modelRegistry.findOrFetch(
+			existingSession.model.provider,
+			existingSession.model.modelId,
+		);
 		if (restoredModel && modelRegistry.hasConfiguredAuth(restoredModel)) {
 			model = restoredModel;
 		}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -813,7 +813,10 @@ async function resolvePreparedStartupModel(options: {
 	let modelFallbackMessage: string | undefined;
 
 	if (!model && hasExistingSession && existingSession.model) {
-		const restoredModel = modelRegistry.find(existingSession.model.provider, existingSession.model.modelId);
+		const restoredModel = await modelRegistry.findOrFetch(
+			existingSession.model.provider,
+			existingSession.model.modelId,
+		);
 		if (restoredModel && modelRegistry.hasConfiguredAuth(restoredModel)) {
 			model = restoredModel;
 		}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -763,6 +763,10 @@ async function prepareRuntimeServices(options: {
 		})),
 	];
 
+	if (config.provider === "openrouter" || config.model?.toLowerCase().startsWith("openrouter/")) {
+		await modelRegistry.refreshOpenRouterModels();
+	}
+
 	const modelPatterns = config.models ?? settingsManager.getEnabledModels();
 	const scopedModels =
 		modelPatterns && modelPatterns.length > 0 ? await resolveModelScope(modelPatterns, modelRegistry) : [];

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2704,7 +2704,7 @@ export class AgentDaemon {
 			const modelRegistry = parentState.runtime.services.modelRegistry;
 			let rehydratedModel: Model<Api> | undefined;
 			if (entry.model) {
-				const resolved = modelRegistry.find(entry.model.provider, entry.model.modelId);
+				const resolved = await modelRegistry.findOrFetch(entry.model.provider, entry.model.modelId);
 				if (resolved && (await modelRegistry.canUseModel(resolved))) {
 					rehydratedModel = resolved;
 				}

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -4,9 +4,10 @@ import { join } from "node:path";
 import type { AnthropicMessagesCompat, Api, Context, Model, OpenAICompletionsCompat } from "@earendil-works/pi-ai";
 import { getApiProvider } from "@earendil-works/pi-ai";
 import { getOAuthProvider, registerOAuthProvider } from "@earendil-works/pi-ai/oauth";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { clearApiKeyCache, ModelRegistry, type ProviderConfigInput } from "../src/core/model-registry.js";
+import { resetOpenRouterModelCache } from "../src/core/openrouter-model-catalog.js";
 
 describe("ModelRegistry", () => {
 	let tempDir: string;
@@ -25,6 +26,8 @@ describe("ModelRegistry", () => {
 			rmSync(tempDir, { recursive: true });
 		}
 		clearApiKeyCache();
+		resetOpenRouterModelCache();
+		vi.unstubAllGlobals();
 	});
 
 	/** Create minimal provider config  */
@@ -1123,6 +1126,10 @@ describe("ModelRegistry", () => {
 
 	describe("auth refresh across processes", () => {
 		test("model catalog includes unauthenticated public models and hides private Prime routes", async () => {
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () => ({ ok: false, status: 503, json: async () => ({}) })),
+			);
 			const savedPrimeApiKey = process.env.PRIME_API_KEY;
 			const savedOpenAiApiKey = process.env.OPENAI_API_KEY;
 			delete process.env.PRIME_API_KEY;

--- a/packages/coding-agent/test/openrouter-live-registry.test.ts
+++ b/packages/coding-agent/test/openrouter-live-registry.test.ts
@@ -1,0 +1,133 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { resetOpenRouterModelCache } from "../src/core/openrouter-model-catalog.js";
+
+const rawEntries = [
+	{
+		id: "test/live-new-model",
+		name: "Live New Model",
+		supported_parameters: ["tools", "reasoning"],
+		architecture: {
+			modality: "text+image->text",
+			input_modalities: ["text", "image"],
+			output_modalities: ["text"],
+		},
+		pricing: { prompt: "0.00000125", completion: "0.00000425", input_cache_read: "0.00000015" },
+		top_provider: { max_completion_tokens: null },
+		context_length: 1048576,
+		reasoning: {
+			mandatory: true,
+			supported_efforts: ["xhigh", "high", "medium", "low", "minimal"],
+			default_effort: "medium",
+		},
+	},
+	{
+		id: "deepseek/deepseek-v4-pro",
+		name: "DeepSeek V4 Pro",
+		supported_parameters: ["tools", "reasoning"],
+		architecture: { modality: "text->text", input_modalities: ["text"], output_modalities: ["text"] },
+		pricing: { prompt: "0.000000435", completion: "0.0000019" },
+		top_provider: { max_completion_tokens: 8192 },
+		context_length: 32768,
+		reasoning: { mandatory: false, supported_efforts: ["high", "xhigh"] },
+	},
+];
+
+const liveResponse = (): Partial<Response> => ({ ok: true, status: 200, json: async () => ({ data: rawEntries }) });
+
+describe("ModelRegistry live OpenRouter catalog", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-test-openrouter-live-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = join(tempDir, "models.json");
+		authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		resetOpenRouterModelCache();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => liveResponse() as Response),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		resetOpenRouterModelCache();
+		if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+	});
+
+	test("adds a newly released model from the live catalog", async () => {
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		const snapshot = await registry.refreshModelCatalog();
+		const model = snapshot.models.find((m) => m.provider === "openrouter" && m.id === "test/live-new-model");
+		expect(model).toBeDefined();
+		expect(model?.thinkingLevelMap?.off).toBeNull();
+		expect(model?.input).toEqual(["text", "image"]);
+	});
+
+	test("preserves virtual aliases and snapshot transport compat", async () => {
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		const snapshot = await registry.refreshModelCatalog();
+		expect(snapshot.models.some((m) => m.provider === "openrouter" && m.id === "auto")).toBe(true);
+		expect(snapshot.models.some((m) => m.provider === "openrouter" && m.id.startsWith("~"))).toBe(true);
+		const deepseek = snapshot.models.find((m) => m.provider === "openrouter" && m.id === "deepseek/deepseek-v4-pro");
+		expect(deepseek?.compat).toMatchObject({
+			requiresReasoningContentOnAssistantMessages: true,
+			thinkingFormat: "deepseek",
+		});
+		expect(deepseek?.thinkingLevelMap?.xhigh).toBe("max");
+	});
+
+	test("drops snapshot OpenRouter models that the live catalog omitted", async () => {
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		const snapshot = await registry.refreshModelCatalog();
+		const openrouter = snapshot.models.filter((m) => m.provider === "openrouter");
+		expect(openrouter.some((m) => m.id === "test/live-new-model")).toBe(true);
+		expect(openrouter.some((m) => m.id === "deepseek/deepseek-v4-pro")).toBe(true);
+		expect(openrouter.some((m) => m.id === "auto")).toBe(true);
+		expect(openrouter.some((m) => m.id === "ai21/jamba-large-1.7")).toBe(false);
+	});
+
+	test("a custom same-id model still wins over the live entry", async () => {
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					openrouter: {
+						api: "openai-completions",
+						apiKey: "TEST_KEY",
+						models: [
+							{
+								id: "test/live-new-model",
+								name: "Custom Muse",
+								reasoning: false,
+								input: ["text"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 1000,
+								maxTokens: 100,
+							},
+						],
+					},
+				},
+			}),
+		);
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		await registry.refreshModelCatalog();
+		const model = registry.find("openrouter", "test/live-new-model");
+		expect(model?.name).toBe("Custom Muse");
+		expect(model?.reasoning).toBe(false);
+	});
+
+	test("second refresh retains live models", async () => {
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		await registry.refreshModelCatalog();
+		await registry.refreshModelCatalog();
+		expect(registry.find("openrouter", "test/live-new-model")).toBeDefined();
+	});
+});

--- a/packages/coding-agent/test/openrouter-live-registry.test.ts
+++ b/packages/coding-agent/test/openrouter-live-registry.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { getModel } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
@@ -34,6 +35,16 @@ const rawEntries = [
 		top_provider: { max_completion_tokens: 8192 },
 		context_length: 32768,
 		reasoning: { mandatory: false, supported_efforts: ["high", "xhigh"] },
+	},
+	{
+		id: "moonshotai/kimi-k2.5",
+		name: "MoonshotAI: Kimi K2.5",
+		supported_parameters: ["tools", "reasoning"],
+		architecture: { modality: "text+image->text", input_modalities: ["text", "image"], output_modalities: ["text"] },
+		pricing: { prompt: "0.000999", completion: "0.000999", input_cache_read: "0.000999" },
+		top_provider: { max_completion_tokens: 999999 },
+		context_length: 262144,
+		reasoning: { mandatory: false },
 	},
 ];
 
@@ -129,5 +140,24 @@ describe("ModelRegistry live OpenRouter catalog", () => {
 		await registry.refreshModelCatalog();
 		await registry.refreshModelCatalog();
 		expect(registry.find("openrouter", "test/live-new-model")).toBeDefined();
+	});
+
+	test("findOrFetch loads a live-only OpenRouter model for session restore", async () => {
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		expect(registry.find("openrouter", "test/live-new-model")).toBeUndefined();
+		const restored = await registry.findOrFetch("openrouter", "test/live-new-model");
+		expect(restored?.id).toBe("test/live-new-model");
+		expect(registry.find("openrouter", "test/live-new-model")).toBeDefined();
+	});
+
+	test("keeps snapshot cost and output caps for known OpenRouter ids", async () => {
+		const snapshot = getModel("openrouter", "moonshotai/kimi-k2.5");
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		await registry.refreshModelCatalog();
+		const live = registry.find("openrouter", "moonshotai/kimi-k2.5");
+		expect(live?.maxTokens).toBe(snapshot.maxTokens);
+		expect(live?.cost).toEqual(snapshot.cost);
+		expect(live?.contextWindow).toBe(snapshot.contextWindow);
+		expect(live?.thinkingLevelMap).toEqual(snapshot.thinkingLevelMap);
 	});
 });

--- a/packages/coding-agent/test/openrouter-live-registry.test.ts
+++ b/packages/coding-agent/test/openrouter-live-registry.test.ts
@@ -160,4 +160,18 @@ describe("ModelRegistry live OpenRouter catalog", () => {
 		expect(live?.contextWindow).toBe(snapshot.contextWindow);
 		expect(live?.thinkingLevelMap).toEqual(snapshot.thinkingLevelMap);
 	});
+
+	test("findOrFetch refetches when a fresh cache omitted the restored id", async () => {
+		const fetchMock = vi.mocked(fetch);
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ data: rawEntries.filter((entry) => entry.id !== "test/live-new-model") }),
+		} as Response);
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		await registry.refreshModelCatalog();
+		expect(registry.find("openrouter", "test/live-new-model")).toBeUndefined();
+		expect((await registry.findOrFetch("openrouter", "test/live-new-model"))?.id).toBe("test/live-new-model");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
 });

--- a/packages/coding-agent/test/openrouter-model-catalog.test.ts
+++ b/packages/coding-agent/test/openrouter-model-catalog.test.ts
@@ -1,0 +1,95 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getOpenRouterModels, resetOpenRouterModelCache } from "../src/core/openrouter-model-catalog.js";
+
+const model: Model<Api> = {
+	id: "vendor/live-new",
+	name: "Live New",
+	api: "openai-completions",
+	provider: "openrouter",
+	baseUrl: "https://openrouter.ai/api/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 4000,
+	maxTokens: 1000,
+};
+
+const okResponse = (): Partial<Response> => ({
+	ok: true,
+	status: 200,
+	json: async () => ({
+		data: [
+			{
+				id: "vendor/live-new",
+				name: "Live New",
+				supported_parameters: ["tools"],
+				architecture: { modality: "text->text", input_modalities: ["text"], output_modalities: ["text"] },
+				pricing: {},
+				top_provider: { max_completion_tokens: 1000 },
+				context_length: 4000,
+			},
+		],
+	}),
+});
+
+afterEach(() => resetOpenRouterModelCache());
+
+describe("getOpenRouterModels", () => {
+	test("returns cached results without a second fetch", async () => {
+		const fetchMock = vi.fn(async () => okResponse() as Response);
+		const first = await getOpenRouterModels(fetchMock as typeof fetch);
+		const second = await getOpenRouterModels(fetchMock as typeof fetch);
+		expect(first?.[0].id).toBe("vendor/live-new");
+		expect(second?.[0].id).toBe("vendor/live-new");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("deduplicates concurrent callers", async () => {
+		let resolveGate: (() => void) | undefined;
+		const gate = new Promise<void>((r) => {
+			resolveGate = r;
+		});
+		const fetchMock = vi.fn(async () => {
+			await gate;
+			return okResponse() as Response;
+		});
+		const p1 = getOpenRouterModels(fetchMock as typeof fetch);
+		const p2 = getOpenRouterModels(fetchMock as typeof fetch);
+		resolveGate?.();
+		const [a, b] = await Promise.all([p1, p2]);
+		expect(a?.[0].id).toBe("vendor/live-new");
+		expect(b?.[0].id).toBe("vendor/live-new");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("returns undefined on a cold failure", async () => {
+		const fetchMock = vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) }) as Response);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toBeUndefined();
+	});
+
+	test("returns last-known-good on a later failure and backs off", async () => {
+		vi.useFakeTimers();
+		const start = Date.now();
+		const fetchMock = vi
+			.fn(async () => okResponse() as Response)
+			.mockResolvedValueOnce(okResponse() as Response)
+			.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) } as Response);
+		await getOpenRouterModels(fetchMock as typeof fetch);
+		vi.setSystemTime(start + 5 * 60_000 + 1);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toEqual([model]);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toEqual([model]);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		vi.useRealTimers();
+	});
+
+	test("returns undefined on a malformed payload", async () => {
+		const fetchMock = vi.fn(async () => ({ ...okResponse(), json: async () => ({ not: "data" }) }) as Response);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toBeUndefined();
+	});
+
+	test("treats a zero-valid-model payload as a failure", async () => {
+		const fetchMock = vi.fn(async () => ({ ...okResponse(), json: async () => ({ data: [{}] }) }) as Response);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/openrouter-model-catalog.test.ts
+++ b/packages/coding-agent/test/openrouter-model-catalog.test.ts
@@ -116,4 +116,36 @@ describe("getOpenRouterModels", () => {
 		expect(await getOpenRouterModels(fetchMock as typeof fetch, "vendor/live-new")).toEqual([model]);
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
+
+	test("requireId refetches when a concurrent general refresh lacks the id", async () => {
+		let resolveGate: (() => void) | undefined;
+		const gate = new Promise<void>((r) => {
+			resolveGate = r;
+		});
+		const fetchMock = vi
+			.fn(async () => okResponse("vendor/later") as Response)
+			.mockImplementationOnce(async () => {
+				await gate;
+				return okResponse() as Response;
+			});
+		const general = getOpenRouterModels(fetchMock as typeof fetch);
+		const restore = getOpenRouterModels(fetchMock as typeof fetch, "vendor/later");
+		resolveGate?.();
+		expect((await general)?.[0].id).toBe("vendor/live-new");
+		expect((await restore)?.[0].id).toBe("vendor/later");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test("stops refetching for a requireId a fresh catalog did not contain", async () => {
+		vi.useFakeTimers();
+		const start = Date.now();
+		const fetchMock = vi.fn(async () => okResponse() as Response);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch, "vendor/gone")).toEqual([model]);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch, "vendor/gone")).toEqual([model]);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		vi.setSystemTime(start + 5 * 60_000 + 1);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch, "vendor/gone")).toEqual([model]);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		vi.useRealTimers();
+	});
 });

--- a/packages/coding-agent/test/openrouter-model-catalog.test.ts
+++ b/packages/coding-agent/test/openrouter-model-catalog.test.ts
@@ -15,13 +15,13 @@ const model: Model<Api> = {
 	maxTokens: 1000,
 };
 
-const okResponse = (): Partial<Response> => ({
+const okResponse = (id = "vendor/live-new"): Partial<Response> => ({
 	ok: true,
 	status: 200,
 	json: async () => ({
 		data: [
 			{
-				id: "vendor/live-new",
+				id,
 				name: "Live New",
 				supported_parameters: ["tools"],
 				architecture: { modality: "text->text", input_modalities: ["text"], output_modalities: ["text"] },
@@ -91,5 +91,29 @@ describe("getOpenRouterModels", () => {
 	test("treats a zero-valid-model payload as a failure", async () => {
 		const fetchMock = vi.fn(async () => ({ ...okResponse(), json: async () => ({ data: [{}] }) }) as Response);
 		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toBeUndefined();
+	});
+
+	test("refetches when requireId is missing from a fresh cache", async () => {
+		vi.useFakeTimers();
+		const start = Date.now();
+		const fetchMock = vi
+			.fn(async () => okResponse() as Response)
+			.mockResolvedValueOnce(okResponse() as Response)
+			.mockResolvedValueOnce(okResponse("vendor/later") as Response);
+		await getOpenRouterModels(fetchMock as typeof fetch);
+		vi.setSystemTime(start + 60_000);
+		expect((await getOpenRouterModels(fetchMock as typeof fetch, "vendor/later"))?.[0].id).toBe("vendor/later");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		vi.useRealTimers();
+	});
+
+	test("retries a cold failure when requireId is missing", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) } as Response)
+			.mockResolvedValueOnce(okResponse() as Response);
+		expect(await getOpenRouterModels(fetchMock as typeof fetch)).toBeUndefined();
+		expect(await getOpenRouterModels(fetchMock as typeof fetch, "vendor/live-new")).toEqual([model]);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
 });


### PR DESCRIPTION
OpenRouter adds and drops models between releases, but the picker still came from the snapshot baked in at generate time. This fetches the live catalog when you open the model picker or run `model list`, and keeps the snapshot as the offline / failure / first-load fallback.

## Why this is a new PR

[#804](https://github.com/PrimeIntellect-ai/prime-agent/pull/804) did the same job on an older main, and it also tried to invent live reasoning-effort maps. That second part landed independently in [#1258](https://github.com/PrimeIntellect-ai/prime-agent/pull/1258) (`getOpenRouterReasoningCapabilities`). Rebasing #804 as-is would have reintroduced a weaker parser: omitted `supported_efforts` meant “every gateway effort,” while #1258 treats that as toggle-only and `null` as every effort.

This branch is based on current main and uses that helper. The remaining user-visible change is live catalog membership (new models appear, removed ones leave).

## Behavior

- Live fetch on catalog queries, session restore of an OpenRouter id, saved OpenRouter defaults, and `--model openrouter/...`. Other startup paths do not wait on the network.
- 5 minute cache, 3 second timeout, one in-flight request, 30 second backoff after failure. Restore of a missing OpenRouter id bypasses TTL and backoff so a stale cache cannot hide a newly listed model.
- For ids already in the snapshot, live overlay keeps snapshot `cost`, `maxTokens`, `contextWindow`, and `thinkingLevelMap` (the generate-models corrections such as Kimi K2.5’s 4096 output cap). Snapshot `featured` / `headers` / extra compat are merged. Virtual aliases (`auto`, `~*-latest`) stay even when the filtered endpoint omits them.
- `models.json` overrides still win.
- Generator `fetchOpenRouterModels()` now calls the shared parser so the next snapshot regen cannot drift from runtime parsing. This PR does not regenerate `models.generated.ts`.

Closes #804.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fetch the live OpenRouter model catalog and merge it with the snapshot registry
> - Adds [openrouter-model-catalog.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1310/files#diff-826a7bde17d30273d5f74ccb977e7c9735958ff4dc6cc6c05b71d559433ee627) to fetch and cache the live OpenRouter catalog with a 5-minute TTL, in-flight deduplication, 3-second timeout, and 30-second failure backoff.
> - Adds `resolveOpenRouterCatalog` in [model-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1310/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453) to merge the live catalog with the generated snapshot, using live membership/capabilities while preserving snapshot cost, limits, and virtual aliases as fallback.
> - Extracts a shared [openrouter-models.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1310/files#diff-72b94a81b18b69003032ae3e45c50805864bb85275242ccd014789a860b797ce) parser (`parseOpenRouterModels`) that normalizes catalog entries: filters non-tool and batch variants, converts pricing to $/million, clamps `maxTokens` to `contextWindow`, and applies DeepSeek-specific compat overrides.
> - Session restore, startup model resolution, daemon rehydration, and the `list-models` CLI command all call `findOrFetch` or `refreshOpenRouterModels` to opportunistically load OpenRouter models missing from the snapshot.
> - Risk: live network requests are made during model registry initialization and session restore; failures are swallowed and fall back to the snapshot, but may add latency on slow or offline connections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b95c10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->