### PR TITLE
fix(coding-agent): report a supported Codex client version for model discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#702](https://github.com/PrimeIntellect-ai/prime-agent/issues/702)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#702](https://github.com/PrimeIntellect-ai/prime-agent/issues/702)).
+- Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#1375](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375) by [@bilelrais](https://github.com/bilelrais)).
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -387,8 +387,9 @@ function readOpenAICodexAccountId(token: string): string | undefined {
  *
  * Skipping step 2 fails silently and asymmetrically: `rlm` subagent delegation and `find_models()` resolve
  * through `getExecutableModels()` and lose the model, while `/model` reads the unfiltered `getAvailable()`
- * and keeps offering it. A model working as the session model is therefore not evidence that delegation can
- * see it, and the spawn error reports it as unavailable or unauthenticated rather than undiscovered.
+ * and keeps offering it.
+ *
+ * Catalog behaviour measured 2026-08-13; see #702.
  */
 const OPENAI_CODEX_CLIENT_VERSION = "0.147.0";
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -376,8 +376,19 @@ function readOpenAICodexAccountId(token: string): string | undefined {
  * The Codex backend gates its model catalog on the reported client version: it answers HTTP 200 with a
  * catalog that grows as the version rises, so a low version yields a silently empty or partial list rather
  * than an error. Prime Agent's own package version is far below the Codex CLI's version line, so it must
- * report a supported Codex client version here instead. Raise this when the Codex CLI publishes a release
- * that gates newer models.
+ * report a supported Codex client version here instead.
+ *
+ * Shipping a new Codex model takes two edits, and both are required:
+ * 1. Add the model to `codexModels` in `packages/ai/scripts/generate-models.ts` and regenerate. That list is
+ *    explicit, not fetched, so an unlisted model does not exist for Prime Agent at all.
+ * 2. Raise this constant to a Codex CLI release whose catalog includes that model. `getExecutableModels()`
+ *    below intersects the registry with the discovered catalog, so a listed model the catalog omits is
+ *    dropped.
+ *
+ * Skipping step 2 fails silently and asymmetrically: `rlm` subagent delegation and `find_models()` resolve
+ * through `getExecutableModels()` and lose the model, while `/model` reads the unfiltered `getAvailable()`
+ * and keeps offering it. A model working as the session model is therefore not evidence that delegation can
+ * see it, and the spawn error reports it as unavailable or unauthenticated rather than undiscovered.
  */
 const OPENAI_CODEX_CLIENT_VERSION = "0.147.0";
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -27,7 +27,7 @@ import { dirname, join } from "path";
 import { type Static, type TProperties, Type } from "typebox";
 import type { Validator } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
-import { getAgentDir, VERSION } from "../config.js";
+import { getAgentDir } from "../config.js";
 import type { AuthSourceToken, AuthStatus, AuthStorage } from "./auth-storage.js";
 import { PRIME_INFERENCE_PROVIDER_ID } from "./prime-inference-auth.js";
 import {
@@ -372,6 +372,15 @@ function readOpenAICodexAccountId(token: string): string | undefined {
 	}
 }
 
+/**
+ * The Codex backend gates its model catalog on the reported client version: it answers HTTP 200 with a
+ * catalog that grows as the version rises, so a low version yields a silently empty or partial list rather
+ * than an error. Prime Agent's own package version is far below the Codex CLI's version line, so it must
+ * report a supported Codex client version here instead. Raise this when the Codex CLI publishes a release
+ * that gates newer models.
+ */
+const OPENAI_CODEX_CLIENT_VERSION = "0.147.0";
+
 function openAICodexModelsUrl(baseUrl: string): string {
 	const normalized = baseUrl.replace(/\/+$/, "");
 	let path: string;
@@ -383,7 +392,7 @@ function openAICodexModelsUrl(baseUrl: string): string {
 		path = `${normalized}/codex/models`;
 	}
 	const url = new URL(path);
-	url.searchParams.set("client_version", VERSION);
+	url.searchParams.set("client_version", OPENAI_CODEX_CLIENT_VERSION);
 	return url.toString();
 }
 

--- a/packages/coding-agent/test/suite/regressions/702-codex-client-version.test.ts
+++ b/packages/coding-agent/test/suite/regressions/702-codex-client-version.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { VERSION } from "../../../src/config.js";
 import { AuthStorage } from "../../../src/core/auth-storage.js";

--- a/packages/coding-agent/test/suite/regressions/702-codex-client-version.test.ts
+++ b/packages/coding-agent/test/suite/regressions/702-codex-client-version.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { VERSION } from "../../../src/config.js";
+import { AuthStorage } from "../../../src/core/auth-storage.js";
+import { ModelRegistry } from "../../../src/core/model-registry.js";
+
+function codexAccessToken(accountId: string): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+describe("issue #702 codex model discovery client version", () => {
+	const tempDirs: string[] = [];
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		while (tempDirs.length > 0) {
+			const dir = tempDirs.pop();
+			if (dir) {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("reports a supported codex client version so the backend returns a catalog", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "codex-client-version-"));
+		tempDirs.push(tempDir);
+		const authPath = join(tempDir, "auth.json");
+		writeFileSync(
+			authPath,
+			JSON.stringify({
+				"openai-codex": {
+					type: "oauth",
+					access: codexAccessToken("account-123"),
+					refresh: "refresh-token",
+					expires: Date.now() + 60 * 60 * 1000,
+					accountId: "account-123",
+				},
+			}),
+		);
+
+		const registry = ModelRegistry.create(AuthStorage.create(authPath), join(tempDir, "models.json"));
+		const codexModels = registry.getAvailable().filter((model) => model.provider === "openai-codex");
+		expect(codexModels.length).toBeGreaterThan(0);
+
+		const requestedUrls: string[] = [];
+		globalThis.fetch = (async (input: Parameters<typeof globalThis.fetch>[0]) => {
+			requestedUrls.push(input instanceof Request ? input.url : input.toString());
+			return new Response(JSON.stringify({ models: codexModels.map((model) => ({ slug: model.id })) }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof globalThis.fetch;
+
+		const executable = await registry.getExecutableModels();
+
+		const discoveryUrl = requestedUrls.find((url) => url.includes("/codex/models"));
+		expect(discoveryUrl).toBeDefined();
+		const clientVersion = new URL(discoveryUrl ?? "").searchParams.get("client_version");
+		expect(clientVersion).not.toBe(VERSION);
+		expect(clientVersion).toMatch(/^\d+\.\d+\.\d+$/);
+		const [major, minor] = (clientVersion ?? "0.0.0").split(".").map(Number);
+		expect((major ?? 0) > 0 || (minor ?? 0) >= 144).toBe(true);
+
+		expect(executable.some((model) => model.provider === "openai-codex")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/702-codex-client-version.test.ts
+++ b/packages/coding-agent/test/suite/regressions/702-codex-client-version.test.ts
@@ -2,7 +2,6 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { VERSION } from "../../../src/config.js";
 import { AuthStorage } from "../../../src/core/auth-storage.js";
 import { ModelRegistry } from "../../../src/core/model-registry.js";
 
@@ -27,7 +26,7 @@ describe("issue #702 codex model discovery client version", () => {
 		}
 	});
 
-	it("reports a supported codex client version so the backend returns a catalog", async () => {
+	it("reports a Codex CLI client version on the discovery request instead of the package version", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "codex-client-version-"));
 		tempDirs.push(tempDir);
 		const authPath = join(tempDir, "auth.json");
@@ -62,7 +61,9 @@ describe("issue #702 codex model discovery client version", () => {
 		const discoveryUrl = requestedUrls.find((url) => url.includes("/codex/models"));
 		expect(discoveryUrl).toBeDefined();
 		const clientVersion = new URL(discoveryUrl ?? "").searchParams.get("client_version");
-		expect(clientVersion).not.toBe(VERSION);
+		// Prime Agent's own version is 0.x well below this floor, so this assertion fails on the
+		// unfixed source. Comparing against VERSION directly would pass today and break silently
+		// once the lockstep package version reaches the pinned constant.
 		expect(clientVersion).toMatch(/^\d+\.\d+\.\d+$/);
 		const [major, minor] = (clientVersion ?? "0.0.0").split(".").map(Number);
 		expect((major ?? 0) > 0 || (minor ?? 0) >= 144).toBe(true);


### PR DESCRIPTION
## Problem

`rlm` subagent spawns and `find_models()` never offer any `openai-codex/*` model, failing with `Requested subagent model "openai-codex/gpt-5.6-sol" is unavailable, unauthenticated, or expired` despite a valid, unexpired OAuth credential.

`ModelRegistry.getExecutableModels()` discovers Codex models against `https://chatgpt.com/backend-api/codex/models?client_version=<VERSION>` and passed Prime Agent's own package version. The backend gates its catalog on the Codex CLI version line, so `0.7.x` reads as an ancient client.

Measured against the backend with one valid token, varying only `client_version` (`originator` varied across `pi`, `codex`, `codex_cli_rs`, `codex_vscode` with no effect):

| `client_version` | models returned |
|---|---|
| `0.7.0`, `0.7.1`, `0.7.2`, `0.8.0` | 0 |
| `0.100.0` | 4 |
| `0.143.0` | 6 |
| `0.144.0`, `0.146.0`, `0.147.0` | 9 |

The response is graded rather than binary, so a floor that merely clears zero returns a silently partial catalog, which is harder to diagnose than the empty case because it looks like success.

The empty set then filters every `openai-codex` model out of `getExecutableModels()`. `/model` resolves through the unfiltered `getAvailable()`, so a user can be actively running `gpt-5.6-sol` as their main model while a subagent spawn reports it unavailable.

## Change

Replaced `VERSION` with a named `OPENAI_CODEX_CLIENT_VERSION` constant pinned to the current Codex CLI release (`0.147.0`), documented with the reason it exists and when to raise it. `VERSION` had no other use in the file, so its import was dropped.

## Testing

`packages/coding-agent/test/suite/regressions/702-codex-client-version.test.ts` builds a registry from a temporary `auth.json` holding a Codex OAuth credential, stubs `fetch`, and asserts the discovery URL reports a version other than Prime Agent's own and at or above the Codex CLI line, and that Codex models survive into `getExecutableModels()`. Verified to fail on the unfixed source (`expected '0.7.2' not to be '0.7.2'`) and pass with the change. No real provider APIs or tokens.

`npm run check` clean.

## Open

The pin needs raising when the Codex CLI gates newer models behind a later version; the comment says so, but nothing enforces it, and the failure mode is a silently smaller catalog.

Discovery failure is also indistinguishable from an auth failure at the call site: when the 5s `AbortSignal.timeout` fires or the request throws, Codex models are dropped and the caller reports "unavailable, unauthenticated, or expired". #702 suggests surfacing discovery-empty as a distinct error. That is a separate change to the error path and is not included here.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex model discovery by reporting a supported `client_version` instead of package version
> The Codex backend gates its model catalog by the reported client version. The coding agent was sending its own package version, causing `openai-codex` models to be invisible to `rlm` subagents and `find_models`.
>
> - Introduces a fixed constant `OPENAI_CODEX_CLIENT_VERSION = "0.147.0"` in [model-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453) that matches a known Codex CLI release.
> - Adds a regression test in [702-codex-client-version.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375/files#diff-9fc8217cf335dfa9678b228b20f710d3436ed51a659feca8a0e78305b6a62e5c) that asserts the discovery URL contains a semver-compatible `client_version` above a minimum threshold.
> - Behavioral Change: the `client_version` sent during Codex model discovery is now fixed at `0.147.0` and will not change automatically when the package version is bumped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5680c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->