### PR TITLE
Resume queued messages after Ctrl+C interrupt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed queued steering and follow-up messages staying parked after Ctrl+C: an interrupt now resumes the session input pump instead of waiting for a later dummy submit.
 - Fixed new top-level daemon sessions inheriting an RLM child depth from the supervisor process.
 
 ## [0.7.3] - 2026-08-17

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -192,7 +192,7 @@ Submit messages while the agent is working:
 
 - **Enter** queues a *steering* message, delivered after the current assistant turn finishes executing its tool calls
 - **Alt+Enter** queues a *follow-up* message, delivered only after the agent finishes all work
-- **Ctrl+C** interrupts active work; queued messages are kept and resume after your next submit or edit
+- **Ctrl+C** interrupts active work; queued messages are kept and resume after the interrupt
 - **Escape** clears the input without interrupting active work
 - **Alt+Up / Alt+Down** browse queued messages individually and return to the editor draft
 - While browsing, **Enter** applies the edit as steering input and **Alt+Enter** applies it as a follow-up; submitting an empty edit deletes the item

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -68,7 +68,7 @@ You can submit messages while the agent is still working:
 
 - **Enter** queues a steering message, delivered after the current assistant turn finishes executing its tool calls.
 - **Alt+Enter** queues a follow-up message, delivered after the agent finishes all work.
-- **Ctrl+C** interrupts the current operation and briefly shows the exit hint; press it again while the hint is visible to exit. Queued messages are kept and resume after your next submit or edit.
+- **Ctrl+C** interrupts the current operation and briefly shows the exit hint; press it again while the hint is visible to exit. Queued messages are kept and resume after the interrupt.
 - **Escape** clears the input bar without interrupting the agent.
 - **Alt+Up / Alt+Down** browse queued messages one at a time and return to the untouched draft.
 - While browsing, **Enter** applies the edit as steering input and **Alt+Enter** applies it as a follow-up; submitting an empty edit deletes the item.

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -905,6 +905,15 @@ export class DaemonAgentConnection implements AgentConnection {
 		await this.requestOk({ type: "abort", activeSessionId: this.activeSessionId });
 	}
 
