### PR TITLE
feat(coding-agent): add opt-in atomic idle session archiving (atomic_session_archive capability)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added an opt-in `atomic_session_archive` daemon capability with `get_archive_occupancy` and `archive_session_if_idle` commands to archive an idle top-level session and its artifacts atomically.
 - Fixed Shift+Enter no longer inserting a newline in terminals that send a literal `\n` (for example a Ghostty `shift+enter=text:\n` mapping): the byte decoded as `ctrl+j` and triggered the new edit-diff toggle instead of the editor newline.
 - Removed a system prompt paragraph referring to an async `bash()` kernel helper and managed jobs that do not exist in the runtime.
 - Changed RLM guidance to orchestrate independent workers in parallel, use available async shell helpers safely, end the turn instead of sleeping, polling, or blocking on long awaits, provide proactive outcome-focused progress updates from root agents, and use simplified technical English for user-facing prose.

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+// Revision 17 adds optional atomic session archive occupancy and compare-and-archive commands behind the atomic_session_archive capability.
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-e9a97dd90ceb";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -100,7 +101,8 @@ export type DaemonServerCapability =
 	| "transient_bash"
 	| "session_input_admission"
 	| "prompt_admission_cancellation"
-	| "queue_message_mutation";
+	| "queue_message_mutation"
+	| "atomic_session_archive";
 
 export type DaemonReplayStatus = "complete" | "partial" | "unavailable";
 
@@ -139,6 +141,7 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"session_input_admission",
 	"prompt_admission_cancellation",
 	"queue_message_mutation",
