### PR TITLE
fix(daemon): skip failed workers in heartbeat catalog

### DIFF
--- a/packages/coding-agent/.changes/eng-5432-heartbeat-catalog-failed-workers.md
+++ b/packages/coding-agent/.changes/eng-5432-heartbeat-catalog-failed-workers.md
@@ -1,0 +1,1 @@
+- Fixed the Agents View heartbeat refresh failing entirely ("Cannot list heartbeats while session worker is failed") when any resident worker was terminally failed: failed workers are now excluded from the global catalog while recovering and disconnected workers still fail closed.

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1859,7 +1859,9 @@ export class DaemonSupervisor {
 					const match = await this.findWorkerForClient(client, command.activeSessionId);
 					return this.forwardToWorker(match.worker, command);
 				}
-				const workers = [...this.workers.values()].filter((worker) => this.isLiveWorker(worker));
+				const workers = [...this.workers.values()].filter(
+					(worker) => this.isLiveWorker(worker) && worker.descriptor.lifecycle !== "failed",
+				);
 				const heartbeats = new Map<string, AgentConnectionHeartbeat>();
 				const snapshots: Array<{ heartbeats?: AgentConnectionHeartbeat[]; response?: DaemonResponse }> =
 					await Promise.all(

--- a/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts
@@ -30,7 +30,7 @@ function createSupervisorHarness(): SupervisorHarness {
 	}) as unknown as SupervisorHarness;
 }
 
-function worker(lifecycle: "ready" | "recovering", connected = true) {
+function worker(lifecycle: "ready" | "recovering" | "failed", connected = true) {
 	return {
 		descriptor: { lifecycle },
 		...(connected ? { client: {} } : {}),
@@ -135,6 +135,26 @@ describe("daemon supervisor heartbeat aggregation", () => {
 		expect(response).toMatchObject({
 			success: false,
 			error: "Cannot list heartbeats while session worker is recovering",
+		});
+		expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
+	});
+
+	it("skips terminally failed workers without blocking healthy heartbeats", async () => {
+		const supervisor = createSupervisorHarness();
+		supervisor.workers.set("healthy", worker("ready"));
+		supervisor.workers.set("failed", worker("failed", false));
+		supervisor.forwardToWorker = vi.fn(async (_target, command) =>
+			success(command.id, command.type, { heartbeats: [{ job: { id: "heartbeat-1" } }] }),
+		);
+
+		const response = await supervisor.handleCommand({} as DaemonSocketClient, {
+			id: "list-failed-worker",
+			type: "heartbeats_list",
+		});
+
+		expect(response).toMatchObject({
+			success: true,
+			data: { heartbeats: [{ job: { id: "heartbeat-1" } }] },
 		});
 		expect(supervisor.forwardToWorker).toHaveBeenCalledOnce();
 	});


### PR DESCRIPTION
Linear: ENG-5432 — https://linear.app/primeintellect/issue/ENG-5432/heartbeat-catalog-fails-when-any-resident-worker-is-terminally-failed

## Context

The global heartbeat catalog currently fails when any resident session worker is terminally failed and has no cached heartbeat snapshot. This makes the Agents View show `Failed to refresh heartbeats: Cannot list heartbeats while session worker is failed`, even when the selected agent and other workers are healthy.

## Changes

- Exclude terminally failed workers from global heartbeat aggregation.
- Keep existing strict behavior for recovering, disconnected, and request-failing workers so temporary catalog gaps are not silently hidden.
- Add a regression test covering one healthy worker alongside one failed worker.

## Validation

- `npm --prefix packages/coding-agent test -- test/daemon-supervisor-heartbeats.test.ts`
- `npm exec -- tsgo --noEmit`
- `biome check packages/coding-agent/src/modes/daemon/daemon-supervisor.ts packages/coding-agent/test/daemon-supervisor-heartbeats.test.ts` (Biome 2.5.5)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small daemon catalog filter change with a targeted test; recovering/disconnected workers still fail closed, so behavior is narrowly scoped.
> 
> **Overview**
> Stops the global Agents View heartbeat refresh from failing when any resident worker is terminally failed.
> 
> `heartbeats_list` now excludes workers with `lifecycle === "failed"` from catalog aggregation, so healthy workers still return heartbeats. Recovering and disconnected workers continue to fail closed. Adds a regression test for a mixed healthy/failed worker set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ff7813b3add4ec48a7a96171fd4601638ab14f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip terminally `failed` workers in `DaemonSupervisor` heartbeat aggregation
> - Excludes workers with `descriptor.lifecycle === 'failed'` from the global `heartbeats_list` response when there is no active session, so one terminally failed resident worker no longer blocks the whole heartbeat catalog
> - Adds a test in [daemon-supervisor-heartbeats.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1621/files#diff-64cb5d9fa065c24d1ea7e5dfd8a9d09dcdc5a3077b2adb1fb17cffd65ca7da6d) with one healthy `ready` worker and one disconnected `failed` worker, asserting the list returns success with only the healthy heartbeat
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7ff781.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->