### PR TITLE
fix(coding-agent): mark truncated entries in the refiner overview

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed the continual harness refiner rewriting entries it was only shown a fragment of; it now sees how much is hidden, can request entries in full, and updates to entries it has not seen are refused ([#1317](https://github.com/PrimeIntellect-ai/prime-agent/pull/1317) by [@bilelrais](https://github.com/bilelrais)).
+- Fixed the continual harness refiner rewriting entries it was only shown a fragment of; it now sees how much is hidden, can request entries in full, and updates to entries it has not seen are refused; its editing rules also now state that the overview and the system prompt render only an entry's leading characters, so an entry's opening must say what it is and when to open it ([#1317](https://github.com/PrimeIntellect-ai/prime-agent/pull/1317) by [@bilelrais](https://github.com/bilelrais)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the continual harness refiner rewriting entries it was only shown a fragment of; it now sees how much is hidden, can request entries in full, and updates to entries it has not seen are refused ([#1317](https://github.com/PrimeIntellect-ai/prime-agent/pull/1317) by [@bilelrais](https://github.com/bilelrais)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7926,6 +7926,7 @@ export class AgentSession {
 				rollbackOf: plan.rollbackOf,
 				scope: targetScope,
 				baselineState: plan.baselineState,
+				fullyVisibleIds: plan.fullyVisibleIds,
 			});
 			result.harnessStatePath = saveHarnessState(targetHarnessStateDir, state);
 			if (targetScope === "global") {

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -144,6 +144,7 @@ Continual harness components:
 
 Editing model:
 - An \`update\` replaces the entry's entire \`content\`; text you do not reproduce is removed.
+- The harness overview and every agent's system prompt render only the leading characters of an entry's \`content\` — a mechanical slice, not a summary — so the opening of \`content\` is the entry's interface: begin it with what the entry is and when to open it, never with a date, a header, or narrative.
 - \`... (+N chars not shown)\` marks an entry you were not shown in full; an update to one is refused.
 - Each overview entry has a canonical \`scope:kind:id\` identifier. To see entries in full, reply with \`{"expand": ["scope:kind:id", ...]}\` and nothing else. Copy each identifier exactly; you may expand again in a later reply.
 

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -1123,7 +1123,7 @@ export async function reviewAutoRefine(
 ${context.reason}; ${context.turnsSinceLastReview} assistant turns since last auto-refine review
 </trigger>`,
 		`<current_harness_state>
-${overviewForPrompt(state)}
+${overviewForPrompt(state).text}
 </current_harness_state>`,
 		`<refinement_history>
 ${historyForPrompt(history)}

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -34,6 +34,7 @@ const REFINER_EXPANSION_BUDGET = 80_000;
 export type RefinementKind = "prompt" | "memory" | "skill" | "subagent";
 export type RefinementAction = "create" | "update" | "delete";
 export type HarnessScope = "local" | "global";
+export type HarnessEntryIdentity = `${HarnessScope}:${RefinementKind}:${string}`;
 
 export interface HarnessEntry {
 	id: string;
@@ -144,12 +145,12 @@ Continual harness components:
 Editing model:
 - An \`update\` replaces the entry's entire \`content\`; text you do not reproduce is removed.
 - \`... (+N chars not shown)\` marks an entry you were not shown in full; an update to one is refused.
-- To see entries in full, reply with \`{"expand": ["id", ...]}\` and nothing else. List every entry you need; you may expand again in a later reply.
+- Each overview entry has a canonical \`scope:kind:id\` identifier. To see entries in full, reply with \`{"expand": ["scope:kind:id", ...]}\` and nothing else. Copy each identifier exactly; you may expand again in a later reply.
 
 Scope and persistence policy:
 - The default editable continual harness store is local to the current Prime Agent session. Use it for session-specific progress, active task state, current-run coordination notes, temporary blockers, and project facts that should not affect other sessions.
 - A caller may explicitly request global refinement. Global edits must be stable cross-session lessons, durable user preferences, reusable skills/subagents, or tool/environment facts that should affect future sessions.
-- Entry ids in the harness overview may carry a display-only \`local:\` or \`global:\` prefix. Always use the bare id (no prefix) in edits.
+- Expansion requests use the exact canonical \`scope:kind:id\` identifier shown in the harness overview. Edits already carry \`kind\` and apply to the requested scope. Always use the bare id (no prefix) in edits.
 - All edits in one refinement apply only to the requested scope's store. During a local refinement, global entries are read-only context: never propose update or delete edits for them; create a local entry instead when a session-specific override is genuinely needed.
 - Project/workspace-specific lessons may be persisted globally only when the title, path, or content explicitly names the project/workspace and the lesson is likely to be reused in future sessions for that project. Prefer local edits when the lesson only belongs in the current conversation.
 - Use memory for declarative facts and preferences, skill for repeatable procedures exposed as Python calls, prompt for narrow behavioral policy addendums, and subagent for reusable delegation roles.
@@ -253,6 +254,10 @@ function objectRecord(value: unknown): Record<string, unknown> | undefined {
 
 function normalizeHarnessScope(value: unknown, fallback: HarnessScope): HarnessScope {
 	return value === "global" || value === "local" ? value : fallback;
+}
+
+function harnessEntryIdentity(scope: HarnessScope, kind: RefinementKind, id: string): HarnessEntryIdentity {
+	return `${scope}:${kind}:${id}`;
 }
 
 export function inferRefinementResultScope(result: RefinementResult): HarnessScope | undefined {
@@ -528,13 +533,36 @@ export function formatHarnessStateForPrompt(
 	return lines.join("\n").trim();
 }
 
-function overviewForPrompt(state: HarnessState): { text: string; fullyVisible: Set<string> } {
+interface BaselineHarnessEntry {
+	identity: HarnessEntryIdentity;
+	kind: RefinementKind;
+	scope: HarnessScope;
+	entry: HarnessEntry;
+}
+
+function overviewForPrompt(state: HarnessState): {
+	text: string;
+	fullyVisible: Set<HarnessEntryIdentity>;
+	baselineEntries: Map<string, BaselineHarnessEntry>;
+} {
 	const lines: string[] = [];
-	const fullyVisible = new Set<string>();
+	const fullyVisible = new Set<HarnessEntryIdentity>();
+	const baselineEntries = new Map<string, BaselineHarnessEntry>();
 	for (const kind of Object.keys(state.entries) as RefinementKind[]) {
 		const entries = Object.values(state.entries[kind]);
 		lines.push(`${kind}: ${entries.length}`);
 		for (const entry of entries.slice(0, REFINER_ENTRY_LIMIT)) {
+			const scope = normalizeHarnessScope(entry.scope, "global");
+			const identity = harnessEntryIdentity(scope, kind, entry.id);
+			if (baselineEntries.has(identity)) {
+				throw new Error(`Duplicate canonical harness entry identity: ${identity}`);
+			}
+			baselineEntries.set(identity, {
+				identity,
+				kind,
+				scope,
+				entry: cloneEntry(entry)!,
+			});
 			const flattened = entry.content.replace(/\s+/g, " ");
 			const hidden = flattened.length - REFINER_ENTRY_CONTENT_LIMIT;
 			// An update replaces the entry, so a refiner that cannot tell a truncated
@@ -545,31 +573,31 @@ function overviewForPrompt(state: HarnessState): { text: string; fullyVisible: S
 					: flattened;
 			// An entry short enough to render whole needs no expansion round-trip.
 			if (hidden <= 0) {
-				fullyVisible.add(entry.id);
+				fullyVisible.add(identity);
 			}
 			const argumentsText =
-				entry.kind === "skill" && Object.keys(entry.arguments).length > 0
+				kind === "skill" && Object.keys(entry.arguments).length > 0
 					? ` args=${JSON.stringify(entry.arguments).slice(0, 240)}`
 					: "";
 			const referenceText =
-				entry.kind === "skill" && Object.keys(entry.reference).length > 0
+				kind === "skill" && Object.keys(entry.reference).length > 0
 					? ` ref=${JSON.stringify(entry.reference).slice(0, 240)}`
 					: "";
 			lines.push(
-				`- [${entry.scope ?? "global"}:${entry.id}] ${entry.title} (${entry.path}, v${entry.version})${referenceText}${argumentsText}: ${content}`,
+				`- [${identity}] ${entry.title} (${entry.path}, v${entry.version})${referenceText}${argumentsText}: ${content}`,
 			);
 		}
 		if (entries.length > REFINER_ENTRY_LIMIT) {
 			lines.push(`- +${entries.length - REFINER_ENTRY_LIMIT} more ${kind} entries`);
 		}
 	}
-	return { text: lines.join("\n"), fullyVisible };
+	return { text: lines.join("\n"), fullyVisible, baselineEntries };
 }
 
 /**
- * A refiner may answer with `{"expand": ["id", ...]}` instead of edits when an entry it
- * needs is truncated in the overview. Returns the requested ids, or undefined when the
- * reply is a normal proposal.
+ * A refiner may answer with `{"expand": ["scope:kind:id", ...]}` instead of edits when
+ * an entry it needs is truncated in the overview. Returns the requested canonical
+ * identifiers, or undefined when the reply is a normal proposal.
  */
 function parseExpandRequest(text: string): string[] | undefined {
 	let value: unknown;
@@ -591,44 +619,34 @@ function parseExpandRequest(text: string): string[] | undefined {
 	const ids = record.expand.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
 	return ids.length > 0 ? ids : undefined;
 }
-
-/** Entry ids are rendered with a display-only scope prefix, so accept either form. */
-function findEntryById(state: HarnessState, id: string): HarnessEntry | undefined {
-	const bare = id.replace(/^(local|global):/, "");
-	for (const kind of Object.keys(state.entries) as RefinementKind[]) {
-		const records = state.entries[kind];
-		const match = records[id] ?? records[bare];
-		if (match) {
-			return match;
-		}
-	}
-	return undefined;
-}
-
 /**
- * Render requested entries in full, within a character budget. Withheld and unknown ids
- * are reported so the refiner knows it is still working without them.
+ * Render baseline entries requested by exact canonical identity, within a character
+ * budget. Withheld and unknown identities are reported so the refiner knows it is still
+ * working without them.
  */
 function expansionForPrompt(
-	state: HarnessState,
-	ids: string[],
-	expanded: Set<string>,
+	baselineEntries: ReadonlyMap<string, BaselineHarnessEntry>,
+	identities: string[],
+	expanded: Set<HarnessEntryIdentity>,
 	budget: number,
 ): { text: string; budget: number } {
 	const lines: string[] = [];
-	for (const id of ids) {
-		const entry = findEntryById(state, id);
-		if (!entry) {
-			lines.push(`- ${id}: not found`);
+	for (const identity of identities) {
+		const baseline = baselineEntries.get(identity);
+		if (!baseline) {
+			lines.push(`- ${identity}: not found`);
 			continue;
 		}
+		const { entry } = baseline;
 		if (entry.content.length > budget) {
-			lines.push(`- ${entry.id}: withheld, expansion budget exhausted (${entry.content.length} chars)`);
+			lines.push(`- ${identity}: withheld, expansion budget exhausted (${entry.content.length} chars)`);
 			continue;
 		}
 		budget -= entry.content.length;
-		expanded.add(entry.id);
-		lines.push(`<entry id="${entry.id}" kind="${entry.kind}" title="${entry.title}">\n${entry.content}\n</entry>`);
+		expanded.add(baseline.identity);
+		lines.push(
+			`<entry identifier="${baseline.identity}" id="${entry.id}" kind="${baseline.kind}" scope="${baseline.scope}" title="${entry.title}">\n${entry.content}\n</entry>`,
+		);
 	}
 	return { text: lines.join("\n\n"), budget };
 }
@@ -800,8 +818,8 @@ export function applyRefinementProposal(
 		rollbackOf?: string;
 		scope?: HarnessScope;
 		baselineState?: HarnessState;
-		/** Ids the refiner saw in full. When provided, updates to any other id are refused. */
-		fullyVisibleIds?: Set<string>;
+		/** Canonical entry identities the refiner saw in full. Other updates are refused. */
+		fullyVisibleIds?: ReadonlySet<HarnessEntryIdentity>;
 	},
 ): RefinementResult {
 	const appliedEdits: AppliedRefinementEdit[] = [];
@@ -851,7 +869,14 @@ export function applyRefinementProposal(
 			appliedEdits.push({ ...edit, id, applied: false, error: "entry not found" });
 			continue;
 		}
-		if (edit.action === "update" && options.fullyVisibleIds && !options.fullyVisibleIds.has(id)) {
+		const visibilityIdentity = before
+			? harnessEntryIdentity(normalizeHarnessScope(before.scope, options.scope ?? "global"), edit.kind, before.id)
+			: undefined;
+		if (
+			edit.action === "update" &&
+			options.fullyVisibleIds &&
+			(!visibilityIdentity || !options.fullyVisibleIds.has(visibilityIdentity))
+		) {
 			// An update replaces the entry, so it may only be applied when the refiner
 			// was shown the entry in full.
 			appliedEdits.push({
@@ -954,8 +979,8 @@ export function getRefinementHistory(entries: readonly CustomEntry[]): Refinemen
 export interface RefinementPlan {
 	proposal: RefinementProposal;
 	id: string;
-	/** Entry ids the refiner saw in full, either untruncated or via an expansion round. */
-	fullyVisibleIds?: Set<string>;
+	/** Canonical entry identities seen in full, either initially or through expansion. */
+	fullyVisibleIds?: Set<HarnessEntryIdentity>;
 	rollbackOf?: string;
 	rollbackScope?: HarnessScope;
 	/** Target-scope state captured before planning, used to reject conflicting edits at apply time. */
@@ -1050,7 +1075,7 @@ export async function planRefinement(
 			return { proposal: parseProposal(text), id, fullyVisibleIds: fullyVisible };
 		}
 
-		const expansion = expansionForPrompt(state, requested, fullyVisible, budget);
+		const expansion = expansionForPrompt(overview.baselineEntries, requested, fullyVisible, budget);
 		budget = expansion.budget;
 		const isFinalRound = round + 1 >= REFINER_MAX_EXPANSION_ROUNDS;
 		conversation.push(response, {

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -11,7 +11,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { Model } from "@earendil-works/pi-ai";
+import type { Message, Model } from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai";
 import { getAgentDir } from "../../config.js";
 import { serializeConversation } from "../compaction/utils.js";
@@ -28,6 +28,8 @@ const DEFAULT_OVERVIEW_REFINEMENT_LIMIT = 5;
 const DEFAULT_OVERVIEW_CONTENT_LIMIT = 180;
 const REFINER_ENTRY_LIMIT = 40;
 const REFINER_ENTRY_CONTENT_LIMIT = 240;
+const REFINER_MAX_EXPANSION_ROUNDS = 3;
+const REFINER_EXPANSION_BUDGET = 80_000;
 
 export type RefinementKind = "prompt" | "memory" | "skill" | "subagent";
 export type RefinementAction = "create" | "update" | "delete";
@@ -142,6 +144,9 @@ Continual harness components:
 Editing model:
 - An \`update\` edit replaces the entry's entire \`content\`; text you do not reproduce is removed.
 - Entries in the harness state above are truncated. \`... (+N chars not shown)\` marks text you were not given.
+- You may only update an entry you have been shown in full. An update to a truncated entry is refused.
+- To see one, reply with \`{"expand": ["entry-id", ...]}\` and nothing else. Those entries are returned in
+  full and you may then emit edits, or expand again. Prefer expanding over rewriting from a fragment.
 
 Scope and persistence policy:
 - The default editable continual harness store is local to the current Prime Agent session. Use it for session-specific progress, active task state, current-run coordination notes, temporary blockers, and project facts that should not affect other sessions.
@@ -525,8 +530,9 @@ export function formatHarnessStateForPrompt(
 	return lines.join("\n").trim();
 }
 
-function overviewForPrompt(state: HarnessState): string {
+function overviewForPrompt(state: HarnessState): { text: string; fullyVisible: Set<string> } {
 	const lines: string[] = [];
+	const fullyVisible = new Set<string>();
 	for (const kind of Object.keys(state.entries) as RefinementKind[]) {
 		const entries = Object.values(state.entries[kind]);
 		lines.push(`${kind}: ${entries.length}`);
@@ -539,6 +545,10 @@ function overviewForPrompt(state: HarnessState): string {
 				hidden > 0
 					? `${flattened.slice(0, REFINER_ENTRY_CONTENT_LIMIT)}... (+${hidden} chars not shown)`
 					: flattened;
+			// An entry short enough to render whole needs no expansion round-trip.
+			if (hidden <= 0) {
+				fullyVisible.add(entry.id);
+			}
 			const argumentsText =
 				entry.kind === "skill" && Object.keys(entry.arguments).length > 0
 					? ` args=${JSON.stringify(entry.arguments).slice(0, 240)}`
@@ -555,7 +565,74 @@ function overviewForPrompt(state: HarnessState): string {
 			lines.push(`- +${entries.length - REFINER_ENTRY_LIMIT} more ${kind} entries`);
 		}
 	}
-	return lines.join("\n");
+	return { text: lines.join("\n"), fullyVisible };
+}
+
+/**
+ * A refiner may answer with `{"expand": ["id", ...]}` instead of edits when an entry it
+ * needs is truncated in the overview. Returns the requested ids, or undefined when the
+ * reply is a normal proposal.
+ */
+function parseExpandRequest(text: string): string[] | undefined {
+	let value: unknown;
+	try {
+		value = extractJsonObject(text);
+	} catch {
+		return undefined;
+	}
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	if (Array.isArray(record.edits)) {
+		return undefined;
+	}
+	if (!Array.isArray(record.expand)) {
+		return undefined;
+	}
+	const ids = record.expand.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+	return ids.length > 0 ? ids : undefined;
+}
+
+/** Entry ids are rendered with a display-only scope prefix, so accept either form. */
+function findEntryById(state: HarnessState, id: string): HarnessEntry | undefined {
+	const bare = id.replace(/^(local|global):/, "");
+	for (const kind of Object.keys(state.entries) as RefinementKind[]) {
+		const records = state.entries[kind];
+		const match = records[id] ?? records[bare];
+		if (match) {
+			return match;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Render requested entries in full, within a character budget. Withheld and unknown ids
+ * are reported so the refiner knows it is still working without them.
+ */
+function renderExpansion(
+	state: HarnessState,
+	ids: string[],
+	expanded: Set<string>,
+	remaining: { budget: number },
+): string {
+	const lines: string[] = [];
+	for (const id of ids) {
+		const entry = findEntryById(state, id);
+		if (!entry) {
+			lines.push(`- ${id}: not found`);
+			continue;
+		}
+		if (entry.content.length > remaining.budget) {
+			lines.push(`- ${entry.id}: withheld, expansion budget exhausted (${entry.content.length} chars)`);
+			continue;
+		}
+		remaining.budget -= entry.content.length;
+		expanded.add(entry.id);
+		lines.push(`<entry id="${entry.id}" kind="${entry.kind}" title="${entry.title}">\n${entry.content}\n</entry>`);
+	}
+	return lines.join("\n\n");
 }
 
 function historyForPrompt(history: RefinementResult[]): string {
@@ -720,7 +797,14 @@ function validateEdit(edit: RefinementEdit, computedId?: string): string | undef
 export function applyRefinementProposal(
 	state: HarnessState,
 	proposal: RefinementProposal,
-	options: { id: string; rollbackOf?: string; scope?: HarnessScope; baselineState?: HarnessState },
+	options: {
+		id: string;
+		rollbackOf?: string;
+		scope?: HarnessScope;
+		baselineState?: HarnessState;
+		/** Ids the refiner saw in full. When provided, updates to any other id are refused. */
+		fullyVisibleIds?: Set<string>;
+	},
 ): RefinementResult {
 	const appliedEdits: AppliedRefinementEdit[] = [];
 	const proposalModifiedKeys = new Set<string>();
@@ -767,6 +851,18 @@ export function applyRefinementProposal(
 		}
 		if (edit.action === "update" && !before) {
 			appliedEdits.push({ ...edit, id, applied: false, error: "entry not found" });
+			continue;
+		}
+		if (edit.action === "update" && options.fullyVisibleIds && !options.fullyVisibleIds.has(id)) {
+			// An update replaces the entry, so it may only be applied when the refiner
+			// was shown the entry in full.
+			appliedEdits.push({
+				...edit,
+				id,
+				before,
+				applied: false,
+				error: "entry was not shown in full; update refused",
+			});
 			continue;
 		}
 
@@ -860,6 +956,8 @@ export function getRefinementHistory(entries: readonly CustomEntry[]): Refinemen
 export interface RefinementPlan {
 	proposal: RefinementProposal;
 	id: string;
+	/** Entry ids the refiner saw in full, either untruncated or via an expansion round. */
+	fullyVisibleIds?: Set<string>;
 	rollbackOf?: string;
 	rollbackScope?: HarnessScope;
 	/** Target-scope state captured before planning, used to reject conflicting edits at apply time. */
@@ -906,8 +1004,10 @@ export async function planRefinement(
 	const scopeInstruction = options.global
 		? "Requested refinement scope: global. Only propose stable cross-session continual harness edits, durable user preferences, reusable skills/subagents, or explicitly project-qualified facts that should affect future Prime Agent sessions. Do not persist session-only progress, temporary blockers, or current-run coordination globally."
 		: "Requested refinement scope: local. Prefer local continual harness edits for current task progress, temporary blockers, current-run coordination, and project facts that are not clearly reusable across Prime Agent sessions. Global entries in the overview are read-only context: do not propose update or delete edits for them; create a local entry instead if an override is needed.";
+	const overview = overviewForPrompt(state);
+	const fullyVisible = new Set(overview.fullyVisible);
 	const userPrompt = [
-		`<current_harness_state>\n${overviewForPrompt(state)}\n</current_harness_state>`,
+		`<current_harness_state>\n${overview.text}\n</current_harness_state>`,
 		`<refinement_history>\n${historyForPrompt(history)}\n</refinement_history>`,
 		`<conversation>\n${conversationText}\n</conversation>`,
 		`<scope_policy>\n${scopeInstruction}\n</scope_policy>`,
@@ -923,27 +1023,50 @@ export async function planRefinement(
 	// Keep the refinement request non-reasoning regardless of the interactive session
 	// thinking level so the model uses its output budget for the JSON object.
 	void thinkingLevel;
-	const response = await completeSimple(
-		model,
-		{
-			systemPrompt: REFINEMENT_SYSTEM_PROMPT,
-			messages: [{ role: "user", content: [{ type: "text", text: userPrompt }], timestamp: Date.now() }],
-		},
-		{ maxTokens: refinementMaxOutputTokens(model), signal, apiKey, headers },
-	);
+	const conversation: Message[] = [
+		{ role: "user", content: [{ type: "text", text: userPrompt }], timestamp: Date.now() },
+	];
+	const remaining = { budget: REFINER_EXPANSION_BUDGET };
 
-	if (response.stopReason === "error") {
-		throw new Error(`Refinement failed: ${response.errorMessage || "Unknown error"}`);
-	}
-	if (response.stopReason === "length") {
-		throw new Error(`Refinement failed: ${TRUNCATED_JSON_ERROR}`);
-	}
+	for (let round = 0; ; round++) {
+		const response = await completeSimple(
+			model,
+			{ systemPrompt: REFINEMENT_SYSTEM_PROMPT, messages: conversation },
+			{ maxTokens: refinementMaxOutputTokens(model), signal, apiKey, headers },
+		);
 
-	const text = response.content
-		.filter((content): content is { type: "text"; text: string } => content.type === "text")
-		.map((content) => content.text)
-		.join("\n");
-	return { proposal: parseProposal(text), id };
+		if (response.stopReason === "error") {
+			throw new Error(`Refinement failed: ${response.errorMessage || "Unknown error"}`);
+		}
+		if (response.stopReason === "length") {
+			throw new Error(`Refinement failed: ${TRUNCATED_JSON_ERROR}`);
+		}
+
+		const text = response.content
+			.filter((content): content is { type: "text"; text: string } => content.type === "text")
+			.map((content) => content.text)
+			.join("\n");
+
+		const requested = round < REFINER_MAX_EXPANSION_ROUNDS ? parseExpandRequest(text) : undefined;
+		if (!requested) {
+			return { proposal: parseProposal(text), id, fullyVisibleIds: fullyVisible };
+		}
+
+		const rendered = renderExpansion(state, requested, fullyVisible, remaining);
+		const isFinalRound = round + 1 >= REFINER_MAX_EXPANSION_ROUNDS;
+		conversation.push(response, {
+			role: "user",
+			content: [
+				{
+					type: "text",
+					text: `<expanded_entries>\n${rendered}\n</expanded_entries>${
+						isFinalRound ? "\n\nThis is the last expansion round. Return edits now, or an empty edits array." : ""
+					}`,
+				},
+			],
+			timestamp: Date.now(),
+		});
+	}
 }
 
 function parseAutoRefineReview(text: string): AutoRefineReview {
@@ -1026,5 +1149,6 @@ export async function refineHarness(
 		id: plan.id,
 		rollbackOf: plan.rollbackOf,
 		scope: plan.rollbackScope ?? (options.global ? "global" : "local"),
+		fullyVisibleIds: plan.fullyVisibleIds,
 	});
 }

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -149,6 +149,9 @@ Scope and persistence policy:
 - Create or update the smallest relevant component: repeated delegation roles should become subagent specs, repeated procedures should become skills, durable facts/preferences should become memories, and narrow behavioral policies should become prompt addendums.
 - When an edit is persisted, include metadata such as \`{"scope":"local"}\` or \`{"scope":"global"}\` when that helps future review understand the intended blast radius.
 
+An \`update\` edit replaces the entry's entire \`content\`; text you do not reproduce is removed.
+Entries in the continual harness state above are truncated, and \`... (+N chars not shown)\`
+marks text you were not given.
 Use the trajectory, current continual harness state, and prior refinement history. Prefer
 small evidence-backed edits. If prior refinements caused issues, rollback or
 replace the faulty editable entries. Never edit source files directly. Output

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -26,6 +26,8 @@ const REFINEMENT_HISTORY_FILE_NAME = "refinements.jsonl";
 const DEFAULT_OVERVIEW_ENTRY_LIMIT = 6;
 const DEFAULT_OVERVIEW_REFINEMENT_LIMIT = 5;
 const DEFAULT_OVERVIEW_CONTENT_LIMIT = 180;
+const REFINER_ENTRY_LIMIT = 40;
+const REFINER_ENTRY_CONTENT_LIMIT = 240;
 
 export type RefinementKind = "prompt" | "memory" | "skill" | "subagent";
 export type RefinementAction = "create" | "update" | "delete";
@@ -524,8 +526,15 @@ function overviewForPrompt(state: HarnessState): string {
 	for (const kind of Object.keys(state.entries) as RefinementKind[]) {
 		const entries = Object.values(state.entries[kind]);
 		lines.push(`${kind}: ${entries.length}`);
-		for (const entry of entries.slice(0, 40)) {
-			const content = entry.content.replace(/\s+/g, " ").slice(0, 240);
+		for (const entry of entries.slice(0, REFINER_ENTRY_LIMIT)) {
+			const flattened = entry.content.replace(/\s+/g, " ");
+			const hidden = flattened.length - REFINER_ENTRY_CONTENT_LIMIT;
+			// An update replaces the entry, so a refiner that cannot tell a truncated
+			// entry from a complete one drops everything it was never shown.
+			const content =
+				hidden > 0
+					? `${flattened.slice(0, REFINER_ENTRY_CONTENT_LIMIT)}... (+${hidden} chars not shown)`
+					: flattened;
 			const argumentsText =
 				entry.kind === "skill" && Object.keys(entry.arguments).length > 0
 					? ` args=${JSON.stringify(entry.arguments).slice(0, 240)}`
@@ -538,8 +547,8 @@ function overviewForPrompt(state: HarnessState): string {
 				`- [${entry.scope ?? "global"}:${entry.id}] ${entry.title} (${entry.path}, v${entry.version})${referenceText}${argumentsText}: ${content}`,
 			);
 		}
-		if (entries.length > 40) {
-			lines.push(`- +${entries.length - 40} more ${kind} entries`);
+		if (entries.length > REFINER_ENTRY_LIMIT) {
+			lines.push(`- +${entries.length - REFINER_ENTRY_LIMIT} more ${kind} entries`);
 		}
 	}
 	return lines.join("\n");

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -142,11 +142,10 @@ Continual harness components:
 - subagent: reusable delegation specs, including purpose, instructions, and when to invoke. Include the RLM-native call form: compose a concise task prompt and spawn with \`handle = await rlm("sub-task")\`; admission returns immediately with \`rlm_child_id\`, \`name\`, \`session_dir\`, and \`model\`, never the child's answer. Results arrive only through explicit \`agent_message\` replies or files; children reply with \`await agent_message.send(message, receiver_role="parent")\`. Use \`await rlm.list_subagents()\` to recover direct child handles and \`await agent_message.send(..., receiver_role="child", receiver_name=handle.name)\` for follow-ups. Do not invent wrappers like \`run_subagent(...)\`.
 
 Editing model:
-- An \`update\` edit replaces the entry's entire \`content\`; text you do not reproduce is removed.
-- Entries in the harness state above are truncated. \`... (+N chars not shown)\` marks text you were not given.
-- You may only update an entry you have been shown in full. An update to a truncated entry is refused.
-- To see one, reply with \`{"expand": ["entry-id", ...]}\` and nothing else. Those entries are returned in
-  full and you may then emit edits, or expand again. Prefer expanding over rewriting from a fragment.
+- An \`update\` replaces the entry's entire \`content\`; text you do not reproduce is removed.
+- \`... (+N chars not shown)\` marks an entry you were not shown in full; an update to one is refused.
+- To see entries in full, reply with \`{"expand": ["id", ...]}\` and nothing else. List every entry you
+  need; you may expand again in a later reply.
 
 Scope and persistence policy:
 - The default editable continual harness store is local to the current Prime Agent session. Use it for session-specific progress, active task state, current-run coordination notes, temporary blockers, and project facts that should not affect other sessions.

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -144,8 +144,7 @@ Continual harness components:
 Editing model:
 - An \`update\` replaces the entry's entire \`content\`; text you do not reproduce is removed.
 - \`... (+N chars not shown)\` marks an entry you were not shown in full; an update to one is refused.
-- To see entries in full, reply with \`{"expand": ["id", ...]}\` and nothing else. List every entry you
-  need; you may expand again in a later reply.
+- To see entries in full, reply with \`{"expand": ["id", ...]}\` and nothing else. List every entry you need; you may expand again in a later reply.
 
 Scope and persistence policy:
 - The default editable continual harness store is local to the current Prime Agent session. Use it for session-specific progress, active task state, current-run coordination notes, temporary blockers, and project facts that should not affect other sessions.
@@ -610,12 +609,12 @@ function findEntryById(state: HarnessState, id: string): HarnessEntry | undefine
  * Render requested entries in full, within a character budget. Withheld and unknown ids
  * are reported so the refiner knows it is still working without them.
  */
-function renderExpansion(
+function expansionForPrompt(
 	state: HarnessState,
 	ids: string[],
 	expanded: Set<string>,
-	remaining: { budget: number },
-): string {
+	budget: number,
+): { text: string; budget: number } {
 	const lines: string[] = [];
 	for (const id of ids) {
 		const entry = findEntryById(state, id);
@@ -623,15 +622,15 @@ function renderExpansion(
 			lines.push(`- ${id}: not found`);
 			continue;
 		}
-		if (entry.content.length > remaining.budget) {
+		if (entry.content.length > budget) {
 			lines.push(`- ${entry.id}: withheld, expansion budget exhausted (${entry.content.length} chars)`);
 			continue;
 		}
-		remaining.budget -= entry.content.length;
+		budget -= entry.content.length;
 		expanded.add(entry.id);
 		lines.push(`<entry id="${entry.id}" kind="${entry.kind}" title="${entry.title}">\n${entry.content}\n</entry>`);
 	}
-	return lines.join("\n\n");
+	return { text: lines.join("\n\n"), budget };
 }
 
 function historyForPrompt(history: RefinementResult[]): string {
@@ -1025,7 +1024,7 @@ export async function planRefinement(
 	const conversation: Message[] = [
 		{ role: "user", content: [{ type: "text", text: userPrompt }], timestamp: Date.now() },
 	];
-	const remaining = { budget: REFINER_EXPANSION_BUDGET };
+	let budget = REFINER_EXPANSION_BUDGET;
 
 	for (let round = 0; ; round++) {
 		const response = await completeSimple(
@@ -1051,14 +1050,15 @@ export async function planRefinement(
 			return { proposal: parseProposal(text), id, fullyVisibleIds: fullyVisible };
 		}
 
-		const rendered = renderExpansion(state, requested, fullyVisible, remaining);
+		const expansion = expansionForPrompt(state, requested, fullyVisible, budget);
+		budget = expansion.budget;
 		const isFinalRound = round + 1 >= REFINER_MAX_EXPANSION_ROUNDS;
 		conversation.push(response, {
 			role: "user",
 			content: [
 				{
 					type: "text",
-					text: `<expanded_entries>\n${rendered}\n</expanded_entries>${
+					text: `<expanded_entries>\n${expansion.text}\n</expanded_entries>${
 						isFinalRound ? "\n\nThis is the last expansion round. Return edits now, or an empty edits array." : ""
 					}`,
 				},

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -139,6 +139,10 @@ Continual harness components:
 - skill: installed Python REPL skill. Skill create/update edits MUST include a \`reference\` object with \`{"type":"python"}\`, a Python import, and a callable or call pattern; they also MUST include an \`arguments\` object describing accepted inputs, required fields, defaults, and constraints. Use \`{}\` for \`arguments\` only when the Python callable truly needs no external inputs. Include the RLM-native call form \`await <skill_import>(...)\`.
 - subagent: reusable delegation specs, including purpose, instructions, and when to invoke. Include the RLM-native call form: compose a concise task prompt and spawn with \`handle = await rlm("sub-task")\`; admission returns immediately with \`rlm_child_id\`, \`name\`, \`session_dir\`, and \`model\`, never the child's answer. Results arrive only through explicit \`agent_message\` replies or files; children reply with \`await agent_message.send(message, receiver_role="parent")\`. Use \`await rlm.list_subagents()\` to recover direct child handles and \`await agent_message.send(..., receiver_role="child", receiver_name=handle.name)\` for follow-ups. Do not invent wrappers like \`run_subagent(...)\`.
 
+Editing model:
+- An \`update\` edit replaces the entry's entire \`content\`; text you do not reproduce is removed.
+- Entries in the harness state above are truncated. \`... (+N chars not shown)\` marks text you were not given.
+
 Scope and persistence policy:
 - The default editable continual harness store is local to the current Prime Agent session. Use it for session-specific progress, active task state, current-run coordination notes, temporary blockers, and project facts that should not affect other sessions.
 - A caller may explicitly request global refinement. Global edits must be stable cross-session lessons, durable user preferences, reusable skills/subagents, or tool/environment facts that should affect future sessions.
@@ -149,9 +153,6 @@ Scope and persistence policy:
 - Create or update the smallest relevant component: repeated delegation roles should become subagent specs, repeated procedures should become skills, durable facts/preferences should become memories, and narrow behavioral policies should become prompt addendums.
 - When an edit is persisted, include metadata such as \`{"scope":"local"}\` or \`{"scope":"global"}\` when that helps future review understand the intended blast radius.
 
-An \`update\` edit replaces the entry's entire \`content\`; text you do not reproduce is removed.
-Entries in the continual harness state above are truncated, and \`... (+N chars not shown)\`
-marks text you were not given.
 Use the trajectory, current continual harness state, and prior refinement history. Prefer
 small evidence-backed edits. If prior refinements caused issues, rollback or
 replace the faulty editable entries. Never edit source files directly. Output

--- a/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
@@ -10,6 +10,7 @@ import {
 	type HarnessEntryIdentity,
 	loadHarnessState,
 	planRefinement,
+	reviewAutoRefine,
 } from "../../../src/core/refinement/index.js";
 
 const { completeSimpleMock } = vi.hoisted(() => ({
@@ -77,6 +78,49 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 			maxTokens: 8192,
 		};
 	}
+
+	it("passes the rendered harness overview to the auto-refine reviewer", async () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		const distinctiveToken = "REVIEW_OVERVIEW_DISTINCTIVE_TOKEN";
+		state.entries.prompt.card = {
+			id: "card",
+			kind: "prompt",
+			title: "Card",
+			content: distinctiveToken,
+			path: "general",
+			scope: "local",
+			reference: {},
+			arguments: {},
+			metadata: {},
+			source: "agent",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			version: 1,
+		};
+		completeSimpleMock.mockResolvedValueOnce(
+			assistantText(JSON.stringify({ shouldRefine: true, rationale: "review-visible" })),
+		);
+
+		const review = await reviewAutoRefine(
+			[{ role: "user", content: "review the trajectory", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			createRefineModel(),
+			"api-key",
+			{ reason: "turn_interval", turnsSinceLastReview: 1 },
+		);
+
+		const requestText: string = completeSimpleMock.mock.calls[0][1].messages[0].content[0].text;
+		const overviewStart = requestText.indexOf("<current_harness_state>");
+		const overviewEnd = requestText.indexOf("</current_harness_state>", overviewStart);
+		expect(overviewStart).toBeGreaterThanOrEqual(0);
+		expect(overviewEnd).toBeGreaterThan(overviewStart);
+		const overviewBlock = requestText.slice(overviewStart, overviewEnd);
+		expect(overviewBlock).toContain(`- [local:prompt:card] Card (general, v1): ${distinctiveToken}`);
+		expect(overviewBlock).toContain(distinctiveToken);
+		expect(overviewBlock).not.toContain("[object Object]");
+		expect(review).toMatchObject({ shouldRefine: true, rationale: "review-visible" });
+	});
 
 	it("tells the refiner when an entry is longer than the overview shows", async () => {
 		const state = loadHarnessState(makeTempDir(), "local");

--- a/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
@@ -279,4 +279,106 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		const result = applyRefinementProposal(state, plan.proposal, { id: "r3", fullyVisibleIds: plan.fullyVisibleIds });
 		expect(result.appliedEdits[0].applied).toBe(true);
 	});
+
+	it("expands several entries at once and across rounds", async () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		for (const name of ["alpha", "beta", "gamma"]) {
+			state.entries.prompt[name] = {
+				id: name,
+				kind: "prompt",
+				title: name,
+				content: `${name.toUpperCase()} head. ${"filler. ".repeat(60)}${name}-tail`,
+				path: "general",
+				scope: "local",
+				reference: {},
+				arguments: {},
+				metadata: {},
+				source: "agent",
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				version: 1,
+			};
+		}
+
+		completeSimpleMock
+			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["alpha", "beta"] })))
+			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["gamma"] })))
+			.mockResolvedValueOnce(
+				assistantText(
+					JSON.stringify({
+						summary: "s",
+						rationale: "r",
+						expectedOutcome: "e",
+						edits: [
+							{ action: "update", kind: "prompt", id: "alpha", title: "alpha", content: "A" },
+							{ action: "update", kind: "prompt", id: "gamma", title: "gamma", content: "G" },
+						],
+					}),
+				),
+			);
+
+		const plan = await planRefinement(
+			[{ role: "user", content: "revise these", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			createRefineModel(),
+			"api-key",
+			{},
+		);
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(3);
+		const round2 = completeSimpleMock.mock.calls[1][1].messages[2].content[0].text;
+		expect(round2).toContain("alpha-tail");
+		expect(round2).toContain("beta-tail");
+		const round3 = completeSimpleMock.mock.calls[2][1].messages[4].content[0].text;
+		expect(round3).toContain("gamma-tail");
+		expect([...(plan.fullyVisibleIds ?? [])].sort()).toEqual(["alpha", "beta", "gamma"]);
+
+		const result = applyRefinementProposal(state, plan.proposal, { id: "r4", fullyVisibleIds: plan.fullyVisibleIds });
+		expect(result.appliedEdits.every((edit) => edit.applied)).toBe(true);
+	});
+
+	it("accepts the display-prefixed id form the overview renders", async () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		state.entries.prompt.note = {
+			id: "note",
+			kind: "prompt",
+			title: "Note",
+			content: `HEAD. ${"filler. ".repeat(60)}note-tail`,
+			path: "general",
+			scope: "local",
+			reference: {},
+			arguments: {},
+			metadata: {},
+			source: "agent",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			version: 1,
+		};
+
+		completeSimpleMock
+			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["local:note"] })))
+			.mockResolvedValueOnce(
+				assistantText(
+					JSON.stringify({
+						summary: "s",
+						rationale: "r",
+						expectedOutcome: "e",
+						edits: [{ action: "update", kind: "prompt", id: "note", title: "Note", content: "rewritten" }],
+					}),
+				),
+			);
+
+		const plan = await planRefinement(
+			[{ role: "user", content: "revise", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			createRefineModel(),
+			"api-key",
+			{},
+		);
+
+		expect(completeSimpleMock.mock.calls[1][1].messages[2].content[0].text).toContain("note-tail");
+		expect(plan.fullyVisibleIds?.has("note")).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
@@ -5,7 +5,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type * as PiAi from "@earendil-works/pi-ai";
 import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadHarnessState, planRefinement } from "../../../src/core/refinement/index.js";
+import { applyRefinementProposal, loadHarnessState, planRefinement } from "../../../src/core/refinement/index.js";
 
 const { completeSimpleMock } = vi.hoisted(() => ({
 	completeSimpleMock: vi.fn(),
@@ -136,5 +136,147 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		const request = completeSimpleMock.mock.calls[0][1];
 		expect(request.systemPrompt).toContain("replaces the entry's entire");
 		expect(request.systemPrompt).toContain("chars not shown");
+	});
+
+	it("expands an entry on request and applies the update it could not otherwise make", async () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		const tail = "SUBAGENT LIFECYCLE: delete children only at an approved boundary.";
+		state.entries.prompt.long_note = {
+			id: "long_note",
+			kind: "prompt",
+			title: "Long note",
+			content: `HEAD. ${"filler clause. ".repeat(60)}${tail}`,
+			path: "general",
+			scope: "local",
+			reference: {},
+			arguments: {},
+			metadata: {},
+			source: "agent",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			version: 1,
+		};
+
+		completeSimpleMock
+			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["long_note"] })))
+			.mockResolvedValueOnce(
+				assistantText(
+					JSON.stringify({
+						summary: "s",
+						rationale: "r",
+						expectedOutcome: "e",
+						edits: [
+							{
+								action: "update",
+								kind: "prompt",
+								id: "long_note",
+								title: "Long note",
+								content: "rewritten in full",
+							},
+						],
+					}),
+				),
+			);
+
+		const plan = await planRefinement(
+			[{ role: "user", content: "update the long note", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			createRefineModel(),
+			"api-key",
+			{},
+		);
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(2);
+		// Round two must carry the prior assistant turn plus the expanded entry.
+		const second = completeSimpleMock.mock.calls[1][1];
+		expect(second.messages).toHaveLength(3);
+		expect(second.messages[1].role).toBe("assistant");
+		expect(second.messages[2].content[0].text).toContain(tail);
+		expect(plan.fullyVisibleIds?.has("long_note")).toBe(true);
+
+		const result = applyRefinementProposal(state, plan.proposal, { id: "r1", fullyVisibleIds: plan.fullyVisibleIds });
+		expect(result.appliedEdits[0].applied).toBe(true);
+		expect(state.entries.prompt.long_note.content).toBe("rewritten in full");
+	});
+
+	it("refuses an update to an entry the refiner never saw in full", () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		state.entries.prompt.long_note = {
+			id: "long_note",
+			kind: "prompt",
+			title: "Long note",
+			content: "x".repeat(2000),
+			path: "general",
+			scope: "local",
+			reference: {},
+			arguments: {},
+			metadata: {},
+			source: "agent",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			version: 1,
+		};
+
+		const result = applyRefinementProposal(
+			state,
+			{
+				summary: "s",
+				rationale: "r",
+				expectedOutcome: "e",
+				edits: [{ action: "update", kind: "prompt", id: "long_note", title: "Long note", content: "short delta" }],
+			},
+			{ id: "r2", fullyVisibleIds: new Set<string>() },
+		);
+
+		expect(result.appliedEdits[0]).toMatchObject({
+			applied: false,
+			error: "entry was not shown in full; update refused",
+		});
+		expect(state.entries.prompt.long_note.content).toHaveLength(2000);
+	});
+
+	it("lets the refiner update a short entry without an expansion round", async () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		state.entries.memory.card = {
+			id: "card",
+			kind: "memory",
+			title: "Card",
+			content: "A short routing card.",
+			path: "general",
+			scope: "local",
+			reference: {},
+			arguments: {},
+			metadata: {},
+			source: "agent",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			version: 1,
+		};
+
+		completeSimpleMock.mockResolvedValueOnce(
+			assistantText(
+				JSON.stringify({
+					summary: "s",
+					rationale: "r",
+					expectedOutcome: "e",
+					edits: [{ action: "update", kind: "memory", id: "card", title: "Card", content: "A shorter card." }],
+				}),
+			),
+		);
+
+		const plan = await planRefinement(
+			[{ role: "user", content: "tighten the card", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			createRefineModel(),
+			"api-key",
+			{},
+		);
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		expect(plan.fullyVisibleIds?.has("card")).toBe(true);
+		const result = applyRefinementProposal(state, plan.proposal, { id: "r3", fullyVisibleIds: plan.fullyVisibleIds });
+		expect(result.appliedEdits[0].applied).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
@@ -117,4 +117,24 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		// from a complete entry will silently drop everything it was not shown.
 		expect(entryLine).toMatch(/\.\.\.|not shown|truncated/);
 	});
+
+	it("tells the refiner that an update replaces the entry and what the truncation marker means", async () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		completeSimpleMock.mockResolvedValueOnce(
+			assistantText(JSON.stringify({ summary: "no-op", rationale: "none", expectedOutcome: "none", edits: [] })),
+		);
+
+		await planRefinement(
+			[{ role: "user", content: "anything", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			createRefineModel(),
+			"api-key",
+			{},
+		);
+
+		const request = completeSimpleMock.mock.calls[0][1];
+		expect(request.systemPrompt).toContain("replaces the entry's entire");
+		expect(request.systemPrompt).toContain("chars not shown");
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type * as PiAi from "@earendil-works/pi-ai";
+import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadHarnessState, planRefinement } from "../../../src/core/refinement/index.js";
+
+const { completeSimpleMock } = vi.hoisted(() => ({
+	completeSimpleMock: vi.fn(),
+}));
+
+vi.mock("@earendil-works/pi-ai", async (importOriginal) => {
+	const actual = await importOriginal<typeof PiAi>();
+	return {
+		...actual,
+		completeSimple: completeSimpleMock,
+	};
+});
+
+describe("issue #1290 refiner overview truncation: entries cut to the per-entry window must be marked", () => {
+	let tempDir: string | undefined;
+
+	beforeEach(() => {
+		completeSimpleMock.mockReset();
+	});
+
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = undefined;
+		}
+	});
+
+	function makeTempDir(): string {
+		tempDir = mkdtempSync(join(tmpdir(), "prime-agent-1290-"));
+		return tempDir;
+	}
+
+	function assistantText(text: string): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: "openai-completions",
+			provider: "prime-inference",
+			model: "openai/gpt-5.5",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+	}
+
+	function createRefineModel(): Model<"openai-completions"> {
+		return {
+			id: "openai/gpt-5.5",
+			name: "GPT 5.5",
+			api: "openai-completions",
+			provider: "prime-inference",
+			baseUrl: "https://inference.primeintellect.ai/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 8192,
+		};
+	}
+
+	it("tells the refiner when an entry is longer than the overview shows", async () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		const visibleHead = "OPERATING PROCEDURE - do not restate blocks already recorded here.";
+		const hiddenTail = "SUBAGENT LIFECYCLE: delete an action's children only at an approved boundary.";
+		state.entries.prompt.long_note = {
+			id: "long_note",
+			kind: "prompt",
+			title: "Long note",
+			content: `${visibleHead} ${"filler clause. ".repeat(60)}${hiddenTail}`,
+			path: "general",
+			scope: "local",
+			reference: {},
+			arguments: {},
+			metadata: {},
+			source: "agent",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			version: 1,
+		};
+
+		completeSimpleMock.mockResolvedValueOnce(
+			assistantText(JSON.stringify({ summary: "no-op", rationale: "none", expectedOutcome: "none", edits: [] })),
+		);
+
+		await planRefinement(
+			[{ role: "user", content: "consider the long note", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			createRefineModel(),
+			"api-key",
+			{},
+		);
+
+		const userPrompt: string = completeSimpleMock.mock.calls[0][1].messages[0].content[0].text;
+		const entryLine = userPrompt.split("\n").find((line: string) => line.includes("[local:long_note]"));
+
+		expect(entryLine).toBeDefined();
+		expect(entryLine).toContain(visibleHead);
+		// The tail sits beyond the per-entry window, so the refiner never receives it.
+		expect(userPrompt).not.toContain(hiddenTail);
+		// An update replaces the whole entry, so a refiner that cannot tell a fragment
+		// from a complete entry will silently drop everything it was not shown.
+		expect(entryLine).toMatch(/\.\.\.|not shown|truncated/);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
@@ -381,4 +381,77 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		expect(completeSimpleMock.mock.calls[1][1].messages[2].content[0].text).toContain("note-tail");
 		expect(plan.fullyVisibleIds?.has("note")).toBe(true);
 	});
+
+	it("stops expanding after the round limit and still returns a proposal", async () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		state.entries.prompt.note = {
+			id: "note",
+			kind: "prompt",
+			title: "Note",
+			content: `HEAD. ${"filler. ".repeat(60)}note-tail`,
+			path: "general",
+			scope: "local",
+			reference: {},
+			arguments: {},
+			metadata: {},
+			source: "agent",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			version: 1,
+		};
+		// A refiner that only ever asks to expand, never proposing edits.
+		completeSimpleMock.mockResolvedValue(assistantText(JSON.stringify({ expand: ["note"] })));
+
+		const plan = await planRefinement(
+			[{ role: "user", content: "go", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			createRefineModel(),
+			"api-key",
+			{},
+		);
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(4);
+		expect(plan.proposal.edits).toEqual([]);
+		const lastInjected = completeSimpleMock.mock.calls[3][1].messages.at(-1).content[0].text;
+		expect(lastInjected).toContain("last expansion round");
+	});
+
+	it("withholds an entry that does not fit the expansion budget and says so", async () => {
+		const state = loadHarnessState(makeTempDir(), "local");
+		state.entries.prompt.huge = {
+			id: "huge",
+			kind: "prompt",
+			title: "Huge",
+			content: "x".repeat(120_000),
+			path: "general",
+			scope: "local",
+			reference: {},
+			arguments: {},
+			metadata: {},
+			source: "agent",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			version: 1,
+		};
+		completeSimpleMock
+			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["huge", "missing"] })))
+			.mockResolvedValueOnce(
+				assistantText(JSON.stringify({ summary: "s", rationale: "r", expectedOutcome: "e", edits: [] })),
+			);
+
+		const plan = await planRefinement(
+			[{ role: "user", content: "go", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			createRefineModel(),
+			"api-key",
+			{},
+		);
+
+		const injected = completeSimpleMock.mock.calls[1][1].messages[2].content[0].text;
+		expect(injected).toContain("expansion budget exhausted");
+		expect(injected).toContain("missing: not found");
+		expect(plan.fullyVisibleIds?.has("huge")).toBe(false);
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1290-refiner-truncation-marker.test.ts
@@ -5,7 +5,12 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type * as PiAi from "@earendil-works/pi-ai";
 import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { applyRefinementProposal, loadHarnessState, planRefinement } from "../../../src/core/refinement/index.js";
+import {
+	applyRefinementProposal,
+	type HarnessEntryIdentity,
+	loadHarnessState,
+	planRefinement,
+} from "../../../src/core/refinement/index.js";
 
 const { completeSimpleMock } = vi.hoisted(() => ({
 	completeSimpleMock: vi.fn(),
@@ -107,7 +112,7 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		);
 
 		const userPrompt: string = completeSimpleMock.mock.calls[0][1].messages[0].content[0].text;
-		const entryLine = userPrompt.split("\n").find((line: string) => line.includes("[local:long_note]"));
+		const entryLine = userPrompt.split("\n").find((line: string) => line.includes("[local:prompt:long_note]"));
 
 		expect(entryLine).toBeDefined();
 		expect(entryLine).toContain(visibleHead);
@@ -158,7 +163,7 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		};
 
 		completeSimpleMock
-			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["long_note"] })))
+			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["local:prompt:long_note"] })))
 			.mockResolvedValueOnce(
 				assistantText(
 					JSON.stringify({
@@ -193,7 +198,7 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		expect(second.messages).toHaveLength(3);
 		expect(second.messages[1].role).toBe("assistant");
 		expect(second.messages[2].content[0].text).toContain(tail);
-		expect(plan.fullyVisibleIds?.has("long_note")).toBe(true);
+		expect(plan.fullyVisibleIds?.has("local:prompt:long_note")).toBe(true);
 
 		const result = applyRefinementProposal(state, plan.proposal, { id: "r1", fullyVisibleIds: plan.fullyVisibleIds });
 		expect(result.appliedEdits[0].applied).toBe(true);
@@ -226,7 +231,7 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 				expectedOutcome: "e",
 				edits: [{ action: "update", kind: "prompt", id: "long_note", title: "Long note", content: "short delta" }],
 			},
-			{ id: "r2", fullyVisibleIds: new Set<string>() },
+			{ id: "r2", fullyVisibleIds: new Set<HarnessEntryIdentity>() },
 		);
 
 		expect(result.appliedEdits[0]).toMatchObject({
@@ -275,7 +280,7 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		);
 
 		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
-		expect(plan.fullyVisibleIds?.has("card")).toBe(true);
+		expect(plan.fullyVisibleIds?.has("local:memory:card")).toBe(true);
 		const result = applyRefinementProposal(state, plan.proposal, { id: "r3", fullyVisibleIds: plan.fullyVisibleIds });
 		expect(result.appliedEdits[0].applied).toBe(true);
 	});
@@ -301,8 +306,8 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		}
 
 		completeSimpleMock
-			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["alpha", "beta"] })))
-			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["gamma"] })))
+			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["local:prompt:alpha", "local:prompt:beta"] })))
+			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["local:prompt:gamma"] })))
 			.mockResolvedValueOnce(
 				assistantText(
 					JSON.stringify({
@@ -332,13 +337,17 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		expect(round2).toContain("beta-tail");
 		const round3 = completeSimpleMock.mock.calls[2][1].messages[4].content[0].text;
 		expect(round3).toContain("gamma-tail");
-		expect([...(plan.fullyVisibleIds ?? [])].sort()).toEqual(["alpha", "beta", "gamma"]);
+		expect([...(plan.fullyVisibleIds ?? [])].sort()).toEqual([
+			"local:prompt:alpha",
+			"local:prompt:beta",
+			"local:prompt:gamma",
+		]);
 
 		const result = applyRefinementProposal(state, plan.proposal, { id: "r4", fullyVisibleIds: plan.fullyVisibleIds });
 		expect(result.appliedEdits.every((edit) => edit.applied)).toBe(true);
 	});
 
-	it("accepts the display-prefixed id form the overview renders", async () => {
+	it("accepts the canonical identifier form the overview renders", async () => {
 		const state = loadHarnessState(makeTempDir(), "local");
 		state.entries.prompt.note = {
 			id: "note",
@@ -357,7 +366,7 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		};
 
 		completeSimpleMock
-			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["local:note"] })))
+			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["local:prompt:note"] })))
 			.mockResolvedValueOnce(
 				assistantText(
 					JSON.stringify({
@@ -379,7 +388,7 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 		);
 
 		expect(completeSimpleMock.mock.calls[1][1].messages[2].content[0].text).toContain("note-tail");
-		expect(plan.fullyVisibleIds?.has("note")).toBe(true);
+		expect(plan.fullyVisibleIds?.has("local:prompt:note")).toBe(true);
 	});
 
 	it("stops expanding after the round limit and still returns a proposal", async () => {
@@ -400,7 +409,7 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 			version: 1,
 		};
 		// A refiner that only ever asks to expand, never proposing edits.
-		completeSimpleMock.mockResolvedValue(assistantText(JSON.stringify({ expand: ["note"] })));
+		completeSimpleMock.mockResolvedValue(assistantText(JSON.stringify({ expand: ["local:prompt:note"] })));
 
 		const plan = await planRefinement(
 			[{ role: "user", content: "go", timestamp: Date.now() } satisfies AgentMessage],
@@ -435,7 +444,9 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 			version: 1,
 		};
 		completeSimpleMock
-			.mockResolvedValueOnce(assistantText(JSON.stringify({ expand: ["huge", "missing"] })))
+			.mockResolvedValueOnce(
+				assistantText(JSON.stringify({ expand: ["local:prompt:huge", "local:prompt:missing"] })),
+			)
 			.mockResolvedValueOnce(
 				assistantText(JSON.stringify({ summary: "s", rationale: "r", expectedOutcome: "e", edits: [] })),
 			);
@@ -451,7 +462,7 @@ describe("issue #1290 refiner overview truncation: entries cut to the per-entry 
 
 		const injected = completeSimpleMock.mock.calls[1][1].messages[2].content[0].text;
 		expect(injected).toContain("expansion budget exhausted");
-		expect(injected).toContain("missing: not found");
-		expect(plan.fullyVisibleIds?.has("huge")).toBe(false);
+		expect(injected).toContain("local:prompt:missing: not found");
+		expect(plan.fullyVisibleIds?.has("local:prompt:huge")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/1317-refiner-visibility-identity.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1317-refiner-visibility-identity.test.ts
@@ -1,0 +1,141 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	applyRefinementProposal,
+	getGlobalHarnessStateDir,
+	getLocalHarnessStateDir,
+	type HarnessScope,
+	type HarnessState,
+	loadHarnessState,
+	type RefinementKind,
+	saveHarnessState,
+} from "../../../src/core/refinement/index.js";
+import { createHarness, getMessageText, type Harness } from "../harness.js";
+
+function seedEntry(state: HarnessState, scope: HarnessScope, kind: RefinementKind, id: string, content: string): void {
+	const result = applyRefinementProposal(
+		state,
+		{
+			summary: `Seed ${scope} ${kind}`,
+			rationale: "Regression fixture",
+			expectedOutcome: "Entry is available to the refiner",
+			edits: [{ action: "create", kind, id, title: `${kind} ${id}`, content }],
+		},
+		{ id: `seed_${scope}_${kind}_${id}`, scope },
+	);
+	if (!result.appliedEdits[0]?.applied) {
+		throw new Error(`Failed to seed ${scope}:${kind}:${id}`);
+	}
+}
+
+function updateProposal(kind: RefinementKind, id: string, content: string): string {
+	return JSON.stringify({
+		summary: `Update ${kind}`,
+		rationale: "The expanded card appeared relevant",
+		expectedOutcome: "Only the exact visible entry changes",
+		edits: [{ action: "update", kind, id, title: `${kind} ${id}`, content }],
+	});
+}
+
+describe("PR #1317 refiner visibility identity", () => {
+	let harness: Harness | undefined;
+	let previousAgentDir: string | undefined;
+
+	beforeEach(() => {
+		previousAgentDir = process.env.PRIME_AGENT_CODING_AGENT_DIR;
+	});
+
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+		if (previousAgentDir === undefined) {
+			delete process.env.PRIME_AGENT_CODING_AGENT_DIR;
+		} else {
+			process.env.PRIME_AGENT_CODING_AGENT_DIR = previousAgentDir;
+		}
+	});
+
+	it("keeps expansion and update authority isolated across kinds sharing an id", async () => {
+		harness = await createHarness({ persistSession: true });
+		process.env.PRIME_AGENT_CODING_AGENT_DIR = `${harness.tempDir}/agent`;
+		const localDir = getLocalHarnessStateDir(harness.sessionManager.getSessionArtifactDir());
+		if (!localDir) throw new Error("Expected a persisted local harness directory");
+
+		const state = loadHarnessState(localDir, "local");
+		const promptTail = "PROMPT SECRET TAIL: this must not be disclosed or authorized.";
+		const promptContent = `PROMPT HEAD ${"filler ".repeat(80)}${promptTail}`;
+		const memoryContent = "MEMORY CARD: fully visible and safe to expand.";
+		seedEntry(state, "local", "prompt", "card", promptContent);
+		seedEntry(state, "local", "memory", "card", memoryContent);
+		saveHarnessState(localDir, state);
+
+		let initialPrompt = "";
+		let expansionPrompt = "";
+		harness.setResponses([
+			(context) => {
+				initialPrompt = getMessageText(context.messages[0]);
+				return fauxAssistantMessage(JSON.stringify({ expand: ["local:memory:card"] }));
+			},
+			(context) => {
+				expansionPrompt = getMessageText(context.messages.at(-1));
+				return fauxAssistantMessage(updateProposal("prompt", "card", "unauthorized replacement"));
+			},
+		]);
+
+		const result = await harness.session.refine({ instructions: "Review the card entries" });
+
+		expect(initialPrompt).toContain("[local:prompt:card]");
+		expect(initialPrompt).toContain("[local:memory:card]");
+		expect(expansionPrompt).toContain('identifier="local:memory:card"');
+		expect(expansionPrompt).toContain(memoryContent);
+		expect(expansionPrompt).not.toContain(promptTail);
+		expect(result.appliedEdits[0]).toMatchObject({
+			kind: "prompt",
+			id: "card",
+			applied: false,
+			error: "entry was not shown in full; update refused",
+		});
+		expect(loadHarnessState(localDir, "local").entries.prompt.card.content).toBe(promptContent);
+	});
+
+	it("keeps expansion and update authority isolated across scopes sharing a kind and id", async () => {
+		harness = await createHarness({ persistSession: true });
+		process.env.PRIME_AGENT_CODING_AGENT_DIR = `${harness.tempDir}/agent`;
+		const globalDir = getGlobalHarnessStateDir();
+		const localDir = getLocalHarnessStateDir(harness.sessionManager.getSessionArtifactDir());
+		if (!localDir) throw new Error("Expected a persisted local harness directory");
+
+		const globalState = loadHarnessState(globalDir, "global");
+		const localState = loadHarnessState(localDir, "local");
+		const globalContent = "GLOBAL MEMORY CARD: fully visible context.";
+		const localTail = "LOCAL SECRET TAIL: this must remain unchanged.";
+		const localContent = `LOCAL MEMORY HEAD ${"filler ".repeat(80)}${localTail}`;
+		seedEntry(globalState, "global", "memory", "card", globalContent);
+		seedEntry(localState, "local", "memory", "card", localContent);
+		saveHarnessState(globalDir, globalState);
+		saveHarnessState(localDir, localState);
+
+		let expansionPrompt = "";
+		harness.setResponses([
+			fauxAssistantMessage(JSON.stringify({ expand: ["global:memory:card"] })),
+			(context) => {
+				expansionPrompt = getMessageText(context.messages.at(-1));
+				return fauxAssistantMessage(updateProposal("memory", "card", "unauthorized local replacement"));
+			},
+		]);
+
+		const result = await harness.session.refine({ instructions: "Review the shared memory card" });
+
+		expect(expansionPrompt).toContain('identifier="global:memory:card"');
+		expect(expansionPrompt).toContain(globalContent);
+		expect(expansionPrompt).not.toContain(localTail);
+		expect(result.appliedEdits[0]).toMatchObject({
+			kind: "memory",
+			id: "card",
+			applied: false,
+			error: "entry was not shown in full; update refused",
+		});
+		expect(loadHarnessState(localDir, "local").entries.memory.card.content).toBe(localContent);
+		expect(loadHarnessState(globalDir, "global").entries.memory.card.content).toBe(globalContent);
+	});
+});


### PR DESCRIPTION
Refs #1290. **Draft — not ready for review.**

`overviewForPrompt` cut each harness entry to a fixed window with a bare `.slice()` — no ellipsis, no length — and that string is the entire `<current_harness_state>` block the refiner sees. It is then asked to emit complete replacement `content`, with no way to see the rest and nothing stating that an update replaces what is not reproduced.

Measured over one session: **154 applied `update` edits, 0 preserved any prior text, 90 made the entry shorter, and 136 opened with the literal string `"APPEND — prior clauses stand"`.** The largest affected entry was 14,572 chars, of which the refiner saw 240 (1.6%). One representative reply named six sections it could not see and replaced them with a pointer asserting they "remain in force".

## Changes

- `overviewForPrompt` marks truncation and reports the hidden length: `... (+N chars not shown)`, and returns the set of entries it rendered whole.
- `REFINEMENT_SYSTEM_PROMPT` gains a three-line `Editing model:` section: an `update` replaces the entry, what the marker means, and how to ask for more.
- **Expansion round-trip.** The refiner may reply `{"expand": ["id", ...]}`; those entries are injected in full and it may then emit edits or expand again. `completeSimple` returns an `AssistantMessage`, so the prior turn is pushed back verbatim — no `tools` array, no reconstructed turn, and any thinking blocks survive intact. Bounded at 3 expansion rounds (4 calls) and an 80,000-char budget; the final round says so, and withheld or unknown ids are reported rather than silently omitted.
- **Enforcement, not instruction.** `applyRefinementProposal` accepts a `fullyVisibleIds` set and refuses `update` for any id outside it, alongside the existing `"entry changed during refinement planning"` guard. The guarantee does not depend on model compliance.
- Entries short enough to render whole are fully visible by definition, so a harness of short entries never triggers a round-trip and behaves exactly as before.
- Display-prefixed ids (`local:foo`) resolve, since that is the form the overview renders and the form models actually emit.
- The two magic numbers in `overviewForPrompt` are named.

## Testing

`test/suite/regressions/1290-refiner-truncation-marker.test.ts` — 9 tests covering the marker, the prompt text, single and multi-entry expansion, expansion across rounds, the prefixed-id form, the round limit, budget exhaustion, refusal of an unseen entry, and a short entry updating with no round-trip. With `test/refinement.test.ts`: **68 passing.** `npm run check` clean.

Verified end to end against a real model (`claude-opus-5`) on a real 14,572-char entry: the refiner requested expansion, received the entry in full, found the lesson already present at char 10,801, and correctly declined to edit — three runs out of three. From 240 chars that judgement is not available.

## Open

- `REFINER_MAX_EXPANSION_ROUNDS = 3` and `REFINER_EXPANSION_BUDGET = 80_000` are my values with no evidence behind them; maintainers may prefer different ones.
- `overviewForPrompt` now returns `{ text, fullyVisible }` where `historyForPrompt` still returns a string. The set is load-bearing, but the asymmetry is worth a view.
- The control arm is unmeasured: I can show the new path works, not the size of the delta against the old one.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark truncated entries in the refiner overview and refuse updates to entries not seen in full
> - `overviewForPrompt` in [`refinement.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1317/files#diff-17b614d876315ad8ac0165562a8f07a5c4ada3b28928eb02d90f6b93a96ea91d) now annotates truncated entries with `... (+N chars not shown)` and returns a structured result tracking which entries were fully visible.
> - The refiner can request full entry content by canonical identity (`scope:kind:id`) across up to 3 expansion rounds before producing edits, bounded by an 80,000-char budget.
> - `applyRefinementProposal` rejects update edits for entries the refiner did not see in full, recording the edit as unapplied with an explicit error message.
> - Regression tests in [`1290-refiner-truncation-marker.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1317/files#diff-6b029a95ccaa7b291ca23b99f65582fa00fe38b98040678a741c0271d4bd54a3) and [`1317-refiner-visibility-identity.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1317/files#diff-5ba46ef379d51d9167ed62858a01bcbaaff6772ab61d70365709f0f1d635d759) cover truncation markers, expansion flow, budget limits, and cross-kind/cross-scope identity isolation.
> - Behavioral Change: refinement proposals that update large entries the model did not explicitly expand will now be silently refused rather than applied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1aa3f36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->