### PR TITLE
prompt: remove reference to unshipped async bash() kernel helper

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Removed a system prompt paragraph referring to an async `bash()` kernel helper and managed jobs that do not exist in the runtime.
 - Changed RLM guidance to orchestrate independent workers in parallel, use available async shell helpers safely, end the turn instead of sleeping, polling, or blocking on long awaits, provide proactive outcome-focused progress updates from root agents, and use simplified technical English for user-facing prose.
 - Fixed new top-level daemon sessions inheriting an RLM child depth from the supervisor process.
 

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -34,8 +34,6 @@ const IPYTHON_CONTROL_PROMPT = [
 	"",
 	"When running shell commands from IPython, use `%%bash` cells. If you use `%%bash`, it must be the first line of the code cell: no comments, spaces, blank lines, imports, or Python statements before it. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context.",
 	"",
-	"If the runtime provides a documented async `bash()` helper, use `await bash(...)` only for short, bounded work that completes in the current turn; do not wrap it in `asyncio.create_task`. For background work, or work that must survive a kernel restart, session rotation, or teardown, use a managed job with a durable receipt instead.",
-	"",
 	"Important: do not install dependencies into the IPython kernel just to make an external project import or run there. If a project import, test, script, CLI, or dependency check is needed, run it through that project's own environment and normal command interface. For example, in a Python repo use its documented commands, `uv run ...`, `.venv/bin/python ...`, or the active project interpreter from the repo root. Treat failures from that native environment as the relevant result.",
 	"",
 	"Use Python for reading, searching, and editing files — it gives you reusable variables you can slice, filter, and act on without re-reading. Always assign read/search results to named variables so you can revisit them later.",

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -47,8 +47,6 @@ describe("buildRlmPrompt", () => {
 		expect(prompt).toContain("A callable `rlm` is already in your global namespace");
 		expect(prompt).toContain("IPython is the agent's long-lived notebook");
 		expect(prompt).toContain("Each `%%bash` cell runs in a throw-away subshell");
-		// The kernel has no bash() helper (PR #1187 is unmerged); the prompt must not mention one.
-		expect(prompt).not.toContain("bash()");
 	});
 
 	test("discovers requested models through a bounded authenticated host search", () => {

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -47,6 +47,8 @@ describe("buildRlmPrompt", () => {
 		expect(prompt).toContain("A callable `rlm` is already in your global namespace");
 		expect(prompt).toContain("IPython is the agent's long-lived notebook");
 		expect(prompt).toContain("Each `%%bash` cell runs in a throw-away subshell");
+		// The kernel has no bash() helper (PR #1187 is unmerged); the prompt must not mention one.
+		expect(prompt).not.toContain("bash()");
 	});
 
 	test("discovers requested models through a bounded authenticated host search", () => {


### PR DESCRIPTION
## What this does

Removes one paragraph from `IPYTHON_CONTROL_PROMPT` (added in #1188) that tells the model to use an async `bash()` kernel helper and "managed jobs with durable receipts".

## Why

Neither exists:

- `bash()` is the feature from #1187, which is still open and unmerged. Nothing named `bash` is defined in the kernel bootstrap.
- There is no managed-job or receipt facility in the runtime.

The "If the runtime provides..." hedge does not help: it primes the model to look for `bash()` and invent wrappers, which the prompt elsewhere explicitly forbids. A system prompt should only describe capabilities that are actually there.

The surrounding guidance already covers the real mechanisms: `%%bash` cells for shell work, and the nonblocking control-loop rules from #1188 for long-running work.

## Changes

- `rlm.ts`: remove the paragraph (2 lines).
- Changelog entry.

If/when #1187 merges, an affirmative version of this guidance should ship inside that PR's diff so prompt and capability stay in lockstep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change aligning model instructions with actual kernel capabilities; no runtime or auth paths touched.
> 
> **Overview**
> Removes a paragraph from **`IPYTHON_CONTROL_PROMPT`** in `rlm.ts` that told models to use an async **`bash()`** kernel helper and **managed jobs with durable receipts** for background or long-running shell work.
> 
> Those capabilities are not in the runtime (the `bash()` helper is still unmerged), so the text could push the model to hunt for or invent helpers the prompt elsewhere forbids. **Shell work stays documented via `%%bash` cells** and the existing nonblocking control-loop guidance.
> 
> Changelog records the removal under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ff0a00b61290d4a7d0342efbfe4dcbfe849d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove reference to unshipped async `bash()` helper from IPYTHON control prompt
> Deletes a paragraph from the `IPYTHON_CONTROL_PROMPT` constant in [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1508/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) that instructed use of an async `bash()` helper and managed background jobs — neither of which were shipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6ff0a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->