### PR TITLE
refactor(coding-agent): unify kernel graceful shutdown

### DIFF
--- a/packages/coding-agent/.changes/single-kernel-shutdown.md
+++ b/packages/coding-agent/.changes/single-kernel-shutdown.md
@@ -1,0 +1,1 @@
+- Fixed kernel teardown so session cleanup and signal handling share one bounded graceful shutdown path.

--- a/packages/coding-agent/src/core/kernel/repl-manager.ts
+++ b/packages/coding-agent/src/core/kernel/repl-manager.ts
@@ -896,7 +896,7 @@ export class ReplKernelManager {
 		}
 	}
 
-	/** Resolves true when this call performed the cleanup (false: a concurrent teardown won). */
+	/** Resolves true when this call performed the cleanup (false: a concurrent teardown won; a joiner's options are ignored - the first caller's policy wins). */
 	async shutdown(opts: KernelShutdownOptions = {}): Promise<boolean> {
 		const inFlightShutdown = this.gracefulShutdownPromise;
 		if (inFlightShutdown) {
@@ -925,6 +925,7 @@ export class ReplKernelManager {
 			await this.flushSnapshotForDispose();
 			if (this.startStale(generation)) return false;
 		}
+		// Protocol shutdown first: the runtime closes MCP servers and kills live bash() process groups a bare hard-kill would leak.
 		const protocolShutdownAvailable = this.state === "running";
 		this.state = "shutdown";
 		liveKernels.delete(this);

--- a/packages/coding-agent/src/core/kernel/repl-manager.ts
+++ b/packages/coding-agent/src/core/kernel/repl-manager.ts
@@ -17,7 +17,7 @@ import {
 	type ExecuteOptions,
 	type ExecuteResult,
 	errorMessage,
-	HOST_REQUEST_DISPOSE_TIMEOUT_MS,
+	HOST_REQUEST_SHUTDOWN_TIMEOUT_MS,
 	installSignalHandlersOnce,
 	isRecord,
 	KERNEL_ABORT_GRACE_MS,
@@ -29,6 +29,7 @@ import {
 	type KernelDiffDisplay,
 	type KernelManagerOptions,
 	type KernelSentAgentMessage,
+	type KernelShutdownOptions,
 	type KernelStartOptions,
 	liveKernels,
 	MAX_ATTACHMENT_DATA_CHARS,
@@ -129,6 +130,7 @@ export class ReplKernelManager {
 	private startGeneration = 0;
 	/** Generation whose graceful shutdown() owns the teardown, so the exit handler must not run it. */
 	private gracefulShutdownGeneration?: number;
+	private gracefulShutdownPromise?: Promise<boolean>;
 	/** Memoized so concurrent callers all await the same in-flight startup. */
 	private startPromise?: Promise<void>;
 	/** Pending debounced auto-snapshot, if one has been scheduled. */
@@ -889,13 +891,29 @@ export class ReplKernelManager {
 		}
 		if (result === "timeout") {
 			this.appendKernelDiagnostic(
-				`timed out waiting ${timeoutMs}ms for ${tasks.length} host request task(s) during dispose`,
+				`timed out waiting ${timeoutMs}ms for ${tasks.length} host request task(s) during shutdown`,
 			);
 		}
 	}
 
 	/** Resolves true when this call performed the cleanup (false: a concurrent teardown won). */
-	async shutdown(opts: { snapshot?: boolean } = {}): Promise<boolean> {
+	async shutdown(opts: KernelShutdownOptions = {}): Promise<boolean> {
+		const inFlightShutdown = this.gracefulShutdownPromise;
+		if (inFlightShutdown) {
+			await inFlightShutdown;
+			return false;
+		}
+
+		const operation = this.performShutdown(opts);
+		this.gracefulShutdownPromise = operation;
+		try {
+			return await operation;
+		} finally {
+			if (this.gracefulShutdownPromise === operation) this.gracefulShutdownPromise = undefined;
+		}
+	}
+
+	private async performShutdown(opts: KernelShutdownOptions): Promise<boolean> {
 		if (this.state === "shutdown") {
 			liveKernels.delete(this);
 			this.cleanupResources();
@@ -903,42 +921,47 @@ export class ReplKernelManager {
 		}
 		// Captured before any await: teardowns and newer starts bump the counter.
 		const generation = this.startGeneration;
-		// Best-effort final flush (bounded) before teardown — used by signal handlers
-		// so a SIGINT/SIGTERM exit doesn't lose work the debounced snapshot hasn't saved.
 		if (opts.snapshot) {
 			await this.flushSnapshotForDispose();
-			if (this.startStale(generation)) return false; // superseded mid-flush: the newer owner already cleaned this kernel
+			if (this.startStale(generation)) return false;
 		}
+		const protocolShutdownAvailable = this.state === "running";
 		this.state = "shutdown";
 		liveKernels.delete(this);
-		// Claim the teardown: our own child's exit handler must not run cleanupResources
-		// (which bumps the generation and would misread this call as superseded). A
-		// concurrent kill()/dispose() still bumps the generation and supersedes us.
 		this.gracefulShutdownGeneration = generation;
 
 		let shutdownTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
 		let doneWaiterId: string | undefined;
 		let performedCleanup = false;
-		const shutdownDeadline = new Promise<never>((_resolve, reject) => {
-			shutdownTimer = globalThis.setTimeout(
-				() => reject(new Error(`Kernel did not shut down within ${KERNEL_SHUTDOWN_TIMEOUT_MS}ms`)),
-				KERNEL_SHUTDOWN_TIMEOUT_MS,
-			);
-			shutdownTimer.unref?.();
-		});
 		try {
-			if (this.child?.stdin && !this.child.stdin.destroyed) {
+			if (opts.drainHostRequests) {
+				const inFlightHostRequests = [...this.inFlightHostRequests];
+				if (inFlightHostRequests.length > 0) {
+					await this.waitForHostRequestsToSettle(inFlightHostRequests, HOST_REQUEST_SHUTDOWN_TIMEOUT_MS);
+				}
+			}
+			if (
+				protocolShutdownAvailable &&
+				!this.startStale(generation) &&
+				this.child?.stdin &&
+				!this.child.stdin.destroyed
+			) {
 				const requestId = uuid();
 				doneWaiterId = requestId;
 				const doneReply = new Promise<void>((resolve) => {
 					this.pendingDoneWaiters.set(requestId, resolve);
 				});
+				const shutdownDeadline = new Promise<never>((_resolve, reject) => {
+					shutdownTimer = globalThis.setTimeout(
+						() => reject(new Error(`Kernel did not shut down within ${KERNEL_SHUTDOWN_TIMEOUT_MS}ms`)),
+						KERNEL_SHUTDOWN_TIMEOUT_MS,
+					);
+					shutdownTimer.unref?.();
+				});
 				const send = this.writeLine({ type: "shutdown", id: requestId });
 				send.catch(() => undefined);
-				// A kernel that exits without delivering its shutdown done must not stall the deadline.
 				const kernelExit = this.waitForKernelExit();
 				const gracefulReply = Promise.all([send, doneReply]);
-				// Abandoned by the race, a late send failure must not reject unhandled.
 				gracefulReply.catch(() => undefined);
 				await Promise.race([gracefulReply, kernelExit, shutdownDeadline]);
 				await Promise.race([kernelExit, shutdownDeadline]);
@@ -951,8 +974,6 @@ export class ReplKernelManager {
 			if (shutdownTimer) globalThis.clearTimeout(shutdownTimer);
 			if (doneWaiterId) this.pendingDoneWaiters.delete(doneWaiterId);
 			if (this.gracefulShutdownGeneration === generation) this.gracefulShutdownGeneration = undefined;
-			// A superseded shutdown must not tear down the newer start's kernel. Ownership is decided
-			// here, before cleanupResources bumps the generation and would misread this call as superseded.
 			if (!this.startStale(generation)) {
 				this.cleanupResources();
 				performedCleanup = true;
@@ -1112,66 +1133,6 @@ export class ReplKernelManager {
 			await Promise.race([this.snapshotState().then(() => undefined), guard]);
 		} finally {
 			if (timeout) clearTimeout(timeout);
-		}
-	}
-
-	/** Graceful cleanup. Waits briefly for in-flight host request handlers before killing the child. */
-	dispose(): Promise<void> {
-		return (async () => {
-			// Captured before any await: teardowns and newer starts bump the counter.
-			const generation = this.startGeneration;
-			// Final namespace flush while the kernel is still live (session end / reload).
-			await this.flushSnapshotForDispose();
-			if (this.startStale(generation)) return; // superseded mid-flush: the newer owner already cleaned this kernel
-			this.state = "shutdown";
-			liveKernels.delete(this);
-			// Claim the teardown so the child's exit handler does not run
-			// cleanupResources mid-dispose (same contract as shutdown()).
-			this.gracefulShutdownGeneration = generation;
-			const inFlightHostRequests = [...this.inFlightHostRequests];
-			try {
-				if (inFlightHostRequests.length > 0) {
-					await this.waitForHostRequestsToSettle(inFlightHostRequests, HOST_REQUEST_DISPOSE_TIMEOUT_MS);
-				}
-				if (!this.startStale(generation)) {
-					// Bounded protocol shutdown first: the runtime's shutdown branch
-					// closes MCP servers and kills live bash() process groups, which
-					// a bare hard-kill would leak until the orphan reaper runs.
-					await this.requestProtocolShutdown(KERNEL_SHUTDOWN_TIMEOUT_MS);
-				}
-			} finally {
-				if (this.gracefulShutdownGeneration === generation) this.gracefulShutdownGeneration = undefined;
-				if (!this.startStale(generation)) this.cleanupResources(); // else: superseded, the newer owner already cleaned
-			}
-		})();
-	}
-
-	/** Best-effort bounded protocol shutdown; the caller's hard kill remains the backstop. */
-	private async requestProtocolShutdown(timeoutMs: number): Promise<void> {
-		const stdin = this.child?.stdin;
-		if (!stdin || stdin.destroyed) return;
-		const requestId = uuid();
-		let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
-		try {
-			const doneReply = new Promise<void>((resolve) => {
-				this.pendingDoneWaiters.set(requestId, resolve);
-			});
-			const send = this.writeLine({ type: "shutdown", id: requestId });
-			send.catch(() => undefined);
-			const kernelExit = this.waitForKernelExit();
-			const deadline = new Promise<void>((resolve) => {
-				timer = globalThis.setTimeout(resolve, timeoutMs);
-				timer.unref?.();
-			});
-			const gracefulReply = Promise.all([send, doneReply]).then(() => undefined);
-			gracefulReply.catch(() => undefined);
-			await Promise.race([gracefulReply, kernelExit, deadline]);
-			await Promise.race([kernelExit, deadline]);
-		} catch {
-			// Best-effort: cleanupResources still hard-kills the child.
-		} finally {
-			if (timer) globalThis.clearTimeout(timer);
-			this.pendingDoneWaiters.delete(requestId);
 		}
 	}
 

--- a/packages/coding-agent/src/core/kernel/shared.ts
+++ b/packages/coding-agent/src/core/kernel/shared.ts
@@ -3,7 +3,7 @@ import type { KernelBootstrapProgressHandler, KernelPythonSkill } from "./bootst
 import type { RestoreResult, SnapshotResult } from "./state-snapshot.js";
 
 export const DEFAULT_MAX_OUTPUT_CHARS = 65536;
-export const HOST_REQUEST_DISPOSE_TIMEOUT_MS = 5000;
+export const HOST_REQUEST_SHUTDOWN_TIMEOUT_MS = 5000;
 export const KERNEL_SHUTDOWN_TIMEOUT_MS = 5000;
 export const DEFAULT_SNAPSHOT_DEBOUNCE_MS = 1500;
 // Cap how long a graceful dispose waits on the final snapshot; the debounced
@@ -344,16 +344,20 @@ export function createDeferred<T>(): Deferred<T> {
 	return { promise, resolve, reject };
 }
 
+export interface KernelShutdownOptions {
+	snapshot?: boolean;
+	drainHostRequests?: boolean;
+}
+
 /** Public surface every kernel client exposes to the provisioner and session layer. */
 export interface KernelClient {
 	readonly ownerSessionId: string | undefined;
 	readonly isRunning: boolean;
 	start(options?: KernelStartOptions): Promise<void>;
 	execute(code: string, opts?: ExecuteOptions): Promise<ExecuteResult>;
-	shutdown(opts?: { snapshot?: boolean }): Promise<boolean>;
+	shutdown(opts?: KernelShutdownOptions): Promise<boolean>;
 	restart(): Promise<void>;
 	kill(): Promise<void>;
-	dispose(): Promise<void>;
 	disposeSync(): void;
 	snapshotState(): Promise<SnapshotResult | null>;
 	pruneOversizedVariables(): Promise<SnapshotResult | null>;
@@ -369,7 +373,7 @@ let signalHandlersInstalled = false;
 registerSessionResourceCleanup((sessionId) => {
 	for (const k of liveKernels) {
 		if (!sessionId || k.ownerSessionId === sessionId) {
-			void k.dispose();
+			void k.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	}
 });

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -371,7 +371,7 @@ export class IpythonKernelProvisioner {
 		if (!pending) return;
 		try {
 			const m = await pending;
-			await m.dispose();
+			await m.shutdown({ snapshot: true, drainHostRequests: true });
 		} catch {
 			// a failed startup already cleaned up after itself
 		}
@@ -521,7 +521,7 @@ export class IpythonKernelProvisioner {
 				}
 			} catch (error) {
 				// Never leak the kernel process if startup fails after spawn.
-				void m.dispose();
+				void m.shutdown({ snapshot: true, drainHostRequests: true });
 				throw error;
 			}
 			// Only tell the model what was revived once the kernel is actually usable —

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -3906,7 +3906,7 @@ print(_result.name)
 			expect(finished.status).toBe("ok");
 			expect(finished.stdout.trim()).toBe("detached-worker");
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 });

--- a/packages/coding-agent/test/ipython-bootstrap.test.ts
+++ b/packages/coding-agent/test/ipython-bootstrap.test.ts
@@ -93,7 +93,7 @@ describeIfKernel("RLM bootstrap (real kernel)", () => {
 			expect(envResult.status).toBe("ok");
 			expect(envResult.stdout.trim()).toBe("1");
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	}, 60_000);
 
@@ -135,7 +135,7 @@ describeIfKernel("RLM bootstrap (real kernel)", () => {
 			expect(second.diffs?.[0]?.path).toBe(realpathSync(join(secondDir, "same.txt")));
 			expect(first.diffs?.[0]?.path).not.toBe(second.diffs?.[0]?.path);
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	}, 60_000);
 });

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -352,7 +352,7 @@ describe("ReplKernelManager session cleanup during startup", () => {
 			await expect(startup).rejects.toThrow(/Kernel exited before ready|disposed during startup/);
 			expect(manager.isRunning).toBe(false);
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 });

--- a/packages/coding-agent/test/kernel-agent-message-skill.test.ts
+++ b/packages/coding-agent/test/kernel-agent-message-skill.test.ts
@@ -277,6 +277,6 @@ background_send = asyncio.create_task(send_later())`,
 		expect(host.lateSentAgentMessageHandlers.size).toBe(256);
 		expect(host.lateSentAgentMessageHandlers.has("request-0")).toBe(false);
 		expect(host.lateSentAgentMessageHandlers.has("request-299")).toBe(true);
-		await manager.dispose();
+		await manager.shutdown({ snapshot: true, drainHostRequests: true });
 	});
 });

--- a/packages/coding-agent/test/repl-kernel-abort.test.ts
+++ b/packages/coding-agent/test/repl-kernel-abort.test.ts
@@ -328,7 +328,7 @@ describe("ReplKernelManager abort handling", () => {
 			stdin: { destroyed: false, destroy: () => undefined },
 		};
 
-		await manager.dispose();
+		await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		const types = writeLine.mock.calls.map((call) => (call[0] as { type?: string }).type);
 		expect(types).toContain("shutdown");
 		expect(killSignals).toContain("SIGTERM");

--- a/packages/coding-agent/test/repl-kernel-execute.test.ts
+++ b/packages/coding-agent/test/repl-kernel-execute.test.ts
@@ -37,7 +37,7 @@ describeIf("ReplKernelManager execute (real runtime)", () => {
 	});
 
 	afterEach(async () => {
-		await manager?.dispose();
+		await manager?.shutdown({ snapshot: true, drainHostRequests: true });
 		manager = undefined;
 		if (dir) {
 			rmSync(dir, { recursive: true, force: true });
@@ -128,7 +128,7 @@ describeIf("ReplKernelManager execute (real runtime)", () => {
 		expect(r.status).toBe("ok");
 		const pid = Number(r.result);
 		expect(Number.isInteger(pid)).toBe(true);
-		await manager.dispose();
+		await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		let alive = true;
 		for (let i = 0; i < 100; i++) {
 			try {

--- a/packages/coding-agent/test/repl-kernel-parent-watchdog.test.ts
+++ b/packages/coding-agent/test/repl-kernel-parent-watchdog.test.ts
@@ -65,7 +65,7 @@ describe("repl kernel parent watchdog", () => {
 			await expect(manager.execute("x")).rejects.toThrow(/Kernel exited before ready/);
 		} finally {
 			errorSpy.mockRestore();
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 
 		expect(readFileSync(envDump, "utf8")).toMatch(new RegExp(`^PRIME_AGENT_KERNEL_OWNER_PID=${process.pid}$`, "m"));
@@ -95,7 +95,7 @@ describe("repl kernel parent watchdog", () => {
 			const records = existsSync(journalPath) ? readJournalRecords(journalPath) : [];
 			expect(records.some((r) => r.pid === 999999 && !r.active)).toBe(false);
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 
@@ -115,7 +115,7 @@ describe("repl kernel parent watchdog", () => {
 			const records = readJournalRecords(journalPath);
 			expect(records.some((r) => r.pid === 999999 && !r.active)).toBe(true);
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 
@@ -160,7 +160,7 @@ describe("repl kernel parent watchdog", () => {
 		} finally {
 			internals.child = undefined;
 			internals.state = "idle";
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 
@@ -173,7 +173,7 @@ describe("repl kernel parent watchdog", () => {
 			shutdown(): Promise<boolean>;
 			kill(): Promise<void>;
 		};
-		internals.state = "starting";
+		internals.state = "running";
 		// A live child handle keeps waitForKernelExit parked so the send actually blocks the shutdown.
 		const child = Object.assign(new EventEmitter(), {
 			exitCode: null,
@@ -267,7 +267,7 @@ describe("repl kernel parent watchdog", () => {
 			internals.child = undefined;
 			internals.startPromise = undefined;
 			internals.state = "idle";
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 });

--- a/packages/coding-agent/test/repl-kernel-shutdown.test.ts
+++ b/packages/coding-agent/test/repl-kernel-shutdown.test.ts
@@ -11,6 +11,7 @@ type ShutdownInternals = {
 	wireChild: (child: ShutdownInternals["child"]) => void;
 	pendingDoneWaiters: Map<string, () => void>;
 	inFlightHostRequests: Set<Promise<void>>;
+	kernelStderr: string;
 	child: EventEmitter & {
 		exitCode: number | null;
 		signalCode: NodeJS.Signals | null;
@@ -25,11 +26,16 @@ type ShutdownInternals = {
 function configuredManager(
 	onSend: (request: Record<string, unknown>, internals: ShutdownInternals) => void | Promise<void>,
 	hostHandlers?: HostRequestHandlers,
+	withSnapshot = false,
 ): {
 	manager: ReplKernelManager;
 	internals: ShutdownInternals;
 } {
-	const manager = new ReplKernelManager({ cwd: process.cwd(), hostHandlers });
+	const manager = new ReplKernelManager({
+		cwd: process.cwd(),
+		hostHandlers,
+		snapshot: withSnapshot ? { path: "/tmp/shutdown-test.dill", manifestPath: "/tmp/shutdown-test.json" } : undefined,
+	});
 	const internals = manager as unknown as ShutdownInternals;
 	const child = Object.assign(new EventEmitter(), {
 		exitCode: null,
@@ -51,13 +57,18 @@ function configuredManager(
 }
 
 describe("ReplKernelManager graceful shutdown", () => {
-	it("bounds a stuck stdin write with the aggregate shutdown deadline", async () => {
+	it.each([
+		["optional policy", {}],
+		["snapshot-and-drain policy", { snapshot: true, drainHostRequests: true }],
+	] as const)("uses the same diagnostic deadline for the %s", async (_label, options) => {
 		vi.useFakeTimers();
 		try {
-			const { manager, internals } = configuredManager(() => new Promise<void>(() => {}));
-			const shutdown = manager.shutdown();
+			const { manager, internals } = configuredManager(() => new Promise<void>(() => {}), undefined, true);
+			vi.spyOn(manager, "snapshotState").mockResolvedValue(null);
+			const shutdown = manager.shutdown(options);
 			await vi.advanceTimersByTimeAsync(5_000);
-			await shutdown;
+			await expect(shutdown).resolves.toBe(true);
+			expect(internals.kernelStderr).toContain("Kernel did not shut down within 5000ms");
 			expect(internals.child).toBeUndefined();
 		} finally {
 			vi.useRealTimers();
@@ -104,15 +115,20 @@ describe("ReplKernelManager graceful shutdown", () => {
 		}
 	});
 
-	it("settles an in-flight host request before dispose tears the kernel down", async () => {
+	it("flushes a snapshot and drains host requests when session teardown selects both policies", async () => {
 		let releaseHandler: (() => void) | undefined;
 		const handlerBlocked = new Promise<void>((resolve) => {
 			releaseHandler = resolve;
 		});
 		const sentReplies: Record<string, unknown>[] = [];
 		const { manager, internals } = configuredManager(
-			async (request) => {
+			async (request, state) => {
 				if (request.type === "host_reply") sentReplies.push(request);
+				if (request.type === "shutdown") {
+					state.handleEvent({ event: "done", id: request.id, status: "ok" });
+					state.child.exitCode = 0;
+					state.child.emit("exit", 0, null);
+				}
 			},
 			{
 				"test.slow": async () => {
@@ -120,14 +136,18 @@ describe("ReplKernelManager graceful shutdown", () => {
 					return { answer: 42 };
 				},
 			},
+			true,
 		);
+		const snapshot = vi.spyOn(manager, "snapshotState").mockResolvedValue(null);
 
 		internals.handleEvent({ event: "host_request", id: "hr-1", data: { type: "test.slow" } });
-		expect(internals.inFlightHostRequests.size).toBe(1);
+		const shutdown = manager.shutdown({ snapshot: true, drainHostRequests: true });
+		await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
 
-		const dispose = manager.dispose();
+		expect(snapshot).toHaveBeenCalledOnce();
+		expect(internals.writeLine).not.toHaveBeenCalled();
 		releaseHandler?.();
-		await dispose;
+		await shutdown;
 
 		expect(internals.inFlightHostRequests.size).toBe(0);
 		expect(sentReplies).toEqual([{ type: "host_reply", id: "hr-1", data: { status: "ok", answer: 42 } }]);
@@ -152,19 +172,60 @@ describe("ReplKernelManager graceful shutdown", () => {
 					return { answer: 42 };
 				},
 			},
+			true,
 		);
+		const snapshot = vi.spyOn(manager, "snapshotState").mockResolvedValue(null);
 
 		internals.handleEvent({ event: "host_request", id: "hr-1", data: { type: "test.slow" } });
 		const tracked = [...internals.inFlightHostRequests];
 		expect(tracked).toHaveLength(1);
 
 		await manager.shutdown();
+		expect(snapshot).not.toHaveBeenCalled();
 		expect(internals.child).toBeUndefined();
 
 		// The reply write fails against the torn-down child; the task must still settle.
 		releaseHandler?.();
 		await Promise.all(tracked);
 		expect(internals.inFlightHostRequests.size).toBe(0);
+	});
+
+	it("shares one wire exchange across concurrent graceful shutdown calls", async () => {
+		let exitKernel: (() => void) | undefined;
+		const { manager, internals } = configuredManager((request, state) => {
+			state.handleEvent({ event: "done", id: request.id, status: "ok" });
+			exitKernel = () => {
+				state.child.exitCode = 0;
+				state.child.emit("exit", 0, null);
+			};
+		});
+
+		const owner = manager.shutdown();
+		await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+		const concurrent = manager.shutdown();
+		exitKernel?.();
+
+		await expect(owner).resolves.toBe(true);
+		await expect(concurrent).resolves.toBe(false);
+		expect(internals.writeLine).toHaveBeenCalledOnce();
+	});
+
+	it("stands down when a hard teardown supersedes the snapshot flush", async () => {
+		let releaseSnapshot: (() => void) | undefined;
+		const snapshotBlocked = new Promise<null>((resolve) => {
+			releaseSnapshot = () => resolve(null);
+		});
+		const { manager, internals } = configuredManager(() => undefined, undefined, true);
+		vi.spyOn(manager, "snapshotState").mockReturnValue(snapshotBlocked);
+		const child = internals.child;
+
+		const shutdown = manager.shutdown({ snapshot: true });
+		await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+		await manager.kill();
+		releaseSnapshot?.();
+
+		await expect(shutdown).resolves.toBe(false);
+		expect(child.kill).toHaveBeenCalledOnce();
 	});
 
 	it("restart after a graceful shutdown starts the kernel again", async () => {

--- a/packages/coding-agent/test/repl-kernel-startup.test.ts
+++ b/packages/coding-agent/test/repl-kernel-startup.test.ts
@@ -35,7 +35,7 @@ describe("ReplKernelManager startup", () => {
 			);
 		} finally {
 			errorSpy.mockRestore();
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 
@@ -52,7 +52,7 @@ describe("ReplKernelManager startup", () => {
 			await expect(manager.execute("print(1)")).rejects.toThrow(/speaks protocol 1, expected 2/);
 		} finally {
 			errorSpy.mockRestore();
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 
@@ -66,7 +66,7 @@ describe("ReplKernelManager startup", () => {
 			await expect(manager.start()).rejects.toThrow(/ENOENT/);
 		} finally {
 			errorSpy.mockRestore();
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 
@@ -87,7 +87,7 @@ describe("ReplKernelManager startup", () => {
 		} finally {
 			vi.useRealTimers();
 			errorSpy.mockRestore();
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	});
 });

--- a/packages/coding-agent/test/repl-kernel-state-roundtrip.test.ts
+++ b/packages/coding-agent/test/repl-kernel-state-roundtrip.test.ts
@@ -60,7 +60,7 @@ describeIfKernel("repl kernel state snapshot round-trip (real runtime)", { tags:
 			expect(existsSync(snapshotPath)).toBe(true);
 			expect(existsSync(manifestPath)).toBe(true);
 		} finally {
-			await writer.dispose();
+			await writer.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 
 		const reader = newManager();
@@ -72,7 +72,7 @@ describeIfKernel("repl kernel state snapshot round-trip (real runtime)", { tags:
 			const echo = await reader.execute("print(x, double(x), sum(df))");
 			expect(echo.stdout.trim()).toBe("42 84 6");
 		} finally {
-			await reader.dispose();
+			await reader.shutdown({ snapshot: true, drainHostRequests: true });
 		}
 	}, 60_000);
 
@@ -87,7 +87,7 @@ describeIfKernel("repl kernel state snapshot round-trip (real runtime)", { tags:
 			const restore = await manager.restoreState();
 			expect(restore).toEqual({ restored: [], failed: [], path: join(freshDir, "missing.dill") });
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 			rmSync(freshDir, { recursive: true, force: true });
 		}
 	}, 60_000);
@@ -125,7 +125,7 @@ describeIfKernel("repl kernel state snapshot round-trip (real runtime)", { tags:
 			const echo = await manager.execute("print(kept_number + 1, kept_text, 'In' in dir(), 'Out' in dir())");
 			expect(echo.stdout.trim()).toBe("42 hello False False");
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 			rmSync(ipythonArtifactDir, { recursive: true, force: true });
 		}
 	}, 60_000);
@@ -141,7 +141,7 @@ describeIfKernel("repl kernel state snapshot round-trip (real runtime)", { tags:
 			expect(names).not.toContain("_hidden");
 			expect(names).not.toContain("rlm");
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 			rmSync(listDir, { recursive: true, force: true });
 		}
 	}, 60_000);
@@ -170,7 +170,7 @@ describeIfKernel("repl kernel state snapshot round-trip (real runtime)", { tags:
 			expect(remaining).toContain("small_text");
 			expect(remaining).not.toContain("large_text");
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 			rmSync(boundedDir, { recursive: true, force: true });
 		}
 	}, 60_000);
@@ -187,7 +187,7 @@ describeIfKernel("repl kernel state snapshot round-trip (real runtime)", { tags:
 			await manager.execute("auto_var = 'persisted'");
 			await expect.poll(() => existsSync(autoPath), { timeout: 10_000 }).toBe(true);
 		} finally {
-			await manager.dispose();
+			await manager.shutdown({ snapshot: true, drainHostRequests: true });
 			rmSync(autoDir, { recursive: true, force: true });
 		}
 	}, 60_000);


### PR DESCRIPTION
Kernel graceful teardown now has exactly one owner.

- `shutdown(opts)` is the only async graceful teardown: it owns snapshot policy (`opts.snapshot`), optional in-flight host-request drain (`opts.drainHostRequests`), the single wire shutdown exchange, one rejecting deadline with one diagnostic policy, generation ownership, and final hard cleanup.
- `dispose()` and its drifted duplicate `requestProtocolShutdown()` are deleted. Session/provisioner cleanup uses `shutdown({snapshot: true, drainHostRequests: true})`; signal handlers keep `shutdown({snapshot: true})`; `disposeSync()` untouched.
- Concurrent callers share the in-flight operation; only the owner returns `true` (the contract `restart()` and start-failure recovery rely on). This is strictly safer than the previous last-caller-wins race.
- Protocol shutdown still precedes hard kill for running kernels (closes MCP servers and live bash() process groups); a starting-but-not-ready kernel cleans up immediately.

+151/-122. Merge after #1843 (touches the same snapshot-flush region; conflicts will be resolved on this branch after #1843 lands).

Linear: [ENG-5689](https://linear.app/primeintellect/issue/ENG-5689/unify-kernel-graceful-shutdown-audit-f14)