### PR TITLE
fix(coding-agent): list client-owned workers

### DIFF
--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -1644,6 +1644,7 @@ function isSessionSummary(value: unknown): value is SessionSummary {
 		typeof candidate.attachedClients === "number" &&
 		typeof candidate.messageCount === "number" &&
 		(candidate.unfinishedActionCount === undefined || typeof candidate.unfinishedActionCount === "number") &&
+		(candidate.ownerClientId === undefined || typeof candidate.ownerClientId === "string") &&
 		typeof candidate.sessionActions === "object" &&
 		candidate.sessionActions !== null &&
 		typeof candidate.sessionActions.queuedCount === "number" &&

--- a/packages/coding-agent/src/cli/daemon-list-format.ts
+++ b/packages/coding-agent/src/cli/daemon-list-format.ts
@@ -26,6 +26,7 @@ type ListRow = {
 	model: string;
 	messages: string;
 	clients: string;
+	owner: string;
 };
 
 export function formatSessionListTable(sessions: readonly SessionSummary[], nowMs = Date.now()): string {
@@ -37,8 +38,9 @@ export function formatSessionListTable(sessions: readonly SessionSummary[], nowM
 		model: formatSessionModel(session.model),
 		messages: String(session.messageCount),
 		clients: String(session.attachedClients),
+		owner: session.ownerClientId ? "attached" : "",
 	}));
