### PR TITLE
fix(ai): Mistral choices guard, Codex non-retryable errors, faux cache-write token count

### DIFF
--- a/packages/ai/.changes/fix-provider-stream-bugs.md
+++ b/packages/ai/.changes/fix-provider-stream-bugs.md
@@ -1,0 +1,3 @@
+- Fixed Mistral streams crashing on chunks without choices (e.g. usage-only chunks).
+- Fixed Codex retrying non-retryable HTTP errors such as 401/403 due to the error being caught by the retry loop.
+- Fixed faux provider double-counting cache-write tokens in totalTokens.

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -218,10 +218,10 @@ function withUsageEstimate(
 			const cachedChars = commonPrefixLength(previousPrompt, promptText);
 			cacheRead = estimateTokens(previousPrompt.slice(0, cachedChars));
 			cacheWrite = estimateTokens(promptText.slice(cachedChars));
-			input = Math.max(0, promptTokens - cacheRead);
 		} else {
 			cacheWrite = promptTokens;
 		}
+		input = Math.max(0, promptTokens - cacheRead - cacheWrite);
 		promptCache.set(sessionId, promptText);
 	}
 

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -311,7 +311,7 @@ async function consumeChatStream(
 			calculateCost(model, output.usage);
 		}
 
-		const choice = chunk.choices[0];
+		const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
 		if (!choice) continue;
 
 		if (choice.finishReason) {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -247,7 +247,10 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						statusText: response.statusText,
 					});
 					const info = await parseErrorResponse(fakeResponse);
-					throw new Error(info.friendlyMessage || info.message);
+					// Non-retryable HTTP error: set lastError and break so it is thrown below,
+					// instead of being caught by this loop's catch and retried.
+					lastError = new Error(info.friendlyMessage || info.message);
+					break;
 				} catch (error) {
 					if (error instanceof Error) {
 						if (error.name === "AbortError" || error.message === "Request was aborted") {


### PR DESCRIPTION
Fixes three provider bugs found by code review.

### Mistral: crash on choices-less chunks

`packages/ai/src/providers/mistral.ts` accessed `chunk.choices[0]` without a guard. Endpoints that emit usage-only chunks (`choices` missing, empty, or `undefined` — common when `stream_options.include_usage` is on) threw a `TypeError` and aborted the whole stream. Guard with `Array.isArray(chunk.choices)`, matching the existing pattern in `openai-completions.ts`.

### Codex: non-retryable HTTP errors were retried

In `packages/ai/src/providers/openai-codex-responses.ts`, when `isRetryableError()` classified an HTTP status (e.g. 400/401/403) as non-retryable, the code threw — but the `throw` sat inside the same `try` as the `fetch`, so it was caught by the loop's own `catch`, which retried unless the message happened to contain "usage limit". Non-retryable errors now set `lastError` and `break`, and are thrown once after the loop.

### faux: cache-write tokens double-counted

In `packages/ai/src/providers/faux.ts`, `input` subtracted only `cacheRead`, so cached-write tokens stayed in `input` while also being counted in `cacheWrite`, inflating `totalTokens`. Subtract both, matching `openai-completions.ts` usage accounting. First-turn behavior is now `input: 0, cacheWrite: promptTokens` instead of counting the prompt twice.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Mistral `choices` guard, Codex non-retryable errors, and faux cache-write token count
> - In `consumeChatStream` in [mistral.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1647/files#diff-6a24a19d42de9ce9d35e7c4dee33d287375cd53e8d147222d7a2993fd2d163e0), guard `chunk.choices[0]` access so usage-only chunks that lack a `choices` array are skipped instead of throwing.
> - In `streamOpenAICodexResponses` in [openai-codex-responses.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1647/files#diff-69623a8c4e616b30339182296d1b69ed62a9d7fcce14b744ed6e638ecf357abc), non-OK HTTP responses now set `lastError` and break the retry loop, so errors like 401/403 fail fast instead of being retried.
> - In `withUsageEstimate` in [faux.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1647/files#diff-9e72853277e4f31f09b72349148b538edb11ec157a23cd7e76eec22db5214e30), input tokens are now `max(0, promptTokens - cacheRead - cacheWrite)` in all cases, preventing cache-write tokens from being double-counted as input.
> - Risk: `faux` provider `usage.input` values change for sessions with prompt caching enabled; consumers relying on the old (inflated) input count will see lower numbers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c240b2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->