### PR TITLE
fix(agent): prevent stale run updates after reset

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -170,6 +170,7 @@ type ActiveRun = {
 	promise: Promise<void>;
 	resolve: () => void;
 	abortController: AbortController;
+	stale: boolean;
 };
 
 export class Agent {
@@ -316,8 +317,12 @@ export class Agent {
 	}
 
 	reset(): void {
+		const activeRun = this.activeRun;
+		if (activeRun) {
+			activeRun.stale = true;
+			activeRun.abortController.abort();
+		}
 		this._state.messages = [];
-		this._state.isStreaming = false;
 		this._state.streamingMessage = undefined;
 		this._state.pendingToolCalls = new Set<string>();
 		this._state.errorMessage = undefined;
@@ -488,7 +493,7 @@ export class Agent {
 		const promise = new Promise<void>((resolve) => {
 			resolvePromise = resolve;
 		});
-		this.activeRun = { promise, resolve: resolvePromise, abortController };
+		this.activeRun = { promise, resolve: resolvePromise, abortController, stale: false };
 
 		this._state.isStreaming = true;
 		this._state.streamingMessage = undefined;
@@ -504,6 +509,9 @@ export class Agent {
 	}
 
 	private async handleRunFailure(error: unknown, aborted: boolean): Promise<void> {
+		if (this.activeRun?.stale) {
+			return;
+		}
 		const failureMessage = {
 			role: "assistant",
 			content: [{ type: "text", text: "" }],
@@ -540,6 +548,9 @@ export class Agent {
 	 * and `finishRun()` clears runtime-owned state.
 	 */
 	private async processEvents(event: AgentEvent): Promise<void> {
+		if (this.activeRun?.stale) {
+			return;
+		}
 		switch (event.type) {
 			case "message_start":
 				this._state.streamingMessage = event.message;

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -7,6 +7,7 @@ import {
 	type AgentLoopConfig,
 	type AgentMessage,
 	type AgentTool,
+	type AgentToolResult,
 	agentLoop,
 } from "../src/index.js";
 
@@ -402,6 +403,68 @@ describe("Agent", () => {
 		}
 		expect(agent.state.pendingToolCalls.size).toBe(0);
 		expect(agent.state.isStreaming).toBe(false);
+	});
+
+	it("reset() during an active run drops the cancelled run's events and does not repopulate state", async () => {
+		const schema = Type.Object({});
+		let resolveTool: ((result: AgentToolResult<Record<string, never>>) => void) | undefined;
+		const toolDone = new Promise<AgentToolResult<Record<string, never>>>((resolve) => {
+			resolveTool = resolve;
+		});
+		let signalToolStarted: (() => void) | undefined;
+		const toolStarted = new Promise<void>((resolve) => {
+			signalToolStarted = resolve;
+		});
+		const deferredTool: AgentTool<typeof schema, Record<string, never>> = {
+			name: "hang",
+			label: "Hang",
+			description: "Deferred tool",
+			parameters: schema,
+			execute: async () => {
+				signalToolStarted?.();
+				return toolDone;
+			},
+		};
+		const agent = new Agent({
+			initialState: { tools: [deferredTool] },
+			toolExecution: "sequential",
+			shouldStopAfterTurn: () => true,
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "done", reason: "toolUse", message: createToolUseMessage("hang") });
+				});
+				return stream;
+			},
+		});
+
+		const promptPromise = agent.prompt("run");
+		await toolStarted;
+
+		expect(agent.state.isStreaming).toBe(true);
+		expect(agent.state.pendingToolCalls.size).toBe(1);
+
+		agent.reset();
+
+		// reset() clears the visible state, but the cancelled run is still winding down.
+		expect(agent.state.messages).toEqual([]);
+		expect(agent.state.pendingToolCalls.size).toBe(0);
+		expect(agent.state.isStreaming).toBe(true);
+
+		// Let the cancelled run settle and emit its teardown events.
+		resolveTool?.({ content: [{ type: "text", text: "done" }], details: {} });
+		await promptPromise;
+		await agent.waitForIdle();
+
+		// The stale run must not repopulate the transcript reset() cleared.
+		expect(agent.state.messages).toEqual([]);
+		expect(agent.state.pendingToolCalls.size).toBe(0);
+		expect(agent.state.streamingMessage).toBeUndefined();
+		expect(agent.state.errorMessage).toBeUndefined();
+
+		// The run finished and the single-run lifecycle is cleared.
+		expect(agent.state.isStreaming).toBe(false);
+		expect(agent.signal).toBeUndefined();
 	});
 
 	it("should preserve the original failure when the recovery agent_end listener throws", async () => {


### PR DESCRIPTION
## Summary

Fix H7: `Agent.reset()` during an active run could allow the previous run to mutate the newly reset agent state.

## What was happening

`Agent.reset()` cleared the agent state but did not invalidate the active run.

If that run was still executing, it could later emit events such as `message_end`. Those events were still processed against the live agent state, causing data from the pre-reset run to appear again after reset.

## What changed

* Mark the active run as `stale` during `reset()`.
* Abort the active run during reset.
* Ignore events from stale runs in `processEvents()`.
* Ignore errors from stale runs in `handleRunFailure()`.
* Keep `activeRun` until the existing `finishRun()` lifecycle completes.
* Preserve existing `abort()` behavior for normal user-initiated cancellation.

## Regression test

Added a regression test covering:

1. Start an active run with a long-running tool.
2. Call `reset()` while the run is active.
3. Verify the visible state is cleared.
4. Allow the cancelled run to settle.
5. Verify its teardown events do not repopulate or mutate the reset state.
6. Verify the run eventually finishes and `activeRun` is cleared.

## Verification

* `packages/agent/test/agent.test.ts`: 26/26 passing
* Full `packages/agent` suite: 71/71 passing
* `npm run check`: passing

Related discussion: https://github.com/PrimeIntellect-ai/prime-agent/discussions/1541


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark active runs as stale on `Agent.reset` to drop cancelled run events
> - Adds a `stale` flag to `ActiveRun`; `Agent.reset` sets it, aborts the run via `AbortController`, and clears state and queues without setting `isStreaming` to false
> - `processEvents` and `handleRunFailure` now early-return for stale runs, so cancelled runs cannot repopulate messages, errors, or invoke listeners
> - New test verifies state stays empty after a cancelled run settles
> - Risk: `isStreaming` stays true until the aborted run settles, so UI consumers that rely on `isStreaming === false` immediately after `reset()` will see a delay
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8970da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->