### PR TITLE
fix(coding-agent): bound growing session scans

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Restored bare `prime-agent --resume` opening the agents view and the `/resume [id|path]` slash command; bare commands open the agents view and an argument resumes that session in place.
 - Fixed URLs not opening on click in fullscreen mode on terminals such as Ghostty; clicking a link in the transcript, dock, or overlays now opens it in the browser.
 - Fixed ctrl+p ("Toggle agent message expansion") only toggling received agent messages; it now expands and collapses sent agent messages together with received ones.
+- Fixed continuously growing subagent sessions causing runaway CPU, file descriptors, and an unresponsive agents view.
 
 ## [0.7.2] - 2026-08-11
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -923,9 +923,16 @@ interface SessionInfoCacheEntry {
 	info: SessionInfo | null;
 }
 
+interface SessionInfoScan {
+	size: number;
+	mtimeMs: number;
+	promise: Promise<SessionInfo | null>;
+}
+
 // Session files are append-only, so an unchanged (size, mtimeMs) means identical
 // content: cache list metadata and rescan only files that changed.
 const sessionInfoCache = new Map<string, SessionInfoCacheEntry>();
+const sessionInfoScans = new Map<string, SessionInfoScan>();
 
 export async function readSessionInfo(filePath: string): Promise<SessionInfo | null> {
 	let stats: Awaited<ReturnType<typeof stat>>;
@@ -934,16 +941,38 @@ export async function readSessionInfo(filePath: string): Promise<SessionInfo | n
 	} catch {
 		return null;
 	}
+	const snapshotSize = Number(stats.size);
 	const cached = sessionInfoCache.get(filePath);
-	if (cached && cached.size === stats.size && cached.mtimeMs === stats.mtimeMs) {
+	if (cached && cached.size === snapshotSize && cached.mtimeMs === stats.mtimeMs) {
 		return cached.info;
 	}
-	const info = await scanSessionInfo(filePath, stats);
-	sessionInfoCache.set(filePath, { size: stats.size, mtimeMs: stats.mtimeMs, info });
-	return info;
+	const activeScan = sessionInfoScans.get(filePath);
+	if (activeScan) {
+		if (activeScan.size === snapshotSize && activeScan.mtimeMs === stats.mtimeMs) {
+			return activeScan.promise;
+		}
+		await activeScan.promise;
+		return readSessionInfo(filePath);
+	}
+	const scan = scanSessionInfo(filePath, stats, snapshotSize)
+		.then((info) => {
+			sessionInfoCache.set(filePath, { size: snapshotSize, mtimeMs: stats.mtimeMs, info });
+			return info;
+		})
+		.finally(() => {
+			if (sessionInfoScans.get(filePath)?.promise === scan) {
+				sessionInfoScans.delete(filePath);
+			}
+		});
+	sessionInfoScans.set(filePath, { size: snapshotSize, mtimeMs: stats.mtimeMs, promise: scan });
+	return scan;
 }
 
