### PR TITLE
Capability cleanup + three admission/revocation fixes for the host-request dispatcher

### DIFF
--- a/packages/coding-agent/src/core/agent-messages.ts
+++ b/packages/coding-agent/src/core/agent-messages.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
 import type { CustomMessage } from "./messages.js";
 import { canonicalSessionPath } from "./session-lease.js";
 
@@ -529,7 +529,7 @@ export function createAgentMessageHostHandlers(
 		"agent_message.list_agents": createHostRequestHandler(async (_payload, _context) => {
 			if (!controller.roster) throw new Error("agent family roster is not available in this session");
 			return (await controller.roster()) as unknown as Record<string, unknown>;
-		}, contextAwareHostRequestHandler),
+		}),
 		"agent_message.send": createHostRequestHandler(async (payload, _context) => {
 			if (typeof payload.message !== "string") {
 				throw new Error("agent_message.send message must be a string");
@@ -602,7 +602,7 @@ export function createAgentMessageHostHandlers(
 				message: payload.message,
 				receiverRole: payload.receiver_role as AgentFamilyRelationship,
 			})) as unknown as Record<string, unknown>;
-		}, contextAwareHostRequestHandler),
+		}),
 	};
 }
 

--- a/packages/coding-agent/src/core/agent-observe.ts
+++ b/packages/coding-agent/src/core/agent-observe.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandlers } from "./kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandlers } from "./kernel/index.js";
 
 export const AGENT_OBSERVE_SKILL_NAME = "agent-observe";
 export const AGENT_OBSERVE_IMPORT_NAME = "agent_observe";
@@ -72,12 +72,11 @@ export function createAgentObserveHostHandlers(controller: AgentObserveControlle
 	return {
 		"agent_observe.list": createHostRequestHandler(
 			async (_payload, _context) => controller.listAgents() as unknown as Record<string, unknown>,
-			contextAwareHostRequestHandler,
 		),
 		"agent_observe.get": createHostRequestHandler(async (payload, _context) => {
 			if (typeof payload.target !== "string") throw new Error("agent_observe.get target must be a string");
 			return (await controller.getAgent(payload.target)) as unknown as Record<string, unknown>;
-		}, contextAwareHostRequestHandler),
+		}),
 		"agent_observe.recent": createHostRequestHandler(async (payload, _context) => {
 			if (typeof payload.target !== "string") throw new Error("agent_observe.recent target must be a string");
 			return (await controller.recentMessages({
@@ -85,7 +84,7 @@ export function createAgentObserveHostHandlers(controller: AgentObserveControlle
 				limit: normalizeOptionalInteger(payload.limit, "agent_observe.recent limit"),
 				maxChars: normalizeOptionalInteger(payload.max_chars ?? payload.maxChars, "agent_observe.recent max_chars"),
 			})) as unknown as Record<string, unknown>;
-		}, contextAwareHostRequestHandler),
+		}),
 	};
 }
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -403,7 +403,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		childId: string,
 		session: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<void> {
+	): Promise<import("./rlm-runtime.js").RlmSubagentHostDeletionResult> {
 		// Inline teardown has no daemon append, so the exact coordinator token is
 		// its sole pre-destruction fence.
 		authority?.assertCurrent();
@@ -411,7 +411,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		if (!runtime) {
 			authority?.assertCurrent();
 			await session.disposeAsync();
-			return;
+			return { deletionDurability: "absent" };
 		}
 		// A child id can be recycled after an older deletion attempt yields. The
 		// runtime metadata is assigned from CreateRlmSubagentRuntimeOptions before
@@ -436,6 +436,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 				await session.disposeAsync();
 			}
 		}
+		return { deletionDurability: "absent" };
 	}
 
 	private async finishSessionReplacement(withSession?: (ctx: ReplacedSessionContext) => Promise<void>): Promise<void> {

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -795,10 +795,16 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	}
 
 	async dispose(): Promise<void> {
-		if (!this.disposePromise) {
-			this.disposePromise = this.disposeOnce();
+		const disposePromise = this.disposePromise ?? this.disposeOnce();
+		this.disposePromise = disposePromise;
+		try {
+			await disposePromise;
+		} catch (error) {
+			if (this.disposePromise === disposePromise) {
+				this.disposePromise = undefined;
+			}
+			throw error;
 		}
-		await this.disposePromise;
 	}
 }
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -413,31 +413,51 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			// match alone cannot authorize disposing a supplied same-id incarnation.
 			throw new Error("RLM subagent runtime incarnation is no longer resident");
 		}
-		// A child id can be recycled after an older deletion attempt yields. The
-		// runtime metadata is assigned from CreateRlmSubagentRuntimeOptions before
-		// this map becomes addressable, so it is the authoritative incarnation
-		// fence for inline teardown; never treat absent metadata as a match.
+		// A child id can be recycled after an older deletion attempt yields. Any
+		// present coordinator authority must name a complete saved-session
+		// incarnation before it can destroy either the resident or a retained object.
 		if (
 			authority &&
 			(authority.childId !== childId ||
 				runtime.metadata.rlmChildId !== authority.childId ||
-				runtime.metadata.sessionDir !== authority.sessionDir)
+				typeof authority.sessionFile !== "string" ||
+				authority.sessionFile.length === 0 ||
+				typeof authority.sessionId !== "string" ||
+				authority.sessionId.length === 0)
+		) {
+			authority.assertCurrent();
+			throw new Error("RLM subagent deletion authority does not match runtime incarnation");
+		}
+		if (runtime.session !== session) {
+			// Dispose only the exact retained object named by the authority. Leave a
+			// newer map-resident incarnation intact.
+			if (
+				!authority ||
+				dirname(session.sessionFile) !== authority.sessionDir ||
+				session.sessionFile !== authority.sessionFile ||
+				session.sessionId !== authority.sessionId
+			) {
+				authority?.assertCurrent();
+				throw new Error("RLM subagent deletion does not match runtime incarnation");
+			}
+			authority.assertCurrent();
+			await session.disposeAsync();
+			return { deletionDurability: "absent" };
+		}
+		if (
+			authority &&
+			(runtime.metadata.sessionDir !== authority.sessionDir ||
+				runtime.session.sessionFile !== authority.sessionFile ||
+				runtime.session.sessionId !== authority.sessionId)
 		) {
 			authority.assertCurrent();
 			throw new Error("RLM subagent deletion authority does not match runtime incarnation");
 		}
 		authority?.assertCurrent();
-		if (runtime.session !== session) {
-			// The supplied object is the only stale incarnation we may touch. Leave
-			// the newer map resident intact.
-			if (!authority || dirname(session.sessionFile) !== authority.sessionDir) {
-				throw new Error("RLM subagent deletion does not match runtime incarnation");
-			}
-			await session.disposeAsync();
-			return { deletionDurability: "absent" };
-		}
-		this.subagentRuntimes.delete(childId);
 		await runtime.dispose();
+		// Disposal may yield while a newer runtime reuses the child id. Remove only
+		// the exact object this attempt fenced, and retain it for retry on failure.
+		if (this.subagentRuntimes.get(childId) === runtime) this.subagentRuntimes.delete(childId);
 		return { deletionDurability: "absent" };
 	}
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -433,6 +433,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			// newer map-resident incarnation intact.
 			if (
 				!authority ||
+				typeof session.sessionFile !== "string" ||
 				dirname(session.sessionFile) !== authority.sessionDir ||
 				session.sessionFile !== authority.sessionFile ||
 				session.sessionId !== authority.sessionId

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -413,6 +413,19 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			await session.disposeAsync();
 			return;
 		}
+		// A child id can be recycled after an older deletion attempt yields. The
+		// runtime metadata is assigned from CreateRlmSubagentRuntimeOptions before
+		// this map becomes addressable, so it is the authoritative incarnation
+		// fence for inline teardown; never treat absent metadata as a match.
+		if (
+			authority &&
+			(authority.childId !== childId ||
+				runtime.metadata.rlmChildId !== authority.childId ||
+				runtime.metadata.sessionDir !== authority.sessionDir)
+		) {
+			authority.assertCurrent();
+			throw new Error("RLM subagent deletion authority does not match runtime incarnation");
+		}
 		authority?.assertCurrent();
 		this.subagentRuntimes.delete(childId);
 		const shouldDisposeStaleSession = runtime.session !== session;

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -11,7 +11,12 @@ import { flushAgentTraceUpload } from "./agent-traces.js";
 import { isNoModelsAvailableMessage } from "./auth-guidance.js";
 import type { ReplacedSessionContext, SessionShutdownEvent, SessionStartEvent } from "./extensions/index.js";
 import { emitSessionShutdownEvent } from "./extensions/runner.js";
-import type { CreateRlmSubagentRuntimeOptions, RlmSubagentRuntime, SubagentRuntimeHost } from "./rlm-runtime.js";
+import type {
+	CreateRlmSubagentRuntimeOptions,
+	RlmSubagentDeletionAuthority,
+	RlmSubagentRuntime,
+	SubagentRuntimeHost,
+} from "./rlm-runtime.js";
 import type { CreateAgentSessionResult } from "./sdk.js";
 import { assertSessionCwdExists } from "./session-cwd.js";
 import { SessionImportFileNotFoundError } from "./session-import-errors.js";
@@ -394,12 +399,21 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		return runtime;
 	}
 
-	async deleteRlmSubagentRuntime(childId: string, session: AgentSession): Promise<void> {
+	async deleteRlmSubagentRuntime(
+		childId: string,
+		session: AgentSession,
+		authority?: RlmSubagentDeletionAuthority,
+	): Promise<void> {
+		// Inline teardown has no daemon append, so the exact coordinator token is
+		// its sole pre-destruction fence.
+		authority?.assertCurrent();
 		const runtime = this.subagentRuntimes.get(childId);
 		if (!runtime) {
+			authority?.assertCurrent();
 			await session.disposeAsync();
 			return;
 		}
+		authority?.assertCurrent();
 		this.subagentRuntimes.delete(childId);
 		const shouldDisposeStaleSession = runtime.session !== session;
 		try {

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -96,6 +96,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 	private subagentRuntimeHost?: SubagentRuntimeHost;
 	private subagentRuntimes = new Map<string, AgentSessionRuntime>();
 	private disposePromise?: Promise<void>;
+	private disposeStarted = false;
+	private sessionLeaseReleaseDeferred = false;
 
 	constructor(
 		private _session: AgentSession,
@@ -256,6 +258,20 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		if (lease !== this._sessionLease) {
 			lease?.release();
 		}
+	}
+
+	/**
+	 * Atomically defer lease release to the daemon before teardown begins.
+	 *
+	 * A false result means another caller already began disposal (and therefore
+	 * owns its normal release) or there is no lease to defer. Callers must not
+	 * release after a false result.
+	 */
+	claimSessionLeaseReleaseForDaemon(): boolean {
+		if (this.sessionLeaseReleaseDeferred) return true;
+		if (this.disposeStarted || !this._sessionLease) return false;
+		this.sessionLeaseReleaseDeferred = true;
+		return true;
 	}
 
 	/** Release the runtime-owned session-file lease after its daemon has committed retirement. */
@@ -755,7 +771,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		return { cancelled: false };
 	}
 
-	private async disposeOnce(releaseSessionLease = true): Promise<void> {
+	private async disposeOnce(): Promise<void> {
 		let disposeError: unknown;
 		try {
 			await emitSessionShutdownEvent(this.session.extensionRunner, {
@@ -791,13 +807,16 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 				throw disposeError;
 			}
 		} finally {
-			if (releaseSessionLease) this.releaseSessionLease();
+			if (!this.sessionLeaseReleaseDeferred) this.releaseSessionLease();
 		}
 	}
 
-	async dispose(options: { releaseSessionLease?: boolean } = {}): Promise<void> {
-		const disposePromise = this.disposePromise ?? this.disposeOnce(options.releaseSessionLease !== false);
-		this.disposePromise = disposePromise;
+	async dispose(): Promise<void> {
+		if (!this.disposePromise) {
+			this.disposeStarted = true;
+			this.disposePromise = this.disposeOnce();
+		}
+		const disposePromise = this.disposePromise;
 		try {
 			await disposePromise;
 		} catch (error) {

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, existsSync, mkdirSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import type { AgentSession } from "./agent-session.js";
 import type { AgentSessionRuntimeConfig } from "./agent-session-config.js";
 import type {
@@ -409,9 +409,9 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		authority?.assertCurrent();
 		const runtime = this.subagentRuntimes.get(childId);
 		if (!runtime) {
-			authority?.assertCurrent();
-			await session.disposeAsync();
-			return { deletionDurability: "absent" };
+			// With no resident object there is no exact-object fence. A directory
+			// match alone cannot authorize disposing a supplied same-id incarnation.
+			throw new Error("RLM subagent runtime incarnation is no longer resident");
 		}
 		// A child id can be recycled after an older deletion attempt yields. The
 		// runtime metadata is assigned from CreateRlmSubagentRuntimeOptions before
@@ -427,15 +427,17 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			throw new Error("RLM subagent deletion authority does not match runtime incarnation");
 		}
 		authority?.assertCurrent();
-		this.subagentRuntimes.delete(childId);
-		const shouldDisposeStaleSession = runtime.session !== session;
-		try {
-			await runtime.dispose();
-		} finally {
-			if (shouldDisposeStaleSession) {
-				await session.disposeAsync();
+		if (runtime.session !== session) {
+			// The supplied object is the only stale incarnation we may touch. Leave
+			// the newer map resident intact.
+			if (!authority || dirname(session.sessionFile) !== authority.sessionDir) {
+				throw new Error("RLM subagent deletion does not match runtime incarnation");
 			}
+			await session.disposeAsync();
+			return { deletionDurability: "absent" };
 		}
+		this.subagentRuntimes.delete(childId);
+		await runtime.dispose();
 		return { deletionDurability: "absent" };
 	}
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -258,7 +258,8 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		}
 	}
 
-	private releaseSessionLease(): void {
+	/** Release the runtime-owned session-file lease after its daemon has committed retirement. */
+	releaseSessionLease(): void {
 		this._sessionLease?.release();
 		this._sessionLease = undefined;
 	}
@@ -754,7 +755,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		return { cancelled: false };
 	}
 
-	private async disposeOnce(): Promise<void> {
+	private async disposeOnce(releaseSessionLease = true): Promise<void> {
 		let disposeError: unknown;
 		try {
 			await emitSessionShutdownEvent(this.session.extensionRunner, {
@@ -790,12 +791,12 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 				throw disposeError;
 			}
 		} finally {
-			this.releaseSessionLease();
+			if (releaseSessionLease) this.releaseSessionLease();
 		}
 	}
 
-	async dispose(): Promise<void> {
-		const disposePromise = this.disposePromise ?? this.disposeOnce();
+	async dispose(options: { releaseSessionLease?: boolean } = {}): Promise<void> {
+		const disposePromise = this.disposePromise ?? this.disposeOnce(options.releaseSessionLease !== false);
 		this.disposePromise = disposePromise;
 		try {
 			await disposePromise;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9178,6 +9178,11 @@ export class AgentSession {
 		return this._activeRlmChildRuns.get(childId)?.status;
 	}
 
+	/** Whether this exact child is awaiting private deletion reconciliation. */
+	isRlmChildDeletionQuarantined(childId: string): boolean {
+		return this._rlmChildDeletionQuarantines.has(childId);
+	}
+
 	private async _currentActiveSessionId(): Promise<string | undefined> {
 		try {
 			return (await this._agentMessageController?.listAgents())?.current?.activeSessionId;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10095,12 +10095,14 @@ export class AgentSession {
 		// retention, cancellation, and late-startup cleanup.
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
+			let runtimeCreationAttempted = false;
 			// A release hook is not itself proof that a cancelled, never-admitted
 			// child is durably unreachable. Preserve uncertainty rather than deleting
 			// an artifact whose durable owner cannot be proven.
-			let deletionDurability: RlmSubagentDeletionDurability = "unknown";
+			const deletionState: { durability: RlmSubagentDeletionDurability } = { durability: "unknown" };
 			try {
 				throwIfCancelled();
+				runtimeCreationAttempted = true;
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
 				const child = childRuntime.session;
 				if (run.status === "cancelled") throw new Error(run.error ?? "RLM child cancelled");
@@ -10243,10 +10245,10 @@ export class AgentSession {
 									"error",
 									authority,
 								);
-								deletionDurability = outcome?.deletionDurability ?? "unknown";
+								deletionState.durability = outcome?.deletionDurability ?? "unknown";
 							} else {
 								await this._deleteResolvedRlmSubagent(completionSubagent, authority);
-								deletionDurability = "absent";
+								deletionState.durability = "absent";
 							}
 							return { subagent: completionSubagent };
 						},
@@ -10285,6 +10287,7 @@ export class AgentSession {
 					}
 				}
 				if (!run.detachedDeletion && childSession) {
+					const finalizerSession = childSession;
 					// Error/cancellation finalizers share the exact deletion owner with
 					// explicit deletion and the compaction reaper.
 					const inFlight = this._deletingRlmChildren.get(run.id);
@@ -10294,6 +10297,7 @@ export class AgentSession {
 							rlm_child_id: run.id,
 							active_session_id: null,
 							session_id: childSession.sessionId,
+							...(childSession.sessionFile ? { session_file: childSession.sessionFile } : {}),
 							session_name: childSession.sessionName ?? sessionName,
 							session_dir: childSessionDir,
 							status: "error",
@@ -10308,28 +10312,28 @@ export class AgentSession {
 								if (this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 									try {
 										const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
-											childRuntime ?? { session: childSession },
+											childRuntime ?? { session: finalizerSession },
 											subagentOptions,
 											run.status === "cancelled" ? "cancelled" : "error",
 											authority,
 										);
-										deletionDurability = outcome?.deletionDurability ?? "unknown";
+										deletionState.durability = outcome?.deletionDurability ?? "unknown";
 									} catch (releaseError) {
 										if (!this._disposed && !this._disposing) {
 											if (this._isTombstonedRlmSubagentDeletionFailure(releaseError)) {
-												this._rlmChildSessions.set(run.id, childSession);
+												this._rlmChildSessions.set(run.id, finalizerSession);
 												this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
 											} else if (this._isPrecommitRlmSubagentDeletionFailure(releaseError)) {
 												// Keep the live host incarnation attached to the private unknown-
 												// durability lease so an exact-id retry can tombstone and close it.
-												this._rlmChildSessions.set(run.id, childSession);
+												this._rlmChildSessions.set(run.id, finalizerSession);
 											}
 										}
 										throw releaseError;
 									}
 									if (
 										run.status === "cancelled" &&
-										deletionDurability !== "unknown" &&
+										deletionState.durability !== "unknown" &&
 										!this._disposed &&
 										!this._disposing
 									) {
@@ -10339,7 +10343,7 @@ export class AgentSession {
 									return { subagent: finalizerSubagent };
 								}
 								const result = await this._deleteResolvedRlmSubagent(finalizerSubagent, authority);
-								deletionDurability = "absent";
+								deletionState.durability = "absent";
 								return result;
 							},
 						);
@@ -10354,9 +10358,12 @@ export class AgentSession {
 				// ambiguity is quarantined privately rather than being coerced into an
 				// active, idle, or inactive public child.
 				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion) {
-					if (deletionDurability === "absent") {
+					if (!runtimeCreationAttempted || deletionState.durability === "absent") {
+						// Before host creation begins, this exact reserved directory is still
+						// exclusively ours; no durability inference is required to remove it.
 						rmSync(childSessionDir, { recursive: true, force: true });
-					} else if (deletionDurability === "unknown" && !this._disposed && !this._disposing) {
+						deletionState.durability = "absent";
+					} else if (deletionState.durability === "unknown" && !this._disposed && !this._disposing) {
 						// Preserve a private cleanup lease through finalization. Unlike an
 						// explicit-delete failure, it is neither listed nor selector-addressable.
 						this._rlmChildDeletionQuarantines.set(run.id, {
@@ -10372,11 +10379,39 @@ export class AgentSession {
 				}
 			} finally {
 				if (run.detachedDeletion && childRuntime) {
-					// Startup may publish after deletion was requested. It must re-enter
-					// the same incarnation-fenced coordinator, never call the host directly.
-					await this._coordinateRlmSubagentDeletion(run.detachedDeletion, undefined, undefined, (authority) =>
-						this._deleteResolvedRlmSubagent(run.detachedDeletion!, authority),
-					).catch(() => undefined);
+					const publishedRuntime = childRuntime;
+					// The queued deletion may have completed before startup published an
+					// object. Join that exact owner, then release its settled single-flight
+					// slot before fencing and deleting the newly published incarnation.
+					const priorDeletion = this._deletingRlmChildren.get(run.id);
+					if (priorDeletion) {
+						await priorDeletion.promise.catch(() => undefined);
+						if (this._deletingRlmChildren.get(run.id) === priorDeletion) {
+							this._deletingRlmChildren.delete(run.id);
+						}
+					}
+					const publishedDeletion: RlmSubagentRegistryEntry = {
+						...run.detachedDeletion,
+						session_id: publishedRuntime.session.sessionId,
+						...(publishedRuntime.session.sessionFile
+							? { session_file: publishedRuntime.session.sessionFile }
+							: {}),
+					};
+					run.detachedDeletion = publishedDeletion;
+					await this._coordinateRlmSubagentDeletion(publishedDeletion, undefined, undefined, async (authority) => {
+						try {
+							await this._deleteRlmSubagentSession(run.id, publishedRuntime.session, authority);
+						} catch (error) {
+							if (!this._disposed && !this._disposing) {
+								this._rlmChildSessions.set(run.id, publishedRuntime.session);
+								this._rlmChildCleanupFailures.set(run.id, publishedDeletion);
+							}
+							throw error;
+						}
+						this._deletedRlmChildIds.add(run.id);
+						this._removeRlmSubagentTracking(run.id, run);
+						return { subagent: publishedDeletion };
+					}).catch(() => undefined);
 				}
 				if (this._activeRlmChildRuns.get(run.id) === run) {
 					if (this._rlmChildSessions.has(run.id)) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10080,6 +10080,7 @@ export class AgentSession {
 		try {
 			if (requestAuthority) await run.publication.promise;
 			assertRequestCurrent();
+			throwIfCancelled();
 			admissionCommitted = true;
 			if (requestAuthority) requestAuthority.signal.removeEventListener("abort", revokeAdmission);
 		} catch (error) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -169,12 +169,7 @@ import {
 	validateGoalBudget,
 	validateGoalObjective,
 } from "./goals.js";
-import {
-	contextAwareHostRequestHandler,
-	createHostRequestHandler,
-	type HostRequestHandlers,
-	type KernelSentAgentMessage,
-} from "./kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandlers, type KernelSentAgentMessage } from "./kernel/index.js";
 import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { McpManager } from "./mcp/mcp-manager.js";
 import {
@@ -8771,36 +8766,30 @@ export class AgentSession {
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
 			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target) => this.deleteRlmSubagent(target)),
-			"model.info": createHostRequestHandler(
-				async (_payload, _context) => ({
-					id: this.model?.id ?? null,
-					provider: this.model?.provider ?? null,
-					input: this.model?.input ?? [],
-				}),
-				contextAwareHostRequestHandler,
-			),
+			"model.info": createHostRequestHandler(async (_payload, _context) => ({
+				id: this.model?.id ?? null,
+				provider: this.model?.provider ?? null,
+				input: this.model?.input ?? [],
+			})),
 		};
 		if (this._includeGoals) {
 			for (const type of ["goal.get", "goal.create", "goal.complete"]) {
-				handlers[type] = createHostRequestHandler(
-					async (payload, _context) => this.handleGoalHostRequest(type, payload),
-					contextAwareHostRequestHandler,
+				handlers[type] = createHostRequestHandler(async (payload, _context) =>
+					this.handleGoalHostRequest(type, payload),
 				);
 			}
 		}
 		if (this._includeCompactSkill) {
 			for (const type of ["compact.run", "compact.status"]) {
-				handlers[type] = createHostRequestHandler(
-					async (payload, _context) => this.handleCompactHostRequest(type, payload),
-					contextAwareHostRequestHandler,
+				handlers[type] = createHostRequestHandler(async (payload, _context) =>
+					this.handleCompactHostRequest(type, payload),
 				);
 			}
 		}
 		if (this._autoRefineAllowedForSession()) {
 			for (const type of ["refine.run", "refine.status"]) {
-				handlers[type] = createHostRequestHandler(
-					async (payload, _context) => this.handleRefineHostRequest(type, payload),
-					contextAwareHostRequestHandler,
+				handlers[type] = createHostRequestHandler(async (payload, _context) =>
+					this.handleRefineHostRequest(type, payload),
 				);
 			}
 		}
@@ -8811,9 +8800,8 @@ export class AgentSession {
 				"rlm_heartbeat.update",
 				"rlm_heartbeat.delete",
 			]) {
-				handlers[type] = createHostRequestHandler(
-					async (payload, _context) => this.handleRlmHeartbeatHostRequest(type, payload),
-					contextAwareHostRequestHandler,
+				handlers[type] = createHostRequestHandler(async (payload, _context) =>
+					this.handleRlmHeartbeatHostRequest(type, payload),
 				);
 			}
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10188,16 +10188,39 @@ export class AgentSession {
 					);
 				}
 				if (!this.registerRlmChildSession(run.id, child)) {
-					if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
-						await this._subagentRuntimeHost
-							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
-							.then((outcome) => {
+					// Registration can lose a race to delete-before-publication. Join that
+					// exact owner rather than releasing the newly published runtime directly.
+					const inFlight = this._deletingRlmChildren.get(run.id);
+					const finalizerSubagent =
+						inFlight?.subagent ??
+						({
+							rlm_child_id: run.id,
+							active_session_id: null,
+							session_id: child.sessionId,
+							session_name: child.sessionName ?? sessionName,
+							session_dir: childSessionDir,
+							status: "error",
+						} satisfies RlmSubagentRegistryEntry);
+					await this._coordinateRlmSubagentDeletion(
+						finalizerSubagent,
+						undefined,
+						inFlight?.lease,
+						async (authority) => {
+							if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
+								const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
+									childRuntime,
+									subagentOptions,
+									"error",
+									authority,
+								);
 								deletionDurability = outcome?.deletionDurability ?? "unknown";
-							})
-							.catch(() => void child.disposeAsync().catch(() => undefined));
-					} else {
-						await child.disposeAsync().catch(() => undefined);
-					}
+							} else {
+								authority.assertCurrent();
+								await child.disposeAsync();
+							}
+							return { subagent: finalizerSubagent };
+						},
+					).catch(() => undefined);
 				}
 			} catch (error) {
 				const runError = error instanceof Error ? error : new Error(String(error));
@@ -10278,12 +10301,33 @@ export class AgentSession {
 						}
 					}
 				} else if (!run.detachedDeletion) {
+					const finalizerSubagent: RlmSubagentRegistryEntry = {
+						rlm_child_id: run.id,
+						active_session_id: null,
+						session_id: childSession?.sessionId ?? null,
+						session_name: childSession?.sessionName ?? sessionName,
+						session_dir: childSessionDir,
+						status: "error",
+					};
 					try {
-						if (childRuntime && this._subagentRuntimeHost) {
-							await this._subagentRuntimeHost.deleteRlmSubagentRuntime(run.id, childRuntime.session);
-						} else if (childSession) {
-							await childSession.disposeAsync();
-						}
+						await this._coordinateRlmSubagentDeletion(
+							finalizerSubagent,
+							undefined,
+							undefined,
+							async (authority) => {
+								if (childRuntime && this._subagentRuntimeHost) {
+									await this._subagentRuntimeHost.deleteRlmSubagentRuntime(
+										run.id,
+										childRuntime.session,
+										authority,
+									);
+								} else if (childSession) {
+									authority.assertCurrent();
+									await childSession.disposeAsync();
+								}
+								return { subagent: finalizerSubagent };
+							},
+						);
 						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
 							// The known dispose-only host owns no durable registry, so a successful
 							// fallback delete is affirmative absence rather than an I/O guess.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10277,6 +10277,7 @@ export class AgentSession {
 							undefined,
 							inFlight?.lease,
 							async (authority) => {
+								if (this._deletedRlmChildIds.has(run.id)) return { subagent: finalizerSubagent };
 								if (this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 									try {
 										const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9229,6 +9229,9 @@ export class AgentSession {
 				rlm_child_id: run.id,
 				active_session_id: daemonChild?.activeSessionId ?? null,
 				session_id: daemonChild?.sessionId ?? run.session?.sessionId ?? null,
+				...((daemonChild?.sessionPath ?? run.session?.sessionFile)
+					? { session_file: daemonChild?.sessionPath ?? run.session?.sessionFile }
+					: {}),
 				session_name: daemonChild?.sessionName ?? run.session?.sessionName ?? run.sessionName,
 				session_dir: run.sessionDir,
 				status: run.status === "done" ? "completed" : run.status === "error" ? "error" : "running",
@@ -9253,6 +9256,9 @@ export class AgentSession {
 				rlm_child_id: childId,
 				active_session_id: daemonChild?.activeSessionId ?? null,
 				session_id: daemonChild?.sessionId ?? childSession.sessionId,
+				...((daemonChild?.sessionPath ?? childSession.sessionFile)
+					? { session_file: daemonChild?.sessionPath ?? childSession.sessionFile }
+					: {}),
 				session_name:
 					daemonChild?.sessionName ?? childSession.sessionName ?? createDefaultRlmSubagentSessionName("", childId),
 				session_dir: sessionDir,
@@ -9275,6 +9281,7 @@ export class AgentSession {
 				rlm_child_id: childId,
 				active_session_id: daemonChild.activeSessionId,
 				session_id: daemonChild.sessionId,
+				...(daemonChild.sessionPath ? { session_file: daemonChild.sessionPath } : {}),
 				session_name: daemonChild.sessionName ?? createDefaultRlmSubagentSessionName("", childId),
 				session_dir: daemonChild.sessionDir,
 				status: daemonChild.rlmChildRegistryStatus === "completed" ? "completed" : "error",
@@ -9424,6 +9431,7 @@ export class AgentSession {
 							...subagent,
 							active_session_id: daemonChild.activeSessionId,
 							session_id: daemonChild.sessionId,
+							...(daemonChild.sessionPath ? { session_file: daemonChild.sessionPath } : {}),
 							session_name: daemonChild.sessionName ?? subagent.session_name,
 						}
 					: subagent;
@@ -9508,6 +9516,8 @@ export class AgentSession {
 			authority = {
 				childId: subagent.rlm_child_id,
 				sessionDir: subagent.session_dir,
+				...(subagent.session_file ? { sessionFile: subagent.session_file } : {}),
+				...(subagent.session_id ? { sessionId: subagent.session_id } : {}),
 				generation,
 				assertCurrent: () => {
 					if (signal?.aborted) throw new Error("host request authority was revoked");
@@ -9561,6 +9571,7 @@ export class AgentSession {
 			authority ?? {
 				childId,
 				sessionDir: lease.session_dir,
+				...(lease.session_id ? { sessionId: lease.session_id } : {}),
 				generation: 0,
 				assertCurrent: () => {},
 			},

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9774,6 +9774,23 @@ export class AgentSession {
 			if (run.status === "cancelled") throw new Error(run.error ?? "RLM child cancelled");
 		};
 		this._activeRlmChildRuns.set(run.id, run);
+		// Revocation must be armed before the first queued update reaches subscribers:
+		// a subscriber can revoke the request authority as its reaction to that very
+		// update, and an abort listener attached afterwards would never fire.
+		let admissionCommitted = false;
+		const revokeAdmission = () => {
+			if (!admissionCommitted) this._cancelRlmChildRun(run, "host request authority was revoked");
+		};
+		if (requestAuthority) requestAuthority.signal.addEventListener("abort", revokeAdmission, { once: true });
+		try {
+			assertRequestCurrent();
+		} catch (error) {
+			if (requestAuthority) requestAuthority.signal.removeEventListener("abort", revokeAdmission);
+			this._cancelRlmChildRun(run, "host request authority was revoked");
+			this._activeRlmChildRuns.delete(run.id);
+			rmSync(childSessionDir, { recursive: true, force: true });
+			throw error;
+		}
 		const emitChildUpdate = () => {
 			const childModel = childSession?.model ?? modelSelection.model;
 			this._emit({
@@ -9843,12 +9860,6 @@ export class AgentSession {
 		// Runtime startup and the task run are deliberately detached. The public
 		// spawn resolves at admission, while this task owns live tracking, usage,
 		// retention, cancellation, and late-startup cleanup.
-		let admissionCommitted = false;
-		const revokeAdmission = () => {
-			if (!admissionCommitted) this._cancelRlmChildRun(run, "host request authority was revoked");
-		};
-		if (requestAuthority) requestAuthority.signal.addEventListener("abort", revokeAdmission, { once: true });
-		assertRequestCurrent();
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
 			try {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -228,6 +228,7 @@ import {
 	type RlmFindModelsResult,
 	type RlmListSubagentsResult,
 	type RlmSpawnHandle,
+	type RlmSubagentDeletionAuthority,
 	type RlmSubagentDeletionDurability,
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
@@ -1229,10 +1230,18 @@ export class AgentSession {
 	// lifecycle status. Keep its private cleanup lease through finalization until a
 	// host later proves absence or a durable tombstone.
 	private _rlmChildDeletionQuarantines = new Map<string, RlmSubagentRegistryEntry>();
+	/**
+	 * One deletion transaction per child id. A transaction owns a monotonically
+	 * increasing generation and the exact registry entry/lease it was minted
+	 * for; neither a stale waiter nor a reused child id can commit with it.
+	 */
+	private _rlmChildDeletionGeneration = 0;
 	private _deletingRlmChildren = new Map<
 		string,
 		{
 			subagent: RlmSubagentRegistryEntry;
+			generation: number;
+			lease?: RlmSubagentRegistryEntry;
 			promise: Promise<RlmDeleteSubagentResult>;
 		}
 	>();
@@ -7257,9 +7266,17 @@ export class AgentSession {
 			(childId) => !this._activeRlmChildRuns.get(childId)?.detachedDeletion,
 		);
 		await Promise.allSettled(childIds.map((childId) => this.deleteRlmSubagent(childId)));
+		// Quarantine reconciliation shares the same per-child coordinator as an
+		// explicit retry. A reaper is a waiter/promotion candidate, never a
+		// second durable writer racing the user request.
 		await Promise.allSettled(
-			[...this._rlmChildDeletionQuarantines.keys()].map((childId) =>
-				this._resolveRlmChildDeletionQuarantine(childId),
+			[...this._rlmChildDeletionQuarantines.entries()].map(([childId, lease]) =>
+				this._coordinateRlmSubagentDeletion(lease, undefined, lease, async (authority) => {
+					if (!(await this._resolveRlmChildDeletionQuarantine(childId, authority))) {
+						throw new Error("RLM subagent deletion durability is still unknown");
+					}
+					return { subagent: lease };
+				}),
 			),
 		);
 	}
@@ -9319,11 +9336,11 @@ export class AgentSession {
 		if (isRunning()) {
 			return "running";
 		}
-		const result = await this._trackRlmSubagentDeletion(subagent, () => {
+		const result = await this._coordinateRlmSubagentDeletion(subagent, undefined, undefined, (authority) => {
 			if (isRunning()) {
 				return Promise.resolve({ subagent, outcome: "skipped_running" });
 			}
-			return this._deleteResolvedRlmSubagent(subagent);
+			return this._deleteResolvedRlmSubagent(subagent, authority);
 		});
 		return result.outcome === "skipped_running" ? "running" : "deleted";
 	}
@@ -9357,19 +9374,29 @@ export class AgentSession {
 			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
 		}
 		if (inFlight[0]) {
-			// A coalesced waiter retains its own revocation boundary rather than
-			// inheriting the initiating request's authority.
-			const result = await inFlight[0].promise;
-			assertDeleteAuthority();
-			return result;
+			// Join through the coordinator rather than returning the bare owner
+			// promise: if an aborted owner fails before commit, this live waiter can
+			// promote a fresh generation after it drains.
+			const joined = inFlight[0];
+			return this._coordinateRlmSubagentDeletion(joined.subagent, signal, joined.lease, (authority) => {
+				if (joined.lease) {
+					return this._resolveRlmChildDeletionQuarantine(joined.subagent.rlm_child_id, authority).then(
+						(resolved) => {
+							if (!resolved) throw new Error("RLM subagent deletion durability is still unknown");
+							return { subagent: joined.subagent };
+						},
+					);
+				}
+				return this._deleteResolvedRlmSubagent(joined.subagent, authority);
+			});
 		}
 		// Quarantine is deliberately absent from public list/roster/hydration, but
 		// the caller holding the exact opaque child id may explicitly retry its
 		// durability check. Names and session ids cannot address private leases.
 		const quarantined = this._rlmChildDeletionQuarantines.get(target);
 		if (quarantined) {
-			return this._trackRlmSubagentDeletion(quarantined, async () => {
-				if (!(await this._resolveRlmChildDeletionQuarantine(target, assertDeleteAuthority))) {
+			return this._coordinateRlmSubagentDeletion(quarantined, signal, quarantined, async (authority) => {
+				if (!(await this._resolveRlmChildDeletionQuarantine(target, authority))) {
 					throw new Error("RLM subagent deletion durability is still unknown");
 				}
 				return { subagent: quarantined };
@@ -9377,7 +9404,7 @@ export class AgentSession {
 		}
 		if (localMatches[0]) {
 			const subagent = localMatches[0];
-			return this._trackRlmSubagentDeletion(subagent, async () => {
+			return this._coordinateRlmSubagentDeletion(subagent, signal, undefined, async (authority) => {
 				const listedAgents = await this._agentMessageController?.listAgents();
 				const listedSubagents = this._buildRlmSubagentList(listedAgents).subagents;
 				const passiveMatches = listedSubagents.filter(
@@ -9399,8 +9426,8 @@ export class AgentSession {
 							session_name: daemonChild.sessionName ?? subagent.session_name,
 						}
 					: subagent;
-				assertDeleteAuthority();
-				return this._deleteResolvedRlmSubagent(resolvedSubagent);
+				authority.assertCurrent();
+				return this._deleteResolvedRlmSubagent(resolvedSubagent, authority);
 			});
 		}
 
@@ -9413,29 +9440,107 @@ export class AgentSession {
 			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
 		}
 		const subagent = directMatches[0] ?? (await this._resolveDirectRlmSubagent(target));
-		return this._trackRlmSubagentDeletion(subagent, () => {
-			assertDeleteAuthority();
-			return this._deleteResolvedRlmSubagent(subagent);
+		return this._coordinateRlmSubagentDeletion(subagent, signal, undefined, (authority) => {
+			authority.assertCurrent();
+			return this._deleteResolvedRlmSubagent(subagent, authority);
 		});
 	}
 
-	private async _trackRlmSubagentDeletion(
-		subagent: RlmSubagentRegistryEntry,
-		startDeletion: () => Promise<RlmDeleteSubagentResult>,
-	): Promise<RlmDeleteSubagentResult> {
-		const existing = this._deletingRlmChildren.get(subagent.rlm_child_id);
-		if (existing) return existing.promise;
-		const deletion = Promise.resolve().then(startDeletion);
-		this._deletingRlmChildren.set(subagent.rlm_child_id, {
-			subagent,
-			promise: deletion,
+	/** Await a shared durable attempt without transferring the caller's abort authority. */
+	private async _awaitRlmDeletionWithAuthority<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+		if (!signal) return promise;
+		if (signal.aborted) throw new Error("host request authority was revoked");
+		return await new Promise<T>((resolve, reject) => {
+			const abort = () => reject(new Error("host request authority was revoked"));
+			signal.addEventListener("abort", abort, { once: true });
+			void promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
 		});
-		try {
-			return await deletion;
-		} finally {
-			if (this._deletingRlmChildren.get(subagent.rlm_child_id)?.promise === deletion) {
-				this._deletingRlmChildren.delete(subagent.rlm_child_id);
+	}
+
+	/**
+	 * The sole deletion transaction coordinator. It serializes explicit retries
+	 * and compaction reapers by child id, then fences the owner with both a
+	 * monotonic generation and the exact child incarnation/lease. An owner that
+	 * loses request authority before commit leaves no mutation; a live waiter
+	 * retries as the next generation rather than inheriting stale authority.
+	 */
+	private async _coordinateRlmSubagentDeletion(
+		subagent: RlmSubagentRegistryEntry,
+		signal: AbortSignal | undefined,
+		lease: RlmSubagentRegistryEntry | undefined,
+		startDeletion: (authority: RlmSubagentDeletionAuthority) => Promise<RlmDeleteSubagentResult>,
+	): Promise<RlmDeleteSubagentResult> {
+		for (;;) {
+			if (signal?.aborted) throw new Error("host request authority was revoked");
+			const existing = this._deletingRlmChildren.get(subagent.rlm_child_id);
+			if (existing) {
+				// Same id is not enough: an id reuse must never join an older lease.
+				if (
+					existing.subagent.session_dir !== subagent.session_dir ||
+					existing.subagent.session_id !== subagent.session_id ||
+					existing.lease !== lease
+				) {
+					throw new Error("RLM subagent deletion lease changed");
+				}
+				try {
+					const result = await this._awaitRlmDeletionWithAuthority(existing.promise, signal);
+					if (signal?.aborted) throw new Error("host request authority was revoked");
+					return result;
+				} catch (error) {
+					// A request-scoped owner may have been revoked before its append
+					// boundary. A still-live explicit caller or reaper promotes itself
+					// after that owner drains, with a fresh never-reused generation.
+					if (
+						signal?.aborted ||
+						!(error instanceof Error) ||
+						error.message !== "host request authority was revoked"
+					) {
+						throw error;
+					}
+					await Promise.resolve();
+					continue;
+				}
 			}
+			const generation = ++this._rlmChildDeletionGeneration;
+			let authority!: RlmSubagentDeletionAuthority;
+			const deletion = Promise.resolve().then(() => startDeletion(authority));
+			authority = {
+				childId: subagent.rlm_child_id,
+				sessionDir: subagent.session_dir,
+				generation,
+				assertCurrent: () => {
+					if (signal?.aborted) throw new Error("host request authority was revoked");
+					const current = this._deletingRlmChildren.get(subagent.rlm_child_id);
+					if (
+						!current ||
+						current.generation !== generation ||
+						current.subagent !== subagent ||
+						current.lease !== lease ||
+						(lease && this._rlmChildDeletionQuarantines.get(subagent.rlm_child_id) !== lease)
+					) {
+						throw new Error("host request authority was revoked");
+					}
+				},
+			};
+			this._deletingRlmChildren.set(subagent.rlm_child_id, { subagent, generation, lease, promise: deletion });
+			// A request-scoped waiter may abort while the shared commit owner keeps
+			// running. Only the owner's settlement may release the single-flight
+			// slot; otherwise a later retry could append concurrently.
+			void deletion.then(
+				() => {
+					if (this._deletingRlmChildren.get(subagent.rlm_child_id)?.generation === generation) {
+						this._deletingRlmChildren.delete(subagent.rlm_child_id);
+					}
+				},
+				() => {
+					if (this._deletingRlmChildren.get(subagent.rlm_child_id)?.generation === generation) {
+						this._deletingRlmChildren.delete(subagent.rlm_child_id);
+					}
+				},
+			);
+			const result = await this._awaitRlmDeletionWithAuthority(deletion, signal);
+			if (signal?.aborted) throw new Error("host request authority was revoked");
+			return result;
 		}
 	}
 
@@ -9445,17 +9550,24 @@ export class AgentSession {
 	 */
 	private async _resolveRlmChildDeletionQuarantine(
 		childId: string,
-		assertDeleteAuthority: () => void = () => {},
+		authority?: RlmSubagentDeletionAuthority,
 	): Promise<boolean> {
 		const lease = this._rlmChildDeletionQuarantines.get(childId);
 		if (!lease || this._disposed || this._disposing) return false;
-		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId, {
-			assertCurrent: assertDeleteAuthority,
-		});
+		authority?.assertCurrent();
+		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(
+			childId,
+			authority ?? {
+				childId,
+				sessionDir: lease.session_dir,
+				generation: 0,
+				assertCurrent: () => {},
+			},
+		);
 		if (durability !== "absent" && durability !== "tombstoned") return false;
 		// The host await is a revocation boundary. Do not mutate the artifact or
 		// private deletion bookkeeping after its caller has lost authority.
-		assertDeleteAuthority();
+		authority?.assertCurrent();
 		// A retry/reaper can yield while the host reads. It may only discharge the
 		// exact lease it resolved, never a newer lease reusing this child id.
 		if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
@@ -9470,9 +9582,15 @@ export class AgentSession {
 		return true;
 	}
 
-	private _deleteRlmSubagentSession(childId: string, session?: AgentSession): Promise<void> {
+	private _deleteRlmSubagentSession(
+		childId: string,
+		session?: AgentSession,
+		authority?: RlmSubagentDeletionAuthority,
+	): Promise<void> {
 		if (this._subagentRuntimeHost) {
-			return this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
+			return authority
+				? this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session, authority)
+				: this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
 		}
 		return session?.disposeAsync() ?? Promise.resolve();
 	}
@@ -9511,22 +9629,29 @@ export class AgentSession {
 		});
 	}
 
-	private async _deleteResolvedRlmSubagent(subagent: RlmSubagentRegistryEntry): Promise<RlmDeleteSubagentResult> {
+	private async _deleteResolvedRlmSubagent(
+		subagent: RlmSubagentRegistryEntry,
+		authority?: RlmSubagentDeletionAuthority,
+	): Promise<RlmDeleteSubagentResult> {
+		// Nothing local is a durable commit. The host must assert the same token
+		// immediately before any durable/inline teardown; local publication only
+		// follows that successful boundary.
+		authority?.assertCurrent();
 		const childId = subagent.rlm_child_id;
 		const run = this._activeRlmChildRuns.get(childId);
 		if (run) {
-			if (!this._cancelRlmChildRun(run, "Deleted by parent orchestrator")) {
-				this._emitRlmSubagentRemoval(subagent);
-			}
 			const liveSession = run.session;
 			if (run.status === "error" && !liveSession && run.settled) {
+				authority?.assertCurrent();
+				this._emitRlmSubagentRemoval(subagent);
 				this._deletedRlmChildIds.add(childId);
 				this._removeRlmSubagentTracking(childId, run);
 				return { subagent };
 			}
 			if (liveSession) {
+				authority?.assertCurrent();
 				try {
-					await this._deleteRlmSubagentSession(childId, liveSession);
+					await this._deleteRlmSubagentSession(childId, liveSession, authority);
 				} catch (error) {
 					if (this._disposed || this._disposing) {
 						this._removeRlmSubagentTracking(childId, run);
@@ -9542,23 +9667,30 @@ export class AgentSession {
 					run.session = undefined;
 					throw error;
 				}
+				// The successful host call is the deletion boundary. Do not let a
+				// late reply abort undo a committed deletion.
+				if (!this._cancelRlmChildRun(run, "Deleted by parent orchestrator")) {
+					this._emitRlmSubagentRemoval(subagent);
+				}
 				this._deletedRlmChildIds.add(childId);
 				this._removeRlmSubagentTracking(childId, run);
 				return { subagent };
 			}
-
-			// Startup can be blocked in a host before it has a session to close. Admit
-			// deletion immediately, but retain the cancelled run as a hidden tombstone
-			// until startup settles so selectors cannot be reused underneath it.
+			// Startup has no session/host destruction boundary yet, so this mutation
+			// itself needs the request token immediately beforehand.
+			authority?.assertCurrent();
+			if (!this._cancelRlmChildRun(run, "Deleted by parent orchestrator")) {
+				this._emitRlmSubagentRemoval(subagent);
+			}
 			run.detachedDeletion = subagent;
 			this._deletedRlmChildIds.add(childId);
 			return { subagent };
 		}
 
-		this._emitRlmSubagentRemoval(subagent);
 		const retained = this._rlmChildSessions.get(childId);
+		authority?.assertCurrent();
 		try {
-			await this._deleteRlmSubagentSession(childId, retained);
+			await this._deleteRlmSubagentSession(childId, retained, authority);
 		} catch (error) {
 			if (this._disposed || this._disposing) {
 				this._removeRlmSubagentTracking(childId);
@@ -9568,6 +9700,7 @@ export class AgentSession {
 			}
 			throw error;
 		}
+		this._emitRlmSubagentRemoval(subagent);
 		this._deletedRlmChildIds.add(childId);
 		this._removeRlmSubagentTracking(childId);
 		return { subagent };

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -8760,8 +8760,8 @@ export class AgentSession {
 	/** Typed handlers for host requests arriving from the IPython kernel comm bridge. */
 	private _createKernelHostHandlers(): HostRequestHandlers {
 		const handlers: HostRequestHandlers = {
-			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode, signal, isCurrent }) => ({
-				...(await this.runRlmChild(prompt, kwargs, cellSourceCode, { signal, isCurrent })),
+			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode, signal }) => ({
+				...(await this.runRlmChild(prompt, kwargs, cellSourceCode, { signal })),
 			})),
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
@@ -9693,10 +9693,10 @@ export class AgentSession {
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
-		requestAuthority?: { signal: AbortSignal; isCurrent(): boolean },
+		requestAuthority?: { signal: AbortSignal },
 	): Promise<RlmSpawnHandle> {
 		const assertRequestCurrent = () => {
-			if (requestAuthority && (requestAuthority.signal.aborted || !requestAuthority.isCurrent())) {
+			if (requestAuthority?.signal.aborted) {
 				throw new Error("host request authority was revoked");
 			}
 		};
@@ -10076,7 +10076,7 @@ export class AgentSession {
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
-		requestAuthority?: { signal: AbortSignal; isCurrent(): boolean },
+		requestAuthority?: { signal: AbortSignal },
 	): Promise<RlmSpawnHandle> {
 		return this._startRlmChildRun(prompt, kwargs, spawnCode, requestAuthority);
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10047,9 +10047,16 @@ export class AgentSession {
 						// A failed best-effort retry remains available through the retained cleanup maps.
 					}
 				}
-				// Nothing retains a never-admitted cancelled child, so its dir would be a
-				// permanent orphan. Removal happens after the dispose/release paths above.
-				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion) {
+				// A never-admitted cancelled child's dir is an orphan only when nothing
+				// durable references it. Once a runtime host produced a runtime or a
+				// session, its release/delete hooks own persistence (a daemon records a
+				// deleted registry entry that keeps the artifact tree on disk).
+				if (
+					!admissionCommitted &&
+					run.status === "cancelled" &&
+					!run.detachedDeletion &&
+					(!this._subagentRuntimeHost || (!childRuntime && !childSession))
+				) {
 					rmSync(childSessionDir, { recursive: true, force: true });
 				}
 			} finally {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10048,14 +10048,15 @@ export class AgentSession {
 					}
 				}
 				// A never-admitted cancelled child's dir is an orphan only when nothing
-				// durable references it. Once a runtime host produced a runtime or a
-				// session, its release/delete hooks own persistence (a daemon records a
-				// deleted registry entry that keeps the artifact tree on disk).
+				// durable references it. A host with a release hook records deletion
+				// durably (a daemon keeps the artifact tree for its deleted registry
+				// entry); a dispose-only host, like the default in-process runtime,
+				// persists nothing, so its dir is still an orphan to remove.
 				if (
 					!admissionCommitted &&
 					run.status === "cancelled" &&
 					!run.detachedDeletion &&
-					(!this._subagentRuntimeHost || (!childRuntime && !childSession))
+					(!this._subagentRuntimeHost?.releaseRlmSubagentRuntime || (!childRuntime && !childSession))
 				) {
 					rmSync(childSessionDir, { recursive: true, force: true });
 				}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9862,6 +9862,10 @@ export class AgentSession {
 		// retention, cancellation, and late-startup cleanup.
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
+			// A release hook is not itself proof that a cancelled, never-admitted
+			// child is durably unreachable. Only its verified retention outcome may
+			// preserve the artifact directory.
+			let releaseRetained = false;
 			try {
 				throwIfCancelled();
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
@@ -9981,6 +9985,9 @@ export class AgentSession {
 					if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 						await this._subagentRuntimeHost
 							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
+							.then((outcome) => {
+								releaseRetained = outcome.retained;
+							})
 							.catch(() => void child.disposeAsync().catch(() => undefined));
 					} else {
 						await child.disposeAsync().catch(() => undefined);
@@ -10020,11 +10027,12 @@ export class AgentSession {
 				}
 				if (!run.detachedDeletion && childSession && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 					try {
-						await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
+						const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
 							childRuntime ?? { session: childSession },
 							subagentOptions,
 							run.status === "cancelled" ? "cancelled" : "error",
 						);
+						releaseRetained = outcome.retained;
 						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
 							this._deletedRlmChildIds.add(run.id);
 							this._removeRlmSubagentTracking(run.id);
@@ -10047,17 +10055,10 @@ export class AgentSession {
 						// A failed best-effort retry remains available through the retained cleanup maps.
 					}
 				}
-				// A never-admitted cancelled child's dir is an orphan only when nothing
-				// durable references it. A host with a release hook records deletion
-				// durably (a daemon keeps the artifact tree for its deleted registry
-				// entry); a dispose-only host, like the default in-process runtime,
-				// persists nothing, so its dir is still an orphan to remove.
-				if (
-					!admissionCommitted &&
-					run.status === "cancelled" &&
-					!run.detachedDeletion &&
-					(!this._subagentRuntimeHost?.releaseRlmSubagentRuntime || (!childRuntime && !childSession))
-				) {
+				// A never-admitted cancelled child's dir is an orphan unless the release
+				// path verified durable ownership (for example, a daemon tombstone). A
+				// hook's presence alone does not make its artifact tree recoverable.
+				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion && !releaseRetained) {
 					rmSync(childSessionDir, { recursive: true, force: true });
 				}
 			} finally {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9863,6 +9863,7 @@ export class AgentSession {
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
 			try {
+				throwIfCancelled();
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
 				const child = childRuntime.session;
 				if (run.status === "cancelled") throw new Error(run.error ?? "RLM child cancelled");
@@ -9995,7 +9996,9 @@ export class AgentSession {
 				durationMs = Date.now() - startedAt;
 				activity = undefined;
 				emitChildUpdate();
-				if (!run.detachedDeletion) {
+				// A never-admitted spawn already surfaced this outcome to its caller as the
+				// admission exception; a parent notice would duplicate it into the transcript.
+				if (admissionCommitted && !run.detachedDeletion) {
 					if (run.status === "error") {
 						await deliverTerminalMessageToParent(
 							createRlmChildFailureMessage({
@@ -10043,6 +10046,11 @@ export class AgentSession {
 					} catch {
 						// A failed best-effort retry remains available through the retained cleanup maps.
 					}
+				}
+				// Nothing retains a never-admitted cancelled child, so its dir would be a
+				// permanent orphan. Removal happens after the dispose/release paths above.
+				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion) {
+					rmSync(childSessionDir, { recursive: true, force: true });
 				}
 			} finally {
 				if (run.detachedDeletion && childRuntime) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10324,9 +10324,11 @@ export class AgentSession {
 												this._rlmChildSessions.set(run.id, finalizerSession);
 												this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
 											} else if (this._isPrecommitRlmSubagentDeletionFailure(releaseError)) {
-												// Keep the live host incarnation attached to the private unknown-
-												// durability lease so an exact-id retry can tombstone and close it.
+												// Keep the live host incarnation on an opaque retry lease. The
+												// completed-session map is public, so it must not project an
+												// uncommitted release as completed before an exact retry closes it.
 												this._rlmChildSessions.set(run.id, finalizerSession);
+												this._rlmChildDeletionQuarantines.set(run.id, finalizerSubagent);
 											}
 										}
 										throw releaseError;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9571,6 +9571,7 @@ export class AgentSession {
 			authority ?? {
 				childId,
 				sessionDir: lease.session_dir,
+				...(lease.session_file ? { sessionFile: lease.session_file } : {}),
 				...(lease.session_id ? { sessionId: lease.session_id } : {}),
 				generation: 0,
 				assertCurrent: () => {},
@@ -10362,6 +10363,7 @@ export class AgentSession {
 							rlm_child_id: run.id,
 							active_session_id: null,
 							session_id: childSession?.sessionId ?? null,
+							...(childSession?.sessionFile ? { session_file: childSession.sessionFile } : {}),
 							session_name: sessionName,
 							session_dir: childSessionDir,
 							status: "error",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10188,10 +10188,10 @@ export class AgentSession {
 					);
 				}
 				if (!this.registerRlmChildSession(run.id, child)) {
-					// Registration can lose a race to delete-before-publication. Join that
-					// exact owner rather than releasing the newly published runtime directly.
+					// Completion may race a delete-before-publication owner. The finishing
+					// runtime must join that exact lease, never create a second host close.
 					const inFlight = this._deletingRlmChildren.get(run.id);
-					const finalizerSubagent =
+					const completionSubagent =
 						inFlight?.subagent ??
 						({
 							rlm_child_id: run.id,
@@ -10199,13 +10199,16 @@ export class AgentSession {
 							session_id: child.sessionId,
 							session_name: child.sessionName ?? sessionName,
 							session_dir: childSessionDir,
-							status: "error",
+							status: "completed",
 						} satisfies RlmSubagentRegistryEntry);
 					await this._coordinateRlmSubagentDeletion(
-						finalizerSubagent,
+						completionSubagent,
 						undefined,
 						inFlight?.lease,
 						async (authority) => {
+							// A completed explicit deletion can outlive retention. Joining it is
+							// sufficient; never append or close the same incarnation twice.
+							if (this._deletedRlmChildIds.has(run.id)) return { subagent: completionSubagent };
 							if (childRuntime && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
 								const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
 									childRuntime,
@@ -10215,10 +10218,10 @@ export class AgentSession {
 								);
 								deletionDurability = outcome?.deletionDurability ?? "unknown";
 							} else {
-								authority.assertCurrent();
-								await child.disposeAsync();
+								await this._deleteResolvedRlmSubagent(completionSubagent, authority);
+								deletionDurability = "absent";
 							}
-							return { subagent: finalizerSubagent };
+							return { subagent: completionSubagent };
 						},
 					).catch(() => undefined);
 				}
@@ -10254,89 +10257,66 @@ export class AgentSession {
 						);
 					}
 				}
-				if (!run.detachedDeletion && childSession && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
-					const finalizerSubagent: RlmSubagentRegistryEntry = {
-						rlm_child_id: run.id,
-						active_session_id: null,
-						session_id: childSession.sessionId,
-						session_name: childSession.sessionName ?? sessionName,
-						session_dir: childSessionDir,
-						status: run.status === "cancelled" ? "error" : "error",
-					};
+				if (!run.detachedDeletion && childSession) {
+					// Error/cancellation finalizers share the exact deletion owner with
+					// explicit deletion and the compaction reaper.
+					const inFlight = this._deletingRlmChildren.get(run.id);
+					const finalizerSubagent =
+						inFlight?.subagent ??
+						({
+							rlm_child_id: run.id,
+							active_session_id: null,
+							session_id: childSession.sessionId,
+							session_name: childSession.sessionName ?? sessionName,
+							session_dir: childSessionDir,
+							status: "error",
+						} satisfies RlmSubagentRegistryEntry);
 					try {
 						await this._coordinateRlmSubagentDeletion(
 							finalizerSubagent,
 							undefined,
-							undefined,
+							inFlight?.lease,
 							async (authority) => {
-								const outcome = await this._subagentRuntimeHost!.releaseRlmSubagentRuntime!(
-									childRuntime ?? { session: childSession! },
-									subagentOptions,
-									run.status === "cancelled" ? "cancelled" : "error",
-									authority,
-								);
-								deletionDurability = outcome?.deletionDurability ?? "unknown";
-								return { subagent: finalizerSubagent };
-							},
-						);
-						if (
-							run.status === "cancelled" &&
-							deletionDurability !== "unknown" &&
-							!this._disposed &&
-							!this._disposing
-						) {
-							this._deletedRlmChildIds.add(run.id);
-							this._removeRlmSubagentTracking(run.id);
-						}
-					} catch (releaseError) {
-						if (
-							this._isTombstonedRlmSubagentDeletionFailure(releaseError) &&
-							!this._disposed &&
-							!this._disposing
-						) {
-							this._rlmChildSessions.set(run.id, childSession);
-							this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
-						} else {
-							await childSession.disposeAsync().catch(() => undefined);
-						}
-					}
-				} else if (!run.detachedDeletion) {
-					const finalizerSubagent: RlmSubagentRegistryEntry = {
-						rlm_child_id: run.id,
-						active_session_id: null,
-						session_id: childSession?.sessionId ?? null,
-						session_name: childSession?.sessionName ?? sessionName,
-						session_dir: childSessionDir,
-						status: "error",
-					};
-					try {
-						await this._coordinateRlmSubagentDeletion(
-							finalizerSubagent,
-							undefined,
-							undefined,
-							async (authority) => {
-								if (childRuntime && this._subagentRuntimeHost) {
-									await this._subagentRuntimeHost.deleteRlmSubagentRuntime(
-										run.id,
-										childRuntime.session,
-										authority,
-									);
-								} else if (childSession) {
-									authority.assertCurrent();
-									await childSession.disposeAsync();
+								if (this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
+									try {
+										const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
+											childRuntime ?? { session: childSession },
+											subagentOptions,
+											run.status === "cancelled" ? "cancelled" : "error",
+											authority,
+										);
+										deletionDurability = outcome?.deletionDurability ?? "unknown";
+									} catch (releaseError) {
+										if (
+											this._isTombstonedRlmSubagentDeletionFailure(releaseError) &&
+											!this._disposed &&
+											!this._disposing
+										) {
+											this._rlmChildSessions.set(run.id, childSession);
+											this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
+										}
+										throw releaseError;
+									}
+									if (
+										run.status === "cancelled" &&
+										deletionDurability !== "unknown" &&
+										!this._disposed &&
+										!this._disposing
+									) {
+										this._deletedRlmChildIds.add(run.id);
+										this._removeRlmSubagentTracking(run.id);
+									}
+									return { subagent: finalizerSubagent };
 								}
-								return { subagent: finalizerSubagent };
+								const result = await this._deleteResolvedRlmSubagent(finalizerSubagent, authority);
+								deletionDurability = "absent";
+								return result;
 							},
 						);
-						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
-							// The known dispose-only host owns no durable registry, so a successful
-							// fallback delete is affirmative absence rather than an I/O guess.
-							deletionDurability = "absent";
-							this._deletedRlmChildIds.add(run.id);
-							this._removeRlmSubagentTracking(run.id);
-						}
 					} catch {
-						// A failed best-effort retry remains available through the retained cleanup maps.
+						// Precommit failures retain the live maps; tombstoned close failures
+						// retain the coordinator-owned retry entry. A finalizer never bypasses
+						// that state machine with a direct host close.
 					}
 				}
 				// Only an authoritative, successful no-row result proves this exact

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3796,7 +3796,7 @@ export class AgentSession {
 		if (this._disposeAsyncPromise) {
 			return this._disposeAsyncPromise;
 		}
-		this._disposeAsyncPromise = (async () => {
+		const attempt = (async () => {
 			// Drain before marking _disposing so a refine triggered at the final
 			// agent_end completes instead of being aborted by dispose().
 			await this._drainPendingRefinementForDisposal();
@@ -3807,7 +3807,15 @@ export class AgentSession {
 			this._sessionActionCommitDisposeAbortController.abort();
 			await this._disposeAsyncOnce();
 		})();
-		return this._disposeAsyncPromise;
+		this._disposeAsyncPromise = attempt;
+		try {
+			await attempt;
+		} catch (error) {
+			if (this._disposeAsyncPromise === attempt) {
+				this._disposeAsyncPromise = undefined;
+			}
+			throw error;
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9662,6 +9662,14 @@ export class AgentSession {
 					this._rlmChildCleanupFailures.set(childId, subagent);
 					if (run.unsubscribe) this._rlmChildUnsubscribes.set(childId, run.unsubscribe);
 					this._activeRlmChildRuns.delete(childId);
+					// A generic close failure may follow a durable daemon tombstone. Keep
+					// this task on its cancelled terminal path so its finalizer retries the
+					// retained cleanup record rather than completing and losing that route.
+					// A revoked owner is different: a live waiter may promote a fresh
+					// generation, so it must not mutate the run before that commit.
+					if (!(error instanceof Error) || error.message !== "host request authority was revoked") {
+						this._cancelRlmChildRun(run, "Deleted by parent orchestrator");
+					}
 					run.abort = noopRlmChildAbort;
 					run.unsubscribe = undefined;
 					run.session = undefined;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -8765,7 +8765,9 @@ export class AgentSession {
 			})),
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
-			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target) => this.deleteRlmSubagent(target)),
+			"rlm.delete_subagent": createRlmDeleteSubagentHostHandler((target, signal) =>
+				this.deleteRlmSubagent(target, signal),
+			),
 			"model.info": createHostRequestHandler(async (_payload, _context) => ({
 				id: this.model?.id ?? null,
 				provider: this.model?.provider ?? null,
@@ -9315,7 +9317,12 @@ export class AgentSession {
 	}
 
 	/** Delete a running, retained, or passive direct child selected from this parent session's registry. */
-	async deleteRlmSubagent(target: string): Promise<RlmDeleteSubagentResult> {
+	async deleteRlmSubagent(target: string, signal?: AbortSignal): Promise<RlmDeleteSubagentResult> {
+		// Re-checked before each mutating delete so a revocation mid-resolution never mutates.
+		const assertDeleteAuthority = () => {
+			if (signal?.aborted) throw new Error("host request authority was revoked");
+		};
+		assertDeleteAuthority();
 		const inFlight = [...this._deletingRlmChildren.values()].filter(({ subagent }) =>
 			this._rlmSubagentMatchesTarget(subagent, target),
 		);
@@ -9364,6 +9371,7 @@ export class AgentSession {
 							session_name: daemonChild.sessionName ?? subagent.session_name,
 						}
 					: subagent;
+				assertDeleteAuthority();
 				return this._deleteResolvedRlmSubagent(resolvedSubagent);
 			});
 		}
@@ -9377,7 +9385,10 @@ export class AgentSession {
 			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
 		}
 		const subagent = directMatches[0] ?? (await this._resolveDirectRlmSubagent(target));
-		return this._trackRlmSubagentDeletion(subagent, () => this._deleteResolvedRlmSubagent(subagent));
+		return this._trackRlmSubagentDeletion(subagent, () => {
+			assertDeleteAuthority();
+			return this._deleteResolvedRlmSubagent(subagent);
+		});
 	}
 
 	private async _trackRlmSubagentDeletion(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9365,7 +9365,9 @@ export class AgentSession {
 		const quarantined = this._rlmChildDeletionQuarantines.get(target);
 		if (quarantined) {
 			return this._trackRlmSubagentDeletion(quarantined, async () => {
-				await this._resolveRlmChildDeletionQuarantine(target);
+				if (!(await this._resolveRlmChildDeletionQuarantine(target, assertDeleteAuthority))) {
+					throw new Error("RLM subagent deletion durability is still unknown");
+				}
 				return { subagent: quarantined };
 			});
 		}
@@ -9437,11 +9439,17 @@ export class AgentSession {
 	 * Reconcile a private cancelled-spawn cleanup lease. `false` deliberately
 	 * means that durability is still unknown, never that deletion succeeded.
 	 */
-	private async _resolveRlmChildDeletionQuarantine(childId: string): Promise<boolean> {
+	private async _resolveRlmChildDeletionQuarantine(
+		childId: string,
+		assertDeleteAuthority: () => void = () => {},
+	): Promise<boolean> {
 		const lease = this._rlmChildDeletionQuarantines.get(childId);
 		if (!lease || this._disposed || this._disposing) return false;
 		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId);
-		if (durability === "unknown" || durability === undefined) return false;
+		if (durability !== "absent" && durability !== "tombstoned") return false;
+		// The host await is a revocation boundary. Do not mutate the artifact or
+		// private deletion bookkeeping after its caller has lost authority.
+		assertDeleteAuthority();
 		if (durability === "absent") {
 			// This is the sole path which removes the exact quarantined directory.
 			rmSync(lease.session_dir, { recursive: true, force: true });

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9572,6 +9572,17 @@ export class AgentSession {
 		// A retry/reaper can yield while the host reads. It may only discharge the
 		// exact lease it resolved, never a newer lease reusing this child id.
 		if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
+		const retained = this._rlmChildSessions.get(childId);
+		if (retained) {
+			// A precommit release failure left the host runtime live. Durability alone
+			// cannot discharge that lease: retry the typed host deletion so the exact
+			// resident incarnation is closed before local tracking is cleared.
+			await this._deleteRlmSubagentSession(childId, retained, authority);
+			authority?.assertCurrent();
+			if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
+			if (this._rlmChildSessions.get(childId) !== retained) return false;
+			this._removeRlmSubagentTracking(childId);
+		}
 		if (durability === "absent") {
 			// This is the sole path which removes the exact quarantined directory.
 			rmSync(lease.session_dir, { recursive: true, force: true });
@@ -9595,6 +9606,10 @@ export class AgentSession {
 			return deletion.then((result) => result ?? { deletionDurability: "absent" });
 		}
 		return (session?.disposeAsync() ?? Promise.resolve()).then(() => ({ deletionDurability: "absent" }));
+	}
+
+	private _isPrecommitRlmSubagentDeletionFailure(error: unknown): boolean {
+		return error instanceof RlmSubagentHostDeletionError && error.phase === "precommit";
 	}
 
 	private _isTombstonedRlmSubagentDeletionFailure(error: unknown): boolean {
@@ -10288,13 +10303,15 @@ export class AgentSession {
 										);
 										deletionDurability = outcome?.deletionDurability ?? "unknown";
 									} catch (releaseError) {
-										if (
-											this._isTombstonedRlmSubagentDeletionFailure(releaseError) &&
-											!this._disposed &&
-											!this._disposing
-										) {
-											this._rlmChildSessions.set(run.id, childSession);
-											this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
+										if (!this._disposed && !this._disposing) {
+											if (this._isTombstonedRlmSubagentDeletionFailure(releaseError)) {
+												this._rlmChildSessions.set(run.id, childSession);
+												this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
+											} else if (this._isPrecommitRlmSubagentDeletionFailure(releaseError)) {
+												// Keep the live host incarnation attached to the private unknown-
+												// durability lease so an exact-id retry can tombstone and close it.
+												this._rlmChildSessions.set(run.id, childSession);
+											}
 										}
 										throw releaseError;
 									}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9357,7 +9357,11 @@ export class AgentSession {
 			throw new Error(`RLM subagent selector "${target}" is ambiguous in the current parent session`);
 		}
 		if (inFlight[0]) {
-			return inFlight[0].promise;
+			// A coalesced waiter retains its own revocation boundary rather than
+			// inheriting the initiating request's authority.
+			const result = await inFlight[0].promise;
+			assertDeleteAuthority();
+			return result;
 		}
 		// Quarantine is deliberately absent from public list/roster/hydration, but
 		// the caller holding the exact opaque child id may explicitly retry its
@@ -9445,11 +9449,16 @@ export class AgentSession {
 	): Promise<boolean> {
 		const lease = this._rlmChildDeletionQuarantines.get(childId);
 		if (!lease || this._disposed || this._disposing) return false;
-		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId);
+		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId, {
+			assertCurrent: assertDeleteAuthority,
+		});
 		if (durability !== "absent" && durability !== "tombstoned") return false;
 		// The host await is a revocation boundary. Do not mutate the artifact or
 		// private deletion bookkeeping after its caller has lost authority.
 		assertDeleteAuthority();
+		// A retry/reaper can yield while the host reads. It may only discharge the
+		// exact lease it resolved, never a newer lease reusing this child id.
+		if (this._rlmChildDeletionQuarantines.get(childId) !== lease) return false;
 		if (durability === "absent") {
 			// This is the sole path which removes the exact quarantined directory.
 			rmSync(lease.session_dir, { recursive: true, force: true });

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10324,11 +10324,9 @@ export class AgentSession {
 												this._rlmChildSessions.set(run.id, finalizerSession);
 												this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
 											} else if (this._isPrecommitRlmSubagentDeletionFailure(releaseError)) {
-												// Keep the live host incarnation on an opaque retry lease. The
-												// completed-session map is public, so it must not project an
-												// uncommitted release as completed before an exact retry closes it.
+												// Keep the live host incarnation attached to the private unknown-
+												// durability lease so an exact-id retry can tombstone and close it.
 												this._rlmChildSessions.set(run.id, finalizerSession);
-												this._rlmChildDeletionQuarantines.set(run.id, finalizerSubagent);
 											}
 										}
 										throw releaseError;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -228,6 +228,7 @@ import {
 	type RlmFindModelsResult,
 	type RlmListSubagentsResult,
 	type RlmSpawnHandle,
+	type RlmSubagentDeletionDurability,
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
 	type SubagentRuntimeHost,
@@ -1224,6 +1225,10 @@ export class AgentSession {
 	// Failed explicit deletes stay hidden from listings but retain their original
 	// selector so a later delete can retry cleanup without orphaning the runtime.
 	private _rlmChildCleanupFailures = new Map<string, RlmSubagentRegistryEntry>();
+	// A cancelled spawn whose durable deletion could not be proven has no public
+	// lifecycle status. Keep its private cleanup lease through finalization until a
+	// host later proves absence or a durable tombstone.
+	private _rlmChildDeletionQuarantines = new Map<string, RlmSubagentRegistryEntry>();
 	private _deletingRlmChildren = new Map<
 		string,
 		{
@@ -7252,6 +7257,11 @@ export class AgentSession {
 			(childId) => !this._activeRlmChildRuns.get(childId)?.detachedDeletion,
 		);
 		await Promise.allSettled(childIds.map((childId) => this.deleteRlmSubagent(childId)));
+		await Promise.allSettled(
+			[...this._rlmChildDeletionQuarantines.keys()].map((childId) =>
+				this._resolveRlmChildDeletionQuarantine(childId),
+			),
+		);
 	}
 
 	/**
@@ -9211,7 +9221,8 @@ export class AgentSession {
 			if (
 				this._deletingRlmChildren.has(childId) ||
 				recorded.has(childId) ||
-				this._rlmChildCleanupFailures.has(childId)
+				this._rlmChildCleanupFailures.has(childId) ||
+				this._rlmChildDeletionQuarantines.has(childId)
 			) {
 				continue;
 			}
@@ -9237,6 +9248,7 @@ export class AgentSession {
 				this._deletingRlmChildren.has(childId) ||
 				this._deletedRlmChildIds.has(childId) ||
 				this._rlmChildCleanupFailures.has(childId) ||
+				this._rlmChildDeletionQuarantines.has(childId) ||
 				!daemonChild.sessionDir
 			) {
 				continue;
@@ -9411,6 +9423,26 @@ export class AgentSession {
 		}
 	}
 
+	/**
+	 * Reconcile a private cancelled-spawn cleanup lease. `false` deliberately
+	 * means that durability is still unknown, never that deletion succeeded.
+	 */
+	private async _resolveRlmChildDeletionQuarantine(childId: string): Promise<boolean> {
+		const lease = this._rlmChildDeletionQuarantines.get(childId);
+		if (!lease || this._disposed || this._disposing) return false;
+		const durability = await this._subagentRuntimeHost?.resolveRlmSubagentDeletion?.(childId);
+		if (durability === "unknown" || durability === undefined) return false;
+		if (durability === "absent") {
+			// This is the sole path which removes the exact quarantined directory.
+			rmSync(lease.session_dir, { recursive: true, force: true });
+		}
+		// A durable tombstone owns the retained artifact; absence proves this exact
+		// directory is removable. Either conclusion discharges the private lease.
+		this._rlmChildDeletionQuarantines.delete(childId);
+		this._deletedRlmChildIds.add(childId);
+		return true;
+	}
+
 	private _deleteRlmSubagentSession(childId: string, session?: AgentSession): Promise<void> {
 		if (this._subagentRuntimeHost) {
 			return this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
@@ -9424,6 +9456,8 @@ export class AgentSession {
 		this._rlmChildUnsubscribes.delete(childId);
 		this._rlmChildSessions.delete(childId);
 		this._rlmChildCleanupFailures.delete(childId);
+		// Do not clear an unknown-deletion lease here: finalization is precisely the
+		// boundary it must survive.
 		if (!run || this._activeRlmChildRuns.get(childId) === run) {
 			this._activeRlmChildRuns.delete(childId);
 		}
@@ -9863,9 +9897,9 @@ export class AgentSession {
 		void (async () => {
 			let childRuntime: RlmSubagentRuntime | undefined;
 			// A release hook is not itself proof that a cancelled, never-admitted
-			// child is durably unreachable. Only its verified retention outcome may
-			// preserve the artifact directory.
-			let releaseRetained = false;
+			// child is durably unreachable. Preserve uncertainty rather than deleting
+			// an artifact whose durable owner cannot be proven.
+			let deletionDurability: RlmSubagentDeletionDurability = "unknown";
 			try {
 				throwIfCancelled();
 				childRuntime = await this._createRlmSubagentRuntime(subagentOptions);
@@ -9986,7 +10020,7 @@ export class AgentSession {
 						await this._subagentRuntimeHost
 							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
 							.then((outcome) => {
-								releaseRetained = outcome.retained;
+								deletionDurability = outcome.deletionDurability;
 							})
 							.catch(() => void child.disposeAsync().catch(() => undefined));
 					} else {
@@ -10032,8 +10066,13 @@ export class AgentSession {
 							subagentOptions,
 							run.status === "cancelled" ? "cancelled" : "error",
 						);
-						releaseRetained = outcome.retained;
-						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
+						deletionDurability = outcome.deletionDurability;
+						if (
+							run.status === "cancelled" &&
+							deletionDurability !== "unknown" &&
+							!this._disposed &&
+							!this._disposing
+						) {
 							this._deletedRlmChildIds.add(run.id);
 							this._removeRlmSubagentTracking(run.id);
 						}
@@ -10048,6 +10087,9 @@ export class AgentSession {
 							await childSession.disposeAsync();
 						}
 						if (run.status === "cancelled" && !this._disposed && !this._disposing) {
+							// The known dispose-only host owns no durable registry, so a successful
+							// fallback delete is affirmative absence rather than an I/O guess.
+							deletionDurability = "absent";
 							this._deletedRlmChildIds.add(run.id);
 							this._removeRlmSubagentTracking(run.id);
 						}
@@ -10055,11 +10097,25 @@ export class AgentSession {
 						// A failed best-effort retry remains available through the retained cleanup maps.
 					}
 				}
-				// A never-admitted cancelled child's dir is an orphan unless the release
-				// path verified durable ownership (for example, a daemon tombstone). A
-				// hook's presence alone does not make its artifact tree recoverable.
-				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion && !releaseRetained) {
-					rmSync(childSessionDir, { recursive: true, force: true });
+				// Only an authoritative, successful no-row result proves this exact
+				// never-admitted dir is ours to remove. A durable tombstone retains it;
+				// ambiguity is quarantined privately rather than being coerced into an
+				// active, idle, or inactive public child.
+				if (!admissionCommitted && run.status === "cancelled" && !run.detachedDeletion) {
+					if (deletionDurability === "absent") {
+						rmSync(childSessionDir, { recursive: true, force: true });
+					} else if (deletionDurability === "unknown" && !this._disposed && !this._disposing) {
+						// Preserve a private cleanup lease through finalization. Unlike an
+						// explicit-delete failure, it is neither listed nor selector-addressable.
+						this._rlmChildDeletionQuarantines.set(run.id, {
+							rlm_child_id: run.id,
+							active_session_id: null,
+							session_id: childSession?.sessionId ?? null,
+							session_name: sessionName,
+							session_dir: childSessionDir,
+							status: "error",
+						});
+					}
 				}
 			} finally {
 				if (run.detachedDeletion && childRuntime) {
@@ -10079,8 +10135,18 @@ export class AgentSession {
 						run.abort = noopRlmChildAbort;
 						run.unsubscribe = undefined;
 						run.session = undefined;
-					} else if (run.status !== "error" || run.detachedDeletion) {
+					} else if (
+						(run.status !== "error" || run.detachedDeletion) &&
+						!this._rlmChildCleanupFailures.has(run.id)
+					) {
 						this._removeRlmSubagentTracking(run.id, run);
+					} else if (this._rlmChildCleanupFailures.has(run.id)) {
+						// Unknown durability has a retry record but is not an active product
+						// child. Drop live tracking without clearing that internal record.
+						this._activeRlmChildRuns.delete(run.id);
+						run.unsubscribe?.();
+						run.abort = noopRlmChildAbort;
+						run.unsubscribe = undefined;
 					} else {
 						run.unsubscribe?.();
 						run.abort = noopRlmChildAbort;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -230,6 +230,7 @@ import {
 	type RlmSpawnHandle,
 	type RlmSubagentDeletionAuthority,
 	type RlmSubagentDeletionDurability,
+	RlmSubagentHostDeletionError,
 	type RlmSubagentRegistryEntry,
 	type RlmSubagentRuntime,
 	type SubagentRuntimeHost,
@@ -9586,13 +9587,18 @@ export class AgentSession {
 		childId: string,
 		session?: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<void> {
+	): Promise<import("./rlm-runtime.js").RlmSubagentHostDeletionResult> {
 		if (this._subagentRuntimeHost) {
-			return authority
+			const deletion = authority
 				? this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session, authority)
 				: this._subagentRuntimeHost.deleteRlmSubagentRuntime(childId, session);
+			return deletion.then((result) => result ?? { deletionDurability: "absent" });
 		}
-		return session?.disposeAsync() ?? Promise.resolve();
+		return (session?.disposeAsync() ?? Promise.resolve()).then(() => ({ deletionDurability: "absent" }));
+	}
+
+	private _isTombstonedRlmSubagentDeletionFailure(error: unknown): boolean {
+		return error instanceof RlmSubagentHostDeletionError && error.phase === "tombstoned";
 	}
 
 	private _removeRlmSubagentTracking(childId: string, run?: RlmChildRun): void {
@@ -9658,21 +9664,19 @@ export class AgentSession {
 						void liveSession.disposeAsync().catch(() => undefined);
 						throw error;
 					}
-					this._rlmChildSessions.set(childId, liveSession);
-					this._rlmChildCleanupFailures.set(childId, subagent);
-					if (run.unsubscribe) this._rlmChildUnsubscribes.set(childId, run.unsubscribe);
-					this._activeRlmChildRuns.delete(childId);
-					// A generic close failure may follow a durable daemon tombstone. Keep
-					// this task on its cancelled terminal path so its finalizer retries the
-					// retained cleanup record rather than completing and losing that route.
-					// A revoked owner is different: a live waiter may promote a fresh
-					// generation, so it must not mutate the run before that commit.
-					if (!(error instanceof Error) || error.message !== "host request authority was revoked") {
+					// Only a typed post-append close failure may hide a child and retain
+					// retry state. A precommit authority revocation leaves every local
+					// map and list projection live for a fresh owner generation.
+					if (this._isTombstonedRlmSubagentDeletionFailure(error)) {
+						this._rlmChildSessions.set(childId, liveSession);
+						this._rlmChildCleanupFailures.set(childId, subagent);
+						if (run.unsubscribe) this._rlmChildUnsubscribes.set(childId, run.unsubscribe);
+						this._activeRlmChildRuns.delete(childId);
 						this._cancelRlmChildRun(run, "Deleted by parent orchestrator");
+						run.abort = noopRlmChildAbort;
+						run.unsubscribe = undefined;
+						run.session = undefined;
 					}
-					run.abort = noopRlmChildAbort;
-					run.unsubscribe = undefined;
-					run.session = undefined;
 					throw error;
 				}
 				// The successful host call is the deletion boundary. Do not let a
@@ -9703,7 +9707,7 @@ export class AgentSession {
 			if (this._disposed || this._disposing) {
 				this._removeRlmSubagentTracking(childId);
 				void retained?.disposeAsync().catch(() => undefined);
-			} else {
+			} else if (this._isTombstonedRlmSubagentDeletionFailure(error)) {
 				this._rlmChildCleanupFailures.set(childId, subagent);
 			}
 			throw error;
@@ -10188,7 +10192,7 @@ export class AgentSession {
 						await this._subagentRuntimeHost
 							.releaseRlmSubagentRuntime(childRuntime, subagentOptions, "error")
 							.then((outcome) => {
-								deletionDurability = outcome.deletionDurability;
+								deletionDurability = outcome?.deletionDurability ?? "unknown";
 							})
 							.catch(() => void child.disposeAsync().catch(() => undefined));
 					} else {
@@ -10228,13 +10232,30 @@ export class AgentSession {
 					}
 				}
 				if (!run.detachedDeletion && childSession && this._subagentRuntimeHost?.releaseRlmSubagentRuntime) {
+					const finalizerSubagent: RlmSubagentRegistryEntry = {
+						rlm_child_id: run.id,
+						active_session_id: null,
+						session_id: childSession.sessionId,
+						session_name: childSession.sessionName ?? sessionName,
+						session_dir: childSessionDir,
+						status: run.status === "cancelled" ? "error" : "error",
+					};
 					try {
-						const outcome = await this._subagentRuntimeHost.releaseRlmSubagentRuntime(
-							childRuntime ?? { session: childSession },
-							subagentOptions,
-							run.status === "cancelled" ? "cancelled" : "error",
+						await this._coordinateRlmSubagentDeletion(
+							finalizerSubagent,
+							undefined,
+							undefined,
+							async (authority) => {
+								const outcome = await this._subagentRuntimeHost!.releaseRlmSubagentRuntime!(
+									childRuntime ?? { session: childSession! },
+									subagentOptions,
+									run.status === "cancelled" ? "cancelled" : "error",
+									authority,
+								);
+								deletionDurability = outcome?.deletionDurability ?? "unknown";
+								return { subagent: finalizerSubagent };
+							},
 						);
-						deletionDurability = outcome.deletionDurability;
 						if (
 							run.status === "cancelled" &&
 							deletionDurability !== "unknown" &&
@@ -10244,8 +10265,17 @@ export class AgentSession {
 							this._deletedRlmChildIds.add(run.id);
 							this._removeRlmSubagentTracking(run.id);
 						}
-					} catch {
-						await childSession?.disposeAsync().catch(() => undefined);
+					} catch (releaseError) {
+						if (
+							this._isTombstonedRlmSubagentDeletionFailure(releaseError) &&
+							!this._disposed &&
+							!this._disposing
+						) {
+							this._rlmChildSessions.set(run.id, childSession);
+							this._rlmChildCleanupFailures.set(run.id, finalizerSubagent);
+						} else {
+							await childSession.disposeAsync().catch(() => undefined);
+						}
 					}
 				} else if (!run.detachedDeletion) {
 					try {
@@ -10287,14 +10317,11 @@ export class AgentSession {
 				}
 			} finally {
 				if (run.detachedDeletion && childRuntime) {
-					try {
-						await this._deleteRlmSubagentSession(run.id, childRuntime.session);
-					} catch {
-						if (!this._disposed && !this._disposing) {
-							this._rlmChildSessions.set(run.id, childRuntime.session);
-							this._rlmChildCleanupFailures.set(run.id, run.detachedDeletion);
-						}
-					}
+					// Startup may publish after deletion was requested. It must re-enter
+					// the same incarnation-fenced coordinator, never call the host directly.
+					await this._coordinateRlmSubagentDeletion(run.detachedDeletion, undefined, undefined, (authority) =>
+						this._deleteResolvedRlmSubagent(run.detachedDeletion!, authority),
+					).catch(() => undefined);
 				}
 				if (this._activeRlmChildRuns.get(run.id) === run) {
 					if (this._rlmChildSessions.has(run.id)) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -9359,6 +9359,16 @@ export class AgentSession {
 		if (inFlight[0]) {
 			return inFlight[0].promise;
 		}
+		// Quarantine is deliberately absent from public list/roster/hydration, but
+		// the caller holding the exact opaque child id may explicitly retry its
+		// durability check. Names and session ids cannot address private leases.
+		const quarantined = this._rlmChildDeletionQuarantines.get(target);
+		if (quarantined) {
+			return this._trackRlmSubagentDeletion(quarantined, async () => {
+				await this._resolveRlmChildDeletionQuarantine(target);
+				return { subagent: quarantined };
+			});
+		}
 		if (localMatches[0]) {
 			const subagent = localMatches[0];
 			return this._trackRlmSubagentDeletion(subagent, async () => {

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -59,13 +59,12 @@ export const HOST_COMM_TARGET = "host.request";
 export type HostRequestPayload = Record<string, unknown>;
 
 /**
- * Per-call authority minted by this dispatcher.  Although its TypeScript shape is
+ * Per-call authority minted by this dispatcher. Although its TypeScript shape is
  * exported for handler implementations, a value is accepted only when this module
- * has registered its object identity for the active request.
+ * has registered its object identity. Revocation is observable via the signal.
  */
 export interface HostRequestContext {
 	readonly signal: AbortSignal;
-	isCurrent(): boolean;
 }
 
 const factoryCreatedHostRequestHandlers = new WeakSet<object>();
@@ -84,20 +83,8 @@ function assertGenuineHostRequestContext(context: unknown): asserts context is H
 }
 
 function mintHostRequestContext(controller: AbortController): HostRequestContext {
-	let current = true;
-	const context: HostRequestContext = Object.freeze({
-		signal: controller.signal,
-		isCurrent: () => current && !controller.signal.aborted,
-	});
+	const context: HostRequestContext = Object.freeze({ signal: controller.signal });
 	dispatcherCreatedHostRequestContexts.add(context);
-	controller.signal.addEventListener(
-		"abort",
-		() => {
-			current = false;
-			dispatcherCreatedHostRequestContexts.delete(context);
-		},
-		{ once: true },
-	);
 	return context;
 }
 
@@ -110,6 +97,7 @@ export function createHostRequestHandler<
 >(implementation: T): HostRequestHandler {
 	const handler = async (payload: HostRequestPayload, context: HostRequestContext) => {
 		assertGenuineHostRequestContext(context);
+		if (context.signal.aborted) throw new Error("host request authority was revoked");
 		return implementation(payload, context);
 	};
 	factoryCreatedHostRequestHandlers.add(handler);

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -74,14 +74,6 @@ const hostRequestHandlerBrand = Symbol("hostRequestHandler");
 const factoryCreatedHostRequestHandlers = new WeakSet<object>();
 const dispatcherCreatedHostRequestContexts = new WeakSet<object>();
 
-/** Context-aware registrations are explicit; implementation arity is not authority. */
-export interface HostRequestHandlerOptions {
-	readonly contextAware: true;
-}
-
-/** The stable marker makes default/rest callbacks unambiguous without Function.length. */
-export const contextAwareHostRequestHandler: HostRequestHandlerOptions = Object.freeze({ contextAware: true });
-
 /** Handlers receive dispatcher-minted context; provenance is always checked at dispatch time. */
 export type HostRequestHandler = (
 	payload: HostRequestPayload,
@@ -122,17 +114,12 @@ function mintHostRequestContext(
 }
 
 /**
- * Factory registration deliberately requires an explicit capability marker. This
- * accepts binary, rest, and default-parameter implementations without treating
- * Function.length as a security boundary. A missing marker rejects a unary
- * JavaScript registration before it can execute.
+ * Mint a host-request capability. Only factory-minted handlers are dispatched,
+ * and every call is gated on a dispatcher-minted context.
  */
 export function createHostRequestHandler<
 	T extends (payload: HostRequestPayload, context: HostRequestContext) => Promise<Record<string, unknown>>,
->(implementation: T, options: HostRequestHandlerOptions): HostRequestHandlerCapability {
-	if (options?.contextAware !== true) {
-		throw new Error("host request handlers require the context-aware marker");
-	}
+>(implementation: T): HostRequestHandlerCapability {
 	const handler = async (payload: HostRequestPayload, context: HostRequestContext) => {
 		assertGenuineHostRequestContext(context);
 		return implementation(payload, context);

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -64,8 +64,6 @@ export type HostRequestPayload = Record<string, unknown>;
  * has registered its object identity for the active request.
  */
 export interface HostRequestContext {
-	readonly requestId: string;
-	readonly generation: number;
 	readonly signal: AbortSignal;
 	isCurrent(): boolean;
 }
@@ -89,15 +87,9 @@ function assertGenuineHostRequestContext(context: unknown): asserts context is H
 	}
 }
 
-function mintHostRequestContext(
-	requestId: string,
-	generation: number,
-	controller: AbortController,
-): HostRequestContext {
+function mintHostRequestContext(controller: AbortController): HostRequestContext {
 	let current = true;
 	const context: HostRequestContext = Object.freeze({
-		requestId,
-		generation,
 		signal: controller.signal,
 		isCurrent: () => current && !controller.signal.aborted,
 	});
@@ -626,7 +618,6 @@ export class KernelManager {
 	private terminalRevision = 0;
 	/** Once terminal, this manager can never reopen host-request admission. */
 	private terminal = false;
-	private hostRequestGeneration = 0;
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
 	private startPromise?: Promise<void>;
@@ -1349,7 +1340,7 @@ export class KernelManager {
 		this.handledHostRequestCommIds.add(commId);
 		const controller = new AbortController();
 		this.activeHostRequestControllers.set(commId, controller);
-		const context = mintHostRequestContext(uuid(), ++this.hostRequestGeneration, controller);
+		const context = mintHostRequestContext(controller);
 		const task = (async () => {
 			let result: Record<string, unknown>;
 			try {

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -82,14 +82,11 @@ export interface HostRequestHandlerOptions {
 /** The stable marker makes default/rest callbacks unambiguous without Function.length. */
 export const contextAwareHostRequestHandler: HostRequestHandlerOptions = Object.freeze({ contextAware: true });
 
-/** Implementations receive dispatcher-minted context; the marker makes rest/default callbacks unambiguous. */
-export type HostRequestHandlerImplementation = (
+/** Handlers receive dispatcher-minted context; provenance is always checked at dispatch time. */
+export type HostRequestHandler = (
 	payload: HostRequestPayload,
 	context: HostRequestContext,
 ) => Promise<Record<string, unknown>>;
-
-/** Public registration shape; provenance is always checked at dispatch time. */
-export type HostRequestHandler = HostRequestHandlerImplementation;
 
 /** A factory-minted capability. Raw, copied-brand, and fabricated handlers are rejected. */
 type HostRequestHandlerCapability = HostRequestHandler & { readonly [hostRequestHandlerBrand]: true };

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -68,7 +68,6 @@ export interface HostRequestContext {
 	isCurrent(): boolean;
 }
 
-const hostRequestHandlerBrand = Symbol("hostRequestHandler");
 const factoryCreatedHostRequestHandlers = new WeakSet<object>();
 const dispatcherCreatedHostRequestContexts = new WeakSet<object>();
 
@@ -77,9 +76,6 @@ export type HostRequestHandler = (
 	payload: HostRequestPayload,
 	context: HostRequestContext,
 ) => Promise<Record<string, unknown>>;
-
-/** A factory-minted capability. Raw, copied-brand, and fabricated handlers are rejected. */
-type HostRequestHandlerCapability = HostRequestHandler & { readonly [hostRequestHandlerBrand]: true };
 
 function assertGenuineHostRequestContext(context: unknown): asserts context is HostRequestContext {
 	if (typeof context !== "object" || context === null || !dispatcherCreatedHostRequestContexts.has(context)) {
@@ -111,22 +107,18 @@ function mintHostRequestContext(controller: AbortController): HostRequestContext
  */
 export function createHostRequestHandler<
 	T extends (payload: HostRequestPayload, context: HostRequestContext) => Promise<Record<string, unknown>>,
->(implementation: T): HostRequestHandlerCapability {
+>(implementation: T): HostRequestHandler {
 	const handler = async (payload: HostRequestPayload, context: HostRequestContext) => {
 		assertGenuineHostRequestContext(context);
 		return implementation(payload, context);
 	};
 	factoryCreatedHostRequestHandlers.add(handler);
-	return Object.defineProperty(handler, hostRequestHandlerBrand, { value: true }) as HostRequestHandlerCapability;
+	return handler;
 }
 
-/** Reject copied-symbol and raw-function forgeries before they observe payload data. */
-export function assertHostRequestHandler(value: unknown): asserts value is HostRequestHandlerCapability {
-	if (
-		typeof value !== "function" ||
-		(value as Partial<HostRequestHandlerCapability>)[hostRequestHandlerBrand] !== true ||
-		!factoryCreatedHostRequestHandlers.has(value)
-	) {
+/** Reject raw-function forgeries before they observe payload data. */
+export function assertHostRequestHandler(value: unknown): asserts value is HostRequestHandler {
+	if (typeof value !== "function" || !factoryCreatedHostRequestHandlers.has(value)) {
 		throw new Error("host request handler is not a dispatcher-created capability");
 	}
 }

--- a/packages/coding-agent/src/core/mcp/mcp-manager.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-manager.ts
@@ -9,7 +9,7 @@ import {
 } from "@earendil-works/pi-ai/mcp";
 import { registerOAuthProvider, unregisterOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import type { AuthStorage } from "../auth-storage.js";
-import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandlers } from "../kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandlers } from "../kernel/index.js";
 import type { McpServerConfig } from "../settings-manager.js";
 
 export interface McpManagerOptions {
@@ -165,7 +165,7 @@ export class McpManager {
 				const key = await this.authStorage.getApiKey(this.providerId(server));
 				if (!key) throw new Error(`Could not refresh credentials for ${server}`);
 				return {};
-			}, contextAwareHostRequestHandler),
+			}),
 			// Resolved config so the kernel skill connects to the same URL the host
 			// registered/authenticated (honors a user's mcpServers `url` override).
 			"mcp.config": createHostRequestHandler(async (payload, _context) => {
@@ -178,7 +178,7 @@ export class McpManager {
 					config.headers = integration.headers;
 				}
 				return config;
-			}, contextAwareHostRequestHandler),
+			}),
 		};
 		// Only expose begin_login when an interactive login is actually wired, so the
 		// kernel doesn't get a handler whose only behavior is to throw.
@@ -189,7 +189,7 @@ export class McpManager {
 				if (!server) throw new Error("mcp.begin_login requires a server");
 				await beginLogin(server);
 				return {};
-			}, contextAwareHostRequestHandler);
+			});
 		}
 		return handlers;
 	}

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -26,6 +26,8 @@ export interface RlmSubagentRegistryEntry {
 	rlm_child_id: string;
 	active_session_id: string | null;
 	session_id: string | null;
+	/** Persisted session path, when daemon discovery can identify this incarnation. */
+	session_file?: string;
 	session_name: string;
 	session_dir: string;
 	status: RlmSubagentRegistryStatus;
@@ -277,6 +279,12 @@ export interface RlmSubagentDeletionAuthority {
 	/** Exact child incarnation this attempt is allowed to reconcile. */
 	childId: string;
 	sessionDir: string;
+	/**
+	 * Persisted/runtime incarnation fences. Passive deletion has no object
+	 * reference, so it must carry at least one of these when discovery has it.
+	 */
+	sessionFile?: string;
+	sessionId?: string;
 	/** Monotonic per-parent attempt token; never reused after an aborted owner. */
 	generation: number;
 	/**

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -240,6 +240,35 @@ export interface RlmSubagentReleaseOutcome {
 	deletionDurability: RlmSubagentDeletionDurability;
 }
 
+/** The durable phase reached by a host-owned deletion attempt. */
+export type RlmSubagentDeletionPhase = "precommit" | "tombstoned";
+
+/** A successful host deletion always proves a concrete durable outcome. */
+export interface RlmSubagentHostDeletionResult {
+	deletionDurability: Exclude<RlmSubagentDeletionDurability, "unknown">;
+}
+
+/**
+ * A typed host deletion failure. `precommit` guarantees that no durable
+ * tombstone was appended, so the caller must leave its live child tracking
+ * untouched. `tombstoned` means the registry commit is authoritative and only
+ * runtime cleanup remains retryable.
+ */
+export class RlmSubagentHostDeletionError extends Error {
+	readonly phase: RlmSubagentDeletionPhase;
+
+	constructor(phase: RlmSubagentDeletionPhase, cause: unknown) {
+		super(
+			phase === "precommit"
+				? "RLM subagent deletion did not commit"
+				: "RLM subagent tombstone committed but runtime close failed",
+			{ cause },
+		);
+		this.name = "RlmSubagentHostDeletionError";
+		this.phase = phase;
+	}
+}
+
 /**
  * Authority held by the exact host request that asked to reconcile a private
  * deletion lease. This is a typed host contract, never child-controlled data.
@@ -267,6 +296,7 @@ export interface SubagentRuntimeHost {
 		runtime: RlmSubagentRuntime,
 		options: CreateRlmSubagentRuntimeOptions,
 		status: "done" | "error" | "cancelled",
+		authority?: RlmSubagentDeletionAuthority,
 	) => Promise<RlmSubagentReleaseOutcome>;
 	/** Re-check a release whose durability was unknown, without inventing a public child status. */
 	resolveRlmSubagentDeletion?(
@@ -278,6 +308,6 @@ export interface SubagentRuntimeHost {
 		childId: string,
 		session?: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<void>;
+	): Promise<RlmSubagentHostDeletionResult | undefined>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -11,7 +11,6 @@ export interface RlmRunRequest {
 	cellSourceCode?: string;
 	/** Dispatcher authority for this admission; revoked requests must not spawn. */
 	signal: AbortSignal;
-	isCurrent(): boolean;
 }
 
 export interface RlmSpawnHandle {
@@ -159,13 +158,11 @@ export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHand
 		}
 		const kwargs = isRecord(payload.kwargs) ? payload.kwargs : {};
 		const cellSourceCode = typeof payload.cellSourceCode === "string" ? payload.cellSourceCode : undefined;
-		if (context.signal.aborted || !context.isCurrent()) throw new Error("host request authority was revoked");
 		const result = await handler({
 			prompt: payload.prompt,
 			kwargs,
 			cellSourceCode,
 			signal: context.signal,
-			isCurrent: () => context.isCurrent(),
 		});
 		return result as unknown as Record<string, unknown>;
 	});

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -240,6 +240,14 @@ export interface RlmSubagentReleaseOutcome {
 	deletionDurability: RlmSubagentDeletionDurability;
 }
 
+/**
+ * Authority held by the exact host request that asked to reconcile a private
+ * deletion lease. This is a typed host contract, never child-controlled data.
+ */
+export interface RlmSubagentDeletionAuthority {
+	assertCurrent(): void;
+}
+
 export interface SubagentRuntimeHost {
 	createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime>;
 	/** Persist host-owned completion before the child becomes passivation-eligible. */
@@ -251,7 +259,10 @@ export interface SubagentRuntimeHost {
 		status: "done" | "error" | "cancelled",
 	) => Promise<RlmSubagentReleaseOutcome>;
 	/** Re-check a release whose durability was unknown, without inventing a public child status. */
-	resolveRlmSubagentDeletion?(childId: string): Promise<RlmSubagentDeletionDurability>;
+	resolveRlmSubagentDeletion?(
+		childId: string,
+		authority: RlmSubagentDeletionAuthority,
+	): Promise<RlmSubagentDeletionDurability>;
 	/** Close or remove the host-owned child; session is absent when a persisted child is still passive. */
 	deleteRlmSubagentRuntime(childId: string, session?: AgentSession): Promise<void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -53,7 +53,7 @@ export interface RlmFindModelsResult {
 
 export type RlmRunHandler = (request: RlmRunRequest) => Promise<Record<string, unknown>>;
 export type RlmListSubagentsHandler = () => RlmListSubagentsResult | Promise<RlmListSubagentsResult>;
-export type RlmDeleteSubagentHandler = (target: string) => Promise<RlmDeleteSubagentResult>;
+export type RlmDeleteSubagentHandler = (target: string, signal: AbortSignal) => Promise<RlmDeleteSubagentResult>;
 export type RlmFindModelsHandler = (query: string, limit: number) => RlmFindModelsResult | Promise<RlmFindModelsResult>;
 
 const RLM_SUBAGENT_SESSION_NAME_MAX_LENGTH = 64;
@@ -192,11 +192,11 @@ export function createRlmListSubagentsHostHandler(handler: RlmListSubagentsHandl
 
 /** Delete one direct child selected from the current parent session's registry. */
 export function createRlmDeleteSubagentHostHandler(handler: RlmDeleteSubagentHandler): HostRequestHandler {
-	return createHostRequestHandler(async (payload, _context) => {
+	return createHostRequestHandler(async (payload, context) => {
 		if (typeof payload.target !== "string" || !payload.target.trim()) {
 			throw new Error("rlm.delete_subagent target must be a non-empty string");
 		}
-		const { subagent, outcome } = await handler(payload.target.trim());
+		const { subagent, outcome } = await handler(payload.target.trim(), context.signal);
 		return outcome === undefined ? { subagent } : { subagent, outcome };
 	});
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -308,6 +308,6 @@ export interface SubagentRuntimeHost {
 		childId: string,
 		session?: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<RlmSubagentHostDeletionResult | undefined>;
+	): Promise<RlmSubagentHostDeletionResult | void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -2,7 +2,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
-import { contextAwareHostRequestHandler, createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
+import { createHostRequestHandler, type HostRequestHandler } from "./kernel/index.js";
 
 export interface RlmRunRequest {
 	prompt: string;
@@ -168,7 +168,7 @@ export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHand
 			isCurrent: () => context.isCurrent(),
 		});
 		return result as unknown as Record<string, unknown>;
-	}, contextAwareHostRequestHandler);
+	});
 }
 
 /** Search a bounded authenticated model catalog without adding it to the system prompt. */
@@ -182,7 +182,7 @@ export function createRlmFindModelsHostHandler(handler: RlmFindModelsHandler): H
 			throw new Error(`rlm.find_models limit must be an integer from 1 to ${MAX_RLM_MODEL_SEARCH_LIMIT}`);
 		}
 		return { models: (await handler(payload.query, limit as number)).models };
-	}, contextAwareHostRequestHandler);
+	});
 }
 
 /** Expose the current parent session's RLM child registry to its kernel. */
@@ -190,7 +190,7 @@ export function createRlmListSubagentsHostHandler(handler: RlmListSubagentsHandl
 	return createHostRequestHandler(async (_payload, _context) => {
 		const { subagents } = await handler();
 		return { subagents };
-	}, contextAwareHostRequestHandler);
+	});
 }
 
 /** Delete one direct child selected from the current parent session's registry. */
@@ -201,7 +201,7 @@ export function createRlmDeleteSubagentHostHandler(handler: RlmDeleteSubagentHan
 		}
 		const { subagent, outcome } = await handler(payload.target.trim());
 		return outcome === undefined ? { subagent } : { subagent, outcome };
-	}, contextAwareHostRequestHandler);
+	});
 }
 
 export interface RlmSubagentRuntime {

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -229,6 +229,17 @@ export interface CreateRlmSubagentRuntimeOptions {
 	onSessionPublished?: (session: AgentSession) => void;
 }
 
+/**
+ * What the host can prove about a cancelled, never-admitted child's deletion.
+ * This is deliberately not a public child status: uncertainty must never make a
+ * private artifact appear active, idle, or inactive.
+ */
+export type RlmSubagentDeletionDurability = "absent" | "tombstoned" | "unknown";
+
+export interface RlmSubagentReleaseOutcome {
+	deletionDurability: RlmSubagentDeletionDurability;
+}
+
 export interface SubagentRuntimeHost {
 	createRlmSubagentRuntime(options: CreateRlmSubagentRuntimeOptions): Promise<RlmSubagentRuntime>;
 	/** Persist host-owned completion before the child becomes passivation-eligible. */
@@ -238,7 +249,9 @@ export interface SubagentRuntimeHost {
 		runtime: RlmSubagentRuntime,
 		options: CreateRlmSubagentRuntimeOptions,
 		status: "done" | "error" | "cancelled",
-	) => Promise<{ retained: boolean }>;
+	) => Promise<RlmSubagentReleaseOutcome>;
+	/** Re-check a release whose durability was unknown, without inventing a public child status. */
+	resolveRlmSubagentDeletion?(childId: string): Promise<RlmSubagentDeletionDurability>;
 	/** Close or remove the host-owned child; session is absent when a persisted child is still passive. */
 	deleteRlmSubagentRuntime(childId: string, session?: AgentSession): Promise<void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -238,7 +238,7 @@ export interface SubagentRuntimeHost {
 		runtime: RlmSubagentRuntime,
 		options: CreateRlmSubagentRuntimeOptions,
 		status: "done" | "error" | "cancelled",
-	) => Promise<void>;
+	) => Promise<{ retained: boolean }>;
 	/** Close or remove the host-owned child; session is absent when a persisted child is still passive. */
 	deleteRlmSubagentRuntime(childId: string, session?: AgentSession): Promise<void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -245,6 +245,16 @@ export interface RlmSubagentReleaseOutcome {
  * deletion lease. This is a typed host contract, never child-controlled data.
  */
 export interface RlmSubagentDeletionAuthority {
+	/** Exact child incarnation this attempt is allowed to reconcile. */
+	childId: string;
+	sessionDir: string;
+	/** Monotonic per-parent attempt token; never reused after an aborted owner. */
+	generation: number;
+	/**
+	 * Throws unless this exact generation still owns the exact child lease. The
+	 * daemon calls this after its asynchronous registry read and immediately
+	 * before the synchronous append/fsync boundary.
+	 */
 	assertCurrent(): void;
 }
 
@@ -264,6 +274,10 @@ export interface SubagentRuntimeHost {
 		authority: RlmSubagentDeletionAuthority,
 	): Promise<RlmSubagentDeletionDurability>;
 	/** Close or remove the host-owned child; session is absent when a persisted child is still passive. */
-	deleteRlmSubagentRuntime(childId: string, session?: AgentSession): Promise<void>;
+	deleteRlmSubagentRuntime(
+		childId: string,
+		session?: AgentSession,
+		authority?: RlmSubagentDeletionAuthority,
+	): Promise<void>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;
 }

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -308,6 +308,6 @@ export interface SubagentRuntimeHost {
 		childId: string,
 		session?: AgentSession,
 		authority?: RlmSubagentDeletionAuthority,
-	): Promise<RlmSubagentHostDeletionResult | void>;
+	): Promise<RlmSubagentHostDeletionResult | undefined>;
 	disposeRlmSubagentRuntimes?(): Promise<void>;
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1047,8 +1047,8 @@ export class AgentDaemon {
 			authority &&
 			((typeof authority.childId === "string" && authority.childId !== childId) ||
 				(entry !== undefined &&
-					typeof authority.sessionDir === "string" &&
-					authority.sessionDir !== entry.sessionDir))
+					((typeof authority.sessionDir === "string" && authority.sessionDir !== entry.sessionDir) ||
+						(typeof authority.sessionFile === "string" && authority.sessionFile !== entry.sessionFile))))
 		) {
 			authority.assertCurrent();
 			return "unknown";
@@ -2362,7 +2362,12 @@ export class AgentDaemon {
 						!state ||
 						state.runtime.session !== runtime.session ||
 						state.runtime.metadata.sessionDir !== options.sessionDir ||
-						(authority !== undefined && state.runtime.metadata.sessionDir !== authority.sessionDir)
+						(authority !== undefined &&
+							(state.runtime.metadata.sessionDir !== authority.sessionDir ||
+								(typeof authority.sessionFile === "string" &&
+									state.runtime.session.sessionFile !== authority.sessionFile) ||
+								(typeof authority.sessionId === "string" &&
+									state.runtime.session.sessionId !== authority.sessionId)))
 					) {
 						throw new Error("RLM subagent release does not match the resident runtime incarnation");
 					}
@@ -2404,16 +2409,32 @@ export class AgentDaemon {
 					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 						(entry) => entry.childId === childId,
 					);
-					// Concrete deletion requires exact object identity. Passive deletion has no
-					// object fence, so bind it to the complete persisted identity instead.
+					// Concrete deletion requires exact object identity. A passive request and a
+					// post-tombstone cleanup retry have no resident state, so both must bind to
+					// the exact persisted incarnation before they can touch its tombstone or jobs.
+					const persistedMatchesAuthority =
+						persisted !== undefined &&
+						(authority === undefined ||
+							(persisted.sessionDir === authority.sessionDir &&
+								(typeof authority.sessionFile !== "string" ||
+									persisted.sessionFile === authority.sessionFile)));
+					const suppliedSessionMatchesPersisted =
+						session === undefined ||
+						(persistedMatchesAuthority &&
+							(typeof authority?.sessionFile !== "string" || session.sessionFile === authority.sessionFile) &&
+							(typeof authority?.sessionId !== "string" || session.sessionId === authority.sessionId));
 					if (
 						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
 						(state !== undefined && session === undefined) ||
-						(state === undefined && session !== undefined) ||
+						(state === undefined && session !== undefined && !suppliedSessionMatchesPersisted) ||
 						(authority !== undefined &&
 							(state !== undefined
-								? state.runtime.metadata.sessionDir !== authority.sessionDir
-								: persisted === undefined || persisted.sessionDir !== authority.sessionDir))
+								? state.runtime.metadata.sessionDir !== authority.sessionDir ||
+									(typeof authority.sessionFile === "string" &&
+										state.runtime.session.sessionFile !== authority.sessionFile) ||
+									(typeof authority.sessionId === "string" &&
+										state.runtime.session.sessionId !== authority.sessionId)
+								: !persistedMatchesAuthority))
 					) {
 						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
 					}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -5400,10 +5400,17 @@ export class AgentDaemon {
 		const visited = new Set<string>();
 		while (child.runtime.metadata.kind === "subagent") {
 			if (visited.has(child.activeSessionId)) return false;
+			if (
+				this.closingSessions.has(child.activeSessionId) ||
+				this.failedTombstonedRlmCloses.has(child.activeSessionId)
+			)
+				return true;
 			visited.add(child.activeSessionId);
 			const { parentActiveSessionId, rlmChildId } = child.runtime.metadata;
 			if (!parentActiveSessionId || !rlmChildId) return false;
-			const parent = this.sessions.get(parentActiveSessionId);
+			const parent =
+				this.sessions.get(parentActiveSessionId) ??
+				this.failedTombstonedRlmCloses.get(parentActiveSessionId)?.state;
 			if (!parent) return false;
 			if (parent.runtime.session.isRlmChildDeletionQuarantined?.(rlmChildId) === true) return true;
 			child = parent;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -420,18 +420,6 @@ type PassiveRlmSubagent = PassiveRlmRoot & {
 class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
 
-type DaemonSessionCloseFailureStage = "dispose" | "persist" | "cascade";
-
-/** Daemon-private close diagnostics used only to authorize exact cleanup retry. */
-class DaemonSessionCloseError extends Error {
-	readonly stage: DaemonSessionCloseFailureStage;
-
-	constructor(stage: DaemonSessionCloseFailureStage, cause: unknown) {
-		super(cause instanceof Error ? cause.message : String(cause), { cause });
-		this.name = "DaemonSessionCloseError";
-		this.stage = stage;
-	}
-}
 class PrivateSessionUnavailableError extends BoundSessionUnavailableError {}
 
 export async function runDaemonMode(options: DaemonModeOptions): Promise<never> {
@@ -500,11 +488,6 @@ export class AgentDaemon {
 			descendants: Set<ActiveSessionState>;
 			reasonUpgrade?: Promise<void>;
 		}
-	>();
-	/** Exact removed incarnation retained only when its runtime dispose failed. */
-	private readonly failedSessionCloses = new Map<
-		string,
-		{ state: ActiveSessionState; error: DaemonSessionCloseError }
 	>();
 	private readonly failedTombstonedRlmCloses = new Map<string, FailedTombstonedRlmClose>();
 	private readonly closeDisposeErrors = new WeakMap<ActiveSessionState, unknown>();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6427,6 +6427,9 @@ export class AgentDaemon {
 		if (!this.sessions.has(state.activeSessionId)) {
 			return;
 		}
+		// Claim before any close work can yield. A direct disposer that won this
+		// race retains ordinary release ownership; this close must not fabricate it.
+		const daemonOwnsSessionLeaseRelease = state.runtime.claimSessionLeaseReleaseForDaemon?.() ?? false;
 		let closeError: unknown;
 		const captureCloseError = (error: unknown): void => {
 			closeError ??= error;
@@ -6494,9 +6497,7 @@ export class AgentDaemon {
 		this.recordWorkerRecoveryState(state, `closed:${reason}`, false);
 		state.unsubscribe?.();
 		try {
-			// A tombstoned record must retain its lease until the daemon commits the
-			// whole close. Normal direct runtime disposal still releases its own lease.
-			await state.runtime.dispose({ releaseSessionLease: false });
+			await state.runtime.dispose();
 		} catch (error) {
 			captureCloseError(error);
 		}
@@ -6521,7 +6522,7 @@ export class AgentDaemon {
 				await deleteSessionFile(sessionFile).catch(() => undefined);
 			}
 		}
-		state.runtime.releaseSessionLease?.();
+		if (daemonOwnsSessionLeaseRelease) state.runtime.releaseSessionLease();
 		if (closeError) throw closeError;
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1031,12 +1031,33 @@ export class AgentDaemon {
 		authority?: RlmSubagentDeletionAuthority,
 	): Promise<RlmSubagentDeletionDurability> {
 		const latest = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
+		// Every outcome still precedes a potential runtime close except the
+		// synchronous append boundary below, so revocation must win here too.
+		authority?.assertCurrent();
 		if (!latest) return "unknown";
 		const entry = latest.find((candidate) => candidate.childId === childId);
+		// The authority is minted by AgentSession's per-child coordinator. It
+		// binds this append to a particular incarnation, not merely a recycled id.
+		// Validate it once after the asynchronous read and once at the synchronous
+		// append/fsync boundary below.
+		// Compatibility callers only supplied assertCurrent before generations
+		// existed. New coordinator authorities always carry both incarnation fields.
+		if (
+			authority &&
+			((typeof authority.childId === "string" && authority.childId !== childId) ||
+				(entry !== undefined &&
+					typeof authority.sessionDir === "string" &&
+					authority.sessionDir !== entry.sessionDir))
+		) {
+			authority.assertCurrent();
+			return "unknown";
+		}
 		if (!entry) {
+			authority?.assertCurrent();
 			return "absent";
 		}
 		if (entry.status === "deleted") {
+			authority?.assertCurrent();
 			return "tombstoned";
 		}
 		// The complete read above is asynchronous. Revalidate immediately before
@@ -2352,7 +2373,7 @@ export class AgentDaemon {
 			},
 			resolveRlmSubagentDeletion: (childId, authority) =>
 				this.recordRlmSubagentDeletion(parentState, childId, authority),
-			deleteRlmSubagentRuntime: async (childId, session) => {
+			deleteRlmSubagentRuntime: async (childId, session, authority) => {
 				const state = [...this.sessions.values()].find(
 					(candidate) =>
 						candidate.runtime.metadata.kind === "subagent" &&
@@ -2362,12 +2383,37 @@ export class AgentDaemon {
 				const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 					(entry) => entry.childId === childId,
 				);
+				// A child id alone is never an incarnation proof. Do not close a
+				// freshly recycled resident state under an old attempt token.
+				if (
+					authority &&
+					state?.runtime.metadata.sessionDir !== undefined &&
+					state.runtime.metadata.sessionDir !== authority.sessionDir
+				) {
+					authority.assertCurrent();
+					throw new Error("RLM subagent deletion authority does not match runtime incarnation");
+				}
 				const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
 				// Persist the deletion boundary before tearing down the runtime. As with a
 				// resident child, deletion keeps its transcript and artifact tree on disk.
-				await this.recordRlmSubagentDeletion(parentState, childId);
+				const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
+				// A stale incarnation, corrupt registry, or failed append is not
+				// permission to destroy a runtime. Only absence or a tombstone is a
+				// durable deletion boundary.
+				if (deletionDurability === "unknown") {
+					throw new Error("RLM subagent deletion durability is still unknown");
+				}
+				// Absence has no append point of no return: retain authority through
+				// the immediately following destructive close. A tombstone commit,
+				// however, is intentionally durable even if its reply is later stale.
+				if (deletionDurability === "absent") authority?.assertCurrent();
+				// The append is the linearization point. A late request abort must
+				// suppress its reply, not undo or race the already durable tombstone.
 				const staleSession = state && session && state.runtime.session !== session ? session : undefined;
 				try {
+					// `absent` did not append anything. Recheck adjacent to the
+					// destructive call itself; do not apply this after tombstoning.
+					if (deletionDurability === "absent") authority?.assertCurrent();
 					if (state) {
 						await this.closeSession(state, "killed", false);
 					} else {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2187,7 +2187,8 @@ export class AgentDaemon {
 		}
 		const activeIdMatch = this.sessions.get(dueJob.activeSessionId);
 		const terminalizing = this.findFailedTerminalizationBySessionFile(dueJob.sessionFile);
-		if (terminalizing || this.failedTombstonedRlmCloses.get(dueJob.activeSessionId)?.state === activeIdMatch) {
+		const failedClose = this.failedTombstonedRlmCloses.get(dueJob.activeSessionId);
+		if (terminalizing || (failedClose !== undefined && failedClose.state === activeIdMatch)) {
 			return undefined;
 		}
 		const current =
@@ -6374,6 +6375,15 @@ export class AgentDaemon {
 		cascadeChildren = true,
 		descendantCollector?: Set<ActiveSessionState>,
 	): Promise<void> {
+		const terminalizingClose = this.failedTombstonedRlmCloses.get(state.activeSessionId);
+		if (
+			terminalizingClose?.terminalizing &&
+			terminalizingClose.state === state &&
+			terminalizingClose.reason &&
+			this.isStrongerCloseReason(terminalizingClose.reason, reason)
+		) {
+			reason = terminalizingClose.reason;
+		}
 		this.abortWaitingPromptAdmissionsForSession(state.activeSessionId);
 		for (const client of state.clients) {
 			this.abortSideQuestionsFor(client, state.activeSessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -402,6 +402,11 @@ interface PersistedRlmSubagentRegistryEntry {
 	updatedAt: string;
 }
 
+/** A pre-session-id registry row is only usable to upgrade an exact resident. */
+type DeletionRlmSubagentRegistryEntry = Omit<PersistedRlmSubagentRegistryEntry, "sessionId"> & {
+	sessionId?: string;
+};
+
 type PassiveRlmRoot =
 	| { rootParentState: ActiveSessionState; rootInfo?: never }
 	| { rootParentState?: never; rootInfo: SessionInfo };
@@ -965,11 +970,13 @@ export class AgentDaemon {
 	/**
 	 * Strictly read the registry when absence would authorize destructive cleanup.
 	 * Passive discovery may skip a corrupt historical line, but deletion must not
-	 * mistake that ambiguity for proof that a child was never recorded.
+	 * mistake that ambiguity for proof that a child was never recorded. A row
+	 * written before session ids existed is retained only for an exact resident
+	 * session to upgrade; it is never evidence for passive cleanup.
 	 */
 	private async readCompleteRlmSubagentRegistryForDeletion(
 		parentState: ActiveSessionState,
-	): Promise<PersistedRlmSubagentRegistryEntry[] | undefined> {
+	): Promise<DeletionRlmSubagentRegistryEntry[] | undefined> {
 		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
 		if (!path) return undefined;
 		let lines: string[];
@@ -982,12 +989,12 @@ export class AgentDaemon {
 			);
 			return undefined;
 		}
-		const latest = new Map<string, PersistedRlmSubagentRegistryEntry>();
+		const latest = new Map<string, DeletionRlmSubagentRegistryEntry>();
 		for (const line of lines) {
 			const trimmed = line.trim();
 			if (!trimmed) continue;
 			try {
-				const entry = JSON.parse(trimmed) as Partial<PersistedRlmSubagentRegistryEntry>;
+				const entry = JSON.parse(trimmed) as Partial<DeletionRlmSubagentRegistryEntry>;
 				const validIsoTimestamp =
 					typeof entry.updatedAt === "string" &&
 					Number.isFinite(Date.parse(entry.updatedAt)) &&
@@ -1005,8 +1012,8 @@ export class AgentDaemon {
 					typeof entry.sessionName !== "string" ||
 					typeof entry.sessionDir !== "string" ||
 					typeof entry.sessionFile !== "string" ||
-					typeof entry.sessionId !== "string" ||
-					entry.sessionId.length === 0 ||
+					(entry.sessionId !== undefined &&
+						(typeof entry.sessionId !== "string" || entry.sessionId.length === 0)) ||
 					typeof entry.parentSessionId !== "string" ||
 					entry.parentSessionId.length === 0 ||
 					(entry.parentSessionFile !== undefined && typeof entry.parentSessionFile !== "string") ||
@@ -1024,7 +1031,7 @@ export class AgentDaemon {
 				) {
 					return undefined;
 				}
-				latest.set(entry.childId, entry as PersistedRlmSubagentRegistryEntry);
+				latest.set(entry.childId, entry as DeletionRlmSubagentRegistryEntry);
 			} catch {
 				return undefined;
 			}
@@ -1036,53 +1043,62 @@ export class AgentDaemon {
 		parentState: ActiveSessionState,
 		childId: string,
 		authority?: RlmSubagentDeletionAuthority,
+		residentSession?: AgentSession,
 	): Promise<RlmSubagentDeletionDurability> {
 		const latest = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
-		// Every outcome still precedes a potential runtime close except the
-		// synchronous append boundary below, so revocation must win here too.
+		// This check follows the registry read even when this compatible resident
+		// path has no coordinator authority.
 		authority?.assertCurrent();
 		if (!latest) return "unknown";
-		const entry = latest.find((candidate) => candidate.childId === childId);
-		// The authority is minted by AgentSession's per-child coordinator. It
-		// binds this append to a particular incarnation, not merely a recycled id.
-		// Validate it once after the asynchronous read and once at the synchronous
-		// append/fsync boundary below.
-		// Compatibility callers only supplied assertCurrent before generations
-		// existed. New coordinator authorities always carry both incarnation fields.
 		if (
 			authority &&
 			(authority.childId !== childId ||
-				(entry !== undefined &&
-					(authority.sessionDir !== entry.sessionDir ||
-						typeof authority.sessionFile !== "string" ||
-						authority.sessionFile !== entry.sessionFile ||
-						typeof authority.sessionId !== "string" ||
-						authority.sessionId !== entry.sessionId)))
+				typeof authority.sessionDir !== "string" ||
+				typeof authority.sessionFile !== "string" ||
+				authority.sessionFile.length === 0 ||
+				typeof authority.sessionId !== "string" ||
+				authority.sessionId.length === 0)
 		) {
 			authority.assertCurrent();
 			return "unknown";
 		}
+		const entry = latest.find((candidate) => candidate.childId === childId);
 		if (!entry) {
 			authority?.assertCurrent();
 			return "absent";
 		}
-		if (authority) {
-			const info = await readSessionInfo(entry.sessionFile);
-			authority.assertCurrent();
-			if (!info || info.id !== entry.sessionId || authority.sessionId !== info.id) return "unknown";
-		}
+		// Validate the saved-session header after the asynchronous registry read
+		// before any append can be considered. This fences authority-free resident
+		// cleanup just as strictly as coordinator-owned cleanup.
+		const info = await readSessionInfo(entry.sessionFile);
+		authority?.assertCurrent();
+		if (!info) return "unknown";
+		const residentMatchesHeader =
+			residentSession !== undefined &&
+			residentSession.sessionFile === entry.sessionFile &&
+			residentSession.sessionId === info.id &&
+			(entry.sessionId === undefined || entry.sessionId === info.id);
+		const authorityMatchesEntry =
+			authority !== undefined &&
+			authority.childId === entry.childId &&
+			authority.sessionDir === entry.sessionDir &&
+			authority.sessionFile === entry.sessionFile &&
+			authority.sessionId === entry.sessionId &&
+			info.id === entry.sessionId;
+		const legacyResidentUpgrade = entry.sessionId === undefined && authority === undefined && residentMatchesHeader;
+		if (!authorityMatchesEntry && !(authority === undefined && residentMatchesHeader)) return "unknown";
+		if (entry.sessionId === undefined && !legacyResidentUpgrade) return "unknown";
 		if (entry.status === "deleted") {
 			authority?.assertCurrent();
 			return "tombstoned";
 		}
-		// The complete read above is asynchronous. Revalidate immediately before
-		// entering the synchronous append/fsync commit region: before that point a
-		// stale request must leave no registry mutation behind. Once append starts,
-		// finish the durable commit and let the caller suppress its stale reply.
+		// The header and authority are both checked immediately before the
+		// synchronous append/fsync boundary. Once append starts, finish it.
 		authority?.assertCurrent();
 		if (
 			!this.appendRlmSubagentRegistryEntry(parentState, {
 				...entry,
+				sessionId: entry.sessionId ?? info.id,
 				status: "deleted",
 				updatedAt: new Date().toISOString(),
 			})
@@ -2392,7 +2408,12 @@ export class AgentDaemon {
 
 					let deletionDurability: RlmSubagentDeletionDurability = "unknown";
 					if (status === "cancelled") {
-						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id, authority);
+						deletionDurability = await this.recordRlmSubagentDeletion(
+							parentState,
+							options.id,
+							authority,
+							state.runtime.session,
+						);
 						if (deletionDurability === "unknown") {
 							throw new Error("RLM subagent deletion durability is still unknown");
 						}
@@ -2460,7 +2481,12 @@ export class AgentDaemon {
 						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
 					}
 					const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
-					const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
+					const deletionDurability = await this.recordRlmSubagentDeletion(
+						parentState,
+						childId,
+						authority,
+						state?.runtime.session,
+					);
 					if (deletionDurability === "unknown") {
 						throw new Error("RLM subagent deletion durability is still unknown");
 					}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -5536,14 +5536,16 @@ export class AgentDaemon {
 	}
 
 	private runTombstonedCloseAttempt(record: FailedTombstonedRlmClose): void {
-		if (
-			this.shuttingDown ||
-			this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record ||
-			(record.terminalizing && this.sessions.get(record.state.activeSessionId) !== record.state)
-		) {
-			if (this.failedTombstonedRlmCloses.get(record.state.activeSessionId) === record) {
-				this.failedTombstonedRlmCloses.delete(record.state.activeSessionId);
-			}
+		if (this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record) return;
+		if (record.terminalizing && this.sessions.get(record.state.activeSessionId) !== record.state) {
+			this.failedTombstonedRlmCloses.delete(record.state.activeSessionId);
+			return;
+		}
+		if (this.shuttingDown) {
+			// Shutdown clears retry timers but retains terminalization authority for
+			// its synchronous original-reason attempt below.
+			if (record.terminalizing) return;
+			this.failedTombstonedRlmCloses.delete(record.state.activeSessionId);
 			return;
 		}
 		record.retryTimer = undefined;
@@ -5582,6 +5584,33 @@ export class AgentDaemon {
 		}
 	}
 
+	/**
+	 * A shutdown close normally preserves a resumable entry. That must never
+	 * supersede an exact resident that already failed its terminal archive: make
+	 * its one owned close attempt with the original reason before generic shutdown
+	 * teardown. A failure intentionally leaves the private record and lease live
+	 * until process exit rather than treating it as a resumable shutdown close.
+	 */
+	private async closeTerminalizingSessionsForShutdown(): Promise<void> {
+		for (const record of [...this.failedTombstonedRlmCloses.values()]) {
+			if (
+				!record.terminalizing ||
+				this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record ||
+				this.sessions.get(record.state.activeSessionId) !== record.state
+			) {
+				continue;
+			}
+			try {
+				// Join a bounded in-flight attempt when present; otherwise make only
+				// this shutdown-owned attempt. Retrying remains disabled while stopping.
+				await (record.cleanup ?? this.closeSession(record.state, record.reason ?? "killed", false));
+			} catch (error) {
+				if (this.failedTombstonedRlmCloses.get(record.state.activeSessionId) === record) {
+					record.error = error;
+				}
+			}
+		}
+	}
 
 	// Half-bound sessions are hidden from other sessions' listings; the current
 	// session stays visible to itself (controllers run during its own bind).
@@ -7100,7 +7129,10 @@ export class AgentDaemon {
 			cleanup();
 		}
 		this.cronScheduler.stop();
+		await this.closeTerminalizingSessionsForShutdown();
 		for (const state of [...this.sessions.values()]) {
+			const failedTerminalization = this.failedTombstonedRlmCloses.get(state.activeSessionId);
+			if (failedTerminalization?.terminalizing && failedTerminalization.state === state) continue;
 			await this.closeSession(state, closingReason);
 		}
 		for (const client of this.clients) {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -952,12 +952,16 @@ export class AgentDaemon {
 		});
 	}
 
-	private async recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<void> {
+	/** Write (or verify) the deletion tombstone and report whether durable ownership exists. */
+	private async recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<boolean> {
 		const latest = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 			(entry) => entry.childId === childId,
 		);
-		if (!latest || latest.status === "deleted") {
-			return;
+		if (!latest) {
+			return false;
+		}
+		if (latest.status === "deleted") {
+			return true;
 		}
 		if (
 			!this.appendRlmSubagentRegistryEntry(parentState, {
@@ -968,6 +972,7 @@ export class AgentDaemon {
 		) {
 			throw new Error(`Failed to persist deletion for RLM subagent ${childId}`);
 		}
+		return true;
 	}
 
 	private readLatestRlmSubagentRegistry(
@@ -2239,14 +2244,16 @@ export class AgentDaemon {
 				});
 			},
 			releaseRlmSubagentRuntime: async (runtime, options, status) => {
-				// Persist the deletion boundary first, but never let a registry failure
-				// strand the cancelled child as a stale resident session.
-				let deletionError: unknown;
+				// A caller may only retain a never-admitted cancelled child when the
+				// deletion tombstone is durably written. Close it on any write failure,
+				// then explicitly return that the caller still owns its artifact dir.
+				let retained = false;
 				if (status === "cancelled") {
 					try {
-						await this.recordRlmSubagentDeletion(parentState, options.id);
-					} catch (error) {
-						deletionError = error;
+						retained = await this.recordRlmSubagentDeletion(parentState, options.id);
+					} catch {
+						// The close below prevents a stale resident runtime; the caller removes
+						// its exact never-admitted child dir because no durable row exists.
 					}
 				}
 				const state = [...this.sessions.values()].find(
@@ -2261,7 +2268,7 @@ export class AgentDaemon {
 				} else {
 					await runtime.session.disposeAsync();
 				}
-				if (deletionError !== undefined) throw deletionError;
+				return { retained };
 			},
 			deleteRlmSubagentRuntime: async (childId, session) => {
 				const state = [...this.sessions.values()].find(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -450,6 +450,16 @@ interface FailedTombstonedRlmClose {
 	retryTimer?: ReturnType<typeof setTimeout>;
 }
 
+/** A pre-teardown archive failure retains its exact resident state and lease. */
+interface FailedTerminalSessionClose {
+	readonly state: ActiveSessionState;
+	readonly reason: DaemonSessionClosedReason;
+	cleanup?: Promise<void>;
+	error?: unknown;
+	retryAttempt: number;
+	retryTimer?: ReturnType<typeof setTimeout>;
+}
+
 export class AgentDaemon {
 	private server?: Server;
 	private shuttingDown = false;
@@ -493,6 +503,7 @@ export class AgentDaemon {
 		}
 	>();
 	private readonly failedTombstonedRlmCloses = new Map<string, FailedTombstonedRlmClose>();
+	private readonly failedTerminalSessionCloses = new Map<string, FailedTerminalSessionClose>();
 	private readonly sideQuestionRuns = new Map<
 		string,
 		{
@@ -1508,6 +1519,9 @@ export class AgentDaemon {
 			? await resolveDaemonSessionPath(command.sessionPath, cwd, config.sessionDir)
 			: undefined;
 		const sessionKey = sessionPath ? resolve(sessionPath) : undefined;
+		if (sessionKey && this.findFailedTerminalizationBySessionFile(sessionKey)) {
+			throw new PrivateSessionUnavailableError("Session is terminalizing");
+		}
 		if (sessionKey && this.findPassivationBySessionFile(sessionKey)) {
 			await this.waitForPassivation(sessionKey);
 			return this.createRuntime(command, runtimeOpenGuard);
@@ -2180,6 +2194,10 @@ export class AgentDaemon {
 			return undefined;
 		}
 		const activeIdMatch = this.sessions.get(dueJob.activeSessionId);
+		const terminalizing = this.findFailedTerminalSessionCloseBySessionFile(dueJob.sessionFile);
+		if (terminalizing || this.failedTerminalSessionCloses.get(dueJob.activeSessionId)?.state === activeIdMatch) {
+			return undefined;
+		}
 		const current =
 			this.findSessionBySessionFile(dueJob.sessionFile) ??
 			(!requirePersistedJob || activeIdMatch?.runtime.session.sessionId === dueJob.sessionId
@@ -2329,6 +2347,15 @@ export class AgentDaemon {
 		return state === undefined || this.isPublicRlmState(state);
 	}
 
+	private findFailedTerminalSessionCloseBySessionFile(sessionFile: string | undefined): ActiveSessionState | undefined {
+		if (!sessionFile) return undefined;
+		const target = resolve(sessionFile);
+		return [...this.failedTerminalSessionCloses.values()].find((record) => {
+			const file = record.state.runtime.session.sessionFile;
+			return file !== undefined && resolve(file) === target;
+		})?.state;
+	}
+
 	private findSessionBySessionFile(sessionFile: string | undefined): ActiveSessionState | undefined {
 		if (!sessionFile) {
 			return undefined;
@@ -2354,7 +2381,7 @@ export class AgentDaemon {
 		if (this.bindingSessions.has(state.activeSessionId)) {
 			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is still initializing`);
 		}
-		if (this.closingSessions.has(state.activeSessionId) || this.isQuarantinedRlmState(state)) {
+		if (!this.isPublicRlmState(state)) {
 			throw new PrivateSessionUnavailableError(`Active session ${state.activeSessionId} is unavailable`);
 		}
 		return state;
@@ -5449,7 +5476,8 @@ export class AgentDaemon {
 			if (visited.has(child.activeSessionId)) return false;
 			if (
 				this.closingSessions.has(child.activeSessionId) ||
-				this.failedTombstonedRlmCloses.has(child.activeSessionId)
+				this.failedTombstonedRlmCloses.has(child.activeSessionId) ||
+				this.failedTerminalSessionCloses.get(child.activeSessionId)?.state === child
 			)
 				return true;
 			visited.add(child.activeSessionId);
@@ -5457,7 +5485,8 @@ export class AgentDaemon {
 			if (!parentActiveSessionId || !rlmChildId) return false;
 			const parent =
 				this.sessions.get(parentActiveSessionId) ??
-				this.failedTombstonedRlmCloses.get(parentActiveSessionId)?.state;
+				this.failedTombstonedRlmCloses.get(parentActiveSessionId)?.state ??
+				this.failedTerminalSessionCloses.get(parentActiveSessionId)?.state;
 			if (!parent) return false;
 			if (parent.runtime.session.isRlmChildDeletionQuarantined?.(rlmChildId) === true) return true;
 			child = parent;
@@ -5466,7 +5495,11 @@ export class AgentDaemon {
 	}
 
 	private isPublicRlmState(state: ActiveSessionState): boolean {
-		return !this.closingSessions.has(state.activeSessionId) && !this.isQuarantinedRlmState(state);
+		return (
+			!this.closingSessions.has(state.activeSessionId) &&
+			this.failedTerminalSessionCloses.get(state.activeSessionId)?.state !== state &&
+			!this.isQuarantinedRlmState(state)
+		);
 	}
 
 	private findExactRlmState(
@@ -5544,6 +5577,75 @@ export class AgentDaemon {
 
 	private clearTombstonedCloseRetries(): void {
 		for (const record of this.failedTombstonedRlmCloses.values()) {
+			if (record.retryTimer) clearTimeout(record.retryTimer);
+			record.retryTimer = undefined;
+		}
+	}
+
+	private retainFailedTerminalSessionClose(
+		state: ActiveSessionState,
+		reason: DaemonSessionClosedReason,
+		error: unknown,
+	): void {
+		const existing = this.failedTerminalSessionCloses.get(state.activeSessionId);
+		if (existing?.state === state) {
+			existing.error = error;
+			if (!existing.cleanup && !existing.retryTimer) this.scheduleTerminalSessionCloseRetry(existing);
+			return;
+		}
+		const record: FailedTerminalSessionClose = { state, reason, error, retryAttempt: 0 };
+		this.failedTerminalSessionCloses.set(state.activeSessionId, record);
+		this.scheduleTerminalSessionCloseRetry(record);
+	}
+
+	private runTerminalSessionCloseAttempt(record: FailedTerminalSessionClose): void {
+		if (
+			this.shuttingDown ||
+			this.failedTerminalSessionCloses.get(record.state.activeSessionId) !== record ||
+			this.sessions.get(record.state.activeSessionId) !== record.state
+		) {
+			if (this.failedTerminalSessionCloses.get(record.state.activeSessionId) === record) {
+				this.failedTerminalSessionCloses.delete(record.state.activeSessionId);
+			}
+			return;
+		}
+		record.retryTimer = undefined;
+		record.error = undefined;
+		const cleanup = Promise.resolve().then(() => this.closeSession(record.state, record.reason));
+		record.cleanup = cleanup;
+		void cleanup.then(
+			() => {
+				if (this.failedTerminalSessionCloses.get(record.state.activeSessionId) === record) {
+					this.failedTerminalSessionCloses.delete(record.state.activeSessionId);
+				}
+			},
+			(error: unknown) => {
+				if (this.failedTerminalSessionCloses.get(record.state.activeSessionId) !== record) return;
+				record.error = error;
+				record.cleanup = undefined;
+				// Errors after unmapping are irreversible and must not retry a replacement.
+				if (this.sessions.get(record.state.activeSessionId) !== record.state) {
+					this.failedTerminalSessionCloses.delete(record.state.activeSessionId);
+					return;
+				}
+				this.scheduleTerminalSessionCloseRetry(record);
+			},
+		);
+	}
+
+	private scheduleTerminalSessionCloseRetry(record: FailedTerminalSessionClose): void {
+		if (this.shuttingDown || record.retryTimer || record.cleanup) return;
+		const delayMs = Math.min(
+			TOMBSTONED_CLOSE_RETRY_BASE_MS * 2 ** record.retryAttempt,
+			TOMBSTONED_CLOSE_RETRY_MAX_MS,
+		);
+		record.retryAttempt++;
+		record.retryTimer = setTimeout(() => this.runTerminalSessionCloseAttempt(record), delayMs);
+		record.retryTimer.unref();
+	}
+
+	private clearTerminalSessionCloseRetries(): void {
+		for (const record of this.failedTerminalSessionCloses.values()) {
 			if (record.retryTimer) clearTimeout(record.retryTimer);
 			record.retryTimer = undefined;
 		}
@@ -6424,7 +6526,7 @@ export class AgentDaemon {
 		cascadeChildren: boolean,
 		descendants: Set<ActiveSessionState>,
 	): Promise<void> {
-		if (!this.sessions.has(state.activeSessionId)) {
+		if (this.sessions.get(state.activeSessionId) !== state) {
 			return;
 		}
 		// Claim before any close work can yield. A direct disposer that won this
@@ -6436,6 +6538,25 @@ export class AgentDaemon {
 		};
 		const retainsForTombstonedRetry =
 			this.failedTombstonedRlmCloses.get(state.activeSessionId)?.state === state;
+		// Empty draft (no messages, config, or jobs): discard rather than persist an
+		// empty session file. Mirrors the detach-time discard so a config-bearing
+		// draft closed via kill/completed is never wiped.
+		const keepsResumeEntry = this.closeKeepsResumeEntry(reason);
+		const isEmptyDraftSession = !keepsResumeEntry && this.isEmptyDraftContent(state);
+		// Establish the durable terminal boundary before changing any live ownership.
+		// An archive failure leaves this exact resident, including its clients and lease,
+		// intact for the private retry below.
+		if (!keepsResumeEntry && !isEmptyDraftSession) {
+			try {
+				this.archiveSession(state);
+			} catch (error) {
+				if (!retainsForTombstonedRetry) this.retainFailedTerminalSessionClose(state, reason, error);
+				throw error;
+			}
+		}
+		// Cancellation and cascading are now post-terminalization: if either fails,
+		// ordinary closes can still retire safely, while a deletion tombstone retains
+		// its established full-close retry behavior.
 		if (reason === "killed") {
 			try {
 				this.cancelScheduledJobsForSession(state);
@@ -6449,7 +6570,6 @@ export class AgentDaemon {
 				captureCloseError(error);
 			}
 		}
-		// A tombstoned close that failed before teardown is retried intact.
 		if (closeError && retainsForTombstonedRetry) throw closeError;
 		// Abort in-flight status work before any await/dispose so it can't write
 		// agent_status to a session being torn down.
@@ -6457,19 +6577,6 @@ export class AgentDaemon {
 		if (cascadeChildren) {
 			const cascadeError = await this.closeChildSessions(state, reason, waitForAbort, descendants);
 			if (cascadeError) captureCloseError(cascadeError);
-		}
-		// Empty draft (no messages, config, or jobs): discard rather than persist an
-		// empty session file. Mirrors the detach-time discard so a config-bearing
-		// draft closed via kill/completed is never wiped.
-		const keepsResumeEntry = this.closeKeepsResumeEntry(reason);
-		const isEmptyDraftSession = !keepsResumeEntry && this.isEmptyDraftContent(state);
-		// Clean shutdown leaves the session un-archived so it stays in the resume list.
-		if (!keepsResumeEntry && !isEmptyDraftSession) {
-			try {
-				this.archiveSession(state);
-			} catch (error) {
-				captureCloseError(error);
-			}
 		}
 		cancelPendingExtensionUiRequests(state);
 		if (reason === "killed" || reason === "shutdown" || reason === "replaced" || reason === "update") {
@@ -6515,6 +6622,9 @@ export class AgentDaemon {
 		}
 		// Failed non-tombstoned closes are irrevocable: never leave a disposed,
 		// targetable resident behind merely because persistence or cleanup failed.
+		if (this.failedTerminalSessionCloses.get(state.activeSessionId)?.state === state) {
+			this.failedTerminalSessionCloses.delete(state.activeSessionId);
+		}
 		this.sessions.delete(state.activeSessionId);
 		if (isEmptyDraftSession) {
 			const sessionFile = state.runtime.session.sessionFile;
@@ -7021,6 +7131,7 @@ export class AgentDaemon {
 		}
 		this.shuttingDown = true;
 		this.clearTombstonedCloseRetries();
+		this.clearTerminalSessionCloseRetries();
 		if (this.supervisorMonitorTimer) {
 			clearTimeout(this.supervisorMonitorTimer);
 			this.supervisorMonitorTimer = undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2347,42 +2347,48 @@ export class AgentDaemon {
 				});
 			},
 			releaseRlmSubagentRuntime: async (runtime, options, status, authority) => {
-				authority?.assertCurrent();
-				// Preserve the three-way durability proof through release. The finalizer
-				// receives the same incarnation authority as explicit deletion, so it
-				// cannot close a same-id runtime recreated during delayed startup.
-				let deletionDurability: RlmSubagentDeletionDurability = "unknown";
-				if (status === "cancelled") {
-					try {
-						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id, authority);
-					} catch (error) {
-						throw new RlmSubagentHostDeletionError("precommit", error);
-					}
-				}
-				const state = [...this.sessions.values()].find(
-					(candidate) =>
-						candidate.runtime.metadata.kind === "subagent" &&
-						candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
-						candidate.runtime.metadata.rlmChildId === options.id &&
-						candidate.runtime.session === runtime.session,
-				);
-				if (authority && state?.runtime.metadata.sessionDir !== authority.sessionDir) {
-					throw new RlmSubagentHostDeletionError(
-						"precommit",
-						new Error("RLM subagent release authority does not match runtime incarnation"),
-					);
-				}
 				try {
-					if (deletionDurability === "absent") authority?.assertCurrent();
-					if (state) await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
-					else await runtime.session.disposeAsync();
-				} catch (error) {
-					if (deletionDurability === "tombstoned") {
-						throw new RlmSubagentHostDeletionError("tombstoned", error);
+					authority?.assertCurrent();
+					// Resolve the exact resident incarnation before any tombstone append. An
+					// older finalizer can share both child id and directory with its
+					// replacement, so neither field is an object-identity fence.
+					const state = [...this.sessions.values()].find(
+						(candidate) =>
+							candidate.runtime.metadata.kind === "subagent" &&
+							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
+							candidate.runtime.metadata.rlmChildId === options.id,
+					);
+					if (
+						!state ||
+						state.runtime.session !== runtime.session ||
+						state.runtime.metadata.sessionDir !== options.sessionDir ||
+						(authority !== undefined && state.runtime.metadata.sessionDir !== authority.sessionDir)
+					) {
+						throw new Error("RLM subagent release does not match the resident runtime incarnation");
 					}
+
+					let deletionDurability: RlmSubagentDeletionDurability = "unknown";
+					if (status === "cancelled") {
+						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id, authority);
+						if (deletionDurability === "unknown") {
+							throw new Error("RLM subagent deletion durability is still unknown");
+						}
+					}
+
+					try {
+						if (deletionDurability === "absent") authority?.assertCurrent();
+						await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
+					} catch (error) {
+						if (deletionDurability === "tombstoned") {
+							throw new RlmSubagentHostDeletionError("tombstoned", error);
+						}
+						throw error;
+					}
+					return { deletionDurability };
+				} catch (error) {
+					if (error instanceof RlmSubagentHostDeletionError) throw error;
 					throw new RlmSubagentHostDeletionError("precommit", error);
 				}
-				return { deletionDurability };
 			},
 			resolveRlmSubagentDeletion: (childId, authority) =>
 				this.recordRlmSubagentDeletion(parentState, childId, authority),
@@ -2398,33 +2404,34 @@ export class AgentDaemon {
 					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 						(entry) => entry.childId === childId,
 					);
+					// Concrete deletion requires exact object identity. Passive deletion has no
+					// object fence, so bind it to the complete persisted identity instead.
 					if (
-						authority &&
-						state?.runtime.metadata.sessionDir !== undefined &&
-						state.runtime.metadata.sessionDir !== authority.sessionDir
+						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
+						(state !== undefined && session === undefined) ||
+						(state === undefined && session !== undefined) ||
+						(authority !== undefined &&
+							(state !== undefined
+								? state.runtime.metadata.sessionDir !== authority.sessionDir
+								: persisted === undefined || persisted.sessionDir !== authority.sessionDir))
 					) {
-						authority.assertCurrent();
-						throw new Error("RLM subagent deletion authority does not match runtime incarnation");
+						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
 					}
 					const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
 					const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
 					if (deletionDurability === "unknown") {
 						throw new Error("RLM subagent deletion durability is still unknown");
 					}
-					if (deletionDurability === "absent") authority?.assertCurrent();
-					const staleSession = state && session && state.runtime.session !== session ? session : undefined;
 					try {
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						if (state) await this.closeSession(state, "killed", false);
-						else await session?.disposeAsync();
-						await staleSession?.disposeAsync();
+						if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
 					} catch (error) {
 						if (deletionDurability === "tombstoned") {
 							throw new RlmSubagentHostDeletionError("tombstoned", error);
 						}
 						throw error;
 					}
-					if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
 					return { deletionDurability };
 				} catch (error) {
 					if (error instanceof RlmSubagentHostDeletionError) throw error;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -100,11 +100,12 @@ import {
 } from "../../core/cron-jobs.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js";
 import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
-import type {
-	CreateRlmSubagentRuntimeOptions,
-	RlmSubagentDeletionAuthority,
-	RlmSubagentDeletionDurability,
-	SubagentRuntimeHost,
+import {
+	type CreateRlmSubagentRuntimeOptions,
+	type RlmSubagentDeletionAuthority,
+	type RlmSubagentDeletionDurability,
+	RlmSubagentHostDeletionError,
+	type SubagentRuntimeHost,
 } from "../../core/rlm-runtime.js";
 import {
 	canPassivateSession,
@@ -2345,16 +2346,17 @@ export class AgentDaemon {
 					createdAt: metadata.createdAt,
 				});
 			},
-			releaseRlmSubagentRuntime: async (runtime, options, status) => {
-				// Preserve the three-way durability proof through release. A failed
-				// lookup/write is not the same as a verified no-row result.
+			releaseRlmSubagentRuntime: async (runtime, options, status, authority) => {
+				authority?.assertCurrent();
+				// Preserve the three-way durability proof through release. The finalizer
+				// receives the same incarnation authority as explicit deletion, so it
+				// cannot close a same-id runtime recreated during delayed startup.
 				let deletionDurability: RlmSubagentDeletionDurability = "unknown";
 				if (status === "cancelled") {
 					try {
-						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id);
-					} catch {
-						// A defensive fail-closed boundary for injected/legacy persistence
-						// implementations which still throw rather than return unknown.
+						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id, authority);
+					} catch (error) {
+						throw new RlmSubagentHostDeletionError("precommit", error);
 					}
 				}
 				const state = [...this.sessions.values()].find(
@@ -2364,67 +2366,69 @@ export class AgentDaemon {
 						candidate.runtime.metadata.rlmChildId === options.id &&
 						candidate.runtime.session === runtime.session,
 				);
-				if (state) {
-					await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
-				} else {
-					await runtime.session.disposeAsync();
+				if (authority && state?.runtime.metadata.sessionDir !== authority.sessionDir) {
+					throw new RlmSubagentHostDeletionError(
+						"precommit",
+						new Error("RLM subagent release authority does not match runtime incarnation"),
+					);
+				}
+				try {
+					if (deletionDurability === "absent") authority?.assertCurrent();
+					if (state) await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
+					else await runtime.session.disposeAsync();
+				} catch (error) {
+					if (deletionDurability === "tombstoned") {
+						throw new RlmSubagentHostDeletionError("tombstoned", error);
+					}
+					throw new RlmSubagentHostDeletionError("precommit", error);
 				}
 				return { deletionDurability };
 			},
 			resolveRlmSubagentDeletion: (childId, authority) =>
 				this.recordRlmSubagentDeletion(parentState, childId, authority),
 			deleteRlmSubagentRuntime: async (childId, session, authority) => {
-				const state = [...this.sessions.values()].find(
-					(candidate) =>
-						candidate.runtime.metadata.kind === "subagent" &&
-						candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
-						candidate.runtime.metadata.rlmChildId === childId,
-				);
-				const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
-					(entry) => entry.childId === childId,
-				);
-				// A child id alone is never an incarnation proof. Do not close a
-				// freshly recycled resident state under an old attempt token.
-				if (
-					authority &&
-					state?.runtime.metadata.sessionDir !== undefined &&
-					state.runtime.metadata.sessionDir !== authority.sessionDir
-				) {
-					authority.assertCurrent();
-					throw new Error("RLM subagent deletion authority does not match runtime incarnation");
-				}
-				const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
-				// Persist the deletion boundary before tearing down the runtime. As with a
-				// resident child, deletion keeps its transcript and artifact tree on disk.
-				const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
-				// A stale incarnation, corrupt registry, or failed append is not
-				// permission to destroy a runtime. Only absence or a tombstone is a
-				// durable deletion boundary.
-				if (deletionDurability === "unknown") {
-					throw new Error("RLM subagent deletion durability is still unknown");
-				}
-				// Absence has no append point of no return: retain authority through
-				// the immediately following destructive close. A tombstone commit,
-				// however, is intentionally durable even if its reply is later stale.
-				if (deletionDurability === "absent") authority?.assertCurrent();
-				// The append is the linearization point. A late request abort must
-				// suppress its reply, not undo or race the already durable tombstone.
-				const staleSession = state && session && state.runtime.session !== session ? session : undefined;
 				try {
-					// `absent` did not append anything. Recheck adjacent to the
-					// destructive call itself; do not apply this after tombstoning.
-					if (deletionDurability === "absent") authority?.assertCurrent();
-					if (state) {
-						await this.closeSession(state, "killed", false);
-					} else {
-						await session?.disposeAsync();
+					authority?.assertCurrent();
+					const state = [...this.sessions.values()].find(
+						(candidate) =>
+							candidate.runtime.metadata.kind === "subagent" &&
+							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
+							candidate.runtime.metadata.rlmChildId === childId,
+					);
+					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
+						(entry) => entry.childId === childId,
+					);
+					if (
+						authority &&
+						state?.runtime.metadata.sessionDir !== undefined &&
+						state.runtime.metadata.sessionDir !== authority.sessionDir
+					) {
+						authority.assertCurrent();
+						throw new Error("RLM subagent deletion authority does not match runtime incarnation");
 					}
-				} finally {
-					await staleSession?.disposeAsync();
-				}
-				// A killed close can join a passivation close that already skipped killed cleanup.
-				if (childSessionFile) {
-					this.cancelScheduledJobsForSessionFile(childSessionFile);
+					const childSessionFile = persisted?.sessionFile ?? state?.runtime.session.sessionFile;
+					const deletionDurability = await this.recordRlmSubagentDeletion(parentState, childId, authority);
+					if (deletionDurability === "unknown") {
+						throw new Error("RLM subagent deletion durability is still unknown");
+					}
+					if (deletionDurability === "absent") authority?.assertCurrent();
+					const staleSession = state && session && state.runtime.session !== session ? session : undefined;
+					try {
+						if (deletionDurability === "absent") authority?.assertCurrent();
+						if (state) await this.closeSession(state, "killed", false);
+						else await session?.disposeAsync();
+						await staleSession?.disposeAsync();
+					} catch (error) {
+						if (deletionDurability === "tombstoned") {
+							throw new RlmSubagentHostDeletionError("tombstoned", error);
+						}
+						throw error;
+					}
+					if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
+					return { deletionDurability };
+				} catch (error) {
+					if (error instanceof RlmSubagentHostDeletionError) throw error;
+					throw new RlmSubagentHostDeletionError("precommit", error);
 				}
 			},
 			disposeRlmSubagentRuntimes: async () => {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1088,10 +1088,12 @@ export class AgentDaemon {
 		const legacyResidentUpgrade = entry.sessionId === undefined && authority === undefined && residentMatchesHeader;
 		if (!authorityMatchesEntry && !(authority === undefined && residentMatchesHeader)) return "unknown";
 		if (entry.sessionId === undefined && !legacyResidentUpgrade) return "unknown";
-		if (entry.status === "deleted") {
+		if (entry.status === "deleted" && !legacyResidentUpgrade) {
 			authority?.assertCurrent();
 			return "tombstoned";
 		}
+		// A legacy deleted row also crosses the append boundary once to persist
+		// the exact resident identity; subsequent retries observe the modern row.
 		// The header and authority are both checked immediately before the
 		// synchronous append/fsync boundary. Once append starts, finish it.
 		authority?.assertCurrent();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6435,7 +6435,7 @@ export class AgentDaemon {
 			closeError ??= error;
 		};
 		const retainsForTombstonedRetry =
-			this.failedTombstonedRlmCloses.has(state.activeSessionId) || this.isQuarantinedRlmState(state);
+			this.failedTombstonedRlmCloses.get(state.activeSessionId)?.state === state;
 		if (reason === "killed") {
 			try {
 				this.cancelScheduledJobsForSession(state);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -442,18 +442,11 @@ export function isTerminalRemoteAgentMessageError(error: unknown): error is Erro
 
 interface FailedTombstonedRlmClose {
 	readonly state: ActiveSessionState;
-	readonly parentActiveSessionId: string;
-	readonly childId: string;
-	cleanup?: Promise<void>;
-	error?: unknown;
-	retryAttempt: number;
-	retryTimer?: ReturnType<typeof setTimeout>;
-}
-
-/** A pre-teardown archive failure retains its exact resident state and lease. */
-interface FailedTerminalSessionClose {
-	readonly state: ActiveSessionState;
-	readonly reason: DaemonSessionClosedReason;
+	/** Non-tombstoned records wait privately for their archive boundary. */
+	readonly terminalizing?: boolean;
+	readonly reason?: DaemonSessionClosedReason;
+	readonly parentActiveSessionId?: string;
+	readonly childId?: string;
 	cleanup?: Promise<void>;
 	error?: unknown;
 	retryAttempt: number;
@@ -503,7 +496,6 @@ export class AgentDaemon {
 		}
 	>();
 	private readonly failedTombstonedRlmCloses = new Map<string, FailedTombstonedRlmClose>();
-	private readonly failedTerminalSessionCloses = new Map<string, FailedTerminalSessionClose>();
 	private readonly sideQuestionRuns = new Map<
 		string,
 		{
@@ -2194,8 +2186,8 @@ export class AgentDaemon {
 			return undefined;
 		}
 		const activeIdMatch = this.sessions.get(dueJob.activeSessionId);
-		const terminalizing = this.findFailedTerminalSessionCloseBySessionFile(dueJob.sessionFile);
-		if (terminalizing || this.failedTerminalSessionCloses.get(dueJob.activeSessionId)?.state === activeIdMatch) {
+		const terminalizing = this.findFailedTerminalizationBySessionFile(dueJob.sessionFile);
+		if (terminalizing || this.failedTombstonedRlmCloses.get(dueJob.activeSessionId)?.state === activeIdMatch) {
 			return undefined;
 		}
 		const current =
@@ -2347,10 +2339,10 @@ export class AgentDaemon {
 		return state === undefined || this.isPublicRlmState(state);
 	}
 
-	private findFailedTerminalSessionCloseBySessionFile(sessionFile: string | undefined): ActiveSessionState | undefined {
+	private findFailedTerminalizationBySessionFile(sessionFile: string | undefined): ActiveSessionState | undefined {
 		if (!sessionFile) return undefined;
 		const target = resolve(sessionFile);
-		return [...this.failedTerminalSessionCloses.values()].find((record) => {
+		return [...this.failedTombstonedRlmCloses.values()].find((record) => {
 			const file = record.state.runtime.session.sessionFile;
 			return file !== undefined && resolve(file) === target;
 		})?.state;
@@ -5476,8 +5468,7 @@ export class AgentDaemon {
 			if (visited.has(child.activeSessionId)) return false;
 			if (
 				this.closingSessions.has(child.activeSessionId) ||
-				this.failedTombstonedRlmCloses.has(child.activeSessionId) ||
-				this.failedTerminalSessionCloses.get(child.activeSessionId)?.state === child
+				this.failedTombstonedRlmCloses.has(child.activeSessionId)
 			)
 				return true;
 			visited.add(child.activeSessionId);
@@ -5485,8 +5476,7 @@ export class AgentDaemon {
 			if (!parentActiveSessionId || !rlmChildId) return false;
 			const parent =
 				this.sessions.get(parentActiveSessionId) ??
-				this.failedTombstonedRlmCloses.get(parentActiveSessionId)?.state ??
-				this.failedTerminalSessionCloses.get(parentActiveSessionId)?.state;
+				this.failedTombstonedRlmCloses.get(parentActiveSessionId)?.state;
 			if (!parent) return false;
 			if (parent.runtime.session.isRlmChildDeletionQuarantined?.(rlmChildId) === true) return true;
 			child = parent;
@@ -5497,7 +5487,7 @@ export class AgentDaemon {
 	private isPublicRlmState(state: ActiveSessionState): boolean {
 		return (
 			!this.closingSessions.has(state.activeSessionId) &&
-			this.failedTerminalSessionCloses.get(state.activeSessionId)?.state !== state &&
+			this.failedTombstonedRlmCloses.get(state.activeSessionId)?.state !== state &&
 			!this.isQuarantinedRlmState(state)
 		);
 	}
@@ -5510,6 +5500,7 @@ export class AgentDaemon {
 		return (
 			[...this.failedTombstonedRlmCloses.values()].find(
 				(record) =>
+					!record.terminalizing &&
 					record.parentActiveSessionId === parentId &&
 					record.childId === childId &&
 					(!session || record.state.runtime.session === session),
@@ -5545,10 +5536,19 @@ export class AgentDaemon {
 	}
 
 	private runTombstonedCloseAttempt(record: FailedTombstonedRlmClose): void {
-		if (this.shuttingDown || this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record) return;
+		if (
+			this.shuttingDown ||
+			this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record ||
+			(record.terminalizing && this.sessions.get(record.state.activeSessionId) !== record.state)
+		) {
+			if (this.failedTombstonedRlmCloses.get(record.state.activeSessionId) === record) {
+				this.failedTombstonedRlmCloses.delete(record.state.activeSessionId);
+			}
+			return;
+		}
 		record.retryTimer = undefined;
 		record.error = undefined;
-		const cleanup = Promise.resolve().then(() => this.closeSession(record.state, "killed", false));
+		const cleanup = Promise.resolve().then(() => this.closeSession(record.state, record.reason ?? "killed", false));
 		record.cleanup = cleanup;
 		void cleanup.then(
 			() => {
@@ -5582,74 +5582,6 @@ export class AgentDaemon {
 		}
 	}
 
-	private retainFailedTerminalSessionClose(
-		state: ActiveSessionState,
-		reason: DaemonSessionClosedReason,
-		error: unknown,
-	): void {
-		const existing = this.failedTerminalSessionCloses.get(state.activeSessionId);
-		if (existing?.state === state) {
-			existing.error = error;
-			if (!existing.cleanup && !existing.retryTimer) this.scheduleTerminalSessionCloseRetry(existing);
-			return;
-		}
-		const record: FailedTerminalSessionClose = { state, reason, error, retryAttempt: 0 };
-		this.failedTerminalSessionCloses.set(state.activeSessionId, record);
-		this.scheduleTerminalSessionCloseRetry(record);
-	}
-
-	private runTerminalSessionCloseAttempt(record: FailedTerminalSessionClose): void {
-		if (
-			this.shuttingDown ||
-			this.failedTerminalSessionCloses.get(record.state.activeSessionId) !== record ||
-			this.sessions.get(record.state.activeSessionId) !== record.state
-		) {
-			if (this.failedTerminalSessionCloses.get(record.state.activeSessionId) === record) {
-				this.failedTerminalSessionCloses.delete(record.state.activeSessionId);
-			}
-			return;
-		}
-		record.retryTimer = undefined;
-		record.error = undefined;
-		const cleanup = Promise.resolve().then(() => this.closeSession(record.state, record.reason));
-		record.cleanup = cleanup;
-		void cleanup.then(
-			() => {
-				if (this.failedTerminalSessionCloses.get(record.state.activeSessionId) === record) {
-					this.failedTerminalSessionCloses.delete(record.state.activeSessionId);
-				}
-			},
-			(error: unknown) => {
-				if (this.failedTerminalSessionCloses.get(record.state.activeSessionId) !== record) return;
-				record.error = error;
-				record.cleanup = undefined;
-				// Errors after unmapping are irreversible and must not retry a replacement.
-				if (this.sessions.get(record.state.activeSessionId) !== record.state) {
-					this.failedTerminalSessionCloses.delete(record.state.activeSessionId);
-					return;
-				}
-				this.scheduleTerminalSessionCloseRetry(record);
-			},
-		);
-	}
-
-	private scheduleTerminalSessionCloseRetry(record: FailedTerminalSessionClose): void {
-		if (this.shuttingDown || record.retryTimer || record.cleanup) return;
-		const delayMs = Math.min(
-			TOMBSTONED_CLOSE_RETRY_BASE_MS * 2 ** record.retryAttempt,
-			TOMBSTONED_CLOSE_RETRY_MAX_MS,
-		);
-		record.retryAttempt++;
-		record.retryTimer = setTimeout(() => this.runTerminalSessionCloseAttempt(record), delayMs);
-		record.retryTimer.unref();
-	}
-
-	private clearTerminalSessionCloseRetries(): void {
-		for (const record of this.failedTerminalSessionCloses.values()) {
-			if (record.retryTimer) clearTimeout(record.retryTimer);
-			record.retryTimer = undefined;
-		}
-	}
 
 	// Half-bound sessions are hidden from other sessions' listings; the current
 	// session stays visible to itself (controllers run during its own bind).
@@ -6537,7 +6469,8 @@ export class AgentDaemon {
 			closeError ??= error;
 		};
 		const retainsForTombstonedRetry =
-			this.failedTombstonedRlmCloses.get(state.activeSessionId)?.state === state;
+			this.failedTombstonedRlmCloses.get(state.activeSessionId)?.state === state &&
+			!this.failedTombstonedRlmCloses.get(state.activeSessionId)?.terminalizing;
 		// Empty draft (no messages, config, or jobs): discard rather than persist an
 		// empty session file. Mirrors the detach-time discard so a config-bearing
 		// draft closed via kill/completed is never wiped.
@@ -6550,7 +6483,23 @@ export class AgentDaemon {
 			try {
 				this.archiveSession(state);
 			} catch (error) {
-				if (!retainsForTombstonedRetry) this.retainFailedTerminalSessionClose(state, reason, error);
+				if (!retainsForTombstonedRetry) {
+					const existing = this.failedTombstonedRlmCloses.get(state.activeSessionId);
+					if (existing?.state === state) {
+						existing.error = error;
+						if (!existing.cleanup && !existing.retryTimer) this.scheduleTombstonedCloseRetry(existing);
+					} else {
+						const record: FailedTombstonedRlmClose = {
+							state,
+							terminalizing: true,
+							reason,
+							error,
+							retryAttempt: 0,
+						};
+						this.failedTombstonedRlmCloses.set(state.activeSessionId, record);
+						this.scheduleTombstonedCloseRetry(record);
+					}
+				}
 				throw error;
 			}
 		}
@@ -6622,8 +6571,8 @@ export class AgentDaemon {
 		}
 		// Failed non-tombstoned closes are irrevocable: never leave a disposed,
 		// targetable resident behind merely because persistence or cleanup failed.
-		if (this.failedTerminalSessionCloses.get(state.activeSessionId)?.state === state) {
-			this.failedTerminalSessionCloses.delete(state.activeSessionId);
+		if (this.failedTombstonedRlmCloses.get(state.activeSessionId)?.state === state) {
+			this.failedTombstonedRlmCloses.delete(state.activeSessionId);
 		}
 		this.sessions.delete(state.activeSessionId);
 		if (isEmptyDraftSession) {
@@ -7131,7 +7080,6 @@ export class AgentDaemon {
 		}
 		this.shuttingDown = true;
 		this.clearTombstonedCloseRetries();
-		this.clearTerminalSessionCloseRetries();
 		if (this.supervisorMonitorTimer) {
 			clearTimeout(this.supervisorMonitorTimer);
 			this.supervisorMonitorTimer = undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -444,7 +444,6 @@ interface FailedTombstonedRlmClose {
 	readonly childId: string;
 	cleanup?: Promise<void>;
 	error?: unknown;
-	disposeError?: unknown;
 }
 
 export class AgentDaemon {
@@ -490,7 +489,6 @@ export class AgentDaemon {
 		}
 	>();
 	private readonly failedTombstonedRlmCloses = new Map<string, FailedTombstonedRlmClose>();
-	private readonly closeDisposeErrors = new WeakMap<ActiveSessionState, unknown>();
 	private readonly sideQuestionRuns = new Map<
 		string,
 		{
@@ -4353,17 +4351,17 @@ export class AgentDaemon {
 			}
 
 			case "get_state": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_state", summaryForActiveSession(state));
 			}
 
 			case "get_connection_state": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_connection_state", this.createConnectionState(state));
 			}
 
 			case "get_messages": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_messages", {
 					messages: state.runtime.session.messages,
 				});
@@ -5449,8 +5447,8 @@ export class AgentDaemon {
 	private detachTombstonedClose(parent: ActiveSessionState, state: ActiveSessionState, childId: string): void {
 		const existing = this.failedTombstonedRlmCloses.get(state.activeSessionId);
 		if (existing?.state === state) {
-			if (existing.error !== undefined && existing.disposeError !== undefined && !existing.cleanup) {
-				const cleanup = Promise.resolve().then(() => state.runtime.dispose());
+			if (existing.error !== undefined && !existing.cleanup) {
+				const cleanup = Promise.resolve().then(() => this.closeSession(state, "killed", false));
 				existing.cleanup = cleanup
 					.then(() => {
 						if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === existing)
@@ -5458,7 +5456,6 @@ export class AgentDaemon {
 					})
 					.catch((error: unknown) => {
 						existing.error = error;
-						existing.disposeError = error;
 						existing.cleanup = undefined;
 					});
 			}
@@ -5466,16 +5463,16 @@ export class AgentDaemon {
 		}
 		const record: FailedTombstonedRlmClose = { state, parentActiveSessionId: parent.activeSessionId, childId };
 		this.failedTombstonedRlmCloses.set(state.activeSessionId, record);
-		void this.closeSession(state, "killed", false).then(
-			() => {
+		const cleanup = Promise.resolve().then(() => this.closeSession(state, "killed", false));
+		record.cleanup = cleanup
+			.then(() => {
 				if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === record)
 					this.failedTombstonedRlmCloses.delete(state.activeSessionId);
-			},
-			(error: unknown) => {
+			})
+			.catch((error: unknown) => {
 				record.error = error;
-				record.disposeError = this.closeDisposeErrors.get(state);
-			},
-		);
+				record.cleanup = undefined;
+			});
 	}
 
 	// Half-bound sessions are hidden from other sessions' listings; the current
@@ -6401,10 +6398,8 @@ export class AgentDaemon {
 		let disposeError: unknown;
 		try {
 			await state.runtime.dispose();
-			this.closeDisposeErrors.delete(state);
 		} catch (error) {
 			disposeError = error;
-			this.closeDisposeErrors.set(state, error);
 		}
 		for (const client of state.clients) {
 			abortClientSnapshotStreaming(client, state.activeSessionId);
@@ -6415,21 +6410,21 @@ export class AgentDaemon {
 			removeDaemonClientSessionCapabilities(client, state.activeSessionId);
 		}
 		state.clients.clear();
+		if (disposeError) {
+			throw disposeError;
+		}
+		if (persistError) {
+			throw persistError;
+		}
+		if (cascadeError) {
+			throw cascadeError;
+		}
 		this.sessions.delete(state.activeSessionId);
 		if (isEmptyDraftSession) {
 			const sessionFile = state.runtime.session.sessionFile;
 			if (sessionFile) {
 				await deleteSessionFile(sessionFile).catch(() => undefined);
 			}
-		}
-		if (disposeError) {
-			throw disposeError;
-		}
-		if (persistError && !keepsResumeEntry && reason !== "completed") {
-			throw persistError;
-		}
-		if (cascadeError && !keepsResumeEntry && reason !== "completed") {
-			throw cascadeError;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -387,6 +387,8 @@ interface PersistedRlmSubagentRegistryEntry {
 	sessionName: string;
 	sessionDir: string;
 	sessionFile: string;
+	/** Exact saved-session incarnation; paths and directories may be recycled. */
+	sessionId: string;
 	parentSessionId: string;
 	parentSessionFile?: string;
 	rlmDepth?: number;
@@ -927,6 +929,7 @@ export class AgentDaemon {
 			sessionName: string;
 			sessionDir: string;
 			sessionFile: string;
+			sessionId: string;
 			rlmDepth: number;
 			rlmMaxDepth: number;
 			rlmParentNodeId?: string;
@@ -944,6 +947,7 @@ export class AgentDaemon {
 			sessionName: input.sessionName,
 			sessionDir: input.sessionDir,
 			sessionFile: input.sessionFile,
+			sessionId: input.sessionId,
 			parentSessionId: parentSession.sessionId,
 			...(parentSession.sessionFile ? { parentSessionFile: parentSession.sessionFile } : {}),
 			rlmDepth: input.rlmDepth,
@@ -1001,6 +1005,8 @@ export class AgentDaemon {
 					typeof entry.sessionName !== "string" ||
 					typeof entry.sessionDir !== "string" ||
 					typeof entry.sessionFile !== "string" ||
+					typeof entry.sessionId !== "string" ||
+					entry.sessionId.length === 0 ||
 					typeof entry.parentSessionId !== "string" ||
 					entry.parentSessionId.length === 0 ||
 					(entry.parentSessionFile !== undefined && typeof entry.parentSessionFile !== "string") ||
@@ -1045,10 +1051,13 @@ export class AgentDaemon {
 		// existed. New coordinator authorities always carry both incarnation fields.
 		if (
 			authority &&
-			((typeof authority.childId === "string" && authority.childId !== childId) ||
+			(authority.childId !== childId ||
 				(entry !== undefined &&
-					((typeof authority.sessionDir === "string" && authority.sessionDir !== entry.sessionDir) ||
-						(typeof authority.sessionFile === "string" && authority.sessionFile !== entry.sessionFile))))
+					(authority.sessionDir !== entry.sessionDir ||
+						typeof authority.sessionFile !== "string" ||
+						authority.sessionFile !== entry.sessionFile ||
+						typeof authority.sessionId !== "string" ||
+						authority.sessionId !== entry.sessionId)))
 		) {
 			authority.assertCurrent();
 			return "unknown";
@@ -1056,6 +1065,11 @@ export class AgentDaemon {
 		if (!entry) {
 			authority?.assertCurrent();
 			return "absent";
+		}
+		if (authority) {
+			const info = await readSessionInfo(entry.sessionFile);
+			authority.assertCurrent();
+			if (!info || info.id !== entry.sessionId || authority.sessionId !== info.id) return "unknown";
 		}
 		if (entry.status === "deleted") {
 			authority?.assertCurrent();
@@ -1122,6 +1136,8 @@ export class AgentDaemon {
 					typeof entry.sessionName !== "string" ||
 					typeof entry.sessionDir !== "string" ||
 					typeof entry.sessionFile !== "string" ||
+					typeof entry.sessionId !== "string" ||
+					entry.sessionId.length === 0 ||
 					(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted") ||
 					(entry.rlmDepth !== undefined && (!Number.isSafeInteger(entry.rlmDepth) || entry.rlmDepth < 0)) ||
 					(entry.rlmMaxDepth !== undefined && (!Number.isSafeInteger(entry.rlmMaxDepth) || entry.rlmMaxDepth < 0))
@@ -1163,7 +1179,8 @@ export class AgentDaemon {
 				if (entry.status === "deleted" || visited.has(sessionKey)) continue;
 				visited.add(sessionKey);
 				const info = await readSessionInfo(entry.sessionFile);
-				if (!info) continue;
+				// A path is recyclable; passive authority belongs only to this saved header.
+				if (!info || info.id !== entry.sessionId) continue;
 				// A resident child walks its own registry as an outer root below. Avoid
 				// both duplicate rows and attributing its descendants to an ancestor.
 				if (!includeResident && this.findSessionBySessionFile(entry.sessionFile)) continue;
@@ -2336,6 +2353,7 @@ export class AgentDaemon {
 					sessionName: session.sessionName ?? childId,
 					sessionDir: metadata.sessionDir ?? dirname(state.runtime.session.sessionFile),
 					sessionFile: state.runtime.session.sessionFile,
+					sessionId: session.sessionId,
 					rlmDepth: session.rlmDepth,
 					rlmMaxDepth: session.rlmMaxDepth,
 					rlmParentNodeId: metadata.rlmParentNodeId,
@@ -2414,10 +2432,12 @@ export class AgentDaemon {
 					// the exact persisted incarnation before they can touch its tombstone or jobs.
 					const persistedMatchesAuthority =
 						persisted !== undefined &&
-						(authority === undefined ||
-							(persisted.sessionDir === authority.sessionDir &&
-								(typeof authority.sessionFile !== "string" ||
-									persisted.sessionFile === authority.sessionFile)));
+						authority !== undefined &&
+						persisted.sessionDir === authority.sessionDir &&
+						typeof authority.sessionFile === "string" &&
+						persisted.sessionFile === authority.sessionFile &&
+						typeof authority.sessionId === "string" &&
+						persisted.sessionId === authority.sessionId;
 					const suppliedSessionMatchesPersisted =
 						session === undefined ||
 						(persistedMatchesAuthority &&
@@ -2426,6 +2446,7 @@ export class AgentDaemon {
 					if (
 						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
 						(state !== undefined && session === undefined) ||
+						(state === undefined && session === undefined && !persistedMatchesAuthority) ||
 						(state === undefined && session !== undefined && !suppliedSessionMatchesPersisted) ||
 						(authority !== undefined &&
 							(state !== undefined
@@ -2562,6 +2583,7 @@ export class AgentDaemon {
 						sessionName: options.sessionName,
 						sessionDir: options.sessionDir,
 						sessionFile: runtime.session.sessionFile,
+						sessionId: runtime.session.sessionId,
 						rlmDepth: options.rlmDepth,
 						rlmMaxDepth: options.rlmMaxDepth,
 						rlmParentNodeId: options.rlmParentNodeId,

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -344,6 +344,8 @@ const DAEMON_CLIENT_CAPABILITY_SET: ReadonlySet<string> = new Set(DAEMON_SUPPORT
 const CLIENT_CATCHUP_RETRY_MS = 250;
 const UPDATE_RESTART_ABORT_BASH_TIMEOUT_MS = 5000;
 const SUPERVISOR_FENCE_POLL_MS = 250;
+const TOMBSTONED_CLOSE_RETRY_BASE_MS = 250;
+const TOMBSTONED_CLOSE_RETRY_MAX_MS = 30_000;
 const UPDATE_RESTART_MARKER =
 	"<prime_agent_update_interrupted>\n" +
 	"Prime Agent was updated and intentionally interrupted this session. Continue from the saved transcript and restored tool/kernel state. Any running model, tool, bash, or child-agent work may have been partially completed.\n" +
@@ -444,6 +446,8 @@ interface FailedTombstonedRlmClose {
 	readonly childId: string;
 	cleanup?: Promise<void>;
 	error?: unknown;
+	retryAttempt: number;
+	retryTimer?: ReturnType<typeof setTimeout>;
 }
 
 export class AgentDaemon {
@@ -1302,8 +1306,30 @@ export class AgentDaemon {
 		savedSessions: SessionInfo[],
 		scheduledJobs: AgentCronJob[],
 	): Promise<SessionSummary[]> {
-		const passiveByPath = await this.passiveRlmSubagentsByPath(savedSessions);
-		const savedByPath = new Map(savedSessions.map((session) => [resolve(session.path), session]));
+		const privatePaths = new Set(
+			[...this.sessions.values()]
+				.filter((state) => !this.isPublicRlmState(state))
+				.flatMap((state) =>
+					state.runtime.session.sessionFile ? [resolve(state.runtime.session.sessionFile)] : [],
+				),
+		);
+		let removedPrivateDescendant = true;
+		while (removedPrivateDescendant) {
+			removedPrivateDescendant = false;
+			for (const saved of savedSessions) {
+				if (
+					!privatePaths.has(resolve(saved.path)) &&
+					saved.parentSessionPath &&
+					privatePaths.has(resolve(saved.parentSessionPath))
+				) {
+					privatePaths.add(resolve(saved.path));
+					removedPrivateDescendant = true;
+				}
+			}
+		}
+		const publicSavedSessions = savedSessions.filter((session) => !privatePaths.has(resolve(session.path)));
+		const passiveByPath = await this.passiveRlmSubagentsByPath(publicSavedSessions);
+		const savedByPath = new Map(publicSavedSessions.map((session) => [resolve(session.path), session]));
 		for (const [path, passive] of passiveByPath) {
 			savedByPath.set(path, passive.info);
 		}
@@ -2034,10 +2060,16 @@ export class AgentDaemon {
 		return job;
 	}
 
-	private listHeartbeats(): AgentConnectionHeartbeat[] {
+	private listHeartbeats(activeSessionId?: string): AgentConnectionHeartbeat[] {
 		return this.cronStore
 			.list()
-			.filter((job) => isHeartbeatCronJob(job) && (job.status === "active" || job.status === "paused"))
+			.filter(
+				(job) =>
+					isHeartbeatCronJob(job) &&
+					(job.status === "active" || job.status === "paused") &&
+					(!activeSessionId || job.activeSessionId === activeSessionId) &&
+					this.isPublicCronJob(job),
+			)
 			.map((job) => {
 				const state = this.sessions.get(job.activeSessionId);
 				const summary = state ? summaryForActiveSession(state) : undefined;
@@ -2289,6 +2321,12 @@ export class AgentDaemon {
 			sessionFile !== undefined &&
 			resolve(current.sessionFile) === resolve(sessionFile)
 		);
+	}
+
+	private isPublicCronJob(job: AgentCronJob): boolean {
+		const state =
+			this.sessions.get(job.activeSessionId) ?? this.failedTombstonedRlmCloses.get(job.activeSessionId)?.state;
+		return state === undefined || this.isPublicRlmState(state);
 	}
 
 	private findSessionBySessionFile(sessionFile: string | undefined): ActiveSessionState | undefined {
@@ -3734,7 +3772,7 @@ export class AgentDaemon {
 				let sessionDir: string | undefined;
 				if ("activeSessionId" in command) {
 					activeSessionId = command.activeSessionId;
-					const sessionManager = this.getSessionState(activeSessionId).runtime.session.sessionManager;
+					const sessionManager = this.getBoundSessionState(activeSessionId).runtime.session.sessionManager;
 					cwd = sessionManager.getCwd();
 					sessionDir = sessionManager.getSessionDir();
 				} else {
@@ -3889,7 +3927,7 @@ export class AgentDaemon {
 
 			case "detach": {
 				if (command.activeSessionId) {
-					const state = this.getSessionState(command.activeSessionId);
+					const state = this.getBoundSessionState(command.activeSessionId);
 					this.detachClientFromSession(client, state);
 				} else {
 					this.detachClient(client);
@@ -3904,7 +3942,7 @@ export class AgentDaemon {
 			}
 
 			case "rename": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const name = command.name.trim();
 				if (!name) {
 					throw new Error("Session name cannot be empty");
@@ -3915,7 +3953,7 @@ export class AgentDaemon {
 
 			case "rename_saved_session": {
 				if (command.activeSessionId) {
-					this.getSessionState(command.activeSessionId);
+					this.getBoundSessionState(command.activeSessionId);
 				}
 				const state = this.findActiveSessionByFile(command.sessionPath);
 				const name = command.name.trim();
@@ -3956,7 +3994,7 @@ export class AgentDaemon {
 
 			case "delete_saved_session": {
 				if (command.activeSessionId) {
-					this.getSessionState(command.activeSessionId);
+					this.getBoundSessionState(command.activeSessionId);
 				}
 				if (this.findActiveSessionByFile(command.sessionPath)) {
 					throw new Error("Cannot delete the currently active session");
@@ -4142,26 +4180,26 @@ export class AgentDaemon {
 			}
 
 			case "restore_next_turn": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.restorePendingNextTurnMessages(command.messages);
 				return success(command.id, "restore_next_turn");
 			}
 
 			case "restore_actions": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const restored = await state.runtime.session.restoreSessionActions(command.snapshot);
 				if (restored > 0) this.recordWorkerRecoveryState(state, "actions_restored", true);
 				return success(command.id, "restore_actions", { restored });
 			}
 
 			case "append_custom_message": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				await state.runtime.session.sendCustomMessage(command.message);
 				return success(command.id, "append_custom_message");
 			}
 
 			case "resume_queue": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				if (!state.runtime.session.resumeQueuedWork()) {
 					const error = new Error("No queued work to resume");
 					return failure(command.id, "resume_queue", error, serializeDaemonError(error));
@@ -4171,7 +4209,7 @@ export class AgentDaemon {
 
 			case "send_message": {
 				const fromState = command.fromActiveSessionId
-					? this.getSessionState(command.fromActiveSessionId)
+					? this.getBoundSessionState(command.fromActiveSessionId)
 					: undefined;
 				const receipt = await this.sendAgentSessionMessage({
 					targetSelector: command.targetActiveSessionId,
@@ -4201,7 +4239,7 @@ export class AgentDaemon {
 			}
 
 			case "agent_messages_clear": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const cleared = await this.withAgentMessageTargetLock(state.activeSessionId, async () => {
 					this.agentMessageRateLimiter.clearMatching((key) => key.endsWith(`->${state.activeSessionId}`));
 					return state.runtime.session.clearQueuedUserMessagesMatching(isAgentSessionMessagePrompt);
@@ -4210,13 +4248,13 @@ export class AgentDaemon {
 			}
 
 			case "abort": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.requestAbort();
 				return success(command.id, "abort");
 			}
 
 			case "start_side_question": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				if (this.sideQuestionRuns.has(command.sideQuestionId)) {
 					throw new Error(`Side question already exists: ${command.sideQuestionId}`);
 				}
@@ -4254,7 +4292,7 @@ export class AgentDaemon {
 			}
 
 			case "abort_side_question": {
-				this.getSessionState(command.activeSessionId);
+				this.getBoundSessionState(command.activeSessionId);
 				const entry = this.sideQuestionRuns.get(command.sideQuestionId);
 				if (!entry || entry.client !== client || entry.activeSessionId !== command.activeSessionId) {
 					return success(command.id, "abort_side_question", { aborted: false });
@@ -4264,7 +4302,7 @@ export class AgentDaemon {
 			}
 
 			case "execute_bash": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				if (state.runtime.session.isBashRunning) {
 					throw new Error("A bash command is already running");
 				}
@@ -4286,7 +4324,7 @@ export class AgentDaemon {
 			}
 
 			case "execute_bash_and_wait": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(
 					command.id,
 					"execute_bash_and_wait",
@@ -4295,19 +4333,19 @@ export class AgentDaemon {
 			}
 
 			case "abort_bash": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.abortBash();
 				return success(command.id, "abort_bash");
 			}
 
 			case "cancel_rlm_child": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const cancelled = state.runtime.session.cancelRlmChildRun(command.childId);
 				return success(command.id, "cancel_rlm_child", { cancelled });
 			}
 
 			case "delete_rlm_subagent": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const isResidentChildRunning = () => {
 					const childState = [...this.sessions.values()].find(
 						(candidate) =>
@@ -4329,13 +4367,13 @@ export class AgentDaemon {
 			}
 
 			case "wait_for_idle": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				await state.runtime.session.waitForIdle();
 				return success(command.id, "wait_for_idle");
 			}
 
 			case "wait_for_headless_completion": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(
 					command.id,
 					"wait_for_headless_completion",
@@ -4344,7 +4382,7 @@ export class AgentDaemon {
 			}
 
 			case "get_session_header": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_session_header", {
 					header: state.runtime.session.sessionManager.getHeader(),
 				});
@@ -4368,25 +4406,25 @@ export class AgentDaemon {
 			}
 
 			case "get_session_stats": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const stats: SessionStats = state.runtime.session.getSessionStats();
 				return success(command.id, "get_session_stats", stats);
 			}
 
 			case "get_context_tree": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_context_tree", state.runtime.session.getContextTree());
 			}
 
 			case "get_commands": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_commands", {
 					commands: createAgentConnectionCommands(state.runtime.session),
 				});
 			}
 
 			case "get_resource_snapshot": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(
 					command.id,
 					"get_resource_snapshot",
@@ -4395,14 +4433,14 @@ export class AgentDaemon {
 			}
 
 			case "get_available_models": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_available_models", {
 					models: await state.runtime.session.modelRegistry.refreshAvailableModels(),
 				});
 			}
 
 			case "get_model_catalog": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(
 					command.id,
 					"get_model_catalog",
@@ -4411,7 +4449,7 @@ export class AgentDaemon {
 			}
 
 			case "get_queue": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_queue", {
 					steering: [...state.runtime.session.getSteeringMessagePreviews()],
 					followUp: [...state.runtime.session.getFollowUpMessagePreviews()],
@@ -4419,7 +4457,7 @@ export class AgentDaemon {
 			}
 
 			case "mutate_queued_message": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const status = state.runtime.session.mutateQueuedMessage(
 					command.lane,
 					command.index,
@@ -4430,19 +4468,23 @@ export class AgentDaemon {
 			}
 
 			case "clear_queue": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "clear_queue", state.runtime.session.clearQueue());
 			}
 
 			case "abort_and_clear_queue": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const queue = state.runtime.session.clearQueue();
 				state.runtime.session.requestAbort();
 				return success(command.id, "abort_and_clear_queue", queue);
 			}
 
 			case "cron_list": {
+				if (command.activeSessionId) this.getBoundSessionState(command.activeSessionId);
 				const jobs = this.cronStore.list().filter((job) => {
+					if (!this.isPublicCronJob(job)) {
+						return false;
+					}
 					if (!command.includeInactive && job.status !== "active" && job.status !== "paused") {
 						return false;
 					}
@@ -4455,11 +4497,13 @@ export class AgentDaemon {
 			}
 
 			case "heartbeats_list":
+				if (command.activeSessionId) this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "heartbeats_list", {
-					heartbeats: this.listHeartbeats(),
+					heartbeats: this.listHeartbeats(command.activeSessionId),
 				});
 
 			case "heartbeat_manage": {
+				if (this.sessions.has(command.activeSessionId)) this.getBoundSessionState(command.activeSessionId);
 				const heartbeat = this.manageHeartbeat(command.activeSessionId, command.jobId, command.action);
 				if (!heartbeat) {
 					throw new Error(`No active heartbeat found: ${command.jobId}`);
@@ -4468,12 +4512,13 @@ export class AgentDaemon {
 			}
 
 			case "cron_add": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const job = this.createCronJobForState(state, command.schedule, command.prompt);
 				return success(command.id, "cron_add", { job });
 			}
 
 			case "cron_cancel": {
+				if (command.activeSessionId) this.getBoundSessionState(command.activeSessionId);
 				const job = this.cronStore.cancel(command.jobId);
 				if (!job) {
 					throw new Error(`No cron job found: ${command.jobId}`);
@@ -4487,7 +4532,7 @@ export class AgentDaemon {
 			}
 
 			case "heartbeat_get": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const heartbeat = this.cronStore.getHeartbeat(state.activeSessionId);
 				return success(command.id, "heartbeat_get", {
 					heartbeat: heartbeat ?? null,
@@ -4495,14 +4540,14 @@ export class AgentDaemon {
 			}
 
 			case "heartbeat_set": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const deliveryMode = normalizeHeartbeatDeliveryMode(command.deliveryMode);
 				const heartbeat = this.createHeartbeatForState(state, command.schedule, command.prompt, deliveryMode);
 				return success(command.id, "heartbeat_set", { heartbeat });
 			}
 
 			case "heartbeat_update": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const heartbeat = this.updateHeartbeatForState(state, command.action);
 				return success(command.id, "heartbeat_update", {
 					heartbeat: heartbeat ?? null,
@@ -4510,7 +4555,7 @@ export class AgentDaemon {
 			}
 
 			case "set_model": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const session = state.runtime.session;
 				const availableModels = await session.modelRegistry.refreshAvailableModels();
 				const model = availableModels.find((candidate) => {
@@ -4526,7 +4571,7 @@ export class AgentDaemon {
 			}
 
 			case "cycle_model": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const session = state.runtime.session;
 				const result = await session.cycleModel(command.direction, {
 					waitForExtensions: !(session.isStreaming || session.isCompacting),
@@ -4535,68 +4580,68 @@ export class AgentDaemon {
 			}
 
 			case "set_scoped_models": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setScopedModels(command.scopedModels);
 				return success(command.id, "set_scoped_models");
 			}
 
 			case "set_thinking_level": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setThinkingLevel(command.level);
 				return success(command.id, "set_thinking_level");
 			}
 
 			case "set_service_tier": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setServiceTier(command.serviceTier);
 				return success(command.id, "set_service_tier");
 			}
 
 			case "cycle_thinking_level": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const level = state.runtime.session.cycleThinkingLevel();
 				return success(command.id, "cycle_thinking_level", level ? { level } : null);
 			}
 
 			case "set_transport": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.settingsManager.setTransport(command.transport);
 				state.runtime.session.agent.transport = command.transport;
 				return success(command.id, "set_transport");
 			}
 
 			case "set_steering_mode": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setSteeringMode(command.mode);
 				return success(command.id, "set_steering_mode");
 			}
 
 			case "set_follow_up_mode": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setFollowUpMode(command.mode);
 				return success(command.id, "set_follow_up_mode");
 			}
 
 			case "set_auto_compaction": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setAutoCompactionEnabled(command.enabled);
 				return success(command.id, "set_auto_compaction");
 			}
 
 			case "set_auto_retry": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.setAutoRetryEnabled(command.enabled);
 				return success(command.id, "set_auto_retry");
 			}
 
 			case "compact": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.session.compact(command.customInstructions);
 				return success(command.id, "compact", result);
 			}
 
 			case "refine": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.session.refine({
 					instructions: command.instructions,
 					rollbackId: command.rollbackId,
@@ -4606,25 +4651,25 @@ export class AgentDaemon {
 			}
 
 			case "abort_compaction": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.abortCompaction();
 				return success(command.id, "abort_compaction");
 			}
 
 			case "abort_branch_summary": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.abortBranchSummary();
 				return success(command.id, "abort_branch_summary");
 			}
 
 			case "abort_retry": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.abortRetry();
 				return success(command.id, "abort_retry");
 			}
 
 			case "reload": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				// Reload re-evaluates extension modules, which capture client env
 				// (e.g. herdr pane identity) synchronously at load.
 				await withClientEnv(state.clientEnv, () => state.runtime.session.reload());
@@ -4632,7 +4677,7 @@ export class AgentDaemon {
 			}
 
 			case "new_session": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const options = command.parentSession ? { parentSession: command.parentSession } : undefined;
 				const result = await state.runtime.newSession(options);
 				this.rebindCronJobsToState(state);
@@ -4640,7 +4685,7 @@ export class AgentDaemon {
 			}
 
 			case "switch_session": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.switchSession(command.sessionPath, {
 					cwdOverride: command.cwdOverride,
 				});
@@ -4649,7 +4694,7 @@ export class AgentDaemon {
 			}
 
 			case "fork": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.fork(command.entryId, {
 					position: command.position,
 				});
@@ -4658,7 +4703,7 @@ export class AgentDaemon {
 			}
 
 			case "navigate_tree": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.session.navigateTree(command.targetId, {
 					summarize: command.summarize,
 					customInstructions: command.customInstructions,
@@ -4669,25 +4714,25 @@ export class AgentDaemon {
 			}
 
 			case "import_jsonl": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.importFromJsonl(command.inputPath, command.cwdOverride);
 				return success(command.id, "import_jsonl", result);
 			}
 
 			case "export_html": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const path = await state.runtime.session.exportToHtml(command.outputPath);
 				return success(command.id, "export_html", { path });
 			}
 
 			case "export_jsonl": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const path = state.runtime.session.exportToJsonl(command.outputPath);
 				return success(command.id, "export_jsonl", { path });
 			}
 
 			case "set_session_name": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const name = command.name.trim();
 				if (!name) {
 					throw new Error("Session name cannot be empty");
@@ -4697,25 +4742,25 @@ export class AgentDaemon {
 			}
 
 			case "get_rlm_max_depth_status": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_rlm_max_depth_status", state.runtime.session.getRlmMaxDepthStatus());
 			}
 
 			case "set_rlm_max_depth": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const result = await state.runtime.session.setRlmMaxDepth(command.maxDepth, { global: command.global });
 				return success(command.id, "set_rlm_max_depth", result);
 			}
 
 			case "get_session_context": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_session_context", {
 					context: state.runtime.session.buildSessionContext(),
 				});
 			}
 
 			case "get_session_tree": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_session_tree", {
 					flatNodes: state.runtime.session.sessionManager.getFlatTree(),
 					leafId: state.runtime.session.sessionManager.getLeafId(),
@@ -4723,28 +4768,28 @@ export class AgentDaemon {
 			}
 
 			case "get_user_messages_for_forking": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_user_messages_for_forking", {
 					messages: state.runtime.session.getUserMessagesForForking(),
 				});
 			}
 
 			case "get_last_assistant_text": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_last_assistant_text", {
 					text: state.runtime.session.getLastAssistantText(),
 				});
 			}
 
 			case "get_system_prompt": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_system_prompt", {
 					systemPrompt: state.runtime.session.systemPrompt,
 				});
 			}
 
 			case "get_tool_definition": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				return success(command.id, "get_tool_definition", {
 					toolDefinition: createAgentConnectionToolDefinition(
 						state.runtime.session.getToolDefinition(command.name),
@@ -4753,13 +4798,13 @@ export class AgentDaemon {
 			}
 
 			case "set_session_entry_label": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				state.runtime.session.sessionManager.appendLabelChange(command.entryId, command.label);
 				return success(command.id, "set_session_entry_label");
 			}
 
 			case "extension_ui_response": {
-				const state = this.getSessionState(command.activeSessionId);
+				const state = this.getBoundSessionState(command.activeSessionId);
 				const pending = state.extensionUiRequests.get(command.requestId);
 				if (!pending) {
 					throw new Error(`Unknown extension UI request: ${command.requestId}`);
@@ -5447,32 +5492,57 @@ export class AgentDaemon {
 	private detachTombstonedClose(parent: ActiveSessionState, state: ActiveSessionState, childId: string): void {
 		const existing = this.failedTombstonedRlmCloses.get(state.activeSessionId);
 		if (existing?.state === state) {
-			if (existing.error !== undefined && !existing.cleanup) {
-				const cleanup = Promise.resolve().then(() => this.closeSession(state, "killed", false));
-				existing.cleanup = cleanup
-					.then(() => {
-						if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === existing)
-							this.failedTombstonedRlmCloses.delete(state.activeSessionId);
-					})
-					.catch((error: unknown) => {
-						existing.error = error;
-						existing.cleanup = undefined;
-					});
+			if (existing.error !== undefined && !existing.cleanup && !existing.retryTimer) {
+				this.scheduleTombstonedCloseRetry(existing);
 			}
 			return;
 		}
-		const record: FailedTombstonedRlmClose = { state, parentActiveSessionId: parent.activeSessionId, childId };
+		const record: FailedTombstonedRlmClose = {
+			state,
+			parentActiveSessionId: parent.activeSessionId,
+			childId,
+			retryAttempt: 0,
+		};
 		this.failedTombstonedRlmCloses.set(state.activeSessionId, record);
-		const cleanup = Promise.resolve().then(() => this.closeSession(state, "killed", false));
-		record.cleanup = cleanup
-			.then(() => {
-				if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === record)
-					this.failedTombstonedRlmCloses.delete(state.activeSessionId);
-			})
-			.catch((error: unknown) => {
+		this.runTombstonedCloseAttempt(record);
+	}
+
+	private runTombstonedCloseAttempt(record: FailedTombstonedRlmClose): void {
+		if (this.shuttingDown || this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record) return;
+		record.retryTimer = undefined;
+		record.error = undefined;
+		const cleanup = Promise.resolve().then(() => this.closeSession(record.state, "killed", false));
+		record.cleanup = cleanup;
+		void cleanup.then(
+			() => {
+				if (this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record) return;
+				this.failedTombstonedRlmCloses.delete(record.state.activeSessionId);
+			},
+			(error: unknown) => {
+				if (this.failedTombstonedRlmCloses.get(record.state.activeSessionId) !== record) return;
 				record.error = error;
 				record.cleanup = undefined;
-			});
+				this.scheduleTombstonedCloseRetry(record);
+			},
+		);
+	}
+
+	private scheduleTombstonedCloseRetry(record: FailedTombstonedRlmClose): void {
+		if (this.shuttingDown || record.retryTimer || record.cleanup) return;
+		const delayMs = Math.min(
+			TOMBSTONED_CLOSE_RETRY_BASE_MS * 2 ** record.retryAttempt,
+			TOMBSTONED_CLOSE_RETRY_MAX_MS,
+		);
+		record.retryAttempt++;
+		record.retryTimer = setTimeout(() => this.runTombstonedCloseAttempt(record), delayMs);
+		record.retryTimer.unref();
+	}
+
+	private clearTombstonedCloseRetries(): void {
+		for (const record of this.failedTombstonedRlmCloses.values()) {
+			if (record.retryTimer) clearTimeout(record.retryTimer);
+			record.retryTimer = undefined;
+		}
 	}
 
 	// Half-bound sessions are hidden from other sessions' listings; the current
@@ -6545,7 +6615,7 @@ export class AgentDaemon {
 			type: "attach",
 			activeSessionId: state.activeSessionId,
 		});
-		if (this.sessions.get(state.activeSessionId) !== state) {
+		if (this.sessions.get(state.activeSessionId) !== state || !this.isPublicRlmState(state)) {
 			finishClientSnapshotStreaming(client, state.activeSessionId);
 			if (!client.snapshotStreaming && client.catchupActiveSessionIds?.size) {
 				void this.catchUpBackpressuredClient(client).catch((catchupError) =>
@@ -6922,6 +6992,7 @@ export class AgentDaemon {
 			process.exit(exitCode);
 		}
 		this.shuttingDown = true;
+		this.clearTombstonedCloseRetries();
 		if (this.supervisorMonitorTimer) {
 			clearTimeout(this.supervisorMonitorTimer);
 			this.supervisorMonitorTimer = undefined;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -982,13 +982,35 @@ export class AgentDaemon {
 			if (!trimmed) continue;
 			try {
 				const entry = JSON.parse(trimmed) as Partial<PersistedRlmSubagentRegistryEntry>;
+				const validIsoTimestamp =
+					typeof entry.updatedAt === "string" &&
+					Number.isFinite(Date.parse(entry.updatedAt)) &&
+					new Date(Date.parse(entry.updatedAt)).toISOString() === entry.updatedAt;
+				const validModel =
+					entry.model === undefined ||
+					(typeof entry.model === "object" &&
+						entry.model !== null &&
+						!Array.isArray(entry.model) &&
+						typeof entry.model.provider === "string" &&
+						typeof entry.model.modelId === "string");
 				if (
 					entry.type !== "rlm_subagent" ||
 					typeof entry.childId !== "string" ||
 					typeof entry.sessionName !== "string" ||
 					typeof entry.sessionDir !== "string" ||
 					typeof entry.sessionFile !== "string" ||
+					typeof entry.parentSessionId !== "string" ||
+					entry.parentSessionId.length === 0 ||
+					(entry.parentSessionFile !== undefined && typeof entry.parentSessionFile !== "string") ||
+					(entry.rlmParentNodeId !== undefined && typeof entry.rlmParentNodeId !== "string") ||
+					(entry.prompt !== undefined && typeof entry.prompt !== "string") ||
+					(entry.spawnCode !== undefined && typeof entry.spawnCode !== "string") ||
+					!validModel ||
 					(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted") ||
+					typeof entry.createdAt !== "number" ||
+					!Number.isSafeInteger(entry.createdAt) ||
+					entry.createdAt < 0 ||
+					!validIsoTimestamp ||
 					(entry.rlmDepth !== undefined && (!Number.isSafeInteger(entry.rlmDepth) || entry.rlmDepth < 0)) ||
 					(entry.rlmMaxDepth !== undefined && (!Number.isSafeInteger(entry.rlmMaxDepth) || entry.rlmMaxDepth < 0))
 				) {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -5467,11 +5467,8 @@ export class AgentDaemon {
 		const visited = new Set<string>();
 		while (child.runtime.metadata.kind === "subagent") {
 			if (visited.has(child.activeSessionId)) return false;
-			if (
-				this.closingSessions.has(child.activeSessionId) ||
-				this.failedTombstonedRlmCloses.has(child.activeSessionId)
-			)
-				return true;
+			const failedClose = this.failedTombstonedRlmCloses.get(child.activeSessionId);
+			if (this.closingSessions.has(child.activeSessionId) || failedClose?.state === child) return true;
 			visited.add(child.activeSessionId);
 			const { parentActiveSessionId, rlmChildId } = child.runtime.metadata;
 			if (!parentActiveSessionId || !rlmChildId) return false;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -102,6 +102,7 @@ import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js
 import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
 import type {
 	CreateRlmSubagentRuntimeOptions,
+	RlmSubagentDeletionAuthority,
 	RlmSubagentDeletionDurability,
 	SubagentRuntimeHost,
 } from "../../core/rlm-runtime.js";
@@ -1027,6 +1028,7 @@ export class AgentDaemon {
 	private async recordRlmSubagentDeletion(
 		parentState: ActiveSessionState,
 		childId: string,
+		authority?: RlmSubagentDeletionAuthority,
 	): Promise<RlmSubagentDeletionDurability> {
 		const latest = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
 		if (!latest) return "unknown";
@@ -1037,6 +1039,11 @@ export class AgentDaemon {
 		if (entry.status === "deleted") {
 			return "tombstoned";
 		}
+		// The complete read above is asynchronous. Revalidate immediately before
+		// entering the synchronous append/fsync commit region: before that point a
+		// stale request must leave no registry mutation behind. Once append starts,
+		// finish the durable commit and let the caller suppress its stale reply.
+		authority?.assertCurrent();
 		if (
 			!this.appendRlmSubagentRegistryEntry(parentState, {
 				...entry,
@@ -2343,7 +2350,8 @@ export class AgentDaemon {
 				}
 				return { deletionDurability };
 			},
-			resolveRlmSubagentDeletion: (childId) => this.recordRlmSubagentDeletion(parentState, childId),
+			resolveRlmSubagentDeletion: (childId, authority) =>
+				this.recordRlmSubagentDeletion(parentState, childId, authority),
 			deleteRlmSubagentRuntime: async (childId, session) => {
 				const state = [...this.sessions.values()].find(
 					(candidate) =>

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -181,8 +181,6 @@ import {
 	classifySessionRosterStatus,
 	inactiveLifecycleForSession,
 	isActiveSessionBusy,
-	isRlmChildVisibilityQuarantinedByParent,
-	isRlmSubagentVisibilityQuarantined,
 	type SessionSummary,
 	summaryForActiveSession,
 } from "./daemon-session-list.js";
@@ -438,17 +436,6 @@ export function isTerminalRemoteAgentMessageError(error: unknown): error is Erro
 	);
 }
 
-interface RetiringRlmSubagent {
-	state: ActiveSessionState;
-	parentActiveSessionId: string;
-	childId: string;
-	sessionDir: string;
-	sessionFile?: string;
-	sessionId: string;
-	cleanup?: Promise<void>;
-	error?: unknown;
-}
-
 export class AgentDaemon {
 	private server?: Server;
 	private shuttingDown = false;
@@ -491,8 +478,6 @@ export class AgentDaemon {
 			reasonUpgrade?: Promise<void>;
 		}
 	>();
-	/** Tombstoned child incarnations remain resident only until detached close retries finish. */
-	private readonly retiringRlmSubagents = new Map<string, RetiringRlmSubagent>();
 	private readonly sideQuestionRuns = new Map<
 		string,
 		{
@@ -1209,13 +1194,7 @@ export class AgentDaemon {
 		): Promise<void> => {
 			for (const entry of entries) {
 				const sessionKey = resolve(entry.sessionFile);
-				if (
-					entry.status === "deleted" ||
-					visited.has(sessionKey) ||
-					(parentChain.length === 0 &&
-						isRlmChildVisibilityQuarantinedByParent(root.rootParentState, entry.childId))
-				)
-					continue;
+				if (entry.status === "deleted" || visited.has(sessionKey)) continue;
 				visited.add(sessionKey);
 				const info = await readSessionInfo(entry.sessionFile);
 				// A path is recyclable; passive authority belongs only to this saved header.
@@ -1235,7 +1214,6 @@ export class AgentDaemon {
 		};
 		const residentRootPaths = new Set<string>();
 		for (const parentState of this.sessions.values()) {
-			if (this.isPrivateRlmSubagentState(parentState)) continue;
 			const parentFile = parentState.runtime.session.sessionFile;
 			// An in-memory session cannot own a persisted registry.
 			if (!parentFile) continue;
@@ -1274,10 +1252,7 @@ export class AgentDaemon {
 	private async buildRlmChildSnapshotsWithPassiveRlmSubagents(
 		rootState: ActiveSessionState,
 	): Promise<AgentConnectionRlmChildAgentSnapshot[]> {
-		const snapshots = buildRlmChildSnapshots(
-			rootState.activeSessionId,
-			[...this.sessions.values()].filter((state) => !this.isPrivateRlmSubagentState(state)),
-		);
+		const snapshots = buildRlmChildSnapshots(rootState.activeSessionId, [...this.sessions.values()]);
 		const residentParentIds = new Set([
 			rootState.activeSessionId,
 			...snapshots.flatMap((snapshot) => (snapshot.activeSessionId ? [snapshot.activeSessionId] : [])),
@@ -1317,33 +1292,28 @@ export class AgentDaemon {
 		for (const [path, passive] of passiveByPath) {
 			savedByPath.set(path, passive.info);
 		}
-		return buildSessionList(activeSessions, [...savedByPath.values()], scheduledJobs)
-			.filter((summary) => {
-				const state = this.findSessionBySessionFile(summary.sessionFile);
-				return !state || !this.isPrivateRlmSubagentState(state);
-			})
-			.map((summary) => {
-				const passive = summary.sessionFile ? passiveByPath.get(resolve(summary.sessionFile)) : undefined;
-				if (!passive || summary.activeSessionId) return summary;
-				const parentEntry = passive.chain.at(-2);
-				return {
-					...summary,
-					runtimeKind: "subagent",
-					...(passive.chain.length === 1 && passive.rootParentState
-						? { parentActiveSessionId: passive.rootParentState.activeSessionId }
-						: {}),
-					parentSessionId: passive.entry.parentSessionId,
-					parentSessionPath:
-						passive.entry.parentSessionFile ??
-						parentEntry?.sessionFile ??
-						passive.rootParentState?.runtime.session.sessionFile ??
-						passive.rootInfo?.path,
-					rlmDepth: passive.entry.rlmDepth ?? passive.info.rlmDepth,
-					rlmChildId: passive.entry.childId,
-					rlmParentNodeId: passive.entry.rlmParentNodeId ?? passive.entry.childId,
-					spawnCode: passive.entry.spawnCode,
-				};
-			});
+		return buildSessionList(activeSessions, [...savedByPath.values()], scheduledJobs).map((summary) => {
+			const passive = summary.sessionFile ? passiveByPath.get(resolve(summary.sessionFile)) : undefined;
+			if (!passive || summary.activeSessionId) return summary;
+			const parentEntry = passive.chain.at(-2);
+			return {
+				...summary,
+				runtimeKind: "subagent",
+				...(passive.chain.length === 1 && passive.rootParentState
+					? { parentActiveSessionId: passive.rootParentState.activeSessionId }
+					: {}),
+				parentSessionId: passive.entry.parentSessionId,
+				parentSessionPath:
+					passive.entry.parentSessionFile ??
+					parentEntry?.sessionFile ??
+					passive.rootParentState?.runtime.session.sessionFile ??
+					passive.rootInfo?.path,
+				rlmDepth: passive.entry.rlmDepth ?? passive.info.rlmDepth,
+				rlmChildId: passive.entry.childId,
+				rlmParentNodeId: passive.entry.rlmParentNodeId ?? passive.entry.childId,
+				spawnCode: passive.entry.spawnCode,
+			};
+		});
 	}
 
 	private async findPassiveRlmSubagent(
@@ -2331,8 +2301,8 @@ export class AgentDaemon {
 		if (this.bindingSessions.has(state.activeSessionId)) {
 			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is still initializing`);
 		}
-		if (this.closingSessions.has(state.activeSessionId) || this.isPrivateRlmSubagentState(state)) {
-			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is unavailable`);
+		if (this.closingSessions.has(state.activeSessionId)) {
+			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is closing`);
 		}
 		return state;
 	}
@@ -2452,10 +2422,6 @@ export class AgentDaemon {
 					}
 
 					try {
-						if (deletionDurability === "tombstoned") {
-							this.retireRlmSubagentState(parentState, state, options.id, options);
-							return { deletionDurability };
-						}
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
 					} catch (error) {
@@ -2530,14 +2496,6 @@ export class AgentDaemon {
 						throw new Error("RLM subagent deletion durability is still unknown");
 					}
 					try {
-						if (deletionDurability === "tombstoned" && state) {
-							this.retireRlmSubagentState(parentState, state, childId, {
-								id: childId,
-								sessionDir: state.runtime.metadata.sessionDir ?? "",
-							} as CreateRlmSubagentRuntimeOptions);
-							if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
-							return { deletionDurability };
-						}
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						if (state) await this.closeSession(state, "killed", false);
 						if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
@@ -3722,9 +3680,7 @@ export class AgentDaemon {
 			case "ack_result":
 				return undefined;
 			case "list": {
-				const activeSessions = Array.from(this.sessions.values()).filter(
-					(state) => !this.isPrivateRlmSubagentState(state),
-				);
+				const activeSessions = Array.from(this.sessions.values());
 				const scheduledJobs = this.cronStore.list();
 				if (!command.all) {
 					return success(command.id, "list", {
@@ -5421,60 +5377,13 @@ export class AgentDaemon {
 		);
 	}
 
-	private isPrivateRlmSubagentState(state: ActiveSessionState): boolean {
-		return isRlmSubagentVisibilityQuarantined(
-			state,
-			this.sessions,
-			(candidate) => this.retiringRlmSubagents.get(candidate.activeSessionId)?.state === candidate,
-		);
-	}
-
-	private retireRlmSubagentState(
-		parentState: ActiveSessionState,
-		state: ActiveSessionState,
-		childId: string,
-		options: CreateRlmSubagentRuntimeOptions,
-	): void {
-		const existing = this.retiringRlmSubagents.get(state.activeSessionId);
-		if (existing && existing.state === state) {
-			if (!existing.cleanup) this.startRetiredRlmSubagentCleanup(existing);
-			return;
-		}
-		const record = {
-			state,
-			parentActiveSessionId: parentState.activeSessionId,
-			childId,
-			sessionDir: options.sessionDir,
-			sessionFile: state.runtime.session.sessionFile,
-			sessionId: state.runtime.session.sessionId,
-		};
-		this.retiringRlmSubagents.set(state.activeSessionId, record);
-		this.startRetiredRlmSubagentCleanup(record);
-	}
-
-	private startRetiredRlmSubagentCleanup(record: RetiringRlmSubagent): void {
-		if (record.cleanup) return;
-		record.error = undefined;
-		record.cleanup = this.closeSession(record.state, "killed", false)
-			.then(() => {
-				if (this.retiringRlmSubagents.get(record.state.activeSessionId) === record) {
-					this.retiringRlmSubagents.delete(record.state.activeSessionId);
-				}
-			})
-			.catch((error: unknown) => {
-				record.error = error;
-				record.cleanup = undefined;
-			});
-	}
-
 	// Half-bound sessions are hidden from other sessions' listings; the current
 	// session stays visible to itself (controllers run during its own bind).
 	private listTargetableSessionStates(current: ActiveSessionState): ActiveSessionState[] {
 		return [...this.sessions.values()].filter(
 			(state) =>
-				!this.isPrivateRlmSubagentState(state) &&
-				(state.activeSessionId === current.activeSessionId ||
-					(!this.bindingSessions.has(state.activeSessionId) && !this.closingSessions.has(state.activeSessionId))),
+				state.activeSessionId === current.activeSessionId ||
+				(!this.bindingSessions.has(state.activeSessionId) && !this.closingSessions.has(state.activeSessionId)),
 		);
 	}
 
@@ -6394,12 +6303,6 @@ export class AgentDaemon {
 		} catch (error) {
 			disposeError = error;
 		}
-		// A tombstoned retirement may retry physical disposal. Keep the exact state
-		// resident on failure: deleting it here would turn the next close into a
-		// false no-op and lose the only retryable incarnation.
-		if (disposeError) {
-			throw disposeError;
-		}
 		for (const client of state.clients) {
 			abortClientSnapshotStreaming(client, state.activeSessionId);
 		}
@@ -6415,6 +6318,9 @@ export class AgentDaemon {
 			if (sessionFile) {
 				await deleteSessionFile(sessionFile).catch(() => undefined);
 			}
+		}
+		if (disposeError) {
+			throw disposeError;
 		}
 		if (persistError && !keepsResumeEntry && reason !== "completed") {
 			throw persistError;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6427,37 +6427,61 @@ export class AgentDaemon {
 		if (!this.sessions.has(state.activeSessionId)) {
 			return;
 		}
+		let closeError: unknown;
+		const captureCloseError = (error: unknown): void => {
+			closeError ??= error;
+		};
+		const retainsForTombstonedRetry =
+			this.failedTombstonedRlmCloses.has(state.activeSessionId) || this.isQuarantinedRlmState(state);
 		if (reason === "killed") {
-			this.cancelScheduledJobsForSession(state);
+			try {
+				this.cancelScheduledJobsForSession(state);
+			} catch (error) {
+				captureCloseError(error);
+			}
 		} else if (reason !== "shutdown" && reason !== "update") {
-			this.cancelSubagentRlmHeartbeats(state);
+			try {
+				this.cancelSubagentRlmHeartbeats(state);
+			} catch (error) {
+				captureCloseError(error);
+			}
 		}
+		// A tombstoned close that failed before teardown is retried intact.
+		if (closeError && retainsForTombstonedRetry) throw closeError;
 		// Abort in-flight status work before any await/dispose so it can't write
 		// agent_status to a session being torn down.
 		this.summarizer.forget(state.activeSessionId);
-		const cascadeError = cascadeChildren
-			? await this.closeChildSessions(state, reason, waitForAbort, descendants)
-			: undefined;
+		if (cascadeChildren) {
+			const cascadeError = await this.closeChildSessions(state, reason, waitForAbort, descendants);
+			if (cascadeError) captureCloseError(cascadeError);
+		}
 		// Empty draft (no messages, config, or jobs): discard rather than persist an
 		// empty session file. Mirrors the detach-time discard so a config-bearing
 		// draft closed via kill/completed is never wiped.
 		const keepsResumeEntry = this.closeKeepsResumeEntry(reason);
 		const isEmptyDraftSession = !keepsResumeEntry && this.isEmptyDraftContent(state);
-		let persistError: unknown;
 		// Clean shutdown leaves the session un-archived so it stays in the resume list.
 		if (!keepsResumeEntry && !isEmptyDraftSession) {
 			try {
 				this.archiveSession(state);
 			} catch (error) {
-				persistError = error;
+				captureCloseError(error);
 			}
 		}
 		cancelPendingExtensionUiRequests(state);
 		if (reason === "killed" || reason === "shutdown" || reason === "replaced" || reason === "update") {
-			await this.abortBashForClose(state);
+			try {
+				await this.abortBashForClose(state);
+			} catch (error) {
+				captureCloseError(error);
+			}
 		}
 		if (reason === "update") {
-			state.runtime.session.abortForUpdateRestart();
+			try {
+				state.runtime.session.abortForUpdateRestart();
+			} catch (error) {
+				captureCloseError(error);
+			}
 		}
 		if (reason === "killed") {
 			const abort = state.runtime.session.abort().catch(() => undefined);
@@ -6469,11 +6493,12 @@ export class AgentDaemon {
 		}
 		this.recordWorkerRecoveryState(state, `closed:${reason}`, false);
 		state.unsubscribe?.();
-		let disposeError: unknown;
 		try {
-			await state.runtime.dispose();
+			// A tombstoned record must retain its lease until the daemon commits the
+			// whole close. Normal direct runtime disposal still releases its own lease.
+			await state.runtime.dispose({ releaseSessionLease: false });
 		} catch (error) {
-			disposeError = error;
+			captureCloseError(error);
 		}
 		for (const client of state.clients) {
 			abortClientSnapshotStreaming(client, state.activeSessionId);
@@ -6484,15 +6509,11 @@ export class AgentDaemon {
 			removeDaemonClientSessionCapabilities(client, state.activeSessionId);
 		}
 		state.clients.clear();
-		if (disposeError) {
-			throw disposeError;
+		if (closeError && retainsForTombstonedRetry) {
+			throw closeError;
 		}
-		if (persistError) {
-			throw persistError;
-		}
-		if (cascadeError) {
-			throw cascadeError;
-		}
+		// Failed non-tombstoned closes are irrevocable: never leave a disposed,
+		// targetable resident behind merely because persistence or cleanup failed.
 		this.sessions.delete(state.activeSessionId);
 		if (isEmptyDraftSession) {
 			const sessionFile = state.runtime.session.sessionFile;
@@ -6500,6 +6521,8 @@ export class AgentDaemon {
 				await deleteSessionFile(sessionFile).catch(() => undefined);
 			}
 		}
+		state.runtime.releaseSessionLease?.();
+		if (closeError) throw closeError;
 	}
 
 	private async closeChildSessions(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -4519,6 +4519,10 @@ export class AgentDaemon {
 
 			case "cron_cancel": {
 				if (command.activeSessionId) this.getBoundSessionState(command.activeSessionId);
+				const existingJob = this.cronStore.list().find((job) => job.id === command.jobId);
+				if (!existingJob || !this.isPublicCronJob(existingJob)) {
+					throw new Error(`No cron job found: ${command.jobId}`);
+				}
 				const job = this.cronStore.cancel(command.jobId);
 				if (!job) {
 					throw new Error(`No cron job found: ${command.jobId}`);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -181,6 +181,8 @@ import {
 	classifySessionRosterStatus,
 	inactiveLifecycleForSession,
 	isActiveSessionBusy,
+	isRlmChildVisibilityQuarantinedByParent,
+	isRlmSubagentVisibilityQuarantined,
 	type SessionSummary,
 	summaryForActiveSession,
 } from "./daemon-session-list.js";
@@ -436,6 +438,17 @@ export function isTerminalRemoteAgentMessageError(error: unknown): error is Erro
 	);
 }
 
+interface RetiringRlmSubagent {
+	state: ActiveSessionState;
+	parentActiveSessionId: string;
+	childId: string;
+	sessionDir: string;
+	sessionFile?: string;
+	sessionId: string;
+	cleanup?: Promise<void>;
+	error?: unknown;
+}
+
 export class AgentDaemon {
 	private server?: Server;
 	private shuttingDown = false;
@@ -478,6 +491,8 @@ export class AgentDaemon {
 			reasonUpgrade?: Promise<void>;
 		}
 	>();
+	/** Tombstoned child incarnations remain resident only until detached close retries finish. */
+	private readonly retiringRlmSubagents = new Map<string, RetiringRlmSubagent>();
 	private readonly sideQuestionRuns = new Map<
 		string,
 		{
@@ -1194,7 +1209,13 @@ export class AgentDaemon {
 		): Promise<void> => {
 			for (const entry of entries) {
 				const sessionKey = resolve(entry.sessionFile);
-				if (entry.status === "deleted" || visited.has(sessionKey)) continue;
+				if (
+					entry.status === "deleted" ||
+					visited.has(sessionKey) ||
+					(parentChain.length === 0 &&
+						isRlmChildVisibilityQuarantinedByParent(root.rootParentState, entry.childId))
+				)
+					continue;
 				visited.add(sessionKey);
 				const info = await readSessionInfo(entry.sessionFile);
 				// A path is recyclable; passive authority belongs only to this saved header.
@@ -1214,6 +1235,7 @@ export class AgentDaemon {
 		};
 		const residentRootPaths = new Set<string>();
 		for (const parentState of this.sessions.values()) {
+			if (this.isPrivateRlmSubagentState(parentState)) continue;
 			const parentFile = parentState.runtime.session.sessionFile;
 			// An in-memory session cannot own a persisted registry.
 			if (!parentFile) continue;
@@ -1252,7 +1274,10 @@ export class AgentDaemon {
 	private async buildRlmChildSnapshotsWithPassiveRlmSubagents(
 		rootState: ActiveSessionState,
 	): Promise<AgentConnectionRlmChildAgentSnapshot[]> {
-		const snapshots = buildRlmChildSnapshots(rootState.activeSessionId, [...this.sessions.values()]);
+		const snapshots = buildRlmChildSnapshots(
+			rootState.activeSessionId,
+			[...this.sessions.values()].filter((state) => !this.isPrivateRlmSubagentState(state)),
+		);
 		const residentParentIds = new Set([
 			rootState.activeSessionId,
 			...snapshots.flatMap((snapshot) => (snapshot.activeSessionId ? [snapshot.activeSessionId] : [])),
@@ -1292,28 +1317,33 @@ export class AgentDaemon {
 		for (const [path, passive] of passiveByPath) {
 			savedByPath.set(path, passive.info);
 		}
-		return buildSessionList(activeSessions, [...savedByPath.values()], scheduledJobs).map((summary) => {
-			const passive = summary.sessionFile ? passiveByPath.get(resolve(summary.sessionFile)) : undefined;
-			if (!passive || summary.activeSessionId) return summary;
-			const parentEntry = passive.chain.at(-2);
-			return {
-				...summary,
-				runtimeKind: "subagent",
-				...(passive.chain.length === 1 && passive.rootParentState
-					? { parentActiveSessionId: passive.rootParentState.activeSessionId }
-					: {}),
-				parentSessionId: passive.entry.parentSessionId,
-				parentSessionPath:
-					passive.entry.parentSessionFile ??
-					parentEntry?.sessionFile ??
-					passive.rootParentState?.runtime.session.sessionFile ??
-					passive.rootInfo?.path,
-				rlmDepth: passive.entry.rlmDepth ?? passive.info.rlmDepth,
-				rlmChildId: passive.entry.childId,
-				rlmParentNodeId: passive.entry.rlmParentNodeId ?? passive.entry.childId,
-				spawnCode: passive.entry.spawnCode,
-			};
-		});
+		return buildSessionList(activeSessions, [...savedByPath.values()], scheduledJobs)
+			.filter((summary) => {
+				const state = this.findSessionBySessionFile(summary.sessionFile);
+				return !state || !this.isPrivateRlmSubagentState(state);
+			})
+			.map((summary) => {
+				const passive = summary.sessionFile ? passiveByPath.get(resolve(summary.sessionFile)) : undefined;
+				if (!passive || summary.activeSessionId) return summary;
+				const parentEntry = passive.chain.at(-2);
+				return {
+					...summary,
+					runtimeKind: "subagent",
+					...(passive.chain.length === 1 && passive.rootParentState
+						? { parentActiveSessionId: passive.rootParentState.activeSessionId }
+						: {}),
+					parentSessionId: passive.entry.parentSessionId,
+					parentSessionPath:
+						passive.entry.parentSessionFile ??
+						parentEntry?.sessionFile ??
+						passive.rootParentState?.runtime.session.sessionFile ??
+						passive.rootInfo?.path,
+					rlmDepth: passive.entry.rlmDepth ?? passive.info.rlmDepth,
+					rlmChildId: passive.entry.childId,
+					rlmParentNodeId: passive.entry.rlmParentNodeId ?? passive.entry.childId,
+					spawnCode: passive.entry.spawnCode,
+				};
+			});
 	}
 
 	private async findPassiveRlmSubagent(
@@ -2301,8 +2331,8 @@ export class AgentDaemon {
 		if (this.bindingSessions.has(state.activeSessionId)) {
 			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is still initializing`);
 		}
-		if (this.closingSessions.has(state.activeSessionId)) {
-			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is closing`);
+		if (this.closingSessions.has(state.activeSessionId) || this.isPrivateRlmSubagentState(state)) {
+			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is unavailable`);
 		}
 		return state;
 	}
@@ -2422,6 +2452,10 @@ export class AgentDaemon {
 					}
 
 					try {
+						if (deletionDurability === "tombstoned") {
+							this.retireRlmSubagentState(parentState, state, options.id, options);
+							return { deletionDurability };
+						}
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
 					} catch (error) {
@@ -2496,6 +2530,14 @@ export class AgentDaemon {
 						throw new Error("RLM subagent deletion durability is still unknown");
 					}
 					try {
+						if (deletionDurability === "tombstoned" && state) {
+							this.retireRlmSubagentState(parentState, state, childId, {
+								id: childId,
+								sessionDir: state.runtime.metadata.sessionDir ?? "",
+							} as CreateRlmSubagentRuntimeOptions);
+							if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
+							return { deletionDurability };
+						}
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						if (state) await this.closeSession(state, "killed", false);
 						if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
@@ -3680,7 +3722,9 @@ export class AgentDaemon {
 			case "ack_result":
 				return undefined;
 			case "list": {
-				const activeSessions = Array.from(this.sessions.values());
+				const activeSessions = Array.from(this.sessions.values()).filter(
+					(state) => !this.isPrivateRlmSubagentState(state),
+				);
 				const scheduledJobs = this.cronStore.list();
 				if (!command.all) {
 					return success(command.id, "list", {
@@ -5377,13 +5421,60 @@ export class AgentDaemon {
 		);
 	}
 
+	private isPrivateRlmSubagentState(state: ActiveSessionState): boolean {
+		return isRlmSubagentVisibilityQuarantined(
+			state,
+			this.sessions,
+			(candidate) => this.retiringRlmSubagents.get(candidate.activeSessionId)?.state === candidate,
+		);
+	}
+
+	private retireRlmSubagentState(
+		parentState: ActiveSessionState,
+		state: ActiveSessionState,
+		childId: string,
+		options: CreateRlmSubagentRuntimeOptions,
+	): void {
+		const existing = this.retiringRlmSubagents.get(state.activeSessionId);
+		if (existing && existing.state === state) {
+			if (!existing.cleanup) this.startRetiredRlmSubagentCleanup(existing);
+			return;
+		}
+		const record = {
+			state,
+			parentActiveSessionId: parentState.activeSessionId,
+			childId,
+			sessionDir: options.sessionDir,
+			sessionFile: state.runtime.session.sessionFile,
+			sessionId: state.runtime.session.sessionId,
+		};
+		this.retiringRlmSubagents.set(state.activeSessionId, record);
+		this.startRetiredRlmSubagentCleanup(record);
+	}
+
+	private startRetiredRlmSubagentCleanup(record: RetiringRlmSubagent): void {
+		if (record.cleanup) return;
+		record.error = undefined;
+		record.cleanup = this.closeSession(record.state, "killed", false)
+			.then(() => {
+				if (this.retiringRlmSubagents.get(record.state.activeSessionId) === record) {
+					this.retiringRlmSubagents.delete(record.state.activeSessionId);
+				}
+			})
+			.catch((error: unknown) => {
+				record.error = error;
+				record.cleanup = undefined;
+			});
+	}
+
 	// Half-bound sessions are hidden from other sessions' listings; the current
 	// session stays visible to itself (controllers run during its own bind).
 	private listTargetableSessionStates(current: ActiveSessionState): ActiveSessionState[] {
 		return [...this.sessions.values()].filter(
 			(state) =>
-				state.activeSessionId === current.activeSessionId ||
-				(!this.bindingSessions.has(state.activeSessionId) && !this.closingSessions.has(state.activeSessionId)),
+				!this.isPrivateRlmSubagentState(state) &&
+				(state.activeSessionId === current.activeSessionId ||
+					(!this.bindingSessions.has(state.activeSessionId) && !this.closingSessions.has(state.activeSessionId))),
 		);
 	}
 
@@ -6303,6 +6394,12 @@ export class AgentDaemon {
 		} catch (error) {
 			disposeError = error;
 		}
+		// A tombstoned retirement may retry physical disposal. Keep the exact state
+		// resident on failure: deleting it here would turn the next close into a
+		// false no-op and lose the only retryable incarnation.
+		if (disposeError) {
+			throw disposeError;
+		}
 		for (const client of state.clients) {
 			abortClientSnapshotStreaming(client, state.activeSessionId);
 		}
@@ -6318,9 +6415,6 @@ export class AgentDaemon {
 			if (sessionFile) {
 				await deleteSessionFile(sessionFile).catch(() => undefined);
 			}
-		}
-		if (disposeError) {
-			throw disposeError;
 		}
 		if (persistError && !keepsResumeEntry && reason !== "completed") {
 			throw persistError;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2450,9 +2450,8 @@ export class AgentDaemon {
 					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 						(entry) => entry.childId === childId,
 					);
-					// Concrete deletion requires exact object identity. A passive request and a
-					// post-tombstone cleanup retry have no resident state, so both must bind to
-					// the exact persisted incarnation before they can touch its tombstone or jobs.
+					// Concrete deletion requires exact authority. An omitted session is valid
+					// only when its persisted row and resident runtime name the same incarnation.
 					const persistedMatchesAuthority =
 						persisted !== undefined &&
 						authority !== undefined &&
@@ -2461,6 +2460,14 @@ export class AgentDaemon {
 						persisted.sessionFile === authority.sessionFile &&
 						typeof authority.sessionId === "string" &&
 						persisted.sessionId === authority.sessionId;
+					const residentMatchesAuthority =
+						state !== undefined &&
+						authority !== undefined &&
+						state.runtime.metadata.sessionDir === authority.sessionDir &&
+						typeof authority.sessionFile === "string" &&
+						state.runtime.session.sessionFile === authority.sessionFile &&
+						typeof authority.sessionId === "string" &&
+						state.runtime.session.sessionId === authority.sessionId;
 					const suppliedSessionMatchesPersisted =
 						session === undefined ||
 						(persistedMatchesAuthority &&
@@ -2468,17 +2475,13 @@ export class AgentDaemon {
 							(typeof authority?.sessionId !== "string" || session.sessionId === authority.sessionId));
 					if (
 						(state !== undefined && session !== undefined && state.runtime.session !== session) ||
-						(state !== undefined && session === undefined) ||
-						(state === undefined && session === undefined && !persistedMatchesAuthority) ||
+						(state !== undefined &&
+							session === undefined &&
+							(!persistedMatchesAuthority || !residentMatchesAuthority)) ||
+						(state === undefined && session === undefined) ||
 						(state === undefined && session !== undefined && !suppliedSessionMatchesPersisted) ||
 						(authority !== undefined &&
-							(state !== undefined
-								? state.runtime.metadata.sessionDir !== authority.sessionDir ||
-									(typeof authority.sessionFile === "string" &&
-										state.runtime.session.sessionFile !== authority.sessionFile) ||
-									(typeof authority.sessionId === "string" &&
-										state.runtime.session.sessionId !== authority.sessionId)
-								: !persistedMatchesAuthority))
+							(state !== undefined ? !residentMatchesAuthority : !persistedMatchesAuthority))
 					) {
 						throw new Error("RLM subagent deletion does not match the resident runtime incarnation");
 					}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -420,6 +420,20 @@ type PassiveRlmSubagent = PassiveRlmRoot & {
 class RuntimeOpenCancelledError extends Error {}
 class BoundSessionUnavailableError extends Error {}
 
+type DaemonSessionCloseFailureStage = "dispose" | "persist" | "cascade";
+
+/** Daemon-private close diagnostics used only to authorize exact cleanup retry. */
+class DaemonSessionCloseError extends Error {
+	readonly stage: DaemonSessionCloseFailureStage;
+
+	constructor(stage: DaemonSessionCloseFailureStage, cause: unknown) {
+		super(cause instanceof Error ? cause.message : String(cause), { cause });
+		this.name = "DaemonSessionCloseError";
+		this.stage = stage;
+	}
+}
+class PrivateSessionUnavailableError extends BoundSessionUnavailableError {}
+
 export async function runDaemonMode(options: DaemonModeOptions): Promise<never> {
 	const socketPath = options.socketPath ?? defaultDaemonSocketPath();
 	const daemon = new AgentDaemon(socketPath, options);
@@ -434,6 +448,15 @@ export function isTerminalRemoteAgentMessageError(error: unknown): error is Erro
 			error.message.startsWith("Ambiguous") ||
 			error.message === AGENT_FAMILY_REACH_ERROR)
 	);
+}
+
+interface FailedTombstonedRlmClose {
+	readonly state: ActiveSessionState;
+	readonly parentActiveSessionId: string;
+	readonly childId: string;
+	cleanup?: Promise<void>;
+	error?: unknown;
+	disposeError?: unknown;
 }
 
 export class AgentDaemon {
@@ -478,6 +501,13 @@ export class AgentDaemon {
 			reasonUpgrade?: Promise<void>;
 		}
 	>();
+	/** Exact removed incarnation retained only when its runtime dispose failed. */
+	private readonly failedSessionCloses = new Map<
+		string,
+		{ state: ActiveSessionState; error: DaemonSessionCloseError }
+	>();
+	private readonly failedTombstonedRlmCloses = new Map<string, FailedTombstonedRlmClose>();
+	private readonly closeDisposeErrors = new WeakMap<ActiveSessionState, unknown>();
 	private readonly sideQuestionRuns = new Map<
 		string,
 		{
@@ -1214,6 +1244,7 @@ export class AgentDaemon {
 		};
 		const residentRootPaths = new Set<string>();
 		for (const parentState of this.sessions.values()) {
+			if (!this.isPublicRlmState(parentState)) continue;
 			const parentFile = parentState.runtime.session.sessionFile;
 			// An in-memory session cannot own a persisted registry.
 			if (!parentFile) continue;
@@ -1252,7 +1283,10 @@ export class AgentDaemon {
 	private async buildRlmChildSnapshotsWithPassiveRlmSubagents(
 		rootState: ActiveSessionState,
 	): Promise<AgentConnectionRlmChildAgentSnapshot[]> {
-		const snapshots = buildRlmChildSnapshots(rootState.activeSessionId, [...this.sessions.values()]);
+		const snapshots = buildRlmChildSnapshots(
+			rootState.activeSessionId,
+			[...this.sessions.values()].filter((state) => this.isPublicRlmState(state)),
+		);
 		const residentParentIds = new Set([
 			rootState.activeSessionId,
 			...snapshots.flatMap((snapshot) => (snapshot.activeSessionId ? [snapshot.activeSessionId] : [])),
@@ -2259,7 +2293,7 @@ export class AgentDaemon {
 		state: ActiveSessionState,
 		requirePersistedJob: boolean,
 	): boolean {
-		if (this.sessions.get(state.activeSessionId) !== state || this.closingSessions.has(state.activeSessionId)) {
+		if (this.sessions.get(state.activeSessionId) !== state || !this.isPublicRlmState(state)) {
 			return false;
 		}
 		if (!requirePersistedJob) {
@@ -2301,8 +2335,8 @@ export class AgentDaemon {
 		if (this.bindingSessions.has(state.activeSessionId)) {
 			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is still initializing`);
 		}
-		if (this.closingSessions.has(state.activeSessionId)) {
-			throw new BoundSessionUnavailableError(`Active session ${state.activeSessionId} is closing`);
+		if (this.closingSessions.has(state.activeSessionId) || this.isQuarantinedRlmState(state)) {
+			throw new PrivateSessionUnavailableError(`Active session ${state.activeSessionId} is unavailable`);
 		}
 		return state;
 	}
@@ -2312,6 +2346,7 @@ export class AgentDaemon {
 		try {
 			return this.getBoundSessionState(id);
 		} catch (error) {
+			if (error instanceof PrivateSessionUnavailableError) throw error;
 			if (error instanceof BoundSessionUnavailableError) {
 				return this.waitForHydratingChild(this.getSessionState(id), id);
 			}
@@ -2333,6 +2368,7 @@ export class AgentDaemon {
 		try {
 			return this.getBoundSessionState(id);
 		} catch (error) {
+			if (error instanceof PrivateSessionUnavailableError) throw error;
 			if (error instanceof BoundSessionUnavailableError) {
 				return this.waitForHydratingChild(this.getSessionState(id), id);
 			}
@@ -2388,12 +2424,7 @@ export class AgentDaemon {
 					// Resolve the exact resident incarnation before any tombstone append. An
 					// older finalizer can share both child id and directory with its
 					// replacement, so neither field is an object-identity fence.
-					const state = [...this.sessions.values()].find(
-						(candidate) =>
-							candidate.runtime.metadata.kind === "subagent" &&
-							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
-							candidate.runtime.metadata.rlmChildId === options.id,
-					);
+					const state = this.findExactRlmState(parentState.activeSessionId, options.id, runtime.session);
 					if (
 						!state ||
 						state.runtime.session !== runtime.session ||
@@ -2422,6 +2453,10 @@ export class AgentDaemon {
 					}
 
 					try {
+						if (deletionDurability === "tombstoned") {
+							this.detachTombstonedClose(parentState, state, options.id);
+							return { deletionDurability };
+						}
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
 					} catch (error) {
@@ -2441,12 +2476,7 @@ export class AgentDaemon {
 			deleteRlmSubagentRuntime: async (childId, session, authority) => {
 				try {
 					authority?.assertCurrent();
-					const state = [...this.sessions.values()].find(
-						(candidate) =>
-							candidate.runtime.metadata.kind === "subagent" &&
-							candidate.runtime.metadata.parentActiveSessionId === parentState.activeSessionId &&
-							candidate.runtime.metadata.rlmChildId === childId,
-					);
+					const state = this.findExactRlmState(parentState.activeSessionId, childId, session);
 					const persisted = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
 						(entry) => entry.childId === childId,
 					);
@@ -2496,6 +2526,11 @@ export class AgentDaemon {
 						throw new Error("RLM subagent deletion durability is still unknown");
 					}
 					try {
+						if (deletionDurability === "tombstoned" && state) {
+							this.detachTombstonedClose(parentState, state, childId);
+							if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
+							return { deletionDurability };
+						}
 						if (deletionDurability === "absent") authority?.assertCurrent();
 						if (state) await this.closeSession(state, "killed", false);
 						if (childSessionFile) this.cancelScheduledJobsForSessionFile(childSessionFile);
@@ -3680,7 +3715,7 @@ export class AgentDaemon {
 			case "ack_result":
 				return undefined;
 			case "list": {
-				const activeSessions = Array.from(this.sessions.values());
+				const activeSessions = Array.from(this.sessions.values()).filter((state) => this.isPublicRlmState(state));
 				const scheduledJobs = this.cronStore.list();
 				if (!command.all) {
 					return success(command.id, "list", {
@@ -5377,13 +5412,89 @@ export class AgentDaemon {
 		);
 	}
 
+	private isQuarantinedRlmState(state: ActiveSessionState): boolean {
+		let child = state;
+		const visited = new Set<string>();
+		while (child.runtime.metadata.kind === "subagent") {
+			if (visited.has(child.activeSessionId)) return false;
+			visited.add(child.activeSessionId);
+			const { parentActiveSessionId, rlmChildId } = child.runtime.metadata;
+			if (!parentActiveSessionId || !rlmChildId) return false;
+			const parent = this.sessions.get(parentActiveSessionId);
+			if (!parent) return false;
+			if (parent.runtime.session.isRlmChildDeletionQuarantined?.(rlmChildId) === true) return true;
+			child = parent;
+		}
+		return false;
+	}
+
+	private isPublicRlmState(state: ActiveSessionState): boolean {
+		return !this.closingSessions.has(state.activeSessionId) && !this.isQuarantinedRlmState(state);
+	}
+
+	private findExactRlmState(
+		parentId: string,
+		childId: string,
+		session?: AgentSession,
+	): ActiveSessionState | undefined {
+		return (
+			[...this.failedTombstonedRlmCloses.values()].find(
+				(record) =>
+					record.parentActiveSessionId === parentId &&
+					record.childId === childId &&
+					(!session || record.state.runtime.session === session),
+			)?.state ??
+			[...this.sessions.values()].find((state) => {
+				const metadata = state.runtime.metadata;
+				return (
+					metadata.kind === "subagent" &&
+					metadata.parentActiveSessionId === parentId &&
+					metadata.rlmChildId === childId &&
+					(!session || state.runtime.session === session)
+				);
+			})
+		);
+	}
+
+	private detachTombstonedClose(parent: ActiveSessionState, state: ActiveSessionState, childId: string): void {
+		const existing = this.failedTombstonedRlmCloses.get(state.activeSessionId);
+		if (existing?.state === state) {
+			if (existing.error !== undefined && existing.disposeError !== undefined && !existing.cleanup) {
+				const cleanup = Promise.resolve().then(() => state.runtime.dispose());
+				existing.cleanup = cleanup
+					.then(() => {
+						if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === existing)
+							this.failedTombstonedRlmCloses.delete(state.activeSessionId);
+					})
+					.catch((error: unknown) => {
+						existing.error = error;
+						existing.disposeError = error;
+						existing.cleanup = undefined;
+					});
+			}
+			return;
+		}
+		const record: FailedTombstonedRlmClose = { state, parentActiveSessionId: parent.activeSessionId, childId };
+		this.failedTombstonedRlmCloses.set(state.activeSessionId, record);
+		void this.closeSession(state, "killed", false).then(
+			() => {
+				if (this.failedTombstonedRlmCloses.get(state.activeSessionId) === record)
+					this.failedTombstonedRlmCloses.delete(state.activeSessionId);
+			},
+			(error: unknown) => {
+				record.error = error;
+				record.disposeError = this.closeDisposeErrors.get(state);
+			},
+		);
+	}
+
 	// Half-bound sessions are hidden from other sessions' listings; the current
 	// session stays visible to itself (controllers run during its own bind).
 	private listTargetableSessionStates(current: ActiveSessionState): ActiveSessionState[] {
 		return [...this.sessions.values()].filter(
 			(state) =>
-				state.activeSessionId === current.activeSessionId ||
-				(!this.bindingSessions.has(state.activeSessionId) && !this.closingSessions.has(state.activeSessionId)),
+				this.isPublicRlmState(state) &&
+				(state.activeSessionId === current.activeSessionId || !this.bindingSessions.has(state.activeSessionId)),
 		);
 	}
 
@@ -6300,8 +6411,10 @@ export class AgentDaemon {
 		let disposeError: unknown;
 		try {
 			await state.runtime.dispose();
+			this.closeDisposeErrors.delete(state);
 		} catch (error) {
 			disposeError = error;
+			this.closeDisposeErrors.set(state, error);
 		}
 		for (const client of state.clients) {
 			abortClientSnapshotStreaming(client, state.activeSessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -100,7 +100,11 @@ import {
 } from "../../core/cron-jobs.js";
 import { ORPHAN_PROCESS_JOURNAL_ENV } from "../../core/orphan-process-journal.js";
 import { PromptAdmissionCancelledError, waitForPromptAdmission } from "../../core/prompt-admission.js";
-import type { CreateRlmSubagentRuntimeOptions, SubagentRuntimeHost } from "../../core/rlm-runtime.js";
+import type {
+	CreateRlmSubagentRuntimeOptions,
+	RlmSubagentDeletionDurability,
+	SubagentRuntimeHost,
+} from "../../core/rlm-runtime.js";
 import {
 	canPassivateSession,
 	type IdleEvictionMinutes,
@@ -952,27 +956,75 @@ export class AgentDaemon {
 		});
 	}
 
-	/** Write (or verify) the deletion tombstone and report whether durable ownership exists. */
-	private async recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<boolean> {
-		const latest = (await this.readLatestRlmSubagentRegistry(parentState, true)).find(
-			(entry) => entry.childId === childId,
-		);
-		if (!latest) {
-			return false;
+	/**
+	 * Strictly read the registry when absence would authorize destructive cleanup.
+	 * Passive discovery may skip a corrupt historical line, but deletion must not
+	 * mistake that ambiguity for proof that a child was never recorded.
+	 */
+	private async readCompleteRlmSubagentRegistryForDeletion(
+		parentState: ActiveSessionState,
+	): Promise<PersistedRlmSubagentRegistryEntry[] | undefined> {
+		const path = this.rlmSubagentRegistryPath(parentState.runtime.session);
+		if (!path) return undefined;
+		let lines: string[];
+		try {
+			lines = (await readFile(path, "utf8")).split(/\r?\n/);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+			this.log(
+				`failed to read RLM subagent registry for deletion: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return undefined;
 		}
-		if (latest.status === "deleted") {
-			return true;
+		const latest = new Map<string, PersistedRlmSubagentRegistryEntry>();
+		for (const line of lines) {
+			const trimmed = line.trim();
+			if (!trimmed) continue;
+			try {
+				const entry = JSON.parse(trimmed) as Partial<PersistedRlmSubagentRegistryEntry>;
+				if (
+					entry.type !== "rlm_subagent" ||
+					typeof entry.childId !== "string" ||
+					typeof entry.sessionName !== "string" ||
+					typeof entry.sessionDir !== "string" ||
+					typeof entry.sessionFile !== "string" ||
+					(entry.status !== "running" && entry.status !== "completed" && entry.status !== "deleted") ||
+					(entry.rlmDepth !== undefined && (!Number.isSafeInteger(entry.rlmDepth) || entry.rlmDepth < 0)) ||
+					(entry.rlmMaxDepth !== undefined && (!Number.isSafeInteger(entry.rlmMaxDepth) || entry.rlmMaxDepth < 0))
+				) {
+					return undefined;
+				}
+				latest.set(entry.childId, entry as PersistedRlmSubagentRegistryEntry);
+			} catch {
+				return undefined;
+			}
+		}
+		return [...latest.values()];
+	}
+
+	private async recordRlmSubagentDeletion(
+		parentState: ActiveSessionState,
+		childId: string,
+	): Promise<RlmSubagentDeletionDurability> {
+		const latest = await this.readCompleteRlmSubagentRegistryForDeletion(parentState);
+		if (!latest) return "unknown";
+		const entry = latest.find((candidate) => candidate.childId === childId);
+		if (!entry) {
+			return "absent";
+		}
+		if (entry.status === "deleted") {
+			return "tombstoned";
 		}
 		if (
 			!this.appendRlmSubagentRegistryEntry(parentState, {
-				...latest,
+				...entry,
 				status: "deleted",
 				updatedAt: new Date().toISOString(),
 			})
 		) {
-			throw new Error(`Failed to persist deletion for RLM subagent ${childId}`);
+			return "unknown";
 		}
-		return true;
+		return "tombstoned";
 	}
 
 	private readLatestRlmSubagentRegistry(
@@ -2244,16 +2296,15 @@ export class AgentDaemon {
 				});
 			},
 			releaseRlmSubagentRuntime: async (runtime, options, status) => {
-				// A caller may only retain a never-admitted cancelled child when the
-				// deletion tombstone is durably written. Close it on any write failure,
-				// then explicitly return that the caller still owns its artifact dir.
-				let retained = false;
+				// Preserve the three-way durability proof through release. A failed
+				// lookup/write is not the same as a verified no-row result.
+				let deletionDurability: RlmSubagentDeletionDurability = "unknown";
 				if (status === "cancelled") {
 					try {
-						retained = await this.recordRlmSubagentDeletion(parentState, options.id);
+						deletionDurability = await this.recordRlmSubagentDeletion(parentState, options.id);
 					} catch {
-						// The close below prevents a stale resident runtime; the caller removes
-						// its exact never-admitted child dir because no durable row exists.
+						// A defensive fail-closed boundary for injected/legacy persistence
+						// implementations which still throw rather than return unknown.
 					}
 				}
 				const state = [...this.sessions.values()].find(
@@ -2268,8 +2319,9 @@ export class AgentDaemon {
 				} else {
 					await runtime.session.disposeAsync();
 				}
-				return { retained };
+				return { deletionDurability };
 			},
+			resolveRlmSubagentDeletion: (childId) => this.recordRlmSubagentDeletion(parentState, childId),
 			deleteRlmSubagentRuntime: async (childId, session) => {
 				const state = [...this.sessions.values()].find(
 					(candidate) =>

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -354,6 +354,11 @@ export function buildRlmChildSnapshots(
 	const visit = (parent: ActiveSessionState | undefined, parentActiveSessionId: string): void => {
 		const parentNodeId = parent?.runtime.metadata.rlmChildId;
 		for (const child of childrenByParent.get(parentActiveSessionId) ?? []) {
+			const childId = child.runtime.metadata.rlmChildId;
+			// A precommit release failure retains a resident runtime only for exact
+			// tombstone-and-close retry. It is not a public child, and neither are any
+			// descendants reachable solely through that private runtime.
+			if (childId && parent?.runtime.session.isRlmChildDeletionQuarantined(childId)) continue;
 			snapshots.push(rlmChildSnapshotForActiveSession(child, child.runtime.metadata, parentNodeId, parent));
 			// A child passes its own node id to its children as their parent id.
 			visit(child, child.activeSessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -335,40 +335,10 @@ export function summaryForInactiveSession(
  * rlm_child_update events so attach clients can seed their subagent state
  * from daemon memory instead of replaying the event stream.
  */
-export function isRlmSubagentVisibilityQuarantined(
-	state: ActiveSessionState,
-	sessions: ReadonlyMap<string, ActiveSessionState>,
-	isRetiring: (state: ActiveSessionState) => boolean = () => false,
-): boolean {
-	let descendant = state;
-	const visited = new Set<string>();
-	while (descendant.runtime.metadata.kind === "subagent") {
-		if (isRetiring(descendant)) return true;
-		if (visited.has(descendant.activeSessionId)) return false;
-		visited.add(descendant.activeSessionId);
-		const { parentActiveSessionId, rlmChildId } = descendant.runtime.metadata;
-		if (!parentActiveSessionId || !rlmChildId) return false;
-		const parent = sessions.get(parentActiveSessionId);
-		if (!parent) return false;
-		if (parent.runtime.session.isRlmChildDeletionQuarantined(rlmChildId)) return true;
-		descendant = parent;
-	}
-	return false;
-}
-
-/** Whether this exact registry edge is privately quarantined by its resident parent. */
-export function isRlmChildVisibilityQuarantinedByParent(
-	parent: ActiveSessionState | undefined,
-	childId: string | undefined,
-): boolean {
-	return !!childId && !!parent?.runtime.session.isRlmChildDeletionQuarantined(childId);
-}
-
 export function buildRlmChildSnapshots(
 	rootActiveSessionId: string,
 	activeSessions: readonly ActiveSessionState[],
 ): AgentConnectionRlmChildAgentSnapshot[] {
-	const sessionByActiveId = new Map(activeSessions.map((session) => [session.activeSessionId, session]));
 	const childrenByParent = new Map<string, ActiveSessionState[]>();
 	for (const candidate of activeSessions) {
 		const metadata = candidate.runtime.metadata;
@@ -384,7 +354,11 @@ export function buildRlmChildSnapshots(
 	const visit = (parent: ActiveSessionState | undefined, parentActiveSessionId: string): void => {
 		const parentNodeId = parent?.runtime.metadata.rlmChildId;
 		for (const child of childrenByParent.get(parentActiveSessionId) ?? []) {
-			if (isRlmSubagentVisibilityQuarantined(child, sessionByActiveId)) continue;
+			const childId = child.runtime.metadata.rlmChildId;
+			// A precommit release failure retains a resident runtime only for exact
+			// tombstone-and-close retry. It is not a public child, and neither are any
+			// descendants reachable solely through that private runtime.
+			if (childId && parent?.runtime.session.isRlmChildDeletionQuarantined(childId)) continue;
 			snapshots.push(rlmChildSnapshotForActiveSession(child, child.runtime.metadata, parentNodeId, parent));
 			// A child passes its own node id to its children as their parent id.
 			visit(child, child.activeSessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -335,10 +335,40 @@ export function summaryForInactiveSession(
  * rlm_child_update events so attach clients can seed their subagent state
  * from daemon memory instead of replaying the event stream.
  */
+export function isRlmSubagentVisibilityQuarantined(
+	state: ActiveSessionState,
+	sessions: ReadonlyMap<string, ActiveSessionState>,
+	isRetiring: (state: ActiveSessionState) => boolean = () => false,
+): boolean {
+	let descendant = state;
+	const visited = new Set<string>();
+	while (descendant.runtime.metadata.kind === "subagent") {
+		if (isRetiring(descendant)) return true;
+		if (visited.has(descendant.activeSessionId)) return false;
+		visited.add(descendant.activeSessionId);
+		const { parentActiveSessionId, rlmChildId } = descendant.runtime.metadata;
+		if (!parentActiveSessionId || !rlmChildId) return false;
+		const parent = sessions.get(parentActiveSessionId);
+		if (!parent) return false;
+		if (parent.runtime.session.isRlmChildDeletionQuarantined(rlmChildId)) return true;
+		descendant = parent;
+	}
+	return false;
+}
+
+/** Whether this exact registry edge is privately quarantined by its resident parent. */
+export function isRlmChildVisibilityQuarantinedByParent(
+	parent: ActiveSessionState | undefined,
+	childId: string | undefined,
+): boolean {
+	return !!childId && !!parent?.runtime.session.isRlmChildDeletionQuarantined(childId);
+}
+
 export function buildRlmChildSnapshots(
 	rootActiveSessionId: string,
 	activeSessions: readonly ActiveSessionState[],
 ): AgentConnectionRlmChildAgentSnapshot[] {
+	const sessionByActiveId = new Map(activeSessions.map((session) => [session.activeSessionId, session]));
 	const childrenByParent = new Map<string, ActiveSessionState[]>();
 	for (const candidate of activeSessions) {
 		const metadata = candidate.runtime.metadata;
@@ -354,11 +384,7 @@ export function buildRlmChildSnapshots(
 	const visit = (parent: ActiveSessionState | undefined, parentActiveSessionId: string): void => {
 		const parentNodeId = parent?.runtime.metadata.rlmChildId;
 		for (const child of childrenByParent.get(parentActiveSessionId) ?? []) {
-			const childId = child.runtime.metadata.rlmChildId;
-			// A precommit release failure retains a resident runtime only for exact
-			// tombstone-and-close retry. It is not a public child, and neither are any
-			// descendants reachable solely through that private runtime.
-			if (childId && parent?.runtime.session.isRlmChildDeletionQuarantined(childId)) continue;
+			if (isRlmSubagentVisibilityQuarantined(child, sessionByActiveId)) continue;
 			snapshots.push(rlmChildSnapshotForActiveSession(child, child.runtime.metadata, parentNodeId, parent));
 			// A child passes its own node id to its children as their parent id.
 			visit(child, child.activeSessionId);

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -151,6 +151,24 @@ describe("AgentSession concurrent prompt guard", () => {
 		expect(disposed).toBe(true);
 	});
 
+	it("retries disposeAsync after a one-shot teardown failure", async () => {
+		createSession();
+		const internals = session as unknown as {
+			_disposeAsyncOnce: () => Promise<void>;
+		};
+		const disposeOnce = vi
+			.spyOn(internals, "_disposeAsyncOnce")
+			.mockRejectedValueOnce(new Error("one-shot dispose failure"))
+			.mockImplementationOnce(async () => session.dispose());
+
+		const first = session.disposeAsync();
+		const concurrent = session.disposeAsync();
+		await expect(first).rejects.toThrow("one-shot dispose failure");
+		await expect(concurrent).rejects.toThrow("one-shot dispose failure");
+		await expect(session.disposeAsync()).resolves.toBeUndefined();
+		expect(disposeOnce).toHaveBeenCalledTimes(2);
+	});
+
 	it("awaits dispose callbacks when synchronous disposal wins during the refinement drain", async () => {
 		createSession();
 		let releaseDrain: () => void = () => {};

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2699,24 +2699,45 @@ describe("AgentSession rlm recursion", () => {
 	it("keeps failed closure retryable without hanging or late resurrection", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "retry-child") });
 		child.setSessionName("release-worker");
-		let attempts = 0;
+		const childId = "retry-child";
+		const suppliedSessions: Array<AgentSession | undefined> = [];
+		const authorities: Array<{ sessionFile?: string; sessionId?: string }> = [];
+		let tombstones = 0;
+		let schedulerAttempts = 0;
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
-				deleteRlmSubagentRuntime: async (_id, session) => {
-					if (++attempts === 1) throw new RlmSubagentHostDeletionError("tombstoned", new Error("close failed"));
-					await session?.disposeAsync();
+				deleteRlmSubagentRuntime: async (_id, suppliedSession, authority) => {
+					suppliedSessions.push(suppliedSession);
+					authorities.push({ sessionFile: authority?.sessionFile, sessionId: authority?.sessionId });
+					if (tombstones === 0) tombstones++;
+					if (++schedulerAttempts === 1) {
+						throw new RlmSubagentHostDeletionError("tombstoned", new Error("close failed"));
+					}
+					await suppliedSession?.disposeAsync();
+					return { deletionDurability: "tombstoned" };
 				},
 			},
 		});
-		expect(root.registerRlmChildSession("retry-child", child)).toBe(true);
+		expect(root.registerRlmChildSession(childId, child)).toBe(true);
 		await expect(root.deleteRlmSubagent("release-worker")).rejects.toThrow("close failed");
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
-		expect((root as unknown as InspectableRlmSession)._rlmChildCleanupFailures.size).toBe(1);
+		const internals = root as unknown as InspectableRlmSession;
+		expect(internals._rlmChildCleanupFailures.size).toBe(1);
+		expect(internals._rlmChildSessions.get(childId)).toBe(child);
+
 		await expect(root.deleteRlmSubagent("release-worker")).resolves.toMatchObject({
-			subagent: { rlm_child_id: "retry-child" },
+			subagent: { rlm_child_id: childId },
 		});
-		expect((root as unknown as InspectableRlmSession)._rlmChildCleanupFailures.size).toBe(0);
+		expect(suppliedSessions).toEqual([child, child]);
+		expect(authorities).toEqual([
+			{ sessionFile: child.sessionFile, sessionId: child.sessionId },
+			{ sessionFile: child.sessionFile, sessionId: child.sessionId },
+		]);
+		expect(tombstones).toBe(1);
+		expect(schedulerAttempts).toBe(2);
+		expect(internals._rlmChildSessions.has(childId)).toBe(false);
+		expect(internals._rlmChildCleanupFailures.size).toBe(0);
 	});
 
 	it("does not restore failed delete retry state after parent teardown", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -138,6 +138,7 @@ interface InspectableRlmSession {
 		string,
 		Awaited<ReturnType<AgentSession["listRlmSubagents"]>>["subagents"][number]
 	>;
+	_deletedRlmChildIds: Set<string>;
 	_rlmChildSessions: Map<string, AgentSession>;
 	_rlmChildUnsubscribes: Map<string, () => void>;
 	_createKernelHostHandlers(): HostRequestHandlers;
@@ -3123,16 +3124,76 @@ describe("AgentSession rlm recursion", () => {
 		await expect(root.deleteRlmSubagent("revoked during late publication")).rejects.toThrow(
 			'No direct RLM subagent matches "revoked during late publication"',
 		);
-		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
-			subagent: { rlm_child_id: quarantinedChildId },
-		});
+		await expect(root.deleteRlmSubagent(quarantinedChildId)).rejects.toThrow(
+			"RLM subagent deletion durability is still unknown",
+		);
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
+		expect(internals._deletedRlmChildIds.has(quarantinedChildId)).toBe(false);
 		retryDurability = "absent";
 		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
 			subagent: { rlm_child_id: quarantinedChildId },
 		});
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
+	});
+
+	it("rejects a quarantine retry revoked after host durability resolves without mutating", async () => {
+		const admissionController = new AbortController();
+		const child = createSession();
+		let resolveStarted: () => void = () => {};
+		const resolutionStarted = new Promise<void>((resolve) => {
+			resolveStarted = resolve;
+		});
+		let releaseResolution: () => void = () => {};
+		const resolutionGate = new Promise<void>((resolve) => {
+			releaseResolution = resolve;
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async (options) => {
+					admissionController.abort();
+					options.onSessionPublished?.(child);
+					return { session: child };
+				},
+				releaseRlmSubagentRuntime: async (runtime) => {
+					await runtime.session.disposeAsync();
+					return { deletionDurability: "unknown" };
+				},
+				resolveRlmSubagentDeletion: async () => {
+					resolveStarted();
+					await resolutionGate;
+					return "absent";
+				},
+				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+			},
+		});
+
+		await expect(
+			root.runRlmChild("late-revoked quarantine retry", {}, undefined, { signal: admissionController.signal }),
+		).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._rlmChildDeletionQuarantines.size === 1);
+		const childId = [...internals._rlmChildDeletionQuarantines.keys()][0];
+		if (!childId) throw new Error("Missing deletion quarantine");
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		const retryController = new AbortController();
+		const retry = root.deleteRlmSubagent(childId, retryController.signal);
+		await resolutionStarted;
+		retryController.abort();
+		releaseResolution();
+
+		await expect(retry).rejects.toThrow("host request authority was revoked");
+		expect(internals._rlmChildDeletionQuarantines.has(childId)).toBe(true);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(false);
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length).toBe(1);
+
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: childId },
+		});
+		expect(internals._rlmChildDeletionQuarantines.has(childId)).toBe(false);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(true);
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length).toBe(0);
 	});
 
 	it("retains a host-owned runtime dir when revoked-spawn release is tombstoned", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -259,6 +259,7 @@ describe("AgentSession rlm recursion", () => {
 	});
 
 	afterEach(() => {
+		vi.unstubAllEnvs();
 		session?.dispose();
 		session = undefined;
 		rmSync(tempDir, { recursive: true, force: true });
@@ -3619,6 +3620,7 @@ describe("AgentSession RLM session dir", () => {
 	});
 
 	afterEach(() => {
+		vi.unstubAllEnvs();
 		session?.dispose();
 		session = undefined;
 		rmSync(tempDir, { recursive: true, force: true });

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3315,7 +3315,7 @@ describe("AgentSession rlm recursion", () => {
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		let releaseAttempts = 0;
-		const deleteRuntime = vi.fn(async (childId: string, session?: AgentSession, authority) => {
+		const deleteRuntime = vi.fn(async (childId: string, session: AgentSession | undefined, authority) => {
 			expect(authority).toMatchObject({
 				childId,
 				sessionFile: child.sessionFile,

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3036,6 +3036,59 @@ describe("AgentSession rlm recursion", () => {
 		}
 	});
 
+	it("does not delete a subagent after rlm.delete_subagent authority is revoked", async () => {
+		const childId = "revoked-delete-child";
+		const childDir = join(tempDir, childId);
+		mkdirSync(childDir, { recursive: true });
+		const child = createSession({ rlmSessionDir: childDir });
+		child.setSessionName("revoked-delete-worker");
+		const disposeChild = vi.spyOn(child, "disposeAsync");
+		let listingStarted: () => void = () => {};
+		const listingStartedGate = new Promise<void>((resolve) => {
+			listingStarted = resolve;
+		});
+		let releaseListing: () => void = () => {};
+		const listingGate = new Promise<void>((resolve) => {
+			releaseListing = resolve;
+		});
+		const root = createSession({
+			agentMessageController: {
+				listAgents: async () => {
+					listingStarted();
+					await listingGate;
+					return { agents: [] };
+				},
+				sendAgentMessage: vi.fn(),
+			},
+		});
+		expect(root.registerRlmChildSession(childId, child)).toBe(true);
+
+		const replies: CapturedCommReply[] = [];
+		const manager = new KernelManager({
+			python: process.execPath,
+			hostHandlers: (root as unknown as InspectableRlmSession)._createKernelHostHandlers(),
+		});
+		try {
+			const kernel = manager as unknown as KernelCommTestApi;
+			kernel.sendCommMessage = async (commId, data) => {
+				replies.push({ commId, data });
+			};
+			kernel.handleCommMessage(
+				rlmCommOpenData("comm-delete-revoked", { type: "rlm.delete_subagent", target: "revoked-delete-worker" }),
+			);
+			await listingStartedGate;
+			kernel.handleCommMessage(rlmCommClose("comm-delete-revoked"));
+			releaseListing();
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(disposeChild).not.toHaveBeenCalled();
+			expect((await root.listRlmSubagents()).subagents).toMatchObject([{ rlm_child_id: childId }]);
+			expect(replies).toEqual([]);
+		} finally {
+			releaseListing();
+			await manager.dispose();
+		}
+	});
+
 	it("runs parallel rlm comm requests independently", async () => {
 		let active = 0;
 		let maxActive = 0;

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3310,14 +3310,19 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
-	it("retains a precommit late-admission release for an exact-id tombstone-and-close retry", async () => {
+	it("keeps a typed precommit release private until an exact retry tombstones and closes it", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		let releaseAttempts = 0;
-		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
+		const deleteRuntime = vi.fn(async (childId: string, session?: AgentSession, authority) => {
+			expect(authority).toMatchObject({
+				childId,
+				sessionFile: child.sessionFile,
+				sessionId: child.sessionId,
+			});
 			await session?.disposeAsync();
-			return { deletionDurability: "absent" as const };
+			return { deletionDurability: "tombstoned" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3355,6 +3360,7 @@ describe("AgentSession rlm recursion", () => {
 		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(internals._rlmChildSessions).toHaveLength(0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
 	it("rejects a quarantine retry revoked after host durability resolves without mutating", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3088,6 +3088,39 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toEqual([]);
 	});
 
+	it("does not return a spawn handle for a child cancelled between publication and admission", async () => {
+		const controller = new AbortController();
+		const child = createSession();
+		let root: AgentSession | undefined;
+		const runtimeHost: SubagentRuntimeHost = {
+			createRlmSubagentRuntime: async (options) => {
+				options.onSessionPublished?.(child);
+				// Cancel synchronously after publication resolves but before the awaiting
+				// admission continuation can run its checks.
+				const internals = root as unknown as InspectableRlmSession & {
+					_cancelRlmChildRun(run: InspectableRlmRun, reason: string): boolean;
+				};
+				const run = [...internals._activeRlmChildRuns.values()][0];
+				if (!run) throw new Error("Missing registered run");
+				internals._cancelRlmChildRun(run, "cancelled between publication and admission");
+				return { session: child };
+			},
+			deleteRlmSubagentRuntime: async (_childId, session) => {
+				await session?.disposeAsync();
+			},
+		};
+		root = createSession({ subagentRuntimeHost: runtimeHost });
+
+		const admission = root.runRlmChild("cancel during admission", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("cancelled between publication and admission");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
 	it("does not delete a subagent after rlm.delete_subagent authority is revoked", async () => {
 		const childId = "revoked-delete-child";
 		const childDir = join(tempDir, childId);

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -630,6 +630,7 @@ describe("AgentSession rlm recursion", () => {
 				throw new RlmSubagentHostDeletionError("tombstoned", new Error("retained close failed"));
 			}
 			await session.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		settingsManager.applyOverrides({ compaction: { keepRecentTokens: 1 } });
@@ -657,7 +658,11 @@ describe("AgentSession rlm recursion", () => {
 		root.sessionManager.appendMessage(assistantMessage("history response"));
 		expect(root.registerRlmChildSession(childId, child)).toBe(true);
 
-		await expect(root.deleteRlmSubagent("retained-retry-worker")).rejects.toThrow("retained close failed");
+		await expect(root.deleteRlmSubagent("retained-retry-worker")).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "tombstoned",
+			cause: expect.objectContaining({ message: "retained close failed" }),
+		});
 		const internals = root as unknown as InspectableRlmSession;
 		expect(internals._rlmChildCleanupFailures.size).toBe(1);
 
@@ -677,7 +682,7 @@ describe("AgentSession rlm recursion", () => {
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -817,7 +822,10 @@ describe("AgentSession rlm recursion", () => {
 					options.onSessionPublished?.(child);
 					return { session: child };
 				},
-				deleteRlmSubagentRuntime: async (_id, child) => child?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, child) => {
+					await child?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		const spawned = await root.runRlmChild("pending task", { name: "pending-child" });
@@ -874,7 +882,10 @@ describe("AgentSession rlm recursion", () => {
 			},
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
-				deleteRlmSubagentRuntime: async (_id, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		const promptInjectedMessage = vi.fn(async () => terminalInjectionGate);
@@ -920,7 +931,7 @@ describe("AgentSession rlm recursion", () => {
 			},
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: () => startupGate,
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 		const spawned = await root.runRlmChild("pending task", { name: "failing-child" });
@@ -971,7 +982,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => {
 					throw new Error("child startup failed");
 				},
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 		const promptInjectedMessage = vi.fn(async () => failureInjectionGate);
@@ -1024,7 +1035,10 @@ describe("AgentSession rlm recursion", () => {
 					await runtimeCreationGate;
 					return { session: hostedChild };
 				},
-				deleteRlmSubagentRuntime: async (_id, child) => child?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, child) => {
+					await child?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		await root.runRlmChild("blocked startup", { name: "deleted-child" });
@@ -1200,7 +1214,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => {
 					throw new Error("kernel startup failed");
 				},
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -1316,7 +1330,7 @@ describe("AgentSession rlm recursion", () => {
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -1347,7 +1361,10 @@ describe("AgentSession rlm recursion", () => {
 					await runtimeCreationGate;
 					return { session: child };
 				},
-				deleteRlmSubagentRuntime: async (_id, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 
@@ -1369,7 +1386,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => {
 					throw new Error("kernel startup failed");
 				},
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 		const spawned = await root.runRlmChild("start failing child", { name: "reusable-worker" });
@@ -1395,7 +1412,7 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				releaseRlmSubagentRuntime,
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -1405,6 +1422,7 @@ describe("AgentSession rlm recursion", () => {
 				expect.objectContaining({ session: child }),
 				expect.objectContaining({ id: spawned.rlm_child_id }),
 				"error",
+				expect.objectContaining({ childId: spawned.rlm_child_id }),
 			);
 		});
 	});
@@ -1416,7 +1434,10 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				completeRlmSubagentRuntime,
-				deleteRlmSubagentRuntime: async (_id, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 
@@ -1521,6 +1542,7 @@ describe("AgentSession rlm recursion", () => {
 					rlm_child_id: daemonChildId,
 					active_session_id: "child-active",
 					session_id: "child-session",
+					session_file: root.getRlmChildSession(daemonChildId)?.sessionFile,
 					session_name: expectedSessionName,
 					session_dir: result.session_dir,
 					status: "completed",
@@ -1564,7 +1586,7 @@ describe("AgentSession rlm recursion", () => {
 	});
 
 	it("lists passive daemon children using their nonresident registry outcomes", async () => {
-		const deleteRlmSubagentRuntime = vi.fn(async () => {});
+		const deleteRlmSubagentRuntime = vi.fn(async () => ({ deletionDurability: "absent" as const }));
 		const root = createSession({
 			agentMessageController: {
 				listAgents: () => ({
@@ -1633,7 +1655,7 @@ describe("AgentSession rlm recursion", () => {
 		const listingGate = new Promise<void>((resolve) => {
 			releaseListing = resolve;
 		});
-		const deleteRlmSubagentRuntime = vi.fn(async () => {});
+		const deleteRlmSubagentRuntime = vi.fn(async () => ({ deletionDurability: "absent" as const }));
 		const root = createSession({
 			agentMessageController: {
 				listAgents: async () => {
@@ -1779,6 +1801,7 @@ describe("AgentSession rlm recursion", () => {
 					rlm_child_id: rootRun.id,
 					active_session_id: "running-active",
 					session_id: rootRun.session.sessionId,
+					session_file: rootRun.session.sessionFile,
 					session_name: createDefaultRlmSubagentSessionName("slow shard", rootRun.id),
 					session_dir: rootRun.sessionDir,
 					status: "running",
@@ -2308,6 +2331,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				deleteRlmSubagentRuntime: async () => {
 					await child.disposeAsync();
+					return { deletionDurability: "absent" as const };
 				},
 			},
 		});
@@ -2418,7 +2442,7 @@ describe("AgentSession rlm recursion", () => {
 	it("reports a shared running outcome to concurrent inactive-delete callers", async () => {
 		let runningChecks = 0;
 		const isExternallyRunning = () => ++runningChecks >= 5;
-		const deleteRuntime = vi.fn(async () => {});
+		const deleteRuntime = vi.fn(async () => ({ deletionDurability: "absent" as const }));
 		const root = createSession({
 			agentMessageController: {
 				listAgents: () => ({
@@ -2474,7 +2498,7 @@ describe("AgentSession rlm recursion", () => {
 				return stream;
 			},
 		});
-		const deleteRuntime = vi.fn(async () => {});
+		const deleteRuntime = vi.fn(async () => ({ deletionDurability: "absent" as const }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: retainedChild }),
@@ -2515,7 +2539,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				completeRlmSubagentRuntime: () => false,
 				releaseRlmSubagentRuntime,
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 
@@ -2525,6 +2549,7 @@ describe("AgentSession rlm recursion", () => {
 				expect.objectContaining({ session: child }),
 				expect.objectContaining({ id: spawned.rlm_child_id }),
 				"error",
+				expect.objectContaining({ childId: spawned.rlm_child_id }),
 			);
 		});
 		expect(disposeChild).not.toHaveBeenCalled();
@@ -2561,6 +2586,7 @@ describe("AgentSession rlm recursion", () => {
 			await deleteGate;
 			authority.assertCurrent();
 			await childSession?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const releaseRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
 		const root = createSession({
@@ -2613,6 +2639,7 @@ describe("AgentSession rlm recursion", () => {
 			await deleteGate;
 			authority.assertCurrent();
 			await childSession?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const releaseRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
 		const root = createSession({
@@ -2676,13 +2703,18 @@ describe("AgentSession rlm recursion", () => {
 					if (++deleteAttempts === 1)
 						throw new RlmSubagentHostDeletionError("tombstoned", new Error("first close failed"));
 					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
 				},
 			},
 		});
 
 		await root.runRlmChild("slow retry shard", { name: "retry-worker" });
 		await waitFor(() => childStarted);
-		await expect(root.deleteRlmSubagent("retry-worker")).rejects.toThrow("first close failed");
+		await expect(root.deleteRlmSubagent("retry-worker")).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "tombstoned",
+			cause: expect.objectContaining({ message: "first close failed" }),
+		});
 		const internals = root as unknown as InspectableRlmSession;
 		expect(internals._rlmChildCleanupFailures.size).toBe(1);
 		releaseChild();
@@ -2812,7 +2844,10 @@ describe("AgentSession rlm recursion", () => {
 					await runtimeCreationGate;
 					return { session: hostedChild };
 				},
-				deleteRlmSubagentRuntime: async (_id, child) => child?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_id, child) => {
+					await child?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		await root.runRlmChild("blocked before runtime creation", { name: "reserved-worker" });
@@ -2840,6 +2875,7 @@ describe("AgentSession rlm recursion", () => {
 		const hostedChild = createSession();
 		const deleteRuntime = vi.fn(async () => {
 			await hostedChild.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -2881,6 +2917,7 @@ describe("AgentSession rlm recursion", () => {
 				throw new RlmSubagentHostDeletionError("tombstoned", new Error("fallback delete failed"));
 			}
 			await hostedChild.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const releaseRuntime = vi.fn(async () => {
 			throw new Error("cancelled release failed");
@@ -3185,6 +3222,7 @@ describe("AgentSession rlm recursion", () => {
 				createRlmSubagentRuntime: createRuntime,
 				deleteRlmSubagentRuntime: async (_childId, session) => {
 					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
 				},
 			},
 		});
@@ -3231,6 +3269,7 @@ describe("AgentSession rlm recursion", () => {
 			resolveRlmSubagentDeletion: async () => retryDurability,
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
+				return { deletionDurability: "absent" as const };
 			},
 		};
 		const root = createSession({ subagentRuntimeHost: runtimeHost });
@@ -3278,6 +3317,7 @@ describe("AgentSession rlm recursion", () => {
 		let releaseAttempts = 0;
 		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
 			await session?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3344,7 +3384,10 @@ describe("AgentSession rlm recursion", () => {
 					await resolutionGate;
 					return "absent";
 				},
-				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_childId, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 
@@ -3391,7 +3434,10 @@ describe("AgentSession rlm recursion", () => {
 					return { deletionDurability: "unknown" };
 				},
 				resolveRlmSubagentDeletion: async () => "tombstoned",
-				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_childId, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 
@@ -3427,7 +3473,10 @@ describe("AgentSession rlm recursion", () => {
 					await runtime.session.disposeAsync();
 					return { deletionDurability: "tombstoned" };
 				},
-				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+				deleteRlmSubagentRuntime: async (_childId, session) => {
+					await session?.disposeAsync();
+					return { deletionDurability: "absent" as const };
+				},
 			},
 		});
 		await expect(
@@ -3457,6 +3506,7 @@ describe("AgentSession rlm recursion", () => {
 			},
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
+				return { deletionDurability: "absent" as const };
 			},
 		};
 		const root = createSession({ subagentRuntimeHost: runtimeHost });
@@ -3528,6 +3578,7 @@ describe("AgentSession rlm recursion", () => {
 			},
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
+				return { deletionDurability: "absent" as const };
 			},
 		};
 		root = createSession({ subagentRuntimeHost: runtimeHost });
@@ -3613,6 +3664,7 @@ describe("AgentSession rlm recursion", () => {
 			if (authorities.length === 1) await firstGate;
 			authority.assertCurrent();
 			await childSession?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3650,6 +3702,7 @@ describe("AgentSession rlm recursion", () => {
 			await deleteGate;
 			authority?.assertCurrent();
 			await childSession?.disposeAsync();
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3115,10 +3115,18 @@ describe("AgentSession rlm recursion", () => {
 		if (!artifactDir) throw new Error("Missing session artifact dir");
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
 
-		await internals._reapDeletedRlmSubagentRuntimesAfterCompaction();
+		const quarantinedChildId = [...internals._rlmChildDeletionQuarantines.keys()][0];
+		if (!quarantinedChildId) throw new Error("Missing deletion quarantine");
+		// The exact opaque id can retry cleanup even though the lease is omitted from
+		// every product-facing list and cannot be selected by its name or session id.
+		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: quarantinedChildId },
+		});
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
 		retryDurability = "absent";
-		await internals._reapDeletedRlmSubagentRuntimesAfterCompaction();
+		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: quarantinedChildId },
+		});
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -29,6 +29,7 @@ import {
 	createDefaultRlmSubagentSessionName,
 	createRlmDeleteSubagentHostHandler,
 	createRlmRunHostHandler,
+	RlmSubagentHostDeletionError,
 	type SubagentRuntimeHost,
 } from "../src/core/rlm-runtime.js";
 import { SessionManager } from "../src/core/session-manager.js";
@@ -626,7 +627,7 @@ describe("AgentSession rlm recursion", () => {
 		const deleteRuntime = vi.fn(async (_childId: string, session: AgentSession) => {
 			deleteAttempts++;
 			if (deleteAttempts === 1) {
-				throw new Error("retained close failed");
+				throw new RlmSubagentHostDeletionError("tombstoned", new Error("retained close failed"));
 			}
 			await session.disposeAsync();
 		});
@@ -2569,7 +2570,7 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
 				deleteRlmSubagentRuntime: async (_id, session) => {
-					if (++deleteAttempts === 1) throw new Error("first close failed");
+					if (++deleteAttempts === 1) throw new RlmSubagentHostDeletionError("tombstoned", new Error("first close failed"));
 					await session?.disposeAsync();
 				},
 			},
@@ -2599,7 +2600,7 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
 				deleteRlmSubagentRuntime: async (_id, session) => {
-					if (++attempts === 1) throw new Error("close failed");
+					if (++attempts === 1) throw new RlmSubagentHostDeletionError("tombstoned", new Error("close failed"));
 					await session?.disposeAsync();
 				},
 			},
@@ -2752,7 +2753,7 @@ describe("AgentSession rlm recursion", () => {
 		const deleteRuntime = vi.fn(async () => {
 			deleteAttempts++;
 			if (deleteAttempts === 1) {
-				throw new Error("fallback delete failed");
+				throw new RlmSubagentHostDeletionError("tombstoned", new Error("fallback delete failed"));
 			}
 			await hostedChild.disposeAsync();
 		});

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3037,7 +3037,16 @@ describe("AgentSession rlm recursion", () => {
 	});
 
 	it("cleans up a queued run when a subscriber revokes authority on the first child update", async () => {
-		const root = createSession();
+		const child = createSession();
+		const createRuntime = vi.fn(async () => ({ session: child }));
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: createRuntime,
+				deleteRlmSubagentRuntime: async (_childId, session) => {
+					await session?.disposeAsync();
+				},
+			},
+		});
 		const controller = new AbortController();
 		root.subscribe((event) => {
 			if (event.type === "rlm_child_update" && event.child.status === "queued") {
@@ -3052,7 +3061,45 @@ describe("AgentSession rlm recursion", () => {
 		await expect(admission).rejects.toThrow("host request authority was revoked");
 		const internals = root as unknown as InspectableRlmSession;
 		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(createRuntime.mock.calls.length).toBe(0);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		await waitFor(() => readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length === 0);
+		await child.disposeAsync();
+	});
+
+	it("disposes an already-created runtime for a spawn revoked before admission", async () => {
+		const controller = new AbortController();
+		const child = createSession();
+		const disposeChild = vi.spyOn(child, "disposeAsync");
+		const runtimeHost: SubagentRuntimeHost = {
+			createRlmSubagentRuntime: async (options) => {
+				// Revoke while the runtime is being created, then publish late.
+				controller.abort();
+				options.onSessionPublished?.(child);
+				return { session: child };
+			},
+			deleteRlmSubagentRuntime: async (_childId, session) => {
+				await session?.disposeAsync();
+			},
+		};
+		const root = createSession({ subagentRuntimeHost: runtimeHost });
+
+		const admission = root.runRlmChild("revoked during late publication", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		await waitFor(() => disposeChild.mock.calls.length > 0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		await waitFor(() => readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length === 0);
 	});
 
 	it("cleans up a run when authority is already revoked at registration", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3036,6 +3036,58 @@ describe("AgentSession rlm recursion", () => {
 		}
 	});
 
+	it("cleans up a queued run when a subscriber revokes authority on the first child update", async () => {
+		const root = createSession();
+		const controller = new AbortController();
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update" && event.child.status === "queued") {
+				controller.abort();
+			}
+		});
+
+		const admission = root.runRlmChild("revoked by queued-update subscriber", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+	});
+
+	it("cleans up a run when authority is already revoked at registration", async () => {
+		const root = createSession();
+		const controller = new AbortController();
+		const internals = root as unknown as InspectableRlmSession & {
+			_findLastAssistantMessage(): unknown;
+		};
+		// Revoke in the last window before the run is registered; an abort listener
+		// attached to an already-aborted signal never fires.
+		const originalFind = internals._findLastAssistantMessage.bind(root);
+		vi.spyOn(internals, "_findLastAssistantMessage").mockImplementation(() => {
+			controller.abort();
+			return originalFind();
+		});
+		let sawQueuedUpdate = false;
+		root.subscribe((event) => {
+			if (event.type === "rlm_child_update" && event.child.status === "queued") {
+				sawQueuedUpdate = true;
+			}
+		});
+
+		const admission = root.runRlmChild("revoked before registration", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		expect(sawQueuedUpdate).toBe(false);
+		expect(internals._activeRlmChildRuns.size).toBe(0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toEqual([]);
+	});
+
 	it("does not delete a subagent after rlm.delete_subagent authority is revoked", async () => {
 		const childId = "revoked-delete-child";
 		const childDir = join(tempDir, childId);

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -134,6 +134,10 @@ interface InspectableRlmSession {
 		}
 	>;
 	_rlmChildCleanupFailures: Map<string, Awaited<ReturnType<AgentSession["listRlmSubagents"]>>["subagents"][number]>;
+	_rlmChildDeletionQuarantines: Map<
+		string,
+		Awaited<ReturnType<AgentSession["listRlmSubagents"]>>["subagents"][number]
+	>;
 	_rlmChildSessions: Map<string, AgentSession>;
 	_rlmChildUnsubscribes: Map<string, () => void>;
 	_createKernelHostHandlers(): HostRequestHandlers;
@@ -1383,7 +1387,7 @@ describe("AgentSession rlm recursion", () => {
 	it("releases a hosted child when its initial task fails", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "host-error-child") });
 		vi.spyOn(child, "promptAndWait").mockRejectedValue(new Error("child prompt failed"));
-		const releaseRlmSubagentRuntime = vi.fn(async () => ({ retained: false }));
+		const releaseRlmSubagentRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
@@ -2470,7 +2474,7 @@ describe("AgentSession rlm recursion", () => {
 				deleteRlmSubagentRuntime: deleteRuntime,
 				releaseRlmSubagentRuntime: async (runtime, options) => {
 					options.parentSession.registerRlmChildSession(options.id, runtime.session);
-					return { retained: true };
+					return { deletionDurability: "tombstoned" };
 				},
 			},
 		});
@@ -2494,7 +2498,7 @@ describe("AgentSession rlm recursion", () => {
 	it("releases a hosted child when completion persistence fails", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "host-completion-failure-child") });
 		const disposeChild = vi.spyOn(child, "disposeAsync");
-		const releaseRlmSubagentRuntime = vi.fn(async () => ({ retained: false }));
+		const releaseRlmSubagentRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
@@ -3071,25 +3075,24 @@ describe("AgentSession rlm recursion", () => {
 		await child.disposeAsync();
 	});
 
-	it("removes a host-owned runtime dir when release does not retain a revoked spawn", async () => {
+	it("quarantines unknown release durability through finalization and removes it only after a retry proves absence", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		const releaseStatuses: string[] = [];
+		let retryDurability: "unknown" | "absent" = "unknown";
 		const runtimeHost: SubagentRuntimeHost = {
 			createRlmSubagentRuntime: async (options) => {
-				// Revoke while the runtime is being created, then publish late.
 				controller.abort();
 				options.onSessionPublished?.(child);
 				return { session: child };
 			},
-			// A release hook may close a child even when its persistence failed. It
-			// explicitly declines retention, so the caller must clean the exact orphan.
 			releaseRlmSubagentRuntime: async (runtime, _options, status) => {
 				releaseStatuses.push(status);
 				await runtime.session.disposeAsync();
-				return { retained: false };
+				return { deletionDurability: "unknown" };
 			},
+			resolveRlmSubagentDeletion: async () => retryDurability,
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
 			},
@@ -3107,9 +3110,46 @@ describe("AgentSession rlm recursion", () => {
 		expect(releaseStatuses).toEqual(["cancelled"]);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
 		const artifactDir = root.sessionManager.getSessionArtifactDir();
 		if (!artifactDir) throw new Error("Missing session artifact dir");
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
+
+		await internals._reapDeletedRlmSubagentRuntimesAfterCompaction();
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
+		retryDurability = "absent";
+		await internals._reapDeletedRlmSubagentRuntimesAfterCompaction();
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
+	});
+
+	it("retains a host-owned runtime dir when revoked-spawn release is tombstoned", async () => {
+		const controller = new AbortController();
+		const child = createSession();
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async (options) => {
+					controller.abort();
+					options.onSessionPublished?.(child);
+					return { session: child };
+				},
+				releaseRlmSubagentRuntime: async (runtime) => {
+					await runtime.session.disposeAsync();
+					return { deletionDurability: "tombstoned" };
+				},
+				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+			},
+		});
+		await expect(
+			root.runRlmChild("tombstoned late publication", {}, undefined, { signal: controller.signal }),
+		).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 	});
 
 	it("removes a dispose-only host child's dir when a spawn is revoked before admission", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3250,6 +3250,52 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
+	it("retains a precommit late-admission release for an exact-id tombstone-and-close retry", async () => {
+		const controller = new AbortController();
+		const child = createSession();
+		const disposeChild = vi.spyOn(child, "disposeAsync");
+		let releaseAttempts = 0;
+		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
+			await session?.disposeAsync();
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async (options) => {
+					controller.abort();
+					options.onSessionPublished?.(child);
+					return { session: child };
+				},
+				releaseRlmSubagentRuntime: async () => {
+					releaseAttempts++;
+					throw new RlmSubagentHostDeletionError("precommit", new Error("registry write failed"));
+				},
+				resolveRlmSubagentDeletion: async () => "tombstoned",
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+
+		await expect(
+			root.runRlmChild("precommit late publication", {}, undefined, { signal: controller.signal }),
+		).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(releaseAttempts).toBe(1);
+		expect(disposeChild).not.toHaveBeenCalled();
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(1);
+		expect(internals._rlmChildSessions).toHaveLength(1);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		const childId = [...internals._rlmChildDeletionQuarantines.keys()][0];
+		if (!childId) throw new Error("Missing deletion quarantine");
+
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: childId },
+		});
+		expect(deleteRuntime).toHaveBeenCalledOnce();
+		expect(disposeChild).toHaveBeenCalledOnce();
+		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
+		expect(internals._rlmChildSessions).toHaveLength(0);
+	});
+
 	it("rejects a quarantine retry revoked after host durability resolves without mutating", async () => {
 		const admissionController = new AbortController();
 		const child = createSession();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3310,14 +3310,19 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
-	it("retains a precommit late-admission release for an exact-id tombstone-and-close retry", async () => {
+	it("keeps a typed precommit release private until an exact retry tombstones and closes it", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		let releaseAttempts = 0;
-		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
+		const deleteRuntime = vi.fn(async (childId: string, session: AgentSession | undefined, authority) => {
+			expect(authority).toMatchObject({
+				childId,
+				sessionFile: child.sessionFile,
+				sessionId: child.sessionId,
+			});
 			await session?.disposeAsync();
-			return { deletionDurability: "absent" as const };
+			return { deletionDurability: "tombstoned" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3355,6 +3360,7 @@ describe("AgentSession rlm recursion", () => {
 		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(internals._rlmChildSessions).toHaveLength(0);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
 	it("rejects a quarantine retry revoked after host durability resolves without mutating", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3310,19 +3310,14 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
-	it("keeps a typed precommit release private until an exact retry tombstones and closes it", async () => {
+	it("retains a precommit late-admission release for an exact-id tombstone-and-close retry", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
 		let releaseAttempts = 0;
-		const deleteRuntime = vi.fn(async (childId: string, session: AgentSession | undefined, authority) => {
-			expect(authority).toMatchObject({
-				childId,
-				sessionFile: child.sessionFile,
-				sessionId: child.sessionId,
-			});
+		const deleteRuntime = vi.fn(async (_childId: string, session?: AgentSession) => {
 			await session?.disposeAsync();
-			return { deletionDurability: "tombstoned" as const };
+			return { deletionDurability: "absent" as const };
 		});
 		const root = createSession({
 			subagentRuntimeHost: {
@@ -3360,7 +3355,6 @@ describe("AgentSession rlm recursion", () => {
 		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(internals._rlmChildDeletionQuarantines).toHaveLength(0);
 		expect(internals._rlmChildSessions).toHaveLength(0);
-		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 	});
 
 	it("rejects a quarantine retry revoked after host durability resolves without mutating", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3110,29 +3110,33 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
 	});
 
-	it("removes an in-process child's dir when a spawn is revoked before admission", async () => {
+	it("removes a dispose-only host child's dir when a spawn is revoked before admission", async () => {
 		const controller = new AbortController();
-		const root = createSession();
-		const internals = root as unknown as InspectableRlmSession & {
-			_createRlmSubagentRuntime(options: unknown): Promise<{ session: AgentSession }>;
+		const child = createSession();
+		const disposeChild = vi.spyOn(child, "disposeAsync");
+		// The default in-process AgentSessionRuntime self-host shape: no release
+		// hook, dispose-only deletion, no durable registry.
+		const runtimeHost: SubagentRuntimeHost = {
+			createRlmSubagentRuntime: async (options) => {
+				// Revoke while the runtime is being created, then publish late.
+				controller.abort();
+				options.onSessionPublished?.(child);
+				return { session: child };
+			},
+			deleteRlmSubagentRuntime: async (_childId, session) => {
+				await session?.disposeAsync();
+			},
 		};
-		const originalCreateRuntime = internals._createRlmSubagentRuntime.bind(root);
-		let disposeChild: ReturnType<typeof vi.spyOn> | undefined;
-		vi.spyOn(internals, "_createRlmSubagentRuntime").mockImplementation(async (options) => {
-			// Revoke while the inline runtime is being created, then publish late.
-			controller.abort();
-			const runtime = await originalCreateRuntime(options);
-			disposeChild = vi.spyOn(runtime.session, "disposeAsync");
-			return runtime;
-		});
+		const root = createSession({ subagentRuntimeHost: runtimeHost });
 
-		const admission = root.runRlmChild("revoked during inline creation", {}, undefined, {
+		const admission = root.runRlmChild("revoked under dispose-only host", {}, undefined, {
 			signal: controller.signal,
 		});
 
 		await expect(admission).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
 		await waitFor(() => internals._activeRlmChildRuns.size === 0);
-		await waitFor(() => (disposeChild?.mock.calls.length ?? 0) > 0);
+		await waitFor(() => disposeChild.mock.calls.length > 0);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
 		const artifactDir = root.sessionManager.getSessionArtifactDir();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2950,7 +2950,6 @@ describe("AgentSession rlm recursion", () => {
 
 		const admission = root.runRlmChild("revoked before admission", {}, undefined, {
 			signal: controller.signal,
-			isCurrent: () => !controller.signal.aborted,
 		});
 		await resolutionStartedGate;
 		controller.abort();
@@ -2983,7 +2982,6 @@ describe("AgentSession rlm recursion", () => {
 
 		const admission = root.runRlmChild("revoked during runtime admission", {}, undefined, {
 			signal: controller.signal,
-			isCurrent: () => !controller.signal.aborted,
 		});
 		await runtimeEnteredGate;
 		controller.abort();
@@ -3009,11 +3007,11 @@ describe("AgentSession rlm recursion", () => {
 		const manager = new KernelManager({
 			python: process.execPath,
 			hostHandlers: createTestHostHandlers({
-				"rlm.run": createRlmRunHostHandler(async ({ signal, isCurrent }) => {
+				"rlm.run": createRlmRunHostHandler(async ({ signal }) => {
 					handlerStarted();
 					await handlerGate;
-					sawAbortedSignal = signal.aborted && !isCurrent();
-					if (signal.aborted || !isCurrent()) throw new Error("host request authority was revoked");
+					sawAbortedSignal = signal.aborted;
+					if (signal.aborted) throw new Error("host request authority was revoked");
 					sideEffects++;
 					return { ok: true };
 				}),

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2532,6 +2532,99 @@ describe("AgentSession rlm recursion", () => {
 		expect(root.getRlmChildSession(spawned.rlm_child_id)).toBeUndefined();
 	});
 
+	it("routes completion-rejection finalization through the active deletion coordinator exactly once", async () => {
+		let finishChild!: () => void;
+		const finishGate = new Promise<void>((resolve) => {
+			finishChild = resolve;
+		});
+		const child = createSession({
+			rlmSessionDir: join(tempDir, "completion-race-child"),
+			streamFn: (_model, context) => {
+				const stream = createAssistantMessageEventStream();
+				void finishGate.then(() =>
+					stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${userText(context)}`) }),
+				);
+				return stream;
+			},
+		});
+		let releaseDelete!: () => void;
+		const deleteGate = new Promise<void>((resolve) => {
+			releaseDelete = resolve;
+		});
+		const deleteRuntime = vi.fn(async (_id: string, childSession: AgentSession | undefined, authority) => {
+			if (!authority) throw new Error("missing deletion authority");
+			authority.assertCurrent();
+			await deleteGate;
+			authority.assertCurrent();
+			await childSession?.disposeAsync();
+		});
+		const releaseRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				completeRlmSubagentRuntime: () => false,
+				releaseRlmSubagentRuntime: releaseRuntime,
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		const spawned = await root.runRlmChild("completion race", { name: "completion-race" });
+		const deletion = root.deleteRlmSubagent(spawned.rlm_child_id);
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+		finishChild();
+		await Promise.resolve();
+		releaseDelete();
+		await expect(deletion).resolves.toMatchObject({ subagent: { rlm_child_id: spawned.rlm_child_id } });
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(deleteRuntime).toHaveBeenCalledOnce();
+		expect(releaseRuntime).not.toHaveBeenCalled();
+	});
+
+	it("joins a close-failure finalizer to the explicit deletion coordinator exactly once", async () => {
+		let failChild!: () => void;
+		const failGate = new Promise<void>((resolve) => {
+			failChild = resolve;
+		});
+		const child = createSession({
+			rlmSessionDir: join(tempDir, "error-finalizer-race-child"),
+			streamFn: () => {
+				const stream = createAssistantMessageEventStream();
+				void failGate.then(() => stream.push({ type: "error", reason: "error", error: { ...assistantMessage("child failure"), stopReason: "error" } }));
+				return stream;
+			},
+		});
+		let releaseDelete!: () => void;
+		const deleteGate = new Promise<void>((resolve) => {
+			releaseDelete = resolve;
+		});
+		const deleteRuntime = vi.fn(async (_id: string, childSession: AgentSession | undefined, authority) => {
+			if (!authority) throw new Error("missing deletion authority");
+			authority.assertCurrent();
+			await deleteGate;
+			authority.assertCurrent();
+			await childSession?.disposeAsync();
+		});
+		const releaseRuntime = vi.fn(async () => ({ deletionDurability: "unknown" as const }));
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => ({ session: child }),
+				releaseRlmSubagentRuntime: releaseRuntime,
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		const spawned = await root.runRlmChild("error finalizer race", { name: "error-finalizer-race" });
+		const deletion = root.deleteRlmSubagent(spawned.rlm_child_id);
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+		failChild();
+		await Promise.resolve();
+		releaseDelete();
+		await expect(deletion).resolves.toMatchObject({ subagent: { rlm_child_id: spawned.rlm_child_id } });
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		expect(deleteRuntime).toHaveBeenCalledOnce();
+		expect(releaseRuntime).not.toHaveBeenCalled();
+	});
+
 	it("does not let completion retention resurrect a child being deleted", async () => {
 		const root = createSession();
 		const spawned = await root.runRlmChild("fast child", { name: "fast-worker" });

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3196,6 +3196,43 @@ describe("AgentSession rlm recursion", () => {
 		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length).toBe(0);
 	});
 
+	it("discharges a quarantined tombstone without removing its retained artifact", async () => {
+		const admissionController = new AbortController();
+		const child = createSession();
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async (options) => {
+					admissionController.abort();
+					options.onSessionPublished?.(child);
+					return { session: child };
+				},
+				releaseRlmSubagentRuntime: async (runtime) => {
+					await runtime.session.disposeAsync();
+					return { deletionDurability: "unknown" };
+				},
+				resolveRlmSubagentDeletion: async () => "tombstoned",
+				deleteRlmSubagentRuntime: async (_childId, session) => session?.disposeAsync(),
+			},
+		});
+
+		await expect(
+			root.runRlmChild("tombstone quarantine retry", {}, undefined, { signal: admissionController.signal }),
+		).rejects.toThrow("host request authority was revoked");
+		const internals = root as unknown as InspectableRlmSession;
+		await waitFor(() => internals._rlmChildDeletionQuarantines.size === 1);
+		const childId = [...internals._rlmChildDeletionQuarantines.keys()][0];
+		if (!childId) throw new Error("Missing deletion quarantine");
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+
+		await expect(root.deleteRlmSubagent(childId)).resolves.toMatchObject({
+			subagent: { rlm_child_id: childId },
+		});
+		expect(internals._rlmChildDeletionQuarantines.has(childId)).toBe(false);
+		expect(internals._deletedRlmChildIds.has(childId)).toBe(true);
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-")).length).toBe(1);
+	});
+
 	it("retains a host-owned runtime dir when revoked-spawn release is tombstoned", async () => {
 		const controller = new AbortController();
 		const child = createSession();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1619,7 +1619,11 @@ describe("AgentSession rlm recursion", () => {
 
 		expect(await root.listRlmSubagents()).toEqual({ subagents: expected });
 		await expect(root.deleteRlmSubagent("finished-worker")).resolves.toEqual({ subagent: expected[1] });
-		expect(deleteRlmSubagentRuntime).toHaveBeenCalledWith("finished-child", undefined);
+		expect(deleteRlmSubagentRuntime).toHaveBeenCalledWith(
+			"finished-child",
+			undefined,
+			expect.objectContaining({ childId: "finished-child", sessionDir: expected[1].session_dir }),
+		);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [expected[0]] });
 	});
 
@@ -2493,7 +2497,11 @@ describe("AgentSession rlm recursion", () => {
 			() => (root as unknown as InspectableRlmSession)._activeRlmChildRuns.get(childId)?.status !== "running",
 		);
 		await expect(root.deleteInactiveRlmSubagent(childId)).resolves.toBe("deleted");
-		expect(deleteRuntime).toHaveBeenCalledWith(childId, retainedChild);
+		expect(deleteRuntime).toHaveBeenCalledWith(
+			childId,
+			retainedChild,
+			expect.objectContaining({ childId, sessionDir: join(tempDir, "retained-child") }),
+		);
 		await expect(root.deleteInactiveRlmSubagent("unknown-child")).resolves.toBe("not_found");
 	});
 
@@ -3413,6 +3421,82 @@ describe("AgentSession rlm recursion", () => {
 			releaseListing();
 			await manager.dispose();
 		}
+	});
+
+	it("promotes a live deletion waiter after an aborted owner drains", async () => {
+		const childId = "promoted-delete-child";
+		const childDir = join(tempDir, childId);
+		mkdirSync(childDir, { recursive: true });
+		const child = createSession({ rlmSessionDir: childDir });
+		child.setSessionName("promoted-delete-worker");
+		let releaseFirst!: () => void;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const authorities: Array<{ generation: number }> = [];
+		const deleteRuntime = vi.fn(async (_id: string, childSession: AgentSession | undefined, authority) => {
+			if (!authority) throw new Error("missing deletion authority");
+			authorities.push(authority);
+			authority.assertCurrent();
+			if (authorities.length === 1) await firstGate;
+			authority.assertCurrent();
+			await childSession?.disposeAsync();
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected child creation");
+				},
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		expect(root.registerRlmChildSession(childId, child)).toBe(true);
+		const ownerController = new AbortController();
+		const owner = root.deleteRlmSubagent("promoted-delete-worker", ownerController.signal);
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+		const waiter = root.deleteRlmSubagent("promoted-delete-worker");
+		ownerController.abort();
+		await expect(owner).rejects.toThrow("host request authority was revoked");
+		releaseFirst();
+		await expect(waiter).resolves.toMatchObject({ subagent: { rlm_child_id: childId } });
+		expect(authorities).toHaveLength(2);
+		expect(authorities[1]?.generation).toBeGreaterThan(authorities[0]?.generation ?? Infinity);
+	});
+
+	it("keeps a live deletion owner authoritative when only its waiter aborts", async () => {
+		const childId = "caller-local-delete-child";
+		const childDir = join(tempDir, childId);
+		mkdirSync(childDir, { recursive: true });
+		const child = createSession({ rlmSessionDir: childDir });
+		child.setSessionName("caller-local-delete-worker");
+		let releaseDelete!: () => void;
+		const deleteGate = new Promise<void>((resolve) => {
+			releaseDelete = resolve;
+		});
+		const deleteRuntime = vi.fn(async (_id: string, childSession: AgentSession | undefined, authority) => {
+			authority?.assertCurrent();
+			await deleteGate;
+			authority?.assertCurrent();
+			await childSession?.disposeAsync();
+		});
+		const root = createSession({
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("unexpected child creation");
+				},
+				deleteRlmSubagentRuntime: deleteRuntime,
+			},
+		});
+		expect(root.registerRlmChildSession(childId, child)).toBe(true);
+		const owner = root.deleteRlmSubagent("caller-local-delete-worker");
+		await waitFor(() => deleteRuntime.mock.calls.length === 1);
+		const waiterController = new AbortController();
+		const waiter = root.deleteRlmSubagent("caller-local-delete-worker", waiterController.signal);
+		waiterController.abort();
+		await expect(waiter).rejects.toThrow("host request authority was revoked");
+		releaseDelete();
+		await expect(owner).resolves.toMatchObject({ subagent: { rlm_child_id: childId } });
+		expect(deleteRuntime).toHaveBeenCalledOnce();
 	});
 
 	it("runs parallel rlm comm requests independently", async () => {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3070,16 +3070,23 @@ describe("AgentSession rlm recursion", () => {
 		await child.disposeAsync();
 	});
 
-	it("disposes an already-created runtime for a spawn revoked before admission", async () => {
+	it("keeps a host-owned runtime's dir when a spawn is revoked before admission", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
+		const releaseStatuses: string[] = [];
 		const runtimeHost: SubagentRuntimeHost = {
 			createRlmSubagentRuntime: async (options) => {
 				// Revoke while the runtime is being created, then publish late.
 				controller.abort();
 				options.onSessionPublished?.(child);
 				return { session: child };
+			},
+			// Daemon-like release: record the deletion durably and close the session;
+			// the artifact tree stays on disk per the daemon persistence contract.
+			releaseRlmSubagentRuntime: async (runtime, _options, status) => {
+				releaseStatuses.push(status);
+				await runtime.session.disposeAsync();
 			},
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
@@ -3095,6 +3102,37 @@ describe("AgentSession rlm recursion", () => {
 		const internals = root as unknown as InspectableRlmSession;
 		await waitFor(() => internals._activeRlmChildRuns.size === 0);
 		await waitFor(() => disposeChild.mock.calls.length > 0);
+		expect(releaseStatuses).toEqual(["cancelled"]);
+		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
+		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
+		const artifactDir = root.sessionManager.getSessionArtifactDir();
+		if (!artifactDir) throw new Error("Missing session artifact dir");
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
+	});
+
+	it("removes an in-process child's dir when a spawn is revoked before admission", async () => {
+		const controller = new AbortController();
+		const root = createSession();
+		const internals = root as unknown as InspectableRlmSession & {
+			_createRlmSubagentRuntime(options: unknown): Promise<{ session: AgentSession }>;
+		};
+		const originalCreateRuntime = internals._createRlmSubagentRuntime.bind(root);
+		let disposeChild: ReturnType<typeof vi.spyOn> | undefined;
+		vi.spyOn(internals, "_createRlmSubagentRuntime").mockImplementation(async (options) => {
+			// Revoke while the inline runtime is being created, then publish late.
+			controller.abort();
+			const runtime = await originalCreateRuntime(options);
+			disposeChild = vi.spyOn(runtime.session, "disposeAsync");
+			return runtime;
+		});
+
+		const admission = root.runRlmChild("revoked during inline creation", {}, undefined, {
+			signal: controller.signal,
+		});
+
+		await expect(admission).rejects.toThrow("host request authority was revoked");
+		await waitFor(() => internals._activeRlmChildRuns.size === 0);
+		await waitFor(() => (disposeChild?.mock.calls.length ?? 0) > 0);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
 		const artifactDir = root.sessionManager.getSessionArtifactDir();

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3120,6 +3120,9 @@ describe("AgentSession rlm recursion", () => {
 		if (!quarantinedChildId) throw new Error("Missing deletion quarantine");
 		// The exact opaque id can retry cleanup even though the lease is omitted from
 		// every product-facing list and cannot be selected by its name or session id.
+		await expect(root.deleteRlmSubagent("revoked during late publication")).rejects.toThrow(
+			'No direct RLM subagent matches "revoked during late publication"',
+		);
 		await expect(root.deleteRlmSubagent(quarantinedChildId)).resolves.toMatchObject({
 			subagent: { rlm_child_id: quarantinedChildId },
 		});

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2542,7 +2542,11 @@ describe("AgentSession rlm recursion", () => {
 			streamFn: (_model, context) => {
 				const stream = createAssistantMessageEventStream();
 				void finishGate.then(() =>
-					stream.push({ type: "done", reason: "stop", message: assistantMessage(`child answer: ${userText(context)}`) }),
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: assistantMessage(`child answer: ${userText(context)}`),
+					}),
 				);
 				return stream;
 			},
@@ -2589,7 +2593,13 @@ describe("AgentSession rlm recursion", () => {
 			rlmSessionDir: join(tempDir, "error-finalizer-race-child"),
 			streamFn: () => {
 				const stream = createAssistantMessageEventStream();
-				void failGate.then(() => stream.push({ type: "error", reason: "error", error: { ...assistantMessage("child failure"), stopReason: "error" } }));
+				void failGate.then(() =>
+					stream.push({
+						type: "error",
+						reason: "error",
+						error: { ...assistantMessage("child failure"), stopReason: "error" },
+					}),
+				);
 				return stream;
 			},
 		});
@@ -2663,7 +2673,8 @@ describe("AgentSession rlm recursion", () => {
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: hostedChild }),
 				deleteRlmSubagentRuntime: async (_id, session) => {
-					if (++deleteAttempts === 1) throw new RlmSubagentHostDeletionError("tombstoned", new Error("first close failed"));
+					if (++deleteAttempts === 1)
+						throw new RlmSubagentHostDeletionError("tombstoned", new Error("first close failed"));
 					await session?.disposeAsync();
 				},
 			},

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1383,7 +1383,7 @@ describe("AgentSession rlm recursion", () => {
 	it("releases a hosted child when its initial task fails", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "host-error-child") });
 		vi.spyOn(child, "promptAndWait").mockRejectedValue(new Error("child prompt failed"));
-		const releaseRlmSubagentRuntime = vi.fn(async () => {});
+		const releaseRlmSubagentRuntime = vi.fn(async () => ({ retained: false }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
@@ -2470,6 +2470,7 @@ describe("AgentSession rlm recursion", () => {
 				deleteRlmSubagentRuntime: deleteRuntime,
 				releaseRlmSubagentRuntime: async (runtime, options) => {
 					options.parentSession.registerRlmChildSession(options.id, runtime.session);
+					return { retained: true };
 				},
 			},
 		});
@@ -2493,7 +2494,7 @@ describe("AgentSession rlm recursion", () => {
 	it("releases a hosted child when completion persistence fails", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "host-completion-failure-child") });
 		const disposeChild = vi.spyOn(child, "disposeAsync");
-		const releaseRlmSubagentRuntime = vi.fn(async () => {});
+		const releaseRlmSubagentRuntime = vi.fn(async () => ({ retained: false }));
 		const root = createSession({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child }),
@@ -3070,7 +3071,7 @@ describe("AgentSession rlm recursion", () => {
 		await child.disposeAsync();
 	});
 
-	it("keeps a host-owned runtime's dir when a spawn is revoked before admission", async () => {
+	it("removes a host-owned runtime dir when release does not retain a revoked spawn", async () => {
 		const controller = new AbortController();
 		const child = createSession();
 		const disposeChild = vi.spyOn(child, "disposeAsync");
@@ -3082,11 +3083,12 @@ describe("AgentSession rlm recursion", () => {
 				options.onSessionPublished?.(child);
 				return { session: child };
 			},
-			// Daemon-like release: record the deletion durably and close the session;
-			// the artifact tree stays on disk per the daemon persistence contract.
+			// A release hook may close a child even when its persistence failed. It
+			// explicitly declines retention, so the caller must clean the exact orphan.
 			releaseRlmSubagentRuntime: async (runtime, _options, status) => {
 				releaseStatuses.push(status);
 				await runtime.session.disposeAsync();
+				return { retained: false };
 			},
 			deleteRlmSubagentRuntime: async (_childId, session) => {
 				await session?.disposeAsync();
@@ -3101,13 +3103,13 @@ describe("AgentSession rlm recursion", () => {
 		await expect(admission).rejects.toThrow("host request authority was revoked");
 		const internals = root as unknown as InspectableRlmSession;
 		await waitFor(() => internals._activeRlmChildRuns.size === 0);
-		await waitFor(() => disposeChild.mock.calls.length > 0);
+		expect(disposeChild).toHaveBeenCalledOnce();
 		expect(releaseStatuses).toEqual(["cancelled"]);
 		expect(await root.listRlmSubagents()).toEqual({ subagents: [] });
 		expect(root.messages.filter((message) => message.role === "custom")).toEqual([]);
 		const artifactDir = root.sessionManager.getSessionArtifactDir();
 		if (!artifactDir) throw new Error("Missing session artifact dir");
-		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(1);
+		expect(readdirSync(artifactDir).filter((name) => name.startsWith("sub-"))).toHaveLength(0);
 	});
 
 	it("removes a dispose-only host child's dir when a spawn is revoked before admission", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -699,7 +699,7 @@ describe("daemon mode helpers", () => {
 				{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
 				"cancelled",
 			);
-		expect(recordDeletion).toHaveBeenCalledWith(parentState, "child-1");
+		expect(recordDeletion).toHaveBeenCalledWith(parentState, "child-1", undefined, childState.runtime.session);
 		expect(recordDeletion.mock.invocationCallOrder[0]).toBeLessThan(closeSession.mock.invocationCallOrder[1]!);
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
@@ -1119,7 +1119,13 @@ describe("daemon mode helpers", () => {
 				recordRlmSubagentDeletion(
 					parentState: ActiveSessionState,
 					childId: string,
-					authority?: { assertCurrent(): void },
+					authority?: {
+						childId?: string;
+						sessionDir?: string;
+						sessionFile?: string;
+						sessionId?: string;
+						assertCurrent(): void;
+					},
 				): Promise<"absent" | "tombstoned" | "unknown">;
 			};
 			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
@@ -1267,12 +1273,18 @@ describe("daemon mode helpers", () => {
 					.deleteRlmSubagentRuntime(before.childId, beforeChild.runtime.session, {
 						childId: before.childId,
 						sessionDir: before.childSessionDir,
+						sessionFile: before.childSessionFile,
+						sessionId: beforeChild.runtime.session.sessionId,
 						generation: 1,
 						assertCurrent: () => {
 							if (++beforeBoundaryChecks === 2) throw revokedBeforeAppend;
 						},
 					}),
-			).rejects.toBe(revokedBeforeAppend);
+			).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
+				cause: revokedBeforeAppend,
+			});
 			expect(readFileSync(beforeRegistryPath, "utf8")).toBe(beforeRegistry);
 			expect(beforeInternals.sessions.get(beforeChild.activeSessionId)).toBe(beforeChild);
 
@@ -1301,6 +1313,8 @@ describe("daemon mode helpers", () => {
 					.deleteRlmSubagentRuntime(after.childId, afterChild.runtime.session, {
 						childId: after.childId,
 						sessionDir: after.childSessionDir,
+						sessionFile: after.childSessionFile,
+						sessionId: afterChild.runtime.session.sessionId,
 						generation: 1,
 						assertCurrent: () => {
 							if (afterAbort.signal.aborted) throw new Error("host request authority was revoked");
@@ -1627,7 +1641,7 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("closes the exact parent-scoped daemon runtime when a retained subagent is deleted", async () => {
+	it("rejects stale or missing daemon runtime objects without destructive authority", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -1637,9 +1651,7 @@ describe("daemon mode helpers", () => {
 		const parentState = makeState("parent");
 		parentState.runtime = {
 			...parentState.runtime,
-			session: {
-				sessionManager: { getSessionArtifactDir: () => undefined },
-			},
+			session: { sessionManager: { getSessionArtifactDir: () => undefined } },
 		} as ActiveSessionState["runtime"];
 		const childState = makeState("child", parentState.activeSessionId);
 		const foreignChildState = makeState("foreign-child", "other-parent");
@@ -1663,31 +1675,32 @@ describe("daemon mode helpers", () => {
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
 			closeSession: typeof closeSession;
-			createSubagentRuntimeHost(parent: ActiveSessionState): {
-				deleteRlmSubagentRuntime(childId: string, session: ActiveSessionState["runtime"]["session"]): Promise<void>;
-			};
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
 		};
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.sessions.set(foreignChildState.activeSessionId, foreignChildState);
 		internals.closeSession = closeSession;
-
+		const host = internals.createSubagentRuntimeHost(parentState);
 		const staleParentReference = {
 			disposeAsync: vi.fn(async () => {}),
 		} as unknown as ActiveSessionState["runtime"]["session"];
-		const host = internals.createSubagentRuntimeHost(parentState);
-		await host.deleteRlmSubagentRuntime("child-1", staleParentReference);
 
-		expect(closeSession).toHaveBeenCalledOnce();
-		expect(closeSession).toHaveBeenCalledWith(childState, "killed", false);
-		expect(closeSession).not.toHaveBeenCalledWith(foreignChildState, expect.anything());
+		await expect(host.deleteRlmSubagentRuntime("child-1", staleParentReference)).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "precommit",
+		});
+		expect(closeSession).not.toHaveBeenCalled();
 		expect(childSession.disposeAsync).not.toHaveBeenCalled();
-		expect(staleParentReference.disposeAsync).toHaveBeenCalledOnce();
+		expect(staleParentReference.disposeAsync).not.toHaveBeenCalled();
 
 		const missingSession = {
 			disposeAsync: vi.fn(async () => {}),
 		} as unknown as ActiveSessionState["runtime"]["session"];
-		await host.deleteRlmSubagentRuntime("missing-child", missingSession);
-		expect(missingSession.disposeAsync).toHaveBeenCalledOnce();
+		await expect(host.deleteRlmSubagentRuntime("missing-child", missingSession)).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "precommit",
+		});
+		expect(missingSession.disposeAsync).not.toHaveBeenCalled();
 	});
 
 	it("cancels child jobs when deletion joins an in-flight passivation close", async () => {
@@ -7826,13 +7839,23 @@ describe("daemon mode helpers", () => {
 			};
 			parentSession.deleteInactiveRlmSubagent = async (childId) => {
 				if (childId !== fixture.childId) return "not_found";
+				const persisted = JSON.parse(
+					readFileSync(join(fixture.parentArtifactDir, "rlm-subagents.jsonl"), "utf8"),
+				) as { sessionId: string };
 				await (
 					fixture.daemon as unknown as {
 						createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
 					}
 				)
 					.createSubagentRuntimeHost(parentState)
-					.deleteRlmSubagentRuntime(childId);
+					.deleteRlmSubagentRuntime(childId, undefined, {
+						childId,
+						sessionDir: fixture.childSessionDir,
+						sessionFile: fixture.childSessionFile,
+						sessionId: persisted.sessionId,
+						generation: 1,
+						assertCurrent: () => {},
+					});
 				return "deleted";
 			};
 			const client = makeClient("client-1", parentState.activeSessionId);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1016,6 +1016,66 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("fails closed for incomplete or passive deletion and upgrades only an exact resident legacy row", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-resident-deletion-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				recordRlmSubagentDeletion(
+					parentState: ActiveSessionState,
+					childId: string,
+					authority?: { assertCurrent(): void; childId?: string; sessionDir?: string },
+					residentSession?: ActiveSessionState["runtime"]["session"],
+				): Promise<"absent" | "tombstoned" | "unknown">;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const modern = readFileSync(registryPath, "utf8");
+
+			// A coordinator-shaped request that omits either incarnation fence must
+			// not use a matching resident object as a fallback authorization.
+			await expect(
+				internals.recordRlmSubagentDeletion(
+					parent,
+					fixture.childId,
+					{
+						childId: fixture.childId,
+						sessionDir: fixture.childSessionDir,
+						assertCurrent: () => {},
+					},
+					child.runtime.session,
+				),
+			).resolves.toBe("unknown");
+			expect(readFileSync(registryPath, "utf8")).toBe(modern);
+
+			// A passive authority-free request has no incarnation proof and cannot
+			// turn a valid current registry record into a destructive append.
+			await expect(internals.recordRlmSubagentDeletion(parent, fixture.childId)).resolves.toBe("unknown");
+			expect(readFileSync(registryPath, "utf8")).toBe(modern);
+
+			const legacy = JSON.parse(modern) as Record<string, unknown>;
+			delete legacy.sessionId;
+			writeFileSync(registryPath, `${JSON.stringify(legacy)}\n`);
+			await expect(
+				internals.recordRlmSubagentDeletion(parent, fixture.childId, undefined, child.runtime.session),
+			).resolves.toBe("tombstoned");
+			const entries = readFileSync(registryPath, "utf8")
+				.trim()
+				.split(/\r?\n/u)
+				.map((line) => JSON.parse(line) as Record<string, unknown>);
+			expect(entries).toHaveLength(2);
+			expect(entries[1]).toMatchObject({
+				childId: fixture.childId,
+				status: "deleted",
+				sessionId: child.runtime.session.sessionId,
+			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("rechecks retry authority before appending a daemon deletion tombstone", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-deletion-authority-"));
 		try {
@@ -1061,7 +1121,7 @@ describe("daemon mode helpers", () => {
 					sessionDir: "/tmp/unknown",
 					assertCurrent: () => {},
 				}),
-			).resolves.toBe("absent");
+			).resolves.toBe("unknown");
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -720,6 +720,99 @@ describe("daemon mode helpers", () => {
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
 
+	it("reports durable retention only for actual daemon deletion tombstones", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-release-ownership-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createRlmSubagentRuntime(
+					parentState: ActiveSessionState,
+					options: CreateRlmSubagentRuntimeOptions,
+				): Promise<ActiveSessionState["runtime"]>;
+				createSubagentRuntimeHost(parentState: ActiveSessionState): SubagentRuntimeHost;
+				appendRlmSubagentRegistryEntry(parentState: ActiveSessionState, entry: { status: string }): boolean;
+			};
+			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			Object.assign(parentState.runtime.session, {
+				isSessionActive: false,
+				isStreaming: false,
+				isCompacting: false,
+				isBashRunning: false,
+				state: { pendingToolCalls: new Set(), streamingMessage: undefined },
+				thinkingLevel: "off",
+				hasRunningRlmChildren: () => false,
+				getSessionActionSnapshot: () => ({ queuedCount: 0, steering: [], followUps: [] }),
+			});
+			const optionsFor = (id: string): CreateRlmSubagentRuntimeOptions => ({
+				parentSession: parentState.runtime.session,
+				id,
+				prompt: `release ${id}`,
+				sessionName: id,
+				sessionDir: join(fixture.parentArtifactDir, id),
+				model: { provider: "test", id: "model" } as Model<Api>,
+				thinkingLevel: "off",
+				serviceTier: null,
+				scopedModels: [],
+				activeToolNames: [],
+				customTools: [],
+				includeGoals: false,
+				includeCompactSkill: false,
+				rlmDepth: 1,
+				rlmMaxDepth: 4,
+				rlmParentNodeId: id,
+			});
+			const host = internals.createSubagentRuntimeHost(parentState);
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+
+			// A real resident child with its row removed has no durable owner. The host
+			// still closes it, and explicitly returns retained:false.
+			const noRowOptions = optionsFor("release-no-row");
+			const noRowRuntime = await internals.createRlmSubagentRuntime(parentState, noRowOptions);
+			writeFileSync(
+				registryPath,
+				`${readFileSync(registryPath, "utf8")
+					.split("\n")
+					.filter((line) => !line.includes('"childId":"release-no-row"'))
+					.filter(Boolean)
+					.join("\n")}\n`,
+			);
+			await expect(host.releaseRlmSubagentRuntime?.(noRowRuntime, noRowOptions, "cancelled")).resolves.toEqual({
+				retained: false,
+			});
+			expect([...internals.sessions.values()].some((state) => state.runtime.session === noRowRuntime.session)).toBe(
+				false,
+			);
+
+			// The ordinary daemon append/fsync path records the tombstone before close.
+			const retainedOptions = optionsFor("release-tombstoned");
+			const retainedRuntime = await internals.createRlmSubagentRuntime(parentState, retainedOptions);
+			await expect(host.releaseRlmSubagentRuntime?.(retainedRuntime, retainedOptions, "cancelled")).resolves.toEqual(
+				{
+					retained: true,
+				},
+			);
+			expect(readFileSync(registryPath, "utf8")).toContain('"childId":"release-tombstoned"');
+			expect(readFileSync(registryPath, "utf8")).toContain('"status":"deleted"');
+
+			// A deterministic append/fsync failure likewise closes the real resident
+			// runtime but cannot claim durable ownership of its artifact directory.
+			const failedOptions = optionsFor("release-write-failed");
+			const failedRuntime = await internals.createRlmSubagentRuntime(parentState, failedOptions);
+			const append = vi.spyOn(internals, "appendRlmSubagentRegistryEntry").mockReturnValue(false);
+			await expect(host.releaseRlmSubagentRuntime?.(failedRuntime, failedOptions, "cancelled")).resolves.toEqual({
+				retained: false,
+			});
+			expect(append).toHaveBeenCalledWith(parentState, expect.objectContaining({ status: "deleted" }));
+			expect([...internals.sessions.values()].some((state) => state.runtime.session === failedRuntime.session)).toBe(
+				false,
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("persists a real child completion for passive discovery, roster, and listing", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-real-completion-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11283,7 +11283,9 @@ describe("daemon tombstoned retirement", () => {
 		["terminalizes after a one-shot archive recovery", false],
 		["preserves its private archive barrier after persistent failure", true],
 	] as const)("on shutdown %s", async (_name, persistentlyFails) => {
-		const daemon = new AgentDaemon(`/tmp/shutdown-terminalization-${persistentlyFails}.sock`, {
+		vi.useFakeTimers();
+		try {
+			const daemon = new AgentDaemon(`/tmp/shutdown-terminalization-${persistentlyFails}.sock`, {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
 			createRuntime: vi.fn(),
 		});
@@ -11320,28 +11322,32 @@ describe("daemon tombstoned retirement", () => {
 		};
 		internals.sessions.set(state.activeSessionId, state);
 		await expect(internals.closeSession(state, "killed")).rejects.toBe(archiveFailure);
-		const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as typeof process.exit);
-		try {
-			await internals.shutdown(0);
-		} finally {
-			exit.mockRestore();
-		}
+			const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as typeof process.exit);
+			try {
+				await internals.shutdown(0);
+			} finally {
+				exit.mockRestore();
+			}
 
-		expect(appendSessionState).toHaveBeenCalledTimes(2);
-		if (persistentlyFails) {
-			expect(dispose).not.toHaveBeenCalled();
-			expect(releaseSessionLease).not.toHaveBeenCalled();
-			expect(internals.sessions.get(state.activeSessionId)).toBe(state);
-			expect(internals.failedTombstonedRlmCloses.get(state.activeSessionId)).toMatchObject({
-				state,
-				terminalizing: true,
-				reason: "killed",
-			});
-		} else {
-			expect(dispose).toHaveBeenCalledOnce();
-			expect(releaseSessionLease).toHaveBeenCalledOnce();
-			expect(internals.sessions.has(state.activeSessionId)).toBe(false);
-			expect(internals.failedTombstonedRlmCloses.has(state.activeSessionId)).toBe(false);
+			expect(appendSessionState).toHaveBeenCalledTimes(2);
+			if (persistentlyFails) {
+				expect(dispose).not.toHaveBeenCalled();
+				expect(releaseSessionLease).not.toHaveBeenCalled();
+				expect(internals.sessions.get(state.activeSessionId)).toBe(state);
+				expect(internals.failedTombstonedRlmCloses.get(state.activeSessionId)).toMatchObject({
+					state,
+					terminalizing: true,
+					reason: "killed",
+				});
+			} else {
+				expect(dispose).toHaveBeenCalledOnce();
+				expect(releaseSessionLease).toHaveBeenCalledOnce();
+				expect(internals.sessions.has(state.activeSessionId)).toBe(false);
+				expect(internals.failedTombstonedRlmCloses.has(state.activeSessionId)).toBe(false);
+			}
+			expect(vi.getTimerCount()).toBe(0);
+		} finally {
+			vi.useRealTimers();
 		}
 	});
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11236,7 +11236,7 @@ describe("daemon tombstoned retirement", () => {
 			} as never;
 			const internals = daemon as unknown as {
 				sessions: Map<string, ActiveSessionState>;
-				failedTerminalSessionCloses: Map<string, { state: ActiveSessionState }>;
+				failedTombstonedRlmCloses: Map<string, { state: ActiveSessionState }>;
 				closeSession(state: ActiveSessionState, reason: "killed"): Promise<void>;
 				getOrCreateCronJobSession(job: AgentCronJob, persisted: boolean): Promise<ActiveSessionState | undefined>;
 			};
@@ -11248,7 +11248,7 @@ describe("daemon tombstoned retirement", () => {
 			expect(state.clients.has(client)).toBe(true);
 			expect(client.attachedActiveSessionIds.has(state.activeSessionId)).toBe(true);
 			expect(releaseSessionLease).not.toHaveBeenCalled();
-			expect(internals.failedTerminalSessionCloses.get(state.activeSessionId)?.state).toBe(state);
+			expect(internals.failedTombstonedRlmCloses.get(state.activeSessionId)?.state).toBe(state);
 			await expect(
 				internals.getOrCreateCronJobSession(
 					{
@@ -11315,7 +11315,6 @@ describe("daemon tombstoned retirement", () => {
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
 			failedTombstonedRlmCloses: Map<string, { state: ActiveSessionState }>;
-			failedTerminalSessionCloses: Map<string, { state: ActiveSessionState }>;
 			closeSession(state: ActiveSessionState, reason: "killed"): Promise<void>;
 		};
 		internals.sessions.set(ordinary.activeSessionId, ordinary);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1081,6 +1081,11 @@ describe("daemon mode helpers", () => {
 			const original = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
 			const oldSessionId = original.sessionId as string;
 			const replacementSessionId = "replacement-session-id";
+			const replacementEntries = readFileSync(fixture.childSessionFile, "utf8").split(/\r?\n/u);
+			const replacementHeader = JSON.parse(replacementEntries[0]!) as Record<string, unknown>;
+			replacementHeader.id = replacementSessionId;
+			replacementEntries[0] = JSON.stringify(replacementHeader);
+			writeFileSync(fixture.childSessionFile, replacementEntries.join("\n"));
 			writeFileSync(
 				registryPath,
 				`${JSON.stringify(original)}\n${JSON.stringify({

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1074,6 +1074,7 @@ describe("daemon mode helpers", () => {
 			const internals = fixture.daemon as unknown as {
 				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
 				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				closeSession(state: ActiveSessionState, reason: "killed", allowPassivation: false): Promise<void>;
 				cancelScheduledJobsForSessionFile(sessionFile: string): void;
 			};
 			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
@@ -1118,16 +1119,25 @@ describe("daemon mode helpers", () => {
 				sessionId: replacementSessionId,
 				generation: 2,
 			};
+			const replacement = await internals.createRuntime({
+				type: "create",
+				sessionPath: fixture.childSessionFile,
+			});
+			const close = vi.spyOn(internals, "closeSession");
 			await expect(
-				host.deleteRlmSubagentRuntime(fixture.childId, undefined, currentAuthority),
+				host.deleteRlmSubagentRuntime(fixture.childId, replacement.runtime.session, currentAuthority),
 			).rejects.toMatchObject({
 				name: "RlmSubagentHostDeletionError",
 				phase: "tombstoned",
 			});
+			expect(close).toHaveBeenCalledOnce();
 			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
-			await expect(host.deleteRlmSubagentRuntime(fixture.childId, undefined, currentAuthority)).resolves.toEqual({
-				deletionDurability: "tombstoned",
-			});
+			// The coordinator retains the session object after postcommit failure, but
+			// daemon state is already absent. Retry only the remaining scheduler work.
+			await expect(
+				host.deleteRlmSubagentRuntime(fixture.childId, replacement.runtime.session, currentAuthority),
+			).resolves.toEqual({ deletionDurability: "tombstoned" });
+			expect(close).toHaveBeenCalledOnce();
 			expect(cleanup).toHaveBeenCalledTimes(2);
 			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
 		} finally {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -665,7 +665,7 @@ describe("daemon mode helpers", () => {
 		let internals: {
 			sessions: Map<string, ActiveSessionState>;
 			closeSession: (state: ActiveSessionState, reason: "completed" | "killed") => Promise<void>;
-			recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<void>;
+			recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<boolean>;
 			createSubagentRuntimeHost(parentState: ActiveSessionState): SubagentRuntimeHost;
 		};
 		const closeSession = vi.fn(async (state: ActiveSessionState) => {
@@ -675,7 +675,7 @@ describe("daemon mode helpers", () => {
 		internals.sessions.set(parentState.activeSessionId, parentState);
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.closeSession = closeSession;
-		const recordDeletion = vi.fn(async () => undefined);
+		const recordDeletion = vi.fn(async () => true);
 		internals.recordRlmSubagentDeletion = recordDeletion;
 
 		await internals
@@ -701,7 +701,8 @@ describe("daemon mode helpers", () => {
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
-		// A registry failure must not strand the cancelled child as a stale resident session.
+		// A registry failure must not strand the cancelled child as a stale resident session,
+		// and must tell the caller to remove its never-admitted artifact dir.
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.recordRlmSubagentDeletion = vi.fn(async () => {
 			throw new Error("registry write failed");
@@ -714,7 +715,7 @@ describe("daemon mode helpers", () => {
 					{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
 					"cancelled",
 				),
-		).rejects.toThrow("registry write failed");
+		).resolves.toEqual({ retained: false });
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11201,6 +11201,57 @@ describe("daemon tombstoned retirement", () => {
 		},
 	);
 
+	it("retains a failed close only for its exact tombstoned record", async () => {
+		const daemon = new AgentDaemon("/tmp/exact-tombstoned-close.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const cleanupFailure = new Error("archive failed");
+		const ordinary = makeState("ordinary-subagent-close");
+		const tombstoned = makeState("tombstoned-subagent-close");
+		const releases = new Map<ActiveSessionState, ReturnType<typeof vi.fn>>();
+		for (const state of [ordinary, tombstoned]) {
+			const releaseSessionLease = vi.fn();
+			releases.set(state, releaseSessionLease);
+			state.extensionUiRequests = new Map();
+			state.runtime = {
+				...state.runtime,
+				claimSessionLeaseReleaseForDaemon: () => true,
+				dispose: vi.fn(async () => {}),
+				releaseSessionLease,
+				session: {
+					sessionId: `session-${state.activeSessionId}`,
+					sessionFile: `/tmp/${state.activeSessionId}.jsonl`,
+					messages: ["content"],
+					isBashRunning: false,
+					abort: vi.fn(async () => {}),
+					sessionManager: {
+						appendSessionState: vi.fn(() => {
+							throw cleanupFailure;
+						}),
+						hasUserContent: () => true,
+					},
+				},
+			} as never;
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			failedTombstonedRlmCloses: Map<string, { state: ActiveSessionState }>;
+			closeSession(state: ActiveSessionState, reason: "killed"): Promise<void>;
+		};
+		internals.sessions.set(ordinary.activeSessionId, ordinary);
+		internals.sessions.set(tombstoned.activeSessionId, tombstoned);
+		internals.failedTombstonedRlmCloses.set(tombstoned.activeSessionId, { state: tombstoned });
+
+		await expect(internals.closeSession(ordinary, "killed")).rejects.toBe(cleanupFailure);
+		expect(internals.sessions.has(ordinary.activeSessionId)).toBe(false);
+		expect(releases.get(ordinary)).toHaveBeenCalledOnce();
+
+		await expect(internals.closeSession(tombstoned, "killed")).rejects.toBe(cleanupFailure);
+		expect(internals.sessions.get(tombstoned.activeSessionId)).toBe(tombstoned);
+		expect(releases.get(tombstoned)).not.toHaveBeenCalled();
+	});
+
 	it("keeps a tombstoned close lease until its full cleanup retry succeeds", async () => {
 		vi.useFakeTimers();
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-tombstone-lease-"));

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -19,7 +19,7 @@ import {
 	createDefaultRlmSubagentSessionName,
 	type SubagentRuntimeHost,
 } from "../src/core/rlm-runtime.js";
-import { canonicalSessionPath } from "../src/core/session-lease.js";
+import { acquireSessionLease, canonicalSessionPath } from "../src/core/session-lease.js";
 import { readSessionInfo, type SessionInfo, SessionManager } from "../src/core/session-manager.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import {
@@ -11146,6 +11146,96 @@ describe("daemon tombstoned retirement", () => {
 			expect(cancelScheduledJobsForSession).toHaveBeenCalledTimes(2);
 			expect(fixture.runtimeSessions[1]!.disposeAsync).toHaveBeenCalledOnce();
 		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it.each(["completed", "killed"] as const)(
+		"irrevocably retires a non-tombstoned %s close after cleanup failure",
+		async (reason) => {
+			const daemon = new AgentDaemon(`/tmp/retire-${reason}.sock`, {
+				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			const state = makeState(`retire-${reason}`);
+			const client = makeClient(`retire-client-${reason}`, state.activeSessionId);
+			state.clients.add(client);
+			const cleanupFailure = new Error(`${reason} archive failed`);
+			state.extensionUiRequests = new Map();
+			state.runtime = {
+				...state.runtime,
+				dispose: vi.fn(async () => {}),
+				releaseSessionLease: vi.fn(),
+				session: {
+					sessionId: `retire-session-${reason}`,
+					sessionFile: `/tmp/retire-${reason}.jsonl`,
+					messages: ["content"],
+					isBashRunning: false,
+					abort: vi.fn(async () => {}),
+					sessionManager: {
+						appendSessionState: vi.fn(() => {
+							throw cleanupFailure;
+						}),
+						hasUserContent: () => true,
+					},
+				},
+			} as never;
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				closeSession(state: ActiveSessionState, reason: typeof reason): Promise<void>;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+				createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
+			};
+			internals.sessions.set(state.activeSessionId, state);
+
+			await expect(internals.closeSession(state, reason)).rejects.toBe(cleanupFailure);
+			expect(internals.sessions.has(state.activeSessionId)).toBe(false);
+			expect(state.clients.size).toBe(0);
+			expect(client.attachedActiveSessionIds.has(state.activeSessionId)).toBe(false);
+			const listed = (await internals.handleCommand(makeClient(`list-${reason}`, "other"), {
+				type: "list",
+			})) as { data: { sessions: SessionSummary[] } };
+			expect(listed.data.sessions.map((session) => session.activeSessionId)).not.toContain(state.activeSessionId);
+			const targets = await internals.createAgentMessageController(() => makeState("other")).listAgents();
+			expect(targets.agents.map((agent) => agent.activeSessionId)).not.toContain(state.activeSessionId);
+		},
+	);
+
+	it("keeps a tombstoned close lease until its full cleanup retry succeeds", async () => {
+		vi.useFakeTimers();
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-tombstone-lease-"));
+		try {
+			vi.stubEnv("PRIME_AGENT_INTERNAL_SESSION_LEASES", "1");
+			vi.stubEnv("PRIME_AGENT_INTERNAL_SESSION_LEASE_OWNER_ID", "tombstone-lease");
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const archiveFailure = new Error("archive failed");
+			vi.spyOn(child.runtime.session.sessionManager, "appendSessionState")
+				.mockImplementationOnce(() => {
+					throw archiveFailure;
+				})
+				.mockImplementation(() => undefined as never);
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() =>
+				expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(archiveFailure),
+			);
+			expect(() => acquireSessionLease(fixture.childSessionFile, tempDir)).toThrow();
+			await vi.advanceTimersByTimeAsync(250);
+			await vi.waitFor(() => expect(internals.sessions.has(child.activeSessionId)).toBe(false));
+			const reopened = acquireSessionLease(fixture.childSessionFile, tempDir);
+			expect(reopened).toBeDefined();
+			reopened?.release();
+		} finally {
+			vi.unstubAllEnvs();
+			vi.useRealTimers();
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11151,7 +11151,7 @@ describe("daemon tombstoned retirement", () => {
 	});
 
 	it.each(["completed", "killed"] as const)(
-		"irrevocably retires a non-tombstoned %s close after cleanup failure",
+		"irrevocably retires a non-tombstoned %s close after durable archival and cleanup failure",
 		async (reason) => {
 			const daemon = new AgentDaemon(`/tmp/retire-${reason}.sock`, {
 				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
@@ -11160,11 +11160,14 @@ describe("daemon tombstoned retirement", () => {
 			const state = makeState(`retire-${reason}`);
 			const client = makeClient(`retire-client-${reason}`, state.activeSessionId);
 			state.clients.add(client);
-			const cleanupFailure = new Error(`${reason} archive failed`);
+			const cleanupFailure = new Error(`${reason} dispose failed`);
+			const appendSessionState = vi.fn();
 			state.extensionUiRequests = new Map();
 			state.runtime = {
 				...state.runtime,
-				dispose: vi.fn(async () => {}),
+				dispose: vi.fn(async () => {
+					throw cleanupFailure;
+				}),
 				releaseSessionLease: vi.fn(),
 				session: {
 					sessionId: `retire-session-${reason}`,
@@ -11172,12 +11175,7 @@ describe("daemon tombstoned retirement", () => {
 					messages: ["content"],
 					isBashRunning: false,
 					abort: vi.fn(async () => {}),
-					sessionManager: {
-						appendSessionState: vi.fn(() => {
-							throw cleanupFailure;
-						}),
-						hasUserContent: () => true,
-					},
+					sessionManager: { appendSessionState, hasUserContent: () => true },
 				},
 			} as never;
 			const internals = daemon as unknown as {
@@ -11189,6 +11187,7 @@ describe("daemon tombstoned retirement", () => {
 			internals.sessions.set(state.activeSessionId, state);
 
 			await expect(internals.closeSession(state, reason)).rejects.toBe(cleanupFailure);
+			expect(appendSessionState).toHaveBeenCalledWith({ status: "archived" });
 			expect(internals.sessions.has(state.activeSessionId)).toBe(false);
 			expect(state.clients.size).toBe(0);
 			expect(client.attachedActiveSessionIds.has(state.activeSessionId)).toBe(false);
@@ -11200,6 +11199,85 @@ describe("daemon tombstoned retirement", () => {
 			expect(targets.agents.map((agent) => agent.activeSessionId)).not.toContain(state.activeSessionId);
 		},
 	);
+
+
+	it("privately retains an archive-failed close until the exact resident terminalizes", async () => {
+		vi.useFakeTimers();
+		try {
+			const daemon = new AgentDaemon("/tmp/archive-terminalization-barrier.sock", {
+				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			const state = makeState("archive-terminalization-barrier");
+			const client = makeClient("archive-terminalization-client", state.activeSessionId);
+			const archiveFailure = new Error("archive failed");
+			const appendSessionState = vi.fn()
+				.mockImplementationOnce(() => {
+					throw archiveFailure;
+				})
+				.mockImplementation(() => undefined);
+			const dispose = vi.fn(async () => {});
+			const releaseSessionLease = vi.fn();
+			state.clients.add(client);
+			state.extensionUiRequests = new Map();
+			state.runtime = {
+				...state.runtime,
+				claimSessionLeaseReleaseForDaemon: () => true,
+				dispose,
+				releaseSessionLease,
+				session: {
+					sessionId: "archive-terminalization-session",
+					sessionFile: "/tmp/archive-terminalization-barrier.jsonl",
+					messages: ["content"],
+					isBashRunning: false,
+					abort: vi.fn(async () => {}),
+					sessionManager: { appendSessionState, hasUserContent: () => true },
+				},
+			} as never;
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				failedTerminalSessionCloses: Map<string, { state: ActiveSessionState }>;
+				closeSession(state: ActiveSessionState, reason: "killed"): Promise<void>;
+				getOrCreateCronJobSession(job: AgentCronJob, persisted: boolean): Promise<ActiveSessionState | undefined>;
+			};
+			internals.sessions.set(state.activeSessionId, state);
+
+			await expect(internals.closeSession(state, "killed")).rejects.toBe(archiveFailure);
+			expect(dispose).not.toHaveBeenCalled();
+			expect(internals.sessions.get(state.activeSessionId)).toBe(state);
+			expect(state.clients.has(client)).toBe(true);
+			expect(client.attachedActiveSessionIds.has(state.activeSessionId)).toBe(true);
+			expect(releaseSessionLease).not.toHaveBeenCalled();
+			expect(internals.failedTerminalSessionCloses.get(state.activeSessionId)?.state).toBe(state);
+			await expect(
+				internals.getOrCreateCronJobSession(
+					{
+						id: "barrier-cron",
+						activeSessionId: state.activeSessionId,
+						sessionId: state.runtime.session.sessionId,
+						sessionFile: state.runtime.session.sessionFile!,
+						cwd: "/tmp",
+						prompt: "should not revive",
+						status: "active",
+						schedule: { kind: "once", expression: new Date().toISOString() },
+						nextRunAt: new Date().toISOString(),
+						createdAt: new Date().toISOString(),
+						updatedAt: new Date().toISOString(),
+						runCount: 0,
+					} as AgentCronJob,
+					false,
+				),
+			).resolves.toBeUndefined();
+
+			await vi.advanceTimersByTimeAsync(250);
+			expect(appendSessionState).toHaveBeenCalledTimes(2);
+			expect(dispose).toHaveBeenCalledOnce();
+			expect(internals.sessions.has(state.activeSessionId)).toBe(false);
+			expect(releaseSessionLease).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 
 	it("retains a failed close only for its exact tombstoned record", async () => {
 		const daemon = new AgentDaemon("/tmp/exact-tombstoned-close.sock", {
@@ -11237,6 +11315,7 @@ describe("daemon tombstoned retirement", () => {
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
 			failedTombstonedRlmCloses: Map<string, { state: ActiveSessionState }>;
+			failedTerminalSessionCloses: Map<string, { state: ActiveSessionState }>;
 			closeSession(state: ActiveSessionState, reason: "killed"): Promise<void>;
 		};
 		internals.sessions.set(ordinary.activeSessionId, ordinary);
@@ -11244,8 +11323,9 @@ describe("daemon tombstoned retirement", () => {
 		internals.failedTombstonedRlmCloses.set(tombstoned.activeSessionId, { state: tombstoned });
 
 		await expect(internals.closeSession(ordinary, "killed")).rejects.toBe(cleanupFailure);
-		expect(internals.sessions.has(ordinary.activeSessionId)).toBe(false);
-		expect(releases.get(ordinary)).toHaveBeenCalledOnce();
+		expect(internals.sessions.get(ordinary.activeSessionId)).toBe(ordinary);
+		expect(internals.failedTerminalSessionCloses.get(ordinary.activeSessionId)?.state).toBe(ordinary);
+		expect(releases.get(ordinary)).not.toHaveBeenCalled();
 
 		await expect(internals.closeSession(tombstoned, "killed")).rejects.toBe(cleanupFailure);
 		expect(internals.sessions.get(tombstoned.activeSessionId)).toBe(tombstoned);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1304,7 +1304,7 @@ describe("daemon mode helpers", () => {
 			await expect(
 				host.deleteRlmSubagentRuntime(fixture.childId, replacement.runtime.session, currentAuthority),
 			).resolves.toEqual({ deletionDurability: "tombstoned" });
-			expect(close).toHaveBeenCalledOnce();
+			expect(close).toHaveBeenCalledTimes(2);
 			expect(cleanup).toHaveBeenCalledTimes(2);
 			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
 		} finally {
@@ -1921,17 +1921,17 @@ describe("daemon mode helpers", () => {
 		expect(listed.agents).not.toContainEqual(
 			expect.objectContaining({ activeSessionId: childState.activeSessionId }),
 		);
-		expect(() => internals.getBoundSessionState(childState.activeSessionId)).toThrow("is closing");
+		expect(() => internals.getBoundSessionState(childState.activeSessionId)).toThrow("unavailable");
 		await expect(
 			controller.sendAgentMessage({ target: childState.activeSessionId, message: "continue" }),
-		).rejects.toThrow("is closing");
+		).rejects.toThrow("unavailable");
 		const client = makeClient("client-1", childState.activeSessionId);
 		for (const command of [
 			{ id: "prompt", type: "prompt", activeSessionId: childState.activeSessionId, message: "continue" },
 			{ id: "steer", type: "steer", activeSessionId: childState.activeSessionId, message: "continue" },
 			{ id: "follow-up", type: "follow_up", activeSessionId: childState.activeSessionId, message: "continue" },
 		] as const) {
-			await expect(internals.handleCommand(client, command)).rejects.toThrow("is closing");
+			await expect(internals.handleCommand(client, command)).rejects.toThrow("unavailable");
 		}
 
 		internals.closingSessions.delete(childState.activeSessionId);
@@ -1948,7 +1948,7 @@ describe("daemon mode helpers", () => {
 		expect(sessionPrompt).not.toHaveBeenCalled();
 	});
 
-	it("removes a closing daemon session even when runtime disposal fails", async () => {
+	it("retains a closing daemon session when runtime disposal fails", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -1992,7 +1992,7 @@ describe("daemon mode helpers", () => {
 		await expect(internals.closeSession(state, "killed", false)).rejects.toThrow("dispose failed");
 
 		expect(dispose).toHaveBeenCalledOnce();
-		expect(internals.sessions.has(state.activeSessionId)).toBe(false);
+		expect(internals.sessions.get(state.activeSessionId)).toBe(state);
 		expect(internals.closingSessions.has(state.activeSessionId)).toBe(false);
 	});
 
@@ -7844,7 +7844,7 @@ describe("daemon mode helpers", () => {
 				childId: fixture.childId,
 			})) as { data: { deleted: boolean } };
 			expect(idle.data).toEqual({ deleted: true });
-			expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
+			await vi.waitFor(() => expect(internals.sessions.has(childState.activeSessionId)).toBe(false));
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -10716,6 +10716,15 @@ describe("daemon tombstoned retirement", () => {
 		expect(internals.isPublicRlmState(child)).toBe(false);
 		expect(internals.isPublicRlmState(grandchild)).toBe(false);
 		expect(internals.isPublicRlmState(sibling)).toBe(true);
+		for (const command of [
+			{ type: "get_state", activeSessionId: child.activeSessionId },
+			{ type: "get_connection_state", activeSessionId: child.activeSessionId },
+			{ type: "get_messages", activeSessionId: child.activeSessionId },
+		] as const) {
+			await expect(
+				internals.handleCommand(makeClient("private-read-client", root.activeSessionId), command),
+			).rejects.toThrow("unavailable");
+		}
 		const listed = (await internals.handleCommand(makeClient("list-client", root.activeSessionId), {
 			type: "list",
 		})) as { data: { sessions: SessionSummary[] } };
@@ -10740,38 +10749,156 @@ describe("daemon tombstoned retirement", () => {
 		).toBe(true);
 
 		internals.closingSessions.delete(child.activeSessionId);
-		internals.sessions.delete(child.activeSessionId);
 		internals.failedTombstonedRlmCloses.set(child.activeSessionId, { state: child });
 		expect(internals.isPublicRlmState(grandchild)).toBe(false);
+		await expect(
+			internals.handleCommand(makeClient("failed-private-read-client", root.activeSessionId), {
+				type: "get_messages",
+				activeSessionId: child.activeSessionId,
+			}),
+		).rejects.toThrow("unavailable");
 	});
 
-	it("retains a failed physical disposal and retries the exact runtime", async () => {
-		const daemon = new AgentDaemon("/tmp/retry-retirement.sock", {
+	it("retries a rejected runtime disposal through the exact full tombstoned close", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-retry-tombstoned-dispose-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const disposeFailure = new Error("dispose failed");
+			fixture.runtimeSessions[1]!.disposeAsync = vi
+				.fn<() => Promise<void>>()
+				.mockRejectedValueOnce(disposeFailure)
+				.mockResolvedValue(undefined);
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() =>
+				expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(disposeFailure),
+			);
+			expect(internals.sessions.get(child.activeSessionId)).toBe(child);
+			expect(fixture.runtimeSessions[1]!.disposeAsync).toHaveBeenCalledOnce();
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() => {
+				expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false);
+				expect(internals.sessions.has(child.activeSessionId)).toBe(false);
+			});
+			expect(fixture.runtimeSessions[1]!.disposeAsync).toHaveBeenCalledTimes(2);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a failed tombstoned cascade private and retries its resident subtree", async () => {
+		const daemon = new AgentDaemon("/tmp/retry-tombstoned-cascade.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
 			createRuntime: vi.fn(),
 		});
-		const parent = makeState("retry-parent");
-		const child = makeState("retry-child", parent.activeSessionId);
-		const dispose = vi.fn(async () => {});
-		child.runtime.dispose = dispose;
-		const disposeFailure = new Error("dispose failed");
+		const root = makeState("cascade-root");
+		const parent = makeState("cascade-parent", root.activeSessionId);
+		const descendant = makeState("cascade-descendant", parent.activeSessionId);
+		Object.assign(parent.runtime.metadata, { kind: "subagent", rlmChildId: "parent" });
+		Object.assign(descendant.runtime.metadata, { kind: "subagent", rlmChildId: "descendant" });
+		const cascadeFailure = new Error("descendant dispose failed");
+		const descendantDispose = vi
+			.fn<() => Promise<void>>()
+			.mockRejectedValueOnce(cascadeFailure)
+			.mockResolvedValue(undefined);
+		for (const [state, dispose] of [
+			[parent, vi.fn(async () => {})],
+			[descendant, descendantDispose],
+		] as const) {
+			state.extensionUiRequests = new Map();
+			state.runtime = {
+				...state.runtime,
+				dispose,
+				session: {
+					sessionId: `session-${state.activeSessionId}`,
+					sessionFile: undefined,
+					isBashRunning: false,
+					abort: vi.fn(async () => {}),
+				},
+			} as unknown as ActiveSessionState["runtime"];
+		}
 		const internals = daemon as unknown as {
-			closeDisposeErrors: WeakMap<ActiveSessionState, unknown>;
+			sessions: Map<string, ActiveSessionState>;
 			failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
-			detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
-			closeSession: ReturnType<typeof vi.fn>;
+			detachTombstonedClose(root: ActiveSessionState, child: ActiveSessionState, id: string): void;
+			isPublicRlmState(state: ActiveSessionState): boolean;
+			cancelScheduledJobsForSession: ReturnType<typeof vi.fn>;
+			isEmptyDraftContent: ReturnType<typeof vi.fn>;
+			abortBashForClose: ReturnType<typeof vi.fn>;
+			recordWorkerRecoveryState: ReturnType<typeof vi.fn>;
+			broadcastToSession: ReturnType<typeof vi.fn>;
 		};
-		internals.closeSession = vi.fn(async () => {
-			internals.closeDisposeErrors.set(child, disposeFailure);
-			throw disposeFailure;
-		});
-		internals.detachTombstonedClose(parent, child, "child-1");
+		for (const state of [root, parent, descendant]) internals.sessions.set(state.activeSessionId, state);
+		internals.cancelScheduledJobsForSession = vi.fn();
+		internals.isEmptyDraftContent = vi.fn(() => true);
+		internals.abortBashForClose = vi.fn(async () => {});
+		internals.recordWorkerRecoveryState = vi.fn();
+		internals.broadcastToSession = vi.fn();
+
+		internals.detachTombstonedClose(root, parent, "parent");
 		await vi.waitFor(() =>
-			expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(disposeFailure),
+			expect(internals.failedTombstonedRlmCloses.get(parent.activeSessionId)?.error).toBe(cascadeFailure),
 		);
-		internals.detachTombstonedClose(parent, child, "child-1");
-		await vi.waitFor(() => expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false));
-		expect(dispose).toHaveBeenCalledOnce();
+		expect(internals.sessions.get(parent.activeSessionId)).toBe(parent);
+		expect(internals.sessions.get(descendant.activeSessionId)).toBe(descendant);
+		expect(internals.isPublicRlmState(parent)).toBe(false);
+		expect(internals.isPublicRlmState(descendant)).toBe(false);
+
+		internals.detachTombstonedClose(root, parent, "parent");
+		await vi.waitFor(() => {
+			expect(internals.failedTombstonedRlmCloses.has(parent.activeSessionId)).toBe(false);
+			expect(internals.sessions.has(parent.activeSessionId)).toBe(false);
+			expect(internals.sessions.has(descendant.activeSessionId)).toBe(false);
+		});
+		expect(descendantDispose).toHaveBeenCalledTimes(2);
+	});
+
+	it("retries a tombstoned close that failed before disposal", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-retry-tombstoned-pre-dispose-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+				cancelScheduledJobsForSession: ReturnType<typeof vi.fn>;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const preDisposeFailure = new Error("pre-dispose close failed");
+			const cancelScheduledJobsForSession = vi.fn().mockImplementationOnce(() => {
+				throw preDisposeFailure;
+			});
+			internals.cancelScheduledJobsForSession = cancelScheduledJobsForSession;
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() =>
+				expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(preDisposeFailure),
+			);
+			expect(internals.sessions.get(child.activeSessionId)).toBe(child);
+			expect(fixture.runtimeSessions[1]!.disposeAsync).not.toHaveBeenCalled();
+
+			internals.detachTombstonedClose(parent, child, fixture.childId);
+			await vi.waitFor(() => {
+				expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false);
+				expect(internals.sessions.has(child.activeSessionId)).toBe(false);
+			});
+			expect(cancelScheduledJobsForSession).toHaveBeenCalledTimes(2);
+			expect(fixture.runtimeSessions[1]!.disposeAsync).toHaveBeenCalledOnce();
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11182,7 +11182,7 @@ describe("daemon tombstoned retirement", () => {
 			} as never;
 			const internals = daemon as unknown as {
 				sessions: Map<string, ActiveSessionState>;
-				closeSession(state: ActiveSessionState, reason: typeof reason): Promise<void>;
+				closeSession(state: ActiveSessionState, reason: "completed" | "killed"): Promise<void>;
 				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
 				createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
 			};

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -665,7 +665,10 @@ describe("daemon mode helpers", () => {
 		let internals: {
 			sessions: Map<string, ActiveSessionState>;
 			closeSession: (state: ActiveSessionState, reason: "completed" | "killed") => Promise<void>;
-			recordRlmSubagentDeletion(parentState: ActiveSessionState, childId: string): Promise<boolean>;
+			recordRlmSubagentDeletion(
+				parentState: ActiveSessionState,
+				childId: string,
+			): Promise<"absent" | "tombstoned" | "unknown">;
 			createSubagentRuntimeHost(parentState: ActiveSessionState): SubagentRuntimeHost;
 		};
 		const closeSession = vi.fn(async (state: ActiveSessionState) => {
@@ -675,7 +678,7 @@ describe("daemon mode helpers", () => {
 		internals.sessions.set(parentState.activeSessionId, parentState);
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.closeSession = closeSession;
-		const recordDeletion = vi.fn(async () => true);
+		const recordDeletion = vi.fn(async () => "tombstoned" as const);
 		internals.recordRlmSubagentDeletion = recordDeletion;
 
 		await internals
@@ -702,7 +705,7 @@ describe("daemon mode helpers", () => {
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
 		// A registry failure must not strand the cancelled child as a stale resident session,
-		// and must tell the caller to remove its never-admitted artifact dir.
+		// but must retain the artifact because durability is unknown.
 		internals.sessions.set(childState.activeSessionId, childState);
 		internals.recordRlmSubagentDeletion = vi.fn(async () => {
 			throw new Error("registry write failed");
@@ -715,7 +718,7 @@ describe("daemon mode helpers", () => {
 					{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
 					"cancelled",
 				),
-		).resolves.toEqual({ retained: false });
+		).resolves.toEqual({ deletionDurability: "unknown" });
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
@@ -767,7 +770,7 @@ describe("daemon mode helpers", () => {
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
 
 			// A real resident child with its row removed has no durable owner. The host
-			// still closes it, and explicitly returns retained:false.
+			// still closes it, and explicitly proves the artifact is absent.
 			const noRowOptions = optionsFor("release-no-row");
 			const noRowRuntime = await internals.createRlmSubagentRuntime(parentState, noRowOptions);
 			writeFileSync(
@@ -779,7 +782,7 @@ describe("daemon mode helpers", () => {
 					.join("\n")}\n`,
 			);
 			await expect(host.releaseRlmSubagentRuntime?.(noRowRuntime, noRowOptions, "cancelled")).resolves.toEqual({
-				retained: false,
+				deletionDurability: "absent",
 			});
 			expect([...internals.sessions.values()].some((state) => state.runtime.session === noRowRuntime.session)).toBe(
 				false,
@@ -790,24 +793,43 @@ describe("daemon mode helpers", () => {
 			const retainedRuntime = await internals.createRlmSubagentRuntime(parentState, retainedOptions);
 			await expect(host.releaseRlmSubagentRuntime?.(retainedRuntime, retainedOptions, "cancelled")).resolves.toEqual(
 				{
-					retained: true,
+					deletionDurability: "tombstoned",
 				},
 			);
 			expect(readFileSync(registryPath, "utf8")).toContain('"childId":"release-tombstoned"');
 			expect(readFileSync(registryPath, "utf8")).toContain('"status":"deleted"');
 
 			// A deterministic append/fsync failure likewise closes the real resident
-			// runtime but cannot claim durable ownership of its artifact directory.
+			// runtime but leaves durable ownership unknown, so the caller retains it.
 			const failedOptions = optionsFor("release-write-failed");
 			const failedRuntime = await internals.createRlmSubagentRuntime(parentState, failedOptions);
 			const append = vi.spyOn(internals, "appendRlmSubagentRegistryEntry").mockReturnValue(false);
 			await expect(host.releaseRlmSubagentRuntime?.(failedRuntime, failedOptions, "cancelled")).resolves.toEqual({
-				retained: false,
+				deletionDurability: "unknown",
 			});
 			expect(append).toHaveBeenCalledWith(parentState, expect.objectContaining({ status: "deleted" }));
 			expect([...internals.sessions.values()].some((state) => state.runtime.session === failedRuntime.session)).toBe(
 				false,
 			);
+
+			// A malformed registry history cannot prove that a child is absent.
+			const malformedOptions = optionsFor("release-malformed");
+			const malformedRuntime = await internals.createRlmSubagentRuntime(parentState, malformedOptions);
+			writeFileSync(registryPath, `${readFileSync(registryPath, "utf8")}not-json\n`);
+			await expect(
+				host.releaseRlmSubagentRuntime?.(malformedRuntime, malformedOptions, "cancelled"),
+			).resolves.toEqual({ deletionDurability: "unknown" });
+
+			// An unreadable registry has the same fail-closed result, rather than
+			// treating the missing child row as authority to remove artifacts.
+			append.mockRestore();
+			const readFaultOptions = optionsFor("release-read-fault");
+			const readFaultRuntime = await internals.createRlmSubagentRuntime(parentState, readFaultOptions);
+			rmSync(registryPath);
+			mkdirSync(registryPath);
+			await expect(
+				host.releaseRlmSubagentRuntime?.(readFaultRuntime, readFaultOptions, "cancelled"),
+			).resolves.toEqual({ deletionDurability: "unknown" });
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -701,7 +701,7 @@ describe("daemon mode helpers", () => {
 			);
 		expect(recordDeletion).toHaveBeenCalledWith(parentState, "child-1", undefined, childState.runtime.session);
 		expect(recordDeletion.mock.invocationCallOrder[0]).toBeLessThan(closeSession.mock.invocationCallOrder[1]!);
-		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
+		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed", false);
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
 		// A registry failure is precommit: keep the live incarnation resident and
@@ -736,7 +736,7 @@ describe("daemon mode helpers", () => {
 		).resolves.toEqual({ deletionDurability: "tombstoned" });
 		expect(retryDeletion).toHaveBeenCalledOnce();
 		expect(closeSession).toHaveBeenCalledTimes(closeCountBeforeFailure + 1);
-		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
+		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed", false);
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
 
@@ -812,7 +812,7 @@ describe("daemon mode helpers", () => {
 		).resolves.toEqual({ deletionDurability: "tombstoned" });
 		expect(internals.recordRlmSubagentDeletion).toHaveBeenCalledOnce();
 		expect(internals.closeSession).toHaveBeenCalledOnce();
-		expect(internals.closeSession).toHaveBeenCalledWith(newState, "killed");
+		expect(internals.closeSession).toHaveBeenCalledWith(newState, "killed", false);
 	});
 
 	it("classifies scheduler failure after a daemon tombstone as postcommit", async () => {
@@ -1391,7 +1391,7 @@ describe("daemon mode helpers", () => {
 			expect(readFileSync(join(after.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")).toContain(
 				'"status":"deleted"',
 			);
-			expect(afterInternals.sessions.has(afterChild.activeSessionId)).toBe(false);
+			await vi.waitFor(() => expect(afterInternals.sessions.has(afterChild.activeSessionId)).toBe(false));
 		} finally {
 			rmSync(beforeTempDir, { recursive: true, force: true });
 			rmSync(afterTempDir, { recursive: true, force: true });
@@ -10605,6 +10605,90 @@ function makeAgentFamilyState(
 	} as never;
 	return { state, acceptAgentMessagePrompt };
 }
+
+describe("daemon tombstoned retirement", () => {
+	it("returns from host deletion while an exact tombstoned close remains gated and hidden", async () => {
+		const daemon = new AgentDaemon("/tmp/gated-retirement.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parent = makeState("gated-parent");
+		const child = makeState("gated-child", parent.activeSessionId);
+		child.runtime = {
+			...child.runtime,
+			session: { sessionId: "gated-session", sessionFile: "/tmp/child-1.jsonl" },
+		} as ActiveSessionState["runtime"];
+		Object.assign(child.runtime.metadata, { kind: "subagent", rlmChildId: "child-1", sessionDir: "/tmp/child-1" });
+		let release!: () => void;
+		let closed = false;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		}).then(() => {
+			closed = true;
+		});
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closingSessions: Map<string, unknown>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+			isPublicRlmState(state: ActiveSessionState): boolean;
+			recordRlmSubagentDeletion: ReturnType<typeof vi.fn>;
+			readLatestRlmSubagentRegistry: ReturnType<typeof vi.fn>;
+			closeSession: ReturnType<typeof vi.fn>;
+		};
+		internals.sessions.set(parent.activeSessionId, parent);
+		internals.sessions.set(child.activeSessionId, child);
+		internals.readLatestRlmSubagentRegistry = vi.fn(async () => [
+			{ childId: "child-1", sessionDir: "/tmp/child-1", sessionFile: child.runtime.session.sessionFile },
+		]);
+		internals.recordRlmSubagentDeletion = vi.fn(async () => "tombstoned" as const);
+		internals.closeSession = vi.fn(() => {
+			internals.closingSessions.set(child.activeSessionId, {});
+			return gate;
+		});
+		const result = await internals
+			.createSubagentRuntimeHost(parent)
+			.deleteRlmSubagentRuntime("child-1", child.runtime.session);
+		expect(result).toEqual({ deletionDurability: "tombstoned" });
+		expect(internals.recordRlmSubagentDeletion).toHaveBeenCalledOnce();
+		expect(internals.closeSession).toHaveBeenCalledWith(child, "killed", false);
+		expect(internals.recordRlmSubagentDeletion.mock.invocationCallOrder[0]).toBeLessThan(
+			internals.closeSession.mock.invocationCallOrder[0]!,
+		);
+		expect(closed).toBe(false);
+		expect(internals.isPublicRlmState(child)).toBe(false);
+		release();
+		await gate;
+	});
+
+	it("retains a failed physical disposal and retries the exact runtime", async () => {
+		const daemon = new AgentDaemon("/tmp/retry-retirement.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parent = makeState("retry-parent");
+		const child = makeState("retry-child", parent.activeSessionId);
+		const dispose = vi.fn(async () => {});
+		child.runtime.dispose = dispose;
+		const disposeFailure = new Error("dispose failed");
+		const internals = daemon as unknown as {
+			closeDisposeErrors: WeakMap<ActiveSessionState, unknown>;
+			failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+			detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+			closeSession: ReturnType<typeof vi.fn>;
+		};
+		internals.closeSession = vi.fn(async () => {
+			internals.closeDisposeErrors.set(child, disposeFailure);
+			throw disposeFailure;
+		});
+		internals.detachTombstonedClose(parent, child, "child-1");
+		await vi.waitFor(() =>
+			expect(internals.failedTombstonedRlmCloses.get(child.activeSessionId)?.error).toBe(disposeFailure),
+		);
+		internals.detachTombstonedClose(parent, child, "child-1");
+		await vi.waitFor(() => expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false));
+		expect(dispose).toHaveBeenCalledOnce();
+	});
+});
 
 function makeState(activeSessionId: string, parentActiveSessionId?: string): ActiveSessionState {
 	return {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1057,6 +1057,70 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("fences passive deletion by its persisted incarnation and retries only post-tombstone cleanup", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-delete-incarnation-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				cancelScheduledJobsForSessionFile(sessionFile: string): void;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const original = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
+			const replacementFile = join(fixture.childSessionDir, "replacement.jsonl");
+			writeFileSync(replacementFile, "replacement");
+			writeFileSync(
+				registryPath,
+				`${JSON.stringify({
+					...original,
+					sessionFile: replacementFile,
+					updatedAt: "2026-01-01T00:00:02.000Z",
+				})}\n`,
+			);
+			const host = internals.createSubagentRuntimeHost(parent);
+			const oldAuthority = {
+				childId: fixture.childId,
+				sessionDir: fixture.childSessionDir,
+				sessionFile: fixture.childSessionFile,
+				sessionId: "old-session-id",
+				generation: 1,
+				assertCurrent: () => {},
+			};
+			await expect(host.deleteRlmSubagentRuntime(fixture.childId, undefined, oldAuthority)).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
+			});
+			expect(readFileSync(registryPath, "utf8")).not.toContain('"status":"deleted"');
+
+			let cleanupAttempts = 0;
+			const cleanup = vi.spyOn(internals, "cancelScheduledJobsForSessionFile").mockImplementation(() => {
+				if (++cleanupAttempts === 1) throw new Error("scheduler cleanup failed once");
+			});
+			const currentAuthority = {
+				...oldAuthority,
+				sessionFile: replacementFile,
+				sessionId: "replacement-session-id",
+				generation: 2,
+			};
+			await expect(
+				host.deleteRlmSubagentRuntime(fixture.childId, undefined, currentAuthority),
+			).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "tombstoned",
+			});
+			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
+			await expect(host.deleteRlmSubagentRuntime(fixture.childId, undefined, currentAuthority)).resolves.toEqual({
+				deletionDurability: "tombstoned",
+			});
+			expect(cleanup).toHaveBeenCalledTimes(2);
+			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("honors daemon deletion authority on both sides of the append boundary", async () => {
 		const beforeTempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-before-append-"));
 		const afterTempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-after-append-"));
@@ -1124,7 +1188,7 @@ describe("daemon mode helpers", () => {
 							if (afterAbort.signal.aborted) throw new Error("host request authority was revoked");
 						},
 					}),
-			).resolves.toBeUndefined();
+			).resolves.toEqual({ deletionDurability: "tombstoned" });
 			expect(readFileSync(join(after.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")).toContain(
 				'"status":"deleted"',
 			);

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -5329,7 +5329,10 @@ describe("daemon mode helpers", () => {
 			messages: [],
 		} as unknown as DaemonOutbound);
 		client.catchupActiveSessionIds = new Set([otherState.activeSessionId]);
-		internals.sessions.delete(state.activeSessionId);
+		(internals as unknown as { closingSessions: Map<string, unknown> }).closingSessions.set(
+			state.activeSessionId,
+			{},
+		);
 		resolveAttach({
 			activeSessionId: state.activeSessionId,
 			snapshot: { summary: {}, state: {}, messages: [] },
@@ -10757,6 +10760,237 @@ describe("daemon tombstoned retirement", () => {
 				activeSessionId: child.activeSessionId,
 			}),
 		).rejects.toThrow("unavailable");
+	});
+
+	it("keeps private session reads and scheduled-job catalogs unpublished", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-private-publications-"));
+		try {
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
+				createRuntime: vi.fn(),
+			});
+			const privateState = makeState("private-session");
+			privateState.runtime = {
+				...privateState.runtime,
+				metadata: { kind: "top-level", createdAt: 1 },
+				session: {
+					sessionId: "private-stable-id",
+					sessionFile: join(tempDir, "private.jsonl"),
+					sessionManager: {
+						getCwd: () => tempDir,
+						getSessionDir: () => tempDir,
+					},
+				},
+			} as never;
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				closingSessions: Map<string, unknown>;
+				cronStore: AgentCronJobStore;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+				buildSessionListWithPassiveRlmSubagents(
+					activeSessions: ActiveSessionState[],
+					savedSessions: SessionInfo[],
+					scheduledJobs: AgentCronJob[],
+				): Promise<SessionSummary[]>;
+			};
+			internals.sessions.set(privateState.activeSessionId, privateState);
+			internals.closingSessions.set(privateState.activeSessionId, {});
+			const savedInfo = (path: string, id: string, parentSessionPath?: string): SessionInfo => ({
+				path,
+				id,
+				cwd: tempDir,
+				parentSessionPath,
+				rlmDepth: parentSessionPath ? 1 : 0,
+				created: new Date(0),
+				modified: new Date(0),
+				messageCount: 1,
+				firstMessage: id,
+				allMessagesText: id,
+			});
+			const privateSaved = savedInfo(join(tempDir, "private.jsonl"), "private-stable-id");
+			const privateDescendant = savedInfo(
+				join(tempDir, "private-descendant.jsonl"),
+				"private-descendant",
+				privateSaved.path,
+			);
+			const publicSaved = savedInfo(join(tempDir, "public.jsonl"), "public-stable-id");
+			const savedList = await internals.buildSessionListWithPassiveRlmSubagents(
+				[],
+				[privateSaved, privateDescendant, publicSaved],
+				[],
+			);
+			expect(savedList.map((session) => session.sessionId)).toEqual([publicSaved.id]);
+
+			const privateCron = internals.cronStore.create({
+				activeSessionId: privateState.activeSessionId,
+				sessionId: "private-stable-id",
+				sessionFile: join(tempDir, "private.jsonl"),
+				cwd: tempDir,
+				scheduleText: "in 1m",
+				prompt: "private cron",
+				now: new Date("2026-01-01T12:00:00.000Z"),
+			});
+			internals.cronStore.cancel(privateCron.id, new Date("2026-01-01T12:00:01.000Z"));
+			const privateHeartbeat = internals.cronStore.createHeartbeat({
+				activeSessionId: privateState.activeSessionId,
+				sessionId: "private-stable-id",
+				sessionFile: join(tempDir, "private.jsonl"),
+				cwd: tempDir,
+				scheduleText: "every 5m",
+				prompt: "private heartbeat",
+				now: new Date("2026-01-01T12:00:02.000Z"),
+			});
+			const globalCron = internals.cronStore.create({
+				activeSessionId: "unloaded-session",
+				sessionId: "unloaded-stable-id",
+				sessionFile: join(tempDir, "unloaded.jsonl"),
+				cwd: tempDir,
+				scheduleText: "in 2m",
+				prompt: "unloaded cron",
+				now: new Date("2026-01-01T12:00:03.000Z"),
+			});
+
+			const guardedMutations = [
+				{ type: "restore_next_turn", messages: [] },
+				{ type: "append_custom_message", message: { customType: "test", content: "private" } },
+				{ type: "resume_queue" },
+				{ type: "agent_messages_clear" },
+				{ type: "abort" },
+				{ type: "abort_side_question", sideQuestionId: "side" },
+				{ type: "execute_bash", command: "echo private" },
+				{ type: "execute_bash_and_wait", command: "echo private" },
+				{ type: "abort_bash" },
+				{ type: "cancel_rlm_child", childId: "child" },
+				{ type: "delete_rlm_subagent", childId: "child" },
+				{ type: "clear_queue" },
+				{ type: "abort_and_clear_queue" },
+				{ type: "cron_add", schedule: "in 1m", prompt: "private" },
+				{ type: "cron_cancel", jobId: privateCron.id },
+				{ type: "heartbeat_set", schedule: "every 5m", prompt: "private" },
+				{ type: "set_thinking_level", level: "medium" },
+				{ type: "set_auto_compaction", enabled: true },
+				{ type: "set_auto_retry", enabled: true },
+				{ type: "abort_compaction" },
+				{ type: "abort_branch_summary" },
+				{ type: "abort_retry" },
+				{ type: "reload" },
+				{ type: "export_html" },
+				{ type: "export_jsonl" },
+				{ type: "set_session_name", name: "private" },
+				{ type: "set_session_entry_label", entryId: "entry", label: "private" },
+			] as const;
+			for (const command of guardedMutations) {
+				await expect(
+					internals.handleCommand(makeClient(`private-${command.type}`, "unloaded-session"), {
+						...command,
+						activeSessionId: privateState.activeSessionId,
+					} as DaemonCommand),
+				).rejects.toThrow("unavailable");
+			}
+
+			const reads = [
+				"get_session_header",
+				"get_state",
+				"get_connection_state",
+				"get_messages",
+				"get_session_stats",
+				"get_context_tree",
+				"get_commands",
+				"get_resource_snapshot",
+				"get_model_catalog",
+				"get_available_models",
+				"get_queue",
+				"heartbeat_get",
+				"get_session_context",
+				"get_session_tree",
+				"get_user_messages_for_forking",
+				"get_last_assistant_text",
+				"get_system_prompt",
+				"get_rlm_max_depth_status",
+			] as const;
+			for (const type of reads) {
+				await expect(
+					internals.handleCommand(makeClient(`private-${type}`, "unloaded-session"), {
+						type,
+						activeSessionId: privateState.activeSessionId,
+					} as DaemonCommand),
+				).rejects.toThrow("unavailable");
+			}
+			await expect(
+				internals.handleCommand(makeClient("private-tool", "unloaded-session"), {
+					type: "get_tool_definition",
+					activeSessionId: privateState.activeSessionId,
+					name: "bash",
+				}),
+			).rejects.toThrow("unavailable");
+			await expect(
+				internals.handleCommand(makeClient("private-saved", "unloaded-session"), {
+					type: "list_saved_sessions",
+					activeSessionId: privateState.activeSessionId,
+					scope: "current",
+				}),
+			).rejects.toThrow("unavailable");
+
+			for (const type of ["cron_list", "heartbeats_list"] as const) {
+				await expect(
+					internals.handleCommand(makeClient(`private-${type}`, "unloaded-session"), {
+						type,
+						activeSessionId: privateState.activeSessionId,
+					}),
+				).rejects.toThrow("unavailable");
+			}
+
+			const cronList = (await internals.handleCommand(makeClient("cron-list", "unloaded-session"), {
+				type: "cron_list",
+				includeInactive: true,
+			})) as { data: { jobs: AgentCronJob[] } };
+			expect(cronList.data.jobs.map((job) => job.id)).toEqual([globalCron.id]);
+			const heartbeatList = (await internals.handleCommand(makeClient("heartbeat-list", "unloaded-session"), {
+				type: "heartbeats_list",
+			})) as { data: { heartbeats: Array<{ job: AgentCronJob }> } };
+			expect(heartbeatList.data.heartbeats.map(({ job }) => job.id)).not.toContain(privateHeartbeat.id);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("reconciles a detached tombstoned close on bounded timer backoff", async () => {
+		vi.useFakeTimers();
+		try {
+			const daemon = new AgentDaemon("/tmp/tombstoned-close-reconcile.sock", {
+				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			const parent = makeState("retry-parent");
+			const child = makeState("retry-child", parent.activeSessionId);
+			Object.assign(child.runtime.metadata, { kind: "subagent", rlmChildId: "child" });
+			const closeSession = vi
+				.fn<(state: ActiveSessionState, reason: "killed", notify: false) => Promise<void>>()
+				.mockRejectedValueOnce(new Error("one-shot close failure"))
+				.mockResolvedValue(undefined);
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				failedTombstonedRlmCloses: Map<string, { error?: unknown }>;
+				detachTombstonedClose(parent: ActiveSessionState, child: ActiveSessionState, id: string): void;
+				closeSession: typeof closeSession;
+			};
+			internals.sessions.set(parent.activeSessionId, parent);
+			internals.sessions.set(child.activeSessionId, child);
+			internals.closeSession = closeSession;
+
+			internals.detachTombstonedClose(parent, child, "child");
+			await vi.runAllTicks();
+			await Promise.resolve();
+			expect(closeSession).toHaveBeenCalledOnce();
+			expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(true);
+			await vi.advanceTimersByTimeAsync(249);
+			expect(closeSession).toHaveBeenCalledOnce();
+			await vi.advanceTimersByTimeAsync(1);
+			expect(closeSession).toHaveBeenCalledTimes(2);
+			expect(internals.failedTombstonedRlmCloses.has(child.activeSessionId)).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("retries a rejected runtime disposal through the exact full tombstoned close", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1022,6 +1022,8 @@ describe("daemon mode helpers", () => {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
 			const internals = fixture.daemon as unknown as {
 				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				closeSession(state: ActiveSessionState, reason: "killed", allowPassivation: false): Promise<void>;
 				recordRlmSubagentDeletion(
 					parentState: ActiveSessionState,
 					childId: string,
@@ -1033,6 +1035,21 @@ describe("daemon mode helpers", () => {
 			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
 			const modern = readFileSync(registryPath, "utf8");
+			const host = internals.createSubagentRuntimeHost(parent);
+			const close = vi.spyOn(internals, "closeSession");
+			const incompleteAuthority = {
+				childId: fixture.childId,
+				sessionDir: fixture.childSessionDir,
+				generation: 1,
+				assertCurrent: () => {},
+			};
+
+			// The public host path must fail before both tombstone append and resident close.
+			await expect(
+				host.deleteRlmSubagentRuntime(fixture.childId, child.runtime.session, incompleteAuthority),
+			).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+			expect(close).not.toHaveBeenCalled();
+			expect(readFileSync(registryPath, "utf8")).toBe(modern);
 
 			// A coordinator-shaped request that omits either incarnation fence must
 			// not use a matching resident object as a fallback authorization.

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -704,9 +704,10 @@ describe("daemon mode helpers", () => {
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
-		// A registry failure must not strand the cancelled child as a stale resident session,
-		// but must retain the artifact because durability is unknown.
+		// A registry failure is precommit: keep the live incarnation resident and
+		// addressable so a later owner can retry the durable tombstone and close once.
 		internals.sessions.set(childState.activeSessionId, childState);
+		const closeCountBeforeFailure = closeSession.mock.calls.length;
 		internals.recordRlmSubagentDeletion = vi.fn(async () => {
 			throw new Error("registry write failed");
 		});
@@ -718,7 +719,23 @@ describe("daemon mode helpers", () => {
 					{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
 					"cancelled",
 				),
-		).resolves.toEqual({ deletionDurability: "unknown" });
+		).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+		expect(closeSession).toHaveBeenCalledTimes(closeCountBeforeFailure);
+		expect(internals.sessions.get(childState.activeSessionId)).toBe(childState);
+
+		const retryDeletion = vi.fn(async () => "tombstoned" as const);
+		internals.recordRlmSubagentDeletion = retryDeletion;
+		await expect(
+			internals
+				.createSubagentRuntimeHost(parentState)
+				.releaseRlmSubagentRuntime?.(
+					{ session: childState.runtime.session },
+					{ id: "child-1" } as CreateRlmSubagentRuntimeOptions,
+					"cancelled",
+				),
+		).resolves.toEqual({ deletionDurability: "tombstoned" });
+		expect(retryDeletion).toHaveBeenCalledOnce();
+		expect(closeSession).toHaveBeenCalledTimes(closeCountBeforeFailure + 1);
 		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -768,6 +768,7 @@ describe("daemon mode helpers", () => {
 			});
 			const host = internals.createSubagentRuntimeHost(parentState);
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const validHistoryEntry = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
 
 			// A real resident child with its row removed has no durable owner. The host
 			// still closes it, and explicitly proves the artifact is absent.
@@ -798,6 +799,34 @@ describe("daemon mode helpers", () => {
 			);
 			expect(readFileSync(registryPath, "utf8")).toContain('"childId":"release-tombstoned"');
 			expect(readFileSync(registryPath, "utf8")).toContain('"status":"deleted"');
+
+			// Every historical line is authority-sensitive: an unrelated syntactically
+			// valid but schema-truncated row makes release durability unknown rather
+			// than authorizing artifact removal as if the child were absent.
+			for (const [label, patch] of [
+				["missing-parent-session-id", { parentSessionId: undefined }],
+				["missing-created-at", { createdAt: undefined }],
+				["missing-updated-at", { updatedAt: undefined }],
+				["malformed-model", { model: { provider: "test" } }],
+			] as const) {
+				const options = optionsFor(`release-${label}`);
+				const runtime = await internals.createRlmSubagentRuntime(parentState, options);
+				writeFileSync(
+					registryPath,
+					`${JSON.stringify(validHistoryEntry)}\n${JSON.stringify({
+						...validHistoryEntry,
+						childId: `unrelated-${label}`,
+						...patch,
+					})}\n`,
+				);
+				await expect(host.releaseRlmSubagentRuntime?.(runtime, options, "cancelled")).resolves.toEqual({
+					deletionDurability: "unknown",
+				});
+				expect(existsSync(options.sessionDir)).toBe(true);
+			}
+
+			// Restore complete history so this control reaches the append boundary.
+			writeFileSync(registryPath, `${JSON.stringify(validHistoryEntry)}\n`);
 
 			// A deterministic append/fsync failure likewise closes the real resident
 			// runtime but leaves durable ownership unknown, so the caller retains it.

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -905,6 +905,84 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("honors daemon deletion authority on both sides of the append boundary", async () => {
+		const beforeTempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-before-append-"));
+		const afterTempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-after-append-"));
+		try {
+			const before = makePersistedRlmDaemonFixture(beforeTempDir);
+			const beforeInternals = before.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				sessions: Map<string, ActiveSessionState>;
+			};
+			const beforeParent = await beforeInternals.createRuntime({
+				type: "create",
+				sessionPath: before.parentSessionFile,
+			});
+			const beforeChild = await beforeInternals.createRuntime({
+				type: "create",
+				sessionPath: before.childSessionFile,
+			});
+			const beforeRegistryPath = join(before.parentArtifactDir, "rlm-subagents.jsonl");
+			const beforeRegistry = readFileSync(beforeRegistryPath, "utf8");
+			const revokedBeforeAppend = new Error("host request authority was revoked");
+			let beforeBoundaryChecks = 0;
+			await expect(
+				beforeInternals
+					.createSubagentRuntimeHost(beforeParent)
+					.deleteRlmSubagentRuntime(before.childId, beforeChild.runtime.session, {
+						childId: before.childId,
+						sessionDir: before.childSessionDir,
+						generation: 1,
+						assertCurrent: () => {
+							if (++beforeBoundaryChecks === 2) throw revokedBeforeAppend;
+						},
+					}),
+			).rejects.toBe(revokedBeforeAppend);
+			expect(readFileSync(beforeRegistryPath, "utf8")).toBe(beforeRegistry);
+			expect(beforeInternals.sessions.get(beforeChild.activeSessionId)).toBe(beforeChild);
+
+			const after = makePersistedRlmDaemonFixture(afterTempDir);
+			const afterInternals = after.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				appendRlmSubagentRegistryEntry(parent: ActiveSessionState, entry: { status: string }): boolean;
+				sessions: Map<string, ActiveSessionState>;
+			};
+			const afterParent = await afterInternals.createRuntime({
+				type: "create",
+				sessionPath: after.parentSessionFile,
+			});
+			const afterChild = await afterInternals.createRuntime({ type: "create", sessionPath: after.childSessionFile });
+			const afterAbort = new AbortController();
+			const appendEntry = afterInternals.appendRlmSubagentRegistryEntry;
+			vi.spyOn(afterInternals, "appendRlmSubagentRegistryEntry").mockImplementation((parentState, entry) => {
+				const result = appendEntry.call(afterInternals, parentState, entry);
+				afterAbort.abort();
+				return result;
+			});
+			await expect(
+				afterInternals
+					.createSubagentRuntimeHost(afterParent)
+					.deleteRlmSubagentRuntime(after.childId, afterChild.runtime.session, {
+						childId: after.childId,
+						sessionDir: after.childSessionDir,
+						generation: 1,
+						assertCurrent: () => {
+							if (afterAbort.signal.aborted) throw new Error("host request authority was revoked");
+						},
+					}),
+			).resolves.toBeUndefined();
+			expect(readFileSync(join(after.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")).toContain(
+				'"status":"deleted"',
+			);
+			expect(afterInternals.sessions.has(afterChild.activeSessionId)).toBe(false);
+		} finally {
+			rmSync(beforeTempDir, { recursive: true, force: true });
+			rmSync(afterTempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("persists a real child completion for passive discovery, roster, and listing", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-real-completion-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1110,6 +1110,73 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("permits omitted-session deletion only for an exact persisted resident authority", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-passive-resident-authority-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				closeSession(state: ActiveSessionState, reason: "killed", allowPassivation: false): Promise<void>;
+			};
+			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const child = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const host = internals.createSubagentRuntimeHost(parent);
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const close = vi.spyOn(internals, "closeSession");
+			const authority = {
+				childId: fixture.childId,
+				sessionDir: fixture.childSessionDir,
+				sessionFile: fixture.childSessionFile,
+				sessionId: child.runtime.session.sessionId,
+				generation: 1,
+				assertCurrent: () => {},
+			};
+
+			await expect(host.deleteRlmSubagentRuntime(fixture.childId, undefined, authority)).resolves.toEqual({
+				deletionDurability: "tombstoned",
+			});
+			expect(close).toHaveBeenCalledOnce();
+			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
+
+			const staleFixture = makePersistedRlmDaemonFixture(join(tempDir, "stale"));
+			const staleInternals = staleFixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				closeSession(state: ActiveSessionState, reason: "killed", allowPassivation: false): Promise<void>;
+			};
+			const staleParent = await staleInternals.createRuntime({
+				type: "create",
+				sessionPath: staleFixture.parentSessionFile,
+			});
+			const staleChild = await staleInternals.createRuntime({
+				type: "create",
+				sessionPath: staleFixture.childSessionFile,
+			});
+			const staleRegistryPath = join(staleFixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const staleEntry = JSON.parse(readFileSync(staleRegistryPath, "utf8")) as Record<string, unknown>;
+			writeFileSync(staleRegistryPath, `${JSON.stringify({ ...staleEntry, sessionId: "stale-session-id" })}\n`);
+			const staleBefore = readFileSync(staleRegistryPath, "utf8");
+			const staleClose = vi.spyOn(staleInternals, "closeSession");
+			await expect(
+				staleInternals
+					.createSubagentRuntimeHost(staleParent)
+					.deleteRlmSubagentRuntime(staleFixture.childId, undefined, {
+						...authority,
+						childId: staleFixture.childId,
+						sessionDir: staleFixture.childSessionDir,
+						sessionFile: staleFixture.childSessionFile,
+						sessionId: "stale-session-id",
+					}),
+			).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+			expect(staleClose).not.toHaveBeenCalled();
+			expect(staleChild.runtime.session.sessionId).not.toBe("stale-session-id");
+			expect(readFileSync(staleRegistryPath, "utf8")).toBe(staleBefore);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("rechecks retry authority before appending a daemon deletion tombstone", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-deletion-authority-"));
 		try {
@@ -7825,7 +7892,7 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("deletes a passive child without hydrating it and treats unknown children benignly", async () => {
+	it("rejects passive deletion without a resident incarnation and treats unknown children benignly", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-lazy-rlm-delete-"));
 		try {
 			const fixture = makePersistedRlmDaemonFixture(tempDir);
@@ -7867,19 +7934,20 @@ describe("daemon mode helpers", () => {
 			})) as { data: { deleted: boolean } };
 			expect(unknown.data).toEqual({ deleted: false });
 
-			const result = (await internals.handleCommand(client, {
-				type: "delete_rlm_subagent",
-				activeSessionId: parentState.activeSessionId,
-				childId: fixture.childId,
-			})) as { data: { deleted: boolean } };
-			expect(result.data).toEqual({ deleted: true });
+			await expect(
+				internals.handleCommand(client, {
+					type: "delete_rlm_subagent",
+					activeSessionId: parentState.activeSessionId,
+					childId: fixture.childId,
+				}),
+			).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
 			expect(fixture.createRuntime).toHaveBeenCalledOnce();
 			expect(existsSync(fixture.childSessionFile)).toBe(true);
 			const persisted = readFileSync(join(fixture.parentArtifactDir, "rlm-subagents.jsonl"), "utf8")
 				.trim()
 				.split(/\r?\n/)
 				.map((line) => JSON.parse(line) as { childId: string; status: string });
-			expect(persisted.at(-1)).toMatchObject({ childId: fixture.childId, status: "deleted" });
+			expect(persisted.at(-1)).toMatchObject({ childId: fixture.childId, status: "completed" });
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -740,6 +740,128 @@ describe("daemon mode helpers", () => {
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
 
+	it("fences stale same-id same-directory daemon release and delete by runtime identity", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-daemon-incarnation-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parentState = makeState("parent-incarnation");
+		const oldState = makeState("old-incarnation", parentState.activeSessionId);
+		const newState = makeState("new-incarnation", parentState.activeSessionId);
+		const sessionDir = "/tmp/recycled-child-directory";
+		const oldSession = {
+			sessionFile: `${sessionDir}/old.jsonl`,
+			disposeAsync: vi.fn(async () => {}),
+		};
+		const newSession = {
+			sessionFile: `${sessionDir}/new.jsonl`,
+			disposeAsync: vi.fn(async () => {}),
+		};
+		for (const [state, session] of [
+			[oldState, oldSession],
+			[newState, newSession],
+		] as const) {
+			state.runtime = {
+				...state.runtime,
+				metadata: {
+					kind: "subagent",
+					createdAt: 1,
+					parentActiveSessionId: parentState.activeSessionId,
+					rlmChildId: "recycled-child",
+					sessionDir,
+				},
+				session,
+			} as never;
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closeSession: ReturnType<typeof vi.fn>;
+			recordRlmSubagentDeletion: ReturnType<typeof vi.fn>;
+			readLatestRlmSubagentRegistry: ReturnType<typeof vi.fn>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+		};
+		internals.sessions.set(parentState.activeSessionId, parentState);
+		// Model recreation: the old object is no longer resident, while the new
+		// object has exactly the same child id and directory.
+		internals.sessions.set(newState.activeSessionId, newState);
+		internals.closeSession = vi.fn(async (state: ActiveSessionState) => {
+			internals.sessions.delete(state.activeSessionId);
+		});
+		internals.recordRlmSubagentDeletion = vi.fn(async () => "tombstoned" as const);
+		internals.readLatestRlmSubagentRegistry = vi.fn(async () => [
+			{ childId: "recycled-child", sessionDir, sessionFile: newSession.sessionFile },
+		]);
+		const host = internals.createSubagentRuntimeHost(parentState);
+		const options = { id: "recycled-child", sessionDir } as CreateRlmSubagentRuntimeOptions;
+
+		await expect(
+			host.releaseRlmSubagentRuntime?.({ session: oldSession } as never, options, "cancelled"),
+		).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+		await expect(host.deleteRlmSubagentRuntime("recycled-child", oldSession as never)).rejects.toMatchObject({
+			name: "RlmSubagentHostDeletionError",
+			phase: "precommit",
+		});
+		expect(internals.recordRlmSubagentDeletion).not.toHaveBeenCalled();
+		expect(internals.closeSession).not.toHaveBeenCalled();
+		expect(oldSession.disposeAsync).not.toHaveBeenCalled();
+		expect(newSession.disposeAsync).not.toHaveBeenCalled();
+		expect(internals.sessions.get(newState.activeSessionId)).toBe(newState);
+
+		await expect(
+			host.releaseRlmSubagentRuntime?.({ session: newSession } as never, options, "cancelled"),
+		).resolves.toEqual({ deletionDurability: "tombstoned" });
+		expect(internals.recordRlmSubagentDeletion).toHaveBeenCalledOnce();
+		expect(internals.closeSession).toHaveBeenCalledOnce();
+		expect(internals.closeSession).toHaveBeenCalledWith(newState, "killed");
+	});
+
+	it("classifies scheduler failure after a daemon tombstone as postcommit", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-daemon-postcommit-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const parentState = makeState("parent-postcommit");
+		const childState = makeState("child-postcommit", parentState.activeSessionId);
+		const sessionDir = "/tmp/postcommit-child";
+		const session = { sessionFile: `${sessionDir}/child.jsonl` };
+		childState.runtime = {
+			...childState.runtime,
+			metadata: {
+				kind: "subagent",
+				createdAt: 1,
+				parentActiveSessionId: parentState.activeSessionId,
+				rlmChildId: "postcommit-child",
+				sessionDir,
+			},
+			session,
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closeSession: ReturnType<typeof vi.fn>;
+			recordRlmSubagentDeletion: ReturnType<typeof vi.fn>;
+			readLatestRlmSubagentRegistry: ReturnType<typeof vi.fn>;
+			cancelScheduledJobsForSessionFile: ReturnType<typeof vi.fn>;
+			createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+		};
+		internals.sessions.set(childState.activeSessionId, childState);
+		internals.closeSession = vi.fn(async () => {});
+		internals.recordRlmSubagentDeletion = vi.fn(async () => "tombstoned" as const);
+		internals.readLatestRlmSubagentRegistry = vi.fn(async () => [
+			{ childId: "postcommit-child", sessionDir, sessionFile: session.sessionFile },
+		]);
+		internals.cancelScheduledJobsForSessionFile = vi.fn(() => {
+			throw new Error("scheduler cleanup failed");
+		});
+
+		await expect(
+			internals
+				.createSubagentRuntimeHost(parentState)
+				.deleteRlmSubagentRuntime("postcommit-child", session as never),
+		).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "tombstoned" });
+		expect(internals.recordRlmSubagentDeletion).toHaveBeenCalledOnce();
+		expect(internals.closeSession).toHaveBeenCalledOnce();
+	});
+
 	it("reports durable retention only for actual daemon deletion tombstones", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-release-ownership-"));
 		try {
@@ -836,9 +958,13 @@ describe("daemon mode helpers", () => {
 						...patch,
 					})}\n`,
 				);
-				await expect(host.releaseRlmSubagentRuntime?.(runtime, options, "cancelled")).resolves.toEqual({
-					deletionDurability: "unknown",
+				await expect(host.releaseRlmSubagentRuntime?.(runtime, options, "cancelled")).rejects.toMatchObject({
+					name: "RlmSubagentHostDeletionError",
+					phase: "precommit",
 				});
+				expect([...internals.sessions.values()].some((state) => state.runtime.session === runtime.session)).toBe(
+					true,
+				);
 				expect(existsSync(options.sessionDir)).toBe(true);
 			}
 
@@ -850,12 +976,15 @@ describe("daemon mode helpers", () => {
 			const failedOptions = optionsFor("release-write-failed");
 			const failedRuntime = await internals.createRlmSubagentRuntime(parentState, failedOptions);
 			const append = vi.spyOn(internals, "appendRlmSubagentRegistryEntry").mockReturnValue(false);
-			await expect(host.releaseRlmSubagentRuntime?.(failedRuntime, failedOptions, "cancelled")).resolves.toEqual({
-				deletionDurability: "unknown",
+			await expect(
+				host.releaseRlmSubagentRuntime?.(failedRuntime, failedOptions, "cancelled"),
+			).rejects.toMatchObject({
+				name: "RlmSubagentHostDeletionError",
+				phase: "precommit",
 			});
 			expect(append).toHaveBeenCalledWith(parentState, expect.objectContaining({ status: "deleted" }));
 			expect([...internals.sessions.values()].some((state) => state.runtime.session === failedRuntime.session)).toBe(
-				false,
+				true,
 			);
 
 			// A malformed registry history cannot prove that a child is absent.
@@ -864,7 +993,10 @@ describe("daemon mode helpers", () => {
 			writeFileSync(registryPath, `${readFileSync(registryPath, "utf8")}not-json\n`);
 			await expect(
 				host.releaseRlmSubagentRuntime?.(malformedRuntime, malformedOptions, "cancelled"),
-			).resolves.toEqual({ deletionDurability: "unknown" });
+			).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+			expect(
+				[...internals.sessions.values()].some((state) => state.runtime.session === malformedRuntime.session),
+			).toBe(true);
 
 			// An unreadable registry has the same fail-closed result, rather than
 			// treating the missing child row as authority to remove artifacts.
@@ -875,7 +1007,10 @@ describe("daemon mode helpers", () => {
 			mkdirSync(registryPath);
 			await expect(
 				host.releaseRlmSubagentRuntime?.(readFaultRuntime, readFaultOptions, "cancelled"),
-			).resolves.toEqual({ deletionDurability: "unknown" });
+			).rejects.toMatchObject({ name: "RlmSubagentHostDeletionError", phase: "precommit" });
+			expect(
+				[...internals.sessions.values()].some((state) => state.runtime.session === readFaultRuntime.session),
+			).toBe(true);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -864,6 +864,47 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("rechecks retry authority before appending a daemon deletion tombstone", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-deletion-authority-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				recordRlmSubagentDeletion(
+					parentState: ActiveSessionState,
+					childId: string,
+					authority?: { assertCurrent(): void },
+				): Promise<"absent" | "tombstoned" | "unknown">;
+			};
+			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
+			const before = readFileSync(registryPath, "utf8");
+			const revoked = new Error("host request authority was revoked");
+
+			// The complete asynchronous registry read must not become authority to
+			// append after the caller has been revoked.
+			await expect(
+				internals.recordRlmSubagentDeletion(parentState, fixture.childId, {
+					assertCurrent: () => {
+						throw revoked;
+					},
+				}),
+			).rejects.toBe(revoked);
+			expect(readFileSync(registryPath, "utf8")).toBe(before);
+
+			await expect(
+				internals.recordRlmSubagentDeletion(parentState, fixture.childId, { assertCurrent: () => {} }),
+			).resolves.toBe("tombstoned");
+			expect(readFileSync(registryPath, "utf8").match(/"childId":"child-1"/g)).toHaveLength(2);
+			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
+			await expect(
+				internals.recordRlmSubagentDeletion(parentState, "unknown", { assertCurrent: () => {} }),
+			).resolves.toBe("absent");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("persists a real child completion for passive discovery, roster, and listing", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-real-completion-"));
 		try {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1045,12 +1045,22 @@ describe("daemon mode helpers", () => {
 			expect(readFileSync(registryPath, "utf8")).toBe(before);
 
 			await expect(
-				internals.recordRlmSubagentDeletion(parentState, fixture.childId, { assertCurrent: () => {} }),
+				internals.recordRlmSubagentDeletion(parentState, fixture.childId, {
+					childId: fixture.childId,
+					sessionDir: fixture.childSessionDir,
+					sessionFile: fixture.childSessionFile,
+					sessionId: JSON.parse(before).sessionId as string,
+					assertCurrent: () => {},
+				}),
 			).resolves.toBe("tombstoned");
 			expect(readFileSync(registryPath, "utf8").match(/"childId":"child-1"/g)).toHaveLength(2);
 			expect(readFileSync(registryPath, "utf8").match(/"status":"deleted"/g)).toHaveLength(1);
 			await expect(
-				internals.recordRlmSubagentDeletion(parentState, "unknown", { assertCurrent: () => {} }),
+				internals.recordRlmSubagentDeletion(parentState, "unknown", {
+					childId: "unknown",
+					sessionDir: "/tmp/unknown",
+					assertCurrent: () => {},
+				}),
 			).resolves.toBe("absent");
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
@@ -1069,13 +1079,13 @@ describe("daemon mode helpers", () => {
 			const parent = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
 			const registryPath = join(fixture.parentArtifactDir, "rlm-subagents.jsonl");
 			const original = JSON.parse(readFileSync(registryPath, "utf8")) as Record<string, unknown>;
-			const replacementFile = join(fixture.childSessionDir, "replacement.jsonl");
-			writeFileSync(replacementFile, "replacement");
+			const oldSessionId = original.sessionId as string;
+			const replacementSessionId = "replacement-session-id";
 			writeFileSync(
 				registryPath,
-				`${JSON.stringify({
+				`${JSON.stringify(original)}\n${JSON.stringify({
 					...original,
-					sessionFile: replacementFile,
+					sessionId: replacementSessionId,
 					updatedAt: "2026-01-01T00:00:02.000Z",
 				})}\n`,
 			);
@@ -1084,7 +1094,7 @@ describe("daemon mode helpers", () => {
 				childId: fixture.childId,
 				sessionDir: fixture.childSessionDir,
 				sessionFile: fixture.childSessionFile,
-				sessionId: "old-session-id",
+				sessionId: oldSessionId,
 				generation: 1,
 				assertCurrent: () => {},
 			};
@@ -1100,8 +1110,7 @@ describe("daemon mode helpers", () => {
 			});
 			const currentAuthority = {
 				...oldAuthority,
-				sessionFile: replacementFile,
-				sessionId: "replacement-session-id",
+				sessionId: replacementSessionId,
 				generation: 2,
 			};
 			await expect(
@@ -5318,6 +5327,7 @@ describe("daemon mode helpers", () => {
 					sessionName: "heartbeat-child",
 					sessionDir: childSessionDir,
 					sessionFile: childSessionFile,
+					sessionId: childManager.getSessionId(),
 					parentSessionId: parentManager.getSessionId(),
 					parentSessionFile,
 					rlmDepth: 1,
@@ -5873,6 +5883,7 @@ describe("daemon mode helpers", () => {
 					sessionName: "cycle-to-root",
 					sessionDir: join(tempDir, "sessions"),
 					sessionFile: fixture.parentSessionFile,
+					sessionId: fixture.parentSessionId,
 					parentSessionId: childInfo.id,
 					parentSessionFile: fixture.childSessionFile,
 					status: "completed",
@@ -6101,6 +6112,7 @@ describe("daemon mode helpers", () => {
 					sessionName: "spawn-worker",
 					sessionDir: siblingSessionDir,
 					sessionFile: siblingSessionFile,
+					sessionId: siblingManager.getSessionId(),
 					parentSessionId: fixture.parentSessionId,
 					parentSessionFile: fixture.parentSessionFile,
 					status: "completed",
@@ -10202,6 +10214,7 @@ function makePersistedRlmDaemonFixture(
 			sessionName: "nested-worker",
 			sessionDir: grandchildSessionDir,
 			sessionFile: grandchildSessionFile,
+			sessionId: grandchildManager.getSessionId(),
 			parentSessionId: childManager.getSessionId(),
 			parentSessionFile: childSessionFile,
 			rlmDepth: 2,
@@ -10221,6 +10234,7 @@ function makePersistedRlmDaemonFixture(
 			sessionName: "spawn-worker",
 			sessionDir: childSessionDir,
 			sessionFile: childSessionFile,
+			sessionId: childManager.getSessionId(),
 			parentSessionId: parentManager.getSessionId(),
 			parentSessionFile,
 			rlmDepth: 1,

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1088,6 +1088,23 @@ describe("daemon mode helpers", () => {
 				status: "deleted",
 				sessionId: child.runtime.session.sessionId,
 			});
+
+			// An already-deleted legacy row still needs one identity-upgrade append so
+			// retained cleanup retries can later prove the exact tombstoned incarnation.
+			writeFileSync(registryPath, `${JSON.stringify({ ...legacy, status: "deleted" })}\n`);
+			await expect(
+				internals.recordRlmSubagentDeletion(parent, fixture.childId, undefined, child.runtime.session),
+			).resolves.toBe("tombstoned");
+			const deletedEntries = readFileSync(registryPath, "utf8")
+				.trim()
+				.split(/\r?\n/u)
+				.map((line) => JSON.parse(line) as Record<string, unknown>);
+			expect(deletedEntries).toHaveLength(2);
+			expect(deletedEntries[1]).toMatchObject({
+				childId: fixture.childId,
+				status: "deleted",
+				sessionId: child.runtime.session.sessionId,
+			});
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -10850,6 +10850,21 @@ describe("daemon tombstoned retirement", () => {
 				now: new Date("2026-01-01T12:00:03.000Z"),
 			});
 
+			const cancel = vi.spyOn(internals.cronStore, "cancel");
+			await expect(
+				internals.handleCommand(makeClient("unscoped-private-cron-cancel", "unloaded-session"), {
+					type: "cron_cancel",
+					jobId: privateCron.id,
+				}),
+			).rejects.toThrow(`No cron job found: ${privateCron.id}`);
+			expect(cancel).not.toHaveBeenCalled();
+			const cancelledGlobalCron = (await internals.handleCommand(
+				makeClient("unscoped-global-cron-cancel", "unloaded-session"),
+				{ type: "cron_cancel", jobId: globalCron.id },
+			)) as { data: { job: AgentCronJob } };
+			expect(cancelledGlobalCron.data.job).toMatchObject({ id: globalCron.id, status: "cancelled" });
+			expect(cancel).toHaveBeenCalledWith(globalCron.id);
+
 			const guardedMutations = [
 				{ type: "restore_next_turn", messages: [] },
 				{ type: "append_custom_message", message: { customType: "test", content: "private" } },

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -10660,6 +10660,91 @@ describe("daemon tombstoned retirement", () => {
 		await gate;
 	});
 
+	it("hides a closing child subtree from daemon lists, targets, and cron jobs", async () => {
+		const daemon = new AgentDaemon("/tmp/closing-subtree.sock", {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const root = makeState("closing-root");
+		const child = makeState("closing-child", root.activeSessionId);
+		const grandchild = makeState("closing-grandchild", child.activeSessionId);
+		const sibling = makeState("closing-sibling", root.activeSessionId);
+		for (const [state, rlmChildId] of [
+			[root, undefined],
+			[child, "child"],
+			[grandchild, "grandchild"],
+			[sibling, "sibling"],
+		] as const) {
+			state.runtime = {
+				...state.runtime,
+				cwd: "/tmp",
+				diagnostics: [],
+				metadata: {
+					...state.runtime.metadata,
+					kind: state === root ? "top-level" : "subagent",
+					...(rlmChildId ? { rlmChildId } : {}),
+				},
+				session: {
+					sessionId: `session-${state.activeSessionId}`,
+					sessionName: state.activeSessionId,
+					isSessionActive: false,
+					isStreaming: false,
+					isCompacting: false,
+					isBashRunning: false,
+					hasRunningRlmChildren: () => false,
+					messages: [],
+					state: { pendingToolCalls: new Set(), streamingMessage: undefined },
+					unfinishedActionCount: 0,
+					sessionManager: { getCwd: () => "/tmp" },
+					getSessionActionSnapshot: () => ({ queuedCount: 0, steering: [], followUps: [] }),
+				},
+			} as never;
+		}
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			closingSessions: Map<string, unknown>;
+			failedTombstonedRlmCloses: Map<string, { state: ActiveSessionState }>;
+			createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			getOrHydrateBoundSessionState(id: string): Promise<ActiveSessionState>;
+			isCronJobRunnableForState(job: AgentCronJob, state: ActiveSessionState, requirePersistedJob: boolean): boolean;
+			isPublicRlmState(state: ActiveSessionState): boolean;
+		};
+		for (const state of [root, child, grandchild, sibling]) internals.sessions.set(state.activeSessionId, state);
+		internals.closingSessions.set(child.activeSessionId, {});
+
+		expect(internals.isPublicRlmState(child)).toBe(false);
+		expect(internals.isPublicRlmState(grandchild)).toBe(false);
+		expect(internals.isPublicRlmState(sibling)).toBe(true);
+		const listed = (await internals.handleCommand(makeClient("list-client", root.activeSessionId), {
+			type: "list",
+		})) as { data: { sessions: SessionSummary[] } };
+		expect(listed.data.sessions.map((session) => session.activeSessionId)).toEqual(
+			expect.arrayContaining([root.activeSessionId, sibling.activeSessionId]),
+		);
+		expect(listed.data.sessions.map((session) => session.activeSessionId)).not.toEqual(
+			expect.arrayContaining([child.activeSessionId, grandchild.activeSessionId]),
+		);
+		const targets = await internals.createAgentMessageController(() => root).listAgents();
+		expect(targets.agents.map((agent) => agent.activeSessionId)).toEqual(
+			expect.arrayContaining([sibling.activeSessionId]),
+		);
+		expect(targets.agents.map((agent) => agent.activeSessionId)).not.toEqual(
+			expect.arrayContaining([child.activeSessionId, grandchild.activeSessionId]),
+		);
+		await expect(internals.getOrHydrateBoundSessionState(grandchild.activeSessionId)).rejects.toThrow("unavailable");
+		const job = { status: "active", activeSessionId: grandchild.activeSessionId } as AgentCronJob;
+		expect(internals.isCronJobRunnableForState(job, grandchild, false)).toBe(false);
+		expect(
+			internals.isCronJobRunnableForState({ ...job, activeSessionId: sibling.activeSessionId }, sibling, false),
+		).toBe(true);
+
+		internals.closingSessions.delete(child.activeSessionId);
+		internals.sessions.delete(child.activeSessionId);
+		internals.failedTombstonedRlmCloses.set(child.activeSessionId, { state: child });
+		expect(internals.isPublicRlmState(grandchild)).toBe(false);
+	});
+
 	it("retains a failed physical disposal and retries the exact runtime", async () => {
 		const daemon = new AgentDaemon("/tmp/retry-retirement.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -11279,6 +11279,72 @@ describe("daemon tombstoned retirement", () => {
 		}
 	});
 
+	it.each([
+		["terminalizes after a one-shot archive recovery", false],
+		["preserves its private archive barrier after persistent failure", true],
+	] as const)("on shutdown %s", async (_name, persistentlyFails) => {
+		const daemon = new AgentDaemon(`/tmp/shutdown-terminalization-${persistentlyFails}.sock`, {
+			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const state = makeState(`shutdown-terminalization-${persistentlyFails}`);
+		const archiveFailure = new Error("archive failed");
+		const appendSessionState = vi.fn(() => {
+			if (persistentlyFails || appendSessionState.mock.calls.length === 1) throw archiveFailure;
+		});
+		const dispose = vi.fn(async () => {});
+		const releaseSessionLease = vi.fn();
+		state.extensionUiRequests = new Map();
+		state.runtime = {
+			...state.runtime,
+			claimSessionLeaseReleaseForDaemon: () => true,
+			dispose,
+			releaseSessionLease,
+			session: {
+				sessionId: `session-${state.activeSessionId}`,
+				sessionFile: `/tmp/${state.activeSessionId}.jsonl`,
+				messages: ["content"],
+				isBashRunning: false,
+				abort: vi.fn(async () => {}),
+				sessionManager: { appendSessionState, hasUserContent: () => true },
+			},
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			failedTombstonedRlmCloses: Map<
+				string,
+				{ state: ActiveSessionState; terminalizing?: boolean; reason?: "killed" }
+			>;
+			closeSession(state: ActiveSessionState, reason: "killed"): Promise<void>;
+			shutdown(exitCode: number): Promise<never>;
+		};
+		internals.sessions.set(state.activeSessionId, state);
+		await expect(internals.closeSession(state, "killed")).rejects.toBe(archiveFailure);
+		const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as typeof process.exit);
+		try {
+			await internals.shutdown(0);
+		} finally {
+			exit.mockRestore();
+		}
+
+		expect(appendSessionState).toHaveBeenCalledTimes(2);
+		if (persistentlyFails) {
+			expect(dispose).not.toHaveBeenCalled();
+			expect(releaseSessionLease).not.toHaveBeenCalled();
+			expect(internals.sessions.get(state.activeSessionId)).toBe(state);
+			expect(internals.failedTombstonedRlmCloses.get(state.activeSessionId)).toMatchObject({
+				state,
+				terminalizing: true,
+				reason: "killed",
+			});
+		} else {
+			expect(dispose).toHaveBeenCalledOnce();
+			expect(releaseSessionLease).toHaveBeenCalledOnce();
+			expect(internals.sessions.has(state.activeSessionId)).toBe(false);
+			expect(internals.failedTombstonedRlmCloses.has(state.activeSessionId)).toBe(false);
+		}
+	});
+
 	it("retains a failed close only for its exact tombstoned record", async () => {
 		const daemon = new AgentDaemon("/tmp/exact-tombstoned-close.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
@@ -11323,7 +11389,8 @@ describe("daemon tombstoned retirement", () => {
 
 		await expect(internals.closeSession(ordinary, "killed")).rejects.toBe(cleanupFailure);
 		expect(internals.sessions.get(ordinary.activeSessionId)).toBe(ordinary);
-		expect(internals.failedTerminalSessionCloses.get(ordinary.activeSessionId)?.state).toBe(ordinary);
+		expect(internals.failedTombstonedRlmCloses.get(ordinary.activeSessionId)?.state).toBe(ordinary);
+		expect(internals.failedTombstonedRlmCloses.get(ordinary.activeSessionId)?.terminalizing).toBe(true);
 		expect(releases.get(ordinary)).not.toHaveBeenCalled();
 
 		await expect(internals.closeSession(tombstoned, "killed")).rejects.toBe(cleanupFailure);

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -589,6 +589,22 @@ describe("buildRlmChildSnapshots", () => {
 		expect(snapshots.map((snapshot) => [snapshot.id, snapshot.status])).toEqual([["sub-aaa", "running"]]);
 	});
 
+	it("omits a precommit-quarantined resident child from attach snapshots", () => {
+		const parent = makeState({ activeSessionId: "parent", quarantinedRlmChildren: ["sub-private"] });
+		const privateChild = makeState({
+			activeSessionId: "private-child",
+			metadata: { kind: "subagent", createdAt: 1, parentActiveSessionId: "parent", rlmChildId: "sub-private" },
+		});
+		const visibleChild = makeState({
+			activeSessionId: "visible-child",
+			metadata: { kind: "subagent", createdAt: 1, parentActiveSessionId: "parent", rlmChildId: "sub-visible" },
+		});
+
+		expect(buildRlmChildSnapshots("parent", [parent, privateChild, visibleChild])).toMatchObject([
+			{ id: "sub-visible" },
+		]);
+	});
+
 	it("keeps terminal run status while projecting a retained child's active follow-up", () => {
 		const parent = makeState({
 			activeSessionId: "parent",
@@ -692,6 +708,7 @@ interface StateOptions {
 	hasUserContent?: boolean;
 	summaryState?: ActiveSessionState["summaryState"];
 	childRunStatuses?: Record<string, "queued" | "running" | "done" | "error" | "cancelled">;
+	quarantinedRlmChildren?: string[];
 	hasRunningRlmChildren?: boolean;
 	hasAcceptedPromptInFlight?: boolean;
 	unfinishedActionCount?: number;
@@ -742,6 +759,8 @@ function makeState(options: StateOptions): ActiveSessionState {
 				},
 				messages: options.messages ?? ([] as AgentMessage[]),
 				getRlmChildRunStatus: (childId: string) => options.childRunStatuses?.[childId],
+				isRlmChildDeletionQuarantined: (childId: string) =>
+					options.quarantinedRlmChildren?.includes(childId) ?? false,
 				hasRunningRlmChildren: () => options.hasRunningRlmChildren ?? false,
 				hasAcceptedPromptInFlight: options.hasAcceptedPromptInFlight ?? false,
 				unfinishedActionCount: options.unfinishedActionCount ?? (options.hasAcceptedPromptInFlight ? 1 : 0),

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -589,20 +589,29 @@ describe("buildRlmChildSnapshots", () => {
 		expect(snapshots.map((snapshot) => [snapshot.id, snapshot.status])).toEqual([["sub-aaa", "running"]]);
 	});
 
-	it("omits a precommit-quarantined resident child from attach snapshots", () => {
+	it("omits a quarantined child subtree without hiding an unrelated sibling", () => {
 		const parent = makeState({ activeSessionId: "parent", quarantinedRlmChildren: ["sub-private"] });
 		const privateChild = makeState({
 			activeSessionId: "private-child",
 			metadata: { kind: "subagent", createdAt: 1, parentActiveSessionId: "parent", rlmChildId: "sub-private" },
+		});
+		const privateGrandchild = makeState({
+			activeSessionId: "private-grandchild",
+			metadata: {
+				kind: "subagent",
+				createdAt: 1,
+				parentActiveSessionId: "private-child",
+				rlmChildId: "sub-private-grandchild",
+			},
 		});
 		const visibleChild = makeState({
 			activeSessionId: "visible-child",
 			metadata: { kind: "subagent", createdAt: 1, parentActiveSessionId: "parent", rlmChildId: "sub-visible" },
 		});
 
-		expect(buildRlmChildSnapshots("parent", [parent, privateChild, visibleChild])).toMatchObject([
-			{ id: "sub-visible" },
-		]);
+		expect(
+			buildRlmChildSnapshots("parent", [parent, privateChild, privateGrandchild, visibleChild]).map(({ id }) => id),
+		).toEqual(["sub-visible"]);
 	});
 
 	it("keeps terminal run status while projecting a retained child's active follow-up", () => {

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -589,29 +589,20 @@ describe("buildRlmChildSnapshots", () => {
 		expect(snapshots.map((snapshot) => [snapshot.id, snapshot.status])).toEqual([["sub-aaa", "running"]]);
 	});
 
-	it("omits a quarantined child subtree without hiding an unrelated sibling", () => {
+	it("omits a precommit-quarantined resident child from attach snapshots", () => {
 		const parent = makeState({ activeSessionId: "parent", quarantinedRlmChildren: ["sub-private"] });
 		const privateChild = makeState({
 			activeSessionId: "private-child",
 			metadata: { kind: "subagent", createdAt: 1, parentActiveSessionId: "parent", rlmChildId: "sub-private" },
-		});
-		const privateGrandchild = makeState({
-			activeSessionId: "private-grandchild",
-			metadata: {
-				kind: "subagent",
-				createdAt: 1,
-				parentActiveSessionId: "private-child",
-				rlmChildId: "sub-private-grandchild",
-			},
 		});
 		const visibleChild = makeState({
 			activeSessionId: "visible-child",
 			metadata: { kind: "subagent", createdAt: 1, parentActiveSessionId: "parent", rlmChildId: "sub-visible" },
 		});
 
-		expect(
-			buildRlmChildSnapshots("parent", [parent, privateChild, privateGrandchild, visibleChild]).map(({ id }) => id),
-		).toEqual(["sub-visible"]);
+		expect(buildRlmChildSnapshots("parent", [parent, privateChild, visibleChild])).toMatchObject([
+			{ id: "sub-visible" },
+		]);
 	});
 
 	it("keeps terminal run status while projecting a retained child's active follow-up", () => {

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import {
-	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
 	type HostRequestHandler,
@@ -72,7 +71,7 @@ export function createTestHostHandlers<
 >(handlers: T): Record<keyof T, HostRequestHandler> {
 	return Object.fromEntries(
 		Object.entries(handlers).map(([type, implementation]) => {
-			const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+			const handler = createHostRequestHandler(implementation);
 			testHostHandlerImplementations.set(handler, implementation);
 			return [type, handler];
 		}),

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
 	createHostRequestHandler,
 	type HostRequestContext,
@@ -23,8 +22,6 @@ export async function invokeHostRequestHandlerForTest(
 	}
 	const controller = new AbortController();
 	const context: HostRequestContext = {
-		requestId: randomUUID(),
-		generation: 0,
 		signal: controller.signal,
 		isCurrent: () => !controller.signal.aborted,
 	};

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -3,22 +3,19 @@ import {
 	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
-	type HostRequestHandlerImplementation,
+	type HostRequestHandler,
 	KernelManager,
 } from "../src/core/kernel/index.js";
 
 /** Raw implementations are retained only for test-created business-unit fixtures. */
-const testHostHandlerImplementations = new WeakMap<
-	HostRequestHandlerImplementation,
-	HostRequestHandlerImplementation
->();
+const testHostHandlerImplementations = new WeakMap<HostRequestHandler, HostRequestHandler>();
 
 /**
  * Calls a raw test fixture with synthetic context. This deliberately bypasses the
  * production wrapper and never registers context identity with production authority.
  */
 export async function invokeHostRequestHandlerForTest(
-	handler: HostRequestHandlerImplementation,
+	handler: HostRequestHandler,
 	payload: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
 	const implementation = testHostHandlerImplementations.get(handler);
@@ -44,7 +41,7 @@ export async function invokeHostRequestHandlerForTest(
  * dispatcher, preserving its authority and revocation boundary in integration tests.
  */
 export async function invokeHostRequestThroughKernelForTest(
-	handler: HostRequestHandlerImplementation,
+	handler: HostRequestHandler,
 	payload: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
 	const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
@@ -72,12 +69,12 @@ export function createTestHostHandlers<
 		string,
 		(payload: Record<string, unknown>, context: HostRequestContext) => Promise<Record<string, unknown>>
 	>,
->(handlers: T): Record<keyof T, HostRequestHandlerImplementation> {
+>(handlers: T): Record<keyof T, HostRequestHandler> {
 	return Object.fromEntries(
 		Object.entries(handlers).map(([type, implementation]) => {
 			const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
 			testHostHandlerImplementations.set(handler, implementation);
 			return [type, handler];
 		}),
-	) as unknown as Record<keyof T, HostRequestHandlerImplementation>;
+	) as unknown as Record<keyof T, HostRequestHandler>;
 }

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -5,7 +5,7 @@ import {
 	KernelManager,
 } from "../src/core/kernel/index.js";
 
-/** Raw implementations are retained only for test-created business-unit fixtures. */
+/** Raw implementations retained per fixture so tests can call them without dispatcher authority. */
 const testHostHandlerImplementations = new WeakMap<HostRequestHandler, HostRequestHandler>();
 
 /**

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -21,10 +21,7 @@ export async function invokeHostRequestHandlerForTest(
 		throw new Error("host request handler has no test-local raw implementation");
 	}
 	const controller = new AbortController();
-	const context: HostRequestContext = {
-		signal: controller.signal,
-		isCurrent: () => !controller.signal.aborted,
-	};
+	const context: HostRequestContext = { signal: controller.signal };
 	try {
 		return await implementation(payload, context);
 	} finally {

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -55,10 +55,7 @@ describe("staged host-request handler authority", () => {
 			calls += 1;
 			return {};
 		});
-		const fabricated = {
-			signal: new AbortController().signal,
-			isCurrent: () => true,
-		};
+		const fabricated = { signal: new AbortController().signal };
 		await expect(handler({ context: fabricated }, fabricated)).rejects.toThrow("host request context is invalid");
 		expect(calls).toBe(0);
 	});

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -23,15 +23,12 @@ describe("staged host-request handler authority", () => {
 		expect(calls).toBe(1);
 	});
 
-	it("rejects copied-symbol forgeries through WeakSet provenance before they run", () => {
-		const genuine = createHostRequestHandler(async (_payload, _context) => ({}));
+	it("rejects handlers that were not minted by the factory", () => {
 		let calls = 0;
 		const forged = async (): Promise<Record<string, unknown>> => {
 			calls += 1;
 			return {};
 		};
-		const brand = Object.getOwnPropertySymbols(genuine)[0];
-		Object.defineProperty(forged, brand, Object.getOwnPropertyDescriptor(genuine, brand)!);
 
 		expect(() => assertHostRequestHandler(forged)).toThrow(
 			"host request handler is not a dispatcher-created capability",

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -1,33 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
 	assertHostRequestHandler,
-	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
 } from "../src/core/kernel/index.js";
 import { invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest } from "./host-request-context.js";
 
 describe("staged host-request handler authority", () => {
-	it("rejects unary factory inputs before they run", () => {
-		let calls = 0;
-		const unary = async (_payload: Record<string, unknown>): Promise<Record<string, unknown>> => {
-			calls += 1;
-			return {};
-		};
-
-		expect(() => {
-			// @ts-expect-error Context-aware registration needs an explicit marker.
-			createHostRequestHandler(unary);
-		}).toThrow("host request handlers require the context-aware marker");
-		expect(calls).toBe(0);
-	});
-
 	it("rejects missing or invalid context before a genuine handler runs", async () => {
 		let calls = 0;
 		const handler = createHostRequestHandler(async (_payload, _context) => {
 			calls += 1;
 			return {};
-		}, contextAwareHostRequestHandler);
+		});
 
 		assertHostRequestHandler(handler);
 		await expect(handler({}, undefined as unknown as HostRequestContext)).rejects.toThrow(
@@ -39,7 +24,7 @@ describe("staged host-request handler authority", () => {
 	});
 
 	it("rejects copied-symbol forgeries through WeakSet provenance before they run", () => {
-		const genuine = createHostRequestHandler(async (_payload, _context) => ({}), contextAwareHostRequestHandler);
+		const genuine = createHostRequestHandler(async (_payload, _context) => ({}));
 		let calls = 0;
 		const forged = async (): Promise<Record<string, unknown>> => {
 			calls += 1;
@@ -54,18 +39,14 @@ describe("staged host-request handler authority", () => {
 		expect(calls).toBe(0);
 	});
 
-	it("uses explicit marker rather than implementation length for rest and default handlers", async () => {
-		const rest = createHostRequestHandler(
-			async (...args: [Record<string, unknown>, HostRequestContext]) => ({
-				requestId: args[1].requestId,
-			}),
-			contextAwareHostRequestHandler,
-		);
+	it("passes dispatcher context to rest and default-parameter handlers", async () => {
+		const rest = createHostRequestHandler(async (...args: [Record<string, unknown>, HostRequestContext]) => ({
+			requestId: args[1].requestId,
+		}));
 		const defaulted = createHostRequestHandler(
 			async (_payload, context = undefined as unknown as HostRequestContext) => ({
 				generation: context.generation,
 			}),
-			contextAwareHostRequestHandler,
 		);
 		expect((await invokeHostRequestHandlerForTest(rest, {})).requestId).toEqual(expect.any(String));
 		expect((await invokeHostRequestHandlerForTest(defaulted, {})).generation).toBe(1);
@@ -76,7 +57,7 @@ describe("staged host-request handler authority", () => {
 		const handler = createHostRequestHandler(async (_payload, _context) => {
 			calls += 1;
 			return {};
-		}, contextAwareHostRequestHandler);
+		});
 		const fabricated = {
 			requestId: "python",
 			generation: 1,

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../src/core/kernel/index.js";
 import { invokeHostRequestThroughKernelForTest as invokeHostRequestHandlerForTest } from "./host-request-context.js";
 
-describe("staged host-request handler authority", () => {
+describe("host-request handler authority", () => {
 	it("rejects missing or invalid context before a genuine handler runs", async () => {
 		let calls = 0;
 		const handler = createHostRequestHandler(async (_payload, _context) => {

--- a/packages/coding-agent/test/host-request-contract.test.ts
+++ b/packages/coding-agent/test/host-request-contract.test.ts
@@ -41,15 +41,15 @@ describe("staged host-request handler authority", () => {
 
 	it("passes dispatcher context to rest and default-parameter handlers", async () => {
 		const rest = createHostRequestHandler(async (...args: [Record<string, unknown>, HostRequestContext]) => ({
-			requestId: args[1].requestId,
+			aborted: args[1].signal.aborted,
 		}));
 		const defaulted = createHostRequestHandler(
 			async (_payload, context = undefined as unknown as HostRequestContext) => ({
-				generation: context.generation,
+				aborted: context.signal.aborted,
 			}),
 		);
-		expect((await invokeHostRequestHandlerForTest(rest, {})).requestId).toEqual(expect.any(String));
-		expect((await invokeHostRequestHandlerForTest(defaulted, {})).generation).toBe(1);
+		expect((await invokeHostRequestHandlerForTest(rest, {})).aborted).toBe(false);
+		expect((await invokeHostRequestHandlerForTest(defaulted, {})).aborted).toBe(false);
 	});
 
 	it("does not accept a structural or payload-supplied context", async () => {
@@ -59,8 +59,6 @@ describe("staged host-request handler authority", () => {
 			return {};
 		});
 		const fabricated = {
-			requestId: "python",
-			generation: 1,
 			signal: new AbortController().signal,
 			isCurrent: () => true,
 		};

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	AGENT_MESSAGE_DISPLAY_MIME,
-	contextAwareHostRequestHandler,
 	createHostRequestHandler,
 	type HostRequestContext,
 	KernelManager,
@@ -263,7 +262,7 @@ describe("KernelManager abort handling", () => {
 			capturedContext = context;
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			state: "running";
@@ -300,7 +299,7 @@ describe("KernelManager abort handling", () => {
 			});
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			state: "running";
@@ -338,7 +337,7 @@ describe("KernelManager abort handling", () => {
 				resolveHandler = resolve;
 			});
 			return { current: context.isCurrent() };
-		}, contextAwareHostRequestHandler);
+		});
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sent: Record<string, unknown>[] = [];
 		const internals = manager as unknown as {
@@ -386,7 +385,7 @@ describe("KernelManager abort handling", () => {
 				throw new Error("first request failed after close");
 			}
 			return { request: "second" };
-		}, contextAwareHostRequestHandler);
+		});
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sent: Record<string, unknown>[] = [];
 		const internals = manager as unknown as {
@@ -423,7 +422,7 @@ describe("KernelManager abort handling", () => {
 	it("sends one error reply when a current host request throws", async () => {
 		const handler = createHostRequestHandler(async () => {
 			throw new Error("handler failed");
-		}, contextAwareHostRequestHandler);
+		});
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sent: Record<string, unknown>[] = [];
 		const internals = manager as unknown as {
@@ -451,7 +450,7 @@ describe("KernelManager abort handling", () => {
 
 	it("does not report handler failure or send an error reply when the ok reply fails", async () => {
 		const implementation = vi.fn(async () => ({ completed: true }));
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sendCommMessage = vi.fn(async () => {
 			throw new Error("reply send failed");
@@ -499,7 +498,7 @@ describe("KernelManager abort handling", () => {
 			});
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			state: "running";
@@ -560,7 +559,7 @@ describe("KernelManager abort handling", () => {
 			});
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			state: "running";
@@ -615,7 +614,7 @@ describe("KernelManager abort handling", () => {
 			capturedContext = context;
 			return { ok: true };
 		});
-		const handler = createHostRequestHandler(implementation, contextAwareHostRequestHandler);
+		const handler = createHostRequestHandler(implementation);
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const internals = manager as unknown as {
 			hostRequestsClosed: boolean;

--- a/packages/coding-agent/test/kernel-abort.test.ts
+++ b/packages/coding-agent/test/kernel-abort.test.ts
@@ -284,7 +284,7 @@ describe("KernelManager abort handling", () => {
 		await Promise.allSettled([...internals.inFlightHostRequests]);
 		expect(capturedContext?.signal.aborted).toBe(true);
 		if (!capturedContext) throw new Error("Expected genuine host request context");
-		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request context is invalid");
+		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request authority was revoked");
 		expect(implementation).toHaveBeenCalledTimes(1);
 		manager.disposeSync();
 	});
@@ -321,7 +321,7 @@ describe("KernelManager abort handling", () => {
 		internals.handleCommMessage({ header: { msg_type: "comm_close" }, content: { comm_id: "request" } });
 		expect(capturedContext?.signal.aborted).toBe(true);
 		if (!capturedContext) throw new Error("Expected genuine host request context");
-		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request context is invalid");
+		await expect(handler({ type: "test" }, capturedContext)).rejects.toThrow("host request authority was revoked");
 		expect(implementation).toHaveBeenCalledTimes(1);
 		resolveHandler?.();
 		await Promise.allSettled([...internals.inFlightHostRequests]);
@@ -336,7 +336,7 @@ describe("KernelManager abort handling", () => {
 			await new Promise<void>((resolve) => {
 				resolveHandler = resolve;
 			});
-			return { current: context.isCurrent() };
+			return { current: !context.signal.aborted };
 		});
 		const manager = new KernelManager({ cwd: process.cwd(), hostHandlers: { test: handler } });
 		const sent: Record<string, unknown>[] = [];

--- a/packages/coding-agent/test/legacy-rlm-host-types.d.ts
+++ b/packages/coding-agent/test/legacy-rlm-host-types.d.ts
@@ -7,6 +7,6 @@ declare module "../src/core/rlm-runtime.js" {
 			runtime: RlmSubagentRuntime,
 			options: CreateRlmSubagentRuntimeOptions,
 			status: "done" | "error" | "cancelled",
-		) => Promise<{ retained: boolean }>;
+		) => Promise<{ deletionDurability: "absent" | "tombstoned" | "unknown" }>;
 	}
 }

--- a/packages/coding-agent/test/legacy-rlm-host-types.d.ts
+++ b/packages/coding-agent/test/legacy-rlm-host-types.d.ts
@@ -7,6 +7,6 @@ declare module "../src/core/rlm-runtime.js" {
 			runtime: RlmSubagentRuntime,
 			options: CreateRlmSubagentRuntimeOptions,
 			status: "done" | "error" | "cancelled",
-		) => Promise<void>;
+		) => Promise<{ retained: boolean }>;
 	}
 }

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -264,22 +264,26 @@ describe("AgentSessionRuntime characterization", () => {
 		expect(beforeInvalidate).toHaveBeenCalledTimes(1);
 	});
 
-	it("does not replay shutdown events when runtime disposal throws", async () => {
+	it("deduplicates concurrent disposal attempts and retries after rejection", async () => {
 		let shutdownCount = 0;
 		const { runtime, disposeSession } = createRuntimeWithFakeSession({
 			onShutdown: () => {
 				shutdownCount += 1;
 			},
 		});
+		let invalidateCount = 0;
 		runtime.setBeforeSessionInvalidate(() => {
-			throw new Error("invalidate failed");
+			invalidateCount += 1;
+			if (invalidateCount === 1) throw new Error("invalidate failed");
 		});
 
-		await expect(runtime.dispose()).rejects.toThrow("invalidate failed");
-		await expect(runtime.dispose()).rejects.toThrow("invalidate failed");
+		const firstAttempt = runtime.dispose();
+		await expect(Promise.all([firstAttempt, runtime.dispose()])).rejects.toThrow("invalidate failed");
+		await expect(runtime.dispose()).resolves.toBeUndefined();
+		await runtime.dispose();
 
-		expect(shutdownCount).toBe(1);
-		expect(disposeSession).toHaveBeenCalledTimes(1);
+		expect(shutdownCount).toBe(2);
+		expect(disposeSession).toHaveBeenCalledTimes(2);
 	});
 
 	it("continues disposing tracked subagents after one child dispose fails", async () => {

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -35,6 +35,13 @@ type RuntimeSubagentMapAccess = {
 	subagentRuntimes: Map<string, AgentSessionRuntime>;
 };
 
+type StrictDeletionAuthority = {
+	childId: string;
+	sessionDir: string;
+	generation: number;
+	assertCurrent: ReturnType<typeof vi.fn>;
+};
+
 describe("AgentSessionRuntime characterization", () => {
 	const cleanups: Array<() => Promise<void> | void> = [];
 
@@ -324,6 +331,61 @@ describe("AgentSessionRuntime characterization", () => {
 		const retainedSession = { disposeAsync: disposeRetained } as unknown as AgentSession;
 		await runtime.deleteRlmSubagentRuntime("retained-child", retainedSession);
 		expect(disposeRetained).toHaveBeenCalledOnce();
+	});
+
+	it("rejects stale inline deletion authority for a recycled child id without mutating the current runtime", async () => {
+		const { runtime, tempDir } = await createRuntimeForTest(() => {});
+		const oldSession = { disposeAsync: vi.fn(async () => {}) } as unknown as AgentSession;
+		const currentSession = {} as AgentSession;
+		const disposeCurrent = vi.fn(async () => {});
+		const currentRuntime = {
+			session: currentSession,
+			dispose: disposeCurrent,
+			metadata: { rlmChildId: "recycled-child", sessionDir: join(tempDir, "current-incarnation") },
+		} as unknown as AgentSessionRuntime;
+		const runtimeWithSubagents = runtime as unknown as RuntimeSubagentMapAccess;
+		runtimeWithSubagents.subagentRuntimes.set("recycled-child", currentRuntime);
+		const authority: StrictDeletionAuthority = {
+			childId: "recycled-child",
+			sessionDir: join(tempDir, "old-incarnation"),
+			generation: 1,
+			assertCurrent: vi.fn(),
+		};
+
+		await expect(runtime.deleteRlmSubagentRuntime("recycled-child", oldSession, authority)).rejects.toThrow(
+			"RLM subagent deletion authority does not match runtime incarnation",
+		);
+
+		expect(authority.assertCurrent).toHaveBeenCalledTimes(2);
+		expect(disposeCurrent).not.toHaveBeenCalled();
+		expect(oldSession.disposeAsync).not.toHaveBeenCalled();
+		expect(runtimeWithSubagents.subagentRuntimes.get("recycled-child")).toBe(currentRuntime);
+	});
+
+	it("deletes an inline runtime only when its authority matches the current incarnation", async () => {
+		const { runtime, tempDir } = await createRuntimeForTest(() => {});
+		const childSession = {} as AgentSession;
+		const disposeChild = vi.fn(async () => {});
+		const sessionDir = join(tempDir, "matching-incarnation");
+		const childRuntime = {
+			session: childSession,
+			dispose: disposeChild,
+			metadata: { rlmChildId: "matching-child", sessionDir },
+		} as unknown as AgentSessionRuntime;
+		const runtimeWithSubagents = runtime as unknown as RuntimeSubagentMapAccess;
+		runtimeWithSubagents.subagentRuntimes.set("matching-child", childRuntime);
+		const authority: StrictDeletionAuthority = {
+			childId: "matching-child",
+			sessionDir,
+			generation: 2,
+			assertCurrent: vi.fn(),
+		};
+
+		await runtime.deleteRlmSubagentRuntime("matching-child", childSession, authority);
+
+		expect(authority.assertCurrent).toHaveBeenCalledTimes(2);
+		expect(disposeChild).toHaveBeenCalledOnce();
+		expect(runtimeWithSubagents.subagentRuntimes.has("matching-child")).toBe(false);
 	});
 
 	it("publishes in-process RLM sessions before create resolves and rejects cancelled startup", async () => {

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -35,6 +35,10 @@ type RuntimeSubagentMapAccess = {
 	subagentRuntimes: Map<string, AgentSessionRuntime>;
 };
 
+type RuntimeSessionLeaseAccess = {
+	_sessionLease?: { release(): void };
+};
+
 type StrictDeletionAuthority = {
 	childId: string;
 	sessionDir: string;
@@ -284,6 +288,47 @@ describe("AgentSessionRuntime characterization", () => {
 
 		expect(shutdownCount).toBe(2);
 		expect(disposeSession).toHaveBeenCalledTimes(2);
+	});
+
+	it("defers lease release when the daemon claims before direct disposal", async () => {
+		const { runtime } = createRuntimeWithFakeSession();
+		const release = vi.fn();
+		let finishShutdown: () => void;
+		const shutdown = new Promise<void>((resolve) => {
+			finishShutdown = resolve;
+		});
+		(runtime as unknown as RuntimeSessionLeaseAccess)._sessionLease = { release };
+		(runtime.session.extensionRunner as unknown as { emit(): Promise<void> }).emit = async () => shutdown;
+
+		expect(runtime.claimSessionLeaseReleaseForDaemon()).toBe(true);
+		const directDispose = runtime.dispose();
+		await vi.waitFor(() => expect(release).not.toHaveBeenCalled());
+		finishShutdown!();
+		await directDispose;
+		expect(release).not.toHaveBeenCalled();
+
+		runtime.releaseSessionLease();
+		runtime.releaseSessionLease();
+		expect(release).toHaveBeenCalledOnce();
+	});
+
+	it("fails closed when direct disposal starts before a daemon lease claim", async () => {
+		const { runtime } = createRuntimeWithFakeSession();
+		const release = vi.fn();
+		let finishShutdown: () => void;
+		const shutdown = new Promise<void>((resolve) => {
+			finishShutdown = resolve;
+		});
+		(runtime as unknown as RuntimeSessionLeaseAccess)._sessionLease = { release };
+		(runtime.session.extensionRunner as unknown as { emit(): Promise<void> }).emit = async () => shutdown;
+
+		const directDispose = runtime.dispose();
+		expect(runtime.claimSessionLeaseReleaseForDaemon()).toBe(false);
+		expect(release).not.toHaveBeenCalled();
+		finishShutdown!();
+		await directDispose;
+
+		expect(release).toHaveBeenCalledOnce();
 	});
 
 	it("continues disposing tracked subagents after one child dispose fails", async () => {

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -41,7 +41,7 @@ type StrictDeletionAuthority = {
 	sessionFile: string;
 	sessionId: string;
 	generation: number;
-	assertCurrent: ReturnType<typeof vi.fn>;
+	assertCurrent: () => void;
 };
 
 describe("AgentSessionRuntime characterization", () => {
@@ -382,7 +382,7 @@ describe("AgentSessionRuntime characterization", () => {
 		};
 
 		await expect(runtime.deleteRlmSubagentRuntime("recycled-child", oldSession, authority)).rejects.toThrow(
-			"RLM subagent deletion authority does not match runtime incarnation",
+			"RLM subagent deletion does not match runtime incarnation",
 		);
 
 		expect(authority.assertCurrent).toHaveBeenCalledTimes(2);
@@ -424,7 +424,7 @@ describe("AgentSessionRuntime characterization", () => {
 		const authority: StrictDeletionAuthority = {
 			childId: "matching-child",
 			sessionDir,
-			sessionFile: childSession.sessionFile,
+			sessionFile: childSession.sessionFile!,
 			sessionId: childSession.sessionId,
 			generation: 2,
 			assertCurrent: vi.fn(),
@@ -502,7 +502,7 @@ describe("AgentSessionRuntime characterization", () => {
 		await runtime.session.runRlmChild("fail after startup");
 
 		await vi.waitFor(() => expect(deleteRlmSubagentRuntime).toHaveBeenCalledOnce());
-		expect(runtime.listSubagentRuntimes()).toEqual([]);
+		await vi.waitFor(() => expect(runtime.listSubagentRuntimes()).toEqual([]));
 	});
 
 	it("plumbs the parent agent identity into runtime-created child prompts", async () => {
@@ -537,7 +537,7 @@ describe("AgentSessionRuntime characterization", () => {
 			createRlmSubagentRuntime: async () => {
 				throw new Error("unexpected child creation");
 			},
-			deleteRlmSubagentRuntime: async () => {},
+			deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			disposeRlmSubagentRuntimes,
 		};
 		const { runtime } = await createRuntimeForTest(() => {});

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -38,6 +38,8 @@ type RuntimeSubagentMapAccess = {
 type StrictDeletionAuthority = {
 	childId: string;
 	sessionDir: string;
+	sessionFile: string;
+	sessionId: string;
 	generation: number;
 	assertCurrent: ReturnType<typeof vi.fn>;
 };
@@ -298,8 +300,8 @@ describe("AgentSessionRuntime characterization", () => {
 		expect(secondDispose).toHaveBeenCalledTimes(1);
 	});
 
-	it("deletes exact and replaced in-process RLM child runtimes and retained sessions", async () => {
-		const { runtime } = await createRuntimeForTest(() => {});
+	it("deletes exact inline runtimes and fences stale or unowned retained sessions", async () => {
+		const { runtime, tempDir } = await createRuntimeForTest(() => {});
 		const childSession = {} as AgentSession;
 		const disposeRuntime = vi.fn(async () => {});
 		const childRuntime = { session: childSession, dispose: disposeRuntime } as unknown as AgentSessionRuntime;
@@ -316,26 +318,51 @@ describe("AgentSessionRuntime characterization", () => {
 		const replacedRuntime = {
 			session: currentSession,
 			dispose: disposeReplacedRuntime,
+			metadata: { rlmChildId: "replaced-child", sessionDir: join(tempDir, "current-incarnation") },
 		} as unknown as AgentSessionRuntime;
 		const disposeStaleSession = vi.fn(async () => {});
-		const staleSession = { disposeAsync: disposeStaleSession } as unknown as AgentSession;
+		const staleSessionDir = join(tempDir, "stale-incarnation");
+		const staleSessionFile = join(staleSessionDir, "stale.jsonl");
+		const staleSession = {
+			sessionFile: staleSessionFile,
+			sessionId: "stale-session",
+			disposeAsync: disposeStaleSession,
+		} as unknown as AgentSession;
 		runtimeWithSubagents.subagentRuntimes.set("replaced-child", replacedRuntime);
 
-		await runtime.deleteRlmSubagentRuntime("replaced-child", staleSession);
-
-		expect(disposeReplacedRuntime).toHaveBeenCalledOnce();
+		await expect(runtime.deleteRlmSubagentRuntime("replaced-child", staleSession)).rejects.toThrow(
+			"RLM subagent deletion does not match runtime incarnation",
+		);
+		expect(disposeStaleSession).not.toHaveBeenCalled();
+		const staleAuthority: StrictDeletionAuthority = {
+			childId: "replaced-child",
+			sessionDir: staleSessionDir,
+			sessionFile: staleSessionFile,
+			sessionId: staleSession.sessionId,
+			generation: 1,
+			assertCurrent: vi.fn(),
+		};
+		await runtime.deleteRlmSubagentRuntime("replaced-child", staleSession, staleAuthority);
 		expect(disposeStaleSession).toHaveBeenCalledOnce();
-		expect(runtimeWithSubagents.subagentRuntimes.has("replaced-child")).toBe(false);
+		expect(disposeReplacedRuntime).not.toHaveBeenCalled();
+		expect(runtimeWithSubagents.subagentRuntimes.get("replaced-child")).toBe(replacedRuntime);
 
 		const disposeRetained = vi.fn(async () => {});
 		const retainedSession = { disposeAsync: disposeRetained } as unknown as AgentSession;
-		await runtime.deleteRlmSubagentRuntime("retained-child", retainedSession);
-		expect(disposeRetained).toHaveBeenCalledOnce();
+		await expect(runtime.deleteRlmSubagentRuntime("retained-child", retainedSession)).rejects.toThrow(
+			"RLM subagent runtime incarnation is no longer resident",
+		);
+		expect(disposeRetained).not.toHaveBeenCalled();
 	});
 
 	it("rejects stale inline deletion authority for a recycled child id without mutating the current runtime", async () => {
 		const { runtime, tempDir } = await createRuntimeForTest(() => {});
-		const oldSession = { disposeAsync: vi.fn(async () => {}) } as unknown as AgentSession;
+		const oldSessionDir = join(tempDir, "old-incarnation");
+		const oldSession = {
+			sessionFile: join(oldSessionDir, "old.jsonl"),
+			sessionId: "old-session",
+			disposeAsync: vi.fn(async () => {}),
+		} as unknown as AgentSession;
 		const currentSession = {} as AgentSession;
 		const disposeCurrent = vi.fn(async () => {});
 		const currentRuntime = {
@@ -347,7 +374,9 @@ describe("AgentSessionRuntime characterization", () => {
 		runtimeWithSubagents.subagentRuntimes.set("recycled-child", currentRuntime);
 		const authority: StrictDeletionAuthority = {
 			childId: "recycled-child",
-			sessionDir: join(tempDir, "old-incarnation"),
+			sessionDir: oldSessionDir,
+			sessionFile: join(oldSessionDir, "wrong.jsonl"),
+			sessionId: oldSession.sessionId,
 			generation: 1,
 			assertCurrent: vi.fn(),
 		};
@@ -364,9 +393,15 @@ describe("AgentSessionRuntime characterization", () => {
 
 	it("deletes an inline runtime only when its authority matches the current incarnation", async () => {
 		const { runtime, tempDir } = await createRuntimeForTest(() => {});
-		const childSession = {} as AgentSession;
-		const disposeChild = vi.fn(async () => {});
 		const sessionDir = join(tempDir, "matching-incarnation");
+		const childSession = {
+			sessionFile: join(sessionDir, "child.jsonl"),
+			sessionId: "matching-session",
+		} as AgentSession;
+		const disposeChild = vi
+			.fn<() => Promise<void>>()
+			.mockRejectedValueOnce(new Error("inline close failed once"))
+			.mockResolvedValueOnce(undefined);
 		const childRuntime = {
 			session: childSession,
 			dispose: disposeChild,
@@ -374,17 +409,35 @@ describe("AgentSessionRuntime characterization", () => {
 		} as unknown as AgentSessionRuntime;
 		const runtimeWithSubagents = runtime as unknown as RuntimeSubagentMapAccess;
 		runtimeWithSubagents.subagentRuntimes.set("matching-child", childRuntime);
+		const incompleteAuthority = {
+			childId: "matching-child",
+			sessionDir,
+			generation: 1,
+			assertCurrent: vi.fn(),
+		};
+		await expect(
+			runtime.deleteRlmSubagentRuntime("matching-child", childSession, incompleteAuthority),
+		).rejects.toThrow("RLM subagent deletion authority does not match runtime incarnation");
+		expect(disposeChild).not.toHaveBeenCalled();
+		expect(runtimeWithSubagents.subagentRuntimes.get("matching-child")).toBe(childRuntime);
+
 		const authority: StrictDeletionAuthority = {
 			childId: "matching-child",
 			sessionDir,
+			sessionFile: childSession.sessionFile,
+			sessionId: childSession.sessionId,
 			generation: 2,
 			assertCurrent: vi.fn(),
 		};
+		await expect(runtime.deleteRlmSubagentRuntime("matching-child", childSession, authority)).rejects.toThrow(
+			"inline close failed once",
+		);
+		expect(runtimeWithSubagents.subagentRuntimes.get("matching-child")).toBe(childRuntime);
 
 		await runtime.deleteRlmSubagentRuntime("matching-child", childSession, authority);
 
-		expect(authority.assertCurrent).toHaveBeenCalledTimes(2);
-		expect(disposeChild).toHaveBeenCalledOnce();
+		expect(authority.assertCurrent).toHaveBeenCalledTimes(4);
+		expect(disposeChild).toHaveBeenCalledTimes(2);
 		expect(runtimeWithSubagents.subagentRuntimes.has("matching-child")).toBe(false);
 	});
 

--- a/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
+++ b/packages/coding-agent/test/suite/regressions/617-subagent-terminal-agent-message.test.ts
@@ -68,7 +68,7 @@ describe("#617 subagent terminal agent messages", () => {
 			rlmMaxDepth: 1,
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child!.session }),
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			},
 		});
 		child.setResponses([fauxAssistantMessage("child completed")]);
@@ -105,7 +105,7 @@ describe("#617 subagent terminal agent messages", () => {
 		parent = await createHarness({
 			subagentRuntimeHost: {
 				createRlmSubagentRuntime: async () => ({ session: child!.session }),
-				deleteRlmSubagentRuntime: async () => {},
+				deleteRlmSubagentRuntime: async () => ({ deletionDurability: "absent" as const }),
 			} as never,
 		});
 		child.setResponses([fauxAssistantMessage("done, no reply to parent")]);


### PR DESCRIPTION
# Capability cleanup + three admission/revocation fixes for the host-request dispatcher

Follow-up to #1243, based on its current head (77b188b92). Targets `core02-host-request-dispatcher` so it can be reviewed in isolation and merged into the PR branch.

PR #1243 turned kernel→host callbacks into factory-minted capability handlers with per-request
abortable contexts. This branch removes the migration scaffolding that shipped with that change
and fixes three bugs in the revocation/admission paths.

## Cleanup commits (behavior-preserving; suite green after each)

1. **37189b745 — collapse `HostRequestHandlerImplementation` into `HostRequestHandler`**
   Two exported names for the same binary `(payload, context) => Promise<...>` shape. Keep one.

2. **d87704083 — drop the context-aware marker from `createHostRequestHandler`**
   The `options` parameter (`HostRequestHandlerOptions` / `contextAwareHostRequestHandler`) had
   exactly one legal value at all 17 call sites. The factory + WeakSet is the provenance
   authority and the TS signature already forces the binary shape; the marker was ceremony.
   Also deletes the test that only exercised the marker.

3. **9d45f218a — shrink `HostRequestContext` to the signal**
   `requestId` and `generation` had zero production consumers (tests just echoed them). The
   `KernelManager.hostRequestGeneration` counter existed solely to feed the deleted field.

4. **d69df06b4 — drop the copyable handler brand symbol**
   The symbol was copyable (the old test literally copied it onto a forgery) and rejected
   nothing the WeakSet did not already reject. With it gone, the
   `HostRequestHandlerCapability` intersection type is vacuous and is deleted too.

5. **7e19130d7 — make the abort signal the single revocation authority**
   `isCurrent()` reduced to `!signal.aborted` (the internal flag only flipped inside the abort
   listener), so call sites like rlm-runtime checked the same bit under two spellings. Delete
   `isCurrent()` everywhere; check `signal.aborted`. Revocation semantics change deliberately:
   a revoked context **stays** in the dispatcher WeakSet — it is still genuine, just no longer
   current. `assertGenuineHostRequestContext` now means only "minted by this dispatcher"; the
   factory wrapper rejects aborted contexts explicitly at dispatch (`"host request authority
   was revoked"` instead of the misleading `"host request context is invalid"` for replayed
   revoked contexts).

6. **a6a8f9d02 — drop migration-era wording from test names/comments** ("staged", marker
   mechanics, "business-unit fixtures").

## Fixes (one commit each, each with a regression test that fails on the base)

**A. 06ae27905 — `rlm.delete_subagent` ignored its authority context**
Repro logic: open the delete comm, close it (revoking authority) while the async selector
listing is in flight → the child was still deleted; only the reply was suppressed.
Fix: `deleteRlmSubagent(target, signal)` threads the request signal through and re-asserts
authority immediately before each mutating delete (the factory wrapper already rejects an
aborted context at dispatch). Test: revoke mid-listing → child not deleted, still listed,
no reply sent.

**B. 220fca4e7 — queued-run leak on pre-revoked spawn**
Repro logic: the run entered `_activeRlmChildRuns` and `emitChildUpdate()` reached subscribers
before the abort listener attached and `assertRequestCurrent()` ran; a subscriber revoking in
reaction to the queued update made the assert throw outside any cleanup path, leaking the run
as "queued" forever (an abort listener attached to an already-aborted signal never fires).
Fix: attach the listener + assert immediately after registration and before the first emit;
route the early throw through the same cancel + deregister cleanup as the late path, and
remove the just-created child session dir like the neighbouring session-name failure path.
Tests: subscriber revokes on the queued update; revocation lands just before registration —
both reject the spawn, leave `_activeRlmChildRuns` empty, and leave no orphaned sub-* dir.

**C. 75df2d8e1 — stale spawn handle for a cancelled child**
Repro logic: after `run.publication.promise` resolves, admission re-checked only authority;
a concurrent `_cancelRlmChildRun` in that window still returned a "successful" handle.
Fix: the admission commit also throws when `run.status === "cancelled"`.
Test: cancel between publication resolve and admission → spawn rejects, no run entry remains.

## Validation

- `npx tsgo --noEmit` clean at every commit.
- `biome check` clean on all touched files.
- Suites green (kernel/host-request/recursion/concurrent/bus/mcp discovery set):
  `acp-kernel-features`, `agent-session-bus`, `agent-session-concurrent`,
  `agent-session-recursion`, `host-request-contract`, `kernel-abort`,
  `kernel-agent-message-skill`, `kernel-agent-observe-skill`, `kernel-attach-image-skill`,
  `kernel-bootstrap`, `kernel-fork-server`, `kernel-goal-skill`, `kernel-rlm-heartbeat-skill`,
  `kernel-startup`, `kernel-state-roundtrip`, `kernel-state-snapshot`, `mcp-manager` —
  224 passed, 15 skipped (skips are environment-gated kernel-python tests, skipped on base too).
- Each fix's regression test was verified to fail with the fix reverted.

## MERGE-ORDER NOTE

When this merges into `core02-host-request-dispatcher` and propagates up to
`v080/core-split-c3-managed-catalog` (PR #1333 and successors), the stacked
`agent-messages.ts` call sites still pass the deleted `contextAwareHostRequestHandler`
constant (import at line 3, call sites ~541/~614 on `pr-1333-review`). Resolution is a
trivial argument + import deletion; no behavioral conflict.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes span host-request revocation, RLM spawn/delete coordination, daemon registry tombstoning, session lease ownership, and close/archive ordering—core orchestration paths where races or partial failure could strand children or delete the wrong incarnation.
> 
> **Overview**
> **Host-request dispatcher** now treats **`AbortSignal` revocation** as the only per-request authority: `HostRequestContext` drops `requestId`, `generation`, and `isCurrent()`, and **`createHostRequestHandler`** no longer needs the context-aware marker. Revoked requests fail with **`host request authority was revoked`** at dispatch. **`rlm.delete_subagent`** and **`rlm.run`** thread the signal through; spawn admission arms abort before the first queued update and rejects cancelled children after publication.
> 
> **RLM subagent lifecycle** is reworked around **deletion durability** (`absent` / `tombstoned` / `unknown`), **`RlmSubagentDeletionAuthority`** (generation + session incarnation fences), and **`_coordinateRlmSubagentDeletion`** so explicit deletes, compaction reapers, and quarantine retries cannot race or commit after revocation. Failed precommit releases land in **private quarantine** (hidden from listings); the daemon persists **`sessionId`** in the registry, validates rows strictly before destructive cleanup, **tombstones before close**, retries failed tombstoned closes with backoff, and hides **terminalizing / quarantined** sessions from public daemon APIs. Runtime teardown adds **lease deferral** to the daemon and **dispose retry** after one-shot failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e7bdf04e0f3f07d608b9b8ec00edd9b33b62d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace capability branding with `AbortSignal`-based revocation in the host-request dispatcher
> - Simplifies `HostRequestContext` to carry only an `AbortSignal`, removing `requestId`, `generation`, and `isCurrent()` from the interface and all call sites.
> - `createHostRequestHandler` now rejects dispatched requests whose signal is already aborted, throwing `'host request authority was revoked'` without requiring an external context-aware marker.
> - `AgentSession.deleteRlmSubagent` and `_startRlmChildRun` now check the signal before and during admission, aborting spawns and deletions cleanly if authority is revoked mid-flight.
> - Provenance verification in `assertHostRequestHandler` is simplified to a `WeakSet` identity check, removing symbol-brand forgery concerns.
> - Behavioral Change: any code reusing a retained `HostRequestContext` after revocation will now receive `'host request authority was revoked'` instead of a context-aware marker rejection.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1357 opened
>
> - Added cancellation check before runtime creation, conditional parent transcript message publishing based on admission status, and recursive session directory cleanup for never-admitted cancelled children in `AgentSession.rlm` child spawn task [e83a5a2]
> - Reworked existing test for queued run cleanup on subscriber authority revocation and added new test for runtime disposal when spawn is revoked before admission [e83a5a2]
> - Modified `AgentSession` cleanup logic to conditionally delete never-admitted cancelled child artifact directories based on subagent runtime host presence [3110923]
> - Added and updated tests in `AgentSession rlm recursion` test suite to validate artifact directory cleanup behavior for revoked spawns [3110923]
> - Modified orphan directory removal condition for cancelled, never-admitted child runs in `AgentSession` [aa1908a]
> - Refactored test to validate dispose-only host directory cleanup behavior [aa1908a]
> - Modified `AgentSession` RLM child spawn task to track whether the host durably retained a cancelled child's artifacts and conditionally delete the child session directory based on this flag [2a26824]
> - Modified `AgentDaemon.createSubagentRuntimeHost.releaseRlmSubagentRuntime` handler to compute and return a `retained` flag for cancelled children and suppress exceptions on registry write failures [2a26824]
> - Changed `SubagentRuntimeHost.releaseRlmSubagentRuntime` interface method signature to return an object with a `retained` boolean property [2a26824]
> - Modified `AgentDaemon.recordRlmSubagentDeletion` utility to return a boolean indicating whether a durable deletion tombstone exists for the child [2a26824]
> - Updated test files to match the new `releaseRlmSubagentRuntime` return type and `recordRlmSubagentDeletion` boolean return, and added test coverage for durable retention scenarios [2a26824]
> - Introduced deletion durability type system and updated host interface contracts [8c97153]
> - Implemented quarantine mechanism for tracking cancelled child spawns with unproven deletion [8c97153]
> - Reworked child spawn cancellation and cleanup flow to distinguish deletion durability states [8c97153]
> - Implemented strict registry validation and durability-aware deletion recording in daemon host [8c97153]
> - Modified subagent listing and deletion operations to handle quarantined children [8c97153]
> - Updated test suites to validate deletion durability model and quarantine behavior [8c97153]
> - Modified `AgentSession.deleteRlmSubagent` and `AgentSession._resolveRlmChildDeletionQuarantine` to enforce deletion authority and durability guarantees before completing quarantined RLM subagent deletions [03ff589]
> - Added test infrastructure and test cases for RLM subagent deletion durability and authority revocation scenarios [03ff589]
> - Added test for discharging quarantined tombstone without removing retained artifact [7f504bc]
> - Introduced deletion coordinator with single-flight semantics and lease-based authority fencing for RLM subagent deletions [cefca6c]
> - Implemented authority-fenced daemon deletion with sessionId incarnation matching and legacy upgrade path [cefca6c]
> - Added typed deletion authority contract and phased error handling for host-request dispatcher [cefca6c]
> - Implemented authority-fenced deletion handlers in daemon subagent runtime host callbacks [cefca6c]
> - Extended session-level deletion methods with authority fencing and structured durability reporting [cefca6c]
> - Extended runtime host deletion methods with authority fencing and incarnation validation [cefca6c]
> - Updated test suite expectations and mocks for authority-fenced deletion contracts and durability reporting [cefca6c]
> - Refined authority validation in `AgentDaemon.SubagentRuntimeHost.deleteRlmSubagentRuntime` to require exact authority matching for passive RLM subagent deletions [43ca8dd]
> - Added quarantine tracking in `AgentSession` RLM subagent release finalizer for failed precommit deletions [43ca8dd]
> - Updated test expectations in `agent-session-recursion` and `daemon-mode` test files to reflect quarantine semantics and stricter authority validation [43ca8dd]
> - Detached tombstoned RLM subagent closes to asynchronous retry with exponential backoff [b0c206d]
> - Implemented quarantine detection and private session filtering across daemon operations [b0c206d]
> - Refactored disposal methods to deduplicate concurrent calls and enable retry after failures [b0c206d]
> - Fixed session map removal and cleanup order in close operations [b0c206d]
> - Added test coverage for disposal retry, tombstoned close detachment, and quarantine visibility [b0c206d]
> - Implemented session lease ownership coordination between `AgentSessionRuntime` and daemon with deferral mechanism [b01731e]
> - Modified `AgentDaemon.closeSessionOnce` to continue teardown despite cleanup failures and coordinate lease release with runtime [b01731e]
> - Added test coverage for session lease coordination and daemon close session behavior [b01731e]
> - Reordered session close sequence in `AgentDaemon.closeSessionOnce` to establish archive boundary before teardown, creating terminalizing records on archive failure [915faf9]
> - Extended `FailedTombstonedRlmClose` interface with terminalizing flag and optional fields for archive-failure session retention [915faf9]
> - Implemented shutdown-specific handling for terminalizing sessions in `AgentDaemon.shutdown` and `AgentDaemon.closeTerminalizingSessionsForShutdown` [915faf9]
> - Enhanced `AgentDaemon.runTombstonedCloseAttempt` to differentiate terminalizing records and honor original close reasons [915faf9]
> - Enforced privacy for terminalizing and failed tombstoned sessions across visibility and state resolution methods [915faf9]
> - Added pre-checks and helpers to detect and prevent operations on terminalizing sessions [915faf9]
> - Updated tests in `daemon-mode.test.ts` to validate terminalizing behavior, archive-failure retention, and shutdown sequences [915faf9]
> - Fixed tombstoned session close handling in `AgentDaemon` [4e7bdf0]
> - Added fake timer usage and timer count assertion to daemon shutdown test [4e7bdf0]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8c97153. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->