### PR TITLE
fix(ai): omit service tier for GitHub Copilot

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed GitHub Copilot OpenAI Responses requests failing when the agent forwarded its unsupported default service tier.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -98,8 +98,9 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention);
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
+			const serviceTier = model.provider === "github-copilot" ? undefined : options?.serviceTier;
 			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId);
-			let params = buildParams(model, context, options);
+			let params = buildParams(model, context, options, serviceTier);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
 				params = nextParams as ResponseCreateParamsStreaming;
@@ -115,7 +116,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 			stream.push({ type: "start", partial: output });
 
 			await processResponsesStream(openaiStream, output, stream, model, {
-				serviceTier: options?.serviceTier,
+				serviceTier,
 				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
 			});
 
@@ -222,7 +223,12 @@ function createClient(
 	});
 }
 
-function buildParams(model: Model<"openai-responses">, context: Context, options?: OpenAIResponsesOptions) {
+function buildParams(
+	model: Model<"openai-responses">,
+	context: Context,
+	options: OpenAIResponsesOptions | undefined,
+	serviceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
+) {
 	const messages = convertResponsesMessages(model, context, OPENAI_TOOL_CALL_PROVIDERS);
 
 	const cacheRetention = resolveCacheRetention(options?.cacheRetention);
@@ -244,8 +250,8 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		params.temperature = options?.temperature;
 	}
 
-	if (options?.serviceTier !== undefined) {
-		params.service_tier = options.serviceTier;
+	if (serviceTier !== undefined) {
+		params.service_tier = serviceTier;
 	}
 
 	if (context.tools && context.tools.length > 0) {

--- a/packages/ai/test/openai-responses-copilot-provider.test.ts
+++ b/packages/ai/test/openai-responses-copilot-provider.test.ts
@@ -91,6 +91,88 @@ describe("openai-responses provider defaults", () => {
 		});
 	});
 
+	it("omits unsupported service tier for GitHub Copilot", async () => {
+		const model = getModel("github-copilot", "gpt-5.6-sol");
+		let capturedPayload: unknown;
+		const sse = `data: ${JSON.stringify({
+			type: "response.completed",
+			response: {
+				status: "completed",
+				usage: {
+					input_tokens: 1000000,
+					output_tokens: 1000000,
+					total_tokens: 2000000,
+					input_tokens_details: { cached_tokens: 0 },
+				},
+			},
+		})}\n\n`;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(sse, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-token",
+				serviceTier: "priority",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		const result = await stream.result();
+
+		expect(capturedPayload).toMatchObject({ model: "gpt-5.6-sol" });
+		expect(capturedPayload).not.toHaveProperty("service_tier");
+		expect(result.usage.cost.input).toBe(model.cost.input);
+		expect(result.usage.cost.output).toBe(model.cost.output);
+	});
+
+	it("preserves supported service tier for OpenAI", async () => {
+		const model = getModel("openai", "gpt-5.5");
+		let capturedPayload: unknown;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-token",
+				serviceTier: "priority",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		expect(capturedPayload).toMatchObject({
+			model: "gpt-5.5",
+			service_tier: "priority",
+		});
+	});
+
 	it.each(["gpt-5.1", "gpt-5.2", "gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.5"] as const)(
 		"sends none reasoning effort for OpenAI %s when no reasoning is requested",
 		async (modelId) => {


### PR DESCRIPTION
## Problem

Prime Agent forwards its internal `default` service tier to GitHub Copilot OpenAI Responses requests. Copilot rejects the unsupported field with HTTP 400, including for GPT-5.6 Sol.

## Fix

Derive one effective service tier per request. GitHub Copilot receives no `service_tier`; supported OpenAI routes retain it. The same effective value now drives cost accounting, avoiding priority/flex pricing for a tier Copilot did not honor.

## Tests

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-responses-copilot-provider.test.ts` — 25 passed
- Regression test fails when the old forwarding behavior is restored, then passes with the fix
- `npm run check` — passed (format, lint, typecheck, installer render, browser smoke)
- Read-only Copilot critic — `NONE`

## Known / out of scope

- This changes only GitHub Copilot's OpenAI Responses transport. OpenAI and OpenAI Codex service-tier support remains unchanged.
- No rendered UI or performance behavior changed, so screenshots and benchmarks do not apply.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix GitHub Copilot requests by omitting unsupported `service_tier` from OpenAI Responses payload
> GitHub Copilot does not support the `service_tier` field, causing requests to fail when a default or explicit tier was set. In [openai-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1366/files#diff-4f45a06d4fa91c758631624991582298b307980aa919b7677cc82830bf2a6aa5), `streamOpenAIResponses` now sets `serviceTier` to `undefined` when the provider is `github-copilot`, omitting the field from the API payload entirely. All other providers continue to use `options.serviceTier` as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef9ef3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Live verification

Matched GitHub Copilot / GPT-5.6 Sol probe:

- Before: Prime process exited 0, but its final event had `stopReason: error` with HTTP 400 `service_tier is not supported`.
- After applying this source change to the installed bundle: isolated-daemon response `PRIME_GPT_FIXED`, `stopReason: stop`, 506 total tokens.
- Normal supervised wrapper: `verdict: PASS`, model `gpt-5.6-sol`, response `PRIME_DEFAULT_GPT_FIXED`.

Existing user sessions were not restarted or interrupted.
