### PR TITLE
feat(coding-agent): sweep empty ghost sessions when opening the agents view

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- The agents view now sweeps abandoned empty sessions on entry (#1531): ghost "(no messages)" files are deleted unless they are open in the daemon, leased by a live process, or bound to scheduled jobs; dead-owner session leases are reclaimed so those rows stop resolving as active.
 - Fixed large IPython variables repeatedly slowing later turns by excluding them from persistent snapshots and removing them when context is compacted.
 - Fixed daemon socket paths being used verbatim in identity derivations: on supported platforms, `--daemon-socket` spellings differing only by duplicate or trailing slashes now normalize to one canonical path, so worker-descriptor namespaces, daemon log files, and persisted descriptors agree.
 - Added a `thinking` option to `rlm.run` for spawning subagents with an explicit reasoning level; invalid levels for the resolved child model fail spawn.

--- a/packages/coding-agent/src/core/session-file-actions.ts
+++ b/packages/coding-agent/src/core/session-file-actions.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { rm, unlink } from "node:fs/promises";
-import { basename } from "node:path";
+import { basename, join } from "node:path";
 import { getSessionArtifactPathForFile } from "./session-manager.js";
 
 export type DeleteSessionFileResult = { ok: true; method: "trash" | "unlink" } | { ok: false; error: string };
@@ -71,4 +71,65 @@ export async function deleteSessionFile(
 		await deleteSessionArtifacts(sessionPath);
 	}
 	return result;
+}
+
+// Entry types present from session bootstrap alone; a file holding only these
+// plus session_state never received a message or user configuration.
+const EMPTY_SESSION_ENTRY_TYPES = new Set([
+	"session",
+	"model_change",
+	"thinking_level_change",
+	"service_tier_change",
+	"session_state",
+]);
+
+/**
+ * True when a session file is an abandoned empty draft: no messages and no
+ * user content, only bootstrap entries and daemon-written session_state.
+ */
+export function isEmptySessionFile(sessionPath: string): boolean {
+	let content: string;
+	try {
+		content = readFileSync(sessionPath, "utf8");
+	} catch {
+		return false;
+	}
+	let sawHeader = false;
+	for (const line of content.split("\n")) {
+		if (!line.trim()) continue;
+		let entry: { type?: unknown };
+		try {
+			entry = JSON.parse(line);
+		} catch {
+			return false;
+		}
+		if (typeof entry.type !== "string" || !EMPTY_SESSION_ENTRY_TYPES.has(entry.type)) {
+			return false;
+		}
+		if (entry.type === "session") sawHeader = true;
+	}
+	return sawHeader;
+}
+
+/**
+ * Delete abandoned empty session files from a session directory. `shouldSkip`
+ * lets the caller exclude files that are live in some other way (open in the
+ * daemon, leased by a live process, or bound to scheduled jobs).
+ */
+export async function sweepEmptySessionFiles(
+	sessionDir: string,
+	shouldSkip: (sessionPath: string) => boolean,
+): Promise<string[]> {
+	if (!existsSync(sessionDir)) return [];
+	const removed: string[] = [];
+	for (const entry of readdirSync(sessionDir)) {
+		if (!entry.endsWith(".jsonl")) continue;
+		const sessionPath = join(sessionDir, entry);
+		if (!isEmptySessionFile(sessionPath) || shouldSkip(sessionPath)) continue;
+		const result = await deleteSessionFile(sessionPath).catch(() => undefined);
+		if (result?.ok) {
+			removed.push(sessionPath);
+		}
+	}
+	return removed;
 }

--- a/packages/coding-agent/src/core/session-lease.ts
+++ b/packages/coding-agent/src/core/session-lease.ts
@@ -229,6 +229,23 @@ function reclaimStaleLease(directory: string): boolean {
 	return true;
 }
 
+/**
+ * True when another live process holds a lease on this session. A lease whose
+ * owner is dead is reclaimed on the spot so it stops blocking deletion.
+ */
+export function hasLiveSessionLease(sessionPath: string, agentDir: string): boolean {
+	const directory = leaseDirectory(agentDir, canonicalSessionPath(sessionPath));
+	if (!existsSync(directory)) {
+		return false;
+	}
+	const owner = readLeaseOwner(directory);
+	if (owner && isLeaseOwnerAlive(owner)) {
+		return true;
+	}
+	reclaimStaleLease(directory);
+	return false;
+}
+
 export function acquireSessionLease(
 	sessionPath: string | undefined,
 	agentDir: string,

--- a/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-mode.ts
@@ -43,6 +43,7 @@ import {
 	deleteDaemonSavedSession,
 	listDaemonSavedSessions,
 	renameDaemonSavedSession,
+	sweepDaemonEmptySessions,
 } from "../daemon/saved-session-catalog.js";
 import { CustomEditor } from "../interactive/components/custom-editor.js";
 import { keyText } from "../interactive/components/keybinding-hints.js";
@@ -861,7 +862,7 @@ export class AgentsViewMode implements Component, Focusable {
 			this.resolveRun = resolve;
 		});
 		void this.refreshSessions();
