### PR TITLE
fix(coding-agent): isolate invalid provider registrations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed an extension with an unavailable provider credential preventing other providers from loading ([#1230](https://github.com/PrimeIntellect-ai/prime-agent/issues/1230)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -234,8 +234,8 @@ export async function createAgentSessionServices(
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			diagnostics.push({
-				type: "error",
-				message: `Extension "${extensionPath}" error: ${message}`,
+				type: "warning",
+				message: `Skipped provider from extension "${extensionPath}": ${message}`,
 			});
 		}
 	}

--- a/packages/coding-agent/test/suite/regressions/1230-provider-registration-isolation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1230-provider-registration-isolation.test.ts
@@ -1,0 +1,82 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerFauxProvider } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAgentSessionServices } from "../../../src/core/agent-session-services.js";
+import { AuthStorage } from "../../../src/core/auth-storage.js";
+
+describe("issue #1230 provider registration isolation", () => {
+	const cleanups: Array<() => void> = [];
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		while (cleanups.length > 0) {
+			cleanups.pop()?.();
+		}
+	});
+
+	it("skips an unavailable provider without blocking valid providers", async () => {
+		vi.stubEnv("UNAVAILABLE_PROVIDER_KEY", "");
+		const tempDir = join(tmpdir(), `pi-1230-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		const faux = registerFauxProvider({ provider: "available-provider" });
+		cleanups.push(() => {
+			faux.unregister();
+			if (existsSync(tempDir)) {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		const authStorage = AuthStorage.inMemory();
+		authStorage.setRuntimeApiKey(faux.getModel().provider, "faux-key");
+		const services = await createAgentSessionServices({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			noBuiltinHerdrReporter: true,
+			telemetryDisabled: true,
+			resourceLoaderOptions: {
+				extensionFactories: [
+					(pi) => {
+						pi.registerProvider("unavailable-provider", {
+							baseUrl: "https://unavailable-provider.test/v1",
+							apiKey: process.env.UNAVAILABLE_PROVIDER_KEY ?? "",
+							api: "openai-completions",
+							models: [
+								{
+									id: "unavailable-model",
+									name: "Unavailable Model",
+									reasoning: false,
+									input: ["text"],
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+									contextWindow: 128000,
+									maxTokens: 4096,
+								},
+							],
+						});
+					},
+					(pi) => {
+						pi.registerProvider(faux.getModel().provider, {
+							baseUrl: faux.getModel().baseUrl,
+							apiKey: "faux-key",
+							api: faux.api,
+							models: faux.models,
+						});
+					},
+				],
+				noPromptTemplates: true,
+				noSkills: true,
+				noThemes: true,
+			},
+		});
+
+		expect(services.modelRegistry.find(faux.getModel().provider, faux.getModel().id)).toBeDefined();
+		expect(services.modelRegistry.find("unavailable-provider", "unavailable-model")).toBeUndefined();
+		expect(services.diagnostics).toContainEqual({
+			type: "warning",
+			message: expect.stringMatching(/unavailable-provider.*apiKey.*oauth/),
+		});
+		expect(services.diagnostics).not.toContainEqual(expect.objectContaining({ type: "error" }));
+	});
+});


### PR DESCRIPTION
## Summary

- treat failed extension provider registrations as non-fatal warnings
- keep valid providers available when another extension has no resolvable credential
- add focused regression coverage for mixed unavailable and valid providers

## Behavior

An invalid provider is skipped with a diagnostic that identifies its extension and validation error. Other provider registrations continue loading, while selecting the skipped provider still follows the existing unavailable-provider path.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-session-services.test.ts test/suite/regressions/1230-provider-registration-isolation.test.ts`
- `npm run check`

Fixes #1230


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate failed provider registrations in coding agent so valid providers still load
> Previously, a single extension with an unavailable provider credential could block other providers from loading. Now, failed provider registrations in `createAgentSessionServices` are caught individually and reported as warnings ("Skipped provider from extension...") instead of errors, leaving valid providers unaffected. A regression test in [1230-provider-registration-isolation.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1341/files#diff-82ac8acca2b6663fbad6d1fd2200383af9b13c1ddfc824ec59a55f19b1a4ae2d) verifies that a missing-credential provider is skipped while a valid provider registers successfully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52add7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->