### PR TITLE
feat(ai): add xAI Grok OAuth

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added built-in xAI Grok OAuth with device authorization, rotating token refresh, and Responses API routing for SuperGrok and X Premium+ subscriptions.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1101,6 +1101,7 @@ Several providers require OAuth authentication instead of static API keys:
 - **Anthropic** (Claude Pro/Max subscription)
 - **OpenAI Codex** (ChatGPT Plus/Pro subscription, access to GPT-5.x Codex models)
 - **GitHub Copilot** (Copilot subscription)
+- **xAI Grok** (SuperGrok / X Premium+ subscription)
 
 For paid Cloud Code Assist subscriptions, set `GOOGLE_CLOUD_PROJECT` or `GOOGLE_CLOUD_PROJECT_ID` to your project ID.
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -26,7 +26,7 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
-const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
+const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode", "xai"]);
 
 /**
  * Resolve cache retention preference.

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -5,6 +5,7 @@
  * for OAuth-based providers:
  * - Anthropic (Claude Pro/Max)
  * - GitHub Copilot
+ * - xAI Grok (SuperGrok / X Premium+)
  */
 
 // Anthropic
@@ -19,8 +20,9 @@ export {
 } from "./github-copilot.js";
 // OpenAI Codex (ChatGPT OAuth)
 export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.js";
-
 export * from "./types.js";
+// xAI Grok (SuperGrok / X Premium+)
+export { loginXai, refreshXaiToken, xaiOAuthProvider } from "./xai.js";
 
 // ============================================================================
 // Provider Registry
@@ -30,11 +32,13 @@ import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
+import { xaiOAuthProvider } from "./xai.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	anthropicOAuthProvider,
 	githubCopilotOAuthProvider,
 	openaiCodexOAuthProvider,
