### PR TITLE
[v0.8 MCP 5] enforce project MCP trust boundaries

### DIFF
--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -150,6 +150,13 @@ export const COMMAND_SPECS: readonly CommandSpec[] = [
 		usage: "config",
 		summary: "Configure package resources",
 	},
+	{
+		path: ["mcp"],
+		usage: "mcp <list|inspect|preview|test|add|enable|disable|remove> ... [--project]",
+		summary: "Manage declarative MCP endpoint records",
+		description:
+			"Commands only read or write credential-free declarations. They never start an MCP runtime or authentication flow. A test probe requires an injected local transport.",
+	},
 ];
 
 export const PUBLIC_COMMAND_NAMES = new Set(

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -155,7 +155,47 @@ export const COMMAND_SPECS: readonly CommandSpec[] = [
 		usage: "mcp <list|inspect|preview|test|add|enable|disable|remove> ... [--project]",
 		summary: "Manage declarative MCP endpoint records",
 		description:
-			"Commands only read or write credential-free declarations. They never start an MCP runtime or authentication flow. A test probe requires an injected local transport.",
+			"Commands only read or write credential-free declarations. They never start an MCP runtime or authentication flow. A test probe returns an offline preview.",
+	},
+	{
+		path: ["mcp", "list"],
+		usage: "mcp list [--project]",
+		summary: "List declared MCP endpoints",
+	},
+	{
+		path: ["mcp", "inspect"],
+		usage: "mcp inspect <name> [--project]",
+		summary: "Inspect an MCP endpoint declaration",
+	},
+	{
+		path: ["mcp", "preview"],
+		usage: "mcp preview <name> [--project]",
+		summary: "Preview an MCP endpoint declaration",
+	},
+	{
+		path: ["mcp", "test"],
+		usage: "mcp test <name> [--project]",
+		summary: "Preview the MCP initialization request",
+	},
+	{
+		path: ["mcp", "add"],
+		usage: "mcp add <name> <url> [--project]",
+		summary: "Add an MCP endpoint declaration",
+	},
+	{
+		path: ["mcp", "enable"],
+		usage: "mcp enable <name> [--project]",
+		summary: "Enable an MCP endpoint declaration",
+	},
+	{
+		path: ["mcp", "disable"],
+		usage: "mcp disable <name> [--project]",
+		summary: "Disable an MCP endpoint declaration",
+	},
+	{
+		path: ["mcp", "remove"],
+		usage: "mcp remove <name> [--project]",
+		summary: "Remove an MCP endpoint declaration",
 	},
 ];
 

--- a/packages/coding-agent/src/cli/public-command.ts
+++ b/packages/coding-agent/src/cli/public-command.ts
@@ -1,5 +1,12 @@
 import chalk from "chalk";
 import { APP_NAME, SELF_UPDATE_INTERACTIVE_CHILD_ENV } from "../config.js";
