### PR TITLE
Fix Windows supervisor replacement launch lock

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#1375](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375) by [@bilelrais](https://github.com/bilelrais)).
 - Added a working hint that recommends sharing traces with Prime Intellect to help train open-source LLMs.
 - Restored bare `prime-agent --resume` opening the agents view and the `/resume [id|path]` slash command; bare commands open the agents view and an argument resumes that session in place.
+- Fixed Windows daemon workers failing to coordinate replacement supervisor launches through named-pipe paths ([#1286](https://github.com/PrimeIntellect-ai/prime-agent/issues/1286)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 - Fixed ctrl+p ("Toggle agent message expansion") only toggling received agent messages; it now expands and collapses sent agent messages together with received ones.
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -187,7 +187,11 @@ import {
 	prepareDaemonSocketPath,
 	restrictDaemonSocketPath,
 } from "./daemon-socket.js";
-import { assertDaemonSupervisorOwnerCurrent, isDaemonShutdownAdmissionActive } from "./daemon-supervisor-ownership.js";
+import {
+	assertDaemonSupervisorOwnerCurrent,
+	defaultDaemonSupervisorRegistryDir,
+	isDaemonShutdownAdmissionActive,
+} from "./daemon-supervisor-ownership.js";
 import {
 	DAEMON_WORKER_ACTIVE_SESSION_ID_ENV,
 	DAEMON_WORKER_RECOVERY_JOURNAL_ENV,
@@ -757,9 +761,11 @@ export class AgentDaemon {
 		}
 		this.supervisorLaunchInProgress = true;
 		const key = createHash("sha256").update(supervisorSocketPath).digest("hex").slice(0, 12);
-		const lockDirectory = join(dirname(supervisorSocketPath), `.supervisor-launch-${key}.lock`);
+		const registryDir = defaultDaemonSupervisorRegistryDir();
+		const lockDirectory = resolve(registryDir, `.supervisor-launch-${key}.lock`);
 		let ownsLock = false;
 		try {
+			mkdirSync(registryDir, { recursive: true, mode: 0o700 });
 			for (let attempt = 0; attempt < 3 && !ownsLock; attempt++) {
 				const token = randomUUID();
 				const candidateDirectory = `${lockDirectory}.candidate-${process.pid}-${token}`;
@@ -774,7 +780,8 @@ export class AgentDaemon {
 				} catch (error) {
 					rmSync(candidateDirectory, { recursive: true, force: true });
 					const code = (error as NodeJS.ErrnoException).code;
-					if (code !== "EEXIST" && code !== "ENOTEMPTY") {
+					const destinationExists = code === "EPERM" && existsSync(lockDirectory);
+					if (code !== "EEXIST" && code !== "ENOTEMPTY" && !destinationExists) {
 						throw error;
 					}
 					let ownerPid: number | undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -246,7 +246,7 @@ class DaemonShutdownAdmission {
 	}
 }
 
-function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
+export function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
 	return environment[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV] ?? resolve(defaultDaemonSocketDir(), "supervisor-owners");
 }
 

--- a/packages/coding-agent/test/suite/regressions/1286-windows-supervisor-lock.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1286-windows-supervisor-lock.test.ts
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentDaemon } from "../../../src/modes/daemon/daemon-mode.js";
+import { createHarness, type Harness } from "../harness.js";
+
+const SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+
+type ReplacementSupervisorLauncher = {
+	supervisorLaunchInProgress: boolean;
+	launchReplacementSupervisor(supervisorSocketPath: string): Promise<void>;
+};
+
+describe("#1286 Windows replacement supervisor lock", () => {
+	let harness: Harness | undefined;
+	const previousRegistryDir = process.env[SUPERVISOR_REGISTRY_DIR_ENV];
+
+	afterEach(() => {
+		if (previousRegistryDir === undefined) {
+			delete process.env[SUPERVISOR_REGISTRY_DIR_ENV];
+		} else {
+			process.env[SUPERVISOR_REGISTRY_DIR_ENV] = previousRegistryDir;
+		}
+		vi.restoreAllMocks();
+		harness?.cleanup();
+		harness = undefined;
+	});
+
+	it("coordinates a named-pipe replacement launch through the supervisor registry", async () => {
+		harness = await createHarness();
+		const registryDir = join(harness.tempDir, "supervisor-owners");
+		process.env[SUPERVISOR_REGISTRY_DIR_ENV] = registryDir;
+		const supervisorSocketPath = String.raw`\\.\pipe\prime-agent-daemon`;
+		const key = createHash("sha256").update(supervisorSocketPath).digest("hex").slice(0, 12);
+		const lockDirectory = resolve(registryDir, `.supervisor-launch-${key}.lock`);
+		mkdirSync(lockDirectory, { recursive: true, mode: 0o700 });
+		writeFileSync(
+			join(lockDirectory, "pid"),
+			`${process.pid}
+`,
+			{ mode: 0o600 },
+		);
+		const processKill = vi.spyOn(process, "kill");
+		const canConnectToSupervisor = vi.fn(async () => true);
+		const log = vi.fn();
+		const daemon = Object.assign(Object.create(AgentDaemon.prototype), {
+			supervisorLaunchInProgress: false,
+			shuttingDown: false,
+			canConnectToSupervisor,
+			log,
+			options: { defaultSessionConfig: { cwd: harness.tempDir } },
+		}) as ReplacementSupervisorLauncher;
+
+		await daemon.launchReplacementSupervisor(supervisorSocketPath);
+
+		expect(processKill).toHaveBeenCalledOnce();
+		expect(processKill).toHaveBeenCalledWith(process.pid, 0);
+		expect(readFileSync(join(lockDirectory, "pid"), "utf8")).toBe(`${process.pid}
+`);
+		expect(existsSync(lockDirectory)).toBe(true);
+		expect(canConnectToSupervisor).not.toHaveBeenCalled();
+		expect(log).not.toHaveBeenCalled();
+		expect(daemon.supervisorLaunchInProgress).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- place the replacement-supervisor launch lock in the existing real filesystem supervisor registry instead of the daemon endpoint directory
- handle Windows directory-rename collision semantics without treating a live contender as a launch failure
- add a cross-platform regression using a literal Windows named-pipe endpoint and the real replacement method

## Validation

- focused regression: 1 passed
- `npm run check`: green (Biome, tsgo, installer render, browser smoke)
- fresh adversarial review: GO after one correction moved registry creation under the existing reset guard

The patch does not change daemon wire/schema/protocol behavior. It preserves the existing socket hash and stale-lock algorithm; PID-reuse/token/ABA hardening is separate scope.

Fixes #1286.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows supervisor replacement launch lock in `AgentDaemon`
> - Changes the lock directory base in `launchReplacementSupervisor` from `dirname(supervisorSocketPath)` to a global registry directory from `defaultDaemonSupervisorRegistryDir()`, fixing failures when `supervisorSocketPath` is a Windows named-pipe path with no valid filesystem directory.
> - Creates the registry directory with mode `0o700` before use and treats `EPERM` on rename (when the destination already exists) as equivalent to a pre-existing lock rather than throwing.
> - Exports `defaultDaemonSupervisorRegistryDir` from [daemon-supervisor-ownership.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1327/files#diff-6f9ef6ce6a9d2bc51c61fe94d59310efffd26d8f7b3966f5355606b2847d06a5) so it can be imported by the daemon mode module.
> - Adds a regression test in [1286-windows-supervisor-lock.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1327/files#diff-14278dca027dc3aa482182f7f40b9d772d616f8ad11275cccc17997074bdb9ad) covering the named-pipe path scenario.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3ddbe9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->