### PR TITLE
fix(coding-agent): relay clipboard through tmux

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed login-link and other clipboard actions in wmux-managed panes by relaying OSC 52 requests through tmux to the browser instead of copying only on the session host.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -19,8 +19,8 @@ function copyToX11Clipboard(options: NativeClipboardExecOptions): void {
 
 const MAX_OSC52_ENCODED_LENGTH = 100_000;
 
-function isRemoteSession(env: NodeJS.ProcessEnv = process.env): boolean {
-	return Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.MOSH_CONNECTION);
+function needsTerminalClipboardRelay(env: NodeJS.ProcessEnv = process.env): boolean {
+	return Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.MOSH_CONNECTION || env.WMUX_PANE_ID);
 }
 
 function emitOsc52(text: string): boolean {
@@ -28,7 +28,15 @@ function emitOsc52(text: string): boolean {
 	if (encoded.length > MAX_OSC52_ENCODED_LENGTH) {
 		return false;
 	}
-	process.stdout.write(`\x1b]52;c;${encoded}\x07`);
+
+	const sequence = `\x1b]52;c;${encoded}\x07`;
+	if (process.env.TMUX && process.env.WMUX_PANE_ID) {
+		// wmux enables tmux passthrough for managed panes, allowing the request to
+		// reach its browser terminal instead of being consumed by tmux.
+		process.stdout.write(`\x1bPtmux;${sequence.replaceAll("\x1b", "\x1b\x1b")}\x1b\\`);
+	} else {
+		process.stdout.write(sequence);
+	}
 	return true;
 }
 
@@ -56,8 +64,8 @@ export async function copyToClipboard(text: string): Promise<void> {
 		// Fall through to platform-specific clipboard tools.
 	}
 
-	const remote = isRemoteSession();
-	if (copied && !remote) {
+	const needsRelay = needsTerminalClipboardRelay();
+	if (copied && !needsRelay) {
 		return;
 	}
 
@@ -116,7 +124,7 @@ export async function copyToClipboard(text: string): Promise<void> {
 		}
 	}
 
-	if (remote || !copied) {
+	if (needsRelay || !copied) {
 		const osc52Copied = emitOsc52(text);
 		copied = copied || osc52Copied;
 	}

--- a/packages/coding-agent/test/clipboard.test.ts
+++ b/packages/coding-agent/test/clipboard.test.ts
@@ -49,7 +49,7 @@ let stdoutWrites: string[];
 let nativeResolved = false;
 
 function osc52Writes(): string[] {
-	return stdoutWrites.filter((write) => write.startsWith("\x1b]52;c;"));
+	return stdoutWrites.filter((write) => write.includes("]52;c;"));
 }
 
 beforeEach(() => {
@@ -57,6 +57,8 @@ beforeEach(() => {
 	vi.stubEnv("SSH_CONNECTION", "");
 	vi.stubEnv("SSH_CLIENT", "");
 	vi.stubEnv("MOSH_CONNECTION", "");
+	vi.stubEnv("WMUX_PANE_ID", "");
+	vi.stubEnv("TMUX", "");
 	stdoutWrites = [];
 	nativeResolved = false;
 	mocks.clipboard.setText.mockReset();
@@ -73,7 +75,7 @@ beforeEach(() => {
 	originalWrite = process.stdout.write.bind(process.stdout);
 	process.stdout.write = ((...args: Parameters<typeof process.stdout.write>) => {
 		const [chunk] = args;
-		if (typeof chunk === "string" && chunk.startsWith("\x1b]52;c;")) {
+		if (typeof chunk === "string" && chunk.includes("]52;c;")) {
 			stdoutWrites.push(chunk);
 			return true;
 		}
@@ -109,6 +111,35 @@ describe("copyToClipboard", () => {
 		expect(nativeResolved).toBe(true);
 		expect(osc52Writes()).toHaveLength(1);
 		expect(mockedExecSync).not.toHaveBeenCalled();
+	});
+
+	test("wmux native success also emits OSC 52 for the browser terminal", async () => {
+		vi.stubEnv("WMUX_PANE_ID", "pane-test");
+
+		await copyToClipboard("hello");
+
+		expect(nativeResolved).toBe(true);
+		expect(osc52Writes()).toEqual(["\x1b]52;c;aGVsbG8=\x07"]);
+		expect(mockedExecSync).not.toHaveBeenCalled();
+	});
+
+	test("keeps plain OSC 52 for non-wmux tmux sessions", async () => {
+		vi.stubEnv("SSH_CONNECTION", "client server");
+		vi.stubEnv("TMUX", "/tmp/tmux/default,1,0");
+
+		await copyToClipboard("hello");
+
+		expect(osc52Writes()).toEqual(["\x1b]52;c;aGVsbG8=\x07"]);
+	});
+
+	test("wraps OSC 52 in tmux passthrough for wmux panes", async () => {
+		vi.stubEnv("SSH_CONNECTION", "client server");
+		vi.stubEnv("WMUX_PANE_ID", "pane-test");
+		vi.stubEnv("TMUX", "/tmp/tmux/default,1,0");
+
+		await copyToClipboard("hello");
+
+		expect(osc52Writes()).toEqual(["\x1bPtmux;\x1b\x1b]52;c;aGVsbG8=\x07\x1b\\"]);
 	});
 
 	test("local shell fallback success skips OSC 52", async () => {

--- a/packages/coding-agent/test/login-dialog.test.ts
+++ b/packages/coding-agent/test/login-dialog.test.ts
@@ -76,6 +76,23 @@ describe("LoginDialogComponent", () => {
 		expect(stripAnsi(dialog.render(48).join("\n"))).toContain("Copied sign-in link");
 	});
 
+	it("uses Alt+C without consuming text in callback-server input", async () => {
+		const dialog = new LoginDialogComponent(createFakeTui(), "openai-codex", () => {}, "ChatGPT");
+		const url =
+			"https://auth.openai.com/oauth/authorize?client_id=test&redirect_uri=http%3A%2F%2Flocalhost%2Fcallback";
+
+		dialog.showAuth(url);
+		const manualInput = dialog.showManualInput("Paste redirect URL below, or complete login in browser:");
+		dialog.handleInput("c");
+		expect(mocks.copyToClipboard).not.toHaveBeenCalled();
+		expect(stripAnsi(dialog.render(88).join("\n"))).toContain("Alt+C copy");
+
+		dialog.handleInput("\x1bc");
+		await vi.waitFor(() => expect(mocks.copyToClipboard).toHaveBeenCalledWith(url));
+		dialog.handleInput("\r");
+		await expect(manualInput).resolves.toBe("c");
+	});
+
 	it("honors a customized login URL copy shortcut", async () => {
 		setKeybindings(new KeybindingsManager({ "app.clipboard.copyLoginUrl": "ctrl+y" }));
 		const dialog = new LoginDialogComponent(createFakeTui(), "anthropic", () => {}, "Anthropic");


### PR DESCRIPTION
## Summary

- treat wmux-managed panes as terminal clipboard relay sessions even when copying on the host succeeds
- pass OSC 52 through wmux-managed tmux sessions while preserving standard behavior for other tmux users
- cover the ChatGPT callback-server `Alt+C` path and exact raw OAuth URL

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/clipboard.test.ts test/login-dialog.test.ts` (23 tests)
- deployed commit `9e50d8b7a` on Haswell for wmux UAT
- confirmed `Alt+C` copies the ChatGPT OAuth URL into the browser clipboard


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clipboard relay in wmux-managed panes by passing OSC 52 through tmux
> - Renames `isRemoteSession` to `needsTerminalClipboardRelay` in [clipboard.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1318/files#diff-45a3d8d1b39efd61753f0f0f1bcb114f2ec5ebf38253cb7a3f3ded67c9e1f8bd) and extends the relay condition to also return `true` when `WMUX_PANE_ID` is set.
> - When both `TMUX` and `WMUX_PANE_ID` are set, `emitOsc52` wraps the OSC 52 sequence in a tmux passthrough (`ESC P tmux; ... ESC \`) so the browser terminal receives it instead of tmux consuming it.
> - `copyToClipboard` now also emits OSC 52 in wmux/SSH/MOSH contexts even when a native clipboard write succeeds, ensuring the clipboard propagates to the remote terminal.
> - Adds tests for wmux OSC 52 emission, plain OSC 52 in non-wmux tmux, and tmux passthrough wrapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e50d8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->