### PR TITLE
ci: refresh the model catalog daily via scheduled workflow

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        # Credentials stay persisted (checkout default): the push step below
-        # needs them. The job only ever pushes to $UPDATE_BRANCH.
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -78,28 +78,29 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        # Note: PRs opened with the default GITHUB_TOKEN do not trigger
-        # pull_request workflows (CI). Push to the branch or close/reopen the
-        # PR to run CI, or swap github.token for a PAT/App token here.
+        # GITHUB_TOKEN-created PRs need a maintainer to close/reopen them
+        # before merge so pull_request CI runs.
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           old=$(git show "HEAD:$CATALOG_FILE" | grep -c 'satisfies Model')
           new=$(grep -c 'satisfies Model' "$CATALOG_FILE")
+          body=$(printf 'Automated daily refresh of `%s` from the live provider catalogs (models.dev, OpenRouter, Vercel AI Gateway, Prime Inference).\n\nModel count: %s -> %s. Review the diff for pricing changes, renames, and removals before merging.\n\nCI does not run automatically on PRs opened by the workflow token. Close and reopen this PR to trigger it.' "$CATALOG_FILE" "$old" "$new")
 
           git switch -c "$UPDATE_BRANCH"
           git add "$CATALOG_FILE"
           git commit -m "chore(ai): refresh the generated model catalog from live provider catalogs"
           git push -f origin "$UPDATE_BRANCH"
 
-          open_prs=$(gh pr list --head "$UPDATE_BRANCH" --base main --state open --json number --jq length)
-          if [ "$open_prs" = "0" ]; then
+          open_pr=$(gh pr list --head "$UPDATE_BRANCH" --base main --state open --json number --jq '.[0].number // empty')
+          if [ -z "$open_pr" ]; then
             gh pr create \
               --base main \
               --head "$UPDATE_BRANCH" \
               --title "chore(ai): refresh the generated model catalog from live provider catalogs" \
-              --body "$(printf 'Automated daily refresh of `%s` from the live provider catalogs (models.dev, OpenRouter, Vercel AI Gateway, Prime Inference).\n\nModel count: %s -> %s. Review the diff for pricing changes, renames, and removals before merging.\n\nCI does not run automatically on PRs opened by the workflow token; push to the branch or close/reopen to trigger it.' "$CATALOG_FILE" "$old" "$new")"
+              --body "$body"
           else
-            echo "Open PR for $UPDATE_BRANCH already exists; force-pushed the refreshed catalog to it."
+            gh pr edit "$open_pr" --body "$body"
+            echo "Updated pull request #$open_pr with the refreshed catalog."
           fi

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -1,0 +1,105 @@
+name: Update model catalog
+
+on:
+  schedule:
+    # Daily at 05:17 UTC; off the top of the hour to dodge the cron rush.
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-model-catalog
+  cancel-in-progress: false
+
+env:
+  UPDATE_BRANCH: bot/update-model-catalog
+  CATALOG_FILE: packages/ai/src/models.generated.ts
+
+jobs:
+  regenerate:
+    name: Regenerate and open PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        # Credentials stay persisted (checkout default): the push step below
+        # needs them. The job only ever pushes to $UPDATE_BRANCH.
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      # npm ci runs every workspace's install scripts, and some need the same
+      # native libraries CI installs (node-canvas builds against cairo/pango).
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate model catalog
+        working-directory: packages/ai
+        run: npm run generate-models
+
+      - name: Guard against gutted providers
+        # generate-models exits 0 even when a source fetch fails, and most
+        # failed sources fall back to an empty list rather than the committed
+        # snapshot. A large drop in total models means a source silently
+        # failed, so refuse to open a PR from that state.
+        run: |
+          old=$(git show "HEAD:$CATALOG_FILE" | grep -c 'satisfies Model')
+          new=$(grep -c 'satisfies Model' "$CATALOG_FILE")
+          echo "Committed snapshot: $old models; regenerated: $new models"
+          if [ "$new" -lt $(( old * 9 / 10 )) ]; then
+            echo "::error::Regenerated catalog dropped from $old to $new models; a provider fetch likely failed."
+            exit 1
+          fi
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet -- "$CATALOG_FILE"; then
+            echo "Catalog unchanged; nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git diff --stat -- "$CATALOG_FILE"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Note: PRs opened with the default GITHUB_TOKEN do not trigger
+        # pull_request workflows (CI). Push to the branch or close/reopen the
+        # PR to run CI, or swap github.token for a PAT/App token here.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          old=$(git show "HEAD:$CATALOG_FILE" | grep -c 'satisfies Model')
+          new=$(grep -c 'satisfies Model' "$CATALOG_FILE")
+
+          git switch -c "$UPDATE_BRANCH"
+          git add "$CATALOG_FILE"
+          git commit -m "chore(ai): refresh the generated model catalog from live provider catalogs"
+          git push -f origin "$UPDATE_BRANCH"
+
+          open_prs=$(gh pr list --head "$UPDATE_BRANCH" --base main --state open --json number --jq length)
+          if [ "$open_prs" = "0" ]; then
+            gh pr create \
+              --base main \
+              --head "$UPDATE_BRANCH" \
+              --title "chore(ai): refresh the generated model catalog from live provider catalogs" \
+              --body "$(printf 'Automated daily refresh of `%s` from the live provider catalogs (models.dev, OpenRouter, Vercel AI Gateway, Prime Inference).\n\nModel count: %s -> %s. Review the diff for pricing changes, renames, and removals before merging.\n\nCI does not run automatically on PRs opened by the workflow token; push to the branch or close/reopen to trigger it.' "$CATALOG_FILE" "$old" "$new")"
+          else
+            echo "Open PR for $UPDATE_BRANCH already exists; force-pushed the refreshed catalog to it."
+          fi