+	xaiOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(

--- a/packages/ai/src/utils/oauth/xai.ts
+++ b/packages/ai/src/utils/oauth/xai.ts
@@ -1,0 +1,254 @@
+import type { Api, Model } from "../../types.js";
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+
+const XAI_OAUTH_DISCOVERY_URL = "https://auth.x.ai/.well-known/openid-configuration";
+const XAI_OAUTH_DEVICE_CODE_URL = "https://auth.x.ai/oauth2/device/code";
+const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const XAI_INFERENCE_BASE_URL = "https://api.x.ai/v1";
+const XAI_REFRESH_SKEW_MS = 60 * 60 * 1000;
+const XAI_SHORT_TOKEN_SKEW_MS = 2 * 60 * 1000;
+const XAI_SHORT_TOKEN_THRESHOLD_MS = 45 * 60 * 1000;
+const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+
+interface XaiOAuthCredentials extends OAuthCredentials {
+	tokenEndpoint: string;
+}
+
+interface XaiDiscovery {
+	authorization_endpoint?: unknown;
+	token_endpoint?: unknown;
+}
+
+interface XaiDeviceCode {
+	device_code?: unknown;
+	user_code?: unknown;
+	verification_uri?: unknown;
+	verification_uri_complete?: unknown;
+	expires_in?: unknown;
+	interval?: unknown;
+}
+
+interface XaiTokenResponse {
+	access_token?: unknown;
+	refresh_token?: unknown;
+	expires_in?: unknown;
+	error?: unknown;
+	error_description?: unknown;
+}
+
+function validateXaiEndpoint(value: unknown, field: string): string {
+	if (typeof value !== "string" || !value) {
+		throw new Error(`xAI OAuth discovery is missing ${field}`);
+	}
+
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error(`xAI OAuth discovery returned an invalid ${field}`);
+	}
+	if (url.protocol !== "https:" || (url.hostname !== "x.ai" && !url.hostname.endsWith(".x.ai"))) {
+		throw new Error(`xAI OAuth discovery returned an untrusted ${field}`);
+	}
+	return url.toString();
+}
+
+async function readJson(response: Response, operation: string): Promise<Record<string, unknown>> {
+	if (!response.ok) {
+		throw new Error(`${operation} failed with HTTP ${response.status}`);
+	}
+	let payload: unknown;
+	try {
+		payload = await response.json();
+	} catch {
+		throw new Error(`${operation} returned invalid JSON`);
+	}
+	if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+		throw new Error(`${operation} returned an invalid response`);
+	}
+	return payload as Record<string, unknown>;
+}
+
+async function discoverXaiOAuth(signal?: AbortSignal): Promise<string> {
+	const response = await fetch(XAI_OAUTH_DISCOVERY_URL, {
+		headers: { Accept: "application/json" },
+		signal,
+	});
+	const discovery = (await readJson(response, "xAI OAuth discovery")) as XaiDiscovery;
+	validateXaiEndpoint(discovery.authorization_endpoint, "authorization_endpoint");
+	return validateXaiEndpoint(discovery.token_endpoint, "token_endpoint");
+}
+
+function formBody(values: Record<string, string>): URLSearchParams {
+	return new URLSearchParams(values);
+}
+
+function requireString(value: unknown, field: string, operation: string): string {
+	if (typeof value !== "string" || !value) {
+		throw new Error(`${operation} response is missing ${field}`);
+	}
+	return value;
+}
+
+function requirePositiveNumber(value: unknown, field: string, operation: string): number {
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+		throw new Error(`${operation} response has invalid ${field}`);
+	}
+	return value;
+}
+
+function credentialsFromToken(
+	payload: XaiTokenResponse,
+	tokenEndpoint: string,
+	previousRefresh?: string,
+): XaiOAuthCredentials {
+	const access = requireString(payload.access_token, "access_token", "xAI OAuth token");
+	const refresh =
+		typeof payload.refresh_token === "string" && payload.refresh_token ? payload.refresh_token : previousRefresh;
+	if (!refresh) {
+		throw new Error("xAI OAuth token response is missing refresh_token");
+	}
+	const expiresIn = requirePositiveNumber(payload.expires_in, "expires_in", "xAI OAuth token");
+	const lifetimeMs = expiresIn * 1000;
+	const refreshSkewMs = lifetimeMs <= XAI_SHORT_TOKEN_THRESHOLD_MS ? XAI_SHORT_TOKEN_SKEW_MS : XAI_REFRESH_SKEW_MS;
+	return {
+		access,
+		refresh,
+		expires: Date.now() + Math.max(0, lifetimeMs - refreshSkewMs),
+		tokenEndpoint,
+	};
+}
+
+function abortableDelay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted) {
+		return Promise.reject(new Error("Login cancelled"));
+	}
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, milliseconds);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(new Error("Login cancelled"));
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+async function requestDeviceCode(signal?: AbortSignal): Promise<XaiDeviceCode> {
+	const response = await fetch(XAI_OAUTH_DEVICE_CODE_URL, {
+		method: "POST",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		body: formBody({ client_id: XAI_OAUTH_CLIENT_ID, scope: XAI_OAUTH_SCOPE }),
+		signal,
+	});
+	return (await readJson(response, "xAI device authorization")) as XaiDeviceCode;
+}
+
+async function pollForToken(
+	tokenEndpoint: string,
+	deviceCode: string,
+	expiresInSeconds: number,
+	intervalSeconds: number,
+	signal?: AbortSignal,
+): Promise<XaiOAuthCredentials> {
+	const deadline = Date.now() + expiresInSeconds * 1000;
+	let intervalMs = Math.max(1000, intervalSeconds * 1000);
+
+	while (Date.now() < deadline) {
+		await abortableDelay(Math.min(intervalMs, deadline - Date.now()), signal);
+		if (Date.now() > deadline) break;
+
+		const response = await fetch(tokenEndpoint, {
+			method: "POST",
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			body: formBody({
+				grant_type: DEVICE_CODE_GRANT,
+				client_id: XAI_OAUTH_CLIENT_ID,
+				device_code: deviceCode,
+			}),
+			signal,
+		});
+		let payload: XaiTokenResponse;
+		try {
+			payload = (await response.json()) as XaiTokenResponse;
+		} catch {
+			throw new Error(`xAI device token request failed with HTTP ${response.status}`);
+		}
+		if (response.ok) {
+			return credentialsFromToken(payload, tokenEndpoint);
+		}
+		if (payload.error === "authorization_pending") continue;
+		if (payload.error === "slow_down") {
+			intervalMs += 5000;
+			continue;
+		}
+		const code = typeof payload.error === "string" ? ` (${payload.error})` : "";
+		throw new Error(`xAI device token request failed with HTTP ${response.status}${code}`);
+	}
+	throw new Error("Timed out waiting for xAI device authorization");
+}
+
+export async function loginXai(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+	const tokenEndpoint = await discoverXaiOAuth(callbacks.signal);
+	const device = await requestDeviceCode(callbacks.signal);
+	const deviceCode = requireString(device.device_code, "device_code", "xAI device authorization");
+	const userCode = requireString(device.user_code, "user_code", "xAI device authorization");
+	const verificationUri = requireString(device.verification_uri, "verification_uri", "xAI device authorization");
+	const verificationUriComplete =
+		typeof device.verification_uri_complete === "string" && device.verification_uri_complete
+			? device.verification_uri_complete
+			: verificationUri;
+	const expiresIn = requirePositiveNumber(device.expires_in, "expires_in", "xAI device authorization");
+	const interval = requirePositiveNumber(device.interval, "interval", "xAI device authorization");
+
+	callbacks.onAuth({ url: verificationUriComplete, instructions: `Enter code: ${userCode}` });
+	callbacks.onProgress?.("Waiting for xAI authorization...");
+	return pollForToken(tokenEndpoint, deviceCode, expiresIn, interval, callbacks.signal);
+}
+
+export async function refreshXaiToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+	const storedEndpoint = (credentials as Partial<XaiOAuthCredentials>).tokenEndpoint;
+	const tokenEndpoint = storedEndpoint
+		? validateXaiEndpoint(storedEndpoint, "token_endpoint")
+		: await discoverXaiOAuth();
+	const response = await fetch(tokenEndpoint, {
+		method: "POST",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		body: formBody({
+			grant_type: "refresh_token",
+			client_id: XAI_OAUTH_CLIENT_ID,
+			refresh_token: credentials.refresh,
+		}),
+	});
+	const payload = (await readJson(response, "xAI token refresh")) as XaiTokenResponse;
+	return credentialsFromToken(payload, tokenEndpoint, credentials.refresh);
+}
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+	id: "xai",
+	name: "xAI Grok (SuperGrok / X Premium+)",
+	login: loginXai,
+	refreshToken: refreshXaiToken,
+	getApiKey(credentials: OAuthCredentials): string {
+		return credentials.access;
+	},
+	modifyModels(models: Model<Api>[]): Model<Api>[] {
+		return models.map((model) => {
+			if (model.provider !== "xai") return model;
+			const { compat: _compat, ...rest } = model;
+			return { ...rest, api: "openai-responses", baseUrl: XAI_INFERENCE_BASE_URL } as Model<Api>;
+		});
+	},
+};

