### PR TITLE
fix(installer): retry transient release resolution failures

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -958,7 +958,8 @@ resolve_prime_agent_version() {
 		"Resolving latest release" \
 		"Resolving latest release" \
 		"Checking the $release_channel release channel." \
-		curl -fsSL "$prime_agent_base_url/$release_channel" -o "$channel_path"; then
+		curl -fsSL --retry 5 --retry-delay 1 --retry-all-errors \
+			"$prime_agent_base_url/$release_channel" -o "$channel_path"; then
 		rm -rf "$channel_dir"
 		printf 'error: could not resolve latest Prime Agent version from %s/%s\n' "$prime_agent_base_url" "$release_channel" >&2
 		exit 1

--- a/install.sh
+++ b/install.sh
@@ -958,19 +958,110 @@ resolve_prime_agent_version() {
 		"Resolving latest release" \
 		"Resolving latest release" \
 		"Checking the $release_channel release channel." \
-		curl -fsSL --retry 5 --retry-delay 1 --retry-all-errors \
-			"$prime_agent_base_url/$release_channel" -o "$channel_path"; then
+		download_channel_marker "$prime_agent_base_url/$release_channel" "$channel_path"; then
 		rm -rf "$channel_dir"
 		printf 'error: could not resolve latest Prime Agent version from %s/%s\n' "$prime_agent_base_url" "$release_channel" >&2
 		exit 1
 	fi
-	channel_version="$(tr -d '[:space:]' <"$channel_path")"
+	channel_version=$(cat "$channel_path")
 	rm -rf "$channel_dir"
-	if [ -z "$channel_version" ]; then
-		printf 'error: could not resolve latest Prime Agent version from %s/%s\n' "$prime_agent_base_url" "$release_channel" >&2
-		exit 1
-	fi
 	normalize_version "$channel_version"
+}
+
+download_channel_marker() {
+	channel_url="$1"
+	channel_path="$2"
+	max_attempts=6
+	attempt=1
+	rm -f "$channel_path"
+
+	while [ "$attempt" -le "$max_attempts" ]; do
+		attempt_path="$channel_path.attempt.$attempt.$$"
+		header_path="$attempt_path.headers"
+		rm -f "$attempt_path" "$header_path"
+
+		if http_status=$(curl -sS -L \
+			--connect-timeout 5 \
+			--max-time 15 \
+			-D "$header_path" \
+			-o "$attempt_path" \
+			-w '%{http_code}' \
+			"$channel_url"); then
+			curl_status=0
+		else
+			curl_status=$?
+		fi
+
+		if [ "$curl_status" -eq 0 ]; then
+			case "$http_status" in
+				2??)
+					if channel_version=$(validate_channel_marker "$attempt_path"); then
+						printf '%s' "$channel_version" >"$attempt_path.validated"
+						rm -f "$attempt_path" "$header_path"
+						mv "$attempt_path.validated" "$channel_path"
+						return 0
+					fi
+					rm -f "$attempt_path" "$header_path" "$attempt_path.validated"
+					return 1
+					;;
+				408|429|5??) retry_channel_request=1 ;;
+				*) retry_channel_request=0 ;;
+			esac
+		else
+			case "$curl_status" in
+				5|6|7|18|28|35|52|55|56|92) retry_channel_request=1 ;;
+				*) retry_channel_request=0 ;;
+			esac
+		fi
+
+		if [ "$retry_channel_request" -ne 1 ] || [ "$attempt" -eq "$max_attempts" ]; then
+			rm -f "$attempt_path" "$header_path"
+			return 1
+		fi
+
+		retry_delay=$(channel_retry_delay "$header_path" "$attempt")
+		rm -f "$attempt_path" "$header_path"
+		sleep "$retry_delay"
+		attempt=$((attempt + 1))
+	done
+	return 1
+}
+
+validate_channel_marker() {
+	marker_path="$1"
+	awk '
+		BEGIN { value = ""; valid = 1 }
+		{
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+			if ($0 == "") next
+			if (value != "") valid = 0
+			value = $0
+		}
+		END {
+			if (!valid || value !~ /^v?[0-9A-Za-z][0-9A-Za-z.-]*$/) exit 1
+			sub(/^v/, "", value)
+			print value
+		}
+	' "$marker_path"
+}
+
+channel_retry_delay() {
+	header_path="$1"
+	attempt="$2"
+	retry_after=$(awk '
+		/^[Rr][Ee][Tt][Rr][Yy]-[Aa][Ff][Tt][Ee][Rr]:[[:space:]]*[0-9]+[[:space:]]*\r?$/ {
+			gsub(/[^0-9]/, "", $0)
+			value = $0
+		}
+		END { if (value != "") print value }
+	' "$header_path" 2>/dev/null || true)
+	case "$retry_after" in
+		''|*[!0-9]*) retry_after="$attempt" ;;
+	esac
+	if [ "$retry_after" -gt 2 ]; then
+		retry_after=2
+	fi
+	printf '%s' "$retry_after"
 }
 
 normalize_version() {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"dev": "concurrently --names \"ai,agent,coding-agent,tui\" --prefix-colors \"cyan,yellow,red,magenta\" \"cd packages/ai && npm run dev\" \"cd packages/agent && npm run dev\" \"cd packages/coding-agent && npm run dev\" \"cd packages/tui && npm run dev\"",
 		"dev:tsc": "cd packages/ai && npm run dev:tsc",
 		"check": "biome check --write --error-on-warnings . && tsgo --noEmit && npm run check:installer && npm run check:browser-smoke",
-		"check:installer": "node scripts/check-installer-render.mjs",
+		"check:installer": "node scripts/check-installer-render.mjs && node scripts/test-installer-channel-resolution.mjs",
 		"check:browser-smoke": "node scripts/check-browser-smoke.mjs",
 		"profile:tui": "node scripts/profile-coding-agent-node.mjs --mode tui",
 		"profile:rpc": "node scripts/profile-coding-agent-node.mjs --mode rpc",

--- a/scripts/test-installer-channel-resolution.mjs
+++ b/scripts/test-installer-channel-resolution.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("../", import.meta.url);
+const workspace = await mkdtemp(join(tmpdir(), "prime-agent-channel-test-"));
+const installer = await readFile(new URL("install.sh", root), "utf8");
+const libraryPath = join(workspace, "installer-functions.sh");
+await writeFile(libraryPath, installer.replace(/\nmain "\$@"\s*$/, "\n"));
+
+function runDownload(url, { recordSleeps = false } = {}) {
+	const outputPath = join(workspace, `channel-${crypto.randomUUID()}`);
+	const sleepPath = `${outputPath}.sleeps`;
+	const script = `
+. "$INSTALLER_LIBRARY"
+${recordSleeps ? 'sleep() { printf "%s\\n" "$1" >>"$SLEEP_PATH"; }' : "sleep() { :; }"}
+download_channel_marker "$CHANNEL_URL" "$CHANNEL_PATH"
+`;
+	return new Promise((resolve) => {
+		const child = spawn("sh", ["-c", script], {
+			env: {
+				...process.env,
+				INSTALLER_LIBRARY: libraryPath,
+				CHANNEL_URL: url,
+				CHANNEL_PATH: outputPath,
+				SLEEP_PATH: sleepPath,
+			},
+		});
+		let stderr = "";
+		child.stderr.setEncoding("utf8");
+		child.stderr.on("data", (chunk) => (stderr += chunk));
+		child.on("close", (status) => resolve({ status, stderr, outputPath, sleepPath }));
+	});
+}
+
+async function withServer(handler, test) {
+	const server = createServer(handler);
+	await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+	try {
+		const { port } = server.address();
+		await test(`http://127.0.0.1:${port}/stable`);
+	} finally {
+		await new Promise((resolve, reject) =>
+			server.close((error) => (error ? reject(error) : resolve())),
+		);
+	}
+}
+
+try {
+	let transientRequests = 0;
+	await withServer(
+		(_req, res) => {
+			transientRequests += 1;
+			if (transientRequests === 1) res.writeHead(503).end("temporarily unavailable");
+			else res.writeHead(200).end("v1.2.3\n");
+		},
+		async (url) => {
+			const result = await runDownload(url);
+			assert.equal(result.status, 0, result.stderr);
+			assert.equal(transientRequests, 2);
+			assert.equal(await readFile(result.outputPath, "utf8"), "1.2.3");
+		},
+	);
+
+	for (const status of [401, 404]) {
+		let requests = 0;
+		await withServer(
+			(_req, res) => {
+				requests += 1;
+				res.writeHead(status).end("permanent failure");
+			},
+			async (url) => {
+				const result = await runDownload(url);
+				assert.notEqual(result.status, 0);
+				assert.equal(requests, 1, `${status} must not be retried`);
+				await assert.rejects(readFile(result.outputPath));
+			},
+		);
+	}
+
+	let partialRequests = 0;
+	await withServer(
+		(_req, res) => {
+			partialRequests += 1;
+			res.writeHead(200, { "Content-Length": "100" });
+			res.write("v9.9.9\n");
+			res.socket.destroy();
+		},
+		async (url) => {
+			const result = await runDownload(url);
+			assert.notEqual(result.status, 0);
+			assert.equal(partialRequests, 6);
+			await assert.rejects(readFile(result.outputPath));
+		},
+	);
+
+	let retryAfterRequests = 0;
+	await withServer(
+		(_req, res) => {
+			retryAfterRequests += 1;
+			if (retryAfterRequests === 1) res.writeHead(429, { "Retry-After": "60" }).end();
+			else res.writeHead(200).end("2.0.0");
+		},
+		async (url) => {
+			const result = await runDownload(url, { recordSleeps: true });
+			assert.equal(result.status, 0, result.stderr);
+			assert.equal(await readFile(result.sleepPath, "utf8"), "2\n");
+		},
+	);
+
+	let exhaustedRequests = 0;
+	await withServer(
+		(_req, res) => {
+			exhaustedRequests += 1;
+			res.writeHead(503).end("still unavailable");
+		},
+		async (url) => {
+			const result = await runDownload(url);
+			assert.notEqual(result.status, 0);
+			assert.equal(exhaustedRequests, 6);
+			await assert.rejects(readFile(result.outputPath));
+		},
+	);
+
+	console.log("installer channel resolution tests passed");
+} finally {
+	await rm(workspace, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Retry transient network failures while resolving the latest Prime Agent release channel in `install.sh`.

The installer previously used a single `curl -fsSL` request for the `stable` or `beta` channel marker. A transient connection reset immediately aborted installation with:

```text
curl: (35) Recv failure: Connection reset by peer
error: could not resolve latest Prime Agent version ...
```

The channel lookup now uses curl's retry support:

- up to 5 retries
- a 1-second delay between retries
- `--retry-all-errors` so connection resets and similar transient transport errors are retried

Permanent failures still follow the existing error path after retries are exhausted. Explicit versions remain unaffected.

## Validation

- `npm run check`
- `sh -n install.sh`
- shell harness with a fake `curl`, confirming the channel resolution command receives the retry flags and still resolves a valid version

Fixes #1193


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry transient release channel resolution failures in the installer
> - Replaces the single `curl` call in `resolve_prime_agent_version` with a new `download_channel_marker` helper that retries up to 6 times on transient errors (HTTP 408/429/5xx and specific curl exit codes), honoring `Retry-After` headers with a 2-second cap.
> - Adds `validate_channel_marker` to enforce a single-line version token pattern and normalize the result (strips leading `v`, trims whitespace); malformed or empty markers now cause resolution to fail explicitly.
> - Adds integration tests in [`scripts/test-installer-channel-resolution.mjs`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1321/files#diff-94fdef8eab291cc02264fe80b623487d2b093a61e0cb8138ff7fe944e907bd25) that spin up a local HTTP server to verify retry, no-retry, and exhaustion scenarios; these run as part of the `check:installer` npm script.
> - Behavioral Change: previously a single curl with no validation was used; permanent errors (e.g. 401/404) now fail immediately without retry, and empty/malformed markers are rejected before use.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54a0861.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->