### PR TITLE
fix(ai): map z.ai thinking off to reasoning_effort "none" for GLM-5.2/5.3

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Fixed z.ai GLM-5.2 and GLM-5.3 requests failing with a 400 when thinking was disabled: the coding endpoint rejects `enable_thinking: false` for effort-capable models, so thinking-off now maps to `reasoning_effort: "none"` and the supported efforts are exposed; proxied z.ai routes (Prime Inference) stay toggle-only.
+- Regenerated the provider catalog, including z.ai reasoning-effort metadata.
+
 ## [0.7.3] - 2026-08-17
 
 - Added provider-derived reasoning levels for OpenRouter and Prime Inference models, including sparse, mandatory, toggle-only, and explicit-off capabilities.

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -17,7 +17,9 @@ import {
 	type AnthropicMessagesCompat,
 	KnownProvider,
 	Model,
+	type ModelThinkingLevel,
 	type OpenAICompletionsCompat,
+	type ThinkingLevelMap,
 } from "../src/types.js";
 import { MODELS as EXISTING_MODELS } from "../src/models.generated.js";
 
@@ -25,11 +27,17 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageRoot = join(__dirname, "..");
 
+interface ModelsDevReasoningOption {
+	type?: string;
+	values?: string[];
+}
+
 interface ModelsDevModel {
 	id: string;
 	name: string;
 	tool_call?: boolean;
 	reasoning?: boolean;
+	reasoning_options?: ModelsDevReasoningOption[];
 	limit?: {
 		context?: number;
 		output?: number;
@@ -111,6 +119,22 @@ const ZAI_THINKING_COMPAT: OpenAICompletionsCompat = {
 	supportsReasoningEffort: false,
 	thinkingFormat: "zai",
 };
+
+// On the z.ai coding endpoint, effort-capable GLM models (5.2+) reject
+// enable_thinking: false; disabling thinking is expressed as reasoning_effort
+// "none" instead (verified against the endpoint; z.ai thinking docs).
+const ZAI_EFFORT_LEVELS: readonly ModelThinkingLevel[] = ["minimal", "low", "medium", "high", "xhigh", "max"];
+
+function buildZaiThinkingLevelMap(model: ModelsDevModel): ThinkingLevelMap | undefined {
+	const efforts = model.reasoning_options?.find((option) => option.type === "effort")?.values;
+	if (!efforts?.length) return undefined;
+	const supported = new Set(efforts);
+	const thinkingLevelMap: ThinkingLevelMap = { off: "none" };
+	for (const level of ZAI_EFFORT_LEVELS) {
+		thinkingLevelMap[level] = supported.has(level) ? level : null;
+	}
+	return thinkingLevelMap;
+}
 
 const PRIME_INFERENCE_BASE_URL = "https://api.pinference.ai/api/v1";
 const PRIME_INFERENCE_COMPAT: OpenAICompletionsCompat = {
@@ -1165,6 +1189,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 				const m = model as ModelsDevModel;
 				if (m.tool_call !== true) continue;
 				const supportsImage = m.modalities?.input?.includes("image");
+				const thinkingLevelMap = buildZaiThinkingLevelMap(m);
 
 				models.push({
 					id: modelId,
@@ -1182,9 +1207,14 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					},
 					compat: {
 						supportsDeveloperRole: false,
+						// The direct z.ai endpoint accepts reasoning_effort for
+						// effort-capable GLM models; proxies of the same models
+						// (e.g. Prime Inference) stay toggle-only.
+						...(thinkingLevelMap ? { supportsReasoningEffort: true } : {}),
 						thinkingFormat: ZAI_THINKING_COMPAT.thinkingFormat,
 						...(!ZAI_TOOL_STREAM_UNSUPPORTED_MODELS.has(modelId) ? { zaiToolStream: true } : {}),
 					},
+					...(thinkingLevelMap ? { thinkingLevelMap } : {}),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 				});

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -21839,8 +21839,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"supportsReasoningEffort":true,"thinkingFormat":"zai","zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"off":"none","minimal":null,"low":null,"medium":null,"high":"high","xhigh":null,"max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,
@@ -21857,8 +21858,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"supportsReasoningEffort":true,"thinkingFormat":"zai","zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"off":"none","minimal":null,"low":null,"medium":null,"high":"high","xhigh":null,"max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,
@@ -21875,8 +21877,9 @@ export const MODELS = {
 			api: "openai-completions",
 			provider: "zai",
 			baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			compat: {"supportsDeveloperRole":false,"thinkingFormat":"zai","zaiToolStream":true},
+			compat: {"supportsDeveloperRole":false,"supportsReasoningEffort":true,"thinkingFormat":"zai","zaiToolStream":true},
 			reasoning: true,
+			thinkingLevelMap: {"off":"none","minimal":null,"low":"low","medium":null,"high":"high","xhigh":null,"max":"max"},
 			input: ["text"],
 			cost: {
 				input: 0,

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -11,6 +11,7 @@ import type {
 	StreamOptions,
 	TextContent,
 	ThinkingContent,
+	ThinkingLevelMap,
 	ToolCall,
 	ToolResultMessage,
 	Usage,
@@ -38,6 +39,7 @@ export interface FauxModelDefinition {
 	id: string;
 	name?: string;
 	reasoning?: boolean;
+	thinkingLevelMap?: ThinkingLevelMap;
 	input?: ("text" | "image")[];
 	cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
 	contextWindow?: number;
@@ -426,6 +428,7 @@ export function registerFauxProvider(options: RegisterFauxProviderOptions = {}):
 		cost: definition.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: definition.contextWindow ?? 128000,
 		maxTokens: definition.maxTokens ?? 16384,
+		...(definition.thinkingLevelMap ? { thinkingLevelMap: { ...definition.thinkingLevelMap } } : {}),
 	})) as [Model<string>, ...Model<string>[]];
 
 	const stream: StreamFunction<string, StreamOptions> = (requestModel, context, streamOptions) => {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -566,7 +566,31 @@ function buildParams(
 	}
 
 	if (compat.thinkingFormat === "zai" && model.reasoning) {
-		(params as any).enable_thinking = !!options?.reasoningEffort;
+		// Effort-capable z.ai models reject enable_thinking: false; disabling
+		// thinking is expressed as reasoning_effort "none" instead. Proxied z.ai
+		// models (e.g. Prime Inference) are toggle-only. The compat flag is
+		// authoritative; map entries only translate levels, with identity and
+		// "none" fallbacks when a map is absent.
+		const offEntry = model.thinkingLevelMap?.off;
+		const offEffort = compat.supportsReasoningEffort ? (offEntry === undefined ? "none" : offEntry) : undefined;
+		const mappedEffort = options?.reasoningEffort ? model.thinkingLevelMap?.[options.reasoningEffort] : undefined;
+		const effort =
+			compat.supportsReasoningEffort && options?.reasoningEffort
+				? mappedEffort === undefined
+					? options.reasoningEffort
+					: mappedEffort
+				: undefined;
+		if (typeof effort === "string") {
+			(params as any).enable_thinking = true;
+			(params as any).reasoning_effort = effort;
+		} else if (options?.reasoningEnabled === false && typeof offEffort === "string") {
+			(params as any).enable_thinking = true;
+			(params as any).reasoning_effort = offEffort;
+		} else {
+			// Unspecified on effort-capable models keeps the provider default
+			// (thinking enabled); toggle-only routes keep the boolean toggle.
+			(params as any).enable_thinking = compat.supportsReasoningEffort ? true : !!options?.reasoningEffort;
+		}
 	} else if (compat.thinkingFormat === "qwen" && model.reasoning) {
 		(params as any).enable_thinking = !!options?.reasoningEffort;
 	} else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {

--- a/packages/ai/test/openai-completions-zai-thinking.test.ts
+++ b/packages/ai/test/openai-completions-zai-thinking.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clampThinkingLevel, getModel, getSupportedThinkingLevels } from "../src/models.js";
+import { streamSimple } from "../src/stream.js";
+
+const mockState = vi.hoisted(() => ({
+	lastParams: undefined as unknown,
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: (params: unknown) => {
+					mockState.lastParams = params;
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							yield {
+								choices: [{ delta: {}, finish_reason: "stop" }],
+								usage: {
+									prompt_tokens: 1,
+									completion_tokens: 1,
+									prompt_tokens_details: { cached_tokens: 0 },
+									completion_tokens_details: { reasoning_tokens: 0 },
+								},
+							};
+						},
+					};
+					const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+						withResponse: () => Promise<{
+							data: typeof stream;
+							response: { status: number; headers: Headers };
+						}>;
+					};
+					promise.withResponse = async () => ({
+						data: stream,
+						response: { status: 200, headers: new Headers() },
+					});
+					return promise;
+				},
+			},
+		};
+	}
+
+	return { default: FakeOpenAI };
+});
+
+async function captureParams(
+	modelId: "glm-4.7" | "glm-5.2" | "glm-5.3",
+	reasoning: "off" | "low" | "high" | undefined,
+) {
+	await streamSimple(
+		getModel("zai", modelId)!,
+		{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+		{ apiKey: "test", ...(reasoning ? { reasoning } : {}) },
+	).result();
+	return mockState.lastParams as { enable_thinking?: boolean; reasoning_effort?: string };
+}
+
+describe("z.ai thinking payload", () => {
+	beforeEach(() => {
+		mockState.lastParams = undefined;
+	});
+
+	it("maps GLM-5.3 thinking off to reasoning_effort none", () => {
+		const model = getModel("zai", "glm-5.3")!;
+		expect(getSupportedThinkingLevels(model)).toEqual(["off", "low", "high", "max"]);
+		expect(clampThinkingLevel(model, "off")).toBe("off");
+	});
+
+	it("keeps GLM-5.2 disable support and exposes high/max efforts", () => {
+		const model = getModel("zai", "glm-5.2")!;
+		expect(getSupportedThinkingLevels(model)).toEqual(["off", "high", "max"]);
+		expect(clampThinkingLevel(model, "off")).toBe("off");
+	});
+
+	it("disables GLM-5.3 thinking through reasoning_effort none", async () => {
+		const params = await captureParams("glm-5.3", "off");
+		expect(params.enable_thinking).toBe(true);
+		expect(params.reasoning_effort).toBe("none");
+	});
+
+	it("sends the mapped effort for GLM-5.3", async () => {
+		const params = await captureParams("glm-5.3", "high");
+		expect(params.enable_thinking).toBe(true);
+		expect(params.reasoning_effort).toBe("high");
+	});
+
+	it("disables GLM-5.2 thinking through reasoning_effort none", async () => {
+		const params = await captureParams("glm-5.2", "off");
+		expect(params.enable_thinking).toBe(true);
+		expect(params.reasoning_effort).toBe("none");
+	});
+
+	it("clamps unsupported GLM-5.2 levels to a supported effort", async () => {
+		const params = await captureParams("glm-5.2", "low");
+		expect(params.enable_thinking).toBe(true);
+		expect(params.reasoning_effort).toBe("high");
+	});
+
+	it("keeps thinking enabled without an effort when reasoning is unspecified for GLM-5.3", async () => {
+		const params = await captureParams("glm-5.3", undefined);
+		expect(params.enable_thinking).toBe(true);
+		expect(params.reasoning_effort).toBeUndefined();
+	});
+
+	it("keeps Prime Inference z.ai routes toggle-only even with an effort map", async () => {
+		const model = getModel("prime-inference", "z-ai/glm-5.2")!;
+		expect(model.compat?.supportsReasoningEffort).toBe(false);
+		expect(model.thinkingLevelMap?.high).toBe("high");
+
+		for (const reasoning of ["high", "off", undefined] as const) {
+			await streamSimple(
+				model,
+				{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+				{ apiKey: "test", ...(reasoning ? { reasoning } : {}) },
+			).result();
+
+			const params = mockState.lastParams as { enable_thinking?: boolean; reasoning_effort?: string };
+			expect(params.enable_thinking).toBe(reasoning === "high");
+			expect(params.reasoning_effort).toBeUndefined();
+		}
+	});
+
+	it("falls back to identity efforts for effort-capable models without a map", async () => {
+		const base = getModel("zai", "glm-5.2")!;
+		const model = { ...base, thinkingLevelMap: undefined };
+
+		await streamSimple(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test", reasoning: "high" },
+		).result();
+		let params = mockState.lastParams as { enable_thinking?: boolean; reasoning_effort?: string };
+		expect(params.enable_thinking).toBe(true);
+		expect(params.reasoning_effort).toBe("high");
+
+		await streamSimple(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test", reasoning: "off" },
+		).result();
+		params = mockState.lastParams as { enable_thinking?: boolean; reasoning_effort?: string };
+		expect(params.enable_thinking).toBe(true);
+		expect(params.reasoning_effort).toBe("none");
+	});
+
+	it("keeps the enable_thinking toggle for effort-less GLM models", async () => {
+		const enabled = await captureParams("glm-4.7", "high");
+		expect(enabled.enable_thinking).toBe(true);
+		expect(enabled.reasoning_effort).toBeUndefined();
+
+		const disabled = await captureParams("glm-4.7", "off");
+		expect(disabled.enable_thinking).toBe(false);
+		expect(disabled.reasoning_effort).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed `/btw` side questions, refinement, auto-refine review, compaction summaries, and branch summaries failing with a 400 on z.ai GLM-5.2/GLM-5.3: background completions now request thinking off explicitly, which the provider layer translates to the route's disable mechanism (`reasoning_effort: "none"` on z.ai), falling back to the lowest supported effort for mandatory-thinking models.
 - Fixed large IPython variables repeatedly slowing later turns by excluding them from persistent snapshots and removing them when context is compacted.
 - Fixed daemon socket paths being used verbatim in identity derivations: on supported platforms, `--daemon-socket` spellings differing only by duplicate or trailing slashes now normalize to one canonical path, so worker-descriptor namespaces, daemon log files, and persisted descriptors agree.
 - Added a `thinking` option to `rlm.run` for spawning subagents with an explicit reasoning level; invalid levels for the resolved child model fail spawn.

--- a/packages/coding-agent/src/core/background-thinking.ts
+++ b/packages/coding-agent/src/core/background-thinking.ts
@@ -1,0 +1,17 @@
+import { clampThinkingLevel, type Model, type ModelThinkingLevel } from "@earendil-works/pi-ai";
+
+/**
+ * Cheapest reasoning request for background (non-interactive) completions such
+ * as refinement, compaction, and status summaries. Requests thinking off when
+ * the model supports it (providers translate this to their disable mechanism,
+ * e.g. reasoning_effort "none" on z.ai GLM-5.2/5.3); mandatory-thinking models
+ * get their lowest supported effort. Returns undefined only for non-reasoning
+ * models.
+ */
+export function backgroundThinkingLevel(
+	model: Model<any>,
+	requested?: ModelThinkingLevel,
+): ModelThinkingLevel | undefined {
+	if (!model.reasoning) return undefined;
+	return clampThinkingLevel(model, requested ?? "off");
+}

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -8,6 +8,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Model } from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai";
+import { backgroundThinkingLevel } from "../background-thinking.js";
 import {
 	convertToLlm,
 	createBranchSummaryMessage,
@@ -279,10 +280,11 @@ export async function generateBranchSummary(
 			timestamp: Date.now(),
 		},
 	];
+	const reasoning = backgroundThinkingLevel(model);
 	const response = await completeSimple(
 		model,
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		{ apiKey, headers, signal, maxTokens: 2048 },
+		{ apiKey, headers, signal, maxTokens: 2048, ...(reasoning ? { reasoning } : {}) },
 	);
 	if (response.stopReason === "aborted") {
 		return { aborted: true };

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -8,6 +8,7 @@
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, Model, Usage } from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai";
+import { backgroundThinkingLevel } from "../background-thinking.js";
 import {
 	convertToLlm,
 	createBranchSummaryMessage,
@@ -536,10 +537,8 @@ export async function generateSummary(
 		},
 	];
 
-	const completionOptions =
-		model.reasoning && thinkingLevel && thinkingLevel !== "off"
-			? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-			: { maxTokens, signal, apiKey, headers };
+	const reasoning = backgroundThinkingLevel(model, thinkingLevel);
+	const completionOptions = { maxTokens, signal, apiKey, headers, ...(reasoning ? { reasoning } : {}) };
 
 	const response = await completeSimple(
 		model,
@@ -769,12 +768,11 @@ async function generateTurnPrefixSummary(
 		},
 	];
 
+	const reasoning = backgroundThinkingLevel(model, thinkingLevel);
 	const response = await completeSimple(
 		model,
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		model.reasoning && thinkingLevel && thinkingLevel !== "off"
-			? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-			: { maxTokens, signal, apiKey, headers },
+		{ maxTokens, signal, apiKey, headers, ...(reasoning ? { reasoning } : {}) },
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/coding-agent/src/core/refinement/refinement.ts
+++ b/packages/coding-agent/src/core/refinement/refinement.ts
@@ -14,6 +14,7 @@ import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core"
 import type { Model } from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai";
 import { getAgentDir } from "../../config.js";
+import { backgroundThinkingLevel } from "../background-thinking.js";
 import { serializeConversation } from "../compaction/utils.js";
 import { convertToLlm } from "../messages.js";
 import type { CustomEntry } from "../session-manager.js";
@@ -909,14 +910,16 @@ export async function planRefinement(
 	// final text, which makes otherwise successful daemon /refine calls fail parsing.
 	// Keep the refinement request non-reasoning regardless of the interactive session
 	// thinking level so the model uses its output budget for the JSON object.
+	// Mandatory-thinking models cannot disable reasoning; use their lowest effort.
 	void thinkingLevel;
+	const reasoning = backgroundThinkingLevel(model);
 	const response = await completeSimple(
 		model,
 		{
 			systemPrompt: REFINEMENT_SYSTEM_PROMPT,
 			messages: [{ role: "user", content: [{ type: "text", text: userPrompt }], timestamp: Date.now() }],
 		},
-		{ maxTokens: refinementMaxOutputTokens(model), signal, apiKey, headers },
+		{ maxTokens: refinementMaxOutputTokens(model), signal, apiKey, headers, ...(reasoning ? { reasoning } : {}) },
 	);
 
 	if (response.stopReason === "error") {
@@ -975,14 +978,22 @@ ${conversationText}
 	].join("\n\n");
 	// Auto-refine review requires parseable JSON. Keep it non-reasoning so
 	// reasoning-capable models use final text budget for the JSON object.
+	// Mandatory-thinking models cannot disable reasoning; use their lowest effort.
 	void thinkingLevel;
+	const reasoning = backgroundThinkingLevel(model);
 	const response = await completeSimple(
 		model,
 		{
 			systemPrompt: AUTO_REFINE_REVIEW_SYSTEM_PROMPT,
 			messages: [{ role: "user", content: [{ type: "text", text: userPrompt }], timestamp: Date.now() }],
 		},
-		{ maxTokens: autoRefineReviewMaxOutputTokens(model), signal, apiKey, headers },
+		{
+			maxTokens: autoRefineReviewMaxOutputTokens(model),
+			signal,
+			apiKey,
+			headers,
+			...(reasoning ? { reasoning } : {}),
+		},
 	);
 	if (response.stopReason === "error") {
 		throw new Error(`Auto-refine review failed: ${response.errorMessage || "Unknown error"}`);

--- a/packages/coding-agent/src/core/side-question.ts
+++ b/packages/coding-agent/src/core/side-question.ts
@@ -1,5 +1,5 @@
 import { Agent, type AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, UserMessage } from "@earendil-works/pi-ai";
+import { type AssistantMessage, clampThinkingLevel, type UserMessage } from "@earendil-works/pi-ai";
 
 export type SideQuestionStatus = "running" | "complete" | "cancelled" | "error";
 
@@ -50,6 +50,10 @@ export function startSideQuestion(
 	if (!model) {
 		throw new Error("Select a model before asking a side question");
 	}
+	// Side questions prefer thinking off; clampThinkingLevel maps that to the
+	// model's disable mechanism (e.g. reasoning_effort "none" on z.ai GLM-5.2+)
+	// or the lowest supported effort when thinking cannot be disabled.
+	const thinkingLevel = clampThinkingLevel(model, "off");
 
 	// Each turn re-clones the live main conversation, so follow-ups always see
 	// the newest main-thread context; earlier side turns are replayed after it.
@@ -83,7 +87,7 @@ export function startSideQuestion(
 			model,
 			systemPrompt: parent.state.systemPrompt,
 			messages: [...structuredClone(parent.state.messages), ...previousTurnMessages],
-			thinkingLevel: "off",
+			thinkingLevel,
 			serviceTier: parent.state.serviceTier,
 			tools: [],
 		},

--- a/packages/coding-agent/test/background-thinking.test.ts
+++ b/packages/coding-agent/test/background-thinking.test.ts
@@ -1,0 +1,60 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { backgroundThinkingLevel } from "../src/core/background-thinking.js";
+
+function createModel(overrides: Partial<Model<"openai-completions">> = {}): Model<"openai-completions"> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api: "openai-completions",
+		provider: "test",
+		baseUrl: "https://example.test",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+		...overrides,
+	};
+}
+
+const MANDATORY_MAP = {
+	off: null,
+	minimal: null,
+	low: "low",
+	medium: null,
+	high: "high",
+	xhigh: null,
+	max: "max",
+} as const;
+
+describe("backgroundThinkingLevel", () => {
+	it("returns undefined for non-reasoning models", () => {
+		expect(backgroundThinkingLevel(createModel({ reasoning: false }), "high")).toBeUndefined();
+	});
+
+	it("requests thinking off when the model supports disabling it", () => {
+		const model = createModel();
+		expect(backgroundThinkingLevel(model)).toBe("off");
+		expect(backgroundThinkingLevel(model, "off")).toBe("off");
+	});
+
+	it("returns the lowest supported effort for mandatory-thinking models", () => {
+		const model = createModel({ thinkingLevelMap: MANDATORY_MAP });
+		expect(backgroundThinkingLevel(model)).toBe("low");
+		expect(backgroundThinkingLevel(model, "off")).toBe("low");
+	});
+
+	it("clamps a requested level for mandatory-thinking models", () => {
+		const model = createModel({ thinkingLevelMap: MANDATORY_MAP });
+		expect(backgroundThinkingLevel(model, "high")).toBe("high");
+		expect(backgroundThinkingLevel(model, "medium")).toBe("high");
+	});
+
+	it("falls forward to the first supported effort on sparse mandatory maps", () => {
+		const model = createModel({
+			thinkingLevelMap: { off: null, minimal: null, low: null, medium: null, high: "high", xhigh: "max" },
+		});
+		expect(backgroundThinkingLevel(model, "off")).toBe("high");
+	});
+});

--- a/packages/coding-agent/test/compaction-summary-reasoning.test.ts
+++ b/packages/coding-agent/test/compaction-summary-reasoning.test.ts
@@ -48,6 +48,16 @@ const mockSummaryResponse: AssistantMessage = {
 	timestamp: Date.now(),
 };
 
+const MANDATORY_THINKING_MAP = {
+	off: null,
+	minimal: null,
+	low: "low",
+	medium: null,
+	high: "high",
+	xhigh: null,
+	max: "max",
+} as const;
+
 const messages: AgentMessage[] = [{ role: "user", content: "Summarize this.", timestamp: Date.now() }];
 
 describe("generateSummary reasoning options", () => {
@@ -76,7 +86,7 @@ describe("generateSummary reasoning options", () => {
 		});
 	});
 
-	it("does not set reasoning when thinking is off", async () => {
+	it("requests thinking off explicitly when the session level is off", async () => {
 		await generateSummary(
 			messages,
 			createModel(true),
@@ -92,8 +102,21 @@ describe("generateSummary reasoning options", () => {
 		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
 		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({
 			apiKey: "test-key",
+			reasoning: "off",
 		});
-		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
+	});
+
+	it("uses the lowest supported effort for mandatory-thinking models", async () => {
+		const mandatory = { ...createModel(true), thinkingLevelMap: MANDATORY_THINKING_MAP };
+
+		await generateSummary(messages, mandatory, 2000, "test-key", undefined, undefined, undefined, undefined, "off");
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({ reasoning: "low" });
+
+		await generateSummary(messages, mandatory, 2000, "test-key");
+
+		expect(completeSimpleMock.mock.calls[1][2]).toMatchObject({ reasoning: "low" });
 	});
 
 	it("does not set reasoning for non-reasoning models", async () => {

--- a/packages/coding-agent/test/refinement.test.ts
+++ b/packages/coding-agent/test/refinement.test.ts
@@ -1035,7 +1035,7 @@ describe("harness refinement", () => {
 			apiKey: "api-key",
 			headers: { "x-test-header": "1" },
 		});
-		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
+		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({ reasoning: "off" });
 		expect(result.appliedEdits[0]).toMatchObject({
 			action: "create",
 			kind: "memory",
@@ -1045,6 +1045,43 @@ describe("harness refinement", () => {
 		expect(state.entries.memory.native_validation.content).toBe(
 			"Run validation through the target project environment.",
 		);
+	});
+
+	it("requests the lowest supported effort for mandatory-thinking models", async () => {
+		const state = loadHarnessState(makeTempDir());
+		completeSimpleMock.mockResolvedValueOnce(
+			assistantText(
+				JSON.stringify({
+					summary: "No edits",
+					rationale: "Nothing durable yet.",
+					expectedOutcome: "No change.",
+					edits: [],
+				}),
+			),
+		);
+
+		await refineHarness(
+			[{ role: "user", content: "Session start.", timestamp: Date.now() } satisfies AgentMessage],
+			state,
+			[],
+			{
+				...createRefineModel(true),
+				thinkingLevelMap: {
+					off: null,
+					minimal: null,
+					low: "low",
+					medium: null,
+					high: "high",
+					xhigh: null,
+					max: "max",
+				},
+			},
+			"api-key",
+			{},
+		);
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({ reasoning: "low" });
 	});
 
 	it("caps the refinement output budget by the model's own maxTokens", async () => {

--- a/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4509-side-questions.test.ts
@@ -1,4 +1,4 @@
-import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, type SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { Container } from "@earendil-works/pi-tui";
 import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, it, vi } from "vitest";
@@ -181,6 +181,49 @@ describe("ENG-4509 side questions", () => {
 
 			expect(events.at(-1)).toMatchObject({ status: "cancelled" });
 			expect(harness.session.isStreaming).toBe(false);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("clamps thinking off to the lowest supported level for mandatory-thinking models", async () => {
+		const harness = await createHarness({
+			models: [
+				{
+					id: "faux-mandatory-thinking",
+					reasoning: true,
+					thinkingLevelMap: {
+						off: null,
+						minimal: null,
+						low: "low",
+						medium: null,
+						high: "high",
+						xhigh: null,
+						max: "max",
+					},
+				},
+			],
+		});
+		try {
+			harness.setResponses([fauxAssistantMessage("main answer")]);
+			await harness.session.prompt("Main context message.");
+
+			let observedReasoning: string | undefined;
+			harness.setResponses([
+				(_context, options) => {
+					observedReasoning = (options as SimpleStreamOptions | undefined)?.reasoning;
+					return fauxAssistantMessage("side answer");
+				},
+			]);
+
+			const events: SideQuestionEvent[] = [];
+			const run = startSideQuestion(harness.session.agent, "mandatory-thinking", "Side question?", (event) => {
+				events.push(event);
+			});
+			await run.done;
+
+			expect(events.at(-1)).toMatchObject({ status: "complete", answer: "side answer" });
+			expect(observedReasoning).toBe("low");
 		} finally {
 			harness.cleanup();
 		}


### PR DESCRIPTION
## Problem

z.ai GLM-5.2/GLM-5.3 on the coding endpoint (`api.z.ai/api/coding/paas/v4`) reject `enable_thinking: false`:

```
400 This model always engages in thinking and cannot be disabled; please use low, high, or max
```

Any completion that requested thinking-off failed: `/btw` side questions hardcode `thinkingLevel: "off"`, and background completions (refinement, auto-refine review, compaction summaries, branch summaries) omit `reasoning`, which the zai branch translated to `enable_thinking: false`.

Verified by live probes against the endpoint:

| payload | glm-4.7 | glm-5-turbo | glm-5.2 | glm-5.3 |
|---|---|---|---|---|
| `enable_thinking: false` | 200, no thinking | 200, no thinking | **400** | **400** |
| `enable_thinking: true` + effort | — | — | 200 | 200 |
| `reasoning_effort: "none"` | — | — | 200, no thinking | 200, no thinking |
| no thinking params | thinks | — | thinks | thinks |

So effort-capable models (5.2+) express "thinking off" as `reasoning_effort: "none"`, not a disable toggle — matching the z.ai thinking docs ("none or minimal indicate that the model stops thinking").

## Changes

**packages/ai**
- `scripts/generate-models.ts`: derive a `thinkingLevelMap` from models.dev `reasoning_options` for direct z.ai models, with `off` mapped to `"none"`; effort-capable direct z.ai models also set `compat.supportsReasoningEffort: true`
- `src/models.generated.ts`: only the three direct z.ai entries change (`glm-5.2`, `glm-5.2-highspeed`, `glm-5.3`) — spliced from generator output, no unrelated catalog churn
- `providers/openai-completions.ts`: zai branch sends `enable_thinking: true` + the mapped `reasoning_effort` for effort-capable models (`"none"` for off, identity fallback for unmapped levels), and keeps the boolean toggle for toggle-only routes. `supportsReasoningEffort` is authoritative, so proxied z.ai routes (Prime Inference, explicitly `false`) never receive `reasoning_effort`
- `providers/faux.ts`: accept `thinkingLevelMap` in test model definitions
- new `test/openai-completions-zai-thinking.test.ts` (10 tests)

**packages/coding-agent**
- `core/side-question.ts`: `/btw` clamps its hardcoded off through `clampThinkingLevel`
- new `core/background-thinking.ts`: background completions request the clamped cheapest level explicitly (off when supported, lowest effort for mandatory-thinking models), so z.ai maps it to `reasoning_effort: "none"` instead of leaving the provider to think at its default effort; applied in refinement, auto-refine review, compaction summaries, and branch summaries

## Payload behavior

| route | reasoning | payload |
|---|---|---|
| z.ai glm-5.2/5.3 | off | `enable_thinking: true, reasoning_effort: "none"` |
| z.ai glm-5.2/5.3 | low/high/max | `enable_thinking: true, reasoning_effort: <mapped>` |
| z.ai glm-5.2/5.3 | unspecified | `enable_thinking: true` |
| z.ai glm-4.7/5-turbo | any | boolean toggle (unchanged) |
| Prime Inference z-ai/glm-* | any | toggle-only (unchanged, per compat contract) |
| all non-zai providers | any | unchanged |

## Testing

- New provider tests cover the matrix above incl. Prime Inference toggle-only for off/high/unspecified and map-less effort-capable fallback
- Coding-agent: new `background-thinking.test.ts`, plus cases in the side-question regression suite, refinement, and compaction-summary tests (167 tests)
- Live end-to-end smoke through the real provider against z.ai confirms the payloads above return 200 with/without thinking as requested
- `npm run check` clean

## Notes

- models.dev lists `reasoning_options: ["high","max"]` for glm-5.2 while the endpoint also accepts `none`/`low`; we map only declared efforts and use `"none"` for off, which the endpoint confirms
- Unrelated upstream catalog drift (pricing, new models) observed during regeneration was deliberately excluded; that belongs in a routine catalog-refresh PR


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix z.ai GLM-5.2/5.3 400 errors by mapping thinking-off to `reasoning_effort: "none"`
> - z.ai GLM-5.2/5.3 models were returning 400 errors when thinking was disabled because `enable_thinking: false` is not supported; the fix maps thinking-off to `reasoning_effort: "none"` with `enable_thinking: true` instead.
> - The model catalog generator ([generate-models.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1565/files#diff-89e0723f62b802c23d445c0de0813e3c9a937463cdc57f1585eedd07c9a4635c)) now reads `reasoning_options` from models.dev and builds a `thinkingLevelMap` for z.ai models, setting `compat.supportsReasoningEffort: true` where supported.
> - [`openai-completions.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1565/files#diff-d3f9c03940767ab76191513078367a64d9e38e58fbdff99f5ad7bf65786b4246) reworks z.ai parameter shaping: effort-capable models use `thinkingLevelMap` for translation; proxies (e.g. Prime Inference) remain toggle-only.
> - A new `backgroundThinkingLevel` utility in [`background-thinking.ts`](https://github.com/PrimeIntellect-ai/prime-agent/pull/1565/files#diff-4086be571548bde82484c7da0f300fe5af5678f268ad7a807d13d019332a498a) returns the cheapest valid reasoning level (off or lowest mandatory effort), used across compaction, refinement, and side-question flows.
> - Behavioral Change: background tasks (summarization, refinement, side questions) now explicitly pass a reasoning option instead of relying on provider defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08751c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->