### PR TITLE
feat: native model failover (fallbackModels)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added native model failover: configure an ordered `fallbackModels` chain in settings or via `--fallback-models` to switch models and continue the same conversation once retries are exhausted on a retryable failure ([#1436](https://github.com/PrimeIntellect-ai/prime-agent/issues/1436)).
 - Fixed fullscreen wheel scrolling in Ghostty while retaining application link clicks; set `terminal.fullscreenMouse` to `false` to use native Cmd-click instead.
 - Changed the agents view to sort idle and inactive sessions by last message time, newest first, while keeping running agents in stable creation order.
 - Fixed `openai-codex` models being invisible to `rlm` subagents and `find_models` because model discovery reported Prime Agent's own version as the Codex client version ([#1375](https://github.com/PrimeIntellect-ai/prime-agent/pull/1375) by [@bilelrais](https://github.com/bilelrais)).

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -228,6 +228,20 @@ When multiple sources specify a session directory, precedence is `--session-dir`
 }
 ```
 
+### Model Failover
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `fallbackModels` | string[] | - | Ordered `"provider/model-id"` failover chain (same format as `--fallback-models` CLI flag) |
+
+```json
+{
+  "fallbackModels": ["anthropic/claude-sonnet-4-5", "openai/gpt-5.2"]
+}
+```
+
+When a model's retry policy is exhausted on a retryable failure (rate limit, server error, network, provider cooldown), the session switches to the next entry and continues the same conversation. Auth and invalid-request failures never trigger failover. Each switch is recorded as a `model_switch` entry in the session file.
+
 ### Markdown
 
 | Setting | Type | Default | Description |

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -25,6 +25,7 @@ export interface Args {
 	fork?: string;
 	sessionDir?: string;
 	models?: string[];
+	fallbackModels?: string[];
 	tools?: string[];
 	noTools?: boolean;
 	noBuiltinTools?: boolean;
@@ -149,6 +150,19 @@ export function parseArgs(args: string[]): Args {
 			result.sessionDir = args[++i];
 		} else if (arg === "--models" && i + 1 < args.length) {
 			result.models = args[++i].split(",").map((s) => s.trim());
+		} else if (arg === "--fallback-models" && i + 1 < args.length) {
+			const entries = args[++i]
+				.split(",")
+				.map((s) => s.trim())
+				.filter((s) => s.length > 0);
+			if (entries.length === 0) {
+				result.diagnostics.push({
+					type: "error",
+					message: `--fallback-models requires at least one "provider/model-id" entry.`,
+				});
+			} else {
+				result.fallbackModels = entries;
+			}
 		} else if (arg === "--no-tools" || arg === "-nt") {
 			result.noTools = true;
 		} else if (arg === "--no-builtin-tools" || arg === "-nbt") {

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -179,6 +179,7 @@ const TOP_LEVEL_OPTION_GROUPS: ReadonlyArray<{ heading: string; options: readonl
 			["--model <id>", "Select a model"],
 			["--api-key <key>", "Use an API key for this run"],
 			["--models <patterns>", "Set comma-separated models for cycling"],
+			["--fallback-models <list>", "Comma-separated provider/model-id failover chain"],
 			["--thinking <level>", "Set reasoning: off, minimal, low, medium, high, xhigh, max"],
 		],
 	},

--- a/packages/coding-agent/src/cli/daemon-launch.ts
+++ b/packages/coding-agent/src/cli/daemon-launch.ts
@@ -491,6 +491,7 @@ const EARLY_LAUNCH_VALUE_FLAGS = new Set([
 	"--fork",
 	"--session-dir",
 	"--models",
+	"--fallback-models",
 	"--tools",
 	"-t",
 	"--thinking",

--- a/packages/coding-agent/src/core/agent-session-config.ts
+++ b/packages/coding-agent/src/core/agent-session-config.ts
@@ -14,6 +14,7 @@ export interface AgentSessionRuntimeConfig {
 	appendSystemPrompt?: string[];
 	thinking?: ThinkingLevel;
 	models?: string[];
+	fallbackModels?: string[];
 	tools?: string[];
 	noTools?: boolean;
 	noBuiltinTools?: boolean;
@@ -65,6 +66,7 @@ export function mergeAgentSessionRuntimeConfig(
 		appendSystemPrompt: cloneArray(override.appendSystemPrompt ?? base.appendSystemPrompt),
 		thinking: override.thinking ?? base.thinking,
 		models: cloneArray(override.models ?? base.models),
+		fallbackModels: cloneArray(override.fallbackModels ?? base.fallbackModels),
 		tools: cloneArray(override.tools ?? base.tools),
 		noTools: override.noTools ?? base.noTools,
 		noBuiltinTools: override.noBuiltinTools ?? base.noBuiltinTools,
@@ -94,6 +96,7 @@ function cloneAgentSessionRuntimeConfig(config: AgentSessionRuntimeConfig): Agen
 		...config,
 		appendSystemPrompt: cloneArray(config.appendSystemPrompt),
 		models: cloneArray(config.models),
+		fallbackModels: cloneArray(config.fallbackModels),
 		tools: cloneArray(config.tools),
 		extensions: cloneArray(config.extensions),
 		skills: cloneArray(config.skills),

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -64,6 +64,8 @@ export interface AgentSessionCreationOptions {
 	/** Provider service tier. Fast mode uses "priority". */
 	serviceTier?: ServiceTier;
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>;
+	/** Ordered failover chain used when the retry policy is exhausted. */
+	fallbackModels?: Model<any>[];
 	tools?: string[];
 	noTools?: "all" | "builtin";
 	customTools?: ToolDefinition[];
@@ -281,6 +283,7 @@ export async function createAgentSessionFromServices(
 		thinkingLevel: options.thinkingLevel,
 		serviceTier: options.serviceTier,
 		scopedModels: options.scopedModels,
+		fallbackModels: options.fallbackModels,
 		tools: options.tools,
 		noTools: options.noTools,
 		customTools: options.customTools,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -357,6 +357,17 @@ export type AgentSessionEvent =
 			finalError?: string;
 	  }
 	| {
+			type: "model_switch";
+			/** Previous model as `provider/id`. */
+			from: string;
+			/** New model as `provider/id`. */
+			to: string;
+			/** Provider failure that exhausted the retry policy on `from`. */
+			reason: string;
+			/** 1-based position of `to` within the configured fallback chain. */
+			attempt: number;
+	  }
+	| {
 			type: "auth_stale";
 			provider: string;
 			sourceTokens?: readonly AuthSourceToken[];
@@ -417,6 +428,12 @@ export interface AgentSessionConfig {
 	agentDir?: string;
 	/** Models to cycle through with Ctrl+P (from --models flag) */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>;
+	/**
+	 * Ordered fallback chain (from fallbackModels settings / --fallback-models).
+	 * When the per-model retry policy is exhausted on a retryable-class failure,
+	 * the session advances to the next chain entry instead of failing terminally.
+	 */
+	fallbackModels?: Model<any>[];
 	/** Resource loader for skills, prompts, themes, context files, system prompt */
 	resourceLoader: ResourceLoader;
 	/** SDK custom tools registered outside extensions */
@@ -1148,6 +1165,12 @@ export class AgentSession {
 
 	// Retry state
 	private _retryAbortController: AbortController | undefined = undefined;
+	/** Resolved fallback chain entries; empty when failover is not configured. */
+	private _fallbackModels: Model<any>[] = [];
+	/** Number of chain entries already consumed by failover in this session. */
+	private _fallbackIndex = 0;
+	/** Every model tried in the current failover run, with the failure that retired it. */
+	private _fallbackFailures: Array<{ model: string; failureClass: string }> = [];
 	private _retryAttempt = 0;
 	private _retryPromise: Promise<void> | undefined = undefined;
 	private _retryResolve: (() => void) | undefined = undefined;
@@ -1292,6 +1315,7 @@ export class AgentSession {
 		this.settingsManager = config.settingsManager;
 		this._serviceTierPreference = config.serviceTierPreference ?? config.agent.state.serviceTier;
 		this._scopedModels = config.scopedModels ?? [];
+		this._fallbackModels = config.fallbackModels ? [...config.fallbackModels] : [];
 		this._resourceLoader = config.resourceLoader;
 		this._customTools = config.customTools ?? [];
 		this._cwd = config.cwd;
@@ -10201,6 +10225,94 @@ export class AgentSession {
 		return false;
 	}
 
+	/**
+	 * Replace the fallback chain. Entries are tried in order after the per-model
+	 * retry policy is exhausted on a retryable-class failure.
+	 */
+	setFallbackModels(models: Model<any>[]): void {
+		this._fallbackModels = [...models];
+		this._fallbackIndex = 0;
+		this._fallbackFailures = [];
+	}
+
+	/** Configured fallback chain, in order. */
+	get fallbackModels(): readonly Model<any>[] {
+		return this._fallbackModels;
+	}
+
+	private _modelSelector(model: Model<any> | undefined): string {
+		return model ? `${model.provider}/${model.id}` : "unknown";
+	}
+
+	/**
+	 * Classify why a model was retired, for the chain-exhaustion report.
+	 * Structured provider diagnostics win over error-message sniffing.
+	 */
+	private _failureClass(message: AssistantMessage): string {
+		const kind = this._getProviderStreamFailureKind(message);
+		if (kind) return kind;
+		const errorMessage = message.errorMessage ?? "";
+		if (/\b429\b|rate.?limit|too many requests/i.test(errorMessage)) return "rate_limit";
+		if (/\b5\d{2}\b|overloaded|unavailable|internal server/i.test(errorMessage)) return "server_error";
+		if (/timeout|timed out|network|connection/i.test(errorMessage)) return "network";
+		if (/cooldown/i.test(errorMessage)) return "cooldown";
+		return "error";
+	}
+
+	/**
+	 * Whether a retry-exhausted failure is eligible for model failover.
+	 * Auth and invalid-request failures are the caller's problem on every model,
+	 * so they must keep failing loudly instead of burning the chain.
+	 */
+	private _canFailoverToNextModel(message: AssistantMessage): boolean {
+		if (this._fallbackIndex >= this._fallbackModels.length) return false;
+		if (this._isStructuredPermanentProviderFailure(message)) return false;
+		if (this._isConcreteProviderAuthFailure(message)) return false;
+		if (this._isAgentLifecycleFailure(message)) return false;
+		if (this._isFauxProviderQueueExhausted(message)) return false;
+		return true;
+	}
+
+	/** Human-readable terminal report naming every model tried and its failure class. */
+	private _formatFallbackExhaustion(message: AssistantMessage): string {
+		const attempts = [
+			...this._fallbackFailures,
+			{ model: this._modelSelector(this.model), failureClass: this._failureClass(message) },
+		];
+		const tried = attempts.map((entry) => `${entry.model} (${entry.failureClass})`).join(", ");
+		return `All fallback models failed: ${tried}. Last error: ${message.errorMessage ?? "unknown error"}`;
+	}
+
+	/**
+	 * Advance to the next fallback chain entry, keeping the same conversation.
+	 * Budget counters are session-scoped and deliberately untouched here.
+	 */
+	private async _failoverToNextModel(message: AssistantMessage): Promise<boolean> {
+		const next = this._fallbackModels[this._fallbackIndex];
+		if (!next) return false;
+
+		const from = this._modelSelector(this.model);
+		const to = this._modelSelector(next);
+		const failureClass = this._failureClass(message);
+		const reason = message.errorMessage ?? failureClass;
+
+		try {
+			await this.setModel(next, { waitForExtensions: false });
+		} catch {
+			// An unusable chain entry must not strand the session: retire it and
+			// let the next _handleRetryableError call try the following entry.
+			this._fallbackIndex++;
+			this._fallbackFailures.push({ model: to, failureClass: "unavailable" });
+			return false;
+		}
+
+		this._fallbackIndex++;
+		this._fallbackFailures.push({ model: from, failureClass });
+		this.sessionManager.appendModelSwitch(from, to, reason, this._fallbackIndex);
+		this._emit({ type: "model_switch", from, to, reason, attempt: this._fallbackIndex });
+		return true;
+	}
+
 	private _finishActiveRetryWithFailure(message: AssistantMessage): void {
 		if (this._retryAttempt === 0) {
 			return;
@@ -10246,13 +10358,37 @@ export class AgentSession {
 		this._retryAttempt++;
 
 		if (this._retryAttempt > settings.maxRetries) {
+			// Per-model retry policy is exhausted. Before failing terminally, try
+			// the next fallback chain entry on the same conversation.
+			if (this._canFailoverToNextModel(message)) {
+				const switched = await this._failoverToNextModel(message);
+				if (switched) {
+					this._emit({
+						type: "auto_retry_end",
+						success: false,
+						attempt: this._retryAttempt - 1,
+						finalError: message.errorMessage,
+					});
+					this._retryAttempt = 0;
+					this._retryAuthFailureSources = [];
+					this._removeTrailingErrorMessage();
+					setTimeout(() => {
+						this.agent.continue().catch(() => {
+							// Failover attempt failed - will be caught by next agent_end
+						});
+					}, 0);
+					return true;
+				}
+			}
+
 			this._markProviderAuthStaleForRetryFailure(message, options);
 			// Max retries exceeded, emit final failure and reset
 			this._emit({
 				type: "auto_retry_end",
 				success: false,
 				attempt: this._retryAttempt - 1,
-				finalError: message.errorMessage,
+				finalError:
+					this._fallbackFailures.length > 0 ? this._formatFallbackExhaustion(message) : message.errorMessage,
 			});
 			this._retryAttempt = 0;
 			this._retryAuthFailureSources = [];
@@ -10271,10 +10407,7 @@ export class AgentSession {
 		});
 
 		// Remove error message from agent state (keep in session for history)
-		const messages = this.agent.state.messages;
-		if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
-			this.agent.state.messages = messages.slice(0, -1);
-		}
+		this._removeTrailingErrorMessage();
 
 		// Wait with exponential backoff (abortable)
 		this._retryAbortController = new AbortController();
@@ -10306,6 +10439,14 @@ export class AgentSession {
 		}, 0);
 
 		return true;
+	}
+
+	/** Drop a trailing assistant error from agent state; session history keeps it. */
+	private _removeTrailingErrorMessage(): void {
+		const messages = this.agent.state.messages;
+		if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
+			this.agent.state.messages = messages.slice(0, -1);
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -339,6 +339,71 @@ export function resolveModelScopeFromModels(patterns: string[], availableModels:
 	return scopedModels;
 }
 
+/**
+ * Resolve an ordered `fallbackModels` chain to concrete models.
+ *
+ * Unlike `--models`, a fallback entry must be an exact `provider/model-id`:
+ * a silently dropped or glob-expanded failover target would surface as a dead
+ * chain only once production was already failing. Invalid entries throw.
+ */
+export function resolveFallbackModelsFromModels(entries: string[], availableModels: Model<Api>[]): Model<Api>[] {
+	const resolved: Model<Api>[] = [];
+
+	for (const entry of entries) {
+		const trimmed = entry.trim();
+		if (!trimmed) {
+			throw new Error(
+				`Invalid fallbackModels entry: empty value. Each entry must be "provider/model-id", for example "anthropic/claude-sonnet-4-5".`,
+			);
+		}
+
+		const separator = trimmed.indexOf("/");
+		const provider = separator === -1 ? "" : trimmed.slice(0, separator).trim();
+		const modelId = separator === -1 ? "" : trimmed.slice(separator + 1).trim();
+		if (!provider || !modelId) {
+			throw new Error(
+				`Invalid fallbackModels entry "${trimmed}": expected "provider/model-id", for example "anthropic/claude-sonnet-4-5".`,
+			);
+		}
+
+		const knownProvider = availableModels.some((model) => model.provider.toLowerCase() === provider.toLowerCase());
+		if (!knownProvider) {
+			const providers = [...new Set(availableModels.map((model) => model.provider))].sort();
+			throw new Error(
+				`Invalid fallbackModels entry "${trimmed}": unknown provider "${provider}". Known providers: ${providers.join(", ") || "none"}.`,
+			);
+		}
+
+		const model = availableModels.find(
+			(candidate) =>
+				candidate.provider.toLowerCase() === provider.toLowerCase() &&
+				candidate.id.toLowerCase() === modelId.toLowerCase(),
+		);
+		if (!model) {
+			const providerModels = availableModels
+				.filter((candidate) => candidate.provider.toLowerCase() === provider.toLowerCase())
+				.map((candidate) => candidate.id)
+				.sort();
+			throw new Error(
+				`Invalid fallbackModels entry "${trimmed}": unknown model "${modelId}" for provider "${provider}". Available: ${providerModels.join(", ") || "none"}.`,
+			);
+		}
+
+		if (!resolved.some((existing) => modelsAreEqual(existing, model))) {
+			resolved.push(model);
+		}
+	}
+
+	return resolved;
+}
+
+/** Resolve a `fallbackModels` chain against the live model registry. */
+export async function resolveFallbackModels(entries: string[], modelRegistry: ModelRegistry): Promise<Model<Api>[]> {
+	if (entries.length === 0) return [];
+	const availableModels = await modelRegistry.refreshAvailableModels();
+	return resolveFallbackModelsFromModels(entries, availableModels);
+}
+
 export async function resolveModelScope(patterns: string[], modelRegistry: ModelRegistry): Promise<ScopedModel[]> {
 	const availableModels = await modelRegistry.refreshAvailableModels();
 	return resolveModelScopeFromModels(patterns, availableModels);

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -37,6 +37,8 @@ export interface CreateAgentSessionOptions extends AgentSessionCreationOptions {
 	thinkingLevel?: ThinkingLevel;
 	/** Models available for cycling (Ctrl+P in interactive mode) */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>;
+	/** Ordered failover chain used when the per-model retry policy is exhausted */
+	fallbackModels?: Model<any>[];
 
 	/**
 	 * Optional default tool suppression mode when no explicit allowlist is provided.
@@ -375,6 +377,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Only the explicit dir — the default may not match injected custom storage.
 		agentDir: options.agentDir,
 		scopedModels: options.scopedModels,
+		fallbackModels: options.fallbackModels,
 		resourceLoader,
 		customTools: options.customTools,
 		modelRegistry,

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -123,6 +123,19 @@ export interface ModelChangeEntry extends SessionEntryBase {
 	modelId: string;
 }
 
+/** Automatic failover from one model to the next `fallbackModels` chain entry. */
+export interface ModelSwitchEntry extends SessionEntryBase {
+	type: "model_switch";
+	/** Previous model as `provider/id`. */
+	from: string;
+	/** New model as `provider/id`. */
+	to: string;
+	/** Provider failure that exhausted the retry policy on `from`. */
+	reason: string;
+	/** 1-based position of `to` within the configured fallback chain. */
+	attempt: number;
+}
+
 export interface CompactionEntry<T = unknown> extends SessionEntryBase {
 	type: "compaction";
 	summary: string;
@@ -251,6 +264,7 @@ export type SessionEntry =
 	| ThinkingLevelChangeEntry
 	| ServiceTierChangeEntry
 	| ModelChangeEntry
+	| ModelSwitchEntry
 	| CompactionEntry
 	| BranchSummaryEntry
 	| CustomEntry
@@ -1534,6 +1548,22 @@ export class SessionManager {
 			timestamp: new Date().toISOString(),
 			provider,
 			modelId,
+		};
+		this._appendEntry(entry);
+		return entry.id;
+	}
+
+	/** Append an automatic model failover record as child of current leaf. Returns entry id. */
+	appendModelSwitch(from: string, to: string, reason: string, attempt: number): string {
+		const entry: ModelSwitchEntry = {
+			type: "model_switch",
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			from,
+			to,
+			reason,
+			attempt,
 		};
 		this._appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -156,6 +156,7 @@ export interface Settings {
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
+	fallbackModels?: string[]; // Ordered "provider/model-id" failover chain (same format as --fallback-models CLI flag)
 	treeFilterMode?: "default" | "no-tools" | "user-only" | "labeled-only" | "all"; // Default: "user-only"
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
@@ -1207,6 +1208,10 @@ export class SettingsManager {
 
 	getEnabledModels(): string[] | undefined {
 		return this.settings.enabledModels;
+	}
+
+	getFallbackModels(): string[] | undefined {
+		return this.settings.fallbackModels;
 	}
 
 	getMcpServers(): Record<string, McpServerConfig> | undefined {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -58,7 +58,13 @@ import type { ExtensionFactory } from "./core/extensions/types.js";
 import { KeybindingsManager } from "./core/keybindings.js";
 import { installFileLogSink, setLogContext } from "./core/logging.js";
 import type { ModelRegistry } from "./core/model-registry.js";
-import { findInitialModel, resolveCliModel, resolveModelScope, type ScopedModel } from "./core/model-resolver.js";
+import {
+	findInitialModel,
+	resolveCliModel,
+	resolveFallbackModels,
+	resolveModelScope,
+	type ScopedModel,
+} from "./core/model-resolver.js";
 import { restoreStdout, takeOverStdout } from "./core/output-guard.js";
 import type { CreateAgentSessionOptions } from "./core/sdk.js";
 import {
@@ -651,6 +657,7 @@ function runtimeConfigFromArgs(
 		appendSystemPrompt: parsed.appendSystemPrompt,
 		thinking: parsed.thinking,
 		models: parsed.models,
+		fallbackModels: parsed.fallbackModels,
 		tools: parsed.tools,
 		noTools: parsed.noTools,
 		noBuiltinTools: parsed.noBuiltinTools,
@@ -679,6 +686,7 @@ function runtimeConfigFromArgs(
 interface PreparedRuntimeServices {
 	services: AgentSessionServices;
 	scopedModels: ScopedModel[];
+	fallbackModels: Model<Api>[];
 	sessionOptions: CreateAgentSessionOptions;
 	cliThinkingFromModel: boolean;
 	diagnostics: AgentSessionRuntimeDiagnostic[];
@@ -697,6 +705,7 @@ export function resolveRuntimeSessionOptions(
 		thinkingLevel: runtimeSessionOptions?.thinkingLevel ?? sessionOptions.thinkingLevel,
 		serviceTier: runtimeSessionOptions?.serviceTier ?? sessionOptions.serviceTier,
 		scopedModels: runtimeSessionOptions?.scopedModels ?? sessionOptions.scopedModels,
+		fallbackModels: runtimeSessionOptions?.fallbackModels ?? sessionOptions.fallbackModels,
 		tools: runtimeSessionOptions?.tools ?? sessionOptions.tools,
 		noTools: runtimeSessionOptions?.noTools ?? sessionOptions.noTools,
 		customTools: runtimeSessionOptions?.customTools ?? sessionOptions.customTools,
@@ -770,6 +779,18 @@ async function prepareRuntimeServices(options: {
 	const modelPatterns = config.models ?? settingsManager.getEnabledModels();
 	const scopedModels =
 		modelPatterns && modelPatterns.length > 0 ? await resolveModelScope(modelPatterns, modelRegistry) : [];
+
+	// CLI --fallback-models overrides the settings.json chain.
+	const fallbackModelEntries = config.fallbackModels ?? settingsManager.getFallbackModels() ?? [];
+	let fallbackModels: Model<Api>[] = [];
+	try {
+		fallbackModels = await resolveFallbackModels(fallbackModelEntries, modelRegistry);
+	} catch (error) {
+		diagnostics.push({
+			type: "error",
+			message: error instanceof Error ? error.message : String(error),
+		});
+	}
 	const {
 		options: sessionOptions,
 		cliThinkingFromModel,
@@ -781,6 +802,9 @@ async function prepareRuntimeServices(options: {
 		modelRegistry,
 		settingsManager,
 	);
+	// The chain is resolved against the registry above; buildSessionOptions
+	// does not know it, so attach it here to carry it through session creation.
+	sessionOptions.fallbackModels = fallbackModels;
 	diagnostics.push(...sessionOptionDiagnostics);
 
 	const effectiveSessionModel = options.sessionOptionsOverride?.model ?? sessionOptions.model;
@@ -798,6 +822,7 @@ async function prepareRuntimeServices(options: {
 	return {
 		services,
 		scopedModels,
+		fallbackModels,
 		sessionOptions,
 		cliThinkingFromModel,
 		diagnostics,

--- a/packages/coding-agent/src/modes/agent-connection/index.ts
+++ b/packages/coding-agent/src/modes/agent-connection/index.ts
@@ -23,6 +23,7 @@ export type {
 	AgentConnectionModelCatalog,
 	AgentConnectionModelChangeEntry,
 	AgentConnectionModelCycleResult,
+	AgentConnectionModelSwitchEntry,
 	AgentConnectionNavigateTreeOptions,
 	AgentConnectionNavigateTreeResult,
 	AgentConnectionNewSessionOptions,

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -169,6 +169,14 @@ export interface AgentConnectionModelChangeEntry extends AgentConnectionSessionE
 	modelId: string;
 }
 
+export interface AgentConnectionModelSwitchEntry extends AgentConnectionSessionEntryBase {
+	type: "model_switch";
+	from: string;
+	to: string;
+	reason: string;
+	attempt: number;
+}
+
 export interface AgentConnectionCompactionEntry extends AgentConnectionSessionEntryBase {
 	type: "compaction";
 	summary: string;
@@ -243,6 +251,7 @@ export type AgentConnectionSessionEntry =
 	| AgentConnectionThinkingLevelChangeEntry
 	| AgentConnectionServiceTierChangeEntry
 	| AgentConnectionModelChangeEntry
+	| AgentConnectionModelSwitchEntry
 	| AgentConnectionCompactionEntry
 	| AgentConnectionBranchSummaryEntry
 	| AgentConnectionCustomEntry
@@ -595,6 +604,7 @@ export type AgentConnectionSessionEvent =
 	  }
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+	| { type: "model_switch"; from: string; to: string; reason: string; attempt: number }
 	| { type: "auth_stale"; provider: string; sourceTokens?: readonly AuthSourceToken[] }
 	| { type: "rlm_child_update"; child: AgentConnectionRlmChildAgentSnapshot }
 	| { type: "recap_update"; recap: string | undefined }

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+// Revision 17 adds the model_switch session entry and event for native model failover.
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-1bcb9e7f1a49";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/test/fallback-models-config.test.ts
+++ b/packages/coding-agent/test/fallback-models-config.test.ts
@@ -1,0 +1,96 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import { parseArgs } from "../src/cli/args.js";
+import { resolveFallbackModels, resolveFallbackModelsFromModels } from "../src/core/model-resolver.js";
+
+const models: Model<"anthropic-messages">[] = [
+	{
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+	},
+	{
+		id: "gpt-4o",
+		name: "GPT-4o",
+		api: "anthropic-messages",
+		provider: "openai",
+		baseUrl: "https://api.openai.com",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 5, output: 15, cacheRead: 0.5, cacheWrite: 5 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	},
+];
+
+describe("--fallback-models CLI flag", () => {
+	test("parses a comma separated chain", () => {
+		const result = parseArgs(["--fallback-models", "anthropic/claude-sonnet-4-5,openai/gpt-4o"]);
+		expect(result.fallbackModels).toEqual(["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]);
+	});
+
+	test("trims whitespace and drops empty entries", () => {
+		const result = parseArgs(["--fallback-models", " anthropic/claude-sonnet-4-5 , , openai/gpt-4o "]);
+		expect(result.fallbackModels).toEqual(["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]);
+	});
+
+	test("is absent when the flag is not passed", () => {
+		expect(parseArgs([]).fallbackModels).toBeUndefined();
+	});
+
+	test("reports an error when the value is empty", () => {
+		const result = parseArgs(["--fallback-models", "  "]);
+		expect(result.diagnostics.some((d) => d.type === "error" && d.message.includes("--fallback-models"))).toBe(true);
+	});
+});
+
+describe("resolveFallbackModelsFromModels", () => {
+	test("resolves entries in order", () => {
+		const resolved = resolveFallbackModelsFromModels(["anthropic/claude-sonnet-4-5", "openai/gpt-4o"], models);
+		expect(resolved.map((m) => `${m.provider}/${m.id}`)).toEqual(["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]);
+		expect(resolved).toHaveLength(2);
+	});
+
+	test("rejects an unknown provider with an actionable error", () => {
+		expect(() => resolveFallbackModelsFromModels(["nosuchprovider/some-model"], models)).toThrow(
+			/fallbackModels.*nosuchprovider\/some-model/s,
+		);
+	});
+
+	test("rejects an unknown model id with an actionable error", () => {
+		expect(() => resolveFallbackModelsFromModels(["anthropic/not-a-real-model"], models)).toThrow(
+			/fallbackModels.*anthropic\/not-a-real-model/s,
+		);
+	});
+
+	test("rejects an empty model id", () => {
+		expect(() => resolveFallbackModelsFromModels(["anthropic/"], models)).toThrow(/fallbackModels/);
+	});
+
+	test("rejects a blank entry", () => {
+		expect(() => resolveFallbackModelsFromModels(["   "], models)).toThrow(/fallbackModels/);
+	});
+
+	test("deduplicates repeated entries while keeping order", () => {
+		const resolved = resolveFallbackModelsFromModels(
+			["anthropic/claude-sonnet-4-5", "openai/gpt-4o", "anthropic/claude-sonnet-4-5"],
+			models,
+		);
+		expect(resolved.map((m) => `${m.provider}/${m.id}`)).toEqual(["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]);
+	});
+
+	test("returns an empty chain for an empty list", () => {
+		expect(resolveFallbackModelsFromModels([], models)).toEqual([]);
+	});
+
+	test("is exported for registry-backed resolution", () => {
+		expect(typeof resolveFallbackModels).toBe("function");
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-fallback-models.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-fallback-models.test.ts
@@ -1,0 +1,283 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ModelSwitchEntry } from "../../src/core/session-manager.js";
+import { createHarness, getAssistantTexts, type Harness } from "./harness.js";
+
+const FALLBACK_MODELS = [{ id: "faux-1" }, { id: "faux-2" }, { id: "faux-3" }];
+
+function transientError(errorMessage = "overloaded_error"): AssistantMessage {
+	return fauxAssistantMessage("", { stopReason: "error", errorMessage });
+}
+
+function structuredFailure(kind: "auth" | "invalid_request", status?: number): AssistantMessage {
+	return {
+		...fauxAssistantMessage("", {
+			stopReason: "error",
+			errorMessage: `provider ${kind} failure`,
+		}),
+		diagnostics: [
+			{
+				type: "provider_stream_failure",
+				timestamp: Date.now(),
+				details: status === undefined ? { kind } : { kind, status },
+			},
+		],
+	};
+}
+
+function modelSwitches(harness: Harness): ModelSwitchEntry[] {
+	return harness.sessionManager
+		.getEntries()
+		.filter((entry): entry is ModelSwitchEntry => entry.type === "model_switch");
+}
+
+describe("native model failover (fallbackModels)", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("advances to the next fallback model once the retry policy is exhausted", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!]);
+
+		harness.setResponses([transientError(), transientError(), transientError(), fauxAssistantMessage("recovered")]);
+
+		await harness.session.prompt("test");
+
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.faux.state.callCount).toBe(4);
+		expect(getAssistantTexts(harness)).toContain("recovered");
+	});
+
+	it("continues the same conversation across the switch", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!]);
+
+		harness.setResponses([transientError(), transientError(), fauxAssistantMessage("after switch")]);
+
+		await harness.session.prompt("remember this");
+
+		const userTexts = harness.session.messages.filter((m) => m.role === "user");
+		expect(userTexts.length).toBe(1);
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(getAssistantTexts(harness)).toContain("after switch");
+	});
+
+	it("records a structured model_switch entry in the session JSONL", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+			persistSession: true,
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!]);
+
+		harness.setResponses([
+			transientError("429 rate limit"),
+			transientError("429 rate limit"),
+			fauxAssistantMessage("ok"),
+		]);
+
+		await harness.session.prompt("test");
+
+		const switches = modelSwitches(harness);
+		expect(switches).toHaveLength(1);
+		expect(switches[0]).toMatchObject({
+			type: "model_switch",
+			from: "faux/faux-1",
+			to: "faux/faux-2",
+			attempt: 1,
+		});
+		expect(switches[0].reason).toContain("429 rate limit");
+		expect(typeof switches[0].timestamp).toBe("string");
+	});
+
+	it("emits a model_switch session event", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!]);
+
+		harness.setResponses([transientError(), transientError(), fauxAssistantMessage("ok")]);
+
+		await harness.session.prompt("test");
+
+		const events = harness.eventsOfType("model_switch");
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ from: "faux/faux-1", to: "faux/faux-2" });
+	});
+
+	it("walks the whole chain when each model keeps failing", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!, harness.getModel("faux-3")!]);
+
+		harness.setResponses([
+			transientError(),
+			transientError(),
+			transientError(),
+			transientError(),
+			fauxAssistantMessage("third model works"),
+		]);
+
+		await harness.session.prompt("test");
+
+		expect(modelSwitches(harness).map((entry) => entry.to)).toEqual(["faux/faux-2", "faux/faux-3"]);
+		expect(harness.session.model?.id).toBe("faux-3");
+		expect(getAssistantTexts(harness)).toContain("third model works");
+	});
+
+	it("does not switch on a 401 auth failure", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!]);
+
+		harness.setResponses([
+			structuredFailure("auth", 401),
+			structuredFailure("auth", 401),
+			structuredFailure("auth", 401),
+		]);
+
+		await harness.session.prompt("test");
+
+		expect(modelSwitches(harness)).toEqual([]);
+		expect(harness.session.model?.id).toBe("faux-1");
+	});
+
+	it("does not switch on an invalid_request failure", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!]);
+
+		harness.setResponses([
+			structuredFailure("invalid_request"),
+			structuredFailure("invalid_request"),
+			structuredFailure("invalid_request"),
+		]);
+
+		await harness.session.prompt("test");
+
+		expect(modelSwitches(harness)).toEqual([]);
+		expect(harness.session.model?.id).toBe("faux-1");
+	});
+
+	it("keeps current behavior when no fallback chain is configured", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([transientError(), transientError()]);
+
+		await harness.session.prompt("test");
+
+		expect(modelSwitches(harness)).toEqual([]);
+		expect(harness.session.model?.id).toBe("faux-1");
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
+	});
+
+	it("reports every attempted model when the chain is exhausted", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!]);
+
+		harness.setResponses([transientError(), transientError(), transientError(), transientError()]);
+
+		await harness.session.prompt("test");
+
+		const ends = harness.eventsOfType("auto_retry_end");
+		const finalError = ends[ends.length - 1]?.finalError ?? "";
+		expect(finalError).toContain("faux/faux-1");
+		expect(finalError).toContain("faux/faux-2");
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toContain(false);
+	});
+
+	it("does not reset goal budget counters across a switch", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+			initialGoal: { objective: "stay alive", tokenBudget: 1_000_000 },
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!]);
+
+		harness.setResponses([
+			{
+				...fauxAssistantMessage("before switch"),
+				usage: {
+					input: 100,
+					output: 50,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 150,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+			},
+		]);
+		await harness.session.prompt("first");
+		const tokensBefore = harness.session.goalState.tokensUsed;
+		expect(tokensBefore).toBeGreaterThan(0);
+
+		harness.setResponses([transientError(), transientError(), fauxAssistantMessage("after switch")]);
+		await harness.session.prompt("second");
+
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.session.goalState.tokensUsed).toBeGreaterThanOrEqual(tokensBefore);
+		expect(harness.session.goalState.objective).toBe("stay alive");
+	});
+
+	it("spawns RLM children on the active fallback model, not the configured default", async () => {
+		const harness = await createHarness({
+			models: FALLBACK_MODELS,
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } },
+			rlmDepth: 0,
+			rlmMaxDepth: 2,
+			subagentRuntimeHost: {
+				createRlmSubagentRuntime: async () => {
+					throw new Error("child runtime intentionally not started in this test");
+				},
+				deleteRlmSubagentRuntime: async () => {},
+			},
+		});
+		harnesses.push(harness);
+		harness.session.setFallbackModels([harness.getModel("faux-2")!]);
+
+		harness.setResponses([transientError(), transientError(), fauxAssistantMessage("switched")]);
+		await harness.session.prompt("test");
+		expect(harness.session.model?.id).toBe("faux-2");
+
+		await harness.session.runRlmChild("child task");
+
+		const childUpdates = harness.eventsOfType("rlm_child_update");
+		expect(childUpdates.length).toBeGreaterThan(0);
+		expect(childUpdates[0].child.model).toBe("faux/faux-2");
+	});
+});

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -63,6 +63,7 @@ export interface HarnessOptions {
 	api?: string;
 	provider?: string;
 	models?: FauxModelDefinition[];
+	fallbackModels?: Model<string>[];
 	settings?: Partial<Settings>;
 	systemPrompt?: string;
 	tools?: AgentTool[];
@@ -196,6 +197,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		agentMessageController: options.agentMessageController,
 		subagentRuntimeHost: options.subagentRuntimeHost,
 		baseToolsOverride: toolMap,
+		fallbackModels: options.fallbackModels,
 		extensionRunnerRef,
 		rlmDepth: options.rlmDepth,
 		rlmMaxDepth: options.rlmMaxDepth,


### PR DESCRIPTION
Implements native ordered model failover, request 3 of #1436.

`fallbackModels` was accepted in settings.json but had no implementation
(zero occurrences in the v0.7.2 bundle and on main), so a harness could look
failover-protected while having none. When a provider-family cooldown struck
the only configured route, long-running work died with no way to continue.

## Behavior

Configure an ordered chain in settings.json, or per-run via `--fallback-models`
which overrides the setting:

```json
{ "fallbackModels": ["anthropic/claude-sonnet-4-5", "openai/gpt-5.2"] }
```

- Failover triggers only after the existing per-model retry policy is exhausted,
  and only for retryable-class failures (429, 5xx, network, provider cooldown).
- Auth (401/403) and invalid-request failures never trigger failover; they keep
  failing loudly, since they would fail identically on every model in the chain.
- A switch keeps the same conversation and session. Autonomous budget counters
  (tokens, turns, time) continue across it and are never reset.
- Each switch appends a structured `model_switch` entry to the session JSONL
  (`{from, to, reason, attempt, timestamp}`) and emits a matching session event.
- RLM children spawned after a switch inherit the active model rather than the
  configured default.
- When the chain is exhausted, the terminal error names every model tried with
  its failure class.

Chain entries must be exact `provider/model-id`. Unlike `--models`, an unmatched
entry is rejected at startup with an actionable error rather than silently
dropped, so a dead failover target surfaces before the outage it was meant to
cover. An absent or empty chain leaves current behavior byte-identical.

## Tests

`packages/coding-agent/test/suite/agent-session-fallback-models.test.ts` (faux
provider, no live APIs) covers the switch, conversation continuity, the JSONL
record, budget monotonicity, the 401 non-trigger, chain exhaustion, and child
model inheritance. `test/fallback-models-config.test.ts` covers flag parsing and
config validation. All test files touching the changed modules pass (219 tests).

Not addressed here: requests 1 and 2 of #1436 (unknown-settings-key rejection
and the batch-mode hang on an over-cap retry delay) are separate concerns.

Draft: opened for direction on the config surface before further work.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native model failover via `fallbackModels` setting and `--fallback-models` CLI flag
> - When the per-model retry policy is exhausted on a retryable failure, `AgentSession` switches to the next model in the configured fallback chain and continues the same conversation without interruption.
> - Fallback models are specified as an ordered list of `provider/model-id` strings via the `--fallback-models` CLI flag or `fallbackModels` in settings.json; the runtime validates and resolves them against the live model registry at startup.
> - A `model_switch` event is emitted and a `model_switch` entry is persisted in the session when failover occurs; if the chain is exhausted, the final retry error lists all attempted models and their failure classes.
> - Auth and `invalid_request` failures do not trigger failover.
> - Daemon protocol schema bumped from 16 to 17 to include the new `model_switch` entry and event types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb6f1ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->