### PR TITLE
chore: add Bugbot review rules

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,46 @@
+# Review rules
+
+## No legacy or migration scaffolding
+
+- When a migration or refactor completes within a PR, its staging scaffolding
+  must be deleted, not kept: no type aliases where two names point at one type,
+  no re-exports "for compatibility" without a live external consumer, no
+  migration-era vocabulary ("staged", "legacy", "new-style") surviving in names,
+  comments, or test titles.
+- Flag any parameter, option type, or constant that has exactly one legal value
+  at every call site. That is ceremony, not configuration.
+- Flag exported symbols, fields, and methods with zero non-test consumers.
+  Speculative surface is worse than dead code in security-relevant modules: it
+  implies invariants that do not exist.
+- Flag predicates that are provably equivalent to an existing check, and call
+  sites that check the same condition twice under two spellings.
+
+## Comments
+
+- Comments must be short, human-readable, and only where the code cannot say
+  it. Flag comments that restate the code, narrate control flow, or describe
+  deleted mechanisms.
+- Doc comments must describe current behavior, not the history of how it got
+  there.
+
+## Compatibility and hot paths
+
+- Validation over persisted user data must accept everything older versions of
+  this product wrote. Check historical on-disk shapes (absent optional fields,
+  old headers) before rejecting; a validator that throws on data our own older
+  releases produced is a bug, and fail-closed handling multiplies the blast
+  radius.
+- If a function that previously swallowed errors starts throwing (or vice
+  versa), every call site must be audited in the same PR.
+- Flag loops that spawn a subprocess per item, and reads of full file contents
+  where only a prefix or header is consumed. Watch for costs that scale with
+  accumulated user state (session history, logs) on per-message or per-request
+  paths.
+- Side effects guarded by abort signals or revocation must check authority
+  immediately before the effect, not only before the reply; attaching an abort
+  listener after an event that can trigger the abort is an ordering bug.
+
+## Tests
+
+- Each bug fix carries a regression test that fails on the pre-fix code.
+- Reject tests that assert incidental details or duplicate existing coverage.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -2,43 +2,22 @@
 
 ## No legacy or migration scaffolding
 
-- When a migration or refactor completes within a PR, its staging scaffolding
-  must be deleted, not kept: no type aliases where two names point at one type,
-  no re-exports "for compatibility" without a live external consumer, no
-  migration-era vocabulary ("staged", "legacy", "new-style") surviving in names,
-  comments, or test titles.
-- Flag any parameter, option type, or constant that has exactly one legal value
-  at every call site. That is ceremony, not configuration.
-- Flag exported symbols, fields, and methods with zero non-test consumers.
-  Speculative surface is worse than dead code in security-relevant modules: it
-  implies invariants that do not exist.
-- Flag predicates that are provably equivalent to an existing check, and call
-  sites that check the same condition twice under two spellings.
+- When a migration or refactor completes within a PR, its staging scaffolding must be deleted, not kept: no type aliases where two names point at one type, no re-exports "for compatibility" without a live external consumer, no migration-era vocabulary ("staged", "legacy", "new-style") surviving in names, comments, or test titles.
+- Flag any parameter, option type, or constant that has exactly one legal value at every call site. That is ceremony, not configuration.
+- Flag exported symbols, fields, and methods with zero non-test consumers. Speculative surface is worse than dead code in security-relevant modules: it implies invariants that do not exist.
+- Flag predicates that are provably equivalent to an existing check, and call sites that check the same condition twice under two spellings.
 
 ## Comments
 
-- Comments must be short, human-readable, and only where the code cannot say
-  it. Flag comments that restate the code, narrate control flow, or describe
-  deleted mechanisms.
-- Doc comments must describe current behavior, not the history of how it got
-  there.
+- Comments must be short, human-readable, and only where the code cannot say it. Flag comments that restate the code, narrate control flow, or describe deleted mechanisms.
+- Doc comments must describe current behavior, not the history of how it got there.
 
 ## Compatibility and hot paths
 
-- Validation over persisted user data must accept everything older versions of
-  this product wrote. Check historical on-disk shapes (absent optional fields,
-  old headers) before rejecting; a validator that throws on data our own older
-  releases produced is a bug, and fail-closed handling multiplies the blast
-  radius.
-- If a function that previously swallowed errors starts throwing (or vice
-  versa), every call site must be audited in the same PR.
-- Flag loops that spawn a subprocess per item, and reads of full file contents
-  where only a prefix or header is consumed. Watch for costs that scale with
-  accumulated user state (session history, logs) on per-message or per-request
-  paths.
-- Side effects guarded by abort signals or revocation must check authority
-  immediately before the effect, not only before the reply; attaching an abort
-  listener after an event that can trigger the abort is an ordering bug.
+- Validation over persisted user data must accept everything older versions of this product wrote. Check historical on-disk shapes (absent optional fields, old headers) before rejecting; a validator that throws on data our own older releases produced is a bug, and fail-closed handling multiplies the blast radius.
+- If a function that previously swallowed errors starts throwing (or vice versa), every call site must be audited in the same PR.
+- Flag loops that spawn a subprocess per item, and reads of full file contents where only a prefix or header is consumed. Watch for costs that scale with accumulated user state (session history, logs) on per-message or per-request paths.
+- Side effects guarded by abort signals or revocation must check authority immediately before the effect, not only before the reply; attaching an abort listener after an event that can trigger the abort is an ordering bug.
 
 ## Tests
 

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -9,10 +9,10 @@
 
 ## Comments
 
