### PR TITLE
fix(tui): sort directory completions first for quoted values

### DIFF
--- a/packages/coding-agent/.changes/fix-edit-diff-occurrence-counting.md
+++ b/packages/coding-agent/.changes/fix-edit-diff-occurrence-counting.md
@@ -1,0 +1,1 @@
+- Fixed the edit tool rejecting a unique exact match when fuzzy normalization (e.g. smart quotes elsewhere in the file) would collapse it into multiple occurrences.

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -126,9 +126,8 @@ export function stripBom(content: string): { bom: string; text: string } {
 }
 
 function countOccurrences(content: string, oldText: string): number {
-	const fuzzyContent = normalizeForFuzzyMatch(content);
-	const fuzzyOldText = normalizeForFuzzyMatch(oldText);
-	return fuzzyContent.split(fuzzyOldText).length - 1;
+	if (oldText.length === 0) return 0;
+	return content.split(oldText).length - 1;
 }
 
 function getNotFoundError(path: string, editIndex: number, totalEdits: number): Error {
@@ -206,7 +205,13 @@ export function applyEditsToNormalizedContent(
 			throw getNotFoundError(path, i, normalizedEdits.length);
 		}
 
-		const occurrences = countOccurrences(baseContent, edit.oldText);
+		// Count occurrences in the same space the match was found in, so an exact
+		// match is not rejected because fuzzy normalization collapses extra hits
+		// (e.g. smart quotes elsewhere in the file).
+		const occurrences = countOccurrences(
+			matchResult.usedFuzzyMatch ? normalizeForFuzzyMatch(baseContent) : baseContent,
+			matchResult.usedFuzzyMatch ? normalizeForFuzzyMatch(edit.oldText) : edit.oldText,
+		);
 		if (occurrences > 1) {
 			throw getDuplicateError(path, i, normalizedEdits.length, occurrences);
 		}

--- a/packages/coding-agent/test/edit-diff-occurrences.test.ts
+++ b/packages/coding-agent/test/edit-diff-occurrences.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { applyEditsToNormalizedContent } from "../src/core/tools/edit-diff.js";
+
+describe("applyEditsToNormalizedContent occurrence counting", () => {
+	test("exact match is unique even if fuzzy normalization would collapse other occurrences", () => {
+		// "it's" appears exactly once, but normalizing the smart quote in "it’s"
+		// would make it look like a second occurrence.
+		const content = "it’s here\nit's there\n";
+		const result = applyEditsToNormalizedContent(content, [{ oldText: "it's", newText: "ITS" }], "file.txt");
+		expect(result.newContent).toBe("it’s here\nITS there\n");
+	});
+
+	test("fuzzy match still counts occurrences in normalized space", () => {
+		// oldText needs fuzzy matching (smart quotes in content) and normalizes
+		// to two occurrences.
+		const content = "it’s here\nit’s there\n";
+		expect(() => applyEditsToNormalizedContent(content, [{ oldText: "it's", newText: "x" }], "file.txt")).toThrow(
+			/must be unique/,
+		);
+	});
+
+	test("genuinely duplicated exact text is rejected", () => {
+		expect(() => applyEditsToNormalizedContent("a\nb\na\n", [{ oldText: "a", newText: "x" }], "file.txt")).toThrow(
+			/must be unique/,
+		);
+	});
+});

--- a/packages/tui/.changes/fix-autocomplete-directory-sorting.md
+++ b/packages/tui/.changes/fix-autocomplete-directory-sorting.md
@@ -1,0 +1,1 @@
+- Fixed directory-first ordering of path completions when the completion value is quoted (e.g. paths containing spaces or `@"..."` prefixes).

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -658,8 +658,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			}
 
 			suggestions.sort((a, b) => {
-				const aIsDir = a.value.endsWith("/");
-				const bIsDir = b.value.endsWith("/");
+				const aIsDir = a.label.endsWith("/");
+				const bIsDir = b.label.endsWith("/");
 				if (aIsDir && !bIsDir) return -1;
 				if (!aIsDir && bIsDir) return 1;
 				return a.label.localeCompare(b.label);


### PR DESCRIPTION
The path-completion sort in `packages/tui/src/autocomplete.ts` decided "is a directory" via `suggestion.value.endsWith("/")`. When the completion value is quoted (paths with spaces, or `@"..."` prefixes), `buildCompletionValue` returns e.g. `@"dir/"` — which ends with `"`, not `/` — so `aIsDir` was always false and the directory-first ordering silently did nothing for quoted completions.

Sort on `label` instead (which is `name + "/"` for directories), matching how the rest of the file treats labels.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix directory completion sorting for quoted values and edit-diff occurrence counting
> - Fix autocomplete directory-first sorting by checking the suggestion label's trailing slash instead of the value's, since quoted values may not end with a slash. See [autocomplete.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1649/files#diff-f0cde3565b6b9c46877a7ffbe713304887d72fddd2af9844e4e2d9a3f147af85).
> - Fix `countOccurrences` in [edit-diff.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1649/files#diff-48501b8162bb8ebe485ea3876aec106c5ba4c5fe5f105479ea6075d5182ea4ef) to count literal occurrences and return 0 for empty `oldText`, instead of counting splits.
> - Fix `applyEditsToNormalizedContent` to count occurrences in the same normalization space as the successful match: exact matches stay unique even if fuzzy normalization would create extra occurrences; fuzzy matches enforce uniqueness in the normalized space.
> - Risk: `countOccurrences` no longer uses fuzzy normalization when counting; callers relying on normalized counting behavior will get literal counts instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60e4a1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->