### PR TITLE
fix(coding-agent): keep Shift+Enter newline working where it sends a raw \n

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed Shift+Enter no longer inserting a newline in terminals that send a literal `\n` (for example a Ghostty `shift+enter=text:\n` mapping): the byte decoded as `ctrl+j` and triggered the new edit-diff toggle instead of the editor newline.
 - Removed a system prompt paragraph referring to an async `bash()` kernel helper and managed jobs that do not exist in the runtime.
 - Changed RLM guidance to orchestrate independent workers in parallel, use available async shell helpers safely, end the turn instead of sleeping, polling, or blocking on long awaits, provide proactive outcome-focused progress updates from root agents, and use simplified technical English for user-facing prose.
 - Fixed new top-level daemon sessions inheriting an RLM child depth from the supervisor process.

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -198,15 +198,11 @@ export class CustomEditor extends Editor {
 			// Fall through to editor handling for delete-char-forward when not empty
 		}
 
-		// Check all other app actions.
-		// A raw "\n" byte is ambiguous: it decodes as ctrl+j, but it is also what
-		// Shift+Enter sends in terminals that map it to a literal newline (and a
-		// traditional newline key itself). Let the editor's newline handling win;
-		// ctrl+j still reaches actions from kitty-protocol terminals as CSI-u.
-		const isLegacyNewlineByte = data === "\n";
+		// Check all other app actions. A raw "\n" is Shift+Enter's newline in some
+		// terminals, so it goes to the editor even though it decodes as ctrl+j.
 		for (const [action, handler] of this.actionHandlers) {
 			if (
-				!isLegacyNewlineByte &&
+				data !== "\n" &&
 				action !== "app.input.clear" &&
 				action !== "app.exit" &&
 				(action !== "app.shortcuts" || this.getText().length === 0) &&

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -198,9 +198,15 @@ export class CustomEditor extends Editor {
 			// Fall through to editor handling for delete-char-forward when not empty
 		}
 
-		// Check all other app actions
+		// Check all other app actions.
+		// A raw "\n" byte is ambiguous: it decodes as ctrl+j, but it is also what
+		// Shift+Enter sends in terminals that map it to a literal newline (and a
+		// traditional newline key itself). Let the editor's newline handling win;
+		// ctrl+j still reaches actions from kitty-protocol terminals as CSI-u.
+		const isLegacyNewlineByte = data === "\n";
 		for (const [action, handler] of this.actionHandlers) {
 			if (
+				!isLegacyNewlineByte &&
 				action !== "app.input.clear" &&
 				action !== "app.exit" &&
 				(action !== "app.shortcuts" || this.getText().length === 0) &&

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5900,8 +5900,7 @@ export class InteractiveMode {
 			this.toggleAgentMessageExpansion();
 			return;
 		}
-		// A raw "\n" decodes as ctrl+j but is Shift+Enter's newline in terminals
-		// that map it literally; hand it to the editor instead of toggling diffs.
+		// A raw "\n" is a newline for the editor, not ctrl+j.
 		if (data !== "\n" && this.keybindings.matches(data, "app.edits.expand")) {
 			this.toggleEditDiffExpansion();
 			return;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5900,7 +5900,9 @@ export class InteractiveMode {
 			this.toggleAgentMessageExpansion();
 			return;
 		}
-		if (this.keybindings.matches(data, "app.edits.expand")) {
+		// A raw "\n" decodes as ctrl+j but is Shift+Enter's newline in terminals
+		// that map it literally; hand it to the editor instead of toggling diffs.
+		if (data !== "\n" && this.keybindings.matches(data, "app.edits.expand")) {
 			this.toggleEditDiffExpansion();
 			return;
 		}

--- a/packages/coding-agent/test/custom-editor.test.ts
+++ b/packages/coding-agent/test/custom-editor.test.ts
@@ -78,6 +78,30 @@ describe("CustomEditor", () => {
 		expect(editor.getText()).toBe("/");
 	});
 
+	it("inserts a newline for a raw \\n byte instead of firing the ctrl+j edit-diff action", () => {
+		const editor = new CustomEditor(fakeTui, editorTheme, new KeybindingsManager());
+		const toggleEditDiffs = vi.fn();
+		editor.onAction("app.edits.expand", toggleEditDiffs);
+
+		editor.handleInput("a");
+		editor.handleInput("\n");
+		editor.handleInput("b");
+
+		expect(toggleEditDiffs).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("a\nb");
+	});
+
+	it("still fires the edit-diff action for kitty CSI-u ctrl+j", () => {
+		const editor = new CustomEditor(fakeTui, editorTheme, new KeybindingsManager());
+		const toggleEditDiffs = vi.fn();
+		editor.onAction("app.edits.expand", toggleEditDiffs);
+
+		editor.handleInput("\x1b[106;5u");
+
+		expect(toggleEditDiffs).toHaveBeenCalledOnce();
+		expect(editor.getText()).toBe("");
+	});
+
 	it("routes Escape through its handler while dismissing autocomplete", async () => {
 		const editor = new CustomEditor(fakeTui, editorTheme, new KeybindingsManager());
 		const handler = vi.fn();


### PR DESCRIPTION
## What this does

Fixes Shift+Enter no longer inserting a newline since 0.7.3, in terminals where Shift+Enter arrives as a literal `\n` byte.

## Root cause

0.7.3 added `app.edits.expand` with the default `ctrl+j` (#1388). The custom editor dispatches app actions **before** the base editor's newline handling, and a raw `\n` (0x0A) decodes as `ctrl+j`. But that byte is exactly what Shift+Enter sends in terminals that map it to a literal newline — the mapping our own `keys.ts` comments recommend for Ghostty (`keybind = shift+enter=text:\n`) — and `ctrl+j` is itself a traditional newline key (`docs/keybindings.md` even suggests `"tui.input.newLine": ["shift+enter", "ctrl+j"]`). Since 0.7.3 that input toggled edit diffs instead of inserting a newline.

Kitty-protocol terminals are unaffected: Shift+Enter arrives as CSI-u `\x1b[13;2u` and real Ctrl+J as `\x1b[106;5u`, which are unambiguous.

Verified against the built tui: `matchesKey("\n", "ctrl+j") === true`.

## The fix

Skip app-action dispatch for the raw `\n` byte in `CustomEditor.handleInput` and in the subagent-line key handler, so it falls through to the editor's newline handling. Ctrl+J keeps toggling edit diffs via its CSI-u encoding.

## Tests

- raw `\n` inserts a newline and does not fire `app.edits.expand`  (fails without the fix)
- kitty CSI-u ctrl+j still fires the action

Linear: [ENG-5305](https://linear.app/primeintellect/issue/ENG-5305/shiftenter-stopped-inserting-a-newline-in-073-raw-n-now-decodes-as-the)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized input routing fix in the interactive TUI with tests; no auth, data, or API surface changes.
> 
> **Overview**
> Restores **Shift+Enter inserting a newline** in terminals that deliver a literal `\n` byte (e.g. Ghostty `shift+enter=text:\n`), which since 0.7.3 was wrongly handled as **`app.edits.expand`** (`ctrl+j`) because app actions run before the editor’s newline path.
> 
> **`CustomEditor`** and the **subagent summary chat** handler now **skip app-action matching** when input is exactly `\n`, so it falls through to normal editor newline handling. **Kitty CSI-u Ctrl+J** still toggles edit diffs.
> 
> Adds regression tests for raw `\n` vs CSI-u ctrl+j, plus a **CHANGELOG** note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f6638a11e97f2f253e353d7d20fb203bb8e39ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Shift+Enter inserting a literal `\n` instead of a newline in the coding agent editor
> Some terminals send a raw `\n` for Shift+Enter, which was being decoded as ctrl+j and triggering the edit-diff toggle (`app.edits.expand`) instead of inserting a newline.
>
> - Adds a guard in [`CustomEditor.handleInput`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1522/files#diff-d9bfbf3acb3425b8392c410c8136af3755b8cc08e825ed9312d29a2b15b82203) to skip action handler matching when the input byte is a raw `\n`, routing it to the editor instead.
> - Adds the same guard in [`InteractiveMode`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1522/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) for the subagent summary chat view's `app.edits.expand` handler.
> - The kitty CSI-u ctrl+j sequence (`\x1b[106;5u`) still correctly triggers the edit-diff toggle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f6638a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->