### PR TITLE
fix(coding-agent): resume suspended input pump on programmatic admission

### DIFF
--- a/packages/coding-agent/.changes/eng-resume-suspended-input-pump-programmatic.md
+++ b/packages/coding-agent/.changes/eng-resume-suspended-input-pump-programmatic.md
@@ -1,0 +1,1 @@
+- Fixed queued agent messages and scheduled follow-ups starving for hours at an idle session after an abort suspended the input pump; only a typed prompt used to resume delivery.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5541,6 +5541,22 @@ export class AgentSession {
 		}
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
 		if (coalescedOwner) {
+			// A coalesced re-fire (the normal shape for a re-firing scheduler, or a
+			// repeated agent message) is still evidence a producer wants delivery.
+			// Resume a pump suspended by an abort so the owning queued action can
+			// drain at idle; otherwise this early return swallows the re-fire and
+			// nothing ever restarts the pump (see #1000). A restart-hold suspension
+			// is left alone: queued inputs must survive into the restart manifest.
+			if (
+				!options.restore &&
+				options.wake !== false &&
+				!this.isStreaming &&
+				this._sessionInputPumpSuspended &&
+				!this._sessionInputSuspendedForUpdateRestart
+			) {
+				this._resumeSessionInputAdmission();
+				this._scheduleSessionInputPump();
+			}
 			if (action.agentMessageId !== coalescedOwner.agentMessageId) {
 				this._rejectAgentMessage(
 					action.agentMessageId,
@@ -5575,6 +5591,23 @@ export class AgentSession {
 			if (action.payload.kind === "turn" && action.wake === "immediate") {
 				this._resumeSessionInputAdmission();
 			}
+			this._scheduleSessionInputPump();
+		}
+		if (
+			!options.restore &&
+			options.wake !== false &&
+			action.payload.kind === "turn" &&
+			!this.isStreaming &&
+			this._sessionInputPumpSuspended &&
+			!this._sessionInputSuspendedForUpdateRestart
+		) {
+			// Programmatic admissions (agent messages, scheduled follow-ups) must resume
+			// a pump suspended by an abort, matching what a typed prompt already does via
+			// _resumeSessionInputAdmission(); otherwise queued work starves at idle until
+			// a human types (see #1000). A restart-hold suspension is left alone: queued
+			// inputs must survive into the restart manifest instead of starting a turn
+			// during teardown.
+			this._resumeSessionInputAdmission();
 			this._scheduleSessionInputPump();
 		}
 		return { accepted: true, disposition, ticket: controller.ticket };

--- a/packages/coding-agent/test/suite/regressions/resume-suspended-input-pump.test.ts
+++ b/packages/coding-agent/test/suite/regressions/resume-suspended-input-pump.test.ts
@@ -1,0 +1,88 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "../harness.js";
+
+describe("suspended input pump resumes on programmatic admission", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("delivers a queued agent message at idle after an abort suspended the pump", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("agent mail handled")]);
+
+		// An abort at idle leaves the input pump suspended.
+		harness.session.requestAbort();
+		await harness.session.agent.waitForIdle();
+
+		await harness.session.queueAgentMessagePrompt("queued agent mail", "followUp");
+
+		await vi.waitFor(() => expect(getAssistantTexts(harness)).toContain("agent mail handled"));
+		expect(getUserTexts(harness)).toContain("queued agent mail");
+	});
+
+	it("delivers items queued before an abort once a later programmatic admission arrives", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("backlog handled"), fauxAssistantMessage("second handled")]);
+
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.queueAgentMessagePrompt("queued before abort", "followUp");
+		harness.session.requestAbort();
+		pause.release();
+		await harness.session.agent.waitForIdle();
+
+		// Without the fix, the backlog starves forever: only a user-typed prompt or
+		// resumeQueuedWork() revives delivery.
+		await harness.session.queueAgentMessagePrompt("queued after abort", "followUp");
+
+		await vi.waitFor(() => {
+			const users = getUserTexts(harness);
+			expect(users).toContain("queued before abort");
+			expect(users).toContain("queued after abort");
+		});
+	});
+
+	it("resumes the pump when a coalesced follow-up re-fires at idle", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("wake handled")]);
+
+		const pause = harness.session.acquireQueuedWorkPause();
+		await harness.session.followUp("wake fire", undefined, { queueKey: "wake:test" });
+		harness.session.requestAbort();
+		pause.release();
+		await harness.session.agent.waitForIdle();
+
+		// A re-fire with the same queueKey coalesces into the queued owner. Without the
+		// fix it is dropped without resuming the pump, so the owner starves forever.
+		await harness.session.followUp("wake fire", undefined, { queueKey: "wake:test" });
+
+		await vi.waitFor(() => expect(getUserTexts(harness)).toContain("wake fire"));
+		expect(getAssistantTexts(harness)).toContain("wake handled");
+	});
+
+	it("does not resume a pump suspended for an update restart", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("should not run during restart hold")]);
+
+		// A restart hold must survive into the restart manifest: it is a different
+		// suspension reason than an ordinary abort and must not be auto-resumed by
+		// programmatic admission.
+		harness.session.abortForUpdateRestart();
+		await harness.session.agent.waitForIdle();
+
+		await harness.session.queueAgentMessagePrompt("queued during restart hold", "followUp");
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(getAssistantTexts(harness)).not.toContain("should not run during restart hold");
+
+		harness.session.resumeQueuedWork();
+		await vi.waitFor(() => expect(getAssistantTexts(harness)).toContain("should not run during restart hold"));
+	});
+});


