### PR TITLE
Identify concurrent Prime Agent terminals automatically

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added automatic task names and stable short IDs to desktop terminal titles so concurrent sessions are easy to distinguish.
 - Fixed fullscreen wheel scrolling in Ghostty while retaining application link clicks; set `terminal.fullscreenMouse` to `false` to use native Cmd-click instead.
 - Changed the agents view to sort idle and inactive sessions by last message time, newest first, while keeping running agents in stable creation order.
 - Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#1375](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375) by [@bilelrais](https://github.com/bilelrais)).

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -828,6 +828,30 @@ export function formatAgentDepthLabel(depth: number | undefined, hasChildren: bo
 	return `depth ${depth}`;
 }
 
+export function deriveAutomaticSessionName(prompt: string, maxLength = 52): string | undefined {
+	const normalized = prompt.replace(/\s+/gu, " ").trim();
+	if (!normalized || normalized.startsWith("/")) return undefined;
+	if (normalized.length <= maxLength) return normalized;
+	const candidate = normalized.slice(0, maxLength + 1);
+	const boundary = candidate.lastIndexOf(" ");
+	return `${candidate.slice(0, boundary >= Math.floor(maxLength * 0.6) ? boundary : maxLength).trimEnd()}…`;
+}
+
+export function formatTerminalIdentityTitle(input: {
+	appTitle: string;
+	sessionId?: string;
+	sessionName?: string;
+	cwd: string;
+}): string {
+	const shortId = input.sessionId
+		?.replace(/[^a-zA-Z0-9]/gu, "")
+		.slice(-5)
+		.toUpperCase();
+	const cwdBasename = path.basename(input.cwd);
+	const identity = [shortId ? `[${shortId}]` : undefined, input.sessionName, cwdBasename].filter(Boolean).join(" — ");
+	return identity ? `${identity} | ${input.appTitle}` : input.appTitle;
+}
+
 export class InteractiveMode {
 	private static readonly EXIT_HINT_DURATION_MS = 2000;
 	private static readonly ESCAPE_REPEAT_WINDOW_MS = 500;
@@ -1478,13 +1502,14 @@ export class InteractiveMode {
 	 * Update terminal title with session name and cwd.
 	 */
 	private updateTerminalTitle(): void {
-		const cwdBasename = path.basename(this.getCurrentCwd());
-		const sessionName = this.getCurrentSessionName();
-		if (sessionName) {
-			this.ui.terminal.setTitle(`${APP_TITLE} - ${sessionName} - ${cwdBasename}`);
-		} else {
-			this.ui.terminal.setTitle(`${APP_TITLE} - ${cwdBasename}`);
-		}
+		this.ui.terminal.setTitle(
+			formatTerminalIdentityTitle({
+				appTitle: APP_TITLE,
+				sessionId: this.connectionState?.sessionId,
+				sessionName: this.getCurrentSessionName(),
+				cwd: this.getCurrentCwd(),
+			}),
+		);
 	}
 
 	/**
@@ -1576,6 +1601,7 @@ export class InteractiveMode {
 				}
 				const prompt = startupPrompts[next]!;
 				try {
+					await this.ensureAutomaticSessionName(prompt.text);
 					await this.agentConnection.prompt(prompt.text, {
 						images: prompt.images,
 						streamingBehavior: next === 0 ? "steer" : "followUp",
@@ -2723,6 +2749,17 @@ export class InteractiveMode {
 
 	private getCurrentCwd(): string {
 		return this.connectionState?.cwd ?? this.uiServices.getInitialCwd();
+	}
+
+	private async ensureAutomaticSessionName(prompt: string): Promise<void> {
+		if (this.getCurrentSessionName() || (this.connectionState?.messageCount ?? 0) > 0) return;
+		const name = deriveAutomaticSessionName(prompt);
+		if (!name) return;
+		try {
+			await this.agentConnection.setSessionName(name);
+		} catch {
+			// Naming is presentation-only and must never block prompt admission.
+		}
 	}
 
 	private getCurrentSessionName(): string | undefined {
@@ -5036,6 +5073,7 @@ export class InteractiveMode {
 					return;
 				}
 				try {
+					await this.ensureAutomaticSessionName(text);
 					await this.agentConnection.prompt(text, {
 						streamingBehavior,
 						queueIfBusy: true,
@@ -9922,6 +9960,7 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 			if (options.name) await this.agentConnection.setSessionName(options.name);
 			if (options.prompt) {
 				this.editor.addToHistory?.(options.prompt);
+				await this.ensureAutomaticSessionName(options.prompt);
 				await this.agentConnection.prompt(options.prompt, { images });
 			}
 		} catch (error: unknown) {

--- a/packages/coding-agent/test/terminal-identity.test.ts
+++ b/packages/coding-agent/test/terminal-identity.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { deriveAutomaticSessionName, formatTerminalIdentityTitle } from "../src/modes/interactive/interactive-mode.js";
+
+describe("terminal identity", () => {
+	test("derives a concise task label from the first prompt", () => {
+		expect(deriveAutomaticSessionName("  Review   the Slack bridge routing  ")).toBe(
+			"Review the Slack bridge routing",
+		);
+		expect(deriveAutomaticSessionName("/reload")).toBeUndefined();
+		expect(
+			deriveAutomaticSessionName(
+				"Investigate why the Prime Agent Slack bridge does not deliver messages to an existing thread",
+			),
+		).toBe("Investigate why the Prime Agent Slack bridge does…");
+	});
+
+	test("puts the stable short id and task first for desktop terminal tabs", () => {
+		expect(
+			formatTerminalIdentityTitle({
+				appTitle: "Prime Agent",
+				sessionId: "01a0092b-fc99-72af-a405-ca7992bb0689",
+				sessionName: "Slack bridge routing",
+				cwd: "/home/tami/pi-slack",
+			}),
+		).toBe("[B0689] — Slack bridge routing — pi-slack | Prime Agent");
+	});
+});


### PR DESCRIPTION
## Summary

- derive a concise session name from the first non-command prompt
- prefix desktop terminal titles with a stable five-character session ID
- keep manual session names authoritative
- keep naming failures non-blocking for prompt admission

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/terminal-identity.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Identify concurrent Prime Agent terminals automatically with short IDs and task names
> - Adds `deriveAutomaticSessionName` to generate a concise session name from the first non-slash-command prompt, truncating at 52 characters to a word boundary with an ellipsis.
> - Adds `formatTerminalIdentityTitle` to build terminal titles in the format `[SHORTID] — sessionName — cwdBasename | appTitle`, where the short ID is a stable 5-character uppercase suffix derived from the session ID.
> - `InteractiveMode` now calls `ensureAutomaticSessionName` before sending the first prompt (from startup, editor submission, or initial session creation) so unnamed sessions are named automatically.
> - Behavioral Change: terminal titles now lead with a short session ID and task name instead of the previous format, affecting all active terminal windows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e897bd4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->