### PR TITLE
fix(coding-agent): accept spawn handles when deleting subagents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
+- Fixed `rlm.delete_subagent()` rejecting the spawn handle returned by `rlm()`.
 
 ## [0.7.2] - 2026-08-11
 

--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -216,16 +216,18 @@ async def list_subagents() -> list[RLMSubagent]:
     return [_subagent_from_payload(entry) for entry in entries]
 
 
-async def delete_subagent(target: str | RLMSubagent) -> RLMSubagent:
+async def delete_subagent(target: str | RLMSpawnHandle | RLMSubagent) -> RLMSubagent:
     """Delete one running or retained direct child from the current parent session."""
-    if isinstance(target, RLMSubagent):
+    if isinstance(target, (RLMSpawnHandle, RLMSubagent)):
         selector = target.rlm_child_id
     elif isinstance(target, str):
         selector = target.strip()
         if not selector:
             raise ValueError("target must not be empty")
     else:
-        raise TypeError(f"target must be str or RLMSubagent, got {type(target).__name__}")
+        raise TypeError(
+            f"target must be str, RLMSpawnHandle, or RLMSubagent, got {type(target).__name__}"
+        )
     payload = await host_request("rlm.delete_subagent", {"target": selector})
     return _subagent_from_payload(payload.get("subagent"), "rlm.delete_subagent")
 
@@ -294,7 +296,7 @@ class _RLMCallable:
     async def list_subagents(self) -> list[RLMSubagent]:
         return await list_subagents()
 
-    async def delete_subagent(self, target: str | RLMSubagent) -> RLMSubagent:
+    async def delete_subagent(self, target: str | RLMSpawnHandle | RLMSubagent) -> RLMSubagent:
         return await delete_subagent(target)
 
     async def __call__(self, prompt: str, **kwargs: Any) -> RLMSpawnHandle:

--- a/prime-agent-runtime/test/test_subagent_registry.py
+++ b/prime-agent-runtime/test/test_subagent_registry.py
@@ -182,6 +182,34 @@ class RlmSubagentRegistryTest(unittest.TestCase):
             {"target": "sub-a1b2c3d4"},
         )
 
+    def test_deletes_spawn_handle_by_child_id(self) -> None:
+        handle = rlm_module.RLMSpawnHandle(
+            rlm_child_id="sub-a1b2c3d4",
+            name="api-reviewer",
+            session_dir=Path("/tmp/parent/sub-a1b2c3d4"),
+            model="anthropic/claude-opus-4-7",
+        )
+        host_request = AsyncMock(
+            return_value={
+                "subagent": {
+                    "rlm_child_id": handle.rlm_child_id,
+                    "active_session_id": None,
+                    "session_id": "session-child",
+                    "session_name": handle.name,
+                    "session_dir": str(handle.session_dir),
+                    "status": "completed",
+                }
+            }
+        )
+
+        with patch.object(rlm_module, "host_request", host_request):
+            asyncio.run(rlm_module.rlm.delete_subagent(handle))
+
+        host_request.assert_awaited_once_with(
+            "rlm.delete_subagent",
+            {"target": "sub-a1b2c3d4"},
+        )
+
     def test_rejects_invalid_delete_response_and_target(self) -> None:
         host_request = AsyncMock(return_value={"subagent": {"status": "completed"}})
 
@@ -191,7 +219,7 @@ class RlmSubagentRegistryTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "target must not be empty"):
             asyncio.run(rlm_module.delete_subagent("   "))
-        with self.assertRaisesRegex(TypeError, "target must be str or RLMSubagent"):
+        with self.assertRaisesRegex(TypeError, "target must be str, RLMSpawnHandle, or RLMSubagent"):
             asyncio.run(rlm_module.delete_subagent(123))
 
     def test_rejects_invalid_registry_payload(self) -> None:


### PR DESCRIPTION
## Summary

- allow `rlm.delete_subagent()` to accept the `RLMSpawnHandle` returned by `rlm()`
- normalize handles to their child ID before crossing the host bridge
- retain existing string and `RLMSubagent` selectors and reject unsupported objects

This aligns the runtime with Prime Agent's model-facing prompt, which already recommends `await rlm.delete_subagent(child)`.

## Verification

- `prime-agent-runtime/test/test_subagent_registry.py`: 11 passed on Linux
- local Python runtime suite: 63 passed, 2 skipped because optional MCP dependencies were absent
- end-to-end Verifiers/Prime Agent episode on Linux + CUDA using a release tarball built from this commit: Qwen3.5-27B executed `child = rlm(...)` followed by `await rlm.delete_subagent(child)`; the child reached `cancelled`, capability reward was 1.0, and the trace had no errors

The E2E evidence is recorded in `lentzl/prime-rl` commit `a026f87a7`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `delete_subagent` to accept `RLMSpawnHandle` as a deletion target
> Expands the accepted argument types for `delete_subagent` in [rlm/__init__.py](https://github.com/PrimeIntellect-ai/prime-agent/pull/1369/files#diff-8f05bb028ac34c9ff421f45f913f35be2a99010ef924da344d7a427869c7ead3) from `str | RLMSubagent` to `str | RLMSpawnHandle | RLMSubagent`. When an `RLMSpawnHandle` is passed, the `rlm_child_id` is extracted and used as the deletion target. The `TypeError` message is updated to reflect the new accepted types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3b922b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->