### PR TITLE
[v0.8 MCP 8] close late probe sessions

### DIFF
--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -152,10 +152,10 @@ export const COMMAND_SPECS: readonly CommandSpec[] = [
 	},
 	{
 		path: ["mcp"],
-		usage: "mcp <list|inspect|preview|test|add|enable|disable|remove> ... [--project]",
+		usage: "mcp <list|inspect|preview|add|enable|disable|remove> ... [--project]",
 		summary: "Manage declarative MCP endpoint records",
 		description:
-			"Commands only read or write credential-free declarations. They never start an MCP runtime or authentication flow. A test probe requires an injected local transport.",
+			"Commands only read or write credential-free declarations. They never start an MCP runtime or authentication flow.",
 	},
 ];
 

--- a/packages/coding-agent/src/cli/public-command.ts
+++ b/packages/coding-agent/src/cli/public-command.ts
@@ -171,6 +171,9 @@ export function composeMcpProjectDeclarationAdmission(
 }
 
 async function runMcpDeclarationCommand(args: string[]): Promise<PublicCommandResult> {
+	// Probing is an internal injected-executor capability only. Reject this
+	// public spelling before parsing or any settings read can occur.
+	if (args[0] === "test") throw new Error("MCP probe is unavailable in this command context.");
 	const command = parseMcpDeclarationCommand(args);
 	const workingDirectory = process.cwd();
 	if (command.scope === "project") {

--- a/packages/coding-agent/src/core/mcp/mcp-probe.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-probe.ts
@@ -1,13 +1,167 @@
 import { type McpDeclaration, previewMcpProbe } from "./mcp-declarations.js";
 
-/**
- * A declaration-only probe contract. It describes the single request a future
- * transport boundary may make, but never opens a session or reaches a network.
- * Transport ownership belongs to the runtime boundary layer.
- */
+/** The probe never constructs a network client. Callers must inject a local test transport. */
+export interface McpProbeTransport {
+	open(request: McpProbeOpenRequest): Promise<McpProbeSession>;
+}
+
+export interface McpProbeOpenRequest {
+	url: string;
+	signal: AbortSignal;
+}
+
+export interface McpProbeSession {
+	request(request: McpProbeRequest): Promise<unknown>;
+	close(): Promise<void> | void;
+}
+
+export interface McpProbeRequest {
+	method: "initialize" | "tools/list";
+	params?: Record<string, unknown>;
+	signal: AbortSignal;
+}
+
+export interface McpDeclarationProbeOptions {
+	/** Explicit offline mode blocks before the injected transport is opened. */
+	offline?: boolean;
+	/** A project declaration must have passed the C05 trust boundary first. */
+	trusted?: boolean;
+	/** Total wall-clock budget for opening and protocol requests. */
+	timeoutMs?: number;
+	/** Receives a redacted failure when a timed-out open later needs cleanup. */
+	onLateCleanupFailure?: (error: Error) => void;
+}
+
+export interface McpDeclarationProbeResult {
+	initialized: true;
+	toolsListed: true;
+}
+
+/** A bounded, offline declaration preview; it never opens a transport. */
 export type McpDeclarationProbePreview = ReturnType<typeof previewMcpProbe>;
 
 /** Returns a bounded, offline preview for an already-validated declaration. */
 export function previewMcpDeclarationProbe(declaration: McpDeclaration): McpDeclarationProbePreview {
 	return previewMcpProbe(declaration);
+}
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+const MAX_TIMEOUT_MS = 10_000;
+
+function boundedTimeout(value: number | undefined): number {
+	if (value === undefined) return DEFAULT_TIMEOUT_MS;
+	if (!Number.isFinite(value) || value <= 0) throw new Error("MCP probe timeout must be a positive finite number.");
+	return Math.max(1, Math.min(Math.floor(value), MAX_TIMEOUT_MS));
+}
+
+function publicProbeError(kind: "disabled" | "offline" | "untrusted" | "timeout" | "failed"): Error {
+	// Never expose endpoint, transport, or protocol error text: any of these can
+	// carry an accidentally credential-bearing URL or response payload.
+	if (kind === "disabled") return new Error("MCP probe is unavailable because this declaration is disabled.");
+	if (kind === "offline") return new Error("MCP probe is unavailable while offline.");
+	if (kind === "untrusted") return new Error("MCP probe is unavailable because this declaration is not trusted.");
+	if (kind === "timeout") return new Error("MCP probe timed out.");
+	return new Error("MCP probe failed.");
+}
+
+function withDeadline<T>(promise: Promise<T> | T, signal: AbortSignal): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const abort = () => reject(publicProbeError("timeout"));
+		if (signal.aborted) abort();
+		else signal.addEventListener("abort", abort, { once: true });
+		Promise.resolve(promise)
+			.then(resolve, reject)
+			.finally(() => signal.removeEventListener("abort", abort));
+	});
+}
+
+/** Close with a fresh bounded signal: a failed operation must not strand its session. */
+async function closeSession(session: McpProbeSession, timeoutMs: number): Promise<Error | undefined> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		await withDeadline(session.close(), controller.signal);
+	} catch {
+		return controller.signal.aborted ? publicProbeError("timeout") : publicProbeError("failed");
+	} finally {
+		clearTimeout(timer);
+	}
+	return undefined;
+}
+
+function reportLateCleanupFailure(options: McpDeclarationProbeOptions, error: Error): void {
+	try {
+		options.onLateCleanupFailure?.(error);
+	} catch {
+		// The probe has already completed. A diagnostic observer cannot revive it.
+	}
+}
+
+/**
+ * Executes the smallest possible read-only MCP handshake using an injected
+ * transport. It has no SDK, fetch, auth, or endpoint implementation, and is
+ * therefore usable only by an explicitly supplied local fake/adapter.
+ */
+export async function runMcpDeclarationProbe(
+	declaration: McpDeclaration,
+	transport: McpProbeTransport,
+	options: McpDeclarationProbeOptions = {},
+): Promise<McpDeclarationProbeResult> {
+	// These guards intentionally precede *all* transport work.
+	if (!declaration.enabled) throw publicProbeError("disabled");
+	if (options.offline) throw publicProbeError("offline");
+	if (options.trusted !== true) throw publicProbeError("untrusted");
+
+	const timeoutMs = boundedTimeout(options.timeoutMs);
+	const operationController = new AbortController();
+	const operationTimer = setTimeout(() => operationController.abort(), timeoutMs);
+	let opening: Promise<McpProbeSession> | undefined;
+	let session: McpProbeSession | undefined;
+	let failure: Error | undefined;
+	try {
+		// Keep the raw opening promise so a transport that resolves after our timeout
+		// is still closed. Awaiting only a deadline wrapper would lose that session.
+		// Deferring the call also sends synchronous adapter failures through redaction.
+		opening = Promise.resolve().then(() =>
+			transport.open({ url: declaration.url, signal: operationController.signal }),
+		);
+		session = await withDeadline(opening, operationController.signal);
+		await withDeadline(
+			session.request({
+				method: "initialize",
+				params: {
+					protocolVersion: "2025-03-26",
+					capabilities: {},
+					clientInfo: { name: "Prime Agent" },
+				},
+				signal: operationController.signal,
+			}),
+			operationController.signal,
+		);
+		await withDeadline(
+			session.request({ method: "tools/list", signal: operationController.signal }),
+			operationController.signal,
+		);
+	} catch (error) {
+		operationController.abort();
+		failure = error instanceof Error && error.message === "MCP probe timed out." ? error : publicProbeError("failed");
+	} finally {
+		clearTimeout(operationTimer);
+		if (session) {
+			const closeFailure = await closeSession(session, timeoutMs);
+			if (!failure && closeFailure) failure = closeFailure;
+		} else if (opening) {
+			// A timeout can win while `open` is still pending. It is not safe to
+			// abandon the eventual session, so arrange bounded, redacted cleanup.
+			void opening.then(
+				async (lateSession) => {
+					const closeFailure = await closeSession(lateSession, timeoutMs);
+					if (closeFailure) reportLateCleanupFailure(options, closeFailure);
+				},
+				() => undefined,
+			);
+		}
+	}
+	if (failure) throw failure;
+	return { initialized: true, toolsListed: true };
 }

