### PR TITLE
chore(release): prepare v0.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.7.3",
+			"version": "0.7.4",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.7.3",
+				"@earendil-works/pi-coding-agent": "^0.7.4",
 				"get-east-asian-width": "^1.6.0"
 			},
 			"devDependencies": {
@@ -5707,10 +5707,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.7.3",
+			"version": "0.7.4",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.7.3",
+				"@earendil-works/pi-ai": "^0.7.4",
 				"typebox": "^1.3.9"
 			},
 			"devDependencies": {
@@ -5741,7 +5741,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.7.3",
+			"version": "0.7.4",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5787,14 +5787,14 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.7.3",
+			"version": "0.7.4",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@agentclientprotocol/sdk": "^1.3.0",
-				"@earendil-works/pi-agent-core": "^0.7.3",
-				"@earendil-works/pi-ai": "^0.7.3",
-				"@earendil-works/pi-tui": "^0.7.3",
+				"@earendil-works/pi-agent-core": "^0.7.4",
+				"@earendil-works/pi-ai": "^0.7.4",
+				"@earendil-works/pi-tui": "^0.7.4",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -5923,7 +5923,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.7.3",
+			"version": "0.7.4",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	"engines": {
 		"node": ">=22.8.0"
 	},
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.7.3",
+		"@earendil-works/pi-coding-agent": "^0.7.4",
 		"get-east-asian-width": "^1.6.0"
 	},
 	"overrides": {

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-08-19
+
 ## [0.7.3] - 2026-08-17
 
 - Changed explicit `off` reasoning selections to reach providers instead of being omitted, preserving provider-specific disable behavior.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.7.3",
+		"@earendil-works/pi-ai": "^0.7.4",
 		"typebox": "^1.3.9"
 	},
 	"keywords": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-08-19
+
 ## [0.7.3] - 2026-08-17
 
 - Added provider-derived reasoning levels for OpenRouter and Prime Inference models, including sparse, mandatory, toggle-only, and explicit-off capabilities.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-08-19
