### PR TITLE
fix(daemon): do not let a compromised lockfile take the supervisor down

### DIFF
--- a/packages/coding-agent/src/cli/daemon-update-restart.ts
+++ b/packages/coding-agent/src/cli/daemon-update-restart.ts
@@ -335,6 +335,8 @@ async function withCoordinatorRegistryGuard<T>(registryDir: string, action: () =
 			minTimeout: COORDINATOR_REGISTRY_LOCK_RETRY_MS,
 			maxTimeout: COORDINATOR_REGISTRY_LOCK_RETRY_MS,
 		},
+		// Never rethrow: proper-lockfile invokes this from a filesystem callback.
+		onCompromised: () => {},
 	});
 	try {
 		return await action();

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -193,6 +193,8 @@ function withLeaseGuard<T>(directory: string, action: () => T): T {
 				realpath: false,
 				lockfilePath: `${directory}.guard`,
 				stale: 5000,
+				// Never rethrow: proper-lockfile invokes this from a filesystem callback.
+				onCompromised: () => {},
 			});
 			break;
 		} catch (error) {

--- a/packages/coding-agent/src/modes/daemon/daemon-socket.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-socket.ts
@@ -15,11 +15,25 @@ const DAEMON_SOCKET_LOCK_UPDATE_MS = 1000;
 
 export class DaemonSocketPathLease {
 	private released = false;
+	private compromised: Error | undefined;
 
 	constructor(
 		readonly socketPath: string,
 		private readonly releaseLock: () => Promise<void>,
 	) {}
+
+	/**
+	 * Record that another process stole this lease after judging it stale. Callers
+	 * observe it through assertSocketLease, which fails where the lease is actually
+	 * relied on rather than from inside a filesystem callback.
+	 */
+	markCompromised(error: Error): void {
+		this.compromised ??= error;
+	}
+
+	get compromisedError(): Error | undefined {
+		return this.compromised;
+	}
 
 	async release(): Promise<void> {
 		if (this.released) {
@@ -47,6 +61,7 @@ export async function acquireDaemonSocketPathLease(socketPath: string): Promise<
 	if (process.platform === "win32") {
 		return undefined;
 	}
+	let lease: DaemonSocketPathLease | undefined;
 	const releaseLock = await lockfile.lock(socketPath, {
 		realpath: false,
 		stale: DAEMON_SOCKET_LOCK_STALE_MS,
@@ -57,8 +72,14 @@ export async function acquireDaemonSocketPathLease(socketPath: string): Promise<
 			minTimeout: DAEMON_SOCKET_RELEASE_POLL_MS,
 			maxTimeout: DAEMON_SOCKET_RELEASE_POLL_MS,
 		},
+		// proper-lockfile defaults onCompromised to `throw err`, and it calls it from
+		// inside the mtime-refresh filesystem callback. This lease is held for the
+		// supervisor's whole lifetime, so a stall past `stale` that lets another
+		// process steal it would take the supervisor down with an uncaught exception.
+		onCompromised: (error) => lease?.markCompromised(error),
 	});
-	return new DaemonSocketPathLease(socketPath, releaseLock);
+	lease = new DaemonSocketPathLease(socketPath, releaseLock);
+	return lease;
 }
 
 export async function prepareDaemonSocketPath(socketPath: string, lease?: DaemonSocketPathLease): Promise<void> {
@@ -69,6 +90,10 @@ export async function prepareDaemonSocketPath(socketPath: string, lease?: Daemon
 	}
 	if (lease) {
 		assertSocketLease(socketPath, lease);
+		const compromised = lease.compromisedError;
+		if (compromised) {
+			throw new Error(`Daemon socket lease for ${socketPath} was compromised: ${compromised.message}`);
+		}
 		await prepareUnixDaemonSocketPath(socketPath);
 		return;
 	}
@@ -159,6 +184,11 @@ export function cleanupDaemonSocketPath(
 	}
 	if (lease) {
 		assertSocketLease(socketPath, lease);
+		if (lease.compromisedError) {
+			// Another process took the lease over, so the socket at this path may be
+			// its own. Leave it alone rather than unlinking a live successor's socket.
+			return;
+		}
 		try {
 			cleanupUnixDaemonSocketPath(socketPath, expectedIdentity);
 		} catch {
@@ -173,6 +203,7 @@ export function cleanupDaemonSocketPath(
 			stale: DAEMON_SOCKET_LOCK_STALE_MS,
 			update: DAEMON_SOCKET_LOCK_UPDATE_MS,
 			retries: 0,
+			onCompromised: () => {},
 		});
 	} catch {
 		return;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor-ownership.ts
@@ -367,6 +367,10 @@ async function withDaemonSupervisorRegistryGuard<T>(registryDir: string, action:
 			minTimeout: REGISTRY_LOCK_RETRY_MS,
 			maxTimeout: REGISTRY_LOCK_RETRY_MS,
 		},
+		// Never rethrow: proper-lockfile invokes this from a filesystem callback, so a
+		// throw here is an uncaught exception rather than a failure the guard can
+		// report. The guarded action still runs and the release below is a no-op.
+		onCompromised: () => {},
 	});
 	try {
 		return await action();

--- a/packages/coding-agent/test/daemon-socket-lease-compromise.test.ts
+++ b/packages/coding-agent/test/daemon-socket-lease-compromise.test.ts
@@ -1,0 +1,59 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	acquireDaemonSocketPathLease,
+	cleanupDaemonSocketPath,
+	prepareDaemonSocketPath,
+} from "../src/modes/daemon/daemon-socket.js";
+
+const isWindows = process.platform === "win32";
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe.skipIf(isWindows)("daemon socket path lease", () => {
+	// proper-lockfile refreshes the lock's mtime on a timer and, when that refresh
+	// finds the lock gone, calls onCompromised - which defaults to rethrowing from
+	// inside the filesystem callback. The supervisor holds this lease for its whole
+	// lifetime and installs no uncaughtException handler, so a lock steal used to
+	// take the entire control plane down. Any regression surfaces here as an
+	// unhandled error rather than as a failed assertion.
+	it("records a stolen lease instead of throwing from the refresh callback", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-socket-lease-"));
+		const socketPath = join(dir, "daemon.sock");
+
+		const lease = await acquireDaemonSocketPathLease(socketPath);
+		expect(lease).toBeDefined();
+		if (!lease) return;
+
+		// Simulate another process judging the lock stale and taking it over.
+		rmSync(`${socketPath}.lock`, { recursive: true, force: true });
+		await delay(2_000);
+
+		expect(lease.compromisedError).toBeDefined();
+		await lease.release().catch(() => undefined);
+		rmSync(dir, { recursive: true, force: true });
+	}, 15_000);
+
+	it("fails startup and skips cleanup once the lease is compromised", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-socket-lease-"));
+		const socketPath = join(dir, "daemon.sock");
+
+		const lease = await acquireDaemonSocketPathLease(socketPath);
+		expect(lease).toBeDefined();
+		if (!lease) return;
+
+		rmSync(`${socketPath}.lock`, { recursive: true, force: true });
+		await delay(2_000);
+
+		await expect(prepareDaemonSocketPath(socketPath, lease)).rejects.toThrow(/compromised/);
+		// Cleanup must not unlink a path a successor may already own, and must not throw.
+		expect(() => cleanupDaemonSocketPath(socketPath, undefined, lease)).not.toThrow();
+
+		await lease.release().catch(() => undefined);
+		rmSync(dir, { recursive: true, force: true });
+	}, 15_000);
+});


