### PR TITLE
fix(coding-agent): re-provision the IPython kernel after an unexpected death

### DIFF
--- a/packages/coding-agent/.changes/fix-dead-kernel-reprovision.md
+++ b/packages/coding-agent/.changes/fix-dead-kernel-reprovision.md
@@ -1,0 +1,1 @@
+- Fixed sessions permanently losing Python after an unexpected IPython kernel exit: the kernel manager now reports unexpected deaths so the provisioner drops the dead handle and provisions a fresh kernel on the next call.

--- a/packages/coding-agent/src/core/kernel/index.ts
+++ b/packages/coding-agent/src/core/kernel/index.ts
@@ -173,6 +173,13 @@ export interface KernelManagerOptions {
 	snapshot?: KernelSnapshotConfig;
 	/** Default: "prime-agent". */
 	username?: string;
+	/**
+	 * Fired at most once when the kernel process dies unexpectedly (spawn error,
+	 * unexpected exit, or a forked kernel disappearing) — never for a shutdown /
+	 * kill / dispose the caller initiated. Lets an owner (e.g. the provisioner)
+	 * drop its handle to this now-dead manager and re-provision on the next use.
+	 */
+	onUnexpectedExit?: () => void;
 }
 
 export interface KernelStartOptions {
@@ -588,9 +595,11 @@ function installSignalHandlersOnce(): void {
 export class KernelManager {
 	private readonly options: Pick<
 		KernelManagerOptions,
-		"python" | "cwd" | "env" | "sessionId" | "hostHandlers" | "pythonSkills" | "snapshot"
+		"python" | "cwd" | "env" | "sessionId" | "hostHandlers" | "pythonSkills" | "snapshot" | "onUnexpectedExit"
 	> &
 		Required<Pick<KernelManagerOptions, "username">>;
+	/** Guards {@link options.onUnexpectedExit} so it fires at most once per manager. */
+	private notifiedUnexpectedExit = false;
 	private readonly session = uuid();
 	private readonly commTargets = new Map<string, string>();
 	private readonly handledHostRequestCommIds = new Set<string>();
@@ -637,8 +646,24 @@ export class KernelManager {
 			hostHandlers: options.hostHandlers,
 			pythonSkills: options.pythonSkills,
 			snapshot: options.snapshot,
+			onUnexpectedExit: options.onUnexpectedExit,
 			username: options.username ?? "prime-agent",
 		};
+	}
+
+	/**
+	 * Notify the owner that the kernel died on its own. Fires at most once, and
+	 * only for deaths we didn't initiate — callers that transition to "shutdown"
+	 * deliberately (shutdown/kill/dispose) never trigger this.
+	 */
+	private notifyUnexpectedExit(): void {
+		if (this.notifiedUnexpectedExit) return;
+		this.notifiedUnexpectedExit = true;
+		try {
+			this.options.onUnexpectedExit?.();
+		} catch {
+			// A misbehaving listener must never mask the kernel teardown.
+		}
 	}
 
 	get ownerSessionId(): string | undefined {
@@ -755,20 +780,24 @@ export class KernelManager {
 
 			kernel.on("error", (err) => {
 				if (this.kernel !== kernel) return;
+				const wasExpected = (this.state as string) === "shutdown";
 				this.appendKernelDiagnostic(`spawn error: ${err.message}`);
 				this.state = "shutdown";
 				liveKernels.delete(this);
 				this.cleanupResources();
+				if (!wasExpected) this.notifyUnexpectedExit();
 			});
 
 			kernel.on("exit", (code, signal) => {
 				if (this.kernel !== kernel) return;
-				if (this.state !== "shutdown") {
+				const wasExpected = (this.state as string) === "shutdown";
+				if (!wasExpected) {
 					this.appendKernelDiagnostic(`unexpected exit code=${code} signal=${signal}`);
 				}
 				this.state = "shutdown";
 				liveKernels.delete(this);
 				this.cleanupResources();
+				if (!wasExpected) this.notifyUnexpectedExit();
 			});
 		}
 
@@ -847,6 +876,9 @@ export class KernelManager {
 		this.state = "shutdown";
 		liveKernels.delete(this);
 		this.cleanupResources();
+		// Reaching here means the kernel was still "running" — this death is always
+		// unexpected (a deliberate teardown would have moved us out of "running").
+		this.notifyUnexpectedExit();
 	}
 
 	// Liveness from the forkserver's reap table; a pid-0 probe would race reuse.

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -414,9 +414,45 @@ export class IpythonKernelProvisioner {
 		}
 	}
 
+	/**
+	 * Forget a manager whose kernel died unexpectedly, so the next {@link ensure}
+	 * starts a fresh one. Only clears state still pointing at this exact manager,
+	 * so a concurrent dispose()/kill() or a newer start already in flight wins.
+	 */
+	private handleManagerDeath(dead: KernelManager): void {
+		// onUnexpectedExit only fires after the kernel reached "running", by which
+		// point startup has settled the memo to this manager — so if we still own
+		// it, clearing both handles synchronously is race-free. If a newer start
+		// already replaced startedManager, leave the memo alone.
+		if (this.startedManager === dead) {
+			this.startedManager = undefined;
+			this.managerPromise = undefined;
+			// Drop the stale restore notice so it can't outlive the dead kernel; a
+			// fresh startKernel() re-populates it from the snapshot it actually revives.
+			this._lastRestore = undefined;
+		}
+		if (this.options?.kernelManagerRef?.current === dead) {
+			this.options.kernelManagerRef.current = undefined;
+		}
+	}
+
 	ensure(onProgress?: KernelBootstrapProgressHandler, signal?: AbortSignal): Promise<KernelManager> {
 		if (signal?.aborted) {
 			return Promise.reject(createAbortError());
+		}
+		// A kernel that died between calls (its onUnexpectedExit may not have fired
+		// yet) must not be handed back — drop the dead handle so the memo check
+		// below re-provisions. A set startedManager means startup already settled
+		// the memo to that same manager, so clearing both here is race-free: no
+		// newer start can be in flight while managerPromise is still populated.
+		if (this.startedManager && !this.startedManager.isRunning) {
+			const dead = this.startedManager;
+			this.startedManager = undefined;
+			this.managerPromise = undefined;
+			this._lastRestore = undefined;
+			if (this.options?.kernelManagerRef?.current === dead) {
+				this.options.kernelManagerRef.current = undefined;
+			}
 		}
 		let cleanupProgressListener: (() => void) | undefined;
 		if (onProgress && !this.startedManager) {
@@ -483,7 +519,7 @@ export class IpythonKernelProvisioner {
 				);
 			}
 			const snapshotDir = this.options?.snapshotDir;
-			const m = new KernelManager({
+			const m: KernelManager = new KernelManager({
 				python: this.options?.python,
 				cwd: this.cwd,
 				env: this.options?.env,
@@ -494,6 +530,10 @@ export class IpythonKernelProvisioner {
 				snapshot: snapshotDir
 					? { path: snapshotPathIn(snapshotDir), manifestPath: manifestPathIn(snapshotDir) }
 					: undefined,
+				// Drop our handle to this manager the moment its kernel dies on its own,
+				// so the next ensure() provisions a fresh kernel instead of handing back
+				// a dead one that rejects every execute() with "Kernel has been shut down".
+				onUnexpectedExit: () => this.handleManagerDeath(m),
 			});
 			let pendingRestore: RestoreResult | undefined;
 			try {

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -325,6 +325,73 @@ describe("IpythonKernelProvisioner", () => {
 		expect(setWorkingMessage).toHaveBeenLastCalledWith(undefined);
 	});
 
+	it("re-provisions when the memoized kernel has died (lazy guard in ensure)", async () => {
+		const { python, countRuns } = writeFakePython();
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python });
+
+		// A prior startKernel settled the memo to a manager whose kernel has since
+		// died on its own: startedManager is set but no longer running.
+		const deadManager = { isRunning: false, dispose: vi.fn(async () => {}) } as unknown as KernelManager;
+		Object.assign(
+			provisioner as unknown as {
+				managerPromise: Promise<KernelManager>;
+				startedManager: KernelManager;
+			},
+			{
+				managerPromise: Promise.resolve(deadManager),
+				startedManager: deadManager,
+			},
+		);
+
+		// ensure() must not hand back the dead manager; it drops it and starts a
+		// fresh kernel (which fails here because python is the stub, proving a new
+		// spawn was attempted rather than the dead handle being reused).
+		await expect(provisioner.ensure()).rejects.toThrow(/Kernel exited before resolving ports/);
+		expect(countRuns()).toBe(1);
+		expect(deadManager.dispose).not.toHaveBeenCalled();
+	});
+
+	it("clears its handle when a kernel reports an unexpected exit (eager callback)", async () => {
+		const provisioner = new IpythonKernelProvisioner(tempDir, {});
+		const manager = { isRunning: false } as unknown as KernelManager;
+		const internals = provisioner as unknown as {
+			managerPromise: Promise<KernelManager>;
+			startedManager: KernelManager;
+			handleManagerDeath: (dead: KernelManager) => void;
+		};
+		Object.assign(internals, {
+			managerPromise: Promise.resolve(manager),
+			startedManager: manager,
+		});
+
+		internals.handleManagerDeath(manager);
+
+		expect(provisioner.manager).toBeUndefined();
+		expect(internals.managerPromise).toBeUndefined();
+	});
+
+	it("keeps its handle if a newer manager replaced the dead one before the callback fires", async () => {
+		const provisioner = new IpythonKernelProvisioner(tempDir, {});
+		const staleManager = { isRunning: false } as unknown as KernelManager;
+		const freshManager = { isRunning: true } as unknown as KernelManager;
+		const freshPromise = Promise.resolve(freshManager);
+		const internals = provisioner as unknown as {
+			managerPromise: Promise<KernelManager>;
+			startedManager: KernelManager;
+			handleManagerDeath: (dead: KernelManager) => void;
+		};
+		Object.assign(internals, {
+			managerPromise: freshPromise,
+			startedManager: freshManager,
+		});
+
+		// A late death notice for the stale manager must not evict the fresh one.
+		internals.handleManagerDeath(staleManager);
+
+		expect(provisioner.manager).toBe(freshManager);
+		expect(internals.managerPromise).toBe(freshPromise);
+	});
+
 	it("does not delete the on-disk snapshot (the kernel survives compaction)", async () => {
 		const snapshotDir = join(tempDir, "artifacts");
 		const provisioner = new IpythonKernelProvisioner(tempDir, { snapshotDir });

--- a/packages/coding-agent/test/kernel-startup.test.ts
+++ b/packages/coding-agent/test/kernel-startup.test.ts
@@ -1,10 +1,21 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KernelManager } from "../src/core/kernel/index.js";
 
 let tempDir = "";
+
+// A stub python must be spawned directly; the default-on forkserver would add a
+// handshake the stub never answers.
+const savedForkFlag = process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+beforeAll(() => {
+	process.env.PRIME_AGENT_KERNEL_FORKSERVER = "0";
+});
+afterAll(() => {
+	if (savedForkFlag === undefined) delete process.env.PRIME_AGENT_KERNEL_FORKSERVER;
+	else process.env.PRIME_AGENT_KERNEL_FORKSERVER = savedForkFlag;
+});
 
 function writeExecutable(filePath: string, content: string): void {
 	writeFileSync(filePath, content);
@@ -37,5 +48,59 @@ describe("KernelManager startup", () => {
 			errorSpy.mockRestore();
 			await manager.dispose();
 		}
+	});
+
+	it("fires onUnexpectedExit when a kernel dies on its own", async () => {
+		const python = join(tempDir, "python");
+		writeExecutable(python, ["#!/bin/sh", "exit 42", ""].join("\n"));
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const onUnexpectedExit = vi.fn();
+		const manager = new KernelManager({ python, cwd: tempDir, onUnexpectedExit });
+
+		try {
+			await expect(manager.execute("print(1)")).rejects.toThrow(/Kernel exited before resolving ports/);
+			await vi.waitFor(() => expect(onUnexpectedExit).toHaveBeenCalledTimes(1));
+		} finally {
+			errorSpy.mockRestore();
+			await manager.dispose();
+		}
+	});
+
+	it("fires onUnexpectedExit at most once even across repeated exit signals", async () => {
+		const onUnexpectedExit = vi.fn();
+		const manager = new KernelManager({ cwd: tempDir, onUnexpectedExit });
+		const internals = manager as unknown as { notifyUnexpectedExit: () => void };
+
+		internals.notifyUnexpectedExit();
+		internals.notifyUnexpectedExit();
+		internals.notifyUnexpectedExit();
+
+		expect(onUnexpectedExit).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not fire onUnexpectedExit when the real exit handler sees a deliberate shutdown", async () => {
+		// Drive the actual wiring: spawn a real (stub) child so doStart attaches its
+		// exit handler, then flip to "shutdown" before the exit so the handler reads
+		// the death as expected — exactly what dispose()/kill() do.
+		const python = join(tempDir, "python");
+		writeExecutable(python, ["#!/bin/sh", "sleep 30", ""].join("\n"));
+		const onUnexpectedExit = vi.fn();
+		const manager = new KernelManager({ python, cwd: tempDir, onUnexpectedExit });
+		const internals = manager as unknown as {
+			state: string;
+			kernel?: { pid?: number; killed: boolean };
+		};
+
+		const startup = manager.start().catch(() => {});
+		// Wait until doStart has spawned the child and attached the exit handler.
+		await vi.waitFor(() => expect(internals.kernel?.pid).toBeGreaterThan(0));
+
+		// A deliberate teardown moves us to "shutdown" first, then kills the child;
+		// the exit handler must classify the resulting exit as expected.
+		await manager.dispose();
+		await startup;
+
+		expect(onUnexpectedExit).not.toHaveBeenCalled();
+		expect(internals.state).toBe("shutdown");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the bug reported in #1659 / #1668 (and the umbrella #764): after an unexpected IPython kernel exit, `IpythonKernelProvisioner` keeps handing back the stopped `KernelManager`, so every later cell fails with `Kernel has been shut down` and Python stays permanently unavailable while the session remains responsive. Still reproduces on current `main`.

This builds on the lazy-guard direction from the earlier attempt (#1658) with a small superset that also recovers **eagerly**, because the root cause is one layer deeper than the `ensure()` cache: `KernelManager` never tells its owner when the kernel dies on its own.

- **`KernelManager.onUnexpectedExit`** — fired at most once, and only for deaths the caller did **not** initiate (deliberate `shutdown`/`kill`/`dispose` transition to `"shutdown"` first, so those stay silent). Wired into all three death sites: spawn `error`, process `exit`, and `checkForkedKernelDeath` (forkserver-forked kernels).
- **Provisioner** uses that callback to drop `startedManager` / `managerPromise` / `_lastRestore` / `kernelManagerRef.current` the moment the kernel dies.
- **`ensure()` lazy guard** still discards a non-running memoized manager before provisioning, as belt-and-suspenders for a death that races between calls.
- The failed cell is never replayed (no duplicate external effects); the next explicit call re-runs the normal `startKernel()` path (snapshot restore + runtime bootstrap), and concurrent recovery calls stay coalesced onto one startup.

## Validation

```text
test/ipython-provisioner.test.ts + test/kernel-startup.test.ts: 23 passed
```

Tests cover the eager callback, the lazy `ensure()` guard, the newer-manager race, once-only firing, and the deliberate-shutdown *no-fire* path. biome + typecheck clean on the changed files. A changelog fragment is included.

Related: #1659, #1668, #1658, #764

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-provision IPython kernel after unexpected death in `IpythonKernelProvisioner`
> - `KernelManager` accepts an optional `onUnexpectedExit` callback that fires at most once when the kernel process exits or errors outside a deliberate shutdown, covering both spawned and forked-kernel paths.
> - `IpythonKernelProvisioner.ensure()` clears memoized manager state when an unexpected exit is reported (or when a lazy check finds a dead manager) so the next call provisions a fresh kernel instead of failing permanently.
> - Risk: `handleManagerDeath` only clears state when the dead manager matches the current `startedManager`; if a newer manager already superseded the stale one, the callback is a no-op — reviewers should confirm this race window is covered in [ipython-provisioner.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1693/files#diff-acde112b894c2a7c08a290667fa9aa34fccd3aeb6a7044304afdd76c5a945ae0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e9b8f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->