### PR TITLE
fix(coding-agent): repair an incomplete JSONL tail before resuming session appends

### DIFF
--- a/packages/coding-agent/.changes/eng-session-jsonl-incomplete-tail-repair.md
+++ b/packages/coding-agent/.changes/eng-session-jsonl-incomplete-tail-repair.md
@@ -1,0 +1,1 @@
+- Fixed a crash-truncated session record silently swallowing the next message too by repairing an incomplete trailing JSONL record on resume instead of leaving it on disk for the next append to concatenate onto.

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,5 +1,13 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, ImageContent, Message, ServiceTier, TextContent, Usage } from "@earendil-works/pi-ai";
+import {
+	type AssistantMessage,
+	getLogger,
+	type ImageContent,
+	type Message,
+	type ServiceTier,
+	type TextContent,
+	type Usage,
+} from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
 import {
 	appendFileSync,
@@ -29,6 +37,8 @@ import {
 	createCustomMessage,
 } from "./messages.js";
 import { cloneUsage } from "./usage.js";
+
+const log = getLogger("coding-agent.session-manager");
 
 export const CURRENT_SESSION_VERSION = 3;
 const SESSION_LIST_SEARCH_TEXT_MAX_CHARS = 64 * 1024;
@@ -537,37 +547,69 @@ export function getDefaultSessionDir(_cwd: string, agentDir: string = getDefault
 	return sessionDir;
 }
 
+export interface LoadedSessionEntries {
+	entries: FileEntry[];
+	/**
+	 * Raw bytes of the file's final non-blank line when it existed but failed to
+	 * parse -- e.g. a crash truncated the previous write mid-record. Only the
+	 * trailing line is ever reported: a malformed line elsewhere is followed by
+	 * content that already round-tripped, so it isn't attributable to an
+	 * in-flight write and is left silently skipped, same as before (see #928;
+	 * out of scope like the row-validation done for #709). Undefined when the
+	 * file's last non-blank line parsed cleanly (the common case).
+	 */
+	incompleteTail?: Buffer;
+}
+
 // Decode per line off a Buffer: toString("utf8") on a whole large file is far slower
 // (one giant UTF-16 string). Splitting on 0x0a is UTF-8-safe.
-function appendEntryFromBuffer(entries: FileEntry[], buffer: Buffer, start = 0, end = buffer.length): void {
-	if (end <= start) return;
+function tryParseLine(buffer: Buffer, start: number, end: number): FileEntry | undefined {
+	if (end <= start) return undefined;
 	try {
-		entries.push(JSON.parse(buffer.toString("utf8", start, end)) as FileEntry);
+		return JSON.parse(buffer.toString("utf8", start, end)) as FileEntry;
 	} catch {
-		// Skip malformed or blank lines.
+		return undefined;
 	}
 }
 
-function parseEntriesFromBuffer(buffer: Buffer): FileEntry[] {
+function parseEntriesFromBuffer(buffer: Buffer): LoadedSessionEntries {
 	const entries: FileEntry[] = [];
+	let incompleteTail: Buffer | undefined;
 	let start = 0;
 	while (start < buffer.length) {
 		let end = buffer.indexOf(0x0a, start);
 		if (end === -1) end = buffer.length;
-		appendEntryFromBuffer(entries, buffer, start, end);
+		if (end > start) {
+			const entry = tryParseLine(buffer, start, end);
+			if (entry !== undefined) {
+				entries.push(entry);
+				incompleteTail = undefined;
+			} else {
+				incompleteTail = Buffer.from(buffer.subarray(start, end));
+			}
+		}
 		start = end + 1;
 	}
-	return entries;
+	return { entries, incompleteTail };
 }
 
-async function parseEntriesFromBufferAsync(buffer: Buffer): Promise<FileEntry[]> {
+async function parseEntriesFromBufferAsync(buffer: Buffer): Promise<LoadedSessionEntries> {
 	const entries: FileEntry[] = [];
+	let incompleteTail: Buffer | undefined;
 	let start = 0;
 	let bytesSinceYield = 0;
 	while (start < buffer.length) {
 		let end = buffer.indexOf(0x0a, start);
 		if (end === -1) end = buffer.length;
-		appendEntryFromBuffer(entries, buffer, start, end);
+		if (end > start) {
+			const entry = tryParseLine(buffer, start, end);
+			if (entry !== undefined) {
+				entries.push(entry);
+				incompleteTail = undefined;
+			} else {
+				incompleteTail = Buffer.from(buffer.subarray(start, end));
+			}
+		}
 		bytesSinceYield += end - start + 1;
 		start = end + 1;
 		if (bytesSinceYield >= SESSION_ASYNC_PARSE_YIELD_BYTES) {
@@ -575,7 +617,7 @@ async function parseEntriesFromBufferAsync(buffer: Buffer): Promise<FileEntry[]>
 			await new Promise<void>((resolve) => setImmediate(resolve));
 		}
 	}
-	return entries;
+	return { entries, incompleteTail };
 }
 
 function finalizeLoadedEntries(entries: FileEntry[]): FileEntry[] {
@@ -589,8 +631,14 @@ function finalizeLoadedEntries(entries: FileEntry[]): FileEntry[] {
 }
 
 export function loadEntriesFromFile(filePath: string): FileEntry[] {
-	if (!existsSync(filePath)) return [];
-	return finalizeLoadedEntries(parseEntriesFromBuffer(readFileSync(filePath)));
+	return loadEntriesFromFileWithTail(filePath).entries;
+}
+
+/** Like {@link loadEntriesFromFile}, but also reports an incomplete trailing record. */
+export function loadEntriesFromFileWithTail(filePath: string): LoadedSessionEntries {
+	if (!existsSync(filePath)) return { entries: [] };
+	const { entries, incompleteTail } = parseEntriesFromBuffer(readFileSync(filePath));
+	return { entries: finalizeLoadedEntries(entries), incompleteTail };
 }
 
 // Async loader for the daemon: reads off the event loop and yields while parsing so a
@@ -600,23 +648,39 @@ export async function loadEntriesFromFileAsync(
 	filePath: string,
 	options: { streamThresholdBytes?: number } = {},
 ): Promise<FileEntry[]> {
-	if (!existsSync(filePath)) return [];
+	return (await loadEntriesFromFileAsyncWithTail(filePath, options)).entries;
+}
+
+/** Like {@link loadEntriesFromFileAsync}, but also reports an incomplete trailing record. */
+export async function loadEntriesFromFileAsyncWithTail(
+	filePath: string,
+	options: { streamThresholdBytes?: number } = {},
+): Promise<LoadedSessionEntries> {
+	if (!existsSync(filePath)) return { entries: [] };
 	const streamThresholdBytes = options.streamThresholdBytes ?? SESSION_STREAMING_LOAD_THRESHOLD_BYTES;
 	if ((await stat(filePath)).size < streamThresholdBytes) {
-		return finalizeLoadedEntries(await parseEntriesFromBufferAsync(await readFile(filePath)));
+		const { entries, incompleteTail } = await parseEntriesFromBufferAsync(await readFile(filePath));
+		return { entries: finalizeLoadedEntries(entries), incompleteTail };
 	}
 
 	const entries: FileEntry[] = [];
+	let incompleteTail: Buffer | undefined;
 	let bytesSinceYield = 0;
 	for await (const line of readLinesAsBuffers(filePath)) {
-		appendEntryFromBuffer(entries, line);
+		const entry = tryParseLine(line, 0, line.length);
+		if (entry !== undefined) {
+			entries.push(entry);
+			incompleteTail = undefined;
+		} else if (line.length > 0) {
+			incompleteTail = Buffer.from(line);
+		}
 		bytesSinceYield += line.length + 1;
 		if (bytesSinceYield >= SESSION_ASYNC_PARSE_YIELD_BYTES) {
 			bytesSinceYield = 0;
 			await new Promise<void>((resolve) => setImmediate(resolve));
 		}
 	}
-	return finalizeLoadedEntries(entries);
+	return { entries: finalizeLoadedEntries(entries), incompleteTail };
 }
 
 function readSessionHeader(filePath: string): Partial<SessionHeader> | undefined {
@@ -1119,6 +1183,7 @@ export class SessionManager {
 		sessionFile: string | undefined,
 		persist: boolean,
 		preloadedEntries?: FileEntry[],
+		preloadedIncompleteTail?: Buffer,
 	) {
 		this.cwd = cwd;
 		this.sessionDir = sessionDir;
@@ -1128,7 +1193,7 @@ export class SessionManager {
 		}
 
 		if (sessionFile) {
-			this.setSessionFile(sessionFile, preloadedEntries);
+			this.setSessionFile(sessionFile, preloadedEntries, preloadedIncompleteTail);
 		} else {
 			this.newSession();
 		}
@@ -1136,13 +1201,21 @@ export class SessionManager {
 
 	/**
 	 * Switch to a different session file (used for resume and branching).
-	 * preloadedEntries must be loadEntriesFromFile(sessionFile) for the same path; it
+	 * preloadedEntries must be loadEntriesFromFile(sessionFile) for the same path (and
+	 * preloadedIncompleteTail its loadEntriesFromFileWithTail/-Async counterpart); it
 	 * lets the async daemon path skip the synchronous re-read.
 	 */
-	setSessionFile(sessionFile: string, preloadedEntries?: FileEntry[]): void {
+	setSessionFile(sessionFile: string, preloadedEntries?: FileEntry[], preloadedIncompleteTail?: Buffer): void {
 		this.sessionFile = resolve(sessionFile);
 		if (existsSync(this.sessionFile)) {
-			this.fileEntries = preloadedEntries ?? loadEntriesFromFile(this.sessionFile);
+			let incompleteTail = preloadedIncompleteTail;
+			if (preloadedEntries) {
+				this.fileEntries = preloadedEntries;
+			} else {
+				const loaded = loadEntriesFromFileWithTail(this.sessionFile);
+				this.fileEntries = loaded.entries;
+				incompleteTail = loaded.incompleteTail;
+			}
 
 			// If file was empty or corrupted (no valid header), truncate and start fresh
 			// to avoid appending messages without a session header (which breaks the session)
@@ -1169,10 +1242,47 @@ export class SessionManager {
 
 			this._buildIndex();
 			this.flushed = true;
+			this._repairIncompleteTail(incompleteTail);
 		} else {
 			const explicitPath = this.sessionFile;
 			this.newSession();
 			this.sessionFile = explicitPath; // preserve explicit path from --resume selector
+		}
+	}
+
+	/**
+	 * A crash mid-write can leave the file's final record truncated. Left alone, the
+	 * fragment's bytes stay on disk and the next appendFileSync (the hot path in
+	 * _persist) concatenates the new entry directly onto it -- producing one combined
+	 * malformed line that also fails to parse, so the new entry is lost too (#928).
+	 * Quarantine the fragment for forensic recovery and force the next persisted entry
+	 * through the atomic rewrite path (temp file + rename, see _rewriteFile) instead of
+	 * a raw append: that rewrite serializes only the entries this instance actually
+	 * loaded, which physically drops the stray trailing bytes before anything new lands.
+	 */
+	private _repairIncompleteTail(incompleteTail: Buffer | undefined): void {
+		if (!incompleteTail || incompleteTail.length === 0 || !this.sessionFile) return;
+		const quarantinePath = `${this.sessionFile}.incomplete-tail-${Date.now()}-${randomUUID().slice(0, 8)}.jsonl`;
+		try {
+			writeFileSync(quarantinePath, incompleteTail);
+			log.warn(
+				`session ${this.sessionFile}: repaired an incomplete trailing record (likely a crash mid-write); ` +
+					`quarantined ${incompleteTail.length} byte(s) to ${quarantinePath}`,
+			);
+		} catch (error) {
+			log.warn(
+				`session ${this.sessionFile}: repaired an incomplete trailing record (likely a crash mid-write), ` +
+					`but could not quarantine it: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+		// Truncate the corrupt tail immediately rather than deferring to the next
+		// append: a session that is only ever read after this (e.g. a passive list/
+		// context-tree view) must not leave the fragment sitting on disk indefinitely.
+		if (this.persist) {
+			this._rewriteFile();
+			this.flushed = true;
+		} else {
+			this.flushed = false;
 		}
 	}
 
@@ -1985,13 +2095,13 @@ export class SessionManager {
 		if (!existsSync(path)) {
 			return SessionManager.open(path, sessionDir, cwdOverride);
 		}
-		const entries = await loadEntriesFromFileAsync(path);
+		const { entries, incompleteTail } = await loadEntriesFromFileAsyncWithTail(path);
 		if (entries.length === 0) {
 			return SessionManager.open(path, sessionDir, cwdOverride);
 		}
 		const cwd = cwdOverride ?? (entries[0] as SessionHeader).cwd;
 		const dir = sessionDir ?? resolve(path, "..");
-		return new SessionManager(cwd ?? process.cwd(), dir, path, true, entries);
+		return new SessionManager(cwd ?? process.cwd(), dir, path, true, entries, incompleteTail);
 	}
 
 	static continueRecent(cwd: string, sessionDir?: string): SessionManager {

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,6 +6,8 @@ import {
 	findMostRecentSession,
 	loadEntriesFromFile,
 	loadEntriesFromFileAsync,
+	loadEntriesFromFileAsyncWithTail,
+	loadEntriesFromFileWithTail,
 	readSessionInfo,
 	resolveSessionRlmDepth,
 	SessionManager,
@@ -71,6 +73,95 @@ describe("loadEntriesFromFile", () => {
 		expect(entries).toHaveLength(2);
 	});
 
+	describe("incomplete trailing record (#928)", () => {
+		const header = '{"type":"session","id":"abc","version":3,"timestamp":"2025-01-01T00:00:00Z","cwd":"/tmp"}';
+		const validMessage =
+			'{"type":"message","id":"1","parentId":null,"timestamp":"2025-01-01T00:00:01Z",' +
+			'"message":{"role":"user","content":"hi","timestamp":1}}';
+		const truncatedTail = '{"type":"message","id":"2","parentId":"1","timestamp":"2025-01-01T00:00:02Z","mess';
+
+		it("loadEntriesFromFileWithTail reports a truncated final record without dropping earlier ones", () => {
+			const file = join(tempDir, "truncated-tail.jsonl");
+			writeFileSync(file, [header, validMessage, truncatedTail].join("\n"));
+
+			const { entries, incompleteTail } = loadEntriesFromFileWithTail(file);
+
+			expect(entries).toHaveLength(2);
+			expect(incompleteTail?.toString("utf8")).toBe(truncatedTail);
+		});
+
+		it("loadEntriesFromFileAsyncWithTail reports the same truncated tail via the streaming path", async () => {
+			const file = join(tempDir, "truncated-tail-streamed.jsonl");
+			writeFileSync(file, [header, validMessage, truncatedTail].join("\n"));
+
+			const { entries, incompleteTail } = await loadEntriesFromFileAsyncWithTail(file, { streamThresholdBytes: 0 });
+
+			expect(entries).toHaveLength(2);
+			expect(incompleteTail?.toString("utf8")).toBe(truncatedTail);
+		});
+
+		it("does not report a tail when the file's last record is valid but unterminated", () => {
+			const file = join(tempDir, "unterminated-but-valid.jsonl");
+			writeFileSync(file, [header, validMessage].join("\n")); // no trailing newline
+
+			expect(loadEntriesFromFileWithTail(file).incompleteTail).toBeUndefined();
+		});
+
+		it("does not report a tail for a malformed line that isn't the last one", () => {
+			const file = join(tempDir, "malformed-middle.jsonl");
+			writeFileSync(file, [header, "not valid json", validMessage, ""].join("\n"));
+
+			expect(loadEntriesFromFileWithTail(file).incompleteTail).toBeUndefined();
+		});
+
+		it("SessionManager.open repairs a truncated tail: quarantines it, keeps earlier records, and round-trips a new append", () => {
+			const file = join(tempDir, "resume-truncated.jsonl");
+			writeFileSync(file, [header, validMessage, truncatedTail].join("\n"));
+
+			const manager = SessionManager.open(file, tempDir);
+
+			// Earlier valid records survive the repair.
+			expect(manager.getEntries()).toHaveLength(1);
+
+			// The corrupt fragment is preserved for forensic recovery, not silently dropped.
+			const quarantineFiles = readdirSync(tempDir).filter((name) => name.includes("incomplete-tail"));
+			expect(quarantineFiles).toHaveLength(1);
+			expect(readFileSync(join(tempDir, quarantineFiles[0]!), "utf8")).toBe(truncatedTail);
+
+			// The on-disk file itself was truncated back to just the valid records:
+			// a naive appendFileSync onto the pre-repair bytes would have produced one
+			// combined malformed line, losing whatever gets appended next too.
+			const onDiskLines = readFileSync(file, "utf8").trim().split("\n");
+			expect(onDiskLines).toHaveLength(2);
+			expect(() => JSON.parse(onDiskLines[1]!)).not.toThrow();
+
+			// A subsequent entry round-trips cleanly instead of concatenating onto the fragment.
+			// (flushNow forces durability the same way it does for any pre-assistant entry;
+			// see its doc comment -- unrelated to this fix.)
+			manager.appendMessage({ role: "user", content: "after repair", timestamp: 2 });
+			manager.flushNow();
+			const reloaded = loadEntriesFromFile(file);
+			expect(reloaded).toHaveLength(3); // header + surviving "hi" message + the new append
+			expect(reloaded[2]).toMatchObject({ message: { content: "after repair" } });
+		});
+
+		it("SessionManager.openAsync repairs a truncated tail the same way as the sync path", async () => {
+			const file = join(tempDir, "resume-truncated-async.jsonl");
+			writeFileSync(file, [header, validMessage, truncatedTail].join("\n"));
+
+			const manager = await SessionManager.openAsync(file, tempDir);
+
+			expect(manager.getEntries()).toHaveLength(1);
+			const onDiskLines = readFileSync(file, "utf8").trim().split("\n");
+			expect(onDiskLines).toHaveLength(2);
+
+			manager.appendMessage({ role: "user", content: "after async repair", timestamp: 2 });
+			manager.flushNow();
+			const reloaded = loadEntriesFromFile(file);
+			expect(reloaded).toHaveLength(3); // header + surviving "hi" message + the new append
+			expect(reloaded[2]).toMatchObject({ message: { content: "after async repair" } });
+		});
+	});
 	it("yields while parsing a multi-megabyte session below the streaming threshold", async () => {
 		const file = join(tempDir, "buffered.jsonl");
 		writeFileSync(


### PR DESCRIPTION
Fixes #928.

Posted for review after discussion in #1764 (per CONTRIBUTING.md's contribution process).

## Summary

A crash mid-write can leave a session's `.jsonl` file's final record truncated. This is #928, one of the "related reports" under the still-open tracker #1380 (*Make persisted session and configuration state crash-safe*). Reproduced fresh on current `main` (`06860844e`) with a new failing-first regression test — not just read from the source.

## Root cause

`parseEntriesFromBuffer` (and friends) already silently skip any line that fails `JSON.parse`, including a truncated trailing fragment — so in-memory state after resume *looks* fine. But the raw bytes of the fragment are never removed from disk, and the hot append path in `_persist()` calls `appendFileSync()` directly onto the existing file:

```ts
} else {
	mkdirSync(dirname(this.sessionFile), { recursive: true });
	appendFileSync(this.sessionFile, `${JSON.stringify(entry)}
`);
	...
}
```

The next real entry lands right after the fragment, producing one combined malformed line that also fails to parse — so the new entry is silently lost too, and this repeats on every future crash/resume cycle at that same file. Confirmed with a direct repro: write a valid header + message + a truncated trailing record (no closing brace, as a crash mid-`fwrite` would leave it), open the session, append a new message, reload — the new message is gone.

## Fix

All in `packages/coding-agent/src/core/session-manager.ts`:

- The buffer/stream parsers now also track whether the file's **final** non-blank line existed but failed to parse, reporting it separately from ordinary mid-file skips. Only the trailing case is a safe, unambiguous repair target — an earlier malformed line is followed by content that already round-tripped, so it isn't attributable to an in-flight write and stays silently skipped exactly as before (out of scope, same as the row-validation done for #709, per the original report's own note).
- New `loadEntriesFromFileWithTail` / `loadEntriesFromFileAsyncWithTail` expose `{ entries, incompleteTail }`; the existing `loadEntriesFromFile` / `loadEntriesFromFileAsync` keep their original `FileEntry[]` signature as thin wrappers, so the one other call site (`context-tree.ts`) is unaffected.
- `SessionManager.setSessionFile` (used by both the sync `SessionManager.open` and, via a new `preloadedIncompleteTail` parameter, the async `SessionManager.openAsync`) now calls a new `_repairIncompleteTail()` after loading: it quarantines the fragment's raw bytes to a `<file>.incomplete-tail-<ts>-<id>.jsonl` sidecar for forensic recovery, logs a warning, and immediately rewrites the session file through the existing atomic temp-file+rename path (`_rewriteFile`) — so the corrupt bytes are gone from disk before any subsequent append can concatenate onto them, not just before the next write happens to occur.

## Acceptance criteria from #928 — all covered by new tests

- Resume distinguishes a complete final record from an incomplete tail.
- Invalid tail bytes are quarantined before append (and truncated immediately, not deferred).
- A subsequent entry round-trips.
- Earlier valid records are preserved.
- Recovery is observable (a log line via `getLogger("coding-agent.session-manager")`, plus the quarantine sidecar).

## Tests

Added 6 tests to `packages/coding-agent/test/session-manager/file-operations.test.ts`, all verified to fail against pre-fix `main` and pass after:
- `loadEntriesFromFileWithTail`/`-AsyncWithTail` report a truncated final record without dropping earlier entries.
- No tail is reported when the last record is valid but simply unterminated (no trailing newline) — not a corruption case.
- No tail is reported for a malformed line that isn't the last one (unchanged legacy skip behavior, intentionally out of scope).
- `SessionManager.open` and `SessionManager.openAsync` both: quarantine the fragment, keep earlier records, physically truncate the on-disk file immediately, and a subsequently appended entry round-trips through a reload instead of being lost.

Also ran the full session-manager-adjacent suite for regressions: `test/session-manager/`, `session-manager-flush.test.ts`, `session-manager-git-state.test.ts`, `sdk-session-manager.test.ts`, `context-tree.test.ts` — **161 + 14 passed, 0 failed**. `npx tsgo -p tsconfig.json --noEmit` and the root `npm run check` (biome, tsgo, installer render, browser smoke) both pass. Added a `packages/coding-agent/.changes/` fragment per the changelog-fragment CI check.