--- a/packages/coding-agent/test/mcp-probe.test.ts
+++ b/packages/coding-agent/test/mcp-probe.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { executeMcpDeclarationCommand, parseMcpDeclarationCommand } from "../src/core/mcp/mcp-declaration-command.js";
-import { previewMcpDeclarationProbe } from "../src/core/mcp/mcp-probe.js";
+import {
+	type McpProbeSession,
+	type McpProbeTransport,
+	previewMcpDeclarationProbe,
+	runMcpDeclarationProbe,
+} from "../src/core/mcp/mcp-probe.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 
 const declaration = { name: "catalog", url: "https://catalog.test/mcp", enabled: true };
@@ -37,5 +42,157 @@ describe("MCP declaration probe contract", () => {
 			}),
 		).resolves.toEqual(previewMcpDeclarationProbe(declaration));
 		expect(opens).toBe(0);
+	});
+});
+
+function fakeTransport(calls: string[], overrides: Partial<McpProbeSession> = {}): McpProbeTransport {
+	return {
+		async open({ url }) {
+			calls.push(`open:${url}`);
+			return {
+				async request(request) {
+					calls.push(request.method);
+				},
+				async close() {
+					calls.push("close");
+				},
+				...overrides,
+			};
+		},
+	};
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+describe("MCP injected probe execution boundary", () => {
+	it("uses only initialize then tools/list and always closes the injected session", async () => {
+		const calls: string[] = [];
+		await expect(runMcpDeclarationProbe(declaration, fakeTransport(calls), { trusted: true })).resolves.toEqual({
+			initialized: true,
+			toolsListed: true,
+		});
+		expect(calls).toEqual(["open:https://catalog.test/mcp", "initialize", "tools/list", "close"]);
+		expect(calls.join(" ")).not.toContain("tools/call");
+	});
+
+	it.each([
+		["disabled", { ...declaration, enabled: false }, { trusted: true }, "disabled"],
+		["offline", declaration, { trusted: true, offline: true }, "offline"],
+		["untrusted", declaration, {}, "not trusted"],
+	] as const)("blocks %s before opening a transport", async (_name, input, options, message) => {
+		const calls: string[] = [];
+		await expect(runMcpDeclarationProbe(input, fakeTransport(calls), options)).rejects.toThrow(message);
+		expect(calls).toEqual([]);
+	});
+
+	it("redacts injected transport failures and closes the session", async () => {
+		const calls: string[] = [];
+		const transport = fakeTransport(calls, {
+			async request(request) {
+				calls.push(request.method);
+				throw new Error("https://alice:secret@catalog.test/mcp?token=secret");
+			},
+		});
+		await expect(runMcpDeclarationProbe(declaration, transport, { trusted: true })).rejects.toThrow(
+			"MCP probe failed.",
+		);
+		expect(calls).toEqual(["open:https://catalog.test/mcp", "initialize", "close"]);
+	});
+
+	it("reports a redacted cleanup failure after a successful handshake", async () => {
+		const calls: string[] = [];
+		const transport = fakeTransport(calls, {
+			async close() {
+				calls.push("close");
+				throw new Error("https://alice:secret@catalog.test/mcp?token=secret");
+			},
+		});
+		await expect(runMcpDeclarationProbe(declaration, transport, { trusted: true })).rejects.toThrow(
+			"MCP probe failed.",
+		);
+		expect(calls).toEqual(["open:https://catalog.test/mcp", "initialize", "tools/list", "close"]);
+	});
+
+	it("closes a transport session that resolves after the operation deadline", async () => {
+		const lateOpen = deferred<McpProbeSession>();
+		let closeCalls = 0;
+		let abortListeners = 0;
+		const transport: McpProbeTransport = {
+			open({ signal }) {
+				signal.addEventListener("abort", () => {
+					abortListeners++;
+				});
+				return lateOpen.promise;
+			},
+		};
+		await expect(runMcpDeclarationProbe(declaration, transport, { trusted: true, timeoutMs: 10 })).rejects.toThrow(
+			"MCP probe timed out.",
+		);
+		expect(abortListeners).toBe(1);
+		lateOpen.resolve({
+			request: async () => undefined,
+			close: async () => {
+				closeCalls++;
+			},
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(closeCalls).toBe(1);
+	});
+
+	it("reports late close failures without revealing transport data", async () => {
+		const lateOpen = deferred<McpProbeSession>();
+		const reported: Error[] = [];
+		const transport: McpProbeTransport = { open: () => lateOpen.promise };
+		await expect(
+			runMcpDeclarationProbe(declaration, transport, {
+				trusted: true,
+				timeoutMs: 10,
+				onLateCleanupFailure: (error) => reported.push(error),
+			}),
+		).rejects.toThrow("MCP probe timed out.");
+		lateOpen.resolve({
+			request: async () => undefined,
+			close: async () => {
+				throw new Error("https://alice:secret@catalog.test/mcp?token=secret");
+			},
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(reported.map((error) => error.message)).toEqual(["MCP probe failed."]);
+	});
+
+	it("keeps fractional positive timeout budgets above zero", async () => {
+		const calls: string[] = [];
+		const delays: number[] = [];
+		const originalSetTimeout = globalThis.setTimeout;
+		const timerSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+			callback: (...args: unknown[]) => void,
+			delay?: number,
+			...args: unknown[]
+		) => {
+			delays.push(Number(delay));
+			return originalSetTimeout(callback, delay, ...args);
+		}) as typeof setTimeout);
+		try {
+			await expect(
+				runMcpDeclarationProbe(declaration, fakeTransport(calls), { trusted: true, timeoutMs: 0.5 }),
+			).resolves.toEqual({ initialized: true, toolsListed: true });
+			expect(delays).toContain(1);
+			expect(delays).not.toContain(0);
+		} finally {
+			timerSpy.mockRestore();
+		}
+	});
+
+	it("does not retain deadline listeners or timers after a completed probe", async () => {
+		const calls: string[] = [];
+		await runMcpDeclarationProbe(declaration, fakeTransport(calls), { trusted: true, timeoutMs: 10 });
+		await new Promise((resolve) => setTimeout(resolve, 15));
+		expect(calls).toEqual(["open:https://catalog.test/mcp", "initialize", "tools/list", "close"]);
 	});
 });

--- a/packages/coding-agent/test/public-command.test.ts
+++ b/packages/coding-agent/test/public-command.test.ts
@@ -58,6 +58,17 @@ describe("public command routing", () => {
 		vi.restoreAllMocks();
 	});
 
+	it("rejects public mcp test before command parsing can access settings", async () => {
+		await expect(handlePublicCommand(["mcp", "test", "catalog"])).resolves.toMatchObject({ handled: true });
+		expect(process.exitCode).toBe(1);
+		expect(console.error).toHaveBeenCalledWith(expect.stringContaining("MCP probe is unavailable"));
+	});
+
+	it("does not advertise mcp test in public help", () => {
+		expect(formatTopLevelHelp()).toContain("mcp");
+		expect(formatTopLevelHelp()).not.toContain("mcp <list|inspect|preview|test");
+	});
+
 	it("rewrites attach into the normal interactive resume path", async () => {
 		await expect(handlePublicCommand(["attach", "worker"])).resolves.toEqual({
 			handled: false,


### PR DESCRIPTION
## Replacement scope

This PR reconstructs and supersedes the unique implementation delta reviewed in #1266 without rewriting that historical branch. The original PR remains the immutable discussion record: https://github.com/PrimeIntellect-ai/prime-agent/pull/1266

- Base: `v080/mcp-split-m5-project-trust`
- Replacement branch: `v080/mcp-split-m8-probe-boundaries`
- Replacement commit: `bba4f89774eb8cca21db081b1314e7c3d6602ba3`
- Propagation/reconciliation merge commits are intentionally excluded.
- #1264 is intentionally omitted from the replacement stacks because its declared-base-to-head tree delta is empty.
- Frozen #1243 (`77b188b92dc91365cb2bc41bdb46a50669d104a8`) is the shared foundation. For reconstructed deltas it is a proven tree-compatible base, not an ancestry claim about the historical PR stack.

## Validation

- Biome 2.5.5 on the exact changed paths: pass
- root `tsgo --noEmit`: pass
- Core focused suite on the final Core tip with live daemon/RLM environment removed and single-worker execution: 11 files, 388 tests passed
- MCP focused suite on the final MCP tip: 9 files, 106 tests passed
- Independent Terra tree/delta review: pass

No original PR was retargeted, closed, merged, or otherwise mutated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces MCP endpoint probing with timeout/cleanup semantics and redacts errors to avoid credential leaks; public `mcp test` behavior changes to always fail before settings access.
> 
> **Overview**
> Adds **`runMcpDeclarationProbe`** in `mcp-probe.ts`: a read-only MCP handshake (`initialize` → `tools/list`) over an **injected** transport only, with disabled/offline/trust guards, **1–10s** timeouts, **generic redacted errors** (no URL/credential leakage), and **always-on session cleanup**—including closing sessions whose `open` resolves **after** the deadline, with optional **`onLateCleanupFailure`** for late close failures.
> 
> **Public CLI change:** **`mcp test`** is removed from help/registry and **rejected immediately** in `public-command.ts` (before parsing or settings), so probing stays an internal injected-executor path; declaration **`test`** still returns the offline preview via existing command execution (tests unchanged for legacy transport injection).
> 
> Tests cover handshake shape, guard rails, redaction, late open/close, and fractional timeout floors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09faec976e4fefacf7f69ce14efa0e59922be428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close late MCP probe sessions and remove `mcp test` from public CLI
> - Adds `runMcpDeclarationProbe` in [mcp-probe.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1338/files#diff-005b7751cf8b273dc1e708748d68af4c67731415c65764836b4b942c03656b7f): a bounded, read-only MCP handshake over an injected transport that runs `initialize` then `tools/list`, redacts all transport/protocol errors, and guarantees session cleanup even when `open` resolves after the timeout deadline.
> - Late-opened sessions are closed asynchronously; failures are reported via an optional `onLateCleanupFailure` callback rather than swallowed silently.
> - Removes `mcp test` from the CLI: the subcommand spec is deleted from the registry and `runMcpDeclarationCommand` rejects immediately if the first argument is `'test'`.
> - Behavioral Change: callers that previously invoked `mcp test` now receive an error before any settings access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09faec9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->