### PR TITLE
fix(coding-agent): close the Amazon Bedrock chunk in the release bundle

### DIFF
--- a/packages/coding-agent/.changes/eng-bundle-amazon-bedrock-chunk-closure.md
+++ b/packages/coding-agent/.changes/eng-bundle-amazon-bedrock-chunk-closure.md
@@ -1,0 +1,1 @@
+- Fixed the Amazon Bedrock provider failing with "Cannot find module" on first use because the release bundle never emitted its chunk.

--- a/packages/coding-agent/scripts/bundle.mjs
+++ b/packages/coding-agent/scripts/bundle.mjs
@@ -11,7 +11,7 @@
  * compiled Bun binary), keyed off the __PI_BUNDLED__ define below, so extension
  * imports of pi packages share the bundle's module instances.
  */
-import { chmodSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -31,8 +31,26 @@ try {
 
 rmSync(outdir, { recursive: true, force: true });
 
+// The Bedrock provider is reached through a deliberately non-literal dynamic
+// import (`register-builtins.ts` builds the specifier at runtime) so esbuild's
+// static reachability analysis never sees it and cannot split it off the way
+// every other provider's plain `import("./provider.js")` gets split and
+// rewritten automatically. Left alone, esbuild never bundles the module or its
+// `@aws-sdk` dependency at all: the compiled output still calls
+// `import("./amazon-bedrock.js")`, but no such file is ever emitted, and
+// Bedrock fails at first use with "Cannot find module" (see #751 — the
+// released v0.7.0 tarball shipped exactly this way). Declaring the module as
+// its own literal, unhashed entry point here forces esbuild to compile and
+// bundle it (and its `@aws-sdk` closure) into the exact filename the runtime
+// specifier expects, without changing the lazy, on-first-use loading behavior
+// for ordinary startup.
+const bedrockEntry = fileURLToPath(import.meta.resolve("@earendil-works/pi-ai/bedrock-provider"));
+
 await build({
-	entryPoints: [join(packageDir, "dist", "cli.js")],
+	entryPoints: [
+		{ in: join(packageDir, "dist", "cli.js"), out: "cli" },
+		{ in: bedrockEntry, out: "amazon-bedrock" },
+	],
 	outdir,
 	bundle: true,
 	splitting: true,
@@ -49,4 +67,20 @@ await build({
 });
 
 chmodSync(join(outdir, "cli.js"), 0o755);
+
+// Verify bundle closure for every provider chunk reachable only through a
+// non-literal dynamic import, which esbuild cannot police on its own: an
+// unresolved specifier fails silently at first use instead of at build time
+// (see #751 and the "provider bundle closure" acceptance criterion tracked in
+// #1379). Extend this list if another provider adopts the same pattern.
+const requiredRuntimeChunks = ["amazon-bedrock.js"];
+const missingRuntimeChunks = requiredRuntimeChunks.filter((name) => !existsSync(join(outdir, name)));
+if (missingRuntimeChunks.length > 0) {
+	throw new Error(
+		`bundle.mjs: expected dist/bundle/{${missingRuntimeChunks.join(", ")}} to exist for a runtime dynamic ` +
+			"import esbuild cannot statically resolve, but esbuild did not emit them. " +
+			"This provider will fail with \"Cannot find module\" at first use.",
+	);
+}
+
 console.log("bundled dist/cli.js -> dist/bundle/");


### PR DESCRIPTION
Fixes #751.

Posted for review after discussion in #1763 (per CONTRIBUTING.md's contribution process).

## Summary

The Amazon Bedrock provider has been broken in every release built from the Node bundle path (`dist/bundle/`, the actual npm/Homebrew/binary install path) since the lazy-provider-loading refactor. The originally reported v0.7.0 release tarball shipped without `dist/bundle/amazon-bedrock.js` at all (#751, one of the "related reports" under the still-open tracker #1379, *Complete CI and release compatibility hardening* — "verify the emitted provider bundle closure, including Amazon Bedrock"). **The exact same gap still reproduces on current `main`** (`06860844e`) — confirmed by actually running the build and inspecting the output, not just reading source.

```bash
cd packages/coding-agent
rm -rf dist/bundle && node scripts/bundle.mjs
ls dist/bundle | grep -i bedrock   # nothing — every other provider has its own dist/bundle/<name>-<hash>.js chunk
```

## Root cause

`packages/ai/src/providers/register-builtins.ts` reaches Bedrock through a specifier built at runtime, not a string literal:

```ts
const importNodeOnlyProvider = (specifier: string): Promise<unknown> => import(specifier);
...
bedrockProviderModulePromise ||= importNodeOnlyProvider("./amazon-bedrock.js").then(...)
```

Git history (`668ebc094`) shows this is deliberate: the specifier is built at runtime (there was even a `new Function("specifier", "return import(specifier)")` at one point, and a `"./amazon-" + "bedrock.js"` string split later) specifically so bundlers never eagerly pull `@aws-sdk` into every build for consumers who never use Bedrock. Every other provider uses a plain `import("./provider.js")` literal, which esbuild's code splitting can see, split into its own chunk, and rewrite the call site to reference (that's why `anthropic-<hash>.js`, `google-vertex-<hash>.js`, etc. all exist and work). Because Bedrock's import is opaque to static analysis, esbuild never bundles the module or its `@aws-sdk` closure and never emits `dist/bundle/amazon-bedrock.js` — but the compiled call site still requests exactly that relative path at runtime. First use throws `Cannot find module` instead of a credentials/config error.

## Why the Bun path already works

`packages/coding-agent/src/bun/register-bedrock.ts` sidesteps this entirely by eagerly, statically importing `@earendil-works/pi-ai/bedrock-provider` and registering it via `setBedrockProviderModule()` before startup — fine there because a compiled Bun binary already embeds everything regardless. Doing the same unconditionally for the Node CLI would regress the startup-latency win lazy provider loading was built for (fixes #2297), so the fix keeps loading lazy for Node and instead makes esbuild aware of the module.

## Fix

In `packages/coding-agent/scripts/bundle.mjs`, declare `@earendil-works/pi-ai/bedrock-provider` (the same static entry point the Bun path already registers) as a second esbuild entry point, resolved via `import.meta.resolve` and named to the exact literal filename (`amazon-bedrock.js`, no content hash via esbuild's `{in, out}` entry point form) the runtime specifier expects:

```js
const bedrockEntry = fileURLToPath(import.meta.resolve("@earendil-works/pi-ai/bedrock-provider"));

await build({
	entryPoints: [
		{ in: join(packageDir, "dist", "cli.js"), out: "cli" },
		{ in: bedrockEntry, out: "amazon-bedrock" },
	],
	...
});
```

esbuild now compiles and bundles the module and its `@aws-sdk` dependency closure into that file (~1.3 MB, in line with other bundled providers, e.g. `mistral-*.js` at ~1.1 MB). Loading stays lazy at runtime: the chunk is only fetched on first actual use of the Bedrock provider, exactly as before.

Also added a post-build check that fails the build if a provider chunk reachable only through a non-literal dynamic import is missing from the output — so a future occurrence of this exact failure mode (silent at build time, only surfacing for a user at first use) fails `npm run build`, which already runs directly in CI (`.github/workflows/ci.yml`), instead of shipping. This directly satisfies the "verify the emitted provider bundle closure, including Amazon Bedrock" acceptance criterion tracked in #1379.

## Validation

- **Before:** the repro above shows no `amazon-bedrock.js`; manually dynamic-importing it from the referencing chunk's own directory throws the exact reported error: `Cannot find module '.../dist/bundle/amazon-bedrock.js' imported from .../dist/bundle/chunk-*.js`.
- **After:** the same repro now resolves successfully and returns the expected `{ bedrockProviderModule }` export.
- `node scripts/bundle.mjs` succeeds; the new closure check passes; `dist/bundle/amazon-bedrock.js` is emitted.
- `npx tsgo -p tsconfig.json --noEmit` passes.
- Root `npm run check` (biome, `tsgo --noEmit`, installer render, browser smoke) passes.
- Deliberately did **not** rely on a full root `npm run build` for validation: its `generate-models` step does a live network fetch of current provider catalogs and rewrites `packages/ai/src/models.generated.ts` nondeterministically — unrelated to this change. Confirmed unmodified `main` also produces this same dirty diff from a plain `npm run build`, and confirmed `tsgo --noEmit` passes cleanly on unmodified `main` without that step, isolating it as pre-existing environment noise rather than something this fix caused.