### PR TITLE
fix(coding-agent): coalesce chatty RLM child usage attribution writes

### DIFF
--- a/packages/coding-agent/.changes/eng-coalesce-child-usage-attribution.md
+++ b/packages/coding-agent/.changes/eng-coalesce-child-usage-attribution.md
@@ -1,0 +1,1 @@
+- Fixed chatty RLM subagents saturating the worker (high CPU, stuck attach/heartbeats) by coalescing rapid-fire child usage attribution writes into a bounded number of persisted entries instead of one per child message.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -247,7 +247,13 @@ import {
 	transitionSessionAction,
 	type WakePolicy,
 } from "./session-action-store.js";
-import type { BranchSummaryEntry, CompactionEntry, SessionContext, SessionMessageEntry } from "./session-manager.js";
+import type {
+	BranchSummaryEntry,
+	ChildUsageAttributionEntry,
+	CompactionEntry,
+	SessionContext,
+	SessionMessageEntry,
+} from "./session-manager.js";
 import {
 	CURRENT_SESSION_VERSION,
 	getLatestCompactionEntry,
@@ -917,6 +923,10 @@ interface RlmSubagentModelSelection {
 
 const KERNEL_STATE_LISTING_TIMEOUT_MS = 5000;
 const RLM_MAX_DEPTH_STATE_CUSTOM_TYPE = "rlm_max_depth_state";
+// A chatty child can emit tens of assistant messages per minute; persisting a full
+// child_usage_attributed JSONL entry per message saturates the worker (#1054).
+// Coalesce rapid-fire attributions to the same parent entry into one flush per window.
+const RLM_CHILD_USAGE_ATTRIBUTION_COALESCE_MS = 1000;
 
 function noopRlmChildAbort(): void {}
 function noopRlmChildEventUnsubscribe(): void {}
@@ -10246,6 +10256,39 @@ export class AgentSession {
 		const label = rlmChildLabel(prompt);
 		let answerPreview: string | undefined;
 		let durationMs: number | undefined;
+		// Coalesce this child's rapid-fire usage attributions into at most one
+		// persisted child_usage_attributed entry per RLM_CHILD_USAGE_ATTRIBUTION_COALESCE_MS
+		// window instead of one JSONL append per assistant message (#1054).
+		let pendingChildUsageDelta: Usage | undefined;
+		let pendingChildUsageOrigin: ChildUsageAttributionEntry["origin"] | undefined;
+		let childUsageAttributionFlushTimer: ReturnType<typeof setTimeout> | undefined;
+		const flushChildUsageAttribution = () => {
+			if (childUsageAttributionFlushTimer) {
+				clearTimeout(childUsageAttributionFlushTimer);
+				childUsageAttributionFlushTimer = undefined;
+			}
+			const delta = pendingChildUsageDelta;
+			const origin = pendingChildUsageOrigin;
+			pendingChildUsageDelta = undefined;
+			pendingChildUsageOrigin = undefined;
+			if (!delta || !parentAssistantForUsage) return;
+			const parentEntry = this._findAssistantEntryForMessage(parentAssistantForUsage);
+			if (!parentEntry) return;
+			attributeChildUsage(parentAssistantForUsage.usage, delta);
+			this.sessionManager.appendChildUsageAttribution(parentEntry.id, delta, parentAssistantForUsage.usage, origin);
+		};
+		const scheduleChildUsageAttribution = (usage: Usage, origin: ChildUsageAttributionEntry["origin"]) => {
+			if (!pendingChildUsageDelta) pendingChildUsageDelta = emptyUsage();
+			addAssistantUsage(pendingChildUsageDelta, usage);
+			pendingChildUsageOrigin = origin;
+			if (!childUsageAttributionFlushTimer) {
+				childUsageAttributionFlushTimer = setTimeout(
+					flushChildUsageAttribution,
+					RLM_CHILD_USAGE_ATTRIBUTION_COALESCE_MS,
+				);
+				childUsageAttributionFlushTimer.unref?.();
+			}
+		};
 		let toolUseCount = 0;
 		let runningToolCount = 0;
 		let activity: RlmChildAgentActivity | undefined;
@@ -10380,30 +10423,19 @@ export class AgentSession {
 					} else if (event.type === "message_end" && event.message.role === "assistant") {
 						const assistant = event.message as AssistantMessage;
 						if (assistant.stopReason !== "error" && assistant.stopReason !== "aborted") {
-							attributeChildUsage(parentAssistantForUsage?.usage ?? emptyUsage(), assistant.usage);
-							if (parentAssistantForUsage) {
-								const parentEntry = this._findAssistantEntryForMessage(parentAssistantForUsage);
-								if (parentEntry) {
-									const messages = child.messages;
-									const assistantIndex = messages.lastIndexOf(assistant);
-									const precedingPrompt = messages
-										.slice(0, assistantIndex)
-										.reverse()
-										.find((message) => message.role === "user" || message.role === "custom");
-									const origin =
-										precedingPrompt?.role === "custom" && isAgentSessionMessage(precedingPrompt)
-											? precedingPrompt.details.id.startsWith("spawn:")
-												? "spawn_task"
-												: "agent_message"
-											: "direct_user";
-									this.sessionManager.appendChildUsageAttribution(
-										parentEntry.id,
-										assistant.usage,
-										parentAssistantForUsage.usage,
-										origin,
-									);
-								}
-							}
+							const messages = child.messages;
+							const assistantIndex = messages.lastIndexOf(assistant);
+							const precedingPrompt = messages
+								.slice(0, assistantIndex)
+								.reverse()
+								.find((message) => message.role === "user" || message.role === "custom");
+							const origin =
+								precedingPrompt?.role === "custom" && isAgentSessionMessage(precedingPrompt)
+									? precedingPrompt.details.id.startsWith("spawn:")
+										? "spawn_task"
+										: "agent_message"
+									: "direct_user";
+							scheduleChildUsageAttribution(assistant.usage, origin);
 						}
 						const text = compactRlmText(readAssistantText(assistant));
 						if (text) answerPreview = text;
@@ -10545,6 +10577,10 @@ export class AgentSession {
 					}
 				}
 			} finally {
+				// Force the final coalesced usage attribution through now: without this, a
+				// child that settles inside the coalescing window would silently drop its
+				// last batch of usage instead of ever persisting it.
+				flushChildUsageAttribution();
 				if (run.detachedDeletion) {
 					run.deletionRunFinished = true;
 					if (!run.settled) {

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -2427,7 +2427,12 @@ describe("AgentSession rlm recursion", () => {
 		expect(attribution.aggregateUsage.cost.total).toBe(10);
 	});
 
-	it("attributes every tool-loop turn in the admitted task to spawn usage", async () => {
+	it("coalesces every tool-loop turn in the admitted task into one spawn usage attribution", async () => {
+		// Regression guard for #1054: a chatty child (or, here, a multi-turn tool
+		// loop) must not persist one child_usage_attributed JSONL entry per
+		// assistant message -- they are coalesced into at most one entry per
+		// RLM_CHILD_USAGE_ATTRIBUTION_COALESCE_MS window, with a forced final
+		// flush once the child settles so no usage from either turn is lost.
 		const tool = {
 			name: "echo",
 			description: "Echo a value",
@@ -2472,8 +2477,77 @@ describe("AgentSession rlm recursion", () => {
 			const attributions = root.sessionManager
 				.getEntries()
 				.filter((entry) => entry.type === "child_usage_attributed");
-			expect(attributions).toHaveLength(2);
-			expect(attributions.map((entry) => entry.origin)).toEqual(["spawn_task", "spawn_task"]);
+			expect(attributions).toHaveLength(1);
+			expect(attributions[0]).toMatchObject({
+				origin: "spawn_task",
+				childUsage: { input: 3, output: 3 },
+				aggregateUsage: { input: 3, output: 3 },
+			});
+		});
+	});
+
+	it("persists far fewer entries than turns for a chatty child, with the correct combined total (#1054)", async () => {
+		const TURN_COUNT = 20;
+		const tool = {
+			name: "echo",
+			description: "Echo a value",
+			label: "echo",
+			parameters: Type.Object({ value: Type.String() }),
+			execute: async (_toolCallId: string, params: { value: string }) => ({
+				content: [{ type: "text" as const, text: params.value }],
+				details: {},
+			}),
+		};
+		const root = createSession({
+			customTools: [tool],
+			streamFn: (_model, context) => {
+				const toolResultCount = context.messages.filter((message) => message.role === "toolResult").length;
+				const stream = createAssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message =
+						toolResultCount < TURN_COUNT
+							? {
+									...assistantMessage("", usage(1, 1)),
+									content: [
+										{
+											type: "toolCall" as const,
+											id: `echo-${toolResultCount}`,
+											name: "echo",
+											arguments: { value: "ok" },
+										},
+									],
+									stopReason: "toolUse" as const,
+								}
+							: assistantMessage("done", usage(0, 0));
+					stream.push({
+						type: "done",
+						reason: toolResultCount < TURN_COUNT ? "toolUse" : "stop",
+						message,
+					});
+				});
+				return stream;
+			},
+		});
+		const parentAssistant = assistantMessage("running ipython", usage(0, 0));
+		root.agent.state.messages.push(parentAssistant);
+		root.sessionManager.appendMessage(parentAssistant);
+
+		await root.runRlmChild("use a tool repeatedly");
+		await vi.waitFor(() => {
+			const attributions = root.sessionManager
+				.getEntries()
+				.filter((entry) => entry.type === "child_usage_attributed");
+			// A per-message write policy would persist one entry per turn (20 here,
+			// matching the reported #1054 shape of ~550 entries for ~550 messages).
+			// Coalescing must cut this down to a small, bounded number of writes
+			// regardless of how many turns land inside the debounce window.
+			expect(attributions.length).toBeLessThan(TURN_COUNT / 2);
+			expect(attributions.length).toBeGreaterThan(0);
+			const totalInput = attributions.reduce((sum, entry) => sum + entry.childUsage.input, 0);
+			const totalOutput = attributions.reduce((sum, entry) => sum + entry.childUsage.output, 0);
+			expect(totalInput).toBe(TURN_COUNT);
+			expect(totalOutput).toBe(TURN_COUNT);
+			expect(attributions.at(-1)?.aggregateUsage).toMatchObject({ input: TURN_COUNT, output: TURN_COUNT });
 		});
 	});
 


### PR DESCRIPTION
Fixes #1054.

Posted for review after discussion in #1788 (per CONTRIBUTING.md's contribution process). Credits @Lauritz-Timm's prior #1060/#1061 upfront -- see the Discussion for the comparison.

## Summary

With active RLM subagents, every child assistant `message_end` appends a `child_usage_attributed` entry to the parent session's transcript, synchronously and unconditionally. With a few fast-working subagents this becomes a firehose: one report measured 553 attribution entries in 20 minutes (peak 73/min), each a full ~600-byte transcript entry that also mutates the parent's assistant-message usage object and advances the transcript leaf/index on every single call. The worker process hosting the parent + children saturated (97-99% CPU, 3.1 GB RSS observed), so the supervisor's `attach`/`heartbeats_list` commands timed out for 25+ minutes and the session became completely unreachable from the UI. This is #1054, one of the "related reports" under the still-open tracker #1382.

**Prior art, credited upfront:** @Lauritz-Timm already diagnosed this and proposed a fix in #1060/#1061 (both closed, not merged, via the maintainer's standard backlog-sweep note citing #1162 as "covering" this — but the underlying bug is still live on current `main`, confirmed with a new regression test below). Their approach and mine converge on the same root cause and a similar shape (accumulate pending usage, flush at a natural boundary, force-flush on cleanup), which isn't surprising given there's really one place in the code this can be fixed. The concrete difference: #1060/#1061 flush on `agent_end` and whenever the attribution `origin` changes; this PR instead debounces on a fixed time window (`RLM_CHILD_USAGE_ATTRIBUTION_COALESCE_MS`, 1s) regardless of origin, plus the same forced flush on run settlement. Either is a reasonable design; I'm not claiming this supersedes their work, just documenting an independent pass with a different coalescing trigger, in case it's a useful alternative or point of comparison for whoever picks this up.

## Root cause

The RLM child event subscriber in `spawnRlmChild` (`agent-session.ts`) calls `attributeChildUsage()` and `sessionManager.appendChildUsageAttribution()` directly and synchronously inside the `"message_end"` handler, once per child assistant message, with no batching of any kind.

## Fix

Track a per-run pending usage delta (summed via the existing `addAssistantUsage`, not just "keep the latest" — each message's usage is an independent, additive cost, so skipping intermediate messages would undercount) and debounce the actual attribute+persist call to at most once per `RLM_CHILD_USAGE_ATTRIBUTION_COALESCE_MS` (1000ms) of inactivity for that child. The run's existing `finally` block also force-flushes any still-pending delta before the child run settles, so a run that finishes inside the coalescing window never silently drops its last batch of usage. This lives entirely at the call site; `SessionManager.appendChildUsageAttribution`'s own contract (synchronous JSONL append) is unchanged, since other tests (`context-tree.test.ts`) rely on it persisting immediately when called.

## Tests

`packages/coding-agent/test/agent-session-recursion.test.ts`:
- Updated the existing "attributes every tool-loop turn..." test (previously asserted exactly 2 separate attribution entries for a 2-turn tool loop): now asserts exactly 1 coalesced entry with the correct combined usage.
- Added "persists far fewer entries than turns for a chatty child...": 20 rapid tool-loop turns produce far fewer than 20 attribution entries (< 10), while the sum of every persisted entry's `childUsage` still equals the exact total across all 20 turns — directly modeling the reported ~550-messages-to-~550-entries shape, now collapsed (21 entries for 20 turns on the pre-fix code, matching the bug's ratio almost exactly).

Both verified to fail against the pre-fix code and pass after.

## Validation

```
cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run \
  test/agent-session-recursion.test.ts test/context-tree.test.ts \
  test/suite/agent-session-queue.test.ts test/suite/agent-session-autonomous.test.ts \
  test/suite/agent-session-goal.test.ts
# 301 passed. 3 pre-existing, unrelated failures (rlmMaxDepth env-var pollution)
# reproduce identically on unmodified main.
```

`npx tsgo -p tsconfig.json --noEmit` and the root `npm run check` (biome, tsgo, installer render, browser smoke) both pass. Added a `packages/coding-agent/.changes/` fragment per the changelog-fragment CI check.