### PR TITLE
feat(acp): implement session/load so BB threads resume with history

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { realpathSync, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 import { Readable } from "node:stream";
 import * as acp from "@agentclientprotocol/sdk";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
@@ -641,12 +642,168 @@ export async function runAcpModeWithConnection(
 			});
 	};
 
+	// --- ACP session restore ------------------------------------------------
+	//
+	// BB stores the `sessionId` returned by session/new as the thread's provider
+	// thread id. When the thread is reopened, BB asks session/load with that id.
+	// prime-agent persists the mapping (ACP id -> its own JSONL session file)
+	// next to its agent dir, so a fresh process can switch back onto the saved
+	// transcript instead of starting with blank history.
+	const acpSessionLinkDir = (sessionFile: string): string => {
+		const agentDir = process.env.PRIME_AGENT_CODING_AGENT_DIR ?? dirname(dirname(sessionFile));
+		return join(agentDir, "acp-sessions");
+	};
+
+	const persistAcpSessionLink = async (acpSessionId: string): Promise<void> => {
+		try {
+			const state = await connection.getState();
+			const sessionFile = state.sessionFile;
+			if (!sessionFile) return;
+			const dir = acpSessionLinkDir(sessionFile);
+			await mkdir(dir, { recursive: true, mode: 0o700 });
+			const target = join(dir, `${acpSessionId}.json`);
+			const temporary = `${target}.${process.pid}.tmp`;
+			await writeFile(
+				temporary,
+				JSON.stringify({ version: 1, acpSessionId, sessionFile, savedAt: new Date().toISOString() }),
+				"utf8",
+			);
+			await rename(temporary, target);
+		} catch {
+			// Losing a mapping only degrades a later resume; never fail session/new over it.
+		}
+	};
+
+	const resolveAcpSessionFile = async (acpSessionId: string): Promise<string | undefined> => {
+		try {
+			const state = await connection.getState();
+			const sessionFile = state.sessionFile;
+			if (!sessionFile) return undefined;
+			const raw = await readFile(join(acpSessionLinkDir(sessionFile), `${acpSessionId}.json`), "utf8");
+			const parsed = JSON.parse(raw) as { sessionFile?: unknown };
+			if (typeof parsed.sessionFile !== "string" || parsed.sessionFile.length === 0) return undefined;
+			try {
+				statSync(parsed.sessionFile);
+			} catch {
+				return undefined;
+			}
+			return parsed.sessionFile;
+		} catch {
+			return undefined;
+		}
+	};
+
+	const admitAcpSession = async (
+		sessionId: string,
+		ctx: any,
+	): Promise<{ cwdMismatch: { requested: string; actual: string } | undefined }> => {
+		// prime-agent's cwd is fixed at startup by the session it was launched
+		// with, so a client-supplied cwd cannot be adopted after the fact.
+		// Report the real cwd back in `_meta` rather than failing the request or
+		// letting the client assume a directory the agent is not using.
+		const requestedCwd = (ctx.params as { cwd?: unknown } | undefined)?.cwd;
+		let cwdMismatch: { requested: string; actual: string } | undefined;
+		if (typeof requestedCwd === "string" && requestedCwd.length > 0) {
+			const actual = await connection
+				.getState()
+				.then((state) => state.cwd)
+				.catch(() => undefined);
+			if (actual && !sameCwd(requestedCwd, actual)) {
+				cwdMismatch = { requested: requestedCwd, actual };
+			}
+		}
+		// Install the listener before fetching the snapshot. Child updates can arrive
+		// while the snapshot request is in flight; the connection remains the
+		// authoritative source used when quiescence is emitted below.
+		const producer = new AcpUpdateProducer(sessionId, ctx.client);
+		let inputPauseRelease: AcpInputPauseRelease | undefined;
+		if (closedInputPause) {
+			let resolve!: () => void;
+			let reject!: (error: unknown) => void;
+			const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+				resolve = resolvePromise;
+				reject = rejectPromise;
+			});
+			void promise.catch(() => undefined);
+			inputPauseRelease = { promise, resolve, reject };
+		}
+		const entry: AcpSessionEntry = {
+			id: sessionId,
+			abort: undefined,
+			cancelling: false,
+			cancelTask: undefined,
+			stopFailure: undefined,
+			inputPause: closedInputPause,
+			inputPauseKey: closedInputPauseKey,
+			inputPauseRelease,
+			pendingTerminal: undefined,
+			promptTask: undefined,
+			resolvePromptTask: undefined,
+			unsubscribe: undefined,
+			producer,
+		};
+		// Subscribe for the session lifetime, not per prompt turn: prime-agent
+		// subagents are fire-and-forget and keep reporting after the spawning turn
+		// ends, so a turn-scoped subscription would drop their updates. One
+		// mapping state per session keeps streaming bash output correlated with
+		// the run that produced it.
+		const mappingState: AcpEventMappingState = {};
+		const observedChildren = new Map<string, unknown>();
+		const unsubscribe = connection.subscribe((event) => {
+			if (event.type === "heartbeats_changed") {
+				void producer.publish(
+					{ sessionUpdate: "session_info_update", _meta: primeAgentMeta({ heartbeatsChanged: true }) },
+					0,
+					"event",
+				);
+				return;
+			}
+			if (event.type !== "session_event") return;
+			if (event.event.type === "rlm_child_update") {
+				observedChildren.set(event.event.child.id, event.event.child);
+			}
+			const turnId = producer.turnForEvent(event.event);
+			for (const update of acpUpdatesForSessionEvent(event.event, mappingState)) {
+				void producer.publish(update, turnId, "event");
+			}
+		});
+		try {
+			const initialSnapshot = await connection.getInitialSnapshot();
+			for (const child of initialSnapshot.children ?? []) {
+				if (observedChildren.has(child.id)) continue;
+				observedChildren.set(child.id, child);
+				const event = { type: "rlm_child_update", child } as const;
+				const turnId = producer.turnForEvent(event);
+				for (const update of acpUpdatesForSessionEvent(event, mappingState)) {
+					void producer.publish(update, turnId, "event");
+				}
+			}
+		} catch (error) {
+			producer.failSessionNewAdmission();
+			unsubscribe();
+			throw error;
+		}
+		// Claim the single-session slot only once the subscription and snapshot are
+		// ready, so a failed setup cannot leave it occupied and unusable.
+		entry.unsubscribe = unsubscribe;
+		session = entry;
+		// The stream wrapper commits this gate after this exact response has
+		// written. Buffered subscription updates retain producer order.
+		pendingSessionNewResponse = {
+			requestId: ctx.requestId,
+			producer: entry.producer,
+			entry,
+			inputPause: closedInputPause,
+		};
+		return { cwdMismatch };
+	};
+
 	const handle = acp
 		.agent({ name: "prime-agent" })
 		.onRequest("initialize", async () => ({
 			protocolVersion: acp.PROTOCOL_VERSION,
 			agentCapabilities: {
-				loadSession: false,
+				loadSession: true,
 				promptCapabilities: { image: true, embeddedContext: true },
 				// Advertise close so a client knows it can release the session (and
 				// the single-session slot) instead of dropping the connection.
@@ -675,114 +832,62 @@ export async function runAcpModeWithConnection(
 					await options.bindHeadlessExtensions?.();
 					bound = true;
 				}
-				// prime-agent's cwd is fixed at startup by the session it was launched
-				// with, so a client-supplied cwd cannot be adopted after the fact.
-				// Report the real cwd back in `_meta` rather than failing the request or
-				// letting the client assume a directory the agent is not using.
-				const requestedCwd = (ctx.params as { cwd?: unknown } | undefined)?.cwd;
-				let cwdMismatch: { requested: string; actual: string } | undefined;
-				if (typeof requestedCwd === "string" && requestedCwd.length > 0) {
-					const actual = await connection
-						.getState()
-						.then((state) => state.cwd)
-						.catch(() => undefined);
-					if (actual && !sameCwd(requestedCwd, actual)) {
-						cwdMismatch = { requested: requestedCwd, actual };
-					}
-				}
 				const sessionId = randomUUID();
-				// Install the listener before fetching the snapshot. Child updates can arrive
-				// while the snapshot request is in flight; the connection remains the
-				// authoritative source used when quiescence is emitted below.
-				const producer = new AcpUpdateProducer(sessionId, ctx.client);
-				let inputPauseRelease: AcpInputPauseRelease | undefined;
-				if (closedInputPause) {
-					let resolve!: () => void;
-					let reject!: (error: unknown) => void;
-					const promise = new Promise<void>((resolvePromise, rejectPromise) => {
-						resolve = resolvePromise;
-						reject = rejectPromise;
-					});
-					void promise.catch(() => undefined);
-					inputPauseRelease = { promise, resolve, reject };
-				}
-				const entry: AcpSessionEntry = {
-					id: sessionId,
-					abort: undefined,
-					cancelling: false,
-					cancelTask: undefined,
-					stopFailure: undefined,
-					inputPause: closedInputPause,
-					inputPauseKey: closedInputPauseKey,
-					inputPauseRelease,
-					pendingTerminal: undefined,
-					promptTask: undefined,
-					resolvePromptTask: undefined,
-					unsubscribe: undefined,
-					producer,
-				};
-				// Subscribe for the session lifetime, not per prompt turn: prime-agent
-				// subagents are fire-and-forget and keep reporting after the spawning turn
-				// ends, so a turn-scoped subscription would drop their updates. One
-				// mapping state per session keeps streaming bash output correlated with
-				// the run that produced it.
-				const mappingState: AcpEventMappingState = {};
-				const observedChildren = new Map<string, unknown>();
-				const unsubscribe = connection.subscribe((event) => {
-					// Heartbeats are connection-scoped, including if one races a prompt.
-					// They therefore intentionally use origin turn 0.
-					if (event.type === "heartbeats_changed") {
-						void producer.publish(
-							{ sessionUpdate: "session_info_update", _meta: primeAgentMeta({ heartbeatsChanged: true }) },
-							0,
-							"event",
-						);
-						return;
-					}
-					if (event.type !== "session_event") return;
-					if (event.event.type === "rlm_child_update") {
-						observedChildren.set(event.event.child.id, event.event.child);
-					}
-					const turnId = producer.turnForEvent(event.event);
-					for (const update of acpUpdatesForSessionEvent(event.event, mappingState)) {
-						void producer.publish(update, turnId, "event");
-					}
-				});
-				try {
-					// Reconcile after subscribing so updates cannot be lost while the snapshot
-					// request is in flight. Do not turn a failed read into an empty roster.
-					const initialSnapshot = await connection.getInitialSnapshot();
-					for (const child of initialSnapshot.children ?? []) {
-						if (observedChildren.has(child.id)) continue;
-						observedChildren.set(child.id, child);
-						const event = { type: "rlm_child_update", child } as const;
-						const turnId = producer.turnForEvent(event);
-						for (const update of acpUpdatesForSessionEvent(event, mappingState)) {
-							void producer.publish(update, turnId, "event");
-						}
-					}
-				} catch (error) {
-					producer.failSessionNewAdmission();
-					unsubscribe();
-					throw error;
-				}
-				// Claim the single-session slot only once the subscription and snapshot are
-				// ready, so a failed setup cannot leave it occupied and unusable.
-				entry.unsubscribe = unsubscribe;
-				session = entry;
-				const response = {
+				const { cwdMismatch } = await admitAcpSession(sessionId, ctx);
+				// Remember the ACP session id -> prime-agent session file mapping so a
+				// later BB thread resume can `session/load` it from a fresh process.
+				await persistAcpSessionLink(sessionId);
+				return {
 					sessionId,
 					...(cwdMismatch ? { _meta: primeAgentMeta({ cwd: cwdMismatch }) } : {}),
 				};
-				// The stream wrapper commits this gate after this exact response has
-				// written. Buffered subscription updates retain producer order.
-				pendingSessionNewResponse = {
-					requestId: ctx.requestId,
-					producer: entry.producer,
-					entry,
-					inputPause: closedInputPause,
+			} finally {
+				sessionNewInFlight = false;
+			}
+		})
+		.onRequest("session/load", async (ctx: any) => {
+			// BB resumes a thread by asking for its previously-advertised ACP session
+			// id. prime-agent persists each session's JSONL on disk, so a fresh
+			// process can reload the thread history instead of starting blank.
+			const params = ctx.params as { sessionId?: unknown; cwd?: unknown } | undefined;
+			if (typeof params?.sessionId !== "string" || params.sessionId.length === 0) {
+				throw new Error("ACP session/load requires a session id.");
+			}
+			if (session || sessionNewInFlight || sessionCloseInFlight) {
+				throw new Error(
+					"prime-agent ACP mode hosts one session per connection; " +
+						"start another prime-agent process for a second session",
+				);
+			}
+			sessionNewInFlight = true;
+			try {
+				if (!bound) {
+					await options.bindHeadlessExtensions?.();
+					bound = true;
+				}
+				const sessionFile = await resolveAcpSessionFile(params.sessionId);
+				if (!sessionFile) {
+					// No persisted mapping: refuse to pretend history was restored. BB
+					// falls back to a fresh session/new and reports the restore failure.
+					throw new Error(`prime-agent has no session "${params.sessionId}" to load.`);
+				}
+				const actual = await connection
+					.getState()
+					.then((state) => state.sessionFile)
+					.catch(() => undefined);
+				const requestedCwd = typeof params.cwd === "string" && params.cwd.length > 0 ? params.cwd : undefined;
+				if (actual !== sessionFile) {
+					const switched = await connection.switchSession(sessionFile, {
+						...(requestedCwd ? { cwdOverride: requestedCwd } : {}),
+					});
+					if (switched.cancelled) {
+						throw new Error(`ACP session/load was cancelled for "${params.sessionId}".`);
+					}
+				}
+				const { cwdMismatch } = await admitAcpSession(params.sessionId, ctx);
+				return {
+					...(cwdMismatch ? { _meta: primeAgentMeta({ cwd: cwdMismatch }) } : {}),
 				};
-				return response;
 			} finally {
 				sessionNewInFlight = false;
 			}

--- a/packages/coding-agent/test/suite/acp-mode.test.ts
+++ b/packages/coding-agent/test/suite/acp-mode.test.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import * as acp from "@agentclientprotocol/sdk";
 import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
@@ -70,12 +71,15 @@ function fakeAcpConnection(
 		onAcquireSessionInputPause?: () => void | Promise<void>;
 		onReleaseSessionInputPause?: () => void | Promise<void>;
 		onCancelRlmChild?: (childId: string) => void | Promise<void>;
+		onSwitchSession?: (sessionPath: string) => void | Promise<void>;
+		state?: Record<string, unknown>;
 	} = {},
 ): any {
 	let listener: ((event: any) => void) | undefined;
 	const messages: any[] = [];
 	const inputPauses = new Map<string, { release(): Promise<void> }>();
 	const snapshot = { state: { cwd: process.cwd() }, messages, children: [] };
+	let switchedTo: string | undefined;
 	return {
 		subscribe(callback: (event: any) => void) {
 			listener = callback;
@@ -84,7 +88,13 @@ function fakeAcpConnection(
 				options.onUnsubscribe?.();
 			};
 		},
-		getState: async () => snapshot.state,
+		switchSession: async (sessionPath: string) => {
+			switchedTo = sessionPath;
+			options.onSwitchSession?.(sessionPath);
+			return { cancelled: false };
+		},
+		getSwitchedTo: () => switchedTo,
+		getState: async () => ({ ...snapshot.state, ...options.state }),
 		getMessages: async () => messages,
 		getInitialSnapshot: async () => {
 			if (options.initialSnapshot) {
@@ -212,6 +222,7 @@ describe("ACP mode end to end", () => {
 		});
 		expect(init.protocolVersion).toBe(acp.PROTOCOL_VERSION);
 		expect(init.agentInfo?.name).toBe("prime-agent");
+		expect(init.agentCapabilities?.loadSession).toBe(true);
 		expect(init._meta).toHaveProperty(PRIME_AGENT_META_NAMESPACE);
 
 		const session = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
@@ -232,6 +243,66 @@ describe("ACP mode end to end", () => {
 		harness.cleanup();
 	}, 30_000);
 
+	it("advertises session/load and restores a mapped session file", async () => {
+		const harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("restored")]);
+		const connection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+		const sessionFile = `${harness.tempDir}/test-session.jsonl`;
+		await writeFile(sessionFile, "", "utf8");
+
+		// Point the registry at the harness temp dir so the mapping round-trips
+		// without touching the real agent directory.
+		const previousAgentDir = process.env.PRIME_AGENT_CODING_AGENT_DIR;
+		process.env.PRIME_AGENT_CODING_AGENT_DIR = harness.tempDir;
+		try {
+			// First ACP connection creates a session; state carries the prime-agent
+			// session file so session/new can persist the ACP id -> file mapping.
+			(connection as any).getState = async () => ({
+				cwd: harness.tempDir,
+				sessionFile,
+				sessionId: "test-session",
+			});
+
+			const { client } = connectAcpClient(connection);
+			await client.request("initialize", { protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: {} });
+			const created = await client.request("session/new", { cwd: harness.tempDir, mcpServers: [] });
+			expect(typeof created.sessionId).toBe("string");
+
+			// A second, fresh ACP connection resumes the same thread id. Its
+			// connection records switchSession() so we can assert the collector
+			// asked to restore the saved transcript file instead of starting blank.
+			const restoredConnection = new InProcessAgentConnection(runtimeHostFor(harness.session));
+			let switchedTo: string | undefined;
+			(restoredConnection as any).getState = async () => ({
+				cwd: harness.tempDir,
+				sessionFile: `${harness.tempDir}/fresh-session.jsonl`,
+				sessionId: "fresh-session",
+			});
+			(restoredConnection as any).switchSession = async (sessionPath: string) => {
+				switchedTo = sessionPath;
+				return { cancelled: false };
+			};
+
+			const restored = connectAcpClient(restoredConnection);
+			await restored.client.request("initialize", {
+				protocolVersion: acp.PROTOCOL_VERSION,
+				clientCapabilities: {},
+			});
+			await expect(
+				restored.client.request("session/load", {
+					sessionId: created.sessionId,
+					cwd: harness.tempDir,
+					mcpServers: [],
+				}),
+			).resolves.toEqual({});
+			expect(switchedTo).toBe(sessionFile);
+			await restored.close();
+			harness.cleanup();
+		} finally {
+			if (previousAgentDir === undefined) delete process.env.PRIME_AGENT_CODING_AGENT_DIR;
+			else process.env.PRIME_AGENT_CODING_AGENT_DIR = previousAgentDir;
+		}
+	});
 	it("queues a follow-up prompt behind injected work instead of rejecting it", async () => {
 		const harness = await createHarness();
 		let releaseInjected!: () => void;


### PR DESCRIPTION
## Problem

When BB resumes a chat thread through its ACP provider, it calls `session/load` with the thread's stored provider thread id. It only restores in-agent history when the agent advertises `loadSession` and answers `session/load`.

prime-agent's ACP mode advertised `loadSession: false` and had no `session/load` handler, so every restarted BB conversation fell back to `session/new` with **blank in-agent history**, and BB showed:

> could not restore the previous session; continuing in a fresh session without in-agent history.

That's the "Prime Agent in BB keeps resetting / losing context" symptom.

## Fix

- Advertise `loadSession: true` in the ACP `initialize` response.
- `session/new` now persists the ACP session id → prime-agent JSONL session file mapping under the agent dir (`<agentDir>/acp-sessions/<id>.json`).
- `session/load` resolves the requested id to the saved transcript, switches the daemon connection back onto that session file, then admits the ACP session as usual — so subsequent prompts continue the restored conversation instead of starting fresh.
- A missing mapping or missing file throws, letting the client fall back to a fresh session with its own warning rather than pretending history was restored.

## Verification

- New end-to-end test resumes a mapped session file across two ACP connections.
- 28/28 `acp-mode.test.ts` tests pass; 74/74 across all ACP-related suites.
- `npm run check`'s remaining type errors are pre-existing missing optional deps in untouched files (`@smithy/types`, `@anthropic-ai/*` in `examples/` and `amazon-bedrock.ts`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `session/load` in `acp-mode` to resume BB threads with history
> - Adds on-disk persistence of ACP session-id to prime-agent session file mappings via `persistAcpSessionLink`, writing `<acpSessionId>.json` atomically under an `acp-sessions/` directory (mode 0700)
> - Adds `resolveAcpSessionFile` to look up and validate a saved session file path for a given ACP session id
> - Extracts shared session admission logic into `admitAcpSession`, used by both `session/new` and the new `session/load` handler
> - `session/new` now persists the session mapping after setup; `session/load` resolves the mapping, switches the connection to the saved session file, and re-establishes streaming updates
> - `acp.agent.initialize` now advertises `agentCapabilities.loadSession=true`
> - Risk: errors in `persistAcpSessionLink` are silently swallowed, so a failed write will not surface until `session/load` cannot find the mapping
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55ef878.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->