-		void this.refreshSavedSessions();
+		void this.sweepEmptySessionsThenRefreshSaved();
 		void this.refreshHeartbeats();
 		this.loadStartupNotices();
 		this.pollTimer = setInterval(() => this.pollSessions(), POLL_INTERVAL_MS);
@@ -2177,6 +2178,21 @@ export class AgentsViewMode implements Component, Focusable {
 			this.refreshSavedSessions({ preserveStatusOnError: true }),
 		]);
 		return results.every(Boolean);
+	}
+
+	/**
+	 * Entry-time cleanup: delete abandoned empty session files (the "(no
+	 * messages)" ghost rows) before loading the saved-session catalog. The
+	 * daemon skips sessions that are open, leased by a live process, or bound
+	 * to scheduled jobs. Best-effort: sweep failures never block the catalog.
+	 */
+	private async sweepEmptySessionsThenRefreshSaved(): Promise<void> {
+		try {
+			await sweepDaemonEmptySessions(this.requireClient());
+		} catch {
+			// Older daemons without the command or transient failures: just load the catalog.
+		}
+		await this.refreshSavedSessions();
 	}
 
 	private async refreshSavedSessions(

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -96,8 +96,13 @@ import {
 	type IdleEvictionMinutes,
 	type SessionPassivationSnapshot,
 } from "../../core/session-action-store.js";
-import { deleteSessionArtifacts, deleteSessionFile } from "../../core/session-file-actions.js";
-import { acquireSessionLease, canonicalSessionPath, type SessionLease } from "../../core/session-lease.js";
+import { deleteSessionArtifacts, deleteSessionFile, sweepEmptySessionFiles } from "../../core/session-file-actions.js";
+import {
+	acquireSessionLease,
+	canonicalSessionPath,
+	hasLiveSessionLease,
+	type SessionLease,
+} from "../../core/session-lease.js";
 import {
 	getSessionArtifactPathForFile,
 	readSessionInfo,
@@ -257,6 +262,7 @@ const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"restore_actions",
 	"append_custom_message",
 	"resume_queue",
+	"sweep_empty_sessions",
 	"send_message",
 	"agent_messages_status",
 	"agent_messages_pause",
@@ -4225,6 +4231,31 @@ export class AgentDaemon {
 					return failure(command.id, "resume_queue", error, serializeDaemonError(error));
 				}
 				return success(command.id, "resume_queue");
+			}
+
+			case "sweep_empty_sessions": {
+				const sessionDir =
+					command.sessionDir ?? this.options.defaultSessionConfig.sessionDir ?? getSessionsDir(this.agentDir);
+				const hasJobsForFile = (sessionPath: string) => {
+					const target = resolve(sessionPath);
+					return this.cronStore
+						.list()
+						.some(
+							(job) =>
+								resolve(job.sessionFile) === target && job.status !== "cancelled" && job.status !== "completed",
+						);
+				};
+				const removed = await sweepEmptySessionFiles(
+					sessionDir,
+					(sessionPath) =>
+						this.findActiveSessionByFile(sessionPath) !== undefined ||
+						hasLiveSessionLease(sessionPath, this.agentDir) ||
+						hasJobsForFile(sessionPath),
+				);
+				if (removed.length > 0) {
+					this.log(`swept ${removed.length} empty session file(s)`);
+				}
+				return success(command.id, "sweep_empty_sessions", { removed });
 			}
 
 			case "send_message": {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -60,8 +60,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 14 carries the client's monotonic telemetry opt-out on attach and reattach.
 // Revision 15 adds the mutate_queued_message command and queue_message_mutation capability.
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
-export const DAEMON_SCHEMA_REVISION = 16;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-16-1bcb9e7f1a49";
+// Revision 17 adds the sweep_empty_sessions command.
+export const DAEMON_SCHEMA_REVISION = 17;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-1bcb9e7f1a49";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -464,6 +465,7 @@ export type DaemonCommand =
 			message: Pick<CustomMessage, "customType" | "content" | "display" | "details">;
 	  }
 	| { id?: string; type: "resume_queue"; activeSessionId: string }
+	| { id?: string; type: "sweep_empty_sessions"; sessionDir?: string }
 	| {
 			id?: string;
 			type: "send_message";
@@ -671,6 +673,7 @@ export const DAEMON_COMMAND_COMPATIBILITY = {
 	restore_actions: LEGACY_DAEMON_COMMAND,
 	append_custom_message: LEGACY_DAEMON_COMMAND,
 	resume_queue: SESSION_INPUT_ADMISSION_COMMAND,
+	sweep_empty_sessions: { minProtocol: 7, minSchemaRevision: 17 },
 	send_message: LEGACY_DAEMON_COMMAND,
 	agent_messages_status: LEGACY_DAEMON_COMMAND,
 	agent_messages_pause: LEGACY_DAEMON_COMMAND,
@@ -833,6 +836,10 @@ export interface DaemonSavedSessionInfo {
 }
 
 export type DaemonDeleteSavedSessionResult = DeleteSessionFileResult;
+
+export interface DaemonSweepEmptySessionsResult {
+	removed: string[];
+}
 export type DaemonAutonomousStatus = AgentAutonomousStatus;
 export type DaemonBashResult = BashResult;
 export type DaemonSessionHeader = AgentConnectionSessionHeader;

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -62,7 +62,7 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 16 adds the "stopping" workerState and stops reporting disconnected workers as "ready".
 // Revision 17 adds the sweep_empty_sessions command.
 export const DAEMON_SCHEMA_REVISION = 17;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-1bcb9e7f1a49";
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-17-89941bf71da6";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;

--- a/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
+++ b/packages/coding-agent/src/modes/daemon/saved-session-catalog.ts
@@ -11,6 +11,7 @@ import type {
 	DaemonDeleteSavedSessionResult,
 	DaemonSavedSessionInfo,
 	DaemonSavedSessionListCommand,
+	DaemonSweepEmptySessionsResult,
 } from "./daemon-protocol.js";
 import { deserializeSavedSessionInfo } from "./saved-session-info.js";
 
@@ -42,6 +43,18 @@ export async function listDaemonSavedSessions(
 	}
 	const data = response.data as { sessions: DaemonSavedSessionInfo[] };
 	return data.sessions.map(deserializeSavedSessionInfo);
+}
+
+export async function sweepDaemonEmptySessions(client: DaemonClient, sessionDir?: string): Promise<string[]> {
+	const command: Extract<DaemonCommand, { type: "sweep_empty_sessions" }> = {
+		type: "sweep_empty_sessions",
+		...(sessionDir ? { sessionDir } : {}),
+	};
+	const response = await client.request(command);
+	if (!response.success) {
+		throw deserializeDaemonError(response);
+	}
+	return (response.data as DaemonSweepEmptySessionsResult).removed;
 }
 
 export async function renameDaemonSavedSession(

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
 import {
 	chmodSync,
@@ -8414,6 +8415,84 @@ describe("daemon mode helpers", () => {
 				status: "cancelled",
 			});
 			expect(internals.cronStore.list().find((job) => job.id === unrelated.id)).toMatchObject({ status: "active" });
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("sweeps empty session files but keeps active, leased, and job-bound ones", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-empty-sweep-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			mkdirSync(sessionDir, { recursive: true });
+			const ghostEntries = [
+				{ type: "session", id: "s1", timestamp: new Date(0).toISOString(), cwd: tempDir },
+				{ type: "session_state", state: { status: "active" } },
+			];
+			const writeSession = (name: string, entries: object[]): string => {
+				const path = join(sessionDir, name);
+				writeFileSync(path, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+				return path;
+			};
+			const ghost = writeSession("ghost.jsonl", ghostEntries);
+			const active = writeSession("active.jsonl", ghostEntries);
+			const leased = writeSession("leased.jsonl", ghostEntries);
+			const scheduled = writeSession("scheduled.jsonl", ghostEntries);
+			const real = writeSession("real.jsonl", [
+				...ghostEntries,
+				{ type: "message", message: { role: "user", content: "hi" } },
+			]);
+			const leaseKey = createHash("sha256").update(canonicalSessionPath(leased)).digest("hex");
+			const leaseDir = join(tempDir, "session-leases", `${leaseKey}.lock`);
+			mkdirSync(leaseDir, { recursive: true });
+			writeFileSync(
+				join(leaseDir, "owner.json"),
+				JSON.stringify({
+					version: 1,
+					token: "t",
+					pid: process.pid,
+					sessionPath: leased,
+					createdAt: new Date(0).toISOString(),
+				}),
+			);
+
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime: async () => {
+					throw new Error("unexpected runtime creation");
+				},
+			});
+			const internals = daemon as unknown as {
+				cronStore: AgentCronJobStore;
+				sessions: Map<string, ActiveSessionState>;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			};
+			const state = makeState("active-1");
+			state.runtime = {
+				metadata: { kind: "subagent", createdAt: 1 },
+				session: { sessionFile: active },
+			} as never;
+			internals.sessions.set(state.activeSessionId, state);
+			internals.cronStore.create({
+				activeSessionId: "active-2",
+				sessionId: "session-2",
+				sessionFile: scheduled,
+				cwd: tempDir,
+				scheduleText: "in 1h",
+				prompt: "keep scheduled session",
+			});
+
+			const response = (await internals.handleCommand(makeClient("client-1", "detached"), {
+				id: "sweep-1",
+				type: "sweep_empty_sessions",
+			})) as { data: { removed: string[] } };
+
+			expect(response.data.removed).toEqual([ghost]);
+			expect(existsSync(ghost)).toBe(false);
+			expect(existsSync(active)).toBe(true);
+			expect(existsSync(leased)).toBe(true);
+			expect(existsSync(scheduled)).toBe(true);
+			expect(existsSync(real)).toBe(true);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/session-sweep.test.ts
+++ b/packages/coding-agent/test/session-sweep.test.ts
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isEmptySessionFile, sweepEmptySessionFiles } from "../src/core/session-file-actions.js";
+import { canonicalSessionPath, hasLiveSessionLease } from "../src/core/session-lease.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const directory of tempDirs.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function createTempDir(): string {
+	const directory = mkdtempSync(join(tmpdir(), "prime-session-sweep-test-"));
+	tempDirs.push(directory);
+	return directory;
+}
+
+function writeSessionFile(dir: string, name: string, entries: object[]): string {
+	const path = join(dir, name);
+	writeFileSync(path, entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n");
+	return path;
+}
+
+const header = { type: "session", id: "s1", timestamp: new Date(0).toISOString(), cwd: "/tmp" };
+const ghostEntries = [
+	header,
+	{ type: "model_change", model: "m" },
+	{ type: "thinking_level_change", level: "medium" },
+	{ type: "service_tier_change", tier: "default" },
+	{ type: "session_state", state: { status: "active" } },
+];
+
+function writeLease(agentDir: string, sessionPath: string, pid: number): string {
+	const key = createHash("sha256").update(canonicalSessionPath(sessionPath)).digest("hex");
+	const lockDirectory = join(agentDir, "session-leases", `${key}.lock`);
+	mkdirSync(lockDirectory, { recursive: true });
+	writeFileSync(
+		join(lockDirectory, "owner.json"),
+		JSON.stringify({
+			version: 1,
+			token: "t",
+			pid,
+			sessionPath,
+			createdAt: new Date(0).toISOString(),
+		}),
+	);
+	return lockDirectory;
+}
+
+describe("isEmptySessionFile", () => {
+	it("detects a ghost draft with only bootstrap entries and session_state", () => {
+		const dir = createTempDir();
+		expect(isEmptySessionFile(writeSessionFile(dir, "ghost.jsonl", ghostEntries))).toBe(true);
+	});
+
+	it("keeps sessions with messages or user content", () => {
+		const dir = createTempDir();
+		const withMessage = writeSessionFile(dir, "msg.jsonl", [
+			...ghostEntries,
+			{ type: "message", message: { role: "user", content: "hi" } },
+		]);
+		const named = writeSessionFile(dir, "named.jsonl", [...ghostEntries, { type: "session_info", name: "kept" }]);
+		expect(isEmptySessionFile(withMessage)).toBe(false);
+		expect(isEmptySessionFile(named)).toBe(false);
+	});
+
+	it("keeps files without a session header or with unparseable lines", () => {
+		const dir = createTempDir();
+		const headerless = writeSessionFile(dir, "headerless.jsonl", [
+			{ type: "session_state", state: { status: "active" } },
+		]);
+		const garbled = join(dir, "garbled.jsonl");
+		writeFileSync(garbled, "not json\n");
+		expect(isEmptySessionFile(headerless)).toBe(false);
+		expect(isEmptySessionFile(garbled)).toBe(false);
+	});
+});
+
+describe("sweepEmptySessionFiles", () => {
+	it("removes ghosts, keeps real sessions, and honors shouldSkip", async () => {
+		const dir = createTempDir();
+		const ghost = writeSessionFile(dir, "ghost.jsonl", ghostEntries);
+		const skipped = writeSessionFile(dir, "skipped.jsonl", ghostEntries);
+		const real = writeSessionFile(dir, "real.jsonl", [
+			...ghostEntries,
+			{ type: "message", message: { role: "user", content: "hi" } },
+		]);
+
+		const removed = await sweepEmptySessionFiles(dir, (path) => path === skipped);
+
+		expect(removed).toEqual([ghost]);
+		expect(existsSync(ghost)).toBe(false);
+		expect(existsSync(skipped)).toBe(true);
+		expect(existsSync(real)).toBe(true);
+	});
+});
+
+describe("hasLiveSessionLease", () => {
+	it("is false without a lease", () => {
+		const agentDir = createTempDir();
+		expect(hasLiveSessionLease(join(agentDir, "s.jsonl"), agentDir)).toBe(false);
+	});
+
+	it("is true while the owner process is alive", () => {
+		const agentDir = createTempDir();
+		const sessionPath = join(agentDir, "s.jsonl");
+		writeLease(agentDir, sessionPath, process.pid);
+		expect(hasLiveSessionLease(sessionPath, agentDir)).toBe(true);
+	});
+
+	it("reclaims a dead-owner lease and reports it as not live", () => {
+		const agentDir = createTempDir();
+		const sessionPath = join(agentDir, "s.jsonl");
+		const lockDirectory = writeLease(agentDir, sessionPath, 2_147_483_647);
+		expect(hasLiveSessionLease(sessionPath, agentDir)).toBe(false);
+		expect(existsSync(lockDirectory)).toBe(false);
+	});
+});


### PR DESCRIPTION
## What this does

Fixes the "(no messages)" ghost-row pollution from discussion #1531 by cleaning up empty sessions when the user enters the agents view. Sessions are cheap to recreate (ctrl+n / `/new`), so abandoned empty drafts get deleted instead of accumulating.

## How it works

New daemon command `sweep_empty_sessions`: deletes session files from the session directory that hold nothing but bootstrap entries (`session`, `model_change`, `thinking_level_change`, `service_tier_change`) and daemon-written `session_state` — no messages, no user content. A file is skipped when it is:

- open in the daemon (`findActiveSessionByFile`)
- leased by a **live** process — and reading a lease now reclaims it on the spot when its owner PID is dead (`hasLiveSessionLease`), which also unblocks the "Session became active; stop it before deleting" dead-lease failure mode from #1531
- bound to active/paused scheduled jobs (cron/heartbeats, matched by session file)

The agents view fires the sweep once on entry, before loading the saved-session catalog. Best-effort: sweep failures (including older daemons without the command) never block the catalog. Protocol schema revision bumps to 17.

Deletion reuses `deleteSessionFile` (trash-first, artifacts cleanup) — same path as manual Ctrl+X.

## Relation to #1079

Ships the spirit of that PR's safe half (bisected safe by the #1531 reporter): sweep + dead-lease reclaim. It deliberately does NOT touch `shouldPersistWithoutAssistant`/persistence semantics — the half the reporter bisected as the regression (it broke passive-session discovery). Legitimate passive RLM children are protected here by the live-lease and open-in-daemon guards rather than by file shape.

## Tests

- `session-sweep.test.ts`: empty-file detection (ghost / with-message / named / headerless / garbled), sweep with skip guard, lease liveness (absent / live / dead-owner reclaim)
- `daemon-mode.test.ts`: end-to-end command test — sweeps the ghost, keeps active, leased, job-bound, and real sessions

All touched suites green (daemon-mode 199, session-lease/artifacts, agents-view suites 116); full typecheck + biome clean.

Linear: [ENG-5326](https://linear.app/primeintellect/issue/ENG-5326/agents-view-sweep-empty-ghost-sessions-on-entry-1531)
Related: #1531, #1079

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e0d17593eefa96a720af2f6e2033dac05f618344. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sweep empty ghost sessions when opening the agents view
> - Adds a `sweep_empty_sessions` daemon command that scans a session directory for `.jsonl` files containing only bootstrap entries (no user messages) and deletes them.
> - Sessions are protected from deletion if they are open in the daemon, held by a live lease, or bound to an incomplete scheduled job; stale leases from dead processes are reclaimed in place.
> - On entering the agents view, `AgentsViewMode` requests the daemon to sweep ghost sessions before loading the saved-session catalog; sweep failures are swallowed so catalog load still proceeds.
> - Bumps the daemon protocol schema to revision 17 with a compatibility gate on `minSchemaRevision 17` for the new command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb9cc61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->