### PR TITLE
fix(edit): export prepared callable name

### DIFF
--- a/packages/coding-agent/skills/edit/SKILL.md
+++ b/packages/coding-agent/skills/edit/SKILL.md
@@ -8,8 +8,13 @@ description: Replace an exact, unique string in an existing file. Use for target
 Make a targeted edit to an existing file by replacing one exact, unique
 occurrence of a string. `old_str` must appear exactly once in the file.
 
-Call directly from the kernel:
+Call the prepared callable directly from the kernel:
 
+    await edit(path="pkg/file.py", old_str=old, new_str=new)
+
+In an ordinary Python process, the package exports the same callable name:
+
+    from edit import edit
     await edit(path="pkg/file.py", old_str=old, new_str=new)
 
 Use exact old/new strings. If the text contains triple double quotes, use

--- a/packages/coding-agent/skills/edit/src/edit/__init__.py
+++ b/packages/coding-agent/skills/edit/src/edit/__init__.py
@@ -45,6 +45,10 @@ async def run(path: str, old_str: str, new_str: str) -> str:
     return f"Edited {resolved_path}"
 
 
+# Match the prepared IPython callable name for ordinary package imports.
+edit = run
+
+
 # Keep in sync with DIFF_DISPLAY_MIME in src/core/kernel/index.ts.
 _DIFF_DISPLAY_MIME = "application/vnd.prime-agent.diff+json"
 


### PR DESCRIPTION
Export the Python edit callable under the same name that Prime Agent prepares in IPython. This makes ordinary package imports match the documented kernel call while retaining `run` as the host entry point. Document both forms in the bundled skill.