### PR TITLE
Test Prime CLI config mode only on POSIX

### DIFF
--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -551,7 +551,9 @@ describe("AuthStorage", () => {
 
 			const config = JSON.parse(readFileSync(primeConfigPath, "utf-8")) as Record<string, unknown>;
 			expect(config.api_key).toBe("new-prime-key");
-			expect(statSync(primeConfigPath).mode & 0o777).toBe(0o600);
+			if (process.platform !== "win32") {
+				expect(statSync(primeConfigPath).mode & 0o777).toBe(0o600);
+			}
 			expect(authStorage.has("prime-inference")).toBe(false);
 			await expect(authStorage.getApiKey("prime-inference")).resolves.toBe("new-prime-key");
 		});


### PR DESCRIPTION
## Summary

- keep the Prime CLI config create/read/source assertions on every platform
- assert final POSIX mode `0o600` only where Node exposes POSIX permission bits

Windows `chmod` cannot represent owner/group/other mode bits and reports `0o666`, so the unconditional assertion was a false failure. Production file creation and permission behavior are unchanged; Linux/macOS coverage remains identical.

## Validation

- `test/auth-storage.test.ts`: 51/51 passed on Windows
- `npm run check`: passed (909 files; tsgo, installer render, browser smoke)
- fresh adversarial review: approved

Fixes #1363


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip file permission mode assertion in Prime CLI config test on Windows
> The file mode check (`statSync(primeConfigPath).mode & 0o777 === 0o600`) in [auth-storage.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1364/files#diff-3c6aa63c02f897b2adca3a38c73c6df1ad8ca39fde071c4ec66ed643ed9a06c5) is now skipped on Windows, where POSIX-style permissions are not supported.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81e625a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->