### PR TITLE
fix(acp): preserve assistant message boundaries

### DIFF
--- a/packages/coding-agent/.changes/codex-acp-assistant-message-boundaries.md
+++ b/packages/coding-agent/.changes/codex-acp-assistant-message-boundaries.md
@@ -1,0 +1,1 @@
+- Fixed ACP assistant chunks to identify message boundaries across autonomous turns.

--- a/packages/coding-agent/.changes/codex-acp-await-terminal-quiescence.md
+++ b/packages/coding-agent/.changes/codex-acp-await-terminal-quiescence.md
@@ -1,1 +1,2 @@
 - Changed ACP prompt requests to resolve only after all causally admitted subagent and parent work has settled.
+- Fixed ACP assistant chunks to identify message boundaries across autonomous turns.

--- a/packages/coding-agent/.changes/codex-acp-await-terminal-quiescence.md
+++ b/packages/coding-agent/.changes/codex-acp-await-terminal-quiescence.md
@@ -1,2 +1,1 @@
 - Changed ACP prompt requests to resolve only after all causally admitted subagent and parent work has settled.
-- Fixed ACP assistant chunks to identify message boundaries across autonomous turns.

--- a/packages/coding-agent/src/modes/acp/acp-events.ts
+++ b/packages/coding-agent/src/modes/acp/acp-events.ts
@@ -121,13 +121,7 @@ function ipythonRichOutput(result: unknown): PrimeAgentIpythonMeta | undefined {
 	return meta.attachments || meta.diffCount !== undefined ? meta : undefined;
 }
 
