### PR TITLE
feat(ai): add glm-5.3 to the z.ai coding plan catalog

### DIFF
--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -20729,5 +20729,23 @@ export const MODELS = {
 			contextWindow: 1000000,
 			maxTokens: 131072,
 		} satisfies Model<"openai-completions">,
+		"glm-5.3": {
+			id: "glm-5.3",
+			name: "GLM-5.3",
+			api: "openai-completions",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/api/coding/paas/v4",
+			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 1000000,
+			maxTokens: 131072,
+		} satisfies Model<"openai-completions">,
 	},
 } as const;


### PR DESCRIPTION
## What

Adds `glm-5.3` to the `zai` (Z.AI Coding Plan) section of `packages/ai/src/models.generated.ts`.

## Why

- z.ai has been serving `glm-5.3` on the coding plan endpoint since **2026-08-14** — `GET https://api.z.ai/api/coding/paas/v4/models` lists it alongside glm-5.2 (verified live with a coding-plan API key).
- The models.dev `zai-coding-plan` catalog now lists it as well (release_date 2026-08-14, 1M context, 131072 output).
- The registry is explicit rather than fetched, so an unlisted model does not exist for Prime Agent at all: the zai section currently tops out at `glm-5.2`, and `find_models()` / model selection cannot reach glm-5.3.

## How

Regenerated the snapshot with `npm run generate-models` (packages/ai) against the live catalogs, then scoped the diff to the zai section only, leaving every other provider section untouched — same approach as #1247. The new entry mirrors the existing glm-5.2 entry exactly (coding-plan baseUrl, `zaiToolStream`, `thinkingFormat: "zai"`, 1000000 context, 131072 output; models.dev lists no per-token pricing for the plan endpoint, so cost stays 0 like its siblings).

## Validation

- `npm run check` clean from the repo root: biome (915 files, no fixes), `tsgo --noEmit`, installer render check, browser smoke check.
- No zai catalog enumeration tests exist to update; `test/zai-test-model.ts` pins its preference list to glm-5.2 first, so provider tests are unaffected.
- Live-endpoint receipt: z.ai coding-plan `/models` returns `glm-5.3` (`created` 2026-08-14).

Happy to route this through a GitHub Discussion first per CONTRIBUTING if maintainers prefer — the branch is ready either way.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add glm-5.3 model to the z.ai coding plan catalog
> Adds a new `glm-5.3` entry to the generated [models.generated.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1443/files#diff-ff7c21ac6b779f6c8f30964fa301e7f89a29bfa77866258b05b9be7f35291fdd) MODELS map. The model uses the `openai-completions` API, is provided by `zai`, has reasoning enabled, supports `zaiToolStream`, and uses `thinkingFormat: "zai"` with `supportsDeveloperRole: false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3b148f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->