### PR TITLE
docs(coding-agent): advisor, prompt-settlement, and ask-user architecture docs

### DIFF
--- a/packages/coding-agent/docs/advisor-architecture.md
+++ b/packages/coding-agent/docs/advisor-architecture.md
@@ -1,0 +1,741 @@
+# Advisor 架构设计
+
+> 状态：架构方向已接受，源码边界仍在逐项压测，尚未进入实现
+>
+> 日期：2026-08-16
+>
+> 范围：`packages/coding-agent` 的 TUI、daemon、Print、JSON、RPC 与 ACP 入口
+>
+> 关联：[Prompt Settlement 架构设计](prompt-settlement.md)（公共结算地基，从本文拆出）、[通用 `ask_user` 会话能力](ask-user.md)（独立会话能力，从本文拆出）
+
+## 1. 结论
+
+Advisor 应实现为 root `AgentSessionRuntime` 持有的一等子运行时，而不是 TUI 专属逻辑、daemon sidecar，或绕过 Prime 会话体系直接拼装的轻量 core `Agent`。Advisor 自身是完整但受限、不可寻址的 `AgentSessionRuntime → AgentSession → Agent`，复用 Prime 既有的模型、认证、配置、transcript、compaction、telemetry 和生命周期机制。
+
+主 Agent 每次 `turn_end` 只提交增量审查快照，不同步等待 Advisor。Advisor 使用独立模型上下文串行消费合并后的快照。首版的 review 只在 delta 到达候选终态（请求—响应模式的 terminal checkpoint、TUI 的 terminal flush）时启动：WIP（`in_progress`）阶段只推进 backlog 与 cursor，不启动模型调用。这既避免把“每 turn 都观察”退化为“每 turn 都额外调用一次模型”，也避免最常见的 1–3 turn 短 prompt 为半成品 trace 支付双倍审查成本。审查无问题时保持静默；有问题时返回 `nit`、`concern` 或 `blocker`，由确定性的路由层根据严重度、主 Agent 状态、用户中断状态和运行模式决定何时反馈及是否唤醒主 Agent。
+
+TUI（包括 daemon 托管的 TUI）保持完全异步：候选回答结束后显示 Advisor 当前状态，不阻塞输入、提交或下一 prompt 的执行。实际 finding 采用 oh-my-pi 已验证的“双通道、单消息”方式：同一条结构化 Advisor 消息既进入主 Agent 上下文，也在 TUI 聊天流渲染为独立卡片。主 Agent 已给出终态文本且没有排队工作时，迟到 `concern` 只保留为可见卡片，不唤醒 Agent；迟到 `blocker` 才启动修正。其他情况下按严重度进入旁注或 steering。所有迟到 finding 保留原 `promptId`、`reviewId` 和审查范围，不做过期重判或 rebase。Print、JSON 以及 RPC/ACP 在自然停止路径优先通过现有 `getContinuationMessages` checkpoint 完成同一 run 内修正；跨 run 的请求结算由 session 级 `PromptSettlementTracker` 与结构化 `PromptOutcome` 承担（见 [prompt-settlement.md](prompt-settlement.md)）。`agent_end` 保持“一次底层 Agent run 结束”的现有含义，不再被当作外部请求结算。
+
+Advisor 故障分两类处理：显式启用前若 `advisor.model` 缺失、非法或不可解析，必须 fail-closed，不接受该次启动/session create；成功启用后的模型调用超时、provider 故障或 runtime 崩溃才有界等待并 fail-open。运行时 fail-open 时主结果仍可交付，但必须按模式报告 Advisor 不可用，且恢复后不得追溯唤醒已经释放的旧请求。
+
+当主 Agent 判断必须由用户补充信息或选择时，调用 Prime 通用的 `ask_user` 会话能力（见 [ask-user.md](ask-user.md)）。它独立于 Advisor 存在与交付；Advisor finding 只是主 Agent 做出“修正、反驳或询问用户”判断的上游证据之一。
+
+### 1.1 决策性质
+
+这是一个跨入口的会话生命周期决策，同时包含 AI 输出分级的不确定性：
+
+- 队列、epoch、结算和投递路由属于可确定、可用状态机测试的工程问题。
+- “是否有问题、严重度为何”属于概率性判断，必须由结构化输出、去重、修正上限和 fail-open 包住。
+- Advisor runtime 及其与主 `AgentSession` 的连接可通过 feature flag 回退，整体可逆性中等。
+- daemon/RPC/JSON 的 wire 变化一旦发布，回退成本较高，必须独立做 capability 或版本治理。
+
+## 2. 为什么 `turn_end` 不等于完整任务结束
+
+Turn / Agent run / Prompt settlement / 外部请求结算四层生命周期的定义与结算流程见 [prompt-settlement.md](prompt-settlement.md)。对 Advisor 重要的是：`turn_end` 比 `agent_end` 提供更早、更完整的工具链观察能力，但两者都不是请求结算。
+
+引入 Advisor 后，每个模式都在 `turn_end` 异步提交 trace delta，review 在自然停止边界启动并按交互契约分流：
+
+```text
+每次 turn_end
+  -> 只提交 trace delta 并推进 backlog，主 Agent 不等待，WIP 阶段不启动 review
+  -> 继续工具、steer、follow-up、goal 或 autonomous continuation
+  -> Agent 原本即将停止
+  -> 请求—响应模式：getContinuationMessages 中进入 Advisor terminal checkpoint
+       -> flush 合并 backlog，启动并有界等待审查
+       -> 无问题/nit：不创建修正 continuation，agent_end
+       -> concern/blocker：返回 Advisor continuation，在同一 run 继续修正
+       -> ask_user 且存在 responder：tool call 等待回答，返回正常结果并在同一 run 继续
+       -> ask_user 无 responder/连接断开：持久化问题并产生 needs_user_input 结算
+       -> 超时/不可用：有界 fail-open 后 agent_end
+  -> TUI：只做非阻塞 terminal probe，并立即 flush 最终 backlog
+       -> 迟到 finding 已就绪：可立即进入同一 run 修正
+       -> review 未完成：agent_end，显示候选回答和 Advisor reviewing 状态
+            -> 用户仍可立即提交并运行下一 prompt
+            -> terminal flush 立即追平最终 backlog，不受 30 秒冷却限制
+            -> pass/nit 或有界 fail-open：只更新 Advisor 状态
+            -> concern：若仍是终态文本且无排队工作，只保留可见卡片；否则正常投递
+            -> blocker：保留原 identity，唤醒或 steer 主 Agent 修正
+```
+
+修正 turn 会再次进入同一流程。TUI 可以在 `PromptOutcome` 前显示候选回答并继续交互；Advisor footer 状态是可观测提示，不是调度状态。finding 卡片则是持久化的会话消息，同时进入主 Agent 上下文。迟到 finding 仍属于原 `promptId`，主 Agent 根据收到时的完整上下文修正、反驳或询问用户。
+
+因此 `turn_end` 适合作为观察点（delta 提交、cursor 推进），但既不是同步闸门，也不是首版 review 的启动点；候选终态才是审查启动边界。`getContinuationMessages` 是自然停止路径的低延迟修正入口，`PromptSettlementTracker` 负责跨 run 的请求模式结算。
+
+## 3. 目标与非目标
+
+### 3.1 目标
+
+- 所有入口共享相同的审查、分级、去重、过期保护和修正循环语义。
+- 无问题时不生成 “LGTM” 一类消息，不污染主上下文和用户界面。
+- `nit`、`concern`、`blocker` 有稳定、可测试的定义和投递规则。
+- TUI/daemon 不因 Advisor 增加前台等待；Advisor 状态只用于可观测性。
+- 请求—响应模式不会过早释放未经审查的候选答案。
+- 用户主动中断后，迟到的 Advisor 结果不能擅自恢复执行。
+- Advisor 运行时故障、超时和 provider 不可用不会无限阻塞主任务；显式启用时的静态配置错误在任务开始前失败。
+- Advisor 同时检查用户请求前提、主 Agent 推理、执行过程和结果正确性，不以“完全照做”替代正确性判断。
+- 主 Agent 需要用户决策时，所有入口使用同一个通用 `ask_user` 会话契约（见 [ask-user.md](ask-user.md)），而不是从 assistant 文本猜测“这是问题”。
+- 保留未来增加多 Advisor、策略审查和更强调查工具的演进空间，但首版不为这些能力引入额外复杂度。
+
+### 3.2 非目标
+
+- Advisor 不替代工具执行前的权限、安全或人工审批；高风险工具仍应在 `tool_call` 前由专门策略阻断。
+- 首版强制 Advisor 只读，不提供配置逃生口，也不允许 Advisor 直接修改工作区。
+- 首版不提供 prompt/pre-tool 双阶段审查，也不在 WIP（`in_progress`）阶段启动审查调用；Advisor 最早在候选终态的 terminal flush 后反馈，以避免增加首轮交互延迟和短 prompt 的双倍审查成本。WIP 提前审查是保留的演进选项（第 18 节）。
+- 首版不提供受限 IPython。当前 IPython kernel 与 worker 共享 OS 权限，真正只读需要独立的进程级 sandbox。
+- 首版不实现多个 Advisor 编排、投票或仲裁。
+- 不把 Advisor 设计成必须由主模型主动调用的 tool。
+- 不改变扩展系统的一般职责，也不要求公共 `turn_end` hook 承担 Advisor 的全部生命周期契约。
+
+## 4. 已确定的产品语义
+
+### 4.1 严重度
+
+| 级别 | 定义 | 例子 | 主 Agent 行为 |
+| --- | --- | --- | --- |
+| `nit` | 不影响需求正确性、安全性或任务可交付性的改进建议 | 命名、表达、非必要的小幅简化 | 作为非打断旁注进入上下文并显示卡片；不唤醒空闲 Agent |
+| `concern` | 很可能导致需求未满足、结果错误、验证不足或明显返工，应在交付前修正 | 漏掉已明确的边界用例、结论缺少必要证据、实现与约束不一致 | 活跃或中途 yield 时要求修正；终态文本后迟到则只保留可见卡片 |
+| `blocker` | 当前结果不可安全或可信地继续，或违反不可妥协约束，需要在最早安全边界处理 | 破坏性误操作风险、凭据泄露、明确错误的关键结论、不可恢复的数据风险 | 进入最高优先级 steering，当前工具批次结束后先修正；终态文本后仍可唤醒 |
+
+严重度由 Advisor 模型通过受约束输出选择，不在本地维护一套脆弱的关键词风险分类器。本地只校验 schema，并根据 severity、主 Agent 状态、用户中断状态和运行模式执行确定性路由。无法解析或没有实质信息的 finding 不得直接注入主上下文。
+
+### 4.2 审查对象与权限边界
+
+Advisor 的审查范围必须覆盖以下对象，但不要求模型输出结构化分类字段：
+
+- 用户请求中的事实前提或目标约束。
+- 主 Agent 的理解、推理或方案。
+- 工具使用、代码修改和验证过程。
+- 最终结论或交付结果的正确性、完整性和证据。
+
+Advisor 可以挑战错误的用户前提，但不能把偏好和取舍包装成客观错误：
+
+- 明确错误且修正不改变用户目标时，主 Agent 应自动纠正并解释。
+- 正确做法会改变产品意图、需求范围或重要取舍时，主 Agent 应询问用户。
+- 仅需告知且不影响交付时，主 Agent 可以说明后继续。
+- 明显不可继续的严重问题由 `blocker` 路由到最早安全边界处理。
+
+Advisor 不输出 `requiredAction`。系统只以 `severity` 决定旁注、steering、唤醒和 settlement 行为；主 Agent 根据 finding 的正文、证据和届时完整上下文自行决定修正、反驳还是询问用户。
+
+主 Agent 的询问路径复用通用 `ask_user`（见 [ask-user.md](ask-user.md)）：存在可交互 responder 时在 tool call 内等待回答并在同一 run 继续；无 responder 时进入持久化 `needs_user_input`；用户明确取消以 `PromptOutcome(cancelled)` 结算且不保存未回答问题；transport 丢失不视为用户取消。
+
+首版只做 post-turn 审查。Git 可以恢复一部分受版本控制的文件变化，但不能保护未跟踪文件、数据库、外部服务、网络操作或已泄露信息；这些是明确接受的首版残余风险，Advisor 不被描述为事前安全边界。
+
+### 4.3 主 Agent 状态下的投递
+
+| 主状态 | `nit` | `concern` | `blocker` |
+| --- | --- | --- | --- |
+| 当前 trace 标记为 `in_progress` | 不投递；候选终态重新判断 | 不投递；候选终态结合完整结果重新判断 | 进入最高优先级 steering；当前工具批次结束后阻止普通续跑并先修正 |
+| 中途 yield、没有终态文本 | 记录，等待下一次自然交互 | 唤醒并启动修正 run | 唤醒并启动修正 run |
+| 终态文本且无排队工作 | 记录为可见卡片 | 保留为可见卡片，不自动唤醒；下次自然交互重新进入上下文 | 保留可见卡片并启动修正 run |
+| 用户主动中断 | 保留到下一次自然交互 | 保留到下一次自然交互，不自动唤醒 | 保留并醒目提示，但不自动唤醒 |
+| 请求—响应模式尚未结算 | 记录，不单独触发修正 | 触发修正并复审 | 触发修正并复审 |
+
+首版 review 只在候选终态启动，因此“当前 trace 标记为 `in_progress`”一行只会被上一 prompt 的迟到 finding 或修正循环中的复审结果命中；路由规则本身与 finding 来源无关。
+
+“用户主动中断”优先于严重度。Advisor 是质量反馈，不是绕过用户停止意图的后台执行权限。
+
+`blocker` 的“立即”是最早安全 turn boundary，不是硬 abort：不得调用用户级 `requestAbort()`，不得强杀正在执行的 provider stream、IPython cell 或工具批次。当前批次完成后，本地调度 fence 必须让 blocker correction 先于普通 steering、follow-up、goal/autonomous continuation 执行。需要在副作用发生前阻断的风险属于独立 pre-tool policy，不由 post-turn Advisor 补救。
+
+### 4.4 反驳与复审
+
+主 Agent 不能无声忽略 finding，但不需要调用专用工具或返回逐项机器状态。Advisor 消息按当前 `reviewId` 中的展示顺序将 findings 编为 `1..N`，只用于让反馈清晰可读；主 Agent 在正常 continuation 中自行修正问题、提供反驳证据，或生成澄清问题。
+
+Advisor 随后重新审查新的完整 trace，而不是消费 `fixed`/`disputed`/`needs_user` 回执。有效修正或有证据的反驳会使问题在新 review 中消失；问题仍成立则重新报告。旧批次在复审输入建立后关闭，不跨 review 维护单条 finding 生命周期。新的 review 若仍有 `concern`/`blocker`，则进入下一次有界修正循环；空数组或仅有 `nit` 时不再阻塞 settlement。达到上限后标记 `unresolved_advisor`：TUI/daemon 展示最新一批未解决 finding 与双方证据；Print/JSON/RPC/ACP 返回当前结果和结构化 unresolved 状态。
+
+### 4.5 无问题时静默
+
+Advisor 的一次模型调用正常结束且没有接受到 `report_findings` 调用，即表示该批 trace 已审查且无问题。它不生成“通过”、`findings: []` 或其他回执消息；review coverage 由 host 在 Advisor turn 成功结束时推进。这样既节省 token，也避免 Advisor 自身输出被下一轮再次审查。
+
+### 4.6 Finding 的双通道展示
+
+每批被接受的 finding 只创建一条结构化 Advisor 会话消息，不分别制造“给 Agent 的隐藏消息”和“给用户的展示消息”：
+
+- 对主 Agent，消息渲染为带 `reviewId`、批次内序号、严重度和行为提示的 advisory 内容，明确要求“权衡并验证，不要盲从”。
+- 对 TUI，同一消息渲染为独立 Advisor 卡片，显示 finding 数量、严重度 badge 和正文；卡片与普通 assistant 文本视觉区分。
+- 一张卡片最多展示本批已接受的 3 个 finding，与首版单次 review 上限一致，不需要额外折叠层。
+- 卡片进入主 session transcript 并持久化，确保 resume、export 和后续主 Agent 上下文看到同一事实；Advisor 私有推理和调查 trace 不进入主 transcript。
+- footer 只显示 Advisor runtime 状态，不重复 finding 正文。
+
+用户主动中断、终态迟到 `concern` 或运行模式不允许自动 turn 时，卡片仍然可见并在下一次自然 resume 时进入上下文；这不是丢弃 finding。`blocker` 只有在用户没有建立 abort fence、且 host 允许 agent-initiated turn 时才可自动唤醒。
+
+### 4.7 与通用 `ask_user` 的关系
+
+`ask_user` 是 Prime 主 Agent 的通用内置工具/会话能力，完整契约见 [ask-user.md](ask-user.md)。对 Advisor 只有三条边界成立：
+
+- `ask_user` 不属于 Advisor 输出 schema，也不由 Advisor 直接调用；Advisor finding 只是主 Agent 做出“修正、反驳或询问用户”判断的上游证据。
+- Advisor 与其他受限 child runtime 通过现有 `baseToolsOverride/allowedToolNames` 排除该工具。
+- 主 Agent 在修正循环中调用 `ask_user` 属于正常 continuation：存在 live responder 时在同一 run 内得到回答，无 responder 时进入结构化澄清终态；两种路径都不计作修正失败。
+
+## 5. 方案比较
+
+| 方案 | 全模式一致性 | 生命周期控制 | 初始改动 | 协议风险 | 长期演进 |
+| --- | --- | --- | --- | --- | --- |
+| A. 普通内置扩展，仅使用现有 hook | 较弱 | 较弱 | 小 | 中 | 较弱 |
+| B. root `AgentSessionRuntime` 持有受限 Advisor 子运行时 | 强 | 强 | 中 | 可控 | 强 |
+| C. daemon/supervisor sidecar | 弱 | 中 | 大 | 高 | 中 |
+| D. 由主模型主动调用 Advisor tool | 弱 | 弱 | 小 | 低 | 弱 |
+
+### 5.1 A：普通内置扩展
+
+优点是接入快，也符合 hook 的表面形态。问题是现有公共 hook 不拥有模式结算、会话代际、模型认证、daemon 生命周期和结构化协议输出。若为 Advisor 持续扩大扩展 API，最终会把核心会话语义隐式地放进一个扩展，难以保证所有模式一致。
+
+### 5.2 B：root runtime 持有 Advisor 子运行时
+
+这是采用方案。root `AgentSessionRuntime` 负责 Advisor 子运行时的创建、资源装配和销毁；主 `AgentSession` 负责提交 trace delta，在现有 `getContinuationMessages` 边界执行自然停止路径的 terminal checkpoint，并通过独立的 prompt settlement 状态机跨 run 追踪结算。公共扩展事件可按需要补充只读字段，但不承担内部状态机。这样既遵循 Prime “完整 Agent 由完整 session/runtime 承载”的架构，也能让所有入口共享队列、过期保护和修正循环。
+
+### 5.3 C：daemon/supervisor sidecar
+
+该方案隔离性好，但 Print、JSON、RPC 和 ACP 不应为了 Advisor 被强制绑定到 daemon。跨进程传输完整增量 transcript 还会增加协议、恢复和隐私边界，收益不足以覆盖复杂度。
+
+### 5.4 D：Advisor tool
+
+由主模型决定是否调用，会重复弱模型“不知道何时求助”的盲点，也无法保证每个候选结果都经过检查。它可以作为未来的主动求助能力，但不能作为默认监督机制。
+
+## 6. 推荐架构
+
+```text
+Root AgentSessionRuntime
+  |-- Main AgentSession
+  |    |-- turn_end：异步提交 trace delta
+  |    |-- getContinuationMessages：自然停止路径的快速 terminal checkpoint
+  |    `-- PromptSettlementTracker：跨 run 的 prompt 所有权与终态（见 prompt-settlement.md）
+  |
+  |-- SessionAdvisorManager
+  |    |-- TranscriptCursor：生成增量审查输入
+  |    |-- ReviewQueue：单飞执行、积压合并、去重（候选终态触发）
+  |    |-- DeliveryRouter：按严重度和主状态投递
+  |    `-- TerminalReviewCheckpoint：有界等待并返回 host continuation / settlement 状态
+  |
+  `-- Advisor AgentSessionRuntime (kind: advisor，不可寻址)
+       `-- Advisor AgentSession
+            |-- 独立 SessionManager / transcript / compaction
+            |-- 强制只读 read / grep / glob / git_read
+            `-- Advisor Agent
+
+Mode adapters
+  |-- TUI（含 daemon 托管）：footer 显示状态、聊天流显示 finding 卡片、交互不阻塞
+  |-- Print：组合的 prompt outcomes 完成后只打印最终文本；故障写 stderr
+  |-- JSON：继续流式输出 agent_end，另以 prompt_outcome 表达结算
+  |-- RPC：提交 ACK 保持即时，以关联 ID 等待 prompt outcome
+  `-- ACP：session/prompt result 等待 prompt outcome 与 headless gate
+```
+
+### 6.1 `SessionAdvisorManager`
+
+由 root `AgentSessionRuntime` 创建、持有和销毁，并连接主、Advisor 两个 session，负责：
+
+- 监听内部 turn-end checkpoint 和 session 生命周期变化。
+- 维护当前 session epoch、transcript cursor、待审查范围和修正次数。
+- 驱动 Advisor 队列与子 runtime，并处理其重建和销毁。
+- 将结构化 advice 交给投递路由。
+- 向主 `AgentSession` 暴露 terminal checkpoint，并与 prompt settlement 状态机交换 review coverage 和 correction ownership。
+- 向模式适配器暴露稳定状态，但不让模式自行推断 Advisor 是否结算。
+
+它不负责渲染 TUI，也不直接编码 JSON、RPC 或 ACP wire shape。
+
+### 6.2 Advisor `AgentSessionRuntime`
+
+Advisor 不是绕过 Prime 体系单独创建的轻量 core `Agent`，也不是普通 RLM 子 Agent。它使用完整且独立的 `AgentSessionRuntime → AgentSession → Agent`，避免监督提示、调查过程和 token 消耗污染主 Agent，同时复用 runtime factory、`ModelRegistry`、provider、认证、telemetry 和 compaction。
+
+该子运行时应增加内部 `kind: "advisor"`，且不可被用户寻址、attach，不进入普通子 Agent roster、消息路由或用户 session 列表。它拥有独立 `SessionManager`、transcript、成本和生命周期；默认关闭 goal、autonomous、RLM、普通 extension 与跨 Agent messaging 等不属于审查职责的能力，但保留完整 session 自身的上下文压缩能力。
+
+Advisor 不实现第二套 provider/model retry loop。其完整 `AgentSession` 直接复用 Prime 现有两层恢复：`streamSimple` 的 `retry.provider` 请求级 timeout/retry，以及 `AgentSession` 的 `retry.enabled/maxRetries/baseDelayMs`、认证失败标记和 retry-chain completion。重试始终对同一个已解析的 `advisor.model` 执行，不走启动/恢复时的模型 fallback 选择；Advisor manager 只用 `reviewTimeoutMs` 包住整条现有 retry chain，并在超时后中止 Advisor 子 session 的当前工作，不影响主 session。
+
+首版通过 `baseToolsOverride` 加确定性 allowlist 强制替换为专用 `read`、`grep`、`glob` 与受控 `git_read`，不提供配置逃生口。四个工具的实现放在 `src/core/tools/`（`read.ts`、`grep.ts`、`glob.ts`、`git-read.ts`），沿用 `bash.ts`/`edit.ts` 的既有先例：作为通用工具实现存在，但不进入 `allToolNames`/`ToolName` union，不改变主 Agent 只有 `ipython` 的默认工具面；Advisor runtime 通过 `baseToolsOverride` 装配它们。
+
+`read`/`grep`/`glob` 以本设计新增的薄 `FileSystemView` 接口为唯一 IO 边界。Prime 当前源码不存在可继承的 filesystem/exec-environment 适配器抽象，因此该接口由本设计引入：v1 只提供本机实现，直连 `node:fs`，读取根为主 session cwd 加 worker 进程本可读的路径（兄弟目录、多仓库、绝对路径、依赖源码），不做额外沙箱；只提供 read 语义，不提供 write、execute、network 或 kernel 能力。“继承主 Agent 的远程/容器文件视图”不是 v1 承诺，作为演进项保留在第 18 节——届时为 `FileSystemView` 增加远程实现，工具代码不变。
+
+`git_read` 是受控只读 git 取证工具，覆盖“变更基线/聚合 diff”这一 trace 与工作区现状都提供不了的证据源：子命令 allowlist 仅限 `log`、`diff`、`show`、`blame`、`status`、`rev-parse`、`ls-files`，明确排除 `fetch`/`pull` 等网络子命令；每次调用强制附加 `--no-pager --no-ext-diff -c core.fsmonitor= -c diff.external=`，防止仓库配置（`.gitattributes` textconv、external diff driver、fsmonitor hook）把“只读 diff”变成任意代码执行。它以受控子进程运行，天然不经 `FileSystemView`，v1 仅本机实现，远程演进时随适配器一起演进。
+
+当前 Prime 唯一内置注册工具 `ipython` 没有 OS 级 sandbox；代码过滤或 prompt 约束不能形成可靠只读边界，因此首版不向 Advisor 暴露 IPython。未来如提供受限 IPython，必须使用与主 Agent filesystem view 对齐的只读 mount、隔离可写临时目录、禁网、禁止访问主 kernel/socket/artifact，并设置进程资源上限。
+
+Advisor 输出必须通过本地结构校验；模型文本不是可信控制指令，不能直接修改工作区或绕过主 Agent 的权限与审批。
+
+#### 6.2.1 Advisor 内置规则
+
+Advisor runtime 必须加载独立、不可由 settings、项目文件或主 Agent 内容覆盖的内置 system prompt，建议落在 `src/core/advisor/system.md`。该 prompt 至少规定：
+
+- 审查用户事实前提、主 Agent 推理、执行过程、最终结果和验证证据是否正确、完整。
+- 用户目标与偏好是约束，但用户提出的事实判断仍可核验和纠正；不能把偏好争议伪装成事实错误。
+- 审查输入是到候选终态为止的完整合并 trace；结合完整结果判断，不对未完成的中间过程臆测问题。
+- 无实质问题静默结束；有问题才调用一次 `report_findings`，单批最多 3 条，并按 severity 定义选择级别。
+- 使用强制只读工具核验证据，避免复述主 Agent 已知信息、空泛不安、无依据猜测和重复建议。
+- Advisor 反馈是供主 Agent 权衡的审查意见，不是权限授予、执行命令或自动修改能力。
+
+主 Agent 的 effective system prompt、`AGENTS.md`、项目规则、权限和运行模式只能作为带明确边界标签的 review policy context 注入。它们描述“主 Agent 应遵守什么”，不能改变 Advisor 身份、输出协议、工具边界或上述内置规则。首版不发现或加载 `WATCHDOG.md`/`WATCHDOG.yml`，也不提供覆盖/追加 Advisor system prompt 的配置字段；确有独立 reviewer-only 项目规则需求时再单独设计第三层扩展。
+
+### 6.3 增量 transcript
+
+主 session 的每个 `turn_end` 只提交自 Advisor cursor 之后的新 trace。该 trace 是主 `AgentSession` 可观察到的完整执行记录，包括用户消息、assistant 文本、provider 可见的 thinking、tool-call 参数、IPython 代码、工具输出、错误、traceback 和必要的 lifecycle 事件。
+
+Advisor 初始化时还必须获得主 Agent 的 effective policy context：有效 system prompt、适用的 `AGENTS.md`/项目规则、工具能力与权限、运行模式及其他会影响正确性判断的 host policy。它们作为“被审查规则”引用，不能覆盖 Advisor 自己的 system prompt。policy snapshot 使用稳定 version/hash 标识；未变化时不在每次 review 重发，变化时发送增量并更新版本。认证信息、凭据和敏感运行值不进入该 snapshot。
+
+Advisor 在 session 创建时已经启用，则 review cursor 从该 session 的首个新 turn 开始，正常覆盖全部后续 trace。若通过 `/advisor on` 在已有 session 中途启用，则采用基线 cursor：
+
+- 将主 Agent 当前有效、已规范化的 bounded transcript 作为只读背景装入 Advisor 上下文，使其理解当前任务、工具结果和已有约束。
+- 记录 `enabledAtCursor`，只允许针对该 cursor 之后的新 trace 生成 finding。
+- cursor 之前的内容标记为 `baseline_only`，不计入 review coverage，不触发历史 finding，也不会在后续 catch-up 中回补审查。
+- `/advisor off` 期间新增的 trace 在再次 `on` 时同样只进入新 baseline，不追溯审查。
+- baseline 使用主 session 当前有效 transcript 表示；已经 compaction 的历史沿用主 session 的有效 summary，不从完整 JSONL 重新展开，以免中途启用造成无界上下文和费用。
+
+Advisor 消费内存中的 session event/trace 流，不在每个 turn 重新读取整个 JSONL；持久化 session JSONL 是恢复时的回放真相源。Advisor cursor 与主上下文独立，主 Agent compaction 后仍保留已审查进度，恢复时则从 JSONL 重建其私有 transcript 和 cursor。输入中排除：
+
+- Advisor 自己产生的 advice、诊断和状态事件。
+- provider 原始载荷、认证信息和不应进入第二模型的敏感元数据。
+- 已确认与当前审查范围无关的 UI 事件。
+
+Advisor 永不共享或连接主 Agent 的 live IPython kernel，也不读取其 namespace、dill snapshot 或 socket。它只能看到已进入 session trace 的 IPython 输入和输出。
+
+消息采用分层压缩：
+
+- 传输层只发送 cursor 之后的增量，不重复发送完整历史。
+- 尚未审查的 trace delta 不做模型摘要，保留主 session 已规范化、持久化的消息内容。
+- 尚未完成修正/复审的 review 批次、当前 prompt 的未审查 trace、最近修正/反驳证据、当前 policy version/hash、session epoch、cursor、review coverage 和 settlement 状态固定保留。
+- 已审查且已解决的旧 trace 与旧 review 对话，由 Advisor 自己的 `AgentSession` compaction 压缩。
+
+主 Agent compaction 不改变 Advisor cursor；Advisor compaction 也不能改变 review coverage 或 settlement ledger。compaction summary 只是模型上下文表示，不是真值来源。
+
+分叉、恢复、切换 session 或替换 runtime 时必须按新的 session lineage 重建 cursor 或递增 epoch，不能继续使用旧快照的偏移量。主 Agent 的普通 compaction 本身不应丢失 Advisor 已持有的审查历史。
+
+### 6.4 Review queue 与背压
+
+- 每个 Advisor runtime 最多一个在途模型请求。
+- 每次 `turn_end` 都记录新的待审查范围，积压范围合并为一个连续批次；每个 delta 仍由 host 标记为 `in_progress` 或 `candidate_terminal`（标记成本趋近于零，保留它为第 18 节的 WIP 演进保留触发语义）。
+- 首版 review 只在 backlog 含候选终态 delta 时启动：请求—响应模式由 terminal checkpoint 触发，TUI 由候选 `agent_end` 后的 terminal flush 触发；修正 turn 完成后的复审同样在新的候选终态出现时启动。
+- `in_progress` delta 只推进 backlog 与 cursor 记录，不单独启动模型调用。因此主 Agent 活跃期间到达的 finding 只能来自上一 prompt 的迟到结果或修正循环中的复审（§4.3 路由不变）。
+- 30 秒是存在 backlog 时两个 review 启动时间之间的最小间隔（约束修正循环复审与多 prompt 连续结算），不是轮询周期；没有新的候选终态时不触发空 review。
+- prompt 准备 settlement 时忽略冷却，立即 flush 最终 backlog。
+- 审查完成时若已有新的候选终态 backlog，则在冷却到期或 terminal flush 时消费合并后的 delta。
+- 所有模式的主 Agent 在正常 turn 进行中都不等待 Advisor 队列。
+- TUI 在候选 `agent_end` 后立即 terminal flush，只更新 Advisor 状态，不等待队列，也不阻止下一 prompt 启动。
+- 请求—响应模式只在 Agent 原本停止前的 terminal checkpoint 等待队列，而不是在每个 `turn_end` 等待。
+
+因此审查频率的语义是“每个候选终态都不会漏掉、全部 trace 都被覆盖”，而不是“每个 turn 都增加一次模型调用”。1–3 turn 的短 prompt 每 prompt 至多一次 review 调用（外加修正后的复审）。
+
+### 6.5 结构化 findings
+
+首版逻辑契约：
+
+```ts
+interface AdvisorFinding {
+  severity: "nit" | "concern" | "blocker";
+  message: string;
+  evidence?: string[];
+}
+
+interface AdvisorReviewResult {
+  reviewId: string;
+  sessionEpoch: number;
+  throughTurn: number;
+  findings: AdvisorFinding[];
+}
+```
+
+有问题时，模型通过 Advisor runtime 内部专用的 `report_findings({ findings })` tool 原子提交一个非空批次。`read`、`grep`、`glob`、`git_read` 可在提交前用于调查；普通 assistant 文本、thinking 或其他 tool 输出均不作为 finding 投递。`reviewId`、`sessionEpoch` 和 `throughTurn` 由 host 根据当前 review lease 附加，findings 按校验和优先级排序后的展示顺序获得仅在该批次有效的 `1..N` 序号；模型不能自行声明 ID、序号或扩大审查范围。
+
+`report_findings` 只在有实质问题时调用，单次调用包含完整批次；正常结束且没有被接受的调用就是静默通过，不属于缺失输出或故障。host 每个 Advisor update 最多接受一次有效调用，多余调用由本地 emission guard 抑制，不触发额外投递或模型重试。
+
+一次 review update 最多接受 3 个独立 finding，按 `blocker → concern → nit` 排序。运行时应执行：
+
+- 空白、套话和无信息内容过滤。
+- `severity` 是唯一系统路由字段；正文和证据只作为主 Agent 判断依据。
+- `reviewId` 与批次内序号只关联同一条 Advisor 消息、卡片和 correction continuation，不构成主 Agent response 协议；复审开始后旧序号失效。
+- 首次投递的 `concern`/`blocker` 以规范化问题、目标范围和严重度生成当前 prompt 内的临时内容指纹，并进入 `awaiting_main` latch。该指纹不是协议 identity，不进入 transcript，prompt 结算后删除。
+- 同一 latch 仍在等待主 Agent 处理时，后续 review 中的等价 finding 继续作为逻辑未解决问题参与 settlement，但 emission guard 不再生成卡片、聊天消息或重复 steering；severity 升级或新的独立问题可以重新投递。
+- 普通 WIP 更新不清除 latch。只有包含该 Advisor 消息后的主 Agent 修正 turn 已完成，或到达最终 settlement checkpoint，才形成有效复审边界：复审仍报告等价问题时保持 latch 并进入下一修正轮，静默通过时才清除。
+- 长度限制和安全转义。
+- `sessionEpoch` 与已审查 turn 范围校验。
+- 超过上限时只保留最高优先级的 3 个，不得把多个独立问题强行拼成一个 finding。
+
+对主 Agent/UI 每个 review 只聚合投递一条 Advisor 消息；同一条消息既作为主 Agent 的 advisory 上下文，也渲染为 TUI 卡片。需要修正时最多启动一个修正 turn，避免一个 review 连续打扰多次。所有请求—响应模式都以最新复审结果是否仍含 `concern`/`blocker` 判断能否结算；`nit` 可以记录和展示，但不阻塞 settlement。TUI 的终态迟到 `concern` 按已接受的卡片保留规则处理，不因其未自动修正而阻塞交互。
+
+emission guard 只控制重复投递，不改变 review 真值。Advisor prompt 必须允许在有效复审边界重新报告仍存在的问题；host 可据内容指纹保持 latch，而不会把重复 finding 误当成新的用户可见提醒或把被抑制的投递误判为通过。
+
+具体 wire schema 可以不同，但必须保留 review 批次 identity、批次内稳定顺序和 review coverage；不增加持久 finding identity。
+
+### 6.6 Session 级 prompt settlement
+
+`PromptSettlementTracker` 与 `PromptOutcome` 的完整契约——lineage、结算范围、终态条件、`status × advisor` 组合矩阵与持久化 ledger——见 [prompt-settlement.md](prompt-settlement.md)。对 Advisor 成立的约束是：
+
+- `completed` 终态要求 Advisor 已审查到该 prompt 最终 trace generation，或明确进入有界 `fail_open`；Advisor 未启用时该条件视为满足，`advisor` 字段记 `disabled`。
+- `needs_user_input`、`cancelled`、`failed` 终态不等待 Advisor；结算后迟到的 finding 不重开 outcome，按 §7.2 的迟到规则处理。
+- 修正循环被封口（达到修正上限、被后续 prompt admission 取代或 `/advisor off`）且问题未清除时以 `unresolved_advisor` 结算，`advisor` 字段为 `unresolved`。
+
+## 7. 状态机与并发约束
+
+### 7.1 Advisor 状态
+
+```text
+disabled
+   |
+   v
+idle <---------> reviewing
+  ^                 |
+  |                 v
+  +----------- catching_up
+  |
+  +-------- unavailable  --(恢复只处理新工作)--> idle
+
+任意状态 -- session disposed --> disposed
+```
+
+- `idle`：没有在途 review 和 backlog。
+- `reviewing`：一个批次正在执行。
+- `catching_up`：批次完成时发现新的候选终态积压，继续合并消费。
+- `unavailable`：超时、认证、provider 或 runtime 错误；按模式报告并 fail-open。
+- `disposed`：会话退出，所有迟到结果永久失效。
+
+### 7.2 过期结果保护
+
+每个 review 必须绑定：
+
+- session identity；
+- session epoch；
+- transcript 起止 cursor；
+- 目标 Agent run generation 与 `throughTurn`。
+
+以下事件至少递增 epoch 或使旧 review 失效：新建/切换 session、fork、恢复时重建 runtime、会话 dispose。主 Agent compaction 作为 trace 事件处理，不应仅因上下文被压缩就丢弃 Advisor 的独立 cursor。迟到结果先校验身份和范围，再决定投递；不得仅凭“当前 session 仍存在”就注入。
+
+用户在 review 期间发起新 prompt，不会使同一 session/epoch 内的旧结果失效，也不要求先做 rebase review。迟到 finding 保留原 `reviewId`、`promptId` 和 `throughTurn`。若 B 已使主 Agent 活跃，A 的 `concern`/`blocker` 按活跃状态路由；若仍停在 A 的终态文本且无排队工作，`concern` 只保留卡片，`blocker` 可唤醒修正。主 Agent 基于届时完整上下文修正、提供反驳证据或询问用户，后续再由 Advisor 审查新的完整 trace。只有 session epoch/lineage 改变、会话 dispose 或用户主动 abort fence 才阻止自动投递。
+
+投递归投递，结算归结算：B 的成功 admission 按第 8 节的封口规则处理 A 的 settlement——B admission 后不再为 A 启动新修正周期，A 在 review coverage 追平后结算；steer 进 B 的迟到修正属于 B 的时间线，A 的终态不重开。
+
+## 8. 修正与复审循环
+
+在 Print、JSON、RPC、ACP 中，一个 review 的全部 `concern`/`blocker` 被聚合为一条 Advisor continuation，优先通过 `getContinuationMessages` 触发同一 Agent run 内的修正；若 compaction 等边界已经结束该 run，修正可以启动继承同一 `promptId` 的新 run。TUI 中，终态迟到 `concern` 只保留可见卡片，终态迟到 `blocker` 可启动新的修正 run；若主 Agent 已因后续输入处于活跃状态，则按严重度进入其正常 steering/continuation 路由。所有实际修正都必须再次进入 Advisor。主 Agent 正常生成修正、证据或澄清问题，不承担 Advisor 专用输出协议；复审直接对当前完整结果重新出具批次。
+
+为防止两个模型互相打断形成死循环：
+
+- 每个 prompt settlement 维护 Advisor 修正计数。
+- Advisor 重新审查修正后的完整 trace；问题消失后结束，仍存在才进入下一循环。
+- 达到 `maxCorrectionCycles` 后停止自动唤醒，保留 finding 与双方证据，并标记 `unresolved_advisor`。
+- 同 session 后续 prompt 的成功 admission 同样封口前一 prompt 的修正循环：已在途的修正 run/continuation 自然完成并复审，此后不再为旧 prompt 启动新的修正周期；旧 prompt 在 review coverage 追平后按结果结算 `completed` 或 `unresolved_advisor`（语义见 [prompt-settlement.md](prompt-settlement.md)）。迟到 `blocker` 仍按 §4.3 进入新 prompt 的 steering，但该修正属于新 prompt 的时间线，旧终态不重开。封口规则对所有模式统一，主动流水线提交的 RPC/JSON 客户端同样适用。
+- Advisor 发出打断性反馈后进入可配置的 immune window。期间仍继续审查，但等价问题不重复打断；新的 blocker 或明确升级可以突破。
+- 去重使用当前 prompt 内的 `awaiting_main` 内容指纹 latch：主 Agent 尚未获得有效处理机会时只维持未解决状态，不重复显示或 steering；有效复审后才清除或进入下一修正轮，不创建持久 finding identity。
+- 主 Agent 收到的消息应明确标识为 Advisor 反馈，并要求验证、修正或说明为何不成立。
+
+修正上限不是“静默忽略”。TUI/daemon 应显示未解决状态并等待用户；Print 输出当前结果并通过 stderr 报告；结构化模式返回当前结果和可机器识别的 unresolved Advisor 状态。主 Agent 判断需要用户决策时调用 `ask_user`：存在 live responder 时在同一 run 内得到回答，无 responder 时进入结构化澄清终态；两种路径都不计作修正失败。
+
+## 9. 各运行模式的 Advisor 契约
+
+结算与 `ask_user` 的模式契约分别见 [prompt-settlement.md](prompt-settlement.md) 与 [ask-user.md](ask-user.md)；本节只保留 Advisor 自身的模式行为。
+
+请求—响应模式中 Advisor 引入的纯等待上限为 `(maxCorrectionCycles + 1) × terminalReviewTimeoutMs`，默认 `3 × 30 秒 = 90 秒`：每次 terminal checkpoint 的有界等待不超过 `terminalReviewTimeoutMs`，修正 run 本身是主 Agent 的真实工作，不计入该上限。调整这三个参数的任何一个都应重新按该公式评估请求模式延迟。
+
+### 9.1 TUI（包括 daemon 托管）
+
+- 主 Agent 与 Advisor 在各 turn 中并行推进，不同步等待每次审查。
+- 候选 `agent_end` 后立即显示回答；Advisor 尚未完成时只显示状态，不把它解释成 TUI 的忙闲或结算闸门。
+- 输入、提交和后续 prompt 执行始终保持现有行为，不新增 Advisor 专用输入队列或 prompt-start fence。
+- terminal flush 立即审查最终 backlog，不受 30 秒最小 review 间隔限制；其 timeout 只结束本次审查，不阻塞 TUI。
+- Advisor 状态固定显示在 TUI footer 的单行位置，不向聊天区追加状态日志。当前内置 footer 虽然有承载位但刻意渲染为空；首版只增加 Advisor 指示，不恢复被隐藏的 token、cost、model、cwd 或 context telemetry。
+- Advisor 未启用时 footer 保持现状。启用后只显示紧凑状态：`Advisor: idle`、`Advisor: reviewing`、`Advisor: correcting`、`Advisor: unavailable` 或 `Advisor: unresolved`；内部 `catching_up` 合并显示为 `reviewing`。
+- UI 只展示可验证的运行状态，不展示 Advisor chain-of-thought、trace 内容或模型调查过程。
+- Advisor turn 正常结束且没有 accepted `report_findings` 时保持静默并回到 `idle`。实际 finding 在聊天流显示独立 Advisor 卡片；卡片显示严重度和正文，并与注入主 Agent 上下文的结构化消息共用同一 identity。
+- `nit` 作为非打断卡片在下一 step boundary 投递；活跃状态下的 `concern`/`blocker` 进入 steering。终态文本后的迟到 `concern` 只显示卡片，迟到 `blocker` 才唤醒修正。
+- Advisor 超时或不可用时更新降级状态，不能影响用户继续交互。
+- 用户主动中断建立 abort fence，所有迟到 advice 只保留，不自动启动 run。
+- detach/reattach 不应改变 Advisor 所属会话；worker 生命周期结束时必须 dispose。
+
+daemon 若增加 Advisor 命令、事件或响应字段，按“可选能力”处理。客户端必须先检查协商 capability，老客户端和老 daemon 均应继续完成普通会话启动与交互。
+
+### 9.2 Print
+
+- 可通过 `--advisor` 为本次进程和 session 临时启用，不修改 settings。
+- `getContinuationMessages` 仍用于自然停止路径的快速修正；跨 run 修正由相同 `promptId` 关联。
+- stdout 只输出最终 settled 的主 Agent 文本，不输出被 Advisor 推翻的中间候选文本。
+- Advisor 不可用或超时时，stdout 仍输出主结果，stderr 输出简短警告。
+- 进程退出后，该请求被标记为 released；Advisor 恢复不得追审并唤醒旧工作。
+
+### 9.3 JSON
+
+- 可通过 `--advisor` 为本次进程和 session 临时启用，不修改 settings。
+- 可以流式输出 Advisor 的非终态事件；`advisor_unavailable`、`unresolved_advisor` 使用结构化事件或字段表达，不依赖 stderr 文本解析。
+
+### 9.4 RPC
+
+- RPC host 可通过 `--advisor` 为其 session 临时启用；连接 daemon 创建 session 时使用协商后的 `advisorEnabled` 参数。
+- 结构化 `advisor_unavailable`/`advisor_unresolved` 作为可选能力协商；未声明能力的客户端继续收到原有主结果契约。
+
+### 9.5 ACP
+
+- ACP host 可通过 `--advisor` 为其 session 临时启用；连接 daemon 创建 session 时使用协商后的 `advisorEnabled` 参数。
+- Prime 专属 Advisor 状态放入可忽略的 namespaced `_meta` 或协议允许的扩展位置，保持 ACP 标准响应有效。
+
+## 10. 故障策略
+
+Advisor 属于质量增强路径，不应成为主 Agent 的单点故障。
+
+这里的 fail-open 只适用于 Advisor 已成功启用后的运行时故障。显式 enable 的前置校验发生在接受 prompt/session create 之前，失败时没有候选主结果可释放。
+
+| 故障 | 行为 |
+| --- | --- |
+| 显式 enable 时 model 缺失/非法/不可解析，或其 provider 本地未配置认证 | 通过现有 available-model 解析 fail-closed；CLI 非零退出，daemon session create 结构化失败，TUI 内 `/advisor on` 仅命令失败 |
+| 单次模型请求超时 | 取消该 review，记录状态；请求模式进入有界 fail-open |
+| 现有 retry chain 结束后凭据/provider/model 仍不可用 | 标记 `unavailable`，当前 review fail-open，不再叠加 Advisor 私有重试 |
+| 队列持续增长 | 合并 delta；达到资源上限后释放请求并报告降级 |
+| runtime 崩溃/重建 | 递增 epoch，丢弃旧结果，只从恢复点处理新工作 |
+| 会话退出 | dispose 并取消在途任务，不投递迟到结果 |
+
+单次 review 的 provider/auth 恢复完全沿用子 `AgentSession` 当前 retry 配置，`reviewTimeoutMs` 是包含这些重试在内的外层总预算，其默认值必须能容纳整条现有 retry 链（见第 11 节的校验规则）；Advisor manager 不再按 batch 自建 sleep、fallback 或 retry counter。一次最终失败使当前 prompt 按模式 fail-open，并把 Advisor 标记为 `unavailable`；只要未触发暂停，后续新 delta 可在正常 30 秒调度边界再次尝试，成功后清零连续失败计数。连续 3 个 review 最终失败后暂停 Advisor，避免 daemon/TUI 对永久错误持续消耗资源；仅 `/advisor off` 后再 `on`、Advisor 配置重载或新 session 清除该暂停。暂停不改变用户持久化的 enabled 设置。
+
+模式反馈：
+
+- TUI/daemon：显示 Advisor 状态，保留可查询诊断；故障不阻塞交互。
+- Print：主结果照常输出，警告写 stderr。
+- JSON/RPC/ACP：主结果照常返回，同时提供结构化 `advisor_unavailable`。
+
+恢复后只处理尚未 released 的当前请求或新产生的 transcript，不追溯唤醒已经交付的历史任务。
+
+上述模式反馈只描述成功启用后的运行时故障；启动前配置错误按 fail-closed 路径返回，不伪装成 `advisor_unavailable` 后继续执行 prompt。
+
+## 11. 配置与启用
+
+Prime 当前没有 `modelRoles` 抽象，首版应复用现有 settings 合并和模型解析方式，新增单一嵌套对象：
+
+```json
+{
+  "advisor": {
+    "enabled": false,
+    "model": "anthropic/claude-sonnet-4-5",
+    "thinkingLevel": "high",
+    "reviewTimeoutMs": 120000,
+    "minReviewIntervalMs": 30000,
+    "terminalReviewTimeoutMs": 30000,
+    "immuneTurns": 3,
+    "maxCorrectionCycles": 2
+  }
+}
+```
+
+这是已接受的首版配置方向；具体 schema 仍需在实现计划阶段通过现有 `SettingsManager` 类型和覆盖规则核对：
+
+- `enabled` 默认关闭，避免用户无感增加模型调用和费用。
+- `advisor.model` 是 canonical `provider/model` 字符串，也是启用 Advisor 的硬性前置条件。Prime 不继承主 Agent 模型，也不在缺失配置时选择默认模型。
+- 启用时直接通过现有 `ModelRegistry.getAvailable()` 和模型解析器判断可用性，不增加 Advisor 专用凭据校验器，也不发送联网探测请求。该列表已排除本地未配置认证的 provider；key 失效、OAuth 刷新失败、限流或网络故障等只能在真实请求中确定的问题按运行时 `unavailable` 处理。
+- `advisor.thinkingLevel` 可选，省略时默认 `high`。不属于 Prime 合法 thinking level 枚举的值属于配置错误并阻止启用；合法但目标模型不支持的值沿用 Prime 现有规则确定性 clamp，并分别保留 requested/effective level 供状态查询。
+- 配置的 Advisor 模型在 runtime 创建时独立解析并固定；主 Agent 后续切换模型不影响 Advisor。显式 `advisor.model` 可选择任意 provider，不增加额外的跨 provider 授权、限制或 UI 警告；trace 内容将到达该 provider 的事实作为残余风险写入配置文档（见第 14 节）。
+- `enabled: true` 但 model 缺失、非法或不可解析时，进程启动 fail-closed 并返回可操作的配置错误，不创建主任务或 Advisor runtime。
+- 不接受 `{ "provider": "...", "id": "..." }` 对象或裸 model id；单字符串避免 provider/id 半配置，并直接复用 Prime 现有 canonical model reference 解析与错误信息。
+- `reviewTimeoutMs` 默认 120000：它是覆盖整条现有 provider/session retry 链的外层总预算，而现有 `retry.provider.maxRetryDelayMs` 默认即 60000。配置值小于 provider 单请求 timeout 与最大退避之和时属于自相矛盾配置——预算连一次顶格退避都容纳不下，等于静默禁用复用的 retry 链——按配置错误在启用时 fail-closed，与 model 校验走同一路径。
+- `terminalReviewTimeoutMs` 是请求—响应模式 terminal checkpoint 的等待上限，默认 30000；Advisor 附加纯等待上限 = `(maxCorrectionCycles + 1) × terminalReviewTimeoutMs`，默认 90 秒（见第 9 节）。
+- 全局与项目级配置采用现有 merge 语义。
+- timeout、30 秒最小 review 间隔、immune window 和修正上限有安全边界并经过校验。
+- Advisor 不增加独立 retry 配置：请求级和 Agent run 级重试复用现有 `retry.provider` 与 `retry.*`；`reviewTimeoutMs` 只提供覆盖整条重试链的 Advisor 外层总预算，模型保持固定。
+- Advisor 的只读工具权限独立于主 Agent 权限，不能因继承配置获得写能力。
+
+TUI 提供 session 级命令：
+
+- `/advisor on`：为当前 session 启用已配置的 Advisor，不修改持久化 settings；model 缺失或不可解析时仅该命令失败，现有主 session 继续运行且 Advisor 保持 disabled；已有 transcript 只作为背景，finding 从 `enabledAtCursor` 之后开始。
+- `/advisor off`：为当前 session 停用 Advisor，终止其后续调度并使在途结果失效，不修改持久化 settings。
+- `/advisor status`：显示 enabled override、`no_model`/runtime 状态、已配置模型、requested/effective thinking level、backlog/review coverage、最近错误、token/cost 和修正轮次，不改变状态。
+
+session override 的优先级高于 settings，并随该 session 生命周期保存和恢复；它不能串到其他 session。无参数或未知子命令返回明确 usage，不采用隐式 toggle，避免误触改变费用行为。Prime 当前将需要跨 TUI/daemon 保持语义的命令定义在 `core/slash-commands.ts`，并由 `AgentSession` 执行；`/advisor` 应沿用同一 session command 路径，而不是做成仅存在于 `interactive-mode.ts` 的本地 UI 命令。
+
+所有直接启动模式提供统一的 `--advisor` 一次性开关，包括 TUI、Print、JSON、RPC 和 ACP：
+
+- `--advisor` 在 runtime 创建前请求把当前 session override 设为 enabled，不修改全局或项目 settings；它不选择模型，也不能绕过 `advisor.model` 的必填约束。model 配置无效时进程在接受 prompt 前以非零状态退出。
+- 对 resume/attach 的 session，显式命令行 override 优先于该 session 已保存的 override；未传参数时沿用 session/settings 的正常解析。
+- attach 到已存在的 daemon session 时（Print/JSON/TUI 的 continue/resume 路径同样适用），`--advisor` 通过 `/advisor on` 的既有 session command wire 通道生效，在接受第一个 prompt 前执行；fail-closed 语义与 TUI 内 `/advisor on` 完全对齐——model 无效时该命令返回结构化失败，client 进程非零退出且不发送 prompt，session 本身继续存活、Advisor 保持 disabled。该命令通道 capability-gated，老 daemon 明确报不支持，不静默降级。中途启用自动落入 §6.3 的 `enabledAtCursor` baseline 语义；共享 session 下任一 client 启用的 override 对全体 attached client 可见，与 `/advisor on` 同语义，非特例。
+- 首版只增加明确的正向开关，不增加隐式 toggle；非 TUI 调用方若需关闭已在 settings 中启用的 Advisor，应使用显式配置覆盖。
+- daemon 进程本身没有全局 `--advisor` 状态。daemon 创建 session 时，通过 capability-gated 的可选 `advisorEnabled: true` 参数表达同一 session override；老 daemon 不支持该 capability 时，client 必须明确报不支持，不能静默声称已启用。daemon worker 无法解析配置模型时，session create 返回结构化失败且不创建 session，不影响 daemon 中其他 session。
+
+## 12. 持久化与可观测性
+
+Advisor 使用自己的 `SessionManager` 和私有 session tree 保存 transcript、compaction、成本和诊断，不混入主对话 transcript。主 transcript 中只保留实际投递给主 Agent 的 advice 及其 review 引用，以便恢复主执行语义。私有 compaction 只处理已审查、已解决历史；固定保留集合及 review/settlement 真值放在 compaction summary 之外的结构化状态中。
+
+至少暴露以下运行状态：
+
+- enabled/disabled/unavailable；
+- 当前 state、backlog 范围和最后审查 turn；
+- 最后一次 advice 的严重度与解决状态；
+- review 次数、修正循环次数、token/cost；
+- 最近错误与超时原因。
+
+持久化格式必须允许未来扩展多 Advisor，但首版运行时只实例化一个。恢复时可从主 session JSONL 回放执行 trace，并恢复或重建 Advisor 私有 transcript/cursor；无论采用哪种方式，都必须通过 session lineage 与 epoch 阻止恢复前在途请求的迟到输出。
+
+daemon worker 重启时未结算 prompt 的恢复与最小 settlement ledger 见 [prompt-settlement.md](prompt-settlement.md)；Advisor 贡献其中的 review coverage、修正次数与 epoch 字段。与 Advisor 直接相关的恢复规则：
+
+- 重启前的在途模型结果全部按 epoch 作废，不能迟到写入新 runtime。
+- 未终态且未 abort/released 的 outcome 重新核对 trace coverage，必要时重新发起 Advisor review。
+- 已终态 outcome 不可重开；恢复后的 Advisor 只处理新工作。
+
+## 13. 协议兼容性
+
+Advisor 的纯内部队列和 runtime 不构成 wire change。以下变化必须分别分类（settlement 与 `ask_user` 的 wire 变化分别见 [prompt-settlement.md](prompt-settlement.md) 与 [ask-user.md](ask-user.md)）：
+
+| 变化 | 建议分类 |
+| --- | --- |
+| daemon 新 Advisor status/event/command | capability-gated |
+| daemon 创建 session 的可选 `advisorEnabled` 参数 | capability-gated；客户端发送前必须检查能力 |
+| daemon 既有响应增加可选 metadata | capability-gated，并验证老客户端忽略能力 |
+| RPC 新结构化 Advisor 状态（`advisor_unavailable`/`advisor_unresolved`） | capability-gated；若无协商机制则版本化 |
+| ACP namespaced `_meta` 中的 Advisor 状态 | 在 ACP 允许未知 metadata 的前提下 backward-compatible |
+| Print stderr 警告 | backward-compatible，不改变 stdout 主结果 |
+
+Advisor 不改变现有 `agent_end` 的 run 终态含义，而是依赖更高层的 prompt settlement。每个实际 daemon wire change 仍必须同步更新 `DAEMON_SCHEMA_REVISION`、命令/事件兼容映射，并覆盖 new-client/old-daemon 与 old-client/new-daemon。只有不兼容变化或启动开始依赖新行为时才按现有规则评估 `DAEMON_PROTOCOL_VERSION` bump；Advisor 本身不得成为无 capability gate 的启动依赖。
+
+## 14. 安全与隐私边界
+
+- 发送给 Advisor 的 trace 执行结构化排除（§6.3：provider 原始载荷、认证信息、env 快照、daemon 控制消息按构造剔除），v1 不做内容级凭据扫描——regex 秘密识别漏报是常态且会误伤证据，做一个漏的版本只会制造“已过滤”的虚假安全感。系统自身持有的凭据（认证 header、env）全部位于结构层，被结构化排除完整覆盖。
+- 已声明的残余风险：tool-call 参数、IPython 输出、错误与 traceback 的内容会到达 `advisor.model` 所属 provider，信任级别与主模型 provider 相同；`advisor.model` 配置为另一家 provider 时即构成跨 provider 内容共享，属用户显式配置的选择，在配置文档提示，不加 UI 警告。
+- Advisor 工具由 `baseToolsOverride` 和 allowlist 强制限定为专用 `read`、`grep`、`glob` 与受控 `git_read`，用户配置不能恢复 IPython、写入或外部副作用能力；文件读取只经 `FileSystemView`（v1 本机实现），`git_read` 以硬化参数的受控子进程运行且 allowlist 排除一切网络子命令，均不扩张 worker 进程的 OS 读取权限。
+- Advisor 不访问主 Agent 的 live kernel、namespace、snapshot、socket 或未进入 trace 的内存状态。
+- advice 作为不可信模型输出进行长度限制、转义和 schema 校验。
+- blocker 只能触发主 Agent 的新推理，不能绕过工具权限或自动批准危险操作。
+- 用户中断、会话销毁和请求 released 都是不可被模型文本覆盖的本地硬边界。
+- post-turn Advisor 不是事前安全屏障；Git 也不能恢复未跟踪文件、数据库、外部系统和已泄漏信息。
+
+## 15. 测试与验收
+
+使用 `packages/coding-agent/test/suite/harness.ts` 和 faux provider，不调用真实 provider、API key 或付费 token。`ask_user` 与 prompt settlement 的验收清单分别见 [ask-user.md](ask-user.md) 与 [prompt-settlement.md](prompt-settlement.md)。Advisor 至少覆盖：
+
+1. 正常路径：多 turn 任务的全部 trace 被增量提交并在候选终态审查，无问题时用户和主 transcript 均无 Advisor 消息。
+2. 默认、模型、命令与启动 override：未配置时 Advisor 不创建 runtime 或产生费用；`advisor.model` 只接受 canonical `provider/model` 字符串，缺失/非法/不可解析或 provider 本地未配置认证时无法启用且不继承主模型；启用复用 `ModelRegistry.getAvailable()`、不发联网探测；`advisor.thinkingLevel` 省略时为 `high`，非法枚举阻止启用，模型不支持时正确 clamp 且 status 同时显示 requested/effective level；`reviewTimeoutMs` 小于 provider 单请求 timeout 与最大退避之和的自相矛盾配置同样 fail-closed；`enabled: true`/`--advisor` 在接受 prompt 前 fail-closed，daemon create 原子失败，TUI 内 `/advisor on` 仅命令失败并保持 disabled；`/advisor off|status` 和有效的 `on` 只修改当前 session override，`off` 后在途结果不投递；daemon 参数受 capability gate，老 daemon 明确拒绝而不静默降级；attach 已有 daemon session 时 `--advisor` 经 session command 通道生效并保持同样的 fail-closed 语义，命令失败不影响 session 本身与其他 attached client。
+3. 中途启用：当前有效 transcript 进入只读 baseline，旧内容不产生 finding、不计入 coverage；只审查 `enabledAtCursor` 后的新 delta，反复 `off`/`on` 不回补停用期间的历史。
+4. 审查对象：错误用户前提、错误推理、执行缺陷和错误结果都能通过具体 message/evidence 被指出；不要求额外分类字段，偏好不被误判为事实错误。
+5. 严重度：三种 severity 的展示和系统路由符合表格定义；系统不解析或执行 Advisor 给出的处理动作，主 Agent 自行判断如何回应。
+6. review 输出、多 finding 与重复抑制：正常 Advisor turn 无 `report_findings` 调用时静默通过；有问题时 1/3 个 findings 以一个非空批次提交，超限裁剪、优先级排序、批次内编号和单次聚合投递均正确；普通文本不投递，多余调用被 emission guard 抑制且不触发重试；等价 finding 在 `awaiting_main` 期间保持逻辑未解决但不重复显示/steering，升级可重新投递；`nit` 不阻塞 settlement。
+7. Trace：Advisor 可见 session trace 中的 IPython 输入、输出、错误和 traceback，但无法访问 live kernel、namespace 或 snapshot。
+8. Advisor prompt 与 policy context：内置 system prompt 覆盖正确性、静默、完整结果判断、severity、只读核验和 advice 边界且不可被覆盖；effective system prompt、适用规则、工具权限和运行模式仅以带边界标签的 review context 按 version/hash 初始化与增量更新；注入内容不能改变 Advisor 身份、协议或工具权限，敏感运行值被排除；首版不加载 WATCHDOG 类第三层规则。
+9. 背压与触发：review 只在 backlog 含候选终态 delta 或 terminal flush 时启动，`in_progress` delta 只扩展 backlog 与 cursor、不产生模型调用；连续 review 启动间隔不少于 30 秒，多个 turn 被合并且无遗漏；无新候选终态不轮询，settlement flush 不受冷却限制。
+10. Continuation 顺序：工具、steer、follow-up、goal 和 autonomous continuation 正常运行；自然停止时优先使用 Advisor terminal checkpoint。
+11. 活跃状态：主 Agent 活跃期间不因当前 prompt 的 WIP delta 产生审查调用或投递；迟到 `nit`/`concern` 按 §4.3 活跃行路由；迟到 `blocker` 在当前 provider/tool 批次完成后的最早安全边界优先 steer，不调用 `requestAbort()`，不强杀工具。
+12. TUI 状态：候选 `agent_end` 后立即显示回答；Advisor review 状态可见但不阻塞 B 的提交和执行；A 的迟到 finding 保留原 identity 并按当时主状态投递。
+13. Footer 与卡片：Advisor 未启用时 footer 仍为空；启用后 footer 只有一行紧凑状态。实际 finding 使用独立 Advisor 卡片，同一结构化消息同时进入主 Agent 上下文，状态更新本身不产生聊天消息。
+14. 用户中断：三种严重度均不能自动恢复已 abort 的会话。
+15. 过期保护：切换、fork、恢复和 dispose 后旧 review 不投递；普通 compaction 不丢失 Advisor cursor。
+16. 跨 prompt 迟到：同一 session/epoch 内 A finding 在 B 到达后保留 A 的 `promptId`、`reviewId` 与范围，不做 generation stale/rebase；B 已活跃时正常 steer，仍停在 A 终态时 late concern 只保留卡片、late blocker 可唤醒；B admission 封口 A 的修正循环，A 按 coverage 追平后的结果结算 `completed`/`unresolved_advisor`，steer 进 B 的修正属于 B 的时间线且 A 终态不重开。
+17. 修正与反驳：主 Agent 无需 Advisor 专用回执即可完成修正、给出可复查反驳证据或提出澄清问题；普通 WIP 不清除 `awaiting_main`，有效修正/terminal 复审中相同问题继续阻塞但不制造重复卡片，静默通过才清除，到达上限后只报告最新一批问题。
+18. 故障与重试复用：显式 enable 的模型配置错误在 prompt 前 fail-closed；成功启用后复用 `retry.provider` 与 `AgentSession` retry chain 且始终使用配置的 Advisor 模型，`reviewTimeoutMs` 覆盖整条链；单次最终失败 fail-open，后续新 delta 可恢复，连续 3 次最终失败后暂停直到 off/on、配置重载或新 session；transport/runtime 丢失不能误报 completed。
+19. 协议：daemon/RPC 能力协商和双向跨版本场景通过。
+20. 权限隔离：Advisor 只能调用强制只读工具，配置不能恢复写工具或 IPython；`read`/`grep`/`glob` 的 IO 只经 `FileSystemView`（v1 本机实现，根为主 session cwd 加 worker 可读路径，支持跨仓库）；`git_read` 只接受 allowlist 子命令、强制硬化参数、拒绝 `fetch`/`pull` 等网络子命令，textconv/external diff/fsmonitor 均不被触发；Advisor 消息不会进入自身 delta，私有 transcript 不污染主 transcript。
+21. 成本：审查 token/cost 独立统计；候选终态触发与队列合并确实减少调用次数，1–3 turn 的短 prompt 每 prompt 至多一次 review 调用（外加修正复审）。
+22. Trace 压缩：未审查 delta、尚未完成响应/复审的 review 批次、当前证据和结构化真值固定保留；仅压缩已审查旧历史，主/Advisor 任一 compaction 都不改变 cursor、coverage 或 settlement。
+
+完成标准不是单个 TUI 演示可用，而是共同核心语义、全部入口、错误路径、协议降级和上述状态流转均有自动化证据。
+
+## 16. 分阶段落地
+
+整体交付按六个可独立验收的切片推进；切片 0–2 的详细范围见关联文档：
+
+| 切片 | 内容 | 所属文档 | 依赖 |
+| --- | --- | --- | --- |
+| 0 | TUI editor-surface FIFO dialog arbiter（修复现有对话框互踩隐患） | [ask-user.md](ask-user.md) | 无 |
+| 1 | `PromptSettlementTracker` + `PromptOutcome` + 各模式结算 | [prompt-settlement.md](prompt-settlement.md) | 无 |
+| 2 | 通用 `ask_user` + `UserInputBroker` + live/fallback/pending 全链路 | [ask-user.md](ask-user.md) | 0、1 |
+| 3 | Advisor 核心：子 runtime、只读工具、cursor、队列、findings、terminal checkpoint | 本文档 | 1 |
+| 4 | Advisor TUI/daemon 面：footer、卡片、迟到投递、capability | 本文档 | 3 |
+| 5 | 持久化与运维面：ledger 集成、重启重建、诊断、默认值调参 | 本文档 + [prompt-settlement.md](prompt-settlement.md) | 2、3、4 |
+
+切片 2 与切片 3 互不依赖，可并行。
+
+Advisor 部分的预计实现触点：
+
+- `src/core/agent-session-runtime.ts`：持有 Advisor 子 runtime，装配模型、认证、settings、telemetry 和资源所有权。
+- `src/core/agent-session.ts`：在 `turn_end` 异步提交 trace，将快速 Advisor checkpoint 接入 `_getContinuationMessages`，并桥接 prompt settlement 的 review coverage 与 correction lineage。
+- `src/core/advisor/`：新增子 runtime factory、queue、cursor、schema、delivery router、terminal checkpoint 和 settlement bridge。
+- `src/core/advisor/system.md`：定义不可被项目内容覆盖的 Advisor 身份、审查范围、静默行为、severity 与 `report_findings` 契约。
+- `src/core/tools/read.ts`、`grep.ts`、`glob.ts`、`git-read.ts`：通用只读工具实现，不进入 `allToolNames`/`ToolName` union（沿 `bash.ts`/`edit.ts` 先例），由 Advisor 经 `baseToolsOverride` 装配。
+- `src/core/filesystem-view.ts`（或等价位置）：本设计新增的薄 `FileSystemView` 接口与 v1 本机实现；`read`/`grep`/`glob` 面向该接口编写，`git_read` 为受控子进程、不经该接口。
+- `src/core/slash-commands.ts` 与 `agent-session.ts`：注册并执行 session-scoped `/advisor on|off|status`。
+- `src/core/settings-manager.ts`：配置类型、默认值、合并和校验（含 `reviewTimeoutMs` 与 retry 链的自洽校验）。
+- `src/cli/args.ts`、`command-registry.ts` 与 runtime/daemon create 装配：解析并传播 `--advisor` session override。
+- `src/modes/interactive/components/footer.ts` 与 `interactive-mode.ts`：显示一行 Advisor 状态，不恢复其他 footer telemetry。
+- `src/modes/interactive/components/`：新增独立 Advisor finding 卡片，消费主 transcript 中的结构化 Advisor custom message。
+- `src/modes/daemon/`：能力协商、schema、事件转发和跨版本测试。
+- `test/suite/`：基于 harness/faux provider 的需求回归与跨模式状态测试。
+
+### 切片 3：Advisor 核心（依赖切片 1）
+
+- 定义逻辑 advice、review 批次 identity 与展示序号、epoch 和 mode policy 类型；先建立 faux provider 的失败测试与确定性 queue/state-machine 测试。
+- 实现完整但受限的 Advisor `AgentSessionRuntime`、增量 cursor、候选终态触发的单飞队列、合并和去重。
+- 定义 `FileSystemView` 接口并交付 v1 本机实现；实现 `core/tools/` 下的通用 `read`、`grep`、`glob`（面向该接口）与受控 `git_read`（子命令 allowlist + 硬化参数），并验证 `baseToolsOverride` 与 allowlist 无配置逃生口。
+- 将快速有界等待接入主 `AgentSession._getContinuationMessages`，排在既有普通 continuation 之后；接通 `concern`/`blocker` 修正、反驳复审、fail-open outcome 与 settlement bridge。
+
+### 切片 4：Advisor TUI/daemon 面（依赖切片 3）
+
+- 接入内部 turn-end trace enqueue、生命周期 fence 和 correction trigger。
+- 实现 Advisor footer 状态、finding 卡片、终态 concern 保留/blocker 唤醒、活跃 steering 和用户 abort fence，不改变 TUI 现有输入调度。
+- 增加 capability-gated daemon 状态/事件及跨版本测试。
+- 验证 Print、JSON、RPC、ACP 组合同一 session outcome 契约；多个 run 可以产生多个 `agent_end`，但每个 prompt 只有一个终态 outcome。
+
+### 切片 5：持久化与运维面（依赖切片 2、3、4）
+
+- 增加 Advisor session artifact、settlement ledger 集成、重启重建、按 `promptId` 状态查询和诊断。
+- 覆盖 worker 重启、连接断开/重连、旧 epoch 结果迟到和无法完整恢复 lineage 的状态测试。
+- 补充配置与用户文档。
+- 基于真实使用数据调整 timeout、immune window 和修正上限默认值。
+
+每个切片都应形成可运行、可验证的完整交付；不得以占位 runtime、假 Advisor 结果或仅覆盖 happy path 的方式提前宣告完成。
+
+## 17. 风险与反证信号
+
+| 风险 | 早期信号 | 缓解 |
+| --- | --- | --- |
+| Advisor 造成明显延迟和成本 | 请求结算 P95 超出 `(maxCorrectionCycles + 1) × terminalReviewTimeoutMs` 基线、token 成本持续升高 | 候选终态触发、队列合并、独立模型选择、有界 timeout、默认 opt-in |
+| 两个 Agent 形成纠错回环 | 同类 advice 重复、修正次数频繁触顶 | 去重、immune window、修正上限、聚合单条建议 |
+| 迟到结果污染新任务 | advice 丢失 A 的 review identity，或被误当作 B 的 finding | 稳定 `promptId`、`reviewId`、epoch、cursor、abort/released fence，并让主 Agent 看到当前完整上下文 |
+| 协议演进破坏老客户端 | 老客户端无法 attach/start | capability gate、schema map、双向兼容测试、本地降级 |
+| Advisor 获得过多权限 | 审查过程产生工作区或外部副作用 | `baseToolsOverride`、allowlist、独立只读工具集和无配置逃生口 |
+| 完整 trace 泄露敏感信息 | Advisor 收到系统凭据，或跨 provider 意外共享 | 结构化排除（§6.3）、跨 provider 残余风险声明与配置文档提示 |
+
+settlement 与 `ask_user` 的风险表分别见 [prompt-settlement.md](prompt-settlement.md) 与 [ask-user.md](ask-user.md)。
+
+若生产数据表明多数任务的审查延迟超过主任务本身、修正命中率长期很低，或 fail-open 频率过高，应重新评估审查触发粒度和默认启用策略，而不是简单增加等待时间。
+
+## 18. 保留的演进空间
+
+当前边界刻意保留以下可逆选项：
+
+- 从单 Advisor 扩展到多个命名 Advisor，共享 queue 接口但使用独立 cursor/runtime。
+- 为特定高风险工具增加 pre-tool policy hook，与 post-turn Advisor 分工而非混合。
+- 在确定性规则下为长时 autonomous run 恢复 WIP（`in_progress`）阶段的提前审查（例如仅投递 `blocker`、仅 autonomous 模式启用）；首版为控制短 prompt 成本不默认开启。
+- 引入更细的同步 backlog 策略，但仍由 terminal checkpoint 与 prompt settlement 控制，不阻塞普通 `turn_end`。
+- 为 `FileSystemView` 增加远程/容器实现，使 Advisor 只读工具无改动地继承主 Agent 的非本机文件视图；`git_read` 随之演进。
+- 在具备进程级 sandbox 后，为 Advisor 增加可选的受限 IPython。评估时注意已核实的成本：平台沙箱矩阵（Linux Landlock / macOS `sandbox-exec`，Windows 无像样的用户态只读方案）、“禁网”与 ipykernel 默认 TCP loopback 传输冲突（需改 `ipc://` 或精细放行）、forkserver 与沙箱不兼容只能走冷启动；且只读 fs 下测试/构建跑不起来，它验证不了运行行为，净增益只是更强的读取分析。
+- 按任务类型选择更便宜或更强的 Advisor 模型，而不改变主 Agent API。
+
+需要重新审议本决策的触发条件：Advisor 必须跨机器运行、必须在工具执行前提供强制授权、需要多 Advisor 法定人数，或 Prime 的所有模式统一迁移到 daemon 托管。除此之外，首版应保持 root `AgentSessionRuntime` 的资源所有权和单 Advisor 模型。
+
+## 19. 与 oh-my-pi Advisor 的关系
+
+本方案参考了 oh-my-pi 已验证的几项机制：按 turn 记录增量 transcript、单飞异步 drain、积压合并、无问题静默、三档严重度、重复抑制、immune window 和独立 Advisor 上下文。
+
+Prime 不直接复制其实现，原因是两者的系统边界不同：
+
+- Prime 的 root `AgentSessionRuntime` 是完整 session 及子运行时的资源和生命周期所有者，适合持有一等 Advisor 子运行时。
+- Prime 需要同时定义 TUI（含 daemon 托管）的 footer 状态、finding 卡片与迟到投递，以及 Print/JSON/RPC/ACP 的结算语义。
+- Prime daemon 有明确的 capability、schema revision 和双向跨版本要求。
+- Prime 当前没有 `modelRoles` 配置抽象，应复用自身的 settings、`ModelRegistry` 和认证链。
+- oh-my-pi 在每个 turn 后即可启动一次审查调用；Prime 首版保留每 turn 的 delta 提交与合并，但把审查启动推迟到候选终态与 terminal flush，避免最常见短 prompt 的双倍审查成本，WIP 提前审查保留为演进选项。
+- oh-my-pi 默认仅给 Advisor `read`、`grep`、`glob`，但允许通过 `WATCHDOG.yml` 扩权，且工具运行在隔离 `ToolSession` 中并遵循常规审批；Prime 首版选择更严格的强制只读、不可配置扩权边界，并在该边界内额外提供受控 `git_read`，补上 oh-my-pi 工具集缺失的“变更基线/聚合 diff”证据源。
+- oh-my-pi 支持 `WATCHDOG.md`/`WATCHDOG.yml` 追加 reviewer-only 项目规则；Prime 首版只使用不可覆盖的内置 Advisor prompt 加主 Agent effective policy context，不引入第三层规则发现与冲突优先级。
+
+`ask_user` 相关的 oh-my-pi 对照（工具注册、批次语义、note、卡片、草稿、FIFO queue、`/tree` 重答等）见 [ask-user.md](ask-user.md)。
+
+Prime 明确采用 oh-my-pi 的一项用户可见语义：同一 Advisor 消息同时注入主 Agent 上下文并渲染为可见卡片；终态迟到 concern 只保留卡片，blocker 才自动唤醒。Prime 仍不以 oh-my-pi 作为运行时依赖或兼容性目标，且保留自身的单 Advisor、强制只读、显式必填 `advisor.model`、PromptOutcome 和跨模式结算设计。
+
+oh-my-pi 的 emission guard 每个 update 最多接受一条 advice，适合持续交互式 steering。Prime 为避免 Print/JSON/RPC/ACP 在同一次结算中逐条发现问题、反复调用模型，保留每个 update 最多一次 `report_findings` 调用、单批最多 3 条独立 finding；对主 Agent 和 TUI 仍只产生一条聚合消息/卡片。
+
+## 20. Prime 源码事实依据
+
+本设计依赖以下当前源码契约；实施前若这些契约变化，应先回到本设计重新核对。settlement 与 `ask_user` 相关的源码事实分别见 [prompt-settlement.md](prompt-settlement.md) 与 [ask-user.md](ask-user.md)。
+
+- `packages/agent/src/agent.ts`：event subscriber 的 Promise 会被等待，因此 `turn_end` listener 只能快速入队，不能直接等待 Advisor 模型调用。
+- `packages/agent/src/types.ts`：`getContinuationMessages` 是 host-owned continuation，并且不得让异常逃逸破坏 Agent loop。
+- `packages/coding-agent/src/core/agent-session.ts`：`_getContinuationMessages` 已承载 goal 与 autonomous continuation；Advisor terminal checkpoint 应排在这些普通 continuation 之后。
+- `packages/coding-agent/src/core/agent-session.ts`：`baseToolsOverride` 与 `allowedToolNames` 是现成的 session 工具边界扩展点。
+- `packages/coding-agent/src/core/tools/index.ts`：当前 `allToolNames` 只注册 `ipython`；`bash.ts`/`edit.ts` 等实现存在于 `core/tools/` 但未进入 `ToolName` union，是“通用工具实现、不进主 Agent 默认集”的现成先例。Prime 尚无可直接复用的内置 `read`、`grep`、`glob`。
+- `packages/coding-agent/src/core/tools/ipython.ts` 与 `src/core/kernel/`：现有 IPython 配置和 kernel manager 没有进程级只读 sandbox；kernel 为 ipykernel + zeromq 本机子进程（direct spawn 或 forkserver），与 worker 同 OS 用户。受限 IPython 的成本判断依据于此。
+- `packages/coding-agent/src/core/`：当前不存在任何 filesystem/exec-environment 适配器抽象，也不存在 trace sanitizer/redact 基础设施；`FileSystemView` 与结构化排除是本设计新增的工作，不是对现有机制的复用。
+- `packages/coding-agent/src/main.ts`：Print/JSON 在 continue/resume 路径可经 `DaemonAgentConnection.attach` 连接已存在的 daemon session，因此 `--advisor` 必须同时定义 create（`advisorEnabled` 参数）与 attach（session command 通道）两条生效路径。
+- `packages/coding-agent/src/core/agent-session-config.ts`：执行模式是 `interactive | print | json | rpc | acp`；daemon 是承载/传输边界，不是替代这些语义的第六种 Agent execution mode。
+- `packages/coding-agent/src/core/slash-commands.ts`：需要跨 client/session 保持语义的内置命令通过 `SESSION_SLASH_COMMAND_NAMES` 标记，并由 `AgentSession` 路径执行；Advisor 开关不能只挂在 TUI 本地 handler。
+- `packages/coding-agent/src/cli/args.ts`：当前顶层 parser 统一解析 TUI、text、JSON、RPC、ACP 与 daemon execution mode 的启动参数；`--advisor` 应在这里成为一等 boolean，而不是落入 extension `unknownFlags`。
+- `packages/coding-agent/src/core/model-resolver.ts`：现有解析器支持 canonical `provider/modelId` 引用；Advisor 应复用该模型注册表与认证解析能力，但不走主模型的默认选择或 fallback 链。
+- `packages/coding-agent/src/core/model-registry.ts`：`getAvailable()` 已通过 `hasConfiguredAuth()` 排除本地未配置认证的模型；Advisor 无需另建凭据预检或发送探测请求。
+- `packages/coding-agent/src/core/sdk.ts` 与 `settings-manager.ts`：provider 请求已统一使用 `retry.provider.timeoutMs/maxRetries/maxRetryDelayMs`（`maxRetryDelayMs` 默认 60000）；Advisor 子 runtime 应复用，不再包一层 provider retry。`reviewTimeoutMs` 的默认值与校验规则必须与这些默认值自洽。
+- `packages/coding-agent/src/core/agent-session.ts`：现有 auto-retry 已处理 retryable provider/auth error、指数退避、认证来源失效标记、retry-chain completion 与 abort；Advisor manager 只增加外层 review deadline 和连续最终失败暂停，不复制该状态机。
+- `packages/coding-agent/src/modes/interactive/components/footer.ts`：Prime 品牌 TUI 的 footer 承载位存在，但当前 `render()` 刻意返回空数组并隐藏 token、cost、model、cwd 和 context telemetry；Advisor 可复用该固定位置而不恢复其他信息。
+- `packages/coding-agent/src/modes/daemon/daemon-protocol.ts`：当前 protocol/version 常量和 schema revision 受兼容性规则约束，任何 Advisor wire 扩展都必须按 capability 与跨版本测试治理。

