### PR TITLE
fix(coding-agent): skip directory fsync in journal compaction on Windows

### DIFF
--- a/packages/coding-agent/.changes/fix-windows-directory-fsync-journal.md
+++ b/packages/coding-agent/.changes/fix-windows-directory-fsync-journal.md
@@ -1,0 +1,1 @@
+- Fixed command-recovery-journal compaction, which threw `EPERM: operation not permitted, fsync` on Windows and repeatedly disabled daemon command acknowledgements.

--- a/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
+++ b/packages/coding-agent/src/modes/daemon/command-recovery-journal.ts
@@ -206,11 +206,16 @@ export class CommandRecoveryJournal {
 			closeSync(descriptor);
 		}
 		renameSync(tempPath, this.path);
-		const directoryDescriptor = openSync(dirname(this.path), "r");
-		try {
-			fsyncSync(directoryDescriptor);
-		} finally {
-			closeSync(directoryDescriptor);
+		// fsyncSync on a directory descriptor is unsupported on Windows and
+		// throws EPERM; the rename durability it would provide is not needed
+		// there. Keep it on POSIX only to avoid failing every compaction.
+		if (process.platform !== "win32") {
+			const directoryDescriptor = openSync(dirname(this.path), "r");
+			try {
+				fsyncSync(directoryDescriptor);
+			} finally {
+				closeSync(directoryDescriptor);
+			}
 		}
 		this.recordCount = records.length;
 	}


### PR DESCRIPTION
## Problem

The daemon command-recovery journal calls `fsyncSync()` on a **directory** file descriptor during `compact()`. On Windows this throws `EPERM: operation not permitted, fsync`, which broke daemon command acknowledgements at every compaction.

## Fix

Skip the directory fsync on Windows; keep it on POSIX where it provides rename durability.

Verified on this Windows box (Git Bash + node):
- `test/command-recovery-journal.test.ts` — 6/6 pass
- Full `npm run check` — pass
