### PR TITLE
fix(runtime): isolate %%bash/%%script cell subprocesses into their own process group and escalate interrupts against it

### DIFF
--- a/prime-agent-runtime/src/rlm/__init__.py
+++ b/prime-agent-runtime/src/rlm/__init__.py
@@ -21,6 +21,14 @@ try:
 except Exception:  # pragma: no cover - only available in kernels
     get_ipython = None  # type: ignore[assignment]
 
+from . import _script_process_group as _script_process_group
+
+# Give every %%bash/%%script cell's subprocess tree its own OS process group
+# and an escalating SIGINT/SIGTERM/SIGKILL interrupt path, without ever
+# touching the kernel process itself. Installed unconditionally so it is live
+# before any user cell (including the very first one) can run. See #849.
+_script_process_group.install()
+
 HOST_COMM_TARGET = "host.request"
 
 

--- a/prime-agent-runtime/src/rlm/_script_process_group.py
+++ b/prime-agent-runtime/src/rlm/_script_process_group.py
@@ -1,0 +1,216 @@
+"""Process-group isolation and interrupt escalation for %%bash/%%script cells.
+
+IPython's ``ScriptMagics.shebang`` (``IPython/core/magics/script.py``, a
+third-party, pip-installed dependency -- not part of this repo) spawns a
+``%%bash``/``%%script`` cell's shell via ``asyncio.create_subprocess_exec``
+with no process-group isolation, so the shell (and anything it execs or
+forks, e.g. a backgrounded ``grep``) shares this kernel process's own OS
+process group. Interrupting the cell (Esc in Prime Agent) only ever reaches
+the kernel's own pid -- via ipykernel's SIGINT delivery for the host's
+``interrupt_request`` -- never the shell's own children, so a stuck or
+backgrounded child leaks and keeps running at full CPU indefinitely (see
+prime-agent#849).
+
+This module, imported unconditionally from :mod:`rlm` at kernel bootstrap:
+
+1. Scopes a process-group-isolating ``asyncio.create_subprocess_exec`` proxy
+   to ``IPython.core.magics.script``'s own module namespace only (no other
+   code in the process is affected).
+2. Tracks every subprocess spawned that way in a small, self-pruning
+   registry.
+3. Installs a ``SIGINT`` handler (chaining to whatever was previously
+   installed, e.g. ipykernel's own) that escalates SIGINT -> SIGTERM ->
+   SIGKILL against each tracked subprocess's *process group* -- never the
+   kernel process itself, which is never made a member of any of these
+   groups and is therefore untouched.
+
+An explicitly backgrounded script (``%%bash --bg``, tracked in IPython's own
+``ScriptMagics.bg_processes``) is excluded: it is expected to outlive its
+cell, so an unrelated later interrupt must not sweep it.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import threading
+from typing import Any, Callable
+
+try:
+    from IPython.core.magics import script as _ipython_script_magics
+except Exception:  # pragma: no cover - only available inside a real kernel
+    _ipython_script_magics = None  # type: ignore[assignment]
+
+# Escalation timeline. Kept as module attributes (not local constants) so
+# tests can shrink them instead of sleeping through production-sized delays.
+SIGTERM_DELAY_SECONDS = 1.0
+SIGKILL_DELAY_SECONDS = 0.5
+
+_INSTALLED_MARKER = "_prime_agent_script_process_group_patch"
+
+# pid -> pgid, for every process the proxy below has spawned that has not yet
+# been confirmed dead. Pruned opportunistically; never grows unbounded across
+# a long session because every registration prunes first.
+_tracked_pids: dict[int, int] = {}
+_tracked_lock = threading.Lock()
+
+
+def _is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _group_alive(pgid: int) -> bool:
+    """Whether any process remains in the group -- NOT whether the original
+    spawned (leader) pid is still alive. A non-interactive bash exits as soon
+    as it hits EOF on its script input, often well before a backgrounded
+    child (`cmd &`) it started finishes; checking the leader's own pid would
+    then wrongly conclude the whole group is already gone -- both here
+    (pruning it out of the tracked registry before an interrupt ever
+    arrives) and during escalation (skipping straight past SIGTERM/SIGKILL)
+    -- and leak exactly the child this module exists to stop.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _prune_tracked_locked() -> None:
+    for pid, pgid in [(pid, pgid) for pid, pgid in _tracked_pids.items() if not _group_alive(pgid)]:
+        _tracked_pids.pop(pid, None)
+
+
+def _register_tracked_pid(pid: int, pgid: int) -> None:
+    with _tracked_lock:
+        _prune_tracked_locked()
+        _tracked_pids[pid] = pgid
+
+
+def _backgrounded_pids() -> set[int]:
+    """PIDs IPython itself considers explicitly backgrounded (%%bash --bg):
+    these must survive an unrelated interrupt, matching user intent.
+    """
+    if _ipython_script_magics is None:
+        return set()
+    try:
+        from IPython.core.interactiveshell import InteractiveShell
+
+        shell = InteractiveShell.instance()
+        script_magics = shell.magics_manager.registry.get("ScriptMagics")
+    except Exception:
+        return set()
+    if script_magics is None:
+        return set()
+    try:
+        return {proc.pid for proc in getattr(script_magics, "bg_processes", []) if proc.pid is not None}
+    except Exception:
+        return set()
+
+
+def _signal_group(pgid: int, sig: int) -> None:
+    try:
+        os.killpg(pgid, sig)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+def _escalate(pid: int, pgid: int) -> None:
+    """Runs on a background daemon thread: SIGINT was already sent by the
+    signal handler before this was scheduled. Wait, then escalate only if the
+    group is still alive.
+
+    SIGINT alone is not sufficient even when the group is reachable: a
+    non-interactive bash sets SIGINT (and SIGQUIT) to be ignored for any
+    `cmd &` backgrounded child by POSIX/bash convention specifically so an
+    interactive Ctrl-C does not reach background jobs -- confirmed
+    empirically (see the plan's Investigation). SIGTERM/SIGKILL are not
+    auto-ignored this way, so the escalation must actually reach them.
+    """
+    threading.Event().wait(SIGTERM_DELAY_SECONDS)
+    if _group_alive(pgid):
+        _signal_group(pgid, signal.SIGTERM)
+        threading.Event().wait(SIGKILL_DELAY_SECONDS)
+        if _group_alive(pgid):
+            _signal_group(pgid, signal.SIGKILL)
+    with _tracked_lock:
+        _tracked_pids.pop(pid, None)
+
+
+def _handle_sigint(signum: int, frame: Any, *, _previous: Callable[..., Any] | None) -> None:
+    with _tracked_lock:
+        _prune_tracked_locked()
+        targets = dict(_tracked_pids)
+    if targets:
+        excluded = _backgrounded_pids()
+        for pid, pgid in targets.items():
+            if pid in excluded:
+                continue
+            _signal_group(pgid, signal.SIGINT)
+            threading.Thread(target=_escalate, args=(pid, pgid), daemon=True).start()
+    # Preserve the kernel's own existing interrupt semantics unconditionally,
+    # even if something above raised: ipykernel's own SIGINT handling (or
+    # whatever was previously installed) must still run.
+    if callable(_previous):
+        _previous(signum, frame)
+    elif _previous == signal.SIG_DFL:
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        os.kill(os.getpid(), signal.SIGINT)
+        signal.signal(signal.SIGINT, lambda s, f: _handle_sigint(s, f, _previous=_previous))
+
+
+class _ScriptMagicsAsyncioProxy:
+    """Forwards every attribute to the real ``asyncio`` module except
+    ``create_subprocess_exec``, which gets process-group isolation. Assigned
+    only to ``IPython.core.magics.script``'s own ``asyncio`` name, so nothing
+    else in the process is affected.
+    """
+
+    def __init__(self, real_asyncio: Any, real_create_subprocess_exec: Callable[..., Any]):
+        self._real_asyncio = real_asyncio
+        self._real_create_subprocess_exec = real_create_subprocess_exec
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real_asyncio, name)
+
+    async def create_subprocess_exec(self, *args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("start_new_session", True)
+        proc = await self._real_create_subprocess_exec(*args, **kwargs)
+        if kwargs.get("start_new_session"):
+            try:
+                pgid = os.getpgid(proc.pid)
+            except ProcessLookupError:
+                pgid = proc.pid
+            _register_tracked_pid(proc.pid, pgid)
+        return proc
+
+
+def install() -> None:
+    """Idempotent: safe to call on every ``import rlm`` (including a kernel
+    restart re-import) without installing duplicate handlers or double-
+    wrapping ``create_subprocess_exec``.
+    """
+    if _ipython_script_magics is None:
+        return
+    if getattr(_ipython_script_magics, _INSTALLED_MARKER, False):
+        return
+
+    real_asyncio = _ipython_script_magics.asyncio
+    real_create_subprocess_exec = real_asyncio.create_subprocess_exec
+    _ipython_script_magics.asyncio = _ScriptMagicsAsyncioProxy(real_asyncio, real_create_subprocess_exec)
+
+    previous_handler = signal.getsignal(signal.SIGINT)
+
+    def _handler(signum: int, frame: Any) -> None:
+        _handle_sigint(signum, frame, _previous=previous_handler)
+
+    signal.signal(signal.SIGINT, _handler)
+    setattr(_ipython_script_magics, _INSTALLED_MARKER, True)

--- a/prime-agent-runtime/test/test_script_process_group.py
+++ b/prime-agent-runtime/test/test_script_process_group.py
@@ -1,0 +1,197 @@
+"""Regression tests for #849: an interrupted %%bash/%%script cell's subprocess
+tree must actually stop, without ever touching the kernel process itself.
+
+Drives the real installed IPython.core.magics.script module and asyncio
+subprocess machinery directly (no full Jupyter kernel is needed), matching the
+style of the rest of this suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import time
+import unittest
+
+from IPython.core.magics import script as ipython_script_magics
+
+from rlm import _script_process_group
+
+
+def _process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _spawn_bash_with_grandchild():
+    """Spawn bash exactly the way ScriptMagics.shebang does -- through
+    whatever asyncio.create_subprocess_exec is currently bound to on the
+    ipython_script_magics module -- running a command that itself forks a
+    real, independently-observable grandchild (mirroring a %%bash cell like
+    `some_long_command & echo $!`).
+    """
+
+    async def _spawn():
+        p = await ipython_script_magics.asyncio.create_subprocess_exec(
+            "bash",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        p.stdin.write(b"sleep 30 & echo $!\n")
+        await p.stdin.drain()
+        p.stdin.close()
+        grandchild_pid = int((await p.stdout.readline()).strip())
+        return p, grandchild_pid
+
+    return asyncio.run(_spawn())
+
+
+def _cleanup(*pids: int) -> None:
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+class ScriptProcessGroupInstallTest(unittest.TestCase):
+    """rlm's patch (import rlm -> _script_process_group.install()) must have
+    already run by the time these tests import rlm, matching real kernel
+    bootstrap. These exercise the integration end to end.
+    """
+
+    def setUp(self):
+        # Speed up the escalation timeline for the test instead of sleeping
+        # through production-sized delays.
+        self._orig_sigterm_delay = _script_process_group.SIGTERM_DELAY_SECONDS
+        self._orig_sigkill_delay = _script_process_group.SIGKILL_DELAY_SECONDS
+        _script_process_group.SIGTERM_DELAY_SECONDS = 0.05
+        _script_process_group.SIGKILL_DELAY_SECONDS = 0.05
+
+    def tearDown(self):
+        _script_process_group.SIGTERM_DELAY_SECONDS = self._orig_sigterm_delay
+        _script_process_group.SIGKILL_DELAY_SECONDS = self._orig_sigkill_delay
+        with _script_process_group._tracked_lock:
+            _script_process_group._tracked_pids.clear()
+
+    def test_patched_create_subprocess_exec_isolates_a_new_process_group(self):
+        p, grandchild_pid = _spawn_bash_with_grandchild()
+        try:
+            self.assertTrue(_process_alive(grandchild_pid))
+            # Query the group via the grandchild, not bash's own pid: a
+            # non-interactive bash exits as soon as it hits EOF on its
+            # script input, often before this assertion runs, while the
+            # backgrounded grandchild (and the process group itself, which
+            # persists as long as any member remains) lives on.
+            self.assertEqual(
+                os.getpgid(grandchild_pid),
+                p.pid,
+                "the patched asyncio.create_subprocess_exec used by "
+                "ScriptMagics.shebang must isolate the shell into its own "
+                "process group",
+            )
+            self.assertNotEqual(
+                os.getpgid(grandchild_pid),
+                os.getpgid(0),
+                "the isolated process group must differ from this process's own",
+            )
+        finally:
+            _cleanup(grandchild_pid, p.pid)
+
+    def test_sigint_escalates_to_kill_the_whole_group_without_touching_this_process(self):
+        p, grandchild_pid = _spawn_bash_with_grandchild()
+        try:
+            self.assertTrue(_process_alive(grandchild_pid))
+            my_pid_before = os.getpid()
+
+            try:
+                os.kill(os.getpid(), signal.SIGINT)
+                # Give the default/previous handler a chance to raise, then
+                # absorb it here -- production installs this over ipykernel's
+                # own handler, which does not raise KeyboardInterrupt out to
+                # arbitrary code either.
+                time.sleep(0.05)
+            except KeyboardInterrupt:
+                pass
+
+            # Escalation runs on a background thread; wait past both delays.
+            deadline = time.time() + 2.0
+            while time.time() < deadline and _process_alive(grandchild_pid):
+                time.sleep(0.02)
+
+            self.assertFalse(
+                _process_alive(grandchild_pid),
+                "the grandchild must be killed by the SIGINT-triggered group "
+                "escalation, not leaked (this is the exact symptom in #849)",
+            )
+            self.assertFalse(_process_alive(p.pid), "the shell itself must also be gone")
+            self.assertEqual(os.getpid(), my_pid_before, "the kernel process itself must survive untouched")
+        finally:
+            _cleanup(grandchild_pid, p.pid)
+
+    def test_explicitly_backgrounded_subprocess_survives_an_unrelated_interrupt(self):
+        p, grandchild_pid = _spawn_bash_with_grandchild()
+
+        class _FakeBgProcess:
+            pid = p.pid
+
+        class _FakeScriptMagics:
+            bg_processes = [_FakeBgProcess()]
+
+        import IPython.core.interactiveshell as interactiveshell_module
+
+        class _FakeShell:
+            class magics_manager:
+                registry = {"ScriptMagics": _FakeScriptMagics()}
+
+        original_instance = interactiveshell_module.InteractiveShell.instance
+        interactiveshell_module.InteractiveShell.instance = classmethod(lambda cls: _FakeShell())
+        try:
+            try:
+                os.kill(os.getpid(), signal.SIGINT)
+                time.sleep(0.05)
+            except KeyboardInterrupt:
+                pass
+            time.sleep(0.3)  # past both escalation delays
+            # Check the grandchild, not bash itself: a non-interactive bash
+            # exits on EOF regardless of any signal handling, so bash's own
+            # liveness would not distinguish correct from buggy behavior. The
+            # grandchild is the actual backgrounded work that must survive.
+            self.assertTrue(
+                _process_alive(grandchild_pid),
+                "%%bash --bg is an explicit opt-in to outlive its cell; an "
+                "unrelated later interrupt must not sweep it",
+            )
+        finally:
+            interactiveshell_module.InteractiveShell.instance = original_instance
+            _cleanup(grandchild_pid, p.pid)
+
+    def test_completed_subprocess_is_pruned_and_ignored(self):
+        async def _spawn_and_wait():
+            p = await ipython_script_magics.asyncio.create_subprocess_exec(
+                "bash",
+                "-c",
+                "true",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await p.wait()
+            return p
+
+        p = asyncio.run(_spawn_and_wait())
+        time.sleep(0.05)
+        with _script_process_group._tracked_lock:
+            _script_process_group._prune_tracked_locked()
+            self.assertNotIn(p.pid, _script_process_group._tracked_pids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #849.

Posted for review after discussion in #1786 (per CONTRIBUTING.md's contribution process).

## Summary

Interrupting (Esc) an `ipython` cell running a `%%bash` command returns control to the model, but the shell subprocess (and its own children, e.g. a backgrounded `grep`) keep running indefinitely at full CPU. The only recovery is killing the leaf process by hand or choosing "Kill kernel and restart", which loses the whole Python namespace. This is #849, one of the "related reports" under the still-open tracker #1382 (*Complete queued, interrupted, and archived session lifecycle recovery*).

## Root cause

`IPython.core.magics.script.ScriptMagics.shebang` (a third-party, pip-installed dependency, not part of this repo) spawns the cell's shell via `asyncio.create_subprocess_exec` with **no process-group isolation**, so the shell (and anything it execs/forks) shares the kernel process's own OS process group. Its own `KeyboardInterrupt -> SIGINT/terminate/kill` escalation only ever signals the direct child, never that child's own children — and in practice never even runs, since it blocks IPython's dedicated worker thread while the SIGINT-raised `KeyboardInterrupt` is delivered to the *main* thread. `kernel/index.ts`'s `onAbort()`/`interrupt()` only sends a Jupyter `interrupt_request`, which ipykernel turns into `SIGINT` to the kernel's own pid — it never reaches a subprocess either.

Confirmed directly against the real installed kernel-venv (IPython 9.16.1):
- `asyncio.create_subprocess_exec(..., start_new_session=True)` isolates the spawned shell into its own process group.
- A backgrounded child it forks (e.g. `sleep 30 &`) inherits that same group even after being reparented to init.
- `os.killpg` on that group reaches the whole tree while leaving the parent Python process completely untouched.
- A non-interactive bash sets `SIGINT` to be **ignored** for any `&`-backgrounded child (standard POSIX/bash behavior, confirmed empirically) — so an escalation that stops at SIGINT is not sufficient; it must actually reach SIGTERM/SIGKILL.

## Fix

Entirely inside `prime-agent-runtime` — **no TypeScript changes**, since the host's existing `onAbort()`/`interrupt()` already delivers the triggering SIGINT to the kernel's own pid today:

- `prime-agent-runtime/src/rlm/_script_process_group.py` (new): scopes a process-group-isolating `asyncio.create_subprocess_exec` proxy to `IPython.core.magics.script`'s own module namespace only (no other code in the process is affected). Tracks every subprocess spawned that way in a small, self-pruning registry — pruned by **process-group** liveness (`os.killpg(pgid, 0)`), not the original spawned pid's own liveness, since a non-interactive bash exits on EOF well before a backgrounded child it started finishes; checking the leader's pid alone would wrongly conclude the whole group is already gone and skip escalating, leaking exactly the child this exists to stop. Installs a `SIGINT` handler (chaining to whatever was previously installed, e.g. ipykernel's own, so the kernel's own interrupt semantics are unchanged) that signals each tracked group with SIGINT immediately, then escalates to SIGTERM and SIGKILL on a background thread if the group is still alive. An explicitly backgrounded script (`%%bash --bg`, tracked in IPython's own `ScriptMagics.bg_processes`) is excluded, since it's expected to outlive its cell.
- `prime-agent-runtime/src/rlm/__init__.py`: installs the patch unconditionally at import time (`rlm` is already imported for every kernel's bootstrap readiness check), idempotently.

A design that instead put the **kernel itself** in its own process group and group-signaled it on the force-abort timeout was considered and rejected: escalating to SIGKILL on that group would also kill the kernel process on every interrupt-timeout, destroying the user's Python namespace automatically instead of leaving that as the existing, explicit manual "Kill kernel and restart" fallback — a much larger behavior change than this bug calls for.

## Tests

Added `prime-agent-runtime/test/test_script_process_group.py` (4 new tests, all verified to fail against the pre-fix code — either via `ImportError` with the module absent, or the underlying unpatched behavior — and pass after the fix):
- the patched `create_subprocess_exec` isolates a new process group
- SIGINT escalates to kill the whole group (a backgrounded grandchild included) without touching the test process (standing in for the kernel) itself
- an explicitly backgrounded (`%%bash --bg`) subprocess survives an unrelated later interrupt
- a completed subprocess is pruned from the tracked registry

## Validation

```
cd prime-agent-runtime && uv run python -m unittest discover -s test   # exact CI command
# 102 passed (98 existing + 4 new), 0 failed
```

Re-verified RED: with `_script_process_group.py` absent and `__init__.py` reverted, the same command fails with `ImportError`. Root `npm run check` (biome, `tsgo --noEmit`, installer render, browser smoke) passes; this change touches no `packages/*` files, so no changelog fragment is required by the changelog-fragment CI check.