### PR TITLE
fix(session): reflect live IPython kernel cwd so the startup splash `cwd` stays accurate

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3572,6 +3572,12 @@ export class AgentSession {
 			}
 		}
 
+		// Mirror a `%cd` in the IPython kernel onto the session cwd so the idle
+		// splash and footer show the directory the agent is actually operating in.
+		if (event.type === "agent_end") {
+			void this._reconcileWorkingDirectoryFromKernel();
+		}
+
 		if (event.type === "message_start" && startsAgentRun(event.message)) {
 			this._overflowRecovery = "idle";
 		}
@@ -8263,6 +8269,24 @@ export class AgentSession {
 				this._reconnectToAgent();
 			}
 		}
+	}
+
+	/**
+	 * Mirror a `cd`/`%cd` executed in the live IPython kernel onto the session's
+	 * working directory so snapshots, the header, and tool runtimes report the
+	 * effective directory instead of the launch one. Best-effort and never forces
+	 * a kernel start; returns true when the directory actually changed.
+	 */
+	private async _reconcileWorkingDirectoryFromKernel(): Promise<boolean> {
+		const provisioner = this._ipythonKernelProvisioner;
+		if (!provisioner) return false;
+		const liveCwd = await provisioner.getWorkingDirectory().catch(() => undefined);
+		if (!liveCwd) return false;
+		const normalized = resolve(liveCwd);
+		if (resolve(this.sessionManager.getCwd()) === normalized) return false;
+		this.sessionManager.setWorkingDirectory(normalized);
+		this._cwd = normalized;
+		return true;
 	}
 
 	abortBranchSummary(): void {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1302,6 +1302,15 @@ export class SessionManager {
 		return this.cwd;
 	}
 
+	/**
+	 * Move the session's working directory, e.g. to mirror a `cd` executed inside
+	 * a long-lived tool runtime (IPython kernel or boxing shell). Later snapshots
+	 * and sidecars that read {@link getCwd} then report the live directory.
+	 */
+	setWorkingDirectory(cwd: string): void {
+		this.cwd = cwd;
+	}
+
 	getSessionDir(): string {
 		return this.sessionDir;
 	}

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -364,6 +364,24 @@ export class IpythonKernelProvisioner {
 		return this.startedManager?.isRunning ?? false;
 	}
 
+	/**
+	 * Best-effort read of the kernel's current working directory, or undefined
+	 * when no kernel is running or the read fails. Never forces a kernel start;
+	 * callers use this to mirror a `cd`/`%cd` executed in the kernel.
+	 */
+	async getWorkingDirectory(signal?: AbortSignal): Promise<string | undefined> {
+		const m = this.startedManager;
+		if (!m) return undefined;
+		try {
+			const r = await m.execute("import os; print(os.getcwd())", { signal });
+			if (r.status !== "ok") return undefined;
+			const cwd = (r.stdout ?? "").trim();
+			return cwd || undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
 	/** Remove live variables above the snapshot's per-variable size limit. */
 	async pruneOversizedVariables(): Promise<string[] | null> {
 		const m = this.startedManager ?? (await this.managerPromise?.catch(() => undefined));


### PR DESCRIPTION
## Problem

The interactive startup splash (`BrandSplashHeader`) renders a `cwd` line from the
**session working directory**, which is fixed when the session is created. When the
agent changes directory during a session (e.g. `%cd /some/path` in the IPython
kernel), that change is never propagated back:

- The startup banner keeps showing the launch directory (e.g. `cwd ~`).
- The footer, status lines, and tool runtimes keep the stale path.
- `sessionManager.getCwd()` can even point at a directory that no longer exists.

Because the splash re-reads its getters every frame, the fix is entirely on the
worker side: make the session's working directory follow the live kernel cwd.

## Fix

Three small, best-effort changes:

1. **`SessionManager.setWorkingDirectory(cwd)`** — lets the session cwd move.
2. **`IpythonKernelProvisioner.getWorkingDirectory()`** — reads the kernel's
   `os.getcwd()`. It only touches an already-running kernel and never forces a
   spawn; failures return `undefined`.
3. **`AgentSession._reconcileWorkingDirectoryFromKernel()`** — called
   fire-and-forget at `agent_end`. If the live kernel cwd differs, it updates the
   session cwd. The next state snapshot then carries the real directory and the
   banner updates.

## Design notes

- Lazy and best-effort: the reconciliation never boots a kernel and swallows any
  error, so a wedged kernel just leaves the banner stale instead of breaking a turn.
- Runs at `agent_end`, a clean per-turn boundary, so snapshots stay coherent.
- No client (interactive-mode) changes required; it already re-renders `cwd` from
  `connectionState.cwd` on every frame.

## Validation

- Pre-commit `biome check` and `tsgo --noEmit` pass on the whole repository.
- Follow-ups: decide whether `%%bash` `cd` should reconcile too; consider whether
  session-file resolution should follow cwd; manual end-to-end check in the TUI.

Closes #1775
