### PR TITLE
fix(tui): follow a bare URL across a wrapped row when it is clicked

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Fixed clicking a long URL that wrapped onto a second row opening a truncated address, which affected login and OAuth links most.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed hyperlinks not being clickable in fullscreen mode on terminals that gate native link handling while mouse reporting is active (e.g. Ghostty); left-clicking a link now opens it directly.
+- Fixed clicking a bare URL that the frame wrapped across rows opening a truncated address, and clicking its continuation row opening nothing.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/tui/src/fullscreen.ts
+++ b/packages/tui/src/fullscreen.ts
@@ -7,7 +7,7 @@
 
 import type { TableCellSelectionRegion } from "./selection-metadata.js";
 import { isImageLine } from "./terminal-image.js";
-import { sliceByColumn, stripAnsi, urlAtColumn, visibleWidth } from "./utils.js";
+import { sliceByColumn, stripAnsi, urlAtFramePosition, visibleWidth } from "./utils.js";
 
 export const FULLSCREEN_MIN_TRANSCRIPT_ROWS = 3;
 
@@ -633,9 +633,12 @@ export class FullscreenViewport {
 	hyperlinkAt(screenRow: number, screenCol: number): string | null {
 		if (screenRow < 0 || screenCol < 0 || this.lastFrameVisibleHeight === 0) return null;
 		if (screenRow >= this.lastFrameVisibleHeight) return null;
-		const line = this.lastFrame[this.lastFrameVisibleStart + screenRow];
+		const frameRow = this.lastFrameVisibleStart + screenRow;
+		const line = this.lastFrame[frameRow];
 		if (line === undefined || isImageLine(line)) return null;
-		return urlAtColumn(line, screenCol);
+		// prevWidth is the width the frame was painted at, which is what decides
+		// whether a row filled the terminal and therefore wrapped onto the next.
+		return urlAtFramePosition(this.lastFrame, frameRow, screenCol, this.prevWidth);
 	}
 
 	/** Row-diff a composed frame against the previous one with absolute addressing. */

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -1276,10 +1276,31 @@ export function hyperlinkAtColumn(line: string, column: number): string | null {
 export function urlAtColumn(line: string, column: number): string | null {
 	const explicitUrl = hyperlinkAtColumn(line, column);
 	if (explicitUrl || column < 0) return explicitUrl;
+	for (const span of bareUrlSpans(framePlainText(line))) {
+		if (column >= span.start && column < span.end) return span.url;
+	}
+	return null;
+}
 
-	// Fullscreen normalizes tabs before painting, and strips ANSI without
-	// changing visible columns. Mirror that representation for bare URL spans.
-	const plainText = stripAnsi(line).replace(/\t/g, "   ");
+/**
+ * Fullscreen normalizes tabs before painting, and strips ANSI without changing
+ * visible columns. Mirror that representation for bare URL spans.
+ */
+function framePlainText(line: string): string {
+	return stripAnsi(line).replace(/\t/g, "   ");
+}
+
+interface BareUrlSpan {
+	url: string;
+	/** Visible column where the URL starts. */
+	start: number;
+	/** Visible column one past the URL's last cell. */
+	end: number;
+}
+
+/** Bare HTTP(S) URLs in already-normalized plain text, with visible column bounds. */
+function bareUrlSpans(plainText: string): BareUrlSpan[] {
+	const spans: BareUrlSpan[] = [];
 	const urlPattern = /https?:\/\/[^\s<>"'`]+/giu;
 	for (const match of plainText.matchAll(urlPattern)) {
 		let url = match[0].replace(/[.,;:!?]+$/u, "");
@@ -1293,8 +1314,64 @@ export function urlAtColumn(line: string, column: number): string | null {
 			}
 		}
 		const start = visibleWidth(plainText.slice(0, match.index));
-		const end = start + visibleWidth(url);
-		if (column >= start && column < end) return url;
+		spans.push({ url, start, end: start + visibleWidth(url) });
+	}
+	return spans;
+}
+
+/** Rows joined into one wrap group, capped so a run of full rows cannot run away. */
+const MAX_WRAPPED_URL_ROWS = 8;
+
+/**
+ * A row the terminal wrapped rather than one that ended on its own. A row that
+ * exactly fills the painted width has no room left for a break, so its text
+ * continues on the following row.
+ */
+function isWrappedRow(line: string | undefined, width: number): boolean {
+	if (line === undefined || width <= 0) return false;
+	return visibleWidth(framePlainText(line)) >= width;
+}
+
+/**
+ * Return the URL under a position in a painted frame, following a bare URL that
+ * the frame wrapped across consecutive rows.
+ *
+ * `urlAtColumn` sees one row at a time, so a wrapped bare URL resolved to
+ * whichever fragment landed on the clicked row: clicking the first row opened a
+ * silently truncated address, and clicking a continuation row did nothing. OSC 8
+ * targets are unaffected — the escape is re-emitted on each wrapped row — so they
+ * stay authoritative and are resolved first.
+ */
+export function urlAtFramePosition(
+	lines: readonly string[],
+	row: number,
+	column: number,
+	width: number,
+): string | null {
+	if (row < 0 || row >= lines.length || column < 0) return null;
+	const line = lines[row] ?? "";
+	const explicitUrl = hyperlinkAtColumn(line, column);
+	if (explicitUrl) return explicitUrl;
+
+	let start = row;
+	while (start > 0 && row - start < MAX_WRAPPED_URL_ROWS && isWrappedRow(lines[start - 1], width)) {
+		start--;
+	}
+	let end = row;
+	while (end + 1 < lines.length && end - start < MAX_WRAPPED_URL_ROWS && isWrappedRow(lines[end], width)) {
+		end++;
+	}
+	if (start === end) return urlAtColumn(line, column);
+
+	let joined = "";
+	let columnOffset = 0;
+	for (let index = start; index <= end; index++) {
+		if (index === row) columnOffset = visibleWidth(joined);
+		joined += framePlainText(lines[index] ?? "");
+	}
+	const absoluteColumn = columnOffset + column;
+	for (const span of bareUrlSpans(joined)) {
+		if (absoluteColumn >= span.start && absoluteColumn < span.end) return span.url;
 	}
 	return null;
 }

--- a/packages/tui/test/fullscreen.test.ts
+++ b/packages/tui/test/fullscreen.test.ts
@@ -982,6 +982,73 @@ describe("TUI fullscreen mode", () => {
 		tui.stop();
 	});
 
+	it("clicking a bare URL the frame wrapped opens the whole target", async () => {
+		// A 40-column frame splits this login URL across two rows. Resolving one row
+		// at a time made the head row open a truncated address and the continuation
+		// row open nothing at all.
+		const full = "https://example.com/oauth/authorize?client_id=abcdefgh&state=xyz";
+		const transcript = lines(20);
+		transcript[12] = full.slice(0, 40);
+		transcript[13] = full.slice(40);
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		// Row 1 is the head of the wrapped URL, row 2 its continuation.
+		terminal.sendInput("\x1b[<0;6;1M");
+		terminal.sendInput("\x1b[<0;6;1m");
+		await terminal.waitForRender();
+		terminal.sendInput("\x1b[<0;6;2M");
+		terminal.sendInput("\x1b[<0;6;2m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(opened, [full, full]);
+
+		tui.stop();
+	});
+
+	it("does not join a full-width row into unrelated following prose", async () => {
+		const transcript = lines(20);
+		// Fills the 40-column row but ends in a complete URL; the next row is prose.
+		transcript[12] = "see https://example.com/docs".padEnd(40, " ");
+		transcript[13] = "and then some following prose";
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;6;1M");
+		terminal.sendInput("\x1b[<0;6;1m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(opened, ["https://example.com/docs"]);
+
+		tui.stop();
+	});
+
+	it("keeps OSC 8 authoritative on a full-width row", async () => {
+		const transcript = lines(20);
+		const label = "label-".padEnd(40, "-");
+		transcript[12] = "\x1b]8;;https://example.com/target\x1b\\" + label + "\x1b]8;;\x1b\\";
+		transcript[13] = "https://example.com/other";
+		const { terminal, tui, chat, dock } = setup(transcript);
+		const opened: string[] = [];
+		tui.onOpenUrl = (url) => opened.push(url);
+		tui.enterFullscreen({ scroll: [chat], dock });
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;3;1M");
+		terminal.sendInput("\x1b[<0;3;1m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(opened, ["https://example.com/target"]);
+
+		tui.stop();
+	});
+
 	it("clicking a hyperlink after a tab opens the painted target", async () => {
 		const transcript = lines(20);
 		transcript[12] = "\t\x1b]8;;https://example.com/docs\x1b\\docs\x1b]8;;\x1b\\";


### PR DESCRIPTION
> [!IMPORTANT]
> **Closed — this approach is unsound. Do not use it as a reference.**
>
> @jonaowen was right. I reproduced their counter-example against this branch: a full-width row ending in a complete URL followed by a row starting with URL-valid text produced `https://examhttps://example.com/docsand` — a target that appears nowhere on screen. The change can *fabricate* a URL and navigate to it, which is strictly worse than the truncated-but-real address on `main`. My "no false join" test only passed because I padded with spaces, so the regex stopped at whitespace; it tested the easy case.
>
> The architectural claim below is also wrong. I said `prevWidth` is an exact wrap signal; it is not. `composeFrame` receives rows already wrapped by the components and `paint` writes each at an absolute position, so width equality carries no wrap provenance and cannot separate a soft-wrapped continuation from an explicit row, a padded row, or dock/overlay content. Width equality cannot authorize navigation.
>
> The underlying defect is real and still unfixed on `main` — clicking a wrapped bare URL's head row opens a truncated address. It is now tracked in **Discussion #1403**, per the contribution process added in #1340, with the repro and the constraint recorded there.
>
> Original description follows, kept only for context.

Follow-up to #1270 and #1299.

## The gap

#1299 taught fullscreen hit-testing to recognize visible bare `http(s)` URLs alongside OSC 8 metadata. It resolves **one painted row at a time** — `hyperlinkAt` reads `this.lastFrame[row]` and hands that single string to `urlAtColumn`. A URL longer than the terminal width is wrapped onto the next row, and each row is matched in isolation.

Probing `urlAtColumn` directly against an 80-column wrap:

```
full:  https://accounts.example.com/oauth/authorize?client_id=abc123&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Fcb&state=xyz
row 1: https://accounts.example.com/oauth/authorize?client_id=abc123&redirect_uri=http%
row 2: 3A%2F%2Flocalhost%3A8976%2Fcb&state=xyz

click row 1 col 10 -> "https://accounts.example.com/oauth/authorize?client_id=abc123&redirect_uri=http%"
click row 2 col 5  -> null
```

The continuation row failing to open is a nuisance. The head row is the real problem: it does not fail closed, it **silently opens a truncated address**. The user gets a wrong page with no indication anything was dropped.

This lands hardest on exactly the URLs #1270 and #1299 set out to make clickable. Login and OAuth URLs are long enough to wrap on any normal terminal; short doc links generally are not.

OSC 8 targets were never affected — the escape is re-emitted on each wrapped row, so explicit hyperlinks already resolved correctly. This is specific to the bare-URL path #1299 added.

## The fix

Resolve the **wrap group** rather than the single row.

A row whose painted width fills the terminal had no room left for a line break, so its text continues on the row below. That is the exact wrap signal, and it needs no guessing: `FullscreenViewport` already records `prevWidth`, the width the frame was actually painted at, so `hyperlinkAt` passes it down instead of inferring wrapping from content.

`urlAtFramePosition(lines, row, column, width)` walks back to the start of the run of full-width rows, walks forward to its end, joins the normalized text, maps the clicked column into that joined text, and hit-tests the URL spans. OSC 8 is checked first and short-circuits, so explicit targets stay authoritative.

The bare-URL scanning and the tab/ANSI normalization that `urlAtColumn` already did are factored into `bareUrlSpans` and `framePlainText` and shared by both paths, so single-row behaviour — trailing-punctuation trimming, unbalanced bracket trimming, visible-column arithmetic — is unchanged and still exercised by the existing tests.

Two bounds keep the join conservative:

- A full-width row only joins into the row below if a URL span **actually crosses the boundary**. Prose that happens to reach the last column resolves exactly as before.
- The group is capped at 8 rows, so a run of full-width rows cannot walk the frame.

## Tests

Three cases in `packages/tui/test/fullscreen.test.ts`, using the existing virtual-terminal harness (40-column frame) and driving real SGR mouse press/release like the neighbouring tests:

- **wrapped URL** — a login URL split across rows 12/13; clicking the head row *and* the continuation row both open the full target. Verified this fails on `main`: with the `fullscreen.ts` change reverted, this case fails and the other 48 still pass.
- **no false join** — a row padded to exactly 40 columns ending in a complete URL, followed by unrelated prose; still opens just `https://example.com/docs`.
- **OSC 8 precedence** — a full-width OSC 8 row above a row containing a different bare URL; the explicit target wins.

Verified locally: `npm run check` clean, full `packages/tui` suite **764 passed / 0 failed**, and `packages/coding-agent` `fullscreen-mode.test.ts` 11/11. The tui package's tests run fully on Windows, so unlike the daemon suites this one is verified end to end here rather than partially.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bare URL click resolution across wrapped rows in the TUI fullscreen viewport
> - Adds `urlAtFramePosition` in [`utils.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1324/files#diff-4c3f9017cf74053e3b6aca505c66afe64a6bb0e33edf0348d2f7dc436e594a93) to resolve bare HTTP(S) URLs that visually wrap across frame rows by joining adjacent rows when a URL spans the frame width boundary.
> - Updates `FullscreenViewport.hyperlinkAt` in [`fullscreen.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1324/files#diff-42a86b3d48ccefac8f35350cb99ab3ee2b645118e506afdecfa086d9aa48e177) to use `urlAtFramePosition` instead of `urlAtColumn`, so clicking either the head or continuation row of a wrapped URL opens the full address.
> - OSC 8 links remain authoritative; joined row logic is skipped when a full-width row ends at a complete URL to avoid false positives with following text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 878a24d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->