### PR TITLE
fix(daemon): skip parent-directory fsync on Windows in CommandRecoveryJournal.compact

### DIFF
--- a/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
@@ -206,11 +206,17 @@ export class CommandRecoveryJournal {
 			closeSync(descriptor);
 		}
 		renameSync(tempPath, this.path);
-		const directoryDescriptor = openSync(dirname(this.path), "r");
-		try {
-			fsyncSync(directoryDescriptor);
-		} finally {
-			closeSync(directoryDescriptor);
+		if (process.platform !== "win32") {
+			// Durability belt-and-suspenders: fsync the parent directory so the
+			// rename itself is persisted, not just the file contents. Windows/NTFS
+			// rejects opening a directory with a file descriptor for this (EPERM on
+			// every compact); NTFS's own metadata journaling covers this case there.
+			const directoryDescriptor = openSync(dirname(this.path), "r");
+			try {
+				fsyncSync(directoryDescriptor);
+			} finally {
+				closeSync(directoryDescriptor);
+			}
 		}
 		this.recordCount = records.length;
 	}


### PR DESCRIPTION
## Summary
- `compact()` opens the journal's parent directory with `openSync(dir, "r")` and fsyncs it as a durability belt-and-suspenders step (ensuring the preceding `renameSync` is persisted in the parent directory's metadata, not just the file's contents). That's POSIX-only — Windows rejects opening a directory as a file descriptor for this, so every compact (every `COMPACT_AFTER_RECORDS` records, and on every `acknowledge()` that empties the journal) throws `EPERM` on Windows. Observed in production: continuous EPERM in `client-errors.log` on every supervisor ack, and the journal file stuck at 1 byte.
- Skips the directory-fsync step on `win32`; NTFS's own metadata journaling covers the durability guarantee this exists for on POSIX filesystems. The file rename itself (`renameSync`) still happens unconditionally on every platform — only the extra directory-handle fsync is skipped.

## Test plan
- [x] `vitest --run test/command-recovery-journal.test.ts` — 6/6 passing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip parent-directory fsync on Windows in `CommandRecoveryJournal.compact`
> On Windows, `open`+`fsync`+`close` on a directory is unsupported and would fail. The post-rename directory fsync in [command-recovery-journal.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1415/files#diff-ad9ad93f7564a34f4c838495026b460ad85292338ab337c5cdca8f48161ecd3a) is now gated on `process.platform !== 'win32'`. Non-Windows behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0edd257.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->