--- a/packages/ai/test/xai-oauth.test.ts
+++ b/packages/ai/test/xai-oauth.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Model } from "../src/types.js";
+import { loginXai, refreshXaiToken, xaiOAuthProvider } from "../src/utils/oauth/xai.js";
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function requestUrl(input: unknown): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	if (input instanceof Request) return input.url;
+	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+function requestBody(init?: RequestInit): URLSearchParams {
+	if (!(init?.body instanceof URLSearchParams)) {
+		throw new Error("Expected form-encoded request body");
+	}
+	return init.body;
+}
+
+describe.sequential("xAI OAuth", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it("completes the device flow after the server polling interval", async () => {
+		vi.useFakeTimers();
+		const start = new Date("2026-08-12T00:00:00Z");
+		vi.setSystemTime(start);
+		const pollTimes: number[] = [];
+		const authCalls: { url: string; instructions?: string }[] = [];
+		let tokenPolls = 0;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown, init?: RequestInit) => {
+				const url = requestUrl(input);
+				if (url.endsWith("/.well-known/openid-configuration")) {
+					return jsonResponse({
+						authorization_endpoint: "https://auth.x.ai/oauth2/auth",
+						token_endpoint: "https://auth.x.ai/oauth2/token",
+					});
+				}
+				if (url.endsWith("/oauth2/device/code")) {
+					expect(requestBody(init).get("client_id")).toBeTruthy();
+					expect(requestBody(init).get("scope")).toContain("grok-cli:access");
+					return jsonResponse({
+						device_code: "device-code",
+						user_code: "ABCD-EFGH",
+						verification_uri: "https://auth.x.ai/activate",
+						verification_uri_complete: "https://auth.x.ai/activate?code=ABCD-EFGH",
+						expires_in: 900,
+						interval: 5,
+					});
+				}
+				if (url.endsWith("/oauth2/token")) {
+					pollTimes.push(Date.now());
+					expect(requestBody(init).get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:device_code");
+					expect(requestBody(init).get("device_code")).toBe("device-code");
+					tokenPolls += 1;
+					return tokenPolls === 1
+						? jsonResponse({ error: "authorization_pending" }, 400)
+						: jsonResponse({
+								access_token: "access-token",
+								refresh_token: "refresh-token",
+								expires_in: 21600,
+							});
+				}
+				throw new Error(`Unexpected URL: ${url}`);
+			}),
+		);
+
+		const login = loginXai({
+			onAuth: (info) => authCalls.push(info),
+			onPrompt: async () => "",
+		});
+		await vi.advanceTimersByTimeAsync(0);
+		expect(pollTimes).toEqual([]);
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(pollTimes).toEqual([start.getTime() + 5000]);
+		await vi.advanceTimersByTimeAsync(5000);
+		const credentials = await login;
+
+		expect(authCalls).toEqual([
+			{ url: "https://auth.x.ai/activate?code=ABCD-EFGH", instructions: "Enter code: ABCD-EFGH" },
+		]);
+		expect(credentials).toMatchObject({
+			access: "access-token",
+			refresh: "refresh-token",
+			tokenEndpoint: "https://auth.x.ai/oauth2/token",
+		});
+		expect(credentials.expires).toBe(start.getTime() + 5 * 60 * 60 * 1000 + 10000);
+	});
+
+	it("keeps short-lived access tokens usable before proactive refresh", async () => {
+		vi.useFakeTimers();
+		const start = new Date("2026-08-12T00:00:00Z");
+		vi.setSystemTime(start);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => jsonResponse({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 900 })),
+		);
+
+		const refreshed = await refreshXaiToken({
+			access: "old-access",
+			refresh: "old-refresh",
+			expires: 0,
+			tokenEndpoint: "https://auth.x.ai/oauth2/token",
+		});
+		expect(refreshed.expires).toBe(start.getTime() + 13 * 60 * 1000);
+	});
+
+	it("retains or rotates the refresh token and rejects untrusted token endpoints", async () => {
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			expect(requestBody(init).get("grant_type")).toBe("refresh_token");
+			expect(requestBody(init).get("refresh_token")).toBe("old-refresh");
+			return jsonResponse({
+				access_token: "new-access",
+				refresh_token: "new-refresh",
+				expires_in: 21600,
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const refreshed = await refreshXaiToken({
+			access: "old-access",
+			refresh: "old-refresh",
+			expires: 0,
+			tokenEndpoint: "https://auth.x.ai/oauth2/token",
+		});
+		expect(refreshed.refresh).toBe("new-refresh");
+		expect(fetchMock).toHaveBeenCalledOnce();
+
+		await expect(
+			refreshXaiToken({
+				access: "old-access",
+				refresh: "secret-refresh",
+				expires: 0,
+				tokenEndpoint: "https://attacker.example/token",
+			}),
+		).rejects.toThrow("untrusted token_endpoint");
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("uses the Responses API for xAI models only while OAuth is active", () => {
+		const xai = {
+			id: "grok-4.20",
+			name: "Grok 4.20",
+			api: "openai-completions",
+			provider: "xai",
+			baseUrl: "https://api.x.ai/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 30000,
+		} satisfies Model<"openai-completions">;
+		const other = { ...xai, provider: "openai", id: "gpt-test" } satisfies Model<"openai-completions">;
+
+		const modified = xaiOAuthProvider.modifyModels?.([xai, other], {
+			access: "access",
+			refresh: "refresh",
+			expires: Date.now() + 1000,
+		});
+		expect(modified?.[0]).toMatchObject({
+			api: "openai-responses",
+			provider: "xai",
+			baseUrl: "https://api.x.ai/v1",
+		});
+		expect(modified?.[1]).toBe(other);
+	});
+
+	it("cancels while waiting for device approval", async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown) => {
+				const url = requestUrl(input);
+				if (url.endsWith("/.well-known/openid-configuration")) {
+					return jsonResponse({
+						authorization_endpoint: "https://auth.x.ai/oauth2/auth",
+						token_endpoint: "https://auth.x.ai/oauth2/token",
+					});
+				}
+				return jsonResponse({
+					device_code: "device-code",
+					user_code: "ABCD-EFGH",
+					verification_uri: "https://auth.x.ai/activate",
+					expires_in: 900,
+					interval: 5,
+				});
+			}),
+		);
+		const controller = new AbortController();
+		const login = loginXai({ onAuth: () => {}, onPrompt: async () => "", signal: controller.signal });
+		await vi.advanceTimersByTimeAsync(0);
+		controller.abort();
+		await expect(login).rejects.toThrow("Login cancelled");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Added xAI Grok subscription login alongside the existing xAI API-key option.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -18,6 +18,7 @@ Use `/login` in interactive mode, then select a provider:
 - ChatGPT Plus/Pro (Codex)
 - Claude Pro/Max
 - GitHub Copilot
+- xAI Grok (SuperGrok / X Premium+)
 
 Use `/logout` to clear credentials. Tokens are stored in `~/.prime/agent/auth.json` and auto-refresh when expired.
 
@@ -34,6 +35,10 @@ Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party h
 
 - Press Enter for github.com, or enter your GitHub Enterprise Server domain
 - If you get "model not supported", enable it in VS Code: Copilot Chat → model selector → select model → "Enable"
+
+### xAI Grok
+
+Select **xAI Grok (SuperGrok / X Premium+)** to sign in with xAI's device flow. Open the displayed URL, enter the code if prompted, and approve access. Prime Agent stores and refreshes the OAuth tokens automatically and routes xAI models through the Responses API while this login is active. The separate API-key option continues to use `XAI_API_KEY`.
 
 ## API Keys
 

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -934,6 +934,39 @@ describe("AuthStorage", () => {
 		});
 	});
 
