### PR TITLE
[v0.8 Core 9] preserve recovered worker registry authority

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -14,7 +14,7 @@ import lockfile from "proper-lockfile";
 import { getProcessStartId } from "../../core/session-lease.js";
 import { defaultDaemonSocketDir } from "./daemon-socket.js";
 
-const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+export const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
 
 const OWNER_VERSION = 1;
 const REGISTRY_LOCK_STALE_MS = 5000;
@@ -246,7 +246,7 @@ class DaemonShutdownAdmission {
 	}
 }
 
-function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
+export function getDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
 	return environment[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV] ?? resolve(defaultDaemonSocketDir(), "supervisor-owners");
 }
 
@@ -275,7 +275,7 @@ async function mutateDaemonSupervisorOwner(
 	generation: string,
 	expectedToken: string,
 	mutation: (owner: DaemonSupervisorOwnerRecord) => void,
-	registryDir: string = defaultDaemonSupervisorRegistryDir(),
+	registryDir: string = getDaemonSupervisorRegistryDir(),
 ): Promise<DaemonSupervisorOwnerRecord | undefined> {
 	return withDaemonSupervisorRegistryGuard(registryDir, () => {
 		const directory = ownerDirectoryPath(registryDir, generation);
@@ -303,7 +303,7 @@ async function mutateDaemonSupervisorOwner(
 export async function acquireDaemonSupervisorOwnership(
 	options: AcquireDaemonSupervisorOwnershipOptions,
 ): Promise<DaemonSupervisorOwnership> {
-	const registryDir = options.registryDir ?? defaultDaemonSupervisorRegistryDir();
+	const registryDir = options.registryDir ?? getDaemonSupervisorRegistryDir();
 	mkdirSync(registryDir, { recursive: true, mode: 0o700 });
 	const token = randomUUID();
 	const processStartId = getProcessStartId(process.pid);
@@ -371,7 +371,7 @@ export async function assertDaemonSupervisorOwnerCurrent(
 	},
 	validatedFingerprint?: string,
 ): Promise<string> {
-	const registryDir = defaultDaemonSupervisorRegistryDir();
+	const registryDir = getDaemonSupervisorRegistryDir();
 	const current = readOwnerRecord(ownerDirectoryPath(registryDir, owner.generation));
 	if (
 		!current ||
@@ -390,7 +390,7 @@ export async function assertDaemonSupervisorOwnerCurrent(
 }
 
 export async function acquireDaemonShutdownAdmission(): Promise<DaemonShutdownAdmission> {
-	const registryDir = defaultDaemonSupervisorRegistryDir();
+	const registryDir = getDaemonSupervisorRegistryDir();
 	const processStartId = getProcessStartId(process.pid);
 	while (true) {
 		let acquired: DaemonShutdownAdmissionRecord | undefined;
@@ -418,14 +418,14 @@ export async function acquireDaemonShutdownAdmission(): Promise<DaemonShutdownAd
 }
 
 export async function isDaemonShutdownAdmissionActive(): Promise<boolean> {
-	const registryDir = defaultDaemonSupervisorRegistryDir();
+	const registryDir = getDaemonSupervisorRegistryDir();
 	return withDaemonSupervisorRegistryGuard(registryDir, () => readActiveShutdownAdmission(registryDir) !== undefined);
 }
 
 export async function persistDaemonStartupFenceFromOwner(
 	socketPath: string,
 	hello: DaemonSupervisorHelloIdentity,
-	registryDir: string = defaultDaemonSupervisorRegistryDir(),
+	registryDir: string = getDaemonSupervisorRegistryDir(),
 ): Promise<void> {
 	mkdirSync(registryDir, { recursive: true, mode: 0o700 });
 	const fenceDirectory = resolve(registryDir, "startup-fences");
@@ -482,7 +482,7 @@ export async function persistDaemonStartupFenceFromOwner(
 export async function waitForDaemonStartupFence(
 	socketPath: string,
 	timeoutMs = 10_000,
-	registryDir: string = defaultDaemonSupervisorRegistryDir(),
+	registryDir: string = getDaemonSupervisorRegistryDir(),
 ): Promise<void> {
 	const path = startupFencePath(resolve(registryDir, "startup-fences"), socketPath);
 	const deadline = Date.now() + timeoutMs;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -98,6 +98,8 @@ import {
 } from "./daemon-socket.js";
 import {
 	acquireDaemonSupervisorOwnership,
+	DAEMON_SUPERVISOR_REGISTRY_DIR_ENV,
+	getDaemonSupervisorRegistryDir,
 	isDaemonShutdownAdmissionActive,
 	waitForDaemonStartupFence,
 } from "./daemon-supervisor-ownership.js";
@@ -614,6 +616,8 @@ export class DaemonSupervisor {
 	private readonly promptAdmissions = new Map<DaemonSocketClient, Map<string, SupervisorPromptAdmission>>();
 	private readonly signalCleanupHandlers: Array<() => void> = [];
 	private readonly descriptorDir: string;
+	/** Captured from host authority and forwarded to every worker launch. */
+	private readonly supervisorRegistryDir = getDaemonSupervisorRegistryDir();
 	private readonly generation = randomUUID();
 	private readonly supervisorConfigPath: string;
 	private readonly defaultSessionConfig: AgentSessionRuntimeConfig;
@@ -657,13 +661,14 @@ export class DaemonSupervisor {
 				throw new Error("Daemon supervisor config is missing agentDir");
 			}
 			this.socketLease = await acquireDaemonSocketPathLease(this.socketPath);
-			await waitForDaemonStartupFence(this.socketPath);
+			await waitForDaemonStartupFence(this.socketPath, 10_000, this.supervisorRegistryDir);
 			this.ownership = await acquireDaemonSupervisorOwnership({
 				socketPath: this.socketPath,
 				descriptorDir: this.descriptorDir,
 				agentDir,
 				generation: this.generation,
 				appVersion: VERSION,
+				registryDir: this.supervisorRegistryDir,
 			});
 			await prepareDaemonSocketPath(this.socketPath, this.socketLease);
 
@@ -2226,6 +2231,8 @@ export class DaemonSupervisor {
 				[DAEMON_WORKER_ACTIVE_SESSION_ID_ENV]: rootActiveSessionId,
 				[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV]: this.socketPath,
 				[DAEMON_WORKER_RECOVERY_JOURNAL_ENV]: recoveryJournalPath,
+				// Host authority, set after inherited and caller launch env so neither can override it.
+				[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]: this.supervisorRegistryDir,
 				[DAEMON_WORKER_STARTUP_GATE_FD_ENV]: String(WORKER_STARTUP_GATE_FD),
 				[ORPHAN_PROCESS_JOURNAL_ENV]: orphanProcessJournalPath,
 				[SESSION_LEASES_ENABLED_ENV]: "1",

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
+import { DAEMON_SUPERVISOR_REGISTRY_DIR_ENV } from "../src/modes/daemon/daemon-supervisor-ownership.js";
 import {
 	DAEMON_WORKER_STARTUP_GATE_COMMIT,
 	DAEMON_WORKER_SUPERVISOR_SOCKET_ENV,
@@ -38,7 +39,7 @@ const workerLaunchTestState = vi.hoisted(() => ({
 	gateMarkerPath: "",
 	tsxCliPath: "",
 	cliEntrypoint: "",
-	spawned: [] as Array<{ child: ChildProcess; args: readonly string[] }>,
+	spawned: [] as Array<{ child: ChildProcess; args: readonly string[]; env: NodeJS.ProcessEnv | undefined }>,
 }));
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -50,7 +51,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 		spawn(command: string, args: readonly string[], options: SpawnOptions): ChildProcess {
 			const child = actual.spawn(command, args, options);
 			if (workerLaunchTestState.capture) {
-				workerLaunchTestState.spawned.push({ child, args });
+				workerLaunchTestState.spawned.push({ child, args, env: options.env });
 			}
 			return child;
 		},
@@ -114,7 +115,7 @@ vi.mock("../src/core/session-lease.js", async (importOriginal) => {
 	};
 });
 
-const supervisorRegistryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+const supervisorRegistryDirEnv = DAEMON_SUPERVISOR_REGISTRY_DIR_ENV;
 const previousSupervisorRegistryDir = process.env[supervisorRegistryDirEnv];
 const supervisorRegistryDirs = new Set<string>();
 
@@ -640,7 +641,9 @@ describe("daemon worker supervisor monitoring", () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-committed-gate-test-"));
 		const descriptorDir = join(root, "descriptors");
 		const markerPath = join(root, "startup-marker");
+		const registryDir = join(root, "isolated-supervisor-registry");
 		mkdirSync(descriptorDir, { recursive: true });
+		mkdirSync(registryDir, { recursive: true });
 		supervisorRegistryDirs.add(root);
 		workerLaunchTestState.capture = true;
 		workerLaunchTestState.forceMissingProcessStartId = true;
@@ -665,6 +668,7 @@ describe("daemon worker supervisor monitoring", () => {
 			...createSupervisorSnapshotState(),
 			defaultSessionConfig: { cwd: root, agentDir: root },
 			descriptorDir,
+			supervisorRegistryDir: registryDir,
 			socketPath: join(root, "supervisor.sock"),
 			workers,
 			shuttingDown: false,
@@ -675,16 +679,37 @@ describe("daemon worker supervisor monitoring", () => {
 			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
-			launchWorker(command: {
-				type: "create";
-				config: { cwd: string; agentDir: string };
-			}): Promise<{ descriptor: { lifecycle: string } }>;
+			launchWorker(
+				command: { type: "create"; config: { cwd: string; agentDir: string }; launchEnv?: Record<string, string> },
+				existing?: {
+					descriptor: {
+						lifecycle: string;
+						createCommand: { type: "create"; config: { cwd: string; agentDir: string } };
+						launchEnv?: Record<string, string>;
+					};
+				},
+			): Promise<{
+				descriptor: {
+					lifecycle: string;
+					createCommand: { type: "create"; config: { cwd: string; agentDir: string } };
+					launchEnv?: Record<string, string>;
+				};
+			}>;
 		};
 
-		const worker = await supervisor.launchWorker({ type: "create", config: { cwd: root, agentDir: root } });
+		const worker = await supervisor.launchWorker({
+			type: "create",
+			config: { cwd: root, agentDir: root },
+			launchEnv: { [DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]: join(root, "untrusted-registry") },
+		});
+		await supervisor.launchWorker(worker.descriptor.createCommand, worker);
 
+		expect(
+			workerLaunchTestState.spawned.slice(-2).map(({ env }) => env?.[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]),
+		).toEqual([registryDir, registryDir]);
 		expect(readFileSync(markerPath, "utf8")).toBe("start\n");
-		expect(connectWorker).toHaveBeenCalledOnce();
+		expect(worker.descriptor.launchEnv?.[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]).toBeUndefined();
+		expect(connectWorker).toHaveBeenCalledTimes(2);
 		expect(worker.descriptor.lifecycle).toBe("ready");
 		expect(workers.size).toBe(1);
 		expect(readdirSync(descriptorDir).filter((name) => name.endsWith(".json"))).toHaveLength(1);


### PR DESCRIPTION
## Replacement scope

This PR reconstructs and supersedes the unique implementation delta reviewed in #1267 without rewriting that historical branch. The original PR remains the immutable discussion record: https://github.com/PrimeIntellect-ai/prime-agent/pull/1267

- Base: `v080/core-split-c7-lifecycle`
- Replacement branch: `v080/core-split-c9-worker-registry`
- Replacement commit: `5413a1ca6092689c1fb1eb2f5ced6c300d45b2ad`
- Propagation/reconciliation merge commits are intentionally excluded.
- #1264 is intentionally omitted from the replacement stacks because its declared-base-to-head tree delta is empty.
- Frozen #1243 (`77b188b92dc91365cb2bc41bdb46a50669d104a8`) is the shared foundation. For reconstructed deltas it is a proven tree-compatible base, not an ancestry claim about the historical PR stack.

## Validation

- Biome 2.5.5 on the exact changed paths: pass
- root `tsgo --noEmit`: pass
- Core focused suite on the final Core tip with live daemon/RLM environment removed and single-worker execution: 11 files, 388 tests passed
- MCP focused suite on the final MCP tip: 9 files, 106 tests passed
- Independent Terra tree/delta review: pass

No original PR was retargeted, closed, merged, or otherwise mutated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon ownership and worker spawn env for a security-sensitive coordination path; behavior shifts if anything relied on overriding the registry env var.
> 
> **Overview**
> **Pins the daemon supervisor registry directory** so ownership, startup fences, and recovered workers all use the same on-disk authority instead of re-resolving from ambient `process.env` on each call.
> 
> `DaemonSupervisor` captures `supervisorRegistryDir` at startup and passes it into `waitForDaemonStartupFence`, `acquireDaemonSupervisorOwnership`, and every worker spawn. Worker `env` sets `PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR` **after** inherited and caller `launchEnv`, so untrusted overrides cannot redirect registry access. `defaultDaemonSupervisorRegistryDir` is renamed/exported as `getDaemonSupervisorRegistryDir` with the env constant exported for tests and spawn wiring.
> 
> Tests assert both initial and relaunched workers receive the supervisor’s registry path and that `launchEnv` cannot smuggle a different directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240b4543277c96988ae7dd6f3681a6d276374e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve daemon supervisor registry authority across recovered workers
> - Exports `DAEMON_SUPERVISOR_REGISTRY_DIR_ENV` and renames `defaultDaemonSupervisorRegistryDir` to `getDaemonSupervisorRegistryDir` in [daemon-supervisor-ownership.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1336/files#diff-6f9ef6ce6a9d2bc51c61fe94d59310efffd26d8f7b3966f5355606b2847d06a5) so other modules can resolve the registry directory consistently.
> - `DaemonSupervisor` now captures a single `supervisorRegistryDir` at startup and passes it explicitly to fencing and ownership calls, preventing drift between restarts.
> - When spawning worker processes, the supervisor injects `DAEMON_SUPERVISOR_REGISTRY_DIR_ENV` into the worker environment after merging all other env vars, so a caller-supplied value cannot override the supervisor's registry directory.
> - Risk: workers that previously relied on inheriting or overriding the registry env var will now always use the supervisor-enforced value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 240b454.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->