### PR DESCRIPTION
Fixes #1000.

Posted for review after discussion in #1761 (per CONTRIBUTING.md's contribution process).

## Summary

Programmatic prompts (agent messages from subagents, scheduled follow-ups/heartbeats) queued at an **idle** session are never delivered until a human types a prompt. In one report, batches of subagent results sat queued for 8+ hours and all flushed in the same second a human message arrived. This is #1000, one of the "related reports" under the still-open tracker #1382 (*Complete queued, interrupted, and archived session lifecycle recovery*).

Confirmed still present on `main` (`06860844e`) with a new regression test suite that reproduces all three shapes described in the original report.

## Root cause (`_admitSessionInput` in `packages/coding-agent/src/core/agent-session.ts`)

1. `requestAbort()` sets `_sessionInputPumpSuspended = true`. A typed prompt clears it via `_resumeSessionInputAdmission()` (the `prompt()` path), but a programmatic admission does not: the flag is only cleared when `action.payload.kind === "turn" && action.wake === "immediate"`, so queued follow-ups/steer actions with the default wake behavior wait forever at idle.
2. Independent of any abort: when an incoming follow-up **coalesces** into an already-queued owner (the normal shape for a re-firing scheduler, or a repeated agent message with the same `queueKey`), `_admitSessionInput` returns `{ accepted: false, disposition: "queued" }` **before any code that schedules the pump**. Every re-fire is swallowed; nothing ever restarts delivery.

## History

An earlier PR attempt, #895, proposed a fix and was closed in favor of a maintainer-owned stacked PR, #1162 (part of the merged #1158–#1165 stack for tracker #1382):

> This root cause is now covered by maintainer-owned stacked PR #1162 ... We did not inspect or reuse this PR's diff, branch, commits, implementation code, or tests.

#1162 merged, but this specific code path was not part of it — the bug is still live.

Notably, #895's proposed patch toggled `_sessionInputPumpSuspended` directly without checking `_sessionInputSuspendedForUpdateRestart`. That flag is a *different*, deliberate suspension reason (`abortForUpdateRestart()`) meant to hold queued inputs so they survive into the restart manifest instead of starting a turn during teardown (see the existing guarded call site around line 6197: `if (!this._sessionInputSuspendedForUpdateRestart) this._resumeSessionInputAdmission();`). Blindly clearing the flag would have silently reintroduced a second bug — a turn starting mid-restart-teardown — while fixing the first one.

## Fix

Resume a suspended pump on both paths (the coalesced early return, and the general admission path) via the existing `_resumeSessionInputAdmission()` helper, gated on: the action is a `turn`, the session isn't streaming, the pump is actually suspended, and **the suspension is not a restart hold**.

```ts
if (
	!options.restore &&
	options.wake !== false &&
	action.payload.kind === "turn" &&
	!this.isStreaming &&
	this._sessionInputPumpSuspended &&
	!this._sessionInputSuspendedForUpdateRestart
) {
	this._resumeSessionInputAdmission();
	this._scheduleSessionInputPump();
}
```

(mirrored in the coalesced-owner early-return branch above it).

## Tests

Added `packages/coding-agent/test/suite/regressions/resume-suspended-input-pump.test.ts` with 4 cases:
- delivers a queued agent message at idle after an abort suspended the pump
- delivers backlog queued before an abort once a later programmatic admission arrives
- resumes the pump when a coalesced follow-up re-fires at idle
- does **not** resume a pump suspended for an update restart — verified this case fails if the `_sessionInputSuspendedForUpdateRestart` guard is removed, so it actually exercises that hazard

All 4 fail against pre-fix `main` and pass after the fix. Also ran:
- `test/suite/agent-session-queue.test.ts`, `agent-session-action-contracts.test.ts`, `agent-session-action-races.test.ts`, `agent-session-autonomous.test.ts`, `agent-session-goal.test.ts` (195 passed)
- `test/suite/regressions/4257-update-restart-resume.test.ts`, the existing large update-restart suite (35 passed)
- A broader run of the full `packages/coding-agent` suite surfaced 3 unrelated pre-existing failures (`resource-loader.test.ts`, `package-command-paths.test.ts`, `4600-supervisor-singleton.test.ts`); confirmed by re-running them against unmodified `main` that they fail identically there (sandbox-specific: symlink/extension loading and real daemon-socket timing), unrelated to this change.
- Root `npm run check` (biome, `tsgo --noEmit`, installer render, browser smoke) — all green. Added a `packages/coding-agent/.changes/` fragment per the changelog-fragment CI check.