### PR TITLE
Fix prime-agent.sh failing when invoked from outside the repo

### DIFF
--- a/prime-agent.sh
+++ b/prime-agent.sh
@@ -78,4 +78,9 @@ if [[ ! -x "$TSX_BIN" ]]; then
   exit 1
 fi
 
-"$TSX_BIN" "$SCRIPT_DIR/packages/coding-agent/src/cli.ts" ${ARGS[@]+"${ARGS[@]}"}
+# tsx resolves tsconfig `paths` (workspace packages -> src) by walking up
+# from the process cwd, not from the imported file, so it misses this
+# repo's tsconfig.json when invoked from another directory. Pin it
+# explicitly so the process cwd (and therefore --cwd defaulting) is
+# unaffected.
+"$TSX_BIN" --tsconfig "$SCRIPT_DIR/tsconfig.json" "$SCRIPT_DIR/packages/coding-agent/src/cli.ts" ${ARGS[@]+"${ARGS[@]}"}


### PR DESCRIPTION
tsx resolves tsconfig `paths` (workspace packages -> src) by walking up from the process cwd rather than from the imported file, so it missed this repo's tsconfig.json when the script was run from another directory and fell back to real module resolution against an unbuilt dist/. Pin --tsconfig explicitly so resolution no longer depends on the caller's cwd.

<!--
Pull requests are accepted from maintainers and vouched contributors only.
If a maintainer has not invited this work, start with a GitHub Discussion:
https://github.com/PrimeIntellect-ai/prime-agent/discussions
-->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `prime-agent.sh` to pass explicit `--tsconfig` when invoked outside repo
> The script now invokes `tsx` with `--tsconfig "$SCRIPT_DIR/tsconfig.json"`, so tsx loads the repo config regardless of the caller's working directory. Previously, running the script from another directory caused tsx to fail to find the tsconfig.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3b9b0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->