-	return formatTable(["name", "id", "status", "age", "model", "messages", "clients"], rows, formatListCell);
+	return formatTable(["name", "id", "status", "age", "model", "messages", "clients", "owner"], rows, formatListCell);
 }
 
 function sortSessionsForList(sessions: readonly SessionSummary[]): SessionSummary[] {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -81,6 +81,8 @@ export interface SessionSummary {
 	workerState?: "starting" | "ready" | "recovering" | "stopping" | "failed";
 	/** Diagnostic process identity; clients must not use this as a stable session identifier. */
 	workerPid?: number;
+	/** Protocol client that owns this worker; absent for resident (unowned) sessions. */
+	ownerClientId?: string;
 }
 
 /**

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1919,7 +1919,7 @@ export class DaemonSupervisor {
 	}
 
 	private async handleList(
-		client: DaemonSocketClient,
+		_client: DaemonSocketClient,
 		command: Extract<DaemonCommand, { type: "list" }>,
 	): Promise<DaemonResponse> {
 		await Promise.all(
@@ -1931,13 +1931,15 @@ export class DaemonSupervisor {
 		const clientOwnedWorkers = [...this.workers.values()].filter((worker) => !this.isVisibleWorker(worker));
 		// Stopping workers stay listed (with an honest workerState) because this
 		// list also feeds busy-daemon safety checks in daemon-launch.
-		const active = [...this.workers.values()]
-			.filter(
-				(worker) =>
-					this.isVisibleWorker(worker) ||
-					(command.includeClientOwned === true && this.isWorkerAccessibleToClient(client, worker)),
-			)
-			.flatMap((worker) => [...worker.summaries.values()].map((summary) => this.publicSummary(worker, summary)));
+		//
+		// All workers are included regardless of ownership so the operator-facing
+		// `list` command never hides sessions that are demonstrably running (see
+		// issue #1215). The per-client `includeClientOwned` flag is retained for
+		// backward compatibility — it was only needed when owned workers were
+		// filtered out by default.
+		const active = [...this.workers.values()].flatMap((worker) =>
+			[...worker.summaries.values()].map((summary) => this.publicSummary(worker, summary)),
+		);
 		const busyClientOwnedSessionCount = clientOwnedWorkers
 			.flatMap((worker) => [...worker.summaries.values()])
 			.filter(isSessionSummaryBusy).length;
@@ -3233,6 +3235,7 @@ export class DaemonSupervisor {
 				.length,
 			workerState: this.effectiveWorkerState(worker),
 			workerPid: worker.descriptor.pid,
+			ownerClientId: worker.descriptor.ownerClientId,
 		};
 	}
 

--- a/packages/coding-agent/test/daemon-list-format.test.ts
+++ b/packages/coding-agent/test/daemon-list-format.test.ts
@@ -39,7 +39,16 @@ describe("formatSessionListTable", () => {
 		);
 
 		const lines = table.split("\n");
-		expect(lines[0]!.trim().split(/\s+/)).toEqual(["name", "id", "status", "age", "model", "messages", "clients"]);
+		expect(lines[0]!.trim().split(/\s+/)).toEqual([
+			"name",
+			"id",
+			"status",
+			"age",
+			"model",
+			"messages",
+			"clients",
+			"owner",
+		]);
 		expect(lines.slice(1).map((line) => line.trim().split(/\s+/).slice(0, 3))).toEqual([
 			["tool", "ccccddddeeee", "working"],
 			["model", "ddddeeeeffff", "working"],
@@ -51,6 +60,50 @@ describe("formatSessionListTable", () => {
 		expect(table).toContain("openai-codex/gpt-5.5");
 		expect(table).not.toContain("/tmp/project");
 		expect(table).not.toContain("019e71ec-e08a");
+	});
+
+	it("shows owner column for attached sessions", () => {
+		const nowMs = Date.parse("2026-05-29T12:00:00.000Z");
+		const table = stripAnsi(
+			formatSessionListTable(
+				[
+					{
+						...makeSummary({
+							name: "owned",
+							id: "aaaabbbbcccc",
+							lifecycle: "live",
+							activity: "working",
+							clients: 1,
+						}),
+						ownerClientId: "client-1",
+					},
+					makeSummary({
+						name: "resident",
+						id: "ddddeeeeffff",
+						lifecycle: "live",
+						activity: "idle",
+					}),
+				],
+				nowMs,
+			),
+		);
+		const lines = table.split("\n");
+		expect(lines[0]!.trim().split(/\s+/)).toEqual([
+			"name",
+			"id",
+			"status",
+			"age",
+			"model",
+			"messages",
+			"clients",
+			"owner",
+		]);
+		// The attached (owned) session shows "attached" in the owner column.
+		const ownedLine = lines.find((line) => line.includes("owned"));
+		expect(ownedLine).toContain("attached");
+		// The resident (unowned) session has an empty owner column.
+		const residentLine = lines.find((line) => line.includes("resident"));
+		expect(residentLine).not.toContain("attached");
 	});
 });
 


### PR DESCRIPTION
## Summary

Fix `prime-agent list` under-reporting live workers that are owned by another CLI client.

The supervisor previously filtered the list response through `isVisibleWorker()`, which intentionally excludes client-owned workers for attach/selection semantics. Because `prime-agent list` uses a fresh daemon connection, it could not see those workers and incorrectly printed `No active agents.` even while they were running.

This change keeps `isVisibleWorker()` unchanged and fixes only the list path:

- include every resident worker in the daemon list response, regardless of ownership
- expose worker ownership on the public session summary
- add an `owner` column to the CLI table (`attached` for client-owned workers)
- add coverage for owned and unowned list rows

## Validation

- `npx vitest run packages/coding-agent/test/daemon-list-format.test.ts`
- `npx tsgo --noEmit`
- `npx biome check --write --error-on-warnings .`
- repository pre-commit checks passed
- `git diff --check`

Fixes #1215


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix daemon list command to include client-owned worker sessions
> - `DaemonSupervisor.handleList` now returns all workers regardless of ownership, removing the previous filter that excluded client-owned sessions from other clients.
> - `publicSummary` is extended to include `ownerClientId` on each session summary when set on the worker descriptor.
> - The session list table gains an `owner` column that displays `attached` for client-owned sessions and is empty for resident sessions.
> - Risk: clients that previously relied on the list being scoped to visible/accessible workers will now see all sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f97d00a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->