### PR TITLE
Correct harness docstring: state is session-local by default

### DIFF
--- a/prime-agent-runtime/src/rlm/harness.py
+++ b/prime-agent-runtime/src/rlm/harness.py
@@ -1,9 +1,10 @@
 """Persistent harness-state helpers for Prime Agent's RLM kernel.
 
 The state model is intentionally small: it records prompt notes, memory,
-skills, subagent specs, and refinement events in the global agent harness
-directory by default. Execution still belongs to Prime Agent's TypeScript host
-and the existing ``rlm.run`` recursion bridge.
+skills, subagent specs, and refinement events in the session-local harness
+store by default; pass ``global_=True`` for the cross-session global store.
+Execution still belongs to Prime Agent's TypeScript host and the existing
+``rlm.run`` recursion bridge.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What this does

Fixes a stale docstring in the Python runtime's harness module. It claimed that harness state (memories, prompt notes, skills, subagent specs, refinement events) is stored in the global directory by default. The code does the opposite — and has for a while: everything defaults to the session-local store, and the global store is only used when explicitly requested with `global_=True`.

Text-only change; no behavior is affected. Verified against every refinement entry point (the `/refine` command, the session's refine implementation, automatic refinement, and the Python `refine.run()` and `rlm.harness` interfaces): all default to the session-local scope already.

Lines changed: source +4/−3 (docstring only), no tests, no changelog (not user-visible behavior).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only change with no code paths, tests, or user-visible behavior affected.
> 
> **Overview**
> Updates the module docstring in `prime-agent-runtime/src/rlm/harness.py` so it matches how persistence actually works.
> 
> It now states that prompt notes, memory, skills, subagent specs, and refinement events go to the **session-local** harness store by default, and that callers must pass **`global_=True`** for the cross-session global store. The old text incorrectly described the global agent harness directory as the default.
> 
> **No runtime or API behavior changes**—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05898a847127471483b03c0b322ce76129c01ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct `rlm.harness` module docstring to state session-local default store
> Updates the [harness.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/1353/files#diff-441d64dfc5d74f553c86b609beff62210693b468d021d8bded095dea768138cf) module docstring to accurately reflect that the default store is session-local, not global. Also documents that passing `global_=True` switches to the cross-session global store, and clarifies that execution runs in the TypeScript host via `rlm.run`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a05898a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->