### PR TITLE
fix(coding-agent): keep top-level forks ungrouped

### DIFF
--- a/packages/coding-agent/.changes/fix-agents-view-top-level-forks.md
+++ b/packages/coding-agent/.changes/fix-agents-view-top-level-forks.md
@@ -1,0 +1,1 @@
+- Fixed top-level forked sessions being nested as subagents in Agents View.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -252,7 +252,7 @@ export function summaryForUnifiedRecord(record: UnifiedSessionRecord): SessionSu
 		lifecycle: "archived",
 		activity: "idle",
 		isSessionActive: false,
-		runtimeKind: saved.parentSessionPath ? "subagent" : "top-level",
+		runtimeKind: (saved.rlmDepth ?? (saved.parentSessionPath ? 1 : 0)) > 0 ? "subagent" : "top-level",
 		rlmDepth: saved.rlmDepth,
 		sessionId: saved.id,
 		sessionFile: canonicalSessionPath(saved.path),

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -964,6 +964,38 @@ describe("agents view state", () => {
 		});
 	});
 
+	test("keeps saved top-level forks separate while preserving legacy subagent fallback", () => {
+		const parentPath = "/tmp/sessions/parent.jsonl";
+		const { rlmDepth: _legacyDepth, ...legacyChild } = makeSessionInfo({
+			path: "/tmp/sessions/legacy-child.jsonl",
+			id: "legacy-child",
+			parentSessionPath: parentPath,
+		});
+		const records = reconcileUnifiedSessions(
+			[],
+			[
+				makeSessionInfo({ path: parentPath, id: "parent" }),
+				makeSessionInfo({
+					path: "/tmp/sessions/top-level-fork.jsonl",
+					id: "top-level-fork",
+					parentSessionPath: parentPath,
+					rlmDepth: 0,
+				}),
+				legacyChild,
+			],
+		);
+		const rows = buildAgentsViewRows(records);
+
+		expect(rows.find((row) => row.summary.sessionId === "top-level-fork")).toMatchObject({
+			kind: "agent",
+			depth: 0,
+			summary: { runtimeKind: "top-level" },
+		});
+		expect(rows.find((row) => row.kind === "subagent-summary")).toMatchObject({
+			title: "1 subagent",
+		});
+	});
+
 	test("retains the ancestor chain when search matches only a nested subagent", () => {
 		const summaries = [
 			makeSummary({ id: "root", activeSessionId: "root", sessionId: "root-session", sessionName: "Root" }),


### PR DESCRIPTION
## Summary

- treat an explicit saved-session `rlmDepth` as authoritative when deriving `runtimeKind`
- keep top-level forked sessions (`rlmDepth: 0`) as independent Agents View rows
- preserve the existing `parentSessionPath` fallback for legacy sessions without a persisted depth

## Problem

A saved top-level session can retain `parentSessionPath` when it was forked from another session while explicitly persisting `rlmDepth: 0`. Agents View currently classifies every saved session with `parentSessionPath` as a subagent, so these top-level forks are nested and hidden behind expandable subagent rows.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agents-view-state.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix top-level forks showing as subagents in Agents View
> Updates `summaryForUnifiedRecord` in [agents-view-state.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1634/files#diff-2e58b45b4d539a55b0a23f04ab90b169c6783299ca57cf9ce39557d901dcd3a1) so that saved sessions with `rlmDepth === 0` are treated as top-level even when they have a `parentSessionPath`. When `rlmDepth` is undefined, the old behavior of inferring subagent status from `parentSessionPath` still applies, preserving backward compatibility for legacy sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53a5cc6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->