### PR TITLE
Show the working directory before the app name in the window title

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Changed the window title to start with the working directory instead of the app name, so instances stay distinguishable in truncated window lists.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -504,6 +504,10 @@ const envPrefix =
 export const PACKAGE_NAME: string = pkg.name || "@earendil-works/pi-coding-agent";
 export const APP_NAME: string = piConfigName || "pi";
 export const APP_TITLE: string = piConfigName ? APP_NAME : "π";
+
+export function formatWindowTitle(...parts: string[]): string {
+	return [...parts, APP_TITLE].join(" - ");
+}
 export const CONFIG_DIR_NAME: string = pkg.piConfig?.configDir || ".prime/agent";
 export const VERSION: string = pkg.version || "0.0.0";
 

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -13,7 +13,7 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { APP_TITLE, appendRotatingLog, getAgentDir, getClientErrorLogPath, VERSION } from "../../config.js";
+import { appendRotatingLog, formatWindowTitle, getAgentDir, getClientErrorLogPath, VERSION } from "../../config.js";
 import type { AgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import { KeybindingsManager } from "../../core/keybindings.js";
 import { SessionManager } from "../../core/session-manager.js";
@@ -720,7 +720,7 @@ export class AgentsViewMode implements Component, Focusable {
 
 		this.ui = new TUI(new ProcessTerminal(), options.uiServices.settingsManager.getShowHardwareCursor());
 		this.ui.setClearOnShrink(options.uiServices.settingsManager.getClearOnShrink());
-		this.ui.terminal.setTitle(`${APP_TITLE} - Agents`);
+		this.ui.terminal.setTitle(formatWindowTitle("Agents"));
 		this.editor = new CustomEditor(this.ui, getEditorTheme(), this.keybindings, {
 			paddingX: options.uiServices.settingsManager.getEditorPaddingX(),
 			autocompleteMaxVisible: options.uiServices.settingsManager.getAutocompleteMaxVisible(),

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -55,7 +55,7 @@ import {
 } from "../../cli/daemon-update-restart.js";
 import {
 	APP_NAME,
-	APP_TITLE,
+	formatWindowTitle,
 	getAgentDir,
 	getAgentTracesLogPath,
 	getDebugLogPath,
@@ -1467,9 +1467,9 @@ export class InteractiveMode {
 		const cwdBasename = path.basename(this.getCurrentCwd());
 		const sessionName = this.getCurrentSessionName();
 		if (sessionName) {
-			this.ui.terminal.setTitle(`${APP_TITLE} - ${sessionName} - ${cwdBasename}`);
+			this.ui.terminal.setTitle(formatWindowTitle(cwdBasename, sessionName));
 		} else {
-			this.ui.terminal.setTitle(`${APP_TITLE} - ${cwdBasename}`);
+			this.ui.terminal.setTitle(formatWindowTitle(cwdBasename));
 		}
 	}
 

--- a/packages/coding-agent/test/window-title.test.ts
+++ b/packages/coding-agent/test/window-title.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { APP_TITLE, formatWindowTitle } from "../src/config.js";
+
+describe("formatWindowTitle", () => {
+	it("puts the working directory first and the app name last", () => {
+		expect(formatWindowTitle("magic-journey")).toBe(`magic-journey - ${APP_TITLE}`);
+	});
+
+	it("keeps the session name between directory and app name", () => {
+		expect(formatWindowTitle("magic-journey", "review")).toBe(`magic-journey - review - ${APP_TITLE}`);
+	});
+
+	it("formats the agents view the same way", () => {
+		expect(formatWindowTitle("Agents")).toBe(`Agents - ${APP_TITLE}`);
+	});
+});


### PR DESCRIPTION
Closes #1359.

With several instances open, window managers and terminal tab bars show maybe 15 characters per tab. Today every one of them starts with the app name, so the visible part is identical everywhere:

```
prime-agent - pri...
prime-agent - mag...
```

The one word that says which project a tab belongs to is the first thing cut off. Putting the working directory first makes them distinguishable at the width actually shown:

```
prime-agent - pri...
magic-journey - p...
```

The app name stays in the title, just at the end, which is what editors and browsers do for the same reason.

All three call sites move together, so the order cannot drift apart again: the two in `interactive-mode.ts` and the agents view, which previously read `π - Agents`. The order now lives in one `formatWindowTitle` helper in `config.ts` rather than being repeated as a template string in each place.

Tests: three cases in `packages/coding-agent/test/window-title.test.ts` covering the plain, session, and agents-view titles.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show working directory before app name in terminal window title
> Reorders the terminal window title so the working directory appears first, followed by the session name (if set), and the app name last. This makes instances easier to distinguish when window titles are truncated. A new `formatWindowTitle` utility in [config.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1360/files#diff-7a2a7db5c2760673cc5ab02f604ef2192373159e49d4258a81ad6885a5fb1827) standardizes title construction across interactive and agents-view modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8af9e5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->