### PR TITLE
fix(coding-agent): write settings atomically

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1,5 +1,17 @@
 import type { ServiceTier, Transport } from "@earendil-works/pi-ai";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import {
+	closeSync,
+	existsSync,
+	fsyncSync,
+	mkdirSync,
+	mkdtempSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
@@ -217,6 +229,26 @@ export interface SettingsError {
 	error: Error;
 }
 
+function writeSettingsAtomically(path: string, content: string): void {
+	const directory = dirname(path);
+	const temporaryDirectory = mkdtempSync(join(directory, ".settings-"));
+	const temporaryPath = join(temporaryDirectory, "settings.json");
+	const mode = existsSync(path) ? statSync(path).mode & 0o777 : 0o600;
+
+	try {
+		const descriptor = openSync(temporaryPath, "wx", mode);
+		try {
+			writeFileSync(descriptor, content, "utf-8");
+			fsyncSync(descriptor);
+		} finally {
+			closeSync(descriptor);
+		}
+		renameSync(temporaryPath, path);
+	} finally {
+		rmSync(temporaryDirectory, { recursive: true, force: true });
+	}
+}
+
 export class FileSettingsStorage implements SettingsStorage {
 	private globalSettingsPath: string;
 	private projectSettingsPath: string;
@@ -274,7 +306,7 @@ export class FileSettingsStorage implements SettingsStorage {
 				if (!release) {
 					release = this.acquireLockSyncWithRetry(path);
 				}
-				writeFileSync(path, next, "utf-8");
+				writeSettingsAtomically(path, next);
 			}
 		} finally {
 			if (release) {

--- a/packages/coding-agent/test/settings-manager-bug.test.ts
+++ b/packages/coding-agent/test/settings-manager-bug.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SettingsManager } from "../src/core/settings-manager.js";
@@ -143,5 +143,17 @@ describe("SettingsManager - External Edit Preservation", () => {
 
 		const savedProjectSettings = JSON.parse(readFileSync(projectSettingsPath, "utf-8"));
 		expect(savedProjectSettings.extensions).toEqual(["./in-memory-extension.ts"]);
+	});
+
+	it("keeps settings file permissions while replacing its contents", async () => {
+		const settingsPath = join(agentDir, "settings.json");
+		writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }), { mode: 0o640 });
+
+		const manager = SettingsManager.create(projectDir, agentDir);
+		manager.setTheme("light");
+		await manager.flush();
+
+		expect(JSON.parse(readFileSync(settingsPath, "utf-8"))).toMatchObject({ theme: "light" });
+		expect(statSync(settingsPath).mode & 0o777).toBe(0o640);
 	});
 });


### PR DESCRIPTION
## Summary

- write settings to a temporary file and atomically replace the target file
- flush the temporary file before replacement
- preserve existing settings file permissions

## Verification

- npx tsx ../../node_modules/vitest/dist/cli.js --run test/settings-manager-bug.test.ts
- npm run check

Fixes #1428

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Write settings files atomically in coding-agent to preserve file permissions
> - Replaces direct `writeFileSync` in `FileSettingsStorage` with a new `writeSettingsAtomically` helper in [settings-manager.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1429/files#diff-6e8b43ea9be5845c1f130f3a12344386eb8e1e03ca381c3577a40713e6a3d8ab).
> - The helper writes to a temp file (with fsync), then renames it over the target path, preventing partial writes.
> - Existing file permissions are preserved on update; new files default to mode `0o600`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec04761.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->