### PR TITLE
fix(coding-agent): refresh MCP providers after add

### DIFF
--- a/packages/coding-agent/.changes/eng-5433-mcp-oauth-refresh.md
+++ b/packages/coding-agent/.changes/eng-5433-mcp-oauth-refresh.md
@@ -1,0 +1,1 @@
+- Refreshed MCP providers immediately after server changes so OAuth connections can be started without restarting Prime Agent.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1298,6 +1298,11 @@ export class AgentSession {
 		});
 	}
 
+	/** Refreshes MCP provider registrations without rebuilding the session runtime. */
+	refreshMcpProviders(): void {
+		this._mcpManager?.refresh();
+	}
+
 	/**
 	 * Set the RLM heartbeat controller after construction. Used by
 	 * print/headless mode to attach an in-process heartbeat scheduler

--- a/packages/coding-agent/src/core/mcp/mcp-command.ts
+++ b/packages/coding-agent/src/core/mcp/mcp-command.ts
@@ -11,6 +11,7 @@ export interface McpManagementResult {
 		name: string;
 		transport: McpServerConfig["type"];
 		verb: "added" | "replaced" | "removed";
+		usesOAuth: boolean;
 	};
 }
 
@@ -52,7 +53,12 @@ export async function runMcpManagementCommand(
 			action,
 			message: `Removed MCP server "${name}".`,
 			changed: true,
-			serverChange: { name, transport: config.type, verb: "removed" },
+			serverChange: {
+				name,
+				transport: config.type,
+				verb: "removed",
+				usesOAuth: config.type === "http" && config.oauth === true,
+			},
 		};
 	}
 	if (action === "add") {
@@ -70,7 +76,12 @@ export async function runMcpManagementCommand(
 			action,
 			message: `${replaced ? "Replaced" : "Added"} MCP server "${name}".`,
 			changed: true,
-			serverChange: { name, transport: config.type, verb: replaced ? "replaced" : "added" },
+			serverChange: {
+				name,
+				transport: config.type,
+				verb: replaced ? "replaced" : "added",
+				usesOAuth: config.type === "http" && config.oauth === true,
+			},
 		};
 	}
 	throw new Error("Usage: mcp <add|list|get|remove>.");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-services.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-services.ts
@@ -20,6 +20,8 @@ export interface InteractiveModeUiServices {
 	getInitialCwd(): string;
 	getInitialSessionName(): string | undefined;
 	getThemes(): Theme[];
+	/** Refreshes MCP providers after a client-side MCP settings mutation. */
+	refreshMcpProviders?(): void;
 }
 
 type LocalExtensionNewSessionOptions = Parameters<ExtensionCommandContext["newSession"]>[0];
@@ -60,6 +62,7 @@ export function createInteractiveModeUiServices(session: AgentSession): Interact
 		getInitialCwd: () => session.sessionManager.getCwd(),
 		getInitialSessionName: () => session.sessionManager.getSessionName(),
 		getThemes: () => session.resourceLoader.getThemes().themes,
+		refreshMcpProviders: () => session.refreshMcpProviders(),
 	};
 }
 