+
 - Fixed model searches ranking stronger matches ahead of weaker signed-in matches while preferring signed-in providers for equivalent results ([#539](https://github.com/PrimeIntellect-ai/prime-agent/pull/539) by [@eliebak](https://github.com/eliebak)).
 - Fixed large IPython variables repeatedly slowing later turns by excluding them from persistent snapshots and removing them when context is compacted.
 - Fixed daemon socket paths being used verbatim in identity derivations: on supported platforms, `--daemon-socket` spellings differing only by duplicate or trailing slashes now normalize to one canonical path, so worker-descriptor namespaces, daemon log files, and persisted descriptors agree.
@@ -11,6 +13,7 @@
 - Removed a system prompt paragraph referring to an async `bash()` kernel helper and managed jobs that do not exist in the runtime.
 - Changed RLM guidance to orchestrate independent workers in parallel, use available async shell helpers safely, end the turn instead of sleeping, polling, or blocking on long awaits, provide proactive outcome-focused progress updates from root agents, and use simplified technical English for user-facing prose.
 - Fixed new top-level daemon sessions inheriting an RLM child depth from the supervisor process.
+- Fixed active goals stalling after a mid-goal automatic compaction when the previous continuation prompt was already running: only undelivered continuations deduplicate, so a fresh continuation is queued instead of being suppressed.
 
 ## [0.7.3] - 2026-08-17
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"description": "Coding agent CLI with IPython-backed tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -48,9 +48,9 @@
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",
-		"@earendil-works/pi-agent-core": "^0.7.3",
-		"@earendil-works/pi-ai": "^0.7.3",
-		"@earendil-works/pi-tui": "^0.7.3",
+		"@earendil-works/pi-agent-core": "^0.7.4",
+		"@earendil-works/pi-ai": "^0.7.4",
+		"@earendil-works/pi-tui": "^0.7.4",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-08-19
+
 ## [0.7.3] - 2026-08-17
 
 - Fixed hyperlinks not being clickable in fullscreen mode on terminals that gate native link handling while mouse reporting is active (e.g. Ghostty); left-clicking a link now opens it directly.

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Patch release. Bug fixes, small UX/behavior changes behind existing surfaces, and prompt/docs maintenance; no breaking changes, so patch per the no-major-releases policy.

Linear tickets: [ENG-5275](https://linear.app/primeintellect/issue/ENG-5275/require-a-linked-linear-ticket-on-prime-agent-prs), [ENG-5388](https://linear.app/primeintellect/issue/ENG-5388/make-model-search-ranking-respect-match-quality-and-sign-in-state)

## Why this one matters beyond the changelog

The headline is the daemon-identity pair (#1520 + #1449's follow-through): `--daemon-socket` spellings differing only by duplicate or trailing slashes used to derive different worker-descriptor namespaces, log files, and persisted descriptors — the same daemon under two names. Paths now normalize to one canonical form before any identity derivation. Alongside it, #1540 stops large IPython variables from being re-serialized into every later turn (they're excluded from persistent snapshots and dropped on compaction), which was quietly slowing long research sessions.

## Contents

| PR | change |
|---|---|
| #539 | model search ranks exact, prefix/token, and fuzzy matches by intent, then prefers signed-in providers for equivalent results |
| #1540 | large IPython variables no longer slow later turns (excluded from snapshots, removed on compaction) |
| #1520 | daemon socket paths normalize to one canonical form before identity derivation |
| #1510 | `rlm.run` accepts a `thinking` option for spawning subagents with an explicit reasoning level |
| #1372 | opening the agents view with a draft prompt auto-stashes the draft instead of refusing; restored on reopen |
| #1522 | Shift+Enter inserts a newline again in terminals that send a literal `\n` (raw byte decoded as `ctrl+j` and hit the edit-diff toggle) |
| #1496 | new top-level daemon sessions no longer inherit an RLM child depth from the supervisor process |
| #1316 | active goals keep continuing after a mid-goal automatic compaction while the previous continuation is still running |
| #1508 | removed a system-prompt paragraph referencing an unshipped async `bash()` helper |
| #1188 | RLM guidance: parallel workers, no blocking sleeps/polls, proactive progress updates, simplified technical English |
| #1480 | CI now requires a linked Linear ticket on PRs (repo CI only, no changelog entry) |
| #1505 | comment/internal cleanup (no user-facing behavior) |
| #1500 | README badge (no user-facing behavior) |

#1316 merged without a changelog entry; this PR adds it under 0.7.4.

## Version bump

Lockstep across the root package and the four published packages: `agent`, `ai`, `coding-agent`, `tui`. The full diff vs `main` touches only the 10 release files; example and private workspaces are untouched. The lockfile diff is a pure version bump (11 version/range lines), matching the v0.7.3 precedent — a fresh `npm install` was deliberately avoided after it tried to prune unrelated lockfile metadata (local npm version drift); the final lockfile is main's plus version fields only, and `npm ci` against it installs cleanly.

`node scripts/sync-versions.js` reports lockstep and all inter-package dependencies in sync (second run made no changes); `npm run check` is clean at 0.7.4; `git diff --check` is clean.

Changelog sections follow the established precedent: `[Unreleased]` finalized to `[0.7.4] - 2026-08-19` with a fresh empty `[Unreleased]` above, and empty version sections in `agent`, `ai`, and `tui`, which had no entries.

Daemon protocol and schema revision are unchanged since v0.7.3 — no client/daemon compatibility impact.

## Release validation (local, isolated HOME; not a fresh sandbox)

- [x] v0.7.4 candidate packed with `npm run release:pack` against a local channel layout; all four tarball SHA-256s verified (`shasum -a 256 -c SHA256SUMS: OK`), `latest.json` and `stable` manifests correct
- [x] Installed through the real `install.sh` against the local channel (`stable` → `v0.7.4` → `releases/v0.7.4/*.tgz`); installer resolved the channel, verified checksums, installed cleanly, and provisioned the IPython kernel venv
- [x] `prime-agent --version` → 0.7.4; `status` and `doctor` exited 0 (correctly reporting the machine's 0.7.3 daemons as `stale` relative to the 0.7.4 client)
- [x] Offline CLI smokes with a local intercept provider and isolated `HOME`/agent dir: text (`SMOKE-OK-074`), JSON (full event stream `agent_start … agent_end`), and RPC modes all exited 0 with expected output
- [x] Daemon path exercised: prompts via fresh daemons on isolated sockets; incidental live-upgrade of a running 0.7.3 daemon to the 0.7.4 candidate preserved all 202 registered sessions
- [x] Full test matrix on this branch: agent 70 ✓, ai 328 ✓ (731 skipped, keyless), tui 750 ✓ (node:test), coding-agent 4217 ✓ / 60 skipped — zero failures with ambient provider credentials stripped; #539 also passed its full PR CI before inclusion
- [x] All residual failures seen along the way were proven environmental with an unmodified-`main` control run in the identical environment (identical failure fingerprint: real `~/.prime` config, `PRIME_TEAM_ID`/`PRIME_API_KEY`/provider keys in the shell making extra models visible to catalog-cycling tests, `FORCE_COLOR`+`NO_COLOR` node warnings breaking empty-stderr assertions); with those stripped, everything passes — no failure traces to any PR in this release
- [x] Machine state restored afterwards: global install reverted to released v0.7.3 from the production channel (checksum-verified), smoke daemons killed by pid, artifacts cleaned

## Note on the previous release

v0.7.3 published successfully: the production channel's `latest.json` reports `v0.7.3` and `stable` points at it.

Not merging this myself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a0a982119ccacb88f2619f97c3b0ce512652fb39. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release v0.7.4 with fix for active goals stalling after mid-goal automatic compaction
> Bumps all packages from 0.7.3 to 0.7.4. The only functional change is a bug fix in the coding agent: active goals no longer stall after a mid-goal automatic compaction when the previous continuation prompt was already running.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52e1590.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->