### PR TITLE
[v0.8 Core 7] overlap refinement drain with kernel teardown

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1203,6 +1203,8 @@ export class AgentSession {
 	// Set at the start of async teardown so a child finishing mid-disposeAsync doesn't
 	// re-populate the retained map after it's been cleared.
 	private _disposing = false;
+	/** Set before async teardown awaits so runtime rebuilds cannot replace its owned kernel. */
+	private _asyncTeardownStarted = false;
 	private _disposeAsyncPromise?: Promise<void>;
 	private _ipythonKernelProvisioner?: IpythonKernelProvisioner;
 	/** Artifact dir backing the current provisioner's kernel snapshot, if any. */
@@ -3778,24 +3780,46 @@ export class AgentSession {
 	 * the latest state reaches disk instead of racing process exit.
 	 */
 	async disposeAsync(): Promise<void> {
-		if (this._disposed) {
-			return this._disposeCallbacksPromise;
-		}
-		// Concurrent callers await the same in-flight teardown so none resolves before
-		// the kernel snapshot flush finishes.
+		// Concurrent and late callers await the same async teardown, including its
+		// terminal failure. A purely synchronous dispose has no such promise.
 		if (this._disposeAsyncPromise) {
 			return this._disposeAsyncPromise;
 		}
+		if (this._disposed) {
+			return this._disposeCallbacksPromise;
+		}
+		this._asyncTeardownStarted = true;
 		this._disposeAsyncPromise = (async () => {
-			// Drain before marking _disposing so a refine triggered at the final
-			// agent_end completes instead of being aborted by dispose().
-			await this._drainPendingRefinementForDisposal();
-			if (this._disposed) {
-				return this._disposeCallbacksPromise;
+			// Capture both operations before the first await. allSettled observes either
+			// rejection immediately while allowing the independent operation to finish.
+			const drain = this._drainPendingRefinementForDisposal();
+			const kernelDispose = this._ipythonKernelProvisioner?.dispose() ?? Promise.resolve();
+			const failures: unknown[] = [];
+			for (const result of await Promise.allSettled([kernelDispose, drain])) {
+				if (result.status === "rejected") failures.push(result.reason);
 			}
-			this._disposing = true;
-			this._sessionActionCommitDisposeAbortController.abort();
-			await this._disposeAsyncOnce();
+
+			// Drain before marking _disposing so a refine triggered at the final
+			// agent_end completes instead of being aborted by dispose(). Cleanup remains
+			// authoritative even when the drain or kernel teardown failed.
+			if (this._disposed) {
+				await this._disposeCallbacksPromise;
+			} else {
+				this._disposing = true;
+				this._sessionActionCommitDisposeAbortController.abort();
+				try {
+					await this._disposeAsyncOnce();
+				} catch (error) {
+					failures.push(error);
+				} finally {
+					// _disposeAsyncOnce normally owns finalization. Keep the same authority
+					// boundary if an earlier best-effort child cleanup unexpectedly throws.
+					this.dispose();
+					await this._disposeCallbacksPromise;
+				}
+			}
+			if (failures.length === 1) throw failures[0];
+			if (failures.length > 1) throw new AggregateError(failures, "Session disposal failed.");
 		})();
 		return this._disposeAsyncPromise;
 	}
@@ -3949,11 +3973,6 @@ export class AgentSession {
 		this._rlmChildSessions.clear();
 		this._rlmChildCleanupFailures.clear();
 		this._deletedRlmChildIds.clear();
-		try {
-			await this._ipythonKernelProvisioner?.dispose();
-		} catch {
-			// a failed kernel startup already cleaned up after itself
-		}
 		this.dispose();
 		await this._disposeCallbacksPromise;
 	}
@@ -8640,6 +8659,7 @@ export class AgentSession {
 		flagValues?: Map<string, boolean | string>;
 		includeAllExtensionTools?: boolean;
 	}): void {
+		if (this._asyncTeardownStarted) throw new Error("Cannot rebuild a session during disposal.");
 		const pythonSkills = getPythonSkillRuntimeInfo(this._modelVisibleSkills());
 		let configuredBaseToolDefinitions: Record<string, ToolDefinition>;
 		if (this._baseToolsOverride) {
@@ -8883,6 +8903,7 @@ export class AgentSession {
 	}
 
 	async reload(): Promise<void> {
+		if (this._asyncTeardownStarted) throw new Error("Cannot reload a session during disposal.");
 		const previousFlagValues = this._extensionRunner.getFlagValues();
 		await emitSessionShutdownEvent(this._extensionRunner, {
 			type: "session_shutdown",

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -192,6 +192,203 @@ describe("AgentSession concurrent prompt guard", () => {
 		expect(disposed).toBe(true);
 	});
 
+	it("starts the refinement drain before awaiting a deferred kernel provisioner dispose", async () => {
+		createSession();
+		const order: string[] = [];
+		let releaseKernelDispose: () => void = () => {};
+		const kernelDisposeGate = new Promise<void>((resolve) => {
+			releaseKernelDispose = resolve;
+		});
+		const internals = session as unknown as {
+			_drainPendingRefinementForDisposal: () => Promise<void>;
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+		};
+		vi.spyOn(internals, "_drainPendingRefinementForDisposal").mockImplementation(async () => {
+			order.push("drain");
+		});
+		internals._ipythonKernelProvisioner = {
+			dispose: vi.fn(async () => {
+				order.push("kernel-dispose");
+				await kernelDisposeGate;
+			}),
+		};
+
+		const disposal = session.disposeAsync();
+		expect(order).toEqual(["drain", "kernel-dispose"]);
+		releaseKernelDispose();
+		await disposal;
+	});
+
+	it("observes a rejected refinement drain while kernel disposal is pending", async () => {
+		createSession();
+		const drainFailure = new Error("refinement drain failed");
+		const order: string[] = [];
+		let rejectDrain: (error: Error) => void = () => {};
+		const drainGate = new Promise<void>((_resolve, reject) => {
+			rejectDrain = reject;
+		});
+		let releaseKernelDispose: () => void = () => {};
+		const kernelDisposeGate = new Promise<void>((resolve) => {
+			releaseKernelDispose = resolve;
+		});
+		const internals = session as unknown as {
+			_drainPendingRefinementForDisposal: () => Promise<void>;
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+		};
+		vi.spyOn(internals, "_drainPendingRefinementForDisposal").mockImplementation(() => {
+			order.push("drain");
+			return drainGate;
+		});
+		internals._ipythonKernelProvisioner = {
+			dispose: vi.fn(async () => {
+				order.push("kernel-dispose");
+				await kernelDisposeGate;
+				order.push("kernel-dispose-finished");
+			}),
+		};
+		const unhandledRejections: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandledRejections.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			const disposal = session.disposeAsync();
+			expect(order).toEqual(["drain", "kernel-dispose"]);
+			rejectDrain(drainFailure);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(unhandledRejections).toEqual([]);
+
+			releaseKernelDispose();
+			await expect(disposal).rejects.toBe(drainFailure);
+			expect(order).toEqual(["drain", "kernel-dispose", "kernel-dispose-finished"]);
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
+	});
+
+	it("finalizes exactly once and shares a kernel disposal failure across callers", async () => {
+		createSession();
+		const kernelFailure = new Error("kernel disposal failed");
+		const kernelDispose = vi.fn(async () => {
+			throw kernelFailure;
+		});
+		let releaseCallback: () => void = () => {};
+		const callbackGate = new Promise<void>((resolve) => {
+			releaseCallback = resolve;
+		});
+		const callback = vi.fn(async () => callbackGate);
+		session.registerDisposeCallback(callback);
+		const internals = session as unknown as {
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+			_disposed: boolean;
+		};
+		internals._ipythonKernelProvisioner = { dispose: kernelDispose };
+
+		let settled = false;
+		const first = session.disposeAsync().finally(() => {
+			settled = true;
+		});
+		const second = session.disposeAsync();
+		await vi.waitFor(() => expect(callback).toHaveBeenCalledOnce());
+		expect(settled).toBe(false);
+		releaseCallback();
+		await expect(first).rejects.toBe(kernelFailure);
+		await expect(second).rejects.toBe(kernelFailure);
+		expect(kernelDispose).toHaveBeenCalledTimes(1);
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(internals._disposed).toBe(true);
+	});
+
+	it("shares a terminal teardown failure with callers arriving after disposed is set", async () => {
+		createSession();
+		const kernelFailure = new Error("kernel disposal failed");
+		const kernelDispose = vi.fn(async () => {
+			throw kernelFailure;
+		});
+		let releaseCallback: () => void = () => {};
+		const callbackGate = new Promise<void>((resolve) => {
+			releaseCallback = resolve;
+		});
+		let callbackStarted: () => void = () => {};
+		const callbackStartedGate = new Promise<void>((resolve) => {
+			callbackStarted = resolve;
+		});
+		const callback = vi.fn(async () => {
+			callbackStarted();
+			await callbackGate;
+		});
+		session.registerDisposeCallback(callback);
+		const internals = session as unknown as {
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+			_disposed: boolean;
+		};
+		internals._ipythonKernelProvisioner = { dispose: kernelDispose };
+
+		const first = session.disposeAsync();
+		await callbackStartedGate;
+		expect(internals._disposed).toBe(true);
+		expect(callback).toHaveBeenCalledOnce();
+		const late = session.disposeAsync();
+		let lateSettled = false;
+		void late
+			.finally(() => {
+				lateSettled = true;
+			})
+			.catch(() => undefined);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(lateSettled).toBe(false);
+		releaseCallback();
+		await expect(first).rejects.toBe(kernelFailure);
+		await expect(late).rejects.toBe(kernelFailure);
+		expect(kernelDispose).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledOnce();
+	});
+
+	it("blocks runtime reload from replacing the authoritative kernel during async disposal", async () => {
+		createSession();
+		let releaseKernel: () => void = () => {};
+		const kernelGate = new Promise<void>((resolve) => {
+			releaseKernel = resolve;
+		});
+		const kernelDispose = vi.fn(async () => kernelGate);
+		const internals = session as unknown as {
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+		};
+		internals._ipythonKernelProvisioner = { dispose: kernelDispose };
+
+		const disposal = session.disposeAsync();
+		await expect(session.reload()).rejects.toThrow("Cannot reload a session during disposal.");
+		releaseKernel();
+		await disposal;
+		expect(kernelDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("runs finalizers and aggregates concurrent drain and kernel disposal failures", async () => {
+		createSession();
+		const kernelFailure = new Error("kernel disposal failed");
+		const drainFailure = new Error("refinement drain failed");
+		const callback = vi.fn();
+		session.registerDisposeCallback(callback);
+		const internals = session as unknown as {
+			_drainPendingRefinementForDisposal: () => Promise<void>;
+			_ipythonKernelProvisioner?: { dispose(): Promise<void> };
+			_disposed: boolean;
+		};
+		vi.spyOn(internals, "_drainPendingRefinementForDisposal").mockRejectedValue(drainFailure);
+		internals._ipythonKernelProvisioner = {
+			dispose: vi.fn(async () => {
+				throw kernelFailure;
+			}),
+		};
+
+		const failure = await session.disposeAsync().catch((error: unknown) => error);
+		expect(failure).toBeInstanceOf(AggregateError);
+		expect((failure as AggregateError).errors).toEqual([kernelFailure, drainFailure]);
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(internals._disposed).toBe(true);
+	});
+
 	it("should throw when prompt() called while streaming", async () => {
 		createSession();
 


### PR DESCRIPTION
## Replacement scope

This PR reconstructs and supersedes the unique implementation delta reviewed in #1265 without rewriting that historical branch. The original PR remains the immutable discussion record: https://github.com/PrimeIntellect-ai/prime-agent/pull/1265

- Base: `v080/core-split-c4-sibling-validation`
- Replacement branch: `v080/core-split-c7-lifecycle`
- Replacement commit: `2cab0cd1003432619b9e253dd58f01febae93a4f`
- Propagation/reconciliation merge commits are intentionally excluded.
- #1264 is intentionally omitted from the replacement stacks because its declared-base-to-head tree delta is empty.
- Frozen #1243 (`77b188b92dc91365cb2bc41bdb46a50669d104a8`) is the shared foundation. For reconstructed deltas it is a proven tree-compatible base, not an ancestry claim about the historical PR stack.

## Validation

- Biome 2.5.5 on the exact changed paths: pass
- root `tsgo --noEmit`: pass
- Core focused suite on the final Core tip with live daemon/RLM environment removed and single-worker execution: 11 files, 388 tests passed
- MCP focused suite on the final MCP tip: 9 files, 106 tests passed
- Independent Terra tree/delta review: pass

No original PR was retargeted, closed, merged, or otherwise mutated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session shutdown ordering and error surfacing for kernel teardown and concurrent dispose callers; behavior is well covered by new tests but affects core lifecycle paths.
> 
> **Overview**
> **`AgentSession.disposeAsync`** is reworked so graceful shutdown overlaps **refinement drain** and **IPython kernel disposal** instead of awaiting them strictly in sequence. Both start before the first `await`, run under **`Promise.allSettled`**, and rejections surface as a single error or an **`AggregateError`** when both fail—while synchronous cleanup still runs via **`dispose()`** in a `finally` path.
> 
> Concurrent and late **`disposeAsync`** callers now always join the same in-flight **`_disposeAsyncPromise`**, including when **`_disposed`** is already true, so they observe the same terminal outcome (success or failure). Kernel **`dispose()`** is no longer invoked from **`_disposeAsyncOnce`** (where failures were previously swallowed).
> 
> A new **`_asyncTeardownStarted`** flag is set at the start of async teardown; **`reload()`** and **`_buildRuntime()`** throw if called while disposal is underway, preventing the runtime from replacing the kernel mid-teardown.
> 
> Tests in **`agent-session-concurrent.test.ts`** cover parallel start order, failure propagation, single finalization, late callers, reload blocking, and dual failure aggregation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3055505fcbb50022f2fbbc22e8a9d8c754de7fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Overlap refinement drain with kernel teardown in `AgentSession.disposeAsync`
> - `disposeAsync` now runs `_drainPendingRefinementForDisposal()` and `_ipythonKernelProvisioner?.dispose()` concurrently via `Promise.allSettled`, aggregating failures into an `AggregateError` when both reject.
> - All concurrent and late callers (including those arriving after `_disposed` is already true) share the same terminal promise result, including any rejection.
> - Kernel disposal is removed from `_disposeAsyncOnce`, which previously silently swallowed kernel disposal errors.
> - A new `_asyncTeardownStarted` flag causes `_buildRuntime` and `reload` to throw immediately if called after async teardown has begun.
> - New tests in [agent-session-concurrent.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1335/files#diff-d0d40e4452977ae43f9bafdf7e69b6305cdf954e5481a8514b205c8ed84249a3) cover drain/kernel ordering, failure propagation, late-caller sharing, and reload blocking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3055505.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->