### PR TITLE
[v0.8 Core 3] reconstruct managed session catalog

### DIFF
--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -257,7 +257,20 @@ function sameAgentSessionNameParent(
 	if (left.depth === 0 && right.depth === 0) {
 		return true;
 	}
-	return sameAgentFamilyParent(left, right, catalog);
+	if (sameAgentFamilyParent(left, right, catalog)) return true;
+
+	// A passive child can outlive the active parent row that would normally
+	// resolve its family edge. Name reservation must still protect that parent's
+	// sibling namespace, but this weaker direct-claim fallback is deliberately
+	// not used for family reach: reach continues to require an unambiguous,
+	// catalog-resolved parent.
+	if (left.depth !== right.depth || left.depth === 0) return false;
+	return (
+		(left.parentSessionId !== undefined && left.parentSessionId === right.parentSessionId) ||
+		(left.parentSessionPath !== undefined &&
+			right.parentSessionPath !== undefined &&
+			canonicalSessionPath(left.parentSessionPath) === canonicalSessionPath(right.parentSessionPath))
+	);
 }
 
 function sameAgentFamilyParent(
@@ -265,44 +278,38 @@ function sameAgentFamilyParent(
 	right: AgentSessionNameScope,
 	catalog: readonly AgentFamilyCatalogEntry[],
 ): boolean {
-	if (left.parentSessionPath !== undefined && left.parentSessionPath === right.parentSessionPath) {
-		return true;
-	}
-	if (left.parentSessionId !== undefined && left.parentSessionId === right.parentSessionId) {
-		return true;
-	}
-	const hasCatalogParentPair = (parentSessionId: string | undefined, parentSessionPath: string | undefined) =>
-		parentSessionId !== undefined &&
-		parentSessionPath !== undefined &&
-		catalog.some(
-			(entry) =>
-				(entry.id === parentSessionId && entry.sessionPath === parentSessionPath) ||
-				(entry.parentSessionId === parentSessionId && entry.parentSessionPath === parentSessionPath),
+	if (left.depth === 0 && right.depth === 0) {
+		return (
+			left.parentSessionId === undefined &&
+			left.parentSessionPath === undefined &&
+			right.parentSessionId === undefined &&
+			right.parentSessionPath === undefined
 		);
-	if (
-		hasCatalogParentPair(left.parentSessionId, right.parentSessionPath) ||
-		hasCatalogParentPair(right.parentSessionId, left.parentSessionPath)
-	) {
-		return true;
 	}
-	if (
-		left.depth === 0 &&
-		right.depth === 0 &&
-		left.parentSessionPath === undefined &&
-		right.parentSessionPath === undefined &&
-		left.parentSessionId === undefined &&
-		right.parentSessionId === undefined
-	) {
-		return true;
-	}
-	// Unresolved mixed identifiers stay unrelated to avoid false name conflicts across families.
-	return false;
+	if (left.depth !== right.depth || left.depth === 0) return false;
+	const parentFor = (child: AgentSessionNameScope) => {
+		const parents = catalog.filter((entry) => isAgentFamilyParent(entry, child));
+		return parents.length === 1 ? parents[0] : undefined;
+	};
+	const leftParent = parentFor(left);
+	const rightParent = parentFor(right);
+	return leftParent !== undefined && leftParent.id === rightParent?.id;
 }
 
-function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentFamilyCatalogEntry): boolean {
+/**
+ * Validates one persisted parent edge. A child may supply either durable
+ * identifier, but when it supplies both they must identify this same direct
+ * parent. This keeps contradictory records from becoming relatives through
+ * whichever identifier happens to match.
+ */
+function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentSessionNameScope): boolean {
+	if (child.depth <= 0 || parent.depth !== child.depth - 1) return false;
+	const claimsId = child.parentSessionId !== undefined;
+	const claimsPath = child.parentSessionPath !== undefined;
 	return (
-		(child.parentSessionPath !== undefined && child.parentSessionPath === parent.sessionPath) ||
-		(child.parentSessionId !== undefined && child.parentSessionId === parent.id)
+		(claimsId || claimsPath) &&
+		(!claimsId || child.parentSessionId === parent.id) &&
+		(!claimsPath || child.parentSessionPath === parent.sessionPath)
 	);
 }
 
@@ -310,19 +317,21 @@ function isAgentFamilyParent(parent: AgentFamilyCatalogEntry, child: AgentFamily
 export function agentFamilyRelationship(
 	current: AgentFamilyCatalogEntry,
 	target: AgentFamilyCatalogEntry,
+	catalog: readonly AgentFamilyCatalogEntry[] = [current, target],
 ): AgentFamilyRelationship | undefined {
 	if (current.id === target.id) return undefined;
 	if (isAgentFamilyParent(target, current)) return "parent";
 	if (isAgentFamilyParent(current, target)) return "child";
-	if (current.depth === target.depth && sameAgentFamilyParent(current, target, [current, target])) return "sibling";
+	if (sameAgentFamilyParent(current, target, catalog)) return "sibling";
 	return undefined;
 }
 
 export function assertAgentFamilyReach(
 	current: AgentFamilyCatalogEntry,
 	target: AgentFamilyCatalogEntry,
+	catalog?: readonly AgentFamilyCatalogEntry[],
 ): AgentFamilyRelationship {
-	const relationship = agentFamilyRelationship(current, target);
+	const relationship = agentFamilyRelationship(current, target, catalog);
 	if (!relationship) throw new Error(AGENT_FAMILY_REACH_ERROR);
 	return relationship;
 }

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1013,12 +1013,37 @@ export async function readSessionInfo(filePath: string): Promise<SessionInfo | n
 	if (cached && cached.size === stats.size && cached.mtimeMs === stats.mtimeMs) {
 		return cached.info;
 	}
-	const info = await scanSessionInfo(filePath, stats);
+	const info = await scanSessionInfo(filePath, stats, readLinesAsBuffers(filePath));
 	sessionInfoCache.set(filePath, { size: stats.size, mtimeMs: stats.mtimeMs, info });
 	return info;
 }
 
-async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeof stat>>): Promise<SessionInfo | null> {
+/** Parse catalog-authorized bytes without reopening their pathname. */
+export async function readSessionInfoFromBuffer(
+	filePath: string,
+	contents: Buffer,
+	metadata: { mtimeMs: number },
+): Promise<SessionInfo | null> {
+	async function* lines(): AsyncGenerator<Buffer> {
+		let start = 0;
+		while (start < contents.length) {
+			const end = contents.indexOf(0x0a, start);
+			if (end === -1) {
+				yield contents.subarray(start);
+				return;
+			}
+			yield contents.subarray(start, end);
+			start = end + 1;
+		}
+	}
+	return scanSessionInfo(filePath, { mtime: new Date(metadata.mtimeMs) } as Awaited<ReturnType<typeof stat>>, lines());
+}
+
+async function scanSessionInfo(
+	filePath: string,
+	stats: Awaited<ReturnType<typeof stat>>,
+	lines: AsyncIterable<Buffer>,
+): Promise<SessionInfo | null> {
 	try {
 		let header: SessionHeader | undefined;
 		let messageCount = 0;
@@ -1029,7 +1054,7 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 		let agentStatus: AgentStatus | undefined;
 		let lastActivityTime: number | undefined;
 
-		for await (const lineBuffer of readLinesAsBuffers(filePath)) {
+		for await (const lineBuffer of lines) {
 			const line = lineBuffer.toString("utf8");
 			if (!line.trim()) continue;
 

--- a/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-catalog-process.ts
@@ -1,11 +1,17 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { closeSync, constants, openSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
+import { getSessionsDir } from "../../config.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { deleteSessionFile } from "../../core/session-file-actions.js";
-import { readSessionInfo, type SessionInfo, SessionManager } from "../../core/session-manager.js";
+import {
+	readSessionInfo,
+	readSessionInfoFromBuffer,
+	type SessionInfo,
+	SessionManager,
+} from "../../core/session-manager.js";
 
 export const DAEMON_CATALOG_ROLE_ENV = "PRIME_AGENT_INTERNAL_DAEMON_CATALOG";
 
@@ -16,8 +22,9 @@ interface SessionInfoWire extends Omit<SessionInfo, "created" | "modified"> {
 
 type CatalogRequest =
 	| { type: "request"; id: string; command: "list"; cwd?: string; sessionDir?: string }
+	| { type: "request"; id: string; command: "family"; sessionDir?: string }
 	| { type: "request"; id: string; command: "resolve"; selector: string; cwd: string; sessionDir?: string }
-	| { type: "request"; id: string; command: "siblings"; sessionPath: string }
+	| { type: "request"; id: string; command: "siblings"; sessionPath: string; sessionDir?: string }
 	| { type: "request"; id: string; command: "rename"; sessionPath: string; name: string }
 	| { type: "request"; id: string; command: "delete"; sessionPath: string }
 	| { type: "request"; id: string; command: "archive"; sessionPath: string; sessionId: string }
@@ -66,42 +73,339 @@ interface SavedRlmSubagentRegistryEntry {
 	status?: unknown;
 }
 
-export async function listSavedSessionSiblings(sessionPath: string): Promise<SessionInfo[]> {
-	const target = await readSessionInfo(sessionPath);
-	if (!target) throw new Error(`Session not found: ${sessionPath}`);
-	if (!target.parentSessionPath) return [target];
-	const parentPath = resolve(dirname(target.path), target.parentSessionPath);
-	const parent = await readSessionInfo(parentPath);
-	if (!parent) return [target];
-	const registryPath = join(dirname(dirname(parent.path)), "session-artifacts", parent.id, "rlm-subagents.jsonl");
+const MAX_RLM_REGISTRY_BYTES = 1024 * 1024;
+const MAX_RLM_REGISTRY_RECORDS = 10_000;
+const MAX_RLM_FAMILY_EDGES = 10_000;
+const MAX_RLM_FAMILY_NODES = 10_000;
+const MAX_RLM_FAMILY_DEPTH = 64;
+
+interface ManagedRoot {
+	lexical: string;
+	fd: number;
+}
+
+interface ManagedRoots {
+	session: ManagedRoot;
+	artifacts: ManagedRoot | undefined;
+}
+
+interface TrustedFile {
+	path: string;
+	contents: Buffer;
+	mtimeMs: number;
+	dev: string;
+	ino: string;
+}
+
+interface TrustedSession extends SessionInfo {
+	/** The header claim is intentionally separate from SessionInfo's legacy fallback. */
+	persistedDepth: number;
+	persistedParentPath?: string;
+}
+
+function rlmSubagentRegistryPath(parent: SessionInfo, roots: ManagedRoots): string | undefined {
+	const parentDir = dirname(parent.path);
+	const artifactDir =
+		parentDir === roots.session.lexical ? roots.artifacts?.lexical : join(parentDir, "session-artifacts");
+	return artifactDir ? join(artifactDir, parent.id, "rlm-subagents.jsonl") : undefined;
+}
+
+function isWithin(root: string, target: string): boolean {
+	const path = relative(root, target);
+	return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+
+function invalidFamilyTopology(reason: string): Error {
+	return new Error(`Invalid RLM artifact family topology: ${reason}`);
+}
+
+let openAuthorityFdCountForTest = 0;
+/** @internal */
+export function getOpenCatalogAuthorityFdCountForTest(): number {
+	return openAuthorityFdCountForTest;
+}
+
+function openAuthorityRoot(path: string, optional = false): ManagedRoot | undefined {
+	try {
+		// O_NOFOLLOW binds authority to the directory itself, never a pathname target.
+		const fd = openSync(path, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+		openAuthorityFdCountForTest++;
+		return { lexical: path, fd };
+	} catch (error) {
+		if (optional && (error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw invalidFamilyTopology(`managed authority root is unavailable: ${String(error)}`);
+	}
+}
+
+function managedRoots(sessionDir: string | undefined): ManagedRoots {
+	const sessionLexical = resolve(sessionDir ?? "");
+	const session = openAuthorityRoot(sessionLexical)!;
+	try {
+		const artifacts = openAuthorityRoot(join(dirname(sessionLexical), "session-artifacts"), true);
+		return { session, artifacts };
+	} catch (error) {
+		closeSync(session.fd);
+		throw error;
+	}
+}
+
+function closeManagedRoots(roots: ManagedRoots): void {
+	closeSync(roots.session.fd);
+	openAuthorityFdCountForTest--;
+	if (roots.artifacts) {
+		closeSync(roots.artifacts.fd);
+		openAuthorityFdCountForTest--;
+	}
+}
+
+const OPENAT_READ_HELPER = String.raw`import base64,json,os,stat,sys
+MAX=134217728
+def reject(): raise ValueError("invalid")
+def flags(directory=False):
+ value=os.O_RDONLY|os.O_NOFOLLOW
+ if directory: value|=os.O_DIRECTORY
+ return value
+def main():
+ req=json.loads(sys.stdin.buffer.read(131073))
+ parts=req.get("parts"); limit=req.get("limit")
+ if not isinstance(parts,list) or not parts or not isinstance(limit,int) or limit<0 or limit>MAX: reject()
+ if any(not isinstance(p,str) or not p or p in (".","..") or "/" in p or "\\" in p for p in parts): reject()
+ current=os.dup(3)
+ try:
+  for part in parts[:-1]:
+   nxt=os.open(part,flags(True),dir_fd=current); os.close(current); current=nxt
+  fd=os.open(parts[-1],flags(False),dir_fd=current)
+  try:
+   before=os.fstat(fd)
+   if not stat.S_ISREG(before.st_mode) or before.st_size>limit: reject()
+   chunks=[]; total=0
+   while True:
+    chunk=os.read(fd,min(65536,limit+1-total))
+    if not chunk: break
+    chunks.append(chunk); total+=len(chunk)
+    if total>limit: reject()
+   after=os.fstat(fd)
+   if (before.st_dev,before.st_ino,before.st_mode)!=(after.st_dev,after.st_ino,after.st_mode): reject()
+   print(json.dumps({"data":base64.b64encode(b"".join(chunks)).decode("ascii"),"mtimeMs":after.st_mtime_ns/1000000,"dev":str(after.st_dev),"ino":str(after.st_ino)},separators=(",",":")))
+  finally: os.close(fd)
+ finally: os.close(current)
+try: main()
+except FileNotFoundError: sys.exit(44)
+except Exception: sys.stderr.write("catalog openat helper failed\n"); sys.exit(1)
+`;
+
+/** Test-only seam runs after authority selection but before descriptor-relative traversal. */
+let beforeTrustedOpenForTest: ((path: string) => void) | undefined;
+/** @internal */
+export function setCatalogBeforeTrustedOpenForTest(hook: ((path: string) => void) | undefined): void {
+	beforeTrustedOpenForTest = hook;
+}
+
+function readTrustedFile(rawPath: string, roots: ManagedRoots, maxBytes: number): TrustedFile {
+	if (!isAbsolute(rawPath) || rawPath !== resolve(rawPath))
+		throw invalidFamilyTopology("session path is not canonical");
+	const root = [roots.session, roots.artifacts].find((candidate) => candidate && isWithin(candidate.lexical, rawPath));
+	if (!root) throw invalidFamilyTopology("session path escapes managed roots");
+	const suffix = relative(root.lexical, rawPath);
+	const parts = suffix.split(sep);
+	if (!suffix || parts.some((part) => !part || part === "." || part === "..")) {
+		throw invalidFamilyTopology("session path lacks a trusted file component");
+	}
+	beforeTrustedOpenForTest?.(rawPath);
+	const result = spawnSync(
+		process.execPath === process.env.PRIME_AGENT_KERNEL_PYTHON
+			? process.execPath
+			: (process.env.PRIME_AGENT_KERNEL_PYTHON ?? "python3"),
+		["-I", "-c", OPENAT_READ_HELPER],
+		{
+			input: JSON.stringify({ parts, limit: maxBytes }),
+			encoding: "utf8",
+			timeout: 5_000,
+			maxBuffer: maxBytes * 2 + 64 * 1024,
+			stdio: ["pipe", "pipe", "pipe", root.fd],
+			shell: false,
+		},
+	);
+	if (result.status === 44) throw invalidFamilyTopology("descriptor-relative artifact is absent");
+	if (result.error || result.status !== 0 || typeof result.stdout !== "string") {
+		throw invalidFamilyTopology("descriptor-relative artifact read failed");
+	}
+	try {
+		const wire = JSON.parse(result.stdout) as { data?: unknown; mtimeMs?: unknown; dev?: unknown; ino?: unknown };
+		if (
+			typeof wire.data !== "string" ||
+			typeof wire.mtimeMs !== "number" ||
+			typeof wire.dev !== "string" ||
+			typeof wire.ino !== "string"
+		)
+			throw new Error("invalid");
+		return {
+			path: rawPath,
+			contents: Buffer.from(wire.data, "base64"),
+			mtimeMs: wire.mtimeMs,
+			dev: wire.dev,
+			ino: wire.ino,
+		};
+	} catch {
+		throw invalidFamilyTopology("descriptor-relative artifact response is invalid");
+	}
+}
+
+async function readTrustedSession(path: string, roots: ManagedRoots): Promise<TrustedSession> {
+	const trusted = readTrustedFile(path, roots, 128 * 1024 * 1024);
+	const headerLine = trusted.contents
+		.toString("utf8", 0, Math.min(trusted.contents.length, 256 * 1024))
+		.split(/\r?\n/, 1)[0];
+	let header: { type?: unknown; id?: unknown; parentSession?: unknown; rlmDepth?: unknown };
+	try {
+		header = JSON.parse(headerLine ?? "") as typeof header;
+	} catch {
+		throw invalidFamilyTopology("session header is malformed");
+	}
+	const hasParent = header.parentSession !== undefined;
+	const hasDepth = Number.isSafeInteger(header.rlmDepth) && (header.rlmDepth as number) >= 0;
+	if (
+		header.type !== "session" ||
+		typeof header.id !== "string" ||
+		header.id === "" ||
+		(hasParent && typeof header.parentSession !== "string") ||
+		(hasParent && header.parentSession === "") ||
+		(hasParent && !hasDepth) ||
+		(!hasParent && header.rlmDepth !== undefined && !hasDepth)
+	)
+		throw invalidFamilyTopology("session header lacks trustworthy topology claims");
+	const persistedDepth = hasDepth ? (header.rlmDepth as number) : 0;
+	const info = await readSessionInfoFromBuffer(path, trusted.contents, { mtimeMs: trusted.mtimeMs });
+	if (!info || info.id !== header.id) throw invalidFamilyTopology("session metadata does not match its header");
+	return {
+		...info,
+		path,
+		rlmDepth: persistedDepth,
+		persistedDepth,
+		...(hasParent ? { persistedParentPath: header.parentSession as string } : {}),
+	};
+}
+
+async function readLatestRegistry(
+	path: string,
+	roots: ManagedRoots,
+): Promise<SavedRlmSubagentRegistryEntry[] | undefined> {
 	let contents: string;
 	try {
-		contents = await readFile(registryPath, "utf8");
+		contents = readTrustedFile(path, roots, MAX_RLM_REGISTRY_BYTES).contents.toString("utf8");
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [target];
+		if ((error as Error).message.includes("descriptor-relative artifact is absent")) return undefined;
 		throw error;
 	}
 	const latest = new Map<string, SavedRlmSubagentRegistryEntry>();
+	let records = 0;
 	for (const line of contents.split(/\r?\n/)) {
 		if (!line.trim()) continue;
+		if (++records > MAX_RLM_REGISTRY_RECORDS) throw invalidFamilyTopology("registry record limit exhausted");
+		let entry: SavedRlmSubagentRegistryEntry;
 		try {
-			const entry = JSON.parse(line) as SavedRlmSubagentRegistryEntry;
-			if (entry.type === "rlm_subagent" && typeof entry.childId === "string") latest.set(entry.childId, entry);
+			entry = JSON.parse(line) as SavedRlmSubagentRegistryEntry;
 		} catch {
-			// Ignore malformed registry history just like the owning worker does.
+			throw invalidFamilyTopology("registry contains malformed JSON");
 		}
+		if (
+			entry.type !== "rlm_subagent" ||
+			typeof entry.childId !== "string" ||
+			entry.childId === "" ||
+			typeof entry.sessionFile !== "string" ||
+			entry.sessionFile === "" ||
+			(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted")
+		) {
+			throw invalidFamilyTopology("registry contains an invalid edge");
+		}
+		latest.set(entry.childId, entry);
 	}
-	const siblingPaths = new Set<string>([resolve(target.path)]);
-	for (const entry of latest.values()) {
-		if (entry.status !== "deleted" && typeof entry.sessionFile === "string")
-			siblingPaths.add(resolve(entry.sessionFile));
+	return [...latest.values()];
+}
+
+export async function listCatalogFamilySessions(sessionDir?: string): Promise<SessionInfo[]> {
+	const effectiveSessionDir = sessionDir ?? getSessionsDir();
+	const roots = await SessionManager.listAll(undefined, effectiveSessionDir);
+	const authority = managedRoots(effectiveSessionDir);
+	try {
+		const sessions = new Map<string, TrustedSession>();
+		const ids = new Map<string, string>();
+		for (const root of roots) {
+			const trusted = await readTrustedSession(root.path, authority);
+			if (trusted.persistedDepth !== 0 || trusted.persistedParentPath !== undefined) {
+				throw invalidFamilyTopology("managed session seed claims a parent");
+			}
+			const existingPath = ids.get(trusted.id);
+			if (existingPath && existingPath !== trusted.path)
+				throw invalidFamilyTopology("family contains a duplicate session id");
+			ids.set(trusted.id, trusted.path);
+			sessions.set(trusted.path, trusted);
+		}
+		let edges = 0;
+		const visited = new Set<string>();
+		const visit = async (parent: TrustedSession, depth: number, ancestors: ReadonlySet<string>): Promise<void> => {
+			if (depth > MAX_RLM_FAMILY_DEPTH) throw invalidFamilyTopology("family depth limit exhausted");
+			const parentPath = parent.path;
+			if (ancestors.has(parentPath)) throw invalidFamilyTopology("family contains a cycle");
+			if (visited.has(parentPath)) return;
+			visited.add(parentPath);
+			const registryPath = rlmSubagentRegistryPath(parent, authority);
+			if (!registryPath) return;
+			const entries = await readLatestRegistry(registryPath, authority);
+			if (!entries) return;
+			const childAncestors = new Set(ancestors);
+			childAncestors.add(parentPath);
+			for (const entry of entries) {
+				if (entry.status === "deleted") continue;
+				if (++edges > MAX_RLM_FAMILY_EDGES) throw invalidFamilyTopology("family edge limit exhausted");
+				const childPath = entry.sessionFile as string;
+				if (childAncestors.has(childPath)) throw invalidFamilyTopology("family contains a cycle");
+				const child = await readTrustedSession(childPath, authority);
+				if (child.id !== entry.childId) throw invalidFamilyTopology("registry child id does not match session id");
+				if (child.persistedParentPath === undefined)
+					throw invalidFamilyTopology("child lacks a persisted parent path");
+				const claimedParentPath = resolve(dirname(child.path), child.persistedParentPath);
+				readTrustedFile(claimedParentPath, authority, 128 * 1024 * 1024);
+				if (claimedParentPath !== parentPath)
+					throw invalidFamilyTopology("child parent path does not match traversed parent");
+				if (child.persistedDepth !== parent.persistedDepth + 1)
+					throw invalidFamilyTopology("child depth does not equal parent depth plus one");
+				const existingPath = ids.get(child.id);
+				if (existingPath && existingPath !== child.path)
+					throw invalidFamilyTopology("family contains a duplicate session id");
+				const existing = sessions.get(child.path);
+				if (
+					existing &&
+					(existing.id !== child.id ||
+						existing.persistedParentPath !== child.persistedParentPath ||
+						existing.persistedDepth !== child.persistedDepth)
+				) {
+					throw invalidFamilyTopology("family contains a conflicting duplicate");
+				}
+				if (!existing && sessions.size >= MAX_RLM_FAMILY_NODES)
+					throw invalidFamilyTopology("family node limit exhausted");
+				ids.set(child.id, child.path);
+				sessions.set(child.path, child);
+				await visit(child, depth + 1, childAncestors);
+			}
+		};
+		for (const root of [...sessions.values()]) await visit(root, 0, new Set());
+		return [...sessions.values()];
+	} finally {
+		closeManagedRoots(authority);
 	}
-	const siblings = await Promise.all([...siblingPaths].map((path) => readSessionInfo(path)));
-	return siblings.filter(
-		(info): info is SessionInfo =>
-			info !== null &&
-			info.parentSessionPath !== undefined &&
-			resolve(dirname(info.path), info.parentSessionPath) === parentPath,
+}
+export async function listSavedSessionSiblings(sessionPath: string, sessionDir?: string): Promise<SessionInfo[]> {
+	const family = await listCatalogFamilySessions(sessionDir);
+	const targetPath = resolve(sessionPath);
+	const target = family.find((session) => session.path === targetPath);
+	if (!target) throw new Error(`Session not found: ${sessionPath}`);
+	if (!target.parentSessionPath) return [target];
+	const parentPath = resolve(dirname(target.path), target.parentSessionPath);
+	return family.filter(
+		(session) =>
+			session.parentSessionPath !== undefined &&
+			resolve(dirname(session.path), session.parentSessionPath) === parentPath,
 	);
 }
 
@@ -141,6 +445,7 @@ function isCatalogRequest(value: unknown): value is CatalogRequest {
 		candidate.type === "request" &&
 		typeof candidate.id === "string" &&
 		(candidate.command === "list" ||
+			candidate.command === "family" ||
 			candidate.command === "resolve" ||
 			candidate.command === "siblings" ||
 			candidate.command === "rename" ||
@@ -194,6 +499,16 @@ async function handleCatalogRequest(request: CatalogRequest): Promise<void> {
 				});
 				return;
 			}
+			case "family": {
+				const sessions = await listCatalogFamilySessions(request.sessionDir);
+				sendCatalogMessage({
+					type: "response",
+					id: request.id,
+					success: true,
+					data: { sessions: sessions.map(serializeSessionInfo) },
+				});
+				return;
+			}
 			case "resolve": {
 				const localMatch = resolveCatalogSessionMatch(
 					await SessionManager.list(request.cwd, request.sessionDir),
@@ -228,7 +543,11 @@ async function handleCatalogRequest(request: CatalogRequest): Promise<void> {
 					type: "response",
 					id: request.id,
 					success: true,
-					data: { sessions: (await listSavedSessionSiblings(request.sessionPath)).map(serializeSessionInfo) },
+					data: {
+						sessions: (await listSavedSessionSiblings(request.sessionPath, request.sessionDir)).map(
+							serializeSessionInfo,
+						),
+					},
 				});
 				return;
 			case "rename":
@@ -328,12 +647,23 @@ export class DaemonCatalogClient {
 		return data.sessions.map(deserializeSessionInfo);
 	}
 
-	async siblings(sessionPath: string): Promise<SessionInfo[]> {
+	async family(sessionDir?: string): Promise<SessionInfo[]> {
+		const data = await this.request<{ sessions: SessionInfoWire[] }>({
+			type: "request",
+			id: randomUUID(),
+			command: "family",
+			sessionDir,
+		});
+		return data.sessions.map(deserializeSessionInfo);
+	}
+
+	async siblings(sessionPath: string, sessionDir?: string): Promise<SessionInfo[]> {
 		const data = await this.request<{ sessions: SessionInfoWire[] }>({
 			type: "request",
 			id: randomUUID(),
 			command: "siblings",
 			sessionPath,
+			sessionDir,
 		});
 		return data.sessions.map(deserializeSessionInfo);
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -404,6 +404,21 @@ type PassiveRlmSubagent = PassiveRlmRoot & {
 	chain: PersistedRlmSubagentRegistryEntry[];
 };
 
+type AgentFamilyCatalogSource = "saved" | "passive" | "resident" | "remote";
+
+/**
+ * The public catalog has to retain a usable depth for legacy callers, while
+ * authorization must distinguish a persisted claim from a depth inferred by a
+ * legacy reader. These claim fields are deliberately private to catalog
+ * construction and never escape into agent-messages' public roster.
+ */
+type AgentFamilyCatalogCandidate = AgentFamilyCatalogEntry & {
+	source: AgentFamilyCatalogSource;
+	depthClaim?: number;
+	parentSessionIdClaim?: string;
+	parentSessionPathClaim?: string;
+};
+
 class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
 
@@ -2860,18 +2875,30 @@ export class AgentDaemon {
 	}
 
 	private async createAgentObserveListResult(currentState: ActiveSessionState): Promise<AgentObserveListResult> {
+		const catalog = await this.agentFamilyCatalogEntries();
+		this.authoritativeAgentFamilyEntry(currentState, catalog);
 		const agents = this.listTargetableSessionStates(currentState)
-			.filter(
-				(state) =>
-					state.activeSessionId === currentState.activeSessionId ||
-					this.isAgentFamilyReachable(currentState, state),
-			)
-			.map((state) => this.createAgentObserveSummary(state, currentState));
+			.filter((state) => {
+				if (state.activeSessionId === currentState.activeSessionId) return true;
+				try {
+					assertAgentFamilyReach(
+						this.authoritativeAgentFamilyEntry(currentState, catalog),
+						this.authoritativeAgentFamilyEntry(state, catalog),
+						catalog,
+					);
+					return true;
+				} catch (error) {
+					if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) return false;
+					throw error;
+				}
+			})
+			.map((state) => this.createAgentObserveSummary(state, currentState, catalog));
 		const residentIds = new Set(agents.map((agent) => agent.activeSessionId));
 		for (const passive of await this.listPassiveRlmSubagents()) {
 			if (residentIds.has(passive.info.id)) continue;
 			try {
-				assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.passiveAgentFamilyEntry(passive));
+				const passiveEntry = this.authoritativeAgentFamilyEntryForSessionId(passive.info.id, catalog);
+				assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(currentState, catalog), passiveEntry, catalog);
 			} catch (error) {
 				if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) continue;
 				throw error;
@@ -2901,7 +2928,7 @@ export class AgentDaemon {
 			residentIds.add(passive.info.id);
 		}
 		return {
-			current: this.createAgentObserveSummary(currentState, currentState),
+			current: this.createAgentObserveSummary(currentState, currentState, catalog),
 			agents,
 		};
 	}
@@ -2910,10 +2937,12 @@ export class AgentDaemon {
 		currentState: ActiveSessionState,
 		target: string,
 	): Promise<AgentObserveAgentSnapshot> {
-		const targetState = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, target);
-		this.assertAgentFamilyReachable(currentState, targetState);
+		const { targetState, catalog } = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, target);
+		// Hydration may mutate live endpoint fields. Re-authorize and label only from the
+		// captured catalog that authorized the wake, never from a post-hydration rescan.
+		this.assertAgentFamilyReachable(currentState, targetState, catalog);
 		return {
-			agent: this.createAgentObserveSummary(targetState, currentState),
+			agent: this.createAgentObserveSummary(targetState, currentState, catalog),
 		};
 	}
 
@@ -2921,14 +2950,15 @@ export class AgentDaemon {
 		currentState: ActiveSessionState,
 		input: AgentObserveRecentMessagesInput,
 	): Promise<AgentObserveRecentMessagesResult> {
-		const targetState = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, input.target);
-		this.assertAgentFamilyReachable(currentState, targetState);
+		const { targetState, catalog } = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, input.target);
+		// See getAgent: an observation must use its original authorization snapshot.
+		this.assertAgentFamilyReachable(currentState, targetState, catalog);
 		const limit = normalizeObserveLimit(input.limit);
 		const maxChars = normalizeObserveMaxChars(input.maxChars);
 		const messages = targetState.runtime.session.messages;
 		const startIndex = Math.max(0, messages.length - limit);
 		return {
-			agent: this.createAgentObserveSummary(targetState, currentState),
+			agent: this.createAgentObserveSummary(targetState, currentState, catalog),
 			messages: messages
 				.slice(startIndex)
 				.map((message, offset) => createAgentObserveMessagePreview(message, startIndex + offset, maxChars)),
@@ -2941,8 +2971,17 @@ export class AgentDaemon {
 	private createAgentObserveSummary(
 		state: ActiveSessionState,
 		currentState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[],
 	): AgentObserveAgentSummary {
 		const summary = summaryForActiveSession(state);
+		// The catalog is the authorization snapshot, so relationship fields must not
+		// be re-derived from a runtime that may have changed while a passive target woke.
+		const topology = this.authoritativeAgentFamilyEntry(state, catalog);
+		const parentState = topology.parentSessionId
+			? [...this.sessions.values()].find(
+					(candidate) => candidate.runtime.session.sessionId === topology.parentSessionId,
+				)
+			: undefined;
 		const session = state.runtime.session;
 		const messages = session.messages;
 		const latest = messages.at(-1);
@@ -2971,8 +3010,8 @@ export class AgentDaemon {
 			messageCount: summary.messageCount,
 			queuedCount: summary.sessionActions.queuedCount,
 			isSessionActive: summary.isSessionActive,
-			...(summary.parentActiveSessionId ? { parentActiveSessionId: summary.parentActiveSessionId } : {}),
-			...(summary.parentSessionId ? { parentSessionId: summary.parentSessionId } : {}),
+			...(parentState ? { parentActiveSessionId: parentState.activeSessionId } : {}),
+			...(topology.parentSessionId ? { parentSessionId: topology.parentSessionId } : {}),
 			...(summary.rlmChildId ? { rlmChildId: summary.rlmChildId } : {}),
 			...(summary.rlmParentNodeId ? { rlmParentNodeId: summary.rlmParentNodeId } : {}),
 			...(summary.firstMessage ? { firstMessage: summary.firstMessage } : {}),
@@ -4950,6 +4989,8 @@ export class AgentDaemon {
 					passive.rootParentState?.runtime.session.sessionFile ??
 					passive.rootInfo?.path,
 				rlmDepth: info.rlmDepth ?? entry.rlmDepth,
+				// Passive rows are not resident daemon runtimes. Registry state is
+				// retained separately below and must not change roster lifecycle.
 				status: "inactive",
 				rlmChildId: entry.childId,
 				rlmChildRegistryStatus: entry.status,
@@ -5035,9 +5076,11 @@ export class AgentDaemon {
 	}
 
 	private async createAgentFamilyRoster(currentState: ActiveSessionState): Promise<AgentFamilyRosterResult> {
-		const catalog = await this.createAgentFamilyCatalog(currentState);
-		const current = catalog.find((entry) => entry.id === currentState.runtime.session.sessionId);
-		if (!current) throw new Error("Current agent is missing from the family catalog");
+		// Roster membership is an authorization surface: capture the same immutable
+		// authoritative topology used by message delivery, never the legacy Map
+		// catalog whose duplicate IDs overwrite one another.
+		const catalog = await this.agentFamilyCatalogEntries();
+		const current = this.authoritativeAgentFamilyEntry(currentState, catalog);
 		return buildAgentFamilyRoster(current, catalog);
 	}
 
@@ -5255,54 +5298,255 @@ export class AgentDaemon {
 		};
 	}
 
-	private passiveAgentFamilyEntry(passive: PassiveRlmSubagent): AgentFamilyCatalogEntry {
-		const entry = passive.entry;
-		const depth = passive.info.rlmDepth ?? entry.rlmDepth ?? passive.chain.length;
+	/** Capture persisted topology once for an authorization decision. */
+	private async agentFamilyCatalogEntries(): Promise<readonly AgentFamilyCatalogEntry[]> {
+		const saved = await SessionManager.listAll(undefined, this.options.defaultSessionConfig.sessionDir);
+		const entries: AgentFamilyCatalogCandidate[] = await Promise.all(
+			saved.map((info) => this.savedAgentFamilyCandidate(info)),
+		);
+		// Artifact-resident descendants are absent from the saved-session scan.
+		for (const passive of await this.listPassiveRlmSubagents(saved, true)) {
+			entries.push(await this.passiveAgentFamilyCandidate(passive));
+		}
+		for (const state of this.sessions.values()) entries.push(this.residentAgentFamilyCandidate(state));
+		for (const peer of this.remoteAgentPeers.values()) entries.push(this.remoteAgentFamilyCandidate(peer));
+		return Object.freeze(this.mergeEquivalentAgentFamilyCatalogEntries(entries));
+	}
+
+	/** The header is the only durable evidence that a saved depth/path was explicit. */
+	private async persistedTopologyClaims(sessionPath: string): Promise<{ depth?: number; parentSessionPath?: string }> {
+		try {
+			const firstLine = (await readFile(sessionPath, "utf8")).split("\n", 1)[0];
+			if (!firstLine) return {};
+			const header = JSON.parse(firstLine) as { rlmDepth?: unknown; parentSession?: unknown };
+			const depth =
+				typeof header.rlmDepth === "number" && Number.isSafeInteger(header.rlmDepth) && header.rlmDepth >= 0
+					? header.rlmDepth
+					: undefined;
+			const parentSessionPath =
+				typeof header.parentSession === "string" && header.parentSession
+					? canonicalSessionPath(
+							isAbsolute(header.parentSession)
+								? header.parentSession
+								: resolve(dirname(sessionPath), header.parentSession),
+						)
+					: undefined;
+			return { ...(depth !== undefined ? { depth } : {}), ...(parentSessionPath ? { parentSessionPath } : {}) };
+		} catch {
+			return {};
+		}
+	}
+
+	private async savedAgentFamilyCandidate(info: SessionInfo): Promise<AgentFamilyCatalogCandidate> {
+		const claims = await this.persistedTopologyClaims(info.path);
+		return {
+			id: info.id,
+			...(info.name ? { name: info.name } : {}),
+			// resolveSessionRlmDepth is retained only as a usable legacy fallback.
+			// It is deliberately not a claim and therefore cannot contradict an overlay.
+			depth: info.rlmDepth,
+			status: "inactive",
+			sessionPath: canonicalSessionPath(info.path),
+			source: "saved",
+			...(claims.depth !== undefined ? { depthClaim: claims.depth } : {}),
+			...(claims.parentSessionPath
+				? { parentSessionPath: claims.parentSessionPath, parentSessionPathClaim: claims.parentSessionPath }
+				: {}),
+		};
+	}
+
+	private remoteAgentFamilyCandidate(peer: AgentSessionMessageAgentSummary): AgentFamilyCatalogCandidate {
+		// Remote peer state is untrusted topology input. In particular, never let a
+		// malformed subagent be silently coerced into a sibling root by `?? 0`.
+		const depth = peer.rlmDepth;
+		const hasParentSessionId = peer.parentSessionId !== undefined;
+		const hasParentSessionPath = peer.parentSessionPath !== undefined;
+		const parentSessionId =
+			typeof peer.parentSessionId === "string" && peer.parentSessionId.trim() ? peer.parentSessionId : undefined;
 		const parentSessionPath =
-			depth > 0
-				? (entry.parentSessionFile ??
-					passive.chain.at(-2)?.sessionFile ??
-					passive.rootParentState?.runtime.session.sessionFile ??
-					passive.rootInfo?.path)
+			typeof peer.parentSessionPath === "string" && peer.parentSessionPath.trim()
+				? canonicalSessionPath(peer.parentSessionPath)
+				: undefined;
+		if (
+			typeof depth !== "number" ||
+			!Number.isSafeInteger(depth) ||
+			depth < 0 ||
+			(depth === 0 && (hasParentSessionId || hasParentSessionPath)) ||
+			(depth > 0 && !parentSessionId && !parentSessionPath)
+		) {
+			throw new Error(AGENT_FAMILY_REACH_ERROR);
+		}
+		return {
+			id: peer.sessionId,
+			...(peer.sessionName ? { name: peer.sessionName } : {}),
+			depth,
+			status: peer.status ?? "idle",
+			...(peer.sessionPath ? { sessionPath: canonicalSessionPath(peer.sessionPath) } : {}),
+			source: "remote",
+			depthClaim: depth,
+			...(parentSessionId ? { parentSessionId, parentSessionIdClaim: parentSessionId } : {}),
+			...(parentSessionPath ? { parentSessionPath, parentSessionPathClaim: parentSessionPath } : {}),
+		};
+	}
+
+	private residentAgentFamilyCandidate(state: ActiveSessionState): AgentFamilyCatalogCandidate {
+		const entry = this.agentFamilyEntry(state);
+		const session = state.runtime.session;
+		const metadata = state.runtime.metadata;
+		const headerParent = this.resolveHeaderParentSessionPath(state);
+		const parentSessionPath = headerParent ?? metadata.parentSessionFile;
+		// A root has no parent claim. Do not let a stale runtime rlmDepth turn it
+		// into a depth-N orphan when its durable/root metadata still says root.
+		const isUnparentedTopLevel =
+			metadata.kind === "top-level" && !headerParent && !metadata.parentSessionId && !metadata.parentSessionFile;
+		const depthClaim =
+			!isUnparentedTopLevel &&
+			typeof session.rlmDepth === "number" &&
+			Number.isSafeInteger(session.rlmDepth) &&
+			session.rlmDepth >= 0
+				? session.rlmDepth
 				: undefined;
 		return {
+			...entry,
+			...(isUnparentedTopLevel ? { depth: 0 } : {}),
+			source: "resident",
+			...(depthClaim !== undefined ? { depthClaim } : {}),
+			...(metadata.parentSessionId
+				? { parentSessionId: metadata.parentSessionId, parentSessionIdClaim: metadata.parentSessionId }
+				: {}),
+			...(parentSessionPath
+				? {
+						parentSessionPath: canonicalSessionPath(parentSessionPath),
+						parentSessionPathClaim: canonicalSessionPath(parentSessionPath),
+					}
+				: {}),
+		};
+	}
+
+	/**
+	 * Merge a durable row with a passive/resident view only if all *present*
+	 * topology claims agree. In particular, the depth produced for legacy saved
+	 * files is a fallback, not evidence against a newer explicit overlay.
+	 */
+	private mergeEquivalentAgentFamilyCatalogEntries(
+		entries: readonly AgentFamilyCatalogCandidate[],
+	): AgentFamilyCatalogEntry[] {
+		const canonical = entries.map((entry) => ({
+			...entry,
+			...(entry.sessionPath ? { sessionPath: canonicalSessionPath(entry.sessionPath) } : {}),
+			...(entry.parentSessionPath ? { parentSessionPath: canonicalSessionPath(entry.parentSessionPath) } : {}),
+			...(entry.parentSessionPathClaim
+				? { parentSessionPathClaim: canonicalSessionPath(entry.parentSessionPathClaim) }
+				: {}),
+		}));
+		const compatible = (left: AgentFamilyCatalogCandidate, right: AgentFamilyCatalogCandidate) =>
+			left.id === right.id &&
+			left.sessionPath === right.sessionPath &&
+			(left.depthClaim === undefined || right.depthClaim === undefined || left.depthClaim === right.depthClaim) &&
+			(left.parentSessionPathClaim === undefined ||
+				right.parentSessionPathClaim === undefined ||
+				left.parentSessionPathClaim === right.parentSessionPathClaim) &&
+			(left.parentSessionIdClaim === undefined ||
+				right.parentSessionIdClaim === undefined ||
+				left.parentSessionIdClaim === right.parentSessionIdClaim);
+		const groups: AgentFamilyCatalogCandidate[][] = [];
+		for (const entry of canonical) {
+			const group = groups.find((candidate) => candidate.every((member) => compatible(member, entry)));
+			if (group) group.push(entry);
+			else groups.push([entry]);
+		}
+		const sourceRank: Record<AgentFamilyCatalogSource, number> = {
+			saved: 3,
+			passive: 2,
+			resident: 1,
+			remote: 0,
+		};
+		const statusRank: Record<AgentFamilyCatalogEntry["status"], number> = {
+			inactive: 0,
+			idle: 1,
+			running: 2,
+		};
+		const stable = (values: readonly (string | undefined)[]) =>
+			values.filter((value): value is string => value !== undefined).sort()[0];
+		const preferred = <T>(
+			rows: readonly AgentFamilyCatalogCandidate[],
+			get: (row: AgentFamilyCatalogCandidate) => T | undefined,
+		) =>
+			[...rows]
+				.sort((left, right) => sourceRank[right.source] - sourceRank[left.source])
+				.map(get)
+				.find((value): value is T => value !== undefined);
+		return groups.map((rows) => {
+			const status = rows.reduce<AgentFamilyCatalogEntry["status"]>(
+				(best, row) => (statusRank[row.status] > statusRank[best] ? row.status : best),
+				"inactive",
+			);
+			const depth = preferred(rows, (row) => row.depthClaim) ?? preferred(rows, (row) => row.depth)!;
+			const parentSessionId = preferred(rows, (row) => row.parentSessionIdClaim);
+			const parentSessionPath = preferred(rows, (row) => row.parentSessionPathClaim);
+			return {
+				id: rows[0]!.id,
+				depth,
+				status,
+				...(stable(rows.map((row) => row.name)) ? { name: stable(rows.map((row) => row.name)) } : {}),
+				...(parentSessionId ? { parentSessionId } : {}),
+				...(parentSessionPath ? { parentSessionPath } : {}),
+				...(rows[0]!.sessionPath ? { sessionPath: rows[0]!.sessionPath } : {}),
+			};
+		});
+	}
+
+	private async passiveAgentFamilyCandidate(passive: PassiveRlmSubagent): Promise<AgentFamilyCatalogCandidate> {
+		const entry = passive.entry;
+		const claims = await this.persistedTopologyClaims(entry.sessionFile);
+		const registryParentPath = entry.parentSessionFile ? canonicalSessionPath(entry.parentSessionFile) : undefined;
+		const parentSessionPath = claims.parentSessionPath ?? registryParentPath;
+		const depthClaim = claims.depth ?? entry.rlmDepth;
+		return {
 			id: passive.info.id,
-			name: passive.info.name ?? entry.sessionName,
-			depth,
-			status: "idle",
-			...(depth > 0 && entry.parentSessionId ? { parentSessionId: entry.parentSessionId } : {}),
-			...(parentSessionPath ? { parentSessionPath: canonicalSessionPath(parentSessionPath) } : {}),
+			...((passive.info.name ?? entry.sessionName) ? { name: passive.info.name ?? entry.sessionName } : {}),
+			depth: depthClaim ?? passive.info.rlmDepth,
+			status: "inactive",
 			sessionPath: canonicalSessionPath(entry.sessionFile),
+			source: "passive",
+			...(depthClaim !== undefined ? { depthClaim } : {}),
+			...(entry.parentSessionId
+				? { parentSessionId: entry.parentSessionId, parentSessionIdClaim: entry.parentSessionId }
+				: {}),
+			...(parentSessionPath ? { parentSessionPath, parentSessionPathClaim: parentSessionPath } : {}),
 		};
 	}
 
 	private async getOrHydrateAuthorizedAgentFamilyTarget(
 		currentState: ActiveSessionState,
 		target: string,
-	): Promise<ActiveSessionState> {
+	): Promise<{ targetState: ActiveSessionState; catalog: readonly AgentFamilyCatalogEntry[] }> {
+		const catalog = await this.agentFamilyCatalogEntries();
 		try {
-			return this.getBoundSessionState(target);
+			return { targetState: this.getBoundSessionState(target), catalog };
 		} catch (error) {
 			if (error instanceof BoundSessionUnavailableError) {
 				const targetState = this.getSessionState(target);
-				this.assertAgentFamilyReachable(currentState, targetState);
-				return this.getOrHydrateBoundSessionState(target);
+				this.assertAgentFamilyReachable(currentState, targetState, catalog);
+				return { targetState: await this.getOrHydrateBoundSessionState(target), catalog };
 			}
 			if (error instanceof AmbiguousActiveSessionError) {
-				const targetState = this.resolveAgentFamilySessionName(currentState, target, error);
-				return this.getOrHydrateBoundSessionState(targetState.activeSessionId);
+				const targetState = this.resolveAgentFamilySessionName(currentState, target, error, catalog);
+				return { targetState: await this.getOrHydrateBoundSessionState(targetState.activeSessionId), catalog };
 			}
 		}
 		const passive = await this.findPassiveRlmSubagent(target);
-		if (!passive) return this.getOrHydrateBoundSessionState(target);
-		assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.passiveAgentFamilyEntry(passive));
-		return this.hydratePassiveRlmSubagent(passive);
+		if (!passive) return { targetState: await this.getOrHydrateBoundSessionState(target), catalog };
+		const passiveEntry = this.authoritativeAgentFamilyEntryForSessionId(passive.info.id, catalog);
+		assertAgentFamilyReach(this.authoritativeAgentFamilyEntry(currentState, catalog), passiveEntry, catalog);
+		return { targetState: await this.hydratePassiveRlmSubagent(passive), catalog };
 	}
 
 	private resolveAgentFamilySessionName(
 		currentState: ActiveSessionState,
 		target: string,
 		ambiguity: AmbiguousActiveSessionError,
+		catalog: readonly AgentFamilyCatalogEntry[],
 	): ActiveSessionState {
 		const reachableMatches = new Map(
 			[...this.sessions.values()]
@@ -5311,7 +5555,7 @@ export class AgentDaemon {
 					return (
 						(session.sessionId === target || session.sessionName === target) &&
 						(state.activeSessionId === currentState.activeSessionId ||
-							this.isAgentFamilyReachable(currentState, state))
+							this.isAgentFamilyReachable(currentState, state, catalog))
 					);
 				})
 				.map((state) => [state.activeSessionId, state]),
@@ -5321,9 +5565,36 @@ export class AgentDaemon {
 		return matches[0]!;
 	}
 
-	private isAgentFamilyReachable(currentState: ActiveSessionState, targetState: ActiveSessionState): boolean {
+	private authoritativeAgentFamilyEntry(
+		state: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[],
+	): AgentFamilyCatalogEntry {
+		return this.authoritativeAgentFamilyEntryForSessionId(state.runtime.session.sessionId, catalog);
+	}
+
+	private authoritativeAgentFamilyEntryForSessionId(
+		sessionId: string,
+		catalog: readonly AgentFamilyCatalogEntry[],
+	): AgentFamilyCatalogEntry {
+		const entries = catalog.filter((candidate) => candidate.id === sessionId);
+		if (entries.length !== 1) throw new Error(AGENT_FAMILY_REACH_ERROR);
+		return entries[0]!;
+	}
+
+	private isAgentFamilyReachable(
+		currentState: ActiveSessionState,
+		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[] = [
+			this.agentFamilyEntry(currentState),
+			this.agentFamilyEntry(targetState),
+		],
+	): boolean {
 		try {
-			assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.agentFamilyEntry(targetState));
+			assertAgentFamilyReach(
+				this.authoritativeAgentFamilyEntry(currentState, catalog),
+				this.authoritativeAgentFamilyEntry(targetState, catalog),
+				catalog,
+			);
 			return true;
 		} catch (error) {
 			if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) return false;
@@ -5331,17 +5602,49 @@ export class AgentDaemon {
 		}
 	}
 
-	private assertAgentFamilyReachable(currentState: ActiveSessionState, targetState: ActiveSessionState): void {
+	private assertAgentFamilyReachable(
+		currentState: ActiveSessionState,
+		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[] = [
+			this.agentFamilyEntry(currentState),
+			this.agentFamilyEntry(targetState),
+		],
+	): void {
 		if (currentState.activeSessionId === targetState.activeSessionId) return;
-		assertAgentFamilyReach(this.agentFamilyEntry(currentState), this.agentFamilyEntry(targetState));
+		assertAgentFamilyReach(
+			this.authoritativeAgentFamilyEntry(currentState, catalog),
+			this.authoritativeAgentFamilyEntry(targetState, catalog),
+			catalog,
+		);
 	}
 
 	private agentMessageRelationship(
 		fromState: ActiveSessionState | undefined,
 		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[] = [
+			this.agentFamilyEntry(targetState),
+			...(fromState ? [this.agentFamilyEntry(fromState)] : []),
+		],
 	): AgentFamilyRelationship | undefined {
 		if (!fromState) return undefined;
-		return agentFamilyRelationship(this.agentFamilyEntry(targetState), this.agentFamilyEntry(fromState));
+		return agentFamilyRelationship(
+			this.authoritativeAgentFamilyEntry(targetState, catalog),
+			this.authoritativeAgentFamilyEntry(fromState, catalog),
+			catalog,
+		);
+	}
+
+	private cliAgentMessageRelationship(
+		fromState: ActiveSessionState,
+		targetState: ActiveSessionState,
+		catalog: readonly AgentFamilyCatalogEntry[],
+	): AgentFamilyRelationship | undefined {
+		try {
+			return this.agentMessageRelationship(fromState, targetState, catalog);
+		} catch (error) {
+			if (error instanceof Error && error.message === AGENT_FAMILY_REACH_ERROR) return undefined;
+			throw error;
+		}
 	}
 
 	private async sendAgentSessionMessage(options: {
@@ -5358,27 +5661,48 @@ export class AgentDaemon {
 		}
 		const targetSelector = assertDirectAgentMessageTarget(options.targetSelector);
 		const message = normalizeAgentSessionMessage(options.message, DEFAULT_AGENT_MESSAGE_MAX_CHARS);
+		// Agent-origin authorization uses one immutable persisted topology through
+		// selector resolution, wake, and delivery. CLI-origin topology is advisory
+		// label metadata and must not make an otherwise valid delivery unavailable.
+		let catalog: readonly AgentFamilyCatalogEntry[] | undefined;
+		if (options.fromState) {
+			try {
+				catalog = await this.agentFamilyCatalogEntries();
+			} catch (error) {
+				if (options.origin === "agent") throw error;
+				this.log(
+					`Agent family catalog unavailable for CLI message relationship: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
 		let targetState: ActiveSessionState;
 		try {
 			targetState = this.getBoundSessionState(targetSelector);
 		} catch (error) {
 			if (error instanceof BoundSessionUnavailableError) {
+				const unavailableTarget = this.getSessionState(targetSelector);
+				if (this.closingSessions.has(unavailableTarget.activeSessionId)) throw error;
 				if (options.origin === "agent" && options.fromState) {
-					this.assertAgentFamilyReachable(options.fromState, this.getSessionState(targetSelector));
+					this.assertAgentFamilyReachable(options.fromState, unavailableTarget, catalog!);
 				}
 				targetState = await this.getOrHydrateBoundSessionState(targetSelector);
 			} else {
 				if (error instanceof AmbiguousActiveSessionError) {
 					if (options.origin !== "agent" || !options.fromState) throw error;
-					const resolved = this.resolveAgentFamilySessionName(options.fromState, targetSelector, error);
+					const resolved = this.resolveAgentFamilySessionName(options.fromState, targetSelector, error, catalog!);
 					targetState = await this.getOrHydrateBoundSessionState(resolved.activeSessionId);
 				} else {
 					const passiveSubagent = await this.findPassiveRlmSubagent(targetSelector);
 					if (passiveSubagent) {
 						if (options.origin === "agent" && options.fromState) {
+							const passiveEntry = this.authoritativeAgentFamilyEntryForSessionId(
+								passiveSubagent.info.id,
+								catalog!,
+							);
 							assertAgentFamilyReach(
-								this.agentFamilyEntry(options.fromState),
-								this.passiveAgentFamilyEntry(passiveSubagent),
+								this.authoritativeAgentFamilyEntry(options.fromState, catalog!),
+								passiveEntry,
+								catalog!,
 							);
 						}
 						targetState = await this.hydratePassiveRlmSubagent(passiveSubagent);
@@ -5401,11 +5725,14 @@ export class AgentDaemon {
 				}
 			}
 		}
+		if (this.closingSessions.has(targetState.activeSessionId)) {
+			throw new Error(`Active session ${targetState.activeSessionId} is closing`);
+		}
 		if (options.fromState?.activeSessionId === targetState.activeSessionId) {
 			throw new Error("Agent messaging cannot target the sending session");
 		}
 		if (options.origin === "agent" && options.fromState) {
-			this.assertAgentFamilyReachable(options.fromState, targetState);
+			this.assertAgentFamilyReachable(options.fromState, targetState, catalog!);
 		}
 		const releaseQueueSlot = this.reserveAgentMessageQueueSlot(targetState);
 		const senderKey =
@@ -5423,7 +5750,12 @@ export class AgentDaemon {
 			from:
 				options.sender ??
 				this.createAgentSessionMessageSender(options.fromState, options.clientId ?? options.origin),
-			fromRelationship: this.agentMessageRelationship(options.fromState, targetState),
+			fromRelationship:
+				options.origin === "cli" && options.fromState
+					? catalog
+						? this.cliAgentMessageRelationship(options.fromState, targetState, catalog)
+						: undefined
+					: this.agentMessageRelationship(options.fromState, targetState, catalog),
 			target: this.createAgentSessionMessageEndpoint(targetState),
 		};
 		try {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -760,7 +760,10 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 } as const satisfies Record<DaemonCommandName, DaemonCommandCompatibility>;
 
 export function getDaemonCommandCompatibilities(command: DaemonCommand): readonly DaemonCommandCompatibility[] {
-	const compatibility = DAEMON_COMMAND_COMPATIBILITY[command.type];
+	const compatibility =
+		command.type === "rename_saved_session" && command.sessionDir === undefined
+			? LEGACY_DAEMON_COMMAND
+			: DAEMON_COMMAND_COMPATIBILITY[command.type];
 	const carriesTelemetryPolicy =
 		((command.type === "attach" || command.type === "reattach") && command.telemetryDisabled !== undefined) ||
 		(command.type === "create" && command.config?.telemetryDisabled !== undefined);

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+// Revision 17 carries the catalog authority root for inactive saved-session renames.
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-ea658e1e8208";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -597,7 +598,14 @@ export type DaemonCommand =
 	| { id?: string; type: "set_session_name"; activeSessionId: string; name: string; workerToken?: string }
 	| { id?: string; type: "get_rlm_max_depth_status"; activeSessionId: string }
 	| { id?: string; type: "set_rlm_max_depth"; activeSessionId: string; maxDepth: number; global?: boolean }
-	| { id?: string; type: "rename_saved_session"; activeSessionId?: string; sessionPath: string; name: string }
+	| {
+			id?: string;
+			type: "rename_saved_session";
+			activeSessionId?: string;
+			sessionPath: string;
+			name: string;
+			sessionDir?: string;
+	  }
 	| { id?: string; type: "delete_saved_session"; activeSessionId?: string; sessionPath: string }
 	| { id?: string; type: "get_session_context"; activeSessionId: string }
 	| { id?: string; type: "get_session_tree"; activeSessionId: string }
@@ -735,7 +743,7 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 	set_session_name: LEGACY_DAEMON_COMMAND,
 	get_rlm_max_depth_status: RLM_MAX_DEPTH_COMMAND,
 	set_rlm_max_depth: RLM_MAX_DEPTH_COMMAND,
-	rename_saved_session: LEGACY_DAEMON_COMMAND,
+	rename_saved_session: { minProtocol: 7, minSchemaRevision: 17 },
 	delete_saved_session: LEGACY_DAEMON_COMMAND,
 	get_session_context: LEGACY_DAEMON_COMMAND,
 	get_session_tree: FLAT_SESSION_TREE_COMMAND,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -253,6 +253,12 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"shutdown",
 ]);
 
+type FamilyCatalogSource = "persisted" | "artifact" | "live";
+
+type FamilyCatalogCandidate = AgentFamilyCatalogEntry & {
+	source: FamilyCatalogSource;
+};
+
 interface ResidentWorker {
 	descriptor: DaemonWorkerDescriptor;
 	descriptorPath: string;
@@ -1759,14 +1765,24 @@ export class DaemonSupervisor {
 				return this.forwardToWorker(match.worker, command);
 			}
 			case "rename_saved_session": {
-				const target = await this.savedSessionNameReservationInput(command.sessionPath, command.name.trim());
+				const match = command.activeSessionId
+					? await this.findWorkerForClient(client, command.activeSessionId)
+					: undefined;
+				const sessionDir =
+					match?.worker.descriptor.createCommand.config?.sessionDir ??
+					command.sessionDir ??
+					this.defaultSessionConfig.sessionDir;
+				const target = await this.savedSessionNameReservationInput(
+					command.sessionPath,
+					command.name.trim(),
+					sessionDir,
+				);
 				return await this.withSessionNameReservation(target, async () => {
-					await this.assertSupervisorSavedSessionNameAvailable(command.sessionPath, target.name);
-					if (!command.activeSessionId) {
+					await this.assertSupervisorSavedSessionNameAvailable(command.sessionPath, target.name, sessionDir);
+					if (!match) {
 						await this.catalog.rename(command.sessionPath, command.name);
 						return success(command.id, command.type);
 					}
-					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return await this.forwardToWorker(match.worker, {
 						...command,
 						activeSessionId: match.summary.activeSessionId ?? match.summary.id,
@@ -1790,19 +1806,25 @@ export class DaemonSupervisor {
 			const source = command.fromActiveSessionId
 				? await this.findWorkerForClient(client, command.fromActiveSessionId)
 				: undefined;
+			// Hold this persisted topology through pre-wake and post-wake checks.
+			const sourceSessionDir =
+				source?.worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir;
+			const familyCatalog =
+				source && command.agentOrigin === true ? await this.familyCatalogEntries(sourceSessionDir) : undefined;
+			// Session IDs are the stable identities for this authorization snapshot. Do not
+			// rebuild either endpoint from worker summaries after the snapshot is captured.
+			const sourceSessionId = source?.summary.sessionId;
+			let targetSessionId: string;
 			let target: WorkerMatch;
 			try {
 				target = await this.findWorkerForClient(client, command.targetActiveSessionId);
+				targetSessionId = target.summary.sessionId;
 			} catch (error) {
 				if (!(error instanceof Error) || !error.message.startsWith("Unknown active session:")) throw error;
 				const cwd = source?.summary.cwd ?? this.defaultSessionConfig.cwd ?? process.cwd();
 				let sessionPath: string;
 				try {
-					sessionPath = await this.catalog.resolve(
-						command.targetActiveSessionId,
-						cwd,
-						source?.worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir,
-					);
+					sessionPath = await this.catalog.resolve(command.targetActiveSessionId, cwd, sourceSessionDir);
 				} catch (catalogError) {
 					// Preserve selector ambiguity so a2a senders can distinguish it from
 					// the original unknown-active-session lookup failure.
@@ -1811,18 +1833,21 @@ export class DaemonSupervisor {
 					}
 					throw error;
 				}
+				const targetInfo = await readSessionInfo(sessionPath);
+				if (!targetInfo) throw new Error(`Unknown active session: ${command.targetActiveSessionId}`);
+				targetSessionId = targetInfo.id;
 				if (source && command.agentOrigin === true) {
-					const targetInfo = await readSessionInfo(sessionPath);
-					if (!targetInfo) throw new Error(`Unknown active session: ${command.targetActiveSessionId}`);
 					assertAgentFamilyReach(
-						this.familyCatalogEntry(source.summary),
-						this.familyCatalogEntry(summaryForInactiveSession(targetInfo)),
+						this.authoritativeFamilyCatalogEntry(familyCatalog!, sourceSessionId!),
+						this.authoritativeFamilyCatalogEntry(familyCatalog!, targetSessionId),
+						familyCatalog!,
 					);
 				}
 				const worker = await this.createOrReuseWorker(this.protocolClientId(client), {
 					type: "create",
 					sessionPath,
 					continueRecent: false,
+					config: { sessionDir: sourceSessionDir },
 				});
 				const summary =
 					this.findSummaryInWorker(worker, sessionPath) ??
@@ -1832,7 +1857,16 @@ export class DaemonSupervisor {
 			}
 			const targetActiveSessionId = target.summary.activeSessionId ?? target.summary.id;
 			if (source && command.agentOrigin === true) {
-				assertAgentFamilyReach(this.familyCatalogEntry(source.summary), this.familyCatalogEntry(target.summary));
+				// Waking must not substitute a different live session for the target that
+				// was authorized by the captured topology.
+				if (target.summary.sessionId !== targetSessionId) {
+					throw new Error("Agent reach is limited to parent, siblings, and children");
+				}
+				assertAgentFamilyReach(
+					this.authoritativeFamilyCatalogEntry(familyCatalog!, sourceSessionId!),
+					this.authoritativeFamilyCatalogEntry(familyCatalog!, targetSessionId),
+					familyCatalog!,
+				);
 			}
 			if (source) {
 				if ((source.summary.activeSessionId ?? source.summary.id) === targetActiveSessionId) {
@@ -1899,7 +1933,11 @@ export class DaemonSupervisor {
 				if (command.type === "rename" || command.type === "set_session_name") {
 					const reservation = this.summaryNameReservationInput(match.summary, command.name.trim());
 					return await this.withSessionNameReservation(reservation, async () => {
-						await this.assertSupervisorSessionNameAvailable(match.summary, reservation.name);
+						await this.assertSupervisorSessionNameAvailable(
+							match.summary,
+							reservation.name,
+							match.worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir,
+						);
 						return forward();
 					});
 				}
@@ -1968,7 +2006,7 @@ export class DaemonSupervisor {
 		if ("activeSessionId" in command) {
 			const match = await this.findWorkerForClient(client, command.activeSessionId);
 			cwd = match.summary.cwd;
-			sessionDir = this.defaultSessionConfig.sessionDir;
+			sessionDir = match.worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir;
 			activeSessionId = match.summary.activeSessionId ?? match.summary.id;
 		} else {
 			cwd = resolve(command.cwd);
@@ -2009,6 +2047,7 @@ export class DaemonSupervisor {
 			createCommand = { ...command, name: normalizedName };
 		}
 		const ownerClientId = command.lifecycle === "client_owned" ? clientId : undefined;
+		const config = mergeAgentSessionRuntimeConfig(this.defaultSessionConfig, command.config);
 		if (command.sessionPath) {
 			const activeMatches = this.matchWorkers(command.sessionPath);
 			if (activeMatches.length === 1 && !(await this.reclaimStaleWorkerRegistration(activeMatches[0]!.worker))) {
@@ -2017,7 +2056,6 @@ export class DaemonSupervisor {
 			if (activeMatches.length > 1) {
 				throw new Error(`Ambiguous active session "${command.sessionPath}"`);
 			}
-			const config = mergeAgentSessionRuntimeConfig(this.defaultSessionConfig, command.config);
 			const sessionPath = looksLikeSessionPath(command.sessionPath)
 				? resolve(command.sessionPath)
 				: await this.catalog.resolve(command.sessionPath, config.cwd ?? process.cwd(), config.sessionDir);
@@ -2038,7 +2076,9 @@ export class DaemonSupervisor {
 		}
 		const opening = (async () => {
 			if (!createCommand.name) return this.launchWorker(createCommand, undefined, ownerClientId);
-			const savedSiblings = createCommand.sessionPath ? await this.catalog.siblings(createCommand.sessionPath) : [];
+			const savedSiblings = createCommand.sessionPath
+				? await this.catalog.siblings(createCommand.sessionPath, config.sessionDir)
+				: [];
 			const target = savedSiblings.find(
 				(session) => canonicalSessionPath(session.path) === canonicalSessionPath(createCommand.sessionPath!),
 			);
@@ -2048,7 +2088,7 @@ export class DaemonSupervisor {
 				if (target?.parentSessionPath && (target.rlmDepth ?? 0) > 0) {
 					this.assertSavedSiblingNameAvailable(savedSiblings, target, createCommand.name!);
 				} else {
-					await this.assertSupervisorSessionNameAvailable(targetSummary, createCommand.name!);
+					await this.assertSupervisorSessionNameAvailable(targetSummary, createCommand.name!, config.sessionDir);
 				}
 				return this.launchWorker(createCommand, undefined, ownerClientId);
 			});
@@ -3008,19 +3048,93 @@ export class DaemonSupervisor {
 		}
 	}
 
-	private async familyCatalogEntries(): Promise<AgentFamilyCatalogEntry[]> {
-		const active = [...this.workers.values()].flatMap((worker) => [...worker.summaries.values()]);
-		const activePaths = new Set(
-			active.flatMap((summary) => (summary.sessionFile ? [canonicalSessionPath(summary.sessionFile)] : [])),
+	private async familyCatalogEntries(sessionDir?: string): Promise<readonly AgentFamilyCatalogEntry[]> {
+		const live = [...this.workers.values()]
+			.flatMap((worker) => [...worker.summaries.values()])
+			.map((summary): FamilyCatalogCandidate => ({ ...this.familyCatalogEntry(summary), source: "live" }));
+		// Keep the persisted row even when its path is currently active. A live
+		// overlay may fill in missing claims, but it may not silently replace a
+		// conflicting durable topology claim.
+		const saved = await this.catalog.list(undefined, sessionDir);
+		const savedPaths = new Set(saved.map((info) => canonicalSessionPath(info.path)));
+		const persisted = saved.map(
+			(info): FamilyCatalogCandidate => ({
+				...this.familyCatalogEntry(summaryForInactiveSession(info)),
+				source: "persisted",
+			}),
 		);
-		const savedRoots = (await this.catalog.list()).filter(
-			(info) =>
-				(info.rlmDepth ?? (info.parentSessionPath ? -1 : 0)) === 0 &&
-				!activePaths.has(canonicalSessionPath(info.path)),
-		);
-		return [...active, ...savedRoots.map((info) => summaryForInactiveSession(info))].map((summary) =>
-			this.familyCatalogEntry(summary),
-		);
+		// The catalog's bounded registry walk supplies artifact-resident parents
+		// and descendants missing from list(). Preserve their durable rows in the
+		// immutable authorization snapshot; live overlays still cannot replace a
+		// conflicting topology claim.
+		const artifactSessions = this.catalog.family ? await this.catalog.family(sessionDir) : saved;
+		const artifacts = artifactSessions
+			.filter((info) => !savedPaths.has(canonicalSessionPath(info.path)))
+			.map(
+				(info): FamilyCatalogCandidate => ({
+					...this.familyCatalogEntry(summaryForInactiveSession(info)),
+					source: "artifact",
+				}),
+			);
+		return Object.freeze(this.mergeEquivalentFamilyCatalogEntries([...persisted, ...artifacts, ...live]));
+	}
+
+	/**
+	 * Collapse durable/live duplicates only when their stable identity and every
+	 * jointly-present topology claim agree. Incompatible candidates intentionally
+	 * remain duplicated: authoritative endpoint lookup then fails closed.
+	 */
+	private mergeEquivalentFamilyCatalogEntries(entries: readonly FamilyCatalogCandidate[]): AgentFamilyCatalogEntry[] {
+		const compatible = (left: FamilyCatalogCandidate, right: FamilyCatalogCandidate) =>
+			left.id === right.id &&
+			(left.sessionPath === undefined ||
+				right.sessionPath === undefined ||
+				left.sessionPath === right.sessionPath) &&
+			left.depth === right.depth &&
+			(left.parentSessionId === undefined ||
+				right.parentSessionId === undefined ||
+				left.parentSessionId === right.parentSessionId) &&
+			(left.parentSessionPath === undefined ||
+				right.parentSessionPath === undefined ||
+				left.parentSessionPath === right.parentSessionPath);
+		const groups: FamilyCatalogCandidate[][] = [];
+		for (const entry of entries) {
+			const group = groups.find((candidate) => candidate.every((member) => compatible(member, entry)));
+			if (group) group.push(entry);
+			else groups.push([entry]);
+		}
+		const statusRank: Record<AgentFamilyCatalogEntry["status"], number> = { inactive: 0, idle: 1, running: 2 };
+		const preferred = <T>(
+			rows: readonly FamilyCatalogCandidate[],
+			get: (row: FamilyCatalogCandidate) => T | undefined,
+		): T | undefined =>
+			[...rows]
+				.sort(
+					(left, right) =>
+						(({ persisted: 0, artifact: 1, live: 2 })[right.source] ?? 0) -
+						({ persisted: 0, artifact: 1, live: 2 }[left.source] ?? 0),
+				)
+				.map(get)
+				.find((value): value is T => value !== undefined);
+		return groups.map((rows) => {
+			const exemplar = rows[0]!;
+			const name = preferred(rows, (row) => row.name);
+			const parentSessionId = preferred(rows, (row) => row.parentSessionId);
+			const parentSessionPath = preferred(rows, (row) => row.parentSessionPath);
+			const sessionPath = preferred(rows, (row) => row.sessionPath);
+			return {
+				id: exemplar.id,
+				depth: exemplar.depth,
+				status: rows.reduce<AgentFamilyCatalogEntry["status"]>(
+					(best, row) => (statusRank[row.status] > statusRank[best] ? row.status : best),
+					"inactive",
+				),
+				...(name ? { name } : {}),
+				...(parentSessionId ? { parentSessionId } : {}),
+				...(parentSessionPath ? { parentSessionPath } : {}),
+				...(sessionPath ? { sessionPath } : {}),
+			};
+		});
 	}
 
 	private async withSessionNameReservation<T>(
@@ -3042,8 +3156,9 @@ export class DaemonSupervisor {
 	private async assertSupervisorSessionNameAvailable(
 		target: Pick<SessionSummary, "sessionId" | "rlmDepth" | "parentSessionId" | "parentSessionPath">,
 		name: string,
+		sessionDir?: string,
 	): Promise<void> {
-		assertAgentSessionNameAvailable(await this.familyCatalogEntries(), {
+		assertAgentSessionNameAvailable(await this.familyCatalogEntries(sessionDir), {
 			name,
 			depth: target.rlmDepth ?? 0,
 			parentSessionId: target.parentSessionId,
@@ -3055,13 +3170,14 @@ export class DaemonSupervisor {
 	private async savedSessionNameReservationInput(
 		sessionPath: string,
 		name: string,
+		sessionDir?: string,
 	): Promise<{ name: string; depth: number; parentSessionId?: string; parentSessionPath?: string }> {
 		const targetPath = canonicalSessionPath(sessionPath);
 		const active = [...this.workers.values()]
 			.flatMap((worker) => [...worker.summaries.values()])
 			.find((summary) => summary.sessionFile && canonicalSessionPath(summary.sessionFile) === targetPath);
 		if (active) return this.summaryNameReservationInput(active, name);
-		const siblings = await this.catalog.siblings(sessionPath);
+		const siblings = await this.catalog.siblings(sessionPath, sessionDir ?? this.defaultSessionConfig.sessionDir);
 		const saved = siblings.find((info) => canonicalSessionPath(info.path) === targetPath);
 		if (!saved) throw new Error(`Session not found: ${sessionPath}`);
 		return {
@@ -3084,19 +3200,23 @@ export class DaemonSupervisor {
 		};
 	}
 
-	private async assertSupervisorSavedSessionNameAvailable(sessionPath: string, name: string): Promise<void> {
+	private async assertSupervisorSavedSessionNameAvailable(
+		sessionPath: string,
+		name: string,
+		sessionDir?: string,
+	): Promise<void> {
 		const targetPath = canonicalSessionPath(sessionPath);
 		const active = [...this.workers.values()]
 			.flatMap((worker) => [...worker.summaries.values()])
 			.find((summary) => summary.sessionFile && canonicalSessionPath(summary.sessionFile) === targetPath);
-		if (active) return this.assertSupervisorSessionNameAvailable(active, name);
-		const siblings = await this.catalog.siblings(sessionPath);
+		if (active) return this.assertSupervisorSessionNameAvailable(active, name, sessionDir);
+		const siblings = await this.catalog.siblings(sessionPath, sessionDir ?? this.defaultSessionConfig.sessionDir);
 		const saved = siblings.find((info) => canonicalSessionPath(info.path) === targetPath);
 		if (!saved) throw new Error(`Session not found: ${sessionPath}`);
 		if (saved.parentSessionPath && (saved.rlmDepth ?? 0) > 0) {
 			this.assertSavedSiblingNameAvailable(siblings, saved, name);
 		} else {
-			await this.assertSupervisorSessionNameAvailable(summaryForInactiveSession(saved), name);
+			await this.assertSupervisorSessionNameAvailable(summaryForInactiveSession(saved), name, sessionDir);
 		}
 	}
 
@@ -3190,6 +3310,16 @@ export class DaemonSupervisor {
 			throw new Error(`Session worker is ${this.effectiveWorkerState(worker)}`);
 		}
 		return worker.client;
+	}
+
+	/** Resolve both authorization endpoints exclusively from one captured topology snapshot. */
+	private authoritativeFamilyCatalogEntry(
+		catalog: readonly AgentFamilyCatalogEntry[],
+		sessionId: string,
+	): AgentFamilyCatalogEntry {
+		const matches = catalog.filter((entry) => entry.id === sessionId);
+		if (matches.length !== 1) throw new Error("Agent reach is limited to parent, siblings, and children");
+		return matches[0]!;
 	}
 
 	private familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -3049,7 +3049,18 @@ export class DaemonSupervisor {
 	}
 
 	private async familyCatalogEntries(sessionDir?: string): Promise<readonly AgentFamilyCatalogEntry[]> {
+		const effectiveSessionDir = sessionDir ?? this.defaultSessionConfig.sessionDir;
 		const live = [...this.workers.values()]
+			.filter(
+				(worker) =>
+					(worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir) ===
+						effectiveSessionDir ||
+					(Boolean(worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir) &&
+						Boolean(effectiveSessionDir) &&
+						canonicalSessionPath(
+							(worker.descriptor.createCommand.config?.sessionDir ?? this.defaultSessionConfig.sessionDir)!,
+						) === canonicalSessionPath(effectiveSessionDir!)),
+			)
 			.flatMap((worker) => [...worker.summaries.values()])
 			.map((summary): FamilyCatalogCandidate => ({ ...this.familyCatalogEntry(summary), source: "live" }));
 		// Keep the persisted row even when its path is currently active. A live
@@ -3330,8 +3341,16 @@ export class DaemonSupervisor {
 			depth,
 			status: classifySessionRosterStatus(summary),
 			...(depth > 0 && summary.parentSessionId ? { parentSessionId: summary.parentSessionId } : {}),
-			...(depth > 0 && summary.parentSessionPath
-				? { parentSessionPath: canonicalSessionPath(summary.parentSessionPath) }
+			...(depth > 0 && summary.parentSessionPath && (isAbsolute(summary.parentSessionPath) || summary.sessionFile)
+				? {
+						parentSessionPath: canonicalSessionPath(
+							isAbsolute(summary.parentSessionPath)
+								? summary.parentSessionPath
+								: summary.sessionFile
+									? resolve(dirname(summary.sessionFile), summary.parentSessionPath)
+									: summary.parentSessionPath,
+						),
+					}
 				: {}),
 			...(summary.sessionFile ? { sessionPath: canonicalSessionPath(summary.sessionFile) } : {}),
 		};

--- a/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
+++ b/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
@@ -53,7 +53,7 @@ export async function renameDaemonSavedSession(
 	const command: Extract<DaemonCommand, { type: "rename_saved_session" }> =
 		"activeSessionId" in context
 			? { type: "rename_saved_session", activeSessionId: context.activeSessionId, sessionPath, name }
-			: { type: "rename_saved_session", sessionPath, name };
+			: { type: "rename_saved_session", sessionPath, name, sessionDir: context.sessionDir };
 	const response = await client.request(command);
 	if (!response.success) {
 		throw deserializeDaemonError(response);

--- a/packages/coding-agent/test/agent-session-bus.test.ts
+++ b/packages/coding-agent/test/agent-session-bus.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	AGENT_FAMILY_REACH_ERROR,
 	AGENT_MESSAGE_SOURCE,
 	AgentSessionMessageRateLimiter,
 	assertAgentFamilyReach,
@@ -308,10 +309,11 @@ describe("agent session bus", () => {
 				{ id: "orphan-b", depth: 3, status: "inactive" },
 			),
 		).toThrow("Agent reach is limited to parent, siblings, and children");
-		expect(assertAgentFamilyReach(root, child)).toBe("child");
-		expect(assertAgentFamilyReach(child, root)).toBe("parent");
-		expect(assertAgentFamilyReach(child, sibling)).toBe("sibling");
-		expect(assertAgentFamilyReach(sibling, idOnlySibling)).toBe("sibling");
+		const catalog = [root, child, sibling, idOnlySibling, grandchild];
+		expect(assertAgentFamilyReach(root, child, catalog)).toBe("child");
+		expect(assertAgentFamilyReach(child, root, catalog)).toBe("parent");
+		expect(assertAgentFamilyReach(child, sibling, catalog)).toBe("sibling");
+		expect(assertAgentFamilyReach(sibling, idOnlySibling, catalog)).toBe("sibling");
 		expect(() => assertAgentFamilyReach(root, grandchild)).toThrow(
 			"Agent reach is limited to parent, siblings, and children",
 		);
@@ -398,6 +400,67 @@ describe("agent session bus", () => {
 			{ relationship: "parent", name: "orchestrator", id: "root", depth: 0, status: "running" },
 			{ relationship: "sibling", name: "builder", id: "path-child", depth: 1, status: "inactive" },
 		]);
+	});
+
+	it("reserves passive sibling names from direct canonical parent claims without broadening family reach", () => {
+		const catalog = [
+			{ id: "passive-id", name: "worker", depth: 1, status: "inactive" as const, parentSessionId: "parent" },
+			{
+				id: "passive-path",
+				name: "path-worker",
+				depth: 1,
+				status: "inactive" as const,
+				parentSessionPath: "/tmp/prime-agent-parent/../parent.jsonl",
+			},
+		];
+
+		expect(() =>
+			assertAgentSessionNameAvailable(catalog, { name: "worker", depth: 1, parentSessionId: "parent" }),
+		).toThrow("an agent of that name already exists at depth 1 under this parent");
+		expect(() =>
+			assertAgentSessionNameAvailable(catalog, {
+				name: "path-worker",
+				depth: 1,
+				parentSessionPath: "/tmp/parent.jsonl",
+			}),
+		).toThrow("an agent of that name already exists at depth 1 under this parent");
+		// Direct claims reserve names only. They cannot synthesize a relationship
+		// while the parent record is unavailable from the catalog.
+		expect(() => assertAgentFamilyReach(catalog[0]!, catalog[1]!, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+	});
+	it("resolves id-only and path-only catalog claims but rejects contradictory claims", () => {
+		const parent = { id: "parent", depth: 0, status: "running" as const, sessionPath: "/parent" };
+		const idOnly = {
+			id: "id-only",
+			name: "id-worker",
+			depth: 1,
+			status: "inactive" as const,
+			parentSessionId: "parent",
+		};
+		const pathOnly = {
+			id: "path-only",
+			name: "path-worker",
+			depth: 1,
+			status: "inactive" as const,
+			parentSessionPath: "/parent",
+		};
+		const contradictory = {
+			id: "contradictory",
+			depth: 1,
+			status: "inactive" as const,
+			parentSessionId: "parent",
+			parentSessionPath: "/other",
+		};
+		const catalog = [parent, idOnly, pathOnly, contradictory];
+		expect(assertAgentFamilyReach(parent, idOnly, catalog)).toBe("child");
+		expect(assertAgentFamilyReach(parent, pathOnly, catalog)).toBe("child");
+		expect(() => assertAgentFamilyReach(parent, contradictory, catalog)).toThrow(AGENT_FAMILY_REACH_ERROR);
+		expect(() =>
+			assertAgentSessionNameAvailable(catalog, { name: "id-worker", depth: 1, parentSessionId: "parent" }),
+		).toThrow("an agent of that name already exists at depth 1 under this parent");
+		expect(() =>
+			assertAgentSessionNameAvailable(catalog, { name: "path-worker", depth: 1, parentSessionPath: "/parent" }),
+		).toThrow("an agent of that name already exists at depth 1 under this parent");
 	});
 
 	it("builds a sorted nuclear-family roster with inactive members", () => {

--- a/packages/coding-agent/test/daemon-catalog-process.test.ts
+++ b/packages/coding-agent/test/daemon-catalog-process.test.ts
@@ -1,9 +1,15 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 import { type SessionInfo, SessionManager } from "../src/core/session-manager.js";
-import { listSavedSessionSiblings, resolveCatalogSessionMatch } from "../src/modes/daemon/daemon-catalog-process.js";
+import {
+	getOpenCatalogAuthorityFdCountForTest,
+	listCatalogFamilySessions,
+	listSavedSessionSiblings,
+	resolveCatalogSessionMatch,
+	setCatalogBeforeTrustedOpenForTest,
+} from "../src/modes/daemon/daemon-catalog-process.js";
 
 function session(id: string, name: string | undefined, path: string): SessionInfo {
 	return {
@@ -20,17 +26,64 @@ function session(id: string, name: string | undefined, path: string): SessionInf
 	};
 }
 
+function createCatalogFamilyFixture() {
+	const root = mkdtempSync(join(tmpdir(), "prime-catalog-default-session-dir-"));
+	const sessionDir = join(root, "sessions");
+	const parent = SessionManager.create(root, sessionDir);
+	parent.newSession({ rlmDepth: 0 });
+	parent.appendSessionInfo("parent");
+	const first = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-first"));
+	first.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
+	first.appendSessionInfo("first");
+	const second = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-second"));
+	second.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
+	second.appendSessionInfo("second");
+	const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
+	mkdirSync(dirname(registry), { recursive: true });
+	writeFileSync(
+		registry,
+		[
+			{
+				type: "rlm_subagent",
+				childId: first.getSessionId(),
+				sessionFile: first.getSessionFile(),
+				status: "completed",
+			},
+			{
+				type: "rlm_subagent",
+				childId: second.getSessionId(),
+				sessionFile: second.getSessionFile(),
+				status: "completed",
+			},
+		]
+			.map((entry) => JSON.stringify(entry))
+			.join("\n"),
+	);
+	return { root, sessionDir, parent, first, second };
+}
+
+async function withDefaultSessionDir<T>(sessionDir: string, callback: () => Promise<T>): Promise<T> {
+	const previousSessionDir = process.env.PRIME_AGENT_SESSION_DIR;
+	process.env.PRIME_AGENT_SESSION_DIR = sessionDir;
+	try {
+		return await callback();
+	} finally {
+		if (previousSessionDir === undefined) delete process.env.PRIME_AGENT_SESSION_DIR;
+		else process.env.PRIME_AGENT_SESSION_DIR = previousSessionDir;
+	}
+}
+
 describe("daemon catalog selector resolution", () => {
 	it("reads only a saved child's persisted sibling set", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-siblings-"));
 		const sessionDir = join(root, "sessions");
 		const parent = SessionManager.create(root, sessionDir);
-		parent.newSession();
+		parent.newSession({ rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
-		const first = SessionManager.create(root, join(root, "first"));
+		const first = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-first"));
 		first.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
 		first.appendSessionInfo("first");
-		const second = SessionManager.create(root, join(root, "second"));
+		const second = SessionManager.create(root, join(root, "session-artifacts", parent.getSessionId(), "sub-second"));
 		second.newSession({ parentSession: parent.getSessionFile(), rlmDepth: 1 });
 		second.appendSessionInfo("second");
 		const registry = join(dirname(sessionDir), "session-artifacts", parent.getSessionId(), "rlm-subagents.jsonl");
@@ -38,31 +91,74 @@ describe("daemon catalog selector resolution", () => {
 		writeFileSync(
 			registry,
 			[
-				{ type: "rlm_subagent", childId: "first", sessionFile: first.getSessionFile(), status: "completed" },
-				{ type: "rlm_subagent", childId: "second", sessionFile: second.getSessionFile(), status: "completed" },
+				{
+					type: "rlm_subagent",
+					childId: first.getSessionId(),
+					sessionFile: first.getSessionFile(),
+					status: "completed",
+				},
+				{
+					type: "rlm_subagent",
+					childId: second.getSessionId(),
+					sessionFile: second.getSessionFile(),
+					status: "completed",
+				},
 			]
 				.map((entry) => JSON.stringify(entry))
 				.join("\n"),
 		);
 
-		await expect(listSavedSessionSiblings(first.getSessionFile()!)).resolves.toEqual([
+		await expect(listSavedSessionSiblings(first.getSessionFile()!, sessionDir)).resolves.toEqual([
 			expect.objectContaining({ id: first.getSessionId(), name: "first" }),
 			expect.objectContaining({ id: second.getSessionId(), name: "second" }),
 		]);
+	});
+
+	it("uses the configured default session directory for family catalogs", async () => {
+		const { root, sessionDir, parent, first, second } = createCatalogFamilyFixture();
+		try {
+			await withDefaultSessionDir(sessionDir, async () => {
+				await expect(listCatalogFamilySessions()).resolves.toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ id: parent.getSessionId(), name: "parent" }),
+						expect.objectContaining({ id: first.getSessionId(), name: "first" }),
+						expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+					]),
+				);
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
+	});
+
+	it("uses the configured default session directory for saved siblings", async () => {
+		const { root, sessionDir, first, second } = createCatalogFamilyFixture();
+		try {
+			await withDefaultSessionDir(sessionDir, async () => {
+				await expect(listSavedSessionSiblings(first.getSessionFile()!)).resolves.toEqual([
+					expect.objectContaining({ id: first.getSessionId(), name: "first" }),
+					expect.objectContaining({ id: second.getSessionId(), name: "second" }),
+				]);
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
 	});
 
 	it("resolves relative parent headers from each child session directory", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-catalog-relative-siblings-"));
 		const sessionDir = join(root, "sessions");
 		const parent = SessionManager.create(root, sessionDir);
-		parent.newSession();
+		parent.newSession({ rlmDepth: 0 });
 		parent.appendSessionInfo("parent");
 		const parentFile = parent.getSessionFile()!;
-		const firstDir = join(root, "first");
+		const firstDir = join(root, "session-artifacts", parent.getSessionId(), "sub-first");
 		const first = SessionManager.create(root, firstDir);
 		first.newSession({ parentSession: relative(firstDir, parentFile), rlmDepth: 1 });
 		first.appendSessionInfo("first");
-		const secondDir = join(root, "second");
+		const secondDir = join(root, "session-artifacts", parent.getSessionId(), "sub-second");
 		const second = SessionManager.create(root, secondDir);
 		second.newSession({ parentSession: relative(secondDir, parentFile), rlmDepth: 1 });
 		second.appendSessionInfo("second");
@@ -71,17 +167,343 @@ describe("daemon catalog selector resolution", () => {
 		writeFileSync(
 			registry,
 			[
-				{ type: "rlm_subagent", childId: "first", sessionFile: first.getSessionFile(), status: "completed" },
-				{ type: "rlm_subagent", childId: "second", sessionFile: second.getSessionFile(), status: "completed" },
+				{
+					type: "rlm_subagent",
+					childId: first.getSessionId(),
+					sessionFile: first.getSessionFile(),
+					status: "completed",
+				},
+				{
+					type: "rlm_subagent",
+					childId: second.getSessionId(),
+					sessionFile: second.getSessionFile(),
+					status: "completed",
+				},
 			]
 				.map((entry) => JSON.stringify(entry))
 				.join("\n"),
 		);
 
-		await expect(listSavedSessionSiblings(first.getSessionFile()!)).resolves.toEqual([
+		await expect(listSavedSessionSiblings(first.getSessionFile()!, sessionDir)).resolves.toEqual([
 			expect.objectContaining({ id: first.getSessionId(), name: "first" }),
 			expect.objectContaining({ id: second.getSessionId(), name: "second" }),
 		]);
+	});
+
+	it("treats an absent session-artifacts directory as an empty family registry", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-no-artifacts-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+
+		await expect(listCatalogFamilySessions(sessionDir)).resolves.toEqual([
+			expect.objectContaining({ id: "parent", rlmDepth: 0 }),
+		]);
+		expect(getOpenCatalogAuthorityFdCountForTest()).toBe(0);
+	});
+
+	it("walks a trusted depth-two artifact family and fails closed for hostile artifacts", async () => {
+		const makeFixture = (name: string, omitRootDepth = false) => {
+			const root = mkdtempSync(join(tmpdir(), name));
+			const sessionDir = join(root, "sessions");
+			const registryPath = (parentId: string) => {
+				const parentFile = [rootSession, parent, first, second]
+					.find((manager) => manager.getSessionId() === parentId)
+					?.getSessionFile();
+				return parentFile && dirname(parentFile) !== sessionDir
+					? join(dirname(parentFile), "session-artifacts", parentId, "rlm-subagents.jsonl")
+					: join(root, "session-artifacts", parentId, "rlm-subagents.jsonl");
+			};
+			const writeRegistry = (parentId: string, entries: unknown[]) => {
+				const path = registryPath(parentId);
+				mkdirSync(dirname(path), { recursive: true });
+				writeFileSync(
+					path,
+					entries.map((entry) => (typeof entry === "string" ? entry : JSON.stringify(entry))).join("\n"),
+				);
+			};
+			const create = (id: string, dir: string, parentSession?: string, depth = 0) => {
+				const manager = SessionManager.create(root, dir);
+				manager.newSession({ id, parentSession, rlmDepth: depth });
+				manager.appendSessionInfo(id);
+				return manager;
+			};
+			const rootSession = create("root", sessionDir);
+			if (omitRootDepth) {
+				const rootFile = rootSession.getSessionFile()!;
+				const [header, ...entries] = readFileSync(rootFile, "utf8").trimEnd().split(/\r?\n/);
+				const persistedHeader = JSON.parse(header!) as Record<string, unknown>;
+				delete persistedHeader.rlmDepth;
+				writeFileSync(rootFile, `${[JSON.stringify(persistedHeader), ...entries].join("\n")}\n`);
+			}
+			const parent = create(
+				"parent",
+				join(root, "session-artifacts", "root", "sub-parent"),
+				rootSession.getSessionFile(),
+				1,
+			);
+			const first = create(
+				"first",
+				join(root, "session-artifacts", "parent", "sub-first"),
+				parent.getSessionFile(),
+				2,
+			);
+			const second = create(
+				"second",
+				join(root, "session-artifacts", "parent", "sub-second"),
+				parent.getSessionFile(),
+				2,
+			);
+			writeRegistry("root", [
+				{ type: "rlm_subagent", childId: "parent", sessionFile: parent.getSessionFile(), status: "completed" },
+			]);
+			writeRegistry("parent", [
+				{ type: "rlm_subagent", childId: "first", sessionFile: first.getSessionFile(), status: "completed" },
+				{ type: "rlm_subagent", childId: "second", sessionFile: second.getSessionFile(), status: "completed" },
+			]);
+			return { root, sessionDir, rootSession, parent, first, second, registryPath, writeRegistry };
+		};
+		const valid = makeFixture("prime-catalog-family-valid-", true);
+		await expect(listCatalogFamilySessions(valid.sessionDir)).resolves.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "root", rlmDepth: 0 }),
+				expect.objectContaining({ id: "parent", rlmDepth: 1 }),
+				expect.objectContaining({ id: "first", rlmDepth: 2 }),
+				expect.objectContaining({ id: "second", rlmDepth: 2 }),
+			]),
+		);
+		await expect(listSavedSessionSiblings(valid.first.getSessionFile()!, valid.sessionDir)).resolves.toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: "first" }), expect.objectContaining({ id: "second" })]),
+		);
+
+		const cases: Array<[string, (fixture: ReturnType<typeof makeFixture>) => void]> = [
+			[
+				"id mismatch",
+				(fixture) =>
+					fixture.writeRegistry("parent", [
+						{
+							type: "rlm_subagent",
+							childId: "wrong",
+							sessionFile: fixture.first.getSessionFile(),
+							status: "completed",
+						},
+					]),
+			],
+			[
+				"parent mismatch",
+				(fixture) => {
+					const evil = SessionManager.create(
+						fixture.root,
+						join(fixture.root, "session-artifacts", "parent", "sub-evil"),
+					);
+					evil.newSession({ id: "evil", parentSession: fixture.rootSession.getSessionFile(), rlmDepth: 2 });
+					evil.appendSessionInfo("evil");
+					fixture.writeRegistry("parent", [
+						{ type: "rlm_subagent", childId: "evil", sessionFile: evil.getSessionFile(), status: "completed" },
+					]);
+				},
+			],
+			[
+				"depth mismatch",
+				(fixture) => {
+					const evil = SessionManager.create(
+						fixture.root,
+						join(fixture.root, "session-artifacts", "parent", "sub-evil"),
+					);
+					evil.newSession({ id: "evil", parentSession: fixture.parent.getSessionFile(), rlmDepth: 7 });
+					evil.appendSessionInfo("evil");
+					fixture.writeRegistry("parent", [
+						{ type: "rlm_subagent", childId: "evil", sessionFile: evil.getSessionFile(), status: "completed" },
+					]);
+				},
+			],
+			[
+				"external path",
+				(fixture) =>
+					fixture.writeRegistry("parent", [
+						{
+							type: "rlm_subagent",
+							childId: "evil",
+							sessionFile: join(tmpdir(), "outside.jsonl"),
+							status: "completed",
+						},
+					]),
+			],
+			[
+				"path alias",
+				(fixture) =>
+					fixture.writeRegistry("parent", [
+						{
+							type: "rlm_subagent",
+							childId: "first",
+							sessionFile: `${dirname(fixture.first.getSessionFile()!)}/../sub-first/first.jsonl`,
+							status: "completed",
+						},
+					]),
+			],
+			[
+				"cycle",
+				(fixture) =>
+					fixture.writeRegistry("parent", [
+						{
+							type: "rlm_subagent",
+							childId: "root",
+							sessionFile: fixture.rootSession.getSessionFile(),
+							status: "completed",
+						},
+					]),
+			],
+			["malformed", (fixture) => fixture.writeRegistry("parent", ["{not json"])],
+			[
+				"record limit",
+				(fixture) =>
+					fixture.writeRegistry(
+						"parent",
+						Array.from({ length: 10_001 }, (_, index) => ({
+							type: "rlm_subagent",
+							childId: `bad-${index}`,
+							sessionFile: fixture.first.getSessionFile(),
+							status: "completed",
+						})),
+					),
+			],
+		];
+		for (const [label, mutate] of cases) {
+			const fixture = makeFixture(`prime-catalog-family-${label.replace(/\s/g, "-")}-`);
+			mutate(fixture);
+			await expect(listCatalogFamilySessions(fixture.sessionDir), label).rejects.toThrow(
+				"Invalid RLM artifact family topology",
+			);
+		}
+		const symlink = makeFixture("prime-catalog-family-symlink-");
+		const alias = join(symlink.root, "session-artifacts", "parent", "sub-alias", "first.jsonl");
+		mkdirSync(dirname(alias), { recursive: true });
+		symlinkSync(symlink.first.getSessionFile()!, alias);
+		symlink.writeRegistry("parent", [
+			{ type: "rlm_subagent", childId: "first", sessionFile: alias, status: "completed" },
+		]);
+		await expect(listCatalogFamilySessions(symlink.sessionDir)).rejects.toThrow(
+			"Invalid RLM artifact family topology",
+		);
+	});
+
+	it("rejects symlinked roots and deterministic intermediate/final replacement races", async () => {
+		const make = (name: string) => {
+			const root = mkdtempSync(join(tmpdir(), name));
+			const sessionDir = join(root, "sessions");
+			const parent = SessionManager.create(root, sessionDir);
+			parent.newSession({ id: "parent", rlmDepth: 0 });
+			parent.appendSessionInfo("parent");
+			const childDir = join(root, "session-artifacts", "parent", "sub-child");
+			const child = SessionManager.create(root, childDir);
+			child.newSession({ id: "child", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+			child.appendSessionInfo("child");
+			const registry = join(root, "session-artifacts", "parent", "rlm-subagents.jsonl");
+			mkdirSync(dirname(registry), { recursive: true });
+			writeFileSync(
+				registry,
+				JSON.stringify({
+					type: "rlm_subagent",
+					childId: "child",
+					sessionFile: child.getSessionFile(),
+					status: "completed",
+				}),
+			);
+			return { root, sessionDir, parent, child, childDir, registry };
+		};
+
+		const rootLink = make("prime-catalog-root-link-");
+		const movedSessions = `${rootLink.sessionDir}-real`;
+		renameSync(rootLink.sessionDir, movedSessions);
+		symlinkSync(movedSessions, rootLink.sessionDir);
+		await expect(listCatalogFamilySessions(rootLink.sessionDir)).rejects.toThrow(
+			"Invalid RLM artifact family topology",
+		);
+
+		const intermediate = make("prime-catalog-intermediate-swap-");
+		let swappedIntermediate = false;
+		setCatalogBeforeTrustedOpenForTest((path) => {
+			if (swappedIntermediate || path !== intermediate.child.getSessionFile()) return;
+			swappedIntermediate = true;
+			const moved = `${intermediate.childDir}-real`;
+			renameSync(intermediate.childDir, moved);
+			symlinkSync(moved, intermediate.childDir);
+		});
+		await expect(listCatalogFamilySessions(intermediate.sessionDir)).rejects.toThrow(
+			"Invalid RLM artifact family topology",
+		);
+
+		const finalSwap = make("prime-catalog-final-swap-");
+		let swappedFinal = false;
+		setCatalogBeforeTrustedOpenForTest((path) => {
+			if (swappedFinal || path !== finalSwap.child.getSessionFile()) return;
+			swappedFinal = true;
+			const moved = `${path}.real`;
+			renameSync(path, moved);
+			symlinkSync(moved, path);
+		});
+		await expect(listCatalogFamilySessions(finalSwap.sessionDir)).rejects.toThrow(
+			"Invalid RLM artifact family topology",
+		);
+		setCatalogBeforeTrustedOpenForTest(undefined);
+	});
+
+	it("parses session metadata from the same descriptor-bound bytes without a pathname reopen", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-no-reopen-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("bound-name");
+		let removed = false;
+		setCatalogBeforeTrustedOpenForTest((path) => {
+			if (removed || path !== parent.getSessionFile()) return;
+			removed = true;
+			const original = `${path}.opened`;
+			renameSync(path, original);
+			writeFileSync(path, "not a session\n");
+		});
+		// The helper opens after the hook, so it must reject the replacement instead of
+		// authorizing stale bytes. This pins the absence of a later readSessionInfo reopen.
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+		setCatalogBeforeTrustedOpenForTest(undefined);
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("closes authority descriptors after repeated hostile seed failures", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-fd-release-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		const hostile = SessionManager.create(root, sessionDir);
+		hostile.newSession({ id: "hostile", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		hostile.appendSessionInfo("hostile");
+		const baseline = getOpenCatalogAuthorityFdCountForTest();
+		for (let attempt = 0; attempt < 64; attempt++) {
+			await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("Invalid RLM artifact family topology");
+			expect(getOpenCatalogAuthorityFdCountForTest()).toBe(baseline);
+		}
+	});
+
+	it("rejects an unregistered parent-claiming seed and conflicting duplicate identity", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-catalog-orphan-seed-"));
+		const sessionDir = join(root, "sessions");
+		const parent = SessionManager.create(root, sessionDir);
+		parent.newSession({ id: "parent", rlmDepth: 0 });
+		parent.appendSessionInfo("parent");
+		const orphan = SessionManager.create(root, sessionDir);
+		orphan.newSession({ id: "evil", parentSession: parent.getSessionFile(), rlmDepth: 1 });
+		orphan.appendSessionInfo("evil");
+		await expect(listCatalogFamilySessions(sessionDir)).rejects.toThrow("managed session seed claims a parent");
+
+		const duplicateRoot = mkdtempSync(join(tmpdir(), "prime-catalog-duplicate-id-"));
+		const duplicateDir = join(duplicateRoot, "sessions");
+		const duplicate = SessionManager.create(duplicateRoot, duplicateDir);
+		duplicate.newSession({ id: "duplicate", rlmDepth: 0 });
+		duplicate.appendSessionInfo("one");
+		writeFileSync(join(duplicateDir, "alias.jsonl"), readFileSync(duplicate.getSessionFile()!));
+		await expect(listCatalogFamilySessions(duplicateDir)).rejects.toThrow("duplicate session id");
 	});
 
 	it("treats an exact name colliding with another session id prefix as ambiguous", () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	AGENT_FAMILY_REACH_ERROR,
 	type AgentSessionMessageController,
+	assertAgentFamilyReach,
 	DEFAULT_AGENT_MESSAGE_MAX_CHARS,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
@@ -46,6 +47,53 @@ import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js"
 import { DAEMON_WORKER_SUPERVISOR_SOCKET_ENV } from "../src/modes/daemon/daemon-worker-protocol.js";
 
 describe("daemon mode helpers", () => {
+	const useResidentCatalog = (daemon: AgentDaemon) => {
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries?: () => Promise<
+				readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+			>;
+		};
+		internals.agentFamilyCatalogEntries = async () =>
+			Object.freeze(
+				[...internals.sessions.values()].map((state) => {
+					const session = state.runtime.session;
+					const metadata = state.runtime.metadata;
+					const parentSessionId =
+						metadata.parentSessionId ??
+						(metadata.parentActiveSessionId
+							? internals.sessions.get(metadata.parentActiveSessionId)?.runtime.session.sessionId
+							: undefined);
+					return {
+						id: session.sessionId,
+						depth: session.rlmDepth ?? 0,
+						status: "running" as const,
+						...(parentSessionId ? { parentSessionId } : {}),
+						...(session.sessionFile ? { sessionPath: session.sessionFile } : {}),
+					};
+				}),
+			);
+	};
+
+	const installDeterministicAgentFamilyCatalog = (internals: object, states: readonly ActiveSessionState[]) => {
+		const catalogTarget = internals as {
+			agentFamilyCatalogEntries?: () => Promise<
+				readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+			>;
+		};
+		catalogTarget.agentFamilyCatalogEntries = vi.fn(async () =>
+			Object.freeze(
+				states.map((state) => ({
+					id: state.runtime.session.sessionId,
+					depth: state.runtime.session.rlmDepth ?? 0,
+					status: "running" as const,
+					...(state.runtime.metadata.parentSessionId
+						? { parentSessionId: state.runtime.metadata.parentSessionId }
+						: {}),
+				})),
+			),
+		);
+	};
 	it("preserves envelope client identity while registering prompt admission", () => {
 		const daemon = new AgentDaemon("/tmp/unused-daemon.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
@@ -241,6 +289,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const send = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -248,8 +297,9 @@ describe("daemon mode helpers", () => {
 			fromState,
 			origin: "agent",
 		});
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && acceptAgentMessagePrompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
 		resolvePrompt();
@@ -485,6 +535,69 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("fails closed for malformed remote peer topology on daemon ACL surfaces", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-malformed-remote-family.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const root = makeState("root");
+		root.runtime = {
+			...root.runtime,
+			cwd: "/tmp",
+			metadata: { kind: "top-level", createdAt: 1 },
+			session: {
+				sessionId: "session-root",
+				sessionName: "root",
+				rlmDepth: 0,
+				isStreaming: false,
+				isSessionActive: false,
+				unfinishedActionCount: 0,
+				messages: [],
+				sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+				hasRunningRlmChildren: () => false,
+				sessionManager: { getSessionArtifactDir: () => undefined },
+			},
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			remoteAgentPeers: Map<string, Record<string, unknown>>;
+			createAgentMessageController(
+				getCurrentState: () => ActiveSessionState | undefined,
+			): AgentSessionMessageController;
+			createAgentObserveController(getCurrentState: () => ActiveSessionState): AgentObserveController;
+		};
+		internals.sessions.set(root.activeSessionId, root);
+		const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
+		try {
+			for (const malformed of [
+				{ rlmDepth: 0, parentSessionId: "session-root" },
+				{ rlmDepth: -1 },
+				{ rlmDepth: 1 },
+			]) {
+				internals.remoteAgentPeers.clear();
+				internals.remoteAgentPeers.set("malformed-peer", {
+					activeSessionId: "malformed-peer",
+					sessionId: "session-malformed-peer",
+					sessionName: "malformed-peer",
+					runtimeKind: "subagent",
+					cwd: "/tmp/remote",
+					isStreaming: false,
+					unfinishedActionCount: 0,
+					...malformed,
+				});
+				const messaging = internals.createAgentMessageController(() => root);
+				const observe = internals.createAgentObserveController(() => root);
+				await expect(messaging.roster!()).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+				await expect(messaging.sendAgentMessage({ target: "malformed-peer", message: "no" })).rejects.toThrow(
+					AGENT_FAMILY_REACH_ERROR,
+				);
+				await expect(observe.listAgents()).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			}
+		} finally {
+			listAll.mockRestore();
+		}
+	});
+
 	it("canonicalizes symlinked paths in the family catalog and name reservations", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-family-catalog-paths-"));
 		try {
@@ -621,6 +734,7 @@ describe("daemon mode helpers", () => {
 		internals.sessions.set(parentState.activeSessionId, parentState);
 		// A successfully completed RLM child remains idle in this daemon registry.
 		internals.sessions.set(subagentState.activeSessionId, subagentState);
+		installDeterministicAgentFamilyCatalog(internals, [parentState, subagentState]);
 
 		const controller = internals.createAgentMessageController(() => parentState);
 		const subagentSummary = (await controller.listAgents()).agents.find(
@@ -1204,6 +1318,7 @@ describe("daemon mode helpers", () => {
 			},
 			worker: { authenticationToken: "worker-token" },
 		});
+		useResidentCatalog(daemon);
 		const parentState = makeState("parent");
 		const childState = makeState("child", parentState.activeSessionId);
 		const sessionPrompt = vi.fn(async () => {});
@@ -1333,6 +1448,9 @@ describe("daemon mode helpers", () => {
 			session: {
 				sessionId: "session-source",
 				sessionName: "Source",
+				sessionFile: "/tmp/source.jsonl",
+				rlmDepth: 0,
+				sessionManager: { getSessionArtifactDir: () => undefined },
 				isStreaming: false,
 				sessionActions: { queuedCount: 0, steering: [], followUps: [] },
 			},
@@ -1371,6 +1489,9 @@ describe("daemon mode helpers", () => {
 			cwd: "/tmp/remote",
 			isStreaming: false,
 			sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+			rlmDepth: 1,
+			parentSessionId: "session-source",
+			parentSessionPath: "/tmp/source.jsonl",
 		});
 		internals.sendRemoteAgentSessionMessage = sendRemoteAgentSessionMessage;
 
@@ -1833,6 +1954,7 @@ describe("daemon mode helpers", () => {
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetA.activeSessionId, targetA);
 		internals.sessions.set(targetB.activeSessionId, targetB);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetA, targetB]);
 
 		for (let i = 0; i < 3; i++) {
 			await expect(
@@ -2057,6 +2179,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		for (let i = 0; i < 3; i++) {
 			await expect(
@@ -2124,6 +2247,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const first = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -2201,18 +2325,22 @@ describe("daemon mode helpers", () => {
 			return fromState;
 		});
 
+		installDeterministicAgentFamilyCatalog(internals, [...senders, targetState]);
+		const sends: Promise<unknown>[] = [];
 		const errors: unknown[] = [];
 		for (const [i, fromState] of senders.entries()) {
-			void internals
-				.sendAgentSessionMessage({
-					targetSelector: targetState.activeSessionId,
-					message: `message ${i}`,
-					fromState,
-					origin: "agent",
-				})
-				.catch((error) => {
-					errors.push(error);
-				});
+			sends.push(
+				internals
+					.sendAgentSessionMessage({
+						targetSelector: targetState.activeSessionId,
+						message: `message ${i}`,
+						fromState,
+						origin: "agent",
+					})
+					.catch((error) => {
+						errors.push(error);
+					}),
+			);
 		}
 		for (let attempt = 0; attempt < 200 && queueAgentMessagePrompt.mock.calls.length < 12; attempt++) {
 			await Promise.resolve();
@@ -2220,6 +2348,7 @@ describe("daemon mode helpers", () => {
 
 		// With reservations held past queue time, 12 concurrent senders would
 		// count as 24 against the 20-slot cap and the tail would reject.
+		await Promise.all(sends);
 		expect(errors).toEqual([]);
 		expect(queueAgentMessagePrompt).toHaveBeenCalledTimes(12);
 	});
@@ -2264,6 +2393,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		await expect(
 			internals.sendAgentSessionMessage({
@@ -2287,6 +2417,7 @@ describe("daemon mode helpers", () => {
 				throw new Error("unexpected runtime creation");
 			},
 		});
+		useResidentCatalog(daemon);
 		const makeBusyState = (name: string) => {
 			const state = makeState(name);
 			state.runtime = {
@@ -2633,6 +2764,7 @@ describe("daemon mode helpers", () => {
 				throw new Error("unexpected runtime creation");
 			},
 		});
+		useResidentCatalog(daemon);
 		const states = [
 			makeState("root"),
 			makeState("child", "root"),
@@ -2714,11 +2846,169 @@ describe("daemon mode helpers", () => {
 		);
 	});
 
+	it("authorizes depth-two passive siblings only from the persisted daemon topology", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-deep-passive-acl-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const secondGrandchildDir = join(fixture.childSessionDir, "sibling-grandchild");
+			const secondGrandchild = SessionManager.create(tempDir, secondGrandchildDir);
+			secondGrandchild.newSession({ parentSession: fixture.childSessionFile, rlmDepth: 2 });
+			secondGrandchild.flushNow();
+			const secondGrandchildFile = secondGrandchild.getSessionFile();
+			if (!secondGrandchildFile) throw new Error("Missing sibling grandchild session");
+			const childRegistry = join(fixture.childArtifactDir, "rlm-subagents.jsonl");
+			writeFileSync(
+				childRegistry,
+				`${readFileSync(childRegistry, "utf8")}${JSON.stringify({
+					type: "rlm_subagent",
+					childId: "sibling-grandchild",
+					sessionName: "sibling-grandchild",
+					sessionDir: secondGrandchildDir,
+					sessionFile: secondGrandchildFile,
+					parentSessionId: fixture.childSessionId,
+					parentSessionFile: fixture.childSessionFile,
+					rlmDepth: 2,
+					status: "completed",
+					createdAt: 2,
+					updatedAt: "2026-01-01T00:00:02.000Z",
+				})}\n`,
+			);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				agentFamilyCatalogEntries(): Promise<
+					readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+				>;
+			};
+			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const catalog = await internals.agentFamilyCatalogEntries();
+			const first = catalog.find((entry) => entry.id === fixture.grandchildSessionId);
+			const second = catalog.find((entry) => entry.id === secondGrandchild.getSessionId());
+			expect(first).toBeDefined();
+			expect(second).toBeDefined();
+			expect(catalog).toContainEqual(expect.objectContaining({ id: fixture.childSessionId, depth: 1 }));
+			expect(assertAgentFamilyReach(first!, second!, catalog)).toBe("sibling");
+
+			// A depth-two pair claiming the root cannot manufacture the missing depth-one edge.
+			expect(() =>
+				assertAgentFamilyReach(
+					{ ...first!, parentSessionId: fixture.parentSessionId, parentSessionPath: fixture.parentSessionFile },
+					{ ...second!, parentSessionId: fixture.parentSessionId, parentSessionPath: fixture.parentSessionFile },
+					catalog,
+				),
+			).toThrow(AGENT_FAMILY_REACH_ERROR);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("observes residents from the captured family catalog rather than live endpoint fields", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-observe-captured-family.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const source = makeState("source");
+		const target = makeState("target");
+		for (const state of [source, target]) {
+			state.runtime = {
+				...state.runtime,
+				metadata: { kind: "top-level", createdAt: 1 },
+				diagnostics: [],
+				session: {
+					...state.runtime.session,
+					messages: [],
+					hasRunningRlmChildren: vi.fn(() => false),
+					sessionManager: {
+						getHeader: vi.fn(() => ({})),
+						getCwd: vi.fn(() => "/tmp"),
+						getSessionArtifactDir: vi.fn(() => undefined),
+					},
+					getSessionActionSnapshot: vi.fn(() => ({ queuedCount: 0, steering: [], followUps: [] })),
+					state: { streamingMessage: undefined, pendingToolCalls: new Map() },
+					sessionId: `session-${state.activeSessionId}`,
+					sessionFile: `/tmp/${state.activeSessionId}.jsonl`,
+					rlmDepth: 0,
+				},
+			} as never;
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries(): Promise<
+				readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+			>;
+			createAgentObserveController(getCurrentState: () => ActiveSessionState): AgentObserveController;
+		};
+		internals.sessions.set(source.activeSessionId, source);
+		internals.sessions.set(target.activeSessionId, target);
+		Object.assign(internals, {
+			agentFamilyCatalogEntries: vi.fn(async () =>
+				Object.freeze([
+					{ id: "left-parent", depth: 0, status: "inactive", sessionPath: "/tmp/left.jsonl" },
+					{ id: "right-parent", depth: 0, status: "inactive", sessionPath: "/tmp/right.jsonl" },
+					{ id: "session-source", depth: 1, status: "running", parentSessionId: "left-parent" },
+					{ id: "session-target", depth: 1, status: "running", parentSessionId: "right-parent" },
+				]),
+			),
+		});
+
+		// The live root summaries would otherwise be sibling roots. Their conflicting
+		// topology cannot override the captured snapshot's unrelated parent edges.
+		const observed = await internals.createAgentObserveController(() => source).listAgents();
+		expect(observed.agents.map((agent) => agent.activeSessionId)).toEqual(["source"]);
+	});
+
+	it("fails closed for every agent ACL surface when the captured catalog duplicates a stable session ID", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-duplicate-captured-family.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parent = makeAgentFamilyState("parent", "parent");
+		const source = makeAgentFamilyState("source", "source", parent.state);
+		const target = makeAgentFamilyState("target", "target", parent.state);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries(): Promise<
+				readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]
+			>;
+			createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
+			createAgentObserveController(getCurrentState: () => ActiveSessionState): AgentObserveController;
+		};
+		for (const fixture of [parent, source, target])
+			internals.sessions.set(fixture.state.activeSessionId, fixture.state);
+		const sourceId = source.state.runtime.session.sessionId;
+		const parentId = parent.state.runtime.session.sessionId;
+		const targetId = target.state.runtime.session.sessionId;
+		const entries = [
+			{ id: parentId, depth: 0, status: "running" as const },
+			{ id: sourceId, depth: 1, status: "running" as const, parentSessionId: parentId },
+			{ id: sourceId, depth: 1, status: "running" as const, parentSessionId: "forged-parent" },
+			{ id: targetId, depth: 1, status: "running" as const, parentSessionId: parentId },
+		];
+
+		// The current observer must be resolved from the immutable catalog before
+		// self inclusion. Either duplicate ordering is ambiguous and must fail closed.
+		for (const catalog of [entries, [...entries.slice(0, 1), entries[2]!, entries[1]!, entries[3]!]]) {
+			internals.agentFamilyCatalogEntries = vi.fn(async () => Object.freeze(catalog));
+			const observe = internals.createAgentObserveController(() => source.state);
+			await expect(observe.listAgents()).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			await expect(observe.getAgent(target.state.activeSessionId)).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			await expect(observe.recentMessages({ target: target.state.activeSessionId })).rejects.toThrow(
+				AGENT_FAMILY_REACH_ERROR,
+			);
+			await expect(
+				internals
+					.createAgentMessageController(() => source.state)
+					.sendAgentMessage({ target: target.state.activeSessionId, message: "must not deliver" }),
+			).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+		}
+		expect(target.acceptAgentMessagePrompt).not.toHaveBeenCalled();
+	});
+
 	it("resolves a duplicate session name to the only family-reachable agent", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-family-name-resolution.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
 			createRuntime: vi.fn(),
 		});
+		useResidentCatalog(daemon);
 		const observer = makeAgentFamilyState("observer", "observer");
 		const familyHelper = makeAgentFamilyState("family-helper", "helper", observer.state);
 		const otherRoot = makeAgentFamilyState("other-root", "other-root");
@@ -2858,6 +3148,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const first = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -2871,15 +3162,17 @@ describe("daemon mode helpers", () => {
 			fromState,
 			origin: "agent",
 		});
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && prompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(prompt).toHaveBeenCalledTimes(1);
 
 		promptResolves[0]?.();
 		await expect(first).resolves.toMatchObject({ message: "first" });
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && prompt.mock.calls.length < 2; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(prompt).toHaveBeenCalledTimes(2);
 		expect(followUp).not.toHaveBeenCalled();
@@ -3213,6 +3506,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const first = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -3226,15 +3520,17 @@ describe("daemon mode helpers", () => {
 			fromState,
 			origin: "agent",
 		});
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && prompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(prompt).toHaveBeenCalledTimes(1);
 		(targetState.runtime.session as { isStreaming: boolean }).isStreaming = true;
 		promptResolves[0]?.();
 		await expect(first).resolves.toMatchObject({ message: "first" });
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && queueAgentMessagePrompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 
 		expect(prompt).toHaveBeenCalledTimes(1);
 		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
@@ -3667,6 +3963,7 @@ describe("daemon mode helpers", () => {
 		};
 		internals.sessions.set(fromState.activeSessionId, fromState);
 		internals.sessions.set(targetState.activeSessionId, targetState);
+		installDeterministicAgentFamilyCatalog(internals, [fromState, targetState]);
 
 		const first = internals.sendAgentSessionMessage({
 			targetSelector: targetState.activeSessionId,
@@ -3680,8 +3977,9 @@ describe("daemon mode helpers", () => {
 			fromState,
 			origin: "agent",
 		});
-		await Promise.resolve();
-		await Promise.resolve();
+		for (let attempt = 0; attempt < 200 && acceptAgentMessagePrompt.mock.calls.length === 0; attempt++) {
+			await Promise.resolve();
+		}
 		(targetState.runtime.session as { unfinishedActionCount: number }).unfinishedActionCount = 20;
 
 		resolveFirstPrompt();
@@ -4024,6 +4322,7 @@ describe("daemon mode helpers", () => {
 			}): Promise<unknown>;
 		};
 		internals.sessions.set(state.activeSessionId, state);
+		installDeterministicAgentFamilyCatalog(internals, [state]);
 
 		await expect(
 			internals.sendAgentSessionMessage({
@@ -5745,13 +6044,15 @@ describe("daemon mode helpers", () => {
 				sessionPath: fixture.parentSessionFile,
 			});
 
-			await internals
-				.createAgentMessageController(() => parentState)
-				.sendAgentMessage({ target: "renamed-worker", message: "report progress" });
-
-			// The nested header depth must win over the legacy depth-1 default so the
-			// woken child does not come up shallower than persisted.
-			expect(fixture.createRuntime.mock.calls[1]?.[0].sessionOptions?.rlmDepth).toBe(2);
+			// A root may not directly reach a depth-two child. The persisted header
+			// is authoritative even when legacy registry metadata omits depth, and denial
+			// must happen before hydration.
+			await expect(
+				internals
+					.createAgentMessageController(() => parentState)
+					.sendAgentMessage({ target: "renamed-worker", message: "report progress" }),
+			).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			expect(fixture.createRuntime).toHaveBeenCalledOnce();
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -9566,6 +9867,301 @@ describe("daemon mode helpers", () => {
 			}),
 		).rejects.toThrow("Unknown active session: missing");
 	});
+
+	it("delivers disjoint CLI sends while preserving agent-origin catalog ACLs", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-cli-from-state.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const { state: fromState } = makeAgentFamilyState("source", "Source");
+		const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target");
+		const agentFamilyCatalogEntries = vi.fn(async () =>
+			Object.freeze([
+				{
+					id: fromState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: "source-parent",
+				},
+				{
+					id: targetState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: "target-parent",
+				},
+			]),
+		);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				fromState?: ActiveSessionState;
+				origin: "agent" | "cli";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(fromState.activeSessionId, fromState);
+		internals.sessions.set(targetState.activeSessionId, targetState);
+		internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "CLI delivery ignores the family reach ACL",
+				fromState,
+				origin: "cli",
+			}),
+		).resolves.toMatchObject({
+			deliveryStatus: "delivered",
+			target: { activeSessionId: targetState.activeSessionId },
+		});
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+			customMessage: { details: { fromRelationship: undefined } },
+		});
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "agent ACL must reject this",
+				fromState,
+				origin: "agent",
+			}),
+		).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
+	});
+
+	it("labels CLI sibling sends from an authoritative depth-1 catalog", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-cli-sibling-label.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const { state: parentState } = makeAgentFamilyState("parent", "Parent");
+		const { state: fromState } = makeAgentFamilyState("source", "Source", parentState);
+		const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target", parentState);
+		const agentFamilyCatalogEntries = vi.fn(async () =>
+			Object.freeze([
+				{
+					id: parentState.runtime.session.sessionId,
+					depth: 0,
+					status: "running" as const,
+				},
+				{
+					id: fromState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: parentState.runtime.session.sessionId,
+				},
+				{
+					id: targetState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: parentState.runtime.session.sessionId,
+				},
+			]),
+		);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				fromState?: ActiveSessionState;
+				origin: "agent" | "cli";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(parentState.activeSessionId, parentState);
+		internals.sessions.set(fromState.activeSessionId, fromState);
+		internals.sessions.set(targetState.activeSessionId, targetState);
+		internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "sent by the CLI sibling",
+				fromState,
+				origin: "cli",
+			}),
+		).resolves.toMatchObject({ deliveryStatus: "delivered" });
+		expect(agentFamilyCatalogEntries).toHaveBeenCalledOnce();
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+			customMessage: { details: { fromRelationship: "sibling" } },
+		});
+	});
+
+	it("omits a CLI sibling label when the catalog has ambiguous parents", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-cli-ambiguous-sibling.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const { state: firstParent } = makeAgentFamilyState("first-parent", "First parent");
+		const { state: fromState } = makeAgentFamilyState("source", "Source", firstParent);
+		const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target", firstParent);
+		const agentFamilyCatalogEntries = vi.fn(async () =>
+			Object.freeze([
+				{
+					id: firstParent.runtime.session.sessionId,
+					depth: 0,
+					status: "running" as const,
+				},
+				{
+					id: firstParent.runtime.session.sessionId,
+					depth: 0,
+					status: "running" as const,
+				},
+				{
+					id: fromState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: firstParent.runtime.session.sessionId,
+				},
+				{
+					id: targetState.runtime.session.sessionId,
+					depth: 1,
+					status: "running" as const,
+					parentSessionId: firstParent.runtime.session.sessionId,
+				},
+			]),
+		);
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				fromState?: ActiveSessionState;
+				origin: "agent" | "cli";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(fromState.activeSessionId, fromState);
+		internals.sessions.set(targetState.activeSessionId, targetState);
+		internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "sent with ambiguous parent evidence",
+				fromState,
+				origin: "cli",
+			}),
+		).resolves.toMatchObject({ deliveryStatus: "delivered" });
+		expect(agentFamilyCatalogEntries).toHaveBeenCalledOnce();
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+			customMessage: { details: { fromRelationship: undefined } },
+		});
+	});
+
+	it.each(["sender", "target"] as const)(
+		"delivers an unlabeled CLI message with a duplicate %s endpoint while agent origin rejects it",
+		async (duplicate) => {
+			const daemon = new AgentDaemon(`/tmp/prime-agent-cli-duplicate-${duplicate}.sock`, {
+				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			const { state: fromState } = makeAgentFamilyState("source", "Source");
+			const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target");
+			const fromEntry = {
+				id: fromState.runtime.session.sessionId,
+				depth: 0,
+				status: "running" as const,
+			};
+			const targetEntry = {
+				id: targetState.runtime.session.sessionId,
+				depth: 0,
+				status: "running" as const,
+			};
+			const duplicateEntry = duplicate === "sender" ? fromEntry : targetEntry;
+			const agentFamilyCatalogEntries = vi.fn(async () =>
+				Object.freeze([fromEntry, targetEntry, { ...duplicateEntry }]),
+			);
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+				sendAgentSessionMessage(options: {
+					targetSelector: string;
+					message: string;
+					fromState?: ActiveSessionState;
+					origin: "agent" | "cli";
+				}): Promise<unknown>;
+			};
+			internals.sessions.set(fromState.activeSessionId, fromState);
+			internals.sessions.set(targetState.activeSessionId, targetState);
+			internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+
+			await expect(
+				internals.sendAgentSessionMessage({
+					targetSelector: targetState.activeSessionId,
+					message: "CLI delivery treats topology as advisory",
+					fromState,
+					origin: "cli",
+				}),
+			).resolves.toMatchObject({ deliveryStatus: "delivered" });
+			expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+				customMessage: { details: { fromRelationship: undefined } },
+			});
+			await expect(
+				internals.sendAgentSessionMessage({
+					targetSelector: targetState.activeSessionId,
+					message: "agent origin rejects ambiguous authority",
+					fromState,
+					origin: "agent",
+				}),
+			).rejects.toThrow(AGENT_FAMILY_REACH_ERROR);
+			expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
+		},
+	);
+
+	it("delivers an unlabeled CLI message when catalog acquisition fails while agent origin rejects it", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-cli-catalog-failure.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const { state: fromState } = makeAgentFamilyState("source", "Source");
+		const { state: targetState, acceptAgentMessagePrompt } = makeAgentFamilyState("target", "Target");
+		const catalogError = new Error("catalog unavailable");
+		const agentFamilyCatalogEntries = vi.fn(async () => {
+			throw catalogError;
+		});
+		const log = vi.fn();
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			agentFamilyCatalogEntries: typeof agentFamilyCatalogEntries;
+			log: typeof log;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				fromState?: ActiveSessionState;
+				origin: "agent" | "cli";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(fromState.activeSessionId, fromState);
+		internals.sessions.set(targetState.activeSessionId, targetState);
+		internals.agentFamilyCatalogEntries = agentFamilyCatalogEntries;
+		internals.log = log;
+
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "CLI delivery survives catalog failure",
+				fromState,
+				origin: "cli",
+			}),
+		).resolves.toMatchObject({ deliveryStatus: "delivered" });
+		expect(log).toHaveBeenCalledWith(
+			"Agent family catalog unavailable for CLI message relationship: catalog unavailable",
+		);
+		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({
+			customMessage: { details: { fromRelationship: undefined } },
+		});
+		await expect(
+			internals.sendAgentSessionMessage({
+				targetSelector: targetState.activeSessionId,
+				message: "agent origin rejects catalog failure",
+				fromState,
+				origin: "agent",
+			}),
+		).rejects.toBe(catalogError);
+		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
+	});
 });
 
 type CronAdmissionActivity = Partial<{
@@ -9694,7 +10290,7 @@ function makePersistedRlmDaemonFixture(
 	const childId = "child-1";
 	const childSessionDir = join(parentArtifactDir, "sub-1234abcd");
 	const childManager = SessionManager.create(tempDir, childSessionDir);
-	childManager.newSession({ parentSession: parentSessionFile });
+	childManager.newSession({ parentSession: parentSessionFile, rlmDepth: 1 });
 	childManager.appendSessionInfo("spawn-worker");
 	childManager.appendSessionInfo("renamed-worker");
 	childManager.appendMessage({ role: "user", content: "complete this task", timestamp: 1 });
@@ -9708,7 +10304,7 @@ function makePersistedRlmDaemonFixture(
 	mkdirSync(childArtifactDir, { recursive: true });
 	const grandchildSessionDir = join(childSessionDir, "sub-deadbeef");
 	const grandchildManager = SessionManager.create(tempDir, grandchildSessionDir);
-	grandchildManager.newSession({ parentSession: childSessionFile });
+	grandchildManager.newSession({ parentSession: childSessionFile, rlmDepth: 2 });
 	grandchildManager.appendSessionInfo("nested-worker");
 	grandchildManager.appendMessage({ role: "user", content: "complete the nested task", timestamp: 2 });
 	grandchildManager.flushNow();
@@ -9824,9 +10420,12 @@ function makePersistedRlmDaemonFixture(
 		parentArtifactDir,
 		parentSessionId: parentManager.getSessionId(),
 		childId,
+		childSessionId: childManager.getSessionId(),
 		childSessionFile,
 		childSessionDir,
+		childArtifactDir,
 		grandchildId,
+		grandchildSessionId: grandchildManager.getSessionId(),
 		grandchildSessionFile,
 	};
 }

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -93,13 +93,17 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("queue_message_mutation");
 	});
 
-	it("accepts the old-client rename shape but rejects an old daemon for authority-aware renames", () => {
-		const oldClientCommand: DaemonCommand = {
+	it("schema-gates only authority-aware saved-session renames", () => {
+		const detachedLegacy: DaemonCommand = {
 			type: "rename_saved_session",
 			sessionPath: "/tmp/session.jsonl",
 			name: "renamed",
 		};
-		expect(getDaemonCommandCompatibilities(oldClientCommand)).toEqual([{ minProtocol: 7, minSchemaRevision: 17 }]);
+		const activeLegacy: DaemonCommand = { ...detachedLegacy, activeSessionId: "active" };
+		const authorityAware: DaemonCommand = { ...detachedLegacy, sessionDir: "/tmp/sessions" };
+		expect(getDaemonCommandCompatibilities(detachedLegacy)).toEqual([{ minProtocol: 7 }]);
+		expect(getDaemonCommandCompatibilities(activeLegacy)).toEqual([{ minProtocol: 7 }]);
+		expect(getDaemonCommandCompatibilities(authorityAware)).toEqual([{ minProtocol: 7, minSchemaRevision: 17 }]);
 		expect(DAEMON_COMMAND_COMPATIBILITY.rename_saved_session).toEqual({
 			minProtocol: 7,
 			minSchemaRevision: 17,

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -93,6 +93,19 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("queue_message_mutation");
 	});
 
+	it("accepts the old-client rename shape but rejects an old daemon for authority-aware renames", () => {
+		const oldClientCommand: DaemonCommand = {
+			type: "rename_saved_session",
+			sessionPath: "/tmp/session.jsonl",
+			name: "renamed",
+		};
+		expect(getDaemonCommandCompatibilities(oldClientCommand)).toEqual([{ minProtocol: 7, minSchemaRevision: 17 }]);
+		expect(DAEMON_COMMAND_COMPATIBILITY.rename_saved_session).toEqual({
+			minProtocol: 7,
+			minSchemaRevision: 17,
+		});
+	});
+
 	it("schema-gates the RLM max depth commands at their introducing revision", () => {
 		expect(DAEMON_COMMAND_COMPATIBILITY.get_rlm_max_depth_status).toEqual({ minProtocol: 7, minSchemaRevision: 11 });
 		expect(DAEMON_COMMAND_COMPATIBILITY.set_rlm_max_depth).toEqual({ minProtocol: 7, minSchemaRevision: 11 });

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../src/core/session-manager.js";
 import { success } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DaemonSupervisor, idleEvictionSweepIntervalMs } from "../src/modes/daemon/daemon-supervisor.js";
@@ -31,8 +32,17 @@ interface SupervisorInternals {
 	workers: Map<string, WorkerFixture>;
 	clients: Set<{ id: string; attachedActiveSessionIds: Set<string> }>;
 	idleEvictionFence?: Promise<void>;
-	catalog: { resolve: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> };
+	catalog: {
+		resolve: ReturnType<typeof vi.fn>;
+		stop: ReturnType<typeof vi.fn>;
+		list?: ReturnType<typeof vi.fn>;
+		family?: ReturnType<typeof vi.fn>;
+		siblings?: ReturnType<typeof vi.fn>;
+	};
 	createOrReuseWorker: ReturnType<typeof vi.fn>;
+	familyCatalogEntries(
+		sessionDir?: string,
+	): Promise<readonly import("../src/core/agent-messages.js").AgentFamilyCatalogEntry[]>;
 	stopWorker: ReturnType<typeof vi.fn>;
 	log: ReturnType<typeof vi.fn>;
 	scheduleIdleEvictionSweep(): void;
@@ -304,6 +314,50 @@ describe("daemon supervisor whole-tree eviction", () => {
 		});
 	});
 
+	it("uses the merged custom session directory for named saved-session siblings", async () => {
+		const supervisor = makeSupervisor();
+		const sessionPath = "/tmp/custom-sessions/saved.jsonl";
+		const target = {
+			id: "saved",
+			path: sessionPath,
+			cwd: "/tmp/project",
+			parentSessionPath: "/tmp/custom-sessions/parent.jsonl",
+			rlmDepth: 1,
+			created: new Date("2026-08-01T12:00:00.000Z"),
+			modified: new Date("2026-08-01T12:00:00.000Z"),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+		};
+		supervisor.catalog.resolve = vi.fn(async () => sessionPath);
+		supervisor.catalog.siblings = vi.fn(async () => [target]);
+		const launched = makeWorker("launched", [makeSummary("launched-active", Date.now())]);
+		const launchWorker = vi.fn(async () => launched);
+		Object.assign(supervisor, { launchWorker });
+		const createOrReuseWorker = (
+			supervisor as unknown as {
+				createOrReuseWorker(clientId: string, command: object): Promise<WorkerFixture>;
+			}
+		).createOrReuseWorker.bind(supervisor);
+
+		await expect(
+			createOrReuseWorker("client", {
+				id: "named-custom",
+				type: "create",
+				sessionPath: "saved",
+				name: "renamed",
+				config: { sessionDir: "/tmp/custom-sessions" },
+			}),
+		).resolves.toBe(launched);
+		expect(supervisor.catalog.resolve).toHaveBeenCalledWith("saved", expect.any(String), "/tmp/custom-sessions");
+		expect(supervisor.catalog.siblings).toHaveBeenCalledWith(sessionPath, "/tmp/custom-sessions");
+		expect(launchWorker).toHaveBeenCalledWith(
+			expect.objectContaining({ sessionPath, config: { sessionDir: "/tmp/custom-sessions" } }),
+			undefined,
+			undefined,
+		);
+	});
+
 	it("resolves a saved target in the source worker's create-time session directory", async () => {
 		const now = Date.parse("2026-08-01T12:00:00.000Z");
 		const supervisor = makeSupervisor();
@@ -311,9 +365,19 @@ describe("daemon supervisor whole-tree eviction", () => {
 		const source = makeWorker("source", [sourceSummary]);
 		source.descriptor.createCommand.config = { sessionDir: "/tmp/custom-sessions" };
 		source.summaries = new Map([["source-active", sourceSummary]]);
+		// The wake path reads this row before authorizing it, so model an actual
+		// saved session rather than a summary whose sessionFile is not readable.
+		const targetDirectory = mkdtempSync(join(tmpdir(), "prime-supervisor-saved-target-"));
+		tempDirs.push(targetDirectory);
+		const targetManager = SessionManager.create(targetDirectory, join(targetDirectory, "sessions"));
+		targetManager.newSession();
+		targetManager.appendSessionInfo("saved target");
+		targetManager.flushNow();
+		const targetPath = targetManager.getSessionFile();
+		if (!targetPath) throw new Error("Missing saved target session path");
 		const targetSummary = makeSummary("target-active", now, {
-			sessionId: "target-session",
-			sessionFile: "/tmp/target.jsonl",
+			sessionId: targetManager.getSessionId(),
+			sessionFile: targetPath,
 		});
 		const target = makeWorker("target", [targetSummary]);
 		target.descriptor.rootActiveSessionId = "target-active";
@@ -324,7 +388,7 @@ describe("daemon supervisor whole-tree eviction", () => {
 			data: { deliveryStatus: "delivered" },
 		});
 		supervisor.workers.set("source", source);
-		supervisor.catalog.resolve = vi.fn(async () => "/tmp/target.jsonl");
+		supervisor.catalog.resolve = vi.fn(async () => targetPath);
 		supervisor.createOrReuseWorker = vi.fn(async () => target);
 		const client = { id: "sender", attachedActiveSessionIds: new Set<string>() };
 
@@ -339,7 +403,12 @@ describe("daemon supervisor whole-tree eviction", () => {
 		expect(supervisor.catalog.resolve).toHaveBeenCalledWith("target-session", "/tmp/project", "/tmp/custom-sessions");
 		expect(supervisor.createOrReuseWorker).toHaveBeenCalledWith(
 			"sender",
-			expect.objectContaining({ type: "create", sessionPath: "/tmp/target.jsonl", continueRecent: false }),
+			expect.objectContaining({
+				type: "create",
+				sessionPath: targetPath,
+				continueRecent: false,
+				config: { sessionDir: "/tmp/custom-sessions" },
+			}),
 		);
 		expect(target.client?.requestWorker).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -440,5 +509,324 @@ describe("daemon supervisor whole-tree eviction", () => {
 			}),
 		).rejects.toThrow('Ambiguous session selector "target"');
 		expect(supervisor.createOrReuseWorker).not.toHaveBeenCalled();
+	});
+
+	it("captures every inactive descendant for cross-worker sibling authorization", async () => {
+		const supervisor = makeSupervisor();
+		const timestamp = new Date("2026-08-01T12:00:00.000Z");
+		const catalog = [
+			{
+				id: "root",
+				path: "/tmp/root.jsonl",
+				cwd: "/tmp",
+				rlmDepth: 0,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+			{
+				id: "middle",
+				path: "/tmp/middle.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/root.jsonl",
+				rlmDepth: 1,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+			{
+				id: "first",
+				path: "/tmp/first.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/middle.jsonl",
+				rlmDepth: 2,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+			{
+				id: "second",
+				path: "/tmp/second.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/middle.jsonl",
+				rlmDepth: 2,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+		];
+		supervisor.catalog.list = vi.fn(async () => catalog);
+		Object.assign(supervisor.catalog, { family: vi.fn(async () => catalog) });
+		const entries = await supervisor.familyCatalogEntries("/tmp/custom-sessions");
+		expect(supervisor.catalog.list).toHaveBeenCalledWith(undefined, "/tmp/custom-sessions");
+		expect(supervisor.catalog.family).toHaveBeenCalledWith("/tmp/custom-sessions");
+		expect(entries.map((entry) => entry.id)).toEqual(["root", "middle", "first", "second"]);
+		const { assertAgentFamilyReach } = await import("../src/core/agent-messages.js");
+		expect(
+			assertAgentFamilyReach(
+				entries.find((entry) => entry.id === "first")!,
+				entries.find((entry) => entry.id === "second")!,
+				entries,
+			),
+		).toBe("sibling");
+	});
+
+	it("uses the source worker session directory for agent-origin family snapshots", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const source = makeWorker("source", [makeSummary("source-active", now, { sessionId: "source" })]);
+		source.descriptor.createCommand.config = { sessionDir: "/tmp/custom-sessions" };
+		const target = makeWorker("target", [makeSummary("target-active", now, { sessionId: "target" })]);
+		target.client!.requestWorker.mockResolvedValue({
+			type: "response",
+			command: "worker_deliver_message",
+			success: true,
+			data: { deliveryStatus: "delivered" },
+		});
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("target", target);
+		const familyCatalogEntries = vi.fn(async () =>
+			Object.freeze([
+				{ id: "root", depth: 0, status: "inactive" as const },
+				{ id: "source", depth: 1, status: "running" as const, parentSessionId: "root" },
+				{ id: "target", depth: 1, status: "running" as const, parentSessionId: "root" },
+			]),
+		);
+		Object.assign(supervisor, { familyCatalogEntries });
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "custom-root",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: "target-active",
+					message: "deliver",
+				},
+			),
+		).resolves.toMatchObject({ success: true });
+		expect(familyCatalogEntries).toHaveBeenCalledWith("/tmp/custom-sessions");
+	});
+
+	it("rejects active topology that conflicts with the persisted row before remote delivery", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const sourceSummary = makeSummary("source-active", now, {
+			sessionId: "source",
+			rlmDepth: 1,
+			parentSessionPath: "/tmp/root.jsonl",
+		});
+		const targetSummary = makeSummary("target-active", now, {
+			sessionId: "target",
+			sessionFile: "/tmp/target.jsonl",
+			rlmDepth: 1,
+			parentSessionPath: "/tmp/forged-parent.jsonl",
+		});
+		const source = makeWorker("source", [sourceSummary]);
+		const target = makeWorker("target", [targetSummary]);
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("target", target);
+		const timestamp = new Date(now);
+		const catalog = [
+			{
+				id: "root",
+				path: "/tmp/root.jsonl",
+				cwd: "/tmp",
+				rlmDepth: 0,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+			{
+				id: "target",
+				path: "/tmp/target.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/root.jsonl",
+				rlmDepth: 1,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+			},
+		];
+		supervisor.catalog.list = vi.fn(async () => catalog);
+		Object.assign(supervisor.catalog, { family: vi.fn(async () => catalog) });
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "persisted-conflict",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: "target-active",
+					message: "deny",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(target.client?.requestWorker).not.toHaveBeenCalled();
+	});
+
+	it("uses only the source custom directory when denying a conflicting family topology", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const sourceSummary = makeSummary("source-active", now, {
+			sessionId: "source",
+			rlmDepth: 1,
+			parentSessionPath: "/tmp/custom-sessions/root.jsonl",
+		});
+		const targetSummary = makeSummary("target-active", now, {
+			sessionId: "target",
+			sessionFile: "/tmp/custom-sessions/target.jsonl",
+			rlmDepth: 1,
+			parentSessionPath: "/tmp/custom-sessions/forged-parent.jsonl",
+		});
+		const source = makeWorker("source", [sourceSummary]);
+		source.descriptor.createCommand.config = { sessionDir: "/tmp/custom-sessions" };
+		const target = makeWorker("target", [targetSummary]);
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("target", target);
+		const timestamp = new Date(now);
+		const catalog = [
+			{
+				id: "root",
+				path: "/tmp/custom-sessions/root.jsonl",
+				cwd: "/tmp",
+				rlmDepth: 0,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+				allMessagesText: "",
+			},
+			{
+				id: "target",
+				path: "/tmp/custom-sessions/target.jsonl",
+				cwd: "/tmp",
+				parentSessionPath: "/tmp/custom-sessions/root.jsonl",
+				rlmDepth: 1,
+				created: timestamp,
+				modified: timestamp,
+				messageCount: 0,
+				firstMessage: "",
+				allMessagesText: "",
+			},
+		];
+		supervisor.catalog.list = vi.fn(async () => catalog);
+		supervisor.catalog.family = vi.fn(async () => catalog);
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "custom-persisted-conflict",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: "target-active",
+					message: "deny",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(supervisor.catalog.list).toHaveBeenCalledWith(undefined, "/tmp/custom-sessions");
+		expect(supervisor.catalog.family).toHaveBeenCalledWith("/tmp/custom-sessions");
+		expect(target.client?.requestWorker).not.toHaveBeenCalled();
+	});
+
+	it("rejects duplicate snapshot identities before cross-worker delivery", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const sourceSummary = makeSummary("source-active", now, { sessionId: "source" });
+		const targetSummary = makeSummary("target-active", now, { sessionId: "target" });
+		const source = makeWorker("source", [sourceSummary]);
+		const target = makeWorker("target", [targetSummary]);
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("target", target);
+		Object.assign(supervisor, {
+			familyCatalogEntries: vi.fn(async () =>
+				Object.freeze([
+					{ id: "root", depth: 0, status: "inactive" as const },
+					{ id: "source", depth: 1, status: "running" as const, parentSessionId: "root" },
+					{ id: "target", depth: 1, status: "running" as const, parentSessionId: "root" },
+					{ id: "target", depth: 1, status: "running" as const, parentSessionId: "forged" },
+				]),
+			),
+		});
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "duplicate",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: "target-active",
+					message: "deny",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(target.client?.requestWorker).not.toHaveBeenCalled();
+	});
+
+	it("rejects a postwake session substitution without delivery", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-postwake-substitution-"));
+		tempDirs.push(directory);
+		const parentManager = SessionManager.create(directory, join(directory, "sessions"));
+		parentManager.newSession({ rlmDepth: 0 });
+		parentManager.flushNow();
+		const parentPath = parentManager.getSessionFile();
+		if (!parentPath) throw new Error("Missing parent session path");
+		const targetManager = SessionManager.create(directory, join(directory, "sessions"));
+		targetManager.newSession({ parentSession: parentPath, rlmDepth: 1 });
+		targetManager.flushNow();
+		const targetPath = targetManager.getSessionFile();
+		if (!targetPath) throw new Error("Missing target session path");
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const sourceSummary = makeSummary("source-active", now, { sessionId: "source" });
+		const source = makeWorker("source", [sourceSummary]);
+		const substituted = makeSummary("woken-active", now, { sessionId: "substitute", sessionFile: targetPath });
+		const woken = makeWorker("woken", [substituted]);
+		const supervisor = makeSupervisor();
+		supervisor.workers.set("source", source);
+		supervisor.catalog.resolve = vi.fn(async () => targetPath);
+		supervisor.createOrReuseWorker = vi.fn(async () => woken);
+		Object.assign(supervisor, {
+			familyCatalogEntries: vi.fn(async () =>
+				Object.freeze([
+					{ id: parentManager.getSessionId(), depth: 0, status: "inactive" as const, sessionPath: parentPath },
+					{ id: "source", depth: 1, status: "running" as const, parentSessionId: parentManager.getSessionId() },
+					{
+						id: targetManager.getSessionId(),
+						depth: 1,
+						status: "inactive" as const,
+						parentSessionPath: parentPath,
+						sessionPath: targetPath,
+					},
+				]),
+			),
+		});
+		await expect(
+			supervisor.handleCommand(
+				{ id: "sender" },
+				{
+					id: "substitution",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: "source-active",
+					targetActiveSessionId: targetManager.getSessionId(),
+					message: "deny",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(supervisor.createOrReuseWorker).toHaveBeenCalledOnce();
+		expect(woken.client?.requestWorker).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -575,6 +575,45 @@ describe("daemon supervisor whole-tree eviction", () => {
 		).toBe("sibling");
 	});
 
+	it("scopes live family rows to the requested configured session directory", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const source = makeWorker("source", [makeSummary("source", now)]);
+		source.descriptor.createCommand.config = { sessionDir: "/tmp/sessions-a" };
+		const foreign = makeWorker("foreign", [makeSummary("foreign", now)]);
+		foreign.descriptor.createCommand.config = { sessionDir: "/tmp/sessions-b" };
+		supervisor.workers.set("source", source);
+		supervisor.workers.set("foreign", foreign);
+		supervisor.catalog.list = vi.fn(async () => []);
+		Object.assign(supervisor.catalog, { family: vi.fn(async () => []) });
+
+		const entries = await supervisor.familyCatalogEntries("/tmp/sessions-a");
+		expect(entries.map((entry) => entry.id)).toEqual(["source-session"]);
+	});
+
+	it("anchors relative live parent paths to the child session file", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const worker = makeWorker("family", [
+			makeSummary("root", now, { sessionId: "root", sessionFile: "/tmp/family/root.jsonl", rlmDepth: 0 }),
+			makeSummary("child", now, {
+				sessionId: "child",
+				sessionFile: "/tmp/family/children/child.jsonl",
+				rlmDepth: 1,
+				parentSessionId: "root",
+				parentSessionPath: "../root.jsonl",
+			}),
+		]);
+		worker.descriptor.createCommand.config = { sessionDir: "/tmp/sessions" };
+		supervisor.workers.set("family", worker);
+		supervisor.catalog.list = vi.fn(async () => []);
+		Object.assign(supervisor.catalog, { family: vi.fn(async () => []) });
+
+		const entries = await supervisor.familyCatalogEntries("/tmp/sessions");
+		const { assertAgentFamilyReach } = await import("../src/core/agent-messages.js");
+		expect(assertAgentFamilyReach(entries[0]!, entries[1]!, entries)).toBe("child");
+	});
+
 	it("uses the source worker session directory for agent-origin family snapshots", async () => {
 		const now = Date.parse("2026-08-01T12:00:00.000Z");
 		const supervisor = makeSupervisor();
@@ -692,6 +731,7 @@ describe("daemon supervisor whole-tree eviction", () => {
 		const source = makeWorker("source", [sourceSummary]);
 		source.descriptor.createCommand.config = { sessionDir: "/tmp/custom-sessions" };
 		const target = makeWorker("target", [targetSummary]);
+		target.descriptor.createCommand.config = { sessionDir: "/tmp/custom-sessions" };
 		supervisor.workers.set("source", source);
 		supervisor.workers.set("target", target);
 		const timestamp = new Date(now);

--- a/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
@@ -22,13 +22,14 @@ interface SupervisorInternals {
 		clientId: string,
 		command: { type: "create"; name?: string; sessionPath?: string },
 	): Promise<WorkerFixture>;
-	assertSupervisorSavedSessionNameAvailable(sessionPath: string, name: string): Promise<void>;
+	assertSupervisorSavedSessionNameAvailable(sessionPath: string, name: string, sessionDir?: string): Promise<void>;
 	assertSavedSiblingNameAvailable(
 		siblings: Array<Record<string, unknown>>,
 		target: Record<string, unknown>,
 		name: string,
 	): void;
 	familyCatalogEntry(summary: SessionSummary): AgentFamilyCatalogEntry;
+	familyCatalogEntries(): Promise<readonly AgentFamilyCatalogEntry[]>;
 	handleCommand(client: object, command: Record<string, unknown>): Promise<unknown>;
 }
 
@@ -41,7 +42,7 @@ interface WorkerFixture {
 		pid: number;
 		authenticationToken: string;
 		ownerClientId?: string;
-		createCommand: { config: { cwd: string } };
+		createCommand: { config: { cwd: string; sessionDir?: string } };
 	};
 	client: {
 		request: ReturnType<typeof vi.fn>;
@@ -491,6 +492,7 @@ describe("daemon supervisor passive subagent topology", () => {
 			releaseRename = resolve;
 		});
 		const firstWorker = worker("first", [firstSummary]);
+		firstWorker.descriptor.createCommand.config.sessionDir = join(directory, "custom-sessions");
 		firstWorker.client.request.mockImplementation(async () => {
 			await renameGate;
 			return success(undefined, "rename_saved_session", firstSummary);
@@ -503,10 +505,12 @@ describe("daemon supervisor passive subagent topology", () => {
 		}) as unknown as SupervisorInternals;
 		supervisor.workers.set("first", firstWorker);
 		supervisor.workers.set("second", secondWorker);
+		const siblings = vi.fn(async () => []);
+		const list = vi.fn(async () => []);
 		Object.assign(supervisor, {
 			catalog: {
-				siblings: vi.fn(async () => []),
-				list: vi.fn(async () => []),
+				siblings,
+				list,
 			},
 		});
 		const client = { id: "client", attachedActiveSessionIds: new Set<string>() };
@@ -534,6 +538,8 @@ describe("daemon supervisor passive subagent topology", () => {
 		expect(secondWorker.client.request).not.toHaveBeenCalled();
 		releaseRename();
 		await expect(first).resolves.toMatchObject({ success: true });
+		expect(siblings).not.toHaveBeenCalled();
+		expect(list).toHaveBeenCalledWith(undefined, join(directory, "custom-sessions"));
 	});
 
 	it("serializes same-scope inactive renames across catalog validation and commit", async () => {
@@ -563,9 +569,10 @@ describe("daemon supervisor passive subagent topology", () => {
 			defaultSessionConfig: { agentDir: directory, cwd: directory },
 			descriptorDir: join(directory, "workers"),
 		}) as unknown as SupervisorInternals;
+		const siblings = vi.fn(async () => saved);
 		Object.assign(supervisor, {
 			catalog: {
-				siblings: vi.fn(async () => saved),
+				siblings,
 				rename,
 			},
 		});
@@ -575,6 +582,7 @@ describe("daemon supervisor passive subagent topology", () => {
 			type: "rename_saved_session",
 			sessionPath: firstPath,
 			name: "shared",
+			sessionDir: join(directory, "custom-sessions"),
 		});
 		await vi.waitFor(() => expect(rename).toHaveBeenCalledOnce());
 		await expect(
@@ -582,10 +590,12 @@ describe("daemon supervisor passive subagent topology", () => {
 				type: "rename_saved_session",
 				sessionPath: secondPath,
 				name: "shared",
+				sessionDir: join(directory, "custom-sessions"),
 			}),
 		).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
 		releaseRename();
 		await expect(first).resolves.toMatchObject({ success: true });
+		expect(siblings).toHaveBeenCalledWith(firstPath, join(directory, "custom-sessions"));
 	});
 
 	it("reserves named child creates by parent scope until worker launch completes", async () => {
@@ -642,6 +652,156 @@ describe("daemon supervisor passive subagent topology", () => {
 		).rejects.toThrow("an agent of that name already exists at depth 1 under this parent");
 		releaseLaunch();
 		await expect(first).resolves.toBe(launched);
+	});
+
+	it("authorizes live depth-two siblings through an artifact-resident parent across workers", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-artifact-family-reach-"));
+		tempDirs.push(directory);
+		const parentPath = join(directory, "parent.jsonl");
+		const parent = {
+			id: "artifact-parent",
+			path: parentPath,
+			cwd: directory,
+			created: new Date(0),
+			modified: new Date(0),
+			messageCount: 0,
+			firstMessage: "",
+			allMessagesText: "",
+			rlmDepth: 1,
+		};
+		const source = summary({
+			id: "source-active",
+			activeSessionId: "source-active",
+			sessionId: "source-session",
+			runtimeKind: "subagent",
+			rlmDepth: 2,
+			parentSessionId: parent.id,
+		});
+		const target = summary({
+			id: "target-active",
+			activeSessionId: "target-active",
+			sessionId: "target-session",
+			runtimeKind: "subagent",
+			rlmDepth: 2,
+			parentSessionId: parent.id,
+		});
+		const sourceWorker = worker("source", [source]);
+		const targetWorker = worker("target", [target]);
+		targetWorker.client.requestWorker.mockResolvedValue({
+			type: "response",
+			command: "worker_deliver_message",
+			success: true,
+		} as never);
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		supervisor.workers.set("source", sourceWorker);
+		supervisor.workers.set("target", targetWorker);
+		Object.assign(supervisor, { catalog: { list: vi.fn(async () => []), family: vi.fn(async () => [parent]) } });
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "client", attachedActiveSessionIds: new Set<string>() },
+				{
+					id: "message",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: source.activeSessionId,
+					targetActiveSessionId: target.activeSessionId,
+					message: "hello sibling",
+				},
+			),
+		).resolves.toMatchObject({ success: true });
+		expect(targetWorker.client.requestWorker).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "worker_deliver_message", targetActiveSessionId: target.activeSessionId }),
+			expect.any(Number),
+		);
+	});
+
+	it.each([
+		["missing", []],
+		[
+			"malformed",
+			[
+				{
+					id: "artifact-parent",
+					path: join(tmpdir(), "malformed.jsonl"),
+					cwd: "",
+					created: new Date(0),
+					modified: new Date(0),
+					messageCount: 0,
+					firstMessage: "",
+					allMessagesText: "",
+					rlmDepth: 0,
+				},
+			],
+		],
+		[
+			"conflicting",
+			[
+				{
+					id: "artifact-parent",
+					path: join(tmpdir(), "first-parent.jsonl"),
+					cwd: "",
+					created: new Date(0),
+					modified: new Date(0),
+					messageCount: 0,
+					firstMessage: "",
+					allMessagesText: "",
+					rlmDepth: 1,
+				},
+				{
+					id: "artifact-parent",
+					path: join(tmpdir(), "second-parent.jsonl"),
+					cwd: "",
+					created: new Date(0),
+					modified: new Date(0),
+					messageCount: 0,
+					firstMessage: "",
+					allMessagesText: "",
+					rlmDepth: 1,
+				},
+			],
+		],
+	] as const)("denies live depth-two siblings when the artifact parent is %s", async (_kind, parents) => {
+		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-artifact-family-deny-"));
+		tempDirs.push(directory);
+		const child = (id: string) =>
+			summary({
+				id: `${id}-active`,
+				activeSessionId: `${id}-active`,
+				sessionId: `${id}-session`,
+				runtimeKind: "subagent",
+				rlmDepth: 2,
+				parentSessionId: "artifact-parent",
+			});
+		const source = child("source");
+		const target = child("target");
+		const sourceWorker = worker("source", [source]);
+		const targetWorker = worker("target", [target]);
+		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+			defaultSessionConfig: { agentDir: directory, cwd: directory },
+			descriptorDir: join(directory, "workers"),
+		}) as unknown as SupervisorInternals;
+		supervisor.workers.set("source", sourceWorker);
+		supervisor.workers.set("target", targetWorker);
+		Object.assign(supervisor, { catalog: { list: vi.fn(async () => []), family: vi.fn(async () => parents) } });
+
+		await expect(
+			supervisor.handleCommand(
+				{ id: "client", attachedActiveSessionIds: new Set<string>() },
+				{
+					id: "message",
+					type: "send_message",
+					agentOrigin: true,
+					fromActiveSessionId: source.activeSessionId,
+					targetActiveSessionId: target.activeSessionId,
+					message: "hello sibling",
+				},
+			),
+		).rejects.toThrow("Agent reach is limited to parent, siblings, and children");
+		expect(targetWorker.client.requestWorker).not.toHaveBeenCalled();
 	});
 
 	it("retains passive worker summaries but syncs only roots to cross-worker peer maps", async () => {

--- a/packages/coding-agent/test/saved-session-catalog.test.ts
+++ b/packages/coding-agent/test/saved-session-catalog.test.ts
@@ -145,7 +145,12 @@ describe("saved session catalog", () => {
 		});
 
 		expect(fakeClient.commands).toEqual([
-			{ type: "rename_saved_session", sessionPath: "/tmp/sessions/one.jsonl", name: "One" },
+			{
+				type: "rename_saved_session",
+				sessionPath: "/tmp/sessions/one.jsonl",
+				sessionDir: "/tmp/sessions",
+				name: "One",
+			},
 			{ type: "delete_saved_session", sessionPath: "/tmp/sessions/one.jsonl" },
 		]);
 	});


### PR DESCRIPTION
## Replacement scope

This PR reconstructs and supersedes the unique implementation delta reviewed in #1261 without rewriting that historical branch. The original PR remains the immutable discussion record: https://github.com/PrimeIntellect-ai/prime-agent/pull/1261

- Base: `core02-host-request-dispatcher`
- Replacement branch: `v080/core-split-c3-managed-catalog`
- Replacement commit: `b37fc9895f105341355e680a81097e674bd159f8`
- Propagation/reconciliation merge commits are intentionally excluded.
- #1264 is intentionally omitted from the replacement stacks because its declared-base-to-head tree delta is empty.
- Frozen #1243 (`77b188b92dc91365cb2bc41bdb46a50669d104a8`) is the shared foundation. For reconstructed deltas it is a proven tree-compatible base, not an ancestry claim about the historical PR stack.

## Validation

- Biome 2.5.5 on the exact changed paths: pass
- root `tsgo --noEmit`: pass
- Core focused suite on the final Core tip with live daemon/RLM environment removed and single-worker execution: 11 files, 388 tests passed
- MCP focused suite on the final MCP tip: 9 files, 106 tests passed
- Independent Terra tree/delta review: pass

No original PR was retargeted, closed, merged, or otherwise mutated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes agent-to-agent authorization, session catalog trust boundaries, and fail-closed behavior across daemon/supervisor paths; mis-merged topology or stricter family walks could deny legitimate messaging or rename flows.
> 
> **Overview**
> Replaces ad-hoc sibling listing with **`listCatalogFamilySessions`**, which walks RLM registries from managed `O_NOFOLLOW` directory roots using descriptor-relative reads (Python openat helper), validates header/registry topology, and **fails closed** on symlinks, cycles, and hostile artifacts. Siblings and a new catalog **`family`** RPC are derived from that graph; **`readSessionInfoFromBuffer`** avoids reopening paths after authorized reads.
> 
> **Daemon worker and supervisor** now build frozen **`agentFamilyCatalogEntries` / `familyCatalogEntries`** from persisted scans, artifact-resident passive children, and live workers, merging only compatible topology claims. Agent-origin **messaging, observation, rosters, and cross-worker `send_message`** authorize against that snapshot (including post-wake session-id checks); CLI sends stay deliverable but relationship labels are advisory when the catalog is ambiguous or unavailable.
> 
> **`agent-messages`** tightens nuclear-family rules: siblings/parent edges require a **catalog-resolved unique parent**; contradictory id/path parent claims are rejected; name reservation gains a weaker direct-parent fallback that does **not** broaden reach.
> 
> Daemon **schema revision 17** adds optional **`sessionDir`** on detached **`rename_saved_session`** so inactive renames use the correct catalog authority root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b21a401d974cef7105157eb2d83a9e39d899f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconstruct managed session catalog with secure family traversal and sessionDir-scoped authorization
> - Introduces `listCatalogFamilySessions` in [`daemon-catalog-process.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1333/files#diff-0ce2cf2f0eda51eced7102df346434fc17d355dbc6022b11ebf5749da089d51d), which enumerates the full session family graph using descriptor-relative, O_NOFOLLOW file reads via an embedded Python helper to mitigate path traversal and TOCTOU races.
> - Replaces mutable live-topology derivation in [`daemon-mode.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1333/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) with `agentFamilyCatalogEntries`, an immutable merged cross-source catalog snapshot used for all authorization decisions (observe, getAgent, sendMessage).
> - Scopes all session catalog operations (family enumeration, sibling resolution, name availability checks, rename) to an explicit `sessionDir`, propagated through the daemon supervisor and protocol commands.
> - Tightens sibling/parent determination in [`agent-messages.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1333/files#diff-d56c5dcb3c4410339ae008806859f45d787d326d94c56b2e7c839dae397048b6): `sameAgentFamilyParent` now requires catalog-resolved unique parents; malformed remote peer topology is rejected early with `AGENT_FAMILY_REACH_ERROR`.
> - Bumps daemon schema revision to 17 and extends `rename_saved_session` with an optional `sessionDir` field; commands without it remain legacy-compatible.
> - Risk: `listSavedSessionSiblings` now throws if the target session is not found in the authoritative family, and cross-worker delivery is denied if the woken target's identity does not match the pre-authorized snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b21a40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->