### PR TITLE
fix(ai): stop retrying codex auth failures through the transport budget

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed OpenAI Codex authentication failures being retried through the whole transport budget: a 401 or 403 now costs one request instead of four, and is no longer re-sent when the error body happens to mention a rate limit ([#1330](https://github.com/PrimeIntellect-ai/prime-agent/issues/1330)).
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -99,7 +99,30 @@ interface RequestBody {
 // Retry Helpers
 // ============================================================================
 
-function isRetryableError(status: number, errorText: string): boolean {
+/**
+ * A response the retry policy already rejected, for example a 401. It is thrown from
+ * inside the transport try block, so without a distinct type the generic catch below
+ * treats it as a network error and retries it anyway.
+ */
+export class NonRetryableProviderError extends Error {
+	readonly status: number;
+
+	constructor(message: string, status: number) {
+		super(message);
+		this.name = "NonRetryableProviderError";
+		this.status = status;
+	}
+}
+
+/** Auth failures never succeed on a repeat, so they must cost one request, not the budget. */
+export function isNonRetryableAuthStatus(status: number): boolean {
+	return status === 401 || status === 403;
+}
+
+export function isRetryableError(status: number, errorText: string): boolean {
+	if (isNonRetryableAuthStatus(status)) {
+		return false;
+	}
 	if (status === 429 || status === 500 || status === 502 || status === 503 || status === 504) {
 		return true;
 	}
@@ -265,12 +288,17 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						statusText: response.statusText,
 					});
 					const info = await parseErrorResponse(fakeResponse);
-					throw new Error(info.friendlyMessage || info.message);
+					throw new NonRetryableProviderError(info.friendlyMessage || info.message, response.status);
 				} catch (error) {
 					if (error instanceof Error) {
 						if (error.name === "AbortError" || error.message === "Request was aborted") {
 							throw new Error("Request was aborted");
 						}
+					}
+					// The retry policy already rejected this response; retrying it here would
+					// spend the whole budget re-sending a request that cannot start succeeding.
+					if (error instanceof NonRetryableProviderError) {
+						throw error;
 					}
 					lastError = error instanceof Error ? error : new Error(String(error));
 					// Network errors are retryable

--- a/packages/ai/test/codex-auth-retry-transport.test.ts
+++ b/packages/ai/test/codex-auth-retry-transport.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { streamOpenAICodexResponses } from "../src/providers/openai-codex-responses.js";
+import type { Context, Model } from "../src/types.js";
+
+/**
+ * The provider derives an account id from the API key before it ever calls fetch, so a
+ * placeholder token fails with "Failed to extract accountId from token" and never reaches
+ * the transport. This is the minimum shape that gets past it.
+ */
+const b64url = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+const TEST_TOKEN = [
+	b64url({ alg: "none" }),
+	b64url({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_test" } }),
+	"signature",
+].join(".");
+
+const model = {
+	id: "gpt-5.6-luna",
+	name: "Codex",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api/codex",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 8_000,
+} as Model<"openai-codex-responses">;
+
+const context: Context = { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] };
+
+/** Drive a real stream against a stubbed transport and report how many requests it made. */
+async function transportAttempts(status: number, body: string): Promise<{ calls: number; errorMessage: string }> {
+	let calls = 0;
+	vi.stubGlobal("fetch", async () => {
+		calls += 1;
+		return new Response(body, { status, statusText: String(status) });
+	});
+
+	// Force SSE; the websocket path has its own transport and is not what this covers.
+	const stream = streamOpenAICodexResponses(model, context, { apiKey: TEST_TOKEN, transport: "sse" });
+	let errorMessage = "";
+	for await (const event of stream) {
+		if (event.type === "error") {
+			errorMessage = String((event as { error?: { errorMessage?: string } }).error?.errorMessage ?? "");
+		}
+	}
+	return { calls, errorMessage };
+}
+
+describe("issue #1330 codex transport does not retry auth failures", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it.each([401, 403])("issues exactly one request for %i", async (status) => {
+		const { calls } = await transportAttempts(status, '{"error":{"message":"Your session has expired"}}');
+		expect(calls).toBe(1);
+	});
+
+	// The status has to win over the body. Before the fix this retried the full budget
+	// because the transient regex matched the message text.
+	it("issues one request for a 401 whose body reads like a rate limit", async () => {
+		const { calls } = await transportAttempts(401, '{"error":{"message":"rate limit exceeded"}}');
+		expect(calls).toBe(1);
+	});
+
+	it("still spends the budget on a 500", async () => {
+		const { calls } = await transportAttempts(500, '{"error":{"message":"server error"}}');
+		expect(calls).toBeGreaterThan(1);
+	});
+
+	it("keeps the friendly provider message on the terminal event", async () => {
+		const { errorMessage } = await transportAttempts(401, '{"error":{"message":"Your session has expired"}}');
+		expect(errorMessage).toContain("Your session has expired");
+	});
+});

--- a/packages/ai/test/codex-auth-retry.test.ts
+++ b/packages/ai/test/codex-auth-retry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+	isNonRetryableAuthStatus,
+	isRetryableError,
+	NonRetryableProviderError,
+} from "../src/providers/openai-codex-responses.js";
+
+describe("issue #1330 codex auth is not retried", () => {
+	it.each([401, 403])("treats %i as non-retryable", (status) => {
+		expect(isNonRetryableAuthStatus(status)).toBe(true);
+	});
+
+	// These must keep retrying: the transport budget exists for exactly these.
+	it.each([429, 500, 502, 503, 504, 400, 404])("leaves %i alone", (status) => {
+		expect(isNonRetryableAuthStatus(status)).toBe(false);
+	});
+
+	// The decision function itself, not just the predicate: a 401 body often contains
+	// wording the transient regex would otherwise match, so status has to win.
+	it.each([401, 403])("isRetryableError refuses to retry %i", (status) => {
+		expect(isRetryableError(status, '{"error":{"message":"Your session has expired"}}')).toBe(false);
+	});
+
+	it("isRetryableError refuses a 401 even when the body reads like a rate limit", () => {
+		expect(isRetryableError(401, "rate limit exceeded, service unavailable")).toBe(false);
+	});
+
+	it.each([429, 500, 502, 503, 504])("isRetryableError still retries %i", (status) => {
+		expect(isRetryableError(status, "server error")).toBe(true);
+	});
+
+	it("carries the status so callers can mark the right credential stale", () => {
+		const error = new NonRetryableProviderError("Unauthorized", 401);
+		expect(error.status).toBe(401);
+		expect(error.name).toBe("NonRetryableProviderError");
+	});
+
+	// The transport catch decides by type, not by message, because an auth message
+	// has no reliable marker. Previously only "usage limit" escaped the retry path.
+	it("is identifiable by type rather than by message text", () => {
+		const error: unknown = new NonRetryableProviderError("Your session has expired", 401);
+		expect(error instanceof NonRetryableProviderError).toBe(true);
+		expect((error as Error).message).not.toContain("usage limit");
+	});
+});


### PR DESCRIPTION
Addresses the transport-retry half of #1330. Not marked as closing it: the nested `event.error.{code,type,message}` extraction and the coding-agent session-retry changes described there are separate and not in this PR.

## Problem

A 401 costs four requests instead of one.

`isRetryableError` correctly declines to retry a 401, so the code falls through to the friendly-message throw. That throw happens **inside** the transport `try`, and the `catch` below treats anything it receives as a network error:

```ts
const info = await parseErrorResponse(fakeResponse);
throw new Error(info.friendlyMessage || info.message);   // inside the try
} catch (error) {
    lastError = ...;
    // Network errors are retryable
    if (attempt < MAX_RETRIES && !lastError.message.includes("usage limit")) {
        continue;   // re-sends the 401
    }
}
```

The only thing that escapes is a message containing `usage limit`. An expired token does not say that, so it is re-sent `MAX_RETRIES` times with backoff before the user is told to log in. Re-sending an expired credential cannot start succeeding; it only delays the `/login` guidance by the backoff sum.

There is a second, quieter path to the same place. `isRetryableError` falls back to a regex over the response body:

```ts
return /rate.?limit|overloaded|service.?unavailable|.../i.test(errorText);
```

Status is not consulted first, so a 401 whose body happens to mention a rate limit is classified retryable on the text alone.

## Change

`NonRetryableProviderError` carries the status and is thrown instead of a bare `Error`. The transport catch rethrows it untouched, so the retry policy's decision is not re-litigated by the layer below it. Type, not message text, because an auth message has no reliable marker.

`isRetryableError` now checks status before the text fallback, so 401 and 403 are refused regardless of body wording.

Non-auth behaviour is unchanged: 429 and 5xx still retry across the budget, and genuine network errors still hit the generic catch.

## Tests

`packages/ai/test/codex-auth-retry.test.ts`, 19 cases against the real decision function rather than a wrapper:

- `isRetryableError` refuses 401 and 403, and still retries 429, 500, 502, 503, 504.
- **A 401 whose body reads `rate limit exceeded, service unavailable` is still refused.** With the status check removed this one fails as `expected true to be false`, which is the text-fallback path above.
- `NonRetryableProviderError` carries the status so a caller can mark the right credential stale, and is identifiable by type rather than by the old `usage limit` substring.

## What I could not test

I could not add a transport-level test asserting "one fetch for a 401, more than one for a 500". Driving `streamOpenAICodexResponses` with a stubbed `fetch` never reaches the request, so something in auth resolution short-circuits first and I did not want to ship a test that passes without exercising the path. If there is an existing harness for that, point me at it and I will add the count assertion.

Verified with `npm run check` on Node 22.22.3.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenAI Codex auth failures (401/403) to not retry through the transport budget
> - Adds `NonRetryableProviderError` in [openai-codex-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1365/files#diff-69623a8c4e616b30339182296d1b69ed62a9d7fcce14b744ed6e638ecf357abc) to distinguish auth failures from transient errors at the type level.
> - Updates `isRetryableError` to check HTTP status first, so 401/403 responses are never retried even if the error body contains rate-limit language.
> - Updates `streamOpenAICodexResponses` to rethrow `NonRetryableProviderError` immediately in the catch block, bypassing the generic retry loop.
> - Behavioral Change: Auth failures now consume exactly one attempt and surface the provider's original error message instead of exhausting the full retry budget.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00da4a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->