### PR TITLE
fix(coding-agent): protect forkserver from status probes

### DIFF
--- a/packages/coding-agent/.changes/fix-status-forkserver-probe.md
+++ b/packages/coding-agent/.changes/fix-status-forkserver-probe.md
@@ -1,0 +1,1 @@
+- Fixed `prime-agent status` terminating active IPython forkservers by excluding internal control sockets from daemon discovery and preserving the established forkserver connection.

--- a/packages/coding-agent/src/cli/daemon-ps.ts
+++ b/packages/coding-agent/src/cli/daemon-ps.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, lstatSync, readdirSync, readFileSync, rmSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import chalk from "chalk";
 import { APP_NAME, getAgentDir, VERSION } from "../config.js";
@@ -99,7 +100,11 @@ export function parseSsListeners(stdout: string, appName: string): DiscoveredDae
 		if (!owner || !processNameMatches(owner[1]!, appName)) {
 			continue;
 		}
-		daemons.push({ pid: Number.parseInt(owner[2]!, 10), socketPath: normalizeSocketPath(socketPath) });
+		const normalized = normalizeSocketPath(socketPath);
+		if (isKernelForkServerSocketPath(normalized)) {
+			continue;
+		}
+		daemons.push({ pid: Number.parseInt(owner[2]!, 10), socketPath: normalized });
 	}
 	return daemons;
 }
