### PR TITLE
docs(coding-agent): clarify Codex OAuth token usage

### DIFF
--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -201,6 +201,12 @@ The `api` field determines which streaming implementation is used:
 | `google-vertex` | Google Vertex AI API |
 | `bedrock-converse-stream` | Amazon Bedrock Converse API |
 
+> **OpenAI Codex authentication:** When configuring `openai-codex-responses`
+> with tokens obtained from the ChatGPT OAuth flow, use the OAuth
+> `access_token` as `apiKey`, not the `id_token`. Both tokens may contain the
+> `chatgpt_account_id` claim, but the Codex backend authenticates requests with
+> the access token and rejects the ID token.
+
 Most OpenAI-compatible providers work with `openai-completions`. Use model-level `thinkingLevelMap` for model-specific thinking levels, and `compat` for provider quirks:
 
 ```typescript


### PR DESCRIPTION
## Summary

Clarify which OAuth token custom `openai-codex-responses` providers must use.

ChatGPT OAuth returns both an `access_token` and an `id_token`, and both may contain the `chatgpt_account_id` claim. That makes the ID token appear usable as the provider `apiKey`, but the Codex backend rejects it. The documentation now explicitly says to use the OAuth `access_token` and not the `id_token`.

## Validation

- Repository pre-commit checks passed
- `git diff --check`

Fixes #1231


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify OAuth `access_token` usage for `openai-codex-responses` provider in docs
> Adds a note to [custom-provider.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1322/files#diff-13b5babedc02e62033740425608dfca2fabc2c2b89eb264cce4f11778e1af882) clarifying that when using ChatGPT OAuth tokens with the `openai-codex-responses` provider, the OAuth `access_token` must be used as `apiKey`, not the `id_token`. Codex authenticates with the access token and rejects the ID token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd37f08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->