--- a/packages/coding-agent/docs/ask-user.md
+++ b/packages/coding-agent/docs/ask-user.md
@@ -1,0 +1,304 @@
+# 通用 `ask_user` 会话能力设计
+
+> 状态：架构方向已接受，尚未进入实现；本文从 advisor-architecture.md 拆出，`ask_user` 独立于 Advisor 存在与交付
+>
+> 日期：2026-08-16
+>
+> 范围：`packages/coding-agent` 的 TUI、daemon、Print、JSON、RPC 与 ACP 入口
+>
+> 关联：[Prompt Settlement 架构设计](prompt-settlement.md)（fallback 终态依赖 `PromptOutcome`）、[Advisor 架构设计](advisor-architecture.md)（Advisor finding 是主 Agent 调用本能力的上游证据之一）
+
+## 1. 结论
+
+当主 Agent 判断必须由用户补充信息或选择时，不使用私有回执或普通文本猜测，而是调用 Prime 通用的 `ask_user` 会话能力。它是主 Agent 的通用内置工具，不属于 Advisor 输出 schema，也不由 Advisor 直接调用；即使 Advisor 未启用，主 Agent 也能在本身缺少必要信息时调用它。
+
+该能力由 session-owned `UserInputBroker` 根据当前入口是否存在可交互 responder（响应端）选择路径：有 responder 时在当前 tool call 内等待回答，返回正常 tool result，并继续同一个 Agent run；同一 assistant batch 的多个 ask 调用按原始顺序独立串行。没有 responder、responder 断开或入口不支持交互时，才将当前与尚未执行的询问持久化为有序 pending queue，正常结束当前 run，并以 `PromptOutcome(needs_user_input)` 结算当前 prompt。两条路径共享同一问题与答案契约，不从 assistant 文本猜测状态。
+
+root 主 Agent 的普通 coding session 始终注册 `ask_user`，不增加 `ask.enabled` 用户设置；TUI、Print、JSON、RPC 与 ACP 看到同一个工具，只由 responder 能力决定 live 或 fallback。Advisor 和其他受限 child runtime 仍通过现有 `baseToolsOverride/allowedToolNames` 排除它；测试或嵌入式调用方也可显式构造不含该工具的专用 session，但这不是普通用户配置。这样不会出现审查方要求主 Agent 询问、工具却因全局开关关闭的矛盾状态。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 所有入口使用同一个通用 `ask_user` 会话契约：可交互入口在同一 run 内获得回答，无 responder 时以结构化 `needs_user_input` 结束当前 prompt，而不是从 assistant 文本猜测“这是问题”。
+- live 与 fallback 共享同一问题与答案 schema；持久化值不因展示层被截断或改写。
+- 用户主动取消与 transport 丢失是两种不同状态，永不合并为同一个布尔值。
+- TUI 占用 editor surface 的所有非 overlay 对话框统一串行，修复现有互相覆盖的隐患。
+
+### 2.2 非目标
+
+- 不用 `ask_user` 代替工具执行前的权限、安全或人工审批，也不得用它请求密码、token 等敏感凭据。
+- 首版不提供历史 `ask_user` 重新作答。`/tree` 选中既有 ask tool result 时沿用普通树导航，不重开问题、不改写旧结果，也不创建 sibling answer branch；需要改变方向时由用户在目标分支继续发送普通 prompt。
+- fallback 后不新增 `answer_user` 命令或第二套提交协议。
+- 首版不提供 ask timeout 配置或参数。
+- 首版问题不提供模型生成的 `header`；未来若 TUI 需要短标签，应由 host 从问题文本派生或通过兼容扩展增加。
+
+## 3. 工具契约
+
+### 3.1 调用与问题结构
+
+每次调用必须包含 1–4 个问题；该约束在工具参数校验时执行，并由 live responder、fallback 持久化与恢复共同复用，不能由某个 UI adapter 私自放宽。一次调用以现有 `toolCallId` 关联当前 ask 实例，模型不提供额外的 `question.id`：批内问题与答案按不可变数组下标映射，结构化结果同时重复问题文本；fallback 以 `promptId + toolCallId` 定位整次询问。ACP form 等 transport 需要字段键时，由 adapter 临时生成 `q0`、`q1`，这些键不进入模型契约或持久 identity。
+
+每个问题必须包含 `question` 与 `options`，且 `options.length` 只能是 `0` 或 `2–4`：空数组表示纯文本输入，2–4 个预设项表示选择题，运行时统一增加“其他”自由输入；单个选项和超过 4 个选项均在工具参数校验阶段拒绝。工具 schema 不增加冗余的 `kind: "text" | "select"`；各 responder 根据 `options.length` 渲染，fallback 也保存同一原始结构。选项包含 `label`，并可提供短纯文本 `description` 和 Markdown `preview`。问题、label 与 description 必须在没有 preview 时仍足以作答；preview 是补充展示，不能承载唯一必要信息。
+
+多问题 UI 由 host 显示 `问题 1/4` 一类序号；Print 与结构化模式只使用完整问题文本。
+
+### 3.2 字符串规范化
+
+模型生成的 `question` 与 option `label` 先 trim，结果必须非空；label 再做 Unicode NFC 规范化。可选 `description`/`preview` 仅用 trim 判断是否全空白：全空白视为未提供，非空时保留原文，避免改写 Markdown。用户提供的纯文本答案和 `customInput` 必须至少包含一个非空白字符，但校验通过后保留原始字符串，不做 trim；`note` 全空白时视为未提供，非空时同样保留原文。ANSI 与终端控制字符只在 TUI 展示边界过滤，持久化值和结构化协议不静默改写。
+
+option label 经 trim 和 Unicode NFC 规范化后必须非空，并在同一问题内保持大小写敏感的唯一性；规范化后的值作为持久化与 `selectedOptions` 返回值。重复 label 在工具参数校验阶段拒绝。运行时的“其他”等控制项以内部 sentinel 表达，不混入 `selectedOptions`；其最终显示名称随 UI 契约确定，不要求模型伪造控制项 label。
+
+### 3.3 单选、多选与答案
+
+问题支持可选 `multi`，默认 `false`，但 `options: []` 与 `multi: true` 的组合非法。单选答案必须是恰好一个预设选项或一段 custom input，不能同时存在；多选答案可包含多个不重复的预设选项，并可附加一段 custom input。两种模式统一返回原问题文本、`selectedOptions: string[]`、可选 `customInput` 与可选答案级 `note`，避免按题型分裂结果协议。`note` 对该题整组答案生效，不绑定具体 option；这样单选可以表达“选择 A，但有附加条件”，多选也不会丢失归属。
+
+非空选项题可提供 `recommended?: number`，其值必须是有效的原始 `options` 数组下标。它只表达主 Agent 的推荐：TUI 显示独立标识，结构化模式与 fallback 原样携带下标，但任何 adapter 都不得修改原始 label、自动作答或由此引入 timeout 默认选择。`options: []` 时禁止设置 `recommended`。
+
+### 3.4 declined 与 chatRedirect
+
+整次 ask 还支持 host-owned `declined: true` 正常结果，表达“用户拒绝回答，但允许 Agent 继续”。它不是模型 option、custom input、`chatRedirect` 或取消；declined result 不携带选择、custom input 或 note，同一 assistant batch 的后续独立 ask 仍继续展示。主 Agent 收到后自行采用保守默认或解释为何无法继续。TUI/RPC/daemon 显示“跳过并继续”，ACP 标准 `decline` 映射到该结果；ACP `cancel` 与 live 用户取消仍 abort 当前 prompt。fallback pending 可逐项 declined，并作为独立 answer block 持久化。
+
+TUI 及支持该 affordance 的 RPC/daemon responder 提供 host-owned“先讨论”控制项。它不是选项答案、custom input 或取消：选择后当前 ask 返回正常 tool result，details 标记 `chatRedirect: true` 并保留原问题文本，主 Agent 在同一 run 中解释或讨论。该 assistant batch 中尚未展示的后续 ask 不再弹出，各自获得明确 deferred tool result；主 Agent 讨论后自行决定是否重新询问。Print/JSON/ACP fallback 不需要专门控制项，用户可在下一 prompt 直接表达讨论意图。
+
+### 3.5 tool result 与历史
+
+live ask 的 tool result 同时提供简洁的人类可读文本与结构化 details，二者表达同一结算。details 只重复问题文本、`declined`、规范化后的选择、custom input、note 和题型所需字段；完整 options、description 与 preview 已保存在原 tool call 参数中，不在 result 中复制，通过 `toolCallId` 关联即可恢复。TUI 将完成结果持久展示为 Ask 卡片，显示问题和最终答案或 declined 状态；resume/export 复用同一 tool call/result 对。fallback 后产生的回答则作为带旧引用的新 user message 追加，不能回写、替换或伪造旧 fallback tool result。
+
+### 3.6 无 timeout、无专属 payload 上限
+
+首版不提供 ask timeout 配置或参数。live responder 一直等待到用户回答、用户主动取消或 responder 明确变为 unavailable；后者进入持久化 fallback。Print/JSON 直接走 fallback，不启动等待 timer。`recommended` 永远不能触发按时自动选择，避免用户阅读 preview 或暂时离开时被系统代答。
+
+首版遵循 oh-my-pi，不增加 ask 专属的字符数、字节数或总 payload 上限；问题、选项、preview、custom input 复用 Prime 通用 tool/message/protocol 资源边界。TUI 只限制可视布局：对话框使用有界高度和滚动视图，问题标题与 description 使用行数预算，preview 可滚动查看；不得为了适配界面截断持久化值或发送给主 Agent 的答案。未来若需要更严格的 payload budget，应在通用消息/协议层统一治理，而不是只限制 `ask_user`。
+
+### 3.7 调用时机的内置工具说明
+
+`ask_user` 的内置工具说明采用 oh-my-pi 的 default-to-action 原则：主 Agent 必须先穷尽当前上下文、代码、配置、文档、历史和可用工具；只有不同方案存在必须由用户决定的实质取舍时才询问。如果多个方案均可接受，则选择最保守、最标准的方案并继续，同时说明所选默认。用户前提错误且纠正会改变目标、范围或产品意图，也属于必须询问的实质取舍。
+
+工具说明同时规定：不要询问能够自行查证的事实；相关问题优先放在同一次调用中，label 保持简短、差异写入 description，有真实优选时设置 `recommended`；不要由模型添加运行时“其他”控制项；不得用 `ask_user` 代替权限审批、安全策略或请求密码、token 等敏感凭据。host 只硬校验 schema、权限和状态边界，不尝试用关键词分类器判断模型是否“本该询问”。
+
+## 4. `UserInputBroker` 与执行路径
+
+Prime 应在 session 层提供统一的 `UserInputBroker`，把工具 schema、交互 transport 和 prompt settlement 解耦。
+
+### 4.1 autonomous 例外
+
+autonomous 是唯一不按 responder 能力进入 live/fallback 的 root session 策略例外。Prime 现有 autonomous 契约明确无人类输入；启用时工具仍保持注册，但 broker 不弹 UI、不建立 pending queue，也不产生 `needs_user_input`，而是立即闭合为明确的 `human_unavailable_in_autonomous` tool result，让同一 run 按现有 continuation prompt 采用保守假设并验证。该状态不是 transport unavailable。关闭 autonomous 后立即恢复普通 live/fallback 路径，无需重建工具集。
+
+### 4.2 执行路径
+
+```text
+ask_user(toolCallId, questions)
+  -> autonomous 已启用
+       -> 返回 human_unavailable_in_autonomous tool result
+       -> 不展示、不持久化 pending，同一 Agent run 继续
+  -> 有可交互 responder
+       -> 建立仅存于当前 runtime 的 live request
+       -> tool execution 等待结构化 answer
+       -> 返回完整正常 tool result
+       -> 清理 live request，同一 Agent run 继续
+  -> 无 responder / responder 断开 / 模式不支持
+       -> 将问题实体化为可持久化 pending question
+       -> 返回完整的 fallback tool result
+       -> shouldStopAfterTurn 正常结束当前 run
+       -> PromptOutcome(needs_user_input)
+       -> 用户后续通过普通 prompt 通道回答并建立同一 session 的新 prompt
+  -> 用户明确取消
+       -> 请求当前 session prompt abort
+       -> 工具执行器生成明确的 aborted tool result
+       -> PromptOutcome(cancelled)
+       -> 不保存 pending question，不允许主 Agent 自动继续
+```
+
+所有路径都必须依照 Prime 现有工具执行/abort 机制闭合 tool call，不在 provider transcript 中留下悬空调用。live responder 路径不会产生中间 `PromptOutcome`，当前 prompt settlement 保持进行中；fallback 路径不使用 abort 伪装结算，并必须把问题数据放进结构化 outcome。连接断开必须被识别为 responder `unavailable`，不能与用户主动取消混为同一个布尔值。用户主动取消建立与普通用户中断相同的硬停止 fence；后续 Advisor finding、goal 或 autonomous continuation 不得自动恢复该 prompt。
+
+### 4.3 批次支配
+
+`ask_user` 支配所在的整个 assistant tool-call 批次，但只抑制非 ask 工具。host 先收集该批所有参数有效的 `ask_user`，按 assistant 原始顺序逐个执行；每个调用保持自己的 `toolCallId`、1–4 个问题、独立 UI 提交和独立 tool result，不合并、不做语义去重，也不设置整批问题总上限。所有非 ask sibling 均不执行，但仍产生按原始顺序排列的明确 tool result，说明“因等待用户回答而未执行”。
+
+若 live responder 完成全部 ask，主 Agent 在所有完整 tool results 之后继续同一 run。若在第 N 个 ask 时 responder 变为 unavailable，第 N 个及之后尚未执行的 ask 按原始顺序进入 pending queue；之前已回答的调用保留正常结果，所有未回答调用获得闭合的 fallback tool result，`shouldStopAfterTurn` 依非空 pending queue 停止 run。若用户在任一 ask 主动取消，则 abort 当前 prompt，之后尚未执行的 ask 获得 aborted tool result，不形成 pending queue。不得并行打开多个 selector，不得先执行非 ask sibling 再询问。
+
+该规则由 host 在工具执行前基于整条 assistant message 确定，不依赖 tool-call 排列顺序或模型自觉。它同时适用于当前 `sequential` 和 `parallel` 工具执行模式，从而确保澄清前不发生其他副作用。
+
+### 4.4 校验边界
+
+`UserInputBroker` 是所有 responder 答案的最终校验边界，不能信任 TUI、RPC、daemon 或 ACP adapter 已经正确约束输入。校验至少覆盖回答数量与问题数组顺序、字段类型、`selectedOptions` 的规范化 label 成员关系与唯一性、单选/多选/custom input 组合、note 契约，以及 declined 与其他答案字段互斥。非法 live answer 不闭合 tool call，也不转换为取消或 fallback：RPC/daemon 返回结构化错误并保留同一逻辑 request 供重试；ACP 重新 elicitation 同一 `toolCallId`，允许更新短期 transport request ID。pending answer 非法时拒绝对应新 prompt admission，保留 queue 与已答断点。只有 responder 明确 unavailable 才进入 fallback，非法 option 不得自动降级为 custom input。
+
+### 4.5 fallback 后的回答
+
+fallback 后不新增 `answer_user` 命令或第二套提交协议。旧 prompt 已经终态化，用户的下一次输入通过各模式既有 prompt 通道建立新 prompt：TUI/RPC/daemon 可以提交结构化选择，Print/JSON/ACP 也可提交普通文本；host 将可见答案与旧 `promptId/toolCallId` 引用归一化为主 Agent 可见的用户消息。新 prompt 成功 admission 时原子消费对应 pending queue；提交失败则保留队列。用户输入无论是回答、拒绝还是改换话题，都视为对旧等待状态的显式处理，旧 outcome 不重开。
+
+## 5. TUI 交互契约
+
+- `ask_user` 使用 TUI responder 显示聚焦式问题 UI，在 tool execution 内无超时等待回答；回答作为正常 tool result 返回后，同一 Agent run 继续。用户明确取消时终止当前 prompt 并建立 abort fence，不转成 pending question。该等待属于明确的用户交互状态，不由 Advisor footer 代替。
+- `ask_user` 出现时若主编辑器已有草稿，对话框正常显示但暂不取得输入所有权，并提示用户先提交或清空当前草稿。草稿继续由现有编辑器处理：提交时仍按 Prime 既有 `steer`/`followUp` 规则排队，清空或提交导致编辑器为空后，输入所有权才切换给 ask 对话框。草稿不得被丢弃、覆盖或隐式解释为 ask 答案。
+- TUI 在当前高亮选项存在 `preview` 时显示对应 Markdown 预览区域；切换选项只更新该区域，不把 preview 追加成聊天消息，也不改变实际选择结果。preview 作为不可信模型输出过滤 ANSI 与终端控制字符，并服从现有 Markdown renderer 的宽度与转义规则。
+- TUI ask 对话框使用有界高度和滚动视图；问题标题与 description 可视行数受预算约束，preview 完整保留并可滚动查看。布局省略或折叠不得修改 transcript、fallback payload 或 tool result 中的原值。
+- TUI 额外显示“先讨论”运行时控制项；选择后以 `chatRedirect` 正常闭合当前 ask，并让主 Agent 在同一 run 回应，不建立 pending queue 或 abort fence。
+- TUI 还显示整次 ask 级“跳过并继续”；选择后返回 `declined: true` 正常 result，让同批后续 ask 和主 Agent 继续。它与“先讨论”和取消保持独立。
+- TUI 在提交单题答案前允许添加或编辑整题 note；note 与选择/custom input 分开显示并一同返回，不绑定当前高亮行。
+- live ask 完成后在聊天记录中保留完成态 Ask 卡片，显示问题、选择/custom input 与答案级 note；卡片由原 tool call 参数和结构化 result 共同渲染，不在 result 重复 options、description 或 preview。fallback 后的回答显示为新的 user message，不修改旧卡片或旧 tool result。
+
+### 5.1 pending queue 的展示与恢复
+
+TUI 初次打开或重新 attach 到存在 pending queue 的 session 时，自动用正常 ask 选择器展示队首问题，并按队列顺序继续展示后续问题；这是对新 prompt 输入的辅助界面，不复活旧 live Promise、transport request 或旧 prompt outcome。每个 ask 仍以自己的 `toolCallId` 独立作答，答案按原顺序逐项持久化；host 不在中途启动主 Agent，只有整条 pending queue 都已回答时才将多个独立 answer block 组合为一个可见 user message，通过一次既有 prompt admission 恢复执行。该组合只是传输和恢复边界，不合并问题、答案或 identity。
+
+用户在中途按 `Esc` 时只收起当前选择器：已完成答案保持持久化，当前及后续未答项保持 pending，下次从第一个未答项继续。若用户关闭选择器后直接发送普通文本，则明确放弃全部剩余 pending；host 将已答 answer block、剩余问题被放弃的状态与该普通文本一同规范化为新 user prompt，并仅在 admission 成功后原子消费整条队列。自动展示不得阻止用户收起选择器后继续正常编辑。
+
+pending 选择器收起后不增加 `/answer_user`、专用命令或新硬编码快捷键。主编辑器为空且仍有未答 pending 时显示 `Pending question — Enter to answer` 一类提示；执行现有可配置的 editor submit action 重新请求展示第一个未答项。若 editor 非空，同一 submit action 保持普通 prompt 语义并按上段放弃剩余 pending；queue 清空后，空提交恢复现有 no-op。若其他非 overlay 对话框正在占用 editor surface，重开请求进入共享 FIFO arbiter。
+
+### 5.2 editor-surface FIFO dialog arbiter
+
+TUI responder 不能只给 ask 建一个局部锁。Prime 所有占用 `editorContainer` 的非 overlay 对话框必须通过同一个 FIFO dialog arbiter 展示，包括 `ask_user`、extension `select`/`confirm`/`input`/`editor` 及应用内同类 selector；否则任一后到对话框直接清空容器后，会让先前等待的 Promise 失去界面且无法完成。当前项回答、取消或 abort 后才展示下一项；尚未展示就 abort 的请求从队列移除。每次结算必须恢复正确焦点并推进队列。overlay 通知、Advisor footer 和不占用 editor surface 的展示不进入该队列。
+
+现有 `interactive-mode.ts` 中 extension `select`/`input`/`editor`、custom 非 overlay UI 与应用 selector 都会直接清空并替换 `editorContainer`，没有统一 presentation queue——这是今天就存在的对话框互踩隐患，arbiter 作为独立切片先行交付（见第 12 节）。
+
+## 6. daemon 多 responder 契约
+
+daemon 若增加相关命令、事件或响应字段，按“可选能力”处理。客户端必须先检查协商 capability，老客户端和老 daemon 均应继续完成普通会话启动与交互。已 attach 且声明 UI 能力的 daemon client 可作为 live `ask_user` responder；最后一个可用 responder detach 时，broker 将未回答问题转换为持久化 fallback，并结束当前 run，不能让 tool execution 永久等待。capable client reattach 后由 daemon 提供完整 pending queue，客户端自动展示队首；重连 transport 不复用断线前的 request ID。
+
+同一 session 有多个 capable responder 时，daemon 将逻辑 ask 广播给所有已 attach responder，broker 原子接受第一条校验通过的答案。daemon 随即广播 settled 事件，让其他客户端关闭重复选择器；非法答案不参与竞速，迟到合法答案返回结构化 `already_settled`，不能退化成 unknown request。单个 capable responder detach 不影响 live wait，只有最后一个 capable responder 消失才进入 fallback；普通不具备 UI capability 的 attached client 不计入该判断。pending 重连展示采用相同 first-valid-wins 规则。
+
+多 responder 下第一条明确的 live `cancel` 与第一条有效答案同样具有全局结算权：broker 原子 abort 当前 prompt，并广播 settled 关闭所有副本。attached capable client 已拥有同等 session 输入/中断权限，不引入额外 owner 选举。socket 关闭、进程崩溃、capability detach 或 UI transport failure 仍只表示该 responder unavailable；只要还有 capable responder 就继续等待，最后一个消失才 fallback。已经 fallback 的 pending 选择器按 `Esc` 仍只是本地收起，不能追溯取消旧 prompt。
+
+## 7. 各模式映射
+
+模式映射遵循 responder 能力，而不是为每个入口复制工具语义：TUI、具备 UI responder 的 direct RPC、已 attach 的 capable daemon client，以及声明 ACP experimental form elicitation 能力的客户端可在同一 run 内回答；Print 和 JSON 没有 responder，进入结构化 fallback；RPC/daemon 连接断开或 ACP 客户端不支持 elicitation 时也进入 fallback。fallback question 必须持久化，以便后续展示和回答；live Promise、transport request ID 和 UI 组件状态不得持久化。
+
+`needs_user_input` 的 `PromptOutcome` 语义与 Print/JSON 退出码 `2` 的定义见 [prompt-settlement.md](prompt-settlement.md)。
+
+### 7.1 Print
+
+- Print 没有 live responder；`ask_user` 将问题写入 stdout，产生结构化 `needs_user_input` outcome 后结束本次进程。
+- Print 在对应选项下输出 preview 的原始 Markdown 文本，不尝试生成 ANSI 富渲染；stdout 仍包含完整可作答内容。
+- 后续 Print 调用以普通输入建立新 prompt；host 在 session 存在 pending queue 时附加旧引用并消费队列，不要求新的 CLI answer 参数。
+
+### 7.2 JSON
+
+- JSON 没有 live responder；`ask_user` 产生包含问题数据的 `prompt_outcome(needs_user_input)`，不得等待不可到达的交互响应。
+- JSON 的 question payload 原样保留每个选项的 `description` 与 `preview`，不做展示层转换。
+- JSON 调用方用现有 prompt 输入提交后续普通文本；若未来在既有 prompt payload 内增加可选结构化 answers，必须独立做 schema 兼容分类，但首版不要求它。
+
+### 7.3 RPC 与 daemon
+
+- direct RPC 复用现有 `extension_ui_request`/`extension_ui_response` responder：支持该能力且连接存活时，同批 `ask_user` 在 tool execution 内独立串行等待回答并继续同一 run；未协商、连接断开或 responder 不可用时，将当前及剩余调用转换为有序持久化 pending queue，并以结构化 `needs_user_input` 完成该次 prompt。
+- RPC/daemon 的 capable responder 接收结构化 preview 并可按自身 UI 展示；fallback 和持久化不得丢弃该字段。
+- RPC/daemon capable responder 可声明并返回 `chatRedirect`；不支持该 affordance 的客户端仍可正常选择、custom input 或走 fallback，不能因此失去基础 ask 能力。
+- RPC/daemon capable responder 可返回整次 ask 级 `declined`；它正常闭合当前 tool call 并继续后续 ask，不得映射成 cancel、unavailable 或 custom input。
+- RPC/daemon 的结构化 answer 可携带答案级 `note`；不支持 note 的 responder 仍可提交基础答案，该字段保持可选。
+- RPC/daemon responder 的答案在 broker 校验通过前不得 resolve live ask；非法 response 的 command 返回结构化 validation error，并允许客户端针对同一逻辑 request 重新提交。该错误既不是用户取消也不是 responder unavailable。
+- fallback 后 RPC/daemon client 仍使用既有 prompt command 提交结构化选择或普通文本；不增加 `answer_user` command。新 prompt ACK 成功后 pending queue 才能被消费。
+
+### 7.4 ACP
+
+- 客户端声明 `elicitation.form` 时，`ask_user` 通过 ACP SDK 的 experimental form elicitation 在当前 `session/prompt` 内获得回答并继续；option description 映射到标准 enum description，Markdown preview 放入 Prime namespaced `_meta`，支持的客户端可富展示，其他客户端可安全忽略。未声明或交互连接丢失时，保持标准 `end_turn`，并在协议允许的 namespaced `_meta` 中返回 `needs_user_input` 与完整问题数据。不得把 `request_permission` 误用为通用问答协议。
+- ACP form 为每题增加可选的普通 string note property；客户端不填写时不产生 note，不依赖 Prime 私有 UI 控件。
+- ACP `decline` 映射为整次 ask 的 `declined: true` 正常结果；ACP `cancel` 才映射为用户主动取消并 abort 当前 prompt，两者不得合并。
+- ACP form 返回值仍由 broker 按共同 answer schema 校验；非法值不进入 tool result，host 以同一 `toolCallId` 重新发起 elicitation，可使用新的 ACP request ID。只有连接丢失或 capability 消失才进入 fallback。
+- ACP fallback 的后续回答是新的标准 `session/prompt`；host 结合 session pending queue 建立旧引用，不要求 ACP 增加 Prime 私有 answer method。
+
+## 8. 持久化与恢复
+
+- live Promise、transport request ID 和 UI 组件状态不持久化；fallback pending question 必须持久化，以便后续展示和回答。
+- daemon client 通过已协商的 UI responder 串行回答 live `ask_user`；最后一个可用 responder detach 时，当前及剩余未回答调用按序转换为持久化 fallback，而不是仅取消 UI Promise、丢失问题或无限等待。重连后自动展示队首 pending 并按序处理，但不复用旧 transport request ID；`Esc` 只收起 UI，不消费或取消 pending。
+- worker 重启后，无法恢复的当前及剩余 live asks 必须按原始顺序实体化为 pending queue 并进入 `needs_user_input` fallback，不能尝试复活旧 Promise。
+- fallback pending queue 的逐项结构化答案在选择后立即持久化，但不单独启动 Agent；全部回答完成后通过一次新 prompt admission 提交有序 answer blocks。中途 `Esc` 或重启保留断点；普通文本显式放弃剩余项。整条 queue 只在最终 prompt admission 成功后原子消费，失败或再次断开时保留，且始终不改变旧 `needs_user_input` outcome。
+
+settlement ledger 中 pending queue 与 answer blocks 字段的归属见 [prompt-settlement.md](prompt-settlement.md)。
+
+## 9. 协议兼容性
+
+| 变化 | 建议分类 |
+| --- | --- |
+| daemon/RPC 复用既有 extension UI responder 回答 `ask_user` | 既有能力内实现；若新增问题 schema、状态或断线 fallback 字段，则相应部分 capability-gated |
+| RPC/daemon responder 的 `chatRedirect` affordance | 可选 UI capability；不支持时只降级该控制项，不影响基础 ask |
+| daemon/RPC 的 `ask_user` pending question queue 与 `needs_user_input` outcome | capability-gated，并覆盖多 ask 串行、部分已答、断线转换、新客户端/旧 daemon 与旧客户端/新 daemon |
+| daemon 多 responder 的 ask settled/`already_settled` 事件与响应 | capability-gated；新 daemon 向 capable clients 广播并以首个有效答案结算，旧客户端忽略未知 settled 事件仍可由请求结束清理 |
+| fallback answer 提交 | 复用既有 prompt command/method；不新增 wire command，结构化 answers 若后续加入则单独 capability/schema 分类 |
+| ACP experimental `elicitation.form` 的 `ask_user` live responder | capability-gated，客户端未声明时不得调用 |
+| ACP namespaced `_meta` 中的 `ask_user` fallback 状态 | 在 ACP 允许未知 metadata 的前提下 backward-compatible |
+| ACP namespaced `_meta` 中的 option preview | backward-compatible 的可选展示增强；标准 description 必须独立可作答 |
+
+每个实际 daemon wire change 仍必须同步更新 `DAEMON_SCHEMA_REVISION`、命令/事件兼容映射，并覆盖 new-client/old-daemon 与 old-client/new-daemon 双向场景。
+
+## 10. 测试与验收
+
+使用 `packages/coding-agent/test/suite/harness.ts` 和 faux provider，不调用真实 provider、API key 或付费 token。至少覆盖：
+
+1. 注册与排除：root 主 Agent 在所有模式始终注册该工具且无普通用户开关；Advisor/受限 child runtime 通过 allowlist 排除，测试/嵌入式专用 session 可显式不装配；Advisor 关闭时主 Agent 仍可使用。
+2. 调用结构：每个调用严格包含 1–4 个问题，只以自己的 `toolCallId` 关联，模型不提供 `question.id` 或 `header`，调用内问题按不可变数组下标映射、由 host 显示序号，结果重复问题文本，ACP 所需 `q0` 等字段键仅为 adapter 内部细节。
+3. options 契约：每题 `options` 必填且长度只能为 0 或 2–4：空数组渲染纯文本输入，非空数组渲染选择并自动提供“其他”，所有模式和 fallback 使用同一结构，非法数量在工具参数阶段拒绝。选项可携带短纯文本 `description` 与 Markdown `preview`；问题/label/description 在无 preview 时仍须可作答。TUI 高亮时富渲染过滤后的 preview；Print 输出原始 Markdown；JSON/RPC/daemon 原样保留；ACP 用标准 description 加 Prime `_meta`，忽略扩展不影响作答。
+4. label 与答案：option label 经 trim/NFC 后非空并在同题内大小写敏感唯一，规范值用于持久化与答案；运行时控制项使用 sentinel，不混入 `selectedOptions`。`multi` 默认 false，纯文本题不得启用；单选只能返回一个预设项或 custom input，多选可返回多个不重复预设项并附加 custom input，结果统一为 `selectedOptions` 加可选 `customInput`。非空选项题可用合法下标 `recommended` 标记推荐项；各模式显示/传输该提示但不得改 label 或自动选择，纯文本题禁止该字段。
+5. 等待语义：首版无 timeout；live responder 只因回答、主动取消或 unavailable 结束，Print/JSON 立即 fallback。
+6. 批次支配：同一 assistant batch 的全部有效 ask 按原始顺序独立串行，每个保持独立 UI 提交与 tool result，不合并、不去重、不设整批问题上限；只有非 ask sibling 被抑制并获得明确 tool result，sequential/parallel 两种执行模式结果一致。
+7. live 完成与 fallback：TUI、capable direct RPC、已 attach 的 capable daemon client 和支持 ACP form elicitation 的客户端逐个等待回答，全部完成后继续同一 run。Print/JSON、无 responder、断线和不支持 elicitation 的 ACP 将当前及剩余 ask 按序放入持久化 pending queue，并以 `PromptOutcome(needs_user_input)` fallback，不用 abort 伪装结算；此前已回答结果保留。fallback 后结构化选择或普通文本都通过既有 prompt 通道建立新 prompt，携带旧引用，并只在 admission 成功时原子消费队列；旧 outcome 不重开。
+8. 取消：用户主动取消产生当前及剩余 aborted tool results 与 `PromptOutcome(cancelled)`、不保存未回答问题且不能被 Advisor/goal 自动恢复；transport 断线不得误判为取消。live Promise 不持久化，daemon detach/restart 转换后不丢失问题或复活旧 transport request，各模式均不无限等待。
+9. chatRedirect：TUI 与 capable RPC/daemon 选择“先讨论”后，当前 ask 返回 `chatRedirect` 正常结果，同批后续 ask 返回 deferred 结果，主 Agent 在同一 run 讨论后自行决定是否重问；该动作既不是答案也不是取消。
+10. 调用策略：主 Agent 会先穷尽已有信息源，只在必须由用户决定的实质取舍上询问；多个方案都可接受时采用保守标准默认；不会用 ask 代替权限/安全策略或索取敏感凭据。相关问题优先同次调用、有真实优选才设置推荐；这些行为由工具说明与模型测试约束，不引入关键词硬分类。
+11. 资源与布局：不增加 ask 专属 payload 上限，合法内容完整进入持久化与 tool result；TUI 通过有界高度、标题/description 行预算和滚动视图保持可用，不能用静默截断伪装成功。
+12. 答案附注：单选、多选、纯文本和 custom input 均可携带一个可选的答案级 note；note 不绑定 option，TUI/RPC/daemon/ACP 映射一致，不支持的 responder 可省略。
+13. 结果与历史：live result 的可读文本与结构化 details 等价，完成态 Ask 卡片在 resume/export 后仍能由 tool call 参数和 result 正确重建；result 不复制 options/description/preview。fallback answer 只追加带旧引用的可见 user message，旧 tool result、旧 outcome 与旧卡片不可变。
+14. responder 校验：答案数量/顺序错误、未知或重复 option、单选多值、非法 custom input 组合、错误字段类型、非法 note，以及 declined 与答案字段并存均被 broker 拒绝；RPC/daemon 可用同一逻辑 request 重试，ACP 以相同 `toolCallId` 重新 elicitation，tool call 在有效答案前保持等待；pending admission 失败保持 queue/断点，断线才 fallback，非法 option 永不转成 custom input。
+15. decline：TUI/RPC/daemon 的“跳过并继续”和 ACP `decline` 都生成无选择/custom/note 的 `declined: true` 正常 result，同批后续 ask 继续；ACP `cancel` 与 live cancel 仍 abort；fallback pending 可逐项持久化 declined answer block，resume 后不误作普通文本或 unavailable。
+16. daemon 多 responder：两个 capable client 同时收到 ask，首个有效答案原子胜出并触发 settled 广播，另一端关闭选择器且迟到提交得到 `already_settled`；首个非法答案不胜出；任一端明确 live cancel 全局 abort 并关闭其他副本，socket/capability detach 不误判为取消；单端 detach 继续等待，最后一个 capable responder detach 才 fallback，仍 attach 的非 capable client 不能阻止 fallback；pending 重连时 `Esc` 仅本地收起。
+17. 字符串规范化：question/label trim 后空值被拒，label NFC 后执行唯一性；description/preview 全空白变为未提供而非空字段，非空 Markdown 原文不变；纯文本/custom input 全空白被拒但合法原文首尾空白保留；note 全空白省略、非空原文保留；TUI 过滤 ANSI/控制字符只影响渲染，不改变持久化、result 或协议 payload。
+18. TUI 草稿：ask 出现前已有的普通草稿、图片草稿和粘贴快照均继续归主编辑器所有；ask 可见但输入受保护，提交后按原选择进入 `steer` 或 `followUp` 队列，清空后直接解锁 ask；任何路径都不丢草稿、不将其当作答案，并在 ask 完成或取消后恢复正常编辑器焦点。
+19. pending 重连：TUI 启动和 daemon reattach 自动展示第一个未答项并保持顺序；每项答案按自己的 `toolCallId` 持久化且不提前启动 Agent，全部完成后一次 admission 生成含有序 answer blocks 的新 prompt；中途 `Esc`、再次断线和 worker 重启均从持久化断点继续，普通文本提交已有答案并显式放弃剩余项；最终 admission 失败不消费 queue，旧 outcome 不重开，断线前 transport request ID 永不复用。
+20. pending 重开：选择器收起后只有 editor 为空且 queue 未清空时显示按实际 submit keybinding 渲染的提示；空提交经 FIFO arbiter 重开第一个未答项，非空提交执行普通文本/放弃语义；queue 清空后提示消失且空提交恢复 no-op，不添加硬编码键检查或 answer command。
+21. 对话框串行：ask 与 extension select/confirm/input/editor、应用 selector 以两种先后顺序并发请求时严格 FIFO，后到项不能清空或悬挂先到项；回答、取消、当前 abort、排队 abort、组件构造异常和 session dispose 均恰好结算一次、恢复正确焦点并继续或清空队列；overlay 与 Advisor footer 不受阻塞。
+22. autonomous：工具名称始终存在，但启用状态下无论 TUI、RPC、daemon 或 headless 是否有 responder，调用都立即得到 `human_unavailable_in_autonomous` 并继续同一 run，不创建 UI、pending 或 `needs_user_input`；off 后下一次调用恢复正常路径，动态切换不重建工具集，也不把 autonomous 拒绝误报为 transport failure；autonomous human-unavailable 不误用退出码 `2`。
+23. 历史导航：`/tree` 选择已经完成的 ask tool result 只执行现有普通导航，不重新打开 responder、不自动恢复 Agent，也不创建替代答案分支。
+
+## 11. 与 oh-my-pi 的关系
+
+本设计复用了 oh-my-pi `ask` 的多项已验证交互语义，但按 Prime 的系统边界重新定界：
+
+- oh-my-pi 的 `ask.enabled` 默认 true，但 `ask` 只在 `session.hasUI` 时注册，并在 tool execution 内等待 UI 回答；用户取消时调用 `context.abort()` 并抛出 `ToolAbortError`；“Chat about this”则返回 `chatRedirect` 正常结果，让 live Agent turn 继续。Print、JSON 与 ACP 等 headless 入口不会得到该工具。它要求模型为每个问题提供语义 `id`，主要用于批内答案映射和历史重新作答；`options` 必填但未限制最小数量，运行时提供自定义输入；timeout 可配置但默认关闭。Prime 复用其交互语义，但让 root 主 Agent 在所有模式始终拥有工具且不提供普通用户开关，通过 `UserInputBroker` 和持久化 fallback 覆盖 headless 入口；Advisor/受限 child runtime 仍由 allowlist 排除。
+- oh-my-pi 没有 question、option、preview、custom input 或整次 ask 的硬大小上限；它以约 70% 终端高度、滚动视图、标题/description 行预算限制可视布局，而不是截断原始值。Prime 首版沿用这一边界，任何通用 payload hardening 留在 message/protocol 层处理。
+- oh-my-pi 允许用 `n` 给当前 option/Other 添加 note，但每题结果只有一个 `note`，多选时也不返回其 option 归属。Prime 保留一个 note 的简单结果形态，但将其明确为整题答案附注，避免行绑定信息在跨模式映射中丢失。
+- oh-my-pi 在 live ask 完成后持久展示包含问题与答案的 Ask 卡片，并让 tool result 同时携带可读文本和结构化 details。Prime 复用该可审计展示，但避免在 result 重复原 tool call 已保存的完整 options、description 与 preview；fallback answer 继续采用追加式新 user message。
+- oh-my-pi 在 ask 出现时若主编辑器已有草稿，会让 ask 保持可见但通过 input guard 将按键继续路由给草稿编辑器，并提示先提交或清空；草稿清空后 ask 才接管输入。Prime 复用该交互，同时让草稿提交继续走自身已有的 `steer`/`followUp` 队列语义。
+- oh-my-pi 通过统一的 FIFO presentation queue 串行化占用共享 editor surface 的 ask、selector、input 和 editor，避免后到 UI 覆盖先前仍在等待的 Promise。Prime 采用相同约束，并扩展到自身所有非 overlay editor-surface selector。
+- oh-my-pi 允许在 `/tree` 选择旧 ask tool result 后重新打开问题，将新答案写成同一 tool call 下的 sibling branch 并恢复 Agent。Prime 首版明确不复制该便利功能：它不影响正常 ask、fallback 恢复或正确性，却会扩大树导航、恢复执行和 daemon 协议范围。
+- oh-my-pi 的 `ask` 使用 `concurrency = "exclusive"` 串行化 selector，但不会抑制同一 assistant message 的 sibling tools。Prime 复用 selector 串行语义：同批多个 ask 独立按序执行；同时采用更强的批次支配规则抑制所有非 ask sibling，以保证询问发生前不执行同批副作用。
+- oh-my-pi 的 `ask.md` 以提示词而非本地分类器约束调用时机：默认行动，先穷尽代码/配置/文档/历史，仅在必须由用户权衡的实质差异上询问；多个选项都可接受时采用保守标准默认。Prime 复用这一原则，并额外明确禁止用 ask 代替权限/安全策略或索取凭据；Prime 已确定的 0 或 2–4 选项硬 schema 取代其仅写在提示词里的 2–5 建议。
+
+## 12. 分阶段落地
+
+`ask_user` 占整体交付计划中的切片 0 与切片 2（总表见 [advisor-architecture.md](advisor-architecture.md) 第 16 节）：
+
+### 切片 0：editor-surface FIFO dialog arbiter
+
+- 在 `src/modes/interactive/interactive-mode.ts` 增加 TUI-owned FIFO arbiter，将 extension `select`/`confirm`/`input`/`editor`、custom 非 overlay UI 与应用 selector 全部收敛到同一串行队列。
+- 独立验收：现有 extension UI 并发请求不再互相清空容器或悬挂 Promise；overlay 与普通输入调度不受影响。
+- 不依赖 `ask_user` 或 settlement，可独立合入。
+
+### 切片 2：`ask_user` 全链路（依赖切片 0 与 prompt-settlement 切片 1）
+
+- `src/core/user-input/`：新增 session-owned `UserInputBroker`、问题/答案与 responder 结果类型、多 ask 串行调度、live/fallback 转换、pending queue 持久化和 transport adapter 边界。
+- `src/core/tools/` 与 `src/core/tools/index.ts`：新增通用 `ask_user` 工具定义、root 默认注册与批次支配调度；ask 调用之间独立串行，只抑制非 ask sibling，且不进入 Advisor 受限工具集；不增加普通用户 enable 开关。
+- `src/core/tools/ask-user.md`：定义 default-to-action、先穷尽信息源、仅询问实质取舍、保守默认、选项表达以及禁止权限替代/凭据请求的不可配置内置工具说明。
+- `src/core/agent-session.ts`：只在 `ask_user` fallback 时依非空 pending queue 触发 `shouldStopAfterTurn`。
+- `src/modes/interactive/`：ask 对话框、草稿保护、preview、note、pending 重连/重开。
+- `src/modes/rpc/`：把既有 extension UI request/response 接为 live responder。
+- `src/modes/daemon/`：UI responder 生命周期、first-valid-wins、settled/`already_settled`、最后 capable responder detach 时的 fallback 转换。
+- `src/modes/acp/acp-mode.ts`：capability-gated experimental form elicitation，及不支持客户端的 `end_turn` + namespaced metadata fallback。
+- 先建立 faux provider 的失败测试，再以可独立验收的切片接通多调用串行与非 ask sibling 抑制、live answer、断线 fallback、独立 tool result、条件式 `shouldStopAfterTurn`、pending queue、持久化和全模式 outcome。
+
+## 13. Prime 源码事实依据
+
+本设计依赖以下当前源码契约；实施前若这些契约变化，应先回到本设计重新核对：
+
+- `packages/agent/src/agent-loop.ts`：正常 turn 在工具结果追加并发出 `turn_end` 后调用 `shouldStopAfterTurn`；返回 true 时正常发出 `agent_end`，可作为 `ask_user` fallback 闭合 tool call 后的停止边界。live responder 回答后不设置该停止条件，Agent 继续处理下一 turn。
+- `packages/agent/src/agent-loop.ts`：同一 assistant message 的 tool calls 默认整批准备并可并行执行；只有整批每个结果都设置 `terminate` 才会提前结束工具续跑。因此 `ask_user` 需要 host-enforced 批次规划：ask calls 改为按序执行，非 ask calls 生成 suppressed results；fallback 停止不依赖每个 tool result 的 `terminate` 合取值。
+- `packages/agent/src/agent-loop.ts` 与 `packages/coding-agent/src/core/agent-session.ts`：工具等待期间 abort 会生成明确的 `Tool execution aborted` 错误结果；`requestAbort()` 同时取消当前 Agent、retry、compaction 和 session-owned continuation。用户主动取消 `ask_user` 应复用这条硬停止路径，而 transport 断线不得调用它。
+- `packages/coding-agent/src/core/autonomous.ts`：默认 continuation prompt 明确声明 autonomous 模式没有 human input，并要求模型在想提问时采用合理假设后继续验证；因此 `ask_user` 在该状态必须返回确定性的 human-unavailable result，而不能建立 `needs_user_input` fallback。
+- `packages/coding-agent/src/core/tools/index.ts`：当前 `allToolNames` 只注册 `ipython`，Prime 尚无可直接复用的内置 `ask_user`。
+- `packages/coding-agent/src/core/extensions/types.ts` 及交互模式绑定：Prime 已有 `select`、`confirm`、`input`、`editor` UI 抽象，可作为 TUI `ask_user` responder 的实现素材，但当前不是 session-owned 通用 broker。
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`：现有 extension `select`/`input`/`editor`、custom 非 overlay UI 与应用 selector 都会直接清空并替换 `editorContainer`，没有统一 presentation queue；`ask_user` 接入前必须增加共享 arbiter，不能仅串行 ask 自身。
+- `packages/coding-agent/src/modes/rpc/rpc-extension-ui-context.ts`：direct RPC 已用随机 request ID 发出 `extension_ui_request` 并等待 `extension_ui_response`，可复用为 live `ask_user` responder；request ID 是短期 transport 关联，不应成为持久问题 identity。
+- `packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts` 与 `daemon-mode.ts`：daemon 已有 extension UI pending resolver 和能力检查，但最后客户端 detach 时当前行为是取消 pending UI；`ask_user` 需要把该 transport 丢失转换为持久化 fallback，而不是沿用取消即丢弃。
+- `packages/coding-agent/src/modes/daemon/daemon-extension-binding.ts` 与 `daemon-mode.ts`：现有 dialog request 会广播给所有 capable clients，第一条 response 删除共享 resolver，后续响应变成 unknown request；detach 只在 session 没有任何 client 时取消 pending，而不是检查最后一个 UI-capable responder。ask 协议需把这些行为收敛为 first-valid-wins、settled 广播、`already_settled` 和最后 capable responder fallback。
+- `@agentclientprotocol/sdk` 当前依赖版本提供 capability-gated experimental form elicitation；Prime 的 ACP adapter 尚未使用它。其 enum option 原生包含 title 与 description，但没有标准 rich preview 字段，`_meta` 允许可选扩展。支持客户端可通过该能力成为 live responder，Prime preview 通过 namespaced `_meta` 降级，其他客户端走标准 `end_turn` 与 metadata fallback。
+- `@agentclientprotocol/sdk` 1.3.0：elicitation form 原生支持 `type: "array"` 多选、带 title/description 的 `anyOf` items 和 `string[]` 返回值；标准 response 明确区分 `accept`、`decline` 与 `cancel`。Prime 可直接映射既定 multi schema，并必须保留 decline/cancel 差异。
+- `packages/coding-agent/src/modes/acp/acp-stop-reason.ts`：当前 ACP stop reason 不包含 `needs_user_input`；通用 `ask_user` 需保持标准 `end_turn`，并通过协议允许的结构化 metadata 表意，不能自创 stop reason。

--- a/packages/coding-agent/docs/docs.json
+++ b/packages/coding-agent/docs/docs.json
@@ -163,6 +163,22 @@
         {
           "title": "RLM Runtime Architecture",
           "path": "rlm-runtime.md"
+        },
+        {
+          "title": "Advisor Architecture",
+          "path": "advisor-architecture.md"
+        },
+        {
+          "title": "Prompt Settlement Architecture",
+          "path": "prompt-settlement.md"
+        },
+        {
+          "title": "ask_user Capability",
+          "path": "ask-user.md"
+        },
+        {
+          "title": "Continual Harness Ecosystem Roadmap",
+          "path": "continual-harness-roadmap.md"
         }
       ]
     }

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -73,3 +73,7 @@ Public releases are currently installed from versioned release artifacts. The in
 - [Daemon Architecture](daemon.md) - supervisor, catalog, worker, lifecycle, and recovery details.
 - [Agent Connection Architecture](agent-connection.md) - client/runtime connection boundary.
 - [RLM Runtime Architecture](rlm-runtime.md) - ZeroMQ kernel transport and recursive subagent execution.
+- [Advisor Architecture](advisor-architecture.md) - read-only reviewer subruntime, severity routing, and bounded correction loops.
+- [Prompt Settlement Architecture](prompt-settlement.md) - session-level `PromptSettlementTracker` and structured `PromptOutcome` across all entry modes.
+- [ask_user Capability](ask-user.md) - universal user-question tool with live responders and persistent fallback queues.
+- [Continual Harness Ecosystem Roadmap](continual-harness-roadmap.md) - proposed project scope, managed-skill lifecycle, retrieval memory, typed subagents, and validation roadmap.

--- a/packages/coding-agent/docs/prompt-settlement.md
+++ b/packages/coding-agent/docs/prompt-settlement.md
@@ -1,0 +1,217 @@
+# Prompt Settlement 架构设计
+
+> 状态：架构方向已接受，尚未进入实现；本文从 advisor-architecture.md 拆出，作为 Advisor 与通用 `ask_user` 的公共结算地基，可先于两者独立交付
+>
+> 日期：2026-08-16
+>
+> 范围：`packages/coding-agent` 的 TUI、daemon、Print、JSON、RPC 与 ACP 入口
+>
+> 关联：[Advisor 架构设计](advisor-architecture.md)、[通用 `ask_user` 会话能力](ask-user.md)
+
+## 1. 结论
+
+`agent_end` 保持“一次底层 Agent run 结束”的现有含义，不被当作外部请求结算。真正的请求结算由新增的 session 级 `PromptSettlementTracker` 承担：稳定的 `promptId` 在 session 接受输入时创建，所有会影响该 prompt 最终结果的后继工作都继承该 lineage，直到产生结构化 `PromptOutcome` 终态。
+
+当前 `agent-loop.ts` 在 provider `error`、用户/信号 `aborted`、`shouldStopAfterTurn` 返回 true，或 `shouldStopBeforeTurn` 建立停止边界时，都会直接发出 `agent_end`；threshold/requested compaction 及其 continuation 可能跨越多个 Agent run。因此“请求模式只有一个最终 `agent_end`”不成立：`agent_end` 是 run 终态，`PromptOutcome` 才是 prompt 终态。现有 `AgentMessageOutcome`、`promptAndWait(): Promise<void>` 和 `session.waitForIdle()` 都只能作为实现素材，不能原样充当该契约。
+
+settlement 是 Advisor 与 `ask_user` fallback 的公共地基，但它独立成立：当前 RPC client 的 `promptAndWait` 在第一个 `agent_end` 就 resolve，retry 与 compaction continuation 的结果今天就已经被请求方丢失。引入 `PromptOutcome` 修复这一层，与是否启用 Advisor 无关，因此本切片可以先于 Advisor 与 `ask_user` 单独交付和验收。
+
+结算状态机属于可确定、可用状态机测试的工程问题；纯内部队列与状态机可通过 feature flag 回退。daemon/RPC/JSON 的 wire 变化一旦发布，回退成本较高，必须独立做 capability 或版本治理。
+
+## 2. 生命周期分层
+
+Prime 需要区分四层生命周期：
+
+| 层级 | 开始 | 结束 | 含义 |
+| --- | --- | --- | --- |
+| Turn | `turn_start` | `turn_end` | 一次 assistant 响应及其工具调用、工具结果 |
+| Agent run | `agent_start` | `agent_end` | 从一次外部触发开始，到工具链、steer、follow-up 等内部续跑全部结束 |
+| Prompt settlement | session 接受一个 prompt | 产生终态 `PromptOutcome` | 该 prompt 所有影响结果的后继工作已结束，最终 trace 已通过 Advisor，或 Advisor 已按有界规则退出 |
+| 外部请求/任务结算 | 模式入口接收一个或多个 prompt | 模式向调用方宣告完成 | 该模式组合的全部 prompt outcome 与 headless gate 已完成 |
+
+当前一次典型 Agent run 是：
+
+```text
+prompt / trigger
+  -> agent_start
+  -> turn_start
+  -> assistant 流式生成
+  -> 可能执行工具并追加 tool result
+  -> turn_end
+  -> 判断是否因工具、steer、follow-up 等继续
+       -> 是：进入下一 turn
+       -> 否：agent_end，得到候选结果
+```
+
+但 `agent_end` 不是 session 结算：provider retry、threshold/requested compaction 及其 continuation 都可能建立新的 Agent run。session 级结算流程是：
+
+```text
+prompt accepted -> PromptSettlement(admitted)
+  -> 一个或多个 main Agent run / retry / compaction continuation
+  -> Advisor review / correction / re-review（启用时）
+  -> 没有该 prompt 所属的待执行后继工作
+  -> Advisor 已覆盖最终 trace、有界 fail-open，或该终态不等待审查
+  -> PromptOutcome(terminal)
+```
+
+修正 turn 会再次进入同一流程。TUI 可以在 `PromptOutcome` 前显示候选回答并继续交互；settlement 是请求方的结算契约，不是 TUI 的调度状态。
+
+## 3. `PromptSettlementTracker`
+
+当前 `AgentSession` 已有按 `agentMessageId` 记录的 `AgentMessageOutcome`，但它只区分 prompt 的 `delivery` 和当前 turn/action 的 `completion`，完成后立即删除，返回值也是 `Promise<void>`。它不是真正的结算，不能直接改名复用。
+
+首版应新增独立的 `PromptSettlementTracker`。稳定的 `promptId` 在 session 接受输入时创建，所有会影响该 prompt 最终结果的后继工作都继承该 lineage：
+
+- 主 Agent run 及其普通 continuation；
+- provider retry；
+- threshold/requested compaction 与 post-compaction continuation；
+- 属于该 prompt 的 goal/autonomous/headless gate continuation；
+- Advisor review、修正、反驳复审和有界 fail-open（启用时）。
+
+结算范围只包含会改变本次最终回答的 prompt-owned work：主 Agent 正在同步等待的 tool/子 Agent 仍属于当前 run，因而自然包含；后台 auto-refine、独立 cron/heartbeat 和 detached subagent 明确排除。被排除的后台工作即使后来产生消息，也只能建立新的 session work/prompt outcome，不能重新打开已经终态化的旧 outcome。
+
+普通 session action 可以先完成并从 ActionStore 释放，settlement record 继续存在；不能为了等待 Advisor 长期占用 action scheduler。结算也不能依赖全局 `session.waitForIdle()`，因为它既可能被无关 prompt、cron 或 heartbeat 拖住，也未必覆盖 timer 持有的 post-compaction continuation。
+
+同 session 后续 prompt 的成功 admission 封口前一 prompt 的修正循环：已在途的修正 run/continuation 自然完成并复审，但此后不再为前一 prompt 启动新的 Advisor 修正周期；前一 prompt 在 review coverage 追平后按结果原子结算——复审静默为 `completed`，仍有未清除的 `concern`/`blocker` 为 `unresolved_advisor`。封口后迟到的修正（如 blocker steer 进新 prompt 的 run）属于新 prompt 的时间线，旧终态不重开。该规则对所有模式统一：Print 按现有顺序逐条等待 outcome，正常路径不会触发封口；主动流水线提交的 RPC/JSON 客户端接受同样语义。用户提交新 prompt 本身即对旧候选结果的显式处理，系统不为其保留无限期的修正债务。
+
+## 4. `PromptOutcome` 契约
+
+一个 prompt 的 `completed` 终态只在以下条件同时成立时原子产生：
+
+1. 没有该 `promptId` 所属的在途或已调度后继工作；
+2. Advisor 已审查到该 prompt 最终 trace generation，或明确进入有界 `fail_open`；Advisor 未启用时该条件视为满足，`advisor` 字段记 `disabled`；
+3. 没有待执行的 Advisor correction；
+4. 最终消息范围和结构化状态已固定。
+
+建议的逻辑结果：
+
+```ts
+interface PromptOutcome {
+  promptId: string;
+  status: "completed" | "needs_user_input" | "unresolved_advisor" | "failed" | "cancelled";
+  advisor: "passed" | "fail_open" | "unresolved" | "disabled" | "pending";
+  finalMessageIds: string[];
+  pendingQuestions?: PendingUserQuestion[];
+  sessionEpoch: number;
+  traceGeneration: number;
+}
+```
+
+具体字段仍需在实现计划阶段核对现有 message identity 和 wire 类型；`PendingUserQuestion` 必须保留所属 `toolCallId`、原始 `question`、`options` 及其顺序，但不得再增加模型生成的 question identity。`pendingQuestions` 只在 fallback 形成 `needs_user_input` 终态时出现，并按 assistant/问题原始顺序保存当前及尚未执行的 ask；live responder 全部回答时不产生中间 outcome（见 [ask-user.md](ask-user.md)）。核心要求是终态 outcome 必须携带状态和关联 ID，而不是仅通过 Promise resolve 或最后一条文本反推成功。
+
+### 4.1 `status` 与 `advisor` 字段的组合矩阵
+
+`advisor` 表示结算时刻的审查状态，不允许用 `passed` 冒充“未启用”或“未等待”：
+
+| status | 终态条件 | 合法 `advisor` 值 |
+| --- | --- | --- |
+| `completed` | 上述四条件全部成立 | `passed`、`fail_open`、`disabled` |
+| `unresolved_advisor` | 修正循环被封口且问题未清除，条件 1、4 成立 | `unresolved` |
+| `needs_user_input` | 条件 1、4 成立；不等待条件 2、3 | `passed`、`fail_open`、`unresolved`、`disabled`、`pending` |
+| `cancelled` | abort fence 已取消 prompt-owned work，条件 4 成立 | 同上 |
+| `failed` | run 以错误终止且无可继续路径，条件 1、4 成立 | 同上 |
+
+- `disabled`：Advisor 未启用。
+- `pending`：该终态不等待审查，且结算时 review coverage 尚未追平最终 trace；只对非 `completed` 终态合法。
+- `unresolved`：修正循环被封口且问题未清除。封口事件包括达到 `maxCorrectionCycles`、同 session 后续 prompt 的成功 admission（见第 3 节）与 `/advisor off`；三者共用同一状态，不各自增设枚举值。
+- `needs_user_input` 与 `cancelled` 明确不等待 Advisor：把问题交给用户、执行用户的停止意图，都优先于审查完成。审查一段“正在等用户回答”的半截 trace 没有意义，也不得因此推迟向用户展示问题。
+- 结算后迟到的 Advisor finding 不重开 outcome，按 Advisor 文档的迟到 finding 规则处理（终态迟到 `concern` 只保留卡片，`blocker` 视 abort fence 与运行模式决定是否唤醒）。
+
+## 5. 各运行模式的结算契约
+
+各模式的 Advisor 状态反馈与 `ask_user` 交互细节分别见 [advisor-architecture.md](advisor-architecture.md) 与 [ask-user.md](ask-user.md)；本节只定义结算本身。
+
+### 5.1 TUI（包括 daemon 托管）
+
+- settlement 不是 TUI 的忙闲或输入闸门：候选 `agent_end` 后立即显示回答，输入、提交和后续 prompt 执行保持现有行为，不新增 settlement 专用输入队列或 prompt-start fence。
+- `PromptOutcome` 用于 daemon/客户端的状态查询、恢复与诊断，不引入前台等待。
+
+### 5.2 Print
+
+- 每个输入通过 session 级 prompt outcome 等待其全部结果相关后继工作；多个 `messages` 按现有顺序组合等待。
+- stdout 只输出最终 settled 的主 Agent 文本，不输出被 Advisor 推翻的中间候选文本。
+- headless autonomous gate 必须加入当前外部请求的 settlement lineage，或作为子 prompt outcome 被上层显式组合；不能退回全局 idle 猜测。
+- 当前 print-mode 返回值只有 `0` 正常与 `1` 失败语义（信号退出 129/130/143 是独立路径），并会依次发送全部 `messages`。引入 `PromptOutcome(needs_user_input)` 后必须在该点短路剩余输入，并增加专用退出码 `2`：它表示需要外部输入，不是模型或运行时失败。输出完整问题后停止发送本次调用中尚未处理的后续 `messages`，避免越过未决问题；后续调用回答并正常结算后恢复现有 `0` 成功、`1` 失败语义。
+- 进程退出后，该请求被标记为 released；Advisor 恢复不得追审并唤醒旧工作。
+
+### 5.3 JSON
+
+- 可以流式输出主 Agent、多个 `agent_end` 与 Advisor 的非终态事件；`agent_end` 继续只表示底层 run 结束。
+- 新增携带 `promptId` 的结构化 `prompt_outcome` 作为 prompt 结算，不抑制或改写现有 `agent_end`。
+- `needs_user_input`、`advisor_unavailable`、`unresolved_advisor` 使用结构化事件或字段表达，不依赖 stderr 文本解析。
+- JSON 在写出完整的结构化 `prompt_outcome(needs_user_input)` 后同样以退出码 `2` 结束，并停止本次剩余 `messages`。事件是机器可读真值，退出码只是进程级快速分类；`0` 仍只表示本次请求全部完成，`1` 表示失败。
+- 新结构化状态实施前必须审计现有消费者是否允许未知事件；若是 closed union，仍需 schema/version 处理，不能假定为无害的 additive change。
+
+### 5.4 RPC
+
+- `prompt` command 继续在完成提交后即时返回 ACK，不把现有双向协议改造成长时间同步调用。
+- 协商支持 settlement 的 ACK 返回或确认一个稳定 `promptId`；后续 `prompt_outcome` 用该 ID 关联。
+- 当前 RPC client 的 `promptAndWait` 在第一个 `agent_end` 就 resolve，不能作为真正结算；新 client 必须等待对应 `prompt_outcome`。
+- `agent_end` 和其他流式事件保持现有 run 语义，不因 settlement 被隐藏。
+
+### 5.5 ACP
+
+- `session/prompt` 等待初始 prompt outcome，并将 headless autonomous gate 的子 outcomes 组合进同一次 ACP 请求，然后才返回。
+- 保持 ACP 标准响应有效；Prime 专属状态放入可忽略的 namespaced `_meta` 或协议允许的扩展位置。
+- 不要求不了解新契约的 ACP 客户端实现新的启动前握手，也不让可选元数据阻塞会话。
+
+## 6. 持久化与恢复
+
+daemon worker 重启时，未结算 prompt 必须恢复。session artifact 中持久化最小 settlement ledger：`promptId`、状态、session epoch、trace generation/review coverage、修正次数、fallback pending question queue、逐项已答 answer blocks，以及 abort/released fence。Promise、timer、owned-work lease、live `ask_user` responder request、transport request ID 和在途模型调用不持久化；重启后结合主 session JSONL、session action recovery 和 Advisor 私有 transcript 重建可重建部分。
+
+恢复规则：
+
+- 已终态 outcome 不可重开。
+- 未终态且未 abort/released 的 outcome 重新核对 trace coverage，必要时重新发起 Advisor review。
+- 重启前的在途模型结果全部按 epoch 作废，不能迟到写入新 runtime。
+- 原等待连接断开可以报告 transport failure，但 outcome 继续由 daemon 完成；重连客户端可按 `promptId` 查询或订阅最终状态。
+- 无法证明 lineage 完整时不得误报 `completed`，应进入结构化 `failed` 或明确 fail-open 路径。
+
+pending question queue 的逐项持久化、重连展示与 admission 原子消费规则见 [ask-user.md](ask-user.md)；Advisor 私有 transcript 与 review 真值的持久化见 [advisor-architecture.md](advisor-architecture.md)。
+
+## 7. 协议兼容性
+
+| 变化 | 建议分类 |
+| --- | --- |
+| daemon/RPC `promptId` 与 `prompt_outcome` | capability-gated；若无协商机制则版本化 |
+| JSON 新 `prompt_outcome` 与结构化状态 | 先审计消费者；可能需要 schema revision |
+| ACP namespaced `_meta` 中的 settlement 状态 | 在 ACP 允许未知 metadata 的前提下 backward-compatible |
+| Print 退出码 `2` | 行为变化只在 `needs_user_input` 出现时触发；文档化并覆盖脚本兼容测试 |
+
+settlement 不改变现有 `agent_end` 的 run 终态含义，而是增加更高层的 prompt settlement。每个实际 daemon wire change 仍必须同步更新 `DAEMON_SCHEMA_REVISION`、命令/事件兼容映射，并覆盖 new-client/old-daemon 与 old-client/new-daemon；只有不兼容变化或启动开始依赖新行为时才按现有规则评估 `DAEMON_PROTOCOL_VERSION` bump。
+
+## 8. 测试与验收
+
+使用 `packages/coding-agent/test/suite/harness.ts` 和 faux provider，不调用真实 provider、API key 或付费 token。至少覆盖：
+
+1. Prompt settlement lineage：当前 action completion、retry、compaction continuation、Advisor review/correction 都正确继承同一 `promptId`；无关 prompt、cron、heartbeat 和后台维护不误入该结算。
+2. 结算范围：同步 tool/子 Agent 会阻塞 outcome；auto-refine、cron/heartbeat、detached subagent 不阻塞，且迟到结果不能重开终态 outcome。
+3. 组合矩阵：`completed` 严格执行四条件；`needs_user_input`/`cancelled`/`failed` 不等待 Advisor 条件即结算，`advisor` 字段如实记录 `disabled`/`pending`/当时 coverage，不得用 `passed` 冒充未审查。
+4. 竞态：最后一个 owned-work lease 释放与新 correction/compaction continuation 建立并发时，outcome 只能在 generation 稳定且 review coverage 追平（或该终态不等待审查）后原子完成。
+5. 重启恢复：未终态 settlement 从 ledger、session JSONL 和 action recovery 重建；旧在途结果失效，终态 outcome 不重开，重连可查询最终状态。
+6. 模式结算：Print、JSON、RPC、ACP 在必须修正时不提前完成，允许多个 `agent_end`，只产生一个对应的 `prompt_outcome`；RPC ACK 仍即时返回，旧 `promptAndWait` 行为标记为不充分并由新等待逻辑替代。
+7. 退出码：Print/JSON 的 `needs_user_input` 在完整输出问题或结构化 outcome 后返回 `2`，本次后续 `messages` 未发送且保持原顺序；正常完成仍为 `0`、模型/运行时失败仍为 `1`，后续独立调用回答 pending 后可正常返回 `0`。
+8. 协议：daemon/RPC 能力协商和双向跨版本场景通过。
+9. 封口规则：prompt B 成功 admission 后，A 的在途修正自然完成且不再启动新周期；A 按 coverage 追平后的结果结算 `completed`/`unresolved_advisor`；steer 进 B 的迟到修正属于 B 的时间线，A 终态不重开；Print 顺序路径不触发封口，RPC 流水线提交触发并得到相同语义。
+
+## 9. 风险与反证信号
+
+| 风险 | 早期信号 | 缓解 |
+| --- | --- | --- |
+| 各入口行为漂移 | TUI 可修正但 JSON/RPC 提前结束 | 共同 `PromptSettlementTracker` 与跨模式契约测试 |
+| outcome 被全局 idle 污染 | 无关 cron/heartbeat 导致等待或过早释放 | 稳定 `promptId`、owned-work lineage、generation 与原子终态 |
+| worker 重启丢失结算 | 主任务恢复但结算状态消失或重复执行 | 最小 settlement ledger、epoch 作废、JSONL/action recovery 重建、终态不可重开 |
+| 协议演进破坏老客户端 | 老客户端无法 attach/start | capability gate、schema map、双向兼容测试、本地降级 |
+
+## 10. Prime 源码事实依据
+
+本设计依赖以下当前源码契约；实施前若这些契约变化，应先回到本设计重新核对：
+
+- `packages/agent/src/agent-loop.ts`：正常 turn 在工具结果追加并发出 `turn_end` 后调用 `shouldStopAfterTurn`；provider `error`、用户/信号 `aborted`、`shouldStopAfterTurn` 返回 true 或 `shouldStopBeforeTurn` 建立停止边界时都会直接发出 `agent_end`。
+- `packages/coding-agent/src/core/agent-session.ts`：当前 `AgentMessageOutcome.completion` 在 action 完成后立即释放；它等待配置允许的 retry chain 和 agent event queue，但 post-compaction continuation 由 timer 另行调度，不能直接视为最终 prompt outcome。
+- `packages/coding-agent/src/core/agent-session.ts` 与 package-manager recovery：session action recovery 已携带 `agentMessageId`，可作为重建 prompt lineage 的现有锚点，但当前内存 `_agentMessageOutcomes` 本身不会跨 runtime 保存。
+- `packages/coding-agent/src/modes/print-mode.ts` 与 `acp/`：先调用 `promptAndWait`，再单独调用 headless completion，证明外部请求本来就可能组合多个 session 阶段。
+- `packages/coding-agent/src/modes/print-mode.ts`：当前返回值只有 `0` 正常与 `1` 失败语义，并会依次发送全部 `messages`；引入 `PromptOutcome(needs_user_input)` 后必须在该点短路剩余输入，并增加专用退出码 `2`，不能让脚本把未结算任务当作成功。
+- `packages/coding-agent/src/modes/rpc/rpc-mode.ts` 与 `rpc-client.ts`：`prompt` response 只是即时 ACK，当前 client 的 `promptAndWait` 在第一个 `agent_end` resolve，无法表达跨 run 的结算。
+- `packages/coding-agent/src/core/agent-session-config.ts`：执行模式是 `interactive | print | json | rpc | acp`；daemon 是承载/传输边界，不是替代这些语义的第六种 Agent execution mode。
+- `packages/coding-agent/src/modes/daemon/daemon-protocol.ts`：当前 protocol/version 常量和 schema revision 受兼容性规则约束，任何 wire 扩展都必须按 capability 与跨版本测试治理。


### PR DESCRIPTION
## Summary

Adds three architecture design docs (status: direction accepted, pre-implementation), split along delivery boundaries so each can be reviewed and shipped independently:

- **advisor-architecture.md** — root-runtime-owned, read-only reviewer subruntime (`read`/`grep`/`glob`/`git_read` over a new thin `FileSystemView`), candidate-terminal-triggered reviews, severity routing (`nit`/`concern`/`blocker`), bounded correction loops with a prompt-admission sealing rule, fail-closed enable / fail-open runtime faults.
- **prompt-settlement.md** — session-level `PromptSettlementTracker` + structured `PromptOutcome` across TUI/Print/JSON/RPC/ACP; `agent_end` keeps its run-level meaning, settlement becomes a separate contract (also fixes the semantics gap where RPC `promptAndWait` resolves on the first `agent_end`).
- **ask-user.md** — universal `ask_user` session capability: live responders in-run, persistent fallback pending queues with `needs_user_input` outcomes, and a shared TUI editor-surface FIFO dialog arbiter (fixes an existing dialog-clobbering hazard).

All source-code contract claims in the docs were verified against the current tree (section 20 of each doc). Delivery is planned as six independently verifiable slices (arbiter → settlement → ask_user ∥ advisor core → TUI/daemon surface → persistence/ops).

Also registers the new docs (plus the existing continual-harness roadmap page) in `docs.json` and `index.md` navigation.

## Notes

- Docs-only change; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add architecture docs for Advisor, Prompt Settlement, and `ask_user` to coding-agent
> Adds three architecture design documents to the coding-agent docs:
>
> - [advisor-architecture.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1448/files#diff-3efb7001452b496310c7e14484e43c2e4d3391cee8be825b266859fdf3342673) covers the Advisor subsystem lifecycle, severity taxonomy, review triggering, mode behaviors (TUI/daemon/Print/JSON/RPC/ACP), `SessionAdvisorManager`, and phased rollout plan.
> - [prompt-settlement.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1448/files#diff-a8b54d0b23ce6f7776104dd5fea6a1d7ee7bc69dff86fd6395ff4de6408080f7) defines session-level prompt settlement tracking, stable `promptId` lineage across retries, the `PromptOutcome` contract, and per-mode behavior including exit code 2 for `needs_user_input` in Print mode.
> - [ask-user.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1448/files#diff-c8002287bf3a9c8480addd59e51421ff478ae83d4c8ddc2f11b5643f382ef38b) documents the `ask_user` capability contract, `UserInputBroker` architecture, TUI pending queue/FIFO dialog arbiter, daemon multi-responder semantics, persistence/recovery, and phased rollout.
> - Both [docs.json](https://github.com/PrimeIntellect-ai/prime-agent/pull/1448/files#diff-882036ef3174d7c3b16acecda7937bf6ed12c1eb1b8fafd15333c4d76e9e7df9) and [index.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1448/files#diff-218d46321638f6fc86d50aefd277a2551b50e631d37a957a72e9abac03aa1d8c) are updated to register the new pages in the docs site navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 698c231.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->