+	async resumeQueuedWork(): Promise<void> {
+		try {
+			await this.requestOk({ type: "resume_queue", activeSessionId: this.activeSessionId });
+		} catch (error) {
+			if (error instanceof Error && error.message.includes("No queued work to resume")) return;
+			throw error;
+		}
+	}
+
 	async cancelRlmChild(childId: string): Promise<boolean> {
 		try {
 			const result = await this.requestData<{ cancelled: boolean }>({

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -383,6 +383,10 @@ export class InProcessAgentConnection implements AgentConnection {
 		this.session.requestAbort();
 	}
 
+	async resumeQueuedWork(): Promise<void> {
+		this.session.resumeQueuedWork();
+	}
+
 	async cancelRlmChild(childId: string): Promise<boolean> {
 		return this.session.cancelRlmChildRun(childId);
 	}

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -698,6 +698,8 @@ export interface AgentConnection {
 	followUp(message: string, images?: ImageContent[]): Promise<void>;
 	/** Request cancellation of the active turn and return once the request is accepted. */
 	abort(): Promise<void>;
+	/** Unpause the session input pump so queued messages can deliver after an interrupt. */
+	resumeQueuedWork(): Promise<void>;
 	cancelRlmChild(childId: string): Promise<boolean>;
 	waitForIdle(): Promise<void>;
 	waitForHeadlessCompletion(): Promise<AgentAutonomousStatus>;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6737,11 +6737,13 @@ export class InteractiveMode {
 			void this.agentConnection.abortBash();
 		}
 		if (this.isAgentStreaming()) {
-			// The queue is preserved server-side; draining resumes on the next
-			// submit or queued-message edit.
-			void this.agentConnection.abort().catch((error) => {
-				this.showError(error instanceof Error ? error.message : String(error));
-			});
+			const shouldResumeQueue = this.shouldSuppressFeatureHint();
+			void this.agentConnection
+				.abort()
+				.then(() => (shouldResumeQueue ? this.agentConnection.resumeQueuedWork() : undefined))
+				.catch((error) => {
+					this.showError(error instanceof Error ? error.message : String(error));
+				});
 		}
 	}
 

--- a/packages/coding-agent/test/interactive-queue-edit.test.ts
+++ b/packages/coding-agent/test/interactive-queue-edit.test.ts
@@ -435,6 +435,7 @@ describe("interactive queued-message editing", () => {
 describe("interactive interrupt preserves the queue", () => {
 	it("aborts without clearing or restoring queued messages", () => {
 		const abort = vi.fn(async () => {});
+		const resumeQueuedWork = vi.fn(async () => {});
 		const harness = {
 			traceUploadAllAbortController: undefined,
 			sideQuestionEvent: undefined,
@@ -442,12 +443,36 @@ describe("interactive interrupt preserves the queue", () => {
 			isAgentCompacting: () => false,
 			isBashRunning: () => false,
 			isAgentStreaming: () => true,
-			agentConnection: { abort },
+			shouldSuppressFeatureHint: () => false,
+			agentConnection: { abort, resumeQueuedWork },
 			showError: vi.fn(),
 			editor: { getText: () => "", setText: vi.fn() },
 		};
 		(proto.interruptOrClearInput as (this: unknown) => void).call(harness);
 		expect(abort).toHaveBeenCalledOnce();
+		expect(resumeQueuedWork).not.toHaveBeenCalled();
+		expect(harness.editor.setText).not.toHaveBeenCalled();
+	});
+
+	it("resumes queued work after abort when messages are already queued", async () => {
+		const abort = vi.fn(async () => {});
+		const resumeQueuedWork = vi.fn(async () => {});
+		const harness = {
+			traceUploadAllAbortController: undefined,
+			sideQuestionEvent: undefined,
+			getRetryAttempt: () => 0,
+			isAgentCompacting: () => false,
+			isBashRunning: () => false,
+			isAgentStreaming: () => true,
+			shouldSuppressFeatureHint: () => true,
+			agentConnection: { abort, resumeQueuedWork },
+			showError: vi.fn(),
+			editor: { getText: () => "", setText: vi.fn() },
+		};
+		(proto.interruptOrClearInput as (this: unknown) => void).call(harness);
+		expect(abort).toHaveBeenCalledOnce();
+		await Promise.resolve();
+		expect(resumeQueuedWork).toHaveBeenCalledOnce();
 		expect(harness.editor.setText).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Discussion

https://github.com/PrimeIntellect-ai/prime-agent/discussions/1497

This follows CONTRIBUTING: the bug report is in Discussions first. Opening the PR so maintainers can review/merge if they want this behavior. Related but different key: #1476 (Escape parking).

## What this does

After Ctrl+C interrupts an in-flight run, already-queued steering and follow-up messages start draining again. Users no longer need a dummy submit to unstick the queue.

## What the problem looks like

1. The agent is working (long tool run, thinking, browser, IPython).
2. The user presses Enter / Alt+Enter — messages queue at the bottom.
3. The user presses Ctrl+C to stop the current run.
4. The queued messages stay parked. Empty Enter does nothing.
5. Only a *new* submit resumes the pump, then the old items drain one-by-one.

Still present on latest `main` / v0.7.3. #1279 fixed a different stall (silence after automatic compaction).

## Why it happened

`AgentSession.requestAbort()` preserves the durable queue and sets `_sessionInputPumpSuspended = true`. The existing resume API is `resumeQueuedWork()` / daemon `resume_queue` (already used after queue edits and by the daemon). The TUI interrupt path never called it. The comment said draining resumes on the next submit or queued-message edit.

## What changed

Narrow TUI + connection wiring only. No change to Enter-while-busy, Escape, `steeringMode`, or `agent.steer()`.

- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: after a streaming abort, if the visible queue is non-empty, call `resumeQueuedWork()`. Empty-queue interrupts skip it so daemon clients do not get `No queued work to resume`.
- `packages/coding-agent/src/modes/agent-connection/types.ts`: add `resumeQueuedWork()` on `AgentConnection`.
- `in-process-agent-connection.ts`: forward to `session.resumeQueuedWork()`.
- `daemon-agent-connection.ts`: send existing `resume_queue`; swallow the empty-queue error.
- Docs (`README.md`, `docs/usage.md`) and changelog: Ctrl+C now resumes after the interrupt.
- Tests in `test/interactive-queue-edit.test.ts`: empty queue does not resume; non-empty queue resumes after abort.

## Checks

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-queue-edit.test.ts` — 27/27 passed.
- `npm run check` — clean.

## Out of scope on purpose

- Does not interrupt in-flight tools by itself. Ctrl+C still aborts the current run; this only unparks the queue afterwards.
- Does not change Enter-while-busy (still queues until the current turn/run boundary).
- Does not add a stream stall timeout.

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resume queued messages immediately after Ctrl+C interrupt
> - Adds `resumeQueuedWork()` to the `AgentConnection` interface, implemented in both `DaemonAgentConnection` and `InProcessAgentConnection`, to unpause the session input pump.
> - Calls `resumeQueuedWork()` after abort in the Ctrl+C handler in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1498/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316), so queued steering and follow-up messages deliver without waiting for the next submit or edit.
> - The resume call is conditioned on `shouldSuppressFeatureHint()` and tolerates a 'No queued work to resume' error as a no-op.
> - Behavioral Change: queued messages now resume right after Ctrl+C rather than on the next user submit/edit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4facd44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->