### PR TITLE
fix(coding-agent): handle temp-file open failures instead of crashing the process

### DIFF
--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -51,15 +51,27 @@ export async function executeBashWithOperations(
 	let tempFileStream: WriteStream | undefined;
 	let totalBytes = 0;
 
+	let tempFileFailed = false;
 	const ensureTempFile = () => {
-		if (tempFilePath) {
+		if (tempFilePath || tempFileFailed) {
 			return;
 		}
 		const id = randomBytes(8).toString("hex");
-		tempFilePath = join(tmpdir(), `pi-bash-${id}.log`);
-		tempFileStream = createWriteStream(tempFilePath);
+		const path = join(tmpdir(), `pi-bash-${id}.log`);
+		const stream = createWriteStream(path);
+		// createWriteStream reports open failures (unwritable or full TMPDIR, EMFILE)
+		// asynchronously via "error". Without a listener that is an unhandled error
+		// event, which terminates the process. The full-output file is best effort,
+		// so drop it and keep returning the truncated output instead.
+		stream.on("error", () => {
+			tempFileFailed = true;
+			tempFilePath = undefined;
+			tempFileStream = undefined;
+		});
+		tempFilePath = path;
+		tempFileStream = stream;
 		for (const chunk of outputChunks) {
-			tempFileStream.write(chunk);
+			stream.write(chunk);
 		}
 	};
 

--- a/packages/coding-agent/src/core/tools/output-accumulator.ts
+++ b/packages/coding-agent/src/core/tools/output-accumulator.ts
@@ -51,6 +51,7 @@ export class OutputAccumulator {
 
 	private tempFilePath: string | undefined;
 	private tempFileStream: WriteStream | undefined;
+	private tempFileFailed = false;
 
 	constructor(options: OutputAccumulatorOptions = {}) {
 		this.maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
@@ -203,13 +204,24 @@ export class OutputAccumulator {
 	}
 
 	private ensureTempFile(): void {
-		if (this.tempFilePath) {
+		if (this.tempFilePath || this.tempFileFailed) {
 			return;
 		}
-		this.tempFilePath = defaultTempFilePath(this.tempFilePrefix);
-		this.tempFileStream = createWriteStream(this.tempFilePath);
+		const path = defaultTempFilePath(this.tempFilePrefix);
+		const stream = createWriteStream(path);
+		// createWriteStream reports open failures (unwritable or full TMPDIR, EMFILE)
+		// asynchronously via "error". Without a listener that is an unhandled error
+		// event, which terminates the process. Losing the full-output file is
+		// recoverable - the truncated tail is held separately - so degrade instead.
+		stream.on("error", () => {
+			this.tempFileFailed = true;
+			this.tempFilePath = undefined;
+			this.tempFileStream = undefined;
+		});
+		this.tempFilePath = path;
+		this.tempFileStream = stream;
 		for (const chunk of this.rawChunks) {
-			this.tempFileStream.write(chunk);
+			stream.write(chunk);
 		}
 		this.rawChunks = [];
 	}

--- a/packages/coding-agent/test/output-accumulator-temp-file.test.ts
+++ b/packages/coding-agent/test/output-accumulator-temp-file.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { OutputAccumulator } from "../src/core/tools/output-accumulator.js";
+import { DEFAULT_MAX_BYTES } from "../src/core/tools/truncate.js";
+
+const UNWRITABLE_TMPDIR = "/prime-agent-nonexistent-tmpdir-for-tests";
+
+function largeMultiLineOutput(fill: string): string {
+	const line = fill.repeat(1024);
+	const lineCount = Math.ceil((DEFAULT_MAX_BYTES + 4096) / (line.length + 1));
+	return `${Array.from({ length: lineCount }, () => line).join("\n")}\n`;
+}
+
+describe("OutputAccumulator temp file failures", () => {
+	let originalTmpdir: string | undefined;
+
+	beforeEach(() => {
+		originalTmpdir = process.env.TMPDIR;
+		process.env.TMPDIR = UNWRITABLE_TMPDIR;
+	});
+
+	afterEach(() => {
+		if (originalTmpdir === undefined) {
+			delete process.env.TMPDIR;
+		} else {
+			process.env.TMPDIR = originalTmpdir;
+		}
+	});
+
+	// createWriteStream reports an open failure asynchronously. Without an "error"
+	// listener that is an unhandled error event and the process is terminated, so
+	// this test only survives if the accumulator handles it.
+	it("keeps producing output when the temp file cannot be opened", async () => {
+		const accumulator = new OutputAccumulator({ tempFilePrefix: "pi-output-test" });
+		accumulator.append(Buffer.from(largeMultiLineOutput("A")));
+		accumulator.finish();
+
+		const snapshot = accumulator.snapshot({ persistIfTruncated: true });
+
+		// Let the deferred "error" event fire before asserting.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(snapshot.truncation.truncated).toBe(true);
+		expect(snapshot.content.length).toBeGreaterThan(0);
+		await expect(accumulator.closeTempFile()).resolves.toBeUndefined();
+	});
+
+	it("does not advertise a full-output path once the temp file failed", async () => {
+		const accumulator = new OutputAccumulator({ tempFilePrefix: "pi-output-test" });
+		accumulator.append(Buffer.from(largeMultiLineOutput("B")));
+		accumulator.finish();
+		accumulator.snapshot({ persistIfTruncated: true });
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(accumulator.snapshot({ persistIfTruncated: true }).fullOutputPath).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

Both output paths that spill large tool output to a temp file create the `WriteStream` and immediately write to it without registering an `"error"` listener:

- `OutputAccumulator.ensureTempFile` — `core/tools/output-accumulator.ts`
- `ensureTempFile` in `executeBashWithOperations` — `core/bash-executor.ts`

```ts
this.tempFilePath = defaultTempFilePath(this.tempFilePrefix);
this.tempFileStream = createWriteStream(this.tempFilePath);
for (const chunk of this.rawChunks) {
    this.tempFileStream.write(chunk);
}
```

`createWriteStream` reports open failures asynchronously via `"error"`. With no listener, Node treats it as an unhandled error event and terminates the process. `OutputAccumulator` does attach one, but only later inside `closeTempFile`, which is too late and is not reached on the failing path.

## Impact

This fires on **any tool output crossing the 50KB threshold** whenever the temp directory is not writable: `TMPDIR` pointing at a stale path, a full or read-only `/tmp` (ENOSPC/EROFS), or EMFILE under a wide subagent fan-out. The agent dies mid-turn with an ENOENT stack trace and no session state written.

Reproduced with exactly what `ensureTempFile` does:

```
node:events:496
      throw er; // Unhandled 'error' event
Error: ENOENT: no such file or directory, open '/nonexistent-dir-xyz/pi-bash-deadbeef.log'
```

There is a second symptom on the same path: `end()` on a stream that failed to open never emits `"finish"`, so `closeTempFile` never settles and the bash tool call hangs.

## Fix

Register the listener at creation and degrade: mark the temp file as failed, drop the path so callers stop advertising it, and keep returning the truncated output that is held separately in memory. Losing the full-output file is recoverable; losing the process is not.

## Tests

Adds `packages/coding-agent/test/output-accumulator-temp-file.test.ts`, which points `TMPDIR` at a non-existent directory. On `main` the run reports unhandled ENOENT errors and `closeTempFile` times out.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unhandled stream errors in temp-file creation to prevent process crashes in coding agent
> - Adds a `tempFileFailed` guard in [`OutputAccumulator.ensureTempFile`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1546/files#diff-977d05f56f39d1616b5d639f1a1fbae580a7bc6122bf1fb6a193549617ce05ff) and [`executeBashWithOperations`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1546/files#diff-98bffd47aaf72e129b42bae3e6487ac62532a38e638ecf008a6e9496baaf1a8f) to catch `error` events from `createWriteStream` instead of letting them go unhandled.
> - On failure, temp file references are cleared, `fullOutputPath` is left undefined, and output continues in-memory (truncated); subsequent calls skip further temp-file attempts.
> - Adds a Vitest suite in [`output-accumulator-temp-file.test.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1546/files#diff-36e0bf5994bfb79500c75d053b5a2200693e45b52b25557f1baa080be23b9d93) that verifies this behavior by pointing `TMPDIR` at an unwritable path.
> - Behavioral Change: when temp-file creation fails, output is silently truncated to the in-memory buffer rather than crashing the process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bf1213.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->