### PR TITLE
docs: document `rlmMaxDepth` configurability (settings key + `/rlm-max-depth`)

### DIFF
--- a/packages/coding-agent/docs/rlm.md
+++ b/packages/coding-agent/docs/rlm.md
@@ -103,7 +103,9 @@ Successfully completed daemon-backed children remain addressable while their par
 await rlm.delete_subagent(children[0])
 ```
 
-The default recursion depth allows a root agent to create children. Raising the configured depth allows descendants to recurse further.
+The default recursion depth is `1`, which allows a root agent to create children but not grandchildren. Raising the configured depth allows descendants to recurse further; setting it to `0` disables recursion entirely.
+
+Configure the depth with the `rlmMaxDepth` setting in `settings.json`, or change it live in a chat with the `/rlm-max-depth [<int> [--global]]` command (`--global` also saves it as the default for new sessions). Precedence is: per-chat state set via `/rlm-max-depth`, an inherited parent value, then `rlmMaxDepth` in settings, then the `RLM_MAX_DEPTH` environment variable, then the default of `1`. See [Settings](settings.md#recursion).
 
 ### 3. Skills add programmatic capability
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -216,6 +216,18 @@ Normally the package manager's global modules location is queried using `root -g
 
 When multiple sources specify a session directory, precedence is `--session-dir`, `PRIME_AGENT_SESSION_DIR`, the legacy `PRIME_AGENT_CODING_AGENT_SESSION_DIR`, then `sessionDir` in `settings.json`.
 
+### Recursion
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `rlmMaxDepth` | non-negative integer | `1` | Maximum RLM recursion depth: how many levels of `rlm(...)` subagent nesting are allowed. `0` disables recursion. |
+
+```json
+{ "rlmMaxDepth": 3 }
+```
+
+When multiple sources specify the depth, precedence is: per-chat state (set with `/rlm-max-depth [<int> [--global]]`, where `--global` writes this setting), an inherited parent value, `rlmMaxDepth` in settings.json, then the `RLM_MAX_DEPTH` environment variable, then the default of `1`. The effective depth and its source are shown by `/rlm-max-depth` with no argument.
+
 ### Model Cycling
 
 | Setting | Type | Default | Description |


### PR DESCRIPTION
# docs: document `rlmMaxDepth` configurability (settings key + `/rlm-max-depth`)

## Motivation

RLM recursion depth is fully configurable in the code — the `rlmMaxDepth` settings
key (`packages/coding-agent/src/core/settings-manager.ts:136`), the
`/rlm-max-depth [<int> [--global]]` slash command
(`packages/coding-agent/src/core/slash-commands.ts:175`), and the
`RLM_MAX_DEPTH` env fallback
(`packages/coding-agent/src/core/agent-session.ts:_resolveRlmMaxDepth`) all
exist and work — but neither `docs/settings.md` nor `docs/rlm.md` mentions any
of them. `docs/rlm.md` only says "Raising the configured depth allows
descendants to recurse further" without naming the knob, and `docs/settings.md`
has no Recursion section. Users cannot discover how to raise the default depth
of `1`.

We verified the behavior live in a multi-agent fleet: setting `rlmMaxDepth` to
`10` in settings.json unlocked 10 levels of `rlm(...)` recursion, with
`/rlm-max-depth` reporting the effective depth and source (`global`), and the
depth guard firing correctly (`RLM recursion depth limit reached (RLM_DEPTH=n,
RLM_MAX_DEPTH=10)`) once exhausted.

## Proposed change (docs-only)

1. **`packages/coding-agent/docs/settings.md`** — add a "Recursion" section to
   the All Settings reference documenting `rlmMaxDepth` (type, default `1`,
   `0` disables recursion), a JSON example, and the full precedence chain:
   per-chat state (`/rlm-max-depth`, `--global` writes this setting) →
   inherited parent value → `rlmMaxDepth` in settings.json → `RLM_MAX_DEPTH`
   env var → default `1`.
2. **`packages/coding-agent/docs/rlm.md`** — expand the one-line depth mention
   to name `rlmMaxDepth`, the `/rlm-max-depth` command, the precedence chain,
   and link to the new Settings section.

No code changes: the feature already behaves exactly as documented here.

## Evidence of behavior

- `_resolveRlmMaxDepth()` in `packages/coding-agent/src/core/agent-session.ts`
  resolves in the order: persisted per-chat state → `config.rlmMaxDepth`
  (inherited) → `settingsManager.getRlmMaxDepth()` → `RLM_MAX_DEPTH` env → `1`.
- `settings-manager.ts:136` type comment: "default for new sessions; unset
  falls through to RLM_MAX_DEPTH, then 1".
- Live verification: `rlmMaxDepth: 10` in the user-level settings.json
  allowed depth-10 recursion in a running fleet; `/rlm-max-depth` displayed
  `RLM max depth: 10 (global)`.

## Test notes

Docs-only change; no tests added or removed. Existing tests covering the
setting (`packages/coding-agent/test/agent-session-recursion.test.ts`,
`daemon-mode.test.ts`) are unaffected. Rendered docs checked for anchor
consistency (`settings.md#recursion`).



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `rlmMaxDepth` setting and `/rlm-max-depth` command
> Adds documentation for configuring RLM subagent recursion depth across [rlm.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1672/files#diff-2ec933be9333470440c88985cbf8067597cf0d9bf4580f76e1a36781fd951527) and [settings.md](https://github.com/PrimeIntellect-ai/prime-agent/pull/1672/files#diff-fab1566cd80cf0a84c29db9db081b306b113186245fa2356e42a14f9c3b6b552). Covers the `rlmMaxDepth` settings key (non-negative integer, default 1, 0 disables recursion), the `/rlm-max-depth [<int> [--global]]` command, and the full precedence order: per-chat command value, inherited parent value, settings `rlmMaxDepth`, `RLM_MAX_DEPTH` env var, then default 1.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03e3b84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->