### PR TITLE
fix(coding-agent): hold goal continuations while subagent work is unsettled

### DIFF
--- a/packages/coding-agent/.changes/goal-continuation-quiescence.md
+++ b/packages/coding-agent/.changes/goal-continuation-quiescence.md
@@ -1,0 +1,1 @@
+- Fixed `/goal` re-prompting a parent that had correctly delegated to subagents and ended its turn: the continuation now waits until descendant work settles, then resumes automatically.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1060,6 +1060,7 @@ export class AgentSession {
 
 	private _goalState: GoalState = emptyGoalState();
 	private _goalAccountingStartedAt: number | undefined = undefined;
+	private _goalContinuationAwaitsRlmWork = false;
 	private _goalAccountedAssistantMessages = new WeakSet<AssistantMessage>();
 	private _goalAbortInProgress = false;
 	private _autonomousState: AutonomousRuntimeState;
@@ -2032,6 +2033,18 @@ export class AgentSession {
 				contextTools.push(ipythonTool);
 				context.tools = contextTools;
 			}
+		}
+	}
+
+	private _maybeResumeGoalContinuationAfterRlmWork(): void {
+		if (!this._goalContinuationAwaitsRlmWork) return;
+		if (this._disposed || this._disposing || this._hasUnsettledRlmQuiescenceWork()) return;
+		this._goalContinuationAwaitsRlmWork = false;
+		if (this._goalState.status !== "active" || !this._goalState.objective) return;
+		try {
+			this._runOrQueueGoalContext("continuation");
+		} catch {
+			// Continuation resume must not throw into the settlement path.
 		}
 	}
 