+import { executeMcpDeclarationCommand, parseMcpDeclarationCommand } from "../core/mcp/mcp-declaration-command.js";
+import {
+	admitGlobalMcpProjectDeclarations,
+	McpProjectDeclarationReader,
+} from "../core/mcp/mcp-project-declaration-reader.js";
+import { releaseProjectMcpDeclarationAdmission } from "../core/mcp/mcp-project-trust.js";
+import { type Settings, SettingsManager } from "../core/settings-manager.js";
 import { handlePackageCommand, isSelfUpdateSource } from "../package-manager-cli.js";
 import { INTERNAL_RUNTIME_COMMAND_MARKER, parseArgs } from "./args.js";
 import {
@@ -140,9 +147,60 @@ async function runPublicCommand(args: string[]): Promise<PublicCommandResult> {
 		case "config":
 			if (!requireArgumentCount(args.slice(1), 0, "config")) return HANDLED;
 			return continueWith(args);
+		case "mcp":
+			return runMcpDeclarationCommand(args.slice(1));
 		default:
 			return continueWith(args);
 	}
+}
+
+/**
+ * Sole public-command composition point for project MCP policy. It receives a
+ * SettingsManager already loaded by the CLI and reads only its global snapshot.
+ * A project settings value can never create a grant.
+ */
+export function composeMcpProjectDeclarationAdmission(
+	command: ReturnType<typeof parseMcpDeclarationCommand>,
+	globalSettings: Pick<Settings, "mcpProjectTrustPolicy">,
+	workingDirectory: string,
+) {
+	if (command.scope !== "project") return undefined;
+	// The only raw-path authorization. Downstream receives no path or authority
+	// policy, only the opaque admission returned by the shared global composer.
+	return admitGlobalMcpProjectDeclarations(globalSettings, workingDirectory);
+}
+
+async function runMcpDeclarationCommand(args: string[]): Promise<PublicCommandResult> {
+	const command = parseMcpDeclarationCommand(args);
+	const workingDirectory = process.cwd();
+	if (command.scope === "project") {
+		// This global-only read deliberately precedes SettingsManager.create(): a
+		// denied/missing/malformed policy must never open project settings.
+		const admission = composeMcpProjectDeclarationAdmission(
+			command,
+			SettingsManager.loadGlobalSettings(workingDirectory),
+			workingDirectory,
+		);
+		if (!admission) throw new Error("Project MCP declarations are unavailable.");
+		// Do not construct SettingsManager here: it eagerly reads project scope.
+		// This capability-scoped adapter validates around every declaration I/O.
+		try {
+			const reader = await McpProjectDeclarationReader.create(admission);
+			const settings = reader.asCommandSettings();
+			const result = await executeMcpDeclarationCommand(command, settings as SettingsManager, admission);
+			await settings.flush();
+			console.log(JSON.stringify(result, null, 2));
+			return HANDLED;
+		} finally {
+			releaseProjectMcpDeclarationAdmission(admission);
+		}
+	}
+	// User declarations retain the existing full settings behavior.
+	const settings = SettingsManager.create(workingDirectory);
+	const result = await executeMcpDeclarationCommand(command, settings);
+	await settings.flush();
+	console.log(JSON.stringify(result, null, 2));
+	return HANDLED;
 }
 
 function normalizeLeadingDaemonSocketOption(args: string[]): string[] {

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -12,6 +12,12 @@ import type { AgentRlmHeartbeatController } from "./cron-jobs.js";
 import { createHerdrAgentStateExtension } from "./extensions/builtin/herdr-agent-state.js";
 import type { SessionStartEvent, ToolDefinition } from "./extensions/index.js";
 import { McpManager } from "./mcp/mcp-manager.js";
+import { composeMcpProjectDeclarationReader } from "./mcp/mcp-project-declaration-reader.js";
+import {
+	type ProjectMcpDeclarationAdmission,
+	validateProjectMcpDeclarationAdmission,
+} from "./mcp/mcp-project-trust.js";
+import { createMcpRuntimeDeclarationSnapshot } from "./mcp/mcp-runtime-declaration-snapshot.js";
 import { ModelRegistry } from "./model-registry.js";
 import { DefaultResourceLoader, type DefaultResourceLoaderOptions, type ResourceLoader } from "./resource-loader.js";
 import type { SubagentRuntimeHost } from "./rlm-runtime.js";
@@ -44,6 +50,8 @@ export interface CreateAgentSessionServicesOptions {
 	agentDir?: string;
 	authStorage?: AuthStorage;
 	settingsManager?: SettingsManager;
+	/** Explicit opaque admission for an injected manager; absence is fail-closed. */
+	projectMcpAdmission?: ProjectMcpDeclarationAdmission;
 	modelRegistry?: ModelRegistry;
 	extensionFlagValues?: Map<string, boolean | string>;
 	resourceLoaderOptions?: Omit<DefaultResourceLoaderOptions, "cwd" | "agentDir" | "settingsManager">;
@@ -180,78 +188,110 @@ export async function createAgentSessionServices(
 	const cwd = options.cwd;
 	const agentDir = options.agentDir ?? getAgentDir();
 	const authStorage = options.authStorage ?? AuthStorage.create(join(agentDir, "auth.json"));
-	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
-	const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, join(agentDir, "models.json"));
-
-	// MCP integrations: registers OAuth providers and gates the built-in
-	// integration skills by whether the user is logged in (enable-by-login).
-	const mcpManager = new McpManager({
-		authStorage,
-		getUserServers: () => settingsManager.getMcpServers(),
-	});
-	// refresh() resets the OAuth registry to built-ins; re-add user MCP providers too.
-	modelRegistry.setOnOAuthProvidersReset(() => mcpManager.registerUserProviders());
-
-	const userExtensionFactories = options.resourceLoaderOptions?.extensionFactories ?? [];
-	// The built-in Herdr reporter defers to Herdr's own file-based integration
-	// when the loader actually loaded it; two reporters would race on the same
-	// pane. Deferral is late-bound to the loader's loaded paths (inline
-	// factories run after file extensions load), so a file that exists but is
-	// disabled or never discovered does not silence the built-in.
-	// noExtensions is a full opt-out: it disables the built-in reporter too,
-	// not just discovered extension files.
-	const skipHerdrReporter = options.noBuiltinHerdrReporter || options.resourceLoaderOptions?.noExtensions;
-	const builtinExtensionFactories = skipHerdrReporter
-		? []
-		: [createHerdrAgentStateExtension(() => resourceLoader.getLoadedExtensionPaths())];
-	const resourceLoader: DefaultResourceLoader = new DefaultResourceLoader({
-		...(options.resourceLoaderOptions ?? {}),
-		extensionFactories: [...builtinExtensionFactories, ...userExtensionFactories],
+	// Compose the global-only admission and scoped reader before SettingsManager
+	// can load project state. Injected managers remain project-inert unless the
+	// caller carries an explicit opaque admission.
+	const { projectMcpAdmission, projectReader, releaseProjectMcpAdmission } = await composeMcpProjectDeclarationReader({
 		cwd,
 		agentDir,
-		settingsManager,
-		extraBuiltinSkillOverrides: () => mcpManager.getDisabledBuiltinSkillOverrides(),
+		settingsManager: options.settingsManager,
+		projectMcpAdmission: options.projectMcpAdmission,
 	});
-	await resourceLoader.reload();
+	try {
+		const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
+		const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, join(agentDir, "models.json"));
 
-	const diagnostics: AgentSessionRuntimeDiagnostic[] = [];
-	if (
-		!options.telemetryDisabled &&
-		isTelemetryEnabled(settingsManager) &&
-		!settingsManager.getTelemetryNoticeShown()
-	) {
-		diagnostics.push({
-			type: "info",
-			message:
-				"Prime Agent sends pseudonymous usage and performance metrics without prompts, responses, tool content, file paths, or repository data. Disable this with telemetry.enabled=false, PRIME_AGENT_TELEMETRY=0, DO_NOT_TRACK=1, or offline mode.",
+		// A single declaration-only snapshot is captured before any legacy manager
+		// behavior. The scoped reader validates its opaque admission around every
+		// project filesystem operation.
+		const runtimeMcpDeclarations = createMcpRuntimeDeclarationSnapshot({
+			userDocument: settingsManager.getMcpDeclarationDocument("user"),
+			projectAdmission: projectMcpAdmission,
+			readProjectDocument: projectReader
+				? () => {
+						try {
+							return projectReader.getDocument();
+						} catch (error) {
+							// Root replacement/revocation during the scoped callback discards
+							// only the project contribution. Genuine still-authorized I/O or
+							// parse errors retain their normal failure behavior.
+							if (validateProjectMcpDeclarationAdmission(projectMcpAdmission).kind === "granted") throw error;
+							return undefined;
+						}
+					}
+				: undefined,
 		});
-		settingsManager.setTelemetryNoticeShown(true);
-	}
-	const extensionsResult = resourceLoader.getExtensions();
-	for (const { name, config, extensionPath } of extensionsResult.runtime.pendingProviderRegistrations) {
-		try {
-			modelRegistry.registerProvider(name, config);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			diagnostics.push({
-				type: "error",
-				message: `Extension "${extensionPath}" error: ${message}`,
-			});
-		}
-	}
-	extensionsResult.runtime.pendingProviderRegistrations = [];
-	diagnostics.push(...applyExtensionFlagValues(resourceLoader, options.extensionFlagValues));
+		const mcpManager = new McpManager({
+			authStorage,
+			getUserServers: () => settingsManager.getGlobalMcpServers(),
+			getRuntimeDeclarations: () => runtimeMcpDeclarations,
+		});
+		// refresh() resets the OAuth registry to built-ins; re-add user MCP providers too.
+		modelRegistry.setOnOAuthProvidersReset(() => mcpManager.registerUserProviders());
 
-	return {
-		cwd,
-		agentDir,
-		authStorage,
-		settingsManager,
-		modelRegistry,
-		resourceLoader,
-		mcpManager,
-		diagnostics,
-	};
+		const userExtensionFactories = options.resourceLoaderOptions?.extensionFactories ?? [];
+		// The built-in Herdr reporter defers to Herdr's own file-based integration
+		// when the loader actually loaded it; two reporters would race on the same
+		// pane. Deferral is late-bound to the loader's loaded paths (inline
+		// factories run after file extensions load), so a file that exists but is
+		// disabled or never discovered does not silence the built-in.
+		// noExtensions is a full opt-out: it disables the built-in reporter too,
+		// not just discovered extension files.
+		const skipHerdrReporter = options.noBuiltinHerdrReporter || options.resourceLoaderOptions?.noExtensions;
+		const builtinExtensionFactories = skipHerdrReporter
+			? []
+			: [createHerdrAgentStateExtension(() => resourceLoader.getLoadedExtensionPaths())];
+		const resourceLoader: DefaultResourceLoader = new DefaultResourceLoader({
+			...(options.resourceLoaderOptions ?? {}),
+			extensionFactories: [...builtinExtensionFactories, ...userExtensionFactories],
+			cwd,
+			agentDir,
+			settingsManager,
+			extraBuiltinSkillOverrides: () => mcpManager.getDisabledBuiltinSkillOverrides(),
+		});
+		await resourceLoader.reload();
+
+		const diagnostics: AgentSessionRuntimeDiagnostic[] = [];
+		if (
+			!options.telemetryDisabled &&
+			isTelemetryEnabled(settingsManager) &&
+			!settingsManager.getTelemetryNoticeShown()
+		) {
+			diagnostics.push({
+				type: "info",
+				message:
+					"Prime Agent sends pseudonymous usage and performance metrics without prompts, responses, tool content, file paths, or repository data. Disable this with telemetry.enabled=false, PRIME_AGENT_TELEMETRY=0, DO_NOT_TRACK=1, or offline mode.",
+			});
+			settingsManager.setTelemetryNoticeShown(true);
+		}
+		const extensionsResult = resourceLoader.getExtensions();
+		for (const { name, config, extensionPath } of extensionsResult.runtime.pendingProviderRegistrations) {
+			try {
+				modelRegistry.registerProvider(name, config);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				diagnostics.push({
+					type: "error",
+					message: `Extension "${extensionPath}" error: ${message}`,
+				});
+			}
+		}
+		extensionsResult.runtime.pendingProviderRegistrations = [];
+		diagnostics.push(...applyExtensionFlagValues(resourceLoader, options.extensionFlagValues));
+
+		return {
+			cwd,
+			agentDir,
+			authStorage,
+			settingsManager,
+			modelRegistry,
+			resourceLoader,
+			mcpManager,
+			diagnostics,
+		};
+	} finally {
+		releaseProjectMcpAdmission?.();
+	}
 }
 
 /**

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -77,6 +77,21 @@ export {
 	type TurnStartEvent,
 	type WorkingIndicatorOptions,
 } from "./extensions/index.js";
+export {
+	type CreateMcpRuntimeDeclarationSnapshotInput,
+	createMcpRuntimeDeclarationSnapshot,
+	type McpRuntimeDeclaration,
+	type McpRuntimeDeclarationSnapshot,
+	type McpRuntimeDeclarationSource,
+} from "./mcp/mcp-runtime-declaration-snapshot.js";
+export {
+	createMcpProjectTrustAuthority,
+	type McpProjectTrustAuthority,
+	type McpProjectTrustAuthorityInput,
+	type McpProjectTrustAuthorization,
+	type McpProjectTrustBinding,
+	type McpProjectTrustBindingValidation,
+} from "./mcp/project-trust-authority.js";
 export type { RefinementResult } from "./refinement/index.js";
 export type { CreateRlmSubagentRuntimeOptions, RlmSubagentRuntime, SubagentRuntimeHost } from "./rlm-runtime.js";
 export { SessionImportFileNotFoundError } from "./session-import-errors.js";

--- a/packages/coding-agent/src/core/mcp/mcp-declaration-command.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-declaration-command.ts
@@ -1,0 +1,103 @@
+import type { SettingsManager } from "../settings-manager.js";
+import {
+	addMcpDeclaration,
+	type McpDeclarationScope,
+	parseMcpDeclarationDocument,
+	removeMcpDeclaration,
+} from "./mcp-declarations.js";
+import { previewMcpDeclarationProbe } from "./mcp-probe.js";
+import { type ProjectMcpDeclarationAdmission, requireProjectMcpDeclarationAdmission } from "./mcp-project-trust.js";
+import { redactMcpDeclaration, redactMcpDeclarationDocument } from "./mcp-redaction.js";
+
+export type McpDeclarationCommand =
+	| { kind: "list"; scope: McpDeclarationScope }
+	| { kind: "inspect"; scope: McpDeclarationScope; name: string }
+	| { kind: "preview"; scope: McpDeclarationScope; name: string }
+	| { kind: "test"; scope: McpDeclarationScope; name: string }
+	| { kind: "add"; scope: McpDeclarationScope; name: string; url: string }
+	| { kind: "enable" | "disable" | "remove"; scope: McpDeclarationScope; name: string };
+
+function usage(): never {
+	throw new Error("Usage: prime-agent mcp <list|inspect|preview|test|add|enable|disable|remove> ... [--project]");
+}
+
+function parseScope(words: string[]): { words: string[]; scope: McpDeclarationScope } {
+	const projectIndexes: number[] = [];
+	for (const [index, word] of words.entries()) {
+		if (word === "--project") projectIndexes.push(index);
+	}
+	if (projectIndexes.length > 1 || (projectIndexes.length === 1 && projectIndexes[0] !== words.length - 1)) usage();
+	return { words: words.filter((word) => word !== "--project"), scope: projectIndexes.length ? "project" : "user" };
+}
+
+/** Parses declarative commands only. Parsing has no storage, auth, or I/O side effects. */
+export function parseMcpDeclarationCommand(args: string[]): McpDeclarationCommand {
+	const { words, scope } = parseScope(args);
+	const [kind, ...operands] = words;
+	if (kind === "list" && operands.length === 0) return { kind, scope };
+	if (
+		(kind === "inspect" ||
+			kind === "preview" ||
+			kind === "test" ||
+			kind === "enable" ||
+			kind === "disable" ||
+			kind === "remove") &&
+		operands.length === 1
+	) {
+		return { kind, scope, name: operands[0]! };
+	}
+	if (kind === "add" && operands.length === 2) return { kind, scope, name: operands[0]!, url: operands[1]! };
+	usage();
+}
+
+function documentForScope(
+	settings: SettingsManager,
+	scope: McpDeclarationScope,
+	admission: ProjectMcpDeclarationAdmission | undefined,
+) {
+	// Validate before every project settings read; this is intentionally before
+	// getMcpDeclarationDocument so denied state is inert without a project read.
+	if (scope === "project") requireProjectMcpDeclarationAdmission(admission);
+	return settings.getMcpDeclarationDocument(scope);
+}
+
+function writeDocumentForScope(
+	settings: SettingsManager,
+	scope: McpDeclarationScope,
+	document: ReturnType<typeof parseMcpDeclarationDocument>,
+	admission: ProjectMcpDeclarationAdmission | undefined,
+): void {
+	// Validate again at each privileged mutation; no raw path is available here.
+	if (scope === "project") requireProjectMcpDeclarationAdmission(admission);
+	settings.setMcpDeclarationDocument(scope, document);
+}
+
+export async function executeMcpDeclarationCommand(
+	command: McpDeclarationCommand,
+	settings: SettingsManager,
+	admission?: ProjectMcpDeclarationAdmission,
+): Promise<unknown> {
+	const document = documentForScope(settings, command.scope, admission);
+	if (command.kind === "list") return redactMcpDeclarationDocument(document);
+	const declaration = Object.hasOwn(document.servers, command.name) ? document.servers[command.name] : undefined;
+	if (command.kind === "add") {
+		const next = addMcpDeclaration(document, command.name, command.url);
+		writeDocumentForScope(settings, command.scope, next, admission);
+		return redactMcpDeclaration(next.servers[command.name]!);
+	}
+	if (!declaration) throw new Error("No MCP declaration has that name.");
+	if (command.kind === "inspect") return redactMcpDeclaration(declaration);
+	if (command.kind === "preview" || command.kind === "test") {
+		return previewMcpDeclarationProbe(redactMcpDeclaration(declaration));
+	}
+	if (command.kind === "remove") {
+		writeDocumentForScope(settings, command.scope, removeMcpDeclaration(document, command.name), admission);
+		return { removed: command.name };
+	}
+	const next = parseMcpDeclarationDocument({
+		version: 1,
+		servers: { ...document.servers, [command.name]: { ...declaration, enabled: command.kind === "enable" } },
+	});
+	writeDocumentForScope(settings, command.scope, next, admission);
+	return redactMcpDeclaration(next.servers[command.name]!);
+}

--- a/packages/coding-agent/src/core/mcp/mcp-declarations.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-declarations.ts
@@ -1,0 +1,183 @@
+/**
+ * M01's declarative, credential-free MCP record. This module has no transport,
+ * authentication, or process-launch dependency.
+ */
+export const MCP_DECLARATION_VERSION = 1 as const;
+export const MCP_DECLARATION_NAME = /^[a-z][a-z0-9-]{0,62}$/;
+
+export interface McpDeclaration {
+	name: string;
+	url: string;
+	enabled: boolean;
+}
+
+export interface McpDeclarationDocument {
+	version: typeof MCP_DECLARATION_VERSION;
+	servers: Record<string, McpDeclaration>;
+}
+
+export type McpDeclarationScope = "user" | "project";
+
+function fail(message: string): never {
+	// Deliberately never include supplied configuration values in errors: callers
+	// may have provided an accidentally credential-bearing URL or field.
+	throw new Error(message);
+}
+
+/**
+ * Configuration crosses a hostile-data boundary. Only ordinary (or null
+ * prototype) records with enumerable own data properties are accepted. This
+ * intentionally rejects accessors, inherited fields, symbols, and exotic
+ * prototype chains before any configured value is read.
+ */
+function ownDataRecord(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	try {
+		const prototype = Object.getPrototypeOf(value);
+		if (prototype !== Object.prototype && prototype !== null) return false;
+		if (Object.getOwnPropertySymbols(value).length !== 0) return false;
+		for (const key of Object.getOwnPropertyNames(value)) {
+			const descriptor = Object.getOwnPropertyDescriptor(value, key);
+			if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) return false;
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function ownDataKeys(record: Record<string, unknown>, message: string): string[] {
+	if (!ownDataRecord(record)) fail(message);
+	try {
+		return Object.getOwnPropertyNames(record);
+	} catch {
+		return fail(message);
+	}
+}
+
+function ownDataValue(record: Record<string, unknown>, key: string, message: string): unknown {
+	try {
+		const descriptor = Object.getOwnPropertyDescriptor(record, key);
+		if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) fail(message);
+		return descriptor.value;
+	} catch {
+		return fail(message);
+	}
+}
+
+export function normalizeMcpDeclarationName(value: unknown): string {
+	if (typeof value !== "string" || !MCP_DECLARATION_NAME.test(value)) {
+		fail(
+			"MCP declaration names must start with a lowercase letter and contain lowercase letters, digits, or hyphens.",
+		);
+	}
+	return value;
+}
+
+/** Canonical, non-credential-bearing Streamable HTTP endpoint identity. */
+export function normalizeMcpDeclarationUrl(value: unknown): string {
+	if (typeof value !== "string" || /[\s\\]/.test(value)) {
+		fail("MCP declaration URLs must be a single HTTP(S) URL.");
+	}
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		fail("MCP declaration URLs must be a valid HTTP(S) URL.");
+	}
+	if (url.protocol !== "https:" && url.protocol !== "http:") {
+		fail("MCP declaration URLs must use HTTP or HTTPS.");
+	}
+	if (url.username || url.password || url.search || url.hash) {
+		fail("MCP declaration URLs must not contain credentials, query strings, or fragments.");
+	}
+	return url.toString();
+}
+
+function requireExactKeys(record: Record<string, unknown>, keys: readonly string[], message: string): void {
+	const actual = ownDataKeys(record, message);
+	if (actual.length !== keys.length || actual.some((key) => !keys.includes(key))) fail(message);
+}
+
+export function parseMcpDeclaration(value: unknown, expectedName?: string): McpDeclaration {
+	if (!ownDataRecord(value)) fail("MCP declaration must be a plain object with own data fields.");
+	requireExactKeys(value, ["name", "url", "enabled"], "MCP declarations only permit name, url, and enabled fields.");
+	const name = normalizeMcpDeclarationName(
+		ownDataValue(value, "name", "MCP declaration name must be an own data field."),
+	);
+	if (expectedName !== undefined && name !== expectedName) {
+		fail("MCP declaration name must match its settings key.");
+	}
+	const enabled = ownDataValue(value, "enabled", "MCP declaration enabled must be an own data field.");
+	if (typeof enabled !== "boolean") fail("MCP declaration enabled must be a boolean.");
+	return {
+		name,
+		url: normalizeMcpDeclarationUrl(ownDataValue(value, "url", "MCP declaration URL must be an own data field.")),
+		enabled,
+	};
+}
+
+export function emptyMcpDeclarationDocument(): McpDeclarationDocument {
+	return { version: MCP_DECLARATION_VERSION, servers: {} };
+}
+
+export function parseMcpDeclarationDocument(value: unknown): McpDeclarationDocument {
+	if (value === undefined) return emptyMcpDeclarationDocument();
+	if (!ownDataRecord(value)) fail("MCP declaration settings must be a plain object with own data fields.");
+	requireExactKeys(value, ["version", "servers"], "MCP declarations only permit version and servers fields.");
+	if (
+		ownDataValue(value, "version", "MCP declaration version must be an own data field.") !== MCP_DECLARATION_VERSION
+	) {
+		fail("MCP declaration settings use an unsupported format.");
+	}
+	const rawServers = ownDataValue(value, "servers", "MCP declaration servers must be an own data field.");
+	if (!ownDataRecord(rawServers)) fail("MCP declaration settings use an unsupported format.");
+
+	const servers: Record<string, McpDeclaration> = {};
+	const urls = new Set<string>();
+	for (const key of ownDataKeys(rawServers, "MCP declaration servers must be plain own data.")) {
+		const name = normalizeMcpDeclarationName(key);
+		const parsed = parseMcpDeclaration(
+			ownDataValue(rawServers, key, "MCP declaration server must be an own data field."),
+			name,
+		);
+		if (urls.has(parsed.url)) fail("MCP declarations must not repeat an endpoint URL.");
+		urls.add(parsed.url);
+		Object.defineProperty(servers, name, { value: parsed, enumerable: true, configurable: true, writable: true });
+	}
+	return { version: MCP_DECLARATION_VERSION, servers };
+}
+
+export function addMcpDeclaration(
+	document: McpDeclarationDocument,
+	name: unknown,
+	url: unknown,
+): McpDeclarationDocument {
+	const parsedName = normalizeMcpDeclarationName(name);
+	const parsedUrl = normalizeMcpDeclarationUrl(url);
+	if (Object.hasOwn(document.servers, parsedName)) fail("An MCP declaration with that name already exists.");
+	if (Object.values(document.servers).some((server) => server.url === parsedUrl)) {
+		fail("An MCP declaration with that endpoint URL already exists.");
+	}
+	return {
+		version: MCP_DECLARATION_VERSION,
+		servers: { ...document.servers, [parsedName]: { name: parsedName, url: parsedUrl, enabled: true } },
+	};
+}
+
+export function removeMcpDeclaration(document: McpDeclarationDocument, name: unknown): McpDeclarationDocument {
+	const parsedName = normalizeMcpDeclarationName(name);
+	if (!Object.hasOwn(document.servers, parsedName)) fail("No MCP declaration has that name.");
+	const { [parsedName]: _removed, ...servers } = document.servers;
+	return { version: MCP_DECLARATION_VERSION, servers };
+}
+
+/** A static probe request description. Creating it never performs I/O. */
+export function previewMcpProbe(declaration: McpDeclaration): {
+	url: string;
+	method: "POST";
+	redirect: "error";
+	requestKind: "mcp-initialize";
+} {
+	return { url: declaration.url, method: "POST", redirect: "error", requestKind: "mcp-initialize" };
+}

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -11,6 +11,7 @@ import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/
 import type { AuthStorage } from "../auth-storage.js";
 import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandlers } from "../kernel/index.js";
 import type { McpServerConfig } from "../settings-manager.js";
+import type { McpRuntimeDeclarationSnapshot } from "./mcp-runtime-declaration-snapshot.js";
 
 export interface McpManagerOptions {
 	authStorage: AuthStorage;
@@ -18,6 +19,8 @@ export interface McpManagerOptions {
 	getUserServers?: () => Record<string, McpServerConfig> | undefined;
 	/** Start an interactive host-side login for a server. Provided by the UI mode. */
 	beginLogin?: (server: string) => Promise<void>;
+	/** Immutable declaration-only snapshot; never becomes integration config. */
+	getRuntimeDeclarations?: () => McpRuntimeDeclarationSnapshot;
 }
 
 /** A resolved integration: a catalog/user entry plus its provider id. */
@@ -38,6 +41,7 @@ export class McpManager {
 	private readonly authStorage: AuthStorage;
 	private readonly getUserServers: () => Record<string, McpServerConfig> | undefined;
 	private readonly beginLogin?: (server: string) => Promise<void>;
+	private readonly getRuntimeDeclarations: () => McpRuntimeDeclarationSnapshot | undefined;
 	private integrations = new Map<string, ResolvedIntegration>();
 	/** Provider ids we registered for user servers, so refresh can drop removed ones. */
 	private registeredUserProviderIds = new Set<string>();
@@ -46,8 +50,17 @@ export class McpManager {
 		this.authStorage = options.authStorage;
 		this.getUserServers = options.getUserServers ?? (() => undefined);
 		this.beginLogin = options.beginLogin;
+		this.getRuntimeDeclarations = options.getRuntimeDeclarations ?? (() => undefined);
 		this.resolveIntegrations();
 		this.registerProviders();
+	}
+
+	/**
+	 * Narrow internal declaration consumer. This deliberately returns no raw
+	 * settings and is never consulted by OAuth, host handlers, or transports.
+	 */
+	getDeclarationSnapshot(): McpRuntimeDeclarationSnapshot | undefined {
+		return this.getRuntimeDeclarations();
 	}
 
 	/** Re-read settings and re-register providers; call after a session reload. */

--- a/packages/coding-agent/src/core/mcp/mcp-probe.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-probe.ts
@@ -1,0 +1,13 @@
+import { type McpDeclaration, previewMcpProbe } from "./mcp-declarations.js";
+
+/**
+ * A declaration-only probe contract. It describes the single request a future
+ * transport boundary may make, but never opens a session or reaches a network.
+ * Transport ownership belongs to the runtime boundary layer.
+ */
+export type McpDeclarationProbePreview = ReturnType<typeof previewMcpProbe>;
+
+/** Returns a bounded, offline preview for an already-validated declaration. */
+export function previewMcpDeclarationProbe(declaration: McpDeclaration): McpDeclarationProbePreview {
+	return previewMcpProbe(declaration);
+}

--- a/packages/coding-agent/src/core/mcp/mcp-project-declaration-reader.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-project-declaration-reader.ts
@@ -1,0 +1,117 @@
+import { type Settings, SettingsManager } from "../settings-manager.js";
+import type { McpDeclarationDocument } from "./mcp-declarations.js";
+import {
+	admitProjectMcpDeclarations,
+	type ProjectMcpDeclarationAdmission,
+	releaseProjectMcpDeclarationAdmission,
+	requireProjectMcpDeclarationAdmission,
+	validateProjectMcpDeclarationAdmission,
+} from "./mcp-project-trust.js";
+import { ProjectSettingsOpenat } from "./project-settings-openat.js";
+import { createMcpProjectTrustAuthority } from "./project-trust-authority.js";
+
+/** Compose an opaque project admission from a global-only policy snapshot. */
+export function admitGlobalMcpProjectDeclarations(
+	globalSettings: Pick<Settings, "mcpProjectTrustPolicy"> | undefined,
+	cwd: string,
+): ProjectMcpDeclarationAdmission | undefined {
+	const policy = globalSettings?.mcpProjectTrustPolicy;
+	if (!policy) return undefined;
+	const authority = createMcpProjectTrustAuthority({
+		revision: typeof policy.revision === "string" ? policy.revision : "",
+		allowedProjectDirectories:
+			Array.isArray(policy.allowedProjectDirectories) &&
+			policy.allowedProjectDirectories.every((path) => typeof path === "string")
+				? policy.allowedProjectDirectories
+				: [],
+	});
+	return admitProjectMcpDeclarations(cwd, authority);
+}
+
+export interface McpProjectDeclarationReaderComposition {
+	projectMcpAdmission?: ProjectMcpDeclarationAdmission;
+	projectReader?: McpProjectDeclarationReader;
+	/** Present only for an admission made by this composition, never an injection. */
+	releaseProjectMcpAdmission?: () => void;
+}
+
+/**
+ * Builds the sole descriptor-relative declaration seam before ordinary project
+ * settings may be observed. Kernel discovery begins only after admission.
+ */
+export async function composeMcpProjectDeclarationReader(options: {
+	cwd: string;
+	agentDir: string;
+	settingsManager?: SettingsManager;
+	projectMcpAdmission?: ProjectMcpDeclarationAdmission;
+}): Promise<McpProjectDeclarationReaderComposition> {
+	const globalSettings = options.settingsManager
+		? undefined
+		: SettingsManager.loadGlobalSettings(options.cwd, options.agentDir);
+	const internallyAdmitted = options.projectMcpAdmission === undefined;
+	const projectMcpAdmission =
+		options.projectMcpAdmission ?? admitGlobalMcpProjectDeclarations(globalSettings, options.cwd);
+	if (!projectMcpAdmission) return {};
+	try {
+		return {
+			projectMcpAdmission,
+			projectReader: await McpProjectDeclarationReader.create(projectMcpAdmission),
+			...(internallyAdmitted
+				? { releaseProjectMcpAdmission: () => releaseProjectMcpDeclarationAdmission(projectMcpAdmission) }
+				: {}),
+		};
+	} catch (error) {
+		const stillGranted = validateProjectMcpDeclarationAdmission(projectMcpAdmission).kind === "granted";
+		if (internallyAdmitted) releaseProjectMcpDeclarationAdmission(projectMcpAdmission);
+		if (stillGranted) throw error;
+		return {};
+	}
+}
+
+/** The project-MCP-only storage seam. Ordinary SettingsManager behavior remains unchanged. */
+export class McpProjectDeclarationReader {
+	private constructor(
+		private readonly admission: ProjectMcpDeclarationAdmission,
+		private readonly settings: ProjectSettingsOpenat,
+	) {}
+
+	static async create(admission: ProjectMcpDeclarationAdmission): Promise<McpProjectDeclarationReader> {
+		requireProjectMcpDeclarationAdmission(admission);
+		return new McpProjectDeclarationReader(admission, await ProjectSettingsOpenat.create(admission));
+	}
+
+	private assertAvailable(): void {
+		requireProjectMcpDeclarationAdmission(this.admission);
+	}
+
+	getDocument(): McpDeclarationDocument {
+		this.assertAvailable();
+		return this.settings.getDocument();
+	}
+
+	setDocument(document: McpDeclarationDocument): void {
+		this.assertAvailable();
+		this.settings.setDocument(document);
+	}
+
+	/** Adapter limited to executeMcpDeclarationCommand's three methods. */
+	asCommandSettings(): {
+		getMcpDeclarationDocument(scope: "user" | "project"): McpDeclarationDocument;
+		setMcpDeclarationDocument(scope: "user" | "project", document: McpDeclarationDocument): void;
+		flush(): Promise<void>;
+	} {
+		return {
+			getMcpDeclarationDocument: (scope) => {
+				if (scope !== "project") throw new Error("Project MCP declarations are unavailable.");
+				return this.getDocument();
+			},
+			setMcpDeclarationDocument: (scope, document) => {
+				if (scope !== "project") throw new Error("Project MCP declarations are unavailable.");
+				this.setDocument(document);
+			},
+			flush: async () => {
+				this.assertAvailable();
+			},
+		};
+	}
+}

--- a/packages/coding-agent/src/core/mcp/mcp-project-trust.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-project-trust.ts
@@ -1,0 +1,113 @@
+import { emptyMcpDeclarationDocument, type McpDeclarationDocument } from "./mcp-declarations.js";
+import type {
+	McpProjectTrustAuthority,
+	McpProjectTrustAuthorization,
+	McpProjectTrustBinding,
+	McpProjectTrustBindingValidation,
+} from "./project-trust-authority.js";
+import {
+	isMcpProjectTrustAuthority,
+	releaseMcpProjectTrustBinding,
+	withValidatedMcpProjectTrustBinding,
+} from "./project-trust-authority.js";
+
+/** A branded, empty capability whose trust pair stays module-private. */
+export interface ProjectMcpDeclarationAdmission {}
+interface AdmissionPair {
+	readonly authority: McpProjectTrustAuthority;
+	readonly binding: McpProjectTrustBinding;
+}
+const admissions = new WeakSet<object>();
+const releasedAdmissions = new WeakSet<object>();
+const admissionPairs = new WeakMap<object, AdmissionPair>();
+const DENIED: McpProjectTrustBindingValidation = Object.freeze({ kind: "denied" });
+const GRANTED: McpProjectTrustBindingValidation = Object.freeze({ kind: "granted" });
+
+function pairFor(admission: ProjectMcpDeclarationAdmission | undefined): AdmissionPair | undefined {
+	// Membership strictly precedes map access: no forged accessor runs.
+	if (
+		typeof admission !== "object" ||
+		admission === null ||
+		!admissions.has(admission) ||
+		releasedAdmissions.has(admission)
+	)
+		return undefined;
+	return admissionPairs.get(admission);
+}
+
+export function admitProjectMcpDeclarations(
+	rawProjectDirectory: string,
+	authority: McpProjectTrustAuthority | undefined,
+): ProjectMcpDeclarationAdmission | undefined {
+	if (!isMcpProjectTrustAuthority(authority)) return undefined;
+	let authorization: McpProjectTrustAuthorization;
+	try {
+		authorization = authority.authorizeProjectDirectory(rawProjectDirectory);
+	} catch {
+		return undefined;
+	}
+	if (authorization.kind !== "granted") return undefined;
+	// The authority minted and owns the descriptor before publishing this opaque admission.
+	if (withValidatedMcpProjectTrustBinding(authorization.binding, () => true) !== true) {
+		releaseMcpProjectTrustBinding(authorization.binding);
+		return undefined;
+	}
+	const admission = Object.freeze(Object.create(null));
+	admissions.add(admission);
+	admissionPairs.set(admission, Object.freeze({ authority, binding: authorization.binding }));
+	return admission as ProjectMcpDeclarationAdmission;
+}
+
+export function releaseProjectMcpDeclarationAdmission(admission: ProjectMcpDeclarationAdmission | undefined): void {
+	const pair = pairFor(admission);
+	if (!pair || !admission || releasedAdmissions.has(admission as object)) return;
+	releasedAdmissions.add(admission as object);
+	releaseMcpProjectTrustBinding(pair.binding);
+}
+
+export function validateProjectMcpDeclarationAdmission(
+	admission: ProjectMcpDeclarationAdmission | undefined,
+): McpProjectTrustBindingValidation {
+	const pair = pairFor(admission);
+	if (!pair) return DENIED;
+	try {
+		return pair.authority.validateBinding(pair.binding).kind === "granted" ? GRANTED : DENIED;
+	} catch {
+		return DENIED;
+	}
+}
+
+/** The only descriptor route from a genuine admission; it never reopens cwd. */
+export function withValidatedProjectMcpDeclarationAdmission<T>(
+	admission: ProjectMcpDeclarationAdmission | undefined,
+	operation: (rootFd: number) => T,
+): T | undefined {
+	const pair = pairFor(admission);
+	if (!pair || validateProjectMcpDeclarationAdmission(admission).kind !== "granted") return undefined;
+	try {
+		return withValidatedMcpProjectTrustBinding(pair.binding, operation);
+	} catch {
+		return undefined;
+	}
+}
+
+export function requireProjectMcpDeclarationAdmission(
+	admission: ProjectMcpDeclarationAdmission | undefined,
+): ProjectMcpDeclarationAdmission {
+	if (validateProjectMcpDeclarationAdmission(admission).kind !== "granted")
+		throw new Error("Project MCP declarations are unavailable.");
+	return admission!;
+}
+
+export interface ProjectMcpDeclarations {
+	document: McpDeclarationDocument;
+	effective: boolean;
+}
+export function resolveProjectMcpDeclarations(
+	document: McpDeclarationDocument,
+	admission: ProjectMcpDeclarationAdmission | undefined,
+): ProjectMcpDeclarations {
+	if (validateProjectMcpDeclarationAdmission(admission).kind !== "granted")
+		return { document: emptyMcpDeclarationDocument(), effective: false };
+	return { document: structuredClone(document), effective: true };
+}

--- a/packages/coding-agent/src/core/mcp/mcp-redaction.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-redaction.ts
@@ -1,0 +1,37 @@
+import type { McpDeclaration, McpDeclarationDocument } from "./mcp-declarations.js";
+
+const SENSITIVE_KEY = /(?:authorization|credential|secret|token|password|api[_-]?key|cookie|header)/i;
+
+/**
+ * Redact arbitrary persisted MCP-shaped data before rendering it. This is
+ * intentionally defensive even though M01 declarations reject such fields.
+ */
+export function redactMcpValue(value: unknown, key = ""): unknown {
+	if (SENSITIVE_KEY.test(key)) return "<redacted>";
+	if (typeof value === "string") {
+		if (key === "url") {
+			try {
+				const url = new URL(value);
+				if (url.username || url.password || url.search || url.hash) return "<redacted-url>";
+			} catch {
+				return "<redacted-url>";
+			}
+		}
+		return value;
+	}
+	if (Array.isArray(value)) return value.map((entry) => redactMcpValue(entry));
+	if (typeof value === "object" && value !== null) {
+		return Object.fromEntries(
+			Object.entries(value).map(([childKey, child]) => [childKey, redactMcpValue(child, childKey)]),
+		);
+	}
+	return value;
+}
+
+export function redactMcpDeclaration(declaration: McpDeclaration): McpDeclaration {
+	return structuredClone(redactMcpValue(declaration) as McpDeclaration);
+}
+
+export function redactMcpDeclarationDocument(document: McpDeclarationDocument): McpDeclarationDocument {
+	return structuredClone(redactMcpValue(document) as McpDeclarationDocument);
+}

--- a/packages/coding-agent/src/core/mcp/mcp-runtime-declaration-snapshot.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-runtime-declaration-snapshot.ts
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import { type McpDeclaration, type McpDeclarationDocument, parseMcpDeclarationDocument } from "./mcp-declarations.js";
+import { type ProjectMcpDeclarationAdmission, validateProjectMcpDeclarationAdmission } from "./mcp-project-trust.js";
+
+export type McpRuntimeDeclarationSource = "user" | "project";
+
+/** A declaration-only record. No credential, auth, transport, or launch state is admitted. */
+export interface McpRuntimeDeclaration {
+	readonly name: string;
+	readonly endpoint: string;
+	readonly enabled: boolean;
+	readonly source: McpRuntimeDeclarationSource;
+}
+
+/**
+ * An immutable decision detached from settings and raw project paths. The
+ * revision covers the complete ordered selection, including disabled entries.
+ */
+export interface McpRuntimeDeclarationSnapshot {
+	readonly revision: string;
+	readonly declarations: Readonly<Record<string, McpRuntimeDeclaration>>;
+}
+
+export interface CreateMcpRuntimeDeclarationSnapshotInput {
+	/** Already-read user/global declarations. They are parsed before selection. */
+	readonly userDocument?: unknown;
+	/** Missing, forged, stale, or foreign admissions are fail-closed. */
+	readonly projectAdmission?: ProjectMcpDeclarationAdmission;
+	/** Never invoked unless the opaque admission validates first. */
+	readonly readProjectDocument?: () => unknown;
+}
+
+function compareCodePoints(left: string, right: string): number {
+	let leftOffset = 0;
+	let rightOffset = 0;
+	while (leftOffset < left.length && rightOffset < right.length) {
+		const leftPoint = left.codePointAt(leftOffset)!;
+		const rightPoint = right.codePointAt(rightOffset)!;
+		if (leftPoint !== rightPoint) return leftPoint < rightPoint ? -1 : 1;
+		leftOffset += leftPoint > 0xffff ? 2 : 1;
+		rightOffset += rightPoint > 0xffff ? 2 : 1;
+	}
+	return leftOffset === left.length && rightOffset === right.length ? 0 : leftOffset === left.length ? -1 : 1;
+}
+
+function compareNames(left: McpRuntimeDeclaration, right: McpRuntimeDeclaration): number {
+	return compareCodePoints(left.name, right.name);
+}
+
+function freezeDeclaration(declaration: McpRuntimeDeclaration): McpRuntimeDeclaration {
+	return Object.freeze({
+		name: declaration.name,
+		endpoint: declaration.endpoint,
+		enabled: declaration.enabled,
+		source: declaration.source,
+	});
+}
+
+function parseDocument(value: unknown, source: McpRuntimeDeclarationSource): McpRuntimeDeclaration[] {
+	// Reuse the M01 parser: it rejects own accessors, inherited fields, symbols,
+	// exotic prototypes, duplicate endpoints, and malformed URL shapes.
+	const document: McpDeclarationDocument = parseMcpDeclarationDocument(value);
+	const declarations: McpRuntimeDeclaration[] = [];
+	for (const name of Object.getOwnPropertyNames(document.servers)) {
+		const declaration: McpDeclaration = document.servers[name]!;
+		declarations.push({ name: declaration.name, endpoint: declaration.url, enabled: declaration.enabled, source });
+	}
+	return declarations.sort(compareNames);
+}
+
+function snapshotRevision(declarations: readonly McpRuntimeDeclaration[]): string {
+	const canonical = declarations.map(({ name, endpoint, enabled, source }) => [name, endpoint, enabled, source]);
+	return createHash("sha256")
+		.update(JSON.stringify([1, canonical]))
+		.digest("hex");
+}
+
+/**
+ * Select global declarations first. A name or endpoint collision makes the
+ * complete project contribution inert, preventing partial shadow-dependent
+ * configuration. Both selection and resulting records are frozen snapshots.
+ */
+export function createMcpRuntimeDeclarationSnapshot(
+	input: CreateMcpRuntimeDeclarationSnapshotInput = {},
+): McpRuntimeDeclarationSnapshot {
+	const user = parseDocument(input.userDocument, "user");
+	const selected = [...user];
+	const userNames = new Set(user.map((declaration) => declaration.name));
+	const userEndpoints = new Set(user.map((declaration) => declaration.endpoint));
+
+	let project: McpRuntimeDeclaration[] | undefined;
+	if (input.readProjectDocument) {
+		// The first check is deliberately before the callback. A revoked grant
+		// therefore cannot cause even the scoped reader to touch project state.
+		if (validateProjectMcpDeclarationAdmission(input.projectAdmission).kind === "granted") {
+			const rawProjectDocument = input.readProjectDocument();
+			// A root swap during the callback is fail-closed before parsing or use.
+			if (validateProjectMcpDeclarationAdmission(input.projectAdmission).kind === "granted") {
+				const parsedProject = parseDocument(rawProjectDocument, "project");
+				// Parsing can invoke no declarations, but it is still between trust
+				// decisions: do not retain data if validity changed meanwhile.
+				if (validateProjectMcpDeclarationAdmission(input.projectAdmission).kind === "granted") {
+					project = parsedProject;
+				}
+			}
+		}
+	}
+	if (
+		project &&
+		!project.some((declaration) => userNames.has(declaration.name) || userEndpoints.has(declaration.endpoint))
+	) {
+		selected.push(...project);
+	}
+
+	selected.sort(compareNames);
+	const declarations = Object.create(null) as Record<string, McpRuntimeDeclaration>;
+	for (const declaration of selected) {
+		Object.defineProperty(declarations, declaration.name, {
+			value: freezeDeclaration(declaration),
+			enumerable: true,
+			configurable: false,
+			writable: false,
+		});
+	}
+	const snapshot = Object.freeze({ revision: snapshotRevision(selected), declarations: Object.freeze(declarations) });
+	// Validate after freezing, immediately before publication. A swap at any
+	// point from callback entry through immutable-output construction leaves only
+	// the independent user contribution.
+	if (project && validateProjectMcpDeclarationAdmission(input.projectAdmission).kind !== "granted") {
+		const userDeclarations = Object.create(null) as Record<string, McpRuntimeDeclaration>;
+		for (const declaration of user) {
+			Object.defineProperty(userDeclarations, declaration.name, {
+				value: freezeDeclaration(declaration),
+				enumerable: true,
+				configurable: false,
+				writable: false,
+			});
+		}
+		return Object.freeze({
+			revision: snapshotRevision(user),
+			declarations: Object.freeze(userDeclarations),
+		});
+	}
+	return snapshot;
+}

--- a/packages/coding-agent/src/core/mcp/project-settings-openat.ts
+++ b/packages/coding-agent/src/core/mcp/project-settings-openat.ts
@@ -1,0 +1,258 @@
+import { spawnSync } from "node:child_process";
+import { constants, realpathSync, statSync } from "node:fs";
+import { isAbsolute } from "node:path";
+import { ensureKernelPython } from "../kernel/bootstrap.js";
+import { type McpDeclarationDocument, parseMcpDeclarationDocument } from "./mcp-declarations.js";
+import {
+	type ProjectMcpDeclarationAdmission,
+	withValidatedProjectMcpDeclarationAdmission,
+} from "./mcp-project-trust.js";
+
+const MAX_BYTES = 128 * 1024;
+const TIMEOUT_MS = 5_000;
+
+/** stdlib-only; receives a bounded action/document JSON on stdin and trusted root on fd 3. */
+const OPENAT_HELPER = String.raw`import json, os, secrets, signal, stat, sys, time
+MAX=131072
+interrupted=False
+cleaning=False
+class Interrupted(Exception): pass
+def interrupt(_signum,_frame):
+ global interrupted
+ interrupted=True
+ # Raise outside cleanup so blocking Python operations unwind immediately.
+ # Once authoritative cleanup starts, only record the signal and finish it.
+ if not cleaning: raise Interrupted()
+signal.signal(signal.SIGTERM,interrupt)
+signal.signal(signal.SIGINT,interrupt)
+# SIGKILL cannot run cleanup. Its lock deliberately remains fail-closed until
+# manual removal, rather than permitting unsafe stale-lock reclamation.
+def reject(_=None): raise ValueError("invalid")
+def unique(pairs):
+ d={}
+ for k,v in pairs:
+  if k in d: reject()
+  d[k]=v
+ return d
+def load(raw): return json.loads(raw,parse_constant=reject,object_pairs_hook=unique)
+def dflags(): return os.O_RDONLY|os.O_DIRECTORY|os.O_NOFOLLOW
+def directory(parent,name,create):
+ try: return os.open(name,dflags(),dir_fd=parent)
+ except FileNotFoundError:
+  if not create: raise
+  os.mkdir(name,0o700,dir_fd=parent)
+  return os.open(name,dflags(),dir_fd=parent)
+def regular(parent,name,create=False):
+ flags=os.O_RDONLY|os.O_NOFOLLOW
+ if create: flags=os.O_WRONLY|os.O_CREAT|os.O_EXCL|os.O_NOFOLLOW
+ fd=os.open(name,flags,0o600,dir_fd=parent)
+ if not stat.S_ISREG(os.fstat(fd).st_mode): os.close(fd); reject()
+ return fd
+def read(agent):
+ try: fd=regular(agent,"settings.json")
+ except FileNotFoundError: return {}
+ try:
+  data=bytearray()
+  while True:
+   part=os.read(fd,65536)
+   if not part: break
+   data.extend(part)
+   if len(data)>MAX: reject()
+  doc=load(bytes(data).decode("utf-8"))
+  if not isinstance(doc,dict): reject()
+  return doc
+ finally: os.close(fd)
+def acquire(agent):
+ deadline=time.monotonic()+0.25
+ while True:
+  try:
+   os.mkdir("settings.json.lock",0o700,dir_fd=agent)
+   try: return directory(agent,"settings.json.lock",False)
+   except Exception:
+    try: os.rmdir("settings.json.lock",dir_fd=agent)
+    finally: raise
+  except FileExistsError:
+   # Retry only a genuine no-follow directory owned by another participant.
+   # Regular files and symlinks are hostile/legacy poison and fail closed.
+   try: existing=directory(agent,"settings.json.lock",False)
+   except FileNotFoundError:
+    if time.monotonic()>=deadline: reject()
+    continue
+   os.close(existing)
+   if time.monotonic()>=deadline: reject()
+   time.sleep(0.02)
+def write(agent,declarations):
+ owned=False; lockdir=None; temp=None; tempname=None
+ try:
+  blocked={signal.SIGTERM,signal.SIGINT}
+  previous=signal.pthread_sigmask(signal.SIG_BLOCK,blocked)
+  try: lockdir=acquire(agent); owned=True
+  finally: signal.pthread_sigmask(signal.SIG_SETMASK,previous)
+  doc=read(agent); doc["mcpDeclarations"]=declarations
+  raw=(json.dumps(doc,ensure_ascii=False,allow_nan=False,indent=2,separators=(",", ":"))+"\n").encode("utf-8")
+  if len(raw)>MAX: reject()
+  for _ in range(16):
+   candidate=".settings.json."+secrets.token_hex(16)+".tmp"
+   try: temp=regular(agent,candidate,True); tempname=candidate; break
+   except FileExistsError: pass
+  if temp is None: reject()
+  try:
+   offset=0
+   while offset<len(raw):
+    count=os.write(temp,raw[offset:])
+    if count<=0: reject()
+    offset+=count
+   os.fsync(temp)
+  finally: os.close(temp); temp=None
+  os.replace(tempname,"settings.json",src_dir_fd=agent,dst_dir_fd=agent); tempname=None; os.fsync(agent)
+ finally:
+  global cleaning
+  cleaning=True
+  if temp is not None: os.close(temp)
+  if tempname is not None:
+   try: os.unlink(tempname,dir_fd=agent)
+   except FileNotFoundError: pass
+  if lockdir is not None:
+   # Match proper-lockfile's cooperative same-user protocol. POSIX has no
+   # portable identity-bound rmdir-by-fd; a project owner can already replace
+   # either participant's lock path. We never follow it and fail closed when
+   # this immediate no-follow identity check detects a mismatch.
+   opened=os.fstat(lockdir)
+   try: named=os.stat("settings.json.lock",dir_fd=agent,follow_symlinks=False)
+   except FileNotFoundError: named=None
+   if named is None or not stat.S_ISDIR(named.st_mode) or opened.st_dev!=named.st_dev or opened.st_ino!=named.st_ino:
+    os.close(lockdir); lockdir=None; reject()
+  if owned: os.rmdir("settings.json.lock",dir_fd=agent)
+  if lockdir is not None: os.close(lockdir)
+ cleaning=False
+ if interrupted: raise Interrupted()
+def main():
+ raw=sys.stdin.buffer.read(MAX+1)
+ if len(raw)>MAX: reject()
+ request=load(raw.decode("utf-8"))
+ if not isinstance(request,dict) or set(request)-{"action","document"}: reject()
+ action=request.get("action")
+ if not stat.S_ISDIR(os.fstat(3).st_mode): reject()
+ prime=agent=None
+ try:
+  try: prime=directory(3,".prime",action=="write"); agent=directory(prime,"agent",action=="write")
+  except FileNotFoundError:
+   if action=="read": print("{}"); return
+   raise
+  if action=="read":
+   doc=read(agent)
+   # Omission is the sole encoding for an absent declaration setting. This
+   # preserves an explicitly stored JSON null for the TypeScript parser to
+   # reject rather than conflating it with a fresh project.
+   if "mcpDeclarations" in doc:
+    print(json.dumps({"mcpDeclarations":doc["mcpDeclarations"]},ensure_ascii=False,allow_nan=False,separators=(",", ":")))
+   else: print("{}")
+  elif action=="write" and "document" in request: write(agent,request["document"]); print("{}")
+  else: reject()
+ finally:
+  if agent is not None: os.close(agent)
+  if prime is not None: os.close(prime)
+try: main()
+except Exception: sys.stderr.write("project settings helper failed\n"); sys.exit(1)
+`;
+
+function unavailable(): never {
+	// Never expose request, child stderr, settings, paths, or bootstrap diagnostics.
+	throw new Error("Project MCP declarations are unavailable.");
+}
+
+/** The managed kernel resolver is host authority and is never called pre-admission. */
+export async function resolveTrustedProjectSettingsPython(): Promise<string> {
+	try {
+		const python = await ensureKernelPython();
+		if (typeof python !== "string" || !isAbsolute(python)) unavailable();
+		const resolved = realpathSync.native(python);
+		const target = statSync(resolved);
+		if (!target.isFile() || (target.mode & constants.S_IXUSR) === 0) unavailable();
+		return resolved;
+	} catch {
+		unavailable();
+	}
+}
+
+/** POSIX descriptor-relative project settings storage; it has no project path API. */
+export class ProjectSettingsOpenat {
+	private constructor(
+		private readonly admission: ProjectMcpDeclarationAdmission,
+		private readonly python: string,
+	) {}
+
+	static async create(admission: ProjectMcpDeclarationAdmission): Promise<ProjectSettingsOpenat> {
+		// This genuine capability check intentionally occurs before interpreter discovery.
+		if (withValidatedProjectMcpDeclarationAdmission(admission, () => true) !== true) unavailable();
+		return new ProjectSettingsOpenat(admission, await resolveTrustedProjectSettingsPython());
+	}
+
+	private invoke(request: { action: "read" } | { action: "write"; document: McpDeclarationDocument }): unknown {
+		let input: string;
+		try {
+			input = JSON.stringify(request);
+		} catch {
+			unavailable();
+		}
+		if (Buffer.byteLength(input) > MAX_BYTES) unavailable();
+		try {
+			const result = withValidatedProjectMcpDeclarationAdmission(this.admission, (rootFd) =>
+				spawnSync(this.python, ["-I", "-c", OPENAT_HELPER], {
+					input,
+					encoding: "utf8",
+					timeout: TIMEOUT_MS,
+					// A signal racing after os.replace may report failure even though the
+					// atomic commit landed; SIGKILL leaves the lock for manual cleanup.
+					maxBuffer: MAX_BYTES,
+					stdio: ["pipe", "pipe", "pipe", rootFd],
+					shell: false,
+				}),
+			);
+			if (
+				!result ||
+				result.error ||
+				result.status !== 0 ||
+				typeof result.stdout !== "string" ||
+				Buffer.byteLength(result.stdout) > MAX_BYTES
+			)
+				unavailable();
+			try {
+				return JSON.parse(result.stdout);
+			} catch {
+				unavailable();
+			}
+		} catch {
+			unavailable();
+		}
+	}
+
+	getDocument(): McpDeclarationDocument {
+		const response = this.invoke({ action: "read" });
+		if (typeof response !== "object" || response === null || Array.isArray(response)) unavailable();
+		const keys = Object.keys(response);
+		if (keys.length > 1 || (keys.length === 1 && keys[0] !== "mcpDeclarations")) unavailable();
+		try {
+			// The helper omits this member only when the directory or setting is
+			// genuinely absent. An explicit stored null remains data and is rejected
+			// by the declaration parser below.
+			return parseMcpDeclarationDocument(
+				Object.hasOwn(response, "mcpDeclarations")
+					? (response as { mcpDeclarations: unknown }).mcpDeclarations
+					: undefined,
+			);
+		} catch {
+			unavailable();
+		}
+	}
+
+	setDocument(document: McpDeclarationDocument): void {
+		let parsed: McpDeclarationDocument;
+		try {
+			parsed = parseMcpDeclarationDocument(document);
+		} catch {
+			unavailable();
+		}
+		this.invoke({ action: "write", document: parsed! });
+	}
+}

--- a/packages/coding-agent/src/core/mcp/project-trust-authority.ts
+++ b/packages/coding-agent/src/core/mcp/project-trust-authority.ts
@@ -1,0 +1,232 @@
+import { createHash } from "node:crypto";
+import { accessSync, closeSync, constants, fstatSync, lstatSync, openSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+/** Explicit policy input from a global, user-owned authority. */
+export interface McpProjectTrustAuthorityInput {
+	readonly revision: string;
+	readonly allowedProjectDirectories: readonly string[];
+}
+
+declare const mcpProjectTrustBindingBrand: unique symbol;
+export interface McpProjectTrustBinding {
+	readonly [mcpProjectTrustBindingBrand]: never;
+}
+
+export type McpProjectTrustAuthorization =
+	| { readonly kind: "denied" }
+	| { readonly kind: "granted"; readonly binding: McpProjectTrustBinding };
+export type McpProjectTrustBindingValidation = { readonly kind: "denied" } | { readonly kind: "granted" };
+
+export interface McpProjectTrustAuthority {
+	authorizeProjectDirectory(projectDirectory: string): McpProjectTrustAuthorization;
+	validateBinding(binding: unknown): McpProjectTrustBindingValidation;
+}
+
+interface DirectoryIdentity {
+	readonly canonicalPath: string;
+	readonly device: string;
+	readonly inode: string;
+}
+interface RetainedDirectory extends DirectoryIdentity {
+	readonly rootFd: number;
+}
+interface BindingRecord {
+	readonly authority: McpProjectTrustAuthority;
+	readonly revision: string;
+	readonly digest: string;
+	readonly identity: DirectoryIdentity;
+	readonly rootFd: number;
+}
+
+const DENIED: McpProjectTrustAuthorization = Object.freeze({ kind: "denied" });
+const BINDING_DENIED: McpProjectTrustBindingValidation = Object.freeze({ kind: "denied" });
+const BINDING_GRANTED: McpProjectTrustBindingValidation = Object.freeze({ kind: "granted" });
+const genuineAuthorities = new WeakSet<object>();
+const bindingRecords = new WeakMap<object, BindingRecord>();
+const releasedBindings = new WeakSet<object>();
+
+// The authority owns its pinned policy descriptors. Binding records retain the
+// authority strongly, so these cannot close while a live binding can use one.
+const authorityFinalizer = new FinalizationRegistry<readonly number[]>((rootFds) => {
+	for (const rootFd of rootFds) {
+		try {
+			closeSync(rootFd);
+		} catch {
+			/* best effort only */
+		}
+	}
+});
+
+export function isMcpProjectTrustAuthority(value: unknown): value is McpProjectTrustAuthority {
+	return typeof value === "object" && value !== null && genuineAuthorities.has(value);
+}
+
+function supportsRetainedDirectoryFd(): boolean {
+	return process.platform !== "win32" && constants.O_DIRECTORY !== undefined && constants.O_NOFOLLOW !== undefined;
+}
+
+function exactDirectoryIdentity(path: string): DirectoryIdentity | undefined {
+	if (!isAbsolute(path) || resolve(path) !== path) return undefined;
+	try {
+		const initial = lstatSync(path);
+		if (initial.isSymbolicLink() || !initial.isDirectory()) return undefined;
+		accessSync(path, constants.R_OK | constants.X_OK);
+		const canonicalPath = realpathSync.native(path);
+		if (canonicalPath !== path) return undefined;
+		const canonical = statSync(canonicalPath, { bigint: true });
+		if (!canonical.isDirectory()) return undefined;
+		accessSync(canonicalPath, constants.R_OK | constants.X_OK);
+		return { canonicalPath, device: canonical.dev.toString(), inode: canonical.ino.toString() };
+	} catch {
+		return undefined;
+	}
+}
+
+function openRetainedDirectory(path: string): RetainedDirectory | undefined {
+	if (!isAbsolute(path) || resolve(path) !== path) return undefined;
+	let rootFd: number | undefined;
+	try {
+		rootFd = openSync(path, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+		const opened = fstatSync(rootFd, { bigint: true });
+		if (!opened.isDirectory()) throw new Error("not a directory");
+		const identity = exactDirectoryIdentity(path);
+		if (!identity || opened.dev.toString() !== identity.device || opened.ino.toString() !== identity.inode)
+			throw new Error("directory changed during policy capture");
+		return { ...identity, rootFd };
+	} catch {
+		if (rootFd !== undefined)
+			try {
+				closeSync(rootFd);
+			} catch {
+				/* best effort only */
+			}
+		return undefined;
+	}
+}
+function digestSnapshot(revision: string, directories: readonly DirectoryIdentity[]): string {
+	return createHash("sha256")
+		.update(revision)
+		.update("\0")
+		.update(directories.map(({ canonicalPath, device, inode }) => `${canonicalPath}\0${device}\0${inode}`).join("\0"))
+		.digest("hex");
+}
+function sameIdentity(left: DirectoryIdentity, right: DirectoryIdentity): boolean {
+	return left.canonicalPath === right.canonicalPath && left.device === right.device && left.inode === right.inode;
+}
+function retainedDirectoryMatches(identity: DirectoryIdentity, rootFd: number): boolean {
+	try {
+		const current = fstatSync(rootFd, { bigint: true });
+		return (
+			current.isDirectory() &&
+			current.dev.toString() === identity.device &&
+			current.ino.toString() === identity.inode
+		);
+	} catch {
+		return false;
+	}
+}
+function retainedDescriptorMatches(record: BindingRecord): boolean {
+	return retainedDirectoryMatches(record.identity, record.rootFd);
+}
+
+/**
+ * Module-private binding ownership is the only route from a real admission to
+ * its root FD. It validates the retained descriptor and the current policy on
+ * both sides of the operation, preventing path ABA re-open races.
+ */
+export function withValidatedMcpProjectTrustBinding<T>(
+	binding: unknown,
+	operation: (rootFd: number) => T,
+): T | undefined {
+	if (typeof binding !== "object" || binding === null || releasedBindings.has(binding)) return undefined;
+	const record = bindingRecords.get(binding);
+	if (!record || !retainedDescriptorMatches(record) || record.authority.validateBinding(binding).kind !== "granted")
+		return undefined;
+	const result = operation(record.rootFd);
+	return retainedDescriptorMatches(record) && record.authority.validateBinding(binding).kind === "granted"
+		? result
+		: undefined;
+}
+
+/** Explicit release for a real binding; foreign/duplicate releases are inert. */
+export function releaseMcpProjectTrustBinding(binding: unknown): void {
+	if (typeof binding !== "object" || binding === null || releasedBindings.has(binding)) return;
+	const record = bindingRecords.get(binding);
+	if (!record) return;
+	releasedBindings.add(binding);
+	bindingRecords.delete(binding);
+}
+
+export function createMcpProjectTrustAuthority(input: McpProjectTrustAuthorityInput): McpProjectTrustAuthority {
+	const revision = typeof input.revision === "string" ? input.revision : "";
+	const requestedDirectories = Array.isArray(input.allowedProjectDirectories)
+		? [...input.allowedProjectDirectories]
+		: [];
+	const retained = supportsRetainedDirectoryFd()
+		? requestedDirectories.map((directory) =>
+				typeof directory === "string" ? openRetainedDirectory(directory) : undefined,
+			)
+		: [];
+	const valid =
+		supportsRetainedDirectoryFd() &&
+		revision.length > 0 &&
+		retained.every((identity): identity is RetainedDirectory => identity !== undefined) &&
+		new Set(retained.map((identity) => identity.canonicalPath)).size === retained.length;
+	if (!valid) {
+		for (const identity of retained) {
+			if (identity)
+				try {
+					closeSync(identity.rootFd);
+				} catch {
+					/* best effort only */
+				}
+		}
+	}
+	const snapshot = valid
+		? Object.freeze([...retained] as RetainedDirectory[])
+		: Object.freeze([] as RetainedDirectory[]);
+	const snapshotDigest = digestSnapshot(revision, snapshot);
+	const bindings = new WeakSet<object>();
+	const authority: McpProjectTrustAuthority = Object.freeze({
+		authorizeProjectDirectory(projectDirectory: string): McpProjectTrustAuthorization {
+			const requested = typeof projectDirectory === "string" ? exactDirectoryIdentity(projectDirectory) : undefined;
+			const approved = requested ? snapshot.find((candidate) => sameIdentity(candidate, requested)) : undefined;
+			if (!requested || !approved || !retainedDirectoryMatches(approved, approved.rootFd)) return DENIED;
+			const binding = Object.freeze(Object.create(null)) as McpProjectTrustBinding;
+			const record: BindingRecord = Object.freeze({
+				authority,
+				revision,
+				digest: snapshotDigest,
+				identity: approved,
+				rootFd: approved.rootFd,
+			});
+			bindings.add(binding);
+			bindingRecords.set(binding, record);
+			return Object.freeze({ kind: "granted", binding });
+		},
+		validateBinding(binding: unknown): McpProjectTrustBindingValidation {
+			if (typeof binding !== "object" || binding === null || !bindings.has(binding) || releasedBindings.has(binding))
+				return BINDING_DENIED;
+			const record = bindingRecords.get(binding);
+			const currentSnapshot = snapshot.map(({ canonicalPath }) => exactDirectoryIdentity(canonicalPath));
+			if (currentSnapshot.some((identity) => identity === undefined)) return BINDING_DENIED;
+			const current = currentSnapshot as DirectoryIdentity[];
+			if (
+				!record ||
+				record.authority !== authority ||
+				!retainedDescriptorMatches(record) ||
+				record.revision !== revision ||
+				record.digest !== snapshotDigest ||
+				!current.every((identity, index) => sameIdentity(snapshot[index]!, identity)) ||
+				digestSnapshot(revision, current) !== snapshotDigest ||
+				!snapshot.some((approved) => sameIdentity(approved, record.identity))
+			)
+				return BINDING_DENIED;
+			return BINDING_GRANTED;
+		},
+	});
+	genuineAuthorities.add(authority);
+	if (snapshot.length > 0) authorityFinalizer.register(authority, Object.freeze(snapshot.map(({ rootFd }) => rootFd)));
+	return authority;
+}

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -10,6 +10,12 @@ import type { AgentAutonomousConfig } from "./autonomous.js";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.js";
 import type { ExtensionRunner, LoadExtensionsResult, SessionStartEvent, ToolDefinition } from "./extensions/index.js";
 import { McpManager } from "./mcp/mcp-manager.js";
+import { composeMcpProjectDeclarationReader } from "./mcp/mcp-project-declaration-reader.js";
+import {
+	type ProjectMcpDeclarationAdmission,
+	validateProjectMcpDeclarationAdmission,
+} from "./mcp/mcp-project-trust.js";
+import { createMcpRuntimeDeclarationSnapshot } from "./mcp/mcp-runtime-declaration-snapshot.js";
 import { convertToLlm } from "./messages.js";
 import { ModelRegistry } from "./model-registry.js";
 import { findInitialModel } from "./model-resolver.js";
@@ -60,8 +66,13 @@ export interface CreateAgentSessionOptions extends AgentSessionCreationOptions {
 	/** Resource loader. When omitted, DefaultResourceLoader is used. */
 	resourceLoader?: ResourceLoader;
 
-	/** MCP integration manager. When omitted, MCP host handlers are not wired. */
+	/**
+	 * MCP integration manager. When omitted, the SDK creates a global-only
+	 * manager; an explicitly supplied manager is left untouched.
+	 */
 	mcpManager?: McpManager;
+	/** Explicit opaque project declaration admission for an injected settings manager. */
+	projectMcpAdmission?: ProjectMcpDeclarationAdmission;
 
 	/** Session manager. Default: SessionManager.create(cwd) */
 	sessionManager?: SessionManager;
@@ -163,247 +174,290 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const authStorage = options.authStorage ?? AuthStorage.create(authPath);
 	const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, modelsPath);
 
-	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
-	const sessionManager = options.sessionManager ?? SessionManager.create(cwd, getDefaultSessionDir(cwd, agentDir));
+	// An explicit manager is caller authority: do not compose an admission,
+	// construct a scoped reader, or capture declarations on its behalf.
+	const projectMcpComposition = options.mcpManager
+		? undefined
+		: await composeMcpProjectDeclarationReader({
+				cwd,
+				agentDir,
+				settingsManager: options.settingsManager,
+				projectMcpAdmission: options.projectMcpAdmission,
+			});
+	try {
+		const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
+		const sessionManager = options.sessionManager ?? SessionManager.create(cwd, getDefaultSessionDir(cwd, agentDir));
 
-	// Ensure MCP providers are registered and built-in MCP skills are gated by
-	// auth even on the bare SDK path (not just the CLI's createAgentSessionServices).
-	const mcpManager =
-		options.mcpManager ?? new McpManager({ authStorage, getUserServers: () => settingsManager.getMcpServers() });
-	modelRegistry.setOnOAuthProvidersReset(() => mcpManager.registerUserProviders());
+		// Default SDK managers only consume global legacy integrations and one
+		// immutable declaration snapshot. Explicit managers remain untouched.
+		const runtimeMcpDeclarations: ReturnType<typeof createMcpRuntimeDeclarationSnapshot> | undefined =
+			options.mcpManager
+				? undefined
+				: createMcpRuntimeDeclarationSnapshot({
+						userDocument: settingsManager.getMcpDeclarationDocument("user"),
+						projectAdmission: projectMcpComposition?.projectMcpAdmission,
+						readProjectDocument: projectMcpComposition?.projectReader
+							? () => {
+									try {
+										return projectMcpComposition.projectReader?.getDocument();
+									} catch (error) {
+										if (
+											validateProjectMcpDeclarationAdmission(projectMcpComposition.projectMcpAdmission)
+												.kind === "granted"
+										)
+											throw error;
+										return undefined;
+									}
+								}
+							: undefined,
+					});
+		const mcpManager =
+			options.mcpManager ??
+			new McpManager({
+				authStorage,
+				getUserServers: () => settingsManager.getGlobalMcpServers(),
+				getRuntimeDeclarations: () => runtimeMcpDeclarations!,
+			});
+		modelRegistry.setOnOAuthProvidersReset(() => mcpManager.registerUserProviders());
 
-	if (!resourceLoader) {
-		resourceLoader = new DefaultResourceLoader({
-			cwd,
-			agentDir,
-			settingsManager,
-			extraBuiltinSkillOverrides: () => mcpManager.getDisabledBuiltinSkillOverrides(),
-		});
-		await resourceLoader.reload();
-		time("resourceLoader.reload");
-	}
-
-	// Check if session has existing data to restore
-	const existingSession = sessionManager.buildSessionContext();
-	const hasExistingSession = existingSession.messages.length > 0;
-	const hasThinkingEntry = sessionManager.getBranch().some((entry) => entry.type === "thinking_level_change");
-	const hasServiceTierEntry = sessionManager.getBranch().some((entry) => entry.type === "service_tier_change");
-
-	let model = options.model;
-	let modelFallbackMessage: string | undefined;
-
-	// If session has data, try to restore model from it
-	if (!model && hasExistingSession && existingSession.model) {
-		const restoredModel = modelRegistry.find(existingSession.model.provider, existingSession.model.modelId);
-		if (restoredModel && modelRegistry.hasConfiguredAuth(restoredModel)) {
-			model = restoredModel;
+		if (!resourceLoader) {
+			resourceLoader = new DefaultResourceLoader({
+				cwd,
+				agentDir,
+				settingsManager,
+				extraBuiltinSkillOverrides: () => mcpManager.getDisabledBuiltinSkillOverrides(),
+			});
+			await resourceLoader.reload();
+			time("resourceLoader.reload");
 		}
+
+		// Check if session has existing data to restore
+		const existingSession = sessionManager.buildSessionContext();
+		const hasExistingSession = existingSession.messages.length > 0;
+		const hasThinkingEntry = sessionManager.getBranch().some((entry) => entry.type === "thinking_level_change");
+		const hasServiceTierEntry = sessionManager.getBranch().some((entry) => entry.type === "service_tier_change");
+
+		let model = options.model;
+		let modelFallbackMessage: string | undefined;
+
+		// If session has data, try to restore model from it
+		if (!model && hasExistingSession && existingSession.model) {
+			const restoredModel = modelRegistry.find(existingSession.model.provider, existingSession.model.modelId);
+			if (restoredModel && modelRegistry.hasConfiguredAuth(restoredModel)) {
+				model = restoredModel;
+			}
+			if (!model) {
+				modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;
+			}
+		}
+
+		// If still no model, use findInitialModel (checks settings default, then provider defaults)
 		if (!model) {
-			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;
+			const result = await findInitialModel({
+				scopedModels: [],
+				isContinuing: hasExistingSession,
+				defaultProvider: settingsManager.getDefaultProvider(),
+				defaultModelId: settingsManager.getDefaultModel(),
+				defaultThinkingLevel: settingsManager.getDefaultThinkingLevel(),
+				modelRegistry,
+			});
+			model = result.model;
+			if (!model) {
+				modelFallbackMessage = formatNoModelsAvailableMessage();
+			} else if (modelFallbackMessage) {
+				modelFallbackMessage += `. Using ${model.provider}/${model.id}`;
+			}
 		}
-	}
 
-	// If still no model, use findInitialModel (checks settings default, then provider defaults)
-	if (!model) {
-		const result = await findInitialModel({
-			scopedModels: [],
-			isContinuing: hasExistingSession,
-			defaultProvider: settingsManager.getDefaultProvider(),
-			defaultModelId: settingsManager.getDefaultModel(),
-			defaultThinkingLevel: settingsManager.getDefaultThinkingLevel(),
-			modelRegistry,
-		});
-		model = result.model;
+		let thinkingLevel = options.thinkingLevel;
+
+		// If session has data, restore thinking level from it
+		if (thinkingLevel === undefined && hasExistingSession) {
+			thinkingLevel = hasThinkingEntry
+				? (existingSession.thinkingLevel as ThinkingLevel)
+				: (settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL);
+		}
+
+		// Fall back to settings default
+		if (thinkingLevel === undefined) {
+			thinkingLevel = settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;
+		}
+
+		// Clamp to model capabilities
 		if (!model) {
-			modelFallbackMessage = formatNoModelsAvailableMessage();
-		} else if (modelFallbackMessage) {
-			modelFallbackMessage += `. Using ${model.provider}/${model.id}`;
+			thinkingLevel = "off";
+		} else {
+			thinkingLevel = clampThinkingLevel(model, thinkingLevel) as ThinkingLevel;
 		}
-	}
 
-	let thinkingLevel = options.thinkingLevel;
+		const serviceTierPreference =
+			options.serviceTier ??
+			(hasServiceTierEntry ? existingSession.serviceTier : settingsManager.getDefaultServiceTier());
+		const serviceTier =
+			serviceTierPreference === "priority" && (!model || !supportsFastMode(model))
+				? "default"
+				: serviceTierPreference;
 
-	// If session has data, restore thinking level from it
-	if (thinkingLevel === undefined && hasExistingSession) {
-		thinkingLevel = hasThinkingEntry
-			? (existingSession.thinkingLevel as ThinkingLevel)
-			: (settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL);
-	}
+		const allowedToolNames =
+			options.allowedToolNames ?? options.tools ?? (options.noTools === "all" ? [] : undefined);
+		const includeGoals = options.includeGoals ?? (options.tools !== undefined || options.noTools !== "all");
+		const initialActiveToolNames: string[] =
+			options.initialActiveToolNames ?? (options.tools ? [...options.tools] : options.noTools ? [] : ["ipython"]);
 
-	// Fall back to settings default
-	if (thinkingLevel === undefined) {
-		thinkingLevel = settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;
-	}
+		let agent: Agent;
 
-	// Clamp to model capabilities
-	if (!model) {
-		thinkingLevel = "off";
-	} else {
-		thinkingLevel = clampThinkingLevel(model, thinkingLevel) as ThinkingLevel;
-	}
-
-	const serviceTierPreference =
-		options.serviceTier ??
-		(hasServiceTierEntry ? existingSession.serviceTier : settingsManager.getDefaultServiceTier());
-	const serviceTier =
-		serviceTierPreference === "priority" && (!model || !supportsFastMode(model)) ? "default" : serviceTierPreference;
-
-	const allowedToolNames = options.allowedToolNames ?? options.tools ?? (options.noTools === "all" ? [] : undefined);
-	const includeGoals = options.includeGoals ?? (options.tools !== undefined || options.noTools !== "all");
-	const initialActiveToolNames: string[] =
-		options.initialActiveToolNames ?? (options.tools ? [...options.tools] : options.noTools ? [] : ["ipython"]);
-
-	let agent: Agent;
-
-	// Create convertToLlm wrapper that filters images if blockImages is enabled (defense-in-depth)
-	const convertToLlmWithBlockImages = (messages: AgentMessage[]): Message[] => {
-		const converted = convertToLlm(messages);
-		// Check setting dynamically so mid-session changes take effect
-		if (!settingsManager.getBlockImages()) {
-			return converted;
-		}
-		// Filter out ImageContent from all messages, replacing with text placeholder
-		return converted.map((msg) => {
-			if (msg.role === "user" || msg.role === "toolResult") {
-				const content = msg.content;
-				if (Array.isArray(content)) {
-					const hasImages = content.some((c) => c.type === "image");
-					if (hasImages) {
-						const filteredContent = content
-							.map((c) =>
-								c.type === "image" ? { type: "text" as const, text: "Image reading is disabled." } : c,
-							)
-							.filter(
-								(c, i, arr) =>
-									// Dedupe consecutive "Image reading is disabled." texts
-									!(
-										c.type === "text" &&
-										c.text === "Image reading is disabled." &&
-										i > 0 &&
-										arr[i - 1].type === "text" &&
-										(arr[i - 1] as { type: "text"; text: string }).text === "Image reading is disabled."
-									),
-							);
-						return { ...msg, content: filteredContent };
+		// Create convertToLlm wrapper that filters images if blockImages is enabled (defense-in-depth)
+		const convertToLlmWithBlockImages = (messages: AgentMessage[]): Message[] => {
+			const converted = convertToLlm(messages);
+			// Check setting dynamically so mid-session changes take effect
+			if (!settingsManager.getBlockImages()) {
+				return converted;
+			}
+			// Filter out ImageContent from all messages, replacing with text placeholder
+			return converted.map((msg) => {
+				if (msg.role === "user" || msg.role === "toolResult") {
+					const content = msg.content;
+					if (Array.isArray(content)) {
+						const hasImages = content.some((c) => c.type === "image");
+						if (hasImages) {
+							const filteredContent = content
+								.map((c) =>
+									c.type === "image" ? { type: "text" as const, text: "Image reading is disabled." } : c,
+								)
+								.filter(
+									(c, i, arr) =>
+										// Dedupe consecutive "Image reading is disabled." texts
+										!(
+											c.type === "text" &&
+											c.text === "Image reading is disabled." &&
+											i > 0 &&
+											arr[i - 1].type === "text" &&
+											(arr[i - 1] as { type: "text"; text: string }).text === "Image reading is disabled."
+										),
+								);
+							return { ...msg, content: filteredContent };
+						}
 					}
 				}
-			}
-			return msg;
+				return msg;
+			});
+		};
+
+		const extensionRunnerRef: { current?: ExtensionRunner } = {};
+
+		agent = new Agent({
+			initialState: {
+				systemPrompt: "",
+				model,
+				thinkingLevel,
+				serviceTier,
+				tools: [],
+			},
+			convertToLlm: convertToLlmWithBlockImages,
+			streamFn: async (model, context, options) => {
+				const auth = await modelRegistry.getApiKeyAndHeaders(model);
+				if (!auth.ok) {
+					throw new Error(auth.error);
+				}
+				const providerRetrySettings = settingsManager.getProviderRetrySettings();
+				return streamSimple(model, context, {
+					...options,
+					apiKey: auth.apiKey,
+					timeoutMs: options?.timeoutMs ?? providerRetrySettings.timeoutMs,
+					maxRetries: options?.maxRetries ?? providerRetrySettings.maxRetries,
+					maxRetryDelayMs: options?.maxRetryDelayMs ?? providerRetrySettings.maxRetryDelayMs,
+					headers: auth.headers || options?.headers ? { ...auth.headers, ...options?.headers } : undefined,
+				});
+			},
+			onPayload: async (payload, _model) => {
+				const runner = extensionRunnerRef.current;
+				if (!runner?.hasHandlers("before_provider_request")) {
+					return payload;
+				}
+				return runner.emitBeforeProviderRequest(payload);
+			},
+			onResponse: async (response, _model) => {
+				const runner = extensionRunnerRef.current;
+				if (!runner?.hasHandlers("after_provider_response")) {
+					return;
+				}
+				await runner.emit({
+					type: "after_provider_response",
+					status: response.status,
+					headers: response.headers,
+				});
+			},
+			sessionId: sessionManager.getSessionId(),
+			transformContext: async (messages) => {
+				const runner = extensionRunnerRef.current;
+				if (!runner) return messages;
+				return runner.emitContext(messages);
+			},
+			steeringMode: settingsManager.getSteeringMode(),
+			followUpMode: settingsManager.getFollowUpMode(),
+			transport: settingsManager.getTransport(),
+			thinkingBudgets: settingsManager.getThinkingBudgets(),
+			maxRetryDelayMs: settingsManager.getProviderRetrySettings().maxRetryDelayMs,
 		});
-	};
 
-	const extensionRunnerRef: { current?: ExtensionRunner } = {};
-
-	agent = new Agent({
-		initialState: {
-			systemPrompt: "",
-			model,
-			thinkingLevel,
-			serviceTier,
-			tools: [],
-		},
-		convertToLlm: convertToLlmWithBlockImages,
-		streamFn: async (model, context, options) => {
-			const auth = await modelRegistry.getApiKeyAndHeaders(model);
-			if (!auth.ok) {
-				throw new Error(auth.error);
+		// Restore messages if session has existing data
+		if (hasExistingSession) {
+			agent.state.messages = existingSession.messages;
+			if (!hasThinkingEntry) {
+				sessionManager.appendThinkingLevelChange(thinkingLevel);
 			}
-			const providerRetrySettings = settingsManager.getProviderRetrySettings();
-			return streamSimple(model, context, {
-				...options,
-				apiKey: auth.apiKey,
-				timeoutMs: options?.timeoutMs ?? providerRetrySettings.timeoutMs,
-				maxRetries: options?.maxRetries ?? providerRetrySettings.maxRetries,
-				maxRetryDelayMs: options?.maxRetryDelayMs ?? providerRetrySettings.maxRetryDelayMs,
-				headers: auth.headers || options?.headers ? { ...auth.headers, ...options?.headers } : undefined,
-			});
-		},
-		onPayload: async (payload, _model) => {
-			const runner = extensionRunnerRef.current;
-			if (!runner?.hasHandlers("before_provider_request")) {
-				return payload;
+		} else {
+			// Save initial configuration for new sessions so it can be restored on resume.
+			if (model) {
+				sessionManager.appendModelChange(model.provider, model.id);
 			}
-			return runner.emitBeforeProviderRequest(payload);
-		},
-		onResponse: async (response, _model) => {
-			const runner = extensionRunnerRef.current;
-			if (!runner?.hasHandlers("after_provider_response")) {
-				return;
-			}
-			await runner.emit({
-				type: "after_provider_response",
-				status: response.status,
-				headers: response.headers,
-			});
-		},
-		sessionId: sessionManager.getSessionId(),
-		transformContext: async (messages) => {
-			const runner = extensionRunnerRef.current;
-			if (!runner) return messages;
-			return runner.emitContext(messages);
-		},
-		steeringMode: settingsManager.getSteeringMode(),
-		followUpMode: settingsManager.getFollowUpMode(),
-		transport: settingsManager.getTransport(),
-		thinkingBudgets: settingsManager.getThinkingBudgets(),
-		maxRetryDelayMs: settingsManager.getProviderRetrySettings().maxRetryDelayMs,
-	});
-
-	// Restore messages if session has existing data
-	if (hasExistingSession) {
-		agent.state.messages = existingSession.messages;
-		if (!hasThinkingEntry) {
 			sessionManager.appendThinkingLevelChange(thinkingLevel);
 		}
-	} else {
-		// Save initial configuration for new sessions so it can be restored on resume.
-		if (model) {
-			sessionManager.appendModelChange(model.provider, model.id);
+		if (!hasServiceTierEntry) {
+			sessionManager.appendServiceTierChange(serviceTierPreference);
 		}
-		sessionManager.appendThinkingLevelChange(thinkingLevel);
-	}
-	if (!hasServiceTierEntry) {
-		sessionManager.appendServiceTierChange(serviceTierPreference);
-	}
 
-	const session = new AgentSession({
-		agent,
-		sessionManager,
-		settingsManager,
-		serviceTierPreference,
-		cwd,
-		// Only the explicit dir — the default may not match injected custom storage.
-		agentDir: options.agentDir,
-		scopedModels: options.scopedModels,
-		resourceLoader,
-		customTools: options.customTools,
-		modelRegistry,
-		mcpManager,
-		initialActiveToolNames,
-		allowedToolNames,
-		includeGoals,
-		includeCompactSkill: options.includeCompactSkill,
-		rlmHeartbeatController: options.rlmHeartbeatController,
-		agentMessageController: options.agentMessageController,
-		agentObserveController: options.agentObserveController,
-		extensionRunnerRef,
-		rlmDepth: options.rlmDepth,
-		rlmMaxDepth: options.rlmMaxDepth,
-		rlmSessionDir: options.rlmSessionDir,
-		rlmParentNodeId: options.rlmParentNodeId,
-		rlmParentAgent: options.rlmParentAgent,
-		subagentRuntimeHost: options.subagentRuntimeHost,
-		sessionStartEvent: options.sessionStartEvent,
-		prewarmIpythonKernel: options.prewarmIpythonKernel,
-		autonomous: options.autonomous,
-		serializedRefine: options.serializedRefine,
-		initialGoal: options.initialGoal,
-	});
-	const extensionsResult = resourceLoader.getExtensions();
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			serviceTierPreference,
+			cwd,
+			// Only the explicit dir — the default may not match injected custom storage.
+			agentDir: options.agentDir,
+			scopedModels: options.scopedModels,
+			resourceLoader,
+			customTools: options.customTools,
+			modelRegistry,
+			mcpManager,
+			initialActiveToolNames,
+			allowedToolNames,
+			includeGoals,
+			includeCompactSkill: options.includeCompactSkill,
+			rlmHeartbeatController: options.rlmHeartbeatController,
+			agentMessageController: options.agentMessageController,
+			agentObserveController: options.agentObserveController,
+			extensionRunnerRef,
+			rlmDepth: options.rlmDepth,
+			rlmMaxDepth: options.rlmMaxDepth,
+			rlmSessionDir: options.rlmSessionDir,
+			rlmParentNodeId: options.rlmParentNodeId,
+			rlmParentAgent: options.rlmParentAgent,
+			subagentRuntimeHost: options.subagentRuntimeHost,
+			sessionStartEvent: options.sessionStartEvent,
+			prewarmIpythonKernel: options.prewarmIpythonKernel,
+			autonomous: options.autonomous,
+			serializedRefine: options.serializedRefine,
+			initialGoal: options.initialGoal,
+		});
+		const extensionsResult = resourceLoader.getExtensions();
 
-	return {
-		session,
-		extensionsResult,
-		modelFallbackMessage,
-	};
+		return {
+			session,
+			extensionsResult,
+			modelFallbackMessage,
+		};
+	} finally {
+		projectMcpComposition?.releaseProjectMcpAdmission?.();
+	}
 }

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -4,6 +4,11 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
+import {
+	type McpDeclarationDocument,
+	type McpDeclarationScope,
+	parseMcpDeclarationDocument,
+} from "./mcp/mcp-declarations.js";
 
 const RECENT_MODELS_LIMIT = 20;
 export const DEFAULT_IDLE_EVICTION_MINUTES = 90;
@@ -119,6 +124,12 @@ export type McpServerConfig =
 			disabledTools?: string[];
 	  };
 
+/** Global-only Core policy snapshot for M01 project MCP admission. */
+export interface McpProjectTrustPolicy {
+	revision: string;
+	allowedProjectDirectories: string[];
+}
+
 export interface Settings {
 	onboardingShown?: boolean;
 	onboardingCompleted?: boolean;
@@ -144,7 +155,11 @@ export interface Settings {
 	quietStartup?: boolean;
 	shellCommandPrefix?: string; // Prefix prepended to every bash command (e.g., "shopt -s expand_aliases" for alias support)
 	npmCommand?: string[]; // Command used for npm package lookup/install operations, argv-style (e.g., ["mise", "exec", "node@20", "--", "npm"])
-	mcpServers?: Record<string, McpServerConfig>; // User-declared MCP servers (name → config); built-ins are in the ai/mcp catalog
+	mcpServers?: Record<string, McpServerConfig>; // Legacy runtime-owned MCP integrations; M01 does not read or write this field.
+	/** M01 credential-free MCP declarations. Project declarations remain inert without Core trust. */
+	mcpDeclarations?: McpDeclarationDocument;
+	/** Global-only M01 project policy; public composition ignores project-local copies. */
+	mcpProjectTrustPolicy?: McpProjectTrustPolicy;
 	packages?: PackageSource[]; // Array of npm/git package sources (string or object with filtering)
 	extensions?: string[]; // Array of local extension file paths or directories
 	skills?: string[]; // Array of local skill file paths or directories
@@ -333,10 +348,23 @@ export class SettingsManager {
 		this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
 	}
 
-	/** Create a SettingsManager that loads from files */
+	/** Create a SettingsManager that loads both global and project settings. */
 	static create(cwd: string, agentDir: string = getAgentDir()): SettingsManager {
 		const storage = new FileSettingsStorage(cwd, agentDir);
 		return SettingsManager.fromStorage(storage);
+	}
+
+	/**
+	 * Read only the global settings scope. Project MCP admission uses this before
+	 * it is allowed to open project settings, so no project storage is touched.
+	 */
+	static loadGlobalSettings(cwd: string, agentDir: string = getAgentDir()): Settings {
+		return SettingsManager.loadGlobalSettingsFromStorage(new FileSettingsStorage(cwd, agentDir));
+	}
+
+	/** Storage-level form for bounded callers and tests; it never reads project scope. */
+	static loadGlobalSettingsFromStorage(storage: SettingsStorage): Settings {
+		return SettingsManager.tryLoadFromStorage(storage, "global").settings;
 	}
 
 	/** Create a SettingsManager from an arbitrary storage backend */
@@ -1221,8 +1249,41 @@ export class SettingsManager {
 		return this.settings.enabledModels;
 	}
 
+	/** Legacy/UI view: project values continue to override global values here. */
 	getMcpServers(): Record<string, McpServerConfig> | undefined {
 		return this.settings.mcpServers;
+	}
+
+	/**
+	 * Host-owned MCP integrations use only this global view. Project settings
+	 * remain a UI/legacy overlay and cannot redirect host integration endpoints.
+	 */
+	getGlobalMcpServers(): Record<string, McpServerConfig> | undefined {
+		return structuredClone(this.globalSettings.mcpServers);
+	}
+
+	/** Read one M01 declaration document without merging user and project scope. */
+	getMcpDeclarationDocument(scope: McpDeclarationScope): McpDeclarationDocument {
+		const settings = scope === "user" ? this.globalSettings : this.projectSettings;
+		return parseMcpDeclarationDocument(settings.mcpDeclarations);
+	}
+
+	/**
+	 * Persist a parsed M01 declaration document in exactly one settings scope.
+	 * This never writes mcpServers, auth storage, or any credential-shaped value.
+	 */
+	setMcpDeclarationDocument(scope: McpDeclarationScope, document: McpDeclarationDocument): void {
+		const parsed = parseMcpDeclarationDocument(document);
+		if (scope === "user") {
+			this.globalSettings.mcpDeclarations = structuredClone(parsed);
+			this.markModified("mcpDeclarations");
+			this.save();
+			return;
+		}
+		const projectSettings = structuredClone(this.projectSettings);
+		projectSettings.mcpDeclarations = structuredClone(parsed);
+		this.markProjectModified("mcpDeclarations");
+		this.saveProjectSettings(projectSettings);
 	}
 
 	setEnabledModels(patterns: string[] | undefined): void {

--- a/packages/coding-agent/test/mcp-declarations.test.ts
+++ b/packages/coding-agent/test/mcp-declarations.test.ts
@@ -1,0 +1,277 @@
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createMcpProjectTrustAuthority, type McpProjectTrustAuthority } from "../src/core/index.js";
+import { executeMcpDeclarationCommand, parseMcpDeclarationCommand } from "../src/core/mcp/mcp-declaration-command.js";
+import {
+	addMcpDeclaration,
+	emptyMcpDeclarationDocument,
+	parseMcpDeclarationDocument,
+} from "../src/core/mcp/mcp-declarations.js";
+import {
+	admitProjectMcpDeclarations,
+	releaseProjectMcpDeclarationAdmission,
+	resolveProjectMcpDeclarations,
+} from "../src/core/mcp/mcp-project-trust.js";
+import { redactMcpValue } from "../src/core/mcp/mcp-redaction.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+
+const projectDocument = {
+	version: 1 as const,
+	servers: { catalog: { name: "catalog", url: "https://catalog.test/mcp", enabled: true } },
+};
+
+function fixture(): { directory: string; authority: McpProjectTrustAuthority; dispose(): void } {
+	const directory = realpathSync.native(mkdtempSync(join(tmpdir(), "m01-project-")));
+	return {
+		directory,
+		authority: createMcpProjectTrustAuthority({ revision: "test-policy", allowedProjectDirectories: [directory] }),
+		dispose: () => rmSync(directory, { recursive: true, force: true }),
+	};
+}
+
+describe("M01 declarative MCP contract", () => {
+	it("accepts only canonical credential-free declarations", () => {
+		const document = addMcpDeclaration(emptyMcpDeclarationDocument(), "public-docs", "HTTPS://Example.test:443/mcp");
+		expect(document).toEqual({
+			version: 1,
+			servers: { "public-docs": { name: "public-docs", url: "https://example.test/mcp", enabled: true } },
+		});
+		for (const url of [
+			"https://user:secret@example.test/mcp",
+			"https://example.test/mcp?token=secret",
+			"https://example.test/mcp#token",
+			"file:///tmp/mcp",
+		]) {
+			expect(() => addMcpDeclaration(emptyMcpDeclarationDocument(), "safe", url)).toThrow();
+		}
+		expect(() =>
+			parseMcpDeclarationDocument({
+				version: 1,
+				servers: { x: { name: "x", url: "https://x.test", enabled: true, headers: {} } },
+			}),
+		).toThrow();
+	});
+
+	it("rejects inherited, accessor, and symbol-bearing declaration data without reading it", () => {
+		const inherited = Object.create({ version: 1, servers: {} });
+		const accessor = { version: 1, servers: {} as Record<string, unknown> };
+		Object.defineProperty(accessor, "servers", {
+			enumerable: true,
+			get() {
+				throw new Error("must not read accessor");
+			},
+		});
+		const symbolBearing = { version: 1, servers: {} };
+		Object.defineProperty(symbolBearing, Symbol("hidden"), { value: true, enumerable: false });
+		expect(() => parseMcpDeclarationDocument(inherited)).toThrow();
+		expect(() => parseMcpDeclarationDocument(accessor)).toThrow();
+		expect(() => parseMcpDeclarationDocument(symbolBearing)).toThrow();
+	});
+
+	it("parses non-starting command routing without touching settings or a runtime", () => {
+		expect(parseMcpDeclarationCommand(["add", "catalog", "https://catalog.test/mcp"])).toEqual({
+			kind: "add",
+			scope: "user",
+			name: "catalog",
+			url: "https://catalog.test/mcp",
+		});
+		expect(parseMcpDeclarationCommand(["preview", "catalog", "--project"])).toEqual({
+			kind: "preview",
+			scope: "project",
+			name: "catalog",
+		});
+	});
+
+	it("keeps user scope unchanged and returns a declaration-only test preview", async () => {
+		const settings = SettingsManager.inMemory({ mcpDeclarations: projectDocument });
+		const command = parseMcpDeclarationCommand(["test", "catalog"]);
+		await expect(executeMcpDeclarationCommand(command, settings)).resolves.toEqual({
+			url: "https://catalog.test/mcp",
+			method: "POST",
+			redirect: "error",
+			requestKind: "mcp-initialize",
+		});
+	});
+
+	it("rejects absent Object prototype declaration names", async () => {
+		const settings = SettingsManager.inMemory({ mcpDeclarations: emptyMcpDeclarationDocument() });
+		for (const kind of ["inspect", "preview", "test", "enable", "disable"] as const) {
+			const command = parseMcpDeclarationCommand([kind, "constructor"]);
+			await expect(executeMcpDeclarationCommand(command, settings)).rejects.toThrow(
+				"No MCP declaration has that name.",
+			);
+		}
+	});
+
+	it("rejects a structurally forged authority before authorization or project reads", () => {
+		let calls = 0;
+		const fake = {
+			authorizeProjectDirectory() {
+				calls++;
+				return { kind: "granted", binding: {} };
+			},
+			validateBinding() {
+				calls++;
+				return { kind: "granted" };
+			},
+		};
+		const admission = admitProjectMcpDeclarations("/not-a-project", fake as never);
+		expect(admission).toBeUndefined();
+		expect(calls).toBe(0);
+	});
+
+	it("makes exactly one raw-path authorization at admission and validates an opaque Core binding for project reads", () => {
+		const f = fixture();
+		try {
+			// The actual Core authority returns a single opaque binding at admission.
+			// Subsequent uses only receive that binding; they have no raw path to reauthorize.
+			const admission = admitProjectMcpDeclarations(f.directory, f.authority);
+			expect(admission).toBeDefined();
+			expect(resolveProjectMcpDeclarations(projectDocument, admission)).toEqual({
+				document: projectDocument,
+				effective: true,
+			});
+			expect(resolveProjectMcpDeclarations(projectDocument, admission)).toEqual({
+				document: projectDocument,
+				effective: true,
+			});
+		} finally {
+			f.dispose();
+		}
+	});
+
+	it("denies missing, forged, stale, and foreign bindings before project reads, writes, or probe opens", async () => {
+		const f = fixture();
+		const other = fixture();
+		try {
+			const settings = SettingsManager.inMemory();
+			const list = parseMcpDeclarationCommand(["list", "--project"]);
+			const add = parseMcpDeclarationCommand(["add", "new", "https://new.test/mcp", "--project"]);
+			const test = parseMcpDeclarationCommand(["test", "new", "--project"]);
+			const granted = admitProjectMcpDeclarations(f.directory, f.authority)!;
+			const foreign = { ...admitProjectMcpDeclarations(other.directory, other.authority)! };
+			let forgedAuthorityCalls = 0;
+			const forged = {
+				get authority() {
+					forgedAuthorityCalls++;
+					return { validateBinding: () => ({ kind: "granted" }) };
+				},
+				get binding() {
+					forgedAuthorityCalls++;
+					return {};
+				},
+			};
+			// Admissions are identity capabilities, so copied, forged, and foreign
+			// envelopes all fail before any caller-supplied member is read.
+			for (const admission of [undefined, { ...granted }, forged, foreign]) {
+				await expect(executeMcpDeclarationCommand(list, settings, admission)).rejects.toThrow(
+					"Project MCP declarations are unavailable.",
+				);
+				await expect(executeMcpDeclarationCommand(add, settings, admission)).rejects.toThrow(
+					"Project MCP declarations are unavailable.",
+				);
+				await expect(executeMcpDeclarationCommand(test, settings, admission)).rejects.toThrow(
+					"Project MCP declarations are unavailable.",
+				);
+			}
+			expect(forgedAuthorityCalls).toBe(0);
+			// A binding becomes stale once its bound directory no longer exists.
+			rmSync(f.directory, { recursive: true, force: true });
+			await expect(executeMcpDeclarationCommand(list, settings, granted)).rejects.toThrow(
+				"Project MCP declarations are unavailable.",
+			);
+		} finally {
+			f.dispose();
+			other.dispose();
+		}
+	});
+
+	it("keeps the authority-pinned directory alive across independent binding releases", () => {
+		const f = fixture();
+		try {
+			const first = admitProjectMcpDeclarations(f.directory, f.authority)!;
+			const second = admitProjectMcpDeclarations(f.directory, f.authority)!;
+			releaseProjectMcpDeclarationAdmission(first);
+			expect(resolveProjectMcpDeclarations(projectDocument, first)).toEqual({
+				document: { version: 1, servers: {} },
+				effective: false,
+			});
+			expect(resolveProjectMcpDeclarations(projectDocument, second)).toEqual({
+				document: projectDocument,
+				effective: true,
+			});
+			releaseProjectMcpDeclarationAdmission(second);
+		} finally {
+			f.dispose();
+		}
+	});
+
+	it("returns a project test preview only after a validated Core grant", async () => {
+		const f = fixture();
+		try {
+			const admission = admitProjectMcpDeclarations(f.directory, f.authority)!;
+			const settings = SettingsManager.inMemory();
+			await executeMcpDeclarationCommand(
+				parseMcpDeclarationCommand(["add", "catalog", "https://catalog.test/mcp", "--project"]),
+				settings,
+				admission,
+			);
+			await expect(
+				executeMcpDeclarationCommand(
+					parseMcpDeclarationCommand(["test", "catalog", "--project"]),
+					settings,
+					admission,
+				),
+			).resolves.toEqual({
+				url: "https://catalog.test/mcp",
+				method: "POST",
+				redirect: "error",
+				requestKind: "mcp-initialize",
+			});
+		} finally {
+			f.dispose();
+		}
+	});
+
+	it("redacts credential-shaped fields and unsafe URLs before public rendering", () => {
+		const redacted = redactMcpValue({
+			authorization: "Bearer secret",
+			headers: { "X-Api-Key": "secret" },
+			nested: { token: "secret" },
+			url: "https://u:secret@example.test/mcp",
+		});
+		expect(redacted).toEqual({
+			authorization: "<redacted>",
+			headers: "<redacted>",
+			nested: { token: "<redacted>" },
+			url: "<redacted-url>",
+		});
+		expect(JSON.stringify(redacted)).not.toContain("secret");
+	});
+	it("fails closed when a queued project write loses its approved root", async () => {
+		const f = fixture();
+		const replacement = `${f.directory}-replacement`;
+		const old = `${f.directory}-old`;
+		const agentDir = mkdtempSync(join(tmpdir(), "m01-agent-"));
+		try {
+			const admission = admitProjectMcpDeclarations(f.directory, f.authority)!;
+			const settings = SettingsManager.create(f.directory, agentDir);
+			await executeMcpDeclarationCommand(
+				parseMcpDeclarationCommand(["add", "queued", "https://queued.test/mcp", "--project"]),
+				settings,
+				admission,
+			);
+			renameSync(f.directory, old);
+			mkdirSync(replacement);
+			renameSync(replacement, f.directory);
+			await settings.flush();
+			expect(existsSync(join(f.directory, ".prime", "agent", "settings.json"))).toBe(false);
+		} finally {
+			rmSync(old, { recursive: true, force: true });
+			rmSync(agentDir, { recursive: true, force: true });
+			f.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/mcp-manager.test.ts
+++ b/packages/coding-agent/test/mcp-manager.test.ts
@@ -5,6 +5,7 @@ import { getOAuthProvider, resetOAuthProviders } from "@earendil-works/pi-ai/oau
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { McpManager } from "../src/core/mcp/mcp-manager.js";
+import { createMcpRuntimeDeclarationSnapshot } from "../src/core/mcp/mcp-runtime-declaration-snapshot.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import type { McpServerConfig } from "../src/core/settings-manager.js";
 import { invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest } from "./host-request-context.js";
@@ -168,6 +169,20 @@ describe("McpManager", () => {
 		void manager;
 		// Built-in linear provider must be gone so we don't send the official token to the override URL.
 		expect(getOAuthProvider("mcp:linear")).toBeUndefined();
+	});
+
+	it("keeps declaration snapshots out of host handlers and legacy integrations", () => {
+		const snapshot = createMcpRuntimeDeclarationSnapshot({
+			userDocument: {
+				version: 1,
+				servers: { inert: { name: "inert", url: "https://declaration.example/mcp", enabled: true } },
+			},
+		});
+		const manager = new McpManager({ authStorage, getRuntimeDeclarations: () => snapshot });
+		expect(manager.getDeclarationSnapshot()).toBe(snapshot);
+		expect(manager.listStatus().map((status) => status.server)).not.toContain("inert");
+		expect(manager.hostHandlers()).not.toHaveProperty("mcp.declarations");
+		expect(manager.hostHandlers()).not.toHaveProperty("mcp.config.inert");
 	});
 
 	it("unregisters a user server's OAuth provider when it's removed on refresh()", () => {

--- a/packages/coding-agent/test/mcp-probe.test.ts
+++ b/packages/coding-agent/test/mcp-probe.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { executeMcpDeclarationCommand, parseMcpDeclarationCommand } from "../src/core/mcp/mcp-declaration-command.js";
+import { previewMcpDeclarationProbe } from "../src/core/mcp/mcp-probe.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+
+const declaration = { name: "catalog", url: "https://catalog.test/mcp", enabled: true };
+
+describe("MCP declaration probe contract", () => {
+	it("returns a bounded offline declaration preview", () => {
+		expect(previewMcpDeclarationProbe(declaration)).toEqual({
+			url: "https://catalog.test/mcp",
+			method: "POST",
+			redirect: "error",
+			requestKind: "mcp-initialize",
+		});
+	});
+
+	it("never calls a legacy injected transport when the declaration command is probed", async () => {
+		const settings = SettingsManager.inMemory();
+		settings.setMcpDeclarationDocument("user", { version: 1, servers: { catalog: declaration } });
+		let opens = 0;
+		const executeWithLegacyExtra = executeMcpDeclarationCommand as unknown as (
+			command: ReturnType<typeof parseMcpDeclarationCommand>,
+			settings: SettingsManager,
+			admission: undefined,
+			legacyOptions: { probeTransport: { open(): unknown } },
+		) => Promise<unknown>;
+
+		await expect(
+			executeWithLegacyExtra(parseMcpDeclarationCommand(["test", "catalog"]), settings, undefined, {
+				probeTransport: {
+					open() {
+						opens++;
+						throw new Error("transport must remain unreachable");
+					},
+				},
+			}),
+		).resolves.toEqual(previewMcpDeclarationProbe(declaration));
+		expect(opens).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/mcp-public-composition.test.ts
+++ b/packages/coding-agent/test/mcp-public-composition.test.ts
@@ -1,0 +1,180 @@
+import { mkdtempSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { composeMcpProjectDeclarationAdmission } from "../src/cli/public-command.js";
+import { executeMcpDeclarationCommand, parseMcpDeclarationCommand } from "../src/core/mcp/mcp-declaration-command.js";
+import { McpProjectDeclarationReader } from "../src/core/mcp/mcp-project-declaration-reader.js";
+import { SettingsManager, type SettingsScope, type SettingsStorage } from "../src/core/settings-manager.js";
+
+const projectDocument = {
+	version: 1,
+	servers: { catalog: { name: "catalog", url: "https://catalog.test/mcp", enabled: true } },
+};
+
+class TrackingStorage implements SettingsStorage {
+	readonly reads: Record<SettingsScope, number> = { global: 0, project: 0 };
+	readonly writes: Record<SettingsScope, number> = { global: 0, project: 0 };
+	constructor(private values: Record<SettingsScope, string | undefined>) {}
+	withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void {
+		this.reads[scope]++;
+		const next = fn(this.values[scope]);
+		if (next !== undefined) {
+			this.writes[scope]++;
+			this.values[scope] = next;
+		}
+	}
+	reset(): void {
+		this.reads.global = this.reads.project = this.writes.global = this.writes.project = 0;
+	}
+}
+
+function directory(): { path: string; dispose(): void } {
+	const path = realpathSync.native(mkdtempSync(join(tmpdir(), "m01-public-")));
+	return { path, dispose: () => rmSync(path, { recursive: true, force: true }) };
+}
+
+function storage(global: unknown, project: unknown): TrackingStorage {
+	return new TrackingStorage({ global: JSON.stringify(global), project: JSON.stringify(project) });
+}
+
+function admitFromGlobalStorage(store: TrackingStorage, workingDirectory: string) {
+	return composeMcpProjectDeclarationAdmission(
+		command(),
+		SettingsManager.loadGlobalSettingsFromStorage(store),
+		workingDirectory,
+	);
+}
+
+const command = () => parseMcpDeclarationCommand(["list", "--project"]);
+
+describe("M01 public command project policy composition", () => {
+	it("uses an exact global policy grant and carries only its opaque admission", async () => {
+		const d = directory();
+		try {
+			const store = storage(
+				{ mcpProjectTrustPolicy: { revision: "v1", allowedProjectDirectories: [d.path] } },
+				{ mcpDeclarations: projectDocument },
+			);
+			const admission = admitFromGlobalStorage(store, d.path);
+			expect(admission).toBeDefined();
+			expect(store.reads).toEqual({ global: 1, project: 0 });
+			// Only a grant permits construction of the full project-capable manager.
+			const settings = SettingsManager.fromStorage(store);
+			expect(store.reads).toEqual({ global: 2, project: 1 });
+			await expect(executeMcpDeclarationCommand(command(), settings, admission)).resolves.toEqual(projectDocument);
+		} finally {
+			d.dispose();
+		}
+	});
+
+	it.each([undefined, { revision: 1, allowedProjectDirectories: ["not-a-string-policy"] }])(
+		"denies missing or malformed global policy and project-local self-enable before project I/O",
+		async (policy) => {
+			const d = directory();
+			try {
+				const store = storage(
+					{ mcpProjectTrustPolicy: policy },
+					{
+						mcpProjectTrustPolicy: { revision: "evil", allowedProjectDirectories: [d.path] },
+						mcpDeclarations: projectDocument,
+					},
+				);
+				const admission = admitFromGlobalStorage(store, d.path);
+				expect(admission).toBeUndefined();
+				// Production stops here: a deny must not construct SettingsManager.fromStorage.
+				expect(store.reads).toEqual({ global: 1, project: 0 });
+				expect(store.writes.project).toBe(0);
+				// The downstream boundary independently remains inert if accidentally called.
+				const settings = SettingsManager.inMemory();
+				await expect(executeMcpDeclarationCommand(command(), settings, admission)).rejects.toThrow(
+					"Project MCP declarations are unavailable.",
+				);
+				await expect(
+					executeMcpDeclarationCommand(
+						parseMcpDeclarationCommand(["test", "catalog", "--project"]),
+						settings,
+						admission,
+					),
+				).rejects.toThrow("Project MCP declarations are unavailable.");
+			} finally {
+				d.dispose();
+			}
+		},
+	);
+
+	it("denies an alias at composition and a replaced directory at the validated use boundary", async () => {
+		const d = directory();
+		const old = `${d.path}-old`;
+		try {
+			const store = storage(
+				{ mcpProjectTrustPolicy: { revision: "v1", allowedProjectDirectories: [d.path] } },
+				{ mcpDeclarations: projectDocument },
+			);
+			expect(admitFromGlobalStorage(store, `${d.path}/.`)).toBeUndefined();
+			const admission = admitFromGlobalStorage(store, d.path);
+			const settings = SettingsManager.fromStorage(store);
+			renameSync(d.path, old);
+			mkdtempSync(d.path);
+			await expect(executeMcpDeclarationCommand(command(), settings, admission)).rejects.toThrow(
+				"Project MCP declarations are unavailable.",
+			);
+		} finally {
+			rmSync(old, { recursive: true, force: true });
+			d.dispose();
+		}
+	});
+
+	it("authorizes once at composition and never reauthorizes during a later use", async () => {
+		const d = directory();
+		try {
+			const store = storage(
+				{ mcpProjectTrustPolicy: { revision: "v1", allowedProjectDirectories: [d.path] } },
+				{ mcpDeclarations: projectDocument },
+			);
+			const admission = admitFromGlobalStorage(store, d.path);
+			const settings = SettingsManager.fromStorage(store);
+			await expect(executeMcpDeclarationCommand(command(), settings, admission)).resolves.toEqual(projectDocument);
+			await expect(executeMcpDeclarationCommand(command(), settings, admission)).resolves.toEqual(projectDocument);
+			// execute has only the opaque admission argument; no raw path is available to reauthorize.
+		} finally {
+			d.dispose();
+		}
+	});
+	it("uses the scoped reader for admitted list and add while retaining ordinary project settings", async () => {
+		const d = directory();
+		try {
+			const store = storage(
+				{ mcpProjectTrustPolicy: { revision: "v1", allowedProjectDirectories: [d.path] } },
+				{ ordinary: { retained: true }, mcpDeclarations: projectDocument },
+			);
+			const admission = admitFromGlobalStorage(store, d.path)!;
+			const settingsPath = join(d.path, ".prime", "agent", "settings.json");
+			// The file-backed reader is deliberately the project-MCP-only seam.
+			const { mkdirSync } = await import("node:fs");
+			mkdirSync(join(d.path, ".prime", "agent"), { recursive: true });
+			writeFileSync(
+				settingsPath,
+				JSON.stringify({ ordinary: { retained: true }, mcpDeclarations: projectDocument }),
+			);
+			const reader = await McpProjectDeclarationReader.create(admission);
+			const settings = reader.asCommandSettings();
+			await expect(executeMcpDeclarationCommand(command(), settings as never, admission)).resolves.toEqual(
+				projectDocument,
+			);
+			await expect(
+				executeMcpDeclarationCommand(
+					parseMcpDeclarationCommand(["add", "added", "https://added.test/mcp", "--project"]),
+					settings as never,
+					admission,
+				),
+			).resolves.toMatchObject({ name: "added" });
+			const persisted = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(persisted.ordinary).toEqual({ retained: true });
+			expect(persisted.mcpDeclarations.servers).toHaveProperty("catalog");
+			expect(persisted.mcpDeclarations.servers).toHaveProperty("added");
+		} finally {
+			d.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/mcp-runtime-declaration-snapshot.test.ts
+++ b/packages/coding-agent/test/mcp-runtime-declaration-snapshot.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	admitProjectMcpDeclarations,
+	resolveProjectMcpDeclarations,
+	validateProjectMcpDeclarationAdmission,
+} from "../src/core/mcp/mcp-project-trust.js";
+import { createMcpRuntimeDeclarationSnapshot } from "../src/core/mcp/mcp-runtime-declaration-snapshot.js";
+import { createMcpProjectTrustAuthority } from "../src/core/mcp/project-trust-authority.js";
+
+const userDocument = {
+	version: 1 as const,
+	servers: { catalog: { name: "catalog", url: "HTTPS://Catalog.test:443/mcp", enabled: true } },
+};
+const projectDocument = {
+	version: 1 as const,
+	servers: { search: { name: "search", url: "https://search.test/mcp", enabled: false } },
+};
+
+function directory(): { path: string; dispose(): void } {
+	const path = realpathSync.native(mkdtempSync(join(tmpdir(), "core-mcp-snapshot-")));
+	return { path, dispose: () => rmSync(path, { recursive: true, force: true }) };
+}
+
+function admission(path: string) {
+	return admitProjectMcpDeclarations(
+		path,
+		createMcpProjectTrustAuthority({ revision: "global-r1", allowedProjectDirectories: [path] }),
+	);
+}
+
+describe("Core MCP declaration snapshot", () => {
+	it("creates a frozen declaration-only, code-point-ordered snapshot", () => {
+		const first = createMcpRuntimeDeclarationSnapshot({ userDocument });
+		const second = createMcpRuntimeDeclarationSnapshot({ userDocument: structuredClone(userDocument) });
+		expect(first).toEqual(second);
+		expect(first).toEqual({
+			revision: expect.stringMatching(/^[a-f0-9]{64}$/),
+			declarations: {
+				catalog: { name: "catalog", endpoint: "https://catalog.test/mcp", enabled: true, source: "user" },
+			},
+		});
+		expect(Object.isFrozen(first)).toBe(true);
+		expect(Object.isFrozen(first.declarations)).toBe(true);
+		expect(Object.isFrozen(first.declarations.catalog)).toBe(true);
+		expect(Object.getPrototypeOf(first.declarations)).toBeNull();
+	});
+
+	it("does not read project data for omitted, forged, accessor, or copied foreign admissions", () => {
+		const first = directory();
+		const second = directory();
+		try {
+			const genuine = admission(first.path)!;
+			const foreign = { ...admission(second.path)! };
+			let reads = 0;
+			let fakeValidationCalls = 0;
+			const forged = {
+				get authority() {
+					fakeValidationCalls++;
+					return { validateBinding: () => ({ kind: "granted" }) };
+				},
+				get binding() {
+					fakeValidationCalls++;
+					return {};
+				},
+			};
+			for (const projectAdmission of [undefined, {}, forged, foreign]) {
+				const snapshot = createMcpRuntimeDeclarationSnapshot({
+					userDocument,
+					projectAdmission: projectAdmission as never,
+					readProjectDocument: () => {
+						reads++;
+						return projectDocument;
+					},
+				});
+				expect(snapshot.declarations).toEqual({
+					catalog: { name: "catalog", endpoint: "https://catalog.test/mcp", enabled: true, source: "user" },
+				});
+			}
+			expect(reads).toBe(0);
+			expect(resolveProjectMcpDeclarations(projectDocument, forged as never)).toEqual({
+				document: { version: 1, servers: {} },
+				effective: false,
+			});
+			expect(fakeValidationCalls).toBe(0);
+			expect(Object.getOwnPropertyNames(genuine)).toEqual([]);
+			expect(validateProjectMcpDeclarationAdmission(genuine)).toEqual({ kind: "granted" });
+		} finally {
+			first.dispose();
+			second.dispose();
+		}
+	});
+
+	it("reads project data only after the opaque admission validates and makes collisions inert", () => {
+		const project = directory();
+		try {
+			const granted = admission(project.path)!;
+			let reads = 0;
+			const selected = createMcpRuntimeDeclarationSnapshot({
+				userDocument,
+				projectAdmission: granted,
+				readProjectDocument: () => {
+					reads++;
+					return projectDocument;
+				},
+			});
+			expect(reads).toBe(1);
+			expect(selected.declarations.search).toEqual({
+				name: "search",
+				endpoint: "https://search.test/mcp",
+				enabled: false,
+				source: "project",
+			});
+
+			const colliding = createMcpRuntimeDeclarationSnapshot({
+				userDocument,
+				projectAdmission: granted,
+				readProjectDocument: () => ({
+					version: 1,
+					servers: { catalog: { name: "catalog", url: "https://other.test/mcp", enabled: true } },
+				}),
+			});
+			expect(Object.keys(colliding.declarations)).toEqual(["catalog"]);
+		} finally {
+			project.dispose();
+		}
+	});
+
+	it("uses code-point order rather than locale collation", () => {
+		const original = Object.getOwnPropertyDescriptor(String.prototype, "localeCompare")!;
+		let localeCalls = 0;
+		Object.defineProperty(String.prototype, "localeCompare", {
+			...original,
+			value() {
+				localeCalls++;
+				return 0;
+			},
+		});
+		try {
+			const snapshot = createMcpRuntimeDeclarationSnapshot({
+				userDocument: {
+					version: 1,
+					servers: {
+						zebra: { name: "zebra", url: "https://z.test", enabled: true },
+						apple: { name: "apple", url: "https://a.test", enabled: true },
+					},
+				},
+			});
+			expect(Object.keys(snapshot.declarations)).toEqual(["apple", "zebra"]);
+			expect(localeCalls).toBe(0);
+		} finally {
+			Object.defineProperty(String.prototype, "localeCompare", original);
+		}
+	});
+
+	it("rejects accessor, inherited, and locale-sensitive parser inputs without reading inherited data", () => {
+		const inherited = Object.create({ version: 1, servers: {} });
+		const accessor = { version: 1, servers: {} as Record<string, unknown> };
+		Object.defineProperty(accessor.servers, "catalog", {
+			enumerable: true,
+			get() {
+				throw new Error("must not get accessor");
+			},
+		});
+		expect(() => createMcpRuntimeDeclarationSnapshot({ userDocument: inherited })).toThrow();
+		expect(() => createMcpRuntimeDeclarationSnapshot({ userDocument: accessor })).toThrow();
+		// Names are ASCII-only. Locale collation is never consulted by selection.
+		expect(() =>
+			createMcpRuntimeDeclarationSnapshot({
+				userDocument: { version: 1, servers: { İ: { name: "İ", url: "https://x.test", enabled: true } } },
+			}),
+		).toThrow();
+	});
+});

--- a/packages/coding-agent/test/project-settings-openat.test.ts
+++ b/packages/coding-agent/test/project-settings-openat.test.ts
@@ -1,0 +1,556 @@
+import * as childProcess from "node:child_process";
+import {
+	closeSync,
+	constants,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	openSync,
+	readFileSync,
+	realpathSync,
+	renameSync,
+	rmdirSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import lockfile from "proper-lockfile";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const childProcessSpies = vi.hoisted(() => ({
+	spawnSync: vi.fn(),
+	originalSpawnSync: undefined as typeof import("node:child_process").spawnSync | undefined,
+}));
+const bootstrapSpies = vi.hoisted(() => ({
+	ensureKernelPython: vi.fn(),
+}));
+vi.mock("../src/core/kernel/bootstrap.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/core/kernel/bootstrap.js")>();
+	bootstrapSpies.ensureKernelPython.mockImplementation(actual.ensureKernelPython);
+	return { ...actual, ensureKernelPython: bootstrapSpies.ensureKernelPython };
+});
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	childProcessSpies.originalSpawnSync = actual.spawnSync;
+	childProcessSpies.spawnSync.mockImplementation(actual.spawnSync);
+	return { ...actual, spawnSync: childProcessSpies.spawnSync };
+});
+
+import { McpProjectDeclarationReader } from "../src/core/mcp/mcp-project-declaration-reader.js";
+import {
+	admitProjectMcpDeclarations,
+	releaseProjectMcpDeclarationAdmission,
+} from "../src/core/mcp/mcp-project-trust.js";
+import { resolveTrustedProjectSettingsPython } from "../src/core/mcp/project-settings-openat.js";
+import { createMcpProjectTrustAuthority } from "../src/core/mcp/project-trust-authority.js";
+
+const cleanup: string[] = [];
+const unavailable = "Project MCP declarations are unavailable.";
+
+function root(): string {
+	const path = mkdtempSync(join(realpathSync.native(tmpdir()), "project-openat-"));
+	cleanup.push(path);
+	return path;
+}
+function admission(path: string) {
+	const grant = admitProjectMcpDeclarations(
+		path,
+		createMcpProjectTrustAuthority({ revision: "r1", allowedProjectDirectories: [path] }),
+	);
+	expect(grant).toBeDefined();
+	return grant!;
+}
+function document() {
+	return { version: 1 as const, servers: {} };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	childProcessSpies.spawnSync.mockClear();
+	while (cleanup.length) rmSync(cleanup.pop()!, { recursive: true, force: true });
+});
+
+describe("project settings openat", () => {
+	it("redacts a rejected kernel bootstrap diagnostic", async () => {
+		const diagnostic = "bootstrap secret: /private/kernel-python";
+		bootstrapSpies.ensureKernelPython.mockRejectedValueOnce(new Error(diagnostic));
+
+		let thrown: unknown;
+		try {
+			await resolveTrustedProjectSettingsPython();
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toBeInstanceOf(Error);
+		expect((thrown as Error).message).toBe(unavailable);
+		expect(String(thrown)).not.toContain(diagnostic);
+	});
+
+	it("creates only below its retained root and preserves ordinary settings", async () => {
+		const cwd = root();
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			reader.setDocument(document());
+			writeFileSync(join(cwd, ".prime", "agent", "settings.json"), JSON.stringify({ ordinary: { kept: true } }));
+			reader.setDocument(document());
+			expect(JSON.parse(readFileSync(join(cwd, ".prime", "agent", "settings.json"), "utf8"))).toMatchObject({
+				ordinary: { kept: true },
+				mcpDeclarations: { version: 1 },
+			});
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("treats absent project storage and an omitted declaration setting as an empty document", async () => {
+		for (const setup of [
+			(cwd: string) => cwd,
+			(cwd: string) => {
+				mkdirSync(join(cwd, ".prime", "agent"), { recursive: true });
+				writeFileSync(join(cwd, ".prime", "agent", "settings.json"), JSON.stringify({ ordinary: true }));
+				return cwd;
+			},
+		]) {
+			const cwd = setup(root());
+			const grant = admission(cwd);
+			try {
+				const reader = await McpProjectDeclarationReader.create(grant);
+				expect(reader.getDocument()).toEqual(document());
+			} finally {
+				releaseProjectMcpDeclarationAdmission(grant);
+			}
+		}
+	});
+
+	it("fails closed for an explicitly null project declaration setting", async () => {
+		const cwd = root();
+		mkdirSync(join(cwd, ".prime", "agent"), { recursive: true });
+		writeFileSync(join(cwd, ".prime", "agent", "settings.json"), JSON.stringify({ mcpDeclarations: null }));
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			expect(() => reader.getDocument()).toThrow(unavailable);
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("fails closed for component and leaf symlinks", async () => {
+		for (const kind of ["prime", "agent", "leaf"] as const) {
+			const cwd = root();
+			const outside = root();
+			if (kind === "prime") {
+				symlinkSync(outside, join(cwd, ".prime"), "dir");
+			} else {
+				mkdirSync(join(cwd, ".prime", "agent"), { recursive: true });
+				if (kind === "agent") {
+					rmSync(join(cwd, ".prime", "agent"), { recursive: true });
+					symlinkSync(outside, join(cwd, ".prime", "agent"), "dir");
+				} else {
+					symlinkSync(join(outside, "settings.json"), join(cwd, ".prime", "agent", "settings.json"));
+				}
+			}
+			const grant = admission(cwd);
+			try {
+				const reader = await McpProjectDeclarationReader.create(grant);
+				expect(() => reader.getDocument()).toThrow(unavailable);
+				expect(() => reader.setDocument(document())).toThrow(unavailable);
+			} finally {
+				releaseProjectMcpDeclarationAdmission(grant);
+			}
+		}
+	});
+
+	it("fails closed for malformed, duplicate, and non-finite settings without exposing them", async () => {
+		for (const raw of ["{", '{"ordinary":1,"ordinary":2}', '{"ordinary":NaN}', '{"ordinary":Infinity}']) {
+			const cwd = root();
+			mkdirSync(join(cwd, ".prime", "agent"), { recursive: true });
+			writeFileSync(join(cwd, ".prime", "agent", "settings.json"), raw);
+			const grant = admission(cwd);
+			try {
+				const reader = await McpProjectDeclarationReader.create(grant);
+				expect(() => reader.getDocument()).toThrow(unavailable);
+				expect(() => reader.setDocument(document())).toThrow(unavailable);
+			} finally {
+				releaseProjectMcpDeclarationAdmission(grant);
+			}
+		}
+	});
+
+	it("keeps a permanently replaced root untouched after validation", async () => {
+		const cwd = root();
+		const old = `${cwd}-old`;
+		const replacement = `${cwd}-replacement`;
+		cleanup.push(old, replacement);
+		mkdirSync(join(replacement, ".prime", "agent"), { recursive: true });
+		writeFileSync(
+			join(replacement, ".prime", "agent", "settings.json"),
+			JSON.stringify({ replacementSentinel: true }),
+		);
+		const grant = admission(cwd);
+		const realSpawnSync = childProcessSpies.originalSpawnSync!;
+		childProcessSpies.spawnSync.mockImplementationOnce(((...args: Parameters<typeof realSpawnSync>) => {
+			renameSync(cwd, old);
+			renameSync(replacement, cwd);
+			return realSpawnSync(...args);
+		}) as typeof childProcess.spawnSync);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			expect(() => reader.setDocument(document())).toThrow(unavailable);
+			expect(childProcessSpies.spawnSync).toHaveBeenCalledOnce();
+			const options = childProcessSpies.spawnSync.mock.calls[0]![2]! as { shell?: unknown; stdio?: unknown };
+			expect(options.shell).toBe(false);
+			expect((options.stdio as unknown[])[3]).toEqual(expect.any(Number));
+			expect(JSON.parse(readFileSync(join(cwd, ".prime", "agent", "settings.json"), "utf8"))).toEqual({
+				replacementSentinel: true,
+			});
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("interoperates with the ordinary settings lock and preserves independent updates", async () => {
+		const cwd = root();
+		const agentDir = join(cwd, ".prime", "agent");
+		const settings = join(agentDir, "settings.json");
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settings, JSON.stringify({ ordinary: { before: true } }));
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			const release = lockfile.lockSync(settings, { realpath: false });
+			try {
+				expect(() => reader.setDocument(document())).toThrow(unavailable);
+				expect(JSON.parse(readFileSync(settings, "utf8"))).toEqual({ ordinary: { before: true } });
+				expect(lstatSync(`${settings}.lock`).isDirectory()).toBe(true);
+			} finally {
+				release();
+			}
+
+			reader.setDocument(document());
+			expect(existsSync(`${settings}.lock`)).toBe(false);
+			expect(JSON.parse(readFileSync(settings, "utf8"))).toMatchObject({
+				ordinary: { before: true },
+				mcpDeclarations: { version: 1 },
+			});
+			const releaseAfter = lockfile.lockSync(settings, { realpath: false });
+			releaseAfter();
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("makes a helper-protocol lock visible to the ordinary settings writer", () => {
+		const cwd = root();
+		const agentDir = join(cwd, ".prime", "agent");
+		const settings = join(agentDir, "settings.json");
+		const lock = `${settings}.lock`;
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settings, JSON.stringify({ ordinary: true }));
+		mkdirSync(lock, { mode: 0o700 });
+		try {
+			expect(() => lockfile.lockSync(settings, { realpath: false })).toThrow();
+			expect(lstatSync(lock).isDirectory()).toBe(true);
+		} finally {
+			rmdirSync(lock);
+		}
+		const release = lockfile.lockSync(settings, { realpath: false });
+		release();
+	});
+
+	it("serializes a concurrent ordinary settings update without clobbering either field", async () => {
+		const cwd = root();
+		const agentDir = join(cwd, ".prime", "agent");
+		const settings = join(agentDir, "settings.json");
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settings, JSON.stringify({ ordinary: { before: true } }));
+		const worker = childProcess.spawn(
+			process.execPath,
+			[
+				"-e",
+				`const fs=require("node:fs");const lock=require("proper-lockfile");const p=${JSON.stringify(settings)};const release=lock.lockSync(p,{realpath:false});setTimeout(()=>{const d=JSON.parse(fs.readFileSync(p,"utf8"));d.ordinary={concurrent:true};fs.writeFileSync(p,JSON.stringify(d));release();},100);`,
+			],
+			{ cwd: process.cwd(), stdio: "ignore" },
+		);
+		const workerExit = new Promise<number | null>((resolve) => worker.once("exit", resolve));
+		const waitUntil = Date.now() + 2_000;
+		while (!existsSync(`${settings}.lock`) && Date.now() < waitUntil) {
+			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+		}
+		expect(existsSync(`${settings}.lock`)).toBe(true);
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			reader.setDocument(document());
+			expect(await workerExit).toBe(0);
+			expect(JSON.parse(readFileSync(settings, "utf8"))).toMatchObject({
+				ordinary: { concurrent: true },
+				mcpDeclarations: { version: 1 },
+			});
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("removes its owned lock after a transactional helper failure", async () => {
+		const cwd = root();
+		const agentDir = join(cwd, ".prime", "agent");
+		const settings = join(agentDir, "settings.json");
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settings, "{");
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			expect(() => reader.setDocument(document())).toThrow(unavailable);
+			expect(existsSync(`${settings}.lock`)).toBe(false);
+			expect(readFileSync(settings, "utf8")).toBe("{");
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("fails closed for hostile lock leaves without changing settings or outside targets", async () => {
+		for (const kind of ["regular", "symlink"] as const) {
+			const cwd = root();
+			const outside = root();
+			const agentDir = join(cwd, ".prime", "agent");
+			const settings = join(agentDir, "settings.json");
+			const lock = `${settings}.lock`;
+			mkdirSync(agentDir, { recursive: true });
+			writeFileSync(settings, JSON.stringify({ ordinary: true }));
+			if (kind === "regular") writeFileSync(lock, "legacy lock");
+			else symlinkSync(outside, lock, "dir");
+			const grant = admission(cwd);
+			try {
+				const reader = await McpProjectDeclarationReader.create(grant);
+				expect(() => reader.setDocument(document())).toThrow(unavailable);
+				expect(JSON.parse(readFileSync(settings, "utf8"))).toEqual({ ordinary: true });
+				expect(lstatSync(lock).isSymbolicLink()).toBe(kind === "symlink");
+				expect(readFileSync(settings, "utf8")).not.toContain(outside);
+			} finally {
+				releaseProjectMcpDeclarationAdmission(grant);
+			}
+		}
+	});
+
+	it("retries mkdir when a released lock disappears before its no-follow open", async () => {
+		const cwd = root();
+		const agentDir = join(cwd, ".prime", "agent");
+		const settings = join(agentDir, "settings.json");
+		const lock = `${settings}.lock`;
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settings, JSON.stringify({ ordinary: true }));
+		mkdirSync(lock, { mode: 0o700 });
+		const realSpawnSync = childProcessSpies.originalSpawnSync!;
+		childProcessSpies.spawnSync.mockImplementationOnce(((...spawnArgs: Parameters<typeof realSpawnSync>) => {
+			const [python, rawArgs, options] = spawnArgs;
+			const args = rawArgs as readonly string[];
+			const helper = args[2]!
+				.replace("def acquire(agent):", "INJECT_ENOENT=True\ndef acquire(agent):")
+				.replace(
+					'   try: existing=directory(agent,"settings.json.lock",False)',
+					'   try:\n    if globals().pop("INJECT_ENOENT",False):\n     os.rmdir("settings.json.lock",dir_fd=agent); raise FileNotFoundError()\n    existing=directory(agent,"settings.json.lock",False)',
+				);
+			expect(helper).not.toBe(args[2]);
+			return realSpawnSync(python, [args[0]!, args[1]!, helper], options);
+		}) as typeof childProcess.spawnSync);
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			reader.setDocument(document());
+			expect(existsSync(lock)).toBe(false);
+			expect(JSON.parse(readFileSync(settings, "utf8"))).toMatchObject({
+				ordinary: true,
+				mcpDeclarations: { version: 1 },
+			});
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("cleans a signal raised while opening a newly created lock", async () => {
+		const cwd = root();
+		const agentDir = join(cwd, ".prime", "agent");
+		const settings = join(agentDir, "settings.json");
+		const lock = `${settings}.lock`;
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settings, JSON.stringify({ ordinary: true }));
+		let helper: string | undefined;
+		childProcessSpies.spawnSync.mockImplementationOnce(((_python: string, args: readonly string[]) => {
+			helper = args[2];
+			return { status: 1, stdout: "", stderr: "captured" };
+		}) as typeof childProcess.spawnSync);
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			expect(() => reader.setDocument(document())).toThrow(unavailable);
+			const interruptedHelper = helper!.replace(
+				'try: return directory(agent,"settings.json.lock",False)',
+				'try:\n    result=directory(agent,"settings.json.lock",False)\n    os.kill(os.getpid(),signal.SIGTERM)\n    return result',
+			);
+			expect(interruptedHelper).not.toBe(helper);
+			const rootFd = openSync(cwd, constants.O_RDONLY);
+			const result = childProcessSpies.originalSpawnSync!(
+				await resolveTrustedProjectSettingsPython(),
+				["-I", "-c", interruptedHelper],
+				{
+					input: JSON.stringify({ action: "write", document: document() }),
+					encoding: "utf8",
+					timeout: 5_000,
+					stdio: ["pipe", "pipe", "pipe", rootFd],
+				},
+			);
+			closeSync(rootFd);
+			expect(result.status).toBe(1);
+			expect(result.signal).toBeNull();
+			expect(existsSync(lock)).toBe(false);
+			const release = lockfile.lockSync(settings, { realpath: false });
+			release();
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("linearizes a signal between acquisition return and owned assignment", async () => {
+		const cwd = root();
+		const agentDir = join(cwd, ".prime", "agent");
+		const settings = join(agentDir, "settings.json");
+		const lock = `${settings}.lock`;
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settings, JSON.stringify({ ordinary: true }));
+		let helper: string | undefined;
+		childProcessSpies.spawnSync.mockImplementationOnce(((_python: string, args: readonly string[]) => {
+			helper = args[2];
+			return { status: 1, stdout: "", stderr: "captured" };
+		}) as typeof childProcess.spawnSync);
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			expect(() => reader.setDocument(document())).toThrow(unavailable);
+			const patchedBoundary = helper!.replace(
+				"lockdir=acquire(agent); owned=True",
+				"lockdir=acquire(agent); os.kill(os.getpid(),signal.SIGTERM); owned=True",
+			);
+			expect(patchedBoundary).not.toBe(helper);
+			const predecessorBoundary = patchedBoundary
+				.replace(
+					"  blocked={signal.SIGTERM,signal.SIGINT}\n  previous=signal.pthread_sigmask(signal.SIG_BLOCK,blocked)\n  try: ",
+					"  ",
+				)
+				.replace("\n  finally: signal.pthread_sigmask(signal.SIG_SETMASK,previous)", "");
+			expect(predecessorBoundary).not.toBe(patchedBoundary);
+			const python = await resolveTrustedProjectSettingsPython();
+			const run = (source: string) => {
+				const rootFd = openSync(cwd, constants.O_RDONLY);
+				try {
+					return childProcessSpies.originalSpawnSync!(python, ["-I", "-c", source], {
+						input: JSON.stringify({ action: "write", document: document() }),
+						encoding: "utf8",
+						timeout: 5_000,
+						stdio: ["pipe", "pipe", "pipe", rootFd],
+					});
+				} finally {
+					closeSync(rootFd);
+				}
+			};
+			const predecessor = run(predecessorBoundary);
+			expect(predecessor.status).toBe(1);
+			expect(lstatSync(lock).isDirectory()).toBe(true);
+			rmdirSync(lock);
+			const patched = run(patchedBoundary);
+			expect(patched.status).toBe(1);
+			expect(patched.signal).toBeNull();
+			expect(existsSync(lock)).toBe(false);
+			const release = lockfile.lockSync(settings, { realpath: false });
+			release();
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("cleans its owned lock promptly when an external SIGTERM interrupts the helper", async () => {
+		const cwd = root();
+		const agentDir = join(cwd, ".prime", "agent");
+		const settings = join(agentDir, "settings.json");
+		const lock = `${settings}.lock`;
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settings, JSON.stringify({ ordinary: true }));
+		let helper: string | undefined;
+		childProcessSpies.spawnSync.mockImplementationOnce(((_python: string, args: readonly string[]) => {
+			helper = args[2];
+			return { status: 1, stdout: "", stderr: "captured" };
+		}) as typeof childProcess.spawnSync);
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			expect(() => reader.setDocument(document())).toThrow(unavailable);
+			expect(helper).toBeDefined();
+			const heldHelper = helper!
+				.replace(
+					"  try: lockdir=acquire(agent); owned=True",
+					'  try: lockdir=acquire(agent); owned=True\n  finally:\n   print("LOCK_OWNED",flush=True)\n   signal.pthread_sigmask(signal.SIG_SETMASK,previous)\n  time.sleep(30)',
+				)
+				.replace(
+					"  finally: signal.pthread_sigmask(signal.SIG_SETMASK,previous)\n  doc=read(agent)",
+					"  doc=read(agent)",
+				);
+			expect(heldHelper).not.toBe(helper);
+			const rootFd = openSync(cwd, constants.O_RDONLY);
+			const child = childProcess.spawn(await resolveTrustedProjectSettingsPython(), ["-I", "-c", heldHelper], {
+				stdio: ["pipe", "pipe", "pipe", rootFd],
+			});
+			closeSync(rootFd);
+			child.stdin!.end(JSON.stringify({ action: "write", document: document() }));
+			await new Promise<void>((resolve, reject) => {
+				const timer = setTimeout(() => reject(new Error("ownership marker timed out")), 2_000);
+				child.stdout!.on("data", (chunk) => {
+					if (!String(chunk).includes("LOCK_OWNED")) return;
+					clearTimeout(timer);
+					expect(lstatSync(lock).isDirectory()).toBe(true);
+					resolve();
+				});
+				child.once("error", reject);
+			});
+			const signaledAt = Date.now();
+			child.kill("SIGTERM");
+			const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+				const timer = setTimeout(() => reject(new Error("SIGTERM cleanup timed out")), 2_000);
+				child.once("exit", (code, signal) => {
+					clearTimeout(timer);
+					resolve({ code, signal });
+				});
+			});
+			expect(result).toEqual({ code: 1, signal: null });
+			expect(Date.now() - signaledAt).toBeLessThan(2_000);
+			expect(existsSync(lock)).toBe(false);
+			const release = lockfile.lockSync(settings, { realpath: false });
+			release();
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+
+	it("bounds helper input/output, redacts all child failure detail, and closes a released grant", async () => {
+		const cwd = root();
+		const grant = admission(cwd);
+		try {
+			const reader = await McpProjectDeclarationReader.create(grant);
+			const spawn = vi.spyOn(childProcess, "spawnSync").mockReturnValue({
+				status: 1,
+				stdout: "secret settings path and child stderr",
+				stderr: "secret",
+			} as ReturnType<typeof childProcess.spawnSync>);
+			expect(() => reader.getDocument()).toThrow(unavailable);
+			expect(() => reader.getDocument()).not.toThrow(/secret/);
+			expect(spawn.mock.calls[0]![1]).toEqual(["-I", "-c", expect.any(String)]);
+			releaseProjectMcpDeclarationAdmission(grant);
+			expect(() => reader.getDocument()).toThrow(unavailable);
+		} finally {
+			releaseProjectMcpDeclarationAdmission(grant);
+		}
+	});
+});

--- a/packages/coding-agent/test/project-trust-authority.test.ts
+++ b/packages/coding-agent/test/project-trust-authority.test.ts
@@ -1,0 +1,133 @@
+import { mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsSpies = vi.hoisted(() => ({
+	openSync: vi.fn(),
+	closeSync: vi.fn(),
+	fstatSync: vi.fn(),
+	statSync: vi.fn(),
+	actual: undefined as typeof import("node:fs") | undefined,
+}));
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	fsSpies.actual = actual;
+	return {
+		...actual,
+		openSync: fsSpies.openSync,
+		closeSync: fsSpies.closeSync,
+		fstatSync: fsSpies.fstatSync,
+		statSync: fsSpies.statSync,
+	};
+});
+
+import {
+	createMcpProjectTrustAuthority,
+	releaseMcpProjectTrustBinding,
+	withValidatedMcpProjectTrustBinding,
+} from "../src/core/mcp/project-trust-authority.js";
+
+const cleanup: string[] = [];
+
+function directory(): string {
+	const path = realpathSync.native(mkdtempSync(join(tmpdir(), "project-trust-authority-")));
+	cleanup.push(path);
+	return path;
+}
+
+beforeEach(() => {
+	fsSpies.openSync.mockImplementation(fsSpies.actual!.openSync);
+	fsSpies.closeSync.mockImplementation(fsSpies.actual!.closeSync);
+	fsSpies.fstatSync.mockImplementation(fsSpies.actual!.fstatSync);
+	fsSpies.statSync.mockImplementation(fsSpies.actual!.statSync);
+	for (const spy of [fsSpies.openSync, fsSpies.closeSync, fsSpies.fstatSync, fsSpies.statSync]) spy.mockClear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const spy of [fsSpies.openSync, fsSpies.closeSync, fsSpies.fstatSync, fsSpies.statSync]) spy.mockReset();
+	while (cleanup.length) rmSync(cleanup.pop()!, { recursive: true, force: true });
+});
+
+describe("MCP project trust authority descriptor ownership", () => {
+	it("pins the approved directory once and never reopens its pathname during admission", () => {
+		const path = directory();
+		const authority = createMcpProjectTrustAuthority({ revision: "r1", allowedProjectDirectories: [path] });
+		expect(fsSpies.openSync).toHaveBeenCalledOnce();
+		const pinnedFd = fsSpies.openSync.mock.results[0]!.value as number;
+
+		const authorization = authority.authorizeProjectDirectory(path);
+		expect(authorization.kind).toBe("granted");
+		expect(fsSpies.openSync).toHaveBeenCalledOnce();
+		if (authorization.kind !== "granted") return;
+		expect(withValidatedMcpProjectTrustBinding(authorization.binding, (rootFd) => rootFd)).toBe(pinnedFd);
+	});
+
+	it("keeps operations on the pinned object when pathname identity is forced to look reused", () => {
+		const path = directory();
+		const oldPath = `${path}-old`;
+		cleanup.push(oldPath);
+		const authority = createMcpProjectTrustAuthority({ revision: "r1", allowedProjectDirectories: [path] });
+		const pinnedFd = fsSpies.openSync.mock.results[0]!.value as number;
+		const pinned = fsSpies.actual!.fstatSync(pinnedFd, { bigint: true });
+		renameSync(path, oldPath);
+		mkdirSync(path);
+
+		// Deterministically model an ABA path stat reporting the pinned numeric
+		// identity. The authority still cannot reopen or expose the replacement.
+		const actualStatSync = fsSpies.actual!.statSync;
+		fsSpies.statSync.mockImplementation(((candidate: Parameters<typeof actualStatSync>[0], options?: unknown) => {
+			if (candidate === path && options && typeof options === "object" && "bigint" in options) {
+				const replacement = actualStatSync(path, { bigint: true });
+				return { ...replacement, isDirectory: () => true, dev: pinned.dev, ino: pinned.ino };
+			}
+			return actualStatSync(candidate, options as never);
+		}) as typeof actualStatSync);
+
+		const authorization = authority.authorizeProjectDirectory(path);
+		expect(authorization.kind).toBe("granted");
+		expect(fsSpies.openSync).toHaveBeenCalledOnce();
+		if (authorization.kind !== "granted") return;
+		expect(
+			withValidatedMcpProjectTrustBinding(authorization.binding, (rootFd) => {
+				expect(rootFd).toBe(pinnedFd);
+				const opened = fsSpies.actual!.fstatSync(rootFd, { bigint: true });
+				const replacement = fsSpies.actual!.statSync(path, { bigint: true });
+				expect(opened.ino).toBe(pinned.ino);
+				expect(opened.ino).not.toBe(replacement.ino);
+				return true;
+			}),
+		).toBe(true);
+	});
+
+	it("does not close a shared authority descriptor when either binding is released", () => {
+		const path = directory();
+		const authority = createMcpProjectTrustAuthority({ revision: "r1", allowedProjectDirectories: [path] });
+		const first = authority.authorizeProjectDirectory(path);
+		const second = authority.authorizeProjectDirectory(path);
+		expect(first.kind).toBe("granted");
+		expect(second.kind).toBe("granted");
+		if (first.kind !== "granted" || second.kind !== "granted") return;
+		fsSpies.closeSync.mockClear();
+
+		releaseMcpProjectTrustBinding(first.binding);
+		expect(fsSpies.closeSync).not.toHaveBeenCalled();
+		expect(withValidatedMcpProjectTrustBinding(first.binding, () => true)).toBeUndefined();
+		expect(withValidatedMcpProjectTrustBinding(second.binding, () => true)).toBe(true);
+		releaseMcpProjectTrustBinding(second.binding);
+		expect(fsSpies.closeSync).not.toHaveBeenCalled();
+	});
+
+	it("closes every partially pinned descriptor when policy construction fails", () => {
+		const path = directory();
+		fsSpies.closeSync.mockClear();
+		const authority = createMcpProjectTrustAuthority({
+			revision: "r1",
+			allowedProjectDirectories: [path, path],
+		});
+		expect(fsSpies.openSync).toHaveBeenCalledTimes(2);
+		expect(fsSpies.closeSync).toHaveBeenCalledTimes(2);
+		expect(authority.authorizeProjectDirectory(path)).toEqual({ kind: "denied" });
+	});
+});

--- a/packages/coding-agent/test/public-command.test.ts
+++ b/packages/coding-agent/test/public-command.test.ts
@@ -37,7 +37,7 @@ vi.mock("../src/cli/daemon-ps.js", () => ({
 }));
 
 import { INTERNAL_RUNTIME_COMMAND_MARKER } from "../src/cli/args.js";
-import { formatTopLevelHelp } from "../src/cli/command-registry.js";
+import { formatTopLevelHelp, getChildCommandSpecs } from "../src/cli/command-registry.js";
 import { DAEMON_UPDATE_RESTART_COORDINATOR_FLAG } from "../src/cli/daemon-update-restart.js";
 import { handlePublicCommand } from "../src/cli/public-command.js";
 
@@ -295,6 +295,32 @@ describe("public command routing", () => {
 
 		expect(process.exitCode).toBe(1);
 		expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Unknown command: schedule nonsense"));
+	});
+
+	it("formats parser-exact MCP parent and child help and suggests misspelled child commands", async () => {
+		expect(getChildCommandSpecs(["mcp"]).map((spec) => ({ path: spec.path, usage: spec.usage }))).toEqual([
+			{ path: ["mcp", "list"], usage: "mcp list [--project]" },
+			{ path: ["mcp", "inspect"], usage: "mcp inspect <name> [--project]" },
+			{ path: ["mcp", "preview"], usage: "mcp preview <name> [--project]" },
+			{ path: ["mcp", "test"], usage: "mcp test <name> [--project]" },
+			{ path: ["mcp", "add"], usage: "mcp add <name> <url> [--project]" },
+			{ path: ["mcp", "enable"], usage: "mcp enable <name> [--project]" },
+			{ path: ["mcp", "disable"], usage: "mcp disable <name> [--project]" },
+			{ path: ["mcp", "remove"], usage: "mcp remove <name> [--project]" },
+		]);
+
+		await handlePublicCommand(["help", "mcp"]);
+		expect(console.log).toHaveBeenCalledWith(expect.stringContaining("A test probe returns an offline preview."));
+		for (const command of ["list", "inspect", "preview", "test", "add", "enable", "disable", "remove"]) {
+			expect(console.log).toHaveBeenCalledWith(expect.stringContaining(`  ${command}`));
+		}
+
+		await handlePublicCommand(["mcp", "list", "--help"]);
+		expect(console.log).toHaveBeenLastCalledWith(expect.stringContaining("prime-agent mcp list [--project]"));
+
+		await handlePublicCommand(["help", "mcp", "lis"]);
+		expect(process.exitCode).toBe(1);
+		expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Did you mean "prime-agent help mcp list"?'));
 	});
 
 	it("shows command help when options precede the help flag", async () => {

--- a/packages/coding-agent/test/sdk-mcp-boundary.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-boundary.test.ts
@@ -1,0 +1,366 @@
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	renameSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { createExtensionRuntime } from "../src/core/extensions/loader.js";
+import { McpManager } from "../src/core/mcp/mcp-manager.js";
+import { admitProjectMcpDeclarations } from "../src/core/mcp/mcp-project-trust.js";
+import { createMcpProjectTrustAuthority } from "../src/core/mcp/project-trust-authority.js";
+import type { ResourceLoader } from "../src/core/resource-loader.js";
+import { createAgentSession } from "../src/core/sdk.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager, type SettingsScope, type SettingsStorage } from "../src/core/settings-manager.js";
+import { invokeHostRequestThroughKernelForTest } from "./host-request-context.js";
+
+const mcpBoundarySpies = vi.hoisted(() => ({
+	composeProjectReader: vi.fn(),
+	createScopedReader: vi.fn(),
+	readScopedDocument: vi.fn(),
+	createRuntimeSnapshot: vi.fn(),
+	ensureKernelPython: vi.fn(),
+	spawnSync: vi.fn(),
+}));
+
+vi.mock("../src/core/kernel/bootstrap.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/core/kernel/bootstrap.js")>();
+	mcpBoundarySpies.ensureKernelPython.mockImplementation(actual.ensureKernelPython);
+	return { ...actual, ensureKernelPython: mcpBoundarySpies.ensureKernelPython };
+});
+
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	mcpBoundarySpies.spawnSync.mockImplementation(actual.spawnSync);
+	return { ...actual, spawnSync: mcpBoundarySpies.spawnSync };
+});
+
+vi.mock("../src/core/mcp/mcp-project-declaration-reader.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/core/mcp/mcp-project-declaration-reader.js")>();
+	const createScopedReader = actual.McpProjectDeclarationReader.create;
+	const readScopedDocument = actual.McpProjectDeclarationReader.prototype.getDocument;
+	mcpBoundarySpies.composeProjectReader.mockImplementation(actual.composeMcpProjectDeclarationReader);
+	mcpBoundarySpies.createScopedReader.mockImplementation(createScopedReader);
+	mcpBoundarySpies.readScopedDocument.mockImplementation(readScopedDocument);
+	Object.defineProperty(actual.McpProjectDeclarationReader, "create", {
+		configurable: true,
+		value: mcpBoundarySpies.createScopedReader,
+	});
+	Object.defineProperty(actual.McpProjectDeclarationReader.prototype, "getDocument", {
+		configurable: true,
+		value: mcpBoundarySpies.readScopedDocument,
+	});
+	return { ...actual, composeMcpProjectDeclarationReader: mcpBoundarySpies.composeProjectReader };
+});
+
+vi.mock("../src/core/mcp/mcp-runtime-declaration-snapshot.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/core/mcp/mcp-runtime-declaration-snapshot.js")>();
+	mcpBoundarySpies.createRuntimeSnapshot.mockImplementation(actual.createMcpRuntimeDeclarationSnapshot);
+	return { ...actual, createMcpRuntimeDeclarationSnapshot: mcpBoundarySpies.createRuntimeSnapshot };
+});
+
+const cleanup: string[] = [];
+
+const resourceLoader: ResourceLoader = {
+	getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
+	getSkills: () => ({ skills: [], diagnostics: [] }),
+	getPrompts: () => ({ prompts: [], diagnostics: [] }),
+	getThemes: () => ({ themes: [], diagnostics: [] }),
+	getAgentsFiles: () => ({ agentsFiles: [] }),
+	getSystemPrompt: () => undefined,
+	getAppendSystemPrompt: () => [],
+	extendResources: () => {},
+	reload: async () => {},
+};
+
+function manager(session: unknown): McpManager {
+	return (session as { _mcpManager: McpManager })._mcpManager;
+}
+
+function server(name: string, url: string) {
+	return { [name]: { type: "http" as const, url } };
+}
+
+class MemoryStorage implements SettingsStorage {
+	constructor(private readonly values: Record<SettingsScope, string | undefined>) {}
+	withLock(scope: SettingsScope, callback: (current: string | undefined) => string | undefined): void {
+		const next = callback(this.values[scope]);
+		if (next !== undefined) this.values[scope] = next;
+	}
+}
+
+async function sdk(options: NonNullable<Parameters<typeof createAgentSession>[0]>) {
+	return createAgentSession({ ...options, resourceLoader, sessionManager: SessionManager.inMemory(options.cwd) });
+}
+
+beforeEach(() => {
+	mcpBoundarySpies.composeProjectReader.mockClear();
+	mcpBoundarySpies.createScopedReader.mockClear();
+	mcpBoundarySpies.readScopedDocument.mockClear();
+	mcpBoundarySpies.createRuntimeSnapshot.mockClear();
+	mcpBoundarySpies.ensureKernelPython.mockClear();
+	mcpBoundarySpies.spawnSync.mockClear();
+});
+
+afterEach(() => {
+	while (cleanup.length > 0) {
+		const path = cleanup.pop();
+		if (path && existsSync(path)) rmSync(path, { recursive: true, force: true });
+	}
+});
+
+describe("SDK MCP boundary", () => {
+	it("uses only global legacy integrations and publishes one frozen globally admitted declaration snapshot", async () => {
+		const root = mkdtempSync(join(tmpdir(), "sdk-mcp-boundary-"));
+		const cwd = realpathSync.native(root);
+		const agentDir = join(root, "agent");
+		cleanup.push(root);
+		mkdirSync(join(cwd, ".prime", "agent"), { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({
+				mcpProjectTrustPolicy: { revision: "r1", allowedProjectDirectories: [cwd] },
+				mcpServers: server("global", "https://global.example/mcp"),
+				mcpDeclarations: {
+					version: 1,
+					servers: { user: { name: "user", url: "https://user.example/mcp", enabled: true } },
+				},
+			}),
+		);
+		writeFileSync(
+			join(cwd, ".prime", "agent", "settings.json"),
+			JSON.stringify({
+				mcpServers: server("project", "https://project.example/mcp"),
+				mcpDeclarations: {
+					version: 1,
+					servers: { project: { name: "project", url: "https://project.example/mcp", enabled: true } },
+				},
+			}),
+		);
+
+		const { session } = await sdk({ cwd, agentDir, authStorage: AuthStorage.inMemory() });
+		try {
+			const mcp = manager(session);
+			expect(mcp.listStatus().map((status) => status.server)).toContain("global");
+			expect(mcp.listStatus().map((status) => status.server)).not.toContain("project");
+			const handlers = mcp.hostHandlers();
+			expect(
+				await invokeHostRequestThroughKernelForTest(handlers["mcp.config"] as never, { server: "global" }),
+			).toEqual({
+				url: "https://global.example/mcp",
+			});
+			expect(
+				await invokeHostRequestThroughKernelForTest(handlers["mcp.config"] as never, { server: "project" }),
+			).toEqual({});
+			expect(handlers).not.toHaveProperty("mcp.declarations");
+			const snapshot = mcp.getDeclarationSnapshot()!;
+			expect(snapshot.declarations).toHaveProperty("user");
+			expect(snapshot.declarations).toHaveProperty("project");
+			expect(Object.isFrozen(snapshot)).toBe(true);
+			expect(Object.isFrozen(snapshot.declarations)).toBe(true);
+			expect(Object.isFrozen(snapshot.declarations.project)).toBe(true);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("creates an SDK session for an admitted fresh project without .prime storage", async () => {
+		const root = mkdtempSync(join(tmpdir(), "sdk-mcp-fresh-project-"));
+		const cwd = realpathSync.native(root);
+		const agentDir = join(root, "agent");
+		cleanup.push(root);
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({
+				mcpProjectTrustPolicy: { revision: "r1", allowedProjectDirectories: [cwd] },
+				mcpDeclarations: {
+					version: 1,
+					servers: { user: { name: "user", url: "https://user.example/mcp", enabled: true } },
+				},
+			}),
+		);
+
+		const { session } = await sdk({ cwd, agentDir, authStorage: AuthStorage.inMemory() });
+		try {
+			const declarations = manager(session).getDeclarationSnapshot()!.declarations;
+			expect(declarations).toHaveProperty("user");
+			expect(declarations).not.toHaveProperty("project");
+			expect(existsSync(join(cwd, ".prime"))).toBe(false);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("makes missing, forged, and root-swapped admissions user-only for injected settings", async () => {
+		const root = mkdtempSync(join(tmpdir(), "sdk-mcp-inert-"));
+		const cwd = realpathSync.native(root);
+		const replacement = `${cwd}-replacement`;
+		const old = `${cwd}-old`;
+		cleanup.push(old, replacement, root);
+		mkdirSync(replacement);
+		const authority = createMcpProjectTrustAuthority({ revision: "r1", allowedProjectDirectories: [cwd] });
+		const admission = admitProjectMcpDeclarations(cwd, authority)!;
+		const settingsManager = SettingsManager.fromStorage(
+			new MemoryStorage({
+				global: JSON.stringify({
+					mcpServers: server("global", "https://global.example/mcp"),
+					mcpDeclarations: {
+						version: 1,
+						servers: { user: { name: "user", url: "https://user.example/mcp", enabled: true } },
+					},
+				}),
+				project: JSON.stringify({
+					mcpServers: server("project", "https://project.example/mcp"),
+					mcpDeclarations: {
+						version: 1,
+						servers: { project: { name: "project", url: "https://project.example/mcp", enabled: true } },
+					},
+				}),
+			}),
+		);
+		for (const projectMcpAdmission of [undefined, {} as never]) {
+			const { session } = await sdk({
+				cwd,
+				agentDir: cwd,
+				settingsManager,
+				authStorage: AuthStorage.inMemory(),
+				projectMcpAdmission,
+			});
+			try {
+				const mcp = manager(session);
+				expect(mcp.getDeclarationSnapshot()!.declarations).toHaveProperty("user");
+				expect(mcp.getDeclarationSnapshot()!.declarations).not.toHaveProperty("project");
+				expect(mcp.listStatus().map((status) => status.server)).not.toContain("project");
+			} finally {
+				session.dispose();
+			}
+		}
+		renameSync(cwd, old);
+		renameSync(replacement, cwd);
+		const { session } = await sdk({
+			cwd,
+			agentDir: cwd,
+			settingsManager,
+			authStorage: AuthStorage.inMemory(),
+			projectMcpAdmission: admission,
+		});
+		try {
+			expect(manager(session).getDeclarationSnapshot()!.declarations).toEqual(
+				expect.objectContaining({ user: expect.any(Object) }),
+			);
+			expect(manager(session).getDeclarationSnapshot()!.declarations).not.toHaveProperty("project");
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("leaves every explicitly supplied MCP manager untouched across the project-admission matrix", async () => {
+		const physicalRoot = mkdtempSync(join(tmpdir(), "sdk-mcp-explicit-C04-target-"));
+		const root = `${physicalRoot}-C04-root`;
+		const agentDir = join(root, "agent");
+		const replacement = `${physicalRoot}-replacement`;
+		const old = `${physicalRoot}-old`;
+		cleanup.push(root, old, replacement, physicalRoot);
+		// C04 deliberately has one symlink: the root spelling. The SDK receives the
+		// physical spelling below, so this test never accidentally treats an alias as
+		// a valid admission.
+		symlinkSync(physicalRoot, root, "dir");
+		mkdirSync(agentDir, { recursive: true });
+		const authority = createMcpProjectTrustAuthority({
+			revision: "r1",
+			allowedProjectDirectories: [physicalRoot],
+		});
+		const validAdmission = admitProjectMcpDeclarations(physicalRoot, authority)!;
+
+		const cases: Array<{ name: string; admission: unknown; replaceRoot?: boolean }> = [
+			{ name: "no admission", admission: undefined },
+			{ name: "a genuine valid admission", admission: validAdmission },
+			{ name: "a forged admission", admission: Object.freeze(Object.create(null)) },
+			{ name: "a stale admission after root identity replacement", admission: validAdmission, replaceRoot: true },
+		];
+
+		for (const testCase of cases) {
+			const storageCalls: SettingsScope[] = [];
+			const settingsManager = SettingsManager.fromStorage({
+				withLock(scope, callback) {
+					storageCalls.push(scope);
+					const current =
+						scope === "global"
+							? JSON.stringify({ mcpServers: server("ordinary-global", "https://global.example/mcp") })
+							: JSON.stringify({
+									mcpDeclarations: {
+										version: 1,
+										servers: {
+											project: { name: "project", url: "https://project.example/mcp", enabled: true },
+										},
+									},
+								});
+					return callback(current);
+				},
+			});
+			// This is intentionally an ordinary SettingsManager project-scope load.
+			// The boundary below is only about *scoped project-MCP* composition/read/snapshot.
+			expect(storageCalls).toContain("project");
+			if (testCase.replaceRoot) {
+				mkdirSync(replacement);
+				renameSync(physicalRoot, old);
+				renameSync(replacement, physicalRoot);
+			}
+
+			const supplied = new McpManager({
+				authStorage: AuthStorage.inMemory(),
+				getUserServers: () => server("caller", "https://caller.example/mcp"),
+			});
+			const { session } = await sdk({
+				cwd: root,
+				agentDir,
+				authStorage: AuthStorage.inMemory(),
+				settingsManager,
+				projectMcpAdmission: testCase.admission as never,
+				mcpManager: supplied,
+			});
+			try {
+				expect(manager(session), testCase.name).toBe(supplied);
+				expect(
+					supplied.listStatus().map((status) => status.server),
+					testCase.name,
+				).toContain("caller");
+				expect(
+					await invokeHostRequestThroughKernelForTest(supplied.hostHandlers()["mcp.config"] as never, {
+						server: "caller",
+					}),
+					testCase.name,
+				).toEqual({
+					url: "https://caller.example/mcp",
+				});
+				expect(supplied.getDeclarationSnapshot(), testCase.name).toBeUndefined();
+				// Explicit-manager authority means zero scoped project-MCP composition,
+				// reader construction/read, and runtime declaration snapshot work.
+				expect(mcpBoundarySpies.composeProjectReader, testCase.name).not.toHaveBeenCalled();
+				expect(mcpBoundarySpies.createScopedReader, testCase.name).not.toHaveBeenCalled();
+				expect(mcpBoundarySpies.readScopedDocument, testCase.name).not.toHaveBeenCalled();
+				expect(mcpBoundarySpies.createRuntimeSnapshot, testCase.name).not.toHaveBeenCalled();
+				expect(mcpBoundarySpies.ensureKernelPython, testCase.name).not.toHaveBeenCalled();
+				expect(mcpBoundarySpies.spawnSync, testCase.name).not.toHaveBeenCalled();
+			} finally {
+				session.dispose();
+			}
+			mcpBoundarySpies.composeProjectReader.mockClear();
+			mcpBoundarySpies.createScopedReader.mockClear();
+			mcpBoundarySpies.readScopedDocument.mockClear();
+			mcpBoundarySpies.createRuntimeSnapshot.mockClear();
+			mcpBoundarySpies.ensureKernelPython.mockClear();
+			mcpBoundarySpies.spawnSync.mockClear();
+		}
+	});
+});


### PR DESCRIPTION
## Replacement scope

This PR reconstructs and supersedes the unique implementation delta reviewed in #1263 without rewriting that historical branch. The original PR remains the immutable discussion record: https://github.com/PrimeIntellect-ai/prime-agent/pull/1263

- Base: `core02-host-request-dispatcher`
- Replacement branch: `v080/mcp-split-m5-project-trust`
- Replacement commit: `a3ef6b6697d867a6740eaf8e8592ca85487b4f86`
- Propagation/reconciliation merge commits are intentionally excluded.
- #1264 is intentionally omitted from the replacement stacks because its declared-base-to-head tree delta is empty.
- Frozen #1243 (`77b188b92dc91365cb2bc41bdb46a50669d104a8`) is the shared foundation. For reconstructed deltas it is a proven tree-compatible base, not an ancestry claim about the historical PR stack.

## Validation

- Biome 2.5.5 on the exact changed paths: pass
- root `tsgo --noEmit`: pass
- Core focused suite on the final Core tip with live daemon/RLM environment removed and single-worker execution: 11 files, 388 tests passed
- MCP focused suite on the final MCP tip: 9 files, 106 tests passed
- Independent Terra tree/delta review: pass

No original PR was retargeted, closed, merged, or otherwise mutated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-sensitive project filesystem access, trust policy, and MCP wiring at CLI/SDK startup; misconfiguration or stale bindings fail closed by omitting project declarations rather than surfacing errors in some paths.
> 
> **Overview**
> Introduces **declarative MCP endpoint records** (name, HTTP(S) URL, enabled) separate from legacy `mcpServers`, plus a new **`prime-agent mcp`** command family for list/inspect/preview/test/add/enable/disable/remove on user or **`--project`** scope. Commands only mutate declarations, redact sensitive output, and **`test`** returns an offline initialize probe—no runtime or auth.
> 
> **Project scope** is gated by a global **`mcpProjectTrustPolicy`** (allowed directories + revision). The CLI loads global settings only before admitting project work; denied or malformed policy never opens project settings. Admitted access uses **opaque admission tokens**, a **pinned-directory trust authority** (retained root FD + binding validation), and **descriptor-relative** reads/writes of `.prime/agent/settings.json` via a bounded Python helper.
> 
> Session/SDK startup **composes admission before** full `SettingsManager` project load, builds an **immutable runtime declaration snapshot** (user first; project merged only when admission stays valid; name/endpoint collisions drop the whole project contribution), and passes it to **`McpManager`** via `getDeclarationSnapshot()` while **host handlers still use global-only** legacy servers. Injected `McpManager` instances are left untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15f003a28a4550713dbce9cb80524bb72df6043c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce MCP project trust boundaries with admission-gated declaration snapshots
> - Introduces a `McpProjectTrustAuthority` that pins project directories via retained file descriptors and issues opaque, revocable bindings; bindings are validated before and after use to detect identity changes (ABA, symlink swaps, root replacement).
> - Adds `ProjectMcpDeclarationAdmission` as a capability token gating all project MCP declaration reads and writes; admission is derived from a global trust policy and released after session initialization.
> - Builds a single immutable `McpRuntimeDeclarationSnapshot` combining user and (admission-gated) project declarations, with collision detection, deterministic code-point ordering, and a SHA-256 revision digest; `McpManager` exposes this via `getDeclarationSnapshot()`.
> - Adds a `ProjectSettingsOpenat` class that reads/writes `.prime/agent/settings.json` through a sandboxed stdlib-only Python helper over a dirfd, enforcing size/time limits and cooperative locking without exposing project paths.
> - Extends the CLI with an `mcp` command group (`list`, `inspect`, `preview`, `test`, `add`, `enable`, `disable`, `remove`) that enforces project trust policy for `--project` scope and outputs redacted JSON.
> - Risk: project MCP declarations are silently omitted (fail-closed) whenever admission is absent, invalid, or revoked — including mid-session identity changes to the project root directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15f003a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->