### PR TITLE
fix(coding-agent): make daemon snapshot ids unique with a per-session serial

### DIFF
--- a/packages/coding-agent/src/modes/daemon/active-session-state.ts
+++ b/packages/coding-agent/src/modes/daemon/active-session-state.ts
@@ -40,6 +40,11 @@ export interface ActiveSessionState {
 	extensionUiRequests: Map<string, ActiveSessionExtensionUiRequest>;
 	eventGeneration: string;
 	lastEventSequence: DaemonEventSequence;
+	/** Monotonic per-session snapshot serial: decouples snapshot identity from
+	 *  the (eventGeneration, lastEventSequence) position, which can be reused
+	 *  with different content (fixes "Duplicate snapshot ... did not match
+	 *  cached bytes" killing healthy workers; upstream issue #1229). */
+	snapshotSerial: number;
 	unsubscribe?: () => void;
 	/** Latest background status summary, surfaced in the agents view. */
 	summaryState?: AgentStatus;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1215,6 +1215,7 @@ export class AgentDaemon {
 			extensionUiRequests: new Map(),
 			eventGeneration: createActiveSessionId(),
 			lastEventSequence: 0,
+			snapshotSerial: 0,
 			clientEnv,
 		};
 		this.sessions.set(state.activeSessionId, state);
@@ -3595,7 +3596,7 @@ export class AgentDaemon {
 					});
 				}
 				if (streamsSnapshot) {
-					const snapshotId = `${state.activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}`;
+					const snapshotId = `${state.activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}-${state.snapshotSerial++}`;
 					let transcript: SnapshotTranscriptChunkSource;
 					try {
 						transcript = createSnapshotTranscriptChunks({
@@ -6199,7 +6200,7 @@ export class AgentDaemon {
 		state: ActiveSessionState,
 		message: Extract<DaemonOutbound, { type: "session_replaced" }>,
 	): void {
-		const snapshotId = `${state.activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}`;
+		const snapshotId = `${state.activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}-${state.snapshotSerial++}`;
 		// Mark before the registry read so later events queue behind this snapshot.
 		const snapshotSignal = markClientSnapshotStreaming(client, state.activeSessionId);
 		void this.prepareReplacementSnapshot(client, state, message, snapshotId, snapshotSignal).catch((error) => {
@@ -6397,7 +6398,7 @@ export class AgentDaemon {
 							),
 						});
 					}
-					const snapshotId = `${activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}`;
+					const snapshotId = `${activeSessionId}-${state.eventGeneration}-${state.lastEventSequence}-${state.snapshotSerial++}`;
 					const snapshotSignal = markClientSnapshotStreaming(client, activeSessionId);
 					let transcript: SnapshotTranscriptChunkSource;
 					try {

--- a/packages/coding-agent/test/daemon-extension-binding.test.ts
+++ b/packages/coding-agent/test/daemon-extension-binding.test.ts
@@ -124,6 +124,7 @@ describe("daemon extension binding", () => {
 			extensionUiRequests: new Map(),
 			eventGeneration: "generation-slim",
 			lastEventSequence: 0,
+			snapshotSerial: 0,
 		};
 		await bindActiveSessionState(state, {
 			broadcast: (_state, message) => {
@@ -198,6 +199,7 @@ describe("daemon extension binding", () => {
 			extensionUiRequests: new Map(),
 			eventGeneration: "generation-test",
 			lastEventSequence: 0,
+			snapshotSerial: 0,
 			summaryState: { summary: "old recap", taskState: "completed", basedOnMessageCount: 2 },
 		};
 		await bindActiveSessionState(state, {

--- a/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4257-update-restart-resume.test.ts
@@ -77,6 +77,7 @@ function createState(
 		extensionUiRequests: new Map(),
 		eventGeneration: `generation-${activeSessionId}`,
 		lastEventSequence: 0,
+		snapshotSerial: 0,
 		...(options.clientEnv ? { clientEnv: options.clientEnv } : {}),
 	};
 }

--- a/packages/coding-agent/test/suite/regressions/4657-update-heartbeat-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4657-update-heartbeat-recovery.test.ts
@@ -69,6 +69,7 @@ describe("ENG-4657 update heartbeat recovery", () => {
 			extensionUiRequests: new Map(),
 			eventGeneration: "restored-generation",
 			lastEventSequence: 0,
+			snapshotSerial: 0,
 		};
 		internals.sessions.set(activeSessionId, state);
 		internals.cronScheduler.start();


### PR DESCRIPTION
## Problem

Fixes #1229's kill-a-healthy-worker symptom.

Worker snapshot ids reuse `(activeSessionId, eventGeneration, lastEventSequence)` as transfer identity (daemon-mode.ts). When that position is reused with different bytes - e.g. a long-thinking turn with file reads produces multiple snapshots between event cursor advances - the supervisor's duplicate validation (daemon-supervisor.ts) throws `Duplicate snapshot ... did not match cached bytes` and kills a healthy worker. Users observe `Daemon worker client closed` on `-p --mode text` with `--thinking high/max` plus tool calls.

## Fix

Decouple snapshot identity from the event position. Added a monotonic per-session `snapshotSerial` to `ActiveSessionState`, incremented at each snapshot construction, appended to the id in all three construction sites (normal snapshot, replacement snapshot, and the attach-snapshot path). The id remains an opaque string on the wire, so there is no protocol or capability change.

## Validation

- `npm run check` passes (biome 909 files, tsgo, installer render, browser smoke)
- `test/agent-connection-daemon.test.ts`: 65/65 pass
- Reproduction: the previously-failing combo (`--mode text --offline --thinking high` + file-read tool call) now completes end-to-end when run from source

## Notes

This is the minimal stopgap the issue describes; a broader redesign of the snapshot identity/transfer model can build on it later. Behavior change: duplicate-snapshot byte mismatches can no longer occur for distinct content, so the supervisor's duplicate-validation path only sees true retransmissions.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make daemon snapshot IDs unique with a per-session incrementing serial
> Snapshot IDs in the coding agent daemon were not unique across repeated emissions because they only encoded `(activeSessionId, eventGeneration, lastEventSequence)`. This adds a `snapshotSerial` counter to `ActiveSessionState` (initialized to 0) and appends an incrementing suffix to snapshot IDs in all three emission paths: initial/attach streaming, replacement snapshots, and catch-up snapshots.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12f45e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->