### PR TITLE
feat(acp): report context usage to ACP clients

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added ACP `usage_update` reporting, so an ACP client can show how much of the context window a session has consumed ([#1351](https://github.com/PrimeIntellect-ai/prime-agent/pull/1351) by [@AndriyPytel](https://github.com/AndriyPytel)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/docs/acp.md
+++ b/packages/coding-agent/docs/acp.md
@@ -39,6 +39,9 @@ Session activity arrives as `session/update` notifications:
 | tool starts | `tool_call` (`in_progress`) |
 | tool finishes | `tool_call_update` (`completed` / `failed`) |
 | shell output | `tool_call` plus incremental `tool_call_update` |
+| context fills up | `usage_update` (tokens in context, context window) |
+
+Context usage is reported after every assistant message and after compaction, so a client can show how full the window is. It is omitted while the number is unknown — right after compaction, until the next response is costed — rather than reported as zero.
 
 IPython is Prime Agent's model-facing tool, so a cell is a `tool_call` of kind `execute` whose `rawInput` carries the cell source.
 

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -10,7 +10,7 @@ import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
 import { InProcessAgentConnection } from "../agent-connection/in-process-agent-connection.js";
-import type { AgentConnection } from "../agent-connection/types.js";
+import type { AgentConnection, AgentConnectionSessionEvent } from "../agent-connection/types.js";
 import { latestAutonomousGateAttempt } from "../headless-completion.js";
 import { type AcpEventMappingState, acpUpdatesForSessionEvent } from "./acp-events.js";
 import { primeAgentMeta } from "./acp-meta.js";
@@ -227,6 +227,34 @@ async function turnFailure(connection: AgentConnection, boundary: TurnBoundary):
 	return undefined;
 }
 
+/**
+ * Context-window usage for the session, as ACP's `usage_update`.
+ *
+ * Usage is unknown until a model response has been costed — notably right after
+ * compaction — and a client cannot render a fraction without both numbers, so an
+ * unknown reading is skipped rather than reported as zero.
+ */
+async function acpUsageUpdate(connection: AgentConnection): Promise<Record<string, unknown> | undefined> {
+	const usage = await connection
+		.getState()
+		.then((state) => state.contextUsage)
+		.catch(() => undefined);
+	if (!usage || usage.tokens === null || usage.contextWindow <= 0) return undefined;
+	return { sessionUpdate: "usage_update", used: usage.tokens, size: usage.contextWindow };
+}
+
+/**
+ * Events after which the context can hold a different number of tokens.
+ *
+ * Only a completed assistant message carries the usage the reading is computed
+ * from, and compaction replaces the transcript, so polling on anything else
+ * would cost a round trip per streamed delta to report an unchanged number.
+ */
+function changesContextUsage(event: AgentConnectionSessionEvent): boolean {
+	if (event.type === "compaction_end") return true;
+	return event.type === "message_end" && event.message.role === "assistant";
+}
+
 export async function runAcpMode(runtimeHost: AgentSessionRuntime): Promise<never> {
 	const connection = new InProcessAgentConnection(runtimeHost);
 	return runAcpModeWithConnection(connection, {
@@ -316,6 +344,11 @@ export async function runAcpModeWithConnection(
 					return;
 				}
 				if (event.type !== "session_event") return;
+				if (changesContextUsage(event.event)) {
+					void acpUsageUpdate(connection).then((update) => {
+						if (update) notify(update);
+					});
+				}
 				for (const update of acpUpdatesForSessionEvent(event.event, mappingState)) {
 					notify(update);
 				}

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -1,6 +1,6 @@
 import * as acp from "@agentclientprotocol/sdk";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.js";
 import { PRIME_AGENT_META_NAMESPACE } from "../../src/modes/acp/acp-meta.js";
 import { runAcpModeWithConnection } from "../../src/modes/acp/index.js";
@@ -81,6 +81,32 @@ describe("ACP mode end to end", () => {
 			.map((u) => u.update.content.text)
 			.join("");
 		expect(text).toContain("Hello from prime-agent");
+
+		harness.cleanup();
+	}, 30_000);
+
+	it("reports context usage after the turn", async () => {
+		const harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("Counted.")]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+
+		const { client, updates } = connectAcpClient(connection);
+
+		await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+		await client.request("session/prompt", {
+			sessionId: session.sessionId,
+			prompt: [{ type: "text", text: "Say hello" }],
+		});
+
+		// The reading is taken once the assistant message is costed, which can land
+		// after the prompt resolves.
+		await vi.waitFor(() => {
+			expect(updates.some((u) => u.update?.sessionUpdate === "usage_update")).toBe(true);
+		});
+		const usage = updates.filter((u) => u.update?.sessionUpdate === "usage_update").at(-1)?.update;
+		expect(usage.used).toBeGreaterThan(0);
+		expect(usage.size).toBeGreaterThan(usage.used);
 
 		harness.cleanup();
 	}, 30_000);


### PR DESCRIPTION
## Context

Discussion: #1356.

ACP mode emits no usage information at all, so a client driving Prime Agent over ACP has no way to show how full the context window is — the number is visible only in the TUI's context bar. Nothing in `src/modes/acp/` references usage or the context window.

There is no accepted Issue behind this one; treat it as a proposal attached to the Discussion rather than as invited work.

## Changes

Emit ACP's standard `usage_update` session update:

```json
{ "sessionUpdate": "usage_update", "used": 20846, "size": 1000000 }
```

- `used` / `size` come from `AgentConnectionState.contextUsage`, the same `ContextUsage` the TUI bar renders, so ACP and the TUI cannot disagree.
- Emitted after a completed assistant message and after compaction. Those are the only moments the reading can change (usage is costed when a response completes; compaction replaces the transcript), so a streaming turn does not cost a `getState()` round trip per delta.
- Skipped while the reading is unknown — the window between a compaction and the next costed response, where `tokens` is `null` — rather than reported as zero.

Nothing is added to an ACP object root and no `_meta` is involved: `usage_update` is a first-class `SessionUpdate` variant in `@agentclientprotocol/sdk`, so a vanilla client gets this for free.

## Validation

- `test/suite/acp-mode.test.ts` drives a real ACP client over an in-memory duplex against a faux-backed session and asserts a `usage_update` arrives with `0 < used < size`. Reverting the source change fails it.
- All ACP suites pass: `acp-events` (17), `623-acp-canonical-cwd` (3), `acp-mode` (2), `acp-rlm-subagents` (1), `acp-features` (24).
- `npm run check` passes.
- Verified against a real `prime-agent --mode acp` process with a hand-rolled NDJSON JSON-RPC client: the update lands with the live token count once the turn completes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report context window usage to ACP clients after each assistant turn
> - Adds a `usage_update` session event emitted to ACP clients after every assistant `message_end` event and after compaction, containing `used` (tokens consumed) and `size` (context window size).
> - Introduces `acpUsageUpdate` in [acp-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1351/files#diff-473a1e95bcc808978b4a7a178715a63a4641e6fd423612a47c6ecdcdb5d111ae) to query `AgentConnection` for context usage and build the payload; skips emission when usage is unknown or the context window is zero.
> - Adds an end-to-end test in [acp-mode.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1351/files#diff-098971293ecadb5180b345dc66df0841ad8385c01616c4a5b3cdc6e29e519b5d) verifying that `usage_update` is emitted with `used > 0` and `size > used` after a prompt turn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0cd6c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
