### PR TITLE
Allow Slack bridge session environment

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -189,6 +189,9 @@ export const DAEMON_CLIENT_ENV_KEYS = [
 	"HERDR_SOCKET_PATH",
 	"HERDR_TAB_ID",
 	"HERDR_WORKSPACE_ID",
+	"PI_SLACK_FOREIGN_AGENT_INTAKE_RESULT_PATH",
+	"PI_SLACK_RUNTIME_ENV_PATH",
+	"PI_SLACK_STATE_DIR",
 ] as const;
 
 /** Collect the allowlisted env vars from the client process for the create command. */

--- a/packages/coding-agent/test/daemon-client-env.test.ts
+++ b/packages/coding-agent/test/daemon-client-env.test.ts
@@ -3,9 +3,19 @@ import { execEnvForSession, filterClientEnv, withClientEnv } from "../src/modes/
 
 describe("filterClientEnv", () => {
 	it("keeps only allowlisted keys", () => {
-		expect(filterClientEnv({ HERDR_PANE_ID: "w1:p1", PATH: "/evil", HERDR_ENV: "1" })).toEqual({
+		expect(
+			filterClientEnv({
+				HERDR_PANE_ID: "w1:p1",
+				PATH: "/evil",
+				HERDR_ENV: "1",
+				PI_SLACK_STATE_DIR: "/state",
+				PI_SLACK_FOREIGN_AGENT_INTAKE_RESULT_PATH: "/result.json",
+			}),
+		).toEqual({
 			HERDR_PANE_ID: "w1:p1",
 			HERDR_ENV: "1",
+			PI_SLACK_STATE_DIR: "/state",
+			PI_SLACK_FOREIGN_AGENT_INTAKE_RESULT_PATH: "/result.json",
 		});
 	});
 
@@ -100,6 +110,9 @@ describe("withClientEnv", () => {
 				HERDR_SOCKET_PATH: undefined,
 				HERDR_TAB_ID: undefined,
 				HERDR_WORKSPACE_ID: undefined,
+				PI_SLACK_FOREIGN_AGENT_INTAKE_RESULT_PATH: undefined,
+				PI_SLACK_RUNTIME_ENV_PATH: undefined,
+				PI_SLACK_STATE_DIR: undefined,
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

Allow daemon-backed Prime Agent sessions to forward the three narrowly scoped environment values required by the pi-slack live-session bridge:

- `PI_SLACK_STATE_DIR`
- `PI_SLACK_RUNTIME_ENV_PATH`
- `PI_SLACK_FOREIGN_AGENT_INTAKE_RESULT_PATH`

The daemon already sends a filtered per-session environment in its backward-compatible `create` command. This only extends that existing allowlist; it does not change command or response shapes and does not expose tokens or credentials.

## Motivation

A Slack-originated Prime Agent is created through the daemon. Its bridge extension must register into the same pi-slack state partition and return the live-session record to the intake launcher. Without these values, the worker cannot complete that handshake.

Companion integration: Eleiris-Pi-Ecosystem/pi-slack#104.

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-client-env.test.ts` (9 passed)
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Slack bridge environment variables to daemon client env allowlist
> Adds `PI_SLACK_FOREIGN_AGENT_INTAKE_RESULT_PATH`, `PI_SLACK_RUNTIME_ENV_PATH`, and `PI_SLACK_STATE_DIR` to `DAEMON_CLIENT_ENV_KEYS` in [daemon-protocol.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1439/files#diff-a45bb1297653325fee7a1902ea1e109747510137380c53e92cbbe113436f0d29). These keys are now preserved and forwarded when filtering or constructing the exec env for a session, and are explicitly set to `undefined` when absent from the client env.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0eb55b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->