### PR DESCRIPTION
## Problem

`proper-lockfile` defaults `onCompromised` to `(err) => { throw err; }` and calls it from `setLockAsCompromised`, which runs inside the lock's mtime-refresh filesystem callback. A throw there is an uncaught exception, not something the caller can handle.

None of the daemon's four lock sites pass the option:

- `modes/daemon/daemon-socket.ts` (socket-path lease, and the sync cleanup lock)
- `modes/daemon/daemon-supervisor-ownership.ts` (registry guard)
- `cli/daemon-update-restart.ts` (coordinator guard)
- `core/session-lease.ts` (lease guard)

`core/auth-storage.ts` already passes `onCompromised`, which is what the correct handling looks like.

## Impact

The socket-path lease is the dangerous one. The supervisor acquires it at startup and holds it until it exits, while the refresh runs on a `setTimeout` that cannot fire while the event loop is blocked — and the supervisor blocks it routinely: `execFileSync("ps")` for process identity, `Atomics.wait` in the session-lease guard, `readFileSync` journal loads.

A stall past the 5s `stale` window lets a second supervisor declare the lock stale, `rmdir` it, and take over. The first supervisor's next refresh then throws `ECOMPROMISED`. `daemon-supervisor.ts` installs no `uncaughtException` handler (a repo-wide grep finds them only in `daemon-mode.ts`), so the process dies outright and every session's control plane goes with it.

## Fix

Record the loss on the lease instead of throwing, and act on it where it actually matters:

- `prepareDaemonSocketPath` fails startup loudly with a clear message
- `cleanupDaemonSocketPath` skips the unlink, because the socket at that path may already belong to the successor that stole the lease

The other three sites get a non-throwing handler for the same reason: nothing may throw from that callback.

## Tests

Adds `packages/coding-agent/test/daemon-socket-lease-compromise.test.ts`, which acquires a lease and then removes the lockfile to simulate a steal. On `main` the run reports unhandled errors from the refresh callback and both assertions fail.

All 33 existing daemon/socket/lease/supervisor suites (690 tests) still pass.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix compromised lockfile events to prevent daemon supervisor crashes
> - Adds `onCompromised: () => {}` to `proper-lockfile` calls across daemon socket, session lease, coordinator registry, and supervisor registry guards so that lockfile compromise events no longer throw from filesystem callbacks.
> - Introduces a `compromised` state on `DaemonSocketPathLease` via `markCompromised(error)` and `compromisedError` getter, allowing callers to detect and react to stolen leases without crashing.
> - `prepareDaemonSocketPath` now throws a descriptive error when passed a compromised lease; `cleanupDaemonSocketPath` skips unlinking in the same case.
> - Adds integration tests in [daemon-socket-lease-compromise.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1550/files#diff-23e28ca99ee778da216e58891c67aaefa2a70708a744060e8ba751422854073b) that simulate lock theft and verify correct behavior (skipped on Windows).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d310e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->