### PR TITLE
fix(coding-agent): stop a malformed WebP chunk table from hanging the agent

### DIFF
--- a/packages/coding-agent/src/utils/exif-orientation.ts
+++ b/packages/coding-agent/src/utils/exif-orientation.ts
@@ -13,8 +13,10 @@ function readOrientationFromTiff(bytes: Uint8Array, tiffStart: number): number {
 		return (bytes[pos] << 8) | bytes[pos + 1];
 	};
 
+	// TIFF offsets are unsigned. `<< 24` is a signed shift, so the result needs
+	// `>>> 0` or a high bit turns the offset negative.
 	const read32 = (pos: number): number => {
-		if (le) return bytes[pos] | (bytes[pos + 1] << 8) | (bytes[pos + 2] << 16) | (bytes[pos + 3] << 24);
+		if (le) return (bytes[pos] | (bytes[pos + 1] << 8) | (bytes[pos + 2] << 16) | (bytes[pos + 3] << 24)) >>> 0;
 		return ((bytes[pos] << 24) | (bytes[pos + 1] << 16) | (bytes[pos + 2] << 8) | bytes[pos + 3]) >>> 0;
 	};
 
@@ -66,8 +68,11 @@ function findWebpTiffOffset(bytes: Uint8Array): number {
 	let offset = 12;
 	while (offset + 8 <= bytes.length) {
 		const chunkId = String.fromCharCode(bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]);
+		// RIFF chunk sizes are unsigned. `<< 24` is a signed shift, so a size with the
+		// high bit set would decode negative and walk `offset` backwards or leave it
+		// unchanged, which is an unbreakable loop on the main thread.
 		const chunkSize =
-			bytes[offset + 4] | (bytes[offset + 5] << 8) | (bytes[offset + 6] << 16) | (bytes[offset + 7] << 24);
+			(bytes[offset + 4] | (bytes[offset + 5] << 8) | (bytes[offset + 6] << 16) | (bytes[offset + 7] << 24)) >>> 0;
 		const dataStart = offset + 8;
 
 		if (chunkId === "EXIF") {
@@ -78,7 +83,11 @@ function findWebpTiffOffset(bytes: Uint8Array): number {
 		}
 
 		// RIFF chunks are padded to even size
-		offset = dataStart + chunkSize + (chunkSize % 2);
+		const nextOffset = dataStart + chunkSize + (chunkSize % 2);
+		// A declared size that does not advance the scan means the chunk table is
+		// malformed; stop rather than re-reading the same header forever.
+		if (nextOffset <= offset) return -1;
+		offset = nextOffset;
 	}
 
 	return -1;

--- a/packages/coding-agent/test/exif-orientation.test.ts
+++ b/packages/coding-agent/test/exif-orientation.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const PROBE = fileURLToPath(new URL("./fixtures/exif-webp-scan-probe.ts", import.meta.url));
+const TSX = fileURLToPath(new URL("../../../node_modules/tsx/dist/cli.mjs", import.meta.url));
+
+function runProbe(sizeBytes: readonly number[]): { status: number | null; stdout: string } {
+	const probe = spawnSync(process.execPath, [TSX, PROBE, sizeBytes.join(",")], {
+		encoding: "utf8",
+		timeout: 20_000,
+	});
+	return { status: probe.status, stdout: probe.stdout ?? "" };
+}
+
+describe("WebP EXIF chunk scanning", () => {
+	// RIFF chunk sizes are unsigned, but the scan built them with a signed `<< 24`.
+	// 0xFFFFFFF8 decoded as -8, so the next offset landed back on the current chunk
+	// header and the scan looped forever on the main thread. The event loop is
+	// blocked, so the agent cannot even be interrupted.
+	it.each([
+		["0xFFFFFFF8 decodes to -8", [0xf8, 0xff, 0xff, 0xff]],
+		["0xFFFFFFF9 decodes to -7", [0xf9, 0xff, 0xff, 0xff]],
+		["0x80000000 sets the sign bit", [0x00, 0x00, 0x00, 0x80]],
+	])("terminates when a chunk size %s", (_label, sizeBytes) => {
+		const probe = runProbe(sizeBytes);
+
+		expect(probe.status).toBe(0);
+		expect(probe.stdout.trim()).toBe("ORIENTATION_DEFAULTED");
+	});
+
+	it("still scans past a well-formed chunk", () => {
+		const probe = runProbe([8, 0, 0, 0]);
+
+		expect(probe.status).toBe(0);
+		expect(probe.stdout.trim()).toBe("ORIENTATION_DEFAULTED");
+	});
+});

--- a/packages/coding-agent/test/fixtures/exif-webp-scan-probe.ts
+++ b/packages/coding-agent/test/fixtures/exif-webp-scan-probe.ts
@@ -1,0 +1,29 @@
+/**
+ * Runs applyExifOrientation against a WebP whose RIFF chunk size decodes negative
+ * under a signed shift. Lives in a child process because a regression is an
+ * unbreakable synchronous loop, which no in-process timeout can interrupt.
+ *
+ * Reads the chunk-size bytes as four comma-separated decimals in argv[2].
+ */
+import { applyExifOrientation } from "../../src/utils/exif-orientation.js";
+
+const sizeBytes = (process.argv[2] ?? "").split(",").map((part) => Number.parseInt(part, 10));
+if (sizeBytes.length !== 4 || sizeBytes.some((byte) => !Number.isInteger(byte))) {
+	throw new Error("usage: exif-webp-scan-probe.ts <b0,b1,b2,b3>");
+}
+
+const bytes = Buffer.alloc(12 + 8 + 16);
+bytes.write("RIFF", 0);
+bytes.writeUInt32LE(bytes.length - 8, 4);
+bytes.write("WEBP", 8);
+bytes.write("VP8 ", 12);
+Buffer.from(sizeBytes).copy(bytes, 16);
+
+const sentinel = { sentinel: true };
+const result = applyExifOrientation(
+	undefined as never,
+	sentinel as never,
+	new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
+);
+
+process.stdout.write(result === (sentinel as never) ? "ORIENTATION_DEFAULTED\n" : "UNEXPECTED_RESULT\n");


### PR DESCRIPTION
## Problem

`findWebpTiffOffset` builds the RIFF chunk size with a signed shift:

```ts
const chunkSize =
    bytes[offset + 4] | (bytes[offset + 5] << 8) | (bytes[offset + 6] << 16) | (bytes[offset + 7] << 24);
...
offset = dataStart + chunkSize + (chunkSize % 2);
```

RIFF sizes are unsigned, but `<< 24` is a signed shift, so any size with the high bit set decodes negative.

For `0xFFFFFFF8` (= -8) the advance is `offset + 8 - 8 + -0`, i.e. `offset` is unchanged and the loop re-reads the same chunk header forever. `0xFFFFFFF9` lands on the same fixed point. A size with only the sign bit set walks `offset` far negative and then crawls back in 8-byte steps.

Measured against the exact function body:

| chunk size bytes | result |
| --- | --- |
| `08 00 00 00` | terminates |
| `F8 FF FF FF` | **never terminates** |
| `F9 FF FF FF` | **never terminates** |
| `00 00 00 80` | ~2^28 iterations |

## Impact

The loop is synchronous, so it pins a core and blocks the event loop: the TUI stops repainting and Ctrl-C does nothing. Because it never returns, the `try/catch` in `resizeImage` never runs.

`getExifOrientation` is reached from `resizeImage` and `convertImage`, so any image the agent handles goes through it: a CLI file argument (`cli/file-processor.ts`), a clipboard paste (`interactive-mode.ts`), or an image in the repository the agent is pointed at.

A valid WebP with eight trailing bytes — a 4-byte chunk id plus `F8 FF FF FF` — and a widened RIFF size is enough. Decoders stop at the `VP8 ` chunk, so the file still renders normally everywhere else.

## Fix

Read the size unsigned (`>>> 0`) and refuse to continue when the computed next offset does not move forward.

Also apply the same `>>> 0` to the little-endian TIFF `read32`, which its big-endian sibling on the next line already had; a negative `ifdOffset` slips past the upper-bound-only guard on the following line.

## Tests

Adds `packages/coding-agent/test/exif-orientation.test.ts`. It drives the real `applyExifOrientation` from a child process with a timeout, because a regression is an unbreakable synchronous loop that no in-process timeout can interrupt. The three malformed cases fail on `main`; the well-formed case passes on both.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix infinite loop in WebP EXIF chunk scanner caused by malformed chunk sizes
> - Decodes RIFF chunk sizes as unsigned 32-bit integers using `>>> 0` in `findWebpTiffOffset` to prevent high-bit values from producing negative offsets under signed arithmetic.
> - Adds a non-advancing guard that returns `-1` immediately if the computed next offset does not move forward, breaking the infinite loop.
> - Applies the same unsigned coercion to the 32-bit reader in `readOrientationFromTiff` to prevent negative TIFF offsets.
> - Tests run the scanner in a child process via a probe script so a regression cannot hang the test suite.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47dff41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->