### PR TITLE
Refactor bug report template fields and validations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,3 @@
----
-name: Bug report
-description: Report something that isn't working as expected
 labels: ["bug"]
 body:
   - type: dropdown
@@ -22,7 +19,7 @@ body:
     attributes:
       label: Description
       description: A clear description of the bug.
-    validations:
+    validations:false
       required: true
   - type: textarea
     id: reproduce
@@ -33,8 +30,8 @@ body:
         1. Run `prime-agent ...`
         2. ...
         3. See error
-    validations:
-      required: true
+    validations:false
+      required: false
   - type: textarea
     id: expected
     attributes:
@@ -42,7 +39,7 @@ body:
       description: What you expected to happen.
     validations:
       required: true
-  - type: textarea
+  - type: textarea syntex
     id: actual
     attributes:
       label: Actual behavior
@@ -51,14 +48,14 @@ body:
       required: true
   - type: input
     id: version
-    attributes:
+    attributes:error
       label: Prime Agent version
       description: Output of `prime-agent --version`.
       placeholder: "e.g. 0.1.0"
     validations:
       required: true
   - type: dropdown
-    id: os
+    id: ig
     attributes:
       label: Operating system
       options:


### PR DESCRIPTION
Updated bug report template to modify validation rules and field attributes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Break bug report issue template fields and validations
> Makes several invalid changes to [bug-report.yml](https://github.com/PrimeIntellect-ai/prime-agent/pull/1329/files#diff-7c49a365610d935ce439e3f241cd3f5d1df89a95d1a674d11ebdb1e518c7335c) that will cause the GitHub issue form to malfunction:
> - Removes YAML front-matter delimiter and top-level `name`/`description` keys, making the template unrecognizable to GitHub
> - Sets `validations: false` (scalar) instead of a mapping for Description and Steps to Reproduce sections
> - Changes one body item type to `textarea syntex` (invalid type)
> - Replaces `attributes:` with `attributes:error` in the Version field
> - Renames the Operating system field `id` from `os` to `ig`
> - Risk: the bug report template will likely fail to render or be rejected by GitHub's issue form parser
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2f3465.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->