### PR TITLE
feat(ai): support Fast mode with OpenAI API auth

### DIFF
--- a/packages/ai/.changes/openai-api-fast-mode.md
+++ b/packages/ai/.changes/openai-api-fast-mode.md
@@ -1,0 +1,1 @@
+- Added Fast mode support for eligible models using OpenAI API-key authentication.

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -36,11 +36,12 @@ export function getModels<TProvider extends KnownProvider>(
 }
 
 export function supportsFastMode<TApi extends Api>(model: Model<TApi>): boolean {
-	return (
-		model.provider === "openai-codex" &&
-		model.api === "openai-codex-responses" &&
-		(model.id === "gpt-5.4" || model.id === "gpt-5.5" || model.id === "gpt-5.6" || model.id.startsWith("gpt-5.6-"))
-	);
+	const supportsPriorityServiceTier =
+		(model.provider === "openai-codex" && model.api === "openai-codex-responses") ||
+		(model.provider === "openai" && model.api === "openai-responses");
+	const supportsFastModel =
+		model.id === "gpt-5.4" || model.id === "gpt-5.5" || model.id === "gpt-5.6" || model.id.startsWith("gpt-5.6-");
+	return supportsPriorityServiceTier && supportsFastModel;
 }
 
 export interface CostOverrides {

--- a/packages/ai/test/fast-mode.test.ts
+++ b/packages/ai/test/fast-mode.test.ts
@@ -23,10 +23,14 @@ describe("Fast mode", () => {
 		expect(supportsFastMode(model("openai-codex", id, "openai-codex-responses"))).toBe(true);
 	});
 
-	it("rejects unsupported models and API-key providers", () => {
+	it.each(["gpt-5.4", "gpt-5.5", "gpt-5.6-luna"])("supports %s through OpenAI API-key auth", (id) => {
+		expect(supportsFastMode(model("openai", id, "openai-responses"))).toBe(true);
+	});
+
+	it("rejects unsupported models and providers", () => {
 		expect(supportsFastMode(model("openai-codex", "gpt-5.3-codex", "openai-codex-responses"))).toBe(false);
 		expect(supportsFastMode(model("openai-codex", "gpt-5.4-mini", "openai-codex-responses"))).toBe(false);
-		expect(supportsFastMode(model("openai", "gpt-5.5", "openai-responses"))).toBe(false);
+		expect(supportsFastMode(model("anthropic", "gpt-5.5", "anthropic-messages"))).toBe(false);
 	});
 
 	it("forwards priority through simple stream options", () => {

--- a/packages/coding-agent/.changes/openai-api-fast-mode.md
+++ b/packages/coding-agent/.changes/openai-api-fast-mode.md
@@ -1,0 +1,1 @@
+- Added `/fast` support for eligible models using OpenAI API-key authentication.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7854,7 +7854,7 @@ export class InteractiveMode {
 	}
 
 	private handleFastCommand(): void {
-		const unavailableMessage = "Fast mode requires GPT-5.4, GPT-5.5, or GPT-5.6 with ChatGPT authentication";
+		const unavailableMessage = "Fast mode requires GPT-5.4, GPT-5.5, or GPT-5.6 through ChatGPT or the OpenAI API";
 		if (!this.currentModelSupportsFastMode()) {
 			this.showStatus(unavailableMessage);
 			return;

--- a/packages/coding-agent/test/interactive-mode-effort-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-effort-command.test.ts
@@ -289,8 +289,11 @@ describe("InteractiveMode /effort", () => {
 	});
 
 	describe("Fast mode", () => {
-		it("enables Fast mode and refreshes the model tray", async () => {
-			const context = makeFastContext();
+		it.each([
+			["ChatGPT", testModel("openai-codex", "gpt-5.5", "openai-codex-responses")],
+			["OpenAI API", testModel("openai", "gpt-5.5", "openai-responses")],
+		])("enables Fast mode through %s and refreshes the model tray", async (_auth, model) => {
+			const context = makeFastContext(model);
 
 			fastInteractiveModePrototype.handleFastCommand.call(context);
 			await vi.waitFor(() => expect(context.showStatus).toHaveBeenCalledWith("Fast mode: on"));
@@ -403,7 +406,7 @@ describe("InteractiveMode /effort", () => {
 
 			expect(context.agentConnection.setServiceTier).not.toHaveBeenCalled();
 			expect(context.showStatus).toHaveBeenCalledWith(
-				"Fast mode requires GPT-5.4, GPT-5.5, or GPT-5.6 with ChatGPT authentication",
+				"Fast mode requires GPT-5.4, GPT-5.5, or GPT-5.6 through ChatGPT or the OpenAI API",
 			);
 		});
 


### PR DESCRIPTION
## Summary

Allow `/fast` to use OpenAI API-key authentication. The Responses provider already sends `service_tier`; this updates the model check so eligible API models can opt into priority processing.

## Testing

- `npm run check`
- 62 focused Fast mode and OpenAI Responses tests