+	describe("OAuth refresh persistence", () => {
+		test("persists a rotated xAI refresh token without refreshing every lookup", async () => {
+			writeAuthJson({
+				xai: {
+					type: "oauth",
+					access: "expired-access",
+					refresh: "old-refresh",
+					expires: Date.now() - 1,
+					tokenEndpoint: "https://auth.x.ai/oauth2/token",
+				},
+			});
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(
+					new Response(
+						JSON.stringify({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 900 }),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				);
+			authStorage = AuthStorage.create(authJsonPath);
+
+			expect(await authStorage.getApiKey("xai")).toBe("new-access");
+			expect(await authStorage.getApiKey("xai")).toBe("new-access");
+			expect(fetchSpy).toHaveBeenCalledOnce();
+
+			const stored = JSON.parse(readFileSync(authJsonPath, "utf-8")) as {
+				xai: { access: string; refresh: string; expires: number };
+			};
+			expect(stored.xai).toMatchObject({ access: "new-access", refresh: "new-refresh" });
+			expect(stored.xai.expires).toBeGreaterThan(Date.now());
+		});
+	});
+
 	describe("oauth lock compromise handling", () => {
 		test("returns undefined on compromised lock and allows a later retry", async () => {
 			const providerId = `test-oauth-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`;

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -31,12 +31,14 @@ describe("OAuthSelectorComponent", () => {
 		}
 	});
 
-	it("keeps built-in API key providers separate from OAuth-only providers", () => {
-		const oauthProviderIds = new Set(["anthropic", "github-copilot", "custom-oauth"]);
-		const builtInProviderIds = new Set(["anthropic", "github-copilot", "amazon-bedrock", "openai"]);
+	it("keeps API key modes for built-in providers that also support OAuth", () => {
+		const oauthProviderIds = new Set(["anthropic", "github-copilot", "xai", "custom-oauth"]);
+		const builtInProviderIds = new Set(["anthropic", "github-copilot", "amazon-bedrock", "openai", "xai"]);
 
 		expect(isApiKeyLoginProvider("anthropic", oauthProviderIds, builtInProviderIds)).toBe(true);
 		expect(BUILT_IN_PROVIDER_DISPLAY_NAMES.anthropic).toBe("Anthropic");
+		expect(isApiKeyLoginProvider("xai", oauthProviderIds, builtInProviderIds)).toBe(true);
+		expect(BUILT_IN_PROVIDER_DISPLAY_NAMES.xai).toBe("xAI");
 		expect(isApiKeyLoginProvider("openai", oauthProviderIds, builtInProviderIds)).toBe(true);
 		expect(isApiKeyLoginProvider("github-copilot", oauthProviderIds, builtInProviderIds)).toBe(false);
 		expect(isApiKeyLoginProvider("amazon-bedrock", oauthProviderIds, builtInProviderIds)).toBe(true);


### PR DESCRIPTION
## Summary

- add xAI SuperGrok/X Premium+ device-code OAuth under the existing `xai` provider
- preserve API-key Chat Completions behavior and use Responses only while OAuth is active
- persist rotating refresh tokens and restrict discovered endpoints to HTTPS `x.ai` hosts
- expose subscription OAuth and API-key choices in `/login`

## Validation

- `packages/ai`: `test/xai-oauth.test.ts` (5 passed)
- `packages/coding-agent`: `test/auth-storage.test.ts`, `test/oauth-selector.test.ts` (73 passed)
- `npm run check`

## Related work

Upstream also has #752, #754, #880, and #1154. This branch is the single-commit implementation currently carried on the fork's main branch.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add xAI Grok OAuth with device authorization flow and rotating token refresh
> - Adds [`xaiOAuthProvider`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1314/files#diff-a09114a3bec83ce83a7c3dfcaaf770c8e5e78ece71fae3b8e6de5109a64df65b) implementing the full OAuth device flow: discovers the xAI OIDC token endpoint, requests a device code, prompts the user with a verification URL, and polls for approval with backoff and cancellation support.
> - Refreshes tokens using rotating refresh token logic, with proactive expiry scheduling based on token lifetime and trust validation on all endpoints (HTTPS + x.ai domain only).
> - Routes xAI models through the `openai-responses` API (base URL `https://api.x.ai/v1`) when OAuth is active, treating xAI as an OpenAI-tool-call-capable provider.
> - Registers `xaiOAuthProvider` in the `BUILT_IN_OAUTH_PROVIDERS` registry alongside Anthropic, GitHub Copilot, and OpenAI Codex.
> - Behavioral Change: xAI models accessed via OAuth are rerouted to the Responses API path rather than the default xAI API path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 921fd13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->