### PR TITLE
fix(daemon): move supervisor authority records out of $TMPDIR

### DIFF
--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -103,8 +103,16 @@ class DaemonSupervisorAlreadyRunningError extends Error {
 class DaemonSupervisorOwnershipLostError extends Error {
 	readonly code = "supervisor_generation_stale" as const;
 
-	constructor(generation: string) {
-		super(`Daemon supervisor generation ${generation} no longer owns its registry entry`);
+	constructor(generation: string, details: { socketPath?: string; registryDir?: string } = {}) {
+		const context = [
+			details.socketPath ? `socket: ${details.socketPath}` : undefined,
+			details.registryDir ? `registry: ${details.registryDir}` : undefined,
+		].filter((part) => part !== undefined);
+		super(
+			`Daemon supervisor generation ${generation} no longer owns its registry entry ` +
+				`(record on disk is missing or was replaced)${context.length > 0 ? `; ${context.join("; ")}` : ""}; ` +
+				"restart the daemon to recover — sessions are preserved",
+		);
 		this.name = "DaemonSupervisorOwnershipLostError";
 	}
 }
@@ -185,12 +193,19 @@ class DaemonSupervisorOwnership {
 
 	async assertCurrent(): Promise<void> {
 		if (this.released) {
-			throw new DaemonSupervisorOwnershipLostError(this.record.generation);
+			throw this.ownershipLostError();
 		}
 		const current = readOwnerRecord(this.ownerDirectory);
 		if (!current || !sameOwnerRecord(current, this.record)) {
-			throw new DaemonSupervisorOwnershipLostError(this.record.generation);
+			throw this.ownershipLostError();
 		}
+	}
+
+	private ownershipLostError(): DaemonSupervisorOwnershipLostError {
+		return new DaemonSupervisorOwnershipLostError(this.record.generation, {
+			socketPath: this.record.socketPath,
+			registryDir: this.registryDir,
+		});
 	}
 
 	async updatePhase(phase: DaemonSupervisorOwnerPhase): Promise<void> {
@@ -433,11 +448,11 @@ export async function assertDaemonSupervisorOwnerCurrent(
 		current.socketPath !== normalizeSocketPath(owner.socketPath) ||
 		!isProcessAlive(current.pid)
 	) {
-		throw new DaemonSupervisorOwnershipLostError(owner.generation);
+		throw new DaemonSupervisorOwnershipLostError(owner.generation, { socketPath: owner.socketPath, registryDir });
 	}
 	const fingerprint = ownerRecordFingerprint(current);
 	if (fingerprint !== validatedFingerprint && !isProcessIdentityAlive(current)) {
-		throw new DaemonSupervisorOwnershipLostError(owner.generation);
+		throw new DaemonSupervisorOwnershipLostError(owner.generation, { socketPath: owner.socketPath, registryDir });
 	}
 	return fingerprint;
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -548,7 +548,11 @@ export async function persistDaemonStartupFenceFromOwner(
 		});
 		let matchingOwners = owners.filter((owner) => owner.socketPath === normalizedSocketPath);
 		if (matchingOwners.length === 0 && legacyRegistryDir) {
-			matchingOwners = readLegacyOwnersForSocket(legacyRegistryDir, normalizedSocketPath);
+			// Stale legacy leftovers are expected; keep only records matching the
+			// identity the caller already holds.
+			matchingOwners = readLegacyOwnersForSocket(legacyRegistryDir, normalizedSocketPath).filter(
+				(owner) => owner.token === hello.supervisorOwnerToken && owner.pid === hello.supervisorPid,
+			);
 		}
 		if (matchingOwners.length === 0) {
 			throw new Error(`Daemon supervisor owner does not match ${socketPath}`);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -118,6 +118,62 @@ class DaemonShutdownAdmissionError extends Error {
 	}
 }
 
+/**
+ * Owns a lease-renew loop safely: the unref()'d interval, single-flight
+ * refresh dedup shared by timer-fired and direct calls, and lost-state fencing.
+ */
+class RenewableRegistryRecord {
+	private stopped = false;
+	private lost = false;
+	private refreshPromise?: Promise<void>;
+	private readonly refreshTimer: ReturnType<typeof setInterval>;
+
+	constructor(
+		private readonly registryDir: string,
+		refreshMs: number,
+		private readonly renewUnderGuard: () => void,
+		private readonly createLostError: () => Error,
+	) {
+		this.refreshTimer = setInterval(() => {
+			void this.assertOrRenew().catch(() => undefined);
+		}, refreshMs);
+		this.refreshTimer.unref();
+	}
+
+	async assertOrRenew(): Promise<void> {
+		if (this.stopped || this.lost) {
+			throw this.createLostError();
+		}
+		this.refreshPromise ??= this.performRenew().finally(() => {
+			this.refreshPromise = undefined;
+		});
+		await this.refreshPromise;
+	}
+
+	private async performRenew(): Promise<void> {
+		try {
+			await withDaemonSupervisorRegistryGuard(this.registryDir, () => {
+				// stop() may have completed while this call waited on the guard;
+				// a stopped record must never be rewritten to disk.
+				if (this.stopped || this.lost) {
+					throw this.createLostError();
+				}
+				this.renewUnderGuard();
+			});
+		} catch (error) {
+			this.lost = true;
+			clearInterval(this.refreshTimer);
+			throw error;
+		}
+	}
+
+	async stop(): Promise<void> {
+		this.stopped = true;
+		clearInterval(this.refreshTimer);
+		await this.refreshPromise?.catch(() => undefined);
+	}
+}
+
 class DaemonSupervisorOwnership {
 	private released = false;
 
@@ -181,52 +237,44 @@ class DaemonSupervisorOwnership {
 
 class DaemonShutdownAdmission {
 	private released = false;
-	private lost = false;
-	private refreshPromise?: Promise<void>;
-	private readonly refreshTimer: ReturnType<typeof setInterval>;
+	private readonly renewal: RenewableRegistryRecord;
 
 	constructor(
 		private readonly record: DaemonShutdownAdmissionRecord,
 		private readonly registryDir: string,
 	) {
-		this.refreshTimer = setInterval(() => {
-			this.refreshPromise ??= this.assertOrRenew()
-				.catch(() => undefined)
-				.finally(() => {
-					this.refreshPromise = undefined;
-				});
-		}, SHUTDOWN_ADMISSION_REFRESH_MS);
-		this.refreshTimer.unref();
+		this.renewal = new RenewableRegistryRecord(
+			registryDir,
+			SHUTDOWN_ADMISSION_REFRESH_MS,
+			() => this.renewUnderGuard(),
+			() => new DaemonShutdownAdmissionError("Daemon shutdown admission was lost"),
+		);
 	}
 
 	async assertOrRenew(): Promise<void> {
-		if (this.released || this.lost) {
+		if (this.released) {
 			throw new DaemonShutdownAdmissionError("Daemon shutdown admission was lost");
 		}
-		try {
-			await withDaemonSupervisorRegistryGuard(this.registryDir, () => {
-				const path = shutdownAdmissionPath(this.registryDir);
-				const current = readShutdownAdmission(path);
-				if (
-					!current ||
-					current.token !== this.record.token ||
-					current.pid !== this.record.pid ||
-					current.processStartId !== this.record.processStartId ||
-					Date.parse(current.expiresAt) <= Date.now() ||
-					!matchesExactProcessIdentity(this.record)
-				) {
-					throw new DaemonShutdownAdmissionError("Daemon shutdown admission was lost");
-				}
-				const now = Date.now();
-				this.record.updatedAt = new Date(now).toISOString();
-				this.record.expiresAt = new Date(now + SHUTDOWN_ADMISSION_LEASE_MS).toISOString();
-				writeJsonAtomically(path, this.record);
-			});
-		} catch (error) {
-			this.lost = true;
-			clearInterval(this.refreshTimer);
-			throw error;
+		await this.renewal.assertOrRenew();
+	}
+
+	private renewUnderGuard(): void {
+		const path = shutdownAdmissionPath(this.registryDir);
+		const current = readShutdownAdmission(path);
+		if (
+			!current ||
+			current.token !== this.record.token ||
+			current.pid !== this.record.pid ||
+			current.processStartId !== this.record.processStartId ||
+			Date.parse(current.expiresAt) <= Date.now() ||
+			!matchesExactProcessIdentity(this.record)
+		) {
+			throw new DaemonShutdownAdmissionError("Daemon shutdown admission was lost");
 		}
+		const now = Date.now();
+		this.record.updatedAt = new Date(now).toISOString();
+		this.record.expiresAt = new Date(now + SHUTDOWN_ADMISSION_LEASE_MS).toISOString();
+		writeJsonAtomically(path, this.record);
 	}
 
 	async release(): Promise<void> {
@@ -234,8 +282,7 @@ class DaemonShutdownAdmission {
 			return;
 		}
 		this.released = true;
-		clearInterval(this.refreshTimer);
-		await this.refreshPromise;
+		await this.renewal.stop();
 		await withDaemonSupervisorRegistryGuard(this.registryDir, () => {
 			const path = shutdownAdmissionPath(this.registryDir);
 			const current = readShutdownAdmission(path);

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -9,10 +9,10 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import lockfile from "proper-lockfile";
 import { getProcessStartId } from "../../core/session-lease.js";
-import { defaultDaemonSocketDir } from "./daemon-socket.js";
 
 const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
 
@@ -293,8 +293,14 @@ class DaemonShutdownAdmission {
 	}
 }
 
-function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
-	return environment[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV] ?? resolve(defaultDaemonSocketDir(), "supervisor-owners");
+/**
+ * The registry is durable authority state and must be global per user so
+ * ownerConflicts sees every daemon on the box; it deliberately lives outside
+ * $TMPDIR (whose files macOS dirhelper deletes after 3 days) and outside the
+ * per-invocation agent dir.
+ */
+export function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
+	return environment[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV] ?? join(homedir(), ".prime", "supervisor-owners");
 }
 
 async function withDaemonSupervisorRegistryGuard<T>(registryDir: string, action: () => T | Promise<T>): Promise<T> {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -13,6 +13,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import lockfile from "proper-lockfile";
 import { getProcessStartId } from "../../core/session-lease.js";
+import { defaultDaemonSocketDir } from "./daemon-socket.js";
 
 const DAEMON_SUPERVISOR_REGISTRY_DIR_ENV = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
 
@@ -314,8 +315,42 @@ class DaemonShutdownAdmission {
  * $TMPDIR (whose files macOS dirhelper deletes after 3 days) and outside the
  * per-invocation agent dir.
  */
-export function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
+function defaultDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string {
 	return environment[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV] ?? join(homedir(), ".prime", "supervisor-owners");
+}
+
+/**
+ * Pre-move registry location under $TMPDIR, consulted READ-ONLY while daemons
+ * from before the ~/.prime move may still be running; gated off whenever the
+ * registry is overridden. Remove after one release.
+ */
+function legacyDaemonSupervisorRegistryDir(environment: NodeJS.ProcessEnv = process.env): string | undefined {
+	return environment[DAEMON_SUPERVISOR_REGISTRY_DIR_ENV]
+		? undefined
+		: resolve(defaultDaemonSocketDir(), "supervisor-owners");
+}
+
+/**
+ * Non-mutating legacy scan: never reclaims abandoned directories (old-build
+ * daemons own that location's lifecycle) and runs without the legacy guard —
+ * best-effort is acceptable because records are written rename-atomically.
+ */
+function readLegacyOwnersForSocket(
+	legacyRegistryDir: string,
+	normalizedSocketPath: string,
+): DaemonSupervisorOwnerRecord[] {
+	let entries: string[];
+	try {
+		entries = readdirSync(legacyRegistryDir);
+	} catch {
+		return [];
+	}
+	return entries
+		.filter((name) => name.endsWith(".owner"))
+		.flatMap((name) => {
+			const owner = readOwnerRecord(resolve(legacyRegistryDir, name));
+			return owner && owner.socketPath === normalizedSocketPath ? [owner] : [];
+		});
 }
 
 async function withDaemonSupervisorRegistryGuard<T>(registryDir: string, action: () => T | Promise<T>): Promise<T> {
@@ -438,9 +473,13 @@ export async function assertDaemonSupervisorOwnerCurrent(
 		socketPath: string;
 	},
 	validatedFingerprint?: string,
+	registryDir?: string,
+	legacyRegistryDir: string | undefined = registryDir === undefined ? legacyDaemonSupervisorRegistryDir() : undefined,
 ): Promise<string> {
-	const registryDir = defaultDaemonSupervisorRegistryDir();
-	const current = readOwnerRecord(ownerDirectoryPath(registryDir, owner.generation));
+	registryDir ??= defaultDaemonSupervisorRegistryDir();
+	const current =
+		readOwnerRecord(ownerDirectoryPath(registryDir, owner.generation)) ??
+		(legacyRegistryDir ? readOwnerRecord(ownerDirectoryPath(legacyRegistryDir, owner.generation)) : undefined);
 	if (
 		!current ||
 		current.pid !== owner.pid ||
@@ -493,8 +532,10 @@ export async function isDaemonShutdownAdmissionActive(): Promise<boolean> {
 export async function persistDaemonStartupFenceFromOwner(
 	socketPath: string,
 	hello: DaemonSupervisorHelloIdentity,
-	registryDir: string = defaultDaemonSupervisorRegistryDir(),
+	registryDir?: string,
+	legacyRegistryDir: string | undefined = registryDir === undefined ? legacyDaemonSupervisorRegistryDir() : undefined,
 ): Promise<void> {
+	registryDir ??= defaultDaemonSupervisorRegistryDir();
 	mkdirSync(registryDir, { recursive: true, mode: 0o700 });
 	const fenceDirectory = resolve(registryDir, "startup-fences");
 	mkdirSync(fenceDirectory, { recursive: true, mode: 0o700 });
@@ -505,7 +546,10 @@ export async function persistDaemonStartupFenceFromOwner(
 			const owner = readOwnerRecordForScope(directory, (scope) => scope.socketPath === normalizedSocketPath);
 			return owner ? [owner] : [];
 		});
-		const matchingOwners = owners.filter((owner) => owner.socketPath === normalizedSocketPath);
+		let matchingOwners = owners.filter((owner) => owner.socketPath === normalizedSocketPath);
+		if (matchingOwners.length === 0 && legacyRegistryDir) {
+			matchingOwners = readLegacyOwnersForSocket(legacyRegistryDir, normalizedSocketPath);
+		}
 		if (matchingOwners.length === 0) {
 			throw new Error(`Daemon supervisor owner does not match ${socketPath}`);
 		}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -888,7 +888,10 @@ export class DaemonSupervisor {
 	private async assertCurrentOwnership(): Promise<void> {
 		const ownership = this.ownership;
 		if (!ownership) {
-			const error = new Error(`Daemon supervisor generation ${this.generation} no longer owns its registry entry`);
+			const error = new Error(
+				`Daemon supervisor generation ${this.generation} holds no registry ownership (never acquired or already released); ` +
+					`socket: ${this.socketPath}; restart the daemon to recover — sessions are preserved`,
+			);
 			Object.assign(error, { code: "supervisor_generation_stale" as const });
 			throw error;
 		}

--- a/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	acquireDaemonSupervisorOwnership,
+	defaultDaemonSupervisorRegistryDir,
+} from "../src/modes/daemon/daemon-supervisor-ownership.js";
+
+type Ownership = Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>>;
+
+interface OwnerRecord {
+	token: string;
+	generation: string;
+	updatedAt: string;
+	[key: string]: unknown;
+}
+
+const registryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+	while (cleanupDirs.length > 0) {
+		const dir = cleanupDirs.pop();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function createPaths(): {
+	root: string;
+	registryDir: string;
+	socketPath: string;
+	agentDir: string;
+	descriptorDir: string;
+} {
+	const root = mkdtempSync(join(tmpdir(), "ownership-registry-"));
+	cleanupDirs.push(root);
+	const agentDir = join(root, "agent");
+	mkdirSync(agentDir, { recursive: true });
+	return {
+		root,
+		registryDir: join(root, "registry"),
+		socketPath: join(root, "daemon.sock"),
+		agentDir,
+		descriptorDir: join(root, "workers"),
+	};
+}
+
+async function acquire(paths: ReturnType<typeof createPaths>, generation = "registry-owner"): Promise<Ownership> {
+	return acquireDaemonSupervisorOwnership({
+		agentDir: paths.agentDir,
+		appVersion: "test",
+		descriptorDir: paths.descriptorDir,
+		generation,
+		registryDir: paths.registryDir,
+		socketPath: paths.socketPath,
+	});
+}
+
+function ownerDir(paths: ReturnType<typeof createPaths>, generation: string): string {
+	return join(paths.registryDir, `${generation}.owner`);
+}
+
+function readJson(path: string): OwnerRecord {
+	return JSON.parse(readFileSync(path, "utf8")) as OwnerRecord;
+}
+
+describe("daemon supervisor ownership registry", () => {
+	it("derives the default registry from the durable per-user directory, env override first", () => {
+		// Never touch the real ~/.prime from tests: probe the derivation only.
+		expect(defaultDaemonSupervisorRegistryDir({})).toBe(join(homedir(), ".prime", "supervisor-owners"));
+		expect(defaultDaemonSupervisorRegistryDir({ [registryDirEnv]: "/custom/registry" })).toBe("/custom/registry");
+	});
+
+	it("marks ownership lost when the record is mismatched or absent", async () => {
+		const paths = createPaths();
+		const mismatched = await acquire(paths, "mismatched-owner");
+		const mismatchedPath = join(ownerDir(paths, "mismatched-owner"), "owner.json");
+		const foreign = { ...readJson(mismatchedPath), token: "successor-token" };
+		writeFileSync(mismatchedPath, `${JSON.stringify(foreign, null, 2)}\n`);
+
+		await expect(mismatched.assertCurrent()).rejects.toMatchObject({
+			code: "supervisor_generation_stale",
+			name: "DaemonSupervisorOwnershipLostError",
+		});
+		expect(readJson(mismatchedPath).token).toBe("successor-token");
+		await mismatched.release();
+		rmSync(ownerDir(paths, "mismatched-owner"), { recursive: true, force: true });
+
+		const reaped = await acquire(paths, "reaped-owner");
+		const reapedDir = ownerDir(paths, "reaped-owner");
+		rmSync(reapedDir, { recursive: true, force: true });
+		await expect(reaped.assertCurrent()).rejects.toMatchObject({ code: "supervisor_generation_stale" });
+		expect(existsSync(reapedDir)).toBe(false);
+		await reaped.release();
+	});
+});

--- a/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import {
 	acquireDaemonSupervisorOwnership,
 	defaultDaemonSupervisorRegistryDir,
@@ -93,5 +94,41 @@ describe("daemon supervisor ownership registry", () => {
 		await expect(reaped.assertCurrent()).rejects.toMatchObject({ code: "supervisor_generation_stale" });
 		expect(existsSync(reapedDir)).toBe(false);
 		await reaped.release();
+	});
+
+	it("disambiguates never-acquired from lost-on-disk ownership errors", async () => {
+		const paths = createPaths();
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype) as object, {
+			ownership: undefined,
+			generation: "unowned-generation",
+			socketPath: paths.socketPath,
+		});
+		const assertCurrentOwnership = Reflect.get(supervisor, "assertCurrentOwnership") as () => Promise<void>;
+		const neverAcquired = await assertCurrentOwnership
+			.call(supervisor)
+			.then(() => undefined)
+			.catch((error: unknown) => error as Error & { code?: string });
+		if (!neverAcquired) throw new Error("assertCurrentOwnership did not throw");
+		expect(neverAcquired.code).toBe("supervisor_generation_stale");
+		expect(neverAcquired.message).toContain("holds no registry ownership");
+		expect(neverAcquired.message).toContain(paths.socketPath);
+		expect(neverAcquired.message).toContain("sessions are preserved");
+
+		const ownership = await acquire(paths);
+		const ownerPath = join(ownerDir(paths, ownership.record.generation), "owner.json");
+		const foreign = { ...readJson(ownerPath), token: "successor-token" };
+		writeFileSync(ownerPath, `${JSON.stringify(foreign, null, 2)}\n`);
+		const lostOnDisk = await ownership
+			.assertCurrent()
+			.then(() => undefined)
+			.catch((error: unknown) => error as Error & { code?: string });
+		if (!lostOnDisk) throw new Error("assertCurrent did not throw");
+		expect(lostOnDisk.code).toBe("supervisor_generation_stale");
+		expect(lostOnDisk.message).toContain("no longer owns its registry entry");
+		expect(lostOnDisk.message).toContain(paths.socketPath);
+		expect(lostOnDisk.message).toContain(paths.registryDir);
+		expect(lostOnDisk.message).toContain("sessions are preserved");
+		expect(lostOnDisk.message).not.toBe(neverAcquired.message);
+		await ownership.release();
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
@@ -7,6 +7,7 @@ import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import {
 	acquireDaemonShutdownAdmission,
 	acquireDaemonSupervisorOwnership,
+	assertDaemonSupervisorOwnerCurrent,
 	persistDaemonStartupFenceFromOwner,
 } from "../src/modes/daemon/daemon-supervisor-ownership.js";
 
@@ -87,7 +88,7 @@ describe("daemon supervisor ownership registry", () => {
 			socketPath: paths.socketPath,
 		});
 		const record = legacyOwner.record;
-		if (!record.processStartId) return;
+		expect(record.processStartId).toBeDefined();
 		const hello = {
 			supervisorGeneration: record.generation,
 			supervisorOwnerToken: record.token,
@@ -109,6 +110,36 @@ describe("daemon supervisor ownership registry", () => {
 		await expect(persistDaemonStartupFenceFromOwner(paths.socketPath, hello, paths.registryDir)).rejects.toThrow(
 			/does not match/,
 		);
+		await legacyOwner.release();
+	});
+
+	it("validates a pre-move owner claim through the legacy registry", async () => {
+		const paths = createPaths();
+		const legacyDir = join(paths.root, "legacy-registry");
+		const legacyOwner = await acquireDaemonSupervisorOwnership({
+			agentDir: paths.agentDir,
+			appVersion: "test",
+			descriptorDir: paths.descriptorDir,
+			generation: "legacy-claim-owner",
+			registryDir: legacyDir,
+			socketPath: paths.socketPath,
+		});
+		const identity = {
+			generation: legacyOwner.record.generation,
+			pid: legacyOwner.record.pid,
+			...(legacyOwner.record.processStartId ? { processStartId: legacyOwner.record.processStartId } : {}),
+			socketPath: legacyOwner.record.socketPath,
+		};
+		mkdirSync(paths.registryDir, { recursive: true });
+
+		await expect(
+			assertDaemonSupervisorOwnerCurrent(identity, undefined, paths.registryDir, legacyDir),
+		).resolves.toEqual(expect.any(String));
+
+		// Without the injected legacy dir, an explicit registry never falls back.
+		await expect(assertDaemonSupervisorOwnerCurrent(identity, undefined, paths.registryDir)).rejects.toMatchObject({
+			code: "supervisor_generation_stale",
+		});
 		await legacyOwner.release();
 	});
 

--- a/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import lockfile from "proper-lockfile";
 import { afterEach, describe, expect, it } from "vitest";
@@ -7,7 +7,7 @@ import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import {
 	acquireDaemonShutdownAdmission,
 	acquireDaemonSupervisorOwnership,
-	defaultDaemonSupervisorRegistryDir,
+	persistDaemonStartupFenceFromOwner,
 } from "../src/modes/daemon/daemon-supervisor-ownership.js";
 
 type Ownership = Awaited<ReturnType<typeof acquireDaemonSupervisorOwnership>>;
@@ -75,10 +75,54 @@ function readJson(path: string): OwnerRecord {
 }
 
 describe("daemon supervisor ownership registry", () => {
-	it("derives the default registry from the durable per-user directory, env override first", () => {
-		// Never touch the real ~/.prime from tests: probe the derivation only.
-		expect(defaultDaemonSupervisorRegistryDir({})).toBe(join(homedir(), ".prime", "supervisor-owners"));
-		expect(defaultDaemonSupervisorRegistryDir({ [registryDirEnv]: "/custom/registry" })).toBe("/custom/registry");
+	it("finds a live pre-move owner through the legacy registry when persisting a fence", async () => {
+		const paths = createPaths();
+		const legacyDir = join(paths.root, "legacy-registry");
+		const legacyOwner = await acquireDaemonSupervisorOwnership({
+			agentDir: paths.agentDir,
+			appVersion: "test",
+			descriptorDir: paths.descriptorDir,
+			generation: "legacy-owner",
+			registryDir: legacyDir,
+			socketPath: paths.socketPath,
+		});
+		const record = legacyOwner.record;
+		if (!record.processStartId) return;
+		const hello = {
+			supervisorGeneration: record.generation,
+			supervisorOwnerToken: record.token,
+			supervisorPid: record.pid,
+			supervisorProcessStartId: record.processStartId,
+			supervisorSocketPath: record.socketPath,
+		};
+		const legacyOwnerPath = join(legacyDir, "legacy-owner.owner", "owner.json");
+		const legacyBytes = readFileSync(legacyOwnerPath, "utf8");
+
+		await persistDaemonStartupFenceFromOwner(paths.socketPath, hello, paths.registryDir, legacyDir);
+
+		// The fence lands in the NEW registry; the legacy record is untouched.
+		expect(readdirSync(join(paths.registryDir, "startup-fences"))).toHaveLength(1);
+		expect(readFileSync(legacyOwnerPath, "utf8")).toBe(legacyBytes);
+
+		// Without a legacy dir the same scan fails: the fallback never fires for
+		// an explicitly provided registry.
+		await expect(persistDaemonStartupFenceFromOwner(paths.socketPath, hello, paths.registryDir)).rejects.toThrow(
+			/does not match/,
+		);
+		await legacyOwner.release();
+	});
+
+	it("legacy registry reads never reclaim abandoned legacy directories", async () => {
+		const paths = createPaths();
+		const legacyDir = join(paths.root, "legacy-registry");
+		const abandoned = join(legacyDir, "abandoned.owner");
+		mkdirSync(abandoned, { recursive: true });
+
+		await expect(
+			persistDaemonStartupFenceFromOwner(paths.socketPath, {}, paths.registryDir, legacyDir),
+		).rejects.toThrow(/does not match/);
+
+		expect(existsSync(abandoned)).toBe(true);
 	});
 
 	it("marks ownership lost when the record is mismatched or absent", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-ownership.test.ts
@@ -1,9 +1,11 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import lockfile from "proper-lockfile";
 import { afterEach, describe, expect, it } from "vitest";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 import {
+	acquireDaemonShutdownAdmission,
 	acquireDaemonSupervisorOwnership,
 	defaultDaemonSupervisorRegistryDir,
 } from "../src/modes/daemon/daemon-supervisor-ownership.js";
@@ -18,9 +20,15 @@ interface OwnerRecord {
 }
 
 const registryDirEnv = "PRIME_AGENT_INTERNAL_DAEMON_SUPERVISOR_REGISTRY_DIR";
+const previousRegistryDirEnv = process.env[registryDirEnv];
 const cleanupDirs: string[] = [];
 
 afterEach(() => {
+	if (previousRegistryDirEnv === undefined) {
+		delete process.env[registryDirEnv];
+	} else {
+		process.env[registryDirEnv] = previousRegistryDirEnv;
+	}
 	while (cleanupDirs.length > 0) {
 		const dir = cleanupDirs.pop();
 		if (dir) rmSync(dir, { recursive: true, force: true });
@@ -94,6 +102,27 @@ describe("daemon supervisor ownership registry", () => {
 		await expect(reaped.assertCurrent()).rejects.toMatchObject({ code: "supervisor_generation_stale" });
 		expect(existsSync(reapedDir)).toBe(false);
 		await reaped.release();
+	});
+
+	it("does not resurrect the shutdown admission when release overtakes an in-flight renew", async () => {
+		const paths = createPaths();
+		mkdirSync(paths.registryDir, { recursive: true, mode: 0o700 });
+		process.env[registryDirEnv] = paths.registryDir;
+		const admission = await acquireDaemonShutdownAdmission();
+		const admissionPath = join(paths.registryDir, "shutdown-admission.json");
+		expect(existsSync(admissionPath)).toBe(true);
+		const dropGuard = await lockfile.lock(paths.registryDir, {
+			realpath: false,
+			lockfilePath: join(paths.registryDir, ".guard"),
+		});
+		// The direct renew is now queued behind the held guard.
+		const pending = admission.assertOrRenew();
+		pending.catch(() => undefined);
+		const releasing = admission.release();
+		await dropGuard();
+		await expect(pending).rejects.toMatchObject({ code: "daemon_shutdown_in_progress" });
+		await releasing;
+		expect(existsSync(admissionPath)).toBe(false);
 	});
 
 	it("disambiguates never-acquired from lost-on-disk ownership errors", async () => {

--- a/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4603-worker-recovery.test.ts
@@ -955,7 +955,10 @@ describe("ENG-4603 worker recovery convergence", () => {
 			};
 			expect(record.pid).toBe(process.pid);
 			expect(record.processStartId).toBe(getProcessStartId(process.pid));
-			const refreshTimer = Reflect.get(first, "refreshTimer") as ReturnType<typeof setInterval> | undefined;
+			const renewal = Reflect.get(first, "renewal") as object | undefined;
+			const refreshTimer = renewal
+				? (Reflect.get(renewal, "refreshTimer") as ReturnType<typeof setInterval> | undefined)
+				: undefined;
 			if (!refreshTimer) throw new Error("Shutdown admission did not start its lease refresh");
 			clearInterval(refreshTimer);
 			let acquired = false;


### PR DESCRIPTION
## What this fixes

Any daemon supervisor alive for more than three days wedged permanently: macOS's `com.apple.bsd.dirhelper` deletes files older than 3 days under `$TMPDIR` daily, and the supervisor's ownership registry (`owner.json`/`scope.json`, plus startup fences and the shutdown admission) lived exactly there. Once reaped, every command against that daemon failed with "no longer owns its registry entry" and the only recovery was killing it. This is a clock, not a race — it hit every long-lived daemon on macOS.

## The fix: move the records, don't outrun the cleaner

The registry only lived in `$TMPDIR` by proximity: the daemon *socket* needs a short path (the ~104-byte `sun_path` limit), and the registry rode along in the socket dir. But these are JSON files — no path-length constraint applies, and they are durable authority records sitting in the one directory the OS is explicitly allowed to prune.

The registry now lives at `~/.prime/supervisor-owners` (still one global per-user location, which cross-agent-dir conflict detection requires; the internal env override still wins). All registry tenants move together: owner records, startup fences, the shutdown admission. Nothing deletes files behind a live daemon anymore, so the failure mode is simply gone — no renewal machinery, no self-heal, no timer.

## Version-overlap and migration

No record migration — ownership records are per-process-lifetime — but owner-record READS fall back to the legacy `$TMPDIR` location for one release (writes never do). This keeps the standard upgrade path working while a pre-move daemon is still running: the self-update coordinator's fence persist and worker auth both need to read the old daemon's record, and without the fallback a routine upgrade would drain and fence the old daemon, then abort — wedging it until manual restart. The fallback is read-only, exists only when no explicit registry dir or env override is set, and is marked for removal next release. Real socket contention is still resolved by the version-independent socket-path lease at bind. Stale records in the old location are inert and the OS cleaner removes them within 3 days.

## Also in this PR

- **Shutdown-admission renew loop hardened.** Extracting it surfaced a real latent race on main: `package-manager-cli` and `daemon-ps` call `assertOrRenew` directly, bypassing the timer's single-flight promise — so `release()` could complete while a direct renew sat queued on the registry guard and then resurrect `shutdown-admission.json` for up to ~5s. The extracted lease-renew loop funnels every caller through one single-flight slot that release genuinely awaits, and re-checks stopped-state first inside the guarded section. Covered by a deterministic race test (guard held, release overtakes, admission provably not resurrected).
- **The two identical "no longer owns its registry entry" messages are disambiguated** (never-acquired/released vs record missing/replaced on disk) and carry the socket path, registry dir, and remedy ("restart the daemon — sessions are preserved").

## Known follow-up (not this PR)

Acquire only reclaims *conflicting* dead owners, and nothing prunes the durable dir, so crashed daemons on never-reused socket paths leave inert `.owner` dirs behind — bounded growth, a natural `doctor --fix` candidate.

## Testing

Registry derivation + env-override precedence; missing-or-mismatched record stays a coded loss with no overwrite; the admission release-race (deterministic, no sleeps); both disambiguated messages. Supervisor lifecycle/regression suites green (4600 singleton, 4603 worker recovery, package self-update, monitor, 4606 update coordinator); `npm run check` clean.

Net src +71 (+118/−47): the relocation is a one-line derivation change; the rest is the admission-race hardening and the error messages.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move daemon supervisor registry from `$TMPDIR` to `~/.prime/supervisor-owners`
> - Changes `defaultDaemonSupervisorRegistryDir` to use `~/.prime/supervisor-owners` instead of a path derived from the socket directory, making ownership records durable across temp directory cleans.
> - Adds legacy registry fallback in `assertDaemonSupervisorOwnerCurrent` and `persistDaemonStartupFenceFromOwner` so existing records written under the old location are still readable during transition.
> - Introduces `RenewableRegistryRecord` to manage interval-based lease renewal in `DaemonShutdownAdmission` with single-flight deduplication and stop fencing.
> - Enriches `DaemonSupervisorOwnershipLostError` with socket and registry path context to aid recovery.
> - Behavioral Change: the default registry directory changes on upgrade; daemons started before the upgrade will be found via the legacy fallback (read-only) until they restart.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15c7470.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable daemon authority state location and cross-version ownership/fence behavior; incorrect legacy fallback could mis-validate owners, though changes are guarded and heavily tested.
> 
> **Overview**
> Fixes long-lived macOS daemons wedging when **supervisor authority records** (ownership, startup fences, shutdown admission) were stored under **`$TMPDIR`** and reaped after ~3 days. The default registry path is now **`~/.prime/supervisor-owners`** (env override unchanged); sockets stay short-path under temp.
> 
> **Version overlap:** read-only **legacy registry** fallback under the old socket-relative dir for owner checks and startup-fence persistence while pre-move daemons are still running—no migration of records; explicit registry args do not fall back.
> 
> **Shutdown admission:** lease renewal is centralized in **`RenewableRegistryRecord`** (single-flight renew, `stop()` awaits in-flight work, no rewrite after release) so **`release()`** cannot resurrect `shutdown-admission.json` when a direct **`assertOrRenew`** was queued on the registry lock.
> 
> **Errors:** ownership-loss messages include socket/registry paths and recovery hint; **never acquired** vs **record missing/replaced on disk** are distinguished in the supervisor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15c7470fb8f48458891a2e3ffcc473cf35c73b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->