### PR TITLE
test(coding-agent): cover root sibling agent messaging

### DIFF
--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1493,24 +1493,29 @@ describe("daemon mode helpers", () => {
 		expect((await internals.createAgentMessageListResult(source)).agents).toContainEqual(
 			expect.objectContaining({ activeSessionId: remoteSelector }),
 		);
-		const handlers = createAgentMessageHostHandlers(internals.createAgentMessageController(() => source));
-		const roster = await handlers["agent_message.list_agents"]!({});
-		expect(roster.current).toMatchObject({ name: "Source", id: "session-source", depth: 0 });
-		expect(roster.entries).toContainEqual({
-			relationship: "sibling",
-			name: "Remote",
-			id: "session-remote",
-			depth: 0,
-			status: "idle",
-		});
-		await expect(
-			handlers["agent_message.send"]!({
-				message: "continue remotely",
-				receiver_role: "sibling",
-				receiver_name: "Remote",
-			}),
-		).resolves.toEqual(receipt);
-		expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(source, "session-remote", "continue remotely");
+		const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
+		try {
+			const handlers = createAgentMessageHostHandlers(internals.createAgentMessageController(() => source));
+			const roster = await handlers["agent_message.list_agents"]!({});
+			expect(roster.current).toMatchObject({ name: "Source", id: "session-source", depth: 0 });
+			expect(roster.entries).toContainEqual({
+				relationship: "sibling",
+				name: "Remote",
+				id: "session-remote",
+				depth: 0,
+				status: "idle",
+			});
+			await expect(
+				handlers["agent_message.send"]!({
+					message: "continue remotely",
+					receiver_role: "sibling",
+					receiver_name: "Remote",
+				}),
+			).resolves.toEqual(receipt);
+			expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(source, "session-remote", "continue remotely");
+		} finally {
+			listAll.mockRestore();
+		}
 	});
 
 	it("routes nonresident agent-message targets through the supervisor wake path", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	AGENT_FAMILY_REACH_ERROR,
 	type AgentSessionMessageController,
+	createAgentMessageHostHandlers,
 	DEFAULT_AGENT_MESSAGE_MAX_CHARS,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
@@ -1438,7 +1439,7 @@ describe("daemon mode helpers", () => {
 		expect(internals.closingSessions.has(state.activeSessionId)).toBe(false);
 	});
 
-	it("lists and routes agent messages to peers hosted by another worker", async () => {
+	it("lists and role-addresses root siblings hosted by another worker", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -1474,13 +1475,8 @@ describe("daemon mode helpers", () => {
 			createAgentMessageListResult(
 				current: ActiveSessionState,
 			): Promise<{ agents: Array<{ activeSessionId: string }> }>;
+			createAgentMessageController(getCurrentState: () => ActiveSessionState): AgentSessionMessageController;
 			sendRemoteAgentSessionMessage: typeof sendRemoteAgentSessionMessage;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState: ActiveSessionState;
-				origin: "agent";
-			}): Promise<unknown>;
 		};
 		internals.sessions.set(source.activeSessionId, source);
 		internals.remoteAgentPeers.set(remoteSelector, {
@@ -1497,15 +1493,24 @@ describe("daemon mode helpers", () => {
 		expect((await internals.createAgentMessageListResult(source)).agents).toContainEqual(
 			expect.objectContaining({ activeSessionId: remoteSelector }),
 		);
+		const handlers = createAgentMessageHostHandlers(internals.createAgentMessageController(() => source));
+		const roster = await handlers["agent_message.list_agents"]!({});
+		expect(roster.current).toMatchObject({ name: "Source", id: "session-source", depth: 0 });
+		expect(roster.entries).toContainEqual({
+			relationship: "sibling",
+			name: "Remote",
+			id: "session-remote",
+			depth: 0,
+			status: "idle",
+		});
 		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: remoteSelector,
+			handlers["agent_message.send"]!({
 				message: "continue remotely",
-				fromState: source,
-				origin: "agent",
+				receiver_role: "sibling",
+				receiver_name: "Remote",
 			}),
 		).resolves.toEqual(receipt);
-		expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(source, remoteSelector, "continue remotely");
+		expect(sendRemoteAgentSessionMessage).toHaveBeenCalledWith(source, "session-remote", "continue remotely");
 	});
 
 	it("routes nonresident agent-message targets through the supervisor wake path", async () => {


### PR DESCRIPTION
https://linear.app/primeintellect/issue/ENG-5494/cover-top-level-root-sibling-messaging-through-the-daemon-skill-path

## Summary

- extend the remote daemon-peer regression through the public `agent_message` host handlers
- verify `agent_message.list_agents()` exposes a remote depth-0 root as a sibling
- verify `receiver_role="sibling"` plus `receiver_name` selects the root by durable session ID and uses the existing cross-worker route

Current production code already supports messaging between resident top-level roots under one daemon supervisor. This PR closes the missing composed regression without adding duplicate authorization logic or broadening client-owned session visibility.

Related: #1182

## Test plan

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/daemon-mode.test.ts` (199 passed)
- `npm run check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in daemon-mode coverage; no production logic is modified.
> 
> **Overview**
> Updates the daemon-mode regression so cross-worker **root sibling** messaging is exercised through the public `agent_message` host handlers instead of `sendAgentSessionMessage`.
> 
> The test now builds handlers via `createAgentMessageHostHandlers`, asserts `agent_message.list_agents` exposes the remote depth-0 peer as a sibling, and sends with `receiver_role="sibling"` plus `receiver_name`. Routing is still expected to hit `sendRemoteAgentSessionMessage` using the durable remote session ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a30de0aefd1ef11fba52279574ddf007c39722e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite root sibling messaging test to use `agent_message` handlers
> Updates the test in [daemon-mode.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1698/files#diff-e6ffcbd62d8fe753528e06c93d849d9b1799ac2dbadf243304375c6a043243b5) to exercise agent messaging via `createAgentMessageHostHandlers` and `agent_message.send`/`agent_message.list_agents` handlers instead of calling `internals` methods directly. The test now role-addresses a remote sibling by `receiver_role: 'sibling'` and `receiver_name: 'Remote'` and asserts delivery resolves to session id `session-remote`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a30de0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->