-/**
- * Correlates streaming bash output with its run.
- *
- * `bash_output` carries no `runId`, so the id of the most recent `bash_start` is
- * tracked here. Output would otherwise be attributed to a bare fallback id that
- * no `bash_start` ever used, leaving the chunks unattached to any tool call.
- */
+/** Correlates streamed bash output and assistant chunks with their owning run or message. */
 export interface AcpEventMappingState {
 	activeBashRunId?: string;
 	activeAssistantMessageId?: string;

--- a/packages/coding-agent/src/modes/acp/acp-events.ts
+++ b/packages/coding-agent/src/modes/acp/acp-events.ts
@@ -54,12 +54,12 @@ function textContent(text: string): { type: "text"; text: string } {
  * `thinking_delta`) and carries a plain string, so reasoning and visible answer
  * text are distinct ACP update kinds a client can render or hide separately.
  */
-function assistantDeltaUpdates(event: AssistantMessageEvent): AcpSessionUpdate[] {
+function assistantDeltaUpdates(event: AssistantMessageEvent, messageId: string): AcpSessionUpdate[] {
 	if (event.type === "thinking_delta" && event.delta.length > 0) {
-		return [{ sessionUpdate: "agent_thought_chunk", content: textContent(event.delta) }];
+		return [{ sessionUpdate: "agent_thought_chunk", messageId, content: textContent(event.delta) }];
 	}
 	if (event.type === "text_delta" && event.delta.length > 0) {
-		return [{ sessionUpdate: "agent_message_chunk", content: textContent(event.delta) }];
+		return [{ sessionUpdate: "agent_message_chunk", messageId, content: textContent(event.delta) }];
 	}
 	return [];
 }
@@ -130,6 +130,15 @@ function ipythonRichOutput(result: unknown): PrimeAgentIpythonMeta | undefined {
  */
 export interface AcpEventMappingState {
 	activeBashRunId?: string;
+	activeAssistantMessageId?: string;
+	nextAssistantMessageSequence?: number;
+}
+
+function startAssistantMessage(state: AcpEventMappingState): string {
+	const sequence = (state.nextAssistantMessageSequence ?? 0) + 1;
+	state.nextAssistantMessageSequence = sequence;
+	state.activeAssistantMessageId = `prime-agent-assistant-${sequence}`;
+	return state.activeAssistantMessageId;
 }
 
 export function acpUpdatesForSessionEvent(
@@ -137,9 +146,20 @@ export function acpUpdatesForSessionEvent(
 	state: AcpEventMappingState = {},
 ): AcpSessionUpdate[] {
 	switch (event.type) {
+		case "message_start":
+			if (event.message.role === "assistant") startAssistantMessage(state);
+			return [];
+
 		case "message_update":
 			if (event.message.role !== "assistant") return [];
-			return assistantDeltaUpdates(event.assistantMessageEvent);
+			return assistantDeltaUpdates(
+				event.assistantMessageEvent,
+				state.activeAssistantMessageId ?? startAssistantMessage(state),
+			);
+
+		case "message_end":
+			if (event.message.role === "assistant") state.activeAssistantMessageId = undefined;
+			return [];
 
 		case "tool_execution_start": {
 			const cell = event.toolName === IPYTHON_TOOL_NAME ? ipythonCellSource(event.args) : undefined;

--- a/packages/coding-agent/test/acp-events.test.ts
+++ b/packages/coding-agent/test/acp-events.test.ts
@@ -54,6 +54,7 @@ describe("ACP session event mapping", () => {
 			messageId: "prime-agent-assistant-1",
 		});
 		expect(acpUpdatesForSessionEvent(end, state)).toEqual([]);
+		expect(state.activeAssistantMessageId).toBeUndefined();
 
 		expect(acpUpdatesForSessionEvent(start, state)).toEqual([]);
 		expect(acpUpdatesForSessionEvent(assistantDelta("text_delta", "next"), state)[0]).toMatchObject({

--- a/packages/coding-agent/test/acp-events.test.ts
+++ b/packages/coding-agent/test/acp-events.test.ts
@@ -20,12 +20,45 @@ function assistantDelta(type: "text_delta" | "thinking_delta", delta: string): A
 describe("ACP session event mapping", () => {
 	it("maps assistant text deltas to agent_message_chunk", () => {
 		const updates = acpUpdatesForSessionEvent(assistantDelta("text_delta", "hello"));
-		expect(updates).toEqual([{ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hello" } }]);
+		expect(updates).toEqual([
+			{
+				sessionUpdate: "agent_message_chunk",
+				messageId: "prime-agent-assistant-1",
+				content: { type: "text", text: "hello" },
+			},
+		]);
 	});
 
 	it("maps thinking deltas to agent_thought_chunk, not visible text", () => {
 		const updates = acpUpdatesForSessionEvent(assistantDelta("thinking_delta", "reasoning"));
-		expect(updates).toEqual([{ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "reasoning" } }]);
+		expect(updates).toEqual([
+			{
+				sessionUpdate: "agent_thought_chunk",
+				messageId: "prime-agent-assistant-1",
+				content: { type: "text", text: "reasoning" },
+			},
+		]);
+	});
+
+	it("assigns one message id per assistant message", () => {
+		const state: AcpEventMappingState = {};
+		const message = { role: "assistant", content: [], usage: {} } as never;
+		const start = { type: "message_start", message } as AgentConnectionSessionEvent;
+		const end = { type: "message_end", message } as AgentConnectionSessionEvent;
+
+		expect(acpUpdatesForSessionEvent(start, state)).toEqual([]);
+		expect(acpUpdatesForSessionEvent(assistantDelta("thinking_delta", "think"), state)[0]).toMatchObject({
+			messageId: "prime-agent-assistant-1",
+		});
+		expect(acpUpdatesForSessionEvent(assistantDelta("text_delta", "answer"), state)[0]).toMatchObject({
+			messageId: "prime-agent-assistant-1",
+		});
+		expect(acpUpdatesForSessionEvent(end, state)).toEqual([]);
+
+		expect(acpUpdatesForSessionEvent(start, state)).toEqual([]);
+		expect(acpUpdatesForSessionEvent(assistantDelta("text_delta", "next"), state)[0]).toMatchObject({
+			messageId: "prime-agent-assistant-2",
+		});
 	});
 
 	it("ignores empty deltas and non-assistant messages", () => {


### PR DESCRIPTION
## Summary

- attach the ACP-standard messageId to assistant thought and message chunks
- keep one identifier across a streamed assistant message and advance it for the next autonomous turn
- preserve correct root-reply replacement semantics in ACP clients

Related Linear: [ENG-4685](https://linear.app/primeintellect/issue/ENG-4685) (follow-up to the ACP lifecycle work in #1612).

## Validation

- focused ACP event mapping test (18 passing)
- npm run check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized ACP event mapping and test updates; no auth, persistence, or security-sensitive paths.
> 
> **Overview**
> ACP streaming updates for assistant **thought** and **message** chunks now carry a stable **`messageId`**, so clients can group deltas into one assistant reply and distinguish separate autonomous turns.
> 
> **`acpUpdatesForSessionEvent`** ties IDs to session lifecycle: **`message_start`** (assistant) allocates `prime-agent-assistant-N`, all **`message_update`** deltas reuse that id until **`message_end`** clears it. Deltas without a prior start still get an id via the same allocator (backward-compatible for tests and stray updates).
> 
> **`AcpEventMappingState`** extends bash run correlation with **`activeAssistantMessageId`** and a monotonic sequence counter. Tests assert one id per message and increment on the next turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f501866ff75d05f8e524e32495758da8fac1b1cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->