### PR DESCRIPTION
Part of [ENG-5435](https://linear.app/primeintellect/issue/ENG-5435/refresh-and-automate-maintenance-of-the-generated-model-catalog).

## Context

The committed `packages/ai/src/models.generated.ts` snapshot only updates when someone manually runs `npm run generate-models` and opens a PR (#1445, #1481, and now #1632). Release builds regenerate from live catalogs anyway, so the checked-in snapshot silently drifts between manual refreshes. This automates the existing habit without removing human review.

## Changes

New scheduled workflow `.github/workflows/update-model-catalog.yml`:

- Runs daily at 05:17 UTC (plus `workflow_dispatch`), regenerates the catalog, and opens a PR when the snapshot drifted. Reruns force-push the fixed `bot/update-model-catalog` branch, so at most one refresh PR is open at a time; a stale open PR just gets updated.
- Safety guard: `generate-models` exits 0 when a source fetch fails, and every source except Prime Inference falls back to an empty list rather than the committed snapshot. The job fails instead of opening a PR when the regenerated catalog lost more than 10% of its models versus the committed file, so a flaky fetch can't produce a "removed 300 models" PR.
- A human still merges: pricing changes, vendor renames (like the `xai/` -> `spacexai/` move in #1632), and removals deserve eyeballs.

Interactions with existing checks, verified against current workflow configs:

- Contribution gate: bots are allowed automatically per `.github/VOUCHED.td`, so the gate won't auto-close the bot PR.
- Changelog fragment check: skips bot-authored PRs (`user.type != 'Bot'`), so no fragment is required on the automated PRs.

## Validation

- YAML parse-checked. The regeneration + guard path is the same `npm run generate-models` flow validated in #1632, where the guard condition (1260 vs 1252 committed, well above the 90% floor) passes.
- Known caveat, noted in the workflow: PRs opened with the default `GITHUB_TOKEN` don't trigger `pull_request` CI. Push to the branch or close/reopen to run CI, or swap in a PAT/App token if you want CI green automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The workflow has contents and pull-requests write access and force-pushes a bot branch. Failures in generate-models can still produce incomplete catalogs unless the 10% drop guard fires.
> 
> **Overview**
> Automates the previously manual refresh of `packages/ai/src/models.generated.ts` so the checked-in snapshot does not drift between human PRs.
> 
> A new scheduled workflow runs `npm run generate-models` daily (and on dispatch). If the catalog changed, it force-pushes `bot/update-model-catalog` and opens or updates a single PR for review. A guard fails the job if the regenerated file has fewer than 90% of the committed model count, which is meant to catch silent empty-list fallbacks from failed provider fetches.
> 
> PRs still need a human merge. Default `GITHUB_TOKEN` PRs do not run `pull_request` CI until close/reopen or a follow-up push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6365b2417969fbf0fb353cb24c18a35efaeabfe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add daily scheduled workflow to regenerate `models.generated.ts` and open PR
> - New GitHub Actions workflow runs daily at 05:17 UTC (and on manual dispatch) to regenerate the AI model catalog via `npm run generate-models` in `packages/ai`.
> - If `packages/ai/src/models.generated.ts` changes, the workflow force-pushes branch `bot/update-model-catalog` and creates/updates a PR against `main`.
> - Guards against provider failures by failing the job if the new `satisfies Model` count drops below 90% of the previous count.
> - Workflow pins `actions/checkout@v7.0.0` and `actions/setup-node@v7.0.0` by SHA, runs on `ubuntu-latest` with a 20-minute timeout.
> - Risk: PRs created with the default `GITHUB_TOKEN` will not trigger downstream CI checks; the PR body notes this limitation.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6365b24. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>.github/workflows/update-model-catalog.yml — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 61](https://github.com/PrimeIntellect-ai/prime-agent/blob/6365b2417969fbf0fb353cb24c18a35efaeabfe7/.github/workflows/update-model-catalog.yml#L61): The aggregate 90% check does not detect a failed source that supplies fewer than 10% of all models. `generate-models` catches source-fetch errors and returns `[]` (for example, the Vercel AI Gateway fetch), so such a failure removes that provider's catalog yet still passes this test and opens/force-updates a PR containing the silent provider-wide deletion. Track or validate source/provider counts rather than only the global count. <b>[ Failed validation ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->