### PR TITLE
fix(coding-agent): keep the tail of an oversized last line in truncateTail

### DIFF
--- a/.omo/run-continuation/ses_fe81d44d8ffeQ55J0U6l1PjxG5.json
+++ b/.omo/run-continuation/ses_fe81d44d8ffeQ55J0U6l1PjxG5.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_fe81d44d8ffeQ55J0U6l1PjxG5",
+  "updatedAt": "2026-08-19T02:43:56.698Z",
+  "sources": {
+    "background-task": {
+      "state": "idle",
+      "updatedAt": "2026-08-19T02:43:56.698Z"
+    }
+  }
+}

--- a/packages/coding-agent/src/core/tools/truncate.ts
+++ b/packages/coding-agent/src/core/tools/truncate.ts
@@ -185,12 +185,17 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 
 		if (outputBytesCount + lineBytes > maxBytes) {
 			truncatedBy = "bytes";
-			// Edge case: if we haven't added ANY lines yet and this line exceeds maxBytes,
-			// take the end of the line (partial)
-			if (outputLinesArr.length === 0) {
-				const truncatedLine = truncateStringToBytesFromEnd(line, maxBytes);
+			// Edge case: if no line with content has been collected yet and this line
+			// exceeds the remaining budget, keep the end of it (partial). Content that
+			// ends with a newline splits into a trailing empty element, so testing
+			// `outputLinesArr.length === 0` here would skip this fallback and return
+			// nothing at all for output whose last line is longer than maxBytes.
+			if (!outputLinesArr.some((collected) => collected.length > 0)) {
+				const separatorBytes = outputLinesArr.length > 0 ? 1 : 0;
+				const budget = Math.max(0, maxBytes - outputBytesCount - separatorBytes);
+				const truncatedLine = truncateStringToBytesFromEnd(line, budget);
 				outputLinesArr.unshift(truncatedLine);
-				outputBytesCount = Buffer.byteLength(truncatedLine, "utf-8");
+				outputBytesCount += Buffer.byteLength(truncatedLine, "utf-8") + separatorBytes;
 				lastLinePartial = true;
 			}
 			break;

--- a/packages/coding-agent/test/truncate.test.ts
+++ b/packages/coding-agent/test/truncate.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MAX_BYTES, truncateTail } from "../src/core/tools/truncate.js";
+
+const LONG_LINE = "A".repeat(2 * DEFAULT_MAX_BYTES);
+
+describe("truncateTail", () => {
+	it("keeps the tail of an oversized single line without a trailing newline", () => {
+		const result = truncateTail(LONG_LINE);
+
+		expect(result.content.length).toBeGreaterThan(0);
+		expect(result.lastLinePartial).toBe(true);
+		expect(Buffer.byteLength(result.content, "utf-8")).toBeLessThanOrEqual(DEFAULT_MAX_BYTES);
+	});
+
+	it("keeps the tail of an oversized last line when the output ends with a newline", () => {
+		const result = truncateTail(`${LONG_LINE}\n`);
+
+		// A trailing newline splits into an empty final element. That element must not
+		// suppress the partial-line fallback, or the caller gets no output at all.
+		expect(result.content.length).toBeGreaterThan(0);
+		expect(result.content.startsWith("A")).toBe(true);
+		expect(result.lastLinePartial).toBe(true);
+		expect(Buffer.byteLength(result.content, "utf-8")).toBeLessThanOrEqual(DEFAULT_MAX_BYTES);
+	});
+
+	it("keeps the tail when short lines precede an oversized last line", () => {
+		const result = truncateTail(`short1\nshort2\n${LONG_LINE}\n`);
+
+		expect(result.content.length).toBeGreaterThan(0);
+		expect(result.content.startsWith("A")).toBe(true);
+		expect(result.lastLinePartial).toBe(true);
+		expect(Buffer.byteLength(result.content, "utf-8")).toBeLessThanOrEqual(DEFAULT_MAX_BYTES);
+	});
+
+	it("does not truncate content that fits both limits", () => {
+		const result = truncateTail("line1\nline2\n");
+
+		expect(result.truncated).toBe(false);
+		expect(result.content).toBe("line1\nline2\n");
+		expect(result.lastLinePartial).toBe(false);
+	});
+
+	it("still prefers whole trailing lines when they fit the byte budget", () => {
+		const filler = "x".repeat(1024);
+		const content = `${Array.from({ length: 200 }, () => filler).join("\n")}\ntail-line\n`;
+
+		const result = truncateTail(content);
+
+		expect(result.lastLinePartial).toBe(false);
+		expect(result.content.endsWith("tail-line\n")).toBe(true);
+		expect(Buffer.byteLength(result.content, "utf-8")).toBeLessThanOrEqual(DEFAULT_MAX_BYTES);
+	});
+
+	it("respects a maxBytes budget that is smaller than the last line", () => {
+		const result = truncateTail(`${"B".repeat(500)}\n`, { maxBytes: 100 });
+
+		expect(result.content.length).toBeGreaterThan(0);
+		expect(result.lastLinePartial).toBe(true);
+		expect(Buffer.byteLength(result.content, "utf-8")).toBeLessThanOrEqual(100);
+	});
+});


### PR DESCRIPTION
## Problem

`truncateTail` walks content backwards and, when the newest line alone exceeds `maxBytes`, is supposed to fall back to keeping the end of that line. Its own doc comment says so: *"May return partial first line if the last line of original content exceeds byte limit."*

The fallback is gated on `outputLinesArr.length === 0`:

```ts
if (outputBytesCount + lineBytes > maxBytes) {
    truncatedBy = "bytes";
    if (outputLinesArr.length === 0) {   // never true when content ends with "\n"
        ...
    }
    break;
}
```

Content that ends with a newline splits into a trailing empty element. That element is collected first, so the guard is already `false` when the oversized line is reached. The loop breaks with only the empty string collected and returns **empty content**, while `lastLinePartial` stays `false` and `outputLines` reports 1.

## Impact

Almost every command's stdout ends with a newline, so any output whose last line is longer than the 50KB byte budget reaches the model as `(no output)` plus a misleading footer:

```
(no output)

[Showing lines 2-2 of 2 (50.0KB limit). Full output: /tmp/pi-bash-....log]
```

Triggering commands are ordinary: `cat` on a single-line JSON file, `jq -c`, `base64`, a minified bundle, one long log line.

`truncateTail` is on the model-facing path via `OutputAccumulator.snapshot` and `executeBashWithOperations`, and on the display path via `interactive-mode` and `bash-execution`.

Measured on `main`:

| input | `content.length` |
| --- | --- |
| `"A".repeat(100*1024)` | 51200 (correct) |
| `"A".repeat(100*1024) + "\n"` | **0** |
| `"short1\nshort2\n" + "B".repeat(80*1024) + "\n"` | **0** |
| `JSON.stringify({d:"x".repeat(60*1024)}) + "\n"` | **0** |

## Fix

Gate the fallback on whether any line *with content* has been collected, and account for the newline the already-collected empty element contributes so the result still fits `maxBytes`.

No currently-correct case changes behaviour: with no trailing newline the collected array is empty and the arithmetic is identical, and a tail that already has real content still prefers whole lines.

## Tests

Adds `packages/coding-agent/test/truncate.test.ts` (there was no coverage for this module). The three new tail cases fail on `main` and pass with the fix; the two "no change expected" cases pass on both.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `truncateTail` to return a partial tail when the last line exceeds the byte budget
> When the last line overflows the byte budget, `truncateTail` in [truncate.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1545/files#diff-613db378f06f2f77941f985753a45fcf74405985934a54a07c7d6279790231d6) previously suppressed the partial-line fallback if the output ended with a trailing newline (producing an empty final entry in the lines array). The fix replaces the `outputLinesArr.length === 0` guard with a content-aware check so an empty trailing line no longer blocks the fallback. It also introduces `separatorBytes` to correctly account for the leading newline separator when computing the remaining budget for the truncated line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1827229.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->