### PR TITLE
fix(ai): correct Codex SSE event framing and stop retrying rejected requests

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -87,6 +87,18 @@ interface RequestBody {
 	[key: string]: unknown;
 }
 
+/**
+ * A request failure the retry loop must not retry. It is raised inside the same
+ * try block that catches transport errors, so it needs to be distinguishable
+ * there or the catch would retry the very statuses isRetryableError rejected.
+ */
+class NonRetryableCodexRequestError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "NonRetryableCodexRequestError";
+	}
+}
+
 function isRetryableError(status: number, errorText: string): boolean {
 	if (status === 429 || status === 500 || status === 502 || status === 503 || status === 504) {
 		return true;
@@ -247,8 +259,11 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						statusText: response.statusText,
 					});
 					const info = await parseErrorResponse(fakeResponse);
-					throw new Error(info.friendlyMessage || info.message);
+					throw new NonRetryableCodexRequestError(info.friendlyMessage || info.message);
 				} catch (error) {
+					if (error instanceof NonRetryableCodexRequestError) {
+						throw error;
+					}
 					if (error instanceof Error) {
 						if (error.name === "AbortError" || error.message === "Request was aborted") {
 							throw new Error("Request was aborted");
@@ -501,41 +516,77 @@ function normalizeCodexStatus(status: unknown): CodexResponseStatus | undefined 
 	return CODEX_RESPONSE_STATUSES.has(status as CodexResponseStatus) ? (status as CodexResponseStatus) : undefined;
 }
 
+function parseSseEventChunk(chunk: string): Record<string, unknown> | undefined {
+	const dataLines = chunk
+		.split("\n")
+		.filter((l) => l.startsWith("data:"))
+		.map((l) => l.slice(5).trim());
+	if (dataLines.length === 0) return undefined;
+
+	const data = dataLines.join("\n").trim();
+	if (!data || data === "[DONE]") return undefined;
+
+	try {
+		return JSON.parse(data) as Record<string, unknown>;
+	} catch (cause) {
+		throw new CodexProtocolError(`Invalid Codex SSE JSON: ${formatThrownValue(cause)}`, {
+			cause,
+			payload: data,
+		});
+	}
+}
+
 async function* parseSSE(response: Response): AsyncGenerator<Record<string, unknown>> {
 	if (!response.body) return;
 
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
+	// A chunk that ends on the CR of a CRLF pair is held back so the pair is not
+	// normalized into two separate newlines, which would look like an event boundary
+	// in the middle of an event.
+	let pendingCarriageReturn = false;
+
+	const appendToBuffer = (text: string): void => {
+		let next = pendingCarriageReturn ? `\r${text}` : text;
+		pendingCarriageReturn = false;
+		if (next.endsWith("\r")) {
+			next = next.slice(0, -1);
+			pendingCarriageReturn = true;
+		}
+		// SSE separates events with a blank line. On the wire that is CRLF for a
+		// spec-compliant server and for anything behind a proxy that rewrites line
+		// endings, so framing must not assume LF.
+		buffer += next.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+	};
 
 	try {
 		while (true) {
 			const { done, value } = await reader.read();
-			if (done) break;
-			buffer += decoder.decode(value, { stream: true });
+			if (done) {
+				appendToBuffer(decoder.decode());
+				if (pendingCarriageReturn) {
+					buffer += "\n";
+					pendingCarriageReturn = false;
+				}
+				// Emit whatever is left. A body that does not end with a blank line
+				// would otherwise drop its final event, and for Codex that is
+				// response.completed, which carries usage, cost, and the toolUse stop
+				// reason - losing it reports a successful, empty, free turn.
+				const tail = buffer;
+				buffer = "";
+				const event = parseSseEventChunk(tail);
+				if (event) yield event;
+				break;
+			}
+			appendToBuffer(decoder.decode(value, { stream: true }));
 
 			let idx = buffer.indexOf("\n\n");
 			while (idx !== -1) {
 				const chunk = buffer.slice(0, idx);
 				buffer = buffer.slice(idx + 2);
-
-				const dataLines = chunk
-					.split("\n")
-					.filter((l) => l.startsWith("data:"))
-					.map((l) => l.slice(5).trim());
-				if (dataLines.length > 0) {
-					const data = dataLines.join("\n").trim();
-					if (data && data !== "[DONE]") {
-						try {
-							yield JSON.parse(data) as Record<string, unknown>;
-						} catch (cause) {
-							throw new CodexProtocolError(`Invalid Codex SSE JSON: ${formatThrownValue(cause)}`, {
-								cause,
-								payload: data,
-							});
-						}
-					}
-				}
+				const event = parseSseEventChunk(chunk);
+				if (event) yield event;
 				idx = buffer.indexOf("\n\n");
 			}
 		}

--- a/packages/ai/test/openai-codex-sse-framing.test.ts
+++ b/packages/ai/test/openai-codex-sse-framing.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { streamOpenAICodexResponses } from "../src/providers/openai-codex-responses.js";
+import type { AssistantMessage, Context, Model } from "../src/types.js";
+
+const originalFetch = global.fetch;
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	if (originalAgentDir === undefined) {
+		delete process.env.PI_CODING_AGENT_DIR;
+	} else {
+		process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+	}
+	vi.restoreAllMocks();
+});
+
+const RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
+
+const MODEL: Model<"openai-codex-responses"> = {
+	id: "gpt-5.1-codex",
+	name: "GPT-5.1 Codex",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400000,
+	maxTokens: 128000,
+};
+
+const CONTEXT: Context = {
+	systemPrompt: "You are a helpful assistant.",
+	messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+};
+
+function mockToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
+		"utf8",
+	).toString("base64");
+	return `aaa.${payload}.bbb`;
+}
+
+const SSE_EVENTS = [
+	`data: ${JSON.stringify({
+		type: "response.output_item.added",
+		item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+	})}`,
+	`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+	`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+	`data: ${JSON.stringify({
+		type: "response.output_item.done",
+		item: {
+			type: "message",
+			id: "msg_1",
+			role: "assistant",
+			status: "completed",
+			content: [{ type: "output_text", text: "Hello" }],
+		},
+	})}`,
+	`data: ${JSON.stringify({
+		type: "response.completed",
+		response: {
+			status: "completed",
+			usage: {
+				input_tokens: 5,
+				output_tokens: 3,
+				total_tokens: 8,
+				input_tokens_details: { cached_tokens: 0 },
+			},
+		},
+	})}`,
+];
+
+function installFetch(bodyChunks: string[], token: string): ReturnType<typeof vi.fn> {
+	const encoder = new TextEncoder();
+	const fetchMock = vi.fn(async (input: string | URL) => {
+		const url = typeof input === "string" ? input : input.toString();
+		if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+			return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+		}
+		if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+			return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+		}
+		if (url === RESPONSES_URL) {
+			const body = new ReadableStream<Uint8Array>({
+				start(controller) {
+					for (const chunk of bodyChunks) {
+						controller.enqueue(encoder.encode(chunk));
+					}
+					controller.close();
+				},
+			});
+			return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+		}
+		return new Response("not found", { status: 404 });
+	});
+	global.fetch = fetchMock as unknown as typeof fetch;
+	void token;
+	return fetchMock;
+}
+
+async function collect(token: string): Promise<AssistantMessage> {
+	let message: AssistantMessage | undefined;
+	for await (const event of streamOpenAICodexResponses(MODEL, CONTEXT, { apiKey: token })) {
+		if (event.type === "done") {
+			message = event.message;
+		}
+	}
+	if (!message) throw new Error("stream ended without a terminal event");
+	return message;
+}
+
+function useTempAgentDir(): void {
+	process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), "pi-codex-framing-"));
+}
+
+describe("openai-codex SSE framing", () => {
+	it("parses a CRLF-delimited event stream", async () => {
+		useTempAgentDir();
+		const token = mockToken();
+		installFetch([`${SSE_EVENTS.join("\r\n\r\n")}\r\n\r\n`], token);
+
+		const message = await collect(token);
+
+		expect(message.content.find((c) => c.type === "text")?.text).toBe("Hello");
+		expect(message.usage.totalTokens).toBe(8);
+	});
+
+	it("parses a CRLF stream split between the CR and the LF of an event boundary", async () => {
+		useTempAgentDir();
+		const token = mockToken();
+		const body = `${SSE_EVENTS.join("\r\n\r\n")}\r\n\r\n`;
+		const splitAt = body.indexOf("\r\n\r\n") + 1;
+		installFetch([body.slice(0, splitAt), body.slice(splitAt)], token);
+
+		const message = await collect(token);
+
+		expect(message.content.find((c) => c.type === "text")?.text).toBe("Hello");
+		expect(message.usage.totalTokens).toBe(8);
+	});
+
+	it("emits the final event when the body does not end with a blank line", async () => {
+		useTempAgentDir();
+		const token = mockToken();
+		installFetch([SSE_EVENTS.join("\n\n")], token);
+
+		const message = await collect(token);
+
+		expect(message.content.find((c) => c.type === "text")?.text).toBe("Hello");
+		// response.completed is the event that carries usage and the stop reason.
+		expect(message.usage.totalTokens).toBe(8);
+	});
+});
+
+describe("openai-codex request retries", () => {
+	it("does not retry a request the server rejected as invalid", async () => {
+		useTempAgentDir();
+		const token = mockToken();
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === RESPONSES_URL) {
+				return new Response(JSON.stringify({ error: { code: "invalid_request_error", message: "bad model" } }), {
+					status: 400,
+				});
+			}
+			return new Response("not found", { status: 404 });
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		let errorMessage: AssistantMessage | undefined;
+		for await (const event of streamOpenAICodexResponses(MODEL, CONTEXT, { apiKey: token })) {
+			if (event.type === "error") {
+				errorMessage = event.error;
+			}
+		}
+
+		expect(errorMessage?.stopReason).toBe("error");
+		// A 400 is not retryable. isRetryableError already says so; the terminal throw
+		// must not be swallowed by the transport catch and retried anyway.
+		const responseCalls = fetchMock.mock.calls.filter(([input]) => String(input) === RESPONSES_URL);
+		expect(responseCalls).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Problem

Three defects in the OpenAI Codex Responses provider, all on the same request/parse path.

### 1. `parseSSE` frames events on a literal `"\n\n"`

SSE separates events with a blank line, which is CRLF on a spec-compliant server and on anything behind a proxy that rewrites line endings. `\r\n\r\n` contains no two consecutive `\n`, so `indexOf("\n\n")` is permanently `-1`:

- no event is ever yielded
- `buffer` grows for the whole response
- `processResponsesStream` sees an empty iterator, so `output.stopReason` keeps its `"stop"` initializer and **no error is raised**

The caller gets a successful, empty, zero-usage assistant turn. In an agent loop that is a silent-truncation failure, not a visible outage.

`providers/anthropic.ts` already handles `\r`, `\n`, and `\r\n` via `nextLineBreakIndex`/`consumeLine`; `parseSSE` does not.

### 2. The final event is dropped when the body does not end with a blank line

The read loop only emits what it can carve out with `indexOf`, then `break`s straight into the `finally`. There is no trailing flush of `buffer` and no final `decoder.decode()`. For Codex the last event is `response.completed`, which sets usage, cost, and the `toolUse` promotion — so a tool-calling turn is reported as `stop` and the agent loop stops instead of running the tools.

`anthropic.ts` does this correctly (final `decode()`, drain, flush).

### 3. The retry loop retries every non-retryable status

```ts
if (attempt < MAX_RETRIES && isRetryableError(response.status, errorText)) { ...; continue; }
const info = await parseErrorResponse(fakeResponse);
throw new Error(info.friendlyMessage || info.message);   // "do not retry"
} catch (error) {                                        // catches the line above
    ...
    if (attempt < MAX_RETRIES && !lastError.message.includes("usage limit")) { ...; continue; }
```

The `throw` that expresses "this status is not retryable" sits inside the same `try`, so the generic `catch` swallows it and retries anyway. `isRetryableError` only affects which branch does the sleeping. A `400` or a `401` costs four requests and roughly seven seconds of backoff, and re-sends a known-bad token three extra times.

## Fix

- Normalize line endings when appending to the buffer, holding back a trailing CR so a chunk boundary landing inside a CRLF pair does not turn one pair into two newlines and split an event in half.
- Flush the decoder and emit the remaining buffer when the reader reports `done`.
- Raise a distinct error type for the non-retryable path and rethrow it in the `catch`, so `isRetryableError` actually decides.

## Tests

Adds `packages/ai/test/openai-codex-sse-framing.test.ts`: a CRLF stream, a CRLF stream split between the CR and the LF of an event boundary, a body with no trailing blank line, and a 400 asserting exactly one request. All four fail on `main`. The existing Codex suites are unchanged and still pass.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex SSE event framing and stop retrying non-retryable requests
> - Reworks `parseSSE` in [openai-codex-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1547/files#diff-69623a8c4e616b30339182296d1b69ed62a9d7fcce14b744ed6e638ecf357abc) to correctly handle CRLF/CR line endings and chunk boundaries that split a CRLF pair, and flushes the final SSE event even when the stream body lacks a trailing blank line.
> - Introduces `NonRetryableCodexRequestError` so that 400-level rejections are rethrown immediately instead of being treated as transport errors eligible for retry.
> - Extracts a `parseSseEventChunk` helper that joins `data:` lines, skips `[DONE]`, and throws `CodexProtocolError` on malformed JSON.
> - Adds a Vitest suite in [openai-codex-sse-framing.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1547/files#diff-8d1683c3f67cee46c9250d58999adf657d2fbab6f412f87aee0b18661532f1f4) covering CRLF streams, split-chunk boundaries, trailing-newline absence, and no-retry behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17d5757.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->