-async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeof stat>>): Promise<SessionInfo | null> {
+async function scanSessionInfo(
+	filePath: string,
+	stats: Awaited<ReturnType<typeof stat>>,
+	snapshotSize: number,
+): Promise<SessionInfo | null> {
 	try {
 		let header: SessionHeader | undefined;
 		let messageCount = 0;
@@ -954,7 +983,7 @@ async function scanSessionInfo(filePath: string, stats: Awaited<ReturnType<typeo
 		let agentStatus: AgentStatus | undefined;
 		let lastActivityTime: number | undefined;
 
-		for await (const lineBuffer of readLinesAsBuffers(filePath)) {
+		for await (const lineBuffer of readLinesAsBuffers(filePath, { endExclusive: snapshotSize })) {
 			const line = lineBuffer.toString("utf8");
 			if (!line.trim()) continue;
 

--- a/packages/coding-agent/src/utils/file-lines.ts
+++ b/packages/coding-agent/src/utils/file-lines.ts
@@ -34,10 +34,17 @@ export function readFirstLineSync(filePath: string, maxBytes = 64 * 1024): strin
 	return Buffer.concat(chunks).toString("utf8").replace(/\r$/, "");
 }
 
-export async function* readLinesAsBuffers(filePath: string): AsyncGenerator<Buffer> {
+export async function* readLinesAsBuffers(
+	filePath: string,
+	options: { endExclusive?: number } = {},
+): AsyncGenerator<Buffer> {
+	if (options.endExclusive !== undefined && options.endExclusive <= 0) {
+		return;
+	}
 	const pendingParts: Buffer[] = [];
 	let pendingBytes = 0;
-	for await (const chunk of createReadStream(filePath)) {
+	const streamOptions = options.endExclusive === undefined ? undefined : { end: options.endExclusive - 1 };
+	for await (const chunk of createReadStream(filePath, streamOptions)) {
 		const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
 		let start = 0;
 		while (start < buffer.length) {

--- a/packages/coding-agent/test/file-lines.test.ts
+++ b/packages/coding-agent/test/file-lines.test.ts
@@ -58,4 +58,21 @@ describe("readLinesAsBuffers", () => {
 		expect(concatSpy.mock.calls[0]?.[0]).toHaveLength(0);
 		expect((await lines.next()).done).toBe(true);
 	});
+
+	it("bounds reads to an exclusive snapshot size", async () => {
+		fsMocks.createReadStream.mockReturnValue(Readable.from([Buffer.from("first\n")]));
+
+		const lines = readLinesAsBuffers("/unused", { endExclusive: 42 });
+
+		expect((await lines.next()).value?.toString("utf8")).toBe("first");
+		expect((await lines.next()).done).toBe(true);
+		expect(fsMocks.createReadStream).toHaveBeenCalledWith("/unused", { end: 41 });
+	});
+
+	it("does not open an empty snapshot", async () => {
+		const lines = readLinesAsBuffers("/unused", { endExclusive: 0 });
+
+		expect((await lines.next()).done).toBe(true);
+		expect(fsMocks.createReadStream).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/session-info-scanning.test.ts
+++ b/packages/coding-agent/test/session-info-scanning.test.ts
@@ -1,0 +1,117 @@
+import { appendFileSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface ControlledStream {
+	release: () => void;
+}
+
+const fsMocks = vi.hoisted(() => ({
+	createReadStream: vi.fn(),
+	streams: [] as ControlledStream[],
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		createReadStream: fsMocks.createReadStream,
+	};
+});
+
+const { readSessionInfo } = await import("../src/core/session-manager.js");
+
+describe("session info scanning", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "session-info-scan-"));
+		fsMocks.streams.length = 0;
+		fsMocks.createReadStream.mockImplementation((path: string, options?: { end?: number }) => {
+			const contents = readFileSync(path);
+			let release: (() => void) | undefined;
+			const gate = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			fsMocks.streams.push({ release: () => release?.() });
+			return Readable.from(
+				(async function* () {
+					await gate;
+					yield contents.subarray(0, options?.end === undefined ? contents.length : options.end + 1);
+				})(),
+			);
+		});
+	});
+
+	afterEach(() => {
+		for (const stream of fsMocks.streams) stream.release();
+		fsMocks.createReadStream.mockReset();
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("coalesces concurrent scans of the same snapshot and bounds the stream", async () => {
+		const file = writeSessionFile(tempDir, "coalesced");
+		const snapshotSize = statSync(file).size;
+		const scans = Array.from({ length: 20 }, () => readSessionInfo(file));
+
+		await waitForStreamCount(1);
+		expect(fsMocks.createReadStream).toHaveBeenCalledOnce();
+		expect(fsMocks.createReadStream).toHaveBeenCalledWith(file, { end: snapshotSize - 1 });
+
+		fsMocks.streams[0]?.release();
+		const results = await Promise.all(scans);
+		expect(results.every((result) => result?.id === "coalesced")).toBe(true);
+		expect(fsMocks.createReadStream).toHaveBeenCalledOnce();
+	});
+
+	it("queues a follow-up scan when the file changes during an active scan", async () => {
+		const file = writeSessionFile(tempDir, "updated");
+		const first = readSessionInfo(file);
+		await waitForStreamCount(1);
+
+		appendFileSync(
+			file,
+			`${JSON.stringify({
+				type: "session_state",
+				id: "state",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:01.000Z",
+				state: { status: "active" },
+			})}\n`,
+		);
+		const second = readSessionInfo(file);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(fsMocks.createReadStream).toHaveBeenCalledOnce();
+
+		fsMocks.streams[0]?.release();
+		await waitForStreamCount(2);
+		fsMocks.streams[1]?.release();
+
+		expect((await first)?.state).toBeUndefined();
+		expect((await second)?.state).toEqual({ status: "active" });
+	});
+});
+
+function writeSessionFile(directory: string, id: string): string {
+	const file = join(directory, `${id}.jsonl`);
+	writeFileSync(
+		file,
+		`${JSON.stringify({
+			type: "session",
+			id,
+			timestamp: "2026-01-01T00:00:00.000Z",
+			cwd: directory,
+		})}\n`,
+	);
+	return file;
+}
+
+async function waitForStreamCount(expected: number): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		if (fsMocks.streams.length >= expected) return;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+	throw new Error(`Expected ${expected} controlled streams, got ${fsMocks.streams.length}`);
+}


### PR DESCRIPTION
## Summary

- bound session metadata streams to the file size captured before each scan
- coalesce concurrent scans of the same snapshot and serialize follow-up scans for newer snapshots
- add deterministic coverage for stream bounds, scan coalescing, and files changing during an active scan

## Context

Continuously appended subagent JSONL files could keep unbounded read streams chasing a moving EOF. Repeated agents-view refreshes then accumulated overlapping streams, file descriptors, parsing work, and main-thread CPU until the UI became unresponsive.

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/file-lines.test.ts test/session-info-scanning.test.ts test/session-manager/flat-storage.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix runaway CPU and file descriptor growth from unbounded subagent session scans
> - Concurrent `readSessionInfo` calls for the same file snapshot now share a single scan; if the file changes mid-scan, a follow-up scan is queued rather than spawning a new concurrent read.
> - `scanSessionInfo` now reads only up to the file size captured at scan start (`snapshotSize`), preventing reads from chasing a continuously growing file.
> - `readLinesAsBuffers` in [file-lines.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1535/files#diff-29279bea377c244202a98bab59966dd405681b64b4e72e18716015effe92b8a3) gains an optional `endExclusive` byte offset to bound stream reads; passing `0` skips opening the file entirely.
> - Behavioral Change: previously, every concurrent call opened its own stream against the live (growing) file; now scans are coalesced and bounded to the snapshot size at call time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e10ebaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->