### PR TITLE
feat(kernel): add run-scoped host context

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -730,6 +730,7 @@ type PreparedToolCall = {
 	toolCall: AgentToolCall;
 	tool: AgentTool<any>;
 	args: unknown;
+	executionId?: string;
 };
 
 type ImmediateToolCallOutcome = {
@@ -814,6 +815,7 @@ async function prepareToolCall(
 			toolCall,
 			tool,
 			args: validatedArgs,
+			executionId: config.executionId,
 		};
 	} catch (error) {
 		return {
@@ -835,22 +837,28 @@ async function executePreparedToolCall(
 	try {
 		throwIfAborted(signal);
 		const result = await raceWithAbort(
-			prepared.tool.execute(prepared.toolCall.id, prepared.args as never, signal, (partialResult) => {
-				if (!acceptingUpdates || signal?.aborted) {
-					return;
-				}
-				updateEvents.push(
-					Promise.resolve(
-						emit({
-							type: "tool_execution_update",
-							toolCallId: prepared.toolCall.id,
-							toolName: prepared.toolCall.name,
-							args: prepared.toolCall.arguments,
-							partialResult,
-						}),
-					),
-				);
-			}),
+			prepared.tool.execute(
+				prepared.toolCall.id,
+				prepared.args as never,
+				signal,
+				(partialResult) => {
+					if (!acceptingUpdates || signal?.aborted) {
+						return;
+					}
+					updateEvents.push(
+						Promise.resolve(
+							emit({
+								type: "tool_execution_update",
+								toolCallId: prepared.toolCall.id,
+								toolName: prepared.toolCall.name,
+								args: prepared.toolCall.arguments,
+								partialResult,
+							}),
+						),
+					);
+				},
+				{ executionId: prepared.executionId },
+			),
 			signal,
 		);
 		acceptingUpdates = false;

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -57,6 +57,11 @@ const DEFAULT_MODEL = {
 
 type QueueMode = "all" | "one-at-a-time";
 
+export interface AgentRunOptions {
+	/** Opaque host-owned identifier propagated to tool invocations for this run. */
+	executionId?: string;
+}
+
 type MutableAgentState = Omit<AgentState, "isStreaming" | "streamingMessage" | "pendingToolCalls" | "errorMessage"> & {
 	isStreaming: boolean;
 	streamingMessage?: AgentMessage;
@@ -325,20 +330,26 @@ export class Agent {
 		this.clearSteeringQueue();
 	}
 
-	async prompt(message: AgentMessage | AgentMessage[]): Promise<void>;
-	async prompt(input: string, images?: ImageContent[]): Promise<void>;
-	async prompt(input: string | AgentMessage | AgentMessage[], images?: ImageContent[]): Promise<void> {
+	async prompt(message: AgentMessage | AgentMessage[], options?: AgentRunOptions): Promise<void>;
+	async prompt(input: string, images?: ImageContent[], options?: AgentRunOptions): Promise<void>;
+	async prompt(
+		input: string | AgentMessage | AgentMessage[],
+		imagesOrOptions?: ImageContent[] | AgentRunOptions,
+		options?: AgentRunOptions,
+	): Promise<void> {
 		if (this.activeRun) {
 			throw new Error(
 				"Agent is already processing a prompt. Use steer() or followUp() to queue messages, or wait for completion.",
 			);
 		}
+		const images = Array.isArray(imagesOrOptions) ? imagesOrOptions : undefined;
+		const runOptions = Array.isArray(imagesOrOptions) ? options : imagesOrOptions;
 		const messages = this.normalizePromptInput(input, images);
-		await this.runPromptMessages(messages);
+		await this.runPromptMessages(messages, runOptions);
 	}
 
 	/** The last message must convert to a user or tool-result message. */
-	async continue(): Promise<void> {
+	async continue(options?: AgentRunOptions): Promise<void> {
 		if (this.activeRun) {
 			throw new Error("Agent is already processing. Wait for completion before continuing.");
 		}
@@ -346,12 +357,12 @@ export class Agent {
 		const runQueuedMessages = (): Promise<void> | undefined => {
 			const queuedSteering = this.steeringQueue.drain();
 			if (queuedSteering.length > 0) {
-				return this.runPromptMessages(queuedSteering, { skipInitialSteeringPoll: true });
+				return this.runPromptMessages(queuedSteering, { ...options, skipInitialSteeringPoll: true });
 			}
 
 			const queuedFollowUps = this.followUpQueue.drain();
 			if (queuedFollowUps.length > 0) {
-				return this.runPromptMessages(queuedFollowUps);
+				return this.runPromptMessages(queuedFollowUps, options);
 			}
 
 			return undefined;
@@ -387,7 +398,7 @@ export class Agent {
 			}
 		}
 
-		await this.runContinuation();
+		await this.runContinuation(options);
 	}
 
 	private normalizePromptInput(
@@ -411,7 +422,7 @@ export class Agent {
 
 	private async runPromptMessages(
 		messages: AgentMessage[],
-		options: { skipInitialSteeringPoll?: boolean } = {},
+		options: AgentRunOptions & { skipInitialSteeringPoll?: boolean } = {},
 	): Promise<void> {
 		await this.runWithLifecycle(async (signal) => {
 			await runAgentLoop(
@@ -425,11 +436,11 @@ export class Agent {
 		});
 	}
 
-	private async runContinuation(): Promise<void> {
+	private async runContinuation(options: AgentRunOptions = {}): Promise<void> {
 		await this.runWithLifecycle(async (signal) => {
 			await runAgentLoopContinue(
 				this.createContextSnapshot(),
-				this.createLoopConfig(),
+				this.createLoopConfig(options),
 				(event) => this.processEvents(event),
 				signal,
 				this.streamFn,
@@ -445,9 +456,10 @@ export class Agent {
 		};
 	}
 
-	private createLoopConfig(options: { skipInitialSteeringPoll?: boolean } = {}): AgentLoopConfig {
+	private createLoopConfig(options: AgentRunOptions & { skipInitialSteeringPoll?: boolean } = {}): AgentLoopConfig {
 		let skipInitialSteeringPoll = options.skipInitialSteeringPoll === true;
 		return {
+			executionId: options.executionId,
 			model: this._state.model,
 			reasoning: this._state.thinkingLevel,
 			serviceTier: this._state.serviceTier,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -116,6 +116,8 @@ export interface ShouldStopAfterTurnContext {
 export type GetContinuationMessagesContext = ShouldStopAfterTurnContext;
 
 export interface AgentLoopConfig extends SimpleStreamOptions {
+	/** Opaque host-owned identifier propagated to tool invocations for this run. */
+	executionId?: string;
 	model: Model<any>;
 
 	/**
@@ -344,6 +346,11 @@ export interface AgentToolResult<T> {
 /** Callback used by tools to publish partial execution updates. */
 export type AgentToolUpdateCallback<T = any> = (partialResult: AgentToolResult<T>) => void;
 
+/** Host-owned metadata for the agent run that invoked a tool. */
+export interface AgentToolExecutionContext {
+	readonly executionId?: string;
+}
+
 /** Tool definition used by the agent runtime. */
 export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any> extends Tool<TParameters> {
 	/** Human-readable label for UI display. */
@@ -359,6 +366,7 @@ export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any
 		params: Static<TParameters>,
 		signal?: AbortSignal,
 		onUpdate?: AgentToolUpdateCallback<TDetails>,
+		executionContext?: AgentToolExecutionContext,
 	) => Promise<AgentToolResult<TDetails>>;
 	/**
 	 * Per-tool execution mode override.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added typed session-lifetime kernel host-handler registration with host-only per-prompt run context, cancellation metadata, isolated execution correlation, and recursive child inheritance without persistence.
 - Added a `thinking` option to `rlm.run` for spawning subagents with an explicit reasoning level; invalid levels for the resolved child model fail spawn.
 - Changed opening the agents view (full or scoped) with a draft prompt to auto-stash the draft instead of refusing; the draft is restored into the editor when the session is reopened.
 - Fixed Shift+Enter no longer inserting a newline in terminals that send a literal `\n` (for example a Ghostty `shift+enter=text:\n` mapping): the byte decoded as `ctrl+j` and triggered the new edit-diff toggle instead of the editor newline.

--- a/packages/coding-agent/docs/rlm-runtime.md
+++ b/packages/coding-agent/docs/rlm-runtime.md
@@ -31,6 +31,10 @@ the call travels through a Jupyter comm target named `host.request`. `KernelMana
 
 The same bridge supports other typed host requests. Bundled Python skills such as `goal` call `rlm.host_request("goal.get", ...)`; state and policy remain in the TypeScript host.
 
+Embedders may register additional handlers when constructing an `AgentSession`. The handler table is session-lifetime configuration, while each `prompt()` or `promptAndWait()` admission may carry a distinct host-only `runContext`. `KernelManager` correlates a comm with its originating tool execution and supplies the handler with a dispatcher-minted context containing the session ID, recursion depth, run context, cancellation signal, request ID, and generation. These fields are not read from the Python payload, so model-generated code cannot select another run's context or spoof host metadata.
+
+An `rlm.run` child receives the spawning execution's run context, and repeats that propagation for nested children. The value remains in host memory: it is not added to agent messages, action recovery snapshots, session JSONL, or the revivable IPython namespace. Terminal completion, failure, cancellation, and kernel teardown revoke the associated handler contexts. The daemon can retain handlers configured by its embedder, but its remote prompt protocol intentionally does not serialize arbitrary run-context objects.
+
 ## Delegation Flow
 
 ```mermaid
@@ -252,6 +256,8 @@ Exact artifact files are created only when their features are used. Non-persiste
 IPython executes model-generated Python and shell-magics with the worker's OS permissions. The kernel boundary isolates protocol and lifecycle concerns; it is not a security sandbox. Installed Python packages, skills, and extensions are trusted code. Use an external sandbox or restricted execution environment when the workspace or generated code is untrusted.
 
 Provider credentials are resolved by the TypeScript host. The bounded model catalog crosses into Python as metadata; the full auth store does not.
+
+Run-scoped host context follows the same boundary: Python sees only the explicit handler result. The context object itself never crosses into the kernel process.
 
 ## Failure Modes
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -75,6 +75,7 @@ The session manages agent lifecycle, message history, model state, compaction, a
 interface AgentSession {
   // Send a prompt and wait for completion
   prompt(text: string, options?: PromptOptions): Promise<void>;
+  promptAndWait(text: string, options?: PromptOptions): Promise<void>;
 
   // Queue messages during streaming
   steer(text: string): Promise<void>;
@@ -116,6 +117,50 @@ interface AgentSession {
 ```
 
 Session replacement APIs such as new-session, resume, fork, and import live on `AgentSessionRuntime`, not on `AgentSession`.
+
+### Run-scoped kernel host context
+
+Embedders can register additional typed kernel host-request handlers once when they create a session, then attach a host-only context to each admitted prompt execution:
+
+```typescript
+import {
+  createAgentSession,
+  createHostRequestHandler,
+} from "@earendil-works/pi-coding-agent";
+
+interface RequestContext {
+  tenantId: string;
+  credential: { token: string };
+}
+
+const inspectTenant = createHostRequestHandler<RequestContext>(
+  async (payload, { sessionId, recursionDepth, runContext, signal }) => {
+    if (!runContext) throw new Error("This request requires a run context");
+    return {
+      tenantId: runContext.tenantId,
+      query: payload.query,
+      sessionId,
+      recursionDepth,
+      cancelled: signal.aborted,
+    };
+  },
+);
+
+const { session } = await createAgentSession({
+  hostRequestHandlers: { "example.inspect_tenant": inspectTenant },
+});
+
+await session.promptAndWait("Inspect this tenant", {
+  runContext: {
+    tenantId: "tenant-42",
+    credential: { token: process.env.TENANT_TOKEN! },
+  } satisfies RequestContext,
+});
+```
+
+Handler definitions are copied when `AgentSession` is constructed and remain stable for that session. The `runContext` is correlated out of band with the admitted execution, so a Python payload cannot provide or replace it. Recursive children inherit the same value; later prompts on a persistent session may use different values, and separate sessions remain isolated.
+
+Run contexts are memory-only. They are removed and their handler signals are aborted when a run completes, fails, or is cancelled. They are not written to transcripts, queued-action recovery state, session files, or IPython namespace snapshots. Because arbitrary objects are intentionally not serialized, the remote daemon/RPC prompt protocol does not accept `runContext`; use the in-process `AgentSession` API at the host boundary.
 
 ### createAgentSessionRuntime() and AgentSessionRuntime
 

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -335,6 +335,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 					customTools: options.customTools,
 					includeGoals: options.includeGoals,
 					includeCompactSkill: options.includeCompactSkill,
+					hostRequestHandlers: options.hostRequestHandlers,
 					rlmDepth: options.rlmDepth,
 					rlmMaxDepth: options.rlmMaxDepth,
 					rlmSessionDir: options.sessionDir,

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -11,6 +11,7 @@ import type { AgentAutonomousConfig } from "./autonomous.js";
 import type { AgentRlmHeartbeatController } from "./cron-jobs.js";
 import { createHerdrAgentStateExtension } from "./extensions/builtin/herdr-agent-state.js";
 import type { SessionStartEvent, ToolDefinition } from "./extensions/index.js";
+import type { RegisteredHostRequestHandlers } from "./kernel/index.js";
 import { McpManager } from "./mcp/mcp-manager.js";
 import { ModelRegistry } from "./model-registry.js";
 import { DefaultResourceLoader, type DefaultResourceLoaderOptions, type ResourceLoader } from "./resource-loader.js";
@@ -51,6 +52,7 @@ export interface AgentSessionCreationOptions {
 	tools?: string[];
 	noTools?: "all" | "builtin";
 	customTools?: ToolDefinition[];
+	hostRequestHandlers?: RegisteredHostRequestHandlers;
 	initialActiveToolNames?: string[];
 	allowedToolNames?: string[];
 	includeGoals?: boolean;
@@ -240,6 +242,7 @@ export async function createAgentSessionFromServices(
 		tools: options.tools,
 		noTools: options.noTools,
 		customTools: options.customTools,
+		hostRequestHandlers: options.hostRequestHandlers,
 		initialActiveToolNames: options.initialActiveToolNames,
 		allowedToolNames: options.allowedToolNames,
 		includeGoals: options.includeGoals,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -154,7 +154,13 @@ import {
 	validateGoalBudget,
 	validateGoalObjective,
 } from "./goals.js";
-import type { HostRequestHandlers, KernelSentAgentMessage } from "./kernel/index.js";
+import {
+	assertHostRequestHandler,
+	type HostRequestExecutionContext,
+	type HostRequestHandlers,
+	type KernelSentAgentMessage,
+	type RegisteredHostRequestHandlers,
+} from "./kernel/index.js";
 import { type RestoreResult, snapshotPathIn } from "./kernel/state-snapshot.js";
 import type { McpManager } from "./mcp/mcp-manager.js";
 import {
@@ -411,6 +417,8 @@ export interface AgentSessionConfig {
 	 * (refresh, begin_login) are exposed to the kernel.
 	 */
 	mcpManager?: McpManager;
+	/** Additional trusted kernel host handlers registered for the session lifetime. */
+	hostRequestHandlers?: RegisteredHostRequestHandlers;
 	/**
 	 * Override base tools (useful for custom runtimes).
 	 *
@@ -499,6 +507,8 @@ export interface PromptOptions {
 	agentMessageId?: string;
 	content?: (TextContent | ImageContent)[];
 	customMessage?: CustomMessage;
+	/** Host-only value available to kernel host handlers for this admitted execution. */
+	runContext?: unknown;
 }
 
 interface InternalPromptOptions extends PromptOptions {
@@ -868,6 +878,12 @@ interface RlmChildRun {
 	unsubscribe?: () => void;
 }
 
+interface AgentRunScope {
+	readonly executionId: string;
+	readonly runContext: unknown;
+	readonly controller: AbortController;
+}
+
 interface RlmSubagentModelSelection {
 	model: Model<Api>;
 }
@@ -1018,6 +1034,8 @@ export class AgentSession {
 	private _sessionActionCommitOwner: symbol | undefined;
 	private _pendingSessionActionFenceWaiters = 0;
 	private readonly _sessionActionCommitContext = new AsyncLocalStorage<symbol>();
+	private readonly _actionRunScopes = new WeakMap<QueuedSessionAction, AgentRunScope>();
+	private readonly _executionRunScopes = new Map<string, AgentRunScope>();
 	private readonly _sessionActionCommitDisposeAbortController = new AbortController();
 	// Checkpoint and handoff waiters share lifecycle-edge notifications to avoid polling.
 	private readonly _sessionInputCheckpointWaiters = new Set<() => void>();
@@ -1079,6 +1097,7 @@ export class AgentSession {
 	private _agentMessageController?: AgentSessionMessageController;
 	private _agentObserveController?: AgentObserveController;
 	private _mcpManager?: McpManager;
+	private readonly _hostRequestHandlers: RegisteredHostRequestHandlers;
 	private _baseToolsOverride?: Record<string, AgentTool>;
 	private _sessionStartEvent: SessionStartEvent;
 	private _extensionUIContext?: ExtensionUIContext;
@@ -1190,6 +1209,8 @@ export class AgentSession {
 		this._agentMessageController = config.agentMessageController;
 		this._agentObserveController = config.agentObserveController;
 		this._mcpManager = config.mcpManager;
+		this._hostRequestHandlers = Object.freeze({ ...config.hostRequestHandlers });
+		for (const handler of Object.values(this._hostRequestHandlers)) assertHostRequestHandler(handler);
 		this._baseToolsOverride = config.baseToolsOverride;
 		this._sessionStartEvent = config.sessionStartEvent ?? { type: "session_start", reason: "startup" };
 		const headerRlmDepth = this.sessionManager.getHeader()?.rlmDepth;
@@ -1603,6 +1624,7 @@ export class AgentSession {
 			}
 		}
 		for (const action of actions) {
+			this._releaseRunScope(action, error.message);
 			const ticket = this._actionStore.ticketFor(action);
 			if (
 				action.payload.kind === "turn" &&
@@ -4438,6 +4460,7 @@ export class AgentSession {
 					options?.executionPolicy ??
 					(visibleQueued ? this._turnExecutionPolicy("queued") : this._turnExecutionPolicy("injected")),
 				queueVisible: visibleQueued,
+				runContext: options?.runContext,
 			});
 			const result = this._admitSessionInput(action, {
 				immediatelyEligible: !visibleQueued,
@@ -4591,6 +4614,7 @@ export class AgentSession {
 					queueVisible: visibleQueued,
 					acceptedAgentMessage,
 					acceptedBeforeCompletion: options?.returnAfterAccepted === true,
+					runContext: options?.runContext,
 				});
 				if (action.suppressAutonomousContinuation) {
 					this._markAutonomousContinuationSuppressed(primaryDeliveryRecord(action).message);
@@ -5075,6 +5099,7 @@ export class AgentSession {
 			queueVisible?: boolean;
 			acceptedAgentMessage?: boolean;
 			acceptedBeforeCompletion?: boolean;
+			runContext?: unknown;
 		},
 	): QueuedSessionAction {
 		const id = randomUUID();
@@ -5104,7 +5129,7 @@ export class AgentSession {
 			acceptedAgentMessage: options.acceptedAgentMessage ?? false,
 			acceptedBeforeCompletion: options.acceptedBeforeCompletion ?? false,
 		};
-		return {
+		const action: QueuedSessionAction = {
 			id,
 			source: options.source ?? "internal",
 			delivery: this._deliveryPolicy(schedule),
@@ -5120,6 +5145,33 @@ export class AgentSession {
 			agentMessageId: options.agentMessageId,
 			suppressAutonomousContinuation: options.suppressAutonomousContinuation,
 		};
+		this._actionRunScopes.set(action, {
+			executionId: id,
+			runContext: options.runContext,
+			controller: new AbortController(),
+		});
+		return action;
+	}
+
+	private _releaseRunScope(action: QueuedSessionAction, reason: string): void {
+		const scope = this._actionRunScopes.get(action);
+		if (!scope) return;
+		this._actionRunScopes.delete(action);
+		this._executionRunScopes.delete(scope.executionId);
+		scope.controller.abort(reason);
+	}
+
+	private _hostRequestContextForExecution(executionId?: string): HostRequestExecutionContext | undefined {
+		const scope = executionId ? this._executionRunScopes.get(executionId) : undefined;
+		return scope ? { runContext: scope.runContext, signal: scope.controller.signal } : undefined;
+	}
+
+	private _activeRunExecutionId(): string | undefined {
+		for (const action of this._actionStore.activeActions()) {
+			const scope = this._actionRunScopes.get(action);
+			if (scope) return scope.executionId;
+		}
+		return undefined;
 	}
 
 	private _createSessionCommandAction(
@@ -5179,10 +5231,12 @@ export class AgentSession {
 		ticket?: ActionTicket;
 	} {
 		if (this._disposed || this._disposing) {
+			this._releaseRunScope(action, "run rejected before admission");
 			throw new Error("Cannot admit a session action because the session is disposing or disposed.");
 		}
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
 		if (coalescedOwner) {
+			this._releaseRunScope(action, "run coalesced before admission");
 			if (action.agentMessageId !== coalescedOwner.agentMessageId) {
 				this._rejectAgentMessage(
 					action.agentMessageId,
@@ -5234,6 +5288,7 @@ export class AgentSession {
 			suppressAutonomousContinuation?: boolean;
 			resumeIfIdle?: boolean;
 			source?: InputSource | "internal";
+			runContext?: unknown;
 		} = {},
 	): Promise<boolean> {
 		const action = this._createPreparedTurnAction(schedule, text, images, options);
@@ -5341,7 +5396,8 @@ export class AgentSession {
 					if (
 						!next ||
 						next.payload.kind !== "turn" ||
-						!turnExecutionPoliciesEqual(first.payload.executionPolicy, next.payload.executionPolicy)
+						!turnExecutionPoliciesEqual(first.payload.executionPolicy, next.payload.executionPolicy) ||
+						this._actionRunScopes.get(first) !== this._actionRunScopes.get(next)
 					) {
 						break;
 					}
@@ -5436,6 +5492,7 @@ export class AgentSession {
 								action.lifecycle.state === "failed" ||
 								action.lifecycle.state === "cancelled")
 						) {
+							this._releaseRunScope(action, "run completed");
 							this._actionStore.releaseTerminal(action);
 						}
 					}
@@ -5648,9 +5705,16 @@ export class AgentSession {
 					for (const action of turns) transitionSessionAction(action, { state: "committing" });
 					this._notifySessionInputCheckpointChange();
 					this._emitQueueUpdate();
-					return turns.some((action) => action.suppressAutonomousContinuation)
-						? this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(preparedMessages))
-						: this.agent.prompt(preparedMessages);
+					const prompt = (executionId: string) =>
+						turns.some((action) => action.suppressAutonomousContinuation)
+							? this._runWithAutonomousContinuationSuppressed(() =>
+									this.agent.prompt(preparedMessages, { executionId }),
+								)
+							: this.agent.prompt(preparedMessages, { executionId });
+					const runScope = this._actionRunScopes.get(turns[0]);
+					if (!runScope) throw new Error("Prepared turn is missing its execution scope");
+					this._executionRunScopes.set(runScope.executionId, runScope);
+					return prompt(runScope.executionId);
 				});
 			} finally {
 				commitFence.release();
@@ -7208,7 +7272,7 @@ export class AgentSession {
 
 		this._postCompactionContinuationScheduled = false;
 		try {
-			await this.agent.continue();
+			await this.agent.continue({ executionId: this._activeRunExecutionId() });
 			this._forgetConsumedPostCompactionContinuations(continuationMessages);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -8433,7 +8497,9 @@ export class AgentSession {
 			this._ipythonKernelProvisioner = new IpythonKernelProvisioner(this._cwd, {
 				env: this._rlmKernelEnv(),
 				sessionId: this.sessionId,
+				recursionDepth: this._rlmDepth,
 				hostHandlers: this._createKernelHostHandlers(),
+				getHostRequestContext: (executionId) => this._hostRequestContextForExecution(executionId),
 				pythonSkills,
 				snapshotDir: this._ipythonKernelSnapshotDir,
 				readyGate: previousDispose,
@@ -8442,6 +8508,7 @@ export class AgentSession {
 			configuredBaseToolDefinitions = createAllToolDefinitions(this._cwd, {
 				ipython: {
 					provisioner: this._ipythonKernelProvisioner,
+					getHostRequestContext: (executionId) => this._hostRequestContextForExecution(executionId),
 					commandPrefix: this.settingsManager.getShellCommandPrefix(),
 					shellPath: this.settingsManager.getShellPath(),
 					onLateSentAgentMessage: (toolCallId, message) =>
@@ -8534,8 +8601,8 @@ export class AgentSession {
 
 	private _createKernelHostHandlers(): HostRequestHandlers {
 		const handlers: HostRequestHandlers = {
-			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode }) => ({
-				...(await this.runRlmChild(prompt, kwargs, cellSourceCode)),
+			"rlm.run": createRlmRunHostHandler(async ({ prompt, kwargs, cellSourceCode }, context) => ({
+				...(await this._startRlmChildRun(prompt, kwargs, cellSourceCode, context?.runContext)),
 			})),
 			"rlm.find_models": createRlmFindModelsHostHandler((query, limit) => this.findRlmModels(query, limit)),
 			"rlm.list_subagents": createRlmListSubagentsHostHandler(() => this.listRlmSubagents()),
@@ -8632,6 +8699,10 @@ export class AgentSession {
 		}
 		if (this._mcpManager) {
 			Object.assign(handlers, this._mcpManager.hostHandlers());
+		}
+		for (const [type, handler] of Object.entries(this._hostRequestHandlers)) {
+			if (handlers[type]) throw new Error(`Host request handler "${type}" conflicts with a built-in handler`);
+			handlers[type] = (payload, context) => handler(payload, context!);
 		}
 		return handlers;
 	}
@@ -8805,6 +8876,7 @@ export class AgentSession {
 			customTools: [...this._customTools],
 			includeGoals: this._includeGoals,
 			includeCompactSkill: this._includeCompactSkill,
+			hostRequestHandlers: this._hostRequestHandlers,
 			rlmDepth: this._rlmDepth + 1,
 			rlmMaxDepth: this._rlmMaxDepth,
 			rlmParentNodeId: options.id,
@@ -8868,6 +8940,7 @@ export class AgentSession {
 			allowedToolNames: options.allowedToolNames,
 			includeGoals: options.includeGoals,
 			includeCompactSkill: options.includeCompactSkill,
+			hostRequestHandlers: options.hostRequestHandlers,
 			rlmDepth: options.rlmDepth,
 			rlmMaxDepth: options.rlmMaxDepth,
 			rlmSessionDir: options.sessionDir,
@@ -9446,6 +9519,7 @@ export class AgentSession {
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
 		spawnCode?: string,
+		runContext?: unknown,
 	): Promise<RlmSpawnHandle> {
 		const { name: rawName, model: rawModel, thinking: rawThinking, ...unsupported } = kwargs;
 		const unsupportedKwargs = Object.keys(unsupported);
@@ -9554,6 +9628,7 @@ export class AgentSession {
 				model: modelSelection.model,
 				thinkingLevel: requestedThinkingLevel,
 			}),
+			runContext,
 			onSessionPublished: publishChildSession,
 		};
 
@@ -9680,6 +9755,7 @@ export class AgentSession {
 					expandPromptTemplates: false,
 					source: "extension",
 					customMessage: spawnMessage,
+					runContext: subagentOptions.runContext,
 				});
 				if (run.error) throw new Error(run.error);
 				run.status = "done";
@@ -10050,8 +10126,9 @@ export class AgentSession {
 		}
 		this._retryAbortController = undefined;
 
+		const executionId = this._activeRunExecutionId();
 		setTimeout(() => {
-			this.agent.continue().catch(() => {});
+			this.agent.continue({ executionId }).catch(() => {});
 		}, 0);
 
 		return true;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -10,6 +10,7 @@
 
 import type {
 	AgentMessage,
+	AgentToolExecutionContext,
 	AgentToolResult,
 	AgentToolUpdateCallback,
 	ThinkingLevel,
@@ -444,6 +445,7 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 		signal: AbortSignal | undefined,
 		onUpdate: AgentToolUpdateCallback<TDetails> | undefined,
 		ctx: ExtensionContext,
+		executionContext?: AgentToolExecutionContext,
 	): Promise<AgentToolResult<TDetails>>;
 
 	/** Custom rendering for tool call display */

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -77,6 +77,14 @@ export {
 	type TurnStartEvent,
 	type WorkingIndicatorOptions,
 } from "./extensions/index.js";
+export {
+	createHostRequestHandler,
+	type HostRequestContext,
+	type HostRequestInvocationMetadata,
+	type HostRequestPayload,
+	type RegisteredHostRequestHandler,
+	type RegisteredHostRequestHandlers,
+} from "./kernel/index.js";
 export type { RefinementResult } from "./refinement/index.js";
 export type { CreateRlmSubagentRuntimeOptions, RlmSubagentRuntime, SubagentRuntimeHost } from "./rlm-runtime.js";
 export { SessionImportFileNotFoundError } from "./session-import-errors.js";

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -54,21 +54,21 @@ export class KernelBusyAfterInterruptError extends Error {
 /** Comm target the kernel-side `rlm.host_request` shim opens for typed host requests. */
 export const HOST_COMM_TARGET = "host.request";
 
-/**
- * Handles one typed request from Python code running in the kernel.
- * The returned record is sent back verbatim as the comm reply payload.
- *
- * This legacy unary compatibility alias remains the dispatcher and registration
- * contract while context-aware handlers are staged separately below.
- */
-export type HostRequestHandler = (payload: Record<string, unknown>) => Promise<Record<string, unknown>>;
+export type HostRequestPayload = Record<string, unknown>;
+
+/** Safe host-owned metadata associated with the admitted execution. */
+export interface HostRequestInvocationMetadata<RunContext = unknown> {
+	readonly sessionId?: string;
+	readonly recursionDepth: number;
+	readonly runContext: RunContext | undefined;
+}
 
 /**
  * Per-call authority supplied by the host-request dispatcher.
  * `requestId` is an opaque host-minted correlation token and `isCurrent()`
  * lets an implementation reject work after its authority is revoked.
  */
-export interface HostRequestContext {
+export interface HostRequestContext<RunContext = unknown> extends HostRequestInvocationMetadata<RunContext> {
 	readonly requestId: string;
 	readonly generation: number;
 	readonly signal: AbortSignal;
@@ -78,58 +78,88 @@ export interface HostRequestContext {
 const hostRequestHandlerBrand = Symbol("hostRequestHandler");
 
 /** A context-aware implementation that must receive dispatcher authority. */
-export type HostRequestHandlerImplementation = (
-	payload: Record<string, unknown>,
-	context: HostRequestContext,
+export type HostRequestHandlerImplementation<RunContext = unknown> = (
+	payload: HostRequestPayload,
+	context: HostRequestContext<RunContext>,
 ) => Promise<Record<string, unknown>>;
 
-/** A factory-minted, context-aware host-request handler capability. */
-type HostRequestHandlerCapability = HostRequestHandlerImplementation & { readonly [hostRequestHandlerBrand]: true };
+/** Handles one typed request from Python code running in the kernel. */
+export type HostRequestHandler = (
+	payload: HostRequestPayload,
+	context?: HostRequestContext,
+) => Promise<Record<string, unknown>>;
+
+/** A factory-minted handler accepted by the public AgentSession registration API. */
+export type RegisteredHostRequestHandler = HostRequestHandlerImplementation & {
+	readonly [hostRequestHandlerBrand]: true;
+};
+
+export type RegisteredHostRequestHandlers = Readonly<Record<string, RegisteredHostRequestHandler>>;
 
 /** Runtime provenance cannot be recreated by copying the nominal symbol property. */
 const factoryCreatedHostRequestHandlers = new WeakSet<object>();
+const dispatcherCreatedHostRequestContexts = new WeakSet<object>();
 
 function assertGenuineHostRequestContext(context: unknown): asserts context is HostRequestContext {
-	if (
-		typeof context !== "object" ||
-		context === null ||
-		typeof (context as HostRequestContext).requestId !== "string" ||
-		!(context as HostRequestContext).requestId ||
-		!Number.isSafeInteger((context as HostRequestContext).generation) ||
-		typeof (context as HostRequestContext).isCurrent !== "function" ||
-		typeof (context as HostRequestContext).signal !== "object" ||
-		(context as HostRequestContext).signal === null ||
-		typeof (context as HostRequestContext).signal.aborted !== "boolean" ||
-		typeof (context as HostRequestContext).signal.addEventListener !== "function"
-	) {
+	if (typeof context !== "object" || context === null || !dispatcherCreatedHostRequestContexts.has(context)) {
 		throw new Error("host request context is invalid");
 	}
+}
+
+function mintHostRequestContext(
+	requestId: string,
+	generation: number,
+	controller: AbortController,
+	metadata: HostRequestInvocationMetadata,
+): HostRequestContext {
+	let current = true;
+	const context = Object.freeze({
+		requestId,
+		generation,
+		signal: controller.signal,
+		sessionId: metadata.sessionId,
+		recursionDepth: metadata.recursionDepth,
+		runContext: metadata.runContext,
+		isCurrent: () => current && !controller.signal.aborted,
+	});
+	dispatcherCreatedHostRequestContexts.add(context);
+	controller.signal.addEventListener(
+		"abort",
+		() => {
+			current = false;
+		},
+		{ once: true },
+	);
+	return context;
 }
 
 /**
  * Creates a branded wrapper rather than mutating its implementation. Both its
  * generic shape and runtime arity reject unary callbacks before they can run.
  */
-export function createHostRequestHandler<T extends HostRequestHandlerImplementation>(
+export function createHostRequestHandler<
+	RunContext = unknown,
+	T extends HostRequestHandlerImplementation<RunContext> = HostRequestHandlerImplementation<RunContext>,
+>(
 	implementation: T,
 	..._unaryRejection: Parameters<T> extends [unknown, unknown, ...unknown[]]
 		? []
 		: ["host request handlers must accept payload and context"]
-): HostRequestHandlerCapability {
+): RegisteredHostRequestHandler {
 	if (implementation.length < 2) throw new Error("host request handlers must accept payload and context");
-	const handler = async (payload: Record<string, unknown>, context: HostRequestContext) => {
+	const handler = async (payload: HostRequestPayload, context: HostRequestContext) => {
 		assertGenuineHostRequestContext(context);
-		return implementation(payload, context);
+		return implementation(payload, context as HostRequestContext<RunContext>);
 	};
 	factoryCreatedHostRequestHandlers.add(handler);
-	return Object.defineProperty(handler, hostRequestHandlerBrand, { value: true }) as HostRequestHandlerCapability;
+	return Object.defineProperty(handler, hostRequestHandlerBrand, { value: true }) as RegisteredHostRequestHandler;
 }
 
 /** Reject copied-symbol and raw-function forgeries before they observe authenticated payloads. */
-export function assertHostRequestHandler(value: unknown): asserts value is HostRequestHandlerCapability {
+export function assertHostRequestHandler(value: unknown): asserts value is RegisteredHostRequestHandler {
 	if (
 		typeof value !== "function" ||
-		(value as Partial<HostRequestHandlerCapability>)[hostRequestHandlerBrand] !== true ||
+		(value as Partial<RegisteredHostRequestHandler>)[hostRequestHandlerBrand] !== true ||
 		!factoryCreatedHostRequestHandlers.has(value)
 	) {
 		throw new Error("host request handler is not a dispatcher-created capability");
@@ -138,6 +168,12 @@ export function assertHostRequestHandler(value: unknown): asserts value is HostR
 
 /** Host request handlers keyed by request type (e.g. "rlm.run", "goal.complete"). */
 export type HostRequestHandlers = Record<string, HostRequestHandler>;
+
+/** In-memory execution scope used to correlate kernel comms with one admitted run. */
+export interface HostRequestExecutionContext<RunContext = unknown> {
+	readonly runContext: RunContext | undefined;
+	readonly signal: AbortSignal;
+}
 
 /** Where and how to persist the kernel's user namespace so it survives resume. */
 export interface KernelSnapshotConfig {
@@ -157,6 +193,7 @@ export interface KernelManagerOptions {
 	cwd?: string;
 	env?: Record<string, string>;
 	sessionId?: string;
+	recursionDepth?: number;
 	hostHandlers?: HostRequestHandlers;
 	pythonSkills?: readonly KernelPythonSkill[];
 	/** Persist/revive the user namespace across kernel restarts and session resume. */
@@ -179,6 +216,8 @@ export interface ExecuteOptions {
 	maxOutputChars?: number;
 	/** Synthetic host cell (snapshot/restore/list); excluded from lastCellCode attribution. */
 	internal?: boolean;
+	/** Host-only context for requests opened by this cell; never sent to Python. */
+	hostRequestContext?: HostRequestExecutionContext;
 }
 
 /** MIME tag the `edit` skill emits diff payloads under, via `display_data`. */
@@ -578,7 +617,7 @@ function installSignalHandlersOnce(): void {
 export class KernelManager {
 	private readonly options: Pick<
 		KernelManagerOptions,
-		"python" | "cwd" | "env" | "sessionId" | "hostHandlers" | "pythonSkills" | "snapshot"
+		"python" | "cwd" | "env" | "sessionId" | "recursionDepth" | "hostHandlers" | "pythonSkills" | "snapshot"
 	> &
 		Required<Pick<KernelManagerOptions, "username">>;
 	private readonly session = uuid();
@@ -607,6 +646,9 @@ export class KernelManager {
 	// attribute their spawning program.
 	private lastCellCode?: string;
 	private readonly inFlightHostRequests = new Set<Promise<void>>();
+	private readonly activeHostRequestControllers = new Map<string, AbortController>();
+	private readonly executionHostRequestContexts = new Map<string, HostRequestExecutionContext>();
+	private hostRequestGeneration = 0;
 	private state: "idle" | "starting" | "running" | "shutdown" = "idle";
 	/** Memoized so concurrent callers all await the same in-flight startup. */
 	private startPromise?: Promise<void>;
@@ -619,6 +661,7 @@ export class KernelManager {
 			cwd: options.cwd,
 			env: options.env,
 			sessionId: options.sessionId,
+			recursionDepth: options.recursionDepth,
 			hostHandlers: options.hostHandlers,
 			pythonSkills: options.pythonSkills,
 			snapshot: options.snapshot,
@@ -929,6 +972,12 @@ export class KernelManager {
 			this.options.username,
 		);
 		const requestMsgId = msg.header.msg_id;
+		if (opts.hostRequestContext) {
+			this.executionHostRequestContexts.set(requestMsgId, opts.hostRequestContext);
+			const clearContext = () => this.executionHostRequestContexts.delete(requestMsgId);
+			opts.hostRequestContext.signal.addEventListener("abort", clearContext, { once: true });
+			if (opts.hostRequestContext.signal.aborted) clearContext();
+		}
 
 		if (opts.signal?.aborted) {
 			return { stdout: "", stderr: "", status: "aborted", durationMs: Date.now() - started };
@@ -1265,6 +1314,8 @@ export class KernelManager {
 		if (msgType === "comm_close") {
 			this.commTargets.delete(commId);
 			this.handledHostRequestCommIds.delete(commId);
+			this.activeHostRequestControllers.get(commId)?.abort("host request comm was closed");
+			this.activeHostRequestControllers.delete(commId);
 			return;
 		}
 
@@ -1275,28 +1326,40 @@ export class KernelManager {
 			}
 			this.commTargets.set(commId, targetName);
 			if (targetName === HOST_COMM_TARGET) {
-				this.startHostRequestFromComm(commId, content.data);
+				this.startHostRequestFromComm(commId, content.data, incoming);
 			}
 			return;
 		}
 
 		const targetName = this.commTargets.get(commId);
 		if (msgType === "comm_msg" && targetName === HOST_COMM_TARGET) {
-			this.startHostRequestFromComm(commId, content.data);
+			this.startHostRequestFromComm(commId, content.data, incoming);
 		}
 	}
 
-	private startHostRequestFromComm(commId: string, data: unknown): void {
+	private startHostRequestFromComm(commId: string, data: unknown, incoming: JupyterMessage): void {
 		if (this.handledHostRequestCommIds.has(commId)) {
 			return;
 		}
 		this.handledHostRequestCommIds.add(commId);
+		const parentMessageId = (incoming.parent_header as { msg_id?: string }).msg_id;
+		const executionContext = parentMessageId ? this.executionHostRequestContexts.get(parentMessageId) : undefined;
+		const controller = new AbortController();
+		this.activeHostRequestControllers.set(commId, controller);
+		const abortFromRun = () => controller.abort("host request run completed");
+		executionContext?.signal.addEventListener("abort", abortFromRun, { once: true });
+		if (executionContext?.signal.aborted) abortFromRun();
+		const context = mintHostRequestContext(uuid(), ++this.hostRequestGeneration, controller, {
+			sessionId: this.options.sessionId,
+			recursionDepth: this.options.recursionDepth ?? 0,
+			runContext: executionContext?.runContext,
+		});
 
 		const task = (async () => {
 			try {
-				const result = await this.handleHostRequest(data);
+				const result = await this.handleHostRequest(data, context);
 				try {
-					await this.sendCommMessage(commId, { status: "ok", ...result });
+					await this.sendCommMessage(commId, { ...result, status: "ok" });
 				} catch (replyError) {
 					this.appendKernelDiagnostic(
 						`failed to send host request ok reply for comm ${commId}: ${errorMessage(replyError)}`,
@@ -1305,11 +1368,17 @@ export class KernelManager {
 			} catch (error) {
 				this.appendKernelDiagnostic(`host request failed for comm ${commId}: ${errorMessage(error)}`);
 				try {
-					await this.sendCommMessage(commId, { status: "error", error: errorMessage(error) });
+					await this.sendCommMessage(commId, { error: errorMessage(error), status: "error" });
 				} catch (replyError) {
 					this.appendKernelDiagnostic(
 						`failed to send host request error reply for comm ${commId}: ${errorMessage(replyError)}`,
 					);
+				}
+			} finally {
+				executionContext?.signal.removeEventListener("abort", abortFromRun);
+				controller.abort("host request settled");
+				if (this.activeHostRequestControllers.get(commId) === controller) {
+					this.activeHostRequestControllers.delete(commId);
 				}
 			}
 		})();
@@ -1319,7 +1388,7 @@ export class KernelManager {
 		});
 	}
 
-	private async handleHostRequest(data: unknown): Promise<Record<string, unknown>> {
+	private async handleHostRequest(data: unknown, context: HostRequestContext): Promise<Record<string, unknown>> {
 		if (!isRecord(data)) {
 			throw new Error("host request payload must be an object");
 		}
@@ -1335,7 +1404,7 @@ export class KernelManager {
 		// the in-flight execution; detached spawns (asyncio.create_task) fire after
 		// the scheduling cell goes idle, so fall back to that last cell's source.
 		const cellSourceCode = this.activeExecution?.code ?? this.lastCellCode;
-		return handler({ ...data, cellSourceCode });
+		return handler({ ...data, cellSourceCode }, context);
 	}
 
 	private async sendCommMessage(commId: string, data: Record<string, unknown>): Promise<void> {
@@ -1356,6 +1425,11 @@ export class KernelManager {
 	private cleanupResources(killSignal: NodeJS.Signals = "SIGTERM"): void {
 		this.clearSnapshotTimer();
 		this.lateSentAgentMessageHandlers.clear();
+		for (const controller of this.activeHostRequestControllers.values()) {
+			controller.abort("kernel stopped");
+		}
+		this.activeHostRequestControllers.clear();
+		this.executionHostRequestContexts.clear();
 		if (this.forkedLivenessTimer) {
 			globalThis.clearInterval(this.forkedLivenessTimer);
 			this.forkedLivenessTimer = undefined;

--- a/packages/coding-agent/src/core/rlm-runtime.ts
+++ b/packages/coding-agent/src/core/rlm-runtime.ts
@@ -2,7 +2,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model, ServiceTier } from "@earendil-works/pi-ai";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/index.js";
-import type { HostRequestHandler } from "./kernel/index.js";
+import type { HostRequestContext, HostRequestHandler, RegisteredHostRequestHandlers } from "./kernel/index.js";
 import { THINKING_LEVELS } from "./thinking-levels.js";
 
 /** Request emitted by `rlm.run`; cellSourceCode preserves the spawning cell for display. */
@@ -50,7 +50,7 @@ export interface RlmFindModelsResult {
 	models: RlmModelMatch[];
 }
 
-export type RlmRunHandler = (request: RlmRunRequest) => Promise<Record<string, unknown>>;
+export type RlmRunHandler = (request: RlmRunRequest, context?: HostRequestContext) => Promise<Record<string, unknown>>;
 export type RlmListSubagentsHandler = () => RlmListSubagentsResult | Promise<RlmListSubagentsResult>;
 export type RlmDeleteSubagentHandler = (target: string) => Promise<RlmDeleteSubagentResult>;
 export type RlmFindModelsHandler = (query: string, limit: number) => RlmFindModelsResult | Promise<RlmFindModelsResult>;
@@ -163,17 +163,20 @@ export function findRlmModelMatches(query: string, models: Model<Api>[], limit: 
 
 /** Adapt an RlmRunHandler into the typed `rlm.run` kernel host handler. */
 export function createRlmRunHostHandler(handler: RlmRunHandler): HostRequestHandler {
-	return async (payload) => {
+	return async (payload, context) => {
 		if (typeof payload.prompt !== "string") {
 			throw new Error("rlm.run prompt must be a string");
 		}
 		const kwargs = isRecord(payload.kwargs) ? payload.kwargs : {};
 		const cellSourceCode = typeof payload.cellSourceCode === "string" ? payload.cellSourceCode : undefined;
-		const result = await handler({
-			prompt: payload.prompt,
-			kwargs,
-			cellSourceCode,
-		});
+		const result = await handler(
+			{
+				prompt: payload.prompt,
+				kwargs,
+				cellSourceCode,
+			},
+			context,
+		);
 		return result as unknown as Record<string, unknown>;
 	};
 }
@@ -230,9 +233,12 @@ export interface CreateRlmSubagentRuntimeOptions {
 	customTools: ToolDefinition[];
 	includeGoals: boolean;
 	includeCompactSkill: boolean;
+	hostRequestHandlers?: RegisteredHostRequestHandlers;
 	rlmDepth: number;
 	rlmMaxDepth: number;
 	rlmParentNodeId: string;
+	/** Host-only context inherited from the spawning execution. */
+	runContext?: unknown;
 	/** Source of the IPython cell that spawned this subagent, for display. */
 	spawnCode?: string;
 	/** Publish the session to the parent before a host makes the runtime addressable. */

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -354,6 +354,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		scopedModels: options.scopedModels,
 		resourceLoader,
 		customTools: options.customTools,
+		hostRequestHandlers: options.hostRequestHandlers,
 		modelRegistry,
 		mcpManager,
 		initialActiveToolNames,

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -8,6 +8,7 @@ import { withKernelBootPermit } from "../kernel/boot-gate.js";
 import type { KernelBootstrapProgressHandler } from "../kernel/bootstrap.js";
 import {
 	type ExecuteResult,
+	type HostRequestExecutionContext,
 	type HostRequestHandlers,
 	type KernelAttachment,
 	KernelBusyAfterInterruptError,
@@ -275,8 +276,11 @@ export interface IpythonToolOptions {
 	/** Optional explicit shell path for bare %%bash cells. */
 	shellPath?: string;
 	sessionId?: string;
+	recursionDepth?: number;
 	/** Typed host request handlers for the kernel↔host bridge (rlm.run, goal.*, …). */
 	hostHandlers?: HostRequestHandlers;
+	/** Resolves the current admitted run without exposing it to the Python payload. */
+	getHostRequestContext?: (executionId?: string) => HostRequestExecutionContext | undefined;
 	pythonSkills?: readonly PythonSkillRuntimeInfo[];
 	/** Per-session artifact dir where the kernel namespace snapshot is stored. Omit to disable snapshots. */
 	snapshotDir?: string;
@@ -479,6 +483,7 @@ export class IpythonKernelProvisioner {
 				cwd: this.cwd,
 				env: this.options?.env,
 				sessionId: this.options?.sessionId,
+				recursionDepth: this.options?.recursionDepth,
 				hostHandlers: this.options?.hostHandlers,
 				pythonSkills: this.options?.pythonSkills,
 				// Only persistent sessions (which have an artifact dir) get a revivable snapshot.
@@ -571,6 +576,7 @@ async function executeWithBusyKernelChoice(
 	onStream: (chunk: string, name: "stdout" | "stderr") => void,
 	onWorkingMessage: (message?: string) => void,
 	onLateSentAgentMessage: ((toolCallId: string, message: KernelSentAgentMessage) => void) | undefined,
+	hostRequestContext: HostRequestExecutionContext | undefined,
 	ctx: ExtensionContext | undefined,
 ): Promise<{ result: ExecuteResult; kernelRestarted: boolean }> {
 	let kernelRestarted = false;
@@ -584,6 +590,7 @@ async function executeWithBusyKernelChoice(
 					onLateSentAgentMessage: onLateSentAgentMessage
 						? (message) => onLateSentAgentMessage(toolCallId, message)
 						: undefined,
+					hostRequestContext,
 				}),
 				kernelRestarted,
 			};
@@ -630,7 +637,7 @@ export function createIpythonToolDefinition(
 		// The kernel is single-threaded — pi must not run two ipython calls in parallel within a batch.
 		executionMode: "sequential",
 		parameters: ipythonSchema,
-		execute: async (toolCallId, params, signal, onUpdate, ctx) => {
+		execute: async (toolCallId, params, signal, onUpdate, ctx, executionContext) => {
 			let hasWorkingMessage = false;
 			const setToolWorkingMessage = (message?: string) => {
 				setWorkingMessage(ctx, message);
@@ -660,6 +667,7 @@ export function createIpythonToolDefinition(
 					},
 					setToolWorkingMessage,
 					options?.onLateSentAgentMessage,
+					options?.getHostRequestContext?.(executionContext?.executionId),
 					ctx,
 				);
 

--- a/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
+++ b/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
@@ -13,8 +13,8 @@ export function wrapToolDefinition<TDetails = unknown>(
 		parameters: definition.parameters,
 		prepareArguments: definition.prepareArguments,
 		executionMode: definition.executionMode,
-		execute: (toolCallId, params, signal, onUpdate) =>
-			definition.execute(toolCallId, params, signal, onUpdate, ctxFactory?.() as ExtensionContext),
+		execute: (toolCallId, params, signal, onUpdate, executionContext) =>
+			definition.execute(toolCallId, params, signal, onUpdate, ctxFactory?.() as ExtensionContext, executionContext),
 	};
 }
 
@@ -40,6 +40,7 @@ export function createToolDefinitionFromAgentTool(tool: AgentTool<any>): ToolDef
 		parameters: tool.parameters as any,
 		prepareArguments: tool.prepareArguments,
 		executionMode: tool.executionMode,
-		execute: async (toolCallId, params, signal, onUpdate) => tool.execute(toolCallId, params, signal, onUpdate),
+		execute: async (toolCallId, params, signal, onUpdate, _ctx, executionContext) =>
+			tool.execute(toolCallId, params, signal, onUpdate, executionContext),
 	};
 }

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -137,6 +137,14 @@ export {
 } from "./core/extensions/index.js";
 // Footer data provider (git branch + extension statuses - data not otherwise available to extensions)
 export type { ReadonlyFooterDataProvider } from "./core/footer-data-provider.js";
+export {
+	createHostRequestHandler,
+	type HostRequestContext,
+	type HostRequestInvocationMetadata,
+	type HostRequestPayload,
+	type RegisteredHostRequestHandler,
+	type RegisteredHostRequestHandlers,
+} from "./core/kernel/index.js";
 export { convertToLlm } from "./core/messages.js";
 export { ModelRegistry } from "./core/model-registry.js";
 export type {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -2580,6 +2580,7 @@ export class AgentDaemon {
 					customTools: options.customTools,
 					includeGoals: options.includeGoals,
 					includeCompactSkill: options.includeCompactSkill,
+					hostRequestHandlers: options.hostRequestHandlers,
 					agentMessageController: this.createAgentMessageController(() => stateRef),
 					agentObserveController: this.createAgentObserveController(() => stateRef),
 					rlmHeartbeatController: {

--- a/packages/coding-agent/test/host-request-context.ts
+++ b/packages/coding-agent/test/host-request-context.ts
@@ -14,6 +14,8 @@ export function createSyntheticHostRequestContext(): HostRequestContext {
 		requestId: `test-host-request-${requestNumber}`,
 		generation: requestNumber,
 		signal: controller.signal,
+		recursionDepth: 0,
+		runContext: undefined,
 		isCurrent: () => !controller.signal.aborted,
 	};
 }

--- a/packages/coding-agent/test/suite/agent-session-run-context.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-run-context.test.ts
@@ -1,0 +1,204 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { type Context, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	createHostRequestHandler,
+	type HostRequestContext,
+	type RegisteredHostRequestHandlers,
+} from "../../src/core/kernel/index.js";
+import { createHarness, type Harness } from "./harness.js";
+
+const CONTEXT_CELL = {
+	code: 'from rlm import host_request\nawait host_request("test.context", {"runContext": "spoofed", "mode": "capture"})',
+};
+
+function latestTask(context: Context): string {
+	for (let index = context.messages.length - 1; index >= 0; index--) {
+		const message = context.messages[index];
+		if (message?.role !== "user") continue;
+		if (typeof message.content === "string") return message.content;
+		return message.content
+			.filter((part) => part.type === "text")
+			.map((part) => part.text)
+			.join("\n");
+	}
+	return "";
+}
+
+function filesContain(root: string, needle: string): boolean {
+	if (!existsSync(root)) return false;
+	for (const name of readdirSync(root)) {
+		const path = `${root}/${name}`;
+		if (statSync(path).isDirectory()) {
+			if (filesContain(path, needle)) return true;
+		} else if (readFileSync(path).includes(Buffer.from(needle))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function contextHandler(captured: HostRequestContext[]): RegisteredHostRequestHandlers {
+	return {
+		"test.context": createHostRequestHandler(async (payload, context) => {
+			captured.push(context);
+			if (payload.mode === "fail") throw new Error("host handler failed");
+			if (payload.mode === "block") {
+				await new Promise<never>((_resolve, reject) => {
+					const abort = () => reject(new Error("host handler aborted"));
+					context.signal.addEventListener("abort", abort, { once: true });
+					if (context.signal.aborted) abort();
+				});
+			}
+			return { observed: true };
+		}),
+	};
+}
+
+describe("AgentSession run-scoped kernel context", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("isolates sequential contexts, ignores payload spoofing, clears terminal scopes, and never persists them", async () => {
+		const captured: HostRequestContext[] = [];
+		const harness = await createHarness({
+			hostRequestHandlers: contextHandler(captured),
+			persistSession: true,
+		});
+		harnesses.push(harness);
+		const first = { marker: "run-context-secret-first" };
+		const second = { marker: "run-context-secret-second" };
+
+		for (const [prompt, runContext] of [
+			["first", first],
+			["second", second],
+		] as const) {
+			harness.setResponses([
+				fauxAssistantMessage(fauxToolCall("ipython", CONTEXT_CELL), { stopReason: "toolUse" }),
+				fauxAssistantMessage(`${prompt} done`),
+			]);
+			await harness.session.promptAndWait(prompt, { runContext });
+		}
+
+		expect(captured).toHaveLength(2);
+		expect(captured.map((context) => context.runContext)).toEqual([first, second]);
+		expect(captured.map((context) => context.recursionDepth)).toEqual([0, 0]);
+		expect(captured.every((context) => context.sessionId === harness.session.sessionId)).toBe(true);
+		await vi.waitFor(() => expect(captured.every((context) => context.signal.aborted)).toBe(true));
+
+		const recovery = JSON.stringify(harness.session.getSessionActionRecoverySnapshot());
+		expect(recovery).not.toContain(first.marker);
+		expect(recovery).not.toContain(second.marker);
+		await harness.session.disposeAsync();
+		expect(filesContain(harness.tempDir, first.marker)).toBe(false);
+		expect(filesContain(harness.tempDir, second.marker)).toBe(false);
+	});
+
+	it("keeps concurrent sessions isolated", async () => {
+		const leftCaptured: HostRequestContext[] = [];
+		const rightCaptured: HostRequestContext[] = [];
+		const left = await createHarness({ hostRequestHandlers: contextHandler(leftCaptured) });
+		const right = await createHarness({ hostRequestHandlers: contextHandler(rightCaptured) });
+		harnesses.push(left, right);
+		const leftContext = { side: "left" };
+		const rightContext = { side: "right" };
+		for (const harness of [left, right]) {
+			harness.setResponses([
+				fauxAssistantMessage(fauxToolCall("ipython", CONTEXT_CELL), { stopReason: "toolUse" }),
+				fauxAssistantMessage("done"),
+			]);
+		}
+
+		await Promise.all([
+			left.session.promptAndWait("left", { runContext: leftContext }),
+			right.session.promptAndWait("right", { runContext: rightContext }),
+		]);
+
+		expect(leftCaptured).toHaveLength(1);
+		expect(rightCaptured).toHaveLength(1);
+		expect(leftCaptured[0]?.runContext).toBe(leftContext);
+		expect(rightCaptured[0]?.runContext).toBe(rightContext);
+		expect(leftCaptured[0]?.sessionId).toBe(left.session.sessionId);
+		expect(rightCaptured[0]?.sessionId).toBe(right.session.sessionId);
+	});
+
+	it("clears contexts after host failure and cancellation", async () => {
+		const captured: HostRequestContext[] = [];
+		const harness = await createHarness({ hostRequestHandlers: contextHandler(captured) });
+		harnesses.push(harness);
+		const failureCell = {
+			code: 'from rlm import host_request\nawait host_request("test.context", {"mode": "fail"})',
+		};
+		const failureContext = { kind: "failure" };
+		harness.setResponses([fauxAssistantMessage(fauxToolCall("ipython", failureCell), { stopReason: "toolUse" })]);
+		await harness.session.prompt("fail", { runContext: failureContext });
+		await vi.waitFor(() => expect(captured[0]?.signal.aborted).toBe(true));
+		expect(captured[0]?.runContext).toBe(failureContext);
+
+		const blockingCell = {
+			code: 'from rlm import host_request\nawait host_request("test.context", {"mode": "block"})',
+		};
+		harness.setResponses([fauxAssistantMessage(fauxToolCall("ipython", blockingCell), { stopReason: "toolUse" })]);
+		const cancellationContext = { kind: "cancellation" };
+		const prompt = harness.session.prompt("cancel", { runContext: cancellationContext });
+		await vi.waitFor(() => expect(captured).toHaveLength(2));
+		await harness.session.abort();
+		await Promise.allSettled([prompt]);
+		expect(captured[1]?.signal.aborted).toBe(true);
+		expect(captured[1]?.runContext).toBe(cancellationContext);
+	});
+
+	it("propagates one root context to sibling and nested child executions", async () => {
+		const captured: HostRequestContext[] = [];
+		const harness = await createHarness({
+			hostRequestHandlers: contextHandler(captured),
+			rlmMaxDepth: 2,
+		});
+		harnesses.push(harness);
+		const runContext = { request: "family-context" };
+		const response = (context: Context) => {
+			const last = context.messages.at(-1);
+			if (last?.role === "toolResult") return fauxAssistantMessage("done");
+			const task = latestTask(context);
+			if (task.includes("child-a")) {
+				return fauxAssistantMessage(
+					fauxToolCall("ipython", {
+						code: 'from rlm import host_request\nawait host_request("test.context")\nawait rlm("grandchild", name="grandchild")',
+					}),
+					{ stopReason: "toolUse" },
+				);
+			}
+			if (task.includes("child-b") || task.includes("grandchild")) {
+				return fauxAssistantMessage(
+					fauxToolCall("ipython", {
+						code: 'from rlm import host_request\nawait host_request("test.context")',
+					}),
+					{ stopReason: "toolUse" },
+				);
+			}
+			return fauxAssistantMessage(
+				fauxToolCall("ipython", {
+					code: 'from rlm import host_request\nawait rlm("child-a", name="child-a")\nawait rlm("child-b", name="child-b")\nawait host_request("test.context")',
+				}),
+				{ stopReason: "toolUse" },
+			);
+		};
+		harness.setResponses(Array.from({ length: 16 }, () => response));
+
+		await harness.session.promptAndWait("root", { runContext });
+		await vi.waitFor(() => {
+			const inherited = captured.filter((context) => context.runContext === runContext);
+			const depthCounts = new Map<number, number>();
+			for (const context of inherited) {
+				depthCounts.set(context.recursionDepth, (depthCounts.get(context.recursionDepth) ?? 0) + 1);
+			}
+			expect(depthCounts.get(0)).toBeGreaterThanOrEqual(1);
+			expect(depthCounts.get(1)).toBeGreaterThanOrEqual(2);
+			expect(depthCounts.get(2)).toBeGreaterThanOrEqual(1);
+			expect(new Set(inherited.map((context) => context.sessionId)).size).toBe(4);
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -15,6 +15,7 @@ import { AgentSession, type AgentSessionEvent, type AutoRefineReviewer } from ".
 import { AuthStorage } from "../../src/core/auth-storage.js";
 import type { AgentAutonomousConfig } from "../../src/core/autonomous.js";
 import type { ExtensionRunner } from "../../src/core/extensions/index.js";
+import type { RegisteredHostRequestHandlers } from "../../src/core/kernel/index.js";
 import { convertToLlm } from "../../src/core/messages.js";
 import { ModelRegistry } from "../../src/core/model-registry.js";
 import type { SubagentRuntimeHost } from "../../src/core/rlm-runtime.js";
@@ -79,6 +80,7 @@ export interface HarnessOptions {
 	autoRefineReviewer?: AutoRefineReviewer;
 	serializedRefine?: boolean;
 	initialGoal?: { objective: string; tokenBudget?: number };
+	hostRequestHandlers?: RegisteredHostRequestHandlers;
 }
 
 export interface Harness {
@@ -203,6 +205,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		autoRefineReviewer: options.autoRefineReviewer,
 		serializedRefine: options.serializedRefine,
 		initialGoal: options.initialGoal,
+		hostRequestHandlers: options.hostRequestHandlers,
 	});
 
 	const events: AgentSessionEvent[] = [];


### PR DESCRIPTION
## Context

Prime Agent already has authenticated per-call host-request contracts from #1238, while the broader dispatcher work in the closed #1243 branch was not merged. Embedders still need a generic way to attach host-owned authority or request state to one admitted prompt execution without changing tool definitions, exposing that state to model-generated Python, or storing it in session artifacts.

## Changes

- Adds public, factory-validated typed kernel host-handler registration to `AgentSession` / `createAgentSession`; the handler table is copied once and remains stable for the session lifetime.
- Adds `runContext` to in-process `prompt()` / `promptAndWait()` options. An opaque execution ID flows through agent tool invocation metadata, while the actual object stays in a private execution-keyed map rather than a process-global or session-global current-context field.
- Mints handler invocation context in the dispatcher with session ID, recursion depth, run context, request ID, generation/currentness, and cancellation signal. Python payload fields cannot select or override this metadata, and handler result fields cannot override reply status.
- Propagates the spawning execution context to sibling and nested RLM children, including inline, runtime-hosted, and daemon-hosted in-process child creation.
- Revokes execution/handler contexts on completion, failure, cancellation, comm close, and kernel teardown. Run-context objects are not added to messages, queued-action recovery snapshots, session JSONL, runtime metadata, or IPython namespace snapshots.
- Documents the SDK and runtime boundary. Session-lifetime handlers can be configured by daemon embedders, but arbitrary `runContext` objects are consciously not added to the remote daemon/RPC prompt wire format; callers should attach them at the in-process `AgentSession` host boundary.

## Concurrency semantics

Each admitted root action owns a distinct execution scope. Sequential turns in one persistent session therefore resolve different contexts, and parallel sessions use separate keyed maps. Tool calls correlate by opaque execution ID and Jupyter parent message ID; missing correlation yields no run context instead of falling back to another active cell.

## Validation

No paid inference was used. Validation used faux provider responses plus local IPython kernels.

- `npm run check` (Biome with warnings as errors, TypeScript, installer render, browser smoke)
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/agent-session-run-context.test.ts` (4 passed)
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent-session-recursion.test.ts` (98 passed)
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/host-request-contract.test.ts` (3 passed)
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/kernel-goal-skill.test.ts test/kernel-agent-message-skill.test.ts` (7 passed, 3 environment-gated skipped)
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/agent-session-compaction.test.ts` (32 passed)
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agent.test.ts` from `packages/agent` (25 passed)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add run-scoped host context to kernel host request handlers in agent sessions
> - Introduces a `hostRequestHandlers` registration API on `AgentSession` (and `createAgentSession`/daemon) so callers can bind typed, session-lifetime kernel host handlers using a new `createHostRequestHandler` factory.
> - Each admitted agent run gets an `AgentRunScope` carrying a `runContext` (caller-supplied, opaque) and an `AbortSignal`; this scope is correlated to kernel executions via an `executionId` and exposed to host handlers through a dispatcher-minted `HostRequestContext`.
> - `HostRequestContext` now includes `sessionId`, `recursionDepth`, and `runContext` fields; contexts are cryptographically provenance-checked (WeakSet-based) so structurally similar forgeries are rejected.
> - Child subagent runs spawned via `rlm.run` inherit the parent `runContext` and `hostRequestHandlers`, with `recursionDepth` incremented; `runContext` is memory-only and never serialized to disk or recovery snapshots.
> - `executionId` flows from `Agent.prompt`/`Agent.continue` through `AgentLoopConfig` into each tool's `execute` call via a new `AgentToolExecutionContext` parameter.
> - Risk: custom handlers that conflict with built-in handler types throw at session construction time; all active host request contexts are aborted when the kernel stops.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65e7d31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->