### PR TITLE
fix(startup): detect deleted working directory

### DIFF
--- a/packages/coding-agent/.changes/fix-deleted-cwd-startup.md
+++ b/packages/coding-agent/.changes/fix-deleted-cwd-startup.md
@@ -1,0 +1,1 @@
+- Fixed startup from a deleted working directory to show recovery guidance instead of a Node stack trace.

--- a/packages/coding-agent/src/cli-main.ts
+++ b/packages/coding-agent/src/cli-main.ts
@@ -6,6 +6,7 @@ import {
 	isOwnedSessionWorkerProcess,
 	maybeRunOwnedSessionWorkerFrontend,
 } from "./cli/owned-session-worker.js";
+import { ensureStartupCwd } from "./cli/startup-cwd.js";
 import { APP_NAME } from "./config.js";
 
 export async function runCli(): Promise<void> {
@@ -19,9 +20,14 @@ export async function runCli(): Promise<void> {
 	process.env.PI_CODING_AGENT = "true";
 	process.emitWarning = (() => {}) as typeof process.emitWarning;
 
+	const args = process.argv.slice(2);
+	if (!ensureStartupCwd(args, { log: console.error })) {
+		process.exitCode = 1;
+		return;
+	}
+
 	installOwnedSessionWorkerOwnerWatch();
 
-	const args = process.argv.slice(2);
 	const handledByOwnedWorker = await maybeRunOwnedSessionWorkerFrontend(args);
 	if (!handledByOwnedWorker) {
 		if (!isOwnedSessionWorkerProcess()) {

--- a/packages/coding-agent/src/cli/startup-cwd.ts
+++ b/packages/coding-agent/src/cli/startup-cwd.ts
@@ -1,0 +1,43 @@
+import { isAbsolute } from "node:path";
+import { APP_NAME, expandTildePath } from "../config.js";
+import { parseArgs } from "./args.js";
+
+export interface StartupCwdIo {
+	log: (message: string) => void;
+}
+
+function findCwdArg(args: readonly string[]): string | undefined {
+	const index = args.indexOf("--cwd");
+	return index === -1 ? undefined : args[index + 1];
+}
+
+export function ensureStartupCwd(args: readonly string[], io: StartupCwdIo): boolean {
+	try {
+		process.cwd();
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw error;
+		}
+	}
+
+	const parsed = parseArgs([...args]);
+	if (parsed.help || parsed.version) {
+		return true;
+	}
+
+	const cwdArg = findCwdArg(args);
+	const expandedCwd = cwdArg ? expandTildePath(cwdArg) : undefined;
+	if (expandedCwd && isAbsolute(expandedCwd)) {
+		try {
+			process.chdir(expandedCwd);
+			return true;
+		} catch {
+			// Fall through to the deleted-directory guidance.
+		}
+	}
+
+	io.log("Error: Current working directory no longer exists.");
+	io.log(`Change to an existing directory or run ${APP_NAME} --cwd /path/to/project.`);
+	return false;
+}

--- a/packages/coding-agent/test/startup-cwd.test.ts
+++ b/packages/coding-agent/test/startup-cwd.test.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { ensureStartupCwd } from "../src/cli/startup-cwd.js";
+
+function withDeletedCwd(run: (root: string) => void): void {
+	const originalCwd = process.cwd();
+	const root = mkdtempSync(join(tmpdir(), "prime-agent-deleted-cwd-"));
+	const deletedCwd = join(root, "deleted");
+	mkdirSync(deletedCwd);
+
+	try {
+		process.chdir(deletedCwd);
+		rmdirSync(deletedCwd);
+		run(root);
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+describe("ensureStartupCwd", () => {
+	it("reports a deleted working directory without a Node stack trace", () => {
+		withDeletedCwd(() => {
+			const logs: string[] = [];
+
+			expect(ensureStartupCwd([], { log: (message) => logs.push(message) })).toBe(false);
+			expect(logs).toEqual([
+				"Error: Current working directory no longer exists.",
+				"Change to an existing directory or run prime-agent --cwd /path/to/project.",
+			]);
+		});
+	});
+
+	it("recovers through an absolute --cwd", () => {
+		withDeletedCwd((root) => {
+			const replacementCwd = join(root, "replacement");
+			mkdirSync(replacementCwd);
+
+			expect(ensureStartupCwd(["--cwd", replacementCwd], { log: () => {} })).toBe(true);
+			expect(realpathSync(process.cwd())).toBe(realpathSync(replacementCwd));
+		});
+	});
+
+	it("preserves cwd-independent help and version commands", () => {
+		withDeletedCwd(() => {
+			expect(ensureStartupCwd(["--help"], { log: () => {} })).toBe(true);
+			expect(ensureStartupCwd(["--version"], { log: () => {} })).toBe(true);
+			expect(ensureStartupCwd(["--", "--help"], { log: () => {} })).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Detect a deleted startup working directory before worker or daemon initialization.
- Preserve `--help` and `--version`, and allow recovery through an absolute `--cwd`.
- Show concise recovery guidance instead of a raw Node `uv_cwd` stack trace.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/startup-cwd.test.ts`
- `npm run check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CLI startup from a deleted working directory via `ensureStartupCwd`
> - `runCli` calls `ensureStartupCwd` early, before heavy imports and worker watches.
> - `ensureStartupCwd` attempts `process.cwd()`. If it throws ENOENT, it tries to `process.chdir` to an absolute `--cwd` argument. If recovery fails, it logs guidance to stderr and returns false.
> - Behavioral Change: Startup from a deleted CWD now exits with code 1 and logs guidance to stderr instead of crashing with a Node stack trace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5e1169.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->