### PR TITLE
feat(coding-agent): promote opt-in trace sharing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#1375](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375) by [@bilelrais](https://github.com/bilelrais)).
-- Added a working hint that recommends opt-in trace sharing to help train open-source LLMs that use RLM harnesses.
+- Added a working hint that recommends sharing traces with Prime Intellect to help train open-source LLMs.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#1375](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375) by [@bilelrais](https://github.com/bilelrais)).
+- Added a working hint that recommends opt-in trace sharing to help train open-source LLMs that use RLM harnesses.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -72,7 +72,7 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 	},
 	{
 		id: "trace-sharing",
-		getText: () => "Share traces with /traces on to train open-source LLMs that use RLM harnesses.",
+		getText: () => "Share traces with Prime Intellect using /traces on to train open-source LLMs.",
 	},
 	{
 		id: "persistent-ipython",

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -71,6 +71,10 @@ export const FEATURE_HINTS: readonly FeatureHintDefinition[] = [
 		getText: () => "Use /refine to turn useful lessons into reusable skills, memory, and prompts.",
 	},
 	{
+		id: "trace-sharing",
+		getText: () => "Share traces with /traces on to train open-source LLMs that use RLM harnesses.",
+	},
+	{
 		id: "persistent-ipython",
 		getText: () => "Prime Agent keeps IPython variables and helpers between turns and compactions.",
 	},

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -92,6 +92,8 @@ describe("feature hint deck", () => {
 		expect(textById.get("agent-messaging")).toContain("message each other");
 		expect(textById.get("goal")).toContain("/goal");
 		expect(textById.get("refine")).toContain("/refine");
+		expect(textById.get("trace-sharing")).toContain("/traces on");
+		expect(textById.get("trace-sharing")).toContain("open-source LLMs");
 		expect(textById.get("persistent-ipython")).toContain("IPython");
 		expect(textById.get("context-usage")).toContain("/context");
 		expect(textById.get("session-fork")).toContain("/fork");

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -92,8 +92,6 @@ describe("feature hint deck", () => {
 		expect(textById.get("agent-messaging")).toContain("message each other");
 		expect(textById.get("goal")).toContain("/goal");
 		expect(textById.get("refine")).toContain("/refine");
-		expect(textById.get("trace-sharing")).toContain("/traces on");
-		expect(textById.get("trace-sharing")).toContain("open-source LLMs");
 		expect(textById.get("persistent-ipython")).toContain("IPython");
 		expect(textById.get("context-usage")).toContain("/context");
 		expect(textById.get("session-fork")).toContain("/fork");


### PR DESCRIPTION
## Summary

- add a working-screen hint recommending opt-in trace sharing with `/traces on`
- explain that shared traces help train open-source LLMs that use RLM harnesses
- cover the command and open-source training language in the feature-hint test

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-feature-hints.test.ts`
- `npm run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UX and changelog; no behavior changes to trace upload or sharing logic.
> 
> **Overview**
> Adds a **trace-sharing** rotating working-screen hint that tells users they can opt in with **`/traces on`** and that shared traces help train open-source LLMs.
> 
> The hint joins the existing `FEATURE_HINTS` deck in interactive mode (same shuffle-and-display behavior as other capability hints). The unreleased changelog notes the new hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abb2280ecc5dfda913046d1dc2f3dc44463f36d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add feature hint promoting trace sharing via `/traces on`
> Adds a new entry to `FEATURE_HINTS` in [feature-hints.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1377/files#diff-031f07d5a709bbcd6852e0ca041ca0b03ea9d8ddaf2009f5e8556550419250f0) that prompts users to run `/traces on` to share traces with Prime Intellect for open-source LLM training.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abb2280.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->