### PR TITLE
test(coding-agent): make the harness-state atomicity test pass on Windows

### DIFF
--- a/packages/coding-agent/test/refinement.test.ts
+++ b/packages/coding-agent/test/refinement.test.ts
@@ -1,6 +1,6 @@
 import { appendFileSync, chmodSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type * as PiAi from "@earendil-works/pi-ai";
 import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
@@ -217,10 +217,15 @@ describe("harness refinement", () => {
 		const statePath = saveHarnessState(harnessStateDir, state);
 
 		expect(loadHarnessState(harnessStateDir).entries.memory.memory_entry).toBeDefined();
-		expect(readdirSync(harnessStateDir)).toEqual([statePath.split("/").at(-1)]);
-		chmodSync(statePath, 0o600);
-		saveHarnessState(harnessStateDir, state);
-		expect(statSync(statePath).mode & 0o777).toBe(0o600);
+		expect(readdirSync(harnessStateDir)).toEqual([basename(statePath)]);
+		// Windows chmod only toggles the read-only bit, so a POSIX mode never
+		// survives the round trip there and the preservation this asserts is
+		// meaningless. saveHarnessState still runs on both platforms above.
+		if (process.platform !== "win32") {
+			chmodSync(statePath, 0o600);
+			saveHarnessState(harnessStateDir, state);
+			expect(statSync(statePath).mode & 0o777).toBe(0o600);
+		}
 	});
 
 	it("applies create, update, and delete for every editable harness kind", () => {


### PR DESCRIPTION
`test/refinement.test.ts > atomically replaces harness state without leaving temporary files` fails on Windows for two POSIX assumptions. Neither is a product bug — the test is wrong, not the code.

**1. Path separator**

```ts
expect(readdirSync(harnessStateDir)).toEqual([statePath.split("/").at(-1)]);
```

`saveHarnessState` builds `statePath` with `path.join`, so on Windows it contains `\`. Splitting on `/` returns the whole path rather than the filename:

```
- Expected  [ "C:\Users\...\prime-agent-refinement-test-NbADsg\harness_state.json" ]
+ Received  [ "harness_state.json" ]
```

`basename` is separator-correct on every platform.

**2. File mode**

```ts
chmodSync(statePath, 0o600);
saveHarnessState(harnessStateDir, state);
expect(statSync(statePath).mode & 0o777).toBe(0o600);
```

Windows `chmod` only toggles the read-only bit; Node reports `0o666` (438), so this asserts something the platform cannot express:

```
AssertionError: expected 438 to be 384
```

The behaviour under test — `saveHarnessState` reading the existing mode and preserving it across the atomic rename — is genuinely POSIX-only, so the mode assertions now run on POSIX only. The save and re-save still execute on every platform, so the atomicity half of the test is unchanged everywhere. Coverage on Linux and macOS is identical to before.

## Scope

This does not fix a red build: CI is ubuntu-only today, where the test already passed. It removes a false failure for anyone running the suite on Windows, and it is a prerequisite for the Windows matrix leg proposed in #781. There are ~20 open Windows issues, so contributors landing there currently have to distinguish this failure from their own.

Verified: `packages/coding-agent` `test/refinement.test.ts` **59/59 on Windows** (was 58/59 with this one failing), and `npm run check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix harness-state atomicity test to pass on Windows
> Updates the atomicity test in [refinement.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1325/files#diff-00863e8a97f5558182ff8ff3d737756693af93b3c0467130f90b4739f4298195) to use `basename(statePath)` instead of a Unix-style string split, and skips `chmod`/`stat` permission assertions on Windows since the platform does not support POSIX file modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b74f8c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->