### PR TITLE
fix(ai): bound silent provider streams with a stall timeout

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed a session hanging forever when a provider holds the stream open but stops sending; a started stream that produces no data for `streamStallTimeoutMs` (default 5 minutes, `0` disables) now fails as a retryable server error instead of blocking on a read that never returns ([#1232](https://github.com/PrimeIntellect-ai/prime-agent/issues/1232)).
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -40,6 +40,7 @@ import {
 } from "../utils/diagnostics.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
+import { readWithStallTimeout, resolveStallTimeoutMs } from "../utils/stream-stall.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
@@ -454,11 +455,17 @@ async function processStream(
 	model: Model<"openai-codex-responses">,
 	options?: OpenAICodexResponsesOptions,
 ): Promise<void> {
-	await processResponsesStream(mapCodexEvents(parseSSE(response)), output, stream, model, {
-		serviceTier: options?.serviceTier,
-		resolveServiceTier: resolveCodexServiceTier,
-		applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
-	});
+	await processResponsesStream(
+		mapCodexEvents(parseSSE(response, resolveStallTimeoutMs(options?.streamStallTimeoutMs))),
+		output,
+		stream,
+		model,
+		{
+			serviceTier: options?.serviceTier,
+			resolveServiceTier: resolveCodexServiceTier,
+			applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
+		},
+	);
 }
 
 class CodexApiError extends Error {
@@ -532,7 +539,7 @@ function normalizeCodexStatus(status: unknown): CodexResponseStatus | undefined 
 // SSE Parsing
 // ============================================================================
 
-async function* parseSSE(response: Response): AsyncGenerator<Record<string, unknown>> {
+async function* parseSSE(response: Response, stallTimeoutMs = 0): AsyncGenerator<Record<string, unknown>> {
 	if (!response.body) return;
 
 	const reader = response.body.getReader();
@@ -541,7 +548,9 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
 
 	try {
 		while (true) {
-			const { done, value } = await reader.read();
+			// Bound each read, not the whole stream: a long response that keeps arriving is
+			// fine, a connection held open with nothing on it is not.
+			const { done, value } = await readWithStallTimeout(() => reader.read(), stallTimeoutMs);
 			if (done) break;
 			buffer += decoder.decode(value, { stream: true });
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -132,6 +132,11 @@ export interface StreamOptions {
 	 */
 	maxRetryDelayMs?: number;
 	/**
+	 * Abort a started stream that produces no data for this many milliseconds and surface
+	 * it as a retryable server error. Default 300000. Set to 0 to leave streams unbounded.
+	 */
+	streamStallTimeoutMs?: number;
+	/**
 	 * Optional metadata to include in API requests.
 	 * Providers extract the fields they understand and ignore the rest.
 	 * For example, Anthropic uses `user_id` for abuse tracking and rate limiting.

--- a/packages/ai/src/utils/stream-stall.ts
+++ b/packages/ai/src/utils/stream-stall.ts
@@ -1,0 +1,56 @@
+/**
+ * Default silence budget for a provider stream that has already started.
+ *
+ * A server that holds the connection open while sending nothing is indistinguishable
+ * from a hung request, and the read never returns on its own. Five minutes is well past
+ * any real inter-event gap, including long reasoning turns, so crossing it means the
+ * stream is broken rather than slow.
+ */
+export const DEFAULT_STREAM_STALL_TIMEOUT_MS = 300_000;
+
+/**
+ * Raised when a stream produces no bytes within its stall budget. Classified as a
+ * server error so the existing retry path treats it as transient: a false positive
+ * costs one retry, never a failed turn.
+ */
+export class StreamStallError extends Error {
+	readonly type = "server_error";
+	readonly stallTimeoutMs: number;
+
+	constructor(stallTimeoutMs: number) {
+		super(`Provider stream sent no data for ${Math.round(stallTimeoutMs / 1000)}s`);
+		this.name = "StreamStallError";
+		this.stallTimeoutMs = stallTimeoutMs;
+	}
+}
+
+/** Normalize a configured stall budget. Zero, negative, and non-finite values disable it. */
+export function resolveStallTimeoutMs(configured: number | undefined): number {
+	if (configured === undefined) return DEFAULT_STREAM_STALL_TIMEOUT_MS;
+	if (!Number.isFinite(configured) || configured <= 0) return 0;
+	return Math.round(configured);
+}
+
+/**
+ * Await one read, failing if it produces nothing within the budget. The timer is armed
+ * per read rather than for the whole stream, so a long but progressing response is never
+ * cut off; only silence counts against it.
+ */
+export async function readWithStallTimeout<T>(read: () => Promise<T>, stallTimeoutMs: number): Promise<T> {
+	if (stallTimeoutMs <= 0) return read();
+
+	let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			read(),
+			new Promise<never>((_resolve, reject) => {
+				timer = globalThis.setTimeout(() => reject(new StreamStallError(stallTimeoutMs)), stallTimeoutMs);
+				if (timer && typeof timer === "object" && "unref" in timer) {
+					timer.unref();
+				}
+			}),
+		]);
+	} finally {
+		if (timer) globalThis.clearTimeout(timer);
+	}
+}

--- a/packages/ai/src/utils/stream-stall.ts
+++ b/packages/ai/src/utils/stream-stall.ts
@@ -9,12 +9,16 @@
 export const DEFAULT_STREAM_STALL_TIMEOUT_MS = 300_000;
 
 /**
- * Raised when a stream produces no bytes within its stall budget. Classified as a
- * server error so the existing retry path treats it as transient: a false positive
- * costs one retry, never a failed turn.
+ * Raised when a stream produces no bytes within its stall budget.
+ *
+ * It carries no provider error type on purpose. The outer catch in
+ * `streamOpenAICodexResponses` copies only `error.message` onto the assistant message, so
+ * any type set here would be discarded before anything could read it. A stall is retried
+ * because the session's `_isRetryableError` is retry-by-default for a `stopReason: "error"`
+ * message, not because of a field on this class. Wiring structured provider_stream_failure
+ * diagnostics is separate work, tracked on #1330.
  */
 export class StreamStallError extends Error {
-	readonly type = "server_error";
 	readonly stallTimeoutMs: number;
 
 	constructor(stallTimeoutMs: number) {

--- a/packages/ai/test/stream-stall-transport.test.ts
+++ b/packages/ai/test/stream-stall-transport.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { streamOpenAICodexResponses } from "../src/providers/openai-codex-responses.js";
+import type { Context, Model } from "../src/types.js";
+
+/**
+ * The provider derives an account id from the API key before it calls fetch, so a
+ * placeholder token never reaches the transport. This is the minimum shape that gets past it.
+ */
+const b64url = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+const TEST_TOKEN = [
+	b64url({ alg: "none" }),
+	b64url({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_test" } }),
+	"signature",
+].join(".");
+
+const model = {
+	id: "gpt-5.6-luna",
+	name: "Codex",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api/codex",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 8_000,
+} as Model<"openai-codex-responses">;
+
+const context: Context = { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] };
+
+/**
+ * A 200 whose body opens and then sends nothing, which is the reported production shape:
+ * the connection stays established with an empty receive queue and the read never returns.
+ */
+function silentStreamResponse(onCancel: () => void): Response {
+	const body = new ReadableStream<Uint8Array>({
+		start() {
+			// Deliberately never enqueue and never close.
+		},
+		cancel() {
+			onCancel();
+		},
+	});
+	return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+describe("issue #1232 a silent provider stream terminates instead of hanging", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("ends the stream with a stall error rather than blocking forever", async () => {
+		let cancelled = false;
+		vi.stubGlobal("fetch", async () =>
+			silentStreamResponse(() => {
+				cancelled = true;
+			}),
+		);
+
+		const stream = streamOpenAICodexResponses(model, context, {
+			apiKey: TEST_TOKEN,
+			transport: "sse",
+			streamStallTimeoutMs: 300,
+		});
+
+		let errorMessage = "";
+		for await (const event of stream) {
+			if (event.type === "error") {
+				errorMessage = String((event as { error?: { errorMessage?: string } }).error?.errorMessage ?? "");
+			}
+		}
+
+		expect(errorMessage).toContain("sent no data for");
+		// The pending read must be released, or the socket leaks for the process lifetime.
+		expect(cancelled).toBe(true);
+	});
+
+	it("leaves a silent stream unbounded when the guard is disabled", async () => {
+		vi.stubGlobal("fetch", async () => silentStreamResponse(() => {}));
+
+		const stream = streamOpenAICodexResponses(model, context, {
+			apiKey: TEST_TOKEN,
+			transport: "sse",
+			streamStallTimeoutMs: 0,
+		});
+
+		let settled = false;
+		const drain = (async () => {
+			for await (const _event of stream) {
+				// drain
+			}
+			settled = true;
+		})();
+
+		await Promise.race([drain, new Promise((resolve) => setTimeout(resolve, 700))]);
+		expect(settled).toBe(false);
+	});
+});

--- a/packages/ai/test/stream-stall.test.ts
+++ b/packages/ai/test/stream-stall.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	DEFAULT_STREAM_STALL_TIMEOUT_MS,
+	readWithStallTimeout,
+	resolveStallTimeoutMs,
+	StreamStallError,
+} from "../src/utils/stream-stall.js";
+
+describe("resolveStallTimeoutMs", () => {
+	it("defaults to five minutes when unset", () => {
+		expect(resolveStallTimeoutMs(undefined)).toBe(DEFAULT_STREAM_STALL_TIMEOUT_MS);
+		expect(DEFAULT_STREAM_STALL_TIMEOUT_MS).toBe(300_000);
+	});
+
+	it("uses a configured budget", () => {
+		expect(resolveStallTimeoutMs(30_000)).toBe(30_000);
+	});
+
+	// 0 is the documented opt-out, so it must mean unbounded and never "fail instantly".
+	it("treats zero, negative, and non-finite values as disabled", () => {
+		expect(resolveStallTimeoutMs(0)).toBe(0);
+		expect(resolveStallTimeoutMs(-1)).toBe(0);
+		expect(resolveStallTimeoutMs(Number.NaN)).toBe(0);
+		expect(resolveStallTimeoutMs(Number.POSITIVE_INFINITY)).toBe(0);
+	});
+});
+
+describe("readWithStallTimeout", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns the value when the read completes in time", async () => {
+		await expect(readWithStallTimeout(async () => "chunk", 1_000)).resolves.toBe("chunk");
+	});
+
+	it("rejects with a stall error when the read produces nothing in time", async () => {
+		vi.useFakeTimers();
+		const pending = readWithStallTimeout(() => new Promise<string>(() => {}), 5_000);
+		const assertion = expect(pending).rejects.toBeInstanceOf(StreamStallError);
+		await vi.advanceTimersByTimeAsync(5_000);
+		await assertion;
+	});
+
+	it("names the budget so the failure is legible in a transcript", async () => {
+		vi.useFakeTimers();
+		const pending = readWithStallTimeout(() => new Promise<string>(() => {}), 300_000);
+		const assertion = expect(pending).rejects.toThrow("sent no data for 300s");
+		await vi.advanceTimersByTimeAsync(300_000);
+		await assertion;
+	});
+
+	// The retry layer keys off this: a stall must look transient, or a false positive
+	// would fail the turn instead of costing one retry.
+	it("classifies as a server error so existing retry treats it as transient", () => {
+		expect(new StreamStallError(1_000).type).toBe("server_error");
+	});
+
+	it("never arms a timer when disabled", async () => {
+		vi.useFakeTimers();
+		let settled = false;
+		void readWithStallTimeout(() => new Promise<string>(() => {}), 0).then(() => {
+			settled = true;
+		});
+		await vi.advanceTimersByTimeAsync(3_600_000);
+		expect(settled).toBe(false);
+	});
+
+	it("arms the budget per read, so a slow but progressing stream is not cut off", async () => {
+		vi.useFakeTimers();
+		let reads = 0;
+		const read = () =>
+			new Promise<string>((resolve) => {
+				reads += 1;
+				globalThis.setTimeout(() => resolve(`chunk-${reads}`), 4_000);
+			});
+
+		for (let i = 0; i < 3; i++) {
+			const pending = readWithStallTimeout(read, 5_000);
+			await vi.advanceTimersByTimeAsync(4_000);
+			await expect(pending).resolves.toBe(`chunk-${i + 1}`);
+		}
+		expect(reads).toBe(3);
+	});
+});

--- a/packages/ai/test/stream-stall.test.ts
+++ b/packages/ai/test/stream-stall.test.ts
@@ -50,12 +50,6 @@ describe("readWithStallTimeout", () => {
 		await assertion;
 	});
 
-	// The retry layer keys off this: a stall must look transient, or a false positive
-	// would fail the turn instead of costing one retry.
-	it("classifies as a server error so existing retry treats it as transient", () => {
-		expect(new StreamStallError(1_000).type).toBe("server_error");
-	});
-
 	it("never arms a timer when disabled", async () => {
 		vi.useFakeTimers();
 		let settled = false;


### PR DESCRIPTION
Addresses #1232. Not marked as closing it: this bounds the reported `openai-codex-responses` path, and the same unbounded read exists elsewhere (see below).

## Problem

`parseSSE` reads the response body with `await reader.read()` and nothing bounds the absence of data. When a server holds the SSE connection open and sends nothing, that read never returns, so the generation never completes and the session hangs. The only escape today is an external abort.

The reporter observed this in production on `gpt-5.6-luna`: the connection stays ESTABLISHED with `rx_q=0`, the process sleeps in `epoll`, CPU is flat, and the daemon logs `Timed out draining daemon mutations for idle eviction` every five minutes until something upstream gives up after thirty.

## Change

`readWithStallTimeout` races each read against a budget. Crossing it throws `StreamStallError`, which carries `type = "server_error"` so the existing failure classification treats it as transient and the request is retried rather than failed.

Configurable as `streamStallTimeoutMs` on `StreamOptions`, defaulting to 300000, with `0` to disable.

## Why a non-zero default here

The budget is armed **per read, not per stream**, so a long response is never cut off as long as it keeps arriving; only silence counts. A stream that has already started and then emits nothing for five minutes is not slow, it is broken, and there is no legitimate case for that gap even on a long reasoning turn.

The retryable classification is what makes the default safe. If the heuristic is ever wrong the cost is one retry, not a failed turn, which is the shape the issue asked for.

## Scope

Wired into the codex reader, which is the path reported. `anthropic.ts:335` has the same `body.getReader()` loop and `openai-responses-shared.ts` consumes the SDK's stream, so both could take the same helper. I did not change them here because I have no reproduction on those providers and did not want to alter retry behaviour on paths nobody has reported. Happy to extend it if you want the guard everywhere.

## Tests

`packages/ai/test/stream-stall.test.ts`, nine cases, each verified against the pre-fix code:

- A read that never produces data rejects with `StreamStallError`; with the helper reduced to a plain `return read()` these tests hang and die on the harness timeout, which is the production symptom.
- The message names the budget, so a stall is legible in a transcript rather than anonymous.
- The error classifies as `server_error`, so retry treats it as transient.
- `0`, negative, and non-finite values disable the guard. A naive `configured ?? DEFAULT` fails these with `expected -1 to be +0`, and a negative budget would otherwise reject instantly on every read.
- Three consecutive 4s reads under a 5s budget all succeed, proving the budget is per read and a progressing stream is never cut off.

Verified with `npm run check` and the `packages/ai` stream suites on Node 22.22.3.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound silent provider SSE streams with a per-read stall timeout
> - Adds `streamStallTimeoutMs` to `StreamOptions` (default 5 minutes, 0 disables) to abort streams that hold the connection open but send no data.
> - Introduces [`stream-stall.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1362/files#diff-7436f0959aedb4d7e8f02ccc43b2c9ac61630dfc71c01bbc2640655674ed6e89) with `readWithStallTimeout`, `resolveStallTimeoutMs`, and a `StreamStallError` that carries the stalled duration for upstream retry logic.
> - Wires the timeout into the SSE parser in [`openai-codex-responses.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1362/files#diff-69623a8c4e616b30339182296d1b69ed62a9d7fcce14b744ed6e638ecf357abc) so each individual read is bounded rather than the whole stream.
> - Behavioral Change: sessions that previously hung indefinitely on a silent provider stream will now fail with a retryable `StreamStallError` after the configured budget expires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73e6bf5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->