### PR TITLE
feat(coding-agent): show subagent model and effort in agents view

### DIFF
--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -81,6 +81,7 @@ import {
 	getAgentsViewSummaryIdentity as getSummaryIdentity,
 	getUnifiedSessionAncestorSessionIds,
 	hasUnifiedSessionChildren,
+	isSubagentSummary,
 	migrateAgentsViewIdentitySet,
 	reconcileUnifiedSessions,
 	resolveAgentsViewLeftResult,
@@ -2555,7 +2556,7 @@ export class AgentsViewMode implements Component, Focusable {
 		// Keep stable model information ahead of the variable summary so narrow rows truncate the summary first.
 		const summaryText = !pendingDelete && !pendingKill ? row.summary.summary : undefined;
 		const modelLabel =
-			row.summary.runtimeKind === "subagent" && !pendingDelete && !pendingKill && row.summary.model
+			isSubagentSummary(row.summary) && !pendingDelete && !pendingKill && row.summary.model
 				? `${row.summary.model.provider}/${row.summary.model.id}${row.summary.thinkingLevel && row.summary.thinkingLevel !== "off" ? `:${row.summary.thinkingLevel}` : ""}`
 				: undefined;
 		const suffixes = [modelLabel, summaryText].filter(

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2552,15 +2552,13 @@ export class AgentsViewMode implements Component, Focusable {
 			: pendingKill
 				? `${keyText("app.agents.delete")} again to ${row.section === "running" ? "stop" : "delete"}`
 				: styleRowTitle(row);
-		// Append the background summary as a dim suffix on the same line, e.g.
-		// "fix auth · Refactoring token validation". Hidden during delete/stop
-		// confirmations so the warning text stands alone.
+		// Keep stable model information ahead of the variable summary so narrow rows truncate the summary first.
 		const summaryText = !pendingDelete && !pendingKill ? row.summary.summary : undefined;
 		const modelLabel =
 			row.summary.runtimeKind === "subagent" && !pendingDelete && !pendingKill && row.summary.model
 				? `${row.summary.model.provider}/${row.summary.model.id}${row.summary.thinkingLevel && row.summary.thinkingLevel !== "off" ? `:${row.summary.thinkingLevel}` : ""}`
 				: undefined;
-		const suffixes = [summaryText, modelLabel].filter(
+		const suffixes = [modelLabel, summaryText].filter(
 			(suffix): suffix is string => suffix !== undefined && suffix.length > 0,
 		);
 		const titleContent = suffixes.length > 0 ? `${title} ${theme.fg("dim", `· ${suffixes.join(" · ")}`)}` : title;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2560,7 +2560,9 @@ export class AgentsViewMode implements Component, Focusable {
 			row.summary.runtimeKind === "subagent" && !pendingDelete && !pendingKill && row.summary.model
 				? `${row.summary.model.provider}/${row.summary.model.id}${row.summary.thinkingLevel ? `:${row.summary.thinkingLevel}` : ""}`
 				: undefined;
-		const suffixes = [summaryText, modelLabel].filter((suffix): suffix is string => suffix !== undefined);
+		const suffixes = [summaryText, modelLabel].filter(
+			(suffix): suffix is string => suffix !== undefined && suffix.length > 0,
+		);
 		const titleContent = suffixes.length > 0 ? `${title} ${theme.fg("dim", `· ${suffixes.join(" · ")}`)}` : title;
 		const titleCell = formatTableCell(titleContent, titleWidth);
 		const cells = [

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2558,7 +2558,7 @@ export class AgentsViewMode implements Component, Focusable {
 		const summaryText = !pendingDelete && !pendingKill ? row.summary.summary : undefined;
 		const modelLabel =
 			row.summary.runtimeKind === "subagent" && !pendingDelete && !pendingKill && row.summary.model
-				? `${row.summary.model.provider}/${row.summary.model.id}${row.summary.thinkingLevel ? `:${row.summary.thinkingLevel}` : ""}`
+				? `${row.summary.model.provider}/${row.summary.model.id}${row.summary.thinkingLevel && row.summary.thinkingLevel !== "off" ? `:${row.summary.thinkingLevel}` : ""}`
 				: undefined;
 		const suffixes = [summaryText, modelLabel].filter(
 			(suffix): suffix is string => suffix !== undefined && suffix.length > 0,

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2556,7 +2556,12 @@ export class AgentsViewMode implements Component, Focusable {
 		// "fix auth · Refactoring token validation". Hidden during delete/stop
 		// confirmations so the warning text stands alone.
 		const summaryText = !pendingDelete && !pendingKill ? row.summary.summary : undefined;
-		const titleContent = summaryText ? `${title} ${theme.fg("dim", `· ${summaryText}`)}` : title;
+		const modelLabel =
+			row.kind === "subagent" && !pendingKill && row.summary.model
+				? `${row.summary.model.provider}/${row.summary.model.id}${row.summary.thinkingLevel ? `:${row.summary.thinkingLevel}` : ""}`
+				: undefined;
+		const suffixes = [summaryText, modelLabel].filter((suffix): suffix is string => suffix !== undefined);
+		const titleContent = suffixes.length > 0 ? `${title} ${theme.fg("dim", `· ${suffixes.join(" · ")}`)}` : title;
 		const titleCell = formatTableCell(titleContent, titleWidth);
 		const cells = [
 			icon,

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -2557,7 +2557,7 @@ export class AgentsViewMode implements Component, Focusable {
 		// confirmations so the warning text stands alone.
 		const summaryText = !pendingDelete && !pendingKill ? row.summary.summary : undefined;
 		const modelLabel =
-			row.kind === "subagent" && !pendingKill && row.summary.model
+			row.summary.runtimeKind === "subagent" && !pendingDelete && !pendingKill && row.summary.model
 				? `${row.summary.model.provider}/${row.summary.model.id}${row.summary.thinkingLevel ? `:${row.summary.thinkingLevel}` : ""}`
 				: undefined;
 		const suffixes = [summaryText, modelLabel].filter((suffix): suffix is string => suffix !== undefined);

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -901,7 +901,7 @@ function findParentRow(
 	return undefined;
 }
 
-function isSubagentSummary(summary: SessionSummary): boolean {
+export function isSubagentSummary(summary: SessionSummary): boolean {
 	if (summary.runtimeKind) {
 		return summary.runtimeKind === "subagent";
 	}

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -485,7 +485,7 @@ describe("#502 unified session view regressions", () => {
 				summary: "Investigate a variable background status that can be truncated",
 				model: { provider: "prime-inference", id: "gpt-5.6-terra" } as SessionSummary["model"],
 				thinkingLevel: "high" as SessionSummary["thinkingLevel"],
-			},
+			} as SessionSummary,
 			title: "Inspect agents view",
 			subtitle: "",
 			statusLabel: "idle",
@@ -522,6 +522,12 @@ describe("#502 unified session view regressions", () => {
 
 		subagent.summary.summary = "";
 		expect(render(100)).toContain("Inspect agents view · prime-inference/gpt-5.6-terra:high");
+
+		// Older daemons identify subagents through persisted linkage instead of runtimeKind.
+		subagent.summary.runtimeKind = undefined;
+		subagent.summary.rlmChildId = "effort-child";
+		expect(render(100)).toContain("Inspect agents view · prime-inference/gpt-5.6-terra:high");
+
 		subagent.summary.thinkingLevel = "off";
 		subagent.summary.summary = "A later summary";
 		expect(render(100)).toContain("Inspect agents view · prime-inference/gpt-5.6-terra · A later summary");

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -472,7 +472,7 @@ describe("#502 unified session view regressions", () => {
 		expect(rendered).toMatch(/123456 · 2h\s*$/);
 	});
 
-	test("subagent rows show their model and effective effort within the existing responsive title cell", () => {
+	test("scoped subagent rows keep model and effort ahead of summaries", () => {
 		initTheme("dark");
 		const subagent = {
 			// Direct children in a scoped Agents View render as agent rows while
@@ -482,7 +482,7 @@ describe("#502 unified session view regressions", () => {
 			summary: {
 				...summary("effort-child"),
 				runtimeKind: "subagent" as const,
-				summary: "",
+				summary: "Investigate a variable background status that can be truncated",
 				model: { provider: "prime-inference", id: "gpt-5.6-terra" } as SessionSummary["model"],
 				thinkingLevel: "high" as SessionSummary["thinkingLevel"],
 			},
@@ -512,10 +512,21 @@ describe("#502 unified session view regressions", () => {
 				),
 			);
 
+		const full = render(120);
+		expect(full).toContain(
+			"Inspect agents view · prime-inference/gpt-5.6-terra:high · Investigate a variable background status",
+		);
+		const narrow = render(75);
+		expect(narrow).toContain("prime-inference/gpt-5.6-terra:high");
+		expect(narrow).not.toContain("Investigate a variable background status");
+
+		subagent.summary.summary = "";
 		expect(render(100)).toContain("Inspect agents view · prime-inference/gpt-5.6-terra:high");
 		subagent.summary.thinkingLevel = "off";
-		expect(render(100)).toContain("Inspect agents view · prime-inference/gpt-5.6-terra");
+		subagent.summary.summary = "A later summary";
+		expect(render(100)).toContain("Inspect agents view · prime-inference/gpt-5.6-terra · A later summary");
 		expect(render(100)).not.toContain(":off");
+
 		expect(render(20)).toHaveLength(20);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -470,4 +470,44 @@ describe("#502 unified session view regressions", () => {
 		);
 		expect(rendered).toMatch(/123456 · 2h\s*$/);
 	});
+
+	test("subagent rows show their model and effective effort within the existing responsive title cell", () => {
+		const subagent = {
+			kind: "subagent" as const,
+			section: "idle" as const,
+			summary: {
+				...summary("effort-child"),
+				runtimeKind: "subagent" as const,
+				model: { provider: "prime-inference", id: "gpt-5.6-terra" } as SessionSummary["model"],
+				thinkingLevel: "high" as const,
+			},
+			title: "Inspect agents view",
+			subtitle: "",
+			statusLabel: "idle",
+			depth: 1,
+			selectable: true,
+			runningSubagentCount: 0,
+			identity: "effort-child",
+			parentIdentity: "parent",
+		};
+		const harness = {
+			rows: [subagent],
+			selectedIndex: 0,
+			isPendingDeleteRow: () => false,
+			isPendingKillSubagentRow: () => false,
+			getRowIcon: () => "·",
+			formatRowIcon: (_section: string, icon: string) => icon,
+		};
+		const render = (width: number) =>
+			stripAnsi(
+				privateMethod<(this: typeof harness, row: typeof subagent, width: number) => string>("renderRow").call(
+					harness,
+					subagent,
+					width,
+				),
+			);
+
+		expect(render(100)).toContain("prime-inference/gpt-5.6-terra:high");
+		expect(render(20)).toHaveLength(20);
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -473,7 +473,9 @@ describe("#502 unified session view regressions", () => {
 
 	test("subagent rows show their model and effective effort within the existing responsive title cell", () => {
 		const subagent = {
-			kind: "subagent" as const,
+			// Direct children in a scoped Agents View render as agent rows while
+			// retaining their persisted subagent runtime kind.
+			kind: "agent" as const,
 			section: "idle" as const,
 			summary: {
 				...summary("effort-child"),
@@ -492,7 +494,7 @@ describe("#502 unified session view regressions", () => {
 		};
 		const harness = {
 			rows: [subagent],
-			selectedIndex: 0,
+			selectedIndex: -1,
 			isPendingDeleteRow: () => false,
 			isPendingKillSubagentRow: () => false,
 			getRowIcon: () => "·",

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -2,6 +2,7 @@ import stripAnsi from "strip-ansi";
 import { describe, expect, test, vi } from "vitest";
 import { AgentsViewMode } from "../../../src/modes/agents-view/agents-view-mode.js";
 import type { SessionSummary } from "../../../src/modes/daemon/daemon-session-list.js";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.js";
 import { createDeferred as deferred } from "../scheduling.js";
 
 function summary(id: string): SessionSummary {
@@ -472,6 +473,7 @@ describe("#502 unified session view regressions", () => {
 	});
 
 	test("subagent rows show their model and effective effort within the existing responsive title cell", () => {
+		initTheme("dark");
 		const subagent = {
 			// Direct children in a scoped Agents View render as agent rows while
 			// retaining their persisted subagent runtime kind.
@@ -480,6 +482,7 @@ describe("#502 unified session view regressions", () => {
 			summary: {
 				...summary("effort-child"),
 				runtimeKind: "subagent" as const,
+				summary: "",
 				model: { provider: "prime-inference", id: "gpt-5.6-terra" } as SessionSummary["model"],
 				thinkingLevel: "high" as const,
 			},
@@ -509,7 +512,7 @@ describe("#502 unified session view regressions", () => {
 				),
 			);
 
-		expect(render(100)).toContain("prime-inference/gpt-5.6-terra:high");
+		expect(render(100)).toContain("Inspect agents view · prime-inference/gpt-5.6-terra:high");
 		expect(render(20)).toHaveLength(20);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
+++ b/packages/coding-agent/test/suite/regressions/502-unified-session-view.test.ts
@@ -484,7 +484,7 @@ describe("#502 unified session view regressions", () => {
 				runtimeKind: "subagent" as const,
 				summary: "",
 				model: { provider: "prime-inference", id: "gpt-5.6-terra" } as SessionSummary["model"],
-				thinkingLevel: "high" as const,
+				thinkingLevel: "high" as SessionSummary["thinkingLevel"],
 			},
 			title: "Inspect agents view",
 			subtitle: "",
@@ -513,6 +513,9 @@ describe("#502 unified session view regressions", () => {
 			);
 
 		expect(render(100)).toContain("Inspect agents view · prime-inference/gpt-5.6-terra:high");
+		subagent.summary.thinkingLevel = "off";
+		expect(render(100)).toContain("Inspect agents view · prime-inference/gpt-5.6-terra");
+		expect(render(100)).not.toContain(":off");
 		expect(render(20)).toHaveLength(20);
 	});
 });


### PR DESCRIPTION
## Summary

- show each subagent's model and effective reasoning effort directly in Agents View rows
- render stable information first: `name · model/effort · summary`, so variable summaries truncate before model details
- preserve labels for current and pre-`runtimeKind` daemons by reusing the existing subagent classifier
- omit disabled (`off`) effort while preserving real levels
- preserve confirmation prompts and narrow-width behavior

## Validation

- focused Agents View regression covers full and narrow ordering, empty summaries, disabled effort, scoped subagents, and legacy linkage fallback
- exact Biome check passed for all three changed files
- `git diff --check` passed
- independent static review approved exact head `8fdd8b3`

Earlier CI exposed missing theme initialization in the focused rendering test; `1432df0` fixed that failure and the empty-summary separator finding. `b587f98` addressed the disabled-effort finding. `8fdd8b3` addresses the pre-`runtimeKind` Macroscope finding. The focused test could not run locally because the available validation environment lacks `get-east-asian-width`; repository CI runs the complete dependency environment.
