### PR TITLE
fix(coding-agent): connect the built-in Herdr reporter on Windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the built-in Herdr reporter never connecting on Windows, which left panes running Prime Agent stuck showing an unknown agent state.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/coding-agent/src/core/extensions/builtin/herdr-agent-state.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/herdr-agent-state.ts
@@ -161,6 +161,11 @@ function herdrAgentStateExtensionImpl(pi: ExtensionAPI, getLoadedExtensionPaths:
 	let idleTimer: ReturnType<typeof setTimeout> | undefined;
 	let retryTimer: ReturnType<typeof setTimeout> | undefined;
 
+	// On Windows Herdr listens on a named pipe whose name embeds the socket
+	// path; connecting to the bare path fails with ENOTSOCK, and sendRequest
+	// swallows that error, so the pane would silently stay Unknown forever.
+	const socketEndpoint = process.platform === "win32" && socketPath ? `\\\\.\\pipe\\${socketPath}` : socketPath;
+
 	function sendRequest(request: unknown): Promise<void> {
 		return new Promise((resolve) => {
 			let done = false;
@@ -171,7 +176,7 @@ function herdrAgentStateExtensionImpl(pi: ExtensionAPI, getLoadedExtensionPaths:
 				resolve();
 			};
 
-			const socket = createConnection(socketPath!);
+			const socket = createConnection(socketEndpoint!);
 			socket.on("error", finish);
 			socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
 			socket.on("data", finish);

--- a/packages/coding-agent/test/herdr-agent-state.test.ts
+++ b/packages/coding-agent/test/herdr-agent-state.test.ts
@@ -42,6 +42,16 @@ function createMockPi() {
 	return { pi, handlers, busHandlers };
 }
 
+/**
+ * The endpoint the extension will dial for a given HERDR_SOCKET_PATH. Windows
+ * has no Unix domain sockets, so Herdr listens on a named pipe whose name
+ * embeds the socket path; mirror that here or the fake server and the
+ * extension never meet.
+ */
+function listenEndpoint(socketPath: string): string {
+	return process.platform === "win32" ? `\\\\.\\pipe\\${socketPath}` : socketPath;
+}
+
 async function startFakeHerdrServer(socketPath: string): Promise<{
 	server: Server;
 	requests: RecordedRequest[];
@@ -76,7 +86,7 @@ async function startFakeHerdrServer(socketPath: string): Promise<{
 
 	await new Promise<void>((resolve, reject) => {
 		server.on("error", reject);
-		server.listen(socketPath, resolve);
+		server.listen(listenEndpoint(socketPath), resolve);
 	});
 
 	const waitForRequests = (count: number, timeoutMs = 3000): Promise<void> => {


### PR DESCRIPTION
## Problem

Herdr listens on a named pipe on Windows, and the pipe name embeds the socket path. The built-in reporter dialled the bare `HERDR_SOCKET_PATH`, which fails with `ENOTSOCK`. `sendRequest` treats every socket error as a completed send:

```ts
socket.on("error", finish);
```

So the failure is silent. A pane running Prime Agent inside Herdr stays `Unknown` forever, with nothing in any log, and Herdr's working/blocked/idle labelling never works on Windows.

Measured in a real Herdr pane:

```
\\.\pipe\<HERDR_SOCKET_PATH>  -> CONNECTED
<HERDR_SOCKET_PATH>          -> ENOTSOCK
```

## Fix

Build the endpoint the same way Herdr's own file-based integration does.

## Why the tests did not catch it

`test/herdr-agent-state.test.ts` could not run on Windows at all. Its fake server also listened on the bare path, so `server.listen()` threw `EACCES` before any assertion ran:

```
Tests  9 failed | 3 passed (12)
```

The same transform is applied there, so the fake server and the extension meet on the platform's actual transport.

| | before | after |
| --- | --- | --- |
| `test/herdr-agent-state.test.ts` on Windows | 9 failed, 3 passed | 12 passed |
| with this commit's source change reverted | — | 8 failed, 4 passed |

The last row is the point: the suite now fails without the fix, so it is a real regression test rather than one that passes either way.

## Verification

In a Herdr pane on Windows, running the source checkout:

```
before:  agent_status = unknown   agent = None
after:   agent_status = idle      agent = prime-agent
prompt:  working -> idle
```

`npm run check` passes. No protocol, command, or event shape changes; this is a local transport fix, so no `DAEMON_PROTOCOL_VERSION` or `DAEMON_SCHEMA_REVISION` bump.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Herdr reporter connection on Windows by using named pipe endpoint
> On Windows, Unix domain socket paths cause an `ENOTSOCK` error when used directly with `createConnection`. [herdr-agent-state.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1398/files#diff-70837eb42752c61bc0c74d4ac79ed6c43a9d5c1cd8f2d90ea742d729f7dbbaa0) now derives a named pipe endpoint (`\\.\pipe\<socketPath>`) on Windows and dials that instead, fixing the unknown agent state shown in Prime Agent panes. The test's fake Herdr server in [herdr-agent-state.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1398/files#diff-4ebdbf25debeda59aadaf61f5674fa79cef7f4a063ae2b4eebc7ff1388e596ab) is updated to listen on the same platform-specific endpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa3babd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->