@@ -75,6 +78,7 @@ export function createInteractiveModeUiServicesFromServices(options: {
 		getInitialCwd: () => sessionManager.getCwd(),
 		getInitialSessionName: () => sessionManager.getSessionName(),
 		getThemes: () => services.resourceLoader.getThemes().themes,
+		refreshMcpProviders: () => services.mcpManager.refresh(),
 	};
 }
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -8665,12 +8665,15 @@ export class InteractiveMode {
 		try {
 			const result = await runMcpManagementCommand(argv, this.settingsManager, this.modelRegistry.authStorage);
 			if (result.changed && result.serverChange) {
-				const { name, transport, verb } = result.serverChange;
+				const { name, transport, verb, usesOAuth } = result.serverChange;
+				this.uiServices.refreshMcpProviders?.();
 				const successMessage =
 					verb === "removed"
 						? `Removed MCP server "${name}" (${transport}). It is no longer available through mcp.`
-						: `${verb === "replaced" ? "Replaced" : "Added"} MCP server "${name}" (${transport}). Available next turn through mcp.`;
-				await this.reloadAfterMcpChange(result.message, successMessage);
+						: usesOAuth
+							? `${verb === "replaced" ? "Replaced" : "Added"} MCP server "${name}" (${transport}). Run /mcp login ${name} to connect.`
+							: `${verb === "replaced" ? "Replaced" : "Added"} MCP server "${name}" (${transport}). Available next turn through mcp.`;
+				await this.reloadAfterMcpChange(usesOAuth ? successMessage : result.message, successMessage);
 			} else if (result.action === "list") {
 				const builtins = BUILTIN_MCP_CATALOG.map(
 					(entry) => `${entry.label} (${entry.server}): ${isAuthed(entry.server) ? "connected" : "not connected"}`,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -8666,12 +8666,13 @@ export class InteractiveMode {
 			const result = await runMcpManagementCommand(argv, this.settingsManager, this.modelRegistry.authStorage);
 			if (result.changed && result.serverChange) {
 				const { name, transport, verb, usesOAuth } = result.serverChange;
+				const hasMcpProviderRefresh = this.uiServices.refreshMcpProviders !== undefined;
 				this.uiServices.refreshMcpProviders?.();
 				const successMessage =
 					verb === "removed"
 						? `Removed MCP server "${name}" (${transport}). It is no longer available through mcp.`
 						: usesOAuth
-							? `${verb === "replaced" ? "Replaced" : "Added"} MCP server "${name}" (${transport}). Run /mcp login ${name} to connect.`
+							? `${verb === "replaced" ? "Replaced" : "Added"} MCP server "${name}" (${transport}). ${hasMcpProviderRefresh ? "Run" : "Restart Prime Agent, then run"} /mcp login ${name} to connect.`
 							: `${verb === "replaced" ? "Replaced" : "Added"} MCP server "${name}" (${transport}). Available next turn through mcp.`;
 				await this.reloadAfterMcpChange(usesOAuth ? successMessage : result.message, successMessage);
 			} else if (result.action === "list") {

--- a/packages/coding-agent/test/interactive-mode-services.test.ts
+++ b/packages/coding-agent/test/interactive-mode-services.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.js";
+import type { AgentSessionServices } from "../src/core/agent-session-services.js";
+import type { SessionManager } from "../src/core/session-manager.js";
+import {
+	createInteractiveModeUiServices,
+	createInteractiveModeUiServicesFromServices,
+} from "../src/modes/interactive/interactive-mode-services.js";
+
+describe("InteractiveModeUiServices MCP refresh", () => {
+	it("wires local sessions through the narrow session refresh method", () => {
+		const refreshMcpProviders = vi.fn();
+		const session = {
+			settingsManager: {},
+			modelRegistry: {},
+			sessionManager: { getCwd: () => "/local", getSessionName: () => "local-session" },
+			resourceLoader: { getThemes: () => ({ themes: [] }) },
+			refreshMcpProviders,
+		} as unknown as AgentSession;
+
+		const services = createInteractiveModeUiServices(session);
+		services.refreshMcpProviders?.();
+
+		expect(refreshMcpProviders).toHaveBeenCalledOnce();
+		expect(services.getInitialCwd()).toBe("/local");
+	});
+
+	it("wires daemon-backed services directly to the MCP manager", () => {
+		const refresh = vi.fn();
+		const services = createInteractiveModeUiServicesFromServices({
+			services: {
+				settingsManager: {},
+				modelRegistry: {},
+				resourceLoader: { getThemes: () => ({ themes: [] }) },
+				mcpManager: { refresh },
+			} as unknown as AgentSessionServices,
+			sessionManager: {
+				getCwd: () => "/daemon",
+				getSessionName: () => "daemon-session",
+			} as unknown as SessionManager,
+		});
+
+		services.refreshMcpProviders?.();
+
+		expect(refresh).toHaveBeenCalledOnce();
+		expect(services.getInitialSessionName()).toBe("daemon-session");
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1077,6 +1077,7 @@ describe("InteractiveMode MCP command", () => {
 	type McpCommandHarness = {
 		modelRegistry: { authStorage: { get(providerId: string): unknown } };
 		settingsManager: SettingsManager;
+		uiServices: { refreshMcpProviders(): void };
 		showConfigurationMenu(tab: "mcp-connections"): Promise<void>;
 		showStatus(message: string): void;
 		showError(message: string): void;
@@ -1121,6 +1122,7 @@ describe("InteractiveMode MCP command", () => {
 		return {
 			modelRegistry: { authStorage: { get: vi.fn(() => undefined), removeVerified: vi.fn() } },
 			settingsManager: manager,
+			uiServices: { refreshMcpProviders: vi.fn() },
 			chatContainer,
 			ui,
 			showStatus,
@@ -1146,6 +1148,7 @@ describe("InteractiveMode MCP command", () => {
 
 		await handleMcpCommand.call(fakeThis, "add fetch -- uvx mcp-server-fetch --token secret");
 
+		expect(fakeThis.uiServices.refreshMcpProviders).toHaveBeenCalledOnce();
 		expect(normalizeRenderedOutput(fakeThis.chatContainer)).toContain(
 			'Added MCP server "fetch" (stdio). Available next turn through mcp.',
 		);
@@ -1177,6 +1180,39 @@ describe("InteractiveMode MCP command", () => {
 		expect(rendered).toContain("not active in this session");
 		expect(rendered).not.toContain("Available next turn through mcp");
 		expect(manager.getGlobalMcpServers()).toHaveProperty("fetch");
+	});
+
+	test("refreshes MCP providers before deferring a changed command while busy", async () => {
+		const manager = SettingsManager.inMemory({});
+		const events: string[] = [];
+		const fakeThis = createRenderedMcpHarness(manager);
+		fakeThis.uiServices.refreshMcpProviders = vi.fn(() => events.push("refresh"));
+		fakeThis.handleReloadCommand = vi.fn(async () => true);
+		fakeThis.isAgentStreaming = vi.fn(() => true);
+		fakeThis.showStatus = vi.fn((message: string) => events.push(message));
+
+		await handleMcpCommand.call(fakeThis, "add remote --url https://example.test/mcp --oauth");
+
+		expect(events[0]).toBe("refresh");
+		expect(fakeThis.handleReloadCommand).not.toHaveBeenCalled();
+		expect(events.join("\n")).toContain("Run /mcp login remote to connect.");
+		expect(events.join("\n")).toContain("Run /reload after the current turn to activate it.");
+	});
+
+	test("guides OAuth server additions to explicit login after refresh", async () => {
+		const manager = SettingsManager.inMemory({});
+		const fakeThis = createRenderedMcpHarness(manager);
+		const events: string[] = [];
+		fakeThis.uiServices.refreshMcpProviders = vi.fn(() => events.push("refresh"));
+		fakeThis.handleReloadCommand = vi.fn(async () => {
+			events.push("reload");
+			return true;
+		});
+
+		await handleMcpCommand.call(fakeThis, "add remote --url https://example.test/mcp --oauth");
+
+		expect(events).toEqual(["refresh", "reload"]);
+		expect(normalizeRenderedOutput(fakeThis.chatContainer)).toContain("Run /mcp login remote to connect.");
 	});
 
 	test("renders inspectable redacted list and get output", async () => {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1077,7 +1077,7 @@ describe("InteractiveMode MCP command", () => {
 	type McpCommandHarness = {
 		modelRegistry: { authStorage: { get(providerId: string): unknown } };
 		settingsManager: SettingsManager;
-		uiServices: { refreshMcpProviders(): void };
+		uiServices: { refreshMcpProviders?(): void };
 		showConfigurationMenu(tab: "mcp-connections"): Promise<void>;
 		showStatus(message: string): void;
 		showError(message: string): void;
@@ -1213,6 +1213,19 @@ describe("InteractiveMode MCP command", () => {
 
 		expect(events).toEqual(["refresh", "reload"]);
 		expect(normalizeRenderedOutput(fakeThis.chatContainer)).toContain("Run /mcp login remote to connect.");
+	});
+
+	test("keeps OAuth guidance accurate for legacy UI service hosts", async () => {
+		const manager = SettingsManager.inMemory({});
+		const fakeThis = createRenderedMcpHarness(manager);
+		fakeThis.uiServices = {};
+		fakeThis.handleReloadCommand = vi.fn(async () => true);
+
+		await handleMcpCommand.call(fakeThis, "add remote --url https://example.test/mcp --oauth");
+
+		expect(normalizeRenderedOutput(fakeThis.chatContainer)).toContain(
+			"Restart Prime Agent, then run /mcp login remote to connect.",
+		);
 	});
 
 	test("renders inspectable redacted list and get output", async () => {


### PR DESCRIPTION
## Summary

- refresh the TUI-owned MCP provider registry immediately after user server add, replace, or remove
- keep the existing execution-session reload so daemon-backed and local sessions consume the saved configuration
- guide OAuth users to run `/mcp login <name>` without quitting or restarting Prime Agent
- preserve saved configuration and clear guidance when execution reload is deferred or fails

## Scope

This is a client/UI lifecycle fix. It does not add automatic browser login, a daemon protocol change, service-specific behavior, or richer `/mcp get` output.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/interactive-mode-services.test.ts test/interactive-mode-status.test.ts test/mcp-command.test.ts` (179 tests)
- `npm run check`

Linear: [ENG-5433](https://linear.app/primeintellect/issue/ENG-5433/refresh-mcp-oauth-providers-after-interactive-add)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client/UI lifecycle and messaging only; no auth protocol, credential, or daemon changes. Fallback copy remains for hosts without refresh.
> 
> **Overview**
> After adding, replacing, or removing an MCP server in interactive mode, MCP provider registrations now refresh immediately so OAuth login can start without restarting Prime Agent.
> 
> `AgentSession.refreshMcpProviders()` is wired through `InteractiveModeUiServices` (local session and daemon-backed paths). Management results now include `usesOAuth`; OAuth adds/replaces prompt `/mcp login <name>` (or a restart fallback if refresh is unavailable), while non-OAuth servers keep the next-turn availability message. Refresh still runs even when session reload is deferred because the agent is busy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7126df2592b0c6492625ae993f8a5a25a6653076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh MCP providers after `/mcp add` and show OAuth login guidance
> - Adds `AgentSession.refreshMcpProviders()` and wires it through `InteractiveModeUiServices` for both local and daemon-backed sessions
> - Extends `McpManagementResult.serverChange` with a `usesOAuth` flag so callers know when an added/removed HTTP server uses OAuth
> - `InteractiveMode.handleMcpCommand` now calls `refreshMcpProviders()` on successful add/replace/remove and, for OAuth servers, directs the user to run `/mcp login <name>` instead of requiring a restart
> - Behavioral Change: when `refreshMcpProviders` is unavailable (legacy hosts), success messaging for OAuth servers falls back to suggesting a restart rather than immediate `/mcp login` guidance
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7126df2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->