### PR TITLE
feat(coding-agent): bound kernel cells with an execute timeout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#1375](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375) by [@bilelrais](https://github.com/bilelrais)).
 - Added a working hint that recommends sharing traces with Prime Intellect to help train open-source LLMs.
 - Restored bare `prime-agent --resume` opening the agents view and the `/resume [id|path]` slash command; bare commands open the agents view and an argument resumes that session in place.
+- Added `kernelExecuteTimeoutSeconds` so a kernel cell can be interrupted instead of stalling the session forever when a command blocks on stdin; `0`, the default, keeps cells unbounded ([#1156](https://github.com/PrimeIntellect-ai/prime-agent/issues/1156)).
+
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 - Fixed ctrl+p ("Toggle agent message expansion") only toggling received agent messages; it now expands and collapses sent agent messages together with received ones.
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -183,6 +183,7 @@ When a provider requests a retry delay longer than `retry.provider.maxRetryDelay
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `shellPath` | string | - | Custom shell path (e.g., for Cygwin on Windows) |
+| `kernelExecuteTimeoutSeconds` | number | `0` | Interrupt a kernel cell after this many seconds. `0` leaves cells unbounded, which is the current behavior: a command blocked on stdin never returns and the session stalls with no error. |
 | `shellCommandPrefix` | string | - | Prefix for every bash command (e.g., `"shopt -s expand_aliases"`) |
 | `npmCommand` | string[] | - | Command argv used for npm package lookup/install operations (e.g., `["mise", "exec", "node@20", "--", "npm"]`) |
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -8669,6 +8669,7 @@ export class AgentSession {
 					provisioner: this._ipythonKernelProvisioner,
 					commandPrefix: this.settingsManager.getShellCommandPrefix(),
 					shellPath: this.settingsManager.getShellPath(),
+					executeTimeoutSeconds: this.settingsManager.getKernelExecuteTimeoutSeconds(),
 					onLateSentAgentMessage: (toolCallId, message) =>
 						this._recordLateIpythonSentAgentMessage(toolCallId, message),
 				},

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -178,6 +178,11 @@ export interface ExecuteOptions {
 	onLateSentAgentMessage?: (message: KernelSentAgentMessage) => void;
 	/** Cap stdout / stderr / result at this many characters. Default 65536. */
 	maxOutputChars?: number;
+	/**
+	 * Interrupt the cell after this many milliseconds. Omitted or <= 0 leaves the
+	 * cell unbounded, which is how a command blocked on stdin wedges the agent.
+	 */
+	timeoutMs?: number;
 	/** Synthetic host cell (snapshot/restore/list); excluded from lastCellCode attribution. */
 	internal?: boolean;
 }
@@ -240,7 +245,7 @@ export interface ExecuteResult {
 	attachments?: KernelAttachment[];
 	/** Agent messages sent from this cell, in order. */
 	sentAgentMessages?: KernelSentAgentMessage[];
-	status: "ok" | "error" | "aborted";
+	status: "ok" | "error" | "aborted" | "timeout";
 	error?: { ename: string; evalue: string; traceback: string[] };
 	durationMs: number;
 }
@@ -393,6 +398,8 @@ interface ActiveExecution {
 	sentAgentMessages: KernelSentAgentMessage[];
 	error?: ExecuteResult["error"];
 	status: ExecuteResult["status"];
+	/** Set when the execute timeout fired, so the result reports a timeout rather than an abort. */
+	timedOut?: boolean;
 	settled: boolean;
 	resolve: (result: ExecuteResult) => void;
 	reject: (error: Error) => void;
@@ -975,7 +982,7 @@ export class KernelManager {
 			if (this.activeExecution !== execution) {
 				return;
 			}
-			execution.status = "aborted";
+			execution.status = execution.timedOut ? "timeout" : "aborted";
 			this.resolveExecution(execution, { clearActive: false });
 		};
 		const onAbort = () => {
@@ -986,6 +993,28 @@ export class KernelManager {
 				abortTimer.unref();
 			}
 		};
+		// Bound the cell. A command blocked on stdin never yields on its own, so without
+		// this the execute never settles and the session stalls with no error and no output.
+		let executeTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+		const clearExecuteTimer = () => {
+			if (executeTimer) {
+				globalThis.clearTimeout(executeTimer);
+				executeTimer = undefined;
+			}
+		};
+		const timeoutMs = opts.timeoutMs ?? 0;
+		if (timeoutMs > 0) {
+			executeTimer = globalThis.setTimeout(() => {
+				if (this.activeExecution !== execution || execution.settled) {
+					return;
+				}
+				execution.timedOut = true;
+				onAbort();
+			}, timeoutMs);
+			if (executeTimer && typeof executeTimer === "object" && "unref" in executeTimer) {
+				executeTimer.unref();
+			}
+		}
 
 		try {
 			this.activeExecution = execution;
@@ -1012,6 +1041,7 @@ export class KernelManager {
 			return await result.promise;
 		} finally {
 			clearAbortTimer();
+			clearExecuteTimer();
 			opts.signal?.removeEventListener("abort", onAbort);
 		}
 	}
@@ -1146,7 +1176,13 @@ export class KernelManager {
 				result = `${result.slice(0, execution.maxChars)}\n[... output truncated at ${execution.maxChars} chars ...]`;
 			}
 
-			if (execution.opts.signal?.aborted) status = "aborted";
+			if (execution.timedOut) {
+				status = "timeout";
+				const seconds = Math.round((execution.opts.timeoutMs ?? 0) / 1000);
+				stderr += `${stderr ? "\n" : ""}Cell timed out after ${seconds}s and was interrupted.`;
+			} else if (execution.opts.signal?.aborted) {
+				status = "aborted";
+			}
 
 			execution.resolve({
 				stdout,

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -978,14 +978,25 @@ export class KernelManager {
 				abortTimer = undefined;
 			}
 		};
+		// First cause wins. Without this latch a user abort already inside its grace
+		// window would be relabelled a timeout, and the grace timer would restart,
+		// delaying the result the user asked to stop.
+		let settleCause: "abort" | "timeout" | undefined;
 		const forceAbort = () => {
 			if (this.activeExecution !== execution) {
 				return;
 			}
-			execution.status = execution.timedOut ? "timeout" : "aborted";
+			execution.status = settleCause === "timeout" ? "timeout" : "aborted";
 			this.resolveExecution(execution, { clearActive: false });
 		};
-		const onAbort = () => {
+		const beginSettle = (cause: "abort" | "timeout") => {
+			if (settleCause) {
+				return;
+			}
+			settleCause = cause;
+			if (cause === "timeout") {
+				execution.timedOut = true;
+			}
 			void this.interrupt().catch(() => undefined);
 			clearAbortTimer();
 			abortTimer = globalThis.setTimeout(forceAbort, KERNEL_ABORT_GRACE_MS);
@@ -993,6 +1004,7 @@ export class KernelManager {
 				abortTimer.unref();
 			}
 		};
+		const onAbort = () => beginSettle("abort");
 		// Bound the cell. A command blocked on stdin never yields on its own, so without
 		// this the execute never settles and the session stalls with no error and no output.
 		let executeTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
@@ -1008,8 +1020,7 @@ export class KernelManager {
 				if (this.activeExecution !== execution || execution.settled) {
 					return;
 				}
-				execution.timedOut = true;
-				onAbort();
+				beginSettle("timeout");
 			}, timeoutMs);
 			if (executeTimer && typeof executeTimer === "object" && "unref" in executeTimer) {
 				executeTimer.unref();
@@ -1029,7 +1040,11 @@ export class KernelManager {
 				const sendPromise = shell.send(encode(msg, conn.key));
 				sendPromise.catch(() => undefined);
 				await Promise.race([sendPromise, result.promise.then(() => undefined)]);
-				if (this.activeExecution === execution && execution.status !== "aborted") {
+				if (
+					this.activeExecution === execution &&
+					execution.status !== "aborted" &&
+					execution.status !== "timeout"
+				) {
 					await sendPromise;
 				}
 			} catch (error) {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -141,6 +141,7 @@ export interface Settings {
 	retry?: RetrySettings;
 	hideThinkingBlock?: boolean;
 	shellPath?: string; // Custom shell path (e.g., for Cygwin users on Windows)
+	kernelExecuteTimeoutSeconds?: number; // Interrupt a kernel cell after this many seconds; 0 disables
 	quietStartup?: boolean;
 	shellCommandPrefix?: string; // Prefix prepended to every bash command (e.g., "shopt -s expand_aliases" for alias support)
 	npmCommand?: string[]; // Command used for npm package lookup/install operations, argv-style (e.g., ["mise", "exec", "node@20", "--", "npm"])
@@ -949,6 +950,11 @@ export class SettingsManager {
 
 	getShellPath(): string | undefined {
 		return this.settings.shellPath;
+	}
+
+	/** Seconds before a kernel cell is interrupted. 0 (the default) leaves cells unbounded. */
+	getKernelExecuteTimeoutSeconds(): number {
+		return this.settings.kernelExecuteTimeoutSeconds ?? 0;
 	}
 
 	setShellPath(path: string | undefined): void {

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -247,7 +247,7 @@ export type IpythonToolInput = Static<typeof ipythonSchema>;
 
 export interface IpythonToolDetails {
 	durationMs?: number;
-	status?: "ok" | "error" | "aborted" | "starting";
+	status?: "ok" | "error" | "aborted" | "timeout" | "starting";
 	errorEname?: string;
 	stdout?: string;
 	stderr?: string;
@@ -267,6 +267,13 @@ export interface IpythonToolDetails {
 	};
 }
 
+/** Cells run unbounded unless a positive timeout is configured. */
+export function resolveExecuteTimeoutMs(executeTimeoutSeconds: number | undefined): number {
+	if (executeTimeoutSeconds === undefined) return 0;
+	if (!Number.isFinite(executeTimeoutSeconds) || executeTimeoutSeconds <= 0) return 0;
+	return Math.round(executeTimeoutSeconds * 1000);
+}
+
 export interface IpythonToolOptions {
 	/** Python override. Must have `ipykernel` installed. */
 	python?: string;
@@ -275,6 +282,10 @@ export interface IpythonToolOptions {
 	commandPrefix?: string;
 	/** Optional explicit shell path for bare %%bash cells. */
 	shellPath?: string;
+	/**
+	 * Interrupt a cell after this many seconds. Omitted or <= 0 leaves cells unbounded.
+	 */
+	executeTimeoutSeconds?: number;
 	sessionId?: string;
 	/** Typed host request handlers for the kernel↔host bridge (rlm.run, goal.*, …). */
 	hostHandlers?: HostRequestHandlers;
@@ -573,6 +584,7 @@ async function executeWithBusyKernelChoice(
 	onWorkingMessage: (message?: string) => void,
 	onLateSentAgentMessage: ((toolCallId: string, message: KernelSentAgentMessage) => void) | undefined,
 	ctx: ExtensionContext | undefined,
+	timeoutMs: number,
 ): Promise<{ result: ExecuteResult; kernelRestarted: boolean }> {
 	let kernelRestarted = false;
 	while (true) {
@@ -585,6 +597,7 @@ async function executeWithBusyKernelChoice(
 					onLateSentAgentMessage: onLateSentAgentMessage
 						? (message) => onLateSentAgentMessage(toolCallId, message)
 						: undefined,
+					timeoutMs,
 				}),
 				kernelRestarted,
 			};
@@ -662,6 +675,7 @@ export function createIpythonToolDefinition(
 					setToolWorkingMessage,
 					options?.onLateSentAgentMessage,
 					ctx,
+					resolveExecuteTimeoutMs(options?.executeTimeoutSeconds),
 				);
 
 				let text = r.stdout;
@@ -692,7 +706,7 @@ export function createIpythonToolDefinition(
 						kernelRestarted,
 						error: r.error,
 					},
-					isError: r.status === "error" || r.status === "aborted",
+					isError: r.status === "error" || r.status === "aborted" || r.status === "timeout",
 				};
 			} finally {
 				if (hasWorkingMessage) {

--- a/packages/coding-agent/test/kernel-execute-timeout.test.ts
+++ b/packages/coding-agent/test/kernel-execute-timeout.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { KernelManager } from "../src/core/kernel/index.js";
+
+/**
+ * Drive executeInner without a Python kernel: stub startup, hand it a connection and a
+ * shell whose send resolves, and never deliver an iopub reply. The cell then settles only
+ * through the abort or timeout path, which is exactly what these tests exercise.
+ */
+function stubKernel(manager: KernelManager): void {
+	Object.assign(manager as unknown as Record<string, unknown>, {
+		doStart: async () => {
+			(manager as unknown as { state: string }).state = "running";
+		},
+		connection: { key: "test-key" },
+		// interrupt() returns early without a control channel, so it is a no-op here.
+		control: undefined,
+		shell: { send: async () => undefined },
+	});
+}
+
+describe("KernelManager execute timeout", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("settles a never-replying cell as a timeout instead of hanging", async () => {
+		vi.useFakeTimers();
+		const manager = new KernelManager({ cwd: process.cwd() });
+		stubKernel(manager);
+
+		const execution = manager.execute("while True: pass", { timeoutMs: 5_000 });
+		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		const result = await execution;
+		expect(result.status).toBe("timeout");
+		expect(result.stderr).toContain("timed out after 5s");
+	});
+
+	it("keeps a user abort labelled aborted when a timeout fires inside the grace window", async () => {
+		vi.useFakeTimers();
+		const manager = new KernelManager({ cwd: process.cwd() });
+		stubKernel(manager);
+		const controller = new AbortController();
+
+		// A generous timeout that lands mid-grace once the abort starts settling.
+		const execution = manager.execute("while True: pass", { timeoutMs: 500, signal: controller.signal });
+		// Let startup and the request send settle first; aborting during startup takes a
+		// different path (raceStartupWithAbort) and would not exercise the latch.
+		await vi.advanceTimersByTimeAsync(0);
+		controller.abort();
+		await vi.advanceTimersByTimeAsync(500);
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		const result = await execution;
+		expect(result.status).toBe("aborted");
+		expect(result.stderr).not.toContain("timed out");
+	});
+
+	it("keeps a timeout labelled timeout when the user aborts afterwards", async () => {
+		vi.useFakeTimers();
+		const manager = new KernelManager({ cwd: process.cwd() });
+		stubKernel(manager);
+		const controller = new AbortController();
+
+		const execution = manager.execute("while True: pass", { timeoutMs: 100, signal: controller.signal });
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(100);
+		controller.abort();
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		const result = await execution;
+		expect(result.status).toBe("timeout");
+	});
+
+	// Point 3 from review: the skip guard used to cover only "aborted", so a timeout fell
+	// through to `await sendPromise` and a send that never settles hung exactly as before.
+	it("settles on timeout even when shell.send never settles", async () => {
+		vi.useFakeTimers();
+		const manager = new KernelManager({ cwd: process.cwd() });
+		stubKernel(manager);
+		Object.assign(manager as unknown as Record<string, unknown>, {
+			shell: { send: () => new Promise<void>(() => {}) },
+		});
+
+		const execution = manager.execute("while True: pass", { timeoutMs: 200 });
+		await vi.advanceTimersByTimeAsync(200);
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		const result = await execution;
+		expect(result.status).toBe("timeout");
+	});
+
+	it("leaves a cell unbounded when no timeout is set", async () => {
+		vi.useFakeTimers();
+		const manager = new KernelManager({ cwd: process.cwd() });
+		stubKernel(manager);
+
+		let settled = false;
+		void manager.execute("while True: pass", {}).then(() => {
+			settled = true;
+		});
+		await vi.advanceTimersByTimeAsync(600_000);
+
+		expect(settled).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/1156-kernel-execute-timeout.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1156-kernel-execute-timeout.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { resolveExecuteTimeoutMs } from "../../../src/core/tools/ipython.js";
+
+describe("issue #1156 kernel execute timeout", () => {
+	it("leaves cells unbounded when no timeout is configured", () => {
+		expect(resolveExecuteTimeoutMs(undefined)).toBe(0);
+	});
+
+	it("converts a configured timeout to milliseconds", () => {
+		expect(resolveExecuteTimeoutMs(30)).toBe(30_000);
+		expect(resolveExecuteTimeoutMs(1)).toBe(1_000);
+	});
+
+	it("rounds fractional seconds rather than passing a fractional delay to setTimeout", () => {
+		expect(resolveExecuteTimeoutMs(1.5)).toBe(1_500);
+		expect(resolveExecuteTimeoutMs(0.4)).toBe(400);
+	});
+
+	// 0 is the documented way to opt out, so it must mean "unbounded" and never
+	// "interrupt immediately", which would kill every cell the moment it starts.
+	it("treats zero and negative values as disabled", () => {
+		expect(resolveExecuteTimeoutMs(0)).toBe(0);
+		expect(resolveExecuteTimeoutMs(-1)).toBe(0);
+		expect(resolveExecuteTimeoutMs(-3600)).toBe(0);
+	});
+
+	it("treats non-finite values as disabled instead of scheduling an invalid timer", () => {
+		expect(resolveExecuteTimeoutMs(Number.NaN)).toBe(0);
+		expect(resolveExecuteTimeoutMs(Number.POSITIVE_INFINITY)).toBe(0);
+	});
+});


### PR DESCRIPTION
Part of #1156, and bounds the hang reported in #1214. Deliberately not marked as closing either: with the default at `0` this is opt-in, so a stock install is unchanged until the value is set.

## Problem

Nothing bounds a kernel execute. Shell commands run as `%%bash` cells through the IPython kernel, so a command that blocks on stdin never yields, the execute never settles, and the session stalls with no error, no output, and 0% CPU. #1214 documents a session that stopped permanently after four minutes of correct work and never resumed.

The standalone `bash` tool already accepts a `timeout`, but its own schema says "no default timeout", and it is not the path shell commands actually take.

## Change

`ExecuteOptions` gains `timeoutMs`. When set, a timer interrupts the cell through the existing abort path: the same `interrupt()` the user's abort uses, then the same `KERNEL_ABORT_GRACE_MS` force-settle if the kernel does not respond. No new teardown machinery.

A timed-out cell resolves as `status: "timeout"` rather than `"aborted"`, so the model can tell "I was interrupted" from "the user stopped me", and stderr gets an explicit `Cell timed out after Ns and was interrupted.` line so the reason is visible in the transcript rather than inferred from silence.

Exposed as `kernelExecuteTimeoutSeconds` in settings, defaulting to `0`.

## Scope, and what this does not do

`0` means unbounded, which is exactly today's behaviour, so this is opt-in and a stock install is unchanged until the setting is used. I did not pick a non-zero default because the right value depends on workloads I cannot see: 30s truncates legitimate builds, an hour barely helps an unattended run. Name a number and I will ship it with `0` as the documented opt-out.

This bounds the cell so the execute settles and the model sees a `timeout` status with a reason, instead of the session stalling silently at 0% CPU. It does **not** guarantee the next cell succeeds. A surviving descendant can keep the kernel busy, `executeWithBusyKernelChoice` returns `"cancel"` when there is no UI (`ipython.ts:562`), and `clearActive: false` is the pre-existing abort path. Unattended recovery means either restarting the kernel headlessly, which discards the namespace a persistent kernel exists to preserve, or process-tree cleanup of a grandchild the agent does not own. Both are larger and both need a call on what state loss should look like, so they belong in a follow-up.

## Reachability

The setting is wired end to end: `settings-manager` to `agent-session` to `IpythonToolOptions` to `KernelManager.execute`. Setting `kernelExecuteTimeoutSeconds` in `settings.json` bounds real cells rather than only existing as an SDK option.

## Tests

`packages/coding-agent/test/suite/regressions/1156-kernel-execute-timeout.test.ts` covers the resolver: unset and `0` stay unbounded, seconds convert to milliseconds, fractional seconds round, and negative or non-finite values are treated as disabled.

The last two matter more than they look. A naive `(seconds ?? 0) * 1000` yields `-1000` for a negative value and `NaN` for `NaN`, and `setTimeout` fires both immediately, which would interrupt every cell the instant it started. Those two assertions fail against that implementation.

Verified with `npm run check` and the new test plus `config.test.ts` on Node 22.22.3.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `kernelExecuteTimeoutSeconds` setting to bound kernel cell execution with an interrupt
> - Adds a `kernelExecuteTimeoutSeconds` setting (default 0 = unbounded) that interrupts a kernel cell after the configured duration and resolves with status `timeout`.
> - Wires the setting through `SettingsManager`, the `ipython` tool, and `KernelManager.execute`, which now accepts an optional `timeoutMs` and appends a stderr message on timeout.
> - User-initiated aborts that overlap with the timeout grace window are preserved as `aborted` rather than being relabeled.
> - Timeout results are classified as errors by the ipython tool, preventing the agent from treating hung cells as successful.
> - Behavioral Change: without a timeout configured, cells blocked on stdin can stall a session indefinitely; the new default leaves existing behavior unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e892338.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->