### PR TITLE
fix(runtime): honor mcp.types.Tool's inputSchema alias

### DIFF
--- a/prime-agent-runtime/src/rlm/mcp_base.py
+++ b/prime-agent-runtime/src/rlm/mcp_base.py
@@ -33,6 +33,25 @@ __all__ = ["McpIntegration", "McpToolError", "NotEnabled"]
 _EXPIRY_SKEW_SECONDS = 30
 
 
+def _tool_input_schema(t: Any) -> dict[str, Any]:
+    """Read a tool's JSON Schema, honoring the SDK's ``inputSchema`` alias.
+
+    ``mcp.types.Tool`` is a pydantic model whose field is the snake_case
+    ``input_schema`` with a camelCase alias ``inputSchema``. Aliases are only
+    honored on validation and ``model_dump(by_alias=True)``, never as a plain
+    attribute, so a bare ``getattr(t, "inputSchema", None)`` always misses and
+    silently returns an empty schema. Dump by alias first; fall back to
+    ``getattr`` for duck-typed stubs (e.g. in tests) that set the attribute
+    directly rather than being a real pydantic model.
+    """
+    if hasattr(t, "model_dump"):
+        dumped = t.model_dump(by_alias=True, exclude_none=True)
+        schema = dumped.get("inputSchema")
+        if schema:
+            return schema
+    return getattr(t, "inputSchema", None) or {}
+
+
 class NotEnabled(RuntimeError):
     """Raised when an integration has no usable credentials.
 
@@ -264,7 +283,7 @@ class McpIntegration:
                     t.name: {
                         "name": t.name,
                         "description": getattr(t, "description", "") or "",
-                        "inputSchema": getattr(t, "inputSchema", None) or {},
+                        "inputSchema": _tool_input_schema(t),
                     }
                     for t in resp.tools
                 }

--- a/prime-agent-runtime/test/test_mcp_base.py
+++ b/prime-agent-runtime/test/test_mcp_base.py
@@ -26,14 +26,13 @@ class _FakeSession:
         self.calls = []
 
     async def list_tools(self):
-        Tool = type("Tool", (), {})
+        from mcp.types import Tool
 
         def make(name, desc, schema):
-            t = Tool()
-            t.name = name
-            t.description = desc
-            t.inputSchema = schema
-            return t
+            # Real SDK model: input_schema is snake_case with a camelCase
+            # ``inputSchema`` alias, never a plain ``inputSchema`` attribute.
+            # A duck-typed stub here would hide the alias bug (see #1073).
+            return Tool(name=name, description=desc, input_schema=schema)
 
         resp = type("Resp", (), {})()
         resp.tools = [make(*t) for t in self._tools]
@@ -168,6 +167,36 @@ class McpIntegrationTest(unittest.TestCase):
             out = _run(integration.list_issues(team="Eng"))
         self.assertEqual(out, {"issues": [1, 2]})
         self.assertEqual(session.calls, [("list_issues", {"team": "Eng"})])
+
+    def test_list_tools_preserves_input_schema(self):
+        # Regression test for #1073: mcp.types.Tool exposes its schema as the
+        # snake_case field `input_schema` with a camelCase alias `inputSchema`;
+        # the alias is only honored on validation/model_dump(by_alias=True),
+        # never as a plain attribute. A naive `getattr(t, "inputSchema", None)`
+        # always misses and silently returns {}.
+        schema = {
+            "type": "object",
+            "properties": {"libraryName": {"type": "string"}, "query": {"type": "string"}},
+            "required": ["libraryName", "query"],
+        }
+        session = _FakeSession(
+            tools=[("resolve-library-id", "Resolve a library id", schema)],
+            result=None,
+        )
+        self._write_auth(
+            {"type": "oauth", "access": "t", "refresh": "r", "expires": (time.time() + 3600) * 1000}
+        )
+        with self._patch_session(session):
+            integration = _Integration()
+            tools = _run(integration.list_tools())
+        self.assertEqual(
+            tools,
+            [{"name": "resolve-library-id", "description": "Resolve a library id", "inputSchema": schema}],
+        )
+        # __getattr__'s bound-tool docstring reads the same dict; it must also
+        # advertise the real schema instead of falling back to "{}".
+        doc = integration.__getattr__("resolve-library-id").__doc__
+        self.assertIn("libraryName", doc)
 
     def test_unknown_tool_raises_with_available_list(self):
         session = _FakeSession(tools=[("list_issues", "", {})], result=None)


### PR DESCRIPTION
Fixes #1073.

Posted for review after discussion in #1757 (per CONTRIBUTING.md's contribution process).

## Summary

`McpIntegration.list_tools()` (`prime-agent-runtime/src/rlm/mcp_base.py`) always returns `"inputSchema": {}` for every tool of every MCP server, even though the server sends a full JSON Schema. This was already reported and diagnosed in #1073, which is one of the "related reports" under the still-open tracker #1383 (*Harden MCP OAuth discovery and Codex transports* — "preserve MCP tool schemas ..."). The merged stack PR #1164 for that tracker didn't touch this file, so the bug is still present on `main` (verified on `06860844e`).

## Root cause

`mcp.types.Tool` is a pydantic model whose schema field is the snake_case `input_schema`, with a camelCase **alias** `inputSchema`:

```python
from mcp.types import Tool
Tool.model_fields['input_schema'].alias  # -> 'inputSchema'
```

Aliases are honored on validation and on `model_dump(by_alias=True)`, never as a plain attribute. So the existing code

```python
"inputSchema": getattr(t, "inputSchema", None) or {},
```

always misses and silently substitutes `{}`. The same value feeds the per-tool docstring in `__getattr__`, so the documented discovery path ("call `help(<tool>)` for the argument schema") returns nothing for every MCP integration, and callers have to reverse-engineer arguments from the server's validation errors one field at a time — this is exactly what the original report describes with Context7.

The existing regression test in `test_mcp_base.py` didn't catch this because its fake session built tools from a bare duck-typed stub that set the camelCase attribute directly (`t.inputSchema = schema`), which happens to satisfy the buggy `getattr` and therefore encodes the bug rather than catching it.

## Fix

Read the schema via `model_dump(by_alias=True)` first (falls back to plain `getattr` for non-pydantic stand-ins used in tests):

```python
def _tool_input_schema(t: Any) -> dict[str, Any]:
    if hasattr(t, "model_dump"):
        dumped = t.model_dump(by_alias=True, exclude_none=True)
        schema = dumped.get("inputSchema")
        if schema:
            return schema
    return getattr(t, "inputSchema", None) or {}
```

Also rebuilt the test double to construct a real `mcp.types.Tool` instead of the duck-typed stub, and added a regression test asserting the schema round-trips through `list_tools()` and the bound-tool docstring. Confirmed the new test fails against the pre-fix code and passes after the fix.

## Validation

```
cd prime-agent-runtime
uv run python -m unittest discover -s test   # 99 passed (was 98; +1 new test)
```

Also ran the full `npm run check` at the repo root (biome, `tsgo --noEmit`, installer render check, browser smoke check) — all green; this change doesn't touch `packages/*`, so no `.changes/` fragment is required by the changelog-fragment CI check.