### PR TITLE
fix(daemon): close interrupted tool calls

### DIFF
--- a/docs/superpowers/plans/2026-08-13-exact-turn-worker-recovery-plan.md
+++ b/docs/superpowers/plans/2026-08-13-exact-turn-worker-recovery-plan.md
@@ -1,0 +1,99 @@
+# Exact-turn worker recovery implementation plan
+
+**Design:** `docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md`
+
+## Test seams
+
+The approved design fixes three observable seams:
+
+1. `WorkerRecoveryJournal`: durable v2 authority epochs and conditional completion.
+2. `SessionManager`: exact-authority, resumable closure of one assistant tool-use turn.
+3. `DaemonCatalogClient.markInterrupted`: lease-fenced, idempotent catalog recovery result consumed by the supervisor.
+
+Tests exercise these public module boundaries and persisted JSONL output rather than private helpers.
+
+## Commit 1 — journal exact recovery authority
+
+Files:
+
+- `packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts`
+- `packages/coding-agent/src/modes/daemon/daemon-mode.ts`
+- `packages/coding-agent/test/worker-recovery-journal.test.ts`
+- focused daemon-mode tests only if needed
+
+Red/green slices:
+
+1. Parse v2 records and ignore legacy busy records for mutation authority.
+2. Keep one stable `operationId` during a busy epoch; allocate a new id after idle.
+3. Deduplicate only identical authority, including session generation, head, assistant, tool calls, and lineage.
+4. Capture authority from one active-branch snapshot without discarding tool event identity.
+5. Add compare-and-set completion that cannot overwrite a newer busy epoch.
+
+Focal command:
+
+```bash
+npm --prefix packages/coding-agent test -- test/worker-recovery-journal.test.ts
+```
+
+## Commit 2 — exact and resumable session mutation
+
+Files:
+
+- `packages/coding-agent/src/core/session-manager.ts`
+- `packages/coding-agent/test/session-manager/interrupted-tool-results.test.ts`
+
+Red/green slices:
+
+1. Accept exact authority and reject generation, head, assistant, lineage, or tool-call mismatch without writing.
+2. Append only journaled tool-call ids from the authorized assistant entry.
+3. Tag synthetic results with `operationId` and resume an operation-owned partial suffix.
+4. Reject foreign/newer suffixes.
+5. Make stop reason irrelevant when exact tool calls are journaled.
+
+Focal command:
+
+```bash
+npm --prefix packages/coding-agent test -- test/session-manager/interrupted-tool-results.test.ts
+```
+
+## Commit 3 — catalog lease, idempotency, and supervisor completion
+
+Files:
+
+- `packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts`
+- `packages/coding-agent/src/modes/daemon/daemon-supervisor.ts`
+- `packages/coding-agent/test/daemon-catalog-process.test.ts`
+- `packages/coding-agent/test/daemon-supervisor-monitor.test.ts`
+
+Red/green slices:
+
+1. Extend the catalog request/response with v2 authority and `applied | already_applied | stale`.
+2. Serialize by canonical path and acquire the session lease before open/verify/append.
+3. Deduplicate globally by recovery marker `operationId`.
+4. Retry partial result persistence and response-loss replay without duplicates.
+5. Complete only matching journal operation ids; retain busy state on catalog failure.
+6. Cover advance, branch, replacement, live owner, same-path new tool turn, duplicate concurrency, and partial persistence.
+
+Focal commands:
+
+```bash
+npm --prefix packages/coding-agent test -- test/daemon-catalog-process.test.ts
+npm --prefix packages/coding-agent test -- test/daemon-supervisor-monitor.test.ts -t "worker recovery"
+```
+
+## Exact-head verification
+
+Do not run the daemon-capable full repository suite from the live Prime Agent runtime. Run only focal in-process tests, then static gates:
+
+```bash
+npm --prefix packages/coding-agent test -- \
+  test/worker-recovery-journal.test.ts \
+  test/session-manager/interrupted-tool-results.test.ts \
+  test/daemon-catalog-process.test.ts
+npm --prefix packages/coding-agent test -- \
+  test/daemon-supervisor-monitor.test.ts -t "worker recovery"
+npx biome check --error-on-warnings <changed files>
+npx tsgo --noEmit
+```
+
+Finish with independent code/security review over the exact commit and address every P0/P1/P2 finding before push.

--- a/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
@@ -41,6 +41,7 @@ until the session becomes idle. Every busy checkpoint records:
 - `activeSessionId`: runtime identity for diagnostics.
 - `sessionId`: persisted session generation from the session header.
 - `sessionFile`: canonical target path.
+- `agentDir`: the exact session-lease namespace, including custom agent dirs.
 - `headEntryId`: exact active branch head, including `null` for an empty branch.
 - `assistantEntryId`: latest assistant entry on that branch, when one exists.
 - `toolCalls`: the exact unresolved `{ id, name }` set declared by that assistant

--- a/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
@@ -122,8 +122,10 @@ not add even a warning marker because the recovery process no longer owns the
 active transcript. The one exception is `live_session_owner` immediately after
 the supervisor signalled the exact worker generation with `SIGKILL`: process
 termination and lease release are asynchronous, so that result remains retryable
-and the busy journal is preserved. A later attempt with no worker generation to
-kill treats a normal live owner as genuinely stale.
+and the busy journal is preserved. A later attempt with no verified worker
+generation to kill treats a live owner as stale; that result does not prove the
+owner is a new generation, so journal compare-and-set remains the fence that
+prevents completion from clobbering a newer worker epoch.
 
 ## Failure and race behavior
 

--- a/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
@@ -119,7 +119,11 @@ persistence failure leaves the original entry busy for retry.
 
 A stale result is logged with its operation id and reason. It intentionally does
 not add even a warning marker because the recovery process no longer owns the
-active transcript.
+active transcript. The one exception is `live_session_owner` immediately after
+the supervisor signalled the exact worker generation with `SIGKILL`: process
+termination and lease release are asynchronous, so that result remains retryable
+and the busy journal is preserved. A later attempt with no worker generation to
+kill treats a normal live owner as genuinely stale.
 
 ## Failure and race behavior
 
@@ -130,7 +134,8 @@ active transcript.
 | Session branched to another head | `stale`; zero bytes appended. |
 | Path replaced by another session generation | `stale`; zero bytes appended. |
 | Same path receives a newer tool-use turn | `stale`; newer calls remain untouched. |
-| A normal live owner holds the session lease | `stale`; zero bytes appended. |
+| The exact worker was just killed but still holds the session lease | Retryable failure; journal stays busy. |
+| A normal live owner holds the session lease on a later attempt | `stale`; zero bytes appended. |
 | Another recovery holds the session lease | Retryable failure; journal stays busy. |
 | Response lost after marker commit | Replay returns `already_applied`. |
 | Concurrent duplicate requests | Per-path serialization yields one apply and idempotent no-ops. |

--- a/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
@@ -1,0 +1,165 @@
+# Exact-turn worker recovery authority
+
+## Context
+
+PR #1315 closes unresolved tool calls after an isolated daemon worker dies. The
+current recovery request identifies only a session path, active runtime id, and
+operation names. The catalog process therefore reopens whichever branch is
+active when recovery runs, closes tool calls in its latest assistant turn, and
+always appends a recovery marker.
+
+That is unsafe when the session has advanced, branched, or been replaced after
+the worker died. It is also not idempotent when persistence succeeds but the
+catalog response is lost. A retry can append the marker again, and concurrent
+requests can duplicate synthetic results.
+
+## Goals
+
+- Bind recovery mutation authority to the exact persisted session generation,
+  branch lineage, branch head, and assistant tool-use turn observed by the dead
+  worker.
+- Never mutate work produced by a newer or different session owner.
+- Make the complete recovery operation idempotent across response loss,
+  concurrent duplicate requests, and partial multi-result persistence.
+- Preserve the warning that execution and external side effects are unknown.
+- Keep the change local to worker recovery rather than adding a general session
+  transaction framework.
+
+## Non-goals
+
+- Replaying interrupted model or tool execution.
+- Recovering legacy busy journal records that lack mutation authority.
+- Making arbitrary direct `SessionManager` writers transactional.
+- Changing normal session branching semantics.
+
+## Recovery authority
+
+Worker recovery records move to a validated v2 shape. Each busy epoch has one
+stable `operationId`, created at the first durable busy checkpoint and reused
+until the session becomes idle. Every busy checkpoint records:
+
+- `activeSessionId`: runtime identity for diagnostics.
+- `sessionId`: persisted session generation from the session header.
+- `sessionFile`: canonical target path.
+- `headEntryId`: exact active branch head, including `null` for an empty branch.
+- `assistantEntryId`: latest assistant entry on that branch, when one exists.
+- `toolCalls`: the exact unresolved `{ id, name }` set declared by that assistant
+  entry at the checkpoint; tool-execution event payloads preserve the active id.
+- `lineageDigest`: SHA-256 over the ordered active branch entry identities and
+  parent links through `headEntryId`.
+- `operationId`, `operation`, `busy`, and `recordedAt`.
+
+The checkpoint is captured from one in-memory `SessionManager` view. Changes to
+session generation, path, head, assistant entry, or lineage force a new journal
+record even when the event name is unchanged. Idle records end the busy epoch;
+the next busy transition receives a new operation id. Journal writes use a
+journal-local cross-process guard. Recovery completes an epoch with a
+compare-and-set on `operationId` after re-reading the latest record, so it
+cannot overwrite a newer busy epoch created by a resumed worker.
+
+A journal write failure remains fail-safe: execution may continue, but later
+recovery has no valid authority and therefore performs no transcript mutation.
+Legacy v1 busy records are likewise classified stale without mutation.
+
+## Catalog recovery protocol
+
+The supervisor sends the complete v2 authority and operation names to the
+catalog. The catalog returns one of `applied`, `already_applied`, or `stale`.
+Persistence errors remain request failures so the supervisor retains the busy
+journal for retry.
+
+Recovery requests are serialized by canonical session path inside the catalog.
+While processing a request, the catalog acquires the existing cross-process
+session lease with leases explicitly enabled and an owner id derived from the
+recovery `operationId`. A lease held by a normal live session owner makes
+recovery `stale`; a lease held by another recovery attempt is retryable rather
+than stale. A new session owner cannot open the file until recovery releases
+its lease.
+
+Under the lease, recovery follows this order:
+
+1. Search all entries for a `prime-agent.worker_recovery` marker carrying the
+   same `operationId`. If found, return `already_applied` without writing. This
+   is global rather than active-branch-only so later branching cannot cause a
+   completed operation to be applied again.
+2. Open the session and verify `sessionId`.
+3. Verify that the active branch prefix through `headEntryId`, its
+   `lineageDigest`, and `assistantEntryId` exactly match the journal authority.
+4. Permit only a suffix of synthetic tool results owned by the same
+   `operationId`. This is the sole allowed head advance and supports retry after
+   partial multi-result persistence. Any ordinary entry, different operation,
+   different branch, or different head makes the request `stale` without a new
+   write.
+5. Close only the journaled tool-call ids declared by the authorized
+   assistant entry, without depending on its terminal `stopReason`. Synthetic
+   results retain the existing unknown-side-effects wording and include
+   recovery metadata with `operationId` and `assistantEntryId`.
+6. Append exactly one final recovery marker carrying `operationId`, the
+   authority, and operation names. The marker is committed only after all
+   synthetic results.
+
+If an append fails after some synthetic results, the request fails. A retry can
+recognize the owned suffix and append only the missing results and marker. If
+new work appears after that partial suffix, the retry becomes stale instead of
+mutating the newer work.
+
+## Supervisor completion
+
+For a worker with several uncertain sessions, catalog calls may partially
+succeed. Successful operations are safe to replay because their markers are
+idempotency records. The supervisor conditionally clears each busy journal
+entry only after its catalog result is `applied`, `already_applied`, or `stale`.
+The compare-and-set
+succeeds only if the latest on-disk record still has the recovered
+`operationId`; a newer worker checkpoint is never clobbered. A request or
+persistence failure leaves the original entry busy for retry.
+
+A stale result is logged with its operation id and reason. It intentionally does
+not add even a warning marker because the recovery process no longer owns the
+active transcript.
+
+## Failure and race behavior
+
+| Scenario | Result |
+| --- | --- |
+| Exact unchanged interrupted turn | Missing synthetic results and one marker are appended. |
+| Session advanced before recovery | `stale`; zero bytes appended. |
+| Session branched to another head | `stale`; zero bytes appended. |
+| Path replaced by another session generation | `stale`; zero bytes appended. |
+| Same path receives a newer tool-use turn | `stale`; newer calls remain untouched. |
+| A normal live owner holds the session lease | `stale`; zero bytes appended. |
+| Another recovery holds the session lease | Retryable failure; journal stays busy. |
+| Response lost after marker commit | Replay returns `already_applied`. |
+| Concurrent duplicate requests | Per-path serialization yields one apply and idempotent no-ops. |
+| Failure after some synthetic results | Replay resumes only the same operation-owned suffix. |
+| New work follows a partial recovery suffix | `stale`; no further mutation. |
+| Legacy journal lacks authority | `stale`; zero bytes appended. |
+
+## Tests
+
+Focused tests must prove:
+
+1. v2 parsing, stable operation ids within a busy epoch, new ids after idle, and
+   deduplication that includes all authority fields.
+2. Exact-authority recovery closes only the authorized assistant turn and
+   appends one marker.
+3. Advance, alternate branch, session replacement, same-path newer tool-use,
+   lineage mismatch, and held-lease cases append no bytes.
+4. Response-loss replay and concurrent duplicate requests produce exactly one
+   result per tool call and one marker.
+5. Injected failure after the first of several results can resume without
+   duplicates; a foreign suffix after partial persistence blocks continuation.
+6. Supervisor retry retains busy records on request failure but clears them for
+   applied, already-applied, and stale outcomes.
+7. Existing interrupted-result wording and ordinary session behavior remain
+   unchanged.
+
+## Acceptance criteria
+
+- Every recovery mutation is authorized by an exact v2 checkpoint and protected
+  by the session lease.
+- Any authority mismatch produces a byte-for-byte unchanged session file.
+- One operation id can produce at most one recovery marker and one synthetic
+  result per authorized tool call.
+- Focused tests, type checking, formatting, and linting pass for the exact PR
+  head.

--- a/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
@@ -34,9 +34,10 @@ requests can duplicate synthetic results.
 
 ## Recovery authority
 
-Worker recovery records move to a validated v2 shape. Each busy epoch has one
-stable `operationId`, created at the first durable busy checkpoint and reused
-until the session becomes idle. Every busy checkpoint records:
+Worker recovery records move to a validated v2 shape. Each exact-authority busy
+epoch has one stable `operationId`, created at its first durable checkpoint and
+reused while that authority remains unchanged. An authority change starts a new
+epoch even if the worker never reported idle. Every busy checkpoint records:
 
 - `activeSessionId`: runtime identity for diagnostics.
 - `sessionId`: persisted session generation from the session header.
@@ -51,9 +52,10 @@ until the session becomes idle. Every busy checkpoint records:
 - `operationId`, `operation`, `busy`, and `recordedAt`.
 
 The checkpoint is captured from one in-memory `SessionManager` view. Changes to
-session generation, path, head, assistant entry, or lineage force a new journal
-record even when the event name is unchanged. Idle records end the busy epoch;
-the next busy transition receives a new operation id. Journal writes use a
+session generation, path, head, assistant entry, tool calls, or lineage force a
+new journal record and operation id even when the event name is unchanged. Idle
+records end the busy epoch; the next busy transition also receives a new
+operation id. Journal writes use a
 journal-local cross-process guard. Recovery completes an epoch with a
 compare-and-set on `operationId` after re-reading the latest record, so it
 cannot overwrite a newer busy epoch created by a resumed worker.

--- a/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-13-exact-turn-worker-recovery-design.md
@@ -13,6 +13,13 @@ the worker died. It is also not idempotent when persistence succeeds but the
 catalog response is lost. A retry can append the marker again, and concurrent
 requests can duplicate synthetic results.
 
+A second race exists when the assistant entry reaches the transcript after the
+last busy checkpoint. The catalog correctly rejects the older authority as
+stale, but a replacement worker then records `ready` with the unresolved call
+and the supervisor ignores idle records. Recovery must therefore also repair an
+exact unresolved terminal turn while the restoring worker exclusively holds the
+session lease, before it publishes `ready`.
+
 ## Goals
 
 - Bind recovery mutation authority to the exact persisted session generation,
@@ -22,6 +29,8 @@ requests can duplicate synthetic results.
 - Make the complete recovery operation idempotent across response loss,
   concurrent duplicate requests, and partial multi-result persistence.
 - Preserve the warning that execution and external side effects are unknown.
+- Repair unresolved terminal tool calls during worker restore before an idle
+  checkpoint can strand them.
 - Keep the change local to worker recovery rather than adding a general session
   transaction framework.
 
@@ -51,11 +60,11 @@ epoch even if the worker never reported idle. Every busy checkpoint records:
   parent links through `headEntryId`.
 - `operationId`, `operation`, `busy`, and `recordedAt`.
 
-The checkpoint is captured from one in-memory `SessionManager` view. Changes to
-session generation, path, head, assistant entry, tool calls, or lineage force a
-new journal record and operation id even when the event name is unchanged. Idle
-records end the busy epoch; the next busy transition also receives a new
-operation id. Journal writes use a
+The checkpoint is captured from one in-memory `SessionManager` view. While busy,
+changes to session generation, path, head, assistant entry, tool calls, or
+lineage force a new journal record and operation id even when the event name is
+unchanged. An idle record closes the preceding epoch under its operation id;
+the next busy transition receives a new operation id. Journal writes use a
 journal-local cross-process guard. Recovery completes an epoch with a
 compare-and-set on `operationId` after re-reading the latest record, so it
 cannot overwrite a newer busy epoch created by a resumed worker.
@@ -82,9 +91,10 @@ its lease.
 Under the lease, recovery follows this order:
 
 1. Search all entries for a `prime-agent.worker_recovery` marker carrying the
-   same `operationId`. If found, return `already_applied` without writing. This
-   is global rather than active-branch-only so later branching cannot cause a
-   completed operation to be applied again.
+   same `operationId` and full exact authority. A matching marker returns
+   `already_applied`; the same id bound to different authority is stale. The
+   search is global rather than active-branch-only so later branching cannot
+   cause a completed operation to be applied again.
 2. Open the session and verify `sessionId`.
 3. Verify that the active branch prefix through `headEntryId`, its
    `lineageDigest`, and `assistantEntryId` exactly match the journal authority.
@@ -105,6 +115,24 @@ If an append fails after some synthetic results, the request fails. A retry can
 recognize the owned suffix and append only the missing results and marker. If
 new work appears after that partial suffix, the retry becomes stale instead of
 mutating the newer work.
+
+## Restore-time recovery
+
+After a worker opens and binds an existing session under its exclusive session
+lease, it captures the current exact authority before publishing `ready`. If the
+terminal assistant turn has unresolved tool calls, the worker first persists a
+busy `restore_interrupted` epoch with a fresh operation id, then applies the same
+synthetic-result and authority-bound marker helper used by catalog recovery.
+Tools are never replayed and the worker does not automatically continue the
+model turn.
+
+A successful or idempotent apply permits the normal idle `ready` checkpoint,
+which observes no unresolved calls and closes the busy epoch. A stale result,
+journal invariant failure, or persistence error fails the open and leaves the
+busy authority durable. Disposing the failed runtime releases the lease, after
+which the supervisor/catalog path can resume an operation-owned partial suffix
+or recognize its completed marker. Restores with no unresolved calls perform no
+recovery mutation.
 
 ## Supervisor completion
 
@@ -161,15 +189,25 @@ Focused tests must prove:
    duplicates; a foreign suffix after partial persistence blocks continuation.
 6. Supervisor retry retains busy records on request failure but clears them for
    applied, already-applied, and stale outcomes.
-7. Existing interrupted-result wording and ordinary session behavior remain
-   unchanged.
+7. Restore with an unresolved terminal tool call persists busy authority before
+   mutation, appends exactly one synthetic result and marker, then publishes an
+   idle checkpoint with no unresolved calls.
+8. Restore with no unresolved calls performs no recovery mutation, while a
+   crash or persistence failure during restore leaves the busy epoch resumable
+   through the supervisor/catalog path.
+9. Marker deduplication rejects the same operation id when its recorded exact
+   authority differs.
+10. Existing interrupted-result wording and ordinary session behavior remain
+    unchanged.
 
 ## Acceptance criteria
 
 - Every recovery mutation is authorized by an exact v2 checkpoint and protected
   by the session lease.
 - Any authority mismatch produces a byte-for-byte unchanged session file.
-- One operation id can produce at most one recovery marker and one synthetic
-  result per authorized tool call.
+- One operation id can produce at most one authority-matching recovery marker
+  and one synthetic result per authorized tool call.
+- A worker never publishes `ready` while its restored active branch still has an
+  unresolved terminal tool call.
 - Focused tests, type checking, formatting, and linting pass for the exact PR
   head.

--- a/docs/superpowers/specs/2026-08-14-supervisor-shutdown-authority-design.md
+++ b/docs/superpowers/specs/2026-08-14-supervisor-shutdown-authority-design.md
@@ -130,14 +130,17 @@ replacement token. Client wait logic treats rejection as “still running” and
 does not launch a replacement.
 
 Process cleanup represents graceful termination with a structured outcome.
-`shutdown_authority_rejected` is terminal: even with `force`, cleanup does not
-signal the supervisor, stop tracked workers, remove its socket, or kill it in a
-residual sweep. Only timeout or unavailability may enter the existing exact-
-process fallback.
+`shutdown_authority_rejected` is terminal: even with `force`, cleanup protects
+the supervisor plus every tracked worker and child identity/socket from direct
+cleanup and residual convergence. It does not signal them, remove their sockets,
+or delete their descriptors. Only timeout or unavailability may enter the
+existing exact-process fallback.
 
-If the connected daemon disappears between handshake and command, the existing
-wait-for-gone logic handles the disconnect. Version classification and authority
-remain on the original connection, eliminating the probe-to-shutdown TOCTOU.
+If the connected daemon disappears before a response, the existing wait-for-gone
+logic handles the uncertain disconnect. A normal failed response is terminal
+`false`, even if the rejecting process exits independently afterward. Version
+classification and authority remain on the original connection, eliminating the
+probe-to-shutdown TOCTOU.
 
 ## Tests
 
@@ -150,11 +153,11 @@ Focused protocol and supervisor regressions cover:
 3. Each mismatched component—and authority missing process-start identity—is
    rejected without shutdown.
 4. `force` cannot bypass authority at the server or convert rejection into
-   signal fallback or tracked-worker cleanup.
-5. A new client can shut down both an identity-less legacy fixture and a
-   schema-16 fixture that publishes full identity and accepts the new field.
-6. Stale classification, list, and shutdown use one connection, and replacement
-   does not launch after guarded rejection.
+   signal fallback, tracked-worker cleanup, or residual worker termination.
+5. A new client can shut down or restart both an identity-less legacy fixture
+   and a schema-16 fixture that publishes full identity and accepts new fields.
+6. Stale classification, list, and shutdown use one connection; rejection is
+   terminal even if the daemon exits independently afterward.
 7. Public CLI and process cleanup callers include authority, while private
    worker shutdown remains functional.
 

--- a/docs/superpowers/specs/2026-08-14-supervisor-shutdown-authority-design.md
+++ b/docs/superpowers/specs/2026-08-14-supervisor-shutdown-authority-design.md
@@ -130,11 +130,13 @@ replacement token. Client wait logic treats rejection as “still running” and
 does not launch a replacement.
 
 Process cleanup represents graceful termination with a structured outcome.
-`shutdown_authority_rejected` is terminal: even with `force`, cleanup protects
-the supervisor plus every tracked worker and child identity/socket from direct
-cleanup and residual convergence. It does not signal them, remove their sockets,
-or delete their descriptors. Only timeout or unavailability may enter the
-existing exact-process fallback.
+`shutdown_authority_rejected` is terminal: even with `force`, cleanup first
+defers known tracked workers and journaled children behind their supervisor,
+then protects the rejected supervisor plus every tracked worker/child exact
+identity and socket before each remaining direct action, same-path duplicate
+cleanup, and residual convergence. It does not signal them, remove their sockets, or delete their
+descriptors. Only timeout or unavailability may enter the existing exact-process
+fallback.
 
 If the connected daemon disappears before a response, the existing wait-for-gone
 logic handles the uncertain disconnect. A normal failed response is terminal

--- a/docs/superpowers/specs/2026-08-14-supervisor-shutdown-authority-design.md
+++ b/docs/superpowers/specs/2026-08-14-supervisor-shutdown-authority-design.md
@@ -1,0 +1,157 @@
+# Supervisor shutdown authority
+
+## Context
+
+A coordinated daemon upgrade restored the intended workers and supervisor, but
+an obsolete inactive interactive client remained alive with an older wire
+schema. When the upgraded daemon became idle, that client classified it as
+stale, sent the legacy unauthenticated `shutdown` command, and raced other
+clients and workers to replace it. An obsolete generation won the race and then
+failed to recover one intended session under the already-fixed lease race.
+
+The public daemon socket is user-local, but connection access alone must not be
+authority to terminate whichever supervisor happens to own that path. A client
+may decide to replace only the exact supervisor identity it observed during the
+handshake.
+
+## Goals
+
+- Prevent legacy or stale clients from shutting down a newer supervisor.
+- Bind shutdown to the exact supervisor observed on the same connection.
+- Fail closed when authority is missing, incomplete, or stale.
+- Preserve new-client replacement of a legacy supervisor during upgrades.
+- Keep explicit and automatic shutdown callers on one shared command builder.
+- Add regression coverage for missing, matching, and mismatched authority.
+
+## Non-goals
+
+- Authenticating arbitrary operating-system users beyond existing socket
+  permissions.
+- Replacing the update-restart ownership protocol.
+- Changing worker-local shutdown commands.
+- Automatically restarting interactive client processes during an update.
+- Treating build identifiers as compatibility boundaries.
+
+## Considered approaches
+
+### Operational cleanup only
+
+Stopping obsolete clients before every restart restores service but leaves the
+same rollback mechanism available after the next upgrade or dormant client
+reconnection. This is insufficient.
+
+### Exact compare-and-shutdown authority
+
+Require public supervisor shutdown requests to echo the full identity received
+in `daemon_hello`. This is the selected design because it closes the rollback
+race at the terminating process, remains deterministic, and needs no new secret.
+
+### Authenticated shutdown capability
+
+Issuing a new secret capability would also block legacy clients, but introduces
+secret lifecycle, persistence, and recovery complexity without improving the
+same-connection compare-and-set property needed here. This is deferred.
+
+## Authority contract
+
+The existing handshake already publishes the durable supervisor identity:
+
+- supervisor generation;
+- durable owner token;
+- process id;
+- process start identity;
+- normalized supervisor socket path.
+
+A public `shutdown` command gains an optional wire field containing that exact
+identity. It stays optional in the TypeScript wire type solely for forward
+upgrade compatibility with legacy supervisors.
+
+A new supervisor requires the field and compares every supplied component to
+its current durable ownership record before scheduling shutdown. Missing,
+malformed, incomplete, or mismatched authority returns a normal failed response
+and leaves the supervisor, workers, descriptors, and socket untouched. The
+`force` flag changes worker-drain behavior only; it never bypasses authority.
+
+The comparison happens synchronously in command handling before the success
+response and before `setImmediate` schedules shutdown. The server reasserts its
+current durable ownership while validating so a generation that has already
+lost ownership cannot accept termination commands.
+
+## Compatibility
+
+A shared client helper derives shutdown authority from `DaemonClient.hello`:
+
+- When the handshake contains the complete modern identity, the helper includes
+  it in the command.
+- When connected to a legacy supervisor whose handshake lacks any required
+  component, the helper emits the legacy command without authority. The legacy
+  supervisor accepts it, preserving forward upgrade replacement.
+- A legacy client talking to a new supervisor emits no authority. The new
+  supervisor rejects it, preventing rollback.
+
+The command changes the monotonic schema revision and schema identifier. It does
+not change the protocol major version. Shutdown remains classified as a legacy-
+compatible command so a new client may send the authority-optional wire shape
+to an older supervisor; only the new supervisor enforces the field. Worker-
+local shutdown continues to use its existing internal path.
+
+## Production callers
+
+All public shutdown paths use the shared helper rather than constructing the
+command independently:
+
+- explicit CLI shutdown, including force;
+- stale-daemon replacement;
+- process/status cleanup utilities;
+- update and test cleanup paths that target the public supervisor.
+
+The supervisor's command to a resident worker remains unguarded because it is
+sent over the authenticated private worker channel and terminates that worker,
+not the public supervisor.
+
+## Error handling
+
+Authority rejection is fail-closed and side-effect free. The response names a
+stable authority error suitable for tests and diagnostics without disclosing a
+replacement token. Client wait logic treats a rejected shutdown as “still
+running” and does not launch a replacement.
+
+If the connected daemon disappears between handshake and command, the existing
+wait-for-gone logic handles the disconnect. Authority must never be copied from
+a separate probe connection because that would reintroduce a time-of-check /
+time-of-use race.
+
+## Tests
+
+Focused protocol and supervisor regressions cover:
+
+1. A legacy shutdown without authority is rejected by a new supervisor and the
+   same supervisor identity remains reachable.
+2. A command echoing the exact handshake identity is accepted and terminates
+   that supervisor.
+3. Each mismatched component—generation, owner token, pid, process start, and
+   socket path—is independently rejected without shutdown.
+4. `force` cannot bypass missing or mismatched authority.
+5. A new client can still shut down a legacy fixture whose handshake lacks the
+   authority fields.
+6. Automatic stale-daemon replacement does not launch after the guarded
+   supervisor rejects an obsolete client.
+7. Public CLI and process cleanup callers include authority, while private
+   worker shutdown remains functional.
+
+Validation uses isolated socket, descriptor, agent, and session namespaces. No
+daemon-capable suite runs against the live runtime.
+
+## Activation and recovery
+
+After review and validation, publish the new PR head, integrate it into the
+aggregate build in an isolated worktree, and activate it with a coordinated
+restart. Before activation, retire only processes proven to be obsolete and
+unattached; preserve the current root transcript and frozen plugin transcript.
+The empty unattached draft worker may be passivated.
+
+Recovery succeeds only when the activated supervisor identity is verified, the
+root session is restored, the plugin has one live worker under its saved session
+identity, its current authority has no unresolved tool calls, and its journal is
+idle. Resume the plugin from its saved Task 14 checkpoint without replaying
+prior tools.

--- a/docs/superpowers/specs/2026-08-14-supervisor-shutdown-authority-design.md
+++ b/docs/superpowers/specs/2026-08-14-supervisor-shutdown-authority-design.md
@@ -16,12 +16,13 @@ handshake.
 
 ## Goals
 
-- Prevent legacy or stale clients from shutting down a newer supervisor.
-- Bind shutdown to the exact supervisor observed on the same connection.
-- Fail closed when authority is missing, incomplete, or stale.
+- Prevent legacy or stale clients from terminating a newer supervisor.
+- Bind public shutdown and restart to the exact supervisor observed on the same connection.
+- Keep stale classification, idleness checking, and termination on that one connection.
+- Fail closed when authority is missing, incomplete, rejected, or stale.
 - Preserve new-client replacement of a legacy supervisor during upgrades.
-- Keep explicit and automatic shutdown callers on one shared command builder.
-- Add regression coverage for missing, matching, and mismatched authority.
+- Keep explicit and automatic termination callers behind `DaemonClient` methods.
+- Add regression coverage for missing, matching, mismatched, and rejected authority.
 
 ## Non-goals
 
@@ -62,15 +63,19 @@ The existing handshake already publishes the durable supervisor identity:
 - process start identity;
 - normalized supervisor socket path.
 
-A public `shutdown` command gains an optional wire field containing that exact
-identity. It stays optional in the TypeScript wire type solely for forward
-upgrade compatibility with legacy supervisors.
+Public `shutdown` and `restart` commands gain an optional wire field containing
+that exact identity. It stays optional in the wire type solely for forward
+upgrade compatibility with legacy supervisors. The authority shape itself
+requires all five fields, including a non-empty process-start identity. A modern
+hello missing any field cannot produce authority and therefore cannot authorize
+termination.
 
-A new supervisor requires the field and compares every supplied component to
-its current durable ownership record before scheduling shutdown. Missing,
-malformed, incomplete, or mismatched authority returns a normal failed response
-and leaves the supervisor, workers, descriptors, and socket untouched. The
-`force` flag changes worker-drain behavior only; it never bypasses authority.
+A new supervisor requires the field for either public termination command and
+compares every supplied component to its current durable ownership record before
+scheduling shutdown or restart. Missing, malformed, incomplete, or mismatched
+authority returns a normal failed response and leaves the supervisor, workers,
+descriptors, and socket untouched. The `force` flag changes worker-drain
+behavior only; it never bypasses authority.
 
 The comparison happens synchronously in command handling before the success
 response and before `setImmediate` schedules shutdown. The server reasserts its
@@ -79,31 +84,39 @@ lost ownership cannot accept termination commands.
 
 ## Compatibility
 
-A shared client helper derives shutdown authority from `DaemonClient.hello`:
+`DaemonClient` derives termination authority from its own received hello at send
+time; callers cannot supply a hello from another connection:
 
-- When the handshake contains the complete modern identity, the helper includes
-  it in the command.
+- When the handshake contains the complete modern identity, the client includes
+  it in shutdown or restart.
 - When connected to a legacy supervisor whose handshake lacks any required
-  component, the helper emits the legacy command without authority. The legacy
+  component, the client emits the legacy command without authority. The legacy
   supervisor accepts it, preserving forward upgrade replacement.
+- A schema-16 supervisor already publishes complete identity. The new client
+  sends the authority-bearing shape, which its tolerant old parser accepts.
 - A legacy client talking to a new supervisor emits no authority. The new
   supervisor rejects it, preventing rollback.
 
-The command changes the monotonic schema revision and schema identifier. It does
-not change the protocol major version. Shutdown remains classified as a legacy-
-compatible command so a new client may send the authority-optional wire shape
-to an older supervisor; only the new supervisor enforces the field. Worker-
-local shutdown continues to use its existing internal path.
+The commands change the monotonic schema revision to 18 and update the schema
+identifier without changing the protocol major version. Shutdown and restart
+remain legacy-compatible commands so a new client may send the authority-
+optional shapes to an older supervisor; only the new supervisor enforces the
+field. Worker-local shutdown continues to use its authenticated internal path.
 
 ## Production callers
 
-All public shutdown paths use the shared helper rather than constructing the
-command independently:
+All public termination paths use `DaemonClient` methods rather than constructing
+commands from detached hellos:
 
-- explicit CLI shutdown, including force;
+- explicit CLI shutdown and restart, including force;
 - stale-daemon replacement;
 - process/status cleanup utilities;
 - update and test cleanup paths that target the public supervisor.
+
+Stale replacement keeps the version verdict, busy-session query, authority, and
+shutdown request on one connection. It never reconnects after classifying a
+daemon stale; a disconnect aborts replacement so a successor cannot inherit the
+previous owner's stale verdict.
 
 The supervisor's command to a resident worker remains unguarded because it is
 sent over the authenticated private worker channel and terminates that worker,
@@ -113,29 +126,35 @@ not the public supervisor.
 
 Authority rejection is fail-closed and side-effect free. The response names a
 stable authority error suitable for tests and diagnostics without disclosing a
-replacement token. Client wait logic treats a rejected shutdown as “still
-running” and does not launch a replacement.
+replacement token. Client wait logic treats rejection as “still running” and
+does not launch a replacement.
+
+Process cleanup represents graceful termination with a structured outcome.
+`shutdown_authority_rejected` is terminal: even with `force`, cleanup does not
+signal the supervisor, stop tracked workers, remove its socket, or kill it in a
+residual sweep. Only timeout or unavailability may enter the existing exact-
+process fallback.
 
 If the connected daemon disappears between handshake and command, the existing
-wait-for-gone logic handles the disconnect. Authority must never be copied from
-a separate probe connection because that would reintroduce a time-of-check /
-time-of-use race.
+wait-for-gone logic handles the disconnect. Version classification and authority
+remain on the original connection, eliminating the probe-to-shutdown TOCTOU.
 
 ## Tests
 
 Focused protocol and supervisor regressions cover:
 
-1. A legacy shutdown without authority is rejected by a new supervisor and the
-   same supervisor identity remains reachable.
+1. Legacy shutdown and restart without authority are rejected by a new
+   supervisor and the same identity remains reachable.
 2. A command echoing the exact handshake identity is accepted and terminates
    that supervisor.
-3. Each mismatched component—generation, owner token, pid, process start, and
-   socket path—is independently rejected without shutdown.
-4. `force` cannot bypass missing or mismatched authority.
-5. A new client can still shut down a legacy fixture whose handshake lacks the
-   authority fields.
-6. Automatic stale-daemon replacement does not launch after the guarded
-   supervisor rejects an obsolete client.
+3. Each mismatched component—and authority missing process-start identity—is
+   rejected without shutdown.
+4. `force` cannot bypass authority at the server or convert rejection into
+   signal fallback or tracked-worker cleanup.
+5. A new client can shut down both an identity-less legacy fixture and a
+   schema-16 fixture that publishes full identity and accepts the new field.
+6. Stale classification, list, and shutdown use one connection, and replacement
+   does not launch after guarded rejection.
 7. Public CLI and process cleanup callers include authority, while private
    worker shutdown remains functional.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Fixed interrupted-session worker recovery leaving unresolved tool calls open in the transcript: the latest assistant turn's open tool calls are now closed with synthetic error tool results before marking the session recovered; the results state that the tool result and side effects are unknown and were not replayed, so the agent inspects external side effects before retrying.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -8,11 +8,7 @@ import { expandTildePath } from "../config.js";
 import type { AgentSessionEvent } from "../core/agent-session.js";
 import type { AgentSessionRuntimeConfig } from "../core/agent-session-config.js";
 import { type AgentCronJob, formatAgentCronJob } from "../core/cron-jobs.js";
-import {
-	createDaemonShutdownCommand,
-	DaemonClient,
-	type DaemonClientMessageListener,
-} from "../modes/daemon/daemon-client.js";
+import { DaemonClient, type DaemonClientMessageListener } from "../modes/daemon/daemon-client.js";
 import type { DaemonOutbound, DaemonResponse } from "../modes/daemon/daemon-protocol.js";
 import { matchesSessionIdSuffix } from "../modes/daemon/daemon-session-id.js";
 import type { SessionSummary } from "../modes/daemon/daemon-session-list.js";
@@ -244,7 +240,7 @@ async function runDaemonClientCommand(parsed: ParsedDaemonClientCommand): Promis
 				if (parsed.positionals.length !== 0) {
 					throw new Error("Usage: daemon restart");
 				}
-				await printResponseData(client, { type: "restart" }, parsed.json);
+				printResponse(await client.requestSupervisorRestart(), parsed.json);
 				return;
 			case "shutdown":
 				await runShutdown(client, parsed.positionals, parsed.json);
@@ -264,8 +260,7 @@ async function runShutdown(client: DaemonClient, args: string[], json: boolean):
 		}
 		throw new Error(`Unknown shutdown option: ${arg}`);
 	}
-	const hello = await client.waitForHello(3000).catch(() => undefined);
-	await printResponseData(client, createDaemonShutdownCommand(hello, force), json);
+	printResponse(await client.requestSupervisorShutdown(force), json);
 }
 
 async function runOpen(parsed: ParsedDaemonClientCommand): Promise<void> {
@@ -1101,7 +1096,10 @@ async function printResponseData(
 	command: Parameters<DaemonClient["request"]>[0],
 	json: boolean,
 ): Promise<void> {
-	const response = await client.request(command);
+	printResponse(await client.request(command), json);
+}
+
+function printResponse(response: DaemonResponse, json: boolean): void {
 	const data = requireSuccess(response);
 	if (json || data !== undefined) {
 		printJson(data ?? response);

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -8,7 +8,11 @@ import { expandTildePath } from "../config.js";
 import type { AgentSessionEvent } from "../core/agent-session.js";
 import type { AgentSessionRuntimeConfig } from "../core/agent-session-config.js";
 import { type AgentCronJob, formatAgentCronJob } from "../core/cron-jobs.js";
-import { DaemonClient, type DaemonClientMessageListener } from "../modes/daemon/daemon-client.js";
+import {
+	createDaemonShutdownCommand,
+	DaemonClient,
+	type DaemonClientMessageListener,
+} from "../modes/daemon/daemon-client.js";
 import type { DaemonOutbound, DaemonResponse } from "../modes/daemon/daemon-protocol.js";
 import { matchesSessionIdSuffix } from "../modes/daemon/daemon-session-id.js";
 import type { SessionSummary } from "../modes/daemon/daemon-session-list.js";
@@ -260,7 +264,8 @@ async function runShutdown(client: DaemonClient, args: string[], json: boolean):
 		}
 		throw new Error(`Unknown shutdown option: ${arg}`);
 	}
-	await printResponseData(client, { type: "shutdown", force }, json);
+	const hello = await client.waitForHello(3000).catch(() => undefined);
+	await printResponseData(client, createDaemonShutdownCommand(hello, force), json);
 }
 
 async function runOpen(parsed: ParsedDaemonClientCommand): Promise<void> {

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -248,16 +248,22 @@ export async function shutdownConnectedDaemonAndWait(
 	timeoutMs = 5000,
 ): Promise<boolean> {
 	let shutdownAccepted = false;
+	let shutdownRejected = false;
 	let expectedIdentity: DaemonProcessIdentity | undefined;
 	try {
 		const hello = client.hello ?? (await client.waitForHello());
 		expectedIdentity = processIdentityFromDaemonHello(hello);
 		const response = await client.requestSupervisorShutdown();
 		shutdownAccepted = response.success;
+		shutdownRejected = !response.success;
 	} catch {
-		// A connect failure isn't treated as "gone"; waitForDaemonGone is the source of truth.
+		// A disconnect before a response remains uncertain; waitForDaemonGone is
+		// the source of truth only when the daemon did not explicitly reject.
 	} finally {
 		client.close();
+	}
+	if (shutdownRejected) {
+		return false;
 	}
 	return waitForDaemonGone(socketPath, timeoutMs, shutdownAccepted, expectedIdentity);
 }

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -11,7 +11,7 @@ import { resolve } from "node:path";
 import { appendRotatingLog, expandTildePath, getClientErrorLogPath, getDaemonLogPath, VERSION } from "../config.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../core/orphan-process-journal.js";
 import { getProcessStartId, SESSION_LEASE_OWNER_ID_ENV, SESSION_LEASES_ENABLED_ENV } from "../core/session-lease.js";
-import { createDaemonShutdownCommand, DaemonClient, type DaemonHello } from "../modes/daemon/daemon-client.js";
+import { DaemonClient, type DaemonHello } from "../modes/daemon/daemon-client.js";
 import { DAEMON_PROTOCOL_VERSION, DAEMON_SCHEMA_ID } from "../modes/daemon/daemon-protocol.js";
 import { getDaemonRuntimeIdentity } from "../modes/daemon/daemon-runtime-identity.js";
 import { isSessionSummaryBusy, type SessionSummary } from "../modes/daemon/daemon-session-list.js";
@@ -66,8 +66,13 @@ type DaemonVersionProbe =
 	| { status: "current"; hello: DaemonHello }
 	| { status: "stale"; hello?: DaemonHello };
 
-/** Connect to a running daemon and check whether it matches this client's protocol and app version. */
-export async function probeDaemonVersion(socketPath: string): Promise<DaemonVersionProbe> {
+interface ConnectedDaemonVersionProbe {
+	probe: DaemonVersionProbe;
+	client?: DaemonClient;
+}
+
+/** Connect once and keep that exact connection open for any stale replacement. */
+async function probeDaemonVersionConnection(socketPath: string): Promise<ConnectedDaemonVersionProbe> {
 	let client: DaemonClient | undefined;
 	for (const timeoutMs of [250, 2000]) {
 		const candidate = new DaemonClient(socketPath);
@@ -80,7 +85,7 @@ export async function probeDaemonVersion(socketPath: string): Promise<DaemonVers
 		}
 	}
 	if (!client) {
-		return { status: "absent" };
+		return { probe: { status: "absent" } };
 	}
 	try {
 		const hello = await client.waitForHello(2000);
@@ -95,17 +100,20 @@ export async function probeDaemonVersion(socketPath: string): Promise<DaemonVers
 					`v${VERSION}/proto${DAEMON_PROTOCOL_VERSION}/schema ${DAEMON_SCHEMA_ID}/build ${getDaemonRuntimeIdentity().buildId}`,
 			);
 		}
-		if (current) {
-			return { status: "current", hello };
-		}
-		return { status: "stale", hello };
+		return { probe: current ? { status: "current", hello } : { status: "stale", hello }, client };
 	} catch {
-		// Connected but no recognizable greeting: assume a stale daemon.
+		// Connected but no recognizable greeting: assume stale, while preserving
+		// this exact connection so no successor can inherit the stale verdict.
 		logDaemonLaunch(`running daemon on ${socketPath} sent no recognizable hello; treating as stale`);
-		return { status: "stale" };
-	} finally {
-		client.close();
+		return { probe: { status: "stale" }, client };
 	}
+}
+
+/** Connect to a running daemon and check whether it matches this client. */
+export async function probeDaemonVersion(socketPath: string): Promise<DaemonVersionProbe> {
+	const connected = await probeDaemonVersionConnection(socketPath);
+	connected.client?.close();
+	return connected.probe;
 }
 
 export async function listActiveDaemonSessionSummaries(
@@ -238,13 +246,14 @@ export async function shutdownConnectedDaemonAndWait(
 	client: DaemonClient,
 	socketPath: string,
 	timeoutMs = 5000,
-	hello: DaemonHello | undefined = client.hello,
 ): Promise<boolean> {
 	let shutdownAccepted = false;
-	const expectedIdentity = processIdentityFromDaemonHello(hello);
+	let expectedIdentity: DaemonProcessIdentity | undefined;
 	try {
-		const response = await client.request(createDaemonShutdownCommand(hello)).catch(() => undefined);
-		shutdownAccepted = response?.success === true;
+		const hello = client.hello ?? (await client.waitForHello());
+		expectedIdentity = processIdentityFromDaemonHello(hello);
+		const response = await client.requestSupervisorShutdown();
+		shutdownAccepted = response.success;
 	} catch {
 		// A connect failure isn't treated as "gone"; waitForDaemonGone is the source of truth.
 	} finally {
@@ -257,8 +266,7 @@ export async function shutdownDaemonAndWait(socketPath: string, timeoutMs = 5000
 	const client = new DaemonClient(socketPath);
 	try {
 		await client.connect(1000);
-		const hello = await client.waitForHello(2000).catch(() => undefined);
-		return shutdownConnectedDaemonAndWait(client, socketPath, timeoutMs, hello);
+		return shutdownConnectedDaemonAndWait(client, socketPath, timeoutMs);
 	} catch {
 		client.close();
 		return waitForDaemonGone(socketPath, timeoutMs);
@@ -301,30 +309,18 @@ export async function probeRunningDaemonSessions(socketPath: string): Promise<Ru
 
 // Idle-but-loaded sessions reload from disk on the fresh daemon, so only a busy
 // session blocks replacing a stale daemon.
-async function shutdownStaleDaemonIfNotBusy(socketPath: string): Promise<boolean> {
-	const client = new DaemonClient(socketPath);
-	let connected = false;
+async function shutdownStaleDaemonIfNotBusy(client: DaemonClient, socketPath: string): Promise<boolean> {
 	let hasBusySessions = false;
 	let loadedSessionCount = 0;
 	try {
-		await client.connect(1000);
-		connected = true;
-		try {
-			const result = await queryActiveDaemonSessions(client, { includeClientOwned: true });
-			loadedSessionCount = result.sessions.length;
-			hasBusySessions =
-				result.busyClientOwnedSessionCount !== 0 || result.sessions.some((summary) => isSessionBusy(summary));
-		} catch {
-			// Couldn't confirm idleness: treat as busy rather than risk interrupting work.
-			hasBusySessions = true;
-		}
+		const result = await queryActiveDaemonSessions(client, { includeClientOwned: true });
+		loadedSessionCount = result.sessions.length;
+		hasBusySessions =
+			result.busyClientOwnedSessionCount !== 0 || result.sessions.some((summary) => isSessionBusy(summary));
 	} catch {
-		// Couldn't reach it to inspect; don't send a blind shutdown, just verify below.
-	}
-
-	if (!connected) {
-		client.close();
-		return waitForDaemonGone(socketPath);
+		// Couldn't confirm idleness on the probed connection: fail closed instead
+		// of reconnecting and applying its stale verdict to a possible successor.
+		hasBusySessions = true;
 	}
 	if (hasBusySessions) {
 		client.close();
@@ -334,19 +330,20 @@ async function shutdownStaleDaemonIfNotBusy(socketPath: string): Promise<boolean
 	logDaemonLaunch(
 		`replacing stale daemon on ${socketPath} (idle): ${loadedSessionCount} loaded session(s) will reload`,
 	);
-	// Shut down over the same connection whose handshake the client observed:
-	// authority must never be copied from a separate probe connection because
-	// that would reintroduce a time-of-check / time-of-use race.
-	return shutdownConnectedDaemonAndWait(client, socketPath, 5000, client.hello);
+	return shutdownConnectedDaemonAndWait(client, socketPath, 5000);
 }
 
 async function ensureDaemonRunning(socketPath: string, spawnCwd?: string): Promise<void> {
-	const probe = await probeDaemonVersion(socketPath);
+	const connected = await probeDaemonVersionConnection(socketPath);
+	const { probe } = connected;
 	if (probe.status === "current") {
+		connected.client?.close();
 		return;
 	}
 	if (probe.status === "stale") {
-		const stopped = await shutdownStaleDaemonIfNotBusy(socketPath);
+		const client = connected.client;
+		if (!client) throw new StaleDaemonError(socketPath, probe.hello);
+		const stopped = await shutdownStaleDaemonIfNotBusy(client, socketPath);
 		if (!stopped) throw new StaleDaemonError(socketPath, probe.hello);
 	}
 

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -11,7 +11,7 @@ import { resolve } from "node:path";
 import { appendRotatingLog, expandTildePath, getClientErrorLogPath, getDaemonLogPath, VERSION } from "../config.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../core/orphan-process-journal.js";
 import { getProcessStartId, SESSION_LEASE_OWNER_ID_ENV, SESSION_LEASES_ENABLED_ENV } from "../core/session-lease.js";
-import { DaemonClient, type DaemonHello } from "../modes/daemon/daemon-client.js";
+import { createDaemonShutdownCommand, DaemonClient, type DaemonHello } from "../modes/daemon/daemon-client.js";
 import { DAEMON_PROTOCOL_VERSION, DAEMON_SCHEMA_ID } from "../modes/daemon/daemon-protocol.js";
 import { getDaemonRuntimeIdentity } from "../modes/daemon/daemon-runtime-identity.js";
 import { isSessionSummaryBusy, type SessionSummary } from "../modes/daemon/daemon-session-list.js";
@@ -243,7 +243,7 @@ export async function shutdownConnectedDaemonAndWait(
 	let shutdownAccepted = false;
 	const expectedIdentity = processIdentityFromDaemonHello(hello);
 	try {
-		const response = await client.request({ type: "shutdown" }).catch(() => undefined);
+		const response = await client.request(createDaemonShutdownCommand(hello)).catch(() => undefined);
 		shutdownAccepted = response?.success === true;
 	} catch {
 		// A connect failure isn't treated as "gone"; waitForDaemonGone is the source of truth.
@@ -320,21 +320,24 @@ async function shutdownStaleDaemonIfNotBusy(socketPath: string): Promise<boolean
 		}
 	} catch {
 		// Couldn't reach it to inspect; don't send a blind shutdown, just verify below.
-	} finally {
-		client.close();
 	}
 
 	if (!connected) {
+		client.close();
 		return waitForDaemonGone(socketPath);
 	}
 	if (hasBusySessions) {
+		client.close();
 		logDaemonLaunch(`refusing to replace stale daemon on ${socketPath}: busy session(s) present`);
 		return false;
 	}
 	logDaemonLaunch(
 		`replacing stale daemon on ${socketPath} (idle): ${loadedSessionCount} loaded session(s) will reload`,
 	);
-	return shutdownDaemonAndWait(socketPath);
+	// Shut down over the same connection whose handshake the client observed:
+	// authority must never be copied from a separate probe connection because
+	// that would reintroduce a time-of-check / time-of-use race.
+	return shutdownConnectedDaemonAndWait(client, socketPath, 5000, client.hello);
 }
 
 async function ensureDaemonRunning(socketPath: string, spawnCwd?: string): Promise<void> {

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -493,6 +493,30 @@ export function planShutdownAll(daemons: readonly DaemonInfo[], force: boolean):
 	});
 }
 
+export function isProtectedDaemonAction(
+	daemon: Pick<DaemonInfo, "socketPath" | "pid">,
+	protectedSockets: ReadonlySet<string>,
+	protectedProcesses: ReadonlyMap<number, string | undefined>,
+): boolean {
+	if (protectedSockets.has(normalizeSocketPath(daemon.socketPath))) return true;
+	if (daemon.pid === undefined || !protectedProcesses.has(daemon.pid)) return false;
+	const expectedStartId = protectedProcesses.get(daemon.pid);
+	return expectedStartId === undefined || getProcessStartId(daemon.pid) === expectedStartId;
+}
+
+export function orderShutdownActions(
+	actions: readonly ReapAction[],
+	dependentSockets: ReadonlySet<string>,
+	dependentProcesses: ReadonlyMap<number, string | undefined>,
+): ReapAction[] {
+	return [...actions].sort((left, right) => {
+		const dependentOrder =
+			Number(isProtectedDaemonAction(left.daemon, dependentSockets, dependentProcesses)) -
+			Number(isProtectedDaemonAction(right.daemon, dependentSockets, dependentProcesses));
+		return dependentOrder || SHUTDOWN_ALL_ACTION_ORDER[left.kind] - SHUTDOWN_ALL_ACTION_ORDER[right.kind];
+	});
+}
+
 const SHUTDOWN_ALL_ACTION_ORDER: Record<ReapAction["kind"], number> = {
 	shutdown: 0,
 	"remove-file": 1,
@@ -569,17 +593,19 @@ async function runShutdownAllConverging(
 	const protectedProcesses = new Map<number, string | undefined>();
 	const reportedFailures = new Set<string>();
 
-	if (force) {
-		await stopHiddenSupervisors(stopped, failed, handledPids, reportedFailures, assertAdmission);
-	}
 	const daemons = (await discoverDaemons()).filter((daemon) => !isWorkerSocketPath(daemon.socketPath));
 
-	const actions = [...planShutdownAll(daemons, force)].sort(
-		(left, right) => SHUTDOWN_ALL_ACTION_ORDER[left.kind] - SHUTDOWN_ALL_ACTION_ORDER[right.kind],
-	);
+	const dependentSockets = new Set<string>();
+	const dependentProcesses = new Map<number, string | undefined>();
+	collectTrackedDependentScope(dependentSockets, dependentProcesses);
+	const actions = orderShutdownActions(planShutdownAll(daemons, force), dependentSockets, dependentProcesses);
 
 	for (const action of actions) {
 		const { socketPath, pid } = action.daemon;
+		if (isProtectedDaemonAction(action.daemon, protectedSockets, protectedProcesses)) {
+			stopped.push({ socketPath, action: "preserved after shutdown authority rejection" });
+			continue;
+		}
 		if (pid !== undefined && handledPids.has(pid)) {
 			await assertAdmission();
 			removeSocketFile(socketPath);
@@ -657,6 +683,15 @@ async function runShutdownAllConverging(
 	}
 
 	if (force) {
+		await stopHiddenSupervisors(
+			stopped,
+			failed,
+			handledPids,
+			protectedSockets,
+			protectedProcesses,
+			reportedFailures,
+			assertAdmission,
+		);
 		await terminateVerifiedResiduals(
 			stopped,
 			failed,
@@ -694,6 +729,8 @@ async function stopHiddenSupervisors(
 	stopped: Array<{ socketPath: string; action: string }>,
 	failed: Array<{ socketPath: string; reason: string }>,
 	handledPids: Set<number>,
+	protectedSockets: ReadonlySet<string>,
+	protectedProcesses: ReadonlyMap<number, string | undefined>,
 	reportedFailures: Set<string>,
 	assertAdmission: () => Promise<void>,
 ): Promise<void> {
@@ -720,7 +757,13 @@ async function stopHiddenSupervisors(
 				);
 				continue;
 			}
-			hidden.push(...group.filter((listener) => listener.pid !== currentPid));
+			hidden.push(
+				...group.filter(
+					(listener) =>
+						listener.pid !== currentPid &&
+						!isProtectedDaemonAction(listener, protectedSockets, protectedProcesses),
+				),
+			);
 		}
 		if (hidden.length === 0) {
 			return;
@@ -755,6 +798,27 @@ function addProtectedProcess(
 	if (protectedProcesses.get(pid) !== processStartId) {
 		// Conflicting or incomplete identity must broaden protection, never narrow it.
 		protectedProcesses.set(pid, undefined);
+	}
+}
+
+function collectTrackedDependentScope(
+	dependentSockets: Set<string>,
+	dependentProcesses: Map<number, string | undefined>,
+): void {
+	for (const { descriptor } of findAllTrackedWorkers()) {
+		dependentSockets.add(normalizeSocketPath(descriptor.socketPath));
+		addProtectedProcess(dependentProcesses, descriptor.pid, descriptor.processStartId);
+		if (!descriptor.orphanProcessJournalPath) continue;
+		try {
+			for (const orphan of readActiveOrphanProcesses(descriptor.orphanProcessJournalPath, descriptor.pid)) {
+				if (isOrphanProcessIdentityCurrent(orphan)) {
+					addProtectedProcess(dependentProcesses, orphan.pid, orphan.processStartId);
+				}
+			}
+		} catch {
+			// The known worker identity remains deferred; do not infer child identities
+			// from missing or malformed journal data.
+		}
 	}
 }
 
@@ -824,15 +888,7 @@ async function terminateVerifiedResiduals(
 		previousSignature = signature;
 		const seenPids = new Set<number>();
 		for (const listener of listeners) {
-			const protectedStartId = protectedProcesses.get(listener.pid);
-			const protectedProcess =
-				protectedProcesses.has(listener.pid) &&
-				(protectedStartId === undefined || getProcessStartId(listener.pid) === protectedStartId);
-			if (
-				protectedSockets.has(normalizeSocketPath(listener.socketPath)) ||
-				protectedProcess ||
-				seenPids.has(listener.pid)
-			) {
+			if (isProtectedDaemonAction(listener, protectedSockets, protectedProcesses) || seenPids.has(listener.pid)) {
 				continue;
 			}
 			seenPids.add(listener.pid);

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -566,6 +566,7 @@ async function runShutdownAllConverging(
 	const failed: Array<{ socketPath: string; reason: string }> = [];
 	const handledPids = new Set<number>();
 	const protectedSockets = new Set<string>();
+	const protectedProcesses = new Map<number, string | undefined>();
 	const reportedFailures = new Set<string>();
 
 	if (force) {
@@ -599,7 +600,9 @@ async function runShutdownAllConverging(
 				if ((await probeDaemon(socketPath)).reachable) {
 					const outcome = await stopBackgroundService(socketPath, pid, handledPids, force, assertAdmission);
 					preserveTrackedWorkers = outcome.preserveTrackedWorkers === true;
-					if (preserveTrackedWorkers) protectedSockets.add(socketPath);
+					if (preserveTrackedWorkers) {
+						protectAuthorityRejectedScope(socketPath, pid, protectedSockets, protectedProcesses);
+					}
 					apply(outcome, socketPath, stopped, failed);
 				} else {
 					await assertAdmission();
@@ -615,7 +618,9 @@ async function runShutdownAllConverging(
 				if ((await probeDaemon(socketPath)).reachable) {
 					const outcome = await stopBackgroundService(socketPath, pid, handledPids, force, assertAdmission);
 					preserveTrackedWorkers = outcome.preserveTrackedWorkers === true;
-					if (preserveTrackedWorkers) protectedSockets.add(socketPath);
+					if (preserveTrackedWorkers) {
+						protectAuthorityRejectedScope(socketPath, pid, protectedSockets, protectedProcesses);
+					}
 					apply(outcome, socketPath, stopped, failed);
 				} else if (isDaemonProcessListening(pid!, socketPath)) {
 					await assertAdmission();
@@ -634,7 +639,9 @@ async function runShutdownAllConverging(
 			case "shutdown": {
 				const outcome = await stopBackgroundService(socketPath, pid, handledPids, force, assertAdmission);
 				preserveTrackedWorkers = outcome.preserveTrackedWorkers === true;
-				if (preserveTrackedWorkers) protectedSockets.add(socketPath);
+				if (preserveTrackedWorkers) {
+					protectAuthorityRejectedScope(socketPath, pid, protectedSockets, protectedProcesses);
+				}
 				apply(outcome, socketPath, stopped, failed);
 				break;
 			}
@@ -655,6 +662,7 @@ async function runShutdownAllConverging(
 			failed,
 			handledPids,
 			protectedSockets,
+			protectedProcesses,
 			reportedFailures,
 			assertAdmission,
 		);
@@ -735,11 +743,54 @@ async function stopHiddenSupervisors(
 	}
 }
 
+function addProtectedProcess(
+	protectedProcesses: Map<number, string | undefined>,
+	pid: number,
+	processStartId: string | undefined,
+): void {
+	if (!protectedProcesses.has(pid)) {
+		protectedProcesses.set(pid, processStartId);
+		return;
+	}
+	if (protectedProcesses.get(pid) !== processStartId) {
+		// Conflicting or incomplete identity must broaden protection, never narrow it.
+		protectedProcesses.set(pid, undefined);
+	}
+}
+
+export function protectAuthorityRejectedScope(
+	supervisorSocketPath: string,
+	supervisorPid: number | undefined,
+	protectedSockets: Set<string>,
+	protectedProcesses: Map<number, string | undefined>,
+): void {
+	protectedSockets.add(normalizeSocketPath(supervisorSocketPath));
+	if (supervisorPid !== undefined) {
+		addProtectedProcess(protectedProcesses, supervisorPid, getProcessStartId(supervisorPid));
+	}
+	for (const { descriptor } of findTrackedWorkers(supervisorSocketPath)) {
+		protectedSockets.add(normalizeSocketPath(descriptor.socketPath));
+		addProtectedProcess(protectedProcesses, descriptor.pid, descriptor.processStartId);
+		if (!descriptor.orphanProcessJournalPath) continue;
+		try {
+			for (const orphan of readActiveOrphanProcesses(descriptor.orphanProcessJournalPath, descriptor.pid)) {
+				if (isOrphanProcessIdentityCurrent(orphan)) {
+					addProtectedProcess(protectedProcesses, orphan.pid, orphan.processStartId);
+				}
+			}
+		} catch {
+			// Missing or malformed child records cannot reduce protection for the
+			// supervisor and worker identities already captured above.
+		}
+	}
+}
+
 async function terminateVerifiedResiduals(
 	stopped: Array<{ socketPath: string; action: string }>,
 	failed: Array<{ socketPath: string; reason: string }>,
 	handledPids: Set<number>,
 	protectedSockets: ReadonlySet<string>,
+	protectedProcesses: ReadonlyMap<number, string | undefined>,
 	reportedFailures: Set<string>,
 	assertAdmission: () => Promise<void>,
 ): Promise<void> {
@@ -773,7 +824,15 @@ async function terminateVerifiedResiduals(
 		previousSignature = signature;
 		const seenPids = new Set<number>();
 		for (const listener of listeners) {
-			if (protectedSockets.has(listener.socketPath) || seenPids.has(listener.pid)) {
+			const protectedStartId = protectedProcesses.get(listener.pid);
+			const protectedProcess =
+				protectedProcesses.has(listener.pid) &&
+				(protectedStartId === undefined || getProcessStartId(listener.pid) === protectedStartId);
+			if (
+				protectedSockets.has(normalizeSocketPath(listener.socketPath)) ||
+				protectedProcess ||
+				seenPids.has(listener.pid)
+			) {
 				continue;
 			}
 			seenPids.add(listener.pid);

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import { APP_NAME, getAgentDir, VERSION } from "../config.js";
 import { isOrphanProcessIdentityCurrent, readActiveOrphanProcesses } from "../core/orphan-process-journal.js";
 import { getProcessStartId } from "../core/session-lease.js";
-import { DaemonClient } from "../modes/daemon/daemon-client.js";
+import { createDaemonShutdownCommand, DaemonClient } from "../modes/daemon/daemon-client.js";
 import {
 	DAEMON_PROTOCOL_VERSION,
 	DAEMON_SCHEMA_ID,
@@ -1243,7 +1243,8 @@ async function shutdownDaemon(socketPath: string, force: boolean): Promise<boole
 		return false;
 	}
 	try {
-		await client.request({ type: "shutdown", force }, 1500);
+		const hello = await client.waitForHello(2000).catch(() => undefined);
+		await client.request(createDaemonShutdownCommand(hello, force), 1500);
 	} catch {
 		// The daemon may still stop; the connectivity check below is the source of truth.
 	} finally {

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -1150,6 +1150,16 @@ export async function runReap(json: boolean, force: boolean): Promise<void> {
 
 type ReapOutcome = ({ reaped: string } | { skipped: string }) & { preserveTrackedWorkers?: boolean };
 
+export function reapOutcomeFromShutdownAttempt(attempt: DaemonShutdownAttempt, pid: number | undefined): ReapOutcome {
+	if (attempt.status === "stopped") {
+		return { reaped: `stopped idle background service${pid ? ` (pid ${pid})` : ""}` };
+	}
+	if (attempt.status === "authority-rejected") {
+		return { skipped: "shutdown authority rejected", preserveTrackedWorkers: true };
+	}
+	return { skipped: `shutdown request ${attempt.status}` };
+}
+
 function apply(
 	outcome: ReapOutcome,
 	socketPath: string,
@@ -1176,9 +1186,7 @@ async function reapReachableDaemon(socketPath: string, pid: number | undefined):
 	if (probe.sessionCount !== 0) {
 		return { skipped: `now has ${probe.sessionCount ?? "unknown"} session(s)` };
 	}
-	return (await shutdownDaemon(socketPath, false))
-		? { reaped: `stopped idle background service${pid ? ` (pid ${pid})` : ""}` }
-		: { skipped: "shutdown request failed" };
+	return reapOutcomeFromShutdownAttempt(await shutdownDaemon(socketPath, false), pid);
 }
 
 function removeSocketFile(socketPath: string): boolean {

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import { APP_NAME, getAgentDir, VERSION } from "../config.js";
 import { isOrphanProcessIdentityCurrent, readActiveOrphanProcesses } from "../core/orphan-process-journal.js";
 import { getProcessStartId } from "../core/session-lease.js";
-import { createDaemonShutdownCommand, DaemonClient } from "../modes/daemon/daemon-client.js";
+import { DaemonClient } from "../modes/daemon/daemon-client.js";
 import {
 	DAEMON_PROTOCOL_VERSION,
 	DAEMON_SCHEMA_ID,
@@ -565,6 +565,7 @@ async function runShutdownAllConverging(
 	const stopped: Array<{ socketPath: string; action: string }> = [];
 	const failed: Array<{ socketPath: string; reason: string }> = [];
 	const handledPids = new Set<number>();
+	const protectedSockets = new Set<string>();
 	const reportedFailures = new Set<string>();
 
 	if (force) {
@@ -592,15 +593,14 @@ async function runShutdownAllConverging(
 			}
 			continue;
 		}
+		let preserveTrackedWorkers = false;
 		switch (action.kind) {
 			case "remove-file": {
 				if ((await probeDaemon(socketPath)).reachable) {
-					apply(
-						await stopBackgroundService(socketPath, pid, handledPids, force, assertAdmission),
-						socketPath,
-						stopped,
-						failed,
-					);
+					const outcome = await stopBackgroundService(socketPath, pid, handledPids, force, assertAdmission);
+					preserveTrackedWorkers = outcome.preserveTrackedWorkers === true;
+					if (preserveTrackedWorkers) protectedSockets.add(socketPath);
+					apply(outcome, socketPath, stopped, failed);
 				} else {
 					await assertAdmission();
 					if (removeSocketFile(socketPath)) {
@@ -613,12 +613,10 @@ async function runShutdownAllConverging(
 			}
 			case "kill": {
 				if ((await probeDaemon(socketPath)).reachable) {
-					apply(
-						await stopBackgroundService(socketPath, pid, handledPids, force, assertAdmission),
-						socketPath,
-						stopped,
-						failed,
-					);
+					const outcome = await stopBackgroundService(socketPath, pid, handledPids, force, assertAdmission);
+					preserveTrackedWorkers = outcome.preserveTrackedWorkers === true;
+					if (preserveTrackedWorkers) protectedSockets.add(socketPath);
+					apply(outcome, socketPath, stopped, failed);
 				} else if (isDaemonProcessListening(pid!, socketPath)) {
 					await assertAdmission();
 					await forceKillDaemon(pid!);
@@ -633,19 +631,18 @@ async function runShutdownAllConverging(
 				}
 				break;
 			}
-			case "shutdown":
-				apply(
-					await stopBackgroundService(socketPath, pid, handledPids, force, assertAdmission),
-					socketPath,
-					stopped,
-					failed,
-				);
+			case "shutdown": {
+				const outcome = await stopBackgroundService(socketPath, pid, handledPids, force, assertAdmission);
+				preserveTrackedWorkers = outcome.preserveTrackedWorkers === true;
+				if (preserveTrackedWorkers) protectedSockets.add(socketPath);
+				apply(outcome, socketPath, stopped, failed);
 				break;
+			}
 			case "skip":
 				failed.push({ socketPath, reason: action.reason });
 				break;
 		}
-		if (force && action.kind !== "skip") {
+		if (force && action.kind !== "skip" && !preserveTrackedWorkers) {
 			failed.push(
 				...(await forceStopTrackedWorkers(socketPath, assertAdmission)).map((reason) => ({ socketPath, reason })),
 			);
@@ -653,7 +650,14 @@ async function runShutdownAllConverging(
 	}
 
 	if (force) {
-		await terminateVerifiedResiduals(stopped, failed, handledPids, reportedFailures, assertAdmission);
+		await terminateVerifiedResiduals(
+			stopped,
+			failed,
+			handledPids,
+			protectedSockets,
+			reportedFailures,
+			assertAdmission,
+		);
 	}
 
 	if (json) {
@@ -735,6 +739,7 @@ async function terminateVerifiedResiduals(
 	stopped: Array<{ socketPath: string; action: string }>,
 	failed: Array<{ socketPath: string; reason: string }>,
 	handledPids: Set<number>,
+	protectedSockets: ReadonlySet<string>,
 	reportedFailures: Set<string>,
 	assertAdmission: () => Promise<void>,
 ): Promise<void> {
@@ -768,7 +773,7 @@ async function terminateVerifiedResiduals(
 		previousSignature = signature;
 		const seenPids = new Set<number>();
 		for (const listener of listeners) {
-			if (seenPids.has(listener.pid)) {
+			if (protectedSockets.has(listener.socketPath) || seenPids.has(listener.pid)) {
 				continue;
 			}
 			seenPids.add(listener.pid);
@@ -897,11 +902,18 @@ async function stopBackgroundService(
 	assertAdmission: () => Promise<void>,
 ): Promise<ReapOutcome> {
 	await assertAdmission();
-	if (await shutdownDaemon(socketPath, force)) {
+	const shutdownAttempt = await shutdownDaemon(socketPath, force);
+	if (shutdownAttempt.status === "stopped") {
 		if (pid !== undefined) {
 			handledPids.add(pid);
 		}
 		return { reaped: `stopped background service${pid ? ` (pid ${pid})` : ""}` };
+	}
+	if (shutdownAttempt.status === "authority-rejected") {
+		return {
+			skipped: "shutdown authority rejected; refusing signal fallback",
+			preserveTrackedWorkers: true,
+		};
 	}
 	if (!(await canConnectToSocket(socketPath, 250))) {
 		await assertAdmission();
@@ -1136,7 +1148,7 @@ export async function runReap(json: boolean, force: boolean): Promise<void> {
 	}
 }
 
-type ReapOutcome = { reaped: string } | { skipped: string };
+type ReapOutcome = ({ reaped: string } | { skipped: string }) & { preserveTrackedWorkers?: boolean };
 
 function apply(
 	outcome: ReapOutcome,
@@ -1234,29 +1246,39 @@ async function canConnectToSocket(socketPath: string, timeoutMs: number): Promis
  * shutdown ack alone is not proof, so success is reported only once the socket
  * stops accepting connections.
  */
-async function shutdownDaemon(socketPath: string, force: boolean): Promise<boolean> {
+export type DaemonShutdownAttempt =
+	| { status: "stopped" }
+	| { status: "authority-rejected" }
+	| { status: "unavailable" }
+	| { status: "timed-out" };
+
+export async function shutdownDaemon(socketPath: string, force: boolean): Promise<DaemonShutdownAttempt> {
 	const client = new DaemonClient(socketPath);
 	try {
 		await client.connect(1000);
 	} catch {
 		client.close();
-		return false;
+		return { status: "unavailable" };
 	}
+	let authorityRejected = false;
 	try {
-		const hello = await client.waitForHello(2000).catch(() => undefined);
-		await client.request(createDaemonShutdownCommand(hello, force), 1500);
+		const response = await client.requestSupervisorShutdown(force, 1500);
+		authorityRejected = !response.success && response.errorInfo?.code === "shutdown_authority_rejected";
 	} catch {
 		// The daemon may still stop; the connectivity check below is the source of truth.
 	} finally {
 		client.close();
 	}
+	if (authorityRejected) {
+		return { status: "authority-rejected" };
+	}
 
 	const deadline = Date.now() + 5000;
 	while (Date.now() < deadline) {
 		if (!(await canConnectToSocket(socketPath, 250))) {
-			return true;
+			return { status: "stopped" };
 		}
 		await delay(50);
 	}
-	return false;
+	return { status: "timed-out" };
 }

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1629,7 +1629,7 @@ export class SessionManager {
 			return { status: "stale", reason: "generation" };
 		}
 		const currentSessionFile = this.getSessionFile();
-		if (!currentSessionFile || authority.sessionFile !== currentSessionFile) {
+		if (!currentSessionFile || authority.sessionFile !== realpathIfPresent(currentSessionFile)) {
 			return { status: "stale", reason: "sessionFile" };
 		}
 		const branch = this.getBranch();

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,5 +1,13 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, ImageContent, Message, ServiceTier, TextContent, Usage } from "@earendil-works/pi-ai";
+import type {
+	AssistantMessage,
+	ImageContent,
+	Message,
+	ServiceTier,
+	TextContent,
+	ToolResultMessage,
+	Usage,
+} from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
 import {
 	appendFileSync,
@@ -1499,6 +1507,78 @@ export class SessionManager {
 		return entry.id;
 	}
 
+	/** Append a message, undoing the append if persistence fails. */
+	appendMessageWithRollback(message: Message | CustomMessage | BashExecutionMessage): string {
+		return this._appendEntryWithRollback(() => this.appendMessage(message));
+	}
+
+	/**
+	 * Close unresolved tool calls in the terminal assistant tool-use turn of the
+	 * active branch by appending rollback-capable synthetic error toolResult
+	 * messages. Older turns and already-resolved calls are left untouched.
+	 * Returns the number of tool calls closed.
+	 */
+	closeUnresolvedToolCalls(): number {
+		const branch = this.getBranch();
+		let turnIndex = -1;
+		for (let i = branch.length - 1; i >= 0; i--) {
+			const entry = branch[i];
+			if (entry.type === "message" && entry.message.role === "assistant") {
+				turnIndex = i;
+				break;
+			}
+		}
+		if (turnIndex === -1) {
+			return 0;
+		}
+		const turn = branch[turnIndex] as SessionMessageEntry;
+		if (
+			turn.message.role !== "assistant" ||
+			turn.message.stopReason !== "toolUse" ||
+			!hasToolCallBlocks(turn.message)
+		) {
+			return 0;
+		}
+		const open: InterruptedToolCall[] = [];
+		const seen = new Set<string>();
+		for (const block of turn.message.content) {
+			if (!block || block.type !== "toolCall") {
+				continue;
+			}
+			if (typeof block.id !== "string" || typeof block.name !== "string") {
+				continue;
+			}
+			if (seen.has(block.id)) {
+				continue;
+			}
+			seen.add(block.id);
+			open.push({ toolCallId: block.id, toolName: block.name });
+		}
+		const resolved = new Set<string>();
+		for (let i = turnIndex + 1; i < branch.length; i++) {
+			const entry = branch[i];
+			if (entry.type !== "message" || entry.message.role !== "toolResult") {
+				continue;
+			}
+			const result = entry.message as ToolResultMessage;
+			if (typeof result.toolCallId === "string") {
+				resolved.add(result.toolCallId);
+			}
+		}
+		const closed = open.filter((call) => !resolved.has(call.toolCallId));
+		for (const call of closed) {
+			this.appendMessageWithRollback({
+				role: "toolResult",
+				toolCallId: call.toolCallId,
+				toolName: call.toolName,
+				content: [{ type: "text", text: INTERRUPTED_TOOL_RESULT_TEXT }],
+				isError: true,
+				timestamp: Date.now(),
+			});
+		}
+		return closed.length;
+	}
+
 	/** Append a thinking level change as child of current leaf, then advance leaf. Returns entry id. */
 	appendThinkingLevelChange(thinkingLevel: string): string {
 		const entry: ThinkingLevelChangeEntry = {
@@ -2321,4 +2401,24 @@ export class SessionManager {
 		sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
 		return sessions;
 	}
+}
+
+/**
+ * Synthetic toolResult content appended when an interrupted session worker
+ * leaves a terminal assistant tool-use turn unclosed. The wording states
+ * explicitly that whether the tool executed, its result, and any external side
+ * effects are unknown, that recovery did not replay the interrupted execution,
+ * and that the agent must inspect side effects before retrying.
+ */
+const INTERRUPTED_TOOL_RESULT_TEXT =
+	"The tool call was interrupted when the session worker stopped: whether the tool executed, its result, and any external side effects are unknown, and the interrupted execution was not replayed by recovery. Inspect external side effects before retrying this tool call.";
+
+/** A terminal assistant-turn tool call closed by interrupted-tool recovery. */
+interface InterruptedToolCall {
+	toolCallId: string;
+	toolName: string;
+}
+
+function hasToolCallBlocks(message: AssistantMessage): boolean {
+	return message.content.some((block) => block !== null && block.type === "toolCall");
 }

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1602,7 +1602,7 @@ export class SessionManager {
 			const entry = branch[i];
 			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
 			assistantEntryId = entry.id;
-			toolCalls = collectToolCalls(entry.message);
+			toolCalls = collectUnresolvedToolCalls(entry.message, branch.slice(i + 1));
 			break;
 		}
 		const lineageDigest = computeLineageDigest(branch);
@@ -1641,53 +1641,59 @@ export class SessionManager {
 		if (computeLineageDigest(prefix) !== authority.lineageDigest) {
 			return { status: "stale", reason: "lineage" };
 		}
-		if (authority.assistantEntryId === null) {
-			// No assistant entry to close; nothing to do.
-			return { status: "already_applied" };
+		let assistantIndex = -1;
+		for (let i = prefix.length - 1; i >= 0; i--) {
+			const entry = prefix[i];
+			if (entry.type === "message" && entry.message.role === "assistant") {
+				assistantIndex = i;
+				break;
+			}
 		}
-		const assistantEntry = this.byId.get(authority.assistantEntryId);
-		if (
-			!assistantEntry ||
-			assistantEntry.type !== "message" ||
-			assistantEntry.message.role !== "assistant" ||
-			!this._isAncestorOrSelf(assistantEntry.id, authority.headEntryId)
-		) {
+		const assistantEntry = assistantIndex >= 0 ? prefix[assistantIndex] : undefined;
+		const actualAssistantEntryId = assistantEntry?.id ?? null;
+		if (actualAssistantEntryId !== authority.assistantEntryId) {
 			return { status: "stale", reason: "assistant" };
 		}
-		const actualToolCalls = collectToolCalls(assistantEntry.message);
+		const actualToolCalls =
+			assistantEntry?.type === "message" && assistantEntry.message.role === "assistant"
+				? collectUnresolvedToolCalls(assistantEntry.message, prefix.slice(assistantIndex + 1))
+				: [];
 		if (!this._toolCallsEqual(actualToolCalls, authority.toolCalls)) {
 			return { status: "stale", reason: "toolCalls" };
 		}
-		// Identify the suffix entries (everything after the recorded head).
-		const prefixIndex = prefix.length - 1;
-		const suffix = branch.slice(prefixIndex + 1);
-		const declaredIds = new Set(authority.toolCalls.map((call) => call.id));
-		const coveredIds = new Set<string>();
-		for (const entry of suffix) {
+
+		// The sole permitted head advance is an ordered prefix of this operation's
+		// synthetic results. Unknown ids, duplicates, reordering, foreign metadata,
+		// and ordinary transcript entries all make the authority stale.
+		const suffix = branch.slice(prefix.length);
+		if (suffix.length > authority.toolCalls.length) {
+			return { status: "stale", reason: "foreign_suffix" };
+		}
+		for (let i = 0; i < suffix.length; i++) {
+			const entry = suffix[i];
+			const expected = authority.toolCalls[i]!;
 			if (entry.type !== "message" || entry.message.role !== "toolResult") {
 				return { status: "stale", reason: "foreign_suffix" };
 			}
 			const result = entry.message as ToolResultMessage;
-			if (typeof result.toolCallId !== "string" || !declaredIds.has(result.toolCallId)) {
-				return { status: "stale", reason: "foreign_suffix" };
-			}
 			const details = (result as { details?: unknown }).details;
 			const recovery = (details as { recovery?: unknown } | null | undefined)?.recovery;
-			if (!isRecoveryMetadata(recovery)) {
+			if (
+				result.toolCallId !== expected.id ||
+				result.toolName !== expected.name ||
+				result.isError !== true ||
+				!isRecoveryMetadata(recovery) ||
+				recovery.operationId !== authority.operationId ||
+				recovery.assistantEntryId !== authority.assistantEntryId
+			) {
 				return { status: "stale", reason: "foreign_suffix" };
 			}
-			if (recovery.operationId !== authority.operationId) {
-				return { status: "stale", reason: "foreign_suffix" };
-			}
-			coveredIds.add(result.toolCallId);
 		}
-		const missing: ExactRecoveryToolCall[] = [];
-		for (const call of authority.toolCalls) {
-			if (!coveredIds.has(call.id)) missing.push(call);
-		}
+		const missing = authority.toolCalls.slice(suffix.length);
 		if (missing.length === 0) {
 			return { status: "already_applied" };
 		}
+
 		const metadata: RecoverySyntheticMetadata = {
 			operationId: authority.operationId,
 			assistantEntryId: authority.assistantEntryId,
@@ -1706,18 +1712,9 @@ export class SessionManager {
 		return { status: "applied", closed: missing.length };
 	}
 
-	private _isAncestorOrSelf(candidateId: string, descendantId: string | null): boolean {
-		let current = descendantId ? this.byId.get(descendantId) : undefined;
-		while (current) {
-			if (current.id === candidateId) return true;
-			current = current.parentId ? this.byId.get(current.parentId) : undefined;
-		}
-		return false;
-	}
-
 	private _prefixThrough(headId: string | null, branch: SessionEntry[]): SessionEntry[] | null {
 		if (headId === null) {
-			return [...branch];
+			return [];
 		}
 		const index = branch.findIndex((entry) => entry.id === headId);
 		if (index === -1) return null;
@@ -2600,7 +2597,7 @@ export interface ExactRecoverySnapshot {
 	readonly headEntryId: string | null;
 	/** Latest assistant entry id on the active branch, or null if none. */
 	readonly assistantEntryId: string | null;
-	/** Tool calls declared by the latest assistant entry at capture time, ordered by appearance. */
+	/** Unresolved tool calls from the latest assistant entry at capture time, in declaration order. */
 	readonly toolCalls: ReadonlyArray<ExactRecoveryToolCall>;
 	/** Deterministic SHA-256 digest over the active branch through headEntryId. */
 	readonly lineageDigest: string;
@@ -2608,7 +2605,7 @@ export interface ExactRecoverySnapshot {
 
 /** Full exact recovery authority. Combines the snapshot with the journal-bound identity. */
 export interface ExactRecoveryAuthority extends ExactRecoverySnapshot {
-	/** Stable id of the busy epoch; reused across every checkpoint until idle. */
+	/** Stable id of this exact-authority busy epoch. */
 	readonly operationId: string;
 	/** Runtime identity of the dead worker, supplied by the catalog/journal layer. */
 	readonly activeSessionId: string;
@@ -2649,14 +2646,23 @@ function isRecoveryMetadata(value: unknown): value is RecoverySyntheticMetadata 
 	return true;
 }
 
-/** Extract the ordered, de-duplicated unresolved tool call set from an assistant message. */
-function collectToolCalls(message: AssistantMessage): ExactRecoveryToolCall[] {
+/** Extract the ordered unresolved tool calls from one assistant turn at a branch prefix. */
+function collectUnresolvedToolCalls(
+	message: AssistantMessage,
+	entriesAfterAssistant: ReadonlyArray<SessionEntry>,
+): ExactRecoveryToolCall[] {
+	const resolved = new Set<string>();
+	for (const entry of entriesAfterAssistant) {
+		if (entry.type !== "message" || entry.message.role !== "toolResult") continue;
+		const result = entry.message as ToolResultMessage;
+		if (typeof result.toolCallId === "string") resolved.add(result.toolCallId);
+	}
 	const calls: ExactRecoveryToolCall[] = [];
 	const seen = new Set<string>();
 	for (const block of message.content) {
 		if (!block || block.type !== "toolCall") continue;
 		if (typeof block.id !== "string" || typeof block.name !== "string") continue;
-		if (seen.has(block.id)) continue;
+		if (seen.has(block.id) || resolved.has(block.id)) continue;
 		seen.add(block.id);
 		calls.push({ id: block.id, name: block.name });
 	}
@@ -2668,9 +2674,9 @@ function computeLineageDigest(prefix: SessionEntry[]): string {
 	const hash = createHash("sha256");
 	for (const entry of prefix) {
 		hash.update(entry.id);
-		hash.update(" ");
+		hash.update("\0");
 		hash.update(entry.parentId ?? "");
-		hash.update(" ");
+		hash.update("\0");
 	}
 	return hash.digest("hex");
 }

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -8,7 +8,7 @@ import type {
 	ToolResultMessage,
 	Usage,
 } from "@earendil-works/pi-ai";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import {
 	appendFileSync,
 	chmodSync,
@@ -1579,6 +1579,162 @@ export class SessionManager {
 		return closed.length;
 	}
 
+	/**
+	 * Capture a narrow exact-recovery snapshot from the current active branch.
+	 *
+	 * The snapshot is branch-derived only: the supplied `activeSessionId` and
+	 * `operationId` are accepted for the journal binding contract but are not
+	 * recorded in the returned shape. The session-manager exposes no
+	 * journal-specific types; the journal layer composes its own record by
+	 * adding `operationId`, `activeSessionId`, `sessionFile`, and journal
+	 * bookkeeping fields to this snapshot.
+	 */
+	captureExactRecoveryAuthority(_activeSessionId: string, _operationId: string): ExactRecoverySnapshot {
+		const header = this.getHeader();
+		const sessionId = header?.id ?? this.sessionId;
+		const branch = this.getBranch();
+		// headEntryId is the current leaf; the active branch (root to leaf) is the
+		// authority's lineage prefix, so we hash the full branch.
+		const headEntryId = this.leafId;
+		let assistantEntryId: string | null = null;
+		let toolCalls: ExactRecoveryToolCall[] = [];
+		for (let i = branch.length - 1; i >= 0; i--) {
+			const entry = branch[i];
+			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+			assistantEntryId = entry.id;
+			toolCalls = collectToolCalls(entry.message);
+			break;
+		}
+		const lineageDigest = computeLineageDigest(branch);
+		return { sessionId, headEntryId, assistantEntryId, toolCalls, lineageDigest };
+	}
+
+	/**
+	 * Apply exact-authority recovery.
+	 *
+	 * Validates the supplied authority against the current session and either
+	 * appends synthetic error tool results for the journaled tool call ids or
+	 * returns stale/already-applied without writing. The synthetic results
+	 * carry `operationId` and `assistantEntryId` metadata so a retry can resume
+	 * an operation-owned partial suffix.
+	 *
+	 * The `stopReason` of the authorized assistant entry is intentionally
+	 * ignored: when exact tool calls are journaled, the metadata is
+	 * authoritative.
+	 */
+	closeUnresolvedToolCallsWithAuthority(authority: ExactRecoveryAuthority): ExactRecoveryStatus {
+		const header = this.getHeader();
+		const currentSessionId = header?.id ?? this.sessionId;
+		if (authority.sessionId !== currentSessionId) {
+			return { status: "stale", reason: "generation" };
+		}
+		const currentSessionFile = this.getSessionFile();
+		if (!currentSessionFile || authority.sessionFile !== currentSessionFile) {
+			return { status: "stale", reason: "sessionFile" };
+		}
+		const branch = this.getBranch();
+		const prefix = this._prefixThrough(authority.headEntryId, branch);
+		if (prefix === null) {
+			// The head recorded by the journal is not on the active branch.
+			return { status: "stale", reason: "head" };
+		}
+		if (computeLineageDigest(prefix) !== authority.lineageDigest) {
+			return { status: "stale", reason: "lineage" };
+		}
+		if (authority.assistantEntryId === null) {
+			// No assistant entry to close; nothing to do.
+			return { status: "already_applied" };
+		}
+		const assistantEntry = this.byId.get(authority.assistantEntryId);
+		if (
+			!assistantEntry ||
+			assistantEntry.type !== "message" ||
+			assistantEntry.message.role !== "assistant" ||
+			!this._isAncestorOrSelf(assistantEntry.id, authority.headEntryId)
+		) {
+			return { status: "stale", reason: "assistant" };
+		}
+		const actualToolCalls = collectToolCalls(assistantEntry.message);
+		if (!this._toolCallsEqual(actualToolCalls, authority.toolCalls)) {
+			return { status: "stale", reason: "toolCalls" };
+		}
+		// Identify the suffix entries (everything after the recorded head).
+		const prefixIndex = prefix.length - 1;
+		const suffix = branch.slice(prefixIndex + 1);
+		const declaredIds = new Set(authority.toolCalls.map((call) => call.id));
+		const coveredIds = new Set<string>();
+		for (const entry of suffix) {
+			if (entry.type !== "message" || entry.message.role !== "toolResult") {
+				return { status: "stale", reason: "foreign_suffix" };
+			}
+			const result = entry.message as ToolResultMessage;
+			if (typeof result.toolCallId !== "string" || !declaredIds.has(result.toolCallId)) {
+				return { status: "stale", reason: "foreign_suffix" };
+			}
+			const details = (result as { details?: unknown }).details;
+			const recovery = (details as { recovery?: unknown } | null | undefined)?.recovery;
+			if (!isRecoveryMetadata(recovery)) {
+				return { status: "stale", reason: "foreign_suffix" };
+			}
+			if (recovery.operationId !== authority.operationId) {
+				return { status: "stale", reason: "foreign_suffix" };
+			}
+			coveredIds.add(result.toolCallId);
+		}
+		const missing: ExactRecoveryToolCall[] = [];
+		for (const call of authority.toolCalls) {
+			if (!coveredIds.has(call.id)) missing.push(call);
+		}
+		if (missing.length === 0) {
+			return { status: "already_applied" };
+		}
+		const metadata: RecoverySyntheticMetadata = {
+			operationId: authority.operationId,
+			assistantEntryId: authority.assistantEntryId,
+		};
+		for (const call of missing) {
+			this.appendMessageWithRollback({
+				role: "toolResult",
+				toolCallId: call.id,
+				toolName: call.name,
+				content: [{ type: "text", text: INTERRUPTED_TOOL_RESULT_TEXT }],
+				isError: true,
+				timestamp: Date.now(),
+				details: { recovery: metadata },
+			});
+		}
+		return { status: "applied", closed: missing.length };
+	}
+
+	private _isAncestorOrSelf(candidateId: string, descendantId: string | null): boolean {
+		let current = descendantId ? this.byId.get(descendantId) : undefined;
+		while (current) {
+			if (current.id === candidateId) return true;
+			current = current.parentId ? this.byId.get(current.parentId) : undefined;
+		}
+		return false;
+	}
+
+	private _prefixThrough(headId: string | null, branch: SessionEntry[]): SessionEntry[] | null {
+		if (headId === null) {
+			return [...branch];
+		}
+		const index = branch.findIndex((entry) => entry.id === headId);
+		if (index === -1) return null;
+		return branch.slice(0, index + 1);
+	}
+
+	private _toolCallsEqual(
+		left: ReadonlyArray<ExactRecoveryToolCall>,
+		right: ReadonlyArray<ExactRecoveryToolCall>,
+	): boolean {
+		if (left.length !== right.length) return false;
+		for (let i = 0; i < left.length; i++) {
+			if (left[i]!.id !== right[i]!.id || left[i]!.name !== right[i]!.name) return false;
+		}
+		return true;
+	}
+
 	/** Append a thinking level change as child of current leaf, then advance leaf. Returns entry id. */
 	appendThinkingLevelChange(thinkingLevel: string): string {
 		const entry: ThinkingLevelChangeEntry = {
@@ -2421,4 +2577,100 @@ interface InterruptedToolCall {
 
 function hasToolCallBlocks(message: AssistantMessage): boolean {
 	return message.content.some((block) => block !== null && block.type === "toolCall");
+}
+
+/** A single unresolved tool call declared by an assistant turn and journaled for recovery. */
+export interface ExactRecoveryToolCall {
+	readonly id: string;
+	readonly name: string;
+}
+
+/**
+ * Narrow snapshot of one active-branch view, intended for the journal/daemon-mode
+ * layer to record as part of a busy checkpoint. The journal layer supplies
+ * operationId, activeSessionId, and sessionFile alongside this snapshot.
+ *
+ * Branch-derived fields are computed once from a single in-memory view; the
+ * session-manager does not depend on any journal-specific imports.
+ */
+export interface ExactRecoverySnapshot {
+	/** Persisted session generation id (matches the session header id). */
+	readonly sessionId: string;
+	/** Exact active branch head entry id at capture time, including null for an empty branch. */
+	readonly headEntryId: string | null;
+	/** Latest assistant entry id on the active branch, or null if none. */
+	readonly assistantEntryId: string | null;
+	/** Tool calls declared by the latest assistant entry at capture time, ordered by appearance. */
+	readonly toolCalls: ReadonlyArray<ExactRecoveryToolCall>;
+	/** Deterministic SHA-256 digest over the active branch through headEntryId. */
+	readonly lineageDigest: string;
+}
+
+/** Full exact recovery authority. Combines the snapshot with the journal-bound identity. */
+export interface ExactRecoveryAuthority extends ExactRecoverySnapshot {
+	/** Stable id of the busy epoch; reused across every checkpoint until idle. */
+	readonly operationId: string;
+	/** Runtime identity of the dead worker, supplied by the catalog/journal layer. */
+	readonly activeSessionId: string;
+	/** Canonical session file path; validated against the current session's path. */
+	readonly sessionFile: string;
+}
+
+/** Metadata carried by synthetic tool results produced by exact recovery. */
+export interface RecoverySyntheticMetadata {
+	readonly operationId: string;
+	readonly assistantEntryId: string | null;
+}
+
+/** Reason a recovery request was rejected as stale. */
+export type ExactRecoveryStaleReason =
+	| "generation"
+	| "sessionFile"
+	| "head"
+	| "lineage"
+	| "assistant"
+	| "toolCalls"
+	| "foreign_suffix";
+
+/** Outcome of an exact-authority recovery request. */
+export type ExactRecoveryStatus =
+	| { readonly status: "applied"; readonly closed: number }
+	| { readonly status: "already_applied" }
+	| { readonly status: "stale"; readonly reason: ExactRecoveryStaleReason };
+
+/** Shape of the recovery metadata stored on a synthetic toolResult.details. */
+function isRecoveryMetadata(value: unknown): value is RecoverySyntheticMetadata {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as { operationId?: unknown; assistantEntryId?: unknown };
+	if (typeof candidate.operationId !== "string") return false;
+	if (candidate.assistantEntryId !== null && typeof candidate.assistantEntryId !== "string") {
+		return false;
+	}
+	return true;
+}
+
+/** Extract the ordered, de-duplicated unresolved tool call set from an assistant message. */
+function collectToolCalls(message: AssistantMessage): ExactRecoveryToolCall[] {
+	const calls: ExactRecoveryToolCall[] = [];
+	const seen = new Set<string>();
+	for (const block of message.content) {
+		if (!block || block.type !== "toolCall") continue;
+		if (typeof block.id !== "string" || typeof block.name !== "string") continue;
+		if (seen.has(block.id)) continue;
+		seen.add(block.id);
+		calls.push({ id: block.id, name: block.name });
+	}
+	return calls;
+}
+
+/** Compute the deterministic lineage digest for the entries on the active branch prefix. */
+function computeLineageDigest(prefix: SessionEntry[]): string {
+	const hash = createHash("sha256");
+	for (const entry of prefix) {
+		hash.update(entry.id);
+		hash.update(" ");
+		hash.update(entry.parentId ?? "");
+		hash.update(" ");
+	}
+	return hash.digest("hex");
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -32,7 +32,10 @@ export interface CatalogRecoveryAuthority extends ExactRecoveryAuthority {
 	readonly agentDir: string;
 }
 
-export type CatalogRecoveryStaleReason = ExactRecoveryStaleReason | "live_session_owner";
+export type CatalogRecoveryStaleReason =
+	| ExactRecoveryStaleReason
+	| "live_session_owner"
+	| "marker_authority_mismatch";
 
 export type CatalogRecoveryResult =
 	| { readonly status: "applied" }
@@ -377,12 +380,92 @@ function serializeRecovery<T>(sessionPath: string, action: () => Promise<T> | T)
 	return result;
 }
 
-function hasRecoveryMarker(session: SessionManager, operationId: string): boolean {
-	return session.getEntries().some((entry) => {
-		if (entry.type !== "custom_message" || entry.customType !== WORKER_RECOVERY_MARKER) return false;
-		const details = entry.details as { operationId?: unknown } | undefined;
-		return details?.operationId === operationId;
+/**
+ * Marker dedupe is bound to the full exact authority binding (operationId
+ * selects the marker; every authority field including the runtime identity
+ * must match): a journal may only reuse an operationId for an identical
+ * authority epoch, so a marker carrying a different authority can never
+ * authorize this request. The persisted marker records the full normalized
+ * authority it was applied under.
+ */
+function sameRecoveryMarkerAuthority(stored: unknown, authority: CatalogRecoveryAuthority): boolean {
+	if (!stored || typeof stored !== "object") return false;
+	const candidate = stored as Partial<CatalogRecoveryAuthority>;
+	if (
+		typeof candidate.operationId !== "string" ||
+		candidate.operationId !== authority.operationId ||
+		typeof candidate.activeSessionId !== "string" ||
+		candidate.activeSessionId !== authority.activeSessionId ||
+		typeof candidate.sessionId !== "string" ||
+		candidate.sessionId !== authority.sessionId ||
+		typeof candidate.agentDir !== "string" ||
+		candidate.agentDir !== authority.agentDir ||
+		typeof candidate.sessionFile !== "string" ||
+		canonicalSessionPath(candidate.sessionFile) !== authority.sessionFile ||
+		candidate.headEntryId !== authority.headEntryId ||
+		candidate.assistantEntryId !== authority.assistantEntryId ||
+		candidate.lineageDigest !== authority.lineageDigest ||
+		!Array.isArray(candidate.toolCalls) ||
+		candidate.toolCalls.length !== authority.toolCalls.length
+	) {
+		return false;
+	}
+	for (let i = 0; i < authority.toolCalls.length; i++) {
+		const storedCall = candidate.toolCalls[i] as { id?: unknown; name?: unknown } | undefined;
+		const expected = authority.toolCalls[i]!;
+		if (!storedCall || storedCall.id !== expected.id || storedCall.name !== expected.name) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Find the global recovery marker for `operationId`. The lookup is global
+ * rather than active-branch-only so later branching cannot cause a completed
+ * operation to be applied again, but a marker only counts when its recorded
+ * authority exactly matches the request.
+ */
+function findRecoveryMarker(
+	session: SessionManager,
+	authority: CatalogRecoveryAuthority,
+): { readonly sameAuthority: boolean } | undefined {
+	for (const entry of session.getEntries()) {
+		if (entry.type !== "custom_message" || entry.customType !== WORKER_RECOVERY_MARKER) continue;
+		const details = entry.details as { operationId?: unknown; authority?: unknown } | undefined;
+		if (details?.operationId !== authority.operationId) continue;
+		return { sameAuthority: sameRecoveryMarkerAuthority(details.authority, authority) };
+	}
+	return undefined;
+}
+
+/**
+ * Apply exact-authority recovery to an open session: global marker dedupe
+ * (operationId plus the full recorded authority), then synthetic results for
+ * the journaled tool calls, then one final operation marker. Stale authority
+ * performs no writes. The caller owns lease fencing and per-path serialization
+ * so the session file cannot race another owner or writer.
+ */
+export function applyWorkerRecoveryToSession(
+	session: SessionManager,
+	authority: CatalogRecoveryAuthority,
+	operations: readonly string[],
+): CatalogRecoveryResult {
+	const marker = findRecoveryMarker(session, authority);
+	if (marker) {
+		return marker.sameAuthority
+			? { status: "already_applied" }
+			: { status: "stale", reason: "marker_authority_mismatch" };
+	}
+	const recovery = session.closeUnresolvedToolCallsWithAuthority(authority);
+	if (recovery.status === "stale") return recovery;
+	session.appendCustomMessageEntryWithRollback(WORKER_RECOVERY_MARKER, WORKER_RECOVERY_MESSAGE, false, {
+		operationId: authority.operationId,
+		activeSessionId: authority.activeSessionId,
+		operations: [...operations],
+		authority,
 	});
+	return { status: "applied" };
 }
 
 /**
@@ -419,18 +502,7 @@ export async function markSessionInterrupted(
 		if (!lease) throw new Error(`Could not enable the recovery session lease: ${sessionPath}`);
 		try {
 			const session = SessionManager.open(sessionPath);
-			if (hasRecoveryMarker(session, authority.operationId)) {
-				return { status: "already_applied" };
-			}
-			const recovery = session.closeUnresolvedToolCallsWithAuthority(normalizedAuthority);
-			if (recovery.status === "stale") return recovery;
-			session.appendCustomMessageEntryWithRollback(WORKER_RECOVERY_MARKER, WORKER_RECOVERY_MESSAGE, false, {
-				operationId: authority.operationId,
-				activeSessionId: authority.activeSessionId,
-				operations: [...operations],
-				authority: normalizedAuthority,
-			});
-			return { status: "applied" };
+			return applyWorkerRecoveryToSession(session, normalizedAuthority, operations);
 		} finally {
 			lease.release();
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -54,7 +54,9 @@ function isCatalogRecoveryAuthority(value: unknown): value is CatalogRecoveryAut
 		typeof authority.sessionFile !== "string" ||
 		authority.sessionFile.length === 0 ||
 		(typeof authority.headEntryId !== "string" && authority.headEntryId !== null) ||
+		(typeof authority.headEntryId === "string" && authority.headEntryId.length === 0) ||
 		(typeof authority.assistantEntryId !== "string" && authority.assistantEntryId !== null) ||
+		(typeof authority.assistantEntryId === "string" && authority.assistantEntryId.length === 0) ||
 		typeof authority.lineageDigest !== "string" ||
 		!/^[0-9a-f]{64}$/i.test(authority.lineageDigest) ||
 		!Array.isArray(authority.toolCalls)
@@ -513,7 +515,7 @@ export class DaemonCatalogClient {
 	}
 
 	markInterrupted(authority: CatalogRecoveryAuthority, operations: string[]): Promise<CatalogRecoveryResult> {
-		return this.request({
+		return this.request<CatalogRecoveryResult>({
 			type: "request",
 			id: randomUUID(),
 			command: "mark_interrupted",

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -266,15 +266,7 @@ async function handleCatalogRequest(request: CatalogRequest): Promise<void> {
 				return;
 			}
 			case "mark_interrupted":
-				SessionManager.open(request.sessionPath).appendCustomMessageEntry(
-					"prime-agent.worker_recovery",
-					"<prime_agent_worker_interrupted>\nThe isolated session worker stopped during in-flight work. The saved transcript was recovered, but uncertain model, tool, bash, or child-agent work was not replayed. Inspect external side effects before continuing.\n</prime_agent_worker_interrupted>",
-					false,
-					{
-						activeSessionId: request.activeSessionId,
-						operations: request.operations,
-					},
-				);
+				markSessionInterrupted(request.sessionPath, request.activeSessionId, request.operations);
 				sendCatalogMessage({ type: "response", id: request.id, success: true });
 				return;
 			case "shutdown":
@@ -290,6 +282,27 @@ async function handleCatalogRequest(request: CatalogRequest): Promise<void> {
 			error: error instanceof Error ? error.message : String(error),
 		});
 	}
+}
+
+/**
+ * Persist interrupted-session recovery state for a session file: close every
+ * unresolved tool call in the terminal assistant tool-use turn with synthetic
+ * error toolResult messages, then append the prime-agent.worker_recovery marker.
+ * Synthetic results are appended first so they are persisted before the marker.
+ * Exported for focused daemon catalog tests.
+ */
+export function markSessionInterrupted(sessionPath: string, activeSessionId: string, operations: string[]): void {
+	const session = SessionManager.open(sessionPath);
+	session.closeUnresolvedToolCalls();
+	session.appendCustomMessageEntryWithRollback(
+		"prime-agent.worker_recovery",
+		"<prime_agent_worker_interrupted>\nThe isolated session worker stopped during in-flight work. The saved transcript was recovered, but uncertain model, tool, bash, or child-agent work was not replayed. Inspect external side effects before continuing.\n</prime_agent_worker_interrupted>",
+		false,
+		{
+			activeSessionId,
+			operations,
+		},
+	);
 }
 
 export class DaemonCatalogClient {

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -5,9 +5,81 @@ import { dirname, join, resolve } from "node:path";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
-import { readSessionInfo, type SessionInfo, SessionManager } from "../../core/session-manager.js";
+import {
+	acquireSessionLease,
+	canonicalSessionPath,
+	SESSION_LEASE_OWNER_ID_ENV,
+	SESSION_LEASES_ENABLED_ENV,
+	SessionAlreadyActiveError,
+	type SessionLease,
+} from "../../core/session-lease.js";
+import {
+	type ExactRecoveryAuthority,
+	type ExactRecoveryStaleReason,
+	readSessionInfo,
+	type SessionInfo,
+	SessionManager,
+} from "../../core/session-manager.js";
 
 export const DAEMON_CATALOG_ROLE_ENV = "PRIME_AGENT_INTERNAL_DAEMON_CATALOG";
+
+const RECOVERY_LEASE_OWNER_PREFIX = "worker-recovery:";
+const WORKER_RECOVERY_MARKER = "prime-agent.worker_recovery";
+const WORKER_RECOVERY_MESSAGE =
+	"<prime_agent_worker_interrupted>\nThe isolated session worker stopped during in-flight work. The saved transcript was recovered, but uncertain model, tool, bash, or child-agent work was not replayed. Inspect external side effects before continuing.\n</prime_agent_worker_interrupted>";
+
+export interface CatalogRecoveryAuthority extends ExactRecoveryAuthority {
+	readonly agentDir: string;
+}
+
+export type CatalogRecoveryStaleReason = ExactRecoveryStaleReason | "live_session_owner";
+
+export type CatalogRecoveryResult =
+	| { readonly status: "applied" }
+	| { readonly status: "already_applied" }
+	| { readonly status: "stale"; readonly reason: CatalogRecoveryStaleReason };
+
+function isCatalogRecoveryAuthority(value: unknown): value is CatalogRecoveryAuthority {
+	if (!value || typeof value !== "object") return false;
+	const authority = value as Partial<CatalogRecoveryAuthority>;
+	if (
+		typeof authority.operationId !== "string" ||
+		!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(authority.operationId) ||
+		typeof authority.activeSessionId !== "string" ||
+		authority.activeSessionId.length === 0 ||
+		typeof authority.sessionId !== "string" ||
+		authority.sessionId.length === 0 ||
+		typeof authority.agentDir !== "string" ||
+		authority.agentDir.length === 0 ||
+		typeof authority.sessionFile !== "string" ||
+		authority.sessionFile.length === 0 ||
+		(typeof authority.headEntryId !== "string" && authority.headEntryId !== null) ||
+		(typeof authority.assistantEntryId !== "string" && authority.assistantEntryId !== null) ||
+		typeof authority.lineageDigest !== "string" ||
+		!/^[0-9a-f]{64}$/i.test(authority.lineageDigest) ||
+		!Array.isArray(authority.toolCalls)
+	) {
+		return false;
+	}
+	const ids = new Set<string>();
+	for (const call of authority.toolCalls) {
+		if (
+			!call ||
+			typeof call.id !== "string" ||
+			call.id.length === 0 ||
+			typeof call.name !== "string" ||
+			call.name.length === 0
+		) {
+			return false;
+		}
+		if (ids.has(call.id)) return false;
+		ids.add(call.id);
+	}
+	return !(
+		(authority.headEntryId === null && authority.assistantEntryId !== null) ||
+		(authority.assistantEntryId === null && authority.toolCalls.length > 0)
+	);
+}
 
 interface SessionInfoWire extends Omit<SessionInfo, "created" | "modified"> {
 	created: string;
@@ -25,8 +97,7 @@ type CatalogRequest =
 			type: "request";
 			id: string;
 			command: "mark_interrupted";
-			sessionPath: string;
-			activeSessionId: string;
+			authority: CatalogRecoveryAuthority;
 			operations: string[];
 	  }
 	| { type: "request"; id: string; command: "shutdown" };
@@ -266,8 +337,12 @@ async function handleCatalogRequest(request: CatalogRequest): Promise<void> {
 				return;
 			}
 			case "mark_interrupted":
-				markSessionInterrupted(request.sessionPath, request.activeSessionId, request.operations);
-				sendCatalogMessage({ type: "response", id: request.id, success: true });
+				sendCatalogMessage({
+					type: "response",
+					id: request.id,
+					success: true,
+					data: await markSessionInterrupted(request.authority, request.operations),
+				});
 				return;
 			case "shutdown":
 				sendCatalogMessage({ type: "response", id: request.id, success: true });
@@ -284,25 +359,80 @@ async function handleCatalogRequest(request: CatalogRequest): Promise<void> {
 	}
 }
 
-/**
- * Persist interrupted-session recovery state for a session file: close every
- * unresolved tool call in the terminal assistant tool-use turn with synthetic
- * error toolResult messages, then append the prime-agent.worker_recovery marker.
- * Synthetic results are appended first so they are persisted before the marker.
- * Exported for focused daemon catalog tests.
- */
-export function markSessionInterrupted(sessionPath: string, activeSessionId: string, operations: string[]): void {
-	const session = SessionManager.open(sessionPath);
-	session.closeUnresolvedToolCalls();
-	session.appendCustomMessageEntryWithRollback(
-		"prime-agent.worker_recovery",
-		"<prime_agent_worker_interrupted>\nThe isolated session worker stopped during in-flight work. The saved transcript was recovered, but uncertain model, tool, bash, or child-agent work was not replayed. Inspect external side effects before continuing.\n</prime_agent_worker_interrupted>",
-		false,
-		{
-			activeSessionId,
-			operations,
-		},
+const recoveryQueues = new Map<string, Promise<void>>();
+
+function serializeRecovery<T>(sessionPath: string, action: () => Promise<T> | T): Promise<T> {
+	const previous = recoveryQueues.get(sessionPath) ?? Promise.resolve();
+	const result = previous.catch(() => undefined).then(action);
+	const settled = result.then(
+		() => undefined,
+		() => undefined,
 	);
+	recoveryQueues.set(sessionPath, settled);
+	void settled.then(() => {
+		if (recoveryQueues.get(sessionPath) === settled) recoveryQueues.delete(sessionPath);
+	});
+	return result;
+}
+
+function hasRecoveryMarker(session: SessionManager, operationId: string): boolean {
+	return session.getEntries().some((entry) => {
+		if (entry.type !== "custom_message" || entry.customType !== WORKER_RECOVERY_MARKER) return false;
+		const details = entry.details as { operationId?: unknown } | undefined;
+		return details?.operationId === operationId;
+	});
+}
+
+/**
+ * Recover exactly the journal-authorized interrupted turn under the canonical
+ * session lease. Synthetic results precede one global operation marker; stale
+ * authority performs no writes and persistence failures remain retryable.
+ */
+export async function markSessionInterrupted(
+	authority: CatalogRecoveryAuthority,
+	operations: string[],
+): Promise<CatalogRecoveryResult> {
+	if (!isCatalogRecoveryAuthority(authority) || !operations.every((operation) => operation.length > 0)) {
+		throw new Error("Invalid exact worker recovery authority");
+	}
+	const sessionPath = canonicalSessionPath(authority.sessionFile);
+	const normalizedAuthority: CatalogRecoveryAuthority = { ...authority, sessionFile: sessionPath };
+	return serializeRecovery(sessionPath, (): CatalogRecoveryResult => {
+		let lease: SessionLease | undefined;
+		try {
+			lease = acquireSessionLease(sessionPath, authority.agentDir, {
+				...process.env,
+				[SESSION_LEASES_ENABLED_ENV]: "1",
+				[SESSION_LEASE_OWNER_ID_ENV]: `${RECOVERY_LEASE_OWNER_PREFIX}${authority.operationId}`,
+			});
+		} catch (error) {
+			if (error instanceof SessionAlreadyActiveError) {
+				if (error.activeSessionId?.startsWith(RECOVERY_LEASE_OWNER_PREFIX)) {
+					throw new Error(`Concurrent recovery owns the session lease: ${sessionPath}`);
+				}
+				return { status: "stale", reason: "live_session_owner" };
+			}
+			throw error;
+		}
+		if (!lease) throw new Error(`Could not enable the recovery session lease: ${sessionPath}`);
+		try {
+			const session = SessionManager.open(sessionPath);
+			if (hasRecoveryMarker(session, authority.operationId)) {
+				return { status: "already_applied" };
+			}
+			const recovery = session.closeUnresolvedToolCallsWithAuthority(normalizedAuthority);
+			if (recovery.status === "stale") return recovery;
+			session.appendCustomMessageEntryWithRollback(WORKER_RECOVERY_MARKER, WORKER_RECOVERY_MESSAGE, false, {
+				operationId: authority.operationId,
+				activeSessionId: authority.activeSessionId,
+				operations: [...operations],
+				authority: normalizedAuthority,
+			});
+			return { status: "applied" };
+		} finally {
+			lease.release();
+		}
+	});
 }
 
 export class DaemonCatalogClient {
@@ -382,13 +512,12 @@ export class DaemonCatalogClient {
 		return data.archived;
 	}
 
-	async markInterrupted(sessionPath: string, activeSessionId: string, operations: string[]): Promise<void> {
-		await this.request({
+	markInterrupted(authority: CatalogRecoveryAuthority, operations: string[]): Promise<CatalogRecoveryResult> {
+		return this.request({
 			type: "request",
 			id: randomUUID(),
 			command: "mark_interrupted",
-			sessionPath,
-			activeSessionId,
+			authority,
 			operations,
 		});
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -32,10 +32,7 @@ export interface CatalogRecoveryAuthority extends ExactRecoveryAuthority {
 	readonly agentDir: string;
 }
 
-export type CatalogRecoveryStaleReason =
-	| ExactRecoveryStaleReason
-	| "live_session_owner"
-	| "marker_authority_mismatch";
+export type CatalogRecoveryStaleReason = ExactRecoveryStaleReason | "live_session_owner" | "marker_authority_mismatch";
 
 export type CatalogRecoveryResult =
 	| { readonly status: "applied" }

--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -16,6 +16,8 @@ import {
 	type DaemonResponse,
 	type DaemonSavedSessionInfo,
 	type DaemonServerCapability,
+	type DaemonShutdownAuthority,
+	type DaemonShutdownCommand,
 	getDaemonCommandCompatibilities,
 	isDaemonMutatingCommand,
 } from "./daemon-protocol.js";
@@ -27,6 +29,54 @@ type DaemonCommandBody = DistributiveOmit<DaemonCommand, "id">;
 type DaemonWireCommandBody = DaemonCommandBody | DaemonWorkerCommandBody;
 
 export type DaemonHello = Extract<DaemonOutbound, { type: "daemon_hello" }>;
+
+/**
+ * Derive the public supervisor shutdown authority from the handshake observed
+ * on this connection. Returns undefined when the handshake lacks any required
+ * identity component (a legacy supervisor), so callers emit the legacy
+ * command shape without authority and preserve forward-upgrade replacement.
+ */
+export function daemonShutdownAuthorityFromHello(hello: DaemonHello | undefined): DaemonShutdownAuthority | undefined {
+	if (
+		!hello ||
+		typeof hello.supervisorGeneration !== "string" ||
+		hello.supervisorGeneration.length === 0 ||
+		typeof hello.supervisorOwnerToken !== "string" ||
+		hello.supervisorOwnerToken.length === 0 ||
+		typeof hello.supervisorPid !== "number" ||
+		!Number.isInteger(hello.supervisorPid) ||
+		hello.supervisorPid <= 0 ||
+		typeof hello.supervisorSocketPath !== "string" ||
+		hello.supervisorSocketPath.length === 0
+	) {
+		return undefined;
+	}
+	return {
+		supervisorGeneration: hello.supervisorGeneration,
+		supervisorOwnerToken: hello.supervisorOwnerToken,
+		supervisorPid: hello.supervisorPid,
+		...(typeof hello.supervisorProcessStartId === "string" && hello.supervisorProcessStartId.length > 0
+			? { supervisorProcessStartId: hello.supervisorProcessStartId }
+			: {}),
+		supervisorSocketPath: hello.supervisorSocketPath,
+	};
+}
+
+/**
+ * Shared builder for every public supervisor shutdown command. Explicit CLI
+ * shutdown, stale-daemon replacement, process/status cleanup utilities, and
+ * update/test cleanup paths all construct the command through this helper so
+ * authority always comes from the same connection's handshake and a legacy
+ * supervisor keeps receiving the legacy wire shape.
+ */
+export function createDaemonShutdownCommand(hello: DaemonHello | undefined, force?: boolean): DaemonShutdownCommand {
+	const authority = daemonShutdownAuthorityFromHello(hello);
+	return {
+		type: "shutdown",
+		...(force ? { force: true } : {}),
+		...(authority ? { authority } : {}),
+	};
+}
 
 export type DaemonClientMessageListener = (message: DaemonOutbound) => void;
 export type DaemonClientCloseListener = (error: Error) => void;

--- a/packages/coding-agent/src/modes/daemon/daemon-client.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-client.ts
@@ -14,6 +14,7 @@ import {
 	type DaemonProtocolVersion,
 	type DaemonRequestProgress,
 	type DaemonResponse,
+	type DaemonRestartCommand,
 	type DaemonSavedSessionInfo,
 	type DaemonServerCapability,
 	type DaemonShutdownAuthority,
@@ -46,6 +47,8 @@ export function daemonShutdownAuthorityFromHello(hello: DaemonHello | undefined)
 		typeof hello.supervisorPid !== "number" ||
 		!Number.isInteger(hello.supervisorPid) ||
 		hello.supervisorPid <= 0 ||
+		typeof hello.supervisorProcessStartId !== "string" ||
+		hello.supervisorProcessStartId.length === 0 ||
 		typeof hello.supervisorSocketPath !== "string" ||
 		hello.supervisorSocketPath.length === 0
 	) {
@@ -55,9 +58,7 @@ export function daemonShutdownAuthorityFromHello(hello: DaemonHello | undefined)
 		supervisorGeneration: hello.supervisorGeneration,
 		supervisorOwnerToken: hello.supervisorOwnerToken,
 		supervisorPid: hello.supervisorPid,
-		...(typeof hello.supervisorProcessStartId === "string" && hello.supervisorProcessStartId.length > 0
-			? { supervisorProcessStartId: hello.supervisorProcessStartId }
-			: {}),
+		supervisorProcessStartId: hello.supervisorProcessStartId,
 		supervisorSocketPath: hello.supervisorSocketPath,
 	};
 }
@@ -69,6 +70,14 @@ export function daemonShutdownAuthorityFromHello(hello: DaemonHello | undefined)
  * authority always comes from the same connection's handshake and a legacy
  * supervisor keeps receiving the legacy wire shape.
  */
+export function createDaemonRestartCommand(hello: DaemonHello | undefined): DaemonRestartCommand {
+	const authority = daemonShutdownAuthorityFromHello(hello);
+	return {
+		type: "restart",
+		...(authority ? { authority } : {}),
+	};
+}
+
 export function createDaemonShutdownCommand(hello: DaemonHello | undefined, force?: boolean): DaemonShutdownCommand {
 	const authority = daemonShutdownAuthorityFromHello(hello);
 	return {
@@ -338,6 +347,16 @@ export class DaemonClient {
 	enableAutoReconnect(options: DaemonClientReconnectOptions): void {
 		this.requestRecoveryEnabled = true;
 		this.reconnectOptions = options;
+	}
+
+	async requestSupervisorRestart(timeoutMs = 30000): Promise<DaemonResponse> {
+		const hello = this.helloMessage ?? (await this.waitForHello());
+		return this.request(createDaemonRestartCommand(hello), timeoutMs);
+	}
+
+	async requestSupervisorShutdown(force = false, timeoutMs = 30000): Promise<DaemonResponse> {
+		const hello = this.helloMessage ?? (await this.waitForHello());
+		return this.request(createDaemonShutdownCommand(hello, force), timeoutMs);
 	}
 
 	async request(

--- a/packages/coding-agent/src/modes/daemon/daemon-errors.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-errors.ts
@@ -3,7 +3,21 @@ import { SessionImportFileNotFoundError } from "../../core/session-import-errors
 import { SessionAlreadyActiveError } from "../../core/session-lease.js";
 import type { DaemonErrorInfo, DaemonResponse } from "./daemon-protocol.js";
 
+export class DaemonShutdownAuthorityError extends Error {
+	readonly code = "shutdown_authority_rejected" as const;
+
+	constructor() {
+		super(
+			"Daemon shutdown authority rejected: the connection's supervisor identity does not match the running supervisor",
+		);
+		this.name = "DaemonShutdownAuthorityError";
+	}
+}
+
 export function serializeDaemonError(error: unknown): DaemonErrorInfo | undefined {
+	if (error instanceof DaemonShutdownAuthorityError) {
+		return { code: error.code };
+	}
 	if (error instanceof MissingSessionCwdError) {
 		return { code: "missing_session_cwd", issue: error.issue };
 	}
@@ -30,6 +44,9 @@ export function deserializeDaemonError(response: Extract<DaemonResponse, { succe
 	}
 	if (errorInfo?.code === "session_already_active") {
 		return new SessionAlreadyActiveError(errorInfo.sessionPath, errorInfo.activeSessionId);
+	}
+	if (errorInfo?.code === "shutdown_authority_rejected") {
+		return new DaemonShutdownAuthorityError();
 	}
 	return new Error(response.error);
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -23,7 +23,7 @@ import {
 import { readFile } from "node:fs/promises";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
 import { dirname, isAbsolute, join, resolve } from "node:path";
-import { type Api, getLogger, type Model, type ToolResultMessage } from "@earendil-works/pi-ai";
+import { type Api, getLogger, type Model } from "@earendil-works/pi-ai";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
 import {
 	appendRotatingLog,
@@ -111,7 +111,6 @@ import { acquireSessionLease, canonicalSessionPath, type SessionLease } from "..
 import {
 	readSessionInfo,
 	resolveSessionRlmDepth,
-	type SessionEntry,
 	type SessionInfo,
 	SessionManager,
 } from "../../core/session-manager.js";
@@ -208,7 +207,7 @@ import {
 	SNAPSHOT_TARGET_CHUNK_BYTES,
 	type SnapshotTranscriptChunkSource,
 } from "./snapshot-transcript-cache.js";
-import { WorkerRecoveryJournal, type WorkerRecoveryToolCall } from "./worker-recovery-journal.js";
+import { WorkerRecoveryJournal } from "./worker-recovery-journal.js";
 
 export interface DaemonModeOptions {
 	socketPath?: string;
@@ -361,63 +360,6 @@ const RECOVERY_CHECKPOINT_EVENTS: ReadonlySet<string> = new Set([
 	"session_action_update",
 	"rlm_child_update",
 ]);
-
-/**
- * Collect the unresolved `{ id, name }` tool calls declared by the assistant
- * entry at `assistantIndex` in the active branch. A call is unresolved when no
- * toolResult entry after the assistant entry already resolves its id, so the
- * journaled set is exactly what recovery may still need to close. The ids are
- * the tool-execution event identities from the assistant message itself.
- */
-function collectUnresolvedToolCalls(branch: SessionEntry[], assistantIndex: number): WorkerRecoveryToolCall[] {
-	const assistant = branch[assistantIndex];
-	if (assistant?.type !== "message" || assistant.message.role !== "assistant") {
-		return [];
-	}
-	const resolved = new Set<string>();
-	for (let i = assistantIndex + 1; i < branch.length; i++) {
-		const entry = branch[i];
-		if (entry.type !== "message" || entry.message.role !== "toolResult") {
-			continue;
-		}
-		const result = entry.message as ToolResultMessage;
-		if (typeof result.toolCallId === "string") {
-			resolved.add(result.toolCallId);
-		}
-	}
-	const calls: WorkerRecoveryToolCall[] = [];
-	const seen = new Set<string>();
-	for (const block of assistant.message.content) {
-		if (!block || block.type !== "toolCall") {
-			continue;
-		}
-		if (typeof block.id !== "string" || typeof block.name !== "string") {
-			continue;
-		}
-		if (seen.has(block.id) || resolved.has(block.id)) {
-			continue;
-		}
-		seen.add(block.id);
-		calls.push({ id: block.id, name: block.name });
-	}
-	return calls;
-}
-
-/**
- * SHA-256 over the ordered active branch entry identities and their parent
- * links through the branch head. Any advance, branch switch, or structural
- * change on the active branch changes the digest.
- */
-function computeLineageDigest(branch: SessionEntry[]): string {
-	const hash = createHash("sha256");
-	for (const entry of branch) {
-		hash.update(entry.id);
-		hash.update("\0");
-		hash.update(entry.parentId ?? "");
-		hash.update("\n");
-	}
-	return hash.digest("hex");
-}
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
@@ -6343,34 +6285,17 @@ export class AgentDaemon {
 		const busy =
 			busyOverride ?? (isActiveSessionBusy(state) || session.isRetrying || session.hasAcceptedPromptInFlight);
 		try {
-			// Capture the whole recovery authority from one in-memory session
-			// view: exact active branch head, latest assistant entry, its
-			// unresolved tool calls, and the branch lineage digest. Changes to
-			// any of these force a new journal record even when the event name
-			// is unchanged.
-			const sessionManager = session.sessionManager;
-			const branch = sessionManager.getBranch();
-			let assistantEntryId: string | null = null;
-			let toolCalls: WorkerRecoveryToolCall[] = [];
-			for (let i = branch.length - 1; i >= 0; i--) {
-				const entry = branch[i];
-				if (entry.type === "message" && entry.message.role === "assistant") {
-					assistantEntryId = entry.id;
-					toolCalls = collectUnresolvedToolCalls(branch, i);
-					break;
-				}
-			}
+			// SessionManager captures every branch-derived authority field from one
+			// in-memory view so checkpoint and recovery use the same digest and
+			// unresolved-call semantics.
+			const snapshot = session.sessionManager.captureExactRecoveryAuthority(state.activeSessionId, "");
 			this.recoveryJournal.record({
 				activeSessionId: state.activeSessionId,
-				sessionId: session.sessionId,
+				...snapshot,
 				agentDir: this.agentDir,
-				...(session.sessionFile ? { sessionFile: session.sessionFile } : {}),
+				...(session.sessionFile ? { sessionFile: canonicalSessionPath(session.sessionFile) } : {}),
 				busy,
 				operation,
-				headEntryId: sessionManager.getLeafId(),
-				assistantEntryId,
-				toolCalls,
-				lineageDigest: computeLineageDigest(branch),
 			});
 		} catch (error) {
 			this.log(`could not checkpoint worker operation state: ${String(error)}`);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -200,6 +200,10 @@ import {
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 } from "./daemon-worker-protocol.js";
+import {
+	applyWorkerRecoveryToSession,
+	type CatalogRecoveryAuthority,
+} from "./daemon-catalog-process.js";
 import { MutationDrainLatch } from "./mutation-drain-latch.js";
 import { serializeSavedSessionInfo } from "./saved-session-info.js";
 import {
@@ -1244,6 +1248,11 @@ export class AgentDaemon {
 					throw new RuntimeOpenCancelledError();
 				}
 			}
+			// Extensions are bound by this point; repair any unresolved tool calls
+			// of a restored session while this worker holds the session lease.
+			// Failures throw so the catch below removes the state and disposes the
+			// runtime and lease, and no idle `ready` checkpoint strands the calls.
+			this.repairRestoredInterruptedSession(state);
 			onStateBound?.(state);
 		} catch (error) {
 			state.unsubscribe?.();
@@ -1271,6 +1280,79 @@ export class AgentDaemon {
 		this.summarizer.seed(state);
 		this.recordWorkerRecoveryState(state, "ready");
 		return state;
+	}
+
+	/**
+	 * Repair a restored session whose terminal active-branch assistant turn has
+	 * unresolved tool calls. Runs during worker restore while this worker holds
+	 * the session lease exclusively, before the idle `ready` checkpoint could
+	 * strand those calls. Reuses the exact-authority fenced/idempotent
+	 * synthetic-result + marker semantics shared with the catalog; never
+	 * replays tools or mutates on stale authority.
+	 *
+	 * A busy `restore_interrupted` epoch with the exact head/assistant/tool
+	 * call/lineage authority is persisted before any mutation, so a crash in
+	 * the middle is recovered by the supervisor through the catalog after this
+	 * worker's lease is released. Only after a successful or idempotent repair
+	 * does the caller write `ready` with no unresolved tool calls.
+	 */
+	private repairRestoredInterruptedSession(state: ActiveSessionState): void {
+		if (!this.recoveryJournal) {
+			return;
+		}
+		const session = state.runtime.session;
+		const sessionFile = session.sessionFile;
+		if (!sessionFile) {
+			return;
+		}
+		const sessionManager = session.sessionManager;
+		const authority = sessionManager.captureExactRecoveryAuthority(state.activeSessionId, "");
+		if (authority.toolCalls.length === 0) {
+			// Nothing was interrupted; a normal restore never mutates the
+			// transcript or adds a marker.
+			return;
+		}
+		const operation = "restore_interrupted";
+		const recorded = this.recoveryJournal.record({
+			activeSessionId: state.activeSessionId,
+			...authority,
+			agentDir: this.agentDir,
+			sessionFile: canonicalSessionPath(sessionFile),
+			busy: true,
+			operation,
+		});
+		if (recorded.version !== 2 || !recorded.busy) {
+			// Unreachable for a complete v2 input; fail closed rather than let
+			// the caller write an idle `ready` checkpoint that strands the calls.
+			const error = new Error(
+				`Could not journal restore repair authority for ${sessionFile}; session stays busy for recovery`,
+			);
+			this.log(error.message);
+			throw error;
+		}
+		const catalogAuthority: CatalogRecoveryAuthority = {
+			operationId: recorded.operationId,
+			activeSessionId: recorded.activeSessionId,
+			sessionId: recorded.sessionId,
+			agentDir: recorded.agentDir,
+			sessionFile: recorded.sessionFile,
+			headEntryId: recorded.headEntryId,
+			assistantEntryId: recorded.assistantEntryId,
+			toolCalls: recorded.toolCalls,
+			lineageDigest: recorded.lineageDigest,
+		};
+		const result = applyWorkerRecoveryToSession(sessionManager, catalogAuthority, [operation]);
+		if (result.status === "stale") {
+			// The authority was captured from this same in-memory view, so a stale
+			// result is an invariant failure. Fail the open closed and keep the
+			// busy epoch journaled: writing `ready` here would strand the calls.
+			const error = new Error(
+				`Restore repair for ${sessionFile} is stale (${result.reason}); session stays busy for recovery`,
+			);
+			this.log(error.message);
+			throw error;
+		}
+		this.log(`Restore repair for ${sessionFile} ${result.status} under ${recorded.operationId}`);
 	}
 
 	private refreshReplacedSessionState(state: ActiveSessionState): void {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -23,7 +23,7 @@ import {
 import { readFile } from "node:fs/promises";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
 import { dirname, isAbsolute, join, resolve } from "node:path";
-import { type Api, getLogger, type Model } from "@earendil-works/pi-ai";
+import { type Api, getLogger, type Model, type ToolResultMessage } from "@earendil-works/pi-ai";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
 import {
 	appendRotatingLog,
@@ -111,6 +111,7 @@ import { acquireSessionLease, canonicalSessionPath, type SessionLease } from "..
 import {
 	readSessionInfo,
 	resolveSessionRlmDepth,
+	type SessionEntry,
 	type SessionInfo,
 	SessionManager,
 } from "../../core/session-manager.js";
@@ -207,7 +208,7 @@ import {
 	SNAPSHOT_TARGET_CHUNK_BYTES,
 	type SnapshotTranscriptChunkSource,
 } from "./snapshot-transcript-cache.js";
-import { WorkerRecoveryJournal } from "./worker-recovery-journal.js";
+import { WorkerRecoveryJournal, type WorkerRecoveryToolCall } from "./worker-recovery-journal.js";
 
 export interface DaemonModeOptions {
 	socketPath?: string;
@@ -360,6 +361,63 @@ const RECOVERY_CHECKPOINT_EVENTS: ReadonlySet<string> = new Set([
 	"session_action_update",
 	"rlm_child_update",
 ]);
+
+/**
+ * Collect the unresolved `{ id, name }` tool calls declared by the assistant
+ * entry at `assistantIndex` in the active branch. A call is unresolved when no
+ * toolResult entry after the assistant entry already resolves its id, so the
+ * journaled set is exactly what recovery may still need to close. The ids are
+ * the tool-execution event identities from the assistant message itself.
+ */
+function collectUnresolvedToolCalls(branch: SessionEntry[], assistantIndex: number): WorkerRecoveryToolCall[] {
+	const assistant = branch[assistantIndex];
+	if (assistant?.type !== "message" || assistant.message.role !== "assistant") {
+		return [];
+	}
+	const resolved = new Set<string>();
+	for (let i = assistantIndex + 1; i < branch.length; i++) {
+		const entry = branch[i];
+		if (entry.type !== "message" || entry.message.role !== "toolResult") {
+			continue;
+		}
+		const result = entry.message as ToolResultMessage;
+		if (typeof result.toolCallId === "string") {
+			resolved.add(result.toolCallId);
+		}
+	}
+	const calls: WorkerRecoveryToolCall[] = [];
+	const seen = new Set<string>();
+	for (const block of assistant.message.content) {
+		if (!block || block.type !== "toolCall") {
+			continue;
+		}
+		if (typeof block.id !== "string" || typeof block.name !== "string") {
+			continue;
+		}
+		if (seen.has(block.id) || resolved.has(block.id)) {
+			continue;
+		}
+		seen.add(block.id);
+		calls.push({ id: block.id, name: block.name });
+	}
+	return calls;
+}
+
+/**
+ * SHA-256 over the ordered active branch entry identities and their parent
+ * links through the branch head. Any advance, branch switch, or structural
+ * change on the active branch changes the digest.
+ */
+function computeLineageDigest(branch: SessionEntry[]): string {
+	const hash = createHash("sha256");
+	for (const entry of branch) {
+		hash.update(entry.id);
+		hash.update("\0");
+		hash.update(entry.parentId ?? "");
+		hash.update("\n");
+	}
+	return hash.digest("hex");
+}
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
@@ -6285,12 +6343,34 @@ export class AgentDaemon {
 		const busy =
 			busyOverride ?? (isActiveSessionBusy(state) || session.isRetrying || session.hasAcceptedPromptInFlight);
 		try {
+			// Capture the whole recovery authority from one in-memory session
+			// view: exact active branch head, latest assistant entry, its
+			// unresolved tool calls, and the branch lineage digest. Changes to
+			// any of these force a new journal record even when the event name
+			// is unchanged.
+			const sessionManager = session.sessionManager;
+			const branch = sessionManager.getBranch();
+			let assistantEntryId: string | null = null;
+			let toolCalls: WorkerRecoveryToolCall[] = [];
+			for (let i = branch.length - 1; i >= 0; i--) {
+				const entry = branch[i];
+				if (entry.type === "message" && entry.message.role === "assistant") {
+					assistantEntryId = entry.id;
+					toolCalls = collectUnresolvedToolCalls(branch, i);
+					break;
+				}
+			}
 			this.recoveryJournal.record({
 				activeSessionId: state.activeSessionId,
 				sessionId: session.sessionId,
+				agentDir: this.agentDir,
 				...(session.sessionFile ? { sessionFile: session.sessionFile } : {}),
 				busy,
 				operation,
+				headEntryId: sessionManager.getLeafId(),
+				assistantEntryId,
+				toolCalls,
+				lineageDigest: computeLineageDigest(branch),
 			});
 		} catch (error) {
 			this.log(`could not checkpoint worker operation state: ${String(error)}`);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -136,6 +136,7 @@ import {
 	resolveActiveSessionState,
 } from "./active-session-state.js";
 import { createCompactAssistantDelta } from "./compact-session-stream.js";
+import { applyWorkerRecoveryToSession, type CatalogRecoveryAuthority } from "./daemon-catalog-process.js";
 import { DaemonClient } from "./daemon-client.js";
 import { filterClientEnv, withClientEnv } from "./daemon-client-env.js";
 import { deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js";
@@ -200,10 +201,6 @@ import {
 	SESSION_LEASE_OWNER_ID_ENV,
 	SESSION_LEASES_ENABLED_ENV,
 } from "./daemon-worker-protocol.js";
-import {
-	applyWorkerRecoveryToSession,
-	type CatalogRecoveryAuthority,
-} from "./daemon-catalog-process.js";
 import { MutationDrainLatch } from "./mutation-drain-latch.js";
 import { serializeSavedSessionInfo } from "./saved-session-info.js";
 import {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -65,7 +65,7 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 18 applies the same authority to public restart and requires the full
 // process-start identity for every authority-bearing termination command.
 export const DAEMON_SCHEMA_REVISION = 18;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-18-c9d175a9766f";
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-18-2dae6dbd5404";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,10 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+// Revision 17 adds supervisor shutdown authority: the public shutdown command may
+// carry the exact supervisor identity observed on the same connection's handshake.
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-2b8db83c63df";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -346,6 +348,27 @@ export type DaemonSavedSessionListCommand =
 			scope: AgentConnectionSavedSessionScope;
 	  };
 
+/**
+ * The exact durable supervisor identity a client observes in `daemon_hello`.
+ * A public `shutdown` command carries it so connection access alone is not
+ * authority to terminate whichever supervisor happens to own the socket path.
+ */
+export interface DaemonShutdownAuthority {
+	supervisorGeneration: string;
+	supervisorOwnerToken: string;
+	supervisorPid: number;
+	supervisorProcessStartId?: string;
+	supervisorSocketPath: string;
+}
+
+export type DaemonShutdownCommand = {
+	id?: string;
+	type: "shutdown";
+	force?: boolean;
+	/** Optional only for forward upgrade compatibility with legacy supervisors. */
+	authority?: DaemonShutdownAuthority;
+};
+
 export type DaemonCommand =
 	| {
 			id?: string;
@@ -617,7 +640,7 @@ export type DaemonCommand =
 	| { id?: string; type: "prepare_update_restart" }
 	| { id?: string; type: "retry_worker"; activeSessionId: string }
 	| { id?: string; type: "restart" }
-	| { id?: string; type: "shutdown"; force?: boolean };
+	| DaemonShutdownCommand;
 
 type DaemonCommandName = DaemonCommand["type"];
 
@@ -780,7 +803,8 @@ export type DaemonErrorInfo =
 	| { code: "missing_session_cwd"; issue: SessionCwdIssue }
 	| { code: "session_import_file_not_found"; filePath: string }
 	| { code: "session_already_active"; sessionPath: string; activeSessionId?: string }
-	| { code: "command_result_uncertain"; clientId: DaemonClientId; commandId: DaemonCommandId };
+	| { code: "command_result_uncertain"; clientId: DaemonClientId; commandId: DaemonCommandId }
+	| { code: "shutdown_authority_rejected" };
 
 export type DaemonSessionClosedReason = "killed" | "shutdown" | "completed" | "replaced" | "update";
 export type DaemonClosingReason = "shutdown" | "update";

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -62,8 +62,10 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
 // Revision 17 adds supervisor shutdown authority: the public shutdown command may
 // carry the exact supervisor identity observed on the same connection's handshake.
-export const DAEMON_SCHEMA_REVISION = 17;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-2b8db83c63df";
+// Revision 18 applies the same authority to public restart and requires the full
+// process-start identity for every authority-bearing termination command.
+export const DAEMON_SCHEMA_REVISION = 18;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-18-c9d175a9766f";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -350,16 +352,23 @@ export type DaemonSavedSessionListCommand =
 
 /**
  * The exact durable supervisor identity a client observes in `daemon_hello`.
- * A public `shutdown` command carries it so connection access alone is not
- * authority to terminate whichever supervisor happens to own the socket path.
+ * Every public command that terminates the supervisor carries it so connection
+ * access alone is not authority to terminate whichever owner has the socket.
  */
 export interface DaemonShutdownAuthority {
 	supervisorGeneration: string;
 	supervisorOwnerToken: string;
 	supervisorPid: number;
-	supervisorProcessStartId?: string;
+	supervisorProcessStartId: string;
 	supervisorSocketPath: string;
 }
+
+export type DaemonRestartCommand = {
+	id?: string;
+	type: "restart";
+	/** Optional only for forward upgrade compatibility with legacy supervisors. */
+	authority?: DaemonShutdownAuthority;
+};
 
 export type DaemonShutdownCommand = {
 	id?: string;
@@ -639,7 +648,7 @@ export type DaemonCommand =
 	| { id?: string; type: "ack_result"; commandId: string }
 	| { id?: string; type: "prepare_update_restart" }
 	| { id?: string; type: "retry_worker"; activeSessionId: string }
-	| { id?: string; type: "restart" }
+	| DaemonRestartCommand
 	| DaemonShutdownCommand;
 
 type DaemonCommandName = DaemonCommand["type"];

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -315,7 +315,7 @@ export async function acquireDaemonSupervisorOwnership(
 		generation: options.generation,
 		pid: process.pid,
 		...(processStartId ? { processStartId } : {}),
-		socketPath: normalizeSocketPath(options.socketPath),
+		socketPath: normalizeDaemonSupervisorSocketPath(options.socketPath),
 		descriptorDir: canonicalizeFilesystemPath(options.descriptorDir),
 		agentDir: canonicalizeFilesystemPath(options.agentDir),
 		appVersion: options.appVersion,
@@ -377,7 +377,7 @@ export async function assertDaemonSupervisorOwnerCurrent(
 		!current ||
 		current.pid !== owner.pid ||
 		current.processStartId !== owner.processStartId ||
-		current.socketPath !== normalizeSocketPath(owner.socketPath) ||
+		current.socketPath !== normalizeDaemonSupervisorSocketPath(owner.socketPath) ||
 		!isProcessAlive(current.pid)
 	) {
 		throw new DaemonSupervisorOwnershipLostError(owner.generation);
@@ -431,7 +431,7 @@ export async function persistDaemonStartupFenceFromOwner(
 	const fenceDirectory = resolve(registryDir, "startup-fences");
 	mkdirSync(fenceDirectory, { recursive: true, mode: 0o700 });
 	const path = startupFencePath(fenceDirectory, socketPath);
-	const normalizedSocketPath = normalizeSocketPath(socketPath);
+	const normalizedSocketPath = normalizeDaemonSupervisorSocketPath(socketPath);
 	return withDaemonSupervisorRegistryGuard(registryDir, () => {
 		const owners = listOwnerDirectories(registryDir).flatMap((directory) => {
 			const owner = readOwnerRecordForScope(directory, (scope) => scope.socketPath === normalizedSocketPath);
@@ -455,7 +455,7 @@ export async function persistDaemonStartupFenceFromOwner(
 			hello.supervisorGeneration !== owner.generation ||
 			hello.supervisorOwnerToken !== owner.token ||
 			typeof helloSocketPath !== "string" ||
-			normalizeSocketPath(helloSocketPath) !== owner.socketPath ||
+			normalizeDaemonSupervisorSocketPath(helloSocketPath) !== owner.socketPath ||
 			typeof owner.processStartId !== "string" ||
 			hello.supervisorProcessStartId !== owner.processStartId
 		) {
@@ -491,7 +491,7 @@ export async function waitForDaemonStartupFence(
 		if (!fence) {
 			return;
 		}
-		if (fence.socketPath !== normalizeSocketPath(socketPath)) {
+		if (fence.socketPath !== normalizeDaemonSupervisorSocketPath(socketPath)) {
 			throw new Error(`Daemon startup fence does not match ${socketPath}`);
 		}
 		if (!isProcessIdentityAlive(fence)) {
@@ -545,7 +545,13 @@ function isProcessAlive(pid: number): boolean {
 	return true;
 }
 
-function normalizeSocketPath(socketPath: string): string {
+/**
+ * Normalize a supervisor socket path for durable-record and authority
+ * comparisons. The same normalization is applied when the durable owner is
+ * published and when a shutdown authority is validated, so a client cannot
+ * dodge the match with a non-canonical spelling.
+ */
+export function normalizeDaemonSupervisorSocketPath(socketPath: string): string {
 	if (process.platform === "win32") {
 		return socketPath.toLowerCase();
 	}
@@ -794,7 +800,7 @@ function writeJsonAtomically(path: string, value: unknown): void {
 }
 
 function startupFencePath(directory: string, socketPath: string): string {
-	const key = createHash("sha256").update(normalizeSocketPath(socketPath)).digest("hex");
+	const key = createHash("sha256").update(normalizeDaemonSupervisorSocketPath(socketPath)).digest("hex");
 	return resolve(directory, `${key}.json`);
 }
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2921,12 +2921,19 @@ export class DaemonSupervisor {
 		const uncertain = journal.getLatest().filter((record) => record.busy);
 		if (uncertain.length === 0) return;
 
-		const authorized = uncertain.filter(isV2WorkerRecoveryRecord);
+		const supervisorAgentDir = this.defaultSessionConfig?.agentDir;
+		const authorized = uncertain.filter(isV2WorkerRecoveryRecord).filter((record) => {
+			if (!supervisorAgentDir || resolve(record.agentDir) === resolve(supervisorAgentDir)) return true;
+			this.log(`Worker recovery ${record.operationId} is stale: agentDir namespace mismatch`);
+			journal.complete(record.activeSessionId, record.operationId);
+			return false;
+		});
 		for (const legacy of uncertain.filter((record) => !isV2WorkerRecoveryRecord(record))) {
 			// Legacy checkpoints lack exact turn, lineage, lease namespace, and
-			// operation authority. Leave them untouched so no stale supervisor can
-			// hide a newer checkpoint with an unsafe legacy idle write.
+			// operation authority. A guarded legacy-only acknowledgement avoids
+			// retrying forever without ever granting transcript mutation authority.
 			this.log(`Skipped stale legacy worker recovery authority for ${legacy.activeSessionId}; transcript unchanged`);
+			journal.completeLegacy(legacy.activeSessionId);
 		}
 		await this.assertRecoveryAllowed();
 		const recoveryOutcomes = await Promise.allSettled(

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2953,6 +2953,11 @@ export class DaemonSupervisor {
 				await this.assertRecoveryAllowed();
 				if (result.status === "stale") {
 					this.log(`Worker recovery ${record.operationId} is stale: ${result.reason}`);
+					if (killWorkerProcess && result.reason === "live_session_owner") {
+						throw new Error(
+							`Worker recovery ${record.operationId} is waiting for the killed session owner lease to be released`,
+						);
+					}
 				}
 				if (!journal.complete(record.activeSessionId, record.operationId)) {
 					this.log(`Worker recovery ${record.operationId} completion lost CAS to a newer epoch`);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -55,7 +55,7 @@ import {
 	DAEMON_CATALOG_ROLE_ENV,
 	DaemonCatalogClient,
 } from "./daemon-catalog-process.js";
-import { deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js";
+import { DaemonShutdownAuthorityError, deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js";
 import {
 	collectDaemonClientEnv,
 	createDaemonEventMeta,
@@ -73,6 +73,7 @@ import {
 	type DaemonCommand,
 	type DaemonOutbound,
 	type DaemonResponse,
+	type DaemonShutdownAuthority,
 	type DaemonUpdateRestartManifest,
 	failure,
 	isDaemonCommandEnvelope,
@@ -103,6 +104,7 @@ import {
 import {
 	acquireDaemonSupervisorOwnership,
 	isDaemonShutdownAdmissionActive,
+	normalizeDaemonSupervisorSocketPath,
 	waitForDaemonStartupFence,
 } from "./daemon-supervisor-ownership.js";
 import { DaemonWorkerClient } from "./daemon-worker-client.js";
@@ -903,6 +905,35 @@ export class DaemonSupervisor {
 		}
 	}
 
+	/**
+	 * Fail-closed gate for the public shutdown command. Requires the exact
+	 * durable supervisor identity observed on the same connection's handshake,
+	 * reasserts current ownership so a generation that already lost ownership
+	 * cannot accept termination commands, and rejects missing, malformed,
+	 * incomplete, or mismatched authority before any shutdown is scheduled.
+	 * The force flag changes worker-drain behavior only; it never bypasses
+	 * this gate.
+	 */
+	private async assertShutdownAuthority(authority: DaemonShutdownAuthority | undefined): Promise<void> {
+		if (!isCompleteDaemonShutdownAuthority(authority)) {
+			throw new DaemonShutdownAuthorityError();
+		}
+		await this.assertCurrentOwnership();
+		const record = this.ownership?.record;
+		if (!record) {
+			throw new DaemonShutdownAuthorityError();
+		}
+		if (
+			authority.supervisorGeneration !== record.generation ||
+			authority.supervisorOwnerToken !== record.token ||
+			authority.supervisorPid !== record.pid ||
+			authority.supervisorProcessStartId !== record.processStartId ||
+			normalizeDaemonSupervisorSocketPath(authority.supervisorSocketPath) !== record.socketPath
+		) {
+			throw new DaemonShutdownAuthorityError();
+		}
+	}
+
 	private supervisorAuthenticationClaim(): {
 		supervisorGeneration: string;
 		supervisorPid: number;
@@ -1577,6 +1608,7 @@ export class DaemonSupervisor {
 				setImmediate(() => void this.shutdown(0, false, true, false, "update"));
 				return success(command.id, command.type);
 			case "shutdown":
+				await this.assertShutdownAuthority(command.authority);
 				setImmediate(() => void this.shutdown(0, true, false, command.force === true, "shutdown"));
 				return success(command.id, "shutdown");
 			case "prepare_update_restart": {
@@ -5203,4 +5235,23 @@ export class DaemonSupervisor {
 		}
 		process.exit(exitCode);
 	}
+}
+
+function isCompleteDaemonShutdownAuthority(value: unknown): value is DaemonShutdownAuthority {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+	const authority = value as Partial<DaemonShutdownAuthority>;
+	return (
+		typeof authority.supervisorGeneration === "string" &&
+		authority.supervisorGeneration.length > 0 &&
+		typeof authority.supervisorOwnerToken === "string" &&
+		authority.supervisorOwnerToken.length > 0 &&
+		Number.isInteger(authority.supervisorPid) &&
+		(authority.supervisorPid ?? 0) > 0 &&
+		typeof authority.supervisorSocketPath === "string" &&
+		authority.supervisorSocketPath.length > 0 &&
+		(authority.supervisorProcessStartId === undefined ||
+			(typeof authority.supervisorProcessStartId === "string" && authority.supervisorProcessStartId.length > 0))
+	);
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -50,7 +50,11 @@ import type { PrivateFrame } from "../session-worker/private-framing.js";
 import { createActiveSessionId, type DaemonSocketClient } from "./active-session-state.js";
 import { CommandRecoveryJournal, createCommandIdempotencyKey } from "./command-recovery-journal.js";
 import { CompactAssistantStreamReconstructor, isCompactAssistantDelta } from "./compact-session-stream.js";
-import { DAEMON_CATALOG_ROLE_ENV, DaemonCatalogClient } from "./daemon-catalog-process.js";
+import {
+	type CatalogRecoveryAuthority,
+	DAEMON_CATALOG_ROLE_ENV,
+	DaemonCatalogClient,
+} from "./daemon-catalog-process.js";
 import { deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js";
 import {
 	collectDaemonClientEnv,
@@ -120,7 +124,7 @@ import {
 import { MutationDrainLatch } from "./mutation-drain-latch.js";
 import { serializeSavedSessionInfo } from "./saved-session-info.js";
 import { SNAPSHOT_TARGET_CHUNK_BYTES, SnapshotTranscriptCache } from "./snapshot-transcript-cache.js";
-import { WorkerRecoveryJournal } from "./worker-recovery-journal.js";
+import { isV2WorkerRecoveryRecord, WorkerRecoveryJournal } from "./worker-recovery-journal.js";
 
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
 type DaemonCommandBody = DistributiveOmit<DaemonCommand, "id">;
@@ -2914,52 +2918,46 @@ export class DaemonSupervisor {
 			}
 		}
 		const journal = new WorkerRecoveryJournal(worker.descriptor.recoveryJournalPath);
-		const latest = journal.getLatest();
-		const uncertain = latest.filter((record) => record.busy);
-		if (uncertain.length === 0) {
-			return;
-		}
-		const interruptedSessions = new Map<
-			string,
-			{ activeSessionId: string; sessionFile: string; operations: Set<string> }
-		>();
-		for (const record of uncertain) {
-			const sessionFile =
-				record.sessionFile ??
-				(record.activeSessionId === worker.descriptor.rootActiveSessionId
-					? worker.descriptor.sessionFile
-					: undefined);
-			if (!sessionFile) {
-				continue;
-			}
-			const key = `${record.activeSessionId}\0${sessionFile}`;
-			let interrupted = interruptedSessions.get(key);
-			if (!interrupted) {
-				interrupted = { activeSessionId: record.activeSessionId, sessionFile, operations: new Set() };
-				interruptedSessions.set(key, interrupted);
-			}
-			interrupted.operations.add(record.operation);
+		const uncertain = journal.getLatest().filter((record) => record.busy);
+		if (uncertain.length === 0) return;
+
+		const authorized = uncertain.filter(isV2WorkerRecoveryRecord);
+		for (const legacy of uncertain.filter((record) => !isV2WorkerRecoveryRecord(record))) {
+			// Legacy checkpoints lack exact turn, lineage, lease namespace, and
+			// operation authority. Leave them untouched so no stale supervisor can
+			// hide a newer checkpoint with an unsafe legacy idle write.
+			this.log(`Skipped stale legacy worker recovery authority for ${legacy.activeSessionId}; transcript unchanged`);
 		}
 		await this.assertRecoveryAllowed();
-		await Promise.all(
-			[...interruptedSessions.values()].map((interrupted) =>
-				this.catalog.markInterrupted(interrupted.sessionFile, interrupted.activeSessionId, [
-					...interrupted.operations,
-				]),
-			),
+		const recoveryOutcomes = await Promise.allSettled(
+			authorized.map(async (record) => {
+				const authority: CatalogRecoveryAuthority = {
+					operationId: record.operationId,
+					activeSessionId: record.activeSessionId,
+					sessionId: record.sessionId,
+					agentDir: record.agentDir,
+					sessionFile: record.sessionFile,
+					headEntryId: record.headEntryId,
+					assistantEntryId: record.assistantEntryId,
+					toolCalls: record.toolCalls,
+					lineageDigest: record.lineageDigest,
+				};
+				const result = await this.catalog.markInterrupted(authority, [record.operation]);
+				await this.assertRecoveryAllowed();
+				if (result.status === "stale") {
+					this.log(`Worker recovery ${record.operationId} is stale: ${result.reason}`);
+				}
+				if (!journal.complete(record.activeSessionId, record.operationId)) {
+					this.log(`Worker recovery ${record.operationId} completion lost CAS to a newer epoch`);
+				}
+			}),
 		);
-		await this.assertRecoveryAllowed();
-		for (const record of latest) {
-			journal.record({
-				activeSessionId: record.activeSessionId,
-				sessionId: record.sessionId,
-				...(record.sessionFile ? { sessionFile: record.sessionFile } : {}),
-				busy: false,
-				operation: "recovery_hold",
-			});
-		}
+		const failedRecovery = recoveryOutcomes.find(
+			(outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+		);
+		if (failedRecovery) throw failedRecovery.reason;
 		this.log(
-			`Recovered worker ${worker.descriptor.workerId} without replaying uncertain operations: ${uncertain
+			`Recovered worker ${worker.descriptor.workerId} without replaying uncertain operations: ${authorized
 				.map((record) => record.operation)
 				.join(", ")}`,
 		);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -906,8 +906,8 @@ export class DaemonSupervisor {
 	}
 
 	/**
-	 * Fail-closed gate for the public shutdown command. Requires the exact
-	 * durable supervisor identity observed on the same connection's handshake,
+	 * Fail-closed gate for every public supervisor-termination command. Requires
+	 * the exact durable identity observed on the same connection's handshake,
 	 * reasserts current ownership so a generation that already lost ownership
 	 * cannot accept termination commands, and rejects missing, malformed,
 	 * incomplete, or mismatched authority before any shutdown is scheduled.
@@ -1605,6 +1605,7 @@ export class DaemonSupervisor {
 				return success(command.id, command.type, summary ? this.publicSummary(worker, summary) : undefined);
 			}
 			case "restart":
+				await this.assertShutdownAuthority(command.authority);
 				setImmediate(() => void this.shutdown(0, false, true, false, "update"));
 				return success(command.id, command.type);
 			case "shutdown":
@@ -5249,9 +5250,9 @@ function isCompleteDaemonShutdownAuthority(value: unknown): value is DaemonShutd
 		authority.supervisorOwnerToken.length > 0 &&
 		Number.isInteger(authority.supervisorPid) &&
 		(authority.supervisorPid ?? 0) > 0 &&
+		typeof authority.supervisorProcessStartId === "string" &&
+		authority.supervisorProcessStartId.length > 0 &&
 		typeof authority.supervisorSocketPath === "string" &&
-		authority.supervisorSocketPath.length > 0 &&
-		(authority.supervisorProcessStartId === undefined ||
-			(typeof authority.supervisorProcessStartId === "string" && authority.supervisorProcessStartId.length > 0))
+		authority.supervisorSocketPath.length > 0
 	);
 }

--- a/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
@@ -409,6 +409,29 @@ export class WorkerRecoveryJournal {
 		});
 	}
 
+	/**
+	 * Acknowledge one legacy busy record without granting it transcript mutation
+	 * authority. The journal-local guard prevents a stale supervisor from
+	 * overwriting a concurrently written v2 checkpoint for the same session.
+	 */
+	completeLegacy(activeSessionId: string): boolean {
+		return withJournalGuard(this.path, () => {
+			this.refreshLatest();
+			const latest = this.latest.get(activeSessionId);
+			if (!latest || latest.version !== 1 || !latest.busy) return false;
+			const completed: WorkerRecoveryRecordV1 = {
+				...latest,
+				busy: false,
+				operation: "legacy_recovery_stale",
+				recordedAt: new Date().toISOString(),
+			};
+			this.append(completed);
+			this.latest.set(activeSessionId, completed);
+			this.compactIfAllIdle();
+			return true;
+		});
+	}
+
 	getLatest(): WorkerRecoveryRecord[] {
 		return [...this.latest.values()];
 	}

--- a/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
@@ -301,8 +301,8 @@ export class WorkerRecoveryJournal {
 		this.latest = parseRecords(path);
 	}
 
-	record(input: WorkerRecoveryRecordInput): void {
-		withJournalGuard(this.path, () => {
+	record(input: WorkerRecoveryRecordInput): WorkerRecoveryRecord {
+		return withJournalGuard(this.path, () => {
 			this.refreshLatest();
 			const previous = this.latest.get(input.activeSessionId);
 			let record: WorkerRecoveryRecord;
@@ -332,11 +332,15 @@ export class WorkerRecoveryJournal {
 				};
 			}
 			if (sameV2Checkpoint(previous, record)) {
-				return;
+				// The checkpoint is byte-identical to the persisted latest record;
+				// return that durable record rather than the reconstructed one so
+				// callers observe the real persisted authority and recordedAt.
+				return previous!;
 			}
 			this.append(record);
 			this.latest.set(record.activeSessionId, record);
 			this.compactIfAllIdle();
+			return record;
 		});
 	}
 

--- a/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
@@ -160,6 +160,32 @@ function parseRecord(line: string): WorkerRecoveryRecord | undefined {
 	return parseV2(parsed as Record<string, unknown>) ?? parseV1(parsed as Record<string, unknown>);
 }
 
+/**
+ * Recover the session identity from an invalid checkpoint when it was written
+ * far enough to include the complete JSON string. Journal serialization places
+ * activeSessionId before every authority field, so a torn prefix without a
+ * complete identity cannot contain a later authority change.
+ */
+function malformedActiveSessionId(line: string): string | undefined {
+	try {
+		const parsed = JSON.parse(line) as unknown;
+		if (typeof parsed === "object" && parsed !== null) {
+			const activeSessionId = (parsed as Record<string, unknown>).activeSessionId;
+			if (isNonEmptyString(activeSessionId)) return activeSessionId;
+		}
+	} catch {
+		// A truncated JSON object may still contain the complete identity token.
+	}
+	const token = /"activeSessionId"\s*:\s*("(?:\\.|[^"\\])*")/.exec(line)?.[1];
+	if (!token) return undefined;
+	try {
+		const activeSessionId = JSON.parse(token) as unknown;
+		return isNonEmptyString(activeSessionId) ? activeSessionId : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function parseRecords(path: string): Map<string, WorkerRecoveryRecord> {
 	const indexed = new Map<string, { record: WorkerRecoveryRecord; index: number }>();
 	let contents: string;
@@ -169,21 +195,26 @@ function parseRecords(path: string): Map<string, WorkerRecoveryRecord> {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map();
 		throw error;
 	}
-	let lastMalformedIndex = -1;
+	const lastMalformedIndex = new Map<string, number>();
 	const lines = contents.split("\n");
 	for (let index = 0; index < lines.length; index++) {
 		const line = lines[index]!;
 		if (!line) continue;
 		const record = parseRecord(line);
-		if (record) indexed.set(record.activeSessionId, { record, index });
-		else lastMalformedIndex = index;
+		if (record) {
+			indexed.set(record.activeSessionId, { record, index });
+		} else {
+			const activeSessionId = malformedActiveSessionId(line);
+			if (activeSessionId) lastMalformedIndex.set(activeSessionId, index);
+		}
 	}
 	const latest = new Map<string, WorkerRecoveryRecord>();
 	for (const [activeSessionId, { record, index }] of indexed) {
-		// A malformed later checkpoint could contain an authority change that was
-		// only partially persisted. Never fall back to an older busy v2 authority;
-		// a subsequent valid checkpoint may safely supersede the corrupt line.
-		if (record.version === 2 && record.busy && index < lastMalformedIndex) continue;
+		// A malformed later checkpoint for this session could contain an authority
+		// change that was only partially persisted. Never fall back to that session's
+		// older busy v2 authority; unrelated session records remain recoverable.
+		const malformedIndex = lastMalformedIndex.get(activeSessionId) ?? -1;
+		if (record.version === 2 && record.busy && index < malformedIndex) continue;
 		latest.set(activeSessionId, record);
 	}
 	return latest;

--- a/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
@@ -11,6 +11,7 @@ import {
 	writeSync,
 } from "node:fs";
 import { dirname } from "node:path";
+import { lockSync } from "proper-lockfile";
 
 /** One unresolved tool call declared by the authorized assistant entry. */
 export interface WorkerRecoveryToolCall {
@@ -33,10 +34,9 @@ export interface WorkerRecoveryRecordV1 {
 }
 
 /**
- * Validated v2 recovery authority checkpoint. Every busy epoch has one stable
- * `operationId`, created at the first durable busy checkpoint and reused until
- * the session becomes idle. Changes to session generation, agent dir, path,
- * head, assistant entry, tool calls, or lineage force a new record.
+ * Validated v2 recovery authority checkpoint. An unchanged busy authority
+ * reuses one `operationId`; any authority change starts a new epoch so stale
+ * completion cannot clear newer work. Idle also ends the epoch.
  */
 export interface WorkerRecoveryRecordV2 {
 	version: 2;
@@ -44,16 +44,16 @@ export interface WorkerRecoveryRecordV2 {
 	sessionId: string;
 	/** Lease namespace the catalog must use to recover the canonical session path. */
 	agentDir: string;
-	sessionFile?: string;
+	sessionFile: string;
 	/** Exact active branch head; null for an empty branch. */
 	headEntryId: string | null;
 	/** Latest assistant entry on the active branch, when one exists. */
 	assistantEntryId: string | null;
 	/** Exact unresolved `{ id, name }` set declared by the assistant entry. */
-	toolCalls: WorkerRecoveryToolCall[];
+	toolCalls: ReadonlyArray<WorkerRecoveryToolCall>;
 	/** SHA-256 over the ordered active branch identities and parent links. */
 	lineageDigest: string;
-	/** Stable id for the busy epoch; a new id is allocated after the session becomes idle. */
+	/** Stable id for this exact-authority busy epoch. */
 	operationId: string;
 	busy: boolean;
 	operation: string;
@@ -71,7 +71,7 @@ export interface WorkerRecoveryRecordInput {
 	operation: string;
 	headEntryId?: string | null;
 	assistantEntryId?: string | null;
-	toolCalls?: WorkerRecoveryToolCall[];
+	toolCalls?: ReadonlyArray<WorkerRecoveryToolCall>;
 	lineageDigest?: string;
 }
 
@@ -79,12 +79,23 @@ export function isV2WorkerRecoveryRecord(record: WorkerRecoveryRecord): record i
 	return record.version === 2;
 }
 
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
+}
+
 function isToolCall(value: unknown): value is WorkerRecoveryToolCall {
-	if (typeof value !== "object" || value === null) {
-		return false;
-	}
+	if (typeof value !== "object" || value === null) return false;
 	const call = value as WorkerRecoveryToolCall;
-	return typeof call.id === "string" && typeof call.name === "string";
+	return isNonEmptyString(call.id) && isNonEmptyString(call.name);
+}
+
+function hasUniqueToolCallIds(value: readonly unknown[]): boolean {
+	const ids = value.map((call) => (call as WorkerRecoveryToolCall).id);
+	return new Set(ids).size === ids.length;
+}
+
+function isUuid(value: string): boolean {
+	return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 }
 
 function parseV2(record: Record<string, unknown>): WorkerRecoveryRecordV2 | undefined {
@@ -92,19 +103,27 @@ function parseV2(record: Record<string, unknown>): WorkerRecoveryRecordV2 | unde
 		return undefined;
 	}
 	if (
-		typeof record.activeSessionId !== "string" ||
-		typeof record.sessionId !== "string" ||
-		typeof record.agentDir !== "string" ||
+		!isNonEmptyString(record.activeSessionId) ||
+		!isNonEmptyString(record.sessionId) ||
+		!isNonEmptyString(record.agentDir) ||
+		!isNonEmptyString(record.sessionFile) ||
 		typeof record.busy !== "boolean" ||
-		typeof record.operation !== "string" ||
-		typeof record.operationId !== "string" ||
+		!isNonEmptyString(record.operation) ||
+		!isNonEmptyString(record.operationId) ||
+		!isUuid(record.operationId) ||
 		typeof record.lineageDigest !== "string" ||
-		typeof record.recordedAt !== "string" ||
-		(typeof record.sessionFile !== "undefined" && typeof record.sessionFile !== "string") ||
+		!/^[0-9a-f]{64}$/i.test(record.lineageDigest) ||
+		!isNonEmptyString(record.recordedAt) ||
+		Number.isNaN(Date.parse(record.recordedAt)) ||
 		(typeof record.headEntryId !== "string" && record.headEntryId !== null) ||
+		(typeof record.headEntryId === "string" && record.headEntryId.length === 0) ||
 		(typeof record.assistantEntryId !== "string" && record.assistantEntryId !== null) ||
+		(typeof record.assistantEntryId === "string" && record.assistantEntryId.length === 0) ||
 		!Array.isArray(record.toolCalls) ||
-		!record.toolCalls.every(isToolCall)
+		!record.toolCalls.every(isToolCall) ||
+		!hasUniqueToolCallIds(record.toolCalls) ||
+		(record.headEntryId === null && record.assistantEntryId !== null) ||
+		(record.assistantEntryId === null && record.toolCalls.length > 0)
 	) {
 		return undefined;
 	}
@@ -142,29 +161,65 @@ function parseRecord(line: string): WorkerRecoveryRecord | undefined {
 }
 
 function parseRecords(path: string): Map<string, WorkerRecoveryRecord> {
-	const latest = new Map<string, WorkerRecoveryRecord>();
+	const indexed = new Map<string, { record: WorkerRecoveryRecord; index: number }>();
 	let contents: string;
 	try {
 		contents = readFileSync(path, "utf8");
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-			return latest;
-		}
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map();
 		throw error;
 	}
-	for (const line of contents.split("\n")) {
-		if (!line) {
-			continue;
-		}
+	let lastMalformedIndex = -1;
+	const lines = contents.split("\n");
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index]!;
+		if (!line) continue;
 		const record = parseRecord(line);
-		if (record) {
-			latest.set(record.activeSessionId, record);
-		}
+		if (record) indexed.set(record.activeSessionId, { record, index });
+		else lastMalformedIndex = index;
+	}
+	const latest = new Map<string, WorkerRecoveryRecord>();
+	for (const [activeSessionId, { record, index }] of indexed) {
+		// A malformed later checkpoint could contain an authority change that was
+		// only partially persisted. Never fall back to an older busy v2 authority;
+		// a subsequent valid checkpoint may safely supersede the corrupt line.
+		if (record.version === 2 && record.busy && index < lastMalformedIndex) continue;
+		latest.set(activeSessionId, record);
 	}
 	return latest;
 }
 
-function toolCallsEqual(a: WorkerRecoveryToolCall[], b: WorkerRecoveryToolCall[]): boolean {
+function withJournalGuard<T>(path: string, action: () => T): T {
+	let release: (() => void) | undefined;
+	for (let attempt = 0; attempt < 100; attempt++) {
+		try {
+			release = lockSync(path, {
+				realpath: false,
+				lockfilePath: `${path}.guard`,
+				stale: 5000,
+			});
+			break;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ELOCKED") {
+				throw error;
+			}
+			if (attempt === 99) {
+				throw new Error(`Could not coordinate worker recovery journal: ${path}`);
+			}
+			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+		}
+	}
+	if (!release) {
+		throw new Error(`Could not coordinate worker recovery journal: ${path}`);
+	}
+	try {
+		return action();
+	} finally {
+		release();
+	}
+}
+
+function toolCallsEqual(a: ReadonlyArray<WorkerRecoveryToolCall>, b: ReadonlyArray<WorkerRecoveryToolCall>): boolean {
 	if (a.length !== b.length) {
 		return false;
 	}
@@ -176,19 +231,30 @@ function toolCallsEqual(a: WorkerRecoveryToolCall[], b: WorkerRecoveryToolCall[]
 	return true;
 }
 
-/** True when the checkpoint matches the previous v2 record exactly (authority, busy, operation). */
-function sameV2Checkpoint(previous: WorkerRecoveryRecord | undefined, record: WorkerRecoveryRecord): boolean {
-	if (previous?.version !== 2 || record.version !== 2) {
-		return false;
-	}
+function sameV2Authority(
+	previous: WorkerRecoveryRecord | undefined,
+	record: Pick<
+		WorkerRecoveryRecordV2,
+		"sessionId" | "agentDir" | "sessionFile" | "headEntryId" | "assistantEntryId" | "toolCalls" | "lineageDigest"
+	>,
+): previous is WorkerRecoveryRecordV2 {
 	return (
+		previous?.version === 2 &&
 		previous.sessionId === record.sessionId &&
 		previous.agentDir === record.agentDir &&
 		previous.sessionFile === record.sessionFile &&
 		previous.headEntryId === record.headEntryId &&
 		previous.assistantEntryId === record.assistantEntryId &&
 		previous.lineageDigest === record.lineageDigest &&
-		toolCallsEqual(previous.toolCalls, record.toolCalls) &&
+		toolCallsEqual(previous.toolCalls, record.toolCalls)
+	);
+}
+
+/** True when the checkpoint matches the previous v2 record exactly (authority, busy, operation). */
+function sameV2Checkpoint(previous: WorkerRecoveryRecord | undefined, record: WorkerRecoveryRecord): boolean {
+	return (
+		record.version === 2 &&
+		sameV2Authority(previous, record) &&
 		previous.busy === record.busy &&
 		previous.operation === record.operation
 	);
@@ -206,13 +272,24 @@ function isV2Input(input: WorkerRecoveryRecordInput): boolean {
 
 function assertV2Input(input: WorkerRecoveryRecordInput): void {
 	if (
-		typeof input.agentDir !== "string" ||
+		!isNonEmptyString(input.activeSessionId) ||
+		!isNonEmptyString(input.sessionId) ||
+		!isNonEmptyString(input.agentDir) ||
+		!isNonEmptyString(input.sessionFile) ||
+		!isNonEmptyString(input.operation) ||
 		(typeof input.headEntryId !== "string" && input.headEntryId !== null) ||
+		(typeof input.headEntryId === "string" && input.headEntryId.length === 0) ||
 		(typeof input.assistantEntryId !== "string" && input.assistantEntryId !== null) ||
+		(typeof input.assistantEntryId === "string" && input.assistantEntryId.length === 0) ||
 		!Array.isArray(input.toolCalls) ||
-		typeof input.lineageDigest !== "string"
+		!input.toolCalls.every(isToolCall) ||
+		!hasUniqueToolCallIds(input.toolCalls) ||
+		typeof input.lineageDigest !== "string" ||
+		!/^[0-9a-f]{64}$/i.test(input.lineageDigest) ||
+		(input.headEntryId === null && input.assistantEntryId !== null) ||
+		(input.assistantEntryId === null && input.toolCalls.length > 0)
 	) {
-		throw new Error("v2 recovery checkpoints require the complete authority snapshot");
+		throw new Error("v2 recovery checkpoints require a valid complete authority snapshot");
 	}
 }
 
@@ -225,51 +302,62 @@ export class WorkerRecoveryJournal {
 	}
 
 	record(input: WorkerRecoveryRecordInput): void {
-		const previous = this.latest.get(input.activeSessionId);
-		let record: WorkerRecoveryRecord;
-		if (isV2Input(input)) {
-			assertV2Input(input);
-			record = this.buildV2Record(input, previous);
-		} else if (previous?.version === 2) {
-			// Backward-compatible v1-style input (e.g. the supervisor's recovery
-			// hold) that follows a v2 checkpoint: inherit the epoch authority so the
-			// journal stays one coherent v2 stream and completion stays idempotent.
-			record = this.buildV2Record(
-				{
+		withJournalGuard(this.path, () => {
+			this.refreshLatest();
+			const previous = this.latest.get(input.activeSessionId);
+			let record: WorkerRecoveryRecord;
+			if (isV2Input(input)) {
+				assertV2Input(input);
+				record = this.buildV2Record(input, previous);
+			} else if (previous?.version === 2) {
+				// Backward-compatible v1-style input following a v2 checkpoint keeps
+				// the same authority. New recovery code completes epochs through CAS.
+				record = this.buildV2Record(
+					{
+						...input,
+						agentDir: previous.agentDir,
+						sessionFile: input.sessionFile ?? previous.sessionFile,
+						headEntryId: previous.headEntryId,
+						assistantEntryId: previous.assistantEntryId,
+						toolCalls: previous.toolCalls,
+						lineageDigest: previous.lineageDigest,
+					},
+					previous,
+				);
+			} else {
+				record = {
+					version: 1,
 					...input,
-					agentDir: previous.agentDir,
-					sessionFile: input.sessionFile ?? previous.sessionFile,
-					headEntryId: previous.headEntryId,
-					assistantEntryId: previous.assistantEntryId,
-					toolCalls: previous.toolCalls,
-					lineageDigest: previous.lineageDigest,
-				},
-				previous,
-			);
-		} else {
-			record = {
-				version: 1,
-				...input,
-				recordedAt: new Date().toISOString(),
-			};
-		}
-		if (sameV2Checkpoint(previous, record)) {
-			return;
-		}
-		this.append(record);
-		this.latest.set(record.activeSessionId, record);
-		this.compactIfAllIdle();
+					recordedAt: new Date().toISOString(),
+				};
+			}
+			if (sameV2Checkpoint(previous, record)) {
+				return;
+			}
+			this.append(record);
+			this.latest.set(record.activeSessionId, record);
+			this.compactIfAllIdle();
+		});
 	}
 
 	private buildV2Record(
 		input: WorkerRecoveryRecordInput,
 		previous: WorkerRecoveryRecord | undefined,
 	): WorkerRecoveryRecordV2 {
-		// One stable operation id per busy epoch: reused while busy follows busy,
-		// inherited by the idle record that closes the epoch, and freshly allocated
-		// for the first busy checkpoint and for any busy checkpoint after idle.
+		// Reuse only while the exact authority remains busy. Authority changes and
+		// the first busy checkpoint after idle start a new CAS-fenced epoch; an idle
+		// checkpoint inherits the operation id it closes.
+		const authority = {
+			sessionId: input.sessionId,
+			agentDir: input.agentDir!,
+			sessionFile: input.sessionFile!,
+			headEntryId: input.headEntryId!,
+			assistantEntryId: input.assistantEntryId!,
+			toolCalls: input.toolCalls!,
+			lineageDigest: input.lineageDigest!,
+		};
 		const operationId = input.busy
-			? previous?.version === 2 && previous.busy
+			? previous?.version === 2 && previous.busy && sameV2Authority(previous, authority)
 				? previous.operationId
 				: randomUUID()
 			: previous?.version === 2
@@ -280,7 +368,7 @@ export class WorkerRecoveryJournal {
 			activeSessionId: input.activeSessionId,
 			sessionId: input.sessionId,
 			agentDir: input.agentDir!,
-			...(input.sessionFile ? { sessionFile: input.sessionFile } : {}),
+			sessionFile: input.sessionFile!,
 			headEntryId: input.headEntryId!,
 			assistantEntryId: input.assistantEntryId!,
 			toolCalls: input.toolCalls!,
@@ -299,22 +387,26 @@ export class WorkerRecoveryJournal {
 	 * by a newer busy epoch, or owned by a different operation id.
 	 */
 	complete(activeSessionId: string, operationId: string): boolean {
-		const latest = parseRecords(this.path).get(activeSessionId);
-		if (!latest || latest.version !== 2 || latest.operationId !== operationId) {
-			return false;
-		}
-		if (!latest.busy) {
+		return withJournalGuard(this.path, () => {
+			this.refreshLatest();
+			const latest = this.latest.get(activeSessionId);
+			if (!latest || latest.version !== 2 || latest.operationId !== operationId) {
+				return false;
+			}
+			if (!latest.busy) {
+				return true;
+			}
+			const completed: WorkerRecoveryRecordV2 = {
+				...latest,
+				busy: false,
+				operation: "recovery_complete",
+				recordedAt: new Date().toISOString(),
+			};
+			this.append(completed);
+			this.latest.set(latest.activeSessionId, completed);
+			this.compactIfAllIdle();
 			return true;
-		}
-		this.append({
-			...latest,
-			busy: false,
-			operation: "recovery_complete",
-			recordedAt: new Date().toISOString(),
 		});
-		this.latest.set(latest.activeSessionId, { ...latest, busy: false, operation: "recovery_complete" });
-		this.compactIfAllIdle();
-		return true;
 	}
 
 	getLatest(): WorkerRecoveryRecord[] {
@@ -325,6 +417,13 @@ export class WorkerRecoveryJournal {
 		return [...parseRecords(path).values()];
 	}
 
+	private refreshLatest(): void {
+		this.latest.clear();
+		for (const [activeSessionId, record] of parseRecords(this.path)) {
+			this.latest.set(activeSessionId, record);
+		}
+	}
+
 	private compactIfAllIdle(): void {
 		if ([...this.latest.values()].every((entry) => !entry.busy)) {
 			this.compact();
@@ -332,9 +431,16 @@ export class WorkerRecoveryJournal {
 	}
 
 	private append(record: WorkerRecoveryRecord): void {
+		let separator = "";
+		try {
+			const contents = readFileSync(this.path);
+			if (contents.length > 0 && contents.at(-1) !== 0x0a) separator = "\n";
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
 		const descriptor = openSync(this.path, "a", 0o600);
 		try {
-			writeSync(descriptor, `${JSON.stringify(record)}\n`);
+			writeSync(descriptor, `${separator}${JSON.stringify(record)}\n`);
 			fsyncSync(descriptor);
 		} finally {
 			closeSync(descriptor);

--- a/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/worker-recovery-journal.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
 	chmodSync,
 	closeSync,
@@ -11,7 +12,17 @@ import {
 } from "node:fs";
 import { dirname } from "node:path";
 
-export interface WorkerRecoveryRecord {
+/** One unresolved tool call declared by the authorized assistant entry. */
+export interface WorkerRecoveryToolCall {
+	id: string;
+	name: string;
+}
+
+/**
+ * Legacy busy journal record without v2 mutation authority. Kept parseable for
+ * backward compatibility; it cannot authorize recovery mutation or completion.
+ */
+export interface WorkerRecoveryRecordV1 {
 	version: 1;
 	activeSessionId: string;
 	sessionId: string;
@@ -19,6 +30,115 @@ export interface WorkerRecoveryRecord {
 	busy: boolean;
 	operation: string;
 	recordedAt: string;
+}
+
+/**
+ * Validated v2 recovery authority checkpoint. Every busy epoch has one stable
+ * `operationId`, created at the first durable busy checkpoint and reused until
+ * the session becomes idle. Changes to session generation, agent dir, path,
+ * head, assistant entry, tool calls, or lineage force a new record.
+ */
+export interface WorkerRecoveryRecordV2 {
+	version: 2;
+	activeSessionId: string;
+	sessionId: string;
+	/** Lease namespace the catalog must use to recover the canonical session path. */
+	agentDir: string;
+	sessionFile?: string;
+	/** Exact active branch head; null for an empty branch. */
+	headEntryId: string | null;
+	/** Latest assistant entry on the active branch, when one exists. */
+	assistantEntryId: string | null;
+	/** Exact unresolved `{ id, name }` set declared by the assistant entry. */
+	toolCalls: WorkerRecoveryToolCall[];
+	/** SHA-256 over the ordered active branch identities and parent links. */
+	lineageDigest: string;
+	/** Stable id for the busy epoch; a new id is allocated after the session becomes idle. */
+	operationId: string;
+	busy: boolean;
+	operation: string;
+	recordedAt: string;
+}
+
+export type WorkerRecoveryRecord = WorkerRecoveryRecordV1 | WorkerRecoveryRecordV2;
+
+export interface WorkerRecoveryRecordInput {
+	activeSessionId: string;
+	sessionId: string;
+	agentDir?: string;
+	sessionFile?: string;
+	busy: boolean;
+	operation: string;
+	headEntryId?: string | null;
+	assistantEntryId?: string | null;
+	toolCalls?: WorkerRecoveryToolCall[];
+	lineageDigest?: string;
+}
+
+export function isV2WorkerRecoveryRecord(record: WorkerRecoveryRecord): record is WorkerRecoveryRecordV2 {
+	return record.version === 2;
+}
+
+function isToolCall(value: unknown): value is WorkerRecoveryToolCall {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	const call = value as WorkerRecoveryToolCall;
+	return typeof call.id === "string" && typeof call.name === "string";
+}
+
+function parseV2(record: Record<string, unknown>): WorkerRecoveryRecordV2 | undefined {
+	if (record.version !== 2) {
+		return undefined;
+	}
+	if (
+		typeof record.activeSessionId !== "string" ||
+		typeof record.sessionId !== "string" ||
+		typeof record.agentDir !== "string" ||
+		typeof record.busy !== "boolean" ||
+		typeof record.operation !== "string" ||
+		typeof record.operationId !== "string" ||
+		typeof record.lineageDigest !== "string" ||
+		typeof record.recordedAt !== "string" ||
+		(typeof record.sessionFile !== "undefined" && typeof record.sessionFile !== "string") ||
+		(typeof record.headEntryId !== "string" && record.headEntryId !== null) ||
+		(typeof record.assistantEntryId !== "string" && record.assistantEntryId !== null) ||
+		!Array.isArray(record.toolCalls) ||
+		!record.toolCalls.every(isToolCall)
+	) {
+		return undefined;
+	}
+	return record as unknown as WorkerRecoveryRecordV2;
+}
+
+function parseV1(record: Record<string, unknown>): WorkerRecoveryRecordV1 | undefined {
+	if (record.version !== 1) {
+		return undefined;
+	}
+	if (
+		typeof record.activeSessionId !== "string" ||
+		typeof record.sessionId !== "string" ||
+		typeof record.busy !== "boolean" ||
+		typeof record.operation !== "string" ||
+		typeof record.recordedAt !== "string" ||
+		(typeof record.sessionFile !== "undefined" && typeof record.sessionFile !== "string")
+	) {
+		return undefined;
+	}
+	return record as unknown as WorkerRecoveryRecordV1;
+}
+
+function parseRecord(line: string): WorkerRecoveryRecord | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(line);
+	} catch {
+		return undefined;
+	}
+	if (typeof parsed !== "object" || parsed === null) {
+		return undefined;
+	}
+	return parseV2(parsed as Record<string, unknown>) ?? parseV1(parsed as Record<string, unknown>);
 }
 
 function parseRecords(path: string): Map<string, WorkerRecoveryRecord> {
@@ -36,23 +156,64 @@ function parseRecords(path: string): Map<string, WorkerRecoveryRecord> {
 		if (!line) {
 			continue;
 		}
-		let record: WorkerRecoveryRecord;
-		try {
-			record = JSON.parse(line) as WorkerRecoveryRecord;
-		} catch {
-			continue;
-		}
-		if (
-			record.version === 1 &&
-			typeof record.activeSessionId === "string" &&
-			typeof record.sessionId === "string" &&
-			typeof record.busy === "boolean" &&
-			typeof record.operation === "string"
-		) {
+		const record = parseRecord(line);
+		if (record) {
 			latest.set(record.activeSessionId, record);
 		}
 	}
 	return latest;
+}
+
+function toolCallsEqual(a: WorkerRecoveryToolCall[], b: WorkerRecoveryToolCall[]): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	for (let i = 0; i < a.length; i++) {
+		if (a[i]!.id !== b[i]!.id || a[i]!.name !== b[i]!.name) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/** True when the checkpoint matches the previous v2 record exactly (authority, busy, operation). */
+function sameV2Checkpoint(previous: WorkerRecoveryRecord | undefined, record: WorkerRecoveryRecord): boolean {
+	if (previous?.version !== 2 || record.version !== 2) {
+		return false;
+	}
+	return (
+		previous.sessionId === record.sessionId &&
+		previous.agentDir === record.agentDir &&
+		previous.sessionFile === record.sessionFile &&
+		previous.headEntryId === record.headEntryId &&
+		previous.assistantEntryId === record.assistantEntryId &&
+		previous.lineageDigest === record.lineageDigest &&
+		toolCallsEqual(previous.toolCalls, record.toolCalls) &&
+		previous.busy === record.busy &&
+		previous.operation === record.operation
+	);
+}
+
+function isV2Input(input: WorkerRecoveryRecordInput): boolean {
+	return (
+		input.agentDir !== undefined ||
+		input.headEntryId !== undefined ||
+		input.assistantEntryId !== undefined ||
+		input.toolCalls !== undefined ||
+		input.lineageDigest !== undefined
+	);
+}
+
+function assertV2Input(input: WorkerRecoveryRecordInput): void {
+	if (
+		typeof input.agentDir !== "string" ||
+		(typeof input.headEntryId !== "string" && input.headEntryId !== null) ||
+		(typeof input.assistantEntryId !== "string" && input.assistantEntryId !== null) ||
+		!Array.isArray(input.toolCalls) ||
+		typeof input.lineageDigest !== "string"
+	) {
+		throw new Error("v2 recovery checkpoints require the complete authority snapshot");
+	}
 }
 
 export class WorkerRecoveryJournal {
@@ -63,25 +224,97 @@ export class WorkerRecoveryJournal {
 		this.latest = parseRecords(path);
 	}
 
-	record(input: Omit<WorkerRecoveryRecord, "version" | "recordedAt">): void {
+	record(input: WorkerRecoveryRecordInput): void {
 		const previous = this.latest.get(input.activeSessionId);
-		if (
-			previous?.busy === input.busy &&
-			previous.operation === input.operation &&
-			previous.sessionFile === input.sessionFile
-		) {
+		let record: WorkerRecoveryRecord;
+		if (isV2Input(input)) {
+			assertV2Input(input);
+			record = this.buildV2Record(input, previous);
+		} else if (previous?.version === 2) {
+			// Backward-compatible v1-style input (e.g. the supervisor's recovery
+			// hold) that follows a v2 checkpoint: inherit the epoch authority so the
+			// journal stays one coherent v2 stream and completion stays idempotent.
+			record = this.buildV2Record(
+				{
+					...input,
+					agentDir: previous.agentDir,
+					sessionFile: input.sessionFile ?? previous.sessionFile,
+					headEntryId: previous.headEntryId,
+					assistantEntryId: previous.assistantEntryId,
+					toolCalls: previous.toolCalls,
+					lineageDigest: previous.lineageDigest,
+				},
+				previous,
+			);
+		} else {
+			record = {
+				version: 1,
+				...input,
+				recordedAt: new Date().toISOString(),
+			};
+		}
+		if (sameV2Checkpoint(previous, record)) {
 			return;
 		}
-		const record: WorkerRecoveryRecord = {
-			version: 1,
-			...input,
-			recordedAt: new Date().toISOString(),
-		};
 		this.append(record);
 		this.latest.set(record.activeSessionId, record);
-		if ([...this.latest.values()].every((entry) => !entry.busy)) {
-			this.compact();
+		this.compactIfAllIdle();
+	}
+
+	private buildV2Record(
+		input: WorkerRecoveryRecordInput,
+		previous: WorkerRecoveryRecord | undefined,
+	): WorkerRecoveryRecordV2 {
+		// One stable operation id per busy epoch: reused while busy follows busy,
+		// inherited by the idle record that closes the epoch, and freshly allocated
+		// for the first busy checkpoint and for any busy checkpoint after idle.
+		const operationId = input.busy
+			? previous?.version === 2 && previous.busy
+				? previous.operationId
+				: randomUUID()
+			: previous?.version === 2
+				? previous.operationId
+				: randomUUID();
+		return {
+			version: 2,
+			activeSessionId: input.activeSessionId,
+			sessionId: input.sessionId,
+			agentDir: input.agentDir!,
+			...(input.sessionFile ? { sessionFile: input.sessionFile } : {}),
+			headEntryId: input.headEntryId!,
+			assistantEntryId: input.assistantEntryId!,
+			toolCalls: input.toolCalls!,
+			lineageDigest: input.lineageDigest!,
+			operationId,
+			busy: input.busy,
+			operation: input.operation,
+			recordedAt: new Date().toISOString(),
+		};
+	}
+
+	/**
+	 * Compare-and-set completion of a busy epoch. Re-reads the persisted latest
+	 * record and closes the epoch only when it still carries `operationId`.
+	 * Returns false when the latest record is legacy, absent, already superseded
+	 * by a newer busy epoch, or owned by a different operation id.
+	 */
+	complete(activeSessionId: string, operationId: string): boolean {
+		const latest = parseRecords(this.path).get(activeSessionId);
+		if (!latest || latest.version !== 2 || latest.operationId !== operationId) {
+			return false;
 		}
+		if (!latest.busy) {
+			return true;
+		}
+		this.append({
+			...latest,
+			busy: false,
+			operation: "recovery_complete",
+			recordedAt: new Date().toISOString(),
+		});
+		this.latest.set(latest.activeSessionId, { ...latest, busy: false, operation: "recovery_complete" });
+		this.compactIfAllIdle();
+		return true;
 	}
 
 	getLatest(): WorkerRecoveryRecord[] {
@@ -90,6 +323,12 @@ export class WorkerRecoveryJournal {
 
 	static readLatest(path: string): WorkerRecoveryRecord[] {
 		return [...parseRecords(path).values()];
+	}
+
+	private compactIfAllIdle(): void {
+		if ([...this.latest.values()].every((entry) => !entry.busy)) {
+			this.compact();
+		}
 	}
 
 	private append(record: WorkerRecoveryRecord): void {

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -1296,7 +1296,7 @@ export async function runDaemonUpdateRestartCoordinator(options: {
 				},
 			});
 			await shutdownAdmission.assertOrRenew();
-			const stopped = await shutdownConnectedDaemonAndWait(connectedClient, options.socketPath, 10000, hello);
+			const stopped = await shutdownConnectedDaemonAndWait(connectedClient, options.socketPath, 10000);
 			connectedClient = undefined;
 			if (!stopped) {
 				const remainingDaemon = await probeRunningDaemonSessions(options.socketPath);

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -1,10 +1,18 @@
+import { randomUUID } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 import type { ToolResultMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	acquireSessionLease,
+	canonicalSessionPath,
+	SESSION_LEASE_OWNER_ID_ENV,
+	SESSION_LEASES_ENABLED_ENV,
+} from "../src/core/session-lease.js";
 import { type SessionInfo, SessionManager } from "../src/core/session-manager.js";
 import {
+	type CatalogRecoveryAuthority,
 	listSavedSessionSiblings,
 	markSessionInterrupted,
 	resolveCatalogSessionMatch,
@@ -107,7 +115,10 @@ afterEach(() => {
 	}
 });
 
-function createCatalogFixtureSession(): { sessionFile: string } {
+function createCatalogFixtureSession(
+	calls: Array<{ id: string; name: string }> = [{ id: "bash-1", name: "bash" }],
+	operationId = randomUUID(),
+): { sessionFile: string; authority: CatalogRecoveryAuthority; session: SessionManager } {
 	const root = mkdtempSync(join(tmpdir(), "prime-catalog-mark-interrupted-"));
 	catalogTempDirs.push(root);
 	const sessionDir = join(root, "sessions");
@@ -117,7 +128,7 @@ function createCatalogFixtureSession(): { sessionFile: string } {
 		role: "assistant",
 		content: [
 			{ type: "text", text: "calling" },
-			{ type: "toolCall", id: "bash-1", name: "bash", arguments: {} },
+			...calls.map((call) => ({ type: "toolCall" as const, ...call, arguments: {} })),
 		],
 		api: "anthropic-messages",
 		provider: "anthropic",
@@ -134,107 +145,192 @@ function createCatalogFixtureSession(): { sessionFile: string } {
 		timestamp: 2,
 	});
 	const sessionFile = session.getSessionFile();
-	if (!sessionFile) {
-		throw new Error("Fixture session did not persist");
-	}
-	return { sessionFile };
+	if (!sessionFile) throw new Error("Fixture session did not persist");
+	const snapshot = session.captureExactRecoveryAuthority("active-1", operationId);
+	return {
+		sessionFile,
+		session,
+		authority: {
+			...snapshot,
+			operationId,
+			activeSessionId: "active-1",
+			sessionFile: canonicalSessionPath(sessionFile),
+			agentDir: root,
+		},
+	};
+}
+
+function recoveryMarkers(sessionFile: string): Array<{ details?: unknown }> {
+	return SessionManager.open(sessionFile)
+		.getEntries()
+		.filter(
+			(entry): entry is typeof entry & { type: "custom_message" } =>
+				entry.type === "custom_message" && entry.customType === "prime-agent.worker_recovery",
+		);
 }
 
 describe("daemon catalog mark_interrupted", () => {
-	it("persists synthetic tool results before the worker recovery marker", () => {
-		const { sessionFile } = createCatalogFixtureSession();
+	it("applies the exact authority and persists synthetic results before one marker", async () => {
+		const { sessionFile, authority } = createCatalogFixtureSession();
 
-		markSessionInterrupted(sessionFile, "active-1", ["tool_execution"]);
+		await expect(markSessionInterrupted(authority, ["tool_execution"])).resolves.toEqual({ status: "applied" });
 
 		const reopened = SessionManager.open(sessionFile);
 		const context = reopened.buildSessionContext().messages;
 		expect(context.map((message) => message.role)).toEqual(["user", "assistant", "toolResult", "custom"]);
-		expect(context[1]).toMatchObject({
-			role: "assistant",
-			content: [
-				{ type: "text", text: "calling" },
-				{ type: "toolCall", id: "bash-1", name: "bash" },
-			],
-		});
 		expect(context[2]).toMatchObject({
 			role: "toolResult",
 			toolCallId: "bash-1",
 			toolName: "bash",
 			isError: true,
+			details: {
+				recovery: { operationId: authority.operationId, assistantEntryId: authority.assistantEntryId },
+			},
 		});
-		expect(context[3]).toMatchObject({
-			role: "custom",
-			customType: "prime-agent.worker_recovery",
-			details: { activeSessionId: "active-1", operations: ["tool_execution"] },
-		});
-	});
-
-	it("appends an isError toolResult preserving the interrupted tool identity", () => {
-		const { sessionFile } = createCatalogFixtureSession();
-
-		markSessionInterrupted(sessionFile, "active-1", ["tool_execution"]);
-
-		const toolResults = readPersistedToolResults(sessionFile);
-		expect(toolResults).toHaveLength(1);
-		expect(toolResults[0]).toMatchObject({
-			role: "toolResult",
-			toolCallId: "bash-1",
-			toolName: "bash",
-			isError: true,
-		});
-		const text = (toolResults[0]!.content[0] as { text: string }).text;
+		const text = (readPersistedToolResults(sessionFile)[0]!.content[0] as { text: string }).text;
 		expect(text).toContain("whether the tool executed");
 		expect(text).toContain("external side effects are unknown");
-		expect(text).toContain("was not replayed by recovery");
-		expect(text).toContain("Inspect external side effects before retrying");
+		const markers = recoveryMarkers(sessionFile);
+		expect(markers).toHaveLength(1);
+		expect(markers[0]).toMatchObject({
+			details: {
+				operationId: authority.operationId,
+				activeSessionId: "active-1",
+				operations: ["tool_execution"],
+				authority,
+			},
+		});
 	});
 
-	it("persists neither a synthetic result nor a marker when closing tool calls cannot persist", () => {
-		const { sessionFile } = createCatalogFixtureSession();
-		const spy = vi.spyOn(SessionManager.prototype, "appendMessageWithRollback").mockImplementation(() => {
-			throw new Error("disk full");
+	it("deduplicates response-loss replay globally by operationId", async () => {
+		const { sessionFile, authority, session } = createCatalogFixtureSession();
+		await markSessionInterrupted(authority, ["tool_execution"]);
+		// Move to another branch after the committed marker. Global marker lookup
+		// must still win before active-branch authority validation.
+		session.branch(session.getBranch()[0]!.id);
+		session.appendMessage({ role: "user", content: "new branch", timestamp: 3 });
+
+		await expect(markSessionInterrupted(authority, ["tool_execution"])).resolves.toEqual({
+			status: "already_applied",
+		});
+		expect(readPersistedToolResults(sessionFile)).toHaveLength(1);
+		expect(recoveryMarkers(sessionFile)).toHaveLength(1);
+	});
+
+	it("serializes concurrent duplicate requests to one result and one marker", async () => {
+		const { sessionFile, authority } = createCatalogFixtureSession();
+
+		const results = await Promise.all([
+			markSessionInterrupted(authority, ["tool_execution"]),
+			markSessionInterrupted(authority, ["tool_execution"]),
+		]);
+
+		expect(results).toEqual([{ status: "applied" }, { status: "already_applied" }]);
+		expect(readPersistedToolResults(sessionFile)).toHaveLength(1);
+		expect(recoveryMarkers(sessionFile)).toHaveLength(1);
+	});
+
+	it("returns stale without writes after the session advances or generation changes", async () => {
+		for (const mismatch of ["advance", "generation"] as const) {
+			const { sessionFile, authority, session } = createCatalogFixtureSession();
+			const request = mismatch === "generation" ? { ...authority, sessionId: "replaced-generation" } : authority;
+			if (mismatch === "advance") {
+				session.appendMessage({ role: "user", content: "newer work", timestamp: 3 });
+			}
+			const before = readFileSync(sessionFile);
+
+			await expect(markSessionInterrupted(request, ["tool_execution"])).resolves.toMatchObject({
+				status: "stale",
+			});
+			expect(readFileSync(sessionFile)).toEqual(before);
+		}
+	});
+
+	it("classifies a normal live lease owner as stale without opening or writing", async () => {
+		const { sessionFile, authority } = createCatalogFixtureSession();
+		const lease = acquireSessionLease(sessionFile, authority.agentDir, {
+			...process.env,
+			[SESSION_LEASES_ENABLED_ENV]: "1",
+			[SESSION_LEASE_OWNER_ID_ENV]: "live-active-session",
+		});
+		if (!lease) throw new Error("Fixture lease was not enabled");
+		const before = readFileSync(sessionFile);
+		try {
+			await expect(markSessionInterrupted(authority, ["tool_execution"])).resolves.toEqual({
+				status: "stale",
+				reason: "live_session_owner",
+			});
+			expect(readFileSync(sessionFile)).toEqual(before);
+		} finally {
+			lease.release();
+		}
+	});
+
+	it("treats another recovery lease owner as a retryable request failure", async () => {
+		const { sessionFile, authority } = createCatalogFixtureSession();
+		const lease = acquireSessionLease(sessionFile, authority.agentDir, {
+			...process.env,
+			[SESSION_LEASES_ENABLED_ENV]: "1",
+			[SESSION_LEASE_OWNER_ID_ENV]: "worker-recovery:other-operation",
+		});
+		if (!lease) throw new Error("Fixture lease was not enabled");
+		const before = readFileSync(sessionFile);
+		try {
+			await expect(markSessionInterrupted(authority, ["tool_execution"])).rejects.toThrow(
+				"Concurrent recovery owns the session lease",
+			);
+			expect(readFileSync(sessionFile)).toEqual(before);
+		} finally {
+			lease.release();
+		}
+	});
+
+	it("resumes an operation-owned partial result suffix after persistence failure", async () => {
+		const { sessionFile, authority } = createCatalogFixtureSession([
+			{ id: "bash-1", name: "bash" },
+			{ id: "edit-1", name: "edit" },
+		]);
+		const append = SessionManager.prototype.appendMessageWithRollback;
+		let attempts = 0;
+		const spy = vi.spyOn(SessionManager.prototype, "appendMessageWithRollback").mockImplementation(function (
+			this: SessionManager,
+			message,
+		) {
+			attempts++;
+			if (attempts === 2) throw new Error("disk full");
+			return append.call(this, message);
 		});
 		try {
-			expect(() => markSessionInterrupted(sessionFile, "active-1", ["tool_execution"])).toThrow("disk full");
+			await expect(markSessionInterrupted(authority, ["tool_execution"])).rejects.toThrow("disk full");
 		} finally {
 			spy.mockRestore();
 		}
-		const contents = readFileSync(sessionFile, "utf8");
-		expect(contents).not.toContain("prime-agent.worker_recovery");
-		expect(contents).not.toContain("toolResult");
-		expect(contents).not.toContain("unknown");
+		expect(readPersistedToolResults(sessionFile)).toHaveLength(1);
+		expect(recoveryMarkers(sessionFile)).toHaveLength(0);
+
+		await expect(markSessionInterrupted(authority, ["tool_execution"])).resolves.toEqual({ status: "applied" });
+		expect(readPersistedToolResults(sessionFile).map((result) => result.toolCallId)).toEqual(["bash-1", "edit-1"]);
+		expect(recoveryMarkers(sessionFile)).toHaveLength(1);
 	});
 
-	it("resumes partial persistence: a failed marker append keeps the result, retry adds only the marker", () => {
-		const { sessionFile } = createCatalogFixtureSession();
+	it("retries a failed marker append without duplicating persisted results", async () => {
+		const { sessionFile, authority } = createCatalogFixtureSession();
 		const spy = vi
 			.spyOn(SessionManager.prototype, "appendCustomMessageEntryWithRollback")
 			.mockImplementationOnce(() => {
 				throw new Error("marker write failed");
 			});
 		try {
-			expect(() => markSessionInterrupted(sessionFile, "active-1", ["tool_execution"])).toThrow(
-				"marker write failed",
-			);
+			await expect(markSessionInterrupted(authority, ["tool_execution"])).rejects.toThrow("marker write failed");
 		} finally {
 			spy.mockRestore();
 		}
-
-		// The synthetic result was persisted before the marker append failed.
 		expect(readPersistedToolResults(sessionFile)).toHaveLength(1);
-		expect(readFileSync(sessionFile, "utf8")).not.toContain("prime-agent.worker_recovery");
+		expect(recoveryMarkers(sessionFile)).toHaveLength(0);
 
-		// Retrying recovery is resumable: no duplicate result, marker appended once.
-		markSessionInterrupted(sessionFile, "active-1", ["tool_execution"]);
+		await expect(markSessionInterrupted(authority, ["tool_execution"])).resolves.toEqual({ status: "applied" });
 		expect(readPersistedToolResults(sessionFile)).toHaveLength(1);
-		const reopened = SessionManager.open(sessionFile);
-		const context = reopened.buildSessionContext().messages;
-		expect(context.map((message) => message.role)).toEqual(["user", "assistant", "toolResult", "custom"]);
-		expect(context[3]).toMatchObject({
-			role: "custom",
-			customType: "prime-agent.worker_recovery",
-			details: { activeSessionId: "active-1", operations: ["tool_execution"] },
-		});
+		expect(recoveryMarkers(sessionFile)).toHaveLength(1);
 	});
 });
 

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -230,6 +230,16 @@ describe("daemon catalog mark_interrupted", () => {
 		expect(recoveryMarkers(sessionFile)).toHaveLength(1);
 	});
 
+	it("rejects empty entry ids at the IPC authority boundary", async () => {
+		const { authority } = createCatalogFixtureSession();
+		await expect(markSessionInterrupted({ ...authority, headEntryId: "" }, ["tool_execution"])).rejects.toThrow(
+			"Invalid exact worker recovery authority",
+		);
+		await expect(markSessionInterrupted({ ...authority, assistantEntryId: "" }, ["tool_execution"])).rejects.toThrow(
+			"Invalid exact worker recovery authority",
+		);
+	});
+
 	it("returns stale without writes after the session advances or generation changes", async () => {
 		for (const mismatch of ["advance", "generation"] as const) {
 			const { sessionFile, authority, session } = createCatalogFixtureSession();

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -217,6 +217,25 @@ describe("daemon catalog mark_interrupted", () => {
 		expect(recoveryMarkers(sessionFile)).toHaveLength(1);
 	});
 
+	it("does not accept the same operationId with a different authority as already applied", async () => {
+		const { sessionFile, authority } = createCatalogFixtureSession();
+		await expect(markSessionInterrupted(authority, ["tool_execution"])).resolves.toEqual({ status: "applied" });
+
+		// The journal may never reuse an operationId for a different authority,
+		// so a marker under a different authority must not suppress repair.
+		const differentAuthority = {
+			...authority,
+			headEntryId: "entry-other",
+			toolCalls: [{ id: "bash-9", name: "bash" }],
+		};
+		await expect(markSessionInterrupted(differentAuthority, ["tool_execution"])).resolves.toEqual({
+			status: "stale",
+			reason: "marker_authority_mismatch",
+		});
+		expect(readPersistedToolResults(sessionFile)).toHaveLength(1);
+		expect(recoveryMarkers(sessionFile)).toHaveLength(1);
+	});
+
 	it("serializes concurrent duplicate requests to one result and one marker", async () => {
 		const { sessionFile, authority } = createCatalogFixtureSession();
 

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -1,9 +1,14 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
-import { describe, expect, it } from "vitest";
+import type { ToolResultMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { type SessionInfo, SessionManager } from "../src/core/session-manager.js";
-import { listSavedSessionSiblings, resolveCatalogSessionMatch } from "../src/modes/daemon/daemon-catalog-process.js";
+import {
+	listSavedSessionSiblings,
+	markSessionInterrupted,
+	resolveCatalogSessionMatch,
+} from "../src/modes/daemon/daemon-catalog-process.js";
 
 function session(id: string, name: string | undefined, path: string): SessionInfo {
 	return {
@@ -93,3 +98,152 @@ describe("daemon catalog selector resolution", () => {
 		expect(() => resolveCatalogSessionMatch(sessions, "target")).toThrow('Ambiguous session selector "target"');
 	});
 });
+
+const catalogTempDirs: string[] = [];
+
+afterEach(() => {
+	for (const directory of catalogTempDirs.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function createCatalogFixtureSession(): { sessionFile: string } {
+	const root = mkdtempSync(join(tmpdir(), "prime-catalog-mark-interrupted-"));
+	catalogTempDirs.push(root);
+	const sessionDir = join(root, "sessions");
+	const session = SessionManager.create(root, sessionDir);
+	session.appendMessage({ role: "user", content: "run tools", timestamp: 1 });
+	session.appendMessage({
+		role: "assistant",
+		content: [
+			{ type: "text", text: "calling" },
+			{ type: "toolCall", id: "bash-1", name: "bash", arguments: {} },
+		],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 2,
+	});
+	const sessionFile = session.getSessionFile();
+	if (!sessionFile) {
+		throw new Error("Fixture session did not persist");
+	}
+	return { sessionFile };
+}
+
+describe("daemon catalog mark_interrupted", () => {
+	it("persists synthetic tool results before the worker recovery marker", () => {
+		const { sessionFile } = createCatalogFixtureSession();
+
+		markSessionInterrupted(sessionFile, "active-1", ["tool_execution"]);
+
+		const reopened = SessionManager.open(sessionFile);
+		const context = reopened.buildSessionContext().messages;
+		expect(context.map((message) => message.role)).toEqual(["user", "assistant", "toolResult", "custom"]);
+		expect(context[1]).toMatchObject({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "calling" },
+				{ type: "toolCall", id: "bash-1", name: "bash" },
+			],
+		});
+		expect(context[2]).toMatchObject({
+			role: "toolResult",
+			toolCallId: "bash-1",
+			toolName: "bash",
+			isError: true,
+		});
+		expect(context[3]).toMatchObject({
+			role: "custom",
+			customType: "prime-agent.worker_recovery",
+			details: { activeSessionId: "active-1", operations: ["tool_execution"] },
+		});
+	});
+
+	it("appends an isError toolResult preserving the interrupted tool identity", () => {
+		const { sessionFile } = createCatalogFixtureSession();
+
+		markSessionInterrupted(sessionFile, "active-1", ["tool_execution"]);
+
+		const toolResults = readPersistedToolResults(sessionFile);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]).toMatchObject({
+			role: "toolResult",
+			toolCallId: "bash-1",
+			toolName: "bash",
+			isError: true,
+		});
+		const text = (toolResults[0]!.content[0] as { text: string }).text;
+		expect(text).toContain("whether the tool executed");
+		expect(text).toContain("external side effects are unknown");
+		expect(text).toContain("was not replayed by recovery");
+		expect(text).toContain("Inspect external side effects before retrying");
+	});
+
+	it("persists neither a synthetic result nor a marker when closing tool calls cannot persist", () => {
+		const { sessionFile } = createCatalogFixtureSession();
+		const spy = vi.spyOn(SessionManager.prototype, "appendMessageWithRollback").mockImplementation(() => {
+			throw new Error("disk full");
+		});
+		try {
+			expect(() => markSessionInterrupted(sessionFile, "active-1", ["tool_execution"])).toThrow("disk full");
+		} finally {
+			spy.mockRestore();
+		}
+		const contents = readFileSync(sessionFile, "utf8");
+		expect(contents).not.toContain("prime-agent.worker_recovery");
+		expect(contents).not.toContain("toolResult");
+		expect(contents).not.toContain("unknown");
+	});
+
+	it("resumes partial persistence: a failed marker append keeps the result, retry adds only the marker", () => {
+		const { sessionFile } = createCatalogFixtureSession();
+		const spy = vi
+			.spyOn(SessionManager.prototype, "appendCustomMessageEntryWithRollback")
+			.mockImplementationOnce(() => {
+				throw new Error("marker write failed");
+			});
+		try {
+			expect(() => markSessionInterrupted(sessionFile, "active-1", ["tool_execution"])).toThrow(
+				"marker write failed",
+			);
+		} finally {
+			spy.mockRestore();
+		}
+
+		// The synthetic result was persisted before the marker append failed.
+		expect(readPersistedToolResults(sessionFile)).toHaveLength(1);
+		expect(readFileSync(sessionFile, "utf8")).not.toContain("prime-agent.worker_recovery");
+
+		// Retrying recovery is resumable: no duplicate result, marker appended once.
+		markSessionInterrupted(sessionFile, "active-1", ["tool_execution"]);
+		expect(readPersistedToolResults(sessionFile)).toHaveLength(1);
+		const reopened = SessionManager.open(sessionFile);
+		const context = reopened.buildSessionContext().messages;
+		expect(context.map((message) => message.role)).toEqual(["user", "assistant", "toolResult", "custom"]);
+		expect(context[3]).toMatchObject({
+			role: "custom",
+			customType: "prime-agent.worker_recovery",
+			details: { activeSessionId: "active-1", operations: ["tool_execution"] },
+		});
+	});
+});
+
+function readPersistedToolResults(sessionFile: string): ToolResultMessage[] {
+	return readFileSync(sessionFile, "utf8")
+		.trim()
+		.split("\n")
+		.map((line) => JSON.parse(line) as { type: string; message?: unknown })
+		.filter((entry) => entry.type === "message")
+		.map((entry) => entry.message as ToolResultMessage)
+		.filter((message) => message.role === "toolResult");
+}

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DaemonClient, getDaemonSocketCloseReason } from "../src/modes/daemon/daemon-client.js";
+import {
+	createDaemonShutdownCommand,
+	DaemonClient,
+	type DaemonHello,
+	getDaemonSocketCloseReason,
+} from "../src/modes/daemon/daemon-client.js";
 import {
 	DAEMON_COMMAND_COMPATIBILITY,
 	DAEMON_PROTOCOL_VERSION,
@@ -927,3 +932,69 @@ async function captureRejection(promise: Promise<void>): Promise<Error> {
 	}
 	throw new Error("Expected daemon client connect attempt to reject");
 }
+
+describe("createDaemonShutdownCommand", () => {
+	const modernHello: DaemonHello = {
+		type: "daemon_hello" as const,
+		socketPath: "/tmp/d.sock",
+		protocol: { name: "prime-agent.daemon", version: DAEMON_PROTOCOL_VERSION },
+		schemaId: "protocol-7-schema-17-abc",
+		schemaRevision: 17,
+		appVersion: "1.0.0",
+		supervisorGeneration: "gen-1",
+		supervisorOwnerToken: "token-1",
+		supervisorPid: 4242,
+		supervisorProcessStartId: "start-1",
+		supervisorSocketPath: "/tmp/d.sock",
+		clientId: "client-1",
+		serverCapabilities: [],
+	};
+
+	it("derives the full authority from a modern handshake", () => {
+		expect(createDaemonShutdownCommand(modernHello)).toEqual({
+			type: "shutdown",
+			authority: {
+				supervisorGeneration: "gen-1",
+				supervisorOwnerToken: "token-1",
+				supervisorPid: 4242,
+				supervisorProcessStartId: "start-1",
+				supervisorSocketPath: "/tmp/d.sock",
+			},
+		});
+	});
+
+	it("propagates force only when requested", () => {
+		expect(createDaemonShutdownCommand(modernHello, true)).toMatchObject({ force: true });
+		expect(createDaemonShutdownCommand(modernHello, false)).not.toHaveProperty("force");
+		expect(createDaemonShutdownCommand(modernHello)).not.toHaveProperty("force");
+	});
+
+	it("omits authority for a legacy handshake lacking any required identity component", () => {
+		expect(createDaemonShutdownCommand(undefined)).toEqual({ type: "shutdown" });
+		const { supervisorGeneration: _generation, ...legacyHello } = modernHello;
+		expect(createDaemonShutdownCommand(legacyHello)).toEqual({ type: "shutdown" });
+	});
+
+	it("omits authority when the handshake lacks the owner token or pid", () => {
+		expect(createDaemonShutdownCommand({ ...modernHello, supervisorOwnerToken: undefined })).toEqual({
+			type: "shutdown",
+		});
+		expect(createDaemonShutdownCommand({ ...modernHello, supervisorPid: undefined })).toEqual({
+			type: "shutdown",
+		});
+		expect(createDaemonShutdownCommand({ ...modernHello, supervisorPid: 0 })).toEqual({ type: "shutdown" });
+	});
+
+	it("omits supervisorProcessStartId when the handshake omits it", () => {
+		const { supervisorProcessStartId: _startId, ...withoutStartId } = modernHello;
+		expect(createDaemonShutdownCommand(withoutStartId)).toEqual({
+			type: "shutdown",
+			authority: {
+				supervisorGeneration: "gen-1",
+				supervisorOwnerToken: "token-1",
+				supervisorPid: 4242,
+				supervisorSocketPath: "/tmp/d.sock",
+			},
+		});
+	});
+});

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	createDaemonRestartCommand,
 	createDaemonShutdownCommand,
 	DaemonClient,
 	type DaemonHello,
@@ -985,16 +986,16 @@ describe("createDaemonShutdownCommand", () => {
 		expect(createDaemonShutdownCommand({ ...modernHello, supervisorPid: 0 })).toEqual({ type: "shutdown" });
 	});
 
-	it("omits supervisorProcessStartId when the handshake omits it", () => {
+	it("omits authority when the handshake lacks process-start identity", () => {
 		const { supervisorProcessStartId: _startId, ...withoutStartId } = modernHello;
-		expect(createDaemonShutdownCommand(withoutStartId)).toEqual({
-			type: "shutdown",
-			authority: {
-				supervisorGeneration: "gen-1",
-				supervisorOwnerToken: "token-1",
-				supervisorPid: 4242,
-				supervisorSocketPath: "/tmp/d.sock",
-			},
+		expect(createDaemonShutdownCommand(withoutStartId)).toEqual({ type: "shutdown" });
+	});
+
+	it("derives restart authority from the same complete handshake", () => {
+		expect(createDaemonRestartCommand(modernHello)).toEqual({
+			type: "restart",
+			authority: createDaemonShutdownCommand(modernHello).authority,
 		});
+		expect(createDaemonRestartCommand(undefined)).toEqual({ type: "restart" });
 	});
 });

--- a/packages/coding-agent/test/daemon-launch.test.ts
+++ b/packages/coding-agent/test/daemon-launch.test.ts
@@ -12,6 +12,7 @@ import {
 	shutdownDaemonAndWait,
 } from "../src/cli/daemon-launch.js";
 import { ENV_AGENT_DIR, getDaemonLogPath, VERSION } from "../src/config.js";
+import { DaemonClient } from "../src/modes/daemon/daemon-client.js";
 import { DAEMON_PROTOCOL_VERSION, DAEMON_SCHEMA_ID } from "../src/modes/daemon/daemon-protocol.js";
 
 interface FakeDaemonOptions {
@@ -22,8 +23,10 @@ interface FakeDaemonOptions {
 	failList?: boolean;
 	/** When false, the server ignores `shutdown` and stays up. */
 	respondToShutdown?: boolean;
-	/** When true, the server rejects `shutdown` with a failed response and stays up. */
+	/** When true, the server rejects `shutdown` with a failed response. */
 	rejectShutdown?: boolean;
+	/** Close independently after writing a rejected shutdown response. */
+	closeAfterRejectedShutdown?: boolean;
 	protocolVersion?: number;
 	appVersion?: string;
 	schemaId?: string;
@@ -120,9 +123,17 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 							error: "shutdown authority rejected",
 							errorInfo: { code: "shutdown_authority_rejected" },
 						});
+						if (options.closeAfterRejectedShutdown) {
+							server.close();
+							socket.end();
+						}
 						continue;
 					}
 					send(socket, { type: "response", command: "shutdown", id: wire.id, success: true });
+					server.close();
+					socket.end();
+				} else if (command.type === "restart") {
+					send(socket, { type: "response", command: "restart", id: wire.id, success: true });
 					server.close();
 					socket.end();
 				}
@@ -533,6 +544,18 @@ describe("shutdownDaemonAndWait", () => {
 		expect(shutdownCommand?.authority).toBeUndefined();
 	});
 
+	it("returns false when authority is rejected even if the daemon exits afterward", async () => {
+		const daemon = await startFakeDaemon({
+			rejectShutdown: true,
+			closeAfterRejectedShutdown: true,
+			supervisorGeneration: "reject-then-exit-generation",
+			supervisorProcessStartId: "reject-then-exit-start",
+		});
+		cleanups.push(daemon.close);
+
+		await expect(shutdownDaemonAndWait(daemon.socketPath, 100)).resolves.toBe(false);
+	});
+
 	it("sends authority-bearing shutdown to a schema-16 daemon that accepts unknown wire fields", async () => {
 		const commands: Array<Record<string, unknown>> = [];
 		const daemon = await startFakeDaemon({
@@ -558,6 +581,39 @@ describe("shutdownDaemonAndWait", () => {
 				supervisorSocketPath: daemon.socketPath,
 			},
 		});
+	});
+
+	it("sends authority-bearing restart to a schema-16 daemon that accepts unknown wire fields", async () => {
+		const commands: Array<Record<string, unknown>> = [];
+		const daemon = await startFakeDaemon({
+			protocolVersion: DAEMON_PROTOCOL_VERSION,
+			appVersion: VERSION,
+			schemaId: "protocol-7-schema-16-1bcb9e7f1a49",
+			schemaRevision: 16,
+			supervisorGeneration: "schema-16-restart-generation",
+			supervisorOwnerToken: "schema-16-restart-owner",
+			supervisorPid: 424241,
+			supervisorProcessStartId: "schema-16-restart-start",
+			onCommand: (command) => commands.push({ ...(command as Record<string, unknown>) }),
+		});
+		cleanups.push(daemon.close);
+		const client = new DaemonClient(daemon.socketPath);
+		await client.connect();
+		try {
+			const response = await client.requestSupervisorRestart();
+			expect(response.success).toBe(true);
+			expect(commands.find((command) => command.type === "restart")).toMatchObject({
+				authority: {
+					supervisorGeneration: "schema-16-restart-generation",
+					supervisorOwnerToken: "schema-16-restart-owner",
+					supervisorPid: 424241,
+					supervisorProcessStartId: "schema-16-restart-start",
+					supervisorSocketPath: daemon.socketPath,
+				},
+			});
+		} finally {
+			client.close();
+		}
 	});
 
 	it("emits authority from the same connection's hello toward a modern daemon", async () => {

--- a/packages/coding-agent/test/daemon-launch.test.ts
+++ b/packages/coding-agent/test/daemon-launch.test.ts
@@ -22,10 +22,17 @@ interface FakeDaemonOptions {
 	failList?: boolean;
 	/** When false, the server ignores `shutdown` and stays up. */
 	respondToShutdown?: boolean;
+	/** When true, the server rejects `shutdown` with a failed response and stays up. */
+	rejectShutdown?: boolean;
 	protocolVersion?: number;
 	appVersion?: string;
 	schemaId?: string;
 	serverCapabilities?: string[];
+	supervisorGeneration?: string;
+	supervisorOwnerToken?: string;
+	supervisorPid?: number;
+	supervisorProcessStartId?: string;
+	supervisorSocketPath?: string;
 	onCommand?: (command: { type: string }) => void;
 }
 
@@ -49,6 +56,15 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 			protocol: { name: "prime-agent.daemon", version: options.protocolVersion ?? DAEMON_PROTOCOL_VERSION },
 			appVersion: options.appVersion,
 			schemaId: options.schemaId ?? DAEMON_SCHEMA_ID,
+			...(options.supervisorGeneration
+				? {
+						supervisorGeneration: options.supervisorGeneration,
+						supervisorOwnerToken: options.supervisorOwnerToken ?? "fake-owner-token",
+						supervisorPid: options.supervisorPid ?? 1,
+						supervisorSocketPath: options.supervisorSocketPath ?? socketPath,
+					}
+				: {}),
+			...(options.supervisorProcessStartId ? { supervisorProcessStartId: options.supervisorProcessStartId } : {}),
 			clientId: "fake-client",
 			serverCapabilities: options.serverCapabilities ?? [],
 		});
@@ -87,6 +103,17 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 					});
 				} else if (command.type === "shutdown") {
 					if (options.respondToShutdown === false) {
+						continue;
+					}
+					if (options.rejectShutdown) {
+						send(socket, {
+							type: "response",
+							command: "shutdown",
+							id: wire.id,
+							success: false,
+							error: "shutdown authority rejected",
+							errorInfo: { code: "shutdown_authority_rejected" },
+						});
 						continue;
 					}
 					send(socket, { type: "response", command: "shutdown", id: wire.id, success: true });
@@ -259,6 +286,38 @@ describe("ensureInteractiveDaemonRunning", () => {
 		expect(commands).not.toContain("shutdown");
 	});
 
+	it("does not launch a replacement when the guarded supervisor rejects an obsolete client", async () => {
+		const commands: Array<Record<string, unknown>> = [];
+		const daemon = await startFakeDaemon({
+			protocolVersion: DAEMON_PROTOCOL_VERSION,
+			appVersion: VERSION,
+			schemaId: "stale-schema",
+			sessions: [],
+			rejectShutdown: true,
+			supervisorGeneration: "gen-guarded",
+			supervisorOwnerToken: "token-guarded",
+			supervisorPid: 424243,
+			supervisorProcessStartId: "start-guarded",
+			onCommand: (command) => commands.push({ ...(command as Record<string, unknown>) }),
+		});
+		cleanups.push(daemon.close);
+
+		await expect(ensureInteractiveDaemonRunning(daemon.socketPath)).rejects.toThrow("stale");
+		const shutdownCommand = commands.find((command) => command.type === "shutdown");
+		// The obsolete client's shutdown carries the exact identity it observed
+		// on the same connection; the guarded supervisor rejects it, so no
+		// replacement is launched and the supervisor stays serving.
+		expect(shutdownCommand).toBeDefined();
+		expect(shutdownCommand?.authority).toEqual({
+			supervisorGeneration: "gen-guarded",
+			supervisorOwnerToken: "token-guarded",
+			supervisorPid: 424243,
+			supervisorProcessStartId: "start-guarded",
+			supervisorSocketPath: daemon.socketPath,
+		});
+		expect(await probeDaemonVersion(daemon.socketPath)).toMatchObject({ status: "stale" });
+	});
+
 	it("does not treat a live daemon as absent when cold startup delays the first connection", async () => {
 		const daemon = await startFakeDaemon({
 			protocolVersion: DAEMON_PROTOCOL_VERSION,
@@ -428,5 +487,88 @@ describe("shutdownDaemonAndWait", () => {
 		cleanups.push(daemon.close);
 		expect(await shutdownDaemonAndWait(daemon.socketPath, 100)).toBe(true);
 		expect(existsSync(daemon.socketPath)).toBe(true);
+	});
+
+	it("shuts down a legacy daemon whose handshake lacks the supervisor identity", async () => {
+		const commands: Array<{ type: string; authority?: unknown }> = [];
+		const daemon = await startFakeDaemon({
+			sessions: [{ id: "a", activeSessionId: "a", isStreaming: false }],
+			onCommand: (command) => commands.push(command as { type: string; authority?: unknown }),
+		});
+		cleanups.push(daemon.close);
+
+		expect(await shutdownDaemonAndWait(daemon.socketPath)).toBe(true);
+
+		const shutdownCommand = commands.find((command) => command.type === "shutdown");
+		expect(shutdownCommand).toBeDefined();
+		// The legacy handshake lacks the identity, so the new client emits the
+		// legacy command shape without authority and the legacy supervisor
+		// accepts it, preserving forward-upgrade replacement.
+		expect(shutdownCommand?.authority).toBeUndefined();
+	});
+
+	it("emits authority from the same connection's hello toward a modern daemon", async () => {
+		const socketPath = join(tmpdir(), `pa-launch-auth-${Math.random().toString(36).slice(2)}.sock`);
+		const commands: Array<Record<string, unknown>> = [];
+		const dir = mkdtempSync(join(tmpdir(), "pa-launch-auth-"));
+		const server: Server = createServer((socket) => {
+			socket.on("error", () => undefined);
+			send(socket, {
+				type: "daemon_hello",
+				socketPath,
+				protocol: { name: "prime-agent.daemon", version: DAEMON_PROTOCOL_VERSION },
+				appVersion: VERSION,
+				schemaId: DAEMON_SCHEMA_ID,
+				supervisorGeneration: "gen-auth",
+				supervisorOwnerToken: "token-auth",
+				supervisorPid: 424242,
+				supervisorProcessStartId: "start-auth",
+				supervisorSocketPath: socketPath,
+				clientId: "fake-client",
+				serverCapabilities: [],
+			});
+			let buffer = "";
+			socket.on("data", (chunk) => {
+				buffer += chunk.toString();
+				let newline = buffer.indexOf("\n");
+				while (newline !== -1) {
+					const line = buffer.slice(0, newline);
+					buffer = buffer.slice(newline + 1);
+					newline = buffer.indexOf("\n");
+					if (!line.trim()) {
+						continue;
+					}
+					const wire = JSON.parse(line) as { id: string; type?: string; command?: { type: string } };
+					const command = wire.command ?? wire;
+					commands.push(command as Record<string, unknown>);
+					if (command.type === "shutdown") {
+						send(socket, { type: "response", command: "shutdown", id: wire.id, success: true });
+						server.close();
+						socket.end();
+					}
+				}
+			});
+		});
+		cleanups.push(
+			() =>
+				new Promise<void>((resolve) => {
+					server.close(() => resolve());
+					rmSync(dir, { recursive: true, force: true });
+				}),
+		);
+		await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+		expect(await shutdownDaemonAndWait(socketPath)).toBe(true);
+
+		const shutdownCommand = commands.find((command) => command.type === "shutdown");
+		expect(shutdownCommand).toMatchObject({
+			authority: {
+				supervisorGeneration: "gen-auth",
+				supervisorOwnerToken: "token-auth",
+				supervisorPid: 424242,
+				supervisorProcessStartId: "start-auth",
+				supervisorSocketPath: socketPath,
+			},
+		});
 	});
 });

--- a/packages/coding-agent/test/daemon-launch.test.ts
+++ b/packages/coding-agent/test/daemon-launch.test.ts
@@ -27,13 +27,15 @@ interface FakeDaemonOptions {
 	protocolVersion?: number;
 	appVersion?: string;
 	schemaId?: string;
+	schemaRevision?: number;
 	serverCapabilities?: string[];
 	supervisorGeneration?: string;
 	supervisorOwnerToken?: string;
 	supervisorPid?: number;
 	supervisorProcessStartId?: string;
 	supervisorSocketPath?: string;
-	onCommand?: (command: { type: string }) => void;
+	onCommand?: (command: { type: string }, connectionId: number) => void;
+	onConnection?: () => void;
 }
 
 interface FakeDaemon {
@@ -48,7 +50,10 @@ function send(socket: Socket, message: unknown): void {
 async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDaemon> {
 	const dir = mkdtempSync(join(tmpdir(), "pa-launch-"));
 	const socketPath = join(dir, "d.sock");
+	let nextConnectionId = 0;
 	const server: Server = createServer((socket) => {
+		const connectionId = ++nextConnectionId;
+		options.onConnection?.();
 		socket.on("error", () => undefined);
 		send(socket, {
 			type: "daemon_hello",
@@ -56,6 +61,7 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 			protocol: { name: "prime-agent.daemon", version: options.protocolVersion ?? DAEMON_PROTOCOL_VERSION },
 			appVersion: options.appVersion,
 			schemaId: options.schemaId ?? DAEMON_SCHEMA_ID,
+			...(options.schemaRevision !== undefined ? { schemaRevision: options.schemaRevision } : {}),
 			...(options.supervisorGeneration
 				? {
 						supervisorGeneration: options.supervisorGeneration,
@@ -85,7 +91,7 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 					command?: { type: string; id: string };
 				};
 				const command = wire.type === "command" && wire.command ? wire.command : wire;
-				options.onCommand?.(command);
+				options.onCommand?.(command, connectionId);
 				if (command.type === "list") {
 					send(socket, {
 						type: "response",
@@ -318,6 +324,26 @@ describe("ensureInteractiveDaemonRunning", () => {
 		expect(await probeDaemonVersion(daemon.socketPath)).toMatchObject({ status: "stale" });
 	});
 
+	it("classifies and attempts stale replacement on one unchanged connection", async () => {
+		const commandConnections: Array<{ type: string; connectionId: number }> = [];
+		const daemon = await startFakeDaemon({
+			protocolVersion: DAEMON_PROTOCOL_VERSION,
+			appVersion: VERSION,
+			schemaId: "stale-schema",
+			sessions: [],
+			rejectShutdown: true,
+			supervisorGeneration: "same-connection-generation",
+			supervisorProcessStartId: "same-connection-start",
+			onCommand: (command, connectionId) => commandConnections.push({ type: command.type, connectionId }),
+		});
+		cleanups.push(daemon.close);
+
+		await expect(ensureInteractiveDaemonRunning(daemon.socketPath)).rejects.toThrow("stale");
+		const terminatingCommands = commandConnections.filter(({ type }) => type === "list" || type === "shutdown");
+		expect(terminatingCommands.map(({ type }) => type)).toEqual(["list", "shutdown"]);
+		expect(new Set(terminatingCommands.map(({ connectionId }) => connectionId)).size).toBe(1);
+	});
+
 	it("does not treat a live daemon as absent when cold startup delays the first connection", async () => {
 		const daemon = await startFakeDaemon({
 			protocolVersion: DAEMON_PROTOCOL_VERSION,
@@ -505,6 +531,33 @@ describe("shutdownDaemonAndWait", () => {
 		// legacy command shape without authority and the legacy supervisor
 		// accepts it, preserving forward-upgrade replacement.
 		expect(shutdownCommand?.authority).toBeUndefined();
+	});
+
+	it("sends authority-bearing shutdown to a schema-16 daemon that accepts unknown wire fields", async () => {
+		const commands: Array<Record<string, unknown>> = [];
+		const daemon = await startFakeDaemon({
+			protocolVersion: DAEMON_PROTOCOL_VERSION,
+			appVersion: VERSION,
+			schemaId: "protocol-7-schema-16-1bcb9e7f1a49",
+			schemaRevision: 16,
+			supervisorGeneration: "schema-16-generation",
+			supervisorOwnerToken: "schema-16-owner",
+			supervisorPid: 424240,
+			supervisorProcessStartId: "schema-16-start",
+			onCommand: (command) => commands.push({ ...(command as Record<string, unknown>) }),
+		});
+		cleanups.push(daemon.close);
+
+		expect(await shutdownDaemonAndWait(daemon.socketPath)).toBe(true);
+		expect(commands.find((command) => command.type === "shutdown")).toMatchObject({
+			authority: {
+				supervisorGeneration: "schema-16-generation",
+				supervisorOwnerToken: "schema-16-owner",
+				supervisorPid: 424240,
+				supervisorProcessStartId: "schema-16-start",
+				supervisorSocketPath: daemon.socketPath,
+			},
+		});
 	});
 
 	it("emits authority from the same connection's hello toward a modern daemon", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -9985,7 +9985,7 @@ describe("worker recovery authority capture", () => {
 			hash.update(entry.id);
 			hash.update("\0");
 			hash.update(entry.parentId ?? "");
-			hash.update("\n");
+			hash.update("\0");
 		}
 		return hash.digest("hex");
 	}
@@ -10043,8 +10043,8 @@ describe("worker recovery authority capture", () => {
 				expect(record.operationId).toMatch(/^[0-9a-f-]{36}$/);
 			}
 
-			// Resolving the last call and advancing the branch forces a new record
-			// even for the same event name, within the same busy epoch operation id.
+			// Resolving the last call advances the authority and therefore starts a
+			// new operation epoch even though the worker remained busy.
 			manager.appendMessage(toolResult("call-2", "bash"));
 			internals.recordWorkerRecoveryState(state, "tool_execution_end", true);
 			const advanced = WorkerRecoveryJournal.readLatest(journalPath).at(-1)!;
@@ -10054,7 +10054,7 @@ describe("worker recovery authority capture", () => {
 				expect(advanced.assistantEntryId).toBe(assistantEntryId);
 				expect(advanced.toolCalls).toEqual([]);
 				expect(advanced.lineageDigest).toBe(lineageDigestOf(manager));
-				expect(advanced.operationId).toBe(firstOperationId);
+				expect(advanced.operationId).not.toBe(firstOperationId);
 			}
 		} finally {
 			if (previousJournalPath === undefined) {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -21,8 +21,18 @@ import {
 	type SubagentRuntimeHost,
 } from "../src/core/rlm-runtime.js";
 import { canonicalSessionPath } from "../src/core/session-lease.js";
-import { readSessionInfo, type SessionInfo, SessionManager } from "../src/core/session-manager.js";
+import {
+	readSessionInfo,
+	type SessionEntry,
+	type SessionInfo,
+	type SessionMessageEntry,
+	SessionManager,
+} from "../src/core/session-manager.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
+import {
+	type CatalogRecoveryAuthority,
+	markSessionInterrupted,
+} from "../src/modes/daemon/daemon-catalog-process.js";
 import {
 	AgentDaemon,
 	cancelPendingExtensionUiRequests,
@@ -48,7 +58,11 @@ import {
 	DAEMON_WORKER_RECOVERY_JOURNAL_ENV,
 	DAEMON_WORKER_SUPERVISOR_SOCKET_ENV,
 } from "../src/modes/daemon/daemon-worker-protocol.js";
-import { WorkerRecoveryJournal } from "../src/modes/daemon/worker-recovery-journal.js";
+import {
+	isV2WorkerRecoveryRecord,
+	type WorkerRecoveryRecordV2,
+	WorkerRecoveryJournal,
+} from "../src/modes/daemon/worker-recovery-journal.js";
 
 describe("daemon mode helpers", () => {
 	it("preserves envelope client identity while registering prompt admission", () => {
@@ -10056,6 +10070,295 @@ describe("worker recovery authority capture", () => {
 				expect(advanced.lineageDigest).toBe(lineageDigestOf(manager));
 				expect(advanced.operationId).not.toBe(firstOperationId);
 			}
+		} finally {
+			if (previousJournalPath === undefined) {
+				delete process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV];
+			} else {
+				process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV] = previousJournalPath;
+			}
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("worker restore interrupted-session repair", () => {
+	function toolCall(id: string, name: string): AssistantMessage["content"][number] {
+		return { type: "toolCall", id, name, arguments: {} };
+	}
+
+	function assistantTurn(...calls: ReturnType<typeof toolCall>[]): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [{ type: "text", text: "calling tools" }, ...calls],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+	}
+
+	function toolResult(callId: string, name: string): ToolResultMessage {
+		return {
+			role: "toolResult",
+			toolCallId: callId,
+			toolName: name,
+			content: [{ type: "text", text: "ok" }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+	}
+
+	function recoveryMarkers(session: SessionManager): SessionEntry[] {
+		return session
+			.getEntries()
+			.filter(
+				(entry) => entry.type === "custom_message" && entry.customType === "prime-agent.worker_recovery",
+			);
+	}
+
+	function messageRoles(session: SessionManager): string[] {
+		return session
+			.getBranch()
+			.filter((entry) => entry.type === "message")
+			.map((entry) => (entry as SessionMessageEntry).message.role);
+	}
+
+	function createRestoreWorkerDaemon(tempDir: string, sessionDir: string, journalPath: string): AgentDaemon {
+		process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV] = journalPath;
+		return new AgentDaemon(join(tempDir, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+			createRuntime: vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				Object.assign(session, {
+					isSessionActive: false,
+					hasRunningRlmChildren: () => false,
+					isRetrying: false,
+					hasAcceptedPromptInFlight: false,
+				});
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			}),
+			worker: { authenticationToken: "token" },
+		});
+	}
+
+	function restoreWorkerInternals(daemon: AgentDaemon): {
+		createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+	} {
+		return daemon as unknown as {
+			createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+		};
+	}
+
+	it("repairs unresolved tool calls of a restored session before the ready checkpoint", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-restore-repair-"));
+		const previousJournalPath = process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV];
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			manager.appendMessage({ role: "user", content: "run tools", timestamp: 1 });
+			const assistantEntryId = manager.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) throw new Error("Fixture session did not persist");
+
+			const journalPath = join(tempDir, "worker.recovery.jsonl");
+			const daemon = createRestoreWorkerDaemon(tempDir, sessionDir, journalPath);
+			const internals = restoreWorkerInternals(daemon);
+			const record = vi.spyOn(WorkerRecoveryJournal.prototype, "record");
+			try {
+				await internals.createRuntime({ type: "create", sessionPath: sessionFile });
+
+				// The busy restore_interrupted epoch is journaled before the idle
+				// ready checkpoint; both share one operation id for the exact
+				// authority, and the ready authority has no unresolved calls. The
+				// raw journal is compacted to the final idle line, so ordering is
+				// captured through the journal writes themselves.
+				expect(record).toHaveBeenCalledTimes(2);
+				const [busyInput, readyInput] = record.mock.calls.map(([input]) => input);
+				expect(busyInput).toMatchObject({ busy: true, operation: "restore_interrupted" });
+				expect(readyInput).toMatchObject({ busy: false, operation: "ready" });
+				const busyRecord = record.mock.results[0]!.value as WorkerRecoveryRecordV2;
+				const readyRecord = record.mock.results[1]!.value as WorkerRecoveryRecordV2;
+				expect(busyRecord.operationId).toMatch(/^[0-9a-f-]{36}$/);
+				expect(busyRecord.toolCalls).toEqual([{ id: "bash-1", name: "bash" }]);
+				expect(busyRecord.assistantEntryId).toBe(assistantEntryId);
+				expect(busyRecord.headEntryId).toBe(manager.getLeafId());
+				expect(readyRecord.busy).toBe(false);
+				expect(readyRecord.toolCalls).toEqual([]);
+				expect(readyRecord.operationId).toBe(busyRecord.operationId);
+			} finally {
+				record.mockRestore();
+			}
+
+			// The transcript ends with one synthetic result and one marker, and
+			// the durable latest journal record is the idle ready checkpoint.
+			const reopened = SessionManager.open(sessionFile);
+			const context = reopened.buildSessionContext().messages;
+			expect(context.map((message) => message.role)).toEqual(["user", "assistant", "toolResult", "custom"]);
+			expect(context[2]).toMatchObject({
+				role: "toolResult",
+				toolCallId: "bash-1",
+				toolName: "bash",
+				isError: true,
+			});
+			const markers = recoveryMarkers(reopened);
+			expect(markers).toHaveLength(1);
+			const markerDetails = (markers[0] as { details?: unknown }).details as { operationId?: unknown };
+			const records = WorkerRecoveryJournal.readLatest(journalPath);
+			expect(records).toHaveLength(1);
+			expect(records[0]).toMatchObject({ version: 2, busy: false, operation: "ready", toolCalls: [] });
+			expect(records[0]).toMatchObject({ operationId: markerDetails.operationId });
+		} finally {
+			if (previousJournalPath === undefined) {
+				delete process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV];
+			} else {
+				process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV] = previousJournalPath;
+			}
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not mutate a restored session with no unresolved tool calls", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-restore-noop-"));
+		const previousJournalPath = process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV];
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			manager.appendMessage({ role: "user", content: "run tools", timestamp: 1 });
+			manager.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+			manager.appendMessage(toolResult("bash-1", "bash"));
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) throw new Error("Fixture session did not persist");
+
+			const journalPath = join(tempDir, "worker.recovery.jsonl");
+			const daemon = createRestoreWorkerDaemon(tempDir, sessionDir, journalPath);
+			const internals = restoreWorkerInternals(daemon);
+			const record = vi.spyOn(WorkerRecoveryJournal.prototype, "record");
+			try {
+				await internals.createRuntime({ type: "create", sessionPath: sessionFile });
+
+				// No repair epoch is journaled; only the idle ready checkpoint is
+				// written, and the transcript gains no recovery entries. The
+				// daemon-resident session_state entry is not a transcript message.
+				expect(record).toHaveBeenCalledTimes(1);
+				expect(record.mock.calls[0]![0]).toMatchObject({ busy: false, operation: "ready" });
+			} finally {
+				record.mockRestore();
+			}
+
+			const reopened = SessionManager.open(sessionFile);
+			expect(messageRoles(reopened)).toEqual(["user", "assistant", "toolResult"]);
+			expect(recoveryMarkers(reopened)).toHaveLength(0);
+			const records = WorkerRecoveryJournal.readLatest(journalPath);
+			expect(records).toHaveLength(1);
+			expect(records[0]).toMatchObject({ version: 2, busy: false, operation: "ready", toolCalls: [] });
+		} finally {
+			if (previousJournalPath === undefined) {
+				delete process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV];
+			} else {
+				process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV] = previousJournalPath;
+			}
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("recovers the busy restore epoch through the supervisor/catalog seam after a crash", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-restore-retry-"));
+		const previousJournalPath = process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV];
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			manager.appendMessage({ role: "user", content: "run tools", timestamp: 1 });
+			manager.appendMessage(assistantTurn(toolCall("bash-1", "bash"), toolCall("edit-1", "edit")));
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) throw new Error("Fixture session did not persist");
+
+			const journalPath = join(tempDir, "worker.recovery.jsonl");
+			const daemon = createRestoreWorkerDaemon(tempDir, sessionDir, journalPath);
+			const internals = restoreWorkerInternals(daemon);
+
+			const spy = vi.spyOn(SessionManager.prototype, "appendMessageWithRollback").mockImplementation(function (
+				this: SessionManager,
+				message,
+			) {
+				throw new Error("disk full");
+			});
+			try {
+				// The restore repair fails while persisting the first synthetic
+				// result; the open fails closed and no mutation is persisted.
+				await expect(internals.createRuntime({ type: "create", sessionPath: sessionFile })).rejects.toThrow(
+					"disk full",
+				);
+			} finally {
+				spy.mockRestore();
+			}
+
+			// The busy restore_interrupted epoch is durable with the exact
+			// authority, and the transcript is still untouched.
+			const records = WorkerRecoveryJournal.readLatest(journalPath);
+			expect(records).toHaveLength(1);
+			const busy = records[0]!;
+			expect(isV2WorkerRecoveryRecord(busy)).toBe(true);
+			expect(busy).toMatchObject({ version: 2, busy: true, operation: "restore_interrupted" });
+			const opened = SessionManager.open(sessionFile);
+			expect(messageRoles(opened)).toEqual(["user", "assistant"]);
+			expect(recoveryMarkers(opened)).toHaveLength(0);
+			if (!isV2WorkerRecoveryRecord(busy)) {
+				throw new Error("Expected a v2 busy restore_interrupted record");
+			}
+
+			// After the lease is released, the supervisor/catalog machinery
+			// applies the journaled authority and completes the epoch.
+			const authority: CatalogRecoveryAuthority = {
+				operationId: busy.operationId,
+				activeSessionId: busy.activeSessionId,
+				sessionId: busy.sessionId,
+				agentDir: busy.agentDir,
+				sessionFile: busy.sessionFile,
+				headEntryId: busy.headEntryId,
+				assistantEntryId: busy.assistantEntryId,
+				toolCalls: busy.toolCalls,
+				lineageDigest: busy.lineageDigest,
+			};
+			await expect(markSessionInterrupted(authority, ["restore_interrupted"])).resolves.toEqual({
+				status: "applied",
+			});
+			expect(new WorkerRecoveryJournal(journalPath).complete(busy.activeSessionId, busy.operationId)).toBe(true);
+
+			// Exactly the two journaled calls are closed, one marker is appended,
+			// and the durable latest record is the completed epoch.
+			const recovered = SessionManager.open(sessionFile);
+			expect(
+				recovered
+					.getBranch()
+					.filter((entry) => entry.type === "message" && entry.message.role === "toolResult")
+					.map((entry) => (entry as SessionMessageEntry).message.toolCallId),
+			).toEqual(["bash-1", "edit-1"]);
+			expect(recoveryMarkers(recovered)).toHaveLength(1);
+			const latest = WorkerRecoveryJournal.readLatest(journalPath);
+			expect(latest).toHaveLength(1);
+			expect(latest[0]).toMatchObject({ version: 2, busy: false, operation: "recovery_complete" });
+			expect(latest[0]).toMatchObject({ operationId: busy.operationId });
 		} finally {
 			if (previousJournalPath === undefined) {
 				delete process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV];

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1,9 +1,10 @@
+import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Model, ToolResultMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import {
 	AGENT_FAMILY_REACH_ERROR,
@@ -43,7 +44,11 @@ import {
 	failure,
 } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
-import { DAEMON_WORKER_SUPERVISOR_SOCKET_ENV } from "../src/modes/daemon/daemon-worker-protocol.js";
+import {
+	DAEMON_WORKER_RECOVERY_JOURNAL_ENV,
+	DAEMON_WORKER_SUPERVISOR_SOCKET_ENV,
+} from "../src/modes/daemon/daemon-worker-protocol.js";
+import { WorkerRecoveryJournal } from "../src/modes/daemon/worker-recovery-journal.js";
 
 describe("daemon mode helpers", () => {
 	it("preserves envelope client identity while registering prompt admission", () => {
@@ -9938,3 +9943,126 @@ function makeClient(id: string, activeSessionId: string, supportsExtensionUi = f
 		capabilities: new Set(supportsExtensionUi ? ["extension_ui"] : []),
 	};
 }
+describe("worker recovery authority capture", () => {
+	function toolCall(id: string, name: string): AssistantMessage["content"][number] {
+		return { type: "toolCall", id, name, arguments: {} };
+	}
+
+	function assistantTurn(...calls: ReturnType<typeof toolCall>[]): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [{ type: "text", text: "calling tools" }, ...calls],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+	}
+
+	function toolResult(callId: string, name: string): ToolResultMessage {
+		return {
+			role: "toolResult",
+			toolCallId: callId,
+			toolName: name,
+			content: [{ type: "text", text: "ok" }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+	}
+
+	function lineageDigestOf(manager: SessionManager): string {
+		const hash = createHash("sha256");
+		for (const entry of manager.getBranch()) {
+			hash.update(entry.id);
+			hash.update("\0");
+			hash.update(entry.parentId ?? "");
+			hash.update("\n");
+		}
+		return hash.digest("hex");
+	}
+
+	it("captures head, assistant, unresolved tool calls, and lineage in one v2 checkpoint", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-recovery-capture-"));
+		const previousJournalPath = process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV];
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			manager.appendMessage({ role: "user", content: "run tools", timestamp: 1 });
+			const assistantEntryId = manager.appendMessage(
+				assistantTurn(toolCall("call-1", "bash"), toolCall("call-2", "bash")),
+			);
+			// call-1 is already resolved; only call-2 stays unresolved.
+			manager.appendMessage(toolResult("call-1", "bash"));
+
+			const journalPath = join(tempDir, "worker.recovery.jsonl");
+			process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV] = journalPath;
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime: vi.fn(),
+				worker: { authenticationToken: "token" },
+			});
+			const state = makeState("active-1");
+			state.runtime = {
+				...state.runtime,
+				metadata: { kind: "top-level", createdAt: 1 },
+				session: makeRuntimeSession(manager),
+			} as never;
+			const internals = daemon as unknown as {
+				recordWorkerRecoveryState(state: ActiveSessionState, operation: string, busyOverride?: boolean): void;
+			};
+
+			internals.recordWorkerRecoveryState(state, "tool_execution_start", true);
+			// Identical authority within the same busy epoch is deduplicated.
+			internals.recordWorkerRecoveryState(state, "tool_execution_start", true);
+
+			const records = WorkerRecoveryJournal.readLatest(journalPath);
+			expect(records).toHaveLength(1);
+			const record = records[0]!;
+			expect(record.version).toBe(2);
+			const firstOperationId = record.version === 2 ? record.operationId : undefined;
+			if (record.version === 2) {
+				expect(record.agentDir).toBe(tempDir);
+				expect(record.sessionId).toBe(manager.getSessionId());
+				expect(record.sessionFile).toBe(manager.getSessionFile());
+				expect(record.headEntryId).toBe(manager.getLeafId());
+				expect(record.assistantEntryId).toBe(assistantEntryId);
+				expect(record.toolCalls).toEqual([{ id: "call-2", name: "bash" }]);
+				expect(record.lineageDigest).toBe(lineageDigestOf(manager));
+				expect(record.busy).toBe(true);
+				expect(record.operation).toBe("tool_execution_start");
+				expect(record.operationId).toMatch(/^[0-9a-f-]{36}$/);
+			}
+
+			// Resolving the last call and advancing the branch forces a new record
+			// even for the same event name, within the same busy epoch operation id.
+			manager.appendMessage(toolResult("call-2", "bash"));
+			internals.recordWorkerRecoveryState(state, "tool_execution_end", true);
+			const advanced = WorkerRecoveryJournal.readLatest(journalPath).at(-1)!;
+			expect(advanced.version).toBe(2);
+			if (advanced.version === 2) {
+				expect(advanced.headEntryId).toBe(manager.getLeafId());
+				expect(advanced.assistantEntryId).toBe(assistantEntryId);
+				expect(advanced.toolCalls).toEqual([]);
+				expect(advanced.lineageDigest).toBe(lineageDigestOf(manager));
+				expect(advanced.operationId).toBe(firstOperationId);
+			}
+		} finally {
+			if (previousJournalPath === undefined) {
+				delete process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV];
+			} else {
+				process.env[DAEMON_WORKER_RECOVERY_JOURNAL_ENV] = previousJournalPath;
+			}
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -25,14 +25,11 @@ import {
 	readSessionInfo,
 	type SessionEntry,
 	type SessionInfo,
-	type SessionMessageEntry,
 	SessionManager,
+	type SessionMessageEntry,
 } from "../src/core/session-manager.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
-import {
-	type CatalogRecoveryAuthority,
-	markSessionInterrupted,
-} from "../src/modes/daemon/daemon-catalog-process.js";
+import { type CatalogRecoveryAuthority, markSessionInterrupted } from "../src/modes/daemon/daemon-catalog-process.js";
 import {
 	AgentDaemon,
 	cancelPendingExtensionUiRequests,
@@ -60,8 +57,8 @@ import {
 } from "../src/modes/daemon/daemon-worker-protocol.js";
 import {
 	isV2WorkerRecoveryRecord,
-	type WorkerRecoveryRecordV2,
 	WorkerRecoveryJournal,
+	type WorkerRecoveryRecordV2,
 } from "../src/modes/daemon/worker-recovery-journal.js";
 
 describe("daemon mode helpers", () => {
@@ -10120,9 +10117,7 @@ describe("worker restore interrupted-session repair", () => {
 	function recoveryMarkers(session: SessionManager): SessionEntry[] {
 		return session
 			.getEntries()
-			.filter(
-				(entry) => entry.type === "custom_message" && entry.customType === "prime-agent.worker_recovery",
-			);
+			.filter((entry) => entry.type === "custom_message" && entry.customType === "prime-agent.worker_recovery");
 	}
 
 	function messageRoles(session: SessionManager): string[] {
@@ -10299,7 +10294,7 @@ describe("worker restore interrupted-session repair", () => {
 
 			const spy = vi.spyOn(SessionManager.prototype, "appendMessageWithRollback").mockImplementation(function (
 				this: SessionManager,
-				message,
+				_message,
 			) {
 				throw new Error("disk full");
 			});
@@ -10352,7 +10347,7 @@ describe("worker restore interrupted-session repair", () => {
 				recovered
 					.getBranch()
 					.filter((entry) => entry.type === "message" && entry.message.role === "toolResult")
-					.map((entry) => (entry as SessionMessageEntry).message.toolCallId),
+					.map((entry) => ((entry as SessionMessageEntry).message as ToolResultMessage).toolCallId),
 			).toEqual(["bash-1", "edit-1"]);
 			expect(recoveryMarkers(recovered)).toHaveLength(1);
 			const latest = WorkerRecoveryJournal.readLatest(journalPath);

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -26,7 +26,7 @@ describe("daemon protocol helpers", () => {
 	it("keeps the advertised schema identity synchronized with wire type shapes", () => {
 		const source = readFileSync(resolve(__dirname, "../src/modes/daemon/daemon-protocol.ts"), "utf8");
 		const commandSource = source.slice(
-			source.indexOf("export type DaemonCommand ="),
+			source.indexOf("export interface DaemonShutdownAuthority"),
 			source.indexOf("type DaemonCommandName"),
 		);
 		const savedSessionSource = source.slice(

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -138,12 +138,12 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(16);
 	});
 
-	it("adds supervisor shutdown authority at its introducing schema revision", () => {
-		// Revision 17 adds the optional shutdown authority wire field. The
-		// command stays legacy-compatible (no minSchemaRevision gate) so a new
-		// client may send the authority-optional shape to a legacy supervisor;
-		// only the new supervisor enforces the field.
-		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(17);
+	it("adds complete supervisor termination authority at its introducing schema revision", () => {
+		// Revision 18 extends authority to restart and requires the full process
+		// identity. Both commands stay legacy-compatible so a new client may send
+		// the authority-optional shape to an older tolerant supervisor.
+		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(18);
+		expect(DAEMON_COMMAND_COMPATIBILITY.restart).toEqual({ minProtocol: 7 });
 		expect(DAEMON_COMMAND_COMPATIBILITY.shutdown).toEqual({ minProtocol: 7 });
 	});
 

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -138,6 +138,15 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(16);
 	});
 
+	it("adds supervisor shutdown authority at its introducing schema revision", () => {
+		// Revision 17 adds the optional shutdown authority wire field. The
+		// command stays legacy-compatible (no minSchemaRevision gate) so a new
+		// client may send the authority-optional shape to a legacy supervisor;
+		// only the new supervisor enforces the field.
+		expect(DAEMON_SCHEMA_REVISION).toBeGreaterThanOrEqual(17);
+		expect(DAEMON_COMMAND_COMPATIBILITY.shutdown).toEqual({ minProtocol: 7 });
+	});
+
 	it("keeps refine failure events backward-compatible on the existing session event channel", () => {
 		const event: DaemonOutbound = {
 			type: "session_event",

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,11 +15,13 @@ import {
 	planReap,
 	planShutdownAll,
 	planShutdownConfirmation,
+	protectAuthorityRejectedScope,
 	reapOutcomeFromShutdownAttempt,
 	shutdownDaemon,
 	sortDaemons,
 	verifyHelloSupervisorPid,
 } from "../src/cli/daemon-ps.js";
+import { ENV_AGENT_DIR } from "../src/config.js";
 import { getProcessStartId } from "../src/core/session-lease.js";
 import { DAEMON_PROTOCOL_VERSION, DAEMON_SCHEMA_ID } from "../src/modes/daemon/daemon-protocol.js";
 import { defaultDaemonSocketDir } from "../src/modes/daemon/daemon-socket.js";
@@ -276,6 +278,41 @@ describe("shutdownDaemon authority outcome", () => {
 		expect(reapOutcomeFromShutdownAttempt({ status: "stopped" }, 42)).toEqual({
 			reaped: "stopped idle background service (pid 42)",
 		});
+	});
+
+	it("protects the rejected supervisor and every tracked worker listener", () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-daemon-ps-protected-scope-"));
+		const previousAgentDir = process.env[ENV_AGENT_DIR];
+		const supervisorSocketPath = join(directory, "supervisor.sock");
+		const workerSocketPath = join(directory, "worker.sock");
+		const descriptorDirectory = join(directory, "daemon-workers", "scope");
+		mkdirSync(descriptorDirectory, { recursive: true });
+		const workerPid = 987654321;
+		writeFileSync(
+			join(descriptorDirectory, "worker.json"),
+			JSON.stringify({
+				version: 1,
+				supervisorSocketPath,
+				workerId: "worker",
+				pid: workerPid,
+				processStartId: "worker-start",
+				socketPath: workerSocketPath,
+				recoveryJournalPath: join(directory, "recovery.jsonl"),
+			}),
+		);
+		try {
+			process.env[ENV_AGENT_DIR] = directory;
+			const sockets = new Set<string>();
+			const processes = new Map<number, string | undefined>();
+			protectAuthorityRejectedScope(supervisorSocketPath, process.pid, sockets, processes);
+			expect(sockets).toEqual(new Set([supervisorSocketPath, workerSocketPath]));
+			expect(processes.get(process.pid)).toBe(getProcessStartId(process.pid));
+			expect(processes.get(workerPid)).toBe("worker-start");
+		} finally {
+			if (previousAgentDir === undefined) delete process.env[ENV_AGENT_DIR];
+			else process.env[ENV_AGENT_DIR] = previousAgentDir;
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 
 	it("surfaces authority rejection instead of treating a responsive supervisor as unresponsive", async () => {

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -6,8 +6,10 @@ import { describe, expect, it } from "vitest";
 import {
 	type DaemonInfo,
 	evaluateShutdownQuietPeriod,
+	isProtectedDaemonAction,
 	isWorkerSocketPath,
 	mergeDiscoveredDaemonProcesses,
+	orderShutdownActions,
 	parseLsofListeners,
 	parsePrimeAgentProcessIds,
 	parsePsEtimes,
@@ -302,12 +304,42 @@ describe("shutdownDaemon authority outcome", () => {
 		);
 		try {
 			process.env[ENV_AGENT_DIR] = directory;
+			const workerDaemon = {
+				socketPath: workerSocketPath,
+				pid: workerPid,
+				status: "unreachable" as const,
+				isDefault: false,
+			};
+			const supervisorDaemon = {
+				socketPath: supervisorSocketPath,
+				pid: process.pid,
+				status: "current" as const,
+				isDefault: false,
+			};
+			const ordered = orderShutdownActions(
+				[
+					{ kind: "kill", daemon: workerDaemon },
+					{ kind: "shutdown", daemon: supervisorDaemon },
+				],
+				new Set([workerSocketPath]),
+				new Map([[workerPid, "worker-start"]]),
+			);
+			expect(ordered.map((action) => action.daemon.socketPath)).toEqual([supervisorSocketPath, workerSocketPath]);
+
 			const sockets = new Set<string>();
 			const processes = new Map<number, string | undefined>();
 			protectAuthorityRejectedScope(supervisorSocketPath, process.pid, sockets, processes);
 			expect(sockets).toEqual(new Set([supervisorSocketPath, workerSocketPath]));
 			expect(processes.get(process.pid)).toBe(getProcessStartId(process.pid));
 			expect(processes.get(workerPid)).toBe("worker-start");
+			expect(isProtectedDaemonAction(workerDaemon, sockets, processes)).toBe(true);
+			expect(
+				isProtectedDaemonAction(
+					{ socketPath: join(directory, "secondary.sock"), pid: process.pid },
+					sockets,
+					processes,
+				),
+			).toBe(true);
 		} finally {
 			if (previousAgentDir === undefined) delete process.env[ENV_AGENT_DIR];
 			else process.env[ENV_AGENT_DIR] = previousAgentDir;

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -12,10 +15,12 @@ import {
 	planReap,
 	planShutdownAll,
 	planShutdownConfirmation,
+	shutdownDaemon,
 	sortDaemons,
 	verifyHelloSupervisorPid,
 } from "../src/cli/daemon-ps.js";
 import { getProcessStartId } from "../src/core/session-lease.js";
+import { DAEMON_PROTOCOL_VERSION, DAEMON_SCHEMA_ID } from "../src/modes/daemon/daemon-protocol.js";
 import { defaultDaemonSocketDir } from "../src/modes/daemon/daemon-socket.js";
 
 describe("worker socket classification", () => {
@@ -258,6 +263,64 @@ describe("planShutdownConfirmation", () => {
 		expect(planShutdownConfirmation(1, false, false, false)).toBe("tty-error");
 		expect(planShutdownConfirmation(1, true, true, true)).toBe("none");
 		expect(planShutdownConfirmation(0, false, false, true)).toBe("none");
+	});
+});
+
+describe("shutdownDaemon authority outcome", () => {
+	it("surfaces authority rejection instead of treating a responsive supervisor as unresponsive", async () => {
+		if (process.platform === "win32") return;
+		const directory = mkdtempSync(join(tmpdir(), "prime-daemon-ps-authority-"));
+		const socketPath = join(directory, "daemon.sock");
+		const server = createServer((socket) => {
+			socket.on("error", () => undefined);
+			socket.write(
+				`${JSON.stringify({
+					type: "daemon_hello",
+					socketPath,
+					protocol: { name: "prime-agent.daemon", version: DAEMON_PROTOCOL_VERSION },
+					appVersion: "test",
+					schemaId: DAEMON_SCHEMA_ID,
+					schemaRevision: 18,
+					supervisorGeneration: "generation",
+					supervisorOwnerToken: "owner-token",
+					supervisorPid: process.pid,
+					supervisorProcessStartId: getProcessStartId(process.pid) ?? "test-start",
+					supervisorSocketPath: socketPath,
+					clientId: "client",
+					serverCapabilities: [],
+				})}\n`,
+			);
+			let buffer = "";
+			let responded = false;
+			socket.on("data", (chunk) => {
+				if (responded) return;
+				buffer += chunk.toString();
+				const newline = buffer.indexOf("\n");
+				if (newline === -1) return;
+				const wire = JSON.parse(buffer.slice(0, newline)) as { id: string; command?: { type?: string } };
+				if (wire.command?.type !== "shutdown") return;
+				responded = true;
+				socket.write(
+					`${JSON.stringify({
+						id: wire.id,
+						type: "response",
+						command: "shutdown",
+						success: false,
+						error: "authority rejected",
+						errorInfo: { code: "shutdown_authority_rejected" },
+					})}\n`,
+				);
+			});
+		});
+		try {
+			await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+			await expect(shutdownDaemon(socketPath, true)).resolves.toEqual({ status: "authority-rejected" });
+			expect(server.listening).toBe(true);
+		} finally {
+			(server as typeof server & { closeAllConnections?: () => void }).closeAllConnections?.();
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -15,6 +15,7 @@ import {
 	planReap,
 	planShutdownAll,
 	planShutdownConfirmation,
+	reapOutcomeFromShutdownAttempt,
 	shutdownDaemon,
 	sortDaemons,
 	verifyHelloSupervisorPid,
@@ -267,6 +268,16 @@ describe("planShutdownConfirmation", () => {
 });
 
 describe("shutdownDaemon authority outcome", () => {
+	it("never treats a structured rejection object as successful reap", () => {
+		expect(reapOutcomeFromShutdownAttempt({ status: "authority-rejected" }, 42)).toEqual({
+			skipped: "shutdown authority rejected",
+			preserveTrackedWorkers: true,
+		});
+		expect(reapOutcomeFromShutdownAttempt({ status: "stopped" }, 42)).toEqual({
+			reaped: "stopped idle background service (pid 42)",
+		});
+	});
+
 	it("surfaces authority rejection instead of treating a responsive supervisor as unresponsive", async () => {
 		if (process.platform === "win32") return;
 		const directory = mkdtempSync(join(tmpdir(), "prime-daemon-ps-authority-"));

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -3247,6 +3247,37 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("worker recovery retains busy authority while the killed session owner still holds its lease", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-live-owner-"));
+		const journalPath = join(root, "worker.recovery.jsonl");
+		const journal = new WorkerRecoveryJournal(journalPath);
+		journal.record(recoveryRecord(root, "root-active", "root-session", "/tmp/root.jsonl", "tool_execution"));
+		const markInterrupted = vi
+			.fn()
+			.mockResolvedValueOnce({ status: "stale" as const, reason: "live_session_owner" as const })
+			.mockResolvedValueOnce({ status: "applied" as const });
+		const worker = recoveryWorker(root, journalPath);
+		worker.descriptor.pid = 2_147_483_647;
+		const supervisor = recoverySupervisor(markInterrupted);
+
+		try {
+			await expect(supervisor.recoverUncertainWorkerOperations(worker, true)).rejects.toThrow(/session owner lease/);
+			expect(WorkerRecoveryJournal.readLatest(journalPath)[0]).toMatchObject({
+				busy: true,
+				operation: "tool_execution",
+			});
+
+			await supervisor.recoverUncertainWorkerOperations(worker, false);
+			expect(markInterrupted).toHaveBeenCalledTimes(2);
+			expect(WorkerRecoveryJournal.readLatest(journalPath)[0]).toMatchObject({
+				busy: false,
+				operation: "recovery_complete",
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("worker recovery keeps per-session successes complete when a sibling request fails", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-partial-"));
 		const journalPath = join(root, "worker.recovery.jsonl");

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -3332,7 +3332,7 @@ describe("daemon worker supervisor monitoring", () => {
 		const markInterrupted = vi
 			.fn()
 			.mockResolvedValueOnce({ status: "stale" as const, reason: "live_session_owner" as const })
-			.mockResolvedValueOnce({ status: "applied" as const });
+			.mockResolvedValueOnce({ status: "stale" as const, reason: "live_session_owner" as const });
 		const worker = recoveryWorker(root, journalPath);
 		worker.descriptor.pid = 2_147_483_647;
 		const supervisor = recoverySupervisor(markInterrupted);
@@ -3346,6 +3346,7 @@ describe("daemon worker supervisor monitoring", () => {
 
 			await supervisor.recoverUncertainWorkerOperations(worker, false);
 			expect(markInterrupted).toHaveBeenCalledTimes(2);
+			expect(markInterrupted.mock.calls[1]?.[0]).toEqual(markInterrupted.mock.calls[0]?.[0]);
 			expect(WorkerRecoveryJournal.readLatest(journalPath)[0]).toMatchObject({
 				busy: false,
 				operation: "recovery_complete",

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -3192,6 +3192,73 @@ describe("daemon worker supervisor monitoring", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	it("keeps the recovery journal busy when the catalog mark fails", async () => {
+		type RecoveryWorker = {
+			descriptor: {
+				workerId: string;
+				pid: number;
+				rootActiveSessionId: string;
+				recoveryJournalPath: string;
+				orphanProcessJournalPath: string;
+			};
+		};
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-fail-test-"));
+		const journalPath = join(root, "worker.recovery.jsonl");
+		const orphanJournalPath = join(root, "worker.orphans.jsonl");
+		writeFileSync(
+			orphanJournalPath,
+			`${JSON.stringify({
+				version: 1,
+				pid: 987_654,
+				ownerPid: process.pid,
+				processStartId: "reused-process",
+				active: true,
+				recordedAt: new Date().toISOString(),
+			})}\n`,
+		);
+		const journal = new WorkerRecoveryJournal(journalPath);
+		journal.record({
+			activeSessionId: "root-active",
+			sessionId: "root-session",
+			sessionFile: "/tmp/root.jsonl",
+			busy: true,
+			operation: "tool_execution",
+		});
+		const worker: RecoveryWorker = {
+			descriptor: {
+				workerId: "worker-1",
+				pid: process.pid,
+				rootActiveSessionId: "root-active",
+				recoveryJournalPath: journalPath,
+				orphanProcessJournalPath: orphanJournalPath,
+			},
+		};
+		const markInterrupted = vi.fn(async () => {
+			throw new Error("catalog unavailable");
+		});
+		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			catalog: { markInterrupted },
+			log: vi.fn(),
+			assertRecoveryAllowed: vi.fn(async () => {}),
+		}) as {
+			recoverUncertainWorkerOperations(worker: RecoveryWorker, killWorkerProcess: boolean): Promise<void>;
+		};
+
+		try {
+			await expect(supervisor.recoverUncertainWorkerOperations(worker, false)).rejects.toThrow(
+				"catalog unavailable",
+			);
+			expect(markInterrupted).toHaveBeenCalledOnce();
+			expect(WorkerRecoveryJournal.readLatest(journalPath)).toEqual([
+				expect.objectContaining({ activeSessionId: "root-active", busy: true, operation: "tool_execution" }),
+			]);
+		} finally {
+			kill.mockRestore();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 	it.each([
 		{ name: "malformed data", data: undefined, error: /invalid update manifest/ },
 		{

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -3278,6 +3278,30 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
+	it("worker recovery rejects a journaled lease namespace different from the supervisor", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-agent-dir-"));
+		const journalPath = join(root, "worker.recovery.jsonl");
+		const journal = new WorkerRecoveryJournal(journalPath);
+		journal.record(
+			recoveryRecord("/stale/agent-dir", "root-active", "root-session", "/tmp/root.jsonl", "model_stream"),
+		);
+		const markInterrupted = vi.fn();
+		const supervisor = Object.assign(recoverySupervisor(markInterrupted), {
+			defaultSessionConfig: { agentDir: root },
+		});
+		try {
+			await supervisor.recoverUncertainWorkerOperations(recoveryWorker(root, journalPath), false);
+			expect(markInterrupted).not.toHaveBeenCalled();
+			expect(WorkerRecoveryJournal.readLatest(journalPath)[0]).toMatchObject({
+				version: 2,
+				busy: false,
+				operation: "recovery_complete",
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("worker recovery CAS cannot clear a newer resumed busy epoch", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-cas-"));
 		const journalPath = join(root, "worker.recovery.jsonl");
@@ -3304,7 +3328,7 @@ describe("daemon worker supervisor monitoring", () => {
 		}
 	});
 
-	it("worker recovery leaves legacy v1 busy records stale without transcript mutation", async () => {
+	it("worker recovery acknowledges legacy v1 busy records stale without transcript mutation", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-legacy-"));
 		const journalPath = join(root, "worker.recovery.jsonl");
 		const journal = new WorkerRecoveryJournal(journalPath);
@@ -3322,7 +3346,11 @@ describe("daemon worker supervisor monitoring", () => {
 				false,
 			);
 			expect(markInterrupted).not.toHaveBeenCalled();
-			expect(WorkerRecoveryJournal.readLatest(journalPath)[0]).toMatchObject({ version: 1, busy: true });
+			expect(WorkerRecoveryJournal.readLatest(journalPath)[0]).toMatchObject({
+				version: 1,
+				busy: false,
+				operation: "legacy_recovery_stale",
+			});
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -3123,142 +3123,211 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(client.attachedActiveSessionIds).toEqual(new Set());
 	});
 
-	it("marks each busy worker session interrupted independently", async () => {
-		type RecoveryWorker = {
-			descriptor: {
-				workerId: string;
-				pid: number;
-				rootActiveSessionId: string;
-				recoveryJournalPath: string;
-				orphanProcessJournalPath: string;
-			};
+	type RecoveryWorker = {
+		descriptor: {
+			workerId: string;
+			pid: number;
+			rootActiveSessionId: string;
+			recoveryJournalPath: string;
+			orphanProcessJournalPath: string;
 		};
+	};
+
+	function recoveryRecord(
+		root: string,
+		activeSessionId: string,
+		sessionId: string,
+		sessionFile: string,
+		operation: string,
+		headEntryId = `${activeSessionId}-head`,
+	) {
+		return {
+			activeSessionId,
+			sessionId,
+			agentDir: root,
+			sessionFile,
+			headEntryId,
+			assistantEntryId: `${activeSessionId}-assistant`,
+			toolCalls: [{ id: `${activeSessionId}-call`, name: "bash" }],
+			lineageDigest: "a".repeat(64),
+			busy: true,
+			operation,
+		};
+	}
+
+	function recoveryWorker(root: string, journalPath: string): RecoveryWorker {
+		return {
+			descriptor: {
+				workerId: "worker-1",
+				pid: process.pid,
+				rootActiveSessionId: "root-active",
+				recoveryJournalPath: journalPath,
+				orphanProcessJournalPath: join(root, "worker.orphans.jsonl"),
+			},
+		};
+	}
+
+	function recoverySupervisor(markInterrupted: ReturnType<typeof vi.fn>) {
+		return Object.assign(Object.create(DaemonSupervisor.prototype), {
+			catalog: { markInterrupted },
+			log: vi.fn(),
+			assertRecoveryAllowed: vi.fn(async () => {}),
+		}) as {
+			recoverUncertainWorkerOperations(worker: RecoveryWorker, killWorkerProcess: boolean): Promise<void>;
+		};
+	}
+
+	it("worker recovery completes each successful v2 authority independently", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-test-"));
 		const journalPath = join(root, "worker.recovery.jsonl");
-		const orphanJournalPath = join(root, "worker.orphans.jsonl");
-		writeFileSync(
-			orphanJournalPath,
-			`${JSON.stringify({
-				version: 1,
-				pid: 987_654,
-				ownerPid: process.pid,
-				processStartId: "reused-process",
-				active: true,
-				recordedAt: new Date().toISOString(),
-			})}\n`,
-		);
 		const journal = new WorkerRecoveryJournal(journalPath);
-		journal.record({
-			activeSessionId: "root-active",
-			sessionId: "root-session",
-			sessionFile: "/tmp/root.jsonl",
-			busy: true,
-			operation: "model_stream",
-		});
-		journal.record({
-			activeSessionId: "child-active",
-			sessionId: "child-session",
-			sessionFile: "/tmp/child.jsonl",
-			busy: true,
-			operation: "tool_execution",
-		});
-		const worker: RecoveryWorker = {
-			descriptor: {
-				workerId: "worker-1",
-				pid: process.pid,
-				rootActiveSessionId: "root-active",
-				recoveryJournalPath: journalPath,
-				orphanProcessJournalPath: orphanJournalPath,
-			},
-		};
-		const markInterrupted = vi.fn(async () => undefined);
-		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			catalog: { markInterrupted },
-			log: vi.fn(),
-			assertRecoveryAllowed: vi.fn(async () => {}),
-		}) as {
-			recoverUncertainWorkerOperations(worker: RecoveryWorker, killWorkerProcess: boolean): Promise<void>;
-		};
+		journal.record(recoveryRecord(root, "root-active", "root-session", "/tmp/root.jsonl", "model_stream"));
+		journal.record(recoveryRecord(root, "child-active", "child-session", "/tmp/child.jsonl", "tool_execution"));
+		const records = WorkerRecoveryJournal.readLatest(journalPath);
+		const markInterrupted = vi.fn(async () => ({ status: "applied" as const }));
 
 		try {
-			await supervisor.recoverUncertainWorkerOperations(worker, false);
-			expect(kill).not.toHaveBeenCalled();
-			expect(markInterrupted).toHaveBeenCalledTimes(2);
-			expect(markInterrupted).toHaveBeenCalledWith("/tmp/root.jsonl", "root-active", ["model_stream"]);
-			expect(markInterrupted).toHaveBeenCalledWith("/tmp/child.jsonl", "child-active", ["tool_execution"]);
-		} finally {
-			kill.mockRestore();
-			rmSync(root, { recursive: true, force: true });
-		}
-	});
-
-	it("keeps the recovery journal busy when the catalog mark fails", async () => {
-		type RecoveryWorker = {
-			descriptor: {
-				workerId: string;
-				pid: number;
-				rootActiveSessionId: string;
-				recoveryJournalPath: string;
-				orphanProcessJournalPath: string;
-			};
-		};
-		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-fail-test-"));
-		const journalPath = join(root, "worker.recovery.jsonl");
-		const orphanJournalPath = join(root, "worker.orphans.jsonl");
-		writeFileSync(
-			orphanJournalPath,
-			`${JSON.stringify({
-				version: 1,
-				pid: 987_654,
-				ownerPid: process.pid,
-				processStartId: "reused-process",
-				active: true,
-				recordedAt: new Date().toISOString(),
-			})}\n`,
-		);
-		const journal = new WorkerRecoveryJournal(journalPath);
-		journal.record({
-			activeSessionId: "root-active",
-			sessionId: "root-session",
-			sessionFile: "/tmp/root.jsonl",
-			busy: true,
-			operation: "tool_execution",
-		});
-		const worker: RecoveryWorker = {
-			descriptor: {
-				workerId: "worker-1",
-				pid: process.pid,
-				rootActiveSessionId: "root-active",
-				recoveryJournalPath: journalPath,
-				orphanProcessJournalPath: orphanJournalPath,
-			},
-		};
-		const markInterrupted = vi.fn(async () => {
-			throw new Error("catalog unavailable");
-		});
-		const kill = vi.spyOn(process, "kill").mockReturnValue(true);
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			catalog: { markInterrupted },
-			log: vi.fn(),
-			assertRecoveryAllowed: vi.fn(async () => {}),
-		}) as {
-			recoverUncertainWorkerOperations(worker: RecoveryWorker, killWorkerProcess: boolean): Promise<void>;
-		};
-
-		try {
-			await expect(supervisor.recoverUncertainWorkerOperations(worker, false)).rejects.toThrow(
-				"catalog unavailable",
+			await recoverySupervisor(markInterrupted).recoverUncertainWorkerOperations(
+				recoveryWorker(root, journalPath),
+				false,
 			);
-			expect(markInterrupted).toHaveBeenCalledOnce();
+			expect(markInterrupted).toHaveBeenCalledTimes(2);
+			for (const record of records) {
+				if (record.version !== 2) throw new Error("Expected v2 fixture record");
+				expect(markInterrupted).toHaveBeenCalledWith(
+					expect.objectContaining({
+						operationId: record.operationId,
+						activeSessionId: record.activeSessionId,
+						sessionId: record.sessionId,
+						agentDir: root,
+						sessionFile: record.sessionFile,
+						headEntryId: record.headEntryId,
+						assistantEntryId: record.assistantEntryId,
+						toolCalls: record.toolCalls,
+						lineageDigest: record.lineageDigest,
+					}),
+					[record.operation],
+				);
+			}
 			expect(WorkerRecoveryJournal.readLatest(journalPath)).toEqual([
-				expect.objectContaining({ activeSessionId: "root-active", busy: true, operation: "tool_execution" }),
+				expect.objectContaining({ activeSessionId: "root-active", busy: false, operation: "recovery_complete" }),
+				expect.objectContaining({ activeSessionId: "child-active", busy: false, operation: "recovery_complete" }),
 			]);
 		} finally {
-			kill.mockRestore();
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	it("worker recovery completes stale results but retains busy authority on request failure", async () => {
+		for (const outcome of ["stale", "failure"] as const) {
+			const root = mkdtempSync(join(tmpdir(), `prime-supervisor-recovery-${outcome}-`));
+			const journalPath = join(root, "worker.recovery.jsonl");
+			const journal = new WorkerRecoveryJournal(journalPath);
+			journal.record(recoveryRecord(root, "root-active", "root-session", "/tmp/root.jsonl", "tool_execution"));
+			const markInterrupted = vi.fn(async () => {
+				if (outcome === "failure") throw new Error("catalog unavailable");
+				return { status: "stale" as const, reason: "head" as const };
+			});
+			const supervisor = recoverySupervisor(markInterrupted);
+			try {
+				if (outcome === "failure") {
+					await expect(
+						supervisor.recoverUncertainWorkerOperations(recoveryWorker(root, journalPath), false),
+					).rejects.toThrow("catalog unavailable");
+				} else {
+					await supervisor.recoverUncertainWorkerOperations(recoveryWorker(root, journalPath), false);
+				}
+				expect(WorkerRecoveryJournal.readLatest(journalPath)[0]).toMatchObject({
+					busy: outcome === "failure",
+					operation: outcome === "failure" ? "tool_execution" : "recovery_complete",
+				});
+			} finally {
+				rmSync(root, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("worker recovery keeps per-session successes complete when a sibling request fails", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-partial-"));
+		const journalPath = join(root, "worker.recovery.jsonl");
+		const journal = new WorkerRecoveryJournal(journalPath);
+		journal.record(recoveryRecord(root, "root-active", "root-session", "/tmp/root.jsonl", "model_stream"));
+		journal.record(recoveryRecord(root, "child-active", "child-session", "/tmp/child.jsonl", "tool_execution"));
+		const markInterrupted = vi.fn(async (authority: { activeSessionId: string }) => {
+			if (authority.activeSessionId === "child-active") {
+				await Promise.resolve();
+				throw new Error("child catalog failure");
+			}
+			return { status: "applied" as const };
+		});
+		try {
+			await expect(
+				recoverySupervisor(markInterrupted).recoverUncertainWorkerOperations(
+					recoveryWorker(root, journalPath),
+					false,
+				),
+			).rejects.toThrow("child catalog failure");
+			expect(WorkerRecoveryJournal.readLatest(journalPath)).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ activeSessionId: "root-active", busy: false }),
+					expect.objectContaining({ activeSessionId: "child-active", busy: true }),
+				]),
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("worker recovery CAS cannot clear a newer resumed busy epoch", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-cas-"));
+		const journalPath = join(root, "worker.recovery.jsonl");
+		const journal = new WorkerRecoveryJournal(journalPath);
+		const initial = recoveryRecord(root, "root-active", "root-session", "/tmp/root.jsonl", "tool_execution");
+		journal.record(initial);
+		const old = WorkerRecoveryJournal.readLatest(journalPath)[0]!;
+		if (old.version !== 2) throw new Error("Expected v2 fixture record");
+		const markInterrupted = vi.fn(async () => {
+			journal.record({ ...initial, busy: false, operation: "turn_end" });
+			journal.record({ ...initial, headEntryId: "new-head", busy: true, operation: "turn_start" });
+			return { status: "applied" as const };
+		});
+		try {
+			await recoverySupervisor(markInterrupted).recoverUncertainWorkerOperations(
+				recoveryWorker(root, journalPath),
+				false,
+			);
+			const latest = WorkerRecoveryJournal.readLatest(journalPath)[0]!;
+			expect(latest).toMatchObject({ busy: true, headEntryId: "new-head", operation: "turn_start" });
+			if (latest.version === 2) expect(latest.operationId).not.toBe(old.operationId);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("worker recovery leaves legacy v1 busy records stale without transcript mutation", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-recovery-legacy-"));
+		const journalPath = join(root, "worker.recovery.jsonl");
+		const journal = new WorkerRecoveryJournal(journalPath);
+		journal.record({
+			activeSessionId: "root-active",
+			sessionId: "root-session",
+			sessionFile: "/tmp/root.jsonl",
+			busy: true,
+			operation: "tool_execution",
+		});
+		const markInterrupted = vi.fn();
+		try {
+			await recoverySupervisor(markInterrupted).recoverUncertainWorkerOperations(
+				recoveryWorker(root, journalPath),
+				false,
+			);
+			expect(markInterrupted).not.toHaveBeenCalled();
+			expect(WorkerRecoveryJournal.readLatest(journalPath)[0]).toMatchObject({ version: 1, busy: true });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it.each([
 		{ name: "malformed data", data: undefined, error: /invalid update manifest/ },
 		{

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -719,7 +719,7 @@ describe("daemon supervisor resident workers", () => {
 
 		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir, ["--session-dir", sessionDir, "--no-tools"]);
 		const client = await connectEventually(socketPath, supervisor);
-		const restarted = await client.request({ type: "restart" });
+		const restarted = await client.requestSupervisorRestart();
 		expect(restarted.success).toBe(true);
 		client.close();
 		await waitForExit(supervisor);

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -14,7 +14,11 @@ import {
 } from "../src/core/session-lease.js";
 import { readSessionInfo, SessionManager } from "../src/core/session-manager.js";
 import { DaemonAgentConnection } from "../src/modes/agent-connection/daemon-agent-connection.js";
-import { DaemonClient, getDaemonSocketCloseReason } from "../src/modes/daemon/daemon-client.js";
+import {
+	createDaemonShutdownCommand,
+	DaemonClient,
+	getDaemonSocketCloseReason,
+} from "../src/modes/daemon/daemon-client.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import type { DaemonWorkerDescriptor } from "../src/modes/daemon/daemon-worker-protocol.js";
 
@@ -33,7 +37,8 @@ afterEach(async () => {
 		const client = new DaemonClient(socketPath);
 		try {
 			await client.connect(250);
-			await client.request({ type: "shutdown" }, 2000);
+			const hello = await client.waitForHello(1000).catch(() => undefined);
+			await client.request(createDaemonShutdownCommand(hello), 2000);
 		} catch {
 			// Already gone.
 		} finally {
@@ -68,6 +73,11 @@ afterEach(async () => {
 		rmSync(directory, { recursive: true, force: true });
 	}
 });
+
+/** Public shutdown command for the supervisor observed by this client's handshake. */
+function shutdownCommand(client: DaemonClient, force?: boolean): ReturnType<typeof createDaemonShutdownCommand> {
+	return createDaemonShutdownCommand(client.hello, force);
+}
 
 function tempDir(): string {
 	const directory = mkdtempSync(join(tmpdir(), "prime-daemon-supervisor-test-"));
@@ -394,7 +404,7 @@ describe("daemon supervisor resident workers", () => {
 		});
 		expect(countWorkerDescriptors(agentDir)).toBe(1);
 
-		await client.request({ type: "shutdown" });
+		await client.request(shutdownCommand(client));
 		client.close();
 		await waitForSocketGone(socketPath);
 	}, 60_000);
@@ -493,7 +503,7 @@ describe("daemon supervisor resident workers", () => {
 		);
 		expect((await readSessionInfo(sessionFile))?.state?.status).not.toBe("archived");
 
-		await client.request({ type: "shutdown" });
+		await client.request(shutdownCommand(client));
 		client.close();
 		await waitForSocketGone(socketPath);
 	}, 60_000);
@@ -541,7 +551,7 @@ describe("daemon supervisor resident workers", () => {
 			"Adopted client-owned worker descriptor was not removed",
 		);
 		const replacementClient = await connectEventually(socketPath);
-		await replacementClient.request({ type: "shutdown" });
+		await replacementClient.request(shutdownCommand(replacementClient));
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 	}, 60_000);
@@ -590,7 +600,7 @@ describe("daemon supervisor resident workers", () => {
 				deliveryStatus: "queued",
 			},
 		});
-		const shutdown = await client.request({ type: "shutdown" }, 10_000);
+		const shutdown = await client.request(shutdownCommand(client), 10_000);
 		expect(shutdown.success).toBe(true);
 		client.close();
 		await waitForSocketGone(socketPath);
@@ -644,7 +654,7 @@ describe("daemon supervisor resident workers", () => {
 		).toEqual([]);
 		expect((await readSessionInfo(sessionFile))?.state).toEqual({ status: "archived" });
 
-		await client.request({ type: "shutdown" });
+		await client.request(shutdownCommand(client));
 		client.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -694,7 +704,7 @@ describe("daemon supervisor resident workers", () => {
 			),
 		).toEqual([]);
 
-		await client.request({ type: "shutdown" });
+		await client.request(shutdownCommand(client));
 		client.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -721,7 +731,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(readSupervisorConfig(agentDir)).toMatchObject({
 			defaultSessionConfig: { sessionDir, noTools: true },
 		});
-		await replacementClient.request({ type: "shutdown" });
+		await replacementClient.request(shutdownCommand(replacementClient));
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -747,7 +757,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(listed.success).toBe(true);
 		expect(requireSessionList(listed.success ? listed.data : undefined)).toEqual([]);
 
-		await client.request({ type: "shutdown" });
+		await client.request(shutdownCommand(client));
 		client.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -797,7 +807,7 @@ describe("daemon supervisor resident workers", () => {
 		const observer = await connectEventually(socketPath, supervisor);
 		const observerClosed = new Promise<Error>((resolveClose) => observer.onClose(resolveClose));
 
-		expect((await client.request({ type: "shutdown" })).success).toBe(true);
+		expect((await client.request(shutdownCommand(client))).success).toBe(true);
 		client.close();
 		expect(getDaemonSocketCloseReason(await observerClosed)).toBe("shutdown");
 		observer.close();
@@ -817,7 +827,7 @@ describe("daemon supervisor resident workers", () => {
 				(session) => session.activeSessionId || session.workerPid,
 			),
 		).toEqual([]);
-		await replacementClient.request({ type: "shutdown" });
+		await replacementClient.request(shutdownCommand(replacementClient));
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 	}, 30_000);
@@ -881,7 +891,7 @@ describe("daemon supervisor resident workers", () => {
 			20_000,
 		);
 
-		await client.request({ type: "shutdown" });
+		await client.request(shutdownCommand(client));
 		client.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -958,7 +968,7 @@ describe("daemon supervisor resident workers", () => {
 		});
 		expect(attached.success).toBe(true);
 
-		await client.request({ type: "shutdown" });
+		await client.request(shutdownCommand(client));
 		client.close();
 		await waitForSocketGone(socketPath);
 		if (resumedSummary.workerPid) {
@@ -1045,7 +1055,7 @@ describe("daemon supervisor resident workers", () => {
 		expect((await readSessionInfo(sessionFile))?.state).toEqual({ status: "archived" });
 		expect(cronStore.list().find((job) => job.id === heartbeat.id)).toMatchObject({ status: "cancelled" });
 
-		await replacementClient.request({ type: "shutdown" });
+		await replacementClient.request(shutdownCommand(replacementClient));
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 	});
@@ -1108,7 +1118,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(
 			new Set(requireSessionList(adopted.success ? adopted.data : undefined).map((summary) => summary.workerPid)),
 		).toEqual(new Set(pids));
-		await replacementClient.request({ type: "shutdown" });
+		await replacementClient.request(shutdownCommand(replacementClient));
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 		await Promise.all(
@@ -1245,7 +1255,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(
 			new Set(requireSessionList(adopted.success ? adopted.data : undefined).map((summary) => summary.workerPid)),
 		).toEqual(new Set(pids));
-		await replacementClient.request({ type: "shutdown" });
+		await replacementClient.request(shutdownCommand(replacementClient));
 		replacementClient.close();
 		await waitForSocketGone(socketPath);
 		await Promise.all(
@@ -1431,7 +1441,7 @@ describe("daemon supervisor resident workers", () => {
 		await expect(connection.getState()).resolves.toMatchObject({ sessionId: createdSummary.sessionId });
 
 		await connection.dispose();
-		await client.request({ type: "shutdown" });
+		await client.request(shutdownCommand(client));
 		client.close();
 		await waitForSocketGone(socketPath);
 		await waitForProcessGone(recovered.workerPid);
@@ -1499,7 +1509,7 @@ describe("daemon supervisor resident workers", () => {
 		expect(store.list().find((candidate) => candidate.id === job.id)).toBeDefined();
 
 		const replacement = await connectEventually(socketPath);
-		await replacement.request({ type: "shutdown" });
+		await replacement.request(shutdownCommand(replacement));
 		replacement.close();
 		await waitForSocketGone(socketPath);
 		await waitForProcessGone(summary.workerPid);

--- a/packages/coding-agent/test/daemon-supervisor-shutdown-authority.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-shutdown-authority.test.ts
@@ -16,7 +16,12 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../src/config.js";
-import { createDaemonShutdownCommand, DaemonClient, type DaemonHello } from "../src/modes/daemon/daemon-client.js";
+import {
+	createDaemonRestartCommand,
+	createDaemonShutdownCommand,
+	DaemonClient,
+	type DaemonHello,
+} from "../src/modes/daemon/daemon-client.js";
 import type { DaemonCommand, DaemonShutdownAuthority } from "../src/modes/daemon/daemon-protocol.js";
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
@@ -185,6 +190,12 @@ function shutdownCommand(
 	return { ...command, authority: { ...command.authority, ...override } };
 }
 
+function restartCommand(hello: DaemonHello, override?: Partial<DaemonShutdownAuthority>): DaemonCommand {
+	const command = createDaemonRestartCommand(hello);
+	if (!override || !command.authority) return command;
+	return { ...command, authority: { ...command.authority, ...override } };
+}
+
 describe("supervisor shutdown authority", () => {
 	it("rejects a legacy shutdown without authority and keeps the same supervisor reachable", async () => {
 		const { child, socketPath } = spawnIsolatedSupervisor();
@@ -261,6 +272,31 @@ describe("supervisor shutdown authority", () => {
 			const listed = await client.request({ type: "list" }, 5000);
 			expect(listed.success, `expected supervisor reachable after mismatched ${name}`).toBe(true);
 		}
+
+		const accepted = await client.request(shutdownCommand(hello), 10_000);
+		expect(accepted.success).toBe(true);
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForExit(child);
+	});
+
+	it("rejects public restart without exact authority and leaves the supervisor reachable", async () => {
+		const { child, socketPath } = spawnIsolatedSupervisor();
+		const client = await connectEventually(socketPath, child);
+		const hello = client.hello;
+		if (!hello) throw new Error("Missing supervisor hello");
+
+		const missing = await client.request({ type: "restart" }, 5000);
+		expect(missing.success).toBe(false);
+		expect(missing.success ? undefined : missing.errorInfo?.code).toBe("shutdown_authority_rejected");
+
+		const mismatched = await client.request(
+			restartCommand(hello, { supervisorGeneration: "other-generation" }),
+			5000,
+		);
+		expect(mismatched.success).toBe(false);
+		expect(mismatched.success ? undefined : mismatched.errorInfo?.code).toBe("shutdown_authority_rejected");
+		expect((await client.request({ type: "list" }, 5000)).success).toBe(true);
 
 		const accepted = await client.request(shutdownCommand(hello), 10_000);
 		expect(accepted.success).toBe(true);

--- a/packages/coding-agent/test/daemon-supervisor-shutdown-authority.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-shutdown-authority.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Focused supervisor shutdown-authority regressions.
+ *
+ * Design: docs/superpowers/specs/2026-08-14-supervisor-shutdown-authority-design.md
+ *
+ * Spawns a real daemon supervisor per suite with an isolated socket,
+ * descriptor, agent, and supervisor-registry namespace, then exercises the
+ * public shutdown command contract: missing or mismatched authority is
+ * fail-closed and side-effect free, exact handshake identity terminates the
+ * supervisor, and force never bypasses authority.
+ */
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../src/config.js";
+import { createDaemonShutdownCommand, DaemonClient, type DaemonHello } from "../src/modes/daemon/daemon-client.js";
+import type { DaemonCommand, DaemonShutdownAuthority } from "../src/modes/daemon/daemon-protocol.js";
+
+const cliPath = resolve(__dirname, "../src/cli.ts");
+const tsxPath = resolve(__dirname, "../../../node_modules/tsx/dist/cli.mjs");
+const registryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+const tempDirs: string[] = [];
+const children = new Set<ChildProcess>();
+const daemonSockets = new Set<string>();
+const childDiagnostics = new WeakMap<ChildProcess, { stdout: string; stderr: string }>();
+
+afterEach(async () => {
+	for (const socketPath of daemonSockets) {
+		const client = new DaemonClient(socketPath);
+		try {
+			await client.connect(250);
+			const hello = await client.waitForHello(1000).catch(() => undefined);
+			await client.request(createDaemonShutdownCommand(hello), 2000);
+		} catch {
+			// Already gone.
+		} finally {
+			client.close();
+		}
+	}
+	daemonSockets.clear();
+	for (const child of children) {
+		if (child.exitCode === null && child.signalCode === null) {
+			child.kill("SIGTERM");
+		}
+	}
+	children.clear();
+	for (const directory of tempDirs.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function tempDir(): string {
+	const directory = mkdtempSync(join(tmpdir(), "prime-daemon-shutdown-authority-test-"));
+	tempDirs.push(directory);
+	return directory;
+}
+
+function spawnSupervisor(agentDir: string, socketPath: string, cwd: string, registryDir: string): ChildProcess {
+	daemonSockets.add(socketPath);
+	// Scrub inherited daemon worker/supervisor role vars so the spawned CLI
+	// starts in supervisor mode (not worker mode) and sends daemon_hello. A
+	// test running inside a Prime Agent daemon worker would otherwise spawn a
+	// worker-shaped process that listens but never greets.
+	const environment: NodeJS.ProcessEnv = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (key.startsWith("PRIME_AGENT_INTERNAL_")) {
+			continue;
+		}
+		if (value !== undefined) {
+			environment[key] = value;
+		}
+	}
+	environment[ENV_AGENT_DIR] = agentDir;
+	environment[registryDirEnv] = registryDir;
+	environment.PI_OFFLINE = "1";
+	environment.TSX_TSCONFIG_PATH = resolve(__dirname, "../../../tsconfig.json");
+	const child = spawn(
+		process.execPath,
+		[tsxPath, cliPath, "--mode", "daemon", "--daemon-socket", socketPath, "--offline"],
+		{
+			cwd,
+			env: environment,
+			stdio: ["ignore", "pipe", "pipe"],
+		},
+	);
+	children.add(child);
+	const diagnostics = { stdout: "", stderr: "" };
+	childDiagnostics.set(child, diagnostics);
+	child.stdout?.on("data", (chunk: Buffer) => {
+		diagnostics.stdout += chunk.toString("utf8");
+	});
+	child.stderr?.on("data", (chunk: Buffer) => {
+		diagnostics.stderr += chunk.toString("utf8");
+	});
+	return child;
+}
+
+async function connectEventually(socketPath: string, child?: ChildProcess): Promise<DaemonClient> {
+	const deadline = Date.now() + 20_000;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		if (child && (child.exitCode !== null || child.signalCode !== null)) {
+			const diagnostics = childDiagnostics.get(child);
+			throw new Error(
+				`Supervisor exited before becoming ready (code ${child.exitCode}, signal ${child.signalCode})\n` +
+					`stdout:\n${diagnostics?.stdout ?? ""}\nstderr:\n${diagnostics?.stderr ?? ""}`,
+			);
+		}
+		const client = new DaemonClient(socketPath);
+		try {
+			await client.connect(250);
+			await client.waitForHello(1000);
+			return client;
+		} catch (error) {
+			lastError = error;
+			client.close();
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+		}
+	}
+	throw new Error(`Timed out waiting for supervisor: ${String(lastError)}`);
+}
+
+async function waitForSocketGone(socketPath: string): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	while (Date.now() < deadline) {
+		const client = new DaemonClient(socketPath);
+		try {
+			await client.connect(100);
+		} catch {
+			client.close();
+			return;
+		}
+		client.close();
+		await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+	}
+	throw new Error("Daemon supervisor socket remained available after shutdown");
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return;
+	}
+	await new Promise<void>((resolveExit, reject) => {
+		const timeout = setTimeout(() => reject(new Error("Timed out waiting for process exit")), 10_000);
+		child.once("exit", () => {
+			clearTimeout(timeout);
+			resolveExit();
+		});
+	});
+}
+
+interface SpawnedSupervisor {
+	child: ChildProcess;
+	socketPath: string;
+	registryDir: string;
+	agentDir: string;
+	projectDir: string;
+}
+
+function spawnIsolatedSupervisor(): SpawnedSupervisor {
+	const root = tempDir();
+	const agentDir = join(root, "agent");
+	const projectDir = join(root, "project");
+	const registryDir = join(root, "registry");
+	const socketPath = join(root, `d-${randomUUID().slice(0, 8)}.sock`);
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(projectDir, { recursive: true });
+	mkdirSync(registryDir, { recursive: true });
+	const child = spawnSupervisor(agentDir, socketPath, projectDir, registryDir);
+	return { child, socketPath, registryDir, agentDir, projectDir };
+}
+
+function shutdownCommand(
+	hello: DaemonHello | undefined,
+	force?: boolean,
+	override?: Partial<DaemonShutdownAuthority>,
+): DaemonCommand {
+	const command = createDaemonShutdownCommand(hello, force);
+	if (!override || !command.authority) {
+		return command;
+	}
+	return { ...command, authority: { ...command.authority, ...override } };
+}
+
+describe("supervisor shutdown authority", () => {
+	it("rejects a legacy shutdown without authority and keeps the same supervisor reachable", async () => {
+		const { child, socketPath } = spawnIsolatedSupervisor();
+		const client = await connectEventually(socketPath, child);
+
+		const rejected = await client.request({ type: "shutdown" }, 5000);
+		expect(rejected.success).toBe(false);
+		expect(rejected.success ? undefined : rejected.errorInfo?.code).toBe("shutdown_authority_rejected");
+
+		// The same supervisor identity remains reachable and answers commands.
+		const listed = await client.request({ type: "list" }, 5000);
+		expect(listed.success).toBe(true);
+		expect(client.hello?.supervisorGeneration).toBeTypeOf("string");
+
+		// A proper shutdown still terminates it for cleanup.
+		const accepted = await client.request(shutdownCommand(client.hello), 10_000);
+		expect(accepted.success).toBe(true);
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForExit(child);
+	});
+
+	it("accepts a shutdown echoing the exact handshake identity and terminates that supervisor", async () => {
+		const { child, socketPath } = spawnIsolatedSupervisor();
+		const client = await connectEventually(socketPath, child);
+		const hello = client.hello;
+		expect(hello?.supervisorGeneration).toBeTypeOf("string");
+		expect(hello?.supervisorOwnerToken).toBeTypeOf("string");
+		expect(hello?.supervisorPid).toBeGreaterThan(0);
+		expect(hello?.supervisorSocketPath).toBeTypeOf("string");
+
+		const response = await client.request(shutdownCommand(hello), 10_000);
+		expect(response.success).toBe(true);
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForExit(child);
+	});
+
+	it("rejects each mismatched identity component independently without shutdown", async () => {
+		const { child, socketPath } = spawnIsolatedSupervisor();
+		const client = await connectEventually(socketPath, child);
+		const hello = client.hello;
+		if (!hello) throw new Error("Missing supervisor hello");
+
+		const otherSocketPath = `${hello.supervisorSocketPath}.other`;
+		const mismatches: Array<{ name: string; command: DaemonCommand }> = [
+			{
+				name: "generation",
+				command: shutdownCommand(hello, false, { supervisorGeneration: "other-generation" }),
+			},
+			{
+				name: "owner token",
+				command: shutdownCommand(hello, false, { supervisorOwnerToken: "other-token" }),
+			},
+			{
+				name: "pid",
+				command: shutdownCommand(hello, false, { supervisorPid: (hello.supervisorPid ?? 0) + 1 }),
+			},
+			{
+				name: "process start",
+				command: shutdownCommand(hello, false, { supervisorProcessStartId: "other-start-id" }),
+			},
+			{
+				name: "socket path",
+				command: shutdownCommand(hello, false, { supervisorSocketPath: otherSocketPath }),
+			},
+		];
+
+		for (const { name, command } of mismatches) {
+			const rejected = await client.request(command, 5000);
+			expect(rejected.success, `expected rejection for mismatched ${name}`).toBe(false);
+			expect(rejected.success ? undefined : rejected.errorInfo?.code).toBe("shutdown_authority_rejected");
+			// Fail-closed and side-effect free: the same supervisor still answers.
+			const listed = await client.request({ type: "list" }, 5000);
+			expect(listed.success, `expected supervisor reachable after mismatched ${name}`).toBe(true);
+		}
+
+		const accepted = await client.request(shutdownCommand(hello), 10_000);
+		expect(accepted.success).toBe(true);
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForExit(child);
+	});
+
+	it("never lets force bypass missing or mismatched authority", async () => {
+		const { child, socketPath } = spawnIsolatedSupervisor();
+		const client = await connectEventually(socketPath, child);
+		const hello = client.hello;
+		if (!hello) throw new Error("Missing supervisor hello");
+
+		const missing = await client.request({ type: "shutdown", force: true }, 5000);
+		expect(missing.success).toBe(false);
+		expect(missing.success ? undefined : missing.errorInfo?.code).toBe("shutdown_authority_rejected");
+
+		const mismatched = await client.request(
+			shutdownCommand(hello, true, { supervisorOwnerToken: "other-token" }),
+			5000,
+		);
+		expect(mismatched.success).toBe(false);
+		expect(mismatched.success ? undefined : mismatched.errorInfo?.code).toBe("shutdown_authority_rejected");
+
+		const listed = await client.request({ type: "list" }, 5000);
+		expect(listed.success).toBe(true);
+
+		const accepted = await client.request(shutdownCommand(hello, true), 10_000);
+		expect(accepted.success).toBe(true);
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForExit(child);
+	});
+});

--- a/packages/coding-agent/test/session-manager/interrupted-tool-results.test.ts
+++ b/packages/coding-agent/test/session-manager/interrupted-tool-results.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -361,6 +361,44 @@ describe("SessionManager exact-authority recovery", () => {
 			.join(" ");
 		expect(text).toContain("whether the tool executed");
 		expect(text).toContain("Inspect external side effects");
+	});
+
+	it("accepts canonical authority for a session opened through a symlink alias", () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-interrupted-tool-symlink-"));
+		roots.push(root);
+		const realProject = join(root, "real-project");
+		const realSessions = join(root, "real-sessions");
+		const linkedSessions = join(root, "linked-sessions");
+		mkdirSync(realProject, { recursive: true });
+		mkdirSync(realSessions, { recursive: true });
+		symlinkSync(realSessions, linkedSessions, "dir");
+		const session = SessionManager.create(realProject, linkedSessions);
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const aliasedSessionFile = session.getSessionFile();
+		if (!aliasedSessionFile) throw new Error("Fixture session did not persist");
+		const authority = { ...buildAuthority(session), sessionFile: realpathSync(aliasedSessionFile) };
+
+		expect(session.closeUnresolvedToolCallsWithAuthority(authority)).toEqual({ status: "applied", closed: 1 });
+		expect(toolResultEntries(session)).toHaveLength(1);
+	});
+
+	it("returns stale for a genuinely different canonical session file", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+
+		expectStaleWithoutWrite(
+			session.closeUnresolvedToolCallsWithAuthority({
+				...buildAuthority(session),
+				sessionFile: join(dirname(sessionFile), "different.jsonl"),
+			}),
+			before,
+			sessionFile,
+		);
 	});
 
 	it("tags each synthetic result with operationId and assistantEntryId metadata", () => {

--- a/packages/coding-agent/test/session-manager/interrupted-tool-results.test.ts
+++ b/packages/coding-agent/test/session-manager/interrupted-tool-results.test.ts
@@ -1,0 +1,216 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionManager, type SessionMessageEntry } from "../../src/core/session-manager.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+function createSession(): SessionManager {
+	const root = mkdtempSync(join(tmpdir(), "prime-interrupted-tool-results-"));
+	roots.push(root);
+	return SessionManager.create(join(root, "project"), join(root, "sessions"));
+}
+
+function toolCall(id: string, name: string): AssistantMessage["content"][number] {
+	return { type: "toolCall", id, name, arguments: {} };
+}
+
+function assistantTurn(...calls: ReturnType<typeof toolCall>[]): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "calling tools" }, ...calls],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
+}
+
+function toolResult(callId: string, name: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: callId,
+		toolName: name,
+		content: [{ type: "text", text: "ok" }],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+function toolResultEntries(session: SessionManager): SessionMessageEntry[] {
+	return session
+		.getBranch()
+		.filter((entry): entry is SessionMessageEntry => entry.type === "message" && entry.message.role === "toolResult");
+}
+
+describe("SessionManager interrupted tool-call recovery", () => {
+	it("closes every unresolved tool call in the latest assistant turn with an isError toolResult", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash"), toolCall("edit-1", "edit")));
+
+		const closed = session.closeUnresolvedToolCalls();
+
+		expect(closed).toBe(2);
+		const results = toolResultEntries(session);
+		expect(results).toHaveLength(2);
+		expect(results[0]!.message).toMatchObject({
+			role: "toolResult",
+			toolCallId: "bash-1",
+			toolName: "bash",
+			isError: true,
+		});
+		expect(results[1]!.message).toMatchObject({
+			role: "toolResult",
+			toolCallId: "edit-1",
+			toolName: "edit",
+			isError: true,
+		});
+		const text = results
+			.map((entry) => ((entry.message as ToolResultMessage).content[0] as { text: string }).text)
+			.join(" ");
+		expect(text).toContain("whether the tool executed");
+		expect(text).toContain("its result, and any external side effects are unknown");
+		expect(text).toContain("was not replayed by recovery");
+		expect(text).toContain("Inspect external side effects before retrying");
+	});
+
+	it("persists rollback-capable appends and returns no-op on repeat invocation", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+
+		const first = session.closeUnresolvedToolCalls();
+		expect(first).toBe(1);
+
+		const reopened = SessionManager.open(sessionFile);
+		expect(toolResultEntries(reopened)).toHaveLength(1);
+		expect(reopened.closeUnresolvedToolCalls()).toBe(0);
+		expect(toolResultEntries(reopened)).toHaveLength(1);
+	});
+
+	it("resumes after a later synthetic-result append fails", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash"), toolCall("edit-1", "edit")));
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const append = session.appendMessageWithRollback.bind(session);
+		let attempts = 0;
+		const spy = vi.spyOn(session, "appendMessageWithRollback").mockImplementation((message) => {
+			attempts++;
+			if (attempts === 2) throw new Error("disk full");
+			return append(message);
+		});
+
+		expect(() => session.closeUnresolvedToolCalls()).toThrow("disk full");
+		spy.mockRestore();
+		const partiallyRecovered = SessionManager.open(sessionFile);
+		expect(toolResultEntries(partiallyRecovered)).toHaveLength(1);
+		expect(partiallyRecovered.closeUnresolvedToolCalls()).toBe(1);
+		expect(toolResultEntries(SessionManager.open(sessionFile))).toHaveLength(2);
+	});
+
+	it("leaves already-resolved tool calls untouched", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		session.appendMessage(toolResult("bash-1", "bash"));
+
+		expect(session.closeUnresolvedToolCalls()).toBe(0);
+		expect(toolResultEntries(session)).toHaveLength(1);
+	});
+
+	it("closes only the unresolved subset of a partially resolved turn", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash"), toolCall("edit-1", "edit")));
+		session.appendMessage(toolResult("bash-1", "bash"));
+
+		const closed = session.closeUnresolvedToolCalls();
+
+		expect(closed).toBe(1);
+		const results = toolResultEntries(session);
+		expect(results).toHaveLength(2);
+		expect(results[1]!.message).toMatchObject({ toolCallId: "edit-1", toolName: "edit", isError: true });
+	});
+
+	it("is a no-op when the active branch has no open tool calls", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "plain", timestamp: Date.now() });
+		session.appendMessage(assistantTurn());
+
+		expect(session.closeUnresolvedToolCalls()).toBe(0);
+		expect(session.getBranch()).toHaveLength(2);
+	});
+
+	it("ignores unresolved tool calls on an inactive sibling branch", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		const toolTurnId = session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		session.branch(session.getBranch()[0]!.id);
+		session.appendMessage({ role: "user", content: "different path", timestamp: Date.now() });
+
+		expect(session.closeUnresolvedToolCalls()).toBe(0);
+		expect(toolResultEntries(session)).toHaveLength(0);
+		const onSibling = session.getEntry(toolTurnId);
+		expect(onSibling).toBeDefined();
+	});
+
+	it("does not reach back to an older dangling tool call when a later plain assistant turn exists", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("older-1", "bash")));
+		session.appendMessage(assistantTurn());
+
+		expect(session.closeUnresolvedToolCalls()).toBe(0);
+		expect(toolResultEntries(session)).toHaveLength(0);
+	});
+
+	it("skips malformed later assistant content instead of reaching back to an older turn", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("older-1", "bash")));
+		session.appendMessage(
+			assistantTurn(
+				null as unknown as AssistantMessage["content"][number],
+				{ type: "toolCall", id: "malformed-1", arguments: {} } as unknown as AssistantMessage["content"][number],
+				{ type: "toolCall", name: "edit" } as unknown as AssistantMessage["content"][number],
+			),
+		);
+
+		expect(session.closeUnresolvedToolCalls()).toBe(0);
+		expect(toolResultEntries(session)).toHaveLength(0);
+	});
+
+	it("does not close calls when the latest assistant message is not a toolUse turn", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage({
+			...assistantTurn(toolCall("bash-1", "bash")),
+			stopReason: "stop",
+		});
+
+		expect(session.closeUnresolvedToolCalls()).toBe(0);
+		expect(toolResultEntries(session)).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/session-manager/interrupted-tool-results.test.ts
+++ b/packages/coding-agent/test/session-manager/interrupted-tool-results.test.ts
@@ -278,6 +278,28 @@ describe("SessionManager exact-authority recovery", () => {
 		expect(snapshot.lineageDigest).toMatch(/^[0-9a-f]{64}$/);
 	});
 
+	it("captures only the unresolved subset at the authorized head", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash"), toolCall("edit-1", "edit")));
+		session.appendMessage(toolResult("bash-1", "bash"));
+
+		const snapshot = session.captureExactRecoveryAuthority("active-1", "op-1");
+
+		expect(snapshot.toolCalls).toEqual([{ id: "edit-1", name: "edit" }]);
+		const result = session.closeUnresolvedToolCallsWithAuthority({
+			...snapshot,
+			activeSessionId: "active-1",
+			operationId: "op-1",
+			sessionFile: session.getSessionFile()!,
+		});
+		expect(result).toEqual({ status: "applied", closed: 1 });
+		expect(toolResultEntries(session).map((entry) => (entry.message as ToolResultMessage).toolCallId)).toEqual([
+			"bash-1",
+			"edit-1",
+		]);
+	});
+
 	it("produces a deterministic lineageDigest for the same branch", () => {
 		const session = createSession();
 		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
@@ -405,6 +427,23 @@ describe("SessionManager exact-authority recovery", () => {
 		expectStaleWithoutWrite(result, before, sessionFile);
 	});
 
+	it("requires the authorized assistant to be the latest assistant on the recorded lineage", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		const olderAssistantId = session.appendMessage(assistantTurn(toolCall("older-1", "bash")));
+		session.appendMessage(assistantTurn(toolCall("latest-1", "edit")));
+		const sessionFile = session.getSessionFile()!;
+		const before = readFileSync(sessionFile).length;
+
+		const result = session.closeUnresolvedToolCallsWithAuthority({
+			...buildAuthority(session),
+			assistantEntryId: olderAssistantId,
+			toolCalls: [{ id: "older-1", name: "bash" }],
+		});
+
+		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
 	it("returns stale for a lineageDigest mismatch without writing", () => {
 		const session = createSession();
 		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
@@ -482,6 +521,48 @@ describe("SessionManager exact-authority recovery", () => {
 		const result = session.closeUnresolvedToolCallsWithAuthority(authority);
 
 		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
+	it("rejects reordered or duplicate operation-owned suffix results", () => {
+		for (const suffixKind of ["reordered", "duplicate"] as const) {
+			const session = createSession();
+			session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+			const assistantId = session.appendMessage(
+				assistantTurn(toolCall("bash-1", "bash"), toolCall("edit-1", "edit")),
+			);
+			const authority = buildAuthority(session, "op-1");
+			if (suffixKind === "reordered") {
+				session.appendMessage(syntheticResult("edit-1", "edit", "op-1", assistantId));
+			} else {
+				session.appendMessage(syntheticResult("bash-1", "bash", "op-1", assistantId));
+				session.appendMessage(syntheticResult("bash-1", "bash", "op-1", assistantId));
+			}
+			const sessionFile = session.getSessionFile()!;
+			const before = readFileSync(sessionFile).length;
+
+			expectStaleWithoutWrite(session.closeUnresolvedToolCallsWithAuthority(authority), before, sessionFile);
+		}
+	});
+
+	it("rejects a suffix result with foreign assistant metadata or result shape", () => {
+		for (const foreign of ["assistant", "shape"] as const) {
+			const session = createSession();
+			session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+			const assistantId = session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+			const authority = buildAuthority(session, "op-1");
+			const result = syntheticResult(
+				"bash-1",
+				"bash",
+				"op-1",
+				foreign === "assistant" ? "other-assistant" : assistantId,
+			);
+			if (foreign === "shape") result.isError = false;
+			session.appendMessage(result);
+			const sessionFile = session.getSessionFile()!;
+			const before = readFileSync(sessionFile).length;
+
+			expectStaleWithoutWrite(session.closeUnresolvedToolCallsWithAuthority(authority), before, sessionFile);
+		}
 	});
 
 	it("resumes an operation-owned partial suffix without duplicating existing synthetic results", () => {

--- a/packages/coding-agent/test/session-manager/interrupted-tool-results.test.ts
+++ b/packages/coding-agent/test/session-manager/interrupted-tool-results.test.ts
@@ -1,9 +1,15 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SessionManager, type SessionMessageEntry } from "../../src/core/session-manager.js";
+import {
+	type ExactRecoveryAuthority,
+	type ExactRecoverySnapshot,
+	type ExactRecoveryStatus,
+	SessionManager,
+	type SessionMessageEntry,
+} from "../../src/core/session-manager.js";
 
 const roots: string[] = [];
 
@@ -212,5 +218,338 @@ describe("SessionManager interrupted tool-call recovery", () => {
 
 		expect(session.closeUnresolvedToolCalls()).toBe(0);
 		expect(toolResultEntries(session)).toHaveLength(0);
+	});
+});
+
+function buildAuthority(
+	session: SessionManager,
+	operationId: string = "op-1",
+	activeSessionId: string = "active-1",
+): ExactRecoveryAuthority {
+	const snapshot = session.captureExactRecoveryAuthority(activeSessionId, operationId);
+	const sessionFile = session.getSessionFile();
+	if (!sessionFile) throw new Error("Fixture session did not persist");
+	return {
+		sessionId: snapshot.sessionId,
+		headEntryId: snapshot.headEntryId,
+		assistantEntryId: snapshot.assistantEntryId,
+		toolCalls: snapshot.toolCalls,
+		lineageDigest: snapshot.lineageDigest,
+		operationId,
+		activeSessionId,
+		sessionFile,
+	};
+}
+
+function syntheticResult(
+	toolCallId: string,
+	toolName: string,
+	operationId: string,
+	assistantEntryId: string | null,
+): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text: "interrupted" }],
+		isError: true,
+		timestamp: Date.now(),
+		details: { recovery: { operationId, assistantEntryId } },
+	};
+}
+
+function expectStaleWithoutWrite(result: ExactRecoveryStatus, before: number, sessionFile: string): void {
+	expect(result.status).toBe("stale");
+	expect(readFileSync(sessionFile).length).toBe(before);
+}
+
+describe("SessionManager exact-authority recovery", () => {
+	it("captures an exact authority from one active-branch view", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		const assistantId = session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+
+		const snapshot: ExactRecoverySnapshot = session.captureExactRecoveryAuthority("active-9", "op-7");
+
+		expect(snapshot.sessionId).toBe(session.getSessionId());
+		expect(snapshot.headEntryId).toBe(assistantId);
+		expect(snapshot.assistantEntryId).toBe(assistantId);
+		expect(snapshot.toolCalls).toEqual([{ id: "bash-1", name: "bash" }]);
+		expect(snapshot.lineageDigest).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("produces a deterministic lineageDigest for the same branch", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+
+		const first = session.captureExactRecoveryAuthority("active-1", "op-1");
+		const second = session.captureExactRecoveryAuthority("active-1", "op-1");
+
+		expect(first.lineageDigest).toBe(second.lineageDigest);
+		// Capture ignores the operationId argument: the snapshot is branch-derived only.
+		const third = session.captureExactRecoveryAuthority("active-1", "op-DIFFERENT");
+		expect(third.lineageDigest).toBe(first.lineageDigest);
+		expect(third.sessionId).toBe(first.sessionId);
+		expect(third.headEntryId).toBe(first.headEntryId);
+		expect(third.assistantEntryId).toBe(first.assistantEntryId);
+		expect(third.toolCalls).toEqual(first.toolCalls);
+	});
+
+	it("changes the lineageDigest when the branch advances", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+
+		const before = session.captureExactRecoveryAuthority("active-1", "op-1");
+		session.appendMessage({ role: "user", content: "second turn", timestamp: Date.now() });
+		const after = session.captureExactRecoveryAuthority("active-1", "op-1");
+
+		expect(after.lineageDigest).not.toBe(before.lineageDigest);
+		expect(after.headEntryId).not.toBe(before.headEntryId);
+	});
+
+	it("closes every journaled tool call when the authority matches", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash"), toolCall("edit-1", "edit")));
+
+		const result = session.closeUnresolvedToolCallsWithAuthority(buildAuthority(session));
+
+		expect(result.status).toBe("applied");
+		if (result.status === "applied") {
+			expect(result.closed).toBe(2);
+		}
+		const results = toolResultEntries(session);
+		expect(results).toHaveLength(2);
+		expect(results[0]!.message).toMatchObject({
+			role: "toolResult",
+			toolCallId: "bash-1",
+			toolName: "bash",
+			isError: true,
+		});
+		expect(results[1]!.message).toMatchObject({
+			role: "toolResult",
+			toolCallId: "edit-1",
+			toolName: "edit",
+			isError: true,
+		});
+		const text = results
+			.map((entry) => ((entry.message as ToolResultMessage).content[0] as { text: string }).text)
+			.join(" ");
+		expect(text).toContain("whether the tool executed");
+		expect(text).toContain("Inspect external side effects");
+	});
+
+	it("tags each synthetic result with operationId and assistantEntryId metadata", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		const assistantId = session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+
+		const result = session.closeUnresolvedToolCallsWithAuthority(buildAuthority(session, "op-42"));
+
+		expect(result.status).toBe("applied");
+		const results = toolResultEntries(session);
+		expect(results).toHaveLength(1);
+		const details = (results[0]!.message as ToolResultMessage).details as
+			| { recovery?: { operationId?: string; assistantEntryId?: string | null } }
+			| undefined;
+		expect(details?.recovery?.operationId).toBe("op-42");
+		expect(details?.recovery?.assistantEntryId).toBe(assistantId);
+	});
+
+	it("returns stale for a generation mismatch without writing", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+
+		const result = session.closeUnresolvedToolCallsWithAuthority({
+			...buildAuthority(session),
+			sessionId: "different-generation",
+		});
+
+		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
+	it("returns stale for a head mismatch without writing", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const authority = buildAuthority(session);
+		session.appendMessage({ role: "user", content: "second turn", timestamp: Date.now() });
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+
+		const result = session.closeUnresolvedToolCallsWithAuthority(authority);
+
+		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
+	it("returns stale for an assistantEntryId mismatch without writing", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+
+		const result = session.closeUnresolvedToolCallsWithAuthority({
+			...buildAuthority(session),
+			assistantEntryId: "missing-assistant-id",
+		});
+
+		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
+	it("returns stale for a lineageDigest mismatch without writing", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+
+		const result = session.closeUnresolvedToolCallsWithAuthority({
+			...buildAuthority(session),
+			lineageDigest: "f".repeat(64),
+		});
+
+		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
+	it("returns stale for a toolCalls mismatch without writing", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+
+		const result = session.closeUnresolvedToolCallsWithAuthority({
+			...buildAuthority(session),
+			toolCalls: [{ id: "wrong-1", name: "bash" }],
+		});
+
+		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
+	it("returns stale when the active branch is not the captured branch", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const authority = buildAuthority(session);
+		const userEntry = session.getBranch()[0]!;
+		session.branch(userEntry.id);
+		session.appendMessage({ role: "user", content: "different path", timestamp: Date.now() });
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+
+		const result = session.closeUnresolvedToolCallsWithAuthority(authority);
+
+		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
+	it("returns stale when a non-recovery entry appears after the assistant entry", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const authority = buildAuthority(session);
+		session.appendMessage({ role: "user", content: "newer user turn", timestamp: Date.now() });
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+
+		const result = session.closeUnresolvedToolCallsWithAuthority(authority);
+
+		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
+	it("returns stale when a foreign synthetic result appears after the assistant entry", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		const assistantId = session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const authority = buildAuthority(session, "op-1");
+		session.appendMessage(syntheticResult("bash-1", "bash", "op-OTHER", assistantId));
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+
+		const result = session.closeUnresolvedToolCallsWithAuthority(authority);
+
+		expectStaleWithoutWrite(result, before, sessionFile);
+	});
+
+	it("resumes an operation-owned partial suffix without duplicating existing synthetic results", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		const assistantId = session.appendMessage(assistantTurn(toolCall("bash-1", "bash"), toolCall("edit-1", "edit")));
+		const authority = buildAuthority(session, "op-99");
+		session.appendMessage(syntheticResult("bash-1", "bash", "op-99", assistantId));
+
+		const result = session.closeUnresolvedToolCallsWithAuthority(authority);
+
+		expect(result.status).toBe("applied");
+		if (result.status === "applied") {
+			expect(result.closed).toBe(1);
+		}
+		const results = toolResultEntries(session);
+		expect(results).toHaveLength(2);
+		expect(results.map((entry) => (entry.message as ToolResultMessage).toolCallId)).toEqual(["bash-1", "edit-1"]);
+	});
+
+	it("returns already_applied when every journaled tool call is already in the suffix", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(assistantTurn(toolCall("bash-1", "bash")));
+		const authority = buildAuthority(session);
+
+		const first = session.closeUnresolvedToolCallsWithAuthority(authority);
+		const second = session.closeUnresolvedToolCallsWithAuthority(authority);
+
+		expect(first.status).toBe("applied");
+		expect(second.status).toBe("already_applied");
+		expect(toolResultEntries(session)).toHaveLength(1);
+	});
+
+	it("closes the journaled tool call even when the assistant stopReason is not 'toolUse'", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage({
+			...assistantTurn(toolCall("bash-1", "bash")),
+			stopReason: "stop",
+		});
+
+		const result = session.closeUnresolvedToolCallsWithAuthority(buildAuthority(session));
+
+		expect(result.status).toBe("applied");
+		if (result.status === "applied") {
+			expect(result.closed).toBe(1);
+		}
+	});
+
+	it("only appends the journaled tool call IDs, never extras from the assistant content", () => {
+		const session = createSession();
+		session.appendMessage({ role: "user", content: "run tools", timestamp: Date.now() });
+		session.appendMessage(
+			assistantTurn(toolCall("bash-1", "bash"), toolCall("edit-1", "edit"), toolCall("read-1", "read")),
+		);
+
+		const base = buildAuthority(session);
+		const authority: ExactRecoveryAuthority = {
+			...base,
+			toolCalls: [{ id: "bash-1", name: "bash" }],
+		};
+		const result = session.closeUnresolvedToolCallsWithAuthority(authority);
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Fixture session did not persist");
+		const before = readFileSync(sessionFile).length;
+		// Mismatched declaration → no writes.
+		expectStaleWithoutWrite(result, before, sessionFile);
 	});
 });

--- a/packages/coding-agent/test/suite/daemon-serialized-refine-process.test.ts
+++ b/packages/coding-agent/test/suite/daemon-serialized-refine-process.test.ts
@@ -33,7 +33,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../../src/config.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../src/core/orphan-process-journal.js";
 import { SESSION_LEASE_OWNER_ID_ENV, SESSION_LEASES_ENABLED_ENV } from "../../src/core/session-lease.js";
-import { DaemonClient } from "../../src/modes/daemon/daemon-client.js";
+import { createDaemonShutdownCommand, DaemonClient } from "../../src/modes/daemon/daemon-client.js";
 import {
 	DAEMON_WORKER_ACTIVE_SESSION_ID_ENV,
 	DAEMON_WORKER_RECOVERY_JOURNAL_ENV,
@@ -62,7 +62,8 @@ afterEach(async () => {
 		const client = new DaemonClient(socketPath);
 		try {
 			await client.connect(500);
-			await client.request({ type: "shutdown" }, 5000);
+			const hello = await client.waitForHello(1500).catch(() => undefined);
+			await client.request(createDaemonShutdownCommand(hello), 5000);
 		} catch {
 			// The process may have exited before publishing its socket.
 		} finally {

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -16,7 +16,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR, getCronJobsPath } from "../../../src/config.js";
 import { getProcessStartId } from "../../../src/core/session-lease.js";
 import { DaemonAgentConnection } from "../../../src/modes/agent-connection/daemon-agent-connection.js";
-import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
+import { createDaemonShutdownCommand, DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
 import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-list.js";
 import {
 	acquireDaemonSupervisorOwnership,
@@ -510,7 +510,7 @@ async function cleanupRegisteredProcesses(existingClient?: DaemonClient): Promis
 async function forceShutdownReachableSupervisor(socketPath: string, existingClient?: DaemonClient): Promise<void> {
 	if (existingClient?.isConnected) {
 		try {
-			await existingClient.request({ type: "shutdown", force: true }, 5000);
+			await existingClient.request(createDaemonShutdownCommand(existingClient.hello, true), 5000);
 			return;
 		} catch {
 			// Retry through a fresh connection before exact-identity process cleanup.
@@ -520,7 +520,7 @@ async function forceShutdownReachableSupervisor(socketPath: string, existingClie
 	try {
 		await cleanupClient.connect(1000);
 		await cleanupClient.waitForHello(2000);
-		await cleanupClient.request({ type: "shutdown", force: true }, 5000);
+		await cleanupClient.request(createDaemonShutdownCommand(cleanupClient.hello, true), 5000);
 	} catch {
 		// The exact-identity fallback handles an unreachable supervisor.
 	} finally {
@@ -554,7 +554,7 @@ async function stopSupervisor(handle: FixtureHandle, socketPath: string): Promis
 	try {
 		await client.connect(1000);
 		await client.waitForHello(2000);
-		await client.request({ type: "shutdown" }, 5000);
+		await client.request(createDaemonShutdownCommand(client.hello), 5000);
 	} finally {
 		client.close();
 	}
@@ -726,7 +726,7 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 			);
 			await connection.dispose();
 			connection = undefined;
-			await client.request({ type: "shutdown", force: true }, 10_000);
+			await client.request(createDaemonShutdownCommand(client.hello, true), 10_000);
 			client.close();
 			await waitForExit(legacyCleanup);
 			await waitForCleanupProcessExit(workerCleanupIdentity);

--- a/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4600-supervisor-singleton.test.ts
@@ -669,7 +669,7 @@ describe("ENG-4600 daemon supervisor ownership", () => {
 			const originalState = await connection.getState();
 			const reconnecting = waitForConnectionStatus(connection, "reconnecting");
 			const reconnected = waitForConnectionStatus(connection, "connected", 60_000);
-			const restarted = await client.request({ type: "restart" }, 10_000);
+			const restarted = await client.requestSupervisorRestart(10_000);
 			expect(restarted.success).toBe(true);
 			await reconnecting;
 			await waitForExit(predecessor);

--- a/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
@@ -16,7 +16,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { APP_NAME, ENV_AGENT_DIR } from "../../../src/config.js";
 import { getProcessStartId } from "../../../src/core/session-lease.js";
 import { DaemonAgentConnection } from "../../../src/modes/agent-connection/daemon-agent-connection.js";
-import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
+import { createDaemonShutdownCommand, DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
 import type { DaemonResponse } from "../../../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-list.js";
 import {
@@ -809,7 +809,7 @@ describe("ENG-4603 worker recovery convergence", () => {
 			}),
 		);
 		await connection.dispose();
-		await successorClient.request({ type: "shutdown", force: true }, 10_000);
+		await successorClient.request(createDaemonShutdownCommand(successorClient.hello, true), 10_000);
 		successorClient.close();
 		predecessorClient.close();
 		await waitForExit(successor);

--- a/packages/coding-agent/test/suite/regressions/4606-update-restart-coordinator.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4606-update-restart-coordinator.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../src/cli/daemon-update-restart.js";
 import { ENV_AGENT_DIR } from "../../../src/config.js";
 import { DaemonAgentConnection } from "../../../src/modes/agent-connection/daemon-agent-connection.js";
-import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
+import { createDaemonShutdownCommand, DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
 import type { DaemonResponse } from "../../../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-list.js";
 import { createHarness, type Harness } from "../harness.js";
@@ -231,7 +231,7 @@ async function stopDaemon(socketPath: string): Promise<void> {
 	try {
 		await client.connect(500);
 		await client.waitForHello(2000);
-		await client.request({ type: "shutdown", force: true }, 5000).catch(() => undefined);
+		await client.request(createDaemonShutdownCommand(client.hello, true), 5000).catch(() => undefined);
 	} catch {
 		return;
 	} finally {

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -8,7 +8,7 @@ import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../../
 import { ENV_AGENT_DIR } from "../../../src/config.js";
 import type { AutonomousRuntimeState } from "../../../src/core/autonomous.js";
 import type { DaemonSocketClient } from "../../../src/modes/daemon/active-session-state.js";
-import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
+import { createDaemonShutdownCommand, DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
 import { DaemonSupervisor } from "../../../src/modes/daemon/daemon-supervisor.js";
 import { waitForHeadlessCompletion } from "../../../src/modes/headless-completion.js";
 import { RpcClient } from "../../../src/modes/rpc/rpc-client.js";
@@ -40,7 +40,8 @@ afterEach(async () => {
 		const client = new DaemonClient(socketPath);
 		try {
 			await client.connect(500);
-			await client.request({ type: "shutdown" }, 5000);
+			const hello = await client.waitForHello(1500).catch(() => undefined);
+			await client.request(createDaemonShutdownCommand(hello), 5000);
 		} catch {
 			// The process may have exited before publishing its socket.
 		} finally {

--- a/packages/coding-agent/test/suite/regressions/6565-shutdown-authority.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6565-shutdown-authority.test.ts
@@ -10,7 +10,11 @@ import {
 	DaemonClient,
 	type DaemonHello,
 } from "../../../src/modes/daemon/daemon-client.js";
-import type { DaemonShutdownAuthority, DaemonShutdownCommand } from "../../../src/modes/daemon/daemon-protocol.js";
+import type {
+	DaemonRestartCommand,
+	DaemonShutdownAuthority,
+	DaemonShutdownCommand,
+} from "../../../src/modes/daemon/daemon-protocol.js";
 import { createHarness, type Harness } from "../harness.js";
 
 /**
@@ -83,8 +87,8 @@ afterEach(async () => {
 		const client = new DaemonClient(socketPath);
 		try {
 			await client.connect(250);
-			const hello = await client.waitForHello(500);
-			await client.request(createDaemonShutdownCommand(hello, true), 1500).catch(() => undefined);
+			await client.waitForHello(500);
+			await client.requestSupervisorShutdown(true, 1500).catch(() => undefined);
 		} catch {
 			// Socket may already be gone.
 		} finally {
@@ -318,7 +322,7 @@ interface LegacySupervisorMock {
 
 let legacyMockServer: LegacySupervisorMock | undefined;
 
-async function startLegacySupervisorMock(): Promise<string> {
+async function startLegacySupervisorMock(options: { publishSchema16Identity?: boolean } = {}): Promise<string> {
 	const tempDir = mkdtempSync(join(tmpdir(), `prime-legacy-mock-${process.pid}-${randomUUID().slice(0, 8)}-`));
 	const socketPath =
 		process.platform === "win32"
@@ -341,6 +345,15 @@ async function startLegacySupervisorMock(): Promise<string> {
 			appVersion: "0.7.2",
 			clientId: randomUUID(),
 			serverCapabilities: ["attach_snapshot", "event_sequence"],
+			...(options.publishSchema16Identity
+				? {
+						supervisorGeneration: "schema-16-generation",
+						supervisorOwnerToken: "schema-16-owner",
+						supervisorPid: process.pid,
+						supervisorProcessStartId: "schema-16-start",
+						supervisorSocketPath: socketPath,
+					}
+				: {}),
 		};
 		socket.write(`${JSON.stringify(hello)}\n`);
 		let buffer = "";
@@ -557,6 +570,13 @@ describe("daemon supervisor shutdown authority (public seam)", () => {
 				const reachable = await isSocketReachable(paths.socketPath);
 				expect(reachable, `supervisor should remain reachable after ${name} mismatch`).toBe(true);
 			}
+			const { supervisorProcessStartId: _missingStart, ...incomplete } = base;
+			const incompleteResponse = await client.request(
+				{ type: "shutdown", authority: incomplete } as unknown as DaemonShutdownCommand,
+				5000,
+			);
+			expect(incompleteResponse.success, "authority without process-start identity should be rejected").toBe(false);
+			expect(await isSocketReachable(paths.socketPath)).toBe(true);
 			expect(listOwnerRecords(paths.registryDir)).toHaveLength(1);
 		} finally {
 			client.close();
@@ -565,6 +585,32 @@ describe("daemon supervisor shutdown authority (public seam)", () => {
 			handles.delete(handle);
 		}
 	}, 45_000);
+
+	it("public restart cannot bypass missing or mismatched authority", async () => {
+		const paths = await createPaths();
+		const handle = await startSupervisor(paths);
+		const client = await connectEventually(paths.socketPath);
+		try {
+			const hello = client.hello;
+			if (!hello) throw new Error("Supervisor did not publish a daemon_hello");
+			const base = readAuthorityFromHello(hello);
+
+			const missing = await client.request({ type: "restart" } as DaemonRestartCommand, 5000);
+			expect(missing.success).toBe(false);
+			const mismatched = await client.request(
+				{ type: "restart", authority: { ...base, supervisorOwnerToken: "wrong-owner" } } as DaemonRestartCommand,
+				5000,
+			);
+			expect(mismatched.success).toBe(false);
+			expect(await isSocketReachable(paths.socketPath)).toBe(true);
+			expect(listOwnerRecords(paths.registryDir)).toHaveLength(1);
+		} finally {
+			client.close();
+			handle.child.kill("SIGTERM");
+			await waitForHandleExits([handle.child], 4000);
+			handles.delete(handle);
+		}
+	}, 30_000);
 
 	it("force cannot bypass authority rejection", async () => {
 		const paths = await createPaths();
@@ -628,10 +674,33 @@ describe("daemon supervisor shutdown authority (public seam)", () => {
 			// supervisor accepts it and the connection closes with a shutdown reason.
 			const command = createDaemonShutdownCommand(hello);
 			expect(command.authority).toBeUndefined();
-			const response = await client.request(command, 5000);
+			const response = await client.requestSupervisorShutdown(false, 5000);
 			expect(response.command).toBe("shutdown");
 			expect(response.success).toBe(true);
 			expect(legacyMockServer?.shutdownObserved.lastCommand?.authority).toBeUndefined();
+			client.close();
+		} finally {
+			await stopLegacySupervisorMock();
+		}
+	}, 15_000);
+
+	it("preserves cleanup of a schema-16 supervisor that publishes complete identity", async () => {
+		const socketPath = await startLegacySupervisorMock({ publishSchema16Identity: true });
+		try {
+			const client = new DaemonClient(socketPath);
+			await client.connect(500);
+			const hello = await client.waitForHello(1000);
+			expect(hello.schemaRevision).toBe(16);
+
+			const response = await client.requestSupervisorShutdown(false, 5000);
+			expect(response.success).toBe(true);
+			expect(legacyMockServer?.shutdownObserved.lastCommand?.authority).toEqual({
+				supervisorGeneration: "schema-16-generation",
+				supervisorOwnerToken: "schema-16-owner",
+				supervisorPid: process.pid,
+				supervisorProcessStartId: "schema-16-start",
+				supervisorSocketPath: socketPath,
+			});
 			client.close();
 		} finally {
 			await stopLegacySupervisorMock();

--- a/packages/coding-agent/test/suite/regressions/6565-shutdown-authority.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6565-shutdown-authority.test.ts
@@ -5,8 +5,12 @@ import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import type { DaemonHello } from "../../../src/modes/daemon/daemon-client.js";
-import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
+import {
+	createDaemonShutdownCommand,
+	DaemonClient,
+	type DaemonHello,
+} from "../../../src/modes/daemon/daemon-client.js";
+import type { DaemonShutdownAuthority, DaemonShutdownCommand } from "../../../src/modes/daemon/daemon-protocol.js";
 import { createHarness, type Harness } from "../harness.js";
 
 /**
@@ -32,20 +36,6 @@ interface FixtureHandle {
 		reject: (error: Error) => void;
 		timeout: ReturnType<typeof setTimeout>;
 	}>;
-}
-
-interface DaemonSupervisorShutdownAuthority {
-	supervisorGeneration?: string;
-	supervisorOwnerToken?: string;
-	supervisorPid?: number;
-	supervisorProcessStartId?: string;
-	supervisorSocketPath?: string;
-}
-
-interface DaemonShutdownCommand {
-	type: "shutdown";
-	force?: boolean;
-	authority?: DaemonSupervisorShutdownAuthority;
 }
 
 const fixturePath = resolve(__dirname, "../../fixtures/eng-4600-supervisor-fixture.ts");
@@ -93,15 +83,18 @@ afterEach(async () => {
 		const client = new DaemonClient(socketPath);
 		try {
 			await client.connect(250);
-			await client.waitForHello(500);
-			await client.request({ type: "shutdown", force: true } as DaemonShutdownCommand, 1500).catch(() => undefined);
+			const hello = await client.waitForHello(500);
+			await client.request(createDaemonShutdownCommand(hello, true), 1500).catch(() => undefined);
 		} catch {
 			// Socket may already be gone.
 		} finally {
 			client.close();
 		}
 	}
-	await waitForHandleExits(handles, 4000);
+	await waitForHandleExits(
+		[...handles].map((handle) => handle.child),
+		4000,
+	);
 	await waitForHandleExits(cleanupChildProcesses, 4000);
 	handles.clear();
 	cleanupChildProcesses.clear();
@@ -319,6 +312,7 @@ async function startSupervisor(paths: {
 interface LegacySupervisorMock {
 	server: Server;
 	socketPath: string;
+	tempDir: string;
 	shutdownObserved: { count: number; lastCommand?: DaemonShutdownCommand };
 }
 
@@ -390,7 +384,7 @@ async function startLegacySupervisorMock(): Promise<string> {
 			resolveListen();
 		});
 	});
-	legacyMockServer = { server, socketPath, shutdownObserved: { count: 0 } };
+	legacyMockServer = { server, socketPath, tempDir, shutdownObserved: { count: 0 } };
 	return socketPath;
 }
 
@@ -402,31 +396,12 @@ async function stopLegacySupervisorMock(): Promise<void> {
 	legacyMockServer = undefined;
 	await new Promise<void>((resolveClose) => {
 		mock.server.close(() => resolveClose());
-		mock.server.closeAllConnections?.();
+		(mock.server as Server & { closeAllConnections?: () => void }).closeAllConnections?.();
 	});
-	if (process.platform !== "win32") {
-		try {
-			rmSync(mock.socketPath, { force: true });
-		} catch {
-			// Best effort cleanup.
-		}
-	}
+	rmSync(mock.tempDir, { recursive: true, force: true });
 }
 
-async function waitForServerClosed(server: Server | undefined): Promise<void> {
-	if (!server) {
-		return;
-	}
-	if (!server.listening) {
-		return;
-	}
-	await new Promise<void>((resolveClose) => {
-		server.once("close", () => resolveClose());
-		setTimeout(() => resolveClose(), 4000);
-	});
-}
-
-function requireAuthority(authority: DaemonSupervisorShutdownAuthority): DaemonSupervisorShutdownAuthority {
+function requireAuthority(authority: Partial<DaemonShutdownAuthority>): DaemonShutdownAuthority {
 	if (
 		typeof authority.supervisorGeneration !== "string" ||
 		typeof authority.supervisorOwnerToken !== "string" ||
@@ -436,10 +411,16 @@ function requireAuthority(authority: DaemonSupervisorShutdownAuthority): DaemonS
 	) {
 		throw new Error("Supervisor hello did not advertise the modern authority identity");
 	}
-	return authority;
+	return {
+		supervisorGeneration: authority.supervisorGeneration,
+		supervisorOwnerToken: authority.supervisorOwnerToken,
+		supervisorPid: authority.supervisorPid,
+		supervisorProcessStartId: authority.supervisorProcessStartId,
+		supervisorSocketPath: authority.supervisorSocketPath,
+	};
 }
 
-function readAuthorityFromHello(hello: DaemonHello): DaemonSupervisorShutdownAuthority {
+function readAuthorityFromHello(hello: DaemonHello): DaemonShutdownAuthority {
 	return requireAuthority({
 		supervisorGeneration: hello.supervisorGeneration,
 		supervisorOwnerToken: hello.supervisorOwnerToken,
@@ -539,7 +520,7 @@ describe("daemon supervisor shutdown authority (public seam)", () => {
 			const base = readAuthorityFromHello(hello);
 			const mutations: Array<{
 				name: string;
-				mutate: (authority: DaemonSupervisorShutdownAuthority) => DaemonSupervisorShutdownAuthority;
+				mutate: (authority: DaemonShutdownAuthority) => DaemonShutdownAuthority;
 			}> = [
 				{
 					name: "supervisorGeneration",
@@ -645,11 +626,13 @@ describe("daemon supervisor shutdown authority (public seam)", () => {
 			// A new client derives authority from the hello. With no authority fields
 			// present, it must emit the legacy command without authority; the legacy
 			// supervisor accepts it and the connection closes with a shutdown reason.
-			const response = await client.request({ type: "shutdown" } as DaemonShutdownCommand, 5000);
+			const command = createDaemonShutdownCommand(hello);
+			expect(command.authority).toBeUndefined();
+			const response = await client.request(command, 5000);
 			expect(response.command).toBe("shutdown");
 			expect(response.success).toBe(true);
+			expect(legacyMockServer?.shutdownObserved.lastCommand?.authority).toBeUndefined();
 			client.close();
-			await waitForServerClosed(legacyMockServer);
 		} finally {
 			await stopLegacySupervisorMock();
 		}

--- a/packages/coding-agent/test/suite/regressions/6565-shutdown-authority.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6565-shutdown-authority.test.ts
@@ -1,0 +1,657 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DaemonHello } from "../../../src/modes/daemon/daemon-client.js";
+import { DaemonClient } from "../../../src/modes/daemon/daemon-client.js";
+import { createHarness, type Harness } from "../harness.js";
+
+/**
+ * Regression coverage for the supervisor-shutdown-authority contract.
+ *
+ * Public daemon clients invoke the public `shutdown` command to retire the
+ * supervisor whose socket they reached. The wire must bind shutdown to the
+ * same-connection supervisor identity, or a legacy or stale client can
+ * race a new client to retire a different (and still-valid) supervisor. The
+ * test file exercises the public DaemonClient ↔ DaemonSupervisor seam using
+ * a real, isolated supervisor process per test. No production code is mocked.
+ */
+
+type FixtureMessage = { type: "booted" } | { type: "ready" } | { type: "failed"; error: string };
+
+interface FixtureHandle {
+	child: ChildProcess;
+	diagnostics: { stdout: string; stderr: string };
+	messages: FixtureMessage[];
+	waiters: Array<{
+		predicate: (message: FixtureMessage) => boolean;
+		resolve: (message: FixtureMessage) => void;
+		reject: (error: Error) => void;
+		timeout: ReturnType<typeof setTimeout>;
+	}>;
+}
+
+interface DaemonSupervisorShutdownAuthority {
+	supervisorGeneration?: string;
+	supervisorOwnerToken?: string;
+	supervisorPid?: number;
+	supervisorProcessStartId?: string;
+	supervisorSocketPath?: string;
+}
+
+interface DaemonShutdownCommand {
+	type: "shutdown";
+	force?: boolean;
+	authority?: DaemonSupervisorShutdownAuthority;
+}
+
+const fixturePath = resolve(__dirname, "../../fixtures/eng-4600-supervisor-fixture.ts");
+const tsxPath = resolve(__dirname, "../../../../../node_modules/tsx/dist/cli.mjs");
+const tsconfigPath = resolve(__dirname, "../../../../../tsconfig.json");
+const supervisorRegistryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+const workerEnvVarsToStrip = [
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER",
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER_TOKEN",
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER_ACTIVE_SESSION_ID",
+	"PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_SOCKET",
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER_RECOVERY_JOURNAL",
+	"PRIME_AGENT_INTERNAL_DAEMON_WORKER_STARTUP_GATE_FD",
+	"PRIME_AGENT_DAEMON_WORKER_ROLE",
+	"PRIME_AGENT_DAEMON_SUPERVISOR_SOCKET",
+	"PRIME_AGENT_DAEMON_WORKER_AUTH_TOKEN",
+	"PRIME_AGENT_DAEMON_WORKER_ACTIVE_SESSION_ID",
+	"PRIME_AGENT_DAEMON_WORKER_RECOVERY_JOURNAL",
+	"PRIME_AGENT_DAEMON_WORKER_STARTUP_GATE_FD",
+	"PRIME_AGENT_DAEMON_CATALOG_ROLE",
+] as const;
+
+const handles = new Set<FixtureHandle>();
+const harnesses: Harness[] = [];
+const supervisorRegistryDirs = new Set<string>();
+const cleanupRegistryDirs = new Set<string>();
+const cleanupSupervisorSockets = new Set<string>();
+const cleanupChildProcesses = new Set<ChildProcess>();
+
+afterEach(async () => {
+	for (const registryDir of supervisorRegistryDirs) {
+		cleanupRegistryDirs.add(registryDir);
+	}
+	for (const handle of handles) {
+		if (handle.child.exitCode === null && handle.child.signalCode === null) {
+			handle.child.kill("SIGTERM");
+		}
+	}
+	for (const child of cleanupChildProcesses) {
+		if (child.exitCode === null && child.signalCode === null) {
+			child.kill("SIGTERM");
+		}
+	}
+	for (const socketPath of cleanupSupervisorSockets) {
+		const client = new DaemonClient(socketPath);
+		try {
+			await client.connect(250);
+			await client.waitForHello(500);
+			await client.request({ type: "shutdown", force: true } as DaemonShutdownCommand, 1500).catch(() => undefined);
+		} catch {
+			// Socket may already be gone.
+		} finally {
+			client.close();
+		}
+	}
+	await waitForHandleExits(handles, 4000);
+	await waitForHandleExits(cleanupChildProcesses, 4000);
+	handles.clear();
+	cleanupChildProcesses.clear();
+	cleanupSupervisorSockets.clear();
+	supervisorRegistryDirs.clear();
+	while (harnesses.length > 0) {
+		harnesses.pop()?.cleanup();
+	}
+	cleanupRegistryDirs.clear();
+});
+
+function dispatchMessage(handle: FixtureHandle, message: FixtureMessage): void {
+	const waiterIndex = handle.waiters.findIndex((waiter) => waiter.predicate(message));
+	if (waiterIndex === -1) {
+		handle.messages.push(message);
+		return;
+	}
+	const [waiter] = handle.waiters.splice(waiterIndex, 1);
+	if (!waiter) {
+		return;
+	}
+	clearTimeout(waiter.timeout);
+	waiter.resolve(message);
+}
+
+function spawnSupervisorFixture(paths: {
+	agentDir: string;
+	descriptorDir: string;
+	registryDir: string;
+	socketPath: string;
+}): FixtureHandle {
+	const isolatedEnv = stripDaemonWorkerEnv(process.env);
+	const child = spawn(process.execPath, [tsxPath, fixturePath], {
+		cwd: paths.agentDir,
+		env: {
+			...isolatedEnv,
+			[supervisorRegistryDirEnv]: paths.registryDir,
+			ENG_4600_AGENT_DIR: paths.agentDir,
+			ENG_4600_DESCRIPTOR_DIR: paths.descriptorDir,
+			ENG_4600_FIXTURE_MODE: "supervisor",
+			ENG_4600_REGISTRY_DIR: paths.registryDir,
+			ENG_4600_SOCKET_PATH: paths.socketPath,
+			PI_OFFLINE: "1",
+			TSX_TSCONFIG_PATH: tsconfigPath,
+		},
+		stdio: ["ignore", "pipe", "pipe", "ipc"],
+	});
+	const handle: FixtureHandle = {
+		child,
+		diagnostics: { stdout: "", stderr: "" },
+		messages: [],
+		waiters: [],
+	};
+	handles.add(handle);
+	child.stdout?.on("data", (chunk: Buffer) => {
+		handle.diagnostics.stdout += chunk.toString("utf8");
+	});
+	child.stderr?.on("data", (chunk: Buffer) => {
+		handle.diagnostics.stderr += chunk.toString("utf8");
+	});
+	child.on("message", (message: FixtureMessage) => dispatchMessage(handle, message));
+	return handle;
+}
+
+function stripDaemonWorkerEnv(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const cleaned: NodeJS.ProcessEnv = { ...source };
+	for (const key of workerEnvVarsToStrip) {
+		delete cleaned[key];
+	}
+	return cleaned;
+}
+
+async function waitForHandleExits(children: Iterable<ChildProcess>, timeoutMs: number): Promise<void> {
+	const pending = [...children].filter((child) => child.exitCode === null && child.signalCode === null);
+	if (pending.length === 0) {
+		return;
+	}
+	await Promise.all(
+		pending.map(
+			(child) =>
+				new Promise<void>((resolveExit) => {
+					const timer = setTimeout(() => {
+						if (child.exitCode === null && child.signalCode === null) {
+							child.kill("SIGKILL");
+						}
+						resolveExit();
+					}, timeoutMs);
+					child.once("exit", () => {
+						clearTimeout(timer);
+						resolveExit();
+					});
+				}),
+		),
+	);
+}
+
+async function waitForMessage(
+	handle: FixtureHandle,
+	predicate: (message: FixtureMessage) => boolean,
+	timeoutMs = 30_000,
+): Promise<FixtureMessage> {
+	const queuedIndex = handle.messages.findIndex(predicate);
+	if (queuedIndex !== -1) {
+		const [message] = handle.messages.splice(queuedIndex, 1);
+		if (message) {
+			return Promise.resolve(message);
+		}
+	}
+	return new Promise((resolveMessage, rejectMessage) => {
+		const timeout = setTimeout(() => {
+			handle.waiters = handle.waiters.filter((waiter) => waiter.timeout !== timeout);
+			rejectMessage(
+				new Error(
+					`Timed out waiting for fixture message (exit=${handle.child.exitCode}/${handle.child.signalCode})\n${handle.diagnostics.stderr}`,
+				),
+			);
+		}, timeoutMs);
+		handle.waiters.push({ predicate, resolve: resolveMessage, reject: rejectMessage, timeout });
+	});
+}
+
+async function waitForType<T extends FixtureMessage["type"]>(
+	handle: FixtureHandle,
+	type: T,
+	timeoutMs?: number,
+): Promise<Extract<FixtureMessage, { type: T }>> {
+	return (await waitForMessage(handle, (message) => message.type === type, timeoutMs)) as Extract<
+		FixtureMessage,
+		{ type: T }
+	>;
+}
+
+function send(handle: FixtureHandle, type: "go"): void {
+	handle.child.send({ type });
+}
+
+async function createPaths(): Promise<{
+	agentDir: string;
+	descriptorDir: string;
+	registryDir: string;
+	socketPath: string;
+}> {
+	const harness = await createHarness();
+	harnesses.push(harness);
+	const registryDir = join(harness.tempDir, "registry");
+	supervisorRegistryDirs.add(registryDir);
+	cleanupRegistryDirs.add(registryDir);
+	return {
+		agentDir: harness.tempDir,
+		descriptorDir: join(harness.tempDir, "workers"),
+		registryDir,
+		socketPath:
+			process.platform === "win32"
+				? `\\.pipeprime-agent-eng-shutdown-auth-${process.pid}-${randomUUID().slice(0, 8)}`
+				: join(harness.tempDir, "daemon.sock"),
+	};
+}
+
+async function connectEventually(socketPath: string, timeoutMs = 30_000): Promise<DaemonClient> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		const client = new DaemonClient(socketPath);
+		try {
+			await client.connect(500);
+			await client.waitForHello(2000);
+			return client;
+		} catch (error) {
+			lastError = error;
+			client.close();
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+		}
+	}
+	throw new Error(`Timed out connecting to supervisor: ${String(lastError)}`);
+}
+
+async function isSocketReachable(socketPath: string, timeoutMs = 500): Promise<boolean> {
+	const client = new DaemonClient(socketPath);
+	try {
+		await client.connect(timeoutMs);
+		await client.waitForHello(timeoutMs);
+		return true;
+	} catch {
+		return false;
+	} finally {
+		client.close();
+	}
+}
+
+async function waitForSocketGone(socketPath: string, timeoutMs = 10_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!(await isSocketReachable(socketPath))) {
+			return;
+		}
+		await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+	}
+	throw new Error(`Daemon supervisor socket remained available: ${socketPath}`);
+}
+
+async function startSupervisor(paths: {
+	agentDir: string;
+	descriptorDir: string;
+	registryDir: string;
+	socketPath: string;
+}): Promise<FixtureHandle> {
+	cleanupSupervisorSockets.add(paths.socketPath);
+	const handle = spawnSupervisorFixture(paths);
+	await waitForType(handle, "booted");
+	send(handle, "go");
+	await waitForType(handle, "ready");
+	return handle;
+}
+
+interface LegacySupervisorMock {
+	server: Server;
+	socketPath: string;
+	shutdownObserved: { count: number; lastCommand?: DaemonShutdownCommand };
+}
+
+let legacyMockServer: LegacySupervisorMock | undefined;
+
+async function startLegacySupervisorMock(): Promise<string> {
+	const tempDir = mkdtempSync(join(tmpdir(), `prime-legacy-mock-${process.pid}-${randomUUID().slice(0, 8)}-`));
+	const socketPath =
+		process.platform === "win32"
+			? `\\.pipeprime-legacy-mock-${process.pid}-${randomUUID().slice(0, 8)}`
+			: join(tempDir, "legacy.sock");
+	const server = createServer((socket) => {
+		const mock = legacyMockServer;
+		if (!mock) {
+			socket.destroy();
+			return;
+		}
+		// Send a legacy daemon_hello that does NOT include any of the supervisor
+		// authority fields. This represents the seam an obsolete client reaches.
+		const hello = {
+			type: "daemon_hello",
+			socketPath,
+			protocol: { name: "prime-agent.daemon", version: 7 },
+			schemaId: "protocol-7-schema-16-1bcb9e7f1a49",
+			schemaRevision: 16,
+			appVersion: "0.7.2",
+			clientId: randomUUID(),
+			serverCapabilities: ["attach_snapshot", "event_sequence"],
+		};
+		socket.write(`${JSON.stringify(hello)}\n`);
+		let buffer = "";
+		socket.on("data", (chunk: Buffer) => {
+			buffer += chunk.toString("utf8");
+			let newlineIndex = buffer.indexOf("\n");
+			while (newlineIndex !== -1) {
+				const line = buffer.slice(0, newlineIndex);
+				buffer = buffer.slice(newlineIndex + 1);
+				try {
+					const parsed = JSON.parse(line) as { type?: string; id?: string; command?: unknown };
+					if (parsed.type === "command" && parsed.command && typeof parsed.command === "object") {
+						const command = parsed.command as DaemonShutdownCommand;
+						if (command.type === "shutdown") {
+							mock.shutdownObserved.count += 1;
+							mock.shutdownObserved.lastCommand = command;
+							if (parsed.id) {
+								const response = {
+									id: parsed.id,
+									type: "response",
+									command: "shutdown",
+									success: true,
+								};
+								socket.write(`${JSON.stringify(response)}\n`);
+							}
+							socket.write(`${JSON.stringify({ type: "daemon_closing", reason: "shutdown" })}\n`);
+							socket.end();
+						}
+					}
+				} catch {
+					// Ignore malformed input in the mock.
+				}
+				newlineIndex = buffer.indexOf("\n");
+			}
+		});
+	});
+	await new Promise<void>((resolveListen, rejectListen) => {
+		server.once("error", rejectListen);
+		server.listen(socketPath, () => {
+			server.off("error", rejectListen);
+			resolveListen();
+		});
+	});
+	legacyMockServer = { server, socketPath, shutdownObserved: { count: 0 } };
+	return socketPath;
+}
+
+async function stopLegacySupervisorMock(): Promise<void> {
+	const mock = legacyMockServer;
+	if (!mock) {
+		return;
+	}
+	legacyMockServer = undefined;
+	await new Promise<void>((resolveClose) => {
+		mock.server.close(() => resolveClose());
+		mock.server.closeAllConnections?.();
+	});
+	if (process.platform !== "win32") {
+		try {
+			rmSync(mock.socketPath, { force: true });
+		} catch {
+			// Best effort cleanup.
+		}
+	}
+}
+
+async function waitForServerClosed(server: Server | undefined): Promise<void> {
+	if (!server) {
+		return;
+	}
+	if (!server.listening) {
+		return;
+	}
+	await new Promise<void>((resolveClose) => {
+		server.once("close", () => resolveClose());
+		setTimeout(() => resolveClose(), 4000);
+	});
+}
+
+function requireAuthority(authority: DaemonSupervisorShutdownAuthority): DaemonSupervisorShutdownAuthority {
+	if (
+		typeof authority.supervisorGeneration !== "string" ||
+		typeof authority.supervisorOwnerToken !== "string" ||
+		typeof authority.supervisorPid !== "number" ||
+		typeof authority.supervisorProcessStartId !== "string" ||
+		typeof authority.supervisorSocketPath !== "string"
+	) {
+		throw new Error("Supervisor hello did not advertise the modern authority identity");
+	}
+	return authority;
+}
+
+function readAuthorityFromHello(hello: DaemonHello): DaemonSupervisorShutdownAuthority {
+	return requireAuthority({
+		supervisorGeneration: hello.supervisorGeneration,
+		supervisorOwnerToken: hello.supervisorOwnerToken,
+		supervisorPid: hello.supervisorPid,
+		supervisorProcessStartId: hello.supervisorProcessStartId,
+		supervisorSocketPath: hello.supervisorSocketPath,
+	});
+}
+
+function listOwnerRecords(registryDir: string): Array<Record<string, unknown>> {
+	if (!registryDir) {
+		return [];
+	}
+	try {
+		return readdirSync(registryDir)
+			.filter((name) => name.endsWith(".owner"))
+			.map((name) => JSON.parse(require("node:fs").readFileSync(join(registryDir, name, "owner.json"), "utf8")));
+	} catch {
+		return [];
+	}
+}
+
+describe("daemon supervisor shutdown authority (public seam)", () => {
+	it("rejects a public shutdown without authority and keeps the same supervisor reachable", async () => {
+		const paths = await createPaths();
+		const handle = await startSupervisor(paths);
+
+		const client = await connectEventually(paths.socketPath);
+		try {
+			const hello = client.hello;
+			if (!hello) {
+				throw new Error("Supervisor did not publish a daemon_hello");
+			}
+			// Authority is intentionally omitted: a legacy client never had it on the wire.
+			const response = await client.request({ type: "shutdown" } as DaemonShutdownCommand, 5000);
+			expect(response.command).toBe("shutdown");
+			expect(response.success).toBe(false);
+
+			// The supervisor, its socket, its workers, and its descriptors must remain.
+			const retry = await connectEventually(paths.socketPath);
+			try {
+				const followUp = retry.hello;
+				if (!followUp) {
+					throw new Error("Supervisor did not republish a daemon_hello after rejection");
+				}
+				expect(followUp.supervisorGeneration).toBe(hello.supervisorGeneration);
+				expect(followUp.supervisorOwnerToken).toBe(hello.supervisorOwnerToken);
+				expect(followUp.supervisorPid).toBe(hello.supervisorPid);
+				expect(followUp.supervisorProcessStartId).toBe(hello.supervisorProcessStartId);
+				expect(followUp.supervisorSocketPath).toBe(hello.supervisorSocketPath);
+			} finally {
+				retry.close();
+			}
+			expect(listOwnerRecords(paths.registryDir)).toHaveLength(1);
+		} finally {
+			client.close();
+			handle.child.kill("SIGTERM");
+			await waitForHandleExits([handle.child], 4000);
+			handles.delete(handle);
+		}
+	}, 30_000);
+
+	it("accepts a public shutdown whose authority echoes the exact hello identity", async () => {
+		const paths = await createPaths();
+		const handle = await startSupervisor(paths);
+
+		const client = await connectEventually(paths.socketPath);
+		try {
+			const hello = client.hello;
+			if (!hello) {
+				throw new Error("Supervisor did not publish a daemon_hello");
+			}
+			const authority = readAuthorityFromHello(hello);
+			const response = await client.request({ type: "shutdown", authority } as DaemonShutdownCommand, 5000);
+			expect(response.command).toBe("shutdown");
+			expect(response.success).toBe(true);
+		} finally {
+			client.close();
+		}
+		await waitForSocketGone(paths.socketPath);
+		await waitForHandleExits([handle.child], 4000);
+		// The fixture owns the supervisor lifecycle; force-stop only after the
+		// socket is confirmed gone so the cleanup path does not race the graceful shutdown.
+		handles.delete(handle);
+	}, 30_000);
+
+	it("rejects authority mismatches for every component", async () => {
+		const paths = await createPaths();
+		const handle = await startSupervisor(paths);
+
+		const client = await connectEventually(paths.socketPath);
+		try {
+			const hello = client.hello;
+			if (!hello) {
+				throw new Error("Supervisor did not publish a daemon_hello");
+			}
+			const base = readAuthorityFromHello(hello);
+			const mutations: Array<{
+				name: string;
+				mutate: (authority: DaemonSupervisorShutdownAuthority) => DaemonSupervisorShutdownAuthority;
+			}> = [
+				{
+					name: "supervisorGeneration",
+					mutate: (authority) => ({ ...authority, supervisorGeneration: "wrong-generation" }),
+				},
+				{
+					name: "supervisorOwnerToken",
+					mutate: (authority) => ({ ...authority, supervisorOwnerToken: "wrong-owner-token" }),
+				},
+				{
+					name: "supervisorPid",
+					mutate: (authority) => ({ ...authority, supervisorPid: (authority.supervisorPid ?? 0) + 1 }),
+				},
+				{
+					name: "supervisorProcessStartId",
+					mutate: (authority) => ({ ...authority, supervisorProcessStartId: "wrong-process-start" }),
+				},
+				{
+					name: "supervisorSocketPath",
+					mutate: (authority) => ({
+						...authority,
+						supervisorSocketPath: `${authority.supervisorSocketPath ?? ""}.other`,
+					}),
+				},
+			];
+			for (const { name, mutate } of mutations) {
+				const mismatched = mutate(base);
+				const response = await client.request(
+					{ type: "shutdown", authority: mismatched } as DaemonShutdownCommand,
+					5000,
+				);
+				expect(response.command).toBe("shutdown");
+				expect(response.success, `mismatch on ${name} should be rejected`).toBe(false);
+				const reachable = await isSocketReachable(paths.socketPath);
+				expect(reachable, `supervisor should remain reachable after ${name} mismatch`).toBe(true);
+			}
+			expect(listOwnerRecords(paths.registryDir)).toHaveLength(1);
+		} finally {
+			client.close();
+			handle.child.kill("SIGTERM");
+			await waitForHandleExits([handle.child], 4000);
+			handles.delete(handle);
+		}
+	}, 45_000);
+
+	it("force cannot bypass authority rejection", async () => {
+		const paths = await createPaths();
+		const handle = await startSupervisor(paths);
+
+		const client = await connectEventually(paths.socketPath);
+		try {
+			const hello = client.hello;
+			if (!hello) {
+				throw new Error("Supervisor did not publish a daemon_hello");
+			}
+			const base = readAuthorityFromHello(hello);
+			const missingAuthority = { type: "shutdown", force: true } as DaemonShutdownCommand;
+			const missingResponse = await client.request(missingAuthority, 5000);
+			expect(missingResponse.command).toBe("shutdown");
+			expect(missingResponse.success, "force without authority should be rejected").toBe(false);
+
+			const mismatchedAuthority = {
+				type: "shutdown",
+				force: true,
+				authority: { ...base, supervisorGeneration: "wrong-generation" },
+			} as DaemonShutdownCommand;
+			const mismatchedResponse = await client.request(mismatchedAuthority, 5000);
+			expect(mismatchedResponse.command).toBe("shutdown");
+			expect(mismatchedResponse.success, "force with mismatched authority should be rejected").toBe(false);
+
+			const reachable = await isSocketReachable(paths.socketPath);
+			expect(reachable, "supervisor should remain reachable after force rejections").toBe(true);
+			expect(listOwnerRecords(paths.registryDir)).toHaveLength(1);
+		} finally {
+			client.close();
+			handle.child.kill("SIGTERM");
+			await waitForHandleExits([handle.child], 4000);
+			handles.delete(handle);
+		}
+	}, 30_000);
+
+	it("preserves new-client cleanup of a legacy supervisor whose handshake lacks authority fields", async () => {
+		// A legacy supervisor predates the authority helper. Its daemon_hello does
+		// not advertise any of the modern identity fields, so any new client helper
+		// that derives authority from hello must recognise the absence and fall
+		// back to a legacy-compatible shutdown.
+		const socketPath = await startLegacySupervisorMock();
+		try {
+			const client = new DaemonClient(socketPath);
+			await client.connect(500);
+			await client.waitForHello(1000);
+			const hello = client.hello;
+			if (!hello) {
+				throw new Error("Legacy supervisor mock did not publish a daemon_hello");
+			}
+			// The legacy hello must not advertise any of the modern identity fields.
+			expect(hello.supervisorGeneration).toBeUndefined();
+			expect(hello.supervisorOwnerToken).toBeUndefined();
+			expect(hello.supervisorPid).toBeUndefined();
+			expect(hello.supervisorProcessStartId).toBeUndefined();
+			expect(hello.supervisorSocketPath).toBeUndefined();
+
+			// A new client derives authority from the hello. With no authority fields
+			// present, it must emit the legacy command without authority; the legacy
+			// supervisor accepts it and the connection closes with a shutdown reason.
+			const response = await client.request({ type: "shutdown" } as DaemonShutdownCommand, 5000);
+			expect(response.command).toBe("shutdown");
+			expect(response.success).toBe(true);
+			client.close();
+			await waitForServerClosed(legacyMockServer);
+		} finally {
+			await stopLegacySupervisorMock();
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/worker-recovery-journal.test.ts
+++ b/packages/coding-agent/test/worker-recovery-journal.test.ts
@@ -1,8 +1,12 @@
-import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
+import { appendFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { WorkerRecoveryJournal } from "../src/modes/daemon/worker-recovery-journal.js";
+import {
+	isV2WorkerRecoveryRecord,
+	WorkerRecoveryJournal,
+	type WorkerRecoveryRecordV2,
+} from "../src/modes/daemon/worker-recovery-journal.js";
 
 describe("WorkerRecoveryJournal", () => {
 	const roots: string[] = [];
@@ -18,6 +22,22 @@ describe("WorkerRecoveryJournal", () => {
 		roots.push(root);
 		return join(root, "worker.recovery.jsonl");
 	}
+
+	/** Raw persisted lines; readLatest collapses to one record per session. */
+	function fileLines(path: string): string[] {
+		return readFileSync(path, "utf8")
+			.split("\n")
+			.filter((line) => line.length > 0);
+	}
+
+	const v2Authority = {
+		agentDir: "/custom/agent/dir",
+		sessionFile: "/tmp/session-1.jsonl",
+		headEntryId: "entry-9",
+		assistantEntryId: "entry-8",
+		toolCalls: [{ id: "tool_call_42", name: "bash" }],
+		lineageDigest: "a".repeat(64),
+	};
 
 	it("restores the latest operation state per session", () => {
 		const path = createPath();
@@ -64,5 +84,236 @@ describe("WorkerRecoveryJournal", () => {
 		expect(WorkerRecoveryJournal.readLatest(path)).toEqual([
 			expect.objectContaining({ activeSessionId: "active-1", busy: false, operation: "bash_end" }),
 		]);
+	});
+
+	it("records a validated v2 authority checkpoint and preserves tool event identity", () => {
+		const path = createPath();
+		const journal = new WorkerRecoveryJournal(path);
+		journal.record({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			...v2Authority,
+			busy: true,
+			operation: "tool_execution_start",
+		});
+
+		const latest = WorkerRecoveryJournal.readLatest(path);
+		expect(latest).toHaveLength(1);
+		const record = latest[0]!;
+		expect(record.version).toBe(2);
+		expect(isV2WorkerRecoveryRecord(record)).toBe(true);
+		expect(record).toMatchObject({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			agentDir: "/custom/agent/dir",
+			sessionFile: "/tmp/session-1.jsonl",
+			busy: true,
+			operation: "tool_execution_start",
+			headEntryId: "entry-9",
+			assistantEntryId: "entry-8",
+			toolCalls: [{ id: "tool_call_42", name: "bash" }],
+			lineageDigest: "a".repeat(64),
+		});
+		expect(record.recordedAt).toEqual(expect.any(String));
+		if (isV2WorkerRecoveryRecord(record)) {
+			expect(record.operationId).toMatch(/^[0-9a-f-]{36}$/);
+		}
+	});
+
+	it("keeps one stable operationId per busy epoch and allocates a new one after idle", () => {
+		const path = createPath();
+		const journal = new WorkerRecoveryJournal(path);
+		const base = { activeSessionId: "active-1", sessionId: "session-1", ...v2Authority };
+		journal.record({ ...base, busy: true, operation: "turn_start" });
+		journal.record({ ...base, busy: true, operation: "tool_execution_start" });
+		journal.record({ ...base, busy: true, operation: "tool_execution_end" });
+
+		expect(fileLines(path)).toHaveLength(3);
+		const checkpoints = fileLines(path).map((line) => JSON.parse(line) as WorkerRecoveryRecordV2);
+		expect(checkpoints[0]!.operationId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(checkpoints[1]!.operationId).toBe(checkpoints[0]!.operationId);
+		expect(checkpoints[2]!.operationId).toBe(checkpoints[0]!.operationId);
+
+		// The session becomes idle; the idle record closes the same epoch (the
+		// journal compacts the stable all-idle history, keeping just the idle
+		// checkpoint)...
+		journal.record({ ...base, busy: false, operation: "turn_end" });
+		expect(fileLines(path)).toHaveLength(1);
+		const idle = (WorkerRecoveryJournal.readLatest(path)[0] as WorkerRecoveryRecordV2 | undefined)!;
+		expect(idle.busy).toBe(false);
+		expect(idle.operationId).toBe(checkpoints[0]!.operationId);
+
+		// ...and the next busy transition receives a brand new operation id.
+		journal.record({ ...base, busy: true, operation: "turn_start" });
+		const resumed = (WorkerRecoveryJournal.readLatest(path).at(-1) as WorkerRecoveryRecordV2 | undefined)!;
+		expect(resumed.operationId).not.toBe(checkpoints[0]!.operationId);
+	});
+
+	it("deduplicates identical busy checkpoints within one epoch", () => {
+		const path = createPath();
+		const journal = new WorkerRecoveryJournal(path);
+		const checkpoint = {
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			...v2Authority,
+			busy: true,
+			operation: "turn_end",
+		};
+		journal.record(checkpoint);
+		journal.record(checkpoint);
+		journal.record(checkpoint);
+
+		expect(WorkerRecoveryJournal.readLatest(path)).toHaveLength(1);
+	});
+
+	it("forces a new record when any authority field changes even if the event name is unchanged", () => {
+		const path = createPath();
+		const journal = new WorkerRecoveryJournal(path);
+		const base = {
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			...v2Authority,
+			busy: true,
+			operation: "turn_end",
+		};
+		journal.record(base);
+
+		const mutations: Array<[string, Partial<typeof base>]> = [
+			["session generation", { sessionId: "session-2" }],
+			["agentDir", { agentDir: "/other/agent" }],
+			["sessionFile", { sessionFile: "/tmp/session-2.jsonl" }],
+			["headEntryId", { headEntryId: "entry-10" }],
+			["assistantEntryId", { assistantEntryId: "entry-11" }],
+			["toolCalls", { toolCalls: [{ id: "other", name: "edit" }] }],
+			["lineageDigest", { lineageDigest: "b".repeat(64) }],
+		];
+		for (const [, mutation] of mutations) {
+			journal.record({ ...base, ...mutation });
+			const latest = WorkerRecoveryJournal.readLatest(path);
+			expect(latest).toHaveLength(1);
+			expect(latest[0]).toMatchObject(mutation);
+			expect(latest[0]?.operation).toBe("turn_end");
+		}
+		expect(fileLines(path)).toHaveLength(1 + mutations.length);
+	});
+
+	it("completes only the matching busy epoch and cannot clobber a newer one", () => {
+		const path = createPath();
+		const journal = new WorkerRecoveryJournal(path);
+		const base = { activeSessionId: "active-1", sessionId: "session-1", ...v2Authority };
+		journal.record({ ...base, busy: true, operation: "turn_start" });
+		const first = WorkerRecoveryJournal.readLatest(path)[0] as WorkerRecoveryRecordV2;
+
+		// The session goes idle and a resumed worker starts a newer busy epoch.
+		journal.record({ ...base, busy: false, operation: "turn_end" });
+		journal.record({ ...base, busy: true, operation: "turn_start" });
+		const resumed = WorkerRecoveryJournal.readLatest(path).at(-1) as WorkerRecoveryRecordV2;
+		expect(resumed.operationId).not.toBe(first.operationId);
+
+		// Completing the superseded epoch must not overwrite the newer one.
+		expect(journal.complete("active-1", first.operationId)).toBe(false);
+		expect((WorkerRecoveryJournal.readLatest(path).at(-1) as WorkerRecoveryRecordV2).operationId).toBe(
+			resumed.operationId,
+		);
+
+		// Completing the current epoch closes it and stays idempotent.
+		expect(journal.complete("active-1", resumed.operationId)).toBe(true);
+		const closed = WorkerRecoveryJournal.readLatest(path).at(-1) as WorkerRecoveryRecordV2;
+		expect(closed.busy).toBe(false);
+		expect(closed.operationId).toBe(resumed.operationId);
+		expect(journal.complete("active-1", resumed.operationId)).toBe(true);
+	});
+
+	it("completion re-reads the latest record from disk before comparing", () => {
+		const path = createPath();
+		const journalA = new WorkerRecoveryJournal(path);
+		const base = { activeSessionId: "active-1", sessionId: "session-1", ...v2Authority };
+		journalA.record({ ...base, busy: true, operation: "turn_start" });
+		const operationId = (WorkerRecoveryJournal.readLatest(path)[0] as WorkerRecoveryRecordV2).operationId;
+
+		// Another process resumes the session and opens a newer busy epoch.
+		const journalB = new WorkerRecoveryJournal(path);
+		journalB.record({ ...base, busy: false, operation: "turn_end" });
+		journalB.record({ ...base, busy: true, operation: "turn_start" });
+
+		// journalA still holds the stale in-memory view but must observe the newer
+		// epoch through the persisted file.
+		expect(journalA.complete("active-1", operationId)).toBe(false);
+	});
+
+	it("upgrades a v1-style idle hold after a v2 checkpoint by inheriting its authority", () => {
+		const path = createPath();
+		const journal = new WorkerRecoveryJournal(path);
+		journal.record({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			...v2Authority,
+			busy: true,
+			operation: "tool_execution_start",
+		});
+		const first = WorkerRecoveryJournal.readLatest(path)[0] as WorkerRecoveryRecordV2;
+
+		// The supervisor marks the session recovered with the legacy v1-style
+		// record call; the journal must keep the epoch authority and operation id.
+		journal.record({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			busy: false,
+			operation: "recovery_hold",
+		});
+		const closed = WorkerRecoveryJournal.readLatest(path).at(-1)!;
+		expect(closed.version).toBe(2);
+		if (closed.version === 2) {
+			expect(closed.busy).toBe(false);
+			expect(closed.operation).toBe("recovery_hold");
+			expect(closed.operationId).toBe(first.operationId);
+			expect(closed.agentDir).toBe(v2Authority.agentDir);
+			expect(closed.sessionFile).toBe(v2Authority.sessionFile);
+			expect(closed.headEntryId).toBe(v2Authority.headEntryId);
+			expect(closed.toolCalls).toEqual(v2Authority.toolCalls);
+			expect(closed.lineageDigest).toBe(v2Authority.lineageDigest);
+		}
+		// Completion of that closed epoch stays idempotent.
+		expect(journal.complete("active-1", first.operationId)).toBe(true);
+	});
+
+	it("refuses to complete legacy v1 busy records, unknown sessions, and empty journals", () => {
+		const path = createPath();
+		const journal = new WorkerRecoveryJournal(path);
+		journal.record({
+			activeSessionId: "legacy-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session-1.jsonl",
+			busy: true,
+			operation: "model_stream",
+		});
+
+		expect(WorkerRecoveryJournal.readLatest(path)).toHaveLength(1);
+		expect(WorkerRecoveryJournal.readLatest(path)[0]?.version).toBe(1);
+		expect(journal.complete("legacy-1", "any-operation-id")).toBe(false);
+		expect(journal.complete("unknown-session", "any-operation-id")).toBe(false);
+		expect(journal.complete("legacy-1", "")).toBe(false);
+	});
+
+	it("skips malformed v2 records while keeping valid ones", () => {
+		const path = createPath();
+		writeFileSync(path, '{"version":2,"activeSessionId":"bad"}\n');
+		const journal = new WorkerRecoveryJournal(path);
+		journal.record({
+			activeSessionId: "good-1",
+			sessionId: "session-1",
+			agentDir: "/agent",
+			busy: true,
+			operation: "turn_start",
+			headEntryId: null,
+			assistantEntryId: null,
+			toolCalls: [],
+			lineageDigest: "c".repeat(64),
+		});
+
+		const latest = WorkerRecoveryJournal.readLatest(path);
+		expect(latest).toHaveLength(1);
+		expect(latest[0]?.activeSessionId).toBe("good-1");
+		expect(latest[0]).toMatchObject({ headEntryId: null, assistantEntryId: null, toolCalls: [] });
 	});
 });

--- a/packages/coding-agent/test/worker-recovery-journal.test.ts
+++ b/packages/coding-agent/test/worker-recovery-journal.test.ts
@@ -166,7 +166,7 @@ describe("WorkerRecoveryJournal", () => {
 		expect(WorkerRecoveryJournal.readLatest(path)).toHaveLength(1);
 	});
 
-	it("forces a new record when any authority field changes even if the event name is unchanged", () => {
+	it("starts a new operation epoch when any busy authority field changes", () => {
 		const path = createPath();
 		const journal = new WorkerRecoveryJournal(path);
 		const base = {
@@ -177,6 +177,7 @@ describe("WorkerRecoveryJournal", () => {
 			operation: "turn_end",
 		};
 		journal.record(base);
+		let previous = WorkerRecoveryJournal.readLatest(path)[0] as WorkerRecoveryRecordV2;
 
 		const mutations: Array<[string, Partial<typeof base>]> = [
 			["session generation", { sessionId: "session-2" }],
@@ -193,6 +194,9 @@ describe("WorkerRecoveryJournal", () => {
 			expect(latest).toHaveLength(1);
 			expect(latest[0]).toMatchObject(mutation);
 			expect(latest[0]?.operation).toBe("turn_end");
+			const current = latest[0] as WorkerRecoveryRecordV2;
+			expect(current.operationId).not.toBe(previous.operationId);
+			previous = current;
 		}
 		expect(fileLines(path)).toHaveLength(1 + mutations.length);
 	});
@@ -222,6 +226,34 @@ describe("WorkerRecoveryJournal", () => {
 		expect(closed.busy).toBe(false);
 		expect(closed.operationId).toBe(resumed.operationId);
 		expect(journal.complete("active-1", resumed.operationId)).toBe(true);
+	});
+
+	it("refreshes a stale journal instance under the cross-process guard before writing", () => {
+		const path = createPath();
+		const journalA = new WorkerRecoveryJournal(path);
+		const journalB = new WorkerRecoveryJournal(path);
+		journalA.record({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			...v2Authority,
+			busy: true,
+			operation: "turn_start",
+		});
+		journalB.record({
+			activeSessionId: "active-2",
+			sessionId: "session-2",
+			...v2Authority,
+			sessionFile: "/tmp/session-2.jsonl",
+			busy: true,
+			operation: "turn_start",
+		});
+
+		expect(journalB.getLatest()).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ activeSessionId: "active-1", busy: true }),
+				expect.objectContaining({ activeSessionId: "active-2", busy: true }),
+			]),
+		);
 	});
 
 	it("completion re-reads the latest record from disk before comparing", () => {
@@ -295,6 +327,35 @@ describe("WorkerRecoveryJournal", () => {
 		expect(journal.complete("legacy-1", "")).toBe(false);
 	});
 
+	it("does not fall back to an older busy v2 authority after a torn checkpoint", () => {
+		const path = createPath();
+		const journal = new WorkerRecoveryJournal(path);
+		journal.record({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			...v2Authority,
+			busy: true,
+			operation: "tool_execution_start",
+		});
+		appendFileSync(path, '{"version":2,"activeSessionId":"active-1"');
+
+		expect(WorkerRecoveryJournal.readLatest(path)).toEqual([]);
+
+		// A later complete checkpoint supersedes the corrupt line and becomes the
+		// only usable authority.
+		journal.record({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			...v2Authority,
+			headEntryId: "entry-10",
+			busy: true,
+			operation: "tool_execution_start",
+		});
+		expect(WorkerRecoveryJournal.readLatest(path)).toEqual([
+			expect.objectContaining({ version: 2, headEntryId: "entry-10", busy: true }),
+		]);
+	});
+
 	it("skips malformed v2 records while keeping valid ones", () => {
 		const path = createPath();
 		writeFileSync(path, '{"version":2,"activeSessionId":"bad"}\n');
@@ -303,6 +364,7 @@ describe("WorkerRecoveryJournal", () => {
 			activeSessionId: "good-1",
 			sessionId: "session-1",
 			agentDir: "/agent",
+			sessionFile: "/tmp/good-session.jsonl",
 			busy: true,
 			operation: "turn_start",
 			headEntryId: null,

--- a/packages/coding-agent/test/worker-recovery-journal.test.ts
+++ b/packages/coding-agent/test/worker-recovery-journal.test.ts
@@ -363,6 +363,32 @@ describe("WorkerRecoveryJournal", () => {
 		]);
 	});
 
+	it("scopes torn-checkpoint suppression to the affected active session", () => {
+		const path = createPath();
+		const journal = new WorkerRecoveryJournal(path);
+		journal.record({
+			activeSessionId: "active-a",
+			sessionId: "session-a",
+			...v2Authority,
+			sessionFile: "/tmp/session-a.jsonl",
+			busy: true,
+			operation: "tool_execution_start",
+		});
+		journal.record({
+			activeSessionId: "active-b",
+			sessionId: "session-b",
+			...v2Authority,
+			sessionFile: "/tmp/session-b.jsonl",
+			busy: true,
+			operation: "tool_execution_start",
+		});
+		appendFileSync(path, '{"version":2,"activeSessionId":"active-b"');
+
+		expect(WorkerRecoveryJournal.readLatest(path)).toEqual([
+			expect.objectContaining({ version: 2, activeSessionId: "active-a", busy: true }),
+		]);
+	});
+
 	it("skips malformed v2 records while keeping valid ones", () => {
 		const path = createPath();
 		writeFileSync(path, '{"version":2,"activeSessionId":"bad"}\n');

--- a/packages/coding-agent/test/worker-recovery-journal.test.ts
+++ b/packages/coding-agent/test/worker-recovery-journal.test.ts
@@ -309,7 +309,7 @@ describe("WorkerRecoveryJournal", () => {
 		expect(journal.complete("active-1", first.operationId)).toBe(true);
 	});
 
-	it("refuses to complete legacy v1 busy records, unknown sessions, and empty journals", () => {
+	it("refuses v2 completion for legacy records and guardedly acknowledges legacy stale", () => {
 		const path = createPath();
 		const journal = new WorkerRecoveryJournal(path);
 		journal.record({
@@ -325,6 +325,13 @@ describe("WorkerRecoveryJournal", () => {
 		expect(journal.complete("legacy-1", "any-operation-id")).toBe(false);
 		expect(journal.complete("unknown-session", "any-operation-id")).toBe(false);
 		expect(journal.complete("legacy-1", "")).toBe(false);
+		expect(journal.completeLegacy("legacy-1")).toBe(true);
+		expect(WorkerRecoveryJournal.readLatest(path)[0]).toMatchObject({
+			version: 1,
+			busy: false,
+			operation: "legacy_recovery_stale",
+		});
+		expect(journal.completeLegacy("legacy-1")).toBe(false);
 	});
 
 	it("does not fall back to an older busy v2 authority after a torn checkpoint", () => {


### PR DESCRIPTION
## Summary

- close unresolved tool calls in the active branch's terminal `toolUse` turn during daemon recovery
- persist synthetic error results before the existing worker-recovery marker without replaying uncertain work
- keep partial persistence resumable and retain busy recovery-journal records when catalog persistence fails

The synthetic result preserves the original tool call ID and name and states that execution, its result, and external side effects are unknown. Recovery does not automatically resume or retry the operation.

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/session-manager/interrupted-tool-results.test.ts test/daemon-catalog-process.test.ts test/daemon-supervisor-monitor.test.ts`
- 92 focused tests passed

## Scope

No daemon protocol/schema changes, provider transformation changes, automatic resume, or tool replay.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close interrupted tool calls during worker session recovery
> - Adds exact-authority worker recovery: when a daemon worker is killed mid-tool-use, unresolved tool calls in the terminal assistant turn are closed by appending synthetic error `toolResult` messages before the session is marked recovered.
> - Introduces `ExactRecoveryAuthority` snapshots in `SessionManager` capturing session lineage, head entry, assistant entry, and unresolved tool call identities, journaled as v2 busy checkpoints in `WorkerRecoveryJournal`.
> - Catalog recovery (`markSessionInterrupted`) is now lease-fenced, serialized per session path, and returns a structured `CatalogRecoveryResult` (applied / already_applied / stale) with idempotency keyed on `operationId`.
> - Supervisor shutdown and restart now require a `DaemonShutdownAuthority` derived from the connection's `daemon_hello` handshake; commands missing or mismatching authority are rejected with a typed `shutdown_authority_rejected` error.
> - `shutdownDaemonAndWait` and `runShutdownAllConverging` in `daemon-ps` now distinguish authority-rejected outcomes from stopped/unavailable, preserving protected supervisor scopes instead of force-killing them.
> - Risk: schema revision bumped from 16 to 18; supervisors at revision ≥17 require authority on all public shutdown/restart commands, breaking legacy clients that send bare `{ type: 'shutdown' }`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c29d8e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->