@@ -3215,6 +3228,13 @@ export class AgentSession {
 		if (signal?.aborted || this._goalState.status !== "active" || !this._goalState.objective) {
 			return [];
 		}
+		// Delegating and ending the turn is correct behavior; hold the continuation
+		// until descendants settle instead of re-prompting a waiting parent.
+		if (this._hasUnsettledRlmQuiescenceWork()) {
+			this._goalContinuationAwaitsRlmWork = true;
+			return [];
+		}
+		this._goalContinuationAwaitsRlmWork = false;
 		try {
 			this._ensureGoalRuntimeActive(context.context);
 			const nextGoal = {
@@ -9263,6 +9283,7 @@ export class AgentSession {
 		this._abandonedRlmQuiescenceChildIds.add(run.id);
 		this._unsettledRlmChildRuns.delete(run);
 		run.settlement.resolve();
+		this._maybeResumeGoalContinuationAfterRlmWork();
 	}
 
 	private _cancelActiveRlmChildRuns(reason: string): void {
@@ -9601,6 +9622,7 @@ export class AgentSession {
 		run.settlement.resolve();
 		run.deletionReservation.resolve();
 		this._unsettledRlmChildRuns.delete(run);
+		this._maybeResumeGoalContinuationAfterRlmWork();
 	}
 
 	private _observeRlmRunDeletionCleanup(
@@ -10423,6 +10445,7 @@ export class AgentSession {
 					run.settled = true;
 					run.settlement.resolve();
 					this._unsettledRlmChildRuns.delete(run);
+					this._maybeResumeGoalContinuationAfterRlmWork();
 				}
 			}
 		})().catch(() => undefined);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1745,6 +1745,7 @@ export class AgentSession {
 	}
 
 	private _clearQueuedGoalContexts(): void {
+		this._goalContinuationAwaitsRlmWork = false;
 		this._pendingNextTurnMessages = this._pendingNextTurnMessages.filter(
 			(message) => message.customType !== GOAL_CONTEXT_CUSTOM_TYPE,
 		);
@@ -1776,6 +1777,7 @@ export class AgentSession {
 			updatedAt: now,
 		};
 		this._goalAccountingStartedAt = now;
+		this._goalContinuationAwaitsRlmWork = false;
 		this._setGoalState(goal);
 		return this._goalState;
 	}
@@ -2043,8 +2045,9 @@ export class AgentSession {
 			this._goalContinuationAwaitsRlmWork = false;
 			return;
 		}
-		// Keep the deferral while admission is paused; the pause release retries.
-		if (this._sessionInputAdmissionPauses.size > 0) return;
+		// Keep the deferral while admission is paused or the pump is suspended
+		// (post-abort); the pause release and resumeQueuedWork retry.
+		if (this._sessionInputAdmissionPauses.size > 0 || this._sessionInputPumpSuspended) return;
 		try {
 			this._ensureGoalRuntimeActive();
 			const message = createGoalContextMessage(this._goalState, "continuation");
@@ -6723,6 +6726,7 @@ export class AgentSession {
 	/** Resume the scheduler after requestAbort/abortForUpdateRestart suspended it; owned pause leases are unaffected. */
 	resumeQueuedWork(): boolean {
 		this._resumeSessionInputAdmission();
+		this._maybeResumeGoalContinuationAfterRlmWork();
 		this._scheduleSessionInputPump();
 		return this._hasSelectableSessionInput();
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2039,12 +2039,26 @@ export class AgentSession {
 	private _maybeResumeGoalContinuationAfterRlmWork(): void {
 		if (!this._goalContinuationAwaitsRlmWork) return;
 		if (this._disposed || this._disposing || this._hasUnsettledRlmQuiescenceWork()) return;
-		this._goalContinuationAwaitsRlmWork = false;
-		if (this._goalState.status !== "active" || !this._goalState.objective) return;
+		if (this._goalState.status !== "active" || !this._goalState.objective) {
+			this._goalContinuationAwaitsRlmWork = false;
+			return;
+		}
+		// Keep the deferral while admission is paused; the pause release retries.
+		if (this._sessionInputAdmissionPauses.size > 0) return;
 		try {
-			this._runOrQueueGoalContext("continuation");
+			this._ensureGoalRuntimeActive();
+			const message = createGoalContextMessage(this._goalState, "continuation");
+			const normalized = normalizeMessageContent(message.content);
+			// No front: a settling child's terminal notice must be read first.
+			this._admitSessionInput(
+				this._createPreparedTurnAction("followUp", normalized.text, normalized.images, {
+					message,
+					resumeIfIdle: true,
+				}),
+			);
+			this._goalContinuationAwaitsRlmWork = false;
 		} catch {
-			// Continuation resume must not throw into the settlement path.
+			// Admission can race a new pause; the deferral stays set for the retry.
 		}
 	}
 
@@ -6592,6 +6606,7 @@ export class AgentSession {
 				this._sessionInputPumpEpoch++;
 				this._notifySessionInputCheckpointChange();
 				this._flushDeferredRlmTerminalNotices();
+				this._maybeResumeGoalContinuationAfterRlmWork();
 				this._scheduleSessionInputPump();
 			},
 		};

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2048,8 +2048,15 @@ export class AgentSession {
 		// Keep the deferral while admission is paused or the pump is suspended
 		// (post-abort); the pause release and resumeQueuedWork retry.
 		if (this._sessionInputAdmissionPauses.size > 0 || this._sessionInputPumpSuspended) return;
+		const goalBeforeResume = this._goalState;
 		try {
 			this._ensureGoalRuntimeActive();
+			this._setGoalState({
+				...this._goalState,
+				continuationsUsed: this._goalState.continuationsUsed + 1,
+				lastReason: undefined,
+				lastError: undefined,
+			});
 			const message = createGoalContextMessage(this._goalState, "continuation");
 			const normalized = normalizeMessageContent(message.content);
 			// No front: a settling child's terminal notice must be read first.
@@ -2061,7 +2068,8 @@ export class AgentSession {
 			);
 			this._goalContinuationAwaitsRlmWork = false;
 		} catch {
-			// Admission can race a new pause; the deferral stays set for the retry.
+			// Admission can race a new pause; roll back so the retry re-counts.
+			this._setGoalState(goalBeforeResume);
 		}
 	}
 

--- a/packages/coding-agent/test/goal-continuation-quiescence.test.ts
+++ b/packages/coding-agent/test/goal-continuation-quiescence.test.ts
@@ -65,7 +65,7 @@ describe("goal continuation vs unsettled subagent work", () => {
 		expect(mode._goalState.continuationsUsed).toBe(1);
 	});
 
-	it("resumes a deferred continuation exactly once, unqueued and idle-waking", () => {
+	it("resumes a deferred continuation exactly once, unqueued, idle-waking, and counted", () => {
 		const mode = harness({ _goalContinuationAwaitsRlmWork: true });
 		maybeResume.call(mode);
 		maybeResume.call(mode);
@@ -73,6 +73,7 @@ describe("goal continuation vs unsettled subagent work", () => {
 		const [action, options] = mode._admitSessionInput.mock.calls[0]!;
 		expect((action as { options: { resumeIfIdle: boolean } }).options.resumeIfIdle).toBe(true);
 		expect(options).toBeUndefined();
+		expect(mode._goalState.continuationsUsed).toBe(1);
 	});
 
 	it("keeps the deferral while admission is paused and retries after release", () => {
@@ -97,7 +98,7 @@ describe("goal continuation vs unsettled subagent work", () => {
 		expect(mode._goalContinuationAwaitsRlmWork).toBe(true);
 	});
 
-	it("keeps the deferral when admission throws", () => {
+	it("keeps the deferral and rolls back the count when admission throws", () => {
 		const mode = harness({
 			_goalContinuationAwaitsRlmWork: true,
 			_admitSessionInput: vi.fn(() => {
@@ -106,6 +107,7 @@ describe("goal continuation vs unsettled subagent work", () => {
 		});
 		maybeResume.call(mode);
 		expect(mode._goalContinuationAwaitsRlmWork).toBe(true);
+		expect(mode._goalState.continuationsUsed).toBe(0);
 	});
 
 	it("stays deferred while work remains and drops the deferral for inactive goals", () => {

--- a/packages/coding-agent/test/goal-continuation-quiescence.test.ts
+++ b/packages/coding-agent/test/goal-continuation-quiescence.test.ts
@@ -6,11 +6,13 @@ type Harness = {
 	_goalContinuationAwaitsRlmWork: boolean;
 	_disposed: boolean;
 	_disposing: boolean;
+	_sessionInputAdmissionPauses: Set<symbol>;
 	_hasUnsettledRlmQuiescenceWork: () => boolean;
 	_stopGoalContinuationForTerminalMessage: () => boolean;
 	_ensureGoalRuntimeActive: () => void;
 	_setGoalState: (goal: unknown) => void;
-	_runOrQueueGoalContext: ReturnType<typeof vi.fn>;
+	_createPreparedTurnAction: ReturnType<typeof vi.fn>;
+	_admitSessionInput: ReturnType<typeof vi.fn>;
 };
 
 const getGoalContinuation = Reflect.get(AgentSession.prototype, "_getGoalContinuationMessages") as (
@@ -27,13 +29,18 @@ function harness(overrides: Partial<Harness> = {}): Harness {
 		_goalContinuationAwaitsRlmWork: false,
 		_disposed: false,
 		_disposing: false,
+		_sessionInputAdmissionPauses: new Set(),
 		_hasUnsettledRlmQuiescenceWork: () => false,
 		_stopGoalContinuationForTerminalMessage: () => false,
 		_ensureGoalRuntimeActive: () => {},
 		_setGoalState: function (this: Harness, goal: unknown) {
 			this._goalState = goal as Harness["_goalState"];
 		},
-		_runOrQueueGoalContext: vi.fn(),
+		_createPreparedTurnAction: vi.fn((schedule: string, _text: string, _images: unknown, options: unknown) => ({
+			schedule,
+			options,
+		})),
+		_admitSessionInput: vi.fn(),
 		...overrides,
 	};
 }
@@ -56,24 +63,52 @@ describe("goal continuation vs unsettled subagent work", () => {
 		expect(mode._goalState.continuationsUsed).toBe(1);
 	});
 
-	it("resumes a deferred continuation exactly once after settlement", () => {
+	it("resumes a deferred continuation exactly once, unqueued and idle-waking", () => {
 		const mode = harness({ _goalContinuationAwaitsRlmWork: true });
 		maybeResume.call(mode);
 		maybeResume.call(mode);
-		expect(mode._runOrQueueGoalContext).toHaveBeenCalledTimes(1);
-		expect(mode._runOrQueueGoalContext).toHaveBeenCalledWith("continuation");
+		expect(mode._admitSessionInput).toHaveBeenCalledTimes(1);
+		const [action, options] = mode._admitSessionInput.mock.calls[0]!;
+		expect((action as { options: { resumeIfIdle: boolean } }).options.resumeIfIdle).toBe(true);
+		expect(options).toBeUndefined();
 	});
 
-	it("stays deferred while work remains and skips inactive goals", () => {
+	it("keeps the deferral while admission is paused and retries after release", () => {
+		const paused = harness({
+			_goalContinuationAwaitsRlmWork: true,
+			_sessionInputAdmissionPauses: new Set([Symbol("pause")]),
+		});
+		maybeResume.call(paused);
+		expect(paused._admitSessionInput).not.toHaveBeenCalled();
+		expect(paused._goalContinuationAwaitsRlmWork).toBe(true);
+
+		paused._sessionInputAdmissionPauses.clear();
+		maybeResume.call(paused);
+		expect(paused._admitSessionInput).toHaveBeenCalledTimes(1);
+		expect(paused._goalContinuationAwaitsRlmWork).toBe(false);
+	});
+
+	it("keeps the deferral when admission throws", () => {
+		const mode = harness({
+			_goalContinuationAwaitsRlmWork: true,
+			_admitSessionInput: vi.fn(() => {
+				throw new Error("admission race");
+			}),
+		});
+		maybeResume.call(mode);
+		expect(mode._goalContinuationAwaitsRlmWork).toBe(true);
+	});
+
+	it("stays deferred while work remains and drops the deferral for inactive goals", () => {
 		const busy = harness({ _goalContinuationAwaitsRlmWork: true, _hasUnsettledRlmQuiescenceWork: () => true });
 		maybeResume.call(busy);
-		expect(busy._runOrQueueGoalContext).not.toHaveBeenCalled();
+		expect(busy._admitSessionInput).not.toHaveBeenCalled();
 		expect(busy._goalContinuationAwaitsRlmWork).toBe(true);
 
 		const inactive = harness({ _goalContinuationAwaitsRlmWork: true });
 		inactive._goalState = { status: "paused", objective: "ship it", continuationsUsed: 0 };
 		maybeResume.call(inactive);
-		expect(inactive._runOrQueueGoalContext).not.toHaveBeenCalled();
+		expect(inactive._admitSessionInput).not.toHaveBeenCalled();
 		expect(inactive._goalContinuationAwaitsRlmWork).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/goal-continuation-quiescence.test.ts
+++ b/packages/coding-agent/test/goal-continuation-quiescence.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+
+type Harness = {
+	_goalState: { status: string; objective?: string; continuationsUsed: number };
+	_goalContinuationAwaitsRlmWork: boolean;
+	_disposed: boolean;
+	_disposing: boolean;
+	_hasUnsettledRlmQuiescenceWork: () => boolean;
+	_stopGoalContinuationForTerminalMessage: () => boolean;
+	_ensureGoalRuntimeActive: () => void;
+	_setGoalState: (goal: unknown) => void;
+	_runOrQueueGoalContext: ReturnType<typeof vi.fn>;
+};
+
+const getGoalContinuation = Reflect.get(AgentSession.prototype, "_getGoalContinuationMessages") as (
+	this: Harness,
+	context: { message: unknown; context: unknown },
+) => Promise<unknown[]>;
+const maybeResume = Reflect.get(AgentSession.prototype, "_maybeResumeGoalContinuationAfterRlmWork") as (
+	this: Harness,
+) => void;
+
+function harness(overrides: Partial<Harness> = {}): Harness {
+	return {
+		_goalState: { status: "active", objective: "ship it", continuationsUsed: 0 },
+		_goalContinuationAwaitsRlmWork: false,
+		_disposed: false,
+		_disposing: false,
+		_hasUnsettledRlmQuiescenceWork: () => false,
+		_stopGoalContinuationForTerminalMessage: () => false,
+		_ensureGoalRuntimeActive: () => {},
+		_setGoalState: function (this: Harness, goal: unknown) {
+			this._goalState = goal as Harness["_goalState"];
+		},
+		_runOrQueueGoalContext: vi.fn(),
+		...overrides,
+	};
+}
+
+const context = { message: { role: "assistant", stopReason: "stop" }, context: {} };
+
+describe("goal continuation vs unsettled subagent work", () => {
+	it("defers the continuation while descendant work is unsettled", async () => {
+		const mode = harness({ _hasUnsettledRlmQuiescenceWork: () => true });
+		await expect(getGoalContinuation.call(mode, context)).resolves.toEqual([]);
+		expect(mode._goalContinuationAwaitsRlmWork).toBe(true);
+		expect(mode._goalState.continuationsUsed).toBe(0);
+	});
+
+	it("continues normally when no descendant work is pending", async () => {
+		const mode = harness();
+		const messages = await getGoalContinuation.call(mode, context);
+		expect(messages).toHaveLength(1);
+		expect(mode._goalContinuationAwaitsRlmWork).toBe(false);
+		expect(mode._goalState.continuationsUsed).toBe(1);
+	});
+
+	it("resumes a deferred continuation exactly once after settlement", () => {
+		const mode = harness({ _goalContinuationAwaitsRlmWork: true });
+		maybeResume.call(mode);
+		maybeResume.call(mode);
+		expect(mode._runOrQueueGoalContext).toHaveBeenCalledTimes(1);
+		expect(mode._runOrQueueGoalContext).toHaveBeenCalledWith("continuation");
+	});
+
+	it("stays deferred while work remains and skips inactive goals", () => {
+		const busy = harness({ _goalContinuationAwaitsRlmWork: true, _hasUnsettledRlmQuiescenceWork: () => true });
+		maybeResume.call(busy);
+		expect(busy._runOrQueueGoalContext).not.toHaveBeenCalled();
+		expect(busy._goalContinuationAwaitsRlmWork).toBe(true);
+
+		const inactive = harness({ _goalContinuationAwaitsRlmWork: true });
+		inactive._goalState = { status: "paused", objective: "ship it", continuationsUsed: 0 };
+		maybeResume.call(inactive);
+		expect(inactive._runOrQueueGoalContext).not.toHaveBeenCalled();
+		expect(inactive._goalContinuationAwaitsRlmWork).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/goal-continuation-quiescence.test.ts
+++ b/packages/coding-agent/test/goal-continuation-quiescence.test.ts
@@ -7,6 +7,7 @@ type Harness = {
 	_disposed: boolean;
 	_disposing: boolean;
 	_sessionInputAdmissionPauses: Set<symbol>;
+	_sessionInputPumpSuspended: boolean;
 	_hasUnsettledRlmQuiescenceWork: () => boolean;
 	_stopGoalContinuationForTerminalMessage: () => boolean;
 	_ensureGoalRuntimeActive: () => void;
@@ -30,6 +31,7 @@ function harness(overrides: Partial<Harness> = {}): Harness {
 		_disposed: false,
 		_disposing: false,
 		_sessionInputAdmissionPauses: new Set(),
+		_sessionInputPumpSuspended: false,
 		_hasUnsettledRlmQuiescenceWork: () => false,
 		_stopGoalContinuationForTerminalMessage: () => false,
 		_ensureGoalRuntimeActive: () => {},
@@ -86,6 +88,13 @@ describe("goal continuation vs unsettled subagent work", () => {
 		maybeResume.call(paused);
 		expect(paused._admitSessionInput).toHaveBeenCalledTimes(1);
 		expect(paused._goalContinuationAwaitsRlmWork).toBe(false);
+	});
+
+	it("keeps the deferral while the pump is suspended after an abort", () => {
+		const mode = harness({ _goalContinuationAwaitsRlmWork: true, _sessionInputPumpSuspended: true });
+		maybeResume.call(mode);
+		expect(mode._admitSessionInput).not.toHaveBeenCalled();
+		expect(mode._goalContinuationAwaitsRlmWork).toBe(true);
 	});
 
 	it("keeps the deferral when admission throws", () => {


### PR DESCRIPTION
With an active `/goal`, the continuation hook re-prompted the parent the moment it went idle — even when it had just (correctly) spawned subagents and ended its turn to wait. The harness explicitly teaches that pattern ("start the work, record its handle, then end your turn; do not keep the turn open by polling"), then punished it with a full-context LLM call every few seconds, and the model's only escape was the sleep-polling loop reported in #1598.

Linear: ENG-5424 — https://linear.app/primeintellect/issue/ENG-5424/goal-continuation-loop-no-pacing-and-repeated-full-objective-make

## Fix

`_getGoalContinuationMessages` now defers (returns no continuation and sets a flag) while `_hasUnsettledRlmQuiescenceWork()` reports outstanding descendant work — the same recursive predicate the headless/ACP quiescence barrier already trusts, covering unsettled child runs and active child sessions transitively. Each of the three run-settlement sites then calls a resume helper: once the last run settles and the goal is still active, the continuation is admitted through the existing `_runOrQueueGoalContext` path (`resumeIfIdle` wake), so an idle parent picks the goal back up without any new delivery machinery.

No-wake hazard considered: a child that already replied via agent_message delivers no terminal notice on completion, so an idle deferred parent would never wake from session input alone — that is why the resume hooks into run settlement rather than relying on notices.

`/autonomous` is left untouched: its continuations are hard-capped (default 3) and gating them without a matching resume could strand an autonomous run.

Net: +23 lines in agent-session.ts, no protocol changes.

## Validation

- New unit suite: defers while descendant work is unsettled (no `continuationsUsed` burn), continues normally when quiescent, resumes exactly once after settlement, stays deferred while busy, and drops the deferral for non-active goals.
- agent-session recursion/config suites green (130 tests); tsgo + biome green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches goal continuation and session-input scheduling around RLM settlement. A stuck deferral or missed resume could stall an active `/goal`, but the change is small, gated, and covered by unit tests.
> 
> **Overview**
> Stops `/goal` from re-prompting a parent that correctly delegated to subagents and ended its turn. Continuation is deferred while descendant RLM work is unsettled, then resumed automatically once that work settles.
> 
> `_getGoalContinuationMessages` now returns nothing and sets `_goalContinuationAwaitsRlmWork` when `_hasUnsettledRlmQuiescenceWork()` is true, so `continuationsUsed` is not burned. `_maybeResumeGoalContinuationAfterRlmWork` admits a single idle-waking continuation (not front-queued, so a child's terminal notice is read first) after settlement, pause release, or `resumeQueuedWork`. Admission races roll back the count and keep the deferral for retry. `/autonomous` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230e367a5682b98a4f52f057d95a63c21f532ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer `AgentSession` goal continuations until descendant RLM work settles
> Prevents a delegating parent from being re-prompted while its subagent work is still unsettled. When `_getGoalContinuationMessages` detects unsettled RLM quiescence work, it sets `_goalContinuationAwaitsRlmWork` and returns an empty array instead of producing continuation messages.
> - The new `_maybeResumeGoalContinuationAfterRlmWork` helper resumes a deferred continuation once the session is active, RLM work has settled, and admission is available; it increments `continuationsUsed`, clears `lastReason`/`lastError`, and admits a `followUp` turn with `resumeIfIdle=true`.
> - The helper is invoked from five call sites: admission-pause release, `resumeQueuedWork`, `_abandonRlmRunForQuiescence`, `_finishRlmRunDeletion`, and `_observeRlmRunDeletionCleanup`.
> - If admission throws on resume (e.g., a racing pause), the goal state is rolled back so the continuation is re-counted later and the deferral stays in place.
> - Risk: `_getGoalContinuationMessages` now silently returns `[]` whenever RLM quiescence work exists; any caller that relied on non-empty messages during that window will see deferred behavior instead. Review `_clearQueuedGoalContexts` resets of `_goalContinuationAwaitsRlmWork` to confirm no stale deferral persists across goal resets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 230e367.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->