### PR TITLE
fix(coding-agent): count edit occurrences in the matched space

### DIFF
--- a/packages/coding-agent/.changes/fix-edit-diff-occurrence-counting.md
+++ b/packages/coding-agent/.changes/fix-edit-diff-occurrence-counting.md
@@ -1,0 +1,1 @@
+- Fixed the edit tool rejecting a unique exact match when fuzzy normalization (e.g. smart quotes elsewhere in the file) would collapse it into multiple occurrences.

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -126,9 +126,8 @@ export function stripBom(content: string): { bom: string; text: string } {
 }
 
 function countOccurrences(content: string, oldText: string): number {
-	const fuzzyContent = normalizeForFuzzyMatch(content);
-	const fuzzyOldText = normalizeForFuzzyMatch(oldText);
-	return fuzzyContent.split(fuzzyOldText).length - 1;
+	if (oldText.length === 0) return 0;
+	return content.split(oldText).length - 1;
 }
 
 function getNotFoundError(path: string, editIndex: number, totalEdits: number): Error {
@@ -206,7 +205,13 @@ export function applyEditsToNormalizedContent(
 			throw getNotFoundError(path, i, normalizedEdits.length);
 		}
 
-		const occurrences = countOccurrences(baseContent, edit.oldText);
+		// Count occurrences in the same space the match was found in, so an exact
+		// match is not rejected because fuzzy normalization collapses extra hits
+		// (e.g. smart quotes elsewhere in the file).
+		const occurrences = countOccurrences(
+			matchResult.usedFuzzyMatch ? normalizeForFuzzyMatch(baseContent) : baseContent,
+			matchResult.usedFuzzyMatch ? normalizeForFuzzyMatch(edit.oldText) : edit.oldText,
+		);
 		if (occurrences > 1) {
 			throw getDuplicateError(path, i, normalizedEdits.length, occurrences);
 		}

--- a/packages/coding-agent/test/edit-diff-occurrences.test.ts
+++ b/packages/coding-agent/test/edit-diff-occurrences.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { applyEditsToNormalizedContent } from "../src/core/tools/edit-diff.js";
+
+describe("applyEditsToNormalizedContent occurrence counting", () => {
+	test("exact match is unique even if fuzzy normalization would collapse other occurrences", () => {
+		// "it's" appears exactly once, but normalizing the smart quote in "it’s"
+		// would make it look like a second occurrence.
+		const content = "it’s here\nit's there\n";
+		const result = applyEditsToNormalizedContent(content, [{ oldText: "it's", newText: "ITS" }], "file.txt");
+		expect(result.newContent).toBe("it’s here\nITS there\n");
+	});
+
+	test("fuzzy match still counts occurrences in normalized space", () => {
+		// oldText needs fuzzy matching (smart quotes in content) and normalizes
+		// to two occurrences.
+		const content = "it’s here\nit’s there\n";
+		expect(() => applyEditsToNormalizedContent(content, [{ oldText: "it's", newText: "x" }], "file.txt")).toThrow(
+			/must be unique/,
+		);
+	});
+
+	test("genuinely duplicated exact text is rejected", () => {
+		expect(() => applyEditsToNormalizedContent("a\nb\na\n", [{ oldText: "a", newText: "x" }], "file.txt")).toThrow(
+			/must be unique/,
+		);
+	});
+});


### PR DESCRIPTION
`applyEditsToNormalizedContent` matched `oldText` exactly (via `fuzzyFindText`'s exact-match path) but always counted occurrences after `normalizeForFuzzyMatch`. If the file contained text that normalizes to the same string as `oldText` (e.g. both `it’s` and `it's` are present), a unique exact match was rejected with "Found 2 occurrences".

Occurrences are now counted in the same space the match was found in: exact matching counts in the original content, fuzzy matching counts in normalized content. Also avoids `String.split("")` blowups when `oldText` normalizes to an empty string.

Added unit tests covering: unique exact match not rejected by normalization collisions, fuzzy duplicates still rejected, and genuine exact duplicates still rejected.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix edit tool to count occurrences in the matched space
> Fixes duplicate-occurrence detection in `applyEditsToNormalizedContent` so it counts in the same space as the initial match. When the match used fuzzy normalization, both content and `oldText` are normalized before counting; otherwise exact substring counting is used on the original text. `countOccurrences` now returns 0 for empty `oldText`.
>
> Risk: a fuzzy match that has multiple occurrences in normalized space will still be rejected, so edits relying on fuzzy matching against near-duplicate text may now fail where they previously succeeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32c1a81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->