### PR TITLE
Remote model catalog: models stop going stale between releases

### DIFF
--- a/packages/ai/.changes/eng-5261-remote-catalog.md
+++ b/packages/ai/.changes/eng-5261-remote-catalog.md
@@ -1,0 +1,1 @@
+- Added a generation timestamp (MODELS_GENERATED_AT) to the generated model catalog so consumers can compare it against remote catalogs.

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -2373,6 +2373,8 @@ async function generateModels() {
 
 import type { Model } from "./types.js";
 
+export const MODELS_GENERATED_AT = "${new Date().toISOString()}";
+
 export const MODELS = {
 `;
 

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -3,6 +3,8 @@
 
 import type { Model } from "./types.js";
 
+export const MODELS_GENERATED_AT = "2026-08-20T15:21:33.000Z";
+
 export const MODELS = {
 	"amazon-bedrock": {
 		"amazon.nova-2-lite-v1:0": {

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,5 +1,11 @@
-import { MODELS } from "./models.generated.js";
+import { MODELS, MODELS_GENERATED_AT } from "./models.generated.js";
 import type { Api, KnownProvider, Model, ModelThinkingLevel, Usage } from "./types.js";
+
+/** Unix ms timestamp of the bundled catalog generation, undefined if unparsable. */
+export function getModelsGeneratedAt(): number | undefined {
+	const t = Date.parse(MODELS_GENERATED_AT);
+	return Number.isNaN(t) ? undefined : t;
+}
 
 const modelRegistry: Map<string, Map<string, Model<Api>>> = new Map();
 

--- a/packages/coding-agent/.changes/eng-5261-remote-catalog.md
+++ b/packages/coding-agent/.changes/eng-5261-remote-catalog.md
@@ -1,0 +1,1 @@
+- Added a persisted remote model-catalog overlay (models-store.json): per-provider catalogs are fetched from pi.dev with ETag revalidation and a 4-hour freshness window on model-picker open, so new provider models appear without a release; any failure falls back to the bundled catalog.

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -957,6 +957,9 @@ export class ModelRegistry {
 
 	/** Rebuild the model list from current state without touching auth, OAuth registries, or on-disk stores. */
 	private reloadModels(): void {
+		this.providerRequestConfigs.clear();
+		this.modelRequestHeaders.clear();
+		this.loadError = undefined;
 		this.loadModels();
 		for (const [providerName, config] of this.registeredProviders.entries()) {
 			this.applyProviderConfig(providerName, config);

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -10,6 +10,7 @@ import {
 	type AssistantMessageEventStream,
 	type Context,
 	getModels,
+	getModelsGeneratedAt,
 	getProviders,
 	type KnownProvider,
 	type Model,
@@ -36,6 +37,12 @@ import {
 	isPrivatePrimeInferenceModel,
 } from "./prime-inference-models.js";
 import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "./provider-display-names.js";
+import {
+	overlayRemoteModels,
+	REMOTE_CATALOG_STORE_FILE,
+	RemoteCatalogStore,
+	refreshRemoteCatalog,
+} from "./remote-catalog.js";
 import {
 	clearConfigValueCache,
 	resolveConfigValueOrThrow,
@@ -450,6 +457,8 @@ export class ModelRegistry {
 	private openAICodexModelsCache: { authFingerprint: string; modelIds: Set<string>; refreshedAt: number } | undefined;
 	private backgroundPrivatePrimeAuthorization: { fingerprint: string; promise: Promise<void> } | undefined;
 	private loadError: string | undefined = undefined;
+	private readonly remoteCatalogStore: RemoteCatalogStore | undefined;
+	private remoteCatalogRefresh: Promise<void> | undefined;
 
 	/** Re-register dynamic OAuth providers (e.g. user MCP servers) after refresh() resets the registry. */
 	private onOAuthProvidersReset?: () => void;
@@ -458,6 +467,9 @@ export class ModelRegistry {
 		readonly authStorage: AuthStorage,
 		private modelsJsonPath: string | undefined,
 	) {
+		this.remoteCatalogStore = modelsJsonPath
+			? RemoteCatalogStore.open(join(dirname(modelsJsonPath), REMOTE_CATALOG_STORE_FILE))
+			: undefined;
 		this.loadModels();
 	}
 
@@ -488,6 +500,7 @@ export class ModelRegistry {
 		// Credentials may have been written by another process (e.g. the UI
 		// process saving a login while the session lives in the daemon).
 		this.authStorage.reload();
+		this.remoteCatalogStore?.reload();
 		resetApiProviders();
 		resetOAuthProviders();
 		// reset drops everything but model-provider built-ins; re-add MCP integrations
@@ -548,7 +561,11 @@ export class ModelRegistry {
 		modelOverrides: Map<string, Map<string, ModelOverride>>,
 	): Model<Api>[] {
 		return getProviders().flatMap((provider) => {
-			const models = getModels(provider as KnownProvider) as Model<Api>[];
+			const models = overlayRemoteModels(
+				getModels(provider as KnownProvider) as Model<Api>[],
+				provider === PRIME_INFERENCE_PROVIDER_ID ? undefined : this.remoteCatalogStore?.get(provider),
+				getModelsGeneratedAt(),
+			);
 			const providerOverride = overrides.get(provider);
 			const perModelOverrides = modelOverrides.get(provider);
 
@@ -938,7 +955,37 @@ export class ModelRegistry {
 		}
 	}
 
+	/**
+	 * Fetch remote per-provider catalogs into the persisted store, single-flight.
+	 * Reloads the registry when entries changed. Never throws; respects PI_OFFLINE.
+	 */
+	refreshRemoteModelCatalog(): Promise<void> {
+		const store = this.remoteCatalogStore;
+		if (!store || isOfflineModeEnabled()) return Promise.resolve();
+		this.remoteCatalogRefresh ??= refreshRemoteCatalog(
+			store,
+			getProviders().filter((provider) => provider !== PRIME_INFERENCE_PROVIDER_ID),
+			{
+				baseUrl: process.env.PI_MODEL_CATALOG_URL || undefined,
+				signal: AbortSignal.timeout(10_000),
+			},
+		)
+			.then((changed) => {
+				if (changed) this.refresh();
+			})
+			.catch(() => {
+				// Fail open to the bundled catalog.
+			})
+			.finally(() => {
+				this.remoteCatalogRefresh = undefined;
+			});
+		return this.remoteCatalogRefresh;
+	}
+
 	async refreshModelCatalog(): Promise<ModelCatalogSnapshot> {
+		// Never block on the network: the persisted overlay already applies via
+		// loadModels; a completed fetch reloads the registry for the next snapshot.
+		void this.refreshRemoteModelCatalog();
 		const availableModels = await this.refreshAvailableModels();
 		const availablePrivateModels = new Set(
 			availableModels.filter(isPrivatePrimeInferenceModel).map((model) => `${model.provider}/${model.id}`),

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -955,9 +955,17 @@ export class ModelRegistry {
 		}
 	}
 
+	/** Rebuild the model list from current state without touching auth, OAuth registries, or on-disk stores. */
+	private reloadModels(): void {
+		this.loadModels();
+		for (const [providerName, config] of this.registeredProviders.entries()) {
+			this.applyProviderConfig(providerName, config);
+		}
+	}
+
 	/**
 	 * Fetch remote per-provider catalogs into the persisted store, single-flight.
-	 * Reloads the registry when entries changed. Never throws; respects PI_OFFLINE.
+	 * Rebuilds the model list when catalog content changed. Never throws; respects PI_OFFLINE.
 	 */
 	refreshRemoteModelCatalog(): Promise<void> {
 		const store = this.remoteCatalogStore;
@@ -971,7 +979,7 @@ export class ModelRegistry {
 			},
 		)
 			.then((changed) => {
-				if (changed) this.refresh();
+				if (changed) this.reloadModels();
 			})
 			.catch(() => {
 				// Fail open to the bundled catalog.
@@ -984,7 +992,8 @@ export class ModelRegistry {
 
 	async refreshModelCatalog(): Promise<ModelCatalogSnapshot> {
 		// Never block on the network: the persisted overlay already applies via
-		// loadModels; a completed fetch reloads the registry for the next snapshot.
+		// loadModels. Fetched models appear in the next catalog snapshot (picker
+		// TTL/force refresh); cross-connection cache invalidation is deliberately avoided.
 		void this.refreshRemoteModelCatalog();
 		const availableModels = await this.refreshAvailableModels();
 		const availablePrivateModels = new Set(

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -317,7 +317,10 @@ export function resolveModelScopeFromModels(patterns: string[], availableModels:
 
 export async function resolveModelScope(patterns: string[], modelRegistry: ModelRegistry): Promise<ScopedModel[]> {
 	const availableModels = await modelRegistry.refreshAvailableModels();
-	return resolveModelScopeFromModels(patterns, availableModels);
+	const scopedModels = resolveModelScopeFromModels(patterns, availableModels);
+	// A stale catalog heals for the next resolution; never blocks.
+	if (scopedModels.length === 0 && patterns.length > 0) void modelRegistry.refreshRemoteModelCatalog();
+	return scopedModels;
 }
 
 export interface ResolveCliModelResult {
@@ -605,6 +608,8 @@ export async function restoreModelFromSession(
 			? "no auth configured"
 			: "model is not available";
 	log.warn("could not restore model", { provider: savedProvider, model: savedModelId, reason });
+	// A stale catalog heals for the next attempt; never blocks startup.
+	void modelRegistry.refreshRemoteModelCatalog();
 
 	if (shouldPrintMessages) {
 		console.error(chalk.yellow(`Warning: Could not restore model ${savedProvider}/${savedModelId} (${reason}).`));

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -318,7 +318,6 @@ export function resolveModelScopeFromModels(patterns: string[], availableModels:
 export async function resolveModelScope(patterns: string[], modelRegistry: ModelRegistry): Promise<ScopedModel[]> {
 	const availableModels = await modelRegistry.refreshAvailableModels();
 	const scopedModels = resolveModelScopeFromModels(patterns, availableModels);
-	// A stale catalog heals for the next resolution; never blocks.
 	if (scopedModels.length === 0 && patterns.length > 0) void modelRegistry.refreshRemoteModelCatalog();
 	return scopedModels;
 }

--- a/packages/coding-agent/src/core/remote-catalog.ts
+++ b/packages/coding-agent/src/core/remote-catalog.ts
@@ -4,7 +4,7 @@ import { VERSION } from "../config.js";
 import { getPiUserAgent } from "../utils/pi-user-agent.js";
 
 export const REMOTE_CATALOG_STORE_FILE = "models-store.json";
-export const REMOTE_CATALOG_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000;
+const REMOTE_CATALOG_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const DEFAULT_CATALOG_BASE_URL = "https://pi.dev";
 const ATTEMPT_TIMEOUT_MS = 4_000;
 const MAX_RETRIES = 2;
@@ -25,12 +25,36 @@ function isOptionalFiniteNumber(value: unknown): boolean {
 	return value === undefined || (typeof value === "number" && Number.isFinite(value));
 }
 
+function isFiniteNumber(value: unknown): boolean {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+/** Requires every field that registry consumers dereference, so a malformed entry can never overlay a bundled model. */
+function isRemoteModel(value: unknown): value is Model<Api> {
+	if (typeof value !== "object" || value === null) return false;
+	const model = value as Partial<Model<Api>>;
+	return (
+		typeof model.id === "string" &&
+		typeof model.name === "string" &&
+		typeof model.api === "string" &&
+		typeof model.baseUrl === "string" &&
+		typeof model.cost === "object" &&
+		model.cost !== null &&
+		isFiniteNumber(model.cost.input) &&
+		isFiniteNumber(model.cost.output) &&
+		isFiniteNumber(model.cost.cacheRead) &&
+		isFiniteNumber(model.cost.cacheWrite) &&
+		isFiniteNumber(model.contextWindow) &&
+		isFiniteNumber(model.maxTokens)
+	);
+}
+
 function isCatalogEntry(value: unknown): value is RemoteCatalogEntry {
 	if (typeof value !== "object" || value === null) return false;
 	const entry = value as Partial<RemoteCatalogEntry>;
 	return (
 		Array.isArray(entry.models) &&
-		entry.models.every((model) => typeof model === "object" && model !== null && typeof model.id === "string") &&
+		entry.models.every(isRemoteModel) &&
 		isOptionalFiniteNumber(entry.lastModified) &&
 		isOptionalFiniteNumber(entry.checkedAt) &&
 		(entry.etag === undefined || typeof entry.etag === "string")
@@ -115,9 +139,7 @@ function parseCatalog(providerId: string, value: unknown): Model<Api>[] {
 				? Object.values(value)
 				: undefined;
 	if (!entries) throw new Error(`Invalid model catalog for provider "${providerId}"`);
-	return entries
-		.filter((entry): entry is Model<Api> => typeof entry === "object" && entry !== null && "id" in entry)
-		.map((model) => ({ ...model, provider: providerId }));
+	return entries.filter(isRemoteModel).map((model) => ({ ...model, provider: providerId }));
 }
 
 function isRetryableStatus(status: number): boolean {
@@ -159,7 +181,7 @@ async function refreshProvider(
 	baseUrl: string,
 	signal: AbortSignal | undefined,
 	force: boolean,
-): Promise<boolean> {
+): Promise<"skipped" | "checked" | "changed"> {
 	const stored = store.get(providerId);
 	if (
 		!force &&
@@ -167,7 +189,7 @@ async function refreshProvider(
 		stored.lastModified !== undefined &&
 		Date.now() - stored.checkedAt < REMOTE_CATALOG_REFRESH_INTERVAL_MS
 	) {
-		return false;
+		return "skipped";
 	}
 
 	// Only revalidate when a cached body backs the validator, so a 304 can never
@@ -185,18 +207,18 @@ async function refreshProvider(
 		const checkedAt = Date.now();
 		if (response.status === 304 && stored) {
 			store.set(providerId, { ...stored, checkedAt });
-			return true;
+			return "checked";
 		}
 		if (response.status === 404 || response.status === 501) {
 			store.set(providerId, { ...(stored ?? {}), models: [], checkedAt, lastModified: 0, etag: undefined });
-			return true;
+			return stored?.models.length ? "changed" : "checked";
 		}
 		if (!response.ok) {
 			// Transient failure: the cached body and its validator stay valid, so keep
 			// the etag and let the next refresh revalidate.
 			store.set(providerId, { ...(stored ?? { models: [] }), checkedAt });
 			log.warn("remote model catalog request failed", { provider: providerId, status: response.status });
-			return true;
+			return "checked";
 		}
 		const models = parseCatalog(providerId, await response.json());
 		const lastModified = Date.parse(response.headers.get("last-modified") ?? "");
@@ -206,18 +228,23 @@ async function refreshProvider(
 			lastModified: Number.isNaN(lastModified) ? 0 : lastModified,
 			etag: response.headers.get("etag") ?? undefined,
 		});
-		return true;
+		return "changed";
 	} catch (error) {
+		// No lastModified on purpose: a failed first check stays outside the freshness
+		// window so the next user-triggered refresh retries.
 		store.set(providerId, { ...(stored ?? { models: [] }), checkedAt: Date.now() });
 		log.warn("remote model catalog refresh failed", {
 			provider: providerId,
 			error: error instanceof Error ? error.message : String(error),
 		});
-		return true;
+		return "checked";
 	}
 }
 
-/** Refresh all providers concurrently. Fails open per provider; returns true if any entry changed. */
+/**
+ * Refresh all providers concurrently. Fails open per provider. Persists whenever any
+ * check completed (freshness window), but returns true only when catalog content changed.
+ */
 export async function refreshRemoteCatalog(
 	store: RemoteCatalogStore,
 	providerIds: readonly string[],
@@ -227,7 +254,7 @@ export async function refreshRemoteCatalog(
 	const results = await Promise.allSettled(
 		providerIds.map((id) => refreshProvider(store, id, baseUrl, options.signal, options.force ?? false)),
 	);
-	const changed = results.some((result) => result.status === "fulfilled" && result.value);
-	if (changed) store.save();
-	return changed;
+	const outcomes = results.map((result) => (result.status === "fulfilled" ? result.value : "skipped"));
+	if (outcomes.some((outcome) => outcome !== "skipped")) store.save();
+	return outcomes.some((outcome) => outcome === "changed");
 }

--- a/packages/coding-agent/src/core/remote-catalog.ts
+++ b/packages/coding-agent/src/core/remote-catalog.ts
@@ -1,4 +1,4 @@
-import { type Api, getLogger, type Model } from "@earendil-works/pi-ai";
+import { type Api, getApiProvider, getLogger, type Model } from "@earendil-works/pi-ai";
 import { readFileSync, renameSync, writeFileSync } from "fs";
 import { VERSION } from "../config.js";
 import { getPiUserAgent } from "../utils/pi-user-agent.js";
@@ -38,6 +38,9 @@ function isRemoteModel(value: unknown): value is Model<Api> {
 		typeof model.name === "string" &&
 		typeof model.api === "string" &&
 		typeof model.baseUrl === "string" &&
+		typeof model.reasoning === "boolean" &&
+		Array.isArray(model.input) &&
+		model.input.every((input) => input === "text" || input === "image") &&
 		typeof model.cost === "object" &&
 		model.cost !== null &&
 		isFiniteNumber(model.cost.input) &&
@@ -127,7 +130,11 @@ export function overlayRemoteModels(
 	if (localGeneratedAt !== undefined && (entry.lastModified === undefined || entry.lastModified <= localGeneratedAt)) {
 		return bundled;
 	}
-	return mergeModels(bundled, entry.models);
+	// pi.dev may serve apis our fork doesn't support; keep the bundled model instead.
+	return mergeModels(
+		bundled,
+		entry.models.filter((model) => getApiProvider(model.api) !== undefined),
+	);
 }
 
 function parseCatalog(providerId: string, value: unknown): Model<Api>[] {

--- a/packages/coding-agent/src/core/remote-catalog.ts
+++ b/packages/coding-agent/src/core/remote-catalog.ts
@@ -1,0 +1,233 @@
+import { type Api, getLogger, type Model } from "@earendil-works/pi-ai";
+import { readFileSync, renameSync, writeFileSync } from "fs";
+import { VERSION } from "../config.js";
+import { getPiUserAgent } from "../utils/pi-user-agent.js";
+
+export const REMOTE_CATALOG_STORE_FILE = "models-store.json";
+export const REMOTE_CATALOG_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000;
+const DEFAULT_CATALOG_BASE_URL = "https://pi.dev";
+const ATTEMPT_TIMEOUT_MS = 4_000;
+const MAX_RETRIES = 2;
+
+const log = getLogger("coding-agent.remote-catalog");
+
+export interface RemoteCatalogEntry {
+	models: Model<Api>[];
+	/** Unix ms timestamp from the remote catalog's Last-Modified header. */
+	lastModified?: number;
+	/** Unix ms timestamp of the last completed remote check. */
+	checkedAt?: number;
+	/** Opaque validator from the ETag header, stored verbatim and echoed as If-None-Match. */
+	etag?: string;
+}
+
+function isOptionalFiniteNumber(value: unknown): boolean {
+	return value === undefined || (typeof value === "number" && Number.isFinite(value));
+}
+
+function isCatalogEntry(value: unknown): value is RemoteCatalogEntry {
+	if (typeof value !== "object" || value === null) return false;
+	const entry = value as Partial<RemoteCatalogEntry>;
+	return (
+		Array.isArray(entry.models) &&
+		entry.models.every((model) => typeof model === "object" && model !== null && typeof model.id === "string") &&
+		isOptionalFiniteNumber(entry.lastModified) &&
+		isOptionalFiniteNumber(entry.checkedAt) &&
+		(entry.etag === undefined || typeof entry.etag === "string")
+	);
+}
+
+/** Persisted per-provider remote catalogs, written atomically to one JSON file. */
+export class RemoteCatalogStore {
+	private entries: Record<string, RemoteCatalogEntry> = {};
+
+	private constructor(private readonly path: string) {}
+
+	static open(path: string): RemoteCatalogStore {
+		const store = new RemoteCatalogStore(path);
+		store.reload();
+		return store;
+	}
+
+	reload(): void {
+		const entries: Record<string, RemoteCatalogEntry> = {};
+		try {
+			const parsed = JSON.parse(readFileSync(this.path, "utf8")) as unknown;
+			if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+				for (const [providerId, entry] of Object.entries(parsed)) {
+					if (isCatalogEntry(entry)) entries[providerId] = entry;
+				}
+			}
+		} catch {
+			// A missing or invalid store only means the overlay starts empty.
+		}
+		this.entries = entries;
+	}
+
+	get(providerId: string): RemoteCatalogEntry | undefined {
+		return this.entries[providerId];
+	}
+
+	set(providerId: string, entry: RemoteCatalogEntry): void {
+		this.entries[providerId] = entry;
+	}
+
+	save(): void {
+		try {
+			const tmpPath = `${this.path}.${process.pid}.tmp`;
+			writeFileSync(tmpPath, JSON.stringify(this.entries), { mode: 0o600 });
+			renameSync(tmpPath, this.path);
+		} catch {
+			// A failed write only requires a later refetch.
+		}
+	}
+}
+
+function mergeModels(baseline: readonly Model<Api>[], remote: readonly Model<Api>[]): Model<Api>[] {
+	const merged = [...baseline];
+	for (const model of remote) {
+		const index = merged.findIndex((entry) => entry.id === model.id);
+		if (index >= 0) merged[index] = model;
+		else merged.push(model);
+	}
+	return merged;
+}
+
+/** Remote models only apply when the remote catalog is newer than the bundled one. */
+export function overlayRemoteModels(
+	bundled: Model<Api>[],
+	entry: RemoteCatalogEntry | undefined,
+	localGeneratedAt: number | undefined,
+): Model<Api>[] {
+	if (!entry) return bundled;
+	if (localGeneratedAt !== undefined && (entry.lastModified === undefined || entry.lastModified <= localGeneratedAt)) {
+		return bundled;
+	}
+	return mergeModels(bundled, entry.models);
+}
+
+function parseCatalog(providerId: string, value: unknown): Model<Api>[] {
+	const entries = Array.isArray(value)
+		? value
+		: typeof value === "object" && value !== null && "models" in value && Array.isArray(value.models)
+			? value.models
+			: typeof value === "object" && value !== null
+				? Object.values(value)
+				: undefined;
+	if (!entries) throw new Error(`Invalid model catalog for provider "${providerId}"`);
+	return entries
+		.filter((entry): entry is Model<Api> => typeof entry === "object" && entry !== null && "id" in entry)
+		.map((model) => ({ ...model, provider: providerId }));
+}
+
+function isRetryableStatus(status: number): boolean {
+	return status === 408 || status === 429 || status >= 500;
+}
+
+/**
+ * Fetch with a bounded per-attempt timeout so a hung connection is retried
+ * instead of consuming the whole refresh budget. Caller cancellation is terminal.
+ */
+async function fetchCatalog(
+	url: URL,
+	headers: Record<string, string>,
+	signal: AbortSignal | undefined,
+): Promise<Response> {
+	for (let attempt = 0; ; attempt++) {
+		signal?.throwIfAborted();
+		const attemptSignal = AbortSignal.timeout(ATTEMPT_TIMEOUT_MS);
+		try {
+			const response = await fetch(url, {
+				headers,
+				signal: signal ? AbortSignal.any([signal, attemptSignal]) : attemptSignal,
+			});
+			if (attempt >= MAX_RETRIES || !isRetryableStatus(response.status)) return response;
+			try {
+				await response.body?.cancel();
+			} catch {
+				// Nothing more to do if cancelling the body also fails.
+			}
+		} catch (error) {
+			if (signal?.aborted || attempt >= MAX_RETRIES) throw error;
+		}
+	}
+}
+
+async function refreshProvider(
+	store: RemoteCatalogStore,
+	providerId: string,
+	baseUrl: string,
+	signal: AbortSignal | undefined,
+	force: boolean,
+): Promise<boolean> {
+	const stored = store.get(providerId);
+	if (
+		!force &&
+		stored?.checkedAt !== undefined &&
+		stored.lastModified !== undefined &&
+		Date.now() - stored.checkedAt < REMOTE_CATALOG_REFRESH_INTERVAL_MS
+	) {
+		return false;
+	}
+
+	// Only revalidate when a cached body backs the validator, so a 304 can never
+	// leave the overlay empty.
+	const validator = stored?.models.length ? stored.etag : undefined;
+	const url = new URL(`/api/models/providers/${encodeURIComponent(providerId)}`, baseUrl);
+	const headers = {
+		accept: "application/json",
+		"User-Agent": getPiUserAgent(VERSION),
+		...(validator ? { "if-none-match": validator } : {}),
+	};
+
+	try {
+		const response = await fetchCatalog(url, headers, signal);
+		const checkedAt = Date.now();
+		if (response.status === 304 && stored) {
+			store.set(providerId, { ...stored, checkedAt });
+			return true;
+		}
+		if (response.status === 404 || response.status === 501) {
+			store.set(providerId, { ...(stored ?? {}), models: [], checkedAt, lastModified: 0, etag: undefined });
+			return true;
+		}
+		if (!response.ok) {
+			// Transient failure: the cached body and its validator stay valid, so keep
+			// the etag and let the next refresh revalidate.
+			store.set(providerId, { ...(stored ?? { models: [] }), checkedAt });
+			log.warn("remote model catalog request failed", { provider: providerId, status: response.status });
+			return true;
+		}
+		const models = parseCatalog(providerId, await response.json());
+		const lastModified = Date.parse(response.headers.get("last-modified") ?? "");
+		store.set(providerId, {
+			models,
+			checkedAt,
+			lastModified: Number.isNaN(lastModified) ? 0 : lastModified,
+			etag: response.headers.get("etag") ?? undefined,
+		});
+		return true;
+	} catch (error) {
+		store.set(providerId, { ...(stored ?? { models: [] }), checkedAt: Date.now() });
+		log.warn("remote model catalog refresh failed", {
+			provider: providerId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return true;
+	}
+}
+
+/** Refresh all providers concurrently. Fails open per provider; returns true if any entry changed. */
+export async function refreshRemoteCatalog(
+	store: RemoteCatalogStore,
+	providerIds: readonly string[],
+	options: { baseUrl?: string; signal?: AbortSignal; force?: boolean } = {},
+): Promise<boolean> {
+	const baseUrl = options.baseUrl ?? DEFAULT_CATALOG_BASE_URL;
+	const results = await Promise.allSettled(
+		providerIds.map((id) => refreshProvider(store, id, baseUrl, options.signal, options.force ?? false)),
+	);
+	const changed = results.some((result) => result.status === "fulfilled" && result.value);
+	if (changed) store.save();
+	return changed;
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -532,7 +532,6 @@ function buildSessionOptions(
 		}
 		if (resolved.error) {
 			diagnostics.push({ type: "error", message: resolved.error });
-			// A stale catalog heals for the next resolution; never blocks.
 			void modelRegistry.refreshRemoteModelCatalog();
 		}
 		if (resolved.model) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -532,6 +532,8 @@ function buildSessionOptions(
 		}
 		if (resolved.error) {
 			diagnostics.push({ type: "error", message: resolved.error });
+			// A stale catalog heals for the next resolution; never blocks.
+			void modelRegistry.refreshRemoteModelCatalog();
 		}
 		if (resolved.model) {
 			options.model = resolved.model;

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1656,4 +1656,54 @@ describe("ModelRegistry", () => {
 			});
 		});
 	});
+
+	describe("remote catalog overlay", () => {
+		function writeRemoteCatalogStore(lastModified: number) {
+			writeFileSync(
+				join(tempDir, "models-store.json"),
+				JSON.stringify({
+					anthropic: {
+						models: [
+							{
+								id: "claude-test-remote",
+								name: "Claude Test Remote",
+								api: "anthropic-messages",
+								provider: "anthropic",
+								baseUrl: "https://api.anthropic.com",
+								reasoning: false,
+								input: ["text"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 200000,
+								maxTokens: 8192,
+							},
+						],
+						lastModified,
+						checkedAt: Date.now(),
+						etag: '"catalog-1"',
+					},
+				}),
+			);
+		}
+
+		test("serves remote models when the store is newer than the bundled catalog", () => {
+			writeRemoteCatalogStore(Date.now());
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			expect(registry.find("anthropic", "claude-test-remote")).toBeDefined();
+		});
+
+		test("ignores remote models when the store is older than the bundled catalog", () => {
+			writeRemoteCatalogStore(0);
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			expect(registry.find("anthropic", "claude-test-remote")).toBeUndefined();
+		});
+
+		test("still serves the bundled catalog when the store is corrupt", () => {
+			writeFileSync(
+				join(tempDir, "models-store.json"),
+				JSON.stringify({ anthropic: { models: [null], lastModified: Date.now(), checkedAt: Date.now() } }),
+			);
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			expect(getModelsForProvider(registry, "anthropic").length).toBeGreaterThan(0);
+		});
+	});
 });

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { AnthropicMessagesCompat, Api, Context, Model, OpenAICompletionsCompat } from "@earendil-works/pi-ai";
 import { getApiProvider } from "@earendil-works/pi-ai";
 import { getOAuthProvider, registerOAuthProvider } from "@earendil-works/pi-ai/oauth";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { clearApiKeyCache, ModelRegistry, type ProviderConfigInput } from "../src/core/model-registry.js";
 
@@ -1704,6 +1704,48 @@ describe("ModelRegistry", () => {
 			);
 			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
 			expect(getModelsForProvider(registry, "anthropic").length).toBeGreaterThan(0);
+		});
+
+		test("remote-driven reload keeps models.json request auth intact", async () => {
+			writeModelsJson({
+				"custom-provider": providerConfig("https://custom.example.com", [{ id: "custom-model" }]),
+			});
+			process.env.TEST_KEY = "test-key-value";
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const catalog = {
+				"claude-test-remote": {
+					id: "claude-test-remote",
+					name: "Claude Test Remote",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					baseUrl: "https://api.anthropic.com",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200000,
+					maxTokens: 8192,
+				},
+			};
+			vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+				if (String(input).includes("/api/models/providers/anthropic")) {
+					return new Response(JSON.stringify(catalog), {
+						headers: { "last-modified": new Date().toUTCString() },
+					});
+				}
+				return new Response("{}", { headers: { "last-modified": new Date(0).toUTCString() } });
+			});
+			try {
+				await registry.refreshRemoteModelCatalog();
+			} finally {
+				vi.restoreAllMocks();
+				delete process.env.TEST_KEY;
+			}
+
+			expect(registry.find("anthropic", "claude-test-remote")).toBeDefined();
+			const customModel = registry.find("custom-provider", "custom-model");
+			expect(customModel).toBeDefined();
+			const auth = await registry.getApiKeyAndHeaders(customModel!);
+			expect(auth).toMatchObject({ ok: true });
 		});
 	});
 });

--- a/packages/coding-agent/test/remote-catalog.test.ts
+++ b/packages/coding-agent/test/remote-catalog.test.ts
@@ -46,6 +46,7 @@ describe("remote catalog", () => {
 			remote: model("remote"),
 			static: { ...model("static"), name: "updated" },
 			plain: { id: "plain" },
+			exotic: { ...model("exotic"), api: "definitely-not-registered" },
 		};
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response(JSON.stringify(catalog), {
@@ -55,13 +56,15 @@ describe("remote catalog", () => {
 
 		await expect(refresh()).resolves.toBe(true);
 
-		// The malformed id-only entry is dropped and never shadows the bundled model.
-		expect(store.get("test-provider")?.models.map((entry) => entry.id)).toEqual(["remote", "static"]);
-		const bundled = [model("static"), model("plain")];
+		// The malformed id-only entry is dropped at parse time; the well-formed entry
+		// with an unregistered api is stored but never overlays the bundled model.
+		expect(store.get("test-provider")?.models.map((entry) => entry.id)).toEqual(["remote", "static", "exotic"]);
+		const bundled = [model("static"), model("plain"), model("exotic")];
 		const merged = overlayRemoteModels(bundled, store.get("test-provider"), GENERATED_AT);
-		expect(merged.map((entry) => entry.id)).toEqual(["static", "plain", "remote"]);
+		expect(merged.map((entry) => entry.id)).toEqual(["static", "plain", "exotic", "remote"]);
 		expect(merged[0]?.name).toBe("updated");
 		expect(merged[1]?.name).toBe("plain");
+		expect(merged[2]?.api).toBe("openai-completions");
 		expect(overlayRemoteModels(bundled, store.get("test-provider"), GENERATED_AT + 120_000)).toEqual(bundled);
 		expect(overlayRemoteModels(bundled, undefined, GENERATED_AT)).toEqual(bundled);
 	});
@@ -176,7 +179,13 @@ describe("remote catalog", () => {
 		store.reload();
 		expect(store.get("test-provider")).toBeUndefined();
 
-		const corruptEntries = [{ models: "corrupt" }, { models: [null] }, { models: [], lastModified: "yesterday" }];
+		const corruptEntries = [
+			{ models: "corrupt" },
+			{ models: [null] },
+			{ models: [], lastModified: "yesterday" },
+			{ models: [{ ...model("no-reasoning"), reasoning: "yes" }] },
+			{ models: [{ ...model("no-input"), input: undefined }] },
+		];
 		for (const entry of corruptEntries) {
 			writeFileSync(join(tempDir, "models-store.json"), JSON.stringify({ "test-provider": entry }));
 			store.reload();

--- a/packages/coding-agent/test/remote-catalog.test.ts
+++ b/packages/coding-agent/test/remote-catalog.test.ts
@@ -42,18 +42,26 @@ describe("remote catalog", () => {
 	}
 
 	it("overlays remote models only when the remote catalog is newer than the bundled one", async () => {
+		const catalog = {
+			remote: model("remote"),
+			static: { ...model("static"), name: "updated" },
+			plain: { id: "plain" },
+		};
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(JSON.stringify({ remote: model("remote"), static: { ...model("static"), name: "updated" } }), {
+			new Response(JSON.stringify(catalog), {
 				headers: { "last-modified": new Date(GENERATED_AT + 60_000).toUTCString() },
 			}),
 		);
 
-		await refresh();
+		await expect(refresh()).resolves.toBe(true);
 
-		const bundled = [model("static")];
+		// The malformed id-only entry is dropped and never shadows the bundled model.
+		expect(store.get("test-provider")?.models.map((entry) => entry.id)).toEqual(["remote", "static"]);
+		const bundled = [model("static"), model("plain")];
 		const merged = overlayRemoteModels(bundled, store.get("test-provider"), GENERATED_AT);
-		expect(merged.map((entry) => entry.id)).toEqual(["static", "remote"]);
+		expect(merged.map((entry) => entry.id)).toEqual(["static", "plain", "remote"]);
 		expect(merged[0]?.name).toBe("updated");
+		expect(merged[1]?.name).toBe("plain");
 		expect(overlayRemoteModels(bundled, store.get("test-provider"), GENERATED_AT + 120_000)).toEqual(bundled);
 		expect(overlayRemoteModels(bundled, undefined, GENERATED_AT)).toEqual(bundled);
 	});
@@ -105,15 +113,15 @@ describe("remote catalog", () => {
 			return response;
 		});
 
-		await refresh();
-		await expect(refresh({ force: true })).resolves.toBe(true);
+		await expect(refresh()).resolves.toBe(true);
+		await expect(refresh({ force: true })).resolves.toBe(false);
 
 		const stored = store.get("test-provider");
 		expect(stored?.models.map((entry) => entry.id)).toEqual(["remote"]);
 		expect(stored?.etag).toBe('"catalog-1"');
 
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("boom", { status: 500 }));
-		await expect(refresh({ force: true })).resolves.toBe(true);
+		await expect(refresh({ force: true })).resolves.toBe(false);
 		expect(store.get("test-provider")?.models.map((entry) => entry.id)).toEqual(["remote"]);
 		expect(store.get("test-provider")?.etag).toBe('"catalog-1"');
 	});
@@ -185,7 +193,7 @@ describe("remote catalog", () => {
 		);
 
 		await expect(refreshRemoteCatalog(store, ["test-provider"], { signal: AbortSignal.timeout(500) })).resolves.toBe(
-			true,
+			false,
 		);
 		expect(store.get("test-provider")?.models).toEqual([]);
 	});

--- a/packages/coding-agent/test/remote-catalog.test.ts
+++ b/packages/coding-agent/test/remote-catalog.test.ts
@@ -1,0 +1,202 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VERSION } from "../src/config.js";
+import { overlayRemoteModels, RemoteCatalogStore, refreshRemoteCatalog } from "../src/core/remote-catalog.js";
+
+function model(id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "test-provider",
+		baseUrl: "https://example.test/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000,
+		maxTokens: 100,
+	} as Model<Api>;
+}
+
+const GENERATED_AT = Date.parse("2026-07-23T10:00:00.000Z");
+
+describe("remote catalog", () => {
+	let tempDir: string;
+	let store: RemoteCatalogStore;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-test-remote-catalog-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		store = RemoteCatalogStore.open(join(tempDir, "models-store.json"));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		vi.restoreAllMocks();
+	});
+
+	async function refresh(options: { force?: boolean } = {}): Promise<boolean> {
+		return refreshRemoteCatalog(store, ["test-provider"], options);
+	}
+
+	it("overlays remote models only when the remote catalog is newer than the bundled one", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ remote: model("remote"), static: { ...model("static"), name: "updated" } }), {
+				headers: { "last-modified": new Date(GENERATED_AT + 60_000).toUTCString() },
+			}),
+		);
+
+		await refresh();
+		expect(fetchSpy.mock.calls[0]?.[1]?.headers).toMatchObject({
+			"User-Agent": expect.stringContaining(`prime-agent/${VERSION}`),
+		});
+
+		const bundled = [model("static")];
+		const merged = overlayRemoteModels(bundled, store.get("test-provider"), GENERATED_AT);
+		expect(merged.map((entry) => entry.id)).toEqual(["static", "remote"]);
+		expect(merged[0]?.name).toBe("updated");
+		expect(overlayRemoteModels(bundled, store.get("test-provider"), GENERATED_AT + 120_000)).toEqual(bundled);
+		expect(overlayRemoteModels(bundled, undefined, GENERATED_AT)).toEqual(bundled);
+	});
+
+	it("keeps the bundled catalog when the remote last-modified header is older or absent", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ old: model("old") }), {
+				headers: { "last-modified": new Date(GENERATED_AT - 60_000).toUTCString() },
+			}),
+		);
+
+		await refresh();
+
+		const bundled = [model("static")];
+		expect(overlayRemoteModels(bundled, store.get("test-provider"), GENERATED_AT)).toEqual(bundled);
+	});
+
+	it("revalidates a stored catalog with its etag and keeps the overlay on 304", async () => {
+		const responses = [
+			new Response(JSON.stringify({ remote: model("remote") }), {
+				headers: { etag: '"catalog-1"', "last-modified": new Date(GENERATED_AT + 60_000).toUTCString() },
+			}),
+			new Response(null, { status: 304 }),
+		];
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => responses.shift() as Response);
+
+		await refresh();
+		expect(fetchSpy.mock.calls[0]?.[1]?.headers).not.toHaveProperty("if-none-match");
+		const first = store.get("test-provider");
+		expect(first?.etag).toBe('"catalog-1"');
+
+		await refresh({ force: true });
+		expect(fetchSpy.mock.calls[1]?.[1]?.headers).toMatchObject({ "if-none-match": '"catalog-1"' });
+		const second = store.get("test-provider");
+		expect(second?.models.map((entry) => entry.id)).toEqual(["remote"]);
+		expect(second?.etag).toBe('"catalog-1"');
+		expect(second?.checkedAt).toBeGreaterThanOrEqual(first?.checkedAt ?? 0);
+	});
+
+	it("fails open on transport errors and server errors, keeping the stored overlay", async () => {
+		const responses = [
+			new Response(JSON.stringify({ remote: model("remote") }), {
+				headers: { etag: '"catalog-1"', "last-modified": new Date(GENERATED_AT + 60_000).toUTCString() },
+			}),
+		];
+		vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+			const response = responses.shift();
+			if (!response) throw new Error("connection refused");
+			return response;
+		});
+
+		await refresh();
+		await expect(refresh({ force: true })).resolves.toBe(true);
+
+		const stored = store.get("test-provider");
+		expect(stored?.models.map((entry) => entry.id)).toEqual(["remote"]);
+		expect(stored?.etag).toBe('"catalog-1"');
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("boom", { status: 500 }));
+		await expect(refresh({ force: true })).resolves.toBe(true);
+		expect(store.get("test-provider")?.models.map((entry) => entry.id)).toEqual(["remote"]);
+		expect(store.get("test-provider")?.etag).toBe('"catalog-1"');
+	});
+
+	it("drops the overlay and stale etag on 404", async () => {
+		const responses = [
+			new Response(JSON.stringify({ remote: model("remote") }), {
+				headers: { etag: '"catalog-1"', "last-modified": new Date(GENERATED_AT + 60_000).toUTCString() },
+			}),
+			new Response("gone", { status: 404 }),
+		];
+		vi.spyOn(globalThis, "fetch").mockImplementation(async () => responses.shift() as Response);
+
+		await refresh();
+		await refresh({ force: true });
+
+		expect(store.get("test-provider")).toMatchObject({ models: [], lastModified: 0, etag: undefined });
+	});
+
+	it("observes the freshness window unless forced", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+			async () =>
+				new Response(JSON.stringify({ remote: model("remote") }), {
+					headers: { "last-modified": new Date().toUTCString() },
+				}),
+		);
+
+		await refresh();
+		await refresh();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		const stored = store.get("test-provider");
+		store.set("test-provider", {
+			...stored,
+			models: stored?.models ?? [],
+			checkedAt: Date.now() - 5 * 60 * 60 * 1000,
+		});
+		await refresh();
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("reload drops the in-memory overlay when the store file is removed or corrupt", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ remote: model("remote") }), {
+				headers: { "last-modified": new Date(GENERATED_AT + 60_000).toUTCString() },
+			}),
+		);
+		await refresh();
+		expect(store.get("test-provider")?.models).toHaveLength(1);
+
+		rmSync(join(tempDir, "models-store.json"));
+		store.reload();
+		expect(store.get("test-provider")).toBeUndefined();
+
+		const corruptEntries = [
+			{ models: "corrupt" },
+			{ models: [null] },
+			{ models: [{ name: "no id" }] },
+			{ models: [], lastModified: "yesterday" },
+			{ models: [], etag: 42 },
+		];
+		for (const entry of corruptEntries) {
+			writeFileSync(join(tempDir, "models-store.json"), JSON.stringify({ "test-provider": entry }));
+			store.reload();
+			expect(store.get("test-provider")).toBeUndefined();
+		}
+	});
+
+	it("settles in bounded time when a fetch hangs until aborted", async () => {
+		vi.spyOn(globalThis, "fetch").mockImplementation(
+			(_input, init) =>
+				new Promise((_resolve, reject) => {
+					init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+				}),
+		);
+
+		await expect(refreshRemoteCatalog(store, ["test-provider"], { signal: AbortSignal.timeout(500) })).resolves.toBe(
+			true,
+		);
+		expect(store.get("test-provider")?.models).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/remote-catalog.test.ts
+++ b/packages/coding-agent/test/remote-catalog.test.ts
@@ -3,7 +3,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { VERSION } from "../src/config.js";
 import { overlayRemoteModels, RemoteCatalogStore, refreshRemoteCatalog } from "../src/core/remote-catalog.js";
 
 function model(id: string): Model<Api> {
@@ -43,16 +42,13 @@ describe("remote catalog", () => {
 	}
 
 	it("overlays remote models only when the remote catalog is newer than the bundled one", async () => {
-		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response(JSON.stringify({ remote: model("remote"), static: { ...model("static"), name: "updated" } }), {
 				headers: { "last-modified": new Date(GENERATED_AT + 60_000).toUTCString() },
 			}),
 		);
 
 		await refresh();
-		expect(fetchSpy.mock.calls[0]?.[1]?.headers).toMatchObject({
-			"User-Agent": expect.stringContaining(`prime-agent/${VERSION}`),
-		});
 
 		const bundled = [model("static")];
 		const merged = overlayRemoteModels(bundled, store.get("test-provider"), GENERATED_AT);
@@ -172,13 +168,7 @@ describe("remote catalog", () => {
 		store.reload();
 		expect(store.get("test-provider")).toBeUndefined();
 
-		const corruptEntries = [
-			{ models: "corrupt" },
-			{ models: [null] },
-			{ models: [{ name: "no id" }] },
-			{ models: [], lastModified: "yesterday" },
-			{ models: [], etag: 42 },
-		];
+		const corruptEntries = [{ models: "corrupt" }, { models: [null] }, { models: [], lastModified: "yesterday" }];
 		for (const entry of corruptEntries) {
 			writeFileSync(join(tempDir, "models-store.json"), JSON.stringify({ "test-provider": entry }));
 			store.reload();


### PR DESCRIPTION
Fixes ENG-5261 (https://linear.app/primeintellect/issue/ENG-5261/fix-the-model-catalogue-generation)

## Problem

The model catalog is a build-time snapshot: `packages/ai/src/models.generated.ts`, produced by `packages/ai/scripts/generate-models.ts`. Any new or changed provider model needs a regen PR plus a release, and the catalog goes stale for everyone in between (this ticket was filed after #1445's regen broke CI and missed Copilot failures).

## Solution: persisted remote catalog overlay (design from upstream pi)

Upstream pi (earendil-works/pi) solved exactly this with `withRemoteCatalog`: each static built-in provider gets a persisted remote overlay fetched from per-provider catalog JSON, with ETag/If-None-Match revalidation, a 4-hour freshness window, bounded per-attempt timeouts with retry, and remote models only overriding bundled ones when the remote `Last-Modified` is newer than the local bundle's generation time. On ANY error it fails open to the bundled catalog. This PR ports those semantics — including their fixes for pi#7113 (unbounded fetch froze login; every fetch here has a 4s per-attempt timeout combined with the caller's abort signal) and their retry hardening (df018b602) — adapted to our fork's architecture:

- We don't have pi's model-runtime facade or `provider.refreshModels` plumbing, so the overlay hooks into `ModelRegistry` instead — `loadBuiltInModels()` is the single choke point every consumer flows through (`/model` picker, `find_models`, CLI/session model resolution).
- `packages/coding-agent/src/core/remote-catalog.ts` (233 lines) holds everything: `RemoteCatalogStore` (persisted per-provider entries with `models`/`lastModified`/`checkedAt`/`etag`, atomic tmp+rename writes to `models-store.json` in the agent dir, corrupt files validated and dropped on reload), `overlayRemoteModels` (remote-newer-than-bundle gating + merge), and `refreshRemoteCatalog` (concurrent per-provider fetch, 304/404/error semantics copied from upstream, fail-open per provider). Remote entries are strictly validated (id/name/api/baseUrl, finite cost and limits) both on fetch and on store load, so a malformed entry can never shadow a bundled model.
- `generate-models.ts` now emits `MODELS_GENERATED_AT` into the generated file (upstream bc3d36474 pattern), so overlay dominance is compared against the catalog's recorded generation time, not installation-dependent file mtimes. `models.generated.ts` was hand-edited to add the identical line with the timestamp of the last regen commit (bb61ca21c) — a deliberate one-time exception to the "never hand-edit" rule to avoid a full regen diff; the script emits the exact same line going forward.

### Refresh triggers (never block startup/login)

- `/model` picker open (`refreshModelCatalog()`): kicks a single-flight, fire-and-forget refresh; the persisted overlay from the previous run is already applied synchronously, and a fetch that actually changed catalog content rebuilds the model list (narrow reload — auth/OAuth state is never touched) so the picker's next snapshot picks up new models. Startup paths that call `getModelCatalog()` never wait on the network.
- Model-not-found: CLI model resolution errors, empty `--models` scope resolution, and failed session-restore all fire the same fire-and-forget refresh so a stale catalog heals for the next attempt.
- The 4h freshness window plus single-flight dedupe bound the request volume; `PI_OFFLINE` disables it entirely.

## pi.dev as default source vs own publisher

Default catalog source is `https://pi.dev/api/models/providers/<id>` (override via `PI_MODEL_CATALOG_URL`). Since we forked pi, our provider ids match theirs, and their public per-provider catalogs were verified live for anthropic, openai-codex, google, openrouter, kimi-coding, xiaomi, opencode (prime-inference 404s and is excluded from the overlay — it's first-party with its own private-models mechanism). Tradeoff: zero publisher infrastructure to run for v1, at the cost of depending on pi.dev's publish cadence and their catalog shape for shared providers; unknown extra fields in their entries are runtime-inert, and each of our regen+releases resets bundle dominance. If/when our catalogs diverge, we stand up our own publisher (upstream's `publish-model-catalog.yml` + script are a direct template) and flip the default URL — noted as follow-up.

## Validation

- `npm run check` green; `test/remote-catalog.test.ts` (8 behavioral tests) + `test/model-registry.test.ts` (75, incl. 3 new overlay integration tests) all pass.
- Live smoke against pi.dev (openrouter): 86 ms, 351 models fetched with etag + last-modified, 62 model ids not in our bundled catalog (example: `anthropic/claude-fable-5:batch`); a second refresh inside the 4h window performs 0 fetches.
- Fail-open proof: `baseUrl=https://127.0.0.1:9` resolves in 9 ms without throwing and the bundled openrouter catalog (289 models) is still served; a hung fetch that only honors abort settles within the bounded timeout (covered by a test).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add persisted remote model catalog overlay with ETag revalidation and background refresh
> - Bundled model catalog now includes a `MODELS_GENERATED_AT` timestamp; remote entries are overlaid only when newer than the bundled generation time, so models stop going stale between releases.
> - New `RemoteCatalogStore` persists per-provider remote catalogs to disk with entries tracking models, `lastModified`, `checkedAt`, and `etag`; `refreshRemoteCatalog` fetches concurrently with bounded timeouts, retries, and ETag-based `If-None-Match` revalidation under a 4-hour freshness window.
> - `ModelRegistry.refreshRemoteModelCatalog` single-flights concurrent refreshes, skips `PRIME_INFERENCE`, and rebuilds the in-memory model list via `reloadModels` without resetting auth or OAuth registries.
> - `resolveModelScope`, `restoreModelFromSession`, and CLI model resolution errors now trigger a non-blocking background remote catalog refresh so a subsequent attempt sees updated models.
> - Risk: `overlayRemoteModels` in [remote-catalog.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1603/files#diff-59be4777d01acd08c2ffc1cd281ef3cf315318b8dde4eba0a054f82736490886) silently filters out remote models whose `api` is not registered locally; a new provider API shipped remotely but not yet bundled will be dropped until the client is updated. Transport/server errors during `refreshRemoteCatalog` are swallowed and existing overlays are preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6c153f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model discovery and applies remote JSON into the in-process catalog. Fail-open plus strict validation limit blast radius, but a bad remote catalog could still add or replace models until the next regen.
> 
> **Overview**
> New provider models can land without a catalog regen: a persisted overlay (`models-store.json`) is fetched from pi.dev (or `PI_MODEL_CATALOG_URL`) and merged into built-in models when the remote `Last-Modified` is newer than the bundled `MODELS_GENERATED_AT`.
> 
> Refresh is fire-and-forget (picker open, CLI/session model-not-found). It uses ETag revalidation, a 4-hour freshness window, bounded retries, and never blocks startup. Failures keep the bundled catalog. Prime Inference is excluded.
> 
> Malformed remote entries are dropped on parse and on store load so they cannot shadow bundled models. Unknown APIs stay on the bundled definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6c153f564f16e8fd41b87741ece8f8cb97cff1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->