### PR TITLE
fix(coding-agent): pause a stalled goal instead of looping continuations

### DIFF
--- a/packages/coding-agent/.changes/eng-goal-stall-pause-resume.md
+++ b/packages/coding-agent/.changes/eng-goal-stall-pause-resume.md
@@ -1,0 +1,1 @@
+- Fixed Goal Mode injecting identical continuations forever when the model was blocked on user input; a stalled goal now pauses as waiting for user input and resumes on the next user prompt ([#986](https://github.com/PrimeIntellect-ai/prime-agent/issues/986), design and tests originally by [@romankhadka](https://github.com/romankhadka) in #1113).

--- a/packages/coding-agent/docs/long-running-agents.md
+++ b/packages/coding-agent/docs/long-running-agents.md
@@ -196,6 +196,8 @@ await goal.complete()
 
 Goal state records token usage, elapsed time, continuation count, and an optional explicit token budget. The harness keeps prompting an active goal after ordinary assistant turns; only `goal.complete()` marks successful completion. Creating a persistent goal is an explicit user or host action, not something the agent should infer from every task.
 
+Continuations stop when they can no longer make progress. When consecutive goal continuations end without a tool call or a new user message, the goal pauses as waiting for user input instead of re-presenting the same context. A goal paused this way resumes automatically on the next user prompt; an explicit `/goal pause` stays paused until `/goal resume`.
+
 ## Autonomous Mode
 
 Autonomous mode is a bounded host policy for runs where no human input is expected. Prime Agent adds follow-up continuations until configured quality gates pass or a continuation, turn, token, or wall-clock limit is reached.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -149,8 +149,10 @@ import {
 	GOAL_SKILL_NAME,
 	GOAL_STATE_CUSTOM_TYPE,
 	type GoalHostResponse,
+	type GoalPausedBy,
 	type GoalState,
 	type GoalStatus,
+	goalContinuationIsStalled,
 	goalHostResponse,
 	goalTokenDeltaForUsage,
 	isPersistedGoalState,
@@ -1803,7 +1805,7 @@ export class AgentSession {
 		this._setGoalState(emptyGoalState());
 	}
 
-	private _pauseGoal(reason = "Paused by user"): void {
+	private _pauseGoal(reason = "Paused by user", pausedBy: GoalPausedBy = "user"): void {
 		this._clearQueuedGoalContexts();
 		if (this._goalState.status !== "active") {
 			this._emitGoalUpdate();
@@ -1814,8 +1816,28 @@ export class AgentSession {
 			...goal,
 			active: false,
 			status: "paused",
+			pausedBy,
 			lastReason: reason,
 			lastError: undefined,
+		});
+	}
+
+	/**
+	 * Reactivate a goal the host paused waiting for user input (see
+	 * goalContinuationIsStalled). The user message being admitted supplies that
+	 * input; the regular continuation hook takes over after the turn, so no
+	 * goal context is injected here. An explicit `/goal pause` (pausedBy
+	 * "user") is not resumed by this -- only `/goal resume` reactivates it.
+	 */
+	private _resumeGoalForUserInput(): void {
+		if (this._goalState.pausedBy !== "host") {
+			return;
+		}
+		this._setGoalState({
+			...this._goalState,
+			active: true,
+			status: "active",
+			lastReason: undefined,
 		});
 	}
 
@@ -3289,6 +3311,10 @@ export class AgentSession {
 		}
 		this._goalContinuationAwaitsRlmWork = false;
 		try {
+			if (goalContinuationIsStalled(context.newMessages)) {
+				this._pauseGoal("Waiting for user input: goal continuations repeatedly ended without tool calls", "host");
+				return [];
+			}
 			this._ensureGoalRuntimeActive(context.context);
 			const nextGoal = {
 				...this._goalState,
@@ -4888,6 +4914,13 @@ export class AgentSession {
 					return;
 				}
 
+				// A genuine user prompt supplies the input a stall-paused goal was
+				// waiting for. Host-generated internal prompts and custom-message
+				// deliveries (heartbeats, agent messages) do not resume it.
+				if (!isInternalPrompt && !options?.customMessage) {
+					this._resumeGoalForUserInput();
+				}
+
 				const queueForStreaming = this.isStreaming;
 				const queueForBusy = options?.queueIfBusy === true && this._isBusyForSessionInput("preflight");
 				const visibleQueued = queueForStreaming || queueForBusy;
@@ -5084,6 +5117,7 @@ export class AgentSession {
 			throw new Error("Queued prompt normalization did not produce a prompt");
 		}
 
+		this._resumeGoalForUserInput();
 		await this._queuePreparedPrompt("steer", normalized.text, normalized.images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,
@@ -5117,6 +5151,7 @@ export class AgentSession {
 			throw new Error("Queued prompt normalization did not produce a prompt");
 		}
 
+		this._resumeGoalForUserInput();
 		return this._queuePreparedPrompt("followUp", normalized.text, normalized.images, {
 			queueKey: options.queueKey,
 			agentMessageId: options.agentMessageId,

--- a/packages/coding-agent/src/core/goals.ts
+++ b/packages/coding-agent/src/core/goals.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import type { CustomMessage } from "./messages.js";
 
@@ -7,8 +8,28 @@ export const GOAL_CONTEXT_PREVIEW_LABEL = "Goal context";
 export const GOAL_SKILL_NAME = "goal";
 export const MAX_THREAD_GOAL_OBJECTIVE_CHARS = 4000;
 
+/**
+ * Number of consecutive goal continuations that may end without a tool call or
+ * new user message before the goal pauses as waiting for user input. Below
+ * this a continuation is a legitimate nudge; at this count the model has
+ * repeatedly declined to act (e.g. it is waiting on approval, a credential, or
+ * an unanswered question) and re-injecting the same context cannot make
+ * progress -- the goal-mode analogue of `DEFAULT_AUTONOMOUS_LIMITS.maxContinuations`.
+ *
+ * Design credit: this stall-detection approach (count consecutive
+ * no-progress continuation windows, pause as "waiting for user input", resume
+ * on the next genuine user message) is @romankhadka's from #1113 (closed,
+ * unmerged, for #986). Ported here against current main with the same
+ * algorithm and design rationale.
+ */
+export const MAX_STALLED_GOAL_CONTINUATIONS = 3;
+
 export type GoalStatus = "idle" | "active" | "paused" | "budget_limited" | "complete" | "error";
 export type GoalContextKind = "continuation" | "budget_limit" | "objective_updated";
+/** Why a paused goal is paused: "host" is the stall detector (resumed automatically
+ * by the next genuine user message); "user" is an explicit `/goal pause` (only
+ * `/goal resume` reactivates it). */
+export type GoalPausedBy = "user" | "host";
 
 export interface GoalState {
 	active: boolean;
@@ -23,6 +44,7 @@ export interface GoalState {
 	updatedAt?: number;
 	lastReason?: string;
 	lastError?: string;
+	pausedBy?: GoalPausedBy;
 }
 
 /** Goal payload returned to the kernel-side goal skill. Keys are Python-conventional snake_case. */
@@ -69,6 +91,7 @@ export function normalizeGoalState(goal: GoalState): GoalState {
 		tokensUsed: Math.max(0, Math.trunc(goal.tokensUsed)),
 		timeUsedSeconds: Math.max(0, Math.trunc(goal.timeUsedSeconds)),
 		continuationsUsed: Math.max(0, Math.trunc(goal.continuationsUsed)),
+		pausedBy: goal.status === "paused" ? goal.pausedBy : undefined,
 	};
 }
 
@@ -179,6 +202,38 @@ export function createGoalContextMessage(
 	};
 }
 
+/**
+ * Whether injecting another goal continuation into this run would only repeat
+ * the previous one. True when the run's trailing `MAX_STALLED_GOAL_CONTINUATIONS`
+ * goal-context windows all ended without progress: the model saw the same
+ * context that many times and chose no observable action, so the goal should
+ * pause and wait for user input instead of looping. A tool call is observable
+ * work and a user message is new information that can unblock the goal, so
+ * either one ends the stall; host-injected custom messages (heartbeats, agent
+ * messages) are neither.
+ */
+export function goalContinuationIsStalled(runMessages: AgentMessage[]): boolean {
+	let stalledWindows = 0;
+	// Walk backward; each goal context closes the window of messages after it.
+	for (let index = runMessages.length - 1; index >= 0; index--) {
+		const message = runMessages[index];
+		if (message.role === "custom" && message.customType === GOAL_CONTEXT_CUSTOM_TYPE) {
+			stalledWindows++;
+			if (stalledWindows >= MAX_STALLED_GOAL_CONTINUATIONS) {
+				return true;
+			}
+			continue;
+		}
+		if (message.role === "user") {
+			return false;
+		}
+		if (message.role === "assistant" && message.content.some((block) => block.type === "toolCall")) {
+			return false;
+		}
+	}
+	return false;
+}
+
 export function formatGoalUsage(goal: GoalState): string | undefined {
 	if (goal.tokenBudget !== undefined) {
 		return `${goal.tokensUsed} / ${goal.tokenBudget} tokens`;
@@ -226,7 +281,9 @@ The goal persists across turns. Ending one turn does not reduce or redefine the 
 
 Before marking the goal complete, audit the current state against every requirement in the objective. Do not rely on intent, partial progress, memory of earlier work, or a plausible final answer as proof of completion. If the objective is achieved, run \`await goal.complete()\` in ipython so usage accounting is preserved.
 
-Do not call \`goal.complete()\` unless the goal is complete. Do not mark a goal complete merely because the budget is nearly exhausted or because you are stopping work.`;
+Do not call \`goal.complete()\` unless the goal is complete. Do not mark a goal complete merely because the budget is nearly exhausted or because you are stopping work.
+
+If you cannot make progress without new user input (a required approval, credential, or answer), state what you are waiting for and end the turn without tool calls. After repeated turns with no tool calls the goal pauses automatically and resumes with the next user message.`;
 }
 
 function budgetLimitPrompt(goal: GoalState): string {

--- a/packages/coding-agent/test/suite/regressions/986-goal-continuation-loop.test.ts
+++ b/packages/coding-agent/test/suite/regressions/986-goal-continuation-loop.test.ts
@@ -1,0 +1,233 @@
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSession } from "../../../src/core/agent-session.js";
+import {
+	GOAL_CONTEXT_CUSTOM_TYPE,
+	goalContinuationIsStalled,
+	MAX_STALLED_GOAL_CONTINUATIONS,
+} from "../../../src/core/goals.js";
+import { createHarness, getAssistantTexts, type Harness } from "../harness.js";
+
+/**
+ * Regression for https://github.com/PrimeIntellect-ai/prime-agent/issues/986.
+ *
+ * A goal whose continuations repeatedly produce no tool calls (the model is
+ * blocked on user approval, credentials, or an unanswered question) must pause
+ * as waiting for user input instead of injecting identical goal contexts
+ * forever, and must resume when the user actually replies.
+ *
+ * Test design and fixtures are @romankhadka's from #1113 (closed, unmerged),
+ * ported here against current main alongside the matching goals.ts /
+ * agent-session.ts changes -- see that PR's final revision for the original.
+ */
+
+/**
+ * Stand-in for the real ipython tool. `goal.*` cells are dispatched to the
+ * session's goal host-request handler, mirroring the kernel comm bridge;
+ * any other cell is a plain successful execution.
+ */
+function createFauxIpythonTool(sessionRef: { current?: AgentSession }): AgentTool {
+	return {
+		name: "ipython",
+		label: "ipython",
+		description: "Execute Python code in the agent kernel.",
+		parameters: Type.Object({ code: Type.String() }),
+		execute: async (_toolCallId, params) => {
+			const session = sessionRef.current;
+			if (!session) {
+				throw new Error("test session is not initialized");
+			}
+			const code = (params as { code: string }).code.trim();
+			let text = "";
+			if (code.startsWith("goal.")) {
+				const spaceIndex = code.indexOf(" ");
+				const type = spaceIndex < 0 ? code : code.slice(0, spaceIndex);
+				const payload = spaceIndex < 0 ? {} : JSON.parse(code.slice(spaceIndex + 1));
+				text = JSON.stringify(session.handleGoalHostRequest(type, payload));
+			}
+			return {
+				content: [{ type: "text", text }],
+				details: {},
+			};
+		},
+	};
+}
+
+function goalContextMessages(harness: Harness) {
+	return harness.session.messages.filter(
+		(message) => message.role === "custom" && message.customType === GOAL_CONTEXT_CUSTOM_TYPE,
+	);
+}
+
+function fauxGoalContext(): AgentMessage {
+	return {
+		role: "custom",
+		customType: GOAL_CONTEXT_CUSTOM_TYPE,
+		content: "<goal_context>continue</goal_context>",
+		display: true,
+		timestamp: 0,
+	};
+}
+
+function waitingReplies(count: number, text: string) {
+	return Array.from({ length: count }, () => fauxAssistantMessage(text));
+}
+
+describe("regression #986: goal continuation loop", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	async function createGoalHarness(options: { initialGoal?: { objective: string } } = {}): Promise<Harness> {
+		const sessionRef: { current?: AgentSession } = {};
+		const harness = await createHarness({
+			tools: [createFauxIpythonTool(sessionRef)],
+			initialGoal: options.initialGoal,
+		});
+		sessionRef.current = harness.session;
+		harnesses.push(harness);
+		return harness;
+	}
+
+	async function createStallPausedHarness(): Promise<Harness> {
+		const harness = await createGoalHarness();
+		harness.setResponses(waitingReplies(MAX_STALLED_GOAL_CONTINUATIONS, "Still waiting for approval."));
+		await harness.session.prompt("/goal ship the release after approval");
+		expect(harness.session.goalState).toMatchObject({ status: "paused", pausedBy: "host" });
+		return harness;
+	}
+
+	it("pauses the goal as waiting for user input after repeated continuations without tool calls", async () => {
+		const harness = await createGoalHarness();
+		harness.setResponses(
+			waitingReplies(MAX_STALLED_GOAL_CONTINUATIONS, "State unchanged: still waiting for the sandbox key."),
+		);
+
+		await harness.session.prompt("/goal run the evidence harness once the sandbox key arrives");
+
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "paused",
+			pausedBy: "host",
+			continuationsUsed: MAX_STALLED_GOAL_CONTINUATIONS - 1,
+		});
+		expect(harness.session.goalState.lastReason).toContain("Waiting for user input");
+		// Initial context plus the allowed continuations; the loop must not run on.
+		expect(goalContextMessages(harness)).toHaveLength(MAX_STALLED_GOAL_CONTINUATIONS);
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("resets the stall window when a continuation turn makes a tool call", async () => {
+		const harness = await createGoalHarness();
+		harness.setResponses([
+			...waitingReplies(MAX_STALLED_GOAL_CONTINUATIONS - 1, "Still thinking."),
+			fauxAssistantMessage(fauxToolCall("ipython", { code: "print('working')" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("Ran the script; waiting for review."),
+			...waitingReplies(MAX_STALLED_GOAL_CONTINUATIONS, "State unchanged: waiting for review."),
+		]);
+
+		await harness.session.prompt("/goal run the script and wait for review");
+
+		expect(harness.session.goalState).toMatchObject({
+			status: "paused",
+			pausedBy: "host",
+		});
+		// The tool-call turn resets the stall count, so a full round of toolless
+		// continuations is needed again before the goal pauses.
+		expect(goalContextMessages(harness)).toHaveLength(MAX_STALLED_GOAL_CONTINUATIONS * 2);
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("resumes a stall-paused goal on the next user prompt and keeps continuing", async () => {
+		const harness = await createStallPausedHarness();
+
+		harness.appendResponses([
+			fauxAssistantMessage("Approval received, shipping."),
+			fauxAssistantMessage(fauxToolCall("ipython", { code: "goal.complete" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("Shipped."),
+		]);
+
+		await harness.session.prompt("Approved, go ahead.");
+
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "complete",
+			lastReason: "Goal achieved",
+		});
+		// The user prompt reactivated continuations: one more goal context was
+		// injected after the reply before the model completed the goal.
+		expect(goalContextMessages(harness)).toHaveLength(MAX_STALLED_GOAL_CONTINUATIONS + 1);
+		const statusHistory = harness.eventsOfType("goal_update").map((event) => event.goal.status);
+		expect(statusHistory.indexOf("paused")).toBeGreaterThanOrEqual(0);
+		expect(statusHistory.lastIndexOf("active")).toBeGreaterThan(statusHistory.indexOf("paused"));
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("resumes a stall-paused goal for user input delivered via followUp", async () => {
+		const harness = await createStallPausedHarness();
+
+		harness.appendResponses([
+			fauxAssistantMessage(fauxToolCall("ipython", { code: "goal.complete" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("Shipped."),
+		]);
+
+		await harness.session.followUp("Approved, go ahead.", undefined, { resumeIfIdle: true });
+		await harness.session.waitForSessionInputIdle();
+
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "complete",
+			lastReason: "Goal achieved",
+		});
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("does not resume an explicitly paused goal on a user prompt", async () => {
+		const harness = await createGoalHarness({ initialGoal: { objective: "hold until told otherwise" } });
+		await harness.session.prompt("/goal pause");
+		expect(harness.session.goalState).toMatchObject({ status: "paused", pausedBy: "user" });
+
+		harness.setResponses([fauxAssistantMessage("Hello!")]);
+		await harness.session.prompt("Hi there.");
+
+		expect(harness.session.goalState).toMatchObject({ status: "paused", pausedBy: "user" });
+		expect(goalContextMessages(harness)).toHaveLength(0);
+		expect(getAssistantTexts(harness)).toEqual(["Hello!"]);
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("detects stalled continuation windows only when they are consecutive and trailing", () => {
+		const text = () => fauxAssistantMessage("no progress");
+		const toolCall = () =>
+			fauxAssistantMessage(fauxToolCall("ipython", { code: "print('x')" }), { stopReason: "toolUse" });
+		const userReply: AgentMessage = { role: "user", content: "new information", timestamp: 0 };
+
+		const stalledRun = Array.from({ length: MAX_STALLED_GOAL_CONTINUATIONS }, () => [
+			fauxGoalContext(),
+			text(),
+		]).flat();
+		expect(goalContinuationIsStalled(stalledRun)).toBe(true);
+
+		const oneWindowShort = stalledRun.slice(2);
+		expect(goalContinuationIsStalled(oneWindowShort)).toBe(false);
+
+		const userInLastWindow = [...stalledRun, userReply];
+		expect(goalContinuationIsStalled(userInLastWindow)).toBe(false);
+
+		const toolCallInMiddleWindow = [
+			fauxGoalContext(),
+			text(),
+			fauxGoalContext(),
+			toolCall(),
+			fauxGoalContext(),
+			text(),
+		];
+		expect(goalContinuationIsStalled(toolCallInMiddleWindow)).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #986.

Posted for review after discussion in #1790 (per CONTRIBUTING.md's contribution process). This is a port of @romankhadka's prior #1113 -- see the Discussion for full credit and comparison.

## Credit upfront

This fix's design, algorithm, and full regression test suite are **@romankhadka's**, from #1113 (closed, not merged, via the maintainer's standard backlog-sweep note citing #1165 as "covering" this -- the underlying bug is still live on current `main`, confirmed below by porting #1113's own tests and verifying they fail on pre-fix `main`). This is a port of that PR's final revision against current `main`, not independent (re)discovery. If a maintainer picks this up, #1113 and @romankhadka should be the credited source.

## Summary

Goal Mode enters an infinite continuation loop when the goal has no remaining actionable work and is waiting for explicit user input or an external resource. The agent correctly determines it should not proceed without confirmation and returns a coherent "waiting" response — but Goal Mode immediately injects another `goal_context` continuation and the model produces essentially the same response again, indefinitely, consuming tokens and compute without making progress. This is #986.

## Root cause

`_getGoalContinuationMessages` only stops continuing the goal when the terminal assistant message's `stopReason` is `"error"` or `"aborted"`. A normal, successful "I'm blocked, waiting for confirmation" reply ends with `stopReason` `"stop"`/`"toolUse"` like any other reply, so nothing distinguishes a stalled goal from one making real progress; the goal stays `"active"` and `continuationsUsed` just increments forever.

## Fix

`goalContinuationIsStalled(runMessages)` walks the run's message history backward and counts consecutive `goal_context` continuation windows since the last tool call or user message. After `MAX_STALLED_GOAL_CONTINUATIONS` (3) consecutive windows with no observable progress, the goal pauses as `GoalPausedBy` `"host"` (distinct from an explicit `/goal pause`, `"user"`) instead of injecting another continuation. A genuine user message — via `prompt()`, `steer()`, or `followUp()` — resumes a host-paused goal automatically (an explicit `/goal pause` is untouched; only `/goal resume` reactivates that one). Host-generated internal prompts and custom-message deliveries (heartbeats, agent messages) do not resume it, matching the intent that only real new information from the user can unblock a stalled goal.

## Tests

Ported #1113's final `986-goal-continuation-loop.test.ts` (6 cases) verbatim against current `main`:
- pauses after `MAX_STALLED_GOAL_CONTINUATIONS` toolless continuations
- the stall window resets on a tool call
- resumes via `prompt()` and via `followUp()`
- an explicit `/goal pause` is not auto-resumed
- a focused unit test for `goalContinuationIsStalled`'s window-boundary logic

All 6 verified to fail against pre-fix `main` (either a hard `TypeError` for the missing function, or the goal spinning past "paused" into an unrelated "error" state from exhausting other limits) and pass after the port.

## Validation

```
cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run \
  test/suite/regressions/986-goal-continuation-loop.test.ts test/suite/agent-session-goal.test.ts \
  test/suite/agent-session-queue.test.ts test/suite/agent-session-autonomous.test.ts \
  test/agent-session-recursion.test.ts
# 295 passed. 3 pre-existing, unrelated failures in agent-session-recursion.test.ts
# (rlmMaxDepth env-var pollution) reproduce identically on unmodified main.
```

`npx tsgo -p tsconfig.json --noEmit` and the root `npm run check` (biome, tsgo, installer render, browser smoke) both pass. Added a `packages/coding-agent/.changes/` fragment, credited to #1113/@romankhadka, per the changelog-fragment CI check.