### PR TITLE
chore(release): prepare v0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.7.2",
+			"version": "0.7.3",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.7.2",
+				"@earendil-works/pi-coding-agent": "^0.7.3",
 				"get-east-asian-width": "^1.6.0"
 			},
 			"devDependencies": {
@@ -5707,10 +5707,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.7.2",
+			"version": "0.7.3",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.7.2",
+				"@earendil-works/pi-ai": "^0.7.3",
 				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
@@ -5741,7 +5741,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.7.2",
+			"version": "0.7.3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5787,14 +5787,14 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.7.2",
+			"version": "0.7.3",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@agentclientprotocol/sdk": "^1.3.0",
-				"@earendil-works/pi-agent-core": "^0.7.2",
-				"@earendil-works/pi-ai": "^0.7.2",
-				"@earendil-works/pi-tui": "^0.7.2",
+				"@earendil-works/pi-agent-core": "^0.7.3",
+				"@earendil-works/pi-ai": "^0.7.3",
+				"@earendil-works/pi-tui": "^0.7.3",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -5923,7 +5923,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.7.2",
+			"version": "0.7.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=22.8.0"
 	},
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.7.2",
+		"@earendil-works/pi-coding-agent": "^0.7.3",
 		"get-east-asian-width": "^1.6.0"
 	},
 	"overrides": {

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-17
+
+- Changed explicit `off` reasoning selections to reach providers instead of being omitted, preserving provider-specific disable behavior.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.7.2",
+		"@earendil-works/pi-ai": "^0.7.3",
 		"typebox": "^1.3.9"
 	},
 	"keywords": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-17
+
+- Added provider-derived reasoning levels for OpenRouter and Prime Inference models, including sparse, mandatory, toggle-only, and explicit-off capabilities.
+- Added Qwen 3.8 Max to the featured Prime Inference catalog ([#1247](https://github.com/PrimeIntellect-ai/prime-agent/pull/1247) by [@eliebak](https://github.com/eliebak)).
+- Refreshed generated provider catalogs, removed retired routes, and aligned provider defaults and cross-provider handoff fixtures with models currently served.
+
 ## [0.7.2] - 2026-08-11
 
 ## [0.7.1] - 2026-08-07

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-17
+
+- Fixed assistant rendering when provider payloads contain null or sparse content blocks.
+- Added authenticated host-request contracts with per-call request IDs, generation fencing, cancellation signals, and currentness checks.
+- Fixed root daemon shutdown retaining cleanup ownership while kill events are in flight.
+- Changed RLM family discovery to use a daemon-owned append-only spawn ledger with per-child display metadata instead of reconstructing topology from session files.
+- Fixed long-running macOS supervisors losing ownership when system cleanup removed authority records from `$TMPDIR`.
+- Fixed deleted RLM children leaking kernel snapshots while retaining their readable transcript tombstones.
+- Changed Agents View subagent rows to show stable `name · model/effort · summary` metadata.
+- Changed the default Cerebras model to the available `gpt-oss-120b` route and aligned cross-provider handoff fixtures with the generated catalog.
 - Fixed the agent going silent after an automatic context compaction interrupted unfinished work: the tool loop now resumes when a threshold compaction fails or is skipped, and active goals keep continuing after a successful mid-goal threshold compaction.
 - Changed the agents view splash hint from "type to start" to "type to search sessions".
 - Added `app.edits.expand` (`ctrl+j`) to toggle edit diffs; diffs are now shown only by this toggle, and `ctrl+o` no longer affects them.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"description": "Coding agent CLI with IPython-backed tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -48,9 +48,9 @@
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",
-		"@earendil-works/pi-agent-core": "^0.7.2",
-		"@earendil-works/pi-ai": "^0.7.2",
-		"@earendil-works/pi-tui": "^0.7.2",
+		"@earendil-works/pi-agent-core": "^0.7.3",
+		"@earendil-works/pi-ai": "^0.7.3",
+		"@earendil-works/pi-tui": "^0.7.3",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-17
+
 - Fixed hyperlinks not being clickable in fullscreen mode on terminals that gate native link handling while mouse reporting is active (e.g. Ghostty); left-clicking a link now opens it directly.
 
 ## [0.7.2] - 2026-08-11

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Prepare the root package and four published workspaces for the lockstep `0.7.3` patch release.
- Update all internal package ranges and the lockfile to `0.7.3` without changing example or private workspace versions.
- Finalize the Agent, AI, Coding Agent, and TUI changelogs for changes merged since `v0.7.2`.

## Release contents

- Provider-derived reasoning levels and refreshed live model catalogs.
- More durable RLM family topology, supervisor ownership, and deleted-child cleanup.
- Agents View model/effort metadata, edit-diff controls, resume behavior, fullscreen link handling, and other reliability fixes.
- Automatic-compaction continuation recovery.

This is a patch release with no intended breaking changes.

## Validation

- `npm run check`
- `node scripts/sync-versions.js` (second run made no changes)
- Verified example and private extension manifests remain unchanged.
- `git diff --check`

## Release behavior

This PR does not create a tag or publish artifacts. Once merged, the version change on `main` will cause the release workflow to build and validate the production artifacts, create `v0.7.3`, and update the stable R2 release channel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog updates with no runtime code changes in the diff.
> 
> **Overview**
> **Lockstep `0.7.3` patch release prep** for the root `prime-agent` package and the four published workspaces (`pi-agent-core`, `pi-ai`, `pi-coding-agent`, `pi-tui`). Internal dependency ranges and `package-lock.json` are aligned to `0.7.3`; example and private workspace versions are unchanged.
> 
> **Changelogs** are finalized for everything merged since `v0.7.2`, including provider reasoning/catalog work in **pi-ai**, explicit `off` reasoning forwarding in **pi-agent-core**, fullscreen link handling in **pi-tui**, and a large **coding-agent** slice: RLM family ledger and deleted-child cleanup, host-request contracts, compaction continuation, Agents View metadata/sorting, edit-diff toggles (`ctrl+j`), resume behavior, and assorted daemon/supervisor fixes.
> 
> No application source changes in this diff; merging triggers the release workflow to tag and publish artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa49ae9c447835316f723789b0ea248370670c7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release v0.7.3 across all packages
> - Bumps all package versions from 0.7.2 to 0.7.3 across `pi-ai`, `pi-agent`, `pi-coding-agent`, and `pi-tui`
> - Passes explicit `'off'` reasoning selections through to providers instead of omitting them, preserving provider-specific disable behavior
> - Adds provider-derived reasoning levels for OpenRouter and Prime Inference models, updates the model catalog with Qwen 3.8 Max, and removes retired routes
> - Fixes assistant rendering with null/sparse blocks, authenticated host-request contracts (request IDs, fencing, cancellation), daemon shutdown cleanup, and RLM family discovery via append-only spawn ledger
> - Fixes hyperlinks being clickable in fullscreen mode on terminals that gate native link handling while mouse reporting is active
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa49ae9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->