@@ -116,6 +121,9 @@ export function parseLsofListeners(stdout: string): DiscoveredDaemonProcess[] {
 			pid = Number.parseInt(value, 10);
 		} else if (field === "n" && pid !== undefined && value.startsWith("/")) {
 			const socketPath = normalizeSocketPath(value);
+			if (isKernelForkServerSocketPath(socketPath)) {
+				continue;
+			}
 			const key = `${pid}:${socketPath}`;
 			if (!seen.has(key)) {
 				seen.add(key);
@@ -878,6 +886,18 @@ export function isWorkerSocketPath(socketPath: string): boolean {
 		resolve(dirname(socketPath)) === resolve(defaultDaemonSocketDir()) &&
 		basename(socketPath).startsWith("worker-") &&
 		basename(socketPath).endsWith(".sock")
+	);
+}
+
+/** Internal kernel forkserver listeners are not daemon control sockets. */
+export function isKernelForkServerSocketPath(socketPath: string): boolean {
+	if (process.platform === "win32") return false;
+	const normalized = normalizeSocketPath(socketPath);
+	const socketDirectory = dirname(normalized);
+	return (
+		basename(normalized) === "control.sock" &&
+		basename(socketDirectory).startsWith("prime-agent-forkserver-") &&
+		resolve(dirname(socketDirectory)) === resolve(tmpdir())
 	);
 }
 

--- a/packages/coding-agent/src/core/kernel/fork-server.ts
+++ b/packages/coding-agent/src/core/kernel/fork-server.ts
@@ -178,6 +178,12 @@ export class ForkServer {
 			};
 
 			server.on("connection", (socket) => {
+				// The Python forkserver owns the first connection for its lifetime. A
+				// discovery probe must not replace that control channel when it connects.
+				if (this.conn) {
+					socket.destroy();
+					return;
+				}
 				this.conn = socket;
 				socket.setEncoding("utf8");
 				socket.on("data", (chunk: string) => this.onData(chunk));

--- a/packages/coding-agent/test/daemon-ps.test.ts
+++ b/packages/coding-agent/test/daemon-ps.test.ts
@@ -1,8 +1,10 @@
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	type DaemonInfo,
 	evaluateShutdownQuietPeriod,
+	isKernelForkServerSocketPath,
 	isWorkerSocketPath,
 	mergeDiscoveredDaemonProcesses,
 	parseLsofListeners,
@@ -26,11 +28,20 @@ describe("worker socket classification", () => {
 	});
 });
 
+describe("forkserver socket classification", () => {
+	it.runIf(process.platform !== "win32")("recognizes only internal forkserver control sockets", () => {
+		expect(isKernelForkServerSocketPath(join(tmpdir(), "prime-agent-forkserver-abc123", "control.sock"))).toBe(true);
+		expect(isKernelForkServerSocketPath(join(tmpdir(), "prime-agent-forkserver-abc123", "daemon.sock"))).toBe(false);
+		expect(isKernelForkServerSocketPath(join(tmpdir(), "custom", "control.sock"))).toBe(false);
+	});
+});
+
 describe("parseSsListeners", () => {
 	const stdout = [
 		"Netid State  Recv-Q Send-Q Local Address:Port  Peer Address:Port",
 		'u_str LISTEN 0      511    /tmp/custom.sock 10147608 * 0 users:(("prime-agent",pid=1234,fd=22))',
 		'u_str LISTEN 0      511    /tmp/prime-agent-1000/daemon.sock 79453846 * 0 users:(("prime-agent",pid=5678,fd=24))',
+		'u_str LISTEN 0      511    /tmp/prime-agent-forkserver-probe/control.sock 79453847 * 0 users:(("prime-agent",pid=2468,fd=25))',
 		'u_str LISTEN 0      4096   /run/dbus/system_bus_socket 123 * 0 users:(("dbus-daemon",pid=900,fd=3))',
 		'u_str ESTAB  0      0      /tmp/other.sock 456 * 0 users:(("prime-agent",pid=4321,fd=9))',
 		"",
@@ -48,6 +59,7 @@ describe("parseSsListeners", () => {
 		const daemons = parseSsListeners(stdout, "prime-agent");
 		expect(daemons.some((daemon) => daemon.socketPath.includes("dbus"))).toBe(false);
 		expect(daemons.some((daemon) => daemon.pid === 4321)).toBe(false);
+		expect(daemons.some((daemon) => daemon.pid === 2468)).toBe(false);
 	});
 
 	it("honors a different app name", () => {
@@ -57,7 +69,17 @@ describe("parseSsListeners", () => {
 
 describe("parseLsofListeners", () => {
 	it("pairs each pid with its listening unix socket paths", () => {
-		const stdout = ["p1234", "fu", "n/tmp/a.sock", "p5678", "n/tmp/b.sock", "n0x0 (not a path)", ""].join("\n");
+		const stdout = [
+			"p1234",
+			"fu",
+			"n/tmp/a.sock",
+			"p2468",
+			"n/tmp/prime-agent-forkserver-probe/control.sock",
+			"p5678",
+			"n/tmp/b.sock",
+			"n0x0 (not a path)",
+			"",
+		].join("\n");
 		expect(parseLsofListeners(stdout)).toEqual([
 			{ pid: 1234, socketPath: "/tmp/a.sock" },
 			{ pid: 5678, socketPath: "/tmp/b.sock" },

--- a/packages/coding-agent/test/kernel-fork-server-protocol.test.ts
+++ b/packages/coding-agent/test/kernel-fork-server-protocol.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createConnection, type Server } from "node:net";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -229,6 +230,23 @@ describeIf("forkserver kill/liveness protocol (stub python)", () => {
 		server!.dispose();
 		await expect(handle.kill("TERM")).rejects.toBeInstanceOf(ForkServerUnavailable);
 		await expect(handle.isAlive()).rejects.toBeInstanceOf(ForkServerUnavailable);
+	}, 15_000);
+
+	it("keeps the established control channel when another client probes the socket", async () => {
+		const handle = await spawnStubKernel();
+		const listener = (server as unknown as { server?: Server }).server;
+		const address = listener?.address();
+		expect(typeof address).toBe("string");
+
+		await new Promise<void>((resolve, reject) => {
+			const probe = createConnection(address as string);
+			probe.once("connect", () => probe.end());
+			probe.once("close", () => resolve());
+			probe.once("error", reject);
+		});
+
+		expect(server!.isDead).toBe(false);
+		expect(await handle.isAlive()).toBe(true);
 	}, 15_000);
 
 	describe("forkserver orphan journal", () => {


### PR DESCRIPTION
## Summary

- exclude internal forkserver control sockets from daemon discovery
- prevent a second connection from replacing the established forkserver channel
- anchor the exclusion by real path, and promote the control channel only on the child's `ready` handshake
- cover both parser paths, the symlinked-tmpdir fail-open, the startup race, and the live forkserver protocol

## Why

`prime-agent status --json` scans Unix listeners owned by `prime-agent`, probes the internal forkserver socket, and disconnects. The disconnect marks the forkserver dead and terminates every IPython kernel forked from it.

This prevents the initiating teardown. It is distinct from #1659 and closed #1693, which recover after a kernel has already died.

@coleleavitt independently reproduced the fault and closed two gaps in the first version: a `resolve()`-only tmpdir compare that failed open when the socket is reported under an aliased path such as `/private/tmp`, and a startup race where a probe landing between `listen()` and the child's connect still reached `markDead()`. Both now have regressions that fail on the pre-hardening tree.

#1687 removes `fork-server.ts` in the REPL cutover. Until that stack lands both halves apply; after it lands the connection guard belongs on the REPL host, and the `daemon-ps` exclusion still stands.

Discussion: #1695

## Validation

macOS 27 arm64 (node 22.22) and Debian 12 aarch64 in docker (node 22.23):

- `test/daemon-ps.test.ts test/kernel-fork-server-protocol.test.ts`: 38 passed, 1 platform-gated skip on both
- `npm run check`: exit 0 on both, with the Linux run from a fresh clone of the branch
- each guard checked by reverting it: the discovery filter, the connection guard, the realpath anchor, and the handshake gate each fail their tests when removed
- a live forkserver socket driven through the real `ss` and `lsof` discovery paths is excluded, and both the forkserver and its forked kernel survive the probe
- full `npm run test:ci` on macOS shows no failure attributable to this change; the residual failures reproduce identically on unmodified `main`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude forkserver control sockets from daemon discovery and guard control connection
> - `prime-agent status` was discovering internal kernel forkserver control sockets and connecting to them, which terminated active IPython forkservers. Discovery now skips these sockets.
> - New helper `isKernelForkServerSocketPath` in [daemon-ps.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1696/files#diff-d26d176c2fa21f2284ca0dc614dfb273ec8abfce710655afccc3aa35628c848a) detects sockets whose basename is `control.sock`, whose parent dir starts with `prime-agent-forkserver-`, and whose grandparent resolves to the system tmpdir.
> - `parseSsListeners` (Linux) and `parseLsofListeners` (macOS) both filter out matching sockets before returning daemon discovery results.
> - `ForkServer` in [fork-server.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1696/files#diff-65164112dcd341a9e27f5bbd59aa6b335e99b3c538915cde2701e2afa02a5e36) now destroys any inbound connection after the initial control connection is established, preventing probes from replacing the control channel.
> - Risk: any out-of-tree code that relied on discovering forkserver control sockets via `parseSsListeners` or `parseLsofListeners` will no longer see them in the results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee8ede1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->