+	"atomic_session_archive",
 ];
 
 export interface DaemonRuntimeIdentity {
@@ -336,6 +339,48 @@ export interface DaemonUpdateRestartManifest {
 	discardedActiveSessionIds?: string[];
 }
 
+export interface DaemonArchiveOccupancyReceipt {
+	activeSessionId: string;
+	sessionId: string;
+	sessionPath: string;
+	hostGeneration: string;
+	lifecycle: "draft" | "live";
+	workerState: "ready";
+	workerRefresh: "current";
+	activeTurn: boolean;
+	streaming: boolean;
+	compacting: boolean;
+	tools: boolean;
+	bash: boolean;
+	unfinishedActions: number;
+	queuedActions: number;
+	runningChildren: boolean;
+	attachedClients: number;
+	heartbeat: boolean;
+	cron: boolean;
+	busy: boolean;
+	observedAt: string;
+	occupancyDigest: string;
+}
+
+export interface DaemonArchivePostReadback {
+	sessionId: string;
+	sessionPath: string;
+	state: "archived";
+}
+
+export interface DaemonArchiveSessionReceipt {
+	activeSessionId: string;
+	sessionId: string;
+	sessionPath: string;
+	hostGeneration: string;
+	beforeOccupancyDigest: string;
+	archiveReceiptDigest: string;
+	state: "archived";
+	archivedAt: string;
+	postReadback: DaemonArchivePostReadback;
+}
+
 export type DaemonSavedSessionListCommand =
 	| { id?: string; type: "list_saved_sessions"; activeSessionId: string; scope: AgentConnectionSavedSessionScope }
 	| {
@@ -392,6 +437,14 @@ export type DaemonCommand =
 	| { id?: string; type: "complete_owned_session"; activeSessionId: string }
 	| { id?: string; type: "promote_owned_session"; activeSessionId: string }
 	| { id?: string; type: "kill"; activeSessionId: string }
+	| { id?: string; type: "get_archive_occupancy"; activeSessionId: string; sessionId: string }
+	| {
+			id?: string;
+			type: "archive_session_if_idle";
+			activeSessionId: string;
+			sessionId: string;
+			expectedOccupancyDigest: string;
+	  }
 	| { id?: string; type: "rename"; activeSessionId: string; name: string }
 	| {
 			id?: string;
@@ -649,6 +702,11 @@ const DELETE_RLM_SUBAGENT_COMMAND = {
 } as const;
 const FLAT_SESSION_TREE_COMMAND = { minProtocol: 7 } as const;
 const TELEMETRY_POLICY_COMMAND = { minProtocol: 7, minSchemaRevision: 14 } as const;
+const ATOMIC_SESSION_ARCHIVE_COMMAND = {
+	minProtocol: 7,
+	minSchemaRevision: 17,
+	capability: "atomic_session_archive",
+} as const;
 
 export const DAEMON_COMMAND_COMPATIBILITY = {
 	ack_result: LEGACY_DAEMON_COMMAND,
@@ -661,6 +719,8 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 	complete_owned_session: CLIENT_OWNED_DAEMON_COMMAND,
 	promote_owned_session: CLIENT_OWNED_DAEMON_COMMAND,
 	kill: LEGACY_DAEMON_COMMAND,
+	get_archive_occupancy: ATOMIC_SESSION_ARCHIVE_COMMAND,
+	archive_session_if_idle: ATOMIC_SESSION_ARCHIVE_COMMAND,
 	rename: LEGACY_DAEMON_COMMAND,
 	prompt: SESSION_INPUT_ADMISSION_COMMAND,
 	cancel_prompt_admission: PROMPT_ADMISSION_CANCELLATION_COMMAND,
@@ -1037,6 +1097,7 @@ const READ_ONLY_DAEMON_COMMANDS: ReadonlySet<DaemonCommand["type"]> = new Set([
 	"agent_messages_status",
 	"wait_for_idle",
 	"get_session_header",
+	"get_archive_occupancy",
 	"get_state",
 	"get_connection_state",
 	"get_messages",

--- a/packages/coding-agent/src/modes/daemon/daemon-session-archive.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-archive.ts
@@ -1,0 +1,333 @@
+import { createHash } from "node:crypto";
+import { isAbsolute } from "node:path";
+import type {
+	DaemonArchiveOccupancyReceipt,
+	DaemonArchivePostReadback,
+	DaemonArchiveSessionReceipt,
+} from "./daemon-protocol.js";
+
+type ArchiveOccupancyInput = Omit<DaemonArchiveOccupancyReceipt, "busy" | "occupancyDigest">;
+type ArchiveSessionReceiptInput = Omit<DaemonArchiveSessionReceipt, "archiveReceiptDigest" | "state">;
+
+const OCCUPANCY_KEYS = [
+	"activeSessionId",
+	"sessionId",
+	"sessionPath",
+	"hostGeneration",
+	"lifecycle",
+	"workerState",
+	"workerRefresh",
+	"activeTurn",
+	"streaming",
+	"compacting",
+	"tools",
+	"bash",
+	"unfinishedActions",
+	"queuedActions",
+	"runningChildren",
+	"attachedClients",
+	"heartbeat",
+	"cron",
+	"busy",
+	"observedAt",
+	"occupancyDigest",
+] as const;
+
+const ARCHIVE_KEYS = [
+	"activeSessionId",
+	"sessionId",
+	"sessionPath",
+	"hostGeneration",
+	"beforeOccupancyDigest",
+	"archiveReceiptDigest",
+	"state",
+	"archivedAt",
+	"postReadback",
+] as const;
+
+const POST_READBACK_KEYS = ["sessionId", "sessionPath", "state"] as const;
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/;
+
+function canonicalJson(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+	if (value && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		return `{${Object.keys(record)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+			.join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+function digest(value: unknown): string {
+	return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function hasExactKeys(value: object, expected: readonly string[]): boolean {
+	const actual = Object.keys(value).sort();
+	const sortedExpected = [...expected].sort();
+	return actual.length === sortedExpected.length && actual.every((key, index) => key === sortedExpected[index]);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
+}
+
+function isCanonicalTimestamp(value: unknown): value is string {
+	if (typeof value !== "string") return false;
+	const timestamp = Date.parse(value);
+	return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+export async function registerDaemonArchiveOccupancyMutation(
+	readArchiveFence: () => Promise<void> | undefined,
+	waitForIdleEviction: () => Promise<void>,
+	begin: () => void,
+): Promise<void> {
+	const initialArchiveFence = readArchiveFence();
+	if (initialArchiveFence) await initialArchiveFence;
+	await waitForIdleEviction();
+	while (true) {
+		const archiveFence = readArchiveFence();
+		if (!archiveFence) {
+			begin();
+			return;
+		}
+		await archiveFence;
+	}
+}
+
+export interface DaemonArchiveSummaryOccupancy {
+	activeTurn: boolean;
+	streaming: boolean;
+	compacting: boolean;
+	tools: boolean;
+	bash: boolean;
+	unfinishedActions: number;
+	queuedActions: number;
+	runningChildren: boolean;
+}
+
+export function projectDaemonArchiveSummaryOccupancy(value: unknown): DaemonArchiveSummaryOccupancy {
+	if (!value || typeof value !== "object") throw new Error("Archive occupancy summary is incomplete");
+	const summary = value as Record<string, unknown>;
+	const actions = summary.sessionActions;
+	if (
+		!isNonEmptyString(summary.activeSessionId) ||
+		!isNonEmptyString(summary.sessionId) ||
+		!isNonEmptyString(summary.sessionFile) ||
+		!isAbsolute(summary.sessionFile) ||
+		(summary.lifecycle !== "draft" && summary.lifecycle !== "live") ||
+		typeof summary.isSessionActive !== "boolean" ||
+		typeof summary.isStreaming !== "boolean" ||
+		typeof summary.isCompacting !== "boolean" ||
+		typeof summary.isBashRunning !== "boolean" ||
+		typeof summary.isRunningTools !== "boolean" ||
+		typeof summary.hasRunningRlmChildren !== "boolean" ||
+		!isNonNegativeInteger(summary.unfinishedActionCount) ||
+		!actions ||
+		typeof actions !== "object"
+	) {
+		throw new Error("Archive occupancy summary is incomplete");
+	}
+	const actionSnapshot = actions as Record<string, unknown>;
+	if (
+		!isNonNegativeInteger(actionSnapshot.queuedCount) ||
+		!Array.isArray(actionSnapshot.steering) ||
+		!actionSnapshot.steering.every((entry) => typeof entry === "string") ||
+		!Array.isArray(actionSnapshot.followUps) ||
+		!actionSnapshot.followUps.every((entry) => typeof entry === "string") ||
+		(actionSnapshot.active !== undefined &&
+			(!actionSnapshot.active ||
+				typeof actionSnapshot.active !== "object" ||
+				!(["turn", "session_command"] as const).includes(
+					(actionSnapshot.active as { kind?: "turn" | "session_command" }).kind!,
+				) ||
+				!(["preparing", "committing", "running"] as const).includes(
+					(actionSnapshot.active as { phase?: "preparing" | "committing" | "running" }).phase!,
+				)))
+	) {
+		throw new Error("Archive occupancy summary is incomplete");
+	}
+	return {
+		activeTurn: summary.isSessionActive,
+		streaming: summary.isStreaming,
+		compacting: summary.isCompacting,
+		tools: summary.isRunningTools,
+		bash: summary.isBashRunning,
+		unfinishedActions: summary.unfinishedActionCount,
+		queuedActions: actionSnapshot.queuedCount,
+		runningChildren: summary.hasRunningRlmChildren,
+	};
+}
+
+function occupancyProjection(
+	input: ArchiveOccupancyInput,
+): Omit<DaemonArchiveOccupancyReceipt, "observedAt" | "occupancyDigest"> {
+	const busy =
+		input.activeTurn ||
+		input.streaming ||
+		input.compacting ||
+		input.tools ||
+		input.bash ||
+		input.unfinishedActions > 0 ||
+		input.queuedActions > 0 ||
+		input.runningChildren ||
+		input.attachedClients > 0 ||
+		input.heartbeat ||
+		input.cron;
+	return {
+		activeSessionId: input.activeSessionId,
+		sessionId: input.sessionId,
+		sessionPath: input.sessionPath,
+		hostGeneration: input.hostGeneration,
+		lifecycle: input.lifecycle,
+		workerState: input.workerState,
+		workerRefresh: input.workerRefresh,
+		activeTurn: input.activeTurn,
+		streaming: input.streaming,
+		compacting: input.compacting,
+		tools: input.tools,
+		bash: input.bash,
+		unfinishedActions: input.unfinishedActions,
+		queuedActions: input.queuedActions,
+		runningChildren: input.runningChildren,
+		attachedClients: input.attachedClients,
+		heartbeat: input.heartbeat,
+		cron: input.cron,
+		busy,
+	};
+}
+
+export function createDaemonArchiveOccupancyReceipt(input: ArchiveOccupancyInput): DaemonArchiveOccupancyReceipt {
+	const projection = occupancyProjection(input);
+	return {
+		...projection,
+		observedAt: input.observedAt,
+		occupancyDigest: digest(projection),
+	};
+}
+
+function isArchivePostReadback(value: unknown): value is DaemonArchivePostReadback {
+	if (!value || typeof value !== "object" || !hasExactKeys(value, POST_READBACK_KEYS)) return false;
+	const candidate = value as Partial<DaemonArchivePostReadback>;
+	return (
+		isNonEmptyString(candidate.sessionId) &&
+		isNonEmptyString(candidate.sessionPath) &&
+		isAbsolute(candidate.sessionPath) &&
+		candidate.state === "archived"
+	);
+}
+
+export function isDaemonArchiveOccupancyReceipt(value: unknown): value is DaemonArchiveOccupancyReceipt {
+	if (!value || typeof value !== "object" || !hasExactKeys(value, OCCUPANCY_KEYS)) return false;
+	const candidate = value as Partial<DaemonArchiveOccupancyReceipt>;
+	if (
+		!isNonEmptyString(candidate.activeSessionId) ||
+		!isNonEmptyString(candidate.sessionId) ||
+		!isNonEmptyString(candidate.sessionPath) ||
+		!isAbsolute(candidate.sessionPath) ||
+		!isNonEmptyString(candidate.hostGeneration) ||
+		(candidate.lifecycle !== "draft" && candidate.lifecycle !== "live") ||
+		candidate.workerState !== "ready" ||
+		candidate.workerRefresh !== "current" ||
+		typeof candidate.activeTurn !== "boolean" ||
+		typeof candidate.streaming !== "boolean" ||
+		typeof candidate.compacting !== "boolean" ||
+		typeof candidate.tools !== "boolean" ||
+		typeof candidate.bash !== "boolean" ||
+		!isNonNegativeInteger(candidate.unfinishedActions) ||
+		!isNonNegativeInteger(candidate.queuedActions) ||
+		typeof candidate.runningChildren !== "boolean" ||
+		!isNonNegativeInteger(candidate.attachedClients) ||
+		typeof candidate.heartbeat !== "boolean" ||
+		typeof candidate.cron !== "boolean" ||
+		typeof candidate.busy !== "boolean" ||
+		!isCanonicalTimestamp(candidate.observedAt) ||
+		typeof candidate.occupancyDigest !== "string" ||
+		!SHA256_PATTERN.test(candidate.occupancyDigest)
+	) {
+		return false;
+	}
+	const input: ArchiveOccupancyInput = {
+		activeSessionId: candidate.activeSessionId,
+		sessionId: candidate.sessionId,
+		sessionPath: candidate.sessionPath,
+		hostGeneration: candidate.hostGeneration,
+		lifecycle: candidate.lifecycle,
+		workerState: candidate.workerState,
+		workerRefresh: candidate.workerRefresh,
+		activeTurn: candidate.activeTurn,
+		streaming: candidate.streaming,
+		compacting: candidate.compacting,
+		tools: candidate.tools,
+		bash: candidate.bash,
+		unfinishedActions: candidate.unfinishedActions,
+		queuedActions: candidate.queuedActions,
+		runningChildren: candidate.runningChildren,
+		attachedClients: candidate.attachedClients,
+		heartbeat: candidate.heartbeat,
+		cron: candidate.cron,
+		observedAt: candidate.observedAt,
+	};
+	const expected = createDaemonArchiveOccupancyReceipt(input);
+	return candidate.busy === expected.busy && candidate.occupancyDigest === expected.occupancyDigest;
+}
+
+function archiveProjection(
+	input: ArchiveSessionReceiptInput,
+): Omit<DaemonArchiveSessionReceipt, "archiveReceiptDigest"> {
+	return {
+		activeSessionId: input.activeSessionId,
+		sessionId: input.sessionId,
+		sessionPath: input.sessionPath,
+		hostGeneration: input.hostGeneration,
+		beforeOccupancyDigest: input.beforeOccupancyDigest,
+		state: "archived",
+		archivedAt: input.archivedAt,
+		postReadback: input.postReadback,
+	};
+}
+
+export function createArchiveSessionReceipt(input: ArchiveSessionReceiptInput): DaemonArchiveSessionReceipt {
+	const projection = archiveProjection(input);
+	return { ...projection, archiveReceiptDigest: digest(projection) };
+}
+
+export function isDaemonArchiveSessionReceipt(value: unknown): value is DaemonArchiveSessionReceipt {
+	if (!value || typeof value !== "object" || !hasExactKeys(value, ARCHIVE_KEYS)) return false;
+	const candidate = value as Partial<DaemonArchiveSessionReceipt>;
+	if (
+		!isNonEmptyString(candidate.activeSessionId) ||
+		!isNonEmptyString(candidate.sessionId) ||
+		!isNonEmptyString(candidate.sessionPath) ||
+		!isAbsolute(candidate.sessionPath) ||
+		!isNonEmptyString(candidate.hostGeneration) ||
+		typeof candidate.beforeOccupancyDigest !== "string" ||
+		!SHA256_PATTERN.test(candidate.beforeOccupancyDigest) ||
+		typeof candidate.archiveReceiptDigest !== "string" ||
+		!SHA256_PATTERN.test(candidate.archiveReceiptDigest) ||
+		candidate.state !== "archived" ||
+		!isCanonicalTimestamp(candidate.archivedAt) ||
+		!isArchivePostReadback(candidate.postReadback) ||
+		candidate.postReadback.sessionId !== candidate.sessionId ||
+		candidate.postReadback.sessionPath !== candidate.sessionPath
+	) {
+		return false;
+	}
+	const expected = createArchiveSessionReceipt({
+		activeSessionId: candidate.activeSessionId,
+		sessionId: candidate.sessionId,
+		sessionPath: candidate.sessionPath,
+		hostGeneration: candidate.hostGeneration,
+		beforeOccupancyDigest: candidate.beforeOccupancyDigest,
+		archivedAt: candidate.archivedAt,
+		postReadback: candidate.postReadback,
+	});
+	return candidate.archiveReceiptDigest === expected.archiveReceiptDigest;
+}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -26,6 +26,7 @@ import { type AgentSessionRuntimeConfig, mergeAgentSessionRuntimeConfig } from "
 import {
 	type AgentCronJob,
 	AgentCronJobStore,
+	isHeartbeatCronJob,
 	migrateLegacyCronJobsToSessionArtifacts,
 	SESSION_SCHEDULED_JOBS_FILENAME,
 } from "../../core/cron-jobs.js";
@@ -64,6 +65,7 @@ import {
 	DAEMON_SCHEMA_ID,
 	DAEMON_SCHEMA_REVISION,
 	DAEMON_UPDATE_RESTART_FORMAT_VERSION,
+	type DaemonArchiveOccupancyReceipt,
 	type DaemonAttachResult,
 	type DaemonClientCapability,
 	type DaemonClosingReason,
@@ -79,6 +81,12 @@ import {
 	UPDATE_RESTART_DRAIN_COMMANDS,
 } from "./daemon-protocol.js";
 import { getDaemonRuntimeIdentity } from "./daemon-runtime-identity.js";
+import {
+	createArchiveSessionReceipt,
+	createDaemonArchiveOccupancyReceipt,
+	projectDaemonArchiveSummaryOccupancy,
+	registerDaemonArchiveOccupancyMutation,
+} from "./daemon-session-archive.js";
 import { matchesSessionIdSuffix } from "./daemon-session-id.js";
 import {
 	classifySessionRosterStatus,
@@ -165,6 +173,8 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"complete_owned_session",
 	"promote_owned_session",
 	"kill",
+	"get_archive_occupancy",
+	"archive_session_if_idle",
 	"rename",
 	"prompt",
 	"cancel_prompt_admission",
@@ -255,8 +265,12 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"shutdown",
 ]);
 
+interface SupervisorWorkerDescriptor extends DaemonWorkerDescriptor {
+	/** Positive archive ACK persisted before waiting for the worker to exit without process signals. */
+}
+
 interface ResidentWorker {
-	descriptor: DaemonWorkerDescriptor;
+	descriptor: SupervisorWorkerDescriptor;
 	descriptorPath: string;
 	client?: DaemonWorkerClient;
 	heartbeatSnapshot?: AgentConnectionHeartbeat[];
@@ -418,7 +432,7 @@ function isSessionSummary(value: unknown): value is SessionSummary {
 	);
 }
 
-function isDaemonWorkerDescriptor(value: unknown, socketPath: string): value is DaemonWorkerDescriptor {
+function isDaemonWorkerDescriptor(value: unknown, socketPath: string): value is SupervisorWorkerDescriptor {
 	if (!value || typeof value !== "object") {
 		return false;
 	}
@@ -619,6 +633,7 @@ export class DaemonSupervisor {
 	private idleEvictionTimer?: ReturnType<typeof setTimeout>;
 	private idleEvictionSweep?: Promise<void>;
 	private idleEvictionFence?: Promise<void>;
+	private archiveAdmissionFence?: Promise<void>;
 
 	constructor(
 		private readonly socketPath: string,
@@ -883,6 +898,32 @@ export class DaemonSupervisor {
 			if (this.idleEvictionFence === fence) this.idleEvictionFence = undefined;
 			releaseFence();
 		}
+	}
+
+	private async acquireArchiveAdmissionFence(): Promise<() => void> {
+		while (this.archiveAdmissionFence) {
+			await this.archiveAdmissionFence;
+		}
+		let releaseFence: () => void = () => {};
+		const fence = new Promise<void>((resolveFence) => {
+			releaseFence = resolveFence;
+		});
+		this.archiveAdmissionFence = fence;
+		try {
+			await this.mutationDrain.waitForDrain(
+				0,
+				AbortSignal.timeout(30_000),
+				"Timed out draining daemon occupancy mutations for session archive",
+			);
+		} catch (error) {
+			if (this.archiveAdmissionFence === fence) this.archiveAdmissionFence = undefined;
+			releaseFence();
+			throw error;
+		}
+		return () => {
+			if (this.archiveAdmissionFence === fence) this.archiveAdmissionFence = undefined;
+			releaseFence();
+		};
 	}
 
 	private async assertCurrentOwnership(): Promise<void> {
@@ -1349,15 +1390,33 @@ export class DaemonSupervisor {
 			}
 		}
 
-		if (mutation && !UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)) {
-			const idleEvictionFence = this.idleEvictionFence;
-			if (idleEvictionFence) await idleEvictionFence;
-		}
-		// Attach is intentionally read-only and is not fence-gated. If eviction wins
-		// the race, attach fails cleanly with "Session worker is not connected" and
-		// the client retries through the saved-session path instead of mutating state.
-		if (mutation) this.mutationDrain.begin();
+		const isArchiveCommand = command.type === "archive_session_if_idle";
+		const tracksArchiveOccupancy = mutation || command.type === "attach" || command.type === "reattach";
+		let releaseArchiveFence: (() => void) | undefined;
+		let archiveOccupancyMutationBegun = false;
 		try {
+			if (isArchiveCommand) {
+				releaseArchiveFence = await this.acquireArchiveAdmissionFence();
+				const idleEvictionFence = this.idleEvictionFence;
+				if (idleEvictionFence) await idleEvictionFence;
+				this.mutationDrain.begin();
+				archiveOccupancyMutationBegun = true;
+			} else if (tracksArchiveOccupancy) {
+				await registerDaemonArchiveOccupancyMutation(
+					() => this.archiveAdmissionFence,
+					async () => {
+						if (!mutation || UPDATE_RESTART_DRAIN_COMMANDS.has(command.type)) return;
+						const idleEvictionFence = this.idleEvictionFence;
+						if (idleEvictionFence) await idleEvictionFence;
+					},
+					() => {
+						this.mutationDrain.begin();
+						archiveOccupancyMutationBegun = true;
+					},
+				);
+			}
+			// Attach remains read-only for journaling, but participates in the archive
+			// occupancy drain so no client can attach across compare-and-archive.
 			const response = await this.handleCommand(client, command, cancellationAdmission);
 			if (response) {
 				if (journalIdentity) {
@@ -1379,7 +1438,8 @@ export class DaemonSupervisor {
 			}
 			this.write(client, response);
 		} finally {
-			if (mutation) this.mutationDrain.end();
+			if (archiveOccupancyMutationBegun) this.mutationDrain.end();
+			releaseArchiveFence?.();
 		}
 	}
 
@@ -1550,6 +1610,14 @@ export class DaemonSupervisor {
 				const match = await this.findWorkerForClient(client, command.activeSessionId);
 				await this.promoteOwnedWorker(client, match.worker);
 				return success(command.id, command.type, this.publicSummary(match.worker, match.summary));
+			}
+			case "get_archive_occupancy": {
+				const occupancy = await this.readArchiveOccupancy(client, command.activeSessionId, command.sessionId);
+				return success(command.id, command.type, occupancy);
+			}
+			case "archive_session_if_idle": {
+				const receipt = await this.archiveSessionIfIdle(client, command);
+				return success(command.id, command.type, receipt);
 			}
 			case "retry_worker": {
 				const direct = [...this.workers.values()].find(
@@ -3273,6 +3341,214 @@ export class DaemonSupervisor {
 		};
 	}
 
+	private exactArchiveRoot(client: DaemonSocketClient, activeSessionId: string, sessionId: string): WorkerMatch {
+		const matches: WorkerMatch[] = [];
+		for (const worker of this.workers.values()) {
+			if (!this.isWorkerAccessibleToClient(client, worker)) continue;
+			const summary = worker.summaries.get(worker.descriptor.rootActiveSessionId);
+			if (!summary) continue;
+			const rootActiveSessionId = summary.activeSessionId ?? summary.id;
+			if (rootActiveSessionId === activeSessionId && summary.sessionId === sessionId) {
+				matches.push({ worker, summary });
+			}
+		}
+		if (matches.length !== 1) {
+			throw new Error(`Unknown archive root: ${activeSessionId}/${sessionId}`);
+		}
+		return matches[0]!;
+	}
+
+	private async readArchiveOccupancy(
+		client: DaemonSocketClient,
+		activeSessionId: string,
+		sessionId: string,
+	): Promise<DaemonArchiveOccupancyReceipt> {
+		if (!activeSessionId || !sessionId) throw new Error("Archive identity must not be empty");
+		const initial = this.exactArchiveRoot(client, activeSessionId, sessionId);
+		if (
+			initial.worker.descriptor.lifecycle !== "ready" ||
+			!initial.worker.client ||
+			initial.worker.intentionalStop ||
+			initial.worker.descriptor.stopRequestedAt !== undefined
+		) {
+			throw new Error("Archive occupancy is unknown while the session worker is not current");
+		}
+		const descriptorProcessStartId = initial.worker.descriptor.processStartId;
+		if (!descriptorProcessStartId || getProcessStartId(initial.worker.descriptor.pid) !== descriptorProcessStartId) {
+			throw new Error("Archive occupancy worker incarnation is unknown or stale");
+		}
+		await this.refreshWorkerSummaries(initial.worker);
+		if (
+			this.workers.get(initial.worker.descriptor.workerId) !== initial.worker ||
+			initial.worker.descriptor.processStartId !== descriptorProcessStartId ||
+			getProcessStartId(initial.worker.descriptor.pid) !== descriptorProcessStartId
+		) {
+			throw new Error("Archive occupancy is stale after worker replacement");
+		}
+		const current = this.exactArchiveRoot(client, activeSessionId, sessionId);
+		if (
+			current.worker !== initial.worker ||
+			current.worker.descriptor.lifecycle !== "ready" ||
+			!current.worker.client
+		) {
+			throw new Error("Archive occupancy is stale after worker refresh");
+		}
+		if (current.summary.runtimeKind !== undefined && current.summary.runtimeKind !== "top-level") {
+			throw new Error("Archive target is not a top-level root session");
+		}
+		if (current.summary.lifecycle !== "draft" && current.summary.lifecycle !== "live") {
+			throw new Error(`Archive target has unsupported lifecycle ${current.summary.lifecycle}`);
+		}
+		const sessionFile = current.summary.sessionFile;
+		if (!sessionFile) throw new Error("Archive target has no persisted session path");
+		const sessionPath = canonicalSessionPath(sessionFile);
+		const descriptorPath = current.worker.descriptor.sessionFile;
+		if (
+			current.worker.descriptor.rootSessionId !== current.summary.sessionId ||
+			!descriptorPath ||
+			canonicalSessionPath(descriptorPath) !== sessionPath
+		) {
+			throw new Error("Archive target identity does not match its resident root descriptor");
+		}
+
+		const summaries = [...current.worker.summaries.values()];
+		const projections = summaries.map(projectDaemonArchiveSummaryOccupancy);
+		const attachedClients = summaries.reduce((count, summary) => {
+			const id = summary.activeSessionId;
+			return count + [...this.clients].filter((candidate) => candidate.attachedActiveSessionIds.has(id!)).length;
+		}, 0);
+		const scheduleResponse = await this.forwardToWorker(
+			current.worker,
+			{ type: "cron_list", activeSessionId, includeInactive: true },
+			5000,
+		);
+		if (
+			!scheduleResponse.success ||
+			!scheduleResponse.data ||
+			typeof scheduleResponse.data !== "object" ||
+			!Array.isArray((scheduleResponse.data as { jobs?: unknown }).jobs)
+		) {
+			throw new Error("Archive occupancy schedule snapshot is incomplete");
+		}
+		const jobs = (scheduleResponse.data as { jobs: unknown[] }).jobs;
+		if (
+			!jobs.every(
+				(job): job is AgentCronJob =>
+					!!job &&
+					typeof job === "object" &&
+					typeof (job as { id?: unknown }).id === "string" &&
+					typeof (job as { activeSessionId?: unknown }).activeSessionId === "string" &&
+					typeof (job as { sessionId?: unknown }).sessionId === "string" &&
+					typeof (job as { sessionFile?: unknown }).sessionFile === "string" &&
+					["active", "paused", "completed", "cancelled"].includes(String((job as { status?: unknown }).status)),
+			)
+		) {
+			throw new Error("Archive occupancy schedule snapshot is incomplete");
+		}
+		if (
+			current.worker.descriptor.processStartId !== descriptorProcessStartId ||
+			getProcessStartId(current.worker.descriptor.pid) !== descriptorProcessStartId
+		) {
+			throw new Error("Archive occupancy changed during schedule refresh");
+		}
+		const liveJobs = jobs.filter((job) => job.status === "active" || job.status === "paused");
+		for (const job of liveJobs) {
+			const matchingSummary = summaries.find(
+				(summary) =>
+					summary.sessionId === job.sessionId &&
+					summary.sessionFile !== undefined &&
+					canonicalSessionPath(summary.sessionFile) === canonicalSessionPath(job.sessionFile),
+			);
+			if (!matchingSummary) {
+				throw new Error("Archive occupancy schedule identity is ambiguous");
+			}
+		}
+		return createDaemonArchiveOccupancyReceipt({
+			activeSessionId,
+			sessionId,
+			sessionPath,
+			hostGeneration: `${this.generation}:${descriptorProcessStartId}`,
+			lifecycle: current.summary.lifecycle,
+			workerState: "ready",
+			workerRefresh: "current",
+			activeTurn: projections.some((projection) => projection.activeTurn),
+			streaming: projections.some((projection) => projection.streaming),
+			compacting: projections.some((projection) => projection.compacting),
+			tools: projections.some((projection) => projection.tools),
+			bash: projections.some((projection) => projection.bash),
+			unfinishedActions: projections.reduce((count, projection) => count + projection.unfinishedActions, 0),
+			queuedActions: projections.reduce((count, projection) => count + projection.queuedActions, 0),
+			runningChildren: projections.some((projection) => projection.runningChildren),
+			attachedClients,
+			heartbeat: liveJobs.some((job) => isHeartbeatCronJob(job) && job.status === "active"),
+			cron: liveJobs.some((job) => !isHeartbeatCronJob(job)),
+			observedAt: new Date().toISOString(),
+		});
+	}
+
+	private async archiveSessionIfIdle(
+		client: DaemonSocketClient,
+		command: Extract<DaemonCommand, { type: "archive_session_if_idle" }>,
+	) {
+		if (!/^sha256:[a-f0-9]{64}$/.test(command.expectedOccupancyDigest)) {
+			throw new Error("Expected archive occupancy digest is malformed");
+		}
+		const occupancy = await this.readArchiveOccupancy(client, command.activeSessionId, command.sessionId);
+		if (occupancy.occupancyDigest !== command.expectedOccupancyDigest) {
+			throw new Error("Archive occupancy changed after observation");
+		}
+		if (occupancy.busy) {
+			throw new Error("Archive target is currently occupied");
+		}
+		if (occupancy.lifecycle !== "live") {
+			throw new Error("Archive target would require delete semantics instead of resumable archive");
+		}
+
+		const match = this.exactArchiveRoot(client, command.activeSessionId, command.sessionId);
+		const nonResumableSummary = [...match.worker.summaries.values()].find(
+			(summary) => summary.lifecycle !== "live" || !summary.sessionFile,
+		);
+		if (nonResumableSummary) {
+			throw new Error(
+				`Archive blocked because co-resident session is not resumable: ${nonResumableSummary.sessionId}`,
+			);
+		}
+		const artifactContext = this.workerSessionArtifactContext(match.worker);
+		if (!artifactContext || canonicalSessionPath(artifactContext.sessionFile) !== occupancy.sessionPath) {
+			throw new Error("Archive target has no matching persisted artifact context");
+		}
+		await this.stopWorker(match.worker, true, false, true);
+
+		const directReadback = await readSessionInfo(occupancy.sessionPath);
+		const catalogReadback = (await this.catalog.list()).find(
+			(session) => canonicalSessionPath(session.path) === occupancy.sessionPath,
+		);
+		if (
+			!directReadback ||
+			directReadback.id !== occupancy.sessionId ||
+			directReadback.state?.status !== "archived" ||
+			!catalogReadback ||
+			catalogReadback.id !== occupancy.sessionId ||
+			catalogReadback.state?.status !== "archived"
+		) {
+			throw new Error("Persisted archived-state readback is unavailable or mismatched");
+		}
+		const archivedAt = new Date().toISOString();
+		return createArchiveSessionReceipt({
+			activeSessionId: occupancy.activeSessionId,
+			sessionId: occupancy.sessionId,
+			sessionPath: occupancy.sessionPath,
+			hostGeneration: occupancy.hostGeneration,
+			beforeOccupancyDigest: occupancy.occupancyDigest,
+			archivedAt,
+			postReadback: {
+				sessionId: catalogReadback.id,
+				sessionPath: canonicalSessionPath(catalogReadback.path),
+				state: "archived",
+			},
+		});
+	}
+
 	private publicSummary(worker: ResidentWorker, summary: SessionSummary): SessionSummary {
 		const activeSessionId = summary.activeSessionId ?? summary.id;
 		return {
@@ -4966,17 +5242,40 @@ export class DaemonSupervisor {
 
 	private async finalizeArchivedWorkerStop(worker: ResidentWorker): Promise<void> {
 		const context = this.workerSessionArtifactContext(worker);
-		if (!context) {
-			return;
+		const rootSessionId = worker.descriptor.rootSessionId;
+		if (!context || !rootSessionId) {
+			throw new Error("Archived worker tombstone has no exact persisted root identity");
 		}
-		if (worker.descriptor.rootSessionId) {
-			const cronStore = AgentCronJobStore.forSessionArtifacts();
-			cronStore.registerSessionArtifact(worker.descriptor.rootSessionId, context.artifactDir);
-			cronStore.cancelJobsForSession({
-				sessionId: worker.descriptor.rootSessionId,
-				sessionFile: context.sessionFile,
-			});
-			await this.catalog.archive(context.sessionFile, worker.descriptor.rootSessionId);
+		const cronStore = AgentCronJobStore.forSessionArtifacts();
+		cronStore.registerSessionArtifact(rootSessionId, context.artifactDir);
+		cronStore.cancelJobsForSession({ sessionId: rootSessionId, sessionFile: context.sessionFile });
+		if (!(await this.catalog.archive(context.sessionFile, rootSessionId))) {
+			throw new Error("Catalog rejected the archived worker root identity");
+		}
+		await this.assertPersistedArchivedWorkerReadback(worker);
+	}
+
+	private async assertPersistedArchivedWorkerReadback(worker: ResidentWorker): Promise<void> {
+		const context = this.workerSessionArtifactContext(worker);
+		const rootSessionId = worker.descriptor.rootSessionId;
+		if (!context || !rootSessionId) {
+			throw new Error("Archived worker tombstone has no exact persisted root identity");
+		}
+		const sessionPath = canonicalSessionPath(context.sessionFile);
+		const directReadback = await readSessionInfo(context.sessionFile);
+		const catalogMatches = (await this.catalog.list()).filter(
+			(session) => canonicalSessionPath(session.path) === sessionPath,
+		);
+		if (
+			!directReadback ||
+			directReadback.id !== rootSessionId ||
+			canonicalSessionPath(directReadback.path) !== sessionPath ||
+			directReadback.state?.status !== "archived" ||
+			catalogMatches.length !== 1 ||
+			catalogMatches[0]?.id !== rootSessionId ||
+			catalogMatches[0].state?.status !== "archived"
+		) {
+			throw new Error("Persisted archived-state readback is unavailable or mismatched for the exact root");
 		}
 	}
 

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -215,6 +215,146 @@ describe("DaemonClient", () => {
 		client.close();
 	});
 
+	it("degrades atomic archive locally on old daemons without affecting ordinary commands", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, DAEMON_PROTOCOL_VERSION, [], DAEMON_SCHEMA_REVISION - 1);
+
+		await expect(
+			client.request({ type: "get_archive_occupancy", activeSessionId: "active-1", sessionId: "session-1" }),
+		).rejects.toThrow("does not support atomic_session_archive");
+		await expect(
+			client.request({
+				type: "archive_session_if_idle",
+				activeSessionId: "active-1",
+				sessionId: "session-1",
+				expectedOccupancyDigest: `sha256:${"0".repeat(64)}`,
+			}),
+		).rejects.toThrow("does not support atomic_session_archive");
+		expect(socket.writes).toEqual([]);
+
+		const list = client.request({ type: "list" });
+		await vi.waitFor(() => expect(socket.writes).toHaveLength(1));
+		client.close();
+		await expect(list).rejects.toThrow("closed before the operation completed");
+	});
+
+	it("requires the introducing schema revision even when an old daemon advertises atomic archive", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, DAEMON_PROTOCOL_VERSION, ["atomic_session_archive"], DAEMON_SCHEMA_REVISION - 1);
+
+		await expect(
+			client.request({ type: "get_archive_occupancy", activeSessionId: "active-1", sessionId: "session-1" }),
+		).rejects.toThrow("does not support atomic_session_archive");
+		expect(socket.writes).toEqual([]);
+		client.close();
+	});
+
+	it("serializes atomic archive commands and returns their structured responses from a capable daemon", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, DAEMON_PROTOCOL_VERSION, ["atomic_session_archive"], DAEMON_SCHEMA_REVISION);
+
+		const occupancyRequest = client.request({
+			type: "get_archive_occupancy",
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+		});
+		const occupancyEnvelope = JSON.parse(socket.writes[0]!) as { id: string; command: unknown };
+		expect(occupancyEnvelope.command).toMatchObject({
+			type: "get_archive_occupancy",
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+		});
+		const occupancy = {
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionPath: "/tmp/session-1.jsonl",
+			hostGeneration: "supervisor-1:worker-start-1",
+			lifecycle: "live",
+			workerState: "ready",
+			workerRefresh: "current",
+			activeTurn: false,
+			streaming: false,
+			compacting: false,
+			tools: false,
+			bash: false,
+			unfinishedActions: 0,
+			queuedActions: 0,
+			runningChildren: false,
+			attachedClients: 0,
+			heartbeat: false,
+			cron: false,
+			busy: false,
+			observedAt: "2026-08-12T00:00:00.000Z",
+			occupancyDigest: `sha256:${"1".repeat(64)}`,
+		};
+		socket.emit(
+			"data",
+			`${JSON.stringify({ id: occupancyEnvelope.id, type: "response", command: "get_archive_occupancy", success: true, data: occupancy })}\n`,
+		);
+		await expect(occupancyRequest).resolves.toMatchObject({ success: true, data: occupancy });
+
+		const archiveRequest = client.request({
+			type: "archive_session_if_idle",
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			expectedOccupancyDigest: occupancy.occupancyDigest,
+		});
+		const archiveEnvelope = JSON.parse(socket.writes.at(-1)!) as { id: string; command: unknown };
+		expect(archiveEnvelope.command).toMatchObject({
+			type: "archive_session_if_idle",
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			expectedOccupancyDigest: occupancy.occupancyDigest,
+		});
+		const archive = {
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionPath: "/tmp/session-1.jsonl",
+			hostGeneration: occupancy.hostGeneration,
+			beforeOccupancyDigest: occupancy.occupancyDigest,
+			archiveReceiptDigest: `sha256:${"2".repeat(64)}`,
+			state: "archived",
+			archivedAt: "2026-08-12T00:00:01.000Z",
+			postReadback: { sessionId: "session-1", sessionPath: "/tmp/session-1.jsonl", state: "archived" },
+		};
+		socket.emit(
+			"data",
+			`${JSON.stringify({ id: archiveEnvelope.id, type: "response", command: "archive_session_if_idle", success: true, data: archive })}\n`,
+		);
+		await expect(archiveRequest).resolves.toMatchObject({ success: true, data: archive });
+		client.close();
+	});
+
+	it("keeps an old attach shape usable when a new daemon advertises atomic archive", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, DAEMON_PROTOCOL_VERSION, ["atomic_session_archive"], DAEMON_SCHEMA_REVISION);
+		const attach = client.request({ type: "attach", activeSessionId: "active-1" });
+		const envelope = JSON.parse(socket.writes[0]!) as { id: string; command: unknown };
+		expect(envelope.command).toMatchObject({ type: "attach", activeSessionId: "active-1" });
+		socket.emit(
+			"data",
+			`${JSON.stringify({ id: envelope.id, type: "response", command: "attach", success: false, error: "fixture" })}\n`,
+		);
+		await expect(attach).resolves.toMatchObject({ success: false, error: "fixture" });
+		client.close();
+	});
+
 	it("does not send subagent deletion to an old daemon without the capability", async () => {
 		const client = new DaemonClient("/tmp/prime-agent.sock");
 		const connect = client.connect();

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -21,10 +21,22 @@ import {
 	isDaemonMutatingCommand,
 	salvageDaemonCommandId,
 } from "../src/modes/daemon/daemon-protocol.js";
+import {
+	createArchiveSessionReceipt,
+	createDaemonArchiveOccupancyReceipt,
+	isDaemonArchiveOccupancyReceipt,
+	isDaemonArchiveSessionReceipt,
+	projectDaemonArchiveSummaryOccupancy,
+	registerDaemonArchiveOccupancyMutation,
+} from "../src/modes/daemon/daemon-session-archive.js";
 
 describe("daemon protocol helpers", () => {
 	it("keeps the advertised schema identity synchronized with wire type shapes", () => {
 		const source = readFileSync(resolve(__dirname, "../src/modes/daemon/daemon-protocol.ts"), "utf8");
+		const archiveSource = source.slice(
+			source.indexOf("export interface DaemonArchiveOccupancyReceipt"),
+			source.indexOf("export type DaemonSavedSessionListCommand"),
+		);
 		const commandSource = source.slice(
 			source.indexOf("export type DaemonCommand ="),
 			source.indexOf("type DaemonCommandName"),
@@ -38,7 +50,7 @@ describe("daemon protocol helpers", () => {
 			source.indexOf("export const DAEMON_OUTBOUND_COMPATIBILITY"),
 		);
 		const digest = createHash("sha256")
-			.update(`${commandSource}\n${savedSessionSource}\n${outboundSource}`)
+			.update(`${archiveSource}\n${commandSource}\n${savedSessionSource}\n${outboundSource}`)
 			.digest("hex")
 			.slice(0, 12);
 		expect(DAEMON_SCHEMA_ID).toBe(`protocol-${DAEMON_PROTOCOL_VERSION}-schema-${DAEMON_SCHEMA_REVISION}-${digest}`);
@@ -288,5 +300,204 @@ describe("daemon protocol helpers", () => {
 		expect(salvageDaemonCommandId(JSON.stringify({ type: "command", id: 7 }))).toBeUndefined();
 		expect(salvageDaemonCommandId(JSON.stringify("command"))).toBeUndefined();
 		expect(salvageDaemonCommandId("{ not json")).toBeUndefined();
+	});
+	it("capability- and schema-gates atomic session archive without changing the protocol version", () => {
+		expect(DAEMON_PROTOCOL_VERSION).toBe(7);
+		expect(DAEMON_SCHEMA_REVISION).toBe(17);
+		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("atomic_session_archive");
+		expect(DAEMON_COMMAND_COMPATIBILITY.get_archive_occupancy).toEqual({
+			minProtocol: 7,
+			minSchemaRevision: 17,
+			capability: "atomic_session_archive",
+		});
+		expect(DAEMON_COMMAND_COMPATIBILITY.archive_session_if_idle).toEqual({
+			minProtocol: 7,
+			minSchemaRevision: 17,
+			capability: "atomic_session_archive",
+		});
+		expect(isDaemonMutatingCommand({ type: "get_archive_occupancy" })).toBe(false);
+		expect(isDaemonMutatingCommand({ type: "archive_session_if_idle" })).toBe(true);
+	});
+
+	it("binds archive occupancy digests to every decisive identity and occupancy field", () => {
+		const base = {
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionPath: "/tmp/sessions/session-1.jsonl",
+			hostGeneration: "worker-1",
+			lifecycle: "live" as const,
+			workerState: "ready" as const,
+			workerRefresh: "current" as const,
+			activeTurn: false,
+			streaming: false,
+			compacting: false,
+			tools: false,
+			bash: false,
+			unfinishedActions: 0,
+			queuedActions: 0,
+			runningChildren: false,
+			attachedClients: 0,
+			heartbeat: false,
+			cron: false,
+			observedAt: "2026-08-12T00:00:00.000Z",
+		};
+		const receipt = createDaemonArchiveOccupancyReceipt(base);
+		expect(receipt).toMatchObject({
+			...base,
+			busy: false,
+			occupancyDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+		});
+		expect(isDaemonArchiveOccupancyReceipt(receipt)).toBe(true);
+
+		const changes = [
+			{ activeSessionId: "active-2" },
+			{ sessionId: "session-2" },
+			{ sessionPath: "/tmp/sessions/session-2.jsonl" },
+			{ hostGeneration: "worker-2" },
+			{ lifecycle: "draft" as const },
+			{ activeTurn: true },
+			{ streaming: true },
+			{ compacting: true },
+			{ tools: true },
+			{ bash: true },
+			{ unfinishedActions: 1 },
+			{ queuedActions: 1 },
+			{ runningChildren: true },
+			{ attachedClients: 1 },
+			{ heartbeat: true },
+			{ cron: true },
+		];
+		for (const change of changes) {
+			const changed = createDaemonArchiveOccupancyReceipt({ ...base, ...change });
+			expect(changed.occupancyDigest).not.toBe(receipt.occupancyDigest);
+		}
+	});
+
+	it("rejects open, malformed, and digest-mismatched archive receipts", () => {
+		const occupancy = createDaemonArchiveOccupancyReceipt({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionPath: "/tmp/session-1.jsonl",
+			hostGeneration: "worker-1",
+			lifecycle: "live",
+			workerState: "ready",
+			workerRefresh: "current",
+			activeTurn: false,
+			streaming: false,
+			compacting: false,
+			tools: false,
+			bash: false,
+			unfinishedActions: 0,
+			queuedActions: 0,
+			runningChildren: false,
+			attachedClients: 0,
+			heartbeat: false,
+			cron: false,
+			observedAt: "2026-08-12T00:00:00.000Z",
+		});
+		const archive = createArchiveSessionReceipt({
+			activeSessionId: occupancy.activeSessionId,
+			sessionId: occupancy.sessionId,
+			sessionPath: occupancy.sessionPath,
+			hostGeneration: occupancy.hostGeneration,
+			beforeOccupancyDigest: occupancy.occupancyDigest,
+			archivedAt: "2026-08-12T00:00:01.000Z",
+			postReadback: { sessionId: occupancy.sessionId, sessionPath: occupancy.sessionPath, state: "archived" },
+		});
+		expect(isDaemonArchiveSessionReceipt(archive)).toBe(true);
+
+		for (const invalid of [
+			{ ...occupancy, extra: true },
+			{ ...occupancy, sessionId: "" },
+			{ ...occupancy, busy: true },
+			{ ...occupancy, occupancyDigest: `sha256:${"0".repeat(64)}` },
+			Object.fromEntries(Object.entries(occupancy).filter(([key]) => key !== "cron")),
+		]) {
+			expect(isDaemonArchiveOccupancyReceipt(invalid)).toBe(false);
+		}
+		for (const invalid of [
+			{ ...archive, extra: true },
+			{ ...archive, state: "deleted" },
+			{ ...archive, archiveReceiptDigest: `sha256:${"0".repeat(64)}` },
+			{ ...archive, postReadback: { ...archive.postReadback, sessionId: "other" } },
+			Object.fromEntries(Object.entries(archive).filter(([key]) => key !== "postReadback")),
+		]) {
+			expect(isDaemonArchiveSessionReceipt(invalid)).toBe(false);
+		}
+	});
+	it("fails closed when a current worker summary omits decisive occupancy metadata", () => {
+		const complete = {
+			id: "active-1",
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session-1.jsonl",
+			lifecycle: "live",
+			isSessionActive: false,
+			isStreaming: false,
+			isCompacting: false,
+			isBashRunning: false,
+			isRunningTools: false,
+			hasRunningRlmChildren: false,
+			unfinishedActionCount: 0,
+			sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+		};
+		expect(projectDaemonArchiveSummaryOccupancy(complete)).toEqual({
+			activeTurn: false,
+			streaming: false,
+			compacting: false,
+			tools: false,
+			bash: false,
+			unfinishedActions: 0,
+			queuedActions: 0,
+			runningChildren: false,
+		});
+		for (const missing of [
+			"activeSessionId",
+			"sessionId",
+			"sessionFile",
+			"lifecycle",
+			"isSessionActive",
+			"isStreaming",
+			"isCompacting",
+			"isBashRunning",
+			"isRunningTools",
+			"hasRunningRlmChildren",
+			"unfinishedActionCount",
+			"sessionActions",
+		]) {
+			const incomplete = { ...complete } as Record<string, unknown>;
+			delete incomplete[missing];
+			expect(() => projectDaemonArchiveSummaryOccupancy(incomplete), missing).toThrow(
+				"Archive occupancy summary is incomplete",
+			);
+		}
+	});
+
+	it("rechecks archive admission after yielding to idle eviction before registering a mutation", async () => {
+		let releaseIdle: () => void = () => {};
+		const idle = new Promise<void>((resolve) => {
+			releaseIdle = resolve;
+		});
+		let releaseArchive: () => void = () => {};
+		const archive = new Promise<void>((resolve) => {
+			releaseArchive = resolve;
+		});
+		let archiveFence: Promise<void> | undefined;
+		let began = false;
+		const registration = registerDaemonArchiveOccupancyMutation(
+			() => archiveFence,
+			() => idle,
+			() => {
+				began = true;
+			},
+		);
+		archiveFence = archive;
+		releaseIdle();
+		await Promise.resolve();
+		expect(began).toBe(false);
+		archiveFence = undefined;
+		releaseArchive();
+		await registration;
+		expect(began).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-process.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-process.test.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import type { Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -15,6 +16,14 @@ import {
 import { readSessionInfo, SessionManager } from "../src/core/session-manager.js";
 import { DaemonAgentConnection } from "../src/modes/agent-connection/daemon-agent-connection.js";
 import { DaemonClient, getDaemonSocketCloseReason } from "../src/modes/daemon/daemon-client.js";
+import type {
+	DaemonArchiveOccupancyReceipt,
+	DaemonArchiveSessionReceipt,
+} from "../src/modes/daemon/daemon-protocol.js";
+import {
+	isDaemonArchiveOccupancyReceipt,
+	isDaemonArchiveSessionReceipt,
+} from "../src/modes/daemon/daemon-session-archive.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import type { DaemonWorkerDescriptor } from "../src/modes/daemon/daemon-worker-protocol.js";
 
@@ -145,6 +154,22 @@ function countWorkerDescriptors(agentDir: string): number {
 	}
 }
 
+function readCommandJournalRecords(agentDir: string): Array<Record<string, unknown>> {
+	const workersRoot = join(agentDir, "daemon-workers");
+	try {
+		return readdirSync(workersRoot).flatMap((directory) => {
+			const path = join(workersRoot, directory, "command-journal.jsonl");
+			if (!existsSync(path)) return [];
+			return readFileSync(path, "utf8")
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => JSON.parse(line) as Record<string, unknown>);
+		});
+	} catch {
+		return [];
+	}
+}
+
 async function waitForWorkerStopTombstone(agentDir: string): Promise<DaemonWorkerDescriptor> {
 	const deadline = Date.now() + 5000;
 	while (Date.now() < deadline) {
@@ -198,7 +223,11 @@ async function connectEventually(socketPath: string, child?: ChildProcess): Prom
 			await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
 		}
 	}
-	throw new Error(`Timed out waiting for supervisor: ${String(lastError)}`);
+	const diagnostics = child ? childDiagnostics.get(child) : undefined;
+	throw new Error(
+		`Timed out waiting for supervisor: ${String(lastError)}\n` +
+			`stdout:\n${diagnostics?.stdout ?? ""}\nstderr:\n${diagnostics?.stderr ?? ""}`,
+	);
 }
 
 async function waitForSocketGone(socketPath: string): Promise<void> {
@@ -222,6 +251,20 @@ function requireSummary(responseData: unknown): SessionSummary {
 		throw new Error("Missing daemon session summary");
 	}
 	return responseData as SessionSummary;
+}
+
+function requireArchiveOccupancy(responseData: unknown): DaemonArchiveOccupancyReceipt {
+	if (!isDaemonArchiveOccupancyReceipt(responseData)) {
+		throw new Error(`Invalid daemon archive occupancy receipt: ${JSON.stringify(responseData)}`);
+	}
+	return responseData;
+}
+
+function requireArchiveReceipt(responseData: unknown): DaemonArchiveSessionReceipt {
+	if (!isDaemonArchiveSessionReceipt(responseData)) {
+		throw new Error(`Invalid daemon archive receipt: ${JSON.stringify(responseData)}`);
+	}
+	return responseData;
 }
 
 function requireSessionList(responseData: unknown): SessionSummary[] {
@@ -316,6 +359,569 @@ describe("daemon supervisor resident workers", () => {
 		workerPids.delete(summary.workerPid);
 		await waitForSocketGone(socketPath);
 	}, 60_000);
+
+	it("atomically rejects changed occupancy and archives one exact idle root with persisted readback", async () => {
+		const root = tempDir();
+		const agentDir = join(root, "agent");
+		const projectDir = join(root, "project");
+		const sessionDir = join(agentDir, "sessions");
+		const socketPath = join(
+			tmpdir(),
+			`prime-supervisor-atomic-archive-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
+		);
+		mkdirSync(projectDir, { recursive: true });
+		const sessionManager = SessionManager.create(projectDir, sessionDir);
+		sessionManager.appendMessage({ role: "user", content: "archive carrier fixture", timestamp: 1 });
+		sessionManager.flushNow();
+		const sessionFile = sessionManager.getSessionFile();
+		const artifactDir = sessionManager.getSessionArtifactDir();
+		if (!sessionFile || !artifactDir) throw new Error("Archive fixture did not persist");
+		mkdirSync(artifactDir, { recursive: true });
+		const artifactPath = join(artifactDir, "evidence.txt");
+		writeFileSync(artifactPath, "preserve me");
+
+		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+		const client = await connectEventually(socketPath, supervisor);
+		expect(client.hello?.serverCapabilities).toContain("atomic_session_archive");
+		const created = await client.request({
+			type: "create",
+			sessionPath: sessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+		});
+		if (!created.success) throw new Error(created.error);
+		const summary = requireSummary(created.data);
+		if (!summary.workerPid) throw new Error("Archive fixture worker did not expose its pid");
+		workerPids.add(summary.workerPid);
+		const activeSessionId = summary.activeSessionId ?? summary.id;
+
+		const observed = await client.request({
+			type: "get_archive_occupancy",
+			activeSessionId,
+			sessionId: summary.sessionId,
+		});
+		if (!observed.success) throw new Error(observed.error);
+		const before = requireArchiveOccupancy(observed.data);
+		expect(before).toMatchObject({ busy: false, attachedClients: 0, lifecycle: "live" });
+
+		const scheduled = await client.request({
+			type: "cron_add",
+			activeSessionId,
+			schedule: "every 1h",
+			prompt: "do not archive scheduled work",
+		});
+		if (!scheduled.success || !scheduled.data || typeof scheduled.data !== "object") {
+			throw new Error(scheduled.success ? "Scheduled archive fixture returned no job" : scheduled.error);
+		}
+		const scheduledJob = (scheduled.data as { job?: { id?: string } }).job;
+		if (!scheduledJob?.id) throw new Error("Scheduled archive fixture returned no job id");
+		const scheduledOccupancyResponse = await client.request({
+			type: "get_archive_occupancy",
+			activeSessionId,
+			sessionId: summary.sessionId,
+		});
+		if (!scheduledOccupancyResponse.success) throw new Error(scheduledOccupancyResponse.error);
+		const scheduledOccupancy = requireArchiveOccupancy(scheduledOccupancyResponse.data);
+		expect(scheduledOccupancy).toMatchObject({ busy: true, cron: true });
+		const scheduledArchive = await client.request({
+			type: "archive_session_if_idle",
+			activeSessionId,
+			sessionId: summary.sessionId,
+			expectedOccupancyDigest: scheduledOccupancy.occupancyDigest,
+		});
+		expect(scheduledArchive).toMatchObject({ success: false, error: expect.stringContaining("currently occupied") });
+		const cancelled = await client.request({ type: "cron_cancel", activeSessionId, jobId: scheduledJob.id });
+		if (!cancelled.success) throw new Error(cancelled.error);
+
+		const observer = await connectEventually(socketPath, supervisor);
+		const attached = await observer.request({ type: "attach", activeSessionId });
+		if (!attached.success) throw new Error(attached.error);
+		const raced = await client.request({
+			type: "archive_session_if_idle",
+			activeSessionId,
+			sessionId: summary.sessionId,
+			expectedOccupancyDigest: before.occupancyDigest,
+		});
+		expect(raced).toMatchObject({ success: false, error: expect.stringContaining("occupancy changed") });
+		expect(countWorkerDescriptors(agentDir)).toBe(1);
+		await observer.request({ type: "detach", activeSessionId });
+		observer.close();
+
+		const refreshed = await client.request({
+			type: "get_archive_occupancy",
+			activeSessionId,
+			sessionId: summary.sessionId,
+		});
+		if (!refreshed.success) throw new Error(refreshed.error);
+		const idle = requireArchiveOccupancy(refreshed.data);
+		const archived = await client.request(
+			{
+				type: "archive_session_if_idle",
+				activeSessionId,
+				sessionId: summary.sessionId,
+				expectedOccupancyDigest: idle.occupancyDigest,
+			},
+			15_000,
+		);
+		if (!archived.success) throw new Error(archived.error);
+		const receipt = requireArchiveReceipt(archived.data);
+		expect(receipt).toMatchObject({
+			activeSessionId,
+			sessionId: summary.sessionId,
+			sessionPath: idle.sessionPath,
+			beforeOccupancyDigest: idle.occupancyDigest,
+			state: "archived",
+			postReadback: { sessionId: summary.sessionId, sessionPath: idle.sessionPath, state: "archived" },
+		});
+		await waitForProcessGone(summary.workerPid);
+		workerPids.delete(summary.workerPid);
+		expect(countWorkerDescriptors(agentDir)).toBe(0);
+		expect((await readSessionInfo(sessionFile))?.state).toEqual({ status: "archived" });
+		expect(readFileSync(sessionFile, "utf8")).toContain("archive carrier fixture");
+		expect(readFileSync(artifactPath, "utf8")).toBe("preserve me");
+
+		const repeated = await client.request({
+			type: "archive_session_if_idle",
+			activeSessionId,
+			sessionId: summary.sessionId,
+			expectedOccupancyDigest: idle.occupancyDigest,
+		});
+		expect(repeated).toMatchObject({ success: false, error: expect.stringContaining("Unknown archive root") });
+		expect((await readSessionInfo(sessionFile))?.state).toEqual({ status: "archived" });
+
+		await client.request({ type: "shutdown" });
+		client.close();
+		await waitForSocketGone(socketPath);
+	}, 30_000);
+
+	it("catches and journals an archive admission fence timeout without an unhandled rejection", async () => {
+		const root = tempDir();
+		const agentDir = join(root, "agent");
+		const projectDir = join(root, "project");
+		const sessionDir = join(agentDir, "sessions");
+		const socketPath = join(tmpdir(), `prime-arch-fence-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		mkdirSync(projectDir, { recursive: true });
+		const sessionManager = SessionManager.create(projectDir, sessionDir);
+		sessionManager.appendMessage({ role: "user", content: "archive fence fixture", timestamp: 1 });
+		sessionManager.flushNow();
+		const sessionFile = sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Archive fence fixture did not persist");
+
+		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+		const client = await connectEventually(socketPath, supervisor);
+		const created = await client.request({
+			type: "create",
+			sessionPath: sessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+		});
+		if (!created.success) throw new Error(created.error);
+		const summary = requireSummary(created.data);
+		if (!summary.workerPid) throw new Error("Archive fence worker did not expose its pid");
+		workerPids.add(summary.workerPid);
+		const activeSessionId = summary.activeSessionId ?? summary.id;
+		const observedResponse = await client.request({
+			type: "get_archive_occupancy",
+			activeSessionId,
+			sessionId: summary.sessionId,
+		});
+		if (!observedResponse.success) throw new Error(observedResponse.error);
+		const observed = requireArchiveOccupancy(observedResponse.data);
+
+		process.kill(summary.workerPid, "SIGSTOP");
+		const blocker = await connectEventually(socketPath, supervisor);
+		const blockedMutation = blocker
+			.request({ type: "set_session_name", activeSessionId, name: `blocked-${randomUUID()}` }, 45_000)
+			.catch((error: unknown) => error);
+		await waitForCondition(
+			() =>
+				readCommandJournalRecords(agentDir).some(
+					(record) => record.type === "received" && record.commandType === "set_session_name",
+				),
+			"Blocking occupancy mutation was not journaled",
+		);
+
+		const archivePromise = client.request(
+			{
+				type: "archive_session_if_idle",
+				activeSessionId,
+				sessionId: summary.sessionId,
+				expectedOccupancyDigest: observed.occupancyDigest,
+			},
+			40_000,
+		);
+		const archiveSocket = (client as unknown as { socket?: Socket }).socket;
+		if (!archiveSocket) throw new Error("Archive fence client socket was unavailable");
+		(archiveSocket as unknown as { write: (...args: unknown[]) => boolean }).write = () => true;
+		let archiveResult: unknown;
+		try {
+			archiveResult = await archivePromise;
+		} catch (error) {
+			archiveResult = error;
+		} finally {
+			process.kill(summary.workerPid, "SIGCONT");
+		}
+		await blockedMutation;
+		blocker.close();
+
+		expect(archiveResult).toMatchObject({
+			success: false,
+			error: expect.stringContaining("Timed out draining daemon occupancy mutations"),
+		});
+		expect(supervisor.exitCode).toBeNull();
+		const records = readCommandJournalRecords(agentDir);
+		const archiveReceived = records.find(
+			(record) => record.type === "received" && record.commandType === "archive_session_if_idle",
+		);
+		expect(archiveReceived?.key).toEqual(expect.any(String));
+		expect(records).toContainEqual(
+			expect.objectContaining({
+				type: "result",
+				key: archiveReceived?.key,
+				response: expect.objectContaining({
+					success: false,
+					error: expect.stringContaining("Timed out draining daemon occupancy mutations"),
+				}),
+			}),
+		);
+		const diagnostics = childDiagnostics.get(supervisor);
+		expect(diagnostics?.stderr).not.toContain("UnhandledPromiseRejection");
+
+		const recoveryClient = await connectEventually(socketPath, supervisor);
+		expect((await recoveryClient.request({ type: "list" })).success).toBe(true);
+		await recoveryClient.request({ type: "shutdown" });
+		recoveryClient.close();
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForProcessGone(summary.workerPid);
+		workerPids.delete(summary.workerPid);
+	}, 60_000);
+
+	it("blocks a live root with a co-resident draft child before archive can delete either session", async () => {
+		const root = tempDir();
+		const agentDir = join(root, "agent");
+		const projectDir = join(root, "project");
+		const sessionDir = join(agentDir, "sessions");
+		const socketPath = join(tmpdir(), `prime-arch-draft-child-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		mkdirSync(projectDir, { recursive: true });
+		const parentManager = SessionManager.create(projectDir, sessionDir);
+		parentManager.appendMessage({ role: "user", content: "live parent", timestamp: 1 });
+		parentManager.flushNow();
+		const parentSessionFile = parentManager.getSessionFile();
+		const parentArtifactDir = parentManager.getSessionArtifactDir();
+		if (!parentSessionFile || !parentArtifactDir) throw new Error("Archive parent fixture did not persist");
+		const childId = "draft-child";
+		const childSessionDir = join(parentArtifactDir, childId);
+		const childManager = SessionManager.create(projectDir, childSessionDir);
+		childManager.newSession({ parentSession: parentSessionFile });
+		childManager.flushNow();
+		const childSessionFile = childManager.getSessionFile();
+		if (!childSessionFile) throw new Error("Archive child fixture did not persist");
+		writeFileSync(
+			join(parentArtifactDir, "rlm-subagents.jsonl"),
+			`${JSON.stringify({
+				type: "rlm_subagent",
+				childId,
+				sessionName: "draft-child",
+				sessionDir: childSessionDir,
+				sessionFile: childSessionFile,
+				parentSessionId: parentManager.getSessionId(),
+				parentSessionFile,
+				rlmDepth: 1,
+				rlmMaxDepth: 4,
+				rlmParentNodeId: childId,
+				status: "completed",
+				createdAt: 1,
+				updatedAt: "2026-01-01T00:00:00.000Z",
+			})}
+`,
+		);
+
+		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+		const client = await connectEventually(socketPath, supervisor);
+		const createdParent = await client.request({
+			type: "create",
+			sessionPath: parentSessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+		});
+		if (!createdParent.success) throw new Error(createdParent.error);
+		const parent = requireSummary(createdParent.data);
+		if (!parent.workerPid) throw new Error("Archive parent worker did not expose its pid");
+		workerPids.add(parent.workerPid);
+		const createdChild = await client.request({
+			type: "create",
+			sessionPath: childSessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+		});
+		if (!createdChild.success) throw new Error(createdChild.error);
+		const child = requireSummary(createdChild.data);
+		expect(child.lifecycle).toBe("draft");
+		const activeSessionId = parent.activeSessionId ?? parent.id;
+		const observedResponse = await client.request({
+			type: "get_archive_occupancy",
+			activeSessionId,
+			sessionId: parent.sessionId,
+		});
+		if (!observedResponse.success) throw new Error(observedResponse.error);
+		const observed = requireArchiveOccupancy(observedResponse.data);
+		expect(observed).toMatchObject({ busy: false, lifecycle: "live" });
+		const parentBytes = readFileSync(parentSessionFile, "utf8");
+		const childBytes = readFileSync(childSessionFile, "utf8");
+
+		const archived = await client.request({
+			type: "archive_session_if_idle",
+			activeSessionId,
+			sessionId: parent.sessionId,
+			expectedOccupancyDigest: observed.occupancyDigest,
+		});
+		expect(archived).toMatchObject({
+			success: false,
+			error: expect.stringContaining("co-resident session is not resumable"),
+		});
+		expect(readFileSync(parentSessionFile, "utf8")).toBe(parentBytes);
+		expect(readFileSync(childSessionFile, "utf8")).toBe(childBytes);
+		expect(countWorkerDescriptors(agentDir)).toBe(1);
+
+		await client.request({ type: "shutdown" });
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForProcessGone(parent.workerPid);
+		workerPids.delete(parent.workerPid);
+	}, 30_000);
+
+	it("rejects a stale archive digest after the resident worker incarnation recovers", async () => {
+		const root = tempDir();
+		const agentDir = join(root, "agent");
+		const projectDir = join(root, "project");
+		const sessionDir = join(agentDir, "sessions");
+		const socketPath = join(tmpdir(), `prime-arch-inc-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		mkdirSync(projectDir, { recursive: true });
+		const sessionManager = SessionManager.create(projectDir, sessionDir);
+		sessionManager.appendMessage({ role: "user", content: "recover before archive", timestamp: 1 });
+		sessionManager.flushNow();
+		const sessionFile = sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Recovery fixture did not persist");
+
+		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+		const client = await connectEventually(socketPath, supervisor);
+		const created = await client.request({
+			type: "create",
+			sessionPath: sessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+		});
+		if (!created.success) throw new Error(created.error);
+		const original = requireSummary(created.data);
+		if (!original.workerPid) throw new Error("Recovery fixture worker did not expose its pid");
+		workerPids.add(original.workerPid);
+		const activeSessionId = original.activeSessionId ?? original.id;
+		const observedResponse = await client.request({
+			type: "get_archive_occupancy",
+			activeSessionId,
+			sessionId: original.sessionId,
+		});
+		if (!observedResponse.success) throw new Error(observedResponse.error);
+		const observed = requireArchiveOccupancy(observedResponse.data);
+
+		process.kill(original.workerPid, "SIGKILL");
+		await waitForProcessGone(original.workerPid);
+		workerPids.delete(original.workerPid);
+		let recovered: SessionSummary | undefined;
+		const deadline = Date.now() + 20_000;
+		while (Date.now() < deadline) {
+			const listed = await client.request({ type: "list" });
+			if (listed.success) {
+				recovered = requireSessionList(listed.data).find(
+					(candidate) => (candidate.activeSessionId ?? candidate.id) === activeSessionId,
+				);
+				if (recovered?.workerState === "ready" && recovered.workerPid && recovered.workerPid !== original.workerPid)
+					break;
+			}
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+		}
+		if (!recovered?.workerPid || recovered.workerPid === original.workerPid) {
+			throw new Error("Archive fixture worker did not recover with a new incarnation");
+		}
+		workerPids.add(recovered.workerPid);
+		const currentResponse = await client.request({
+			type: "get_archive_occupancy",
+			activeSessionId,
+			sessionId: original.sessionId,
+		});
+		if (!currentResponse.success) throw new Error(currentResponse.error);
+		const current = requireArchiveOccupancy(currentResponse.data);
+		expect(current.hostGeneration).not.toBe(observed.hostGeneration);
+		expect(current.occupancyDigest).not.toBe(observed.occupancyDigest);
+		const stale = await client.request({
+			type: "archive_session_if_idle",
+			activeSessionId,
+			sessionId: original.sessionId,
+			expectedOccupancyDigest: observed.occupancyDigest,
+		});
+		expect(stale).toMatchObject({ success: false, error: expect.stringContaining("occupancy changed") });
+		expect(countWorkerDescriptors(agentDir)).toBe(1);
+
+		await client.request({ type: "shutdown" });
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForProcessGone(recovered.workerPid);
+		workerPids.delete(recovered.workerPid);
+	}, 30_000);
+
+	it("replays the original journaled archive receipt after a lost response without repeating the effect", async () => {
+		const root = tempDir();
+		const agentDir = join(root, "agent");
+		const projectDir = join(root, "project");
+		const sessionDir = join(agentDir, "sessions");
+		const socketPath = join(tmpdir(), `prime-arch-replay-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+		mkdirSync(projectDir, { recursive: true });
+		const sessionManager = SessionManager.create(projectDir, sessionDir);
+		sessionManager.appendMessage({ role: "user", content: "journal archive once", timestamp: 1 });
+		sessionManager.flushNow();
+		const sessionFile = sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Replay fixture did not persist");
+
+		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+		const setupClient = await connectEventually(socketPath, supervisor);
+		const created = await setupClient.request({
+			type: "create",
+			sessionPath: sessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+		});
+		if (!created.success) throw new Error(created.error);
+		const summary = requireSummary(created.data);
+		if (!summary.workerPid) throw new Error("Replay fixture worker did not expose its pid");
+		workerPids.add(summary.workerPid);
+		const activeSessionId = summary.activeSessionId ?? summary.id;
+		const observedResponse = await setupClient.request({
+			type: "get_archive_occupancy",
+			activeSessionId,
+			sessionId: summary.sessionId,
+		});
+		if (!observedResponse.success) throw new Error(observedResponse.error);
+		const observed = requireArchiveOccupancy(observedResponse.data);
+		setupClient.close();
+
+		const replayClient = await connectEventually(socketPath, supervisor);
+		replayClient.enableRequestRecovery();
+		const archivePromise = replayClient.request(
+			{
+				type: "archive_session_if_idle",
+				activeSessionId,
+				sessionId: summary.sessionId,
+				expectedOccupancyDigest: observed.occupancyDigest,
+			},
+			15_000,
+		);
+		await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
+		const lostSocket = (replayClient as unknown as { socket?: Socket }).socket;
+		if (!lostSocket) throw new Error("Replay client socket was unavailable");
+		lostSocket.destroy();
+		await waitForCondition(
+			() => {
+				try {
+					return readFileSync(sessionFile, "utf8").includes('"status":"archived"');
+				} catch {
+					return false;
+				}
+			},
+			"Lost-response archive did not complete",
+			15_000,
+		);
+		await waitForCondition(
+			() => {
+				try {
+					return readdirSync(join(agentDir, "daemon-workers")).some((directory) => {
+						const path = join(agentDir, "daemon-workers", directory, "command-journal.jsonl");
+						return existsSync(path) && readFileSync(path, "utf8").includes('"type":"result"');
+					});
+				} catch {
+					return false;
+				}
+			},
+			"Lost-response archive result was not journaled",
+			5000,
+		);
+		await replayClient.connect();
+		await replayClient.waitForHello();
+		const replayed = await archivePromise;
+		if (!replayed.success) throw new Error(replayed.error);
+		const receipt = requireArchiveReceipt(replayed.data);
+		await waitForProcessGone(summary.workerPid);
+		workerPids.delete(summary.workerPid);
+
+		const journalRoots = readdirSync(join(agentDir, "daemon-workers"));
+		const journalPath = journalRoots
+			.map((directory) => join(agentDir, "daemon-workers", directory, "command-journal.jsonl"))
+			.find(existsSync);
+		if (!journalPath) throw new Error("Archive command journal was unavailable");
+		const journalEntries = readFileSync(journalPath, "utf8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as { response?: { data?: unknown } });
+		expect(journalEntries.some((entry) => JSON.stringify(entry.response?.data) === JSON.stringify(receipt))).toBe(
+			true,
+		);
+		const archivedStateCount = readFileSync(sessionFile, "utf8")
+			.split("\n")
+			.filter((line) => line.includes('"type":"session_state"') && line.includes('"status":"archived"')).length;
+		expect(archivedStateCount).toBe(1);
+		expect(countWorkerDescriptors(agentDir)).toBe(0);
+
+		await replayClient.request({ type: "shutdown" });
+		replayClient.close();
+		await waitForSocketGone(socketPath);
+	}, 30_000);
+
+	it("refuses to archive an empty draft because the existing close path would delete it", async () => {
+		const root = tempDir();
+		const agentDir = join(root, "agent");
+		const projectDir = join(root, "project");
+		const sessionDir = join(agentDir, "sessions");
+		const socketPath = join(
+			tmpdir(),
+			`prime-supervisor-draft-archive-${process.pid}-${randomUUID().slice(0, 8)}.sock`,
+		);
+		mkdirSync(projectDir, { recursive: true });
+		const sessionManager = SessionManager.create(projectDir, sessionDir);
+		sessionManager.flushNow();
+		const sessionFile = sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Draft fixture did not materialize");
+
+		const supervisor = spawnSupervisor(agentDir, socketPath, projectDir);
+		const client = await connectEventually(socketPath, supervisor);
+		const created = await client.request({
+			type: "create",
+			sessionPath: sessionFile,
+			config: { cwd: projectDir, agentDir, sessionDir, noTools: true, noExtensions: true },
+		});
+		if (!created.success) throw new Error(created.error);
+		const summary = requireSummary(created.data);
+		if (!summary.workerPid) throw new Error("Draft worker did not expose its pid");
+		workerPids.add(summary.workerPid);
+		const activeSessionId = summary.activeSessionId ?? summary.id;
+		const observed = await client.request({
+			type: "get_archive_occupancy",
+			activeSessionId,
+			sessionId: summary.sessionId,
+		});
+		if (!observed.success) throw new Error(observed.error);
+		const occupancy = requireArchiveOccupancy(observed.data);
+		expect(occupancy.lifecycle).toBe("draft");
+		const beforeBytes = readFileSync(sessionFile, "utf8");
+		const archived = await client.request({
+			type: "archive_session_if_idle",
+			activeSessionId,
+			sessionId: summary.sessionId,
+			expectedOccupancyDigest: occupancy.occupancyDigest,
+		});
+		expect(archived).toMatchObject({ success: false, error: expect.stringContaining("delete semantics") });
+		expect(readFileSync(sessionFile, "utf8")).toBe(beforeBytes);
+		expect(countWorkerDescriptors(agentDir)).toBe(1);
+
+		await client.request({ type: "shutdown" });
+		client.close();
+		await waitForSocketGone(socketPath);
+		await waitForProcessGone(summary.workerPid);
+		workerPids.delete(summary.workerPid);
+	});
 
 	it("lists, creates, and attaches passive children through their owning worker", async () => {
 		const root = tempDir();


### PR DESCRIPTION
## Summary

Adds an opt-in `atomic_session_archive` daemon capability that lets a client atomically archive one exact idle top-level session: the session file and artifacts are preserved, the session transitions to `archived` state (not `killed`), and the catalog entry is updated — all guarded by an occupancy digest compare.

Context and motivation: https://github.com/PrimeIntellect-ai/prime-agent/discussions/1524.

## Wire protocol

- Schema revision 17; new capability `atomic_session_archive` (server advertises, clients opt in).
- `get_archive_occupancy` (read-only): returns a receipt over the full occupancy of one exact top-level root (active turn, streaming, compaction, tool/bash, unfinished/queued actions, running children, attached clients, heartbeat/cron). Includes `occupancyDigest` binding all fields.
- `archive_session_if_idle` (mutating): requires `expectedOccupancyDigest`. Only proceeds when the current occupancy digest matches, the session is idle, lifecycle is `live`, and every co-resident session on the worker is resumable. The worker is gracefully stopped via the existing `worker_archive_and_shutdown` path (session state becomes `archived`), the catalog archives the root, and a single readback verifies both the session file state and the catalog entry before returning a receipt with `beforeOccupancyDigest` + `postReadback`.
- Any mismatch fails closed with a specific error ("occupancy changed", "currently occupied", "delete semantics", etc.); nothing is modified on failure.

## Implementation

- `daemon-session-archive.ts` (new, 333 lines): pure functions for occupancy projection, receipt construction, and digest computation. Zero supervisor-state dependencies.
- `daemon-supervisor.ts` (+~350): `readArchiveOccupancy` / `archiveSessionIfIdle` handlers; graceful stop reuses the existing stop-ownership and process-identity machinery.
- `daemon-protocol.ts`: two commands, capability, revision 17, compatibility gates (new-client/old-daemon and old-client/new-daemon covered in tests).
- Worker side needs no changes: it already implements `worker_archive_and_shutdown` and archives sessions on close.

## Testing

- `daemon-protocol.test.ts` 21/21, `daemon-client.test.ts` 33/33
- `daemon-supervisor-process.test.ts` 15/15 (real spawned supervisors): digest-change rejection, idle archive with persisted readback, co-resident draft blocking, stale incarnation digest rejection, journaled receipt replay after lost response, empty-draft refusal, shutdown archiving, plus all pre-existing supervisor behavior tests.
- `npm run check` — clean

All commands are capability- and schema-gated; older clients and daemons are unaffected.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in atomic idle session archiving to the coding-agent daemon
> - Adds two new daemon commands, `get_archive_occupancy` and `archive_session_if_idle`, gated behind a new `atomic_session_archive` server capability and protocol schema revision 17.
> - Implements a compare-and-archive flow in [`daemon-supervisor.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1526/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8): computes a digest of current session occupancy, blocks on in-flight mutations, and refuses to archive if occupancy changes, the target session is busy, or co-resident sessions are not resumable.
> - Adds [`daemon-session-archive.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1526/files#diff-375a1c2046707df37f25fe1ef8f52744752348a2d4626b1d1775d018a7a6e462) with canonical JSON digest helpers, strict type guards for archive receipt wire types, and occupancy projection/mutation registration utilities.
> - Archived worker stop now asserts persisted archived-state readback and throws on mismatch.
> - Behavioral Change: `atomic_session_archive` is included in default server capabilities, so all updated daemons advertise support; downlevel clients are protected by the `minSchemaRevision: 17` compatibility gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffdc7a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->