-- Comments must be short, human-readable, and only where the code cannot say it. Flag comments that restate the code, narrate control flow, or describe deleted mechanisms.
+- Comments must be short, human-readable, and only where the code cannot say it. Reject comments that restate code, narrate control flow, or describe deleted mechanisms or history.
 - Doc comments must describe current behavior, not the history of how it got there.
 
 ## Tests
 
-- Each bug fix carries a regression test that fails on the pre-fix code.
-- Reject tests that assert incidental details or duplicate existing coverage.
+- Add a regression test only when it captures meaningful behavior that fails before the fix; do not require one for trivial or documentation-only changes.
+- Reject incidental or duplicate coverage and copy/string snapshot assertions that merely restate labels or descriptions; assert text only when the text is the behavior.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -12,13 +12,6 @@
 - Comments must be short, human-readable, and only where the code cannot say it. Flag comments that restate the code, narrate control flow, or describe deleted mechanisms.
 - Doc comments must describe current behavior, not the history of how it got there.
 
-## Compatibility and hot paths
-
-- Validation over persisted user data must accept everything older versions of this product wrote. Check historical on-disk shapes (absent optional fields, old headers) before rejecting; a validator that throws on data our own older releases produced is a bug, and fail-closed handling multiplies the blast radius.
-- If a function that previously swallowed errors starts throwing (or vice versa), every call site must be audited in the same PR.
-- Flag loops that spawn a subprocess per item, and reads of full file contents where only a prefix or header is consumed. Watch for costs that scale with accumulated user state (session history, logs) on per-message or per-request paths.
-- Side effects guarded by abort signals or revocation must check authority immediately before the effect, not only before the reply; attaching an abort listener after an event that can trigger the abort is an ordering bug.
-
 ## Tests
 
 - Each bug fix carries a regression test that fails on the pre-fix code.


### PR DESCRIPTION
Adds a versioned `.cursor/BUGBOT.md` with review rules distilled from recent PR reviews, so Bugbot enforces them on every PR and the standards evolve by PR like anything else.

Rules cover:
- **No legacy/migration scaffolding**: completed migrations must delete their staging aids — no two-names-one-type aliases, no compat re-exports without a live consumer, no one-legal-value option parameters, no exported surface with zero non-test consumers, no duplicate spellings of the same predicate.
- **Comment discipline**: short, human, only where the code can't say it; no restating code, no migration-era history.
- **Tests**: bug fixes carry a regression test that fails pre-fix; no incidental-detail or duplicate tests.

Verification: comment `bugbot run verbose=true` on any later PR to confirm the file is picked up.

No CHANGELOG bullet: review tooling only, no user-visible behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Cursor/Bugbot review config; no runtime or product behavior changes.
> 
> **Overview**
> Introduces **`.cursor/BUGBOT.md`** as versioned review guidance for Bugbot on future PRs.
> 
> The rules tighten three areas: **completed migrations** must drop staging aliases, compat re-exports, single-value “config,” unused exports, and duplicate predicates; **comments** stay short and describe current behavior only; **tests** require meaningful regression coverage for real fixes and avoid incidental or label-only assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13dbfeae6db5c5785f561679367639b9cb7da01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Bugbot review rules for migrations, comments, and tests
> Adds [BUGBOT.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1350/files#diff-8d00fdbe3d510a66c9b85dfb12aff0fd2feae647361195eb0cdafc40a9c604ad) defining automated review rules for the repository. Rules cover three areas: migrations/refactors (no scaffolding, flag single-value configs and unused exports), comment standards (short, describe current behavior), and test hygiene (regression test per bug fix, no incidental or duplicate tests).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1350 opened
>
> - Updated comment review rules to change rejection terminology from 'Flag' to 'Reject' and to expand rejection criteria to include commit history in addition to comments [d13dbfe]
> - Clarified regression test requirements to mandate tests only when they capture meaningful pre-fix failing behavior and expanded test rejection criteria to include incidental coverage and text-based snapshot assertions that restate labels or descriptions [d13dbfe]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4984aa6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->