### PR TITLE
fix: preserve extension questions in the TUI

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed long extension selector prompts being clipped instead of wrapping to the terminal width.
 - Fixed daemon socket paths being used verbatim in identity derivations: on supported platforms, `--daemon-socket` spellings differing only by duplicate or trailing slashes now normalize to one canonical path, so worker-descriptor namespaces, daemon log files, and persisted descriptors agree.
 - Added a `thinking` option to `rlm.run` for spawning subagents with an explicit reasoning level; invalid levels for the resolved child model fail spawn.
 - Changed opening the agents view (full or scoped) with a draft prompt to auto-stash the draft instead of refusing; the draft is restored into the editor when the session is reopened.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed long extension selector prompts being clipped instead of wrapping to the terminal width.
+- Fixed long extension selector prompts being clipped instead of wrapping to the terminal width ([#1539](https://github.com/PrimeIntellect-ai/prime-agent/pull/1539) by [@felipecsl](https://github.com/felipecsl)).
 - Fixed daemon socket paths being used verbatim in identity derivations: on supported platforms, `--daemon-socket` spellings differing only by duplicate or trailing slashes now normalize to one canonical path, so worker-descriptor namespaces, daemon log files, and persisted descriptors agree.
 - Added a `thinking` option to `rlm.run` for spawning subagents with an explicit reasoning level; invalid levels for the resolved child model fail spawn.
 - Changed opening the agents view (full or scoped) with a draft prompt to auto-stash the draft instead of refusing; the draft is restored into the editor when the session is reopened.

--- a/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
+++ b/packages/coding-agent/src/modes/interactive/components/menu-panel.ts
@@ -247,7 +247,7 @@ export class MenuPanel extends Container {
 		const hasSubtitle = subtitle !== undefined && subtitle.length > 0;
 		const hasHeader = hasTitle || hasSubtitle;
 		if (hasTitle) {
-			lines.push(surfaceLine(theme.bold(theme.fg("text", this.title)), safeWidth));
+			lines.push(...surfaceWrappedLines(theme.bold(theme.fg("text", this.title)), safeWidth));
 		}
 		if (hasSubtitle) {
 			lines.push(...surfaceWrappedLines(theme.fg("muted", subtitle), safeWidth));

--- a/packages/coding-agent/test/extension-selector.test.ts
+++ b/packages/coding-agent/test/extension-selector.test.ts
@@ -18,6 +18,23 @@ describe("ExtensionSelectorComponent", () => {
 		initTheme("dark");
 	});
 
+	it("wraps a long single-line prompt to the available width", () => {
+		const prompt =
+			"This long question must remain fully visible when the daemon client renders it in a narrow terminal window.";
+		const selector = new ExtensionSelectorComponent(prompt, ["Yes", "No"], vi.fn(), vi.fn(), {
+			getRows: () => 24,
+		});
+
+		const outputLines = selector.render(40).map((line) => stripAnsi(line));
+		const promptEnd = outputLines.findIndex((line, index) => index > 1 && line.trim() === "");
+		const renderedPrompt = outputLines
+			.slice(1, promptEnd)
+			.map((line) => line.trim())
+			.join(" ");
+
+		expect(renderedPrompt).toBe(prompt);
+	});
+
 	it("renders a multiline prompt with compact option rows", () => {
 		const selector = new ExtensionSelectorComponent(
 			[

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed terminal focus reports being forwarded to focused components as keyboard input.
+
 ## [0.7.3] - 2026-08-17
 
 - Fixed hyperlinks not being clickable in fullscreen mode on terminals that gate native link handling while mouse reporting is active (e.g. Ghostty); left-clicking a link now opens it directly.

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed terminal focus reports being forwarded to focused components as keyboard input.
+- Fixed terminal focus reports being forwarded to focused components as keyboard input ([#1539](https://github.com/PrimeIntellect-ai/prime-agent/pull/1539) by [@felipecsl](https://github.com/felipecsl)).
 
 ## [0.7.3] - 2026-08-17
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -26,6 +26,8 @@ import {
 } from "./utils.js";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
+const TERMINAL_FOCUS_IN = "\x1b[I";
+const TERMINAL_FOCUS_OUT = "\x1b[O";
 
 function extractKittyImageIds(line: string): number[] {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -877,6 +879,8 @@ export class TUI extends Container {
 			}
 			data = current;
 		}
+
+		if (data === TERMINAL_FOCUS_IN || data === TERMINAL_FOCUS_OUT) return;
 
 		// Consume terminal cell size responses without blocking unrelated input.
 		if (this.consumeCellSizeResponse(data)) {

--- a/packages/tui/test/tui-cell-size-input.test.ts
+++ b/packages/tui/test/tui-cell-size-input.test.ts
@@ -58,6 +58,21 @@ describe("TUI cell size responses", () => {
 		});
 	});
 
+	it("consumes terminal focus reports instead of forwarding them as keyboard input", () => {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+		const recorder = new InputRecorder();
+
+		tui.setFocus(recorder);
+		tui.start();
+
+		terminal.sendInput("\x1b[O");
+		terminal.sendInput("\x1b[I");
+
+		assert.deepStrictEqual(recorder.inputs, []);
+		tui.stop();
+	});
+
 	it("consumes cell size responses and still forwards later user input", () => {
 		withImageTerminal(() => {
 			setCellDimensions({ widthPx: 9, heightPx: 18 });


### PR DESCRIPTION
## Summary

- wrap extension selector titles to the available terminal width
- consume terminal focus reports before they reach focused components
- add regressions for long prompts and focus input

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/extension-selector.test.ts`
- `node --test --import tsx test/tui-cell-size-input.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix extension questions being corrupted in the TUI by terminal focus reports
> - Filters out terminal focus in/out escape sequences (`ESC [ I` and `ESC [ O`) in [tui.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1539/files#diff-0aed3a4b69095fa2ae0cffa8689c7dad409e8b36ab77544b0defb1474fde7311) so they are not forwarded to focused components as keyboard input, which was corrupting extension selector prompts.
> - Fixes long extension selector prompts being clipped by switching [menu-panel.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1539/files#diff-22f82f8366fad943dc6e7f231f4645c864e17b89b5228a1453cc21e1a57a329c) to wrap titles to the panel width instead of truncating them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b063098.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->