### PR TITLE
test(daemon): fix Windows socket-path hangs and EACCES in daemon test suites

### DIFF
--- a/packages/coding-agent/test/daemon-launch.test.ts
+++ b/packages/coding-agent/test/daemon-launch.test.ts
@@ -13,6 +13,8 @@ import {
 } from "../src/cli/daemon-launch.js";
 import { ENV_AGENT_DIR, getDaemonLogPath, VERSION } from "../src/config.js";
 import { DAEMON_PROTOCOL_VERSION, DAEMON_SCHEMA_ID } from "../src/modes/daemon/daemon-protocol.js";
+// 2026-08-21 Nox: Windows can't bind Unix-style Temp socket paths — use the named-pipe helper.
+import { daemonTestSocketPath } from "./helpers/daemon-test-socket.js";
 
 interface FakeDaemonOptions {
 	/** Sessions returned for a `list` command. */
@@ -40,7 +42,8 @@ function send(socket: Socket, message: unknown): void {
 
 async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDaemon> {
 	const dir = mkdtempSync(join(tmpdir(), "pa-launch-"));
-	const socketPath = join(dir, "d.sock");
+	// 2026-08-21 Nox: named pipe on Windows — Temp Unix paths never emit "listening" (30s test hang).
+	const socketPath = daemonTestSocketPath("launch");
 	const server: Server = createServer((socket) => {
 		socket.on("error", () => undefined);
 		send(socket, {
@@ -109,7 +112,8 @@ async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<FakeDae
 
 async function startCrashingDaemon(): Promise<FakeDaemon> {
 	const dir = mkdtempSync(join(tmpdir(), "pa-launch-crash-"));
-	const socketPath = join(dir, "d.sock");
+	// 2026-08-21 Nox: named pipe on Windows — Temp Unix paths never bind in the spawned child.
+	const socketPath = daemonTestSocketPath("launch-crash");
 	const child = spawn(
 		process.execPath,
 		[
@@ -342,7 +346,8 @@ describe("ensureInteractiveDaemonRunning", () => {
 	it("succeeds when the spawned child loses the race to an already-serving daemon", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "pa-launch-startup-race-"));
 		const entrypoint = join(dir, "loser.mjs");
-		const socketPath = join(dir, "d.sock");
+		// 2026-08-21 Nox: named pipe on Windows — Temp Unix path would hang server.listen.
+		const socketPath = daemonTestSocketPath("startup-race");
 		const originalAgentDir = process.env[ENV_AGENT_DIR];
 		process.env[ENV_AGENT_DIR] = join(dir, "agent");
 		writeFileSync(entrypoint, "process.exit(7);");

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -55,6 +55,7 @@ import {
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DAEMON_WORKER_SUPERVISOR_SOCKET_ENV } from "../src/modes/daemon/daemon-worker-protocol.js";
 import { RlmSpawnLedger } from "../src/modes/daemon/rlm-ledger.js";
+import { daemonTestSocketPath } from "./helpers/daemon-test-socket.js";
 
 describe("daemon mode helpers", () => {
 	it("preserves envelope client identity while registering prompt admission", () => {
@@ -1597,8 +1598,8 @@ describe("daemon mode helpers", () => {
 	});
 
 	it("does not retry supervisor agent-message rejections", async () => {
-		const tempDir = mkdtempSync(join(tmpdir(), "pa-msg-"));
-		const socketPath = join(tempDir, "d.sock");
+		const tempDir = mkdtempSync(join(tmpdir(), "pa-reject-test-"));
+		const socketPath = daemonTestSocketPath("reject-test");
 		let connectionCount = 0;
 		const server: Server = createServer((socket) => {
 			connectionCount++;
@@ -1639,8 +1640,8 @@ describe("daemon mode helpers", () => {
 		try {
 			await new Promise<void>((resolve) => server.listen(socketPath, resolve));
 			process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = socketPath;
-			const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
-				defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			const daemon = new AgentDaemon(daemonTestSocketPath("worker-test"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
 				createRuntime: async () => {
 					throw new Error("unexpected runtime creation");
 				},
@@ -1673,7 +1674,7 @@ describe("daemon mode helpers", () => {
 
 	it("routes worker-local session renames through the supervisor", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pa-worker-rename-"));
-		const socketPath = join(tempDir, "s");
+		const socketPath = daemonTestSocketPath("worker-rename");
 		let receivedCommand: Record<string, unknown> | undefined;
 		let releaseResponse: () => void = () => {};
 		const responseGate = new Promise<void>((resolve) => {
@@ -1716,7 +1717,7 @@ describe("daemon mode helpers", () => {
 				server.listen(socketPath, resolve);
 			});
 			process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = socketPath;
-			const daemon = new AgentDaemon(join(tempDir, "worker.sock"), {
+			const daemon = new AgentDaemon(daemonTestSocketPath("worker-sock"), {
 				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
 				createRuntime: vi.fn(),
 				worker: { authenticationToken: "token" },
@@ -1754,7 +1755,7 @@ describe("daemon mode helpers", () => {
 
 	it("does not retry permanent ambiguity errors from the supervisor", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pa-ambiguous-"));
-		const socketPath = join(tempDir, "s");
+		const socketPath = daemonTestSocketPath("ambiguous");
 		let requestCount = 0;
 		const server = createServer((socket) => {
 			socket.write(
@@ -1785,7 +1786,7 @@ describe("daemon mode helpers", () => {
 				server.listen(socketPath, resolve);
 			});
 			process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = socketPath;
-			const daemon = new AgentDaemon(join(tempDir, "worker.sock"), {
+			const daemon = new AgentDaemon(daemonTestSocketPath("worker-sock"), {
 				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
 				createRuntime: vi.fn(),
 			});

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -593,80 +593,84 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("canonicalizes symlinked paths in the family catalog and name reservations", async () => {
-		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-family-catalog-paths-"));
-		try {
-			const realDir = join(tempDir, "real");
-			const aliasDir = join(tempDir, "alias");
-			mkdirSync(realDir);
-			symlinkSync(realDir, aliasDir, "dir");
-			const parentPath = join(realDir, "parent.jsonl");
-			writeFileSync(parentPath, "");
-			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
-				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: tempDir },
-				createRuntime: vi.fn(),
-			});
-			const parent = makeState("parent");
-			parent.runtime = {
-				...parent.runtime,
-				cwd: tempDir,
-				metadata: { kind: "top-level", createdAt: 1 },
-				session: {
-					sessionId: "session-parent",
-					sessionName: "parent",
-					sessionFile: parentPath,
-					sessionManager: { getSessionArtifactDir: () => undefined },
-					rlmDepth: 0,
-					isStreaming: false,
-					isSessionActive: false,
-					unfinishedActionCount: 0,
-					hasRunningRlmChildren: () => false,
-				},
-			} as never;
-			const child = {
-				activeSessionId: "child-active",
-				sessionId: "session-child",
-				sessionName: "child",
-				runtimeKind: "subagent",
-				cwd: tempDir,
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				parentSessionPath: join(aliasDir, "parent.jsonl"),
-				rlmDepth: 1,
-				status: "idle",
-			};
-			const internals = daemon as unknown as {
-				sessions: Map<string, ActiveSessionState>;
-				remoteAgentPeers: Map<string, typeof child>;
-				createAgentFamilyRoster(state: ActiveSessionState): Promise<{ entries: Array<{ id: string }> }>;
-			};
-			internals.sessions.set(parent.activeSessionId, parent);
-			internals.remoteAgentPeers.set(child.activeSessionId, child);
-			const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
+	// 2026-08-21 Nox: creating dir symlinks on Windows requires elevation (EPERM otherwise) — POSIX-only test.
+	it.skipIf(process.platform === "win32")(
+		"canonicalizes symlinked paths in the family catalog and name reservations",
+		async () => {
+			const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-family-catalog-paths-"));
 			try {
-				expect(await internals.createAgentFamilyRoster(parent)).toMatchObject({
-					entries: [expect.objectContaining({ id: "session-child" })],
+				const realDir = join(tempDir, "real");
+				const aliasDir = join(tempDir, "alias");
+				mkdirSync(realDir);
+				symlinkSync(realDir, aliasDir, "dir");
+				const parentPath = join(realDir, "parent.jsonl");
+				writeFileSync(parentPath, "");
+				const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+					defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: tempDir },
+					createRuntime: vi.fn(),
 				});
-				expect(
-					sessionNameReservationKey({
-						name: "worker",
-						depth: 1,
-						parentSessionPath: parentPath,
-					}),
-				).toBe(
-					sessionNameReservationKey({
-						name: "worker",
-						depth: 1,
-						parentSessionPath: join(aliasDir, "parent.jsonl"),
-					}),
-				);
+				const parent = makeState("parent");
+				parent.runtime = {
+					...parent.runtime,
+					cwd: tempDir,
+					metadata: { kind: "top-level", createdAt: 1 },
+					session: {
+						sessionId: "session-parent",
+						sessionName: "parent",
+						sessionFile: parentPath,
+						sessionManager: { getSessionArtifactDir: () => undefined },
+						rlmDepth: 0,
+						isStreaming: false,
+						isSessionActive: false,
+						unfinishedActionCount: 0,
+						hasRunningRlmChildren: () => false,
+					},
+				} as never;
+				const child = {
+					activeSessionId: "child-active",
+					sessionId: "session-child",
+					sessionName: "child",
+					runtimeKind: "subagent",
+					cwd: tempDir,
+					isStreaming: false,
+					unfinishedActionCount: 0,
+					parentSessionPath: join(aliasDir, "parent.jsonl"),
+					rlmDepth: 1,
+					status: "idle",
+				};
+				const internals = daemon as unknown as {
+					sessions: Map<string, ActiveSessionState>;
+					remoteAgentPeers: Map<string, typeof child>;
+					createAgentFamilyRoster(state: ActiveSessionState): Promise<{ entries: Array<{ id: string }> }>;
+				};
+				internals.sessions.set(parent.activeSessionId, parent);
+				internals.remoteAgentPeers.set(child.activeSessionId, child);
+				const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
+				try {
+					expect(await internals.createAgentFamilyRoster(parent)).toMatchObject({
+						entries: [expect.objectContaining({ id: "session-child" })],
+					});
+					expect(
+						sessionNameReservationKey({
+							name: "worker",
+							depth: 1,
+							parentSessionPath: parentPath,
+						}),
+					).toBe(
+						sessionNameReservationKey({
+							name: "worker",
+							depth: 1,
+							parentSessionPath: join(aliasDir, "parent.jsonl"),
+						}),
+					);
+				} finally {
+					listAll.mockRestore();
+				}
 			} finally {
-				listAll.mockRestore();
+				rmSync(tempDir, { recursive: true, force: true });
 			}
-		} finally {
-			rmSync(tempDir, { recursive: true, force: true });
-		}
-	});
+		},
+	);
 
 	it("lists and sends agent messages to completed retained subagents", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
@@ -2586,7 +2590,8 @@ describe("daemon mode helpers", () => {
 		expect((await internals.createAgentObserveListResult(targetState)).current.status).toBe("compacting");
 	});
 
-	it("canonicalizes symlinked family paths before comparison", () => {
+	// 2026-08-21 Nox: creating dir symlinks on Windows requires elevation (EPERM otherwise) — POSIX-only test.
+	it.skipIf(process.platform === "win32")("canonicalizes symlinked family paths before comparison", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-family-paths-"));
 		try {
 			const realDir = join(tempDir, "real");
@@ -7531,41 +7536,49 @@ describe("daemon mode helpers", () => {
 	});
 
 	// chmod-based read-only dirs don't block root, so skip when running as uid 0.
-	it.skipIf(process.getuid?.() === 0)("does not fail a deletion when the artifact dir cannot be removed", async () => {
-		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-artifact-rm-failure-"));
-		let lockedRoot: string | undefined;
-		try {
-			const fixture = makePersistedRlmDaemonFixture(tempDir);
-			const nestedArtifactsRoot = resolve(fixture.childArtifactDir, "..");
-			const internals = fixture.daemon as unknown as {
-				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
-				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
-			};
-			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
-			chmodSync(nestedArtifactsRoot, 0o555);
-			lockedRoot = nestedArtifactsRoot;
+	// 2026-08-21 Nox: Windows ignores POSIX mode bits (chmod 0o555 doesn't block rmSync), so
+	// this perms-based fixture only behaves on POSIX non-root — skip it there like root.
+	it.skipIf(process.getuid?.() === 0 || process.platform === "win32")(
+		"does not fail a deletion when the artifact dir cannot be removed",
+		async () => {
+			const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-artifact-rm-failure-"));
+			let lockedRoot: string | undefined;
+			try {
+				const fixture = makePersistedRlmDaemonFixture(tempDir);
+				const nestedArtifactsRoot = resolve(fixture.childArtifactDir, "..");
+				const internals = fixture.daemon as unknown as {
+					createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+					createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				};
+				const parentState = await internals.createRuntime({
+					type: "create",
+					sessionPath: fixture.parentSessionFile,
+				});
+				chmodSync(nestedArtifactsRoot, 0o555);
+				lockedRoot = nestedArtifactsRoot;
 
-			// Cache cleanup is best-effort: the rm failure must not surface.
-			await internals.createSubagentRuntimeHost(parentState).deleteRlmSubagentRuntime(fixture.childId);
+				// Cache cleanup is best-effort: the rm failure must not surface.
+				await internals.createSubagentRuntimeHost(parentState).deleteRlmSubagentRuntime(fixture.childId);
 
-			expect(existsSync(fixture.childArtifactDir)).toBe(true);
-			// Both tombstones are still durable.
-			const display = JSON.parse(readFileSync(join(fixture.childSessionDir, "rlm-subagent.json"), "utf8")) as {
-				status: string;
-			};
-			expect(display).toMatchObject({ status: "deleted" });
-			const ledgerFile = readdirSync(join(tempDir, "rlm-ledger")).find((name) => name.endsWith(".jsonl"));
-			if (!ledgerFile) throw new Error("Missing RLM ledger file");
-			const ledgerOps = readFileSync(join(tempDir, "rlm-ledger", ledgerFile), "utf8")
-				.trim()
-				.split(/\r?\n/)
-				.map((line) => JSON.parse(line) as { op: string; childId?: string });
-			expect(ledgerOps.some((record) => record.op === "delete" && record.childId === fixture.childId)).toBe(true);
-		} finally {
-			if (lockedRoot) chmodSync(lockedRoot, 0o755);
-			rmSync(tempDir, { recursive: true, force: true });
-		}
-	});
+				expect(existsSync(fixture.childArtifactDir)).toBe(true);
+				// Both tombstones are still durable.
+				const display = JSON.parse(readFileSync(join(fixture.childSessionDir, "rlm-subagent.json"), "utf8")) as {
+					status: string;
+				};
+				expect(display).toMatchObject({ status: "deleted" });
+				const ledgerFile = readdirSync(join(tempDir, "rlm-ledger")).find((name) => name.endsWith(".jsonl"));
+				if (!ledgerFile) throw new Error("Missing RLM ledger file");
+				const ledgerOps = readFileSync(join(tempDir, "rlm-ledger", ledgerFile), "utf8")
+					.trim()
+					.split(/\r?\n/)
+					.map((line) => JSON.parse(line) as { op: string; childId?: string });
+				expect(ledgerOps.some((record) => record.op === "delete" && record.childId === fixture.childId)).toBe(true);
+			} finally {
+				if (lockedRoot) chmodSync(lockedRoot, 0o755);
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		},
+	);
 
 	it("still sweeps and resolves when scheduled-job cancellation throws", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-artifact-cancel-throw-"));

--- a/packages/coding-agent/test/helpers/daemon-test-socket.ts
+++ b/packages/coding-agent/test/helpers/daemon-test-socket.ts
@@ -1,0 +1,9 @@
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Creates a unique IPC endpoint that Node can listen on for the current platform. */
+export function daemonTestSocketPath(prefix: string): string {
+	const name = `${prefix}-${process.pid}-${randomUUID().slice(0, 8)}`;
+	return process.platform === "win32" ? `\\\\.\\pipe\\${name}` : join(tmpdir(), `${name}.sock`);
+}


### PR DESCRIPTION
## Summary
Fixes 14 Windows test failures/timeouts across `daemon-mode.test.ts` and `daemon-launch.test.ts`, all from one root cause: tests hand-rolling Unix-style socket paths under `os.tmpdir()`, which can't bind on win32.

## Root cause
On Windows, `server.listen()` / `createConnection()` against a path like a Temp-dir `d.sock` either hangs forever (no `listening` event) or fails with EACCES. The new `normalizeSocketPath()` only lowercases paths on win32 - it does not convert Unix-style paths to named pipes, so it does not help here.

## Changes
- Add `test/helpers/daemon-test-socket.ts`: `daemonTestSocketPath(prefix)` returns a unique named pipe on win32, a Temp Unix socket elsewhere.
- Replace all hand-rolled socket paths in `daemon-mode.test.ts` (3 sites) and `daemon-launch.test.ts` (`startFakeDaemon`, `startCrashingDaemon`, startup-race test) with the helper. Fixes both the original EACCES/ReferenceError failures and the 30s listen-hangs.
- Skip on Windows: 2 symlink-canonicalization tests (dir symlinks need elevation) and the chmod 0o555 undeletable-dir fixture (Windows ignores POSIX mode bits), consistent with the existing root skip.

## Verification
Full daemon suite on Windows:

```
Test Files  4 passed (4)
     Tests  231 passed | 3 skipped (234)
```

The 3 skips are the POSIX-only fixtures above; all previously failing/hanging tests now pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use platform-appropriate socket paths in daemon test suites
> - Adds `daemonTestSocketPath` helper in [daemon-test-socket.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1614/files#diff-87d411c900ac1d98ee7bd2f712d390e8b3719fa5109c1fa52cd675fc93f9c639) that returns a named pipe on Windows and a tempdir `.sock` on POSIX
> - Replaces ad-hoc Unix-domain socket paths across [daemon-launch.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1614/files#diff-de0ff1d4c967391aa53dadf2d455b15c327d5f145723449a4fe3c04e86fb12c0) and [daemon-mode.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1614/files#diff-e6ffcbd62d8fe753528e06c93d849d9b1799ac2dbadf243304375c6a043243b5) with the helper
> - Skips symlink-based tests on Windows (`process.platform === "win32"`) and extends the chmod-based artifact-deletion skip to include Windows
> - Behavioral Change: Windows tests no longer attempt to bind Unix-domain socket paths, fixing hangs and EACCES errors; symlink and POSIX-permission tests are now skipped on Windows
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da44dad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->