### PR TITLE
fix(coding-agent): stop compaction from silently keeping the whole window

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -384,12 +384,12 @@ export function findCutPoint(
 		const messageTokens = estimateTokens(entry.message);
 		accumulatedTokens += messageTokens;
 		if (accumulatedTokens >= keepRecentTokens) {
-			for (let c = 0; c < cutPoints.length; c++) {
-				if (cutPoints[c] >= i) {
-					cutIndex = cutPoints[c];
-					break;
-				}
-			}
+			// Tool results are never valid cut points, so when a single turn's trailing
+			// results already exceed the budget there is no cut point at or after i.
+			// Fall back to the newest cut point - keeping just the last turn - rather
+			// than to the oldest, which keeps the whole window and makes compaction a
+			// no-op that reports "session is too short to compact".
+			cutIndex = cutPoints.find((candidate) => candidate >= i) ?? cutPoints[cutPoints.length - 1];
 			break;
 		}
 	}

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -67,6 +67,33 @@ function createAssistantMessage(text: string, usage?: Usage): AssistantMessage {
 	};
 }
 
+function createAssistantWithToolCall(text: string, toolCallId: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{ type: "text", text },
+			{ type: "toolCall", id: toolCallId, name: "bash", arguments: {} },
+		],
+		usage: createMockUsage(100, 50),
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+	};
+}
+
+function createToolResultMessage(toolCallId: string, bytes: number): AgentMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "bash",
+		content: [{ type: "text", text: "z".repeat(bytes) }],
+		isError: false,
+		timestamp: Date.now(),
+	} as AgentMessage;
+}
+
 let entryCounter = 0;
 let lastId: string | null = null;
 
@@ -304,6 +331,28 @@ describe("findCutPoint", () => {
 		expect(entries[result.firstKeptEntryIndex].type).toBe("message");
 		const role = (entries[result.firstKeptEntryIndex] as SessionMessageEntry).message.role;
 		expect(role === "user" || role === "assistant").toBe(true);
+	});
+
+	it("keeps the newest turn when trailing tool results alone exceed the budget", () => {
+		// Tool results are never valid cut points, so a turn whose results exceed
+		// keepRecentTokens leaves no cut point at or after the scan position. The
+		// fallback must be the newest cut point, not the oldest: falling back to the
+		// oldest keeps the whole window, so compaction frees nothing and reports
+		// "session is too short to compact" while the context sits at 95%.
+		const entries: SessionEntry[] = [
+			createMessageEntry(createUserMessage("Turn 1")),
+			createMessageEntry(createAssistantMessage("A1")),
+			createMessageEntry(createUserMessage("Turn 2")),
+			createMessageEntry(createAssistantWithToolCall("running two commands", "tc1")),
+			createMessageEntry(createToolResultMessage("tc1", 60 * 1024)),
+			createMessageEntry(createToolResultMessage("tc1", 60 * 1024)),
+		];
+
+		const result = findCutPoint(entries, 0, entries.length, DEFAULT_COMPACTION_SETTINGS.keepRecentTokens);
+
+		expect(result.firstKeptEntryIndex).toBe(3);
+		expect(result.isSplitTurn).toBe(true);
+		expect(result.turnStartIndex).toBe(2);
 	});
 
 	it("should return startIndex if no valid cut points in range", () => {


### PR DESCRIPTION
## Problem

`findCutPoint` scans backwards until it has accumulated `keepRecentTokens`, then looks for the first cut point at or after that entry:

```ts
let cutIndex = cutPoints[0]; // Default: keep from first message (not header)
...
if (accumulatedTokens >= keepRecentTokens) {
    for (let c = 0; c < cutPoints.length; c++) {
        if (cutPoints[c] >= i) { cutIndex = cutPoints[c]; break; }
    }
    break;
}
```

`findValidCutPoints` deliberately excludes `toolResult` entries, so when one turn's trailing tool results already exceed `keepRecentTokens`, the scan stops above the last cut point and no candidate satisfies `cutPoints[c] >= i`. The inner loop completes without assigning and `cutIndex` silently keeps its `cutPoints[0]` initializer — the oldest cut point in the window, i.e. *keep everything*.

## Impact

The threshold check runs at exactly that boundary, where the branch tail is `[assistant(toolCalls), toolResult, ...]`. `keepRecentTokens` defaults to 20000 and `estimateTokens` is `chars/4`, while bash output is capped at 50KB per call (about 12800 estimated tokens) — so **two tool calls in a single turn** are enough.

With `cutIndex` at the oldest cut point, `prepareCompaction` computes an empty `messagesToSummarize` and returns `undefined`. The user sees:

```
Auto-compaction skipped: Session is too short to compact - try again once it grows
```

while `/usage` shows the context above 95%. Every later turn repeats it, including the overflow-recovery compaction, so the session ends with *"Context overflow recovery failed after one compact-and-retry attempt"*. `/compact` cannot rescue it either, since it funnels through the same `prepareCompaction`.

Reproduced against the exported function with `[user, assistant, user, assistant(toolCall), toolResult(60KB), toolResult(60KB)]` and the default settings:

```
main:  { firstKeptEntryIndex: 0, turnStartIndex: -1, isSplitTurn: false }   // keep everything
fixed: { firstKeptEntryIndex: 3, turnStartIndex: 2,  isSplitTurn: true  }
```

## Fix

Fall back to the newest cut point instead of the oldest. Keeping only the last turn is the correct degenerate result when that turn's tail alone exceeds the budget, and it leaves the existing split-turn machinery to summarize the prefix.

## Tests

Adds a `findCutPoint` case to `packages/coding-agent/test/compaction.test.ts`. It fails on `main`. All 16 compaction/session-manager/context suites still pass.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `findCutPoint` to fall back to the newest valid cut point instead of keeping the whole window
> When the token budget is exhausted but no valid cut point exists at or after the current scan index (e.g. trailing tool results exceed the budget), `findCutPoint` in [compaction.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1549/files#diff-ad4b3f096b732189266e944cde055f0e15abda3e3e2244b029909b9a89cee11f) previously fell back to the oldest cut point, making compaction a no-op by keeping the entire context window. It now falls back to the newest valid cut point, keeping only the last turn. A new test covers the case where trailing tool results alone exceed `keepRecentTokens`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e11a83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->