### PR TITLE
ENG-5528

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Prime Agent: A Self-Improving RLM Agent
 </h3>
 
 <p align="center">
-  <a href="https://arxiv.org/abs/2608.23552">Technical Report</a> &bull;
   <a href="packages/coding-agent/docs/index.md">Documentation</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/verifiers">Verifiers</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a>
@@ -25,6 +24,9 @@ Prime Agent: A Self-Improving RLM Agent
   </a>
   <a href="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/build-binaries.yml">
     <img src="https://github.com/PrimeIntellect-ai/prime-agent/actions/workflows/build-binaries.yml/badge.svg" alt="Build Binaries" />
+  </a>
+  <a href="https://arxiv.org/abs/2608.23552">
+    <img src="https://img.shields.io/badge/arXiv-2608.23552-b31b1b.svg" alt="arXiv" />
   </a>
 </p>
 
@@ -118,3 +120,18 @@ Our agent and TUI is built on top of [`pi`](https://github.com/earendil-works/pi
 ## License
 
 Prime Agent is fully open source and released under the [MIT License](LICENSE).
+
+## Citation
+
+If you use this codebase in your research, please cite Prime Agent:
+
+```bibtex
+@article{karten2026prime,
+  title={Prime Agent: A Self-Improving RLM Harness},
+  author={Karten, Seth and Zhang, Alex L. and Thomas, Kevin and Müller, Sebastian and Bakouch, Elie and Auras, Daniel and Senghaas, Mika and Obeid, Fares and Dunas, Konstantin and Hagemann, Johannes and Jaghouar, Sami},
+  journal={arXiv preprint arXiv:2608.23552},
+  year={2026}
+}
+```
+
+Available at [https://arxiv.org/abs/2608.23552](https://arxiv.org/abs/2608.23552).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Prime Agent: A Self-Improving RLM Agent
 </h3>
 
 <p align="center">
+  <a href="https://arxiv.org/abs/2608.23552">Technical Report</a> &bull;
   <a href="packages/coding-agent/docs/index.md">Documentation</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/verifiers">Verifiers</a> &bull;
   <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <h3 align="center">
-Prime Agent: A Self-Improving RLM Agent
+Prime Agent: A Self-Improving RLM Harness
 </h3>
 
 <p align="center">


### PR DESCRIPTION
Add arXiv link to README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the README to align public branding with the paper title (**Self-Improving RLM Harness** instead of **RLM Agent**) and surfaces the arXiv preprint.
> 
> Adds an arXiv badge next to the CI/build badges linking to `https://arxiv.org/abs/2608.23552`, plus a **Citation** section with BibTeX and the same paper URL for research users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2822414955dd907917f5be3c7406c5d283fa9ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->