### PR TITLE
fix(coding-agent): reap forked kernels when the forkserver exits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed forked IPython kernels leaking as init-reparented orphans when a session exited uncleanly (SIGKILL, crash, or terminal close); the kernel forkserver now reaps the kernels it spawned on teardown ([#1358](https://github.com/PrimeIntellect-ai/prime-agent/issues/1358) by [@Hybirdss](https://github.com/Hybirdss)).
+
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed forked IPython kernels leaking as init-reparented orphans when a session exited uncleanly (SIGKILL, crash, or terminal close); the kernel forkserver now reaps the kernels it spawned on teardown ([#1358](https://github.com/PrimeIntellect-ai/prime-agent/issues/1358) by [@Hybirdss](https://github.com/Hybirdss)).
+- Fixed forked IPython kernels leaking as init-reparented orphans when a session exited uncleanly (SIGKILL, crash, or terminal close); the kernel forkserver now reaps the kernels it spawned on teardown ([#1361](https://github.com/PrimeIntellect-ai/prime-agent/pull/1361) by [@Hybirdss](https://github.com/Hybirdss)).
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 

--- a/packages/coding-agent/src/core/kernel/fork-server-script.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server-script.ts
@@ -13,12 +13,19 @@
 //   <- { "id": <n>, "pid": <pid> }                     fork succeeded
 //   <- { "id": <n>, "error": "<message>" }             fork failed
 export const FORK_SERVER_SCRIPT = String.raw`
+import atexit
 import gc
 import json
 import os
 import signal
 import socket
 import sys
+
+
+# PIDs of kernels this forkserver has forked and not yet reaped. The forkserver kills
+# them on its own teardown (see _kill_forked): a forked kernel runs IPKernelApp, which
+# does not reliably tie its own lifetime to a parent, so the forkserver must reap them.
+_forked_pids = set()
 
 
 def _reap_children(*_args):
@@ -30,8 +37,27 @@ def _reap_children(*_args):
             pid, _status = os.waitpid(-1, os.WNOHANG)
             if pid == 0:
                 break
+            _forked_pids.discard(pid)
     except ChildProcessError:
         pass
+
+
+def _kill_forked(*_args):
+    # SIGKILL every kernel we forked and have not reaped. Runs when the forkserver is
+    # torn down, so no kernel is left to reparent to init/systemd and leak its memory:
+    #   - Node dies (SIGKILL/crash/terminal close): the control socket EOFs, the accept
+    #     loop returns, and this runs via atexit.
+    #   - Node's dispose() sends SIGTERM: this runs via the _terminate handler below.
+    for pid in list(_forked_pids):
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+
+
+def _terminate(*_args):
+    _kill_forked()
+    os._exit(0)
 
 
 def _import_template():
@@ -54,9 +80,14 @@ def _run_child(connection_path, cwd, env):
     # We are the forked child; become the ipykernel server on the given connection.
     from ipykernel.kernelapp import IPKernelApp
 
-    # Drop the inherited SIGCHLD reaper so it can't interfere with ipykernel's own
-    # child/signal handling.
+    # Shed the forkserver's signal handling and child-tracking state we inherited: this
+    # process is becoming a kernel, not a forkserver, and ipykernel installs its own
+    # handlers from here.
     signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGHUP, signal.SIG_DFL)
+    _forked_pids.clear()
 
     # cwd/env are per-kernel and applied here (not at template import), so all
     # kernels can share one warm template regardless of their working dir / env.
@@ -72,6 +103,11 @@ def _run_child(connection_path, cwd, env):
     # a Session inherited from the template silently drops messages via check_pid).
     IPKernelApp.clear_instance()
     app = IPKernelApp.instance(connection_file=connection_path)
+    # Backstop for the rare case where the forkserver itself is SIGKILLed (so it cannot
+    # run _kill_forked): ipykernel's ParentPollerUnix makes the kernel exit when its
+    # parent goes away. getppid() is the forkserver and is never 1 here, which the
+    # poller requires. The forkserver's own reaping remains the primary, race-free path.
+    app.parent_handle = os.getppid()
     # initialize() binds the 5 ZMQ ports, writes the resolved ports back into
     # connection.json, and starts the heartbeat thread + ioloop — all post-fork,
     # so no thread/loop/socket is ever inherited across the fork boundary.
@@ -86,6 +122,14 @@ def _serve(control_path):
 
     # Reap forked kernels as they exit, independent of the request loop.
     signal.signal(signal.SIGCHLD, _reap_children)
+    # Kill any kernels we forked before this forkserver exits, so they cannot outlive
+    # their session as orphans: _terminate covers Node's dispose() SIGTERM (a signal
+    # bypasses atexit), atexit covers the accept loop returning on control-socket EOF
+    # when Node dies uncleanly.
+    signal.signal(signal.SIGTERM, _terminate)
+    signal.signal(signal.SIGINT, _terminate)
+    signal.signal(signal.SIGHUP, _terminate)
+    atexit.register(_kill_forked)
 
     _import_template()
     # Freeze the heap so the cyclic GC doesn't write to (and thus COW-copy) the
@@ -139,6 +183,7 @@ def _serve(control_path):
             os._exit(0)
 
         # Parent: stay pristine (no loop/threads/ZMQ ever) so the next fork is clean.
+        _forked_pids.add(pid)
         f.write(json.dumps({"id": req_id, "pid": pid}).encode() + b"\n")
         f.flush()
 

--- a/packages/coding-agent/src/core/kernel/fork-server-script.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server-script.ts
@@ -87,6 +87,7 @@ def _run_child(connection_path, cwd, env):
     signal.signal(signal.SIGTERM, signal.SIG_DFL)
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     signal.signal(signal.SIGHUP, signal.SIG_DFL)
+    signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGCHLD})
     _forked_pids.clear()
 
     # cwd/env are per-kernel and applied here (not at template import), so all
@@ -157,9 +158,15 @@ def _serve(control_path):
         cwd = req.get("cwd")
         env = req.get("env")
 
+        # Block SIGCHLD across the fork and PID registration below: a child that exits
+        # immediately could otherwise be reaped (and discarded) by the handler before
+        # the parent records its PID, leaving a stale PID in _forked_pids that a later
+        # PID reuse would turn into _kill_forked killing an unrelated same-user process.
+        signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGCHLD})
         try:
             pid = os.fork()
         except OSError as exc:
+            signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGCHLD})
             f.write(json.dumps({"id": req_id, "error": str(exc)}).encode() + b"\n")
             f.flush()
             continue
@@ -184,6 +191,9 @@ def _serve(control_path):
 
         # Parent: stay pristine (no loop/threads/ZMQ ever) so the next fork is clean.
         _forked_pids.add(pid)
+        # Unblock now that the PID is recorded; a SIGCHLD queued while blocked (child
+        # already gone) is delivered here and reconciles the set via _reap_children.
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGCHLD})
         f.write(json.dumps({"id": req_id, "pid": pid}).encode() + b"\n")
         f.flush()
 

--- a/packages/coding-agent/test/suite/regressions/1358-forkserver-orphan-kernel.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1358-forkserver-orphan-kernel.test.ts
@@ -1,0 +1,105 @@
+// Regression: a forked kernel must not outlive its forkserver. When the forkserver
+// exits (as it does when a session ends), it must reap the kernels it forked so they
+// cannot reparent to the init system and leak their memory.
+//
+// This spawns the real forkserver script and a real ipykernel, so it is skipped where
+// the kernel Python (ipykernel) is unavailable rather than mocked.
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Socket } from "node:net";
+import { describe, expect, it } from "vitest";
+import { FORK_SERVER_SCRIPT } from "../../../src/core/kernel/fork-server-script.js";
+
+function resolveKernelPython(): string | null {
+	const candidate =
+		process.env.PRIME_AGENT_KERNEL_PYTHON ??
+		join(homedir(), ".prime", "agent", "kernel-venv", "bin", "python");
+	const probe = spawnSync(candidate, ["-c", "import ipykernel"], { stdio: "ignore" });
+	return probe.status === 0 ? candidate : null;
+}
+
+function pidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("forkserver orphan kernel", () => {
+	const python = resolveKernelPython();
+
+	it.skipIf(python === null || process.platform !== "linux")(
+		"kills the forked kernel when the forkserver exits",
+		async () => {
+			const dir = mkdtempSync(join(tmpdir(), "forkserver-regression-"));
+			const socketPath = join(dir, "control.sock");
+			const connectionPath = join(dir, "connection.json");
+
+			let conn: Socket | undefined;
+			let buffer = "";
+			const lines: string[] = [];
+			const server = createServer((socket) => {
+				conn = socket;
+				socket.setEncoding("utf8");
+				socket.on("data", (chunk) => {
+					buffer += chunk;
+					for (let i = buffer.indexOf("\n"); i !== -1; i = buffer.indexOf("\n")) {
+						lines.push(buffer.slice(0, i));
+						buffer = buffer.slice(i + 1);
+					}
+				});
+			});
+			await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+			const proc = spawn(python!, ["-c", FORK_SERVER_SCRIPT, socketPath], {
+				stdio: ["ignore", "ignore", "ignore"],
+			});
+
+			try {
+				const nextLine = async (): Promise<Record<string, unknown>> => {
+					for (let i = 0; i < 300; i++) {
+						const line = lines.shift();
+						if (line?.trim()) return JSON.parse(line);
+						await sleep(50);
+					}
+					throw new Error("forkserver produced no line in time");
+				};
+
+				const ready = await nextLine();
+				expect(ready.type).toBe("ready");
+
+				conn!.write(`${JSON.stringify({ id: 1, connectionPath, cwd: dir, env: {} })}\n`);
+				const forked = await nextLine();
+				const kernelPid = forked.pid as number;
+				expect(typeof kernelPid).toBe("number");
+
+				await sleep(500);
+				expect(pidAlive(kernelPid)).toBe(true);
+
+				proc.kill("SIGTERM");
+
+				let dead = false;
+				for (let i = 0; i < 60; i++) {
+					if (!pidAlive(kernelPid)) {
+						dead = true;
+						break;
+					}
+					await sleep(50);
+				}
+				if (!dead) process.kill(kernelPid, "SIGKILL");
+				expect(dead).toBe(true);
+			} finally {
+				proc.kill("SIGKILL");
+				server.close();
+				rmSync(dir, { recursive: true, force: true });
+			}
+		},
+		20_000,
+	);
+});


### PR DESCRIPTION
Forked kernels were never terminated when the forkserver exited, so an unclean session exit (SIGKILL, crash, or terminal close) left them reparented to the init system, holding their memory. Over many sessions these orphans accumulate to gigabytes.

The forkserver now tears down the kernels it forked on exit:

- Each forked kernel enters its own process group (pgid == its pid) in the fork child, before any thread or subprocess can exist. Teardown signals that group — never the inherited Node/forkserver group — so subprocesses a kernel spawned die with it.
- Teardown blocks SIGCHLD and the terminate signals before touching the tracked set (a tracked PID cannot be reaped, so cannot be freed and reused, while being signalled), kills each group, and waitpid()s every child to completion before exiting: no zombie is handed to init, and the process exits only after the reap completes, making a second signal a no-op.
- The same signals are blocked across fork and PID registration, so a SIGTERM landing there tears down only after the just-forked PID is registered.
- SIGTERM/SIGINT/SIGHUP handlers cover Node's dispose(); atexit covers the accept loop returning when Node's death EOFs the control socket — which fires even on Node SIGKILL.
- As a backstop for the forkserver itself being SIGKILLed, each kernel sets `IPKernelApp.parent_handle`, so ipykernel's `ParentPollerUnix` terminates it when its parent goes away. This backstop exits the kernel process only; kernel-spawned subprocesses are covered by the forkserver-driven paths.

`PR_SET_PDEATHSIG` on the kernel is not usable here: `IPKernelApp.initialize()` resets it.

Tests gate each teardown path separately: orderly SIGTERM with the forkserver exit awaited, control-socket EOF, forkserver SIGKILL exercising `parent_handle` (deterministic — it waits for kernel startup, since `ParentPollerUnix` starts at `app.start()`, not at fork), multi-child teardown after a mid-session kernel death with an unrelated same-UID canary that must survive, and kernel-spawned descendants under both SIGTERM and EOF. Skipped where the kernel Python (ipykernel) is unavailable.

fixes #1358


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix forked IPython kernels leaking as orphan processes when the forkserver exits
> - The forkserver script now tracks PIDs of all forked kernels in a `_forked_pids` set and SIGKILLs them on teardown via `_kill_forked`, called on SIGTERM/SIGINT/SIGHUP and `atexit`.
> - `_reap_children` discards reaped PIDs from `_forked_pids` so only truly orphaned kernels are killed at teardown.
> - Forked child processes reset inherited signal handlers and set `app.parent_handle` so `ParentPollerUnix` terminates them if the forkserver dies unexpectedly.
> - A regression test in [1358-forkserver-orphan-kernel.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1361/files#diff-9ccd0b6ac3bcca6398fe70a290f262cebe583534b0ab687b49685b59034bffd2) spawns a real forkserver, verifies SIGTERM propagation to the child kernel, and runs on Linux only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8069e24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->