### PR TITLE
perf(coding-agent): cache RLM ledger replay

### DIFF
--- a/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
+++ b/packages/coding-agent/src/modes/daemon/rlm-ledger.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+	type BigIntStats,
 	closeSync,
 	existsSync,
 	fstatSync,
@@ -33,9 +34,10 @@ import { readFirstLineSync } from "../../utils/file-lines.js";
  * Multi-writer reality: the supervisor and each session worker hold their own
  * instance over the same file. Appends are single small O_APPEND writes (well
  * under PIPE_BUF-scale sizes), whose atomicity we rely on for interleaving;
- * reads re-read the whole file per operation, so cross-process staleness is
- * bounded to in-flight appends. In-process appends are serialized on an
- * internal queue.
+ * reads stat the file per operation and reuse an in-process replay only while
+ * its identity and metadata remain unchanged. Changed files are re-read in
+ * full, so cross-process staleness is bounded to in-flight appends. In-process
+ * appends are serialized on an internal queue and invalidate the cached replay.
  */
 
 export const RLM_LEDGER_DIR = "rlm-ledger";
@@ -295,6 +297,41 @@ function edgeKey(childId: string, child: string): string {
 	return `${childId}\u0000${canonicalSessionPath(child)}`;
 }
 
+interface RlmLedgerFileIdentity {
+	dev: bigint;
+	ino: bigint;
+	size: bigint;
+	mtimeNs: bigint;
+	ctimeNs: bigint;
+	birthtimeNs: bigint;
+}
+
+function ledgerFileIdentity(stats: BigIntStats): RlmLedgerFileIdentity {
+	return {
+		dev: stats.dev,
+		ino: stats.ino,
+		size: stats.size,
+		mtimeNs: stats.mtimeNs,
+		ctimeNs: stats.ctimeNs,
+		birthtimeNs: stats.birthtimeNs,
+	};
+}
+
+function sameLedgerFileIdentity(left: RlmLedgerFileIdentity, right: RlmLedgerFileIdentity): boolean {
+	return (
+		left.dev === right.dev &&
+		left.ino === right.ino &&
+		left.size === right.size &&
+		left.mtimeNs === right.mtimeNs &&
+		left.ctimeNs === right.ctimeNs &&
+		left.birthtimeNs === right.birthtimeNs
+	);
+}
+
+function cloneLedgerEdges(edges: ReadonlyMap<string, RlmLedgerEdge>): Map<string, RlmLedgerEdge> {
+	return new Map([...edges].map(([key, edge]) => [key, { ...edge }]));
+}
+
 /**
  * Per-sessions-dir spawn ledger. All operations are serialized on an internal
  * queue; the first operation lazily seeds a missing ledger from the existing
@@ -306,6 +343,7 @@ export class RlmSpawnLedger {
 	private readonly canonicalSessionsDir: string;
 	private queue: Promise<unknown> = Promise.resolve();
 	private seedAttempted = false;
+	private replayCache?: { identity: RlmLedgerFileIdentity; edges: Map<string, RlmLedgerEdge> };
 
 	constructor(
 		agentDir: string,
@@ -687,6 +725,7 @@ export class RlmSpawnLedger {
 		// degradation mode) rather than a check-then-rename race.
 		try {
 			linkSync(tempPath, this.path);
+			this.invalidateReplayCache();
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code === "EEXIST") {
@@ -697,6 +736,7 @@ export class RlmSpawnLedger {
 	}
 
 	private appendRecord(record: RlmLedgerRecord): void {
+		this.invalidateReplayCache();
 		const dir = dirname(this.path);
 		mkdirSync(dir, { recursive: true, mode: 0o700 });
 		const isNew = !existsSync(this.path);
@@ -755,6 +795,7 @@ export class RlmSpawnLedger {
 				if (second.length !== first.length || !second.equals(first)) return;
 				if (fstatSync(fd).size !== first.length) return;
 				ftruncateSync(fd, lastNewline + 1);
+				this.invalidateReplayCache();
 				this.log(`RLM ledger: truncated torn final line (${first.length - lastNewline - 1} bytes)`);
 			} finally {
 				closeSync(fd);
@@ -764,16 +805,30 @@ export class RlmSpawnLedger {
 		}
 	}
 
+	private invalidateReplayCache(): void {
+		this.replayCache = undefined;
+	}
+
+	private ledgerFileIdentitySync(): RlmLedgerFileIdentity | undefined {
+		if (!existsSync(this.path)) return undefined;
+		return ledgerFileIdentity(statSync(this.path, { bigint: true }));
+	}
+
 	private replaySync(): Map<string, RlmLedgerEdge> {
-		const edges = new Map<string, RlmLedgerEdge>();
-		if (!existsSync(this.path)) return edges;
-		const size = statSync(this.path).size;
-		if (size > RLM_LEDGER_MAX_BYTES) {
-			throw new Error(`RLM ledger ${this.path} exceeds ${RLM_LEDGER_MAX_BYTES} bytes (${size}); refusing to read`);
+		const identity = this.ledgerFileIdentitySync();
+		if (!identity) return new Map();
+		if (this.replayCache && sameLedgerFileIdentity(this.replayCache.identity, identity)) {
+			return cloneLedgerEdges(this.replayCache.edges);
+		}
+		if (identity.size > BigInt(RLM_LEDGER_MAX_BYTES)) {
+			throw new Error(
+				`RLM ledger ${this.path} exceeds ${RLM_LEDGER_MAX_BYTES} bytes (${identity.size}); refusing to read`,
+			);
 		}
 		const contents = readFileSync(this.path, "utf8");
 		const endsWithNewline = contents.endsWith("\n");
 		const rawLines = contents.split("\n");
+		const edges = new Map<string, RlmLedgerEdge>();
 		let recordCount = 0;
 		for (let index = 0; index < rawLines.length; index++) {
 			const line = rawLines[index].trim();
@@ -823,6 +878,11 @@ export class RlmSpawnLedger {
 					break;
 				}
 			}
+		}
+		const identityAfterRead = this.ledgerFileIdentitySync();
+		if (identityAfterRead && sameLedgerFileIdentity(identity, identityAfterRead)) {
+			this.replayCache = { identity: identityAfterRead, edges };
+			return cloneLedgerEdges(edges);
 		}
 		return edges;
 	}

--- a/packages/coding-agent/test/rlm-ledger.test.ts
+++ b/packages/coding-agent/test/rlm-ledger.test.ts
@@ -1,20 +1,39 @@
+import { spawnSync } from "node:child_process";
 import {
+	appendFileSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	realpathSync,
+	renameSync,
 	rmSync,
 	statSync,
+	utimesSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 
 const linkFailure = vi.hoisted(() => ({ code: undefined as string | undefined }));
+const ledgerReadTracking = vi.hoisted(() => ({
+	enabled: false,
+	count: 0,
+	afterRead: undefined as (() => void) | undefined,
+}));
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>();
 	return {
 		...actual,
+		readFileSync: new Proxy(actual.readFileSync, {
+			apply(target, thisArg, argArray) {
+				const result = Reflect.apply(target, thisArg, argArray);
+				if (ledgerReadTracking.enabled) ledgerReadTracking.count++;
+				const afterRead = ledgerReadTracking.afterRead;
+				ledgerReadTracking.afterRead = undefined;
+				afterRead?.();
+				return result;
+			},
+		}),
 		linkSync: (
 			existingPath: Parameters<typeof actual.linkSync>[0],
 			newPath: Parameters<typeof actual.linkSync>[1],
@@ -104,6 +123,171 @@ describe("rlm spawn ledger", () => {
 		}
 	});
 
+	it("reuses an unchanged replay without exposing cached edge objects", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-cache-hit-"));
+		try {
+			const { sessionsDir, parentFile } = makeRoots(root);
+			const ledger = new RlmSpawnLedger(root, sessionsDir);
+			await ledger.appendSpawn({
+				childId: "sub-11111111",
+				parent: parentFile,
+				child: join(root, "a.jsonl"),
+				depth: 1,
+				name: "original",
+			});
+
+			ledgerReadTracking.count = 0;
+			ledgerReadTracking.enabled = true;
+			try {
+				const first = await ledger.edges();
+				expect(ledgerReadTracking.count).toBe(1);
+				first[0]!.name = "caller mutation";
+
+				await expect(ledger.edges()).resolves.toEqual([expect.objectContaining({ name: "original" })]);
+				expect(ledgerReadTracking.count).toBe(1);
+			} finally {
+				ledgerReadTracking.enabled = false;
+				ledgerReadTracking.count = 0;
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not cache a replay when the ledger changes between its read and identity check", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-cache-read-race-"));
+		try {
+			const { sessionsDir, parentFile } = makeRoots(root);
+			const ledger = new RlmSpawnLedger(root, sessionsDir);
+			await ledger.appendSpawn({
+				childId: "sub-11111111",
+				parent: parentFile,
+				child: join(root, "a.jsonl"),
+				depth: 1,
+				name: "before-race",
+			});
+			const racedRecord = `${JSON.stringify({
+				v: 1,
+				op: "spawn",
+				at: "2026-01-01T00:00:00.000Z",
+				childId: "sub-22222222",
+				parent: canonicalSessionPath(parentFile),
+				child: canonicalSessionPath(join(root, "b.jsonl")),
+				depth: 1,
+				name: "during-race",
+			})}\n`;
+
+			ledgerReadTracking.count = 0;
+			ledgerReadTracking.enabled = true;
+			ledgerReadTracking.afterRead = () => appendFileSync(ledger.ledgerPath, racedRecord);
+			try {
+				await expect(ledger.edges()).resolves.toEqual([expect.objectContaining({ childId: "sub-11111111" })]);
+				expect(ledgerReadTracking.count).toBe(1);
+
+				await expect(ledger.edges()).resolves.toEqual([
+					expect.objectContaining({ childId: "sub-11111111" }),
+					expect.objectContaining({ childId: "sub-22222222" }),
+				]);
+				expect(ledgerReadTracking.count).toBe(2);
+			} finally {
+				ledgerReadTracking.enabled = false;
+				ledgerReadTracking.count = 0;
+				ledgerReadTracking.afterRead = undefined;
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates the replay cache after local and external-process appends", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-cache-append-"));
+		try {
+			const { sessionsDir, parentFile } = makeRoots(root);
+			const ledger = new RlmSpawnLedger(root, sessionsDir);
+			const firstChild = join(root, "a.jsonl");
+			await ledger.appendSpawn({
+				childId: "sub-11111111",
+				parent: parentFile,
+				child: firstChild,
+				depth: 1,
+				name: "first",
+			});
+			await expect(ledger.edges()).resolves.toEqual([expect.objectContaining({ name: "first" })]);
+
+			await ledger.appendRename({ childId: "sub-11111111", child: firstChild, name: "locally-renamed" });
+			await expect(ledger.edges()).resolves.toEqual([expect.objectContaining({ name: "locally-renamed" })]);
+
+			const externalRecord = `${JSON.stringify({
+				v: 1,
+				op: "spawn",
+				at: "2026-01-01T00:00:00.000Z",
+				childId: "sub-22222222",
+				parent: canonicalSessionPath(parentFile),
+				child: canonicalSessionPath(join(root, "b.jsonl")),
+				depth: 1,
+				name: "externally-appended",
+			})}\n`;
+			const externalAppend = spawnSync(
+				process.execPath,
+				[
+					"-e",
+					'require("node:fs").appendFileSync(process.argv[1], process.argv[2])',
+					ledger.ledgerPath,
+					externalRecord,
+				],
+				{ encoding: "utf8" },
+			);
+			expect(externalAppend.error).toBeUndefined();
+			expect(externalAppend.status, externalAppend.stderr).toBe(0);
+			await expect(ledger.edges()).resolves.toEqual([
+				expect.objectContaining({ childId: "sub-11111111", name: "locally-renamed" }),
+				expect.objectContaining({ childId: "sub-22222222", name: "externally-appended" }),
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates the replay cache after a same-size atomic replacement", async () => {
+		const root = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-cache-replace-"));
+		try {
+			const { sessionsDir, parentFile } = makeRoots(root);
+			const ledger = new RlmSpawnLedger(root, sessionsDir);
+			await ledger.appendSpawn({
+				childId: "sub-11111111",
+				parent: parentFile,
+				child: join(root, "a.jsonl"),
+				depth: 1,
+				name: "alpha",
+			});
+			const fixedTimestamp = new Date("2020-01-01T00:00:00.000Z");
+			utimesSync(ledger.ledgerPath, fixedTimestamp, fixedTimestamp);
+			await expect(ledger.edges()).resolves.toEqual([expect.objectContaining({ name: "alpha" })]);
+
+			const before = statSync(ledger.ledgerPath, { bigint: true });
+			const original = readFileSync(ledger.ledgerPath, "utf8");
+			const replacement = original.replace('"name":"alpha"', '"name":"bravo"');
+			expect(Buffer.byteLength(replacement)).toBe(Buffer.byteLength(original));
+			const replacementPath = `${ledger.ledgerPath}.replacement`;
+			writeFileSync(replacementPath, replacement);
+			utimesSync(replacementPath, fixedTimestamp, fixedTimestamp);
+			renameSync(replacementPath, ledger.ledgerPath);
+			const after = statSync(ledger.ledgerPath, { bigint: true });
+			expect(after.size).toBe(before.size);
+			expect(after.mtimeNs).toBe(before.mtimeNs);
+			expect(
+				after.dev !== before.dev ||
+					after.ino !== before.ino ||
+					after.ctimeNs !== before.ctimeNs ||
+					after.birthtimeNs !== before.birthtimeNs,
+			).toBe(true);
+
+			await expect(ledger.edges()).resolves.toEqual([expect.objectContaining({ name: "bravo" })]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects a duplicate canonical child path at append", async () => {
 		const root = mkdtempSync(join(tmpdir(), "prime-rlm-ledger-dup-"));
 		try {
@@ -137,6 +321,7 @@ describe("rlm spawn ledger", () => {
 				depth: 1,
 				name: "a",
 			});
+			await expect(ledger.edges()).resolves.toHaveLength(1);
 			writeFileSync(ledger.ledgerPath, `${readFileSync(ledger.ledgerPath, "utf8")}not json\n`);
 			await expect(ledger.edges()).rejects.toThrow("Malformed RLM ledger line");
 			const fresh = new RlmSpawnLedger(root, sessionsDir);
@@ -163,11 +348,13 @@ describe("rlm spawn ledger", () => {
 				name: "a",
 			});
 			const intact = readFileSync(ledger.ledgerPath, "utf8");
-			// A crashed writer's torn final append (no trailing newline) is
-			// in-progress data: ignored with a log, not fail-closed.
-			writeFileSync(ledger.ledgerPath, `${intact}{"v":1,"op":"spawn","at":"2026-`);
 			const logged: string[] = [];
 			const torn = new RlmSpawnLedger(root, sessionsDir, undefined, (message) => logged.push(message));
+			await expect(torn.edges()).resolves.toEqual([expect.objectContaining({ childId: "sub-11111111" })]);
+			// A crashed writer's torn final append (no trailing newline) is
+			// in-progress data: ignored with a log, not fail-closed, even after
+			// the intact ledger was cached.
+			writeFileSync(ledger.ledgerPath, `${intact}{"v":1,"op":"spawn","at":"2026-`);
 			await expect(torn.edges()).resolves.toEqual([expect.objectContaining({ childId: "sub-11111111" })]);
 			expect(logged.some((message) => message.includes("torn final line"))).toBe(true);
 			// The next append repairs the torn tail with a newline first.


### PR DESCRIPTION
## Summary

The agents view can request RLM topology from every resident worker once per second. Each request currently rereads and reparses the unchanged append-only spawn ledger.

This change caches successful replays using file identity and nanosecond metadata. Local writes invalidate the cache, and a second metadata check prevents publishing a snapshot when another process changes the ledger during a read. Cached edges are cloned before they are returned.

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/rlm-ledger.test.ts` (27 tests passed)
- `npm run check`

The focused tests cover local and external appends, a write during replay, same-size atomic replacement with equal size and mtime, torn tails, malformed records, replay bounds, and caller mutation isolation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache `RlmSpawnLedger.replaySync` results keyed by file identity
> - `replaySync` now stats the ledger file per call and reuses a cached `Map` of edge records only when file identity (dev, ino, size, mtimeNs, ctimeNs, birthtimeNs) is unchanged; callers receive deep-cloned edges so cached objects cannot be mutated externally.
> - Local mutations (`appendRecord`, `truncateTornTailSync`, and seed publication) call `invalidateReplayCache()` before or after writing so subsequent reads reparse fresh content.
> - On a cache miss the file is fully re-read; after read the file is re-stated and the result is cached only if identity matches the pre-read stat, guarding against concurrent appends.
> - Behavioral Change: `replaySync` now performs a `statSync` with `bigint: true` on every call and returns cloned `Map`/edge objects instead of the internal replay `Map`; callers that relied on identity of returned edge objects (e.g. comparing by reference) will see new instances each call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7a5280.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->