### PR TITLE
fix(kernel): use platform-correct venv interpreter path on Windows

### DIFF
--- a/packages/coding-agent/src/core/kernel/bootstrap.ts
+++ b/packages/coding-agent/src/core/kernel/bootstrap.ts
@@ -342,6 +342,13 @@ export function getKernelVenvDir(): string {
 	return path.join(os.homedir(), ".prime", "agent", "kernel-venv");
 }
 
+// `uv venv` lays out the interpreter at Scripts\python.exe on Windows, not
+// bin/python as on Darwin/Linux; hardcoding the POSIX layout breaks every
+// bootstrap and readiness check on Windows before it can report a useful error.
+export function venvPythonPath(venv: string): string {
+	return process.platform === "win32" ? path.join(venv, "Scripts", "python.exe") : path.join(venv, "bin", "python");
+}
+
 function getXdgKernelVenvDir(): string {
 	const dataHome = process.env.XDG_DATA_HOME
 		? path.resolve(expandHome(process.env.XDG_DATA_HOME))
@@ -725,7 +732,7 @@ async function bootstrapVenv(
 ): Promise<void> {
 	await mkdir(path.dirname(venv), { recursive: true });
 	const uv = await ensureUv(options);
-	const python = path.join(venv, "bin", "python");
+	const python = venvPythonPath(venv);
 	const sourceDir = await resolveRuntimeSourceDir();
 	const runtimeRequirement = sourceDir ?? RUNTIME_REQUIREMENT;
 	const runtimeIdentity = await resolveRuntimeIdentity();
@@ -886,7 +893,7 @@ async function ensureKernelPythonUncached(
 	}
 
 	const venv = await resolveWritableKernelVenvDir();
-	const python = path.join(venv, "bin", "python");
+	const python = venvPythonPath(venv);
 	const runtimeIdentity = await resolveRuntimeIdentity();
 	if (await kernelReady(python, venv, runtimeIdentity, pythonSkills)) return python;
 

--- a/packages/coding-agent/test/kernel-bootstrap.test.ts
+++ b/packages/coding-agent/test/kernel-bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	DEFAULT_RLM_EXTRA_IMPORT_NAMES,
@@ -10,6 +10,7 @@ import {
 	getKernelVenvDir,
 	type KernelPythonSkill,
 	resolveRuntimeIdentity,
+	venvPythonPath,
 } from "../src/core/kernel/bootstrap.js";
 
 let tempDir = "";
@@ -103,8 +104,12 @@ function installFakeUv(): string {
 	mkdirSync(binDir, { recursive: true });
 	const logPath = join(tempDir, "uv.log");
 	const extraImportCases = DEFAULT_RLM_EXTRA_IMPORT_NAMES.map((moduleName) => `    "import ${moduleName}") exit 0 ;;`);
+	// Mirrors venvPythonPath()'s layout so the fake `uv venv` writes its stub
+	// interpreter where the real uv would put it on this platform.
+	const venvPythonRelDir = process.platform === "win32" ? "Scripts" : "bin";
+	const venvPythonRelName = process.platform === "win32" ? "python.exe" : "python";
 	process.env.UV_LOG = logPath;
-	process.env.PATH = `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ""}`;
+	process.env.PATH = `${binDir}${process.env.PATH ? `${delimiter}${process.env.PATH}` : ""}`;
 	writeExecutable(
 		join(binDir, "uv"),
 		[
@@ -116,8 +121,8 @@ function installFakeUv(): string {
 			"fi",
 			'if [ "$1" = "venv" ]; then',
 			'  venv="$2"',
-			'  mkdir -p "$venv/bin"',
-			"  cat > \"$venv/bin/python\" <<'PY'",
+			`  mkdir -p "$venv/${venvPythonRelDir}"`,
+			`  cat > "$venv/${venvPythonRelDir}/${venvPythonRelName}" <<'PY'`,
 			"#!/bin/sh",
 			'if [ "$1" = "-c" ]; then',
 			'  case "$2" in',
@@ -129,7 +134,7 @@ function installFakeUv(): string {
 			"fi",
 			"exit 0",
 			"PY",
-			'  chmod +x "$venv/bin/python"',
+			`  chmod +x "$venv/${venvPythonRelDir}/${venvPythonRelName}"`,
 			"  exit 0",
 			"fi",
 			'if [ "$1" = "pip" ]; then',
@@ -179,7 +184,7 @@ describe("kernel bootstrap", () => {
 		const venv = join(tempDir, "kernel-venv");
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
-		await expect(ensureKernelPython()).resolves.toBe(join(venv, "bin", "python"));
+		await expect(ensureKernelPython()).resolves.toBe(venvPythonPath(venv));
 
 		const log = readFileSync(logPath, "utf8");
 		expect(log).toContain("python install 3.11");
@@ -212,7 +217,7 @@ describe("kernel bootstrap", () => {
 
 		try {
 			await expect(ensureKernelPython({ onProgress: (message) => progress.push(message) })).resolves.toBe(
-				join(venv, "bin", "python"),
+				venvPythonPath(venv),
 			);
 		} finally {
 			stderrWrite.mockRestore();
@@ -229,7 +234,7 @@ describe("kernel bootstrap", () => {
 		const pythonSkill = createPythonSkill();
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
-		await expect(ensureKernelPython({ pythonSkills: [pythonSkill] })).resolves.toBe(join(venv, "bin", "python"));
+		await expect(ensureKernelPython({ pythonSkills: [pythonSkill] })).resolves.toBe(venvPythonPath(venv));
 
 		const log = readFileSync(logPath, "utf8");
 		expect(log).toContain(`--editable ${pythonSkill.packagePath}`);
@@ -251,7 +256,7 @@ describe("kernel bootstrap", () => {
 		const dependentSkill = createPythonSkillWithDependency("orchestration-heartbeat", "agent-observe");
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
-		await expect(ensureKernelPython({ pythonSkills: [dependentSkill] })).resolves.toBe(join(venv, "bin", "python"));
+		await expect(ensureKernelPython({ pythonSkills: [dependentSkill] })).resolves.toBe(venvPythonPath(venv));
 
 		const log = readFileSync(logPath, "utf8");
 		expect(log).toContain(`--editable ${dependencySkill.packagePath}`);
@@ -290,7 +295,7 @@ version = "0.1.0"
 		);
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
-		await expect(ensureKernelPython({ pythonSkills: [dependentSkill] })).resolves.toBe(join(venv, "bin", "python"));
+		await expect(ensureKernelPython({ pythonSkills: [dependentSkill] })).resolves.toBe(venvPythonPath(venv));
 
 		const log = readFileSync(logPath, "utf8");
 		expect(log).toContain(`--editable ${dependencySkill.packagePath}`);
@@ -304,7 +309,7 @@ version = "0.1.0"
 		const dependentSkill = createPythonSkillWithDependency("orchestration-heartbeat", "gidgethub[httpx]>4.0.0");
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
-		await expect(ensureKernelPython({ pythonSkills: [dependentSkill] })).resolves.toBe(join(venv, "bin", "python"));
+		await expect(ensureKernelPython({ pythonSkills: [dependentSkill] })).resolves.toBe(venvPythonPath(venv));
 
 		const log = readFileSync(logPath, "utf8");
 		expect(log).toContain(`--editable ${dependencySkill.packagePath}`);
@@ -314,9 +319,9 @@ version = "0.1.0"
 	it("syncs a warm venv when a Python skill pyproject changes", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");
-		const python = join(venv, "bin", "python");
+		const python = venvPythonPath(venv);
 		const pythonSkill = createPythonSkill();
-		mkdirSync(join(venv, "bin"), { recursive: true });
+		mkdirSync(dirname(venvPythonPath(venv)), { recursive: true });
 		writeFakePython(python, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
 		writeBootstrapVersion(venv, [pythonSkill]);
 		writeFileSync(
@@ -347,7 +352,7 @@ dependencies = ["httpx"]
 		process.env.UV_FAIL_ARG = brokenSkill.packagePath;
 
 		await expect(ensureKernelPython({ pythonSkills: [goodSkill, brokenSkill] })).resolves.toBe(
-			join(venv, "bin", "python"),
+			venvPythonPath(venv),
 		);
 
 		const log = readFileSync(logPath, "utf8");
@@ -364,7 +369,7 @@ dependencies = ["httpx"]
 		]);
 
 		await expect(ensureKernelPython({ pythonSkills: [goodSkill, brokenSkill] })).resolves.toBe(
-			join(venv, "bin", "python"),
+			venvPythonPath(venv),
 		);
 
 		const retryLog = readFileSync(logPath, "utf8");
@@ -377,9 +382,9 @@ dependencies = ["httpx"]
 	it("rebuilds a warm venv with legacy unhashed Python skill manifest entries", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");
-		const python = join(venv, "bin", "python");
+		const python = venvPythonPath(venv);
 		const pythonSkill = createPythonSkill();
-		mkdirSync(join(venv, "bin"), { recursive: true });
+		mkdirSync(dirname(venvPythonPath(venv)), { recursive: true });
 		writeFakePython(python, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
 		writeFileSync(
 			join(venv, ".bootstrap-version"),
@@ -407,7 +412,7 @@ dependencies = ["httpx"]
 	it("shares concurrent bootstrap work in one process", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");
-		const python = join(venv, "bin", "python");
+		const python = venvPythonPath(venv);
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
 		await expect(Promise.all([ensureKernelPython(), ensureKernelPython()])).resolves.toEqual([python, python]);
@@ -418,8 +423,8 @@ dependencies = ["httpx"]
 
 	it("reuses a current warm venv without invoking uv", async () => {
 		const venv = join(tempDir, "kernel-venv");
-		const python = join(venv, "bin", "python");
-		mkdirSync(join(venv, "bin"), { recursive: true });
+		const python = venvPythonPath(venv);
+		mkdirSync(dirname(venvPythonPath(venv)), { recursive: true });
 		writeFakePython(python, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
 		writeBootstrapVersion(venv);
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
@@ -430,8 +435,8 @@ dependencies = ["httpx"]
 	it("rebuilds a warm venv whose recorded runtime hash no longer matches local source", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");
-		const python = join(venv, "bin", "python");
-		mkdirSync(join(venv, "bin"), { recursive: true });
+		const python = venvPythonPath(venv);
+		mkdirSync(dirname(venvPythonPath(venv)), { recursive: true });
 		writeFakePython(python, ["ipykernel", "rlm", ...DEFAULT_RLM_EXTRA_IMPORT_NAMES]);
 		writeFileSync(
 			join(venv, ".bootstrap-version"),
@@ -456,8 +461,8 @@ dependencies = ["httpx"]
 	it("rebuilds a warm venv with a stale rlm runtime", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");
-		const python = join(venv, "bin", "python");
-		mkdirSync(join(venv, "bin"), { recursive: true });
+		const python = venvPythonPath(venv);
+		mkdirSync(dirname(venvPythonPath(venv)), { recursive: true });
 		writeExecutable(
 			python,
 			[
@@ -483,11 +488,11 @@ dependencies = ["httpx"]
 	it("rebuilds a broken venv", async () => {
 		const logPath = installFakeUv();
 		const venv = join(tempDir, "kernel-venv");
-		mkdirSync(join(venv, "bin"), { recursive: true });
+		mkdirSync(dirname(venvPythonPath(venv)), { recursive: true });
 		writeBootstrapVersion(venv);
 		process.env.PRIME_AGENT_KERNEL_VENV = venv;
 
-		await expect(ensureKernelPython()).resolves.toBe(join(venv, "bin", "python"));
+		await expect(ensureKernelPython()).resolves.toBe(venvPythonPath(venv));
 
 		expect(readFileSync(logPath, "utf8")).toContain(`venv ${venv} --python 3.11 --seed`);
 	});


### PR DESCRIPTION
## Summary
- `bootstrap.ts` hardcoded `path.join(venv, "bin", "python")` in two places (`bootstrapVenv` and `ensureKernelPythonUncached`). `uv venv` puts the interpreter at `Scripts\python.exe` on Windows, not `bin/python` — so every first-time kernel bootstrap on Windows fails with `Failed to set up the Python kernel runtime. uv.exe pip install --python <venv>\bin\python ... failed with exit code 2`.
- Adds `venvPythonPath()`, following the same `process.platform === "win32"` branch already used by `findExecutable()` in this same file, and uses it at both call sites.
- Updates `kernel-bootstrap.test.ts` to assert against `venvPythonPath()` instead of a hardcoded POSIX path, and fixes `installFakeUv()` joining `PATH` entries with a hardcoded `:` instead of `path.delimiter` — on Windows that silently merges the fake `uv`'s directory into the next `PATH` entry, so the suite was falling back to whatever real `uv` happened to be installed on the machine instead of the fake.

## Known limitation (not fixed here, flagging for visibility)
This suite's `uv`/`python` test doubles are `#!/bin/sh` scripts invoked directly via `spawn()` without a shell. Node can't launch those on native Windows without `shell: true`, which appears to be a separate, pre-existing gap — most of `kernel-bootstrap.test.ts` still can't run as an isolated unit test on Windows because of it (independent of this PR; happy to file separately or take a stab at it if useful). I validated this fix instead against the one path in the suite that falls through to the machine's real `uv` end-to-end ("reuses a current warm venv without invoking uv") — it completes successfully and returns the correct `Scripts\python.exe` path.

## Test plan
- [x] `vitest --run test/kernel-bootstrap.test.ts` — the one test that exercises a real end-to-end bootstrap (falls through to the machine's real `uv`) passes and returns the correct Windows path.
- [ ] CI (this repo doesn't appear to run Windows CI today, which is presumably why this shipped)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix venv interpreter path resolution on Windows in kernel bootstrap
> - Introduces `venvPythonPath(venv)` in [bootstrap.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1414/files#diff-e87b9a04ab9b4ac02e8dd33af2f2f58320d8b7f6be6853acf4a3e05a34623cae) to return the correct interpreter path: `Scripts/python.exe` on Windows, `bin/python` elsewhere.
> - Replaces all hardcoded `join(venv, 'bin', 'python')` calls in `bootstrapVenv` and `ensureKernelPythonUncached` with `venvPythonPath(venv)`.
> - Updates [kernel-bootstrap.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1414/files#diff-41f56d719cdb305c346ca238c1ec65971766309e330e3afc2812b0df018b63ab) to use `venvPythonPath` in assertions and use `path.delimiter` instead of hardcoded `':'` for PATH construction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3c01f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->