### PR TITLE
fix(coding-agent): resolve the kernel venv interpreter per platform

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#1375](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375) by [@bilelrais](https://github.com/bilelrais)).
 - Added a working hint that recommends sharing traces with Prime Intellect to help train open-source LLMs.
 - Restored bare `prime-agent --resume` opening the agents view and the `/resume [id|path]` slash command; bare commands open the agents view and an argument resumes that session in place.
+- Fixed the Python kernel failing to bootstrap on Windows by looking for the venv interpreter at `bin/python` instead of `Scripts\python.exe` ([#1194](https://github.com/PrimeIntellect-ai/prime-agent/issues/1194)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 - Fixed ctrl+p ("Toggle agent message expansion") only toggling received agent messages; it now expands and collapses sent agent messages together with received ones.
 

--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -342,6 +342,14 @@ export function getKernelVenvDir(): string {
 	return path.join(os.homedir(), ".prime", "agent", "kernel-venv");
 }
 
+/**
+ * Interpreter path inside a venv. uv (like virtualenv) follows the platform
+ * layout: `Scripts\python.exe` on Windows, `bin/python` everywhere else.
+ */
+export function getKernelVenvPython(venv: string): string {
+	return process.platform === "win32" ? path.join(venv, "Scripts", "python.exe") : path.join(venv, "bin", "python");
+}
+
 function getXdgKernelVenvDir(): string {
 	const dataHome = process.env.XDG_DATA_HOME
 		? path.resolve(expandHome(process.env.XDG_DATA_HOME))
@@ -725,7 +733,7 @@ async function bootstrapVenv(
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv(options);
-	const python = path.join(venv, "bin", "python");
+	const python = getKernelVenvPython(venv);
 	const sourceDir = await resolveRuntimeSourceDir();
 	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
 	const runtimeIdentity = await resolveRuntimeIdentity();
@@ -886,7 +894,7 @@ async function ensureKernelPythonUncached(
 	}
 
 	const venv = await resolveWritableKernelVenvDir();
-	const python = path.join(venv, "bin", "python");
+	const python = getKernelVenvPython(venv);
 	const runtimeIdentity = await resolveRuntimeIdentity();
 	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +8,7 @@ import {
 	DEFAULT_RLM_EXTRA_UV_ARGS,
 	ensureKernelPython,
 	getKernelVenvDir,
+	getKernelVenvPython,
 	type KernelPythonSkill,
 	resolveRuntimeIdentity,
 } from "../src/core/kernel/bootstrap.js";
@@ -160,6 +161,7 @@ describe("kernel bootstrap", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		process.env = originalEnv;
 		if (tempDir) {
 			rmSync(tempDir, { recursive: true, force: true });
@@ -172,6 +174,31 @@ describe("kernel bootstrap", () => {
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
 		expect(getKernelVenvDir()).toBe(venv);
+	});
+
+	it("resolves the venv interpreter with the platform layout", () => {
+		const venv = join(tempDir, "kernel-venv");
+
+		vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+		expect(getKernelVenvPython(venv)).toBe(join(venv, "bin", "python"));
+
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		expect(getKernelVenvPython(venv)).toBe(join(venv, "Scripts", "python.exe"));
+	});
+
+	it("reuses a warm venv built with the Windows layout", async () => {
+		const logPath = installFakeUv();
+		const venv = join(tempDir, "kernel-venv");
+		const python = join(venv, "Scripts", "python.exe");
+		mkdirSync(join(venv, "Scripts"), { recursive: true });
+		writeFakePython(python, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
+		writeBootstrapVersion(venv);
+		process.env.PRIME_AGENT_KERNEL_VENV = venv;
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+		await expect(ensureKernelPython()).resolves.toBe(python);
+
+		expect(existsSync(logPath)).toBe(false);
 	});
 
 	it("bootstraps a missing venv with uv, ipykernel, prime-agent-runtime, and default extra packages", async () => {


### PR DESCRIPTION
## Problem

First-run kernel bootstrap always fails on Windows. `uv venv` creates the venv with the Windows layout (`Scripts\python.exe`), but `bootstrap.ts` computed the interpreter as `<venv>/bin/python`, which never exists there. The following `uv pip install --python <venv>/bin/python` exits 2 and setup aborts:

```
› setting up python kernel (one-time, ~30s)…
prime-agent: postinstall setup skipped: Failed to set up the Python kernel runtime.
uv.exe pip install --python C:\Users\...\.prime\agent\kernel-venv\bin\python ... failed with exit code 2
```

The same hardcoded path is also used to decide whether a warm venv is reusable, so on Windows every startup treated an already-good venv as broken and tried to rebuild it.

## Fix

Derive the interpreter path from the platform in one place, `getKernelVenvPython()`, and use it at both call sites. This matches the `uv` / `uv.exe` handling already in the same file.

```ts
export function getKernelVenvPython(venv: string): string {
	return process.platform === "win32" ? path.join(venv, "Scripts", "python.exe") : path.join(venv, "bin", "python");
}
```

No behavior change off Windows: `getKernelVenvPython()` returns the previous `<venv>/bin/python`.

## Tests

Two tests in `test/kernel-bootstrap.test.ts`, both verified to fail without the source change:

- `resolves the venv interpreter with the platform layout` — unit coverage for both layouts.
- `reuses a warm venv built with the Windows layout` — with `process.platform` stubbed to `win32`, a warm venv holding `Scripts/python.exe` resolves without invoking `uv` at all. Against the old code this rebuilds the venv and returns the wrong path.

`npm run check` and the touched test files pass.

## Scope

This covers the interpreter-path bug the issue is titled for. The other Windows items reported in the issue comments (missing `windowsHide: true` on kernel spawns, `spawn("sh", ...)` for the uv installer, and the silent "Python skills unavailable" warning under `PRIME_AGENT_KERNEL_PYTHON`) are left for separate PRs.

fixes #1194


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Python venv interpreter path resolution for Windows in kernel bootstrap
> - Introduces `getKernelVenvPython` in [`bootstrap.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1312/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) to return the correct venv interpreter path per platform: `Scripts/python.exe` on `win32`, `bin/python` otherwise.
> - Replaces hardcoded `bin/python` paths in `bootstrapVenv` and `ensureKernelPythonUncached` with `getKernelVenvPython`, so readiness checks, `uv pip install`, and skill sync all use the platform-appropriate interpreter.
> - Adds tests verifying the path resolution logic and a full warm-venv scenario on Windows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d63177a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->