### PR TITLE
fix(coding-agent): reprovision stopped IPython kernels

### DIFF
--- a/packages/coding-agent/.changes/fix-dead-kernel-reprovision.md
+++ b/packages/coding-agent/.changes/fix-dead-kernel-reprovision.md
@@ -1,0 +1,1 @@
+- Fixed sessions permanently losing Python after an unexpected IPython kernel exit by reprovisioning on the next call.

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -418,6 +418,14 @@ export class IpythonKernelProvisioner {
 		if (signal?.aborted) {
 			return Promise.reject(createAbortError());
 		}
+		if (this.startedManager && !this.startedManager.isRunning) {
+			this.managerPromise = undefined;
+			this.startedManager = undefined;
+			this._lastRestore = undefined;
+			if (this.options?.kernelManagerRef) {
+				this.options.kernelManagerRef.current = undefined;
+			}
+		}
 		let cleanupProgressListener: (() => void) | undefined;
 		if (onProgress && !this.startedManager) {
 			this.startupListeners.add(onProgress);

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -102,6 +102,31 @@ describe("IpythonKernelProvisioner", () => {
 		expect(countRuns()).toBe(2);
 	});
 
+	it("reprovisions a stopped kernel and coalesces concurrent callers", async () => {
+		const { python, countRuns } = writeFakePython();
+		const kernelManagerRef: { current?: KernelManager } = {};
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python, kernelManagerRef });
+		const stoppedManager = { isRunning: false } as KernelManager;
+		Object.assign(
+			provisioner as unknown as {
+				managerPromise: Promise<KernelManager>;
+				startedManager: KernelManager;
+			},
+			{
+				managerPromise: Promise.resolve(stoppedManager),
+				startedManager: stoppedManager,
+			},
+		);
+		kernelManagerRef.current = stoppedManager;
+
+		const [a, b] = await Promise.allSettled([provisioner.ensure(), provisioner.ensure()]);
+
+		expect(a.status).toBe("rejected");
+		expect(b.status).toBe("rejected");
+		expect(countRuns()).toBe(1);
+		expect(kernelManagerRef.current).toBeUndefined();
+	});
+
 	it("prewarm() swallows the failure and the next ensure() starts fresh", async () => {
 		const { python, countRuns } = writeFakePython();
 		const provisioner = new IpythonKernelProvisioner(tempDir, { python });


### PR DESCRIPTION
## Summary

- reprovision IPython on the next call when the cached kernel manager stopped unexpectedly
- reuse the existing startup, snapshot restore, and runtime bootstrap path
- keep concurrent recovery calls coalesced onto one kernel startup

On v0.8.0, an unexpected kernel exit leaves `IpythonKernelProvisioner` holding the resolved stopped manager. Every later tool call receives that same manager and fails with `Kernel has been shut down`; the session remains responsive but cannot execute Python.

The failed cell is not replayed, avoiding duplicate external effects. The next explicit call starts a fresh kernel and restores the last snapshot through the existing path.

Related: #764

## Validation

```text
npx tsx ../../node_modules/vitest/dist/cli.js --run test/ipython-provisioner.test.ts
Test Files  1 passed (1)
Tests       17 passed (17)

npm run check
All pre-commit checks passed.
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stopped IPython kernels not reprovisioning in `IpythonKernelProvisioner.ensure`
> When an IPython kernel exits unexpectedly, sessions permanently lose Python because the provisioner reuses a dead cached manager. Adds a guard at the start of `ensure()` in [ipython.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1658/files#diff-812e64dd0562a31155c537ae8f665280f5201d993eea105d5066d0e7d02ee36d) that detects a previously-started-but-stopped manager and clears `managerPromise`, `startedManager`, `_lastRestore`, and `kernelManagerRef.current` so a fresh kernel is provisioned on the next call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c09cc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->