### PR TITLE
fix(coding-agent): keep multi-line string highlighting in expanded ipython cells

### DIFF
--- a/packages/coding-agent/.changes/multiline-python-string-highlight.md
+++ b/packages/coding-agent/.changes/multiline-python-string-highlight.md
@@ -1,0 +1,1 @@
+- Fixed syntax highlighting in the expanded python tool-call view: triple-quoted strings spanning multiple lines now keep their string color instead of only the first line.

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -507,9 +507,14 @@ export class IPythonCellComponent implements Component {
 		this.addBlank(lines, width);
 		const isBashCell = parseIpythonBashCell(code) !== undefined;
 		const rawLines = code.split("\n");
+		// Highlight the whole cell at once so multi-line strings keep their color.
+		const highlightedLines = isBashCell ? [] : highlightCode(code, "python");
 		for (const [index, rawLine] of rawLines.entries()) {
 			const prefix = index === 0 ? theme.fg("dim", "› ") : theme.fg("dim", "  ");
-			const highlighted = this.highlightInputLine(rawLine, isBashCell);
+			const highlighted =
+				isBashCell || MAGIC_LINE_PATTERN.test(rawLine) || parseIpythonBashCell(rawLine) !== undefined
+					? theme.fg("bashMode", rawLine)
+					: (highlightedLines[index] ?? theme.fg("mdCodeBlock", rawLine));
 			this.addWrapped(lines, prefix, highlighted || " ", width);
 		}
 


### PR DESCRIPTION
Linear: ENG-5496 — https://linear.app/primeintellect/issue/ENG-5496/expanded-ipython-tile-triple-quoted-strings-lose-highlighting-after

## Context

In the expanded python tool-call view, a `"""` string spanning multiple lines only has its first line colored as a string. `renderInput` highlighted each line separately, so highlight.js lost its inside-a-string state on every line boundary.

## Changes

- Highlight the whole cell once with the existing `highlightCode(code, "python")` (its output is line-split and each line is ANSI-self-contained) and index into it per line.
- Keep the per-line `%magic`/`!bash` overrides and the bash-cell branch unchanged.
- The collapsed one-line preview path is untouched (inherently single-line).

## Validation

- Verified against cli-highlight directly: whole-block highlighting keeps string color across lines and re-opens ANSI per line, count-preserving.
- `npx vitest --run test/ipython-cell-diff.test.ts test/ipython-cell-wrap.test.ts` (28 passed)
- tsgo --noEmit clean, biome clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only syntax highlighting in the IPython cell UI; no auth, data, or execution-path changes.
> 
> **Overview**
> Fixes expanded IPython cell highlighting so Python triple-quoted strings keep their string color across lines.
> 
> `renderCode` now runs `highlightCode` on the full cell once, then indexes those lines, instead of highlighting each line in isolation (which dropped string state at newlines). Per-line `%magic` / `!bash` and bash-cell coloring is unchanged; the collapsed one-line preview still highlights a single line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c6b6de089b758f3b360cfb6164a72265ce0f9fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix multi-line string highlighting in expanded IPython cells
> Previously, each line in an expanded IPython cell was highlighted independently, which broke coloring for multi-line triple-quoted Python strings. The `IPythonCellComponent.render` method now computes whole-cell Python highlighting once with `highlightCode(code, "python")` and reuses the result per line. Bash and magic lines still render in `bashMode`. See [ipython-cell.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1692/files#diff-0c68a1ddc7ca42ea120720a8a68c087bc0da2b18a8ee0fbdca8136759057bcdf).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c6b6de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->