### PR TITLE
fix(runtime): ordered bash output completion sentinel

### DIFF
--- a/packages/coding-agent/.changes/bash-output-sentinel.md
+++ b/packages/coding-agent/.changes/bash-output-sentinel.md
@@ -1,0 +1,1 @@
+- Fixed `bash()` to capture all foreground output before finalizing results by using an ordered per-command completion marker.

--- a/packages/coding-agent/.changes/bash-output-sentinel.md
+++ b/packages/coding-agent/.changes/bash-output-sentinel.md
@@ -1,1 +1,1 @@
-- Fixed `bash()` to capture all foreground output before finalizing results by using an ordered per-command completion marker.
+- Fixed `bash()` to capture all foreground command output before finalizing results by using an ordered per-command completion marker; output written after the marker (e.g. by `EXIT` traps or background jobs) is not in the awaited result but stays visible via `handle.output()`/`tail()`.

--- a/prime-agent-runtime/src/rlm/bash.py
+++ b/prime-agent-runtime/src/rlm/bash.py
@@ -6,6 +6,7 @@ import asyncio
 import atexit
 import json
 import os
+import secrets
 import selectors
 import shutil
 import signal
@@ -35,6 +36,9 @@ _READ_CHUNK = 65536
 # Fixed child-side fd for the status channel; POSIX shells (notably dash) only
 # guarantee single-digit fds in redirection syntax.
 _STATUS_FD = 9
+_OUTPUT_FD = 8
+_COMPLETION_PREFIX = b"\x1eprime-agent-complete:"
+_COMPLETION_SUFFIX = b"\x1f"
 # Cancelled one-shot awaits: TERM grace before the group KILL, then the bounded
 # wait for a confirmed group exit before CancelledError propagates.
 _CANCEL_TERM_GRACE = 0.5
@@ -116,6 +120,10 @@ class BashHandle:
         self._buffer = _BoundedBuffer()
         self._done = threading.Event()
         self._eof = threading.Event()
+        self._completion_terminal = threading.Event()
+        self._completion_output: str | None = None
+        self._completion_lock = threading.Lock()
+        self._completion_pending = b""
         self._status: int | None = None
         self._status_known = threading.Event()
         self._reaped = False
@@ -133,6 +141,7 @@ class BashHandle:
         # True only while the pump moves a chunk from the pipe into the buffer.
         self._pump_transfer = False
         self._job: int | None = None
+        self._completion_marker: bytes | None = None
         status_write = -1
         if _IS_POSIX:
             # Full-duplex status channel: the child end rides in as stdin (fd 0)
@@ -150,9 +159,19 @@ class BashHandle:
                 os.close(self._status_read)
                 os.close(status_write)
                 raise
-            script = _status_script(_with_prefix(command))
+            completion_token = secrets.token_hex(32)
+            # Halves stop passive echoes; a deliberate forgery freezes only this call while later bytes stay live.
+            token_midpoint = len(completion_token) // 2
+            self._completion_marker = (
+                _COMPLETION_PREFIX + completion_token.encode("ascii") + _COMPLETION_SUFFIX
+            )
+            script = _status_script(
+                _with_prefix(command),
+                completion_token[:token_midpoint],
+                completion_token[token_midpoint:],
+            )
         else:
-            # Windows: the child is created suspended, atomically inside the kill-on-close job.
+            # Windows lacks a foreground-status channel, so its exit drain stays best-effort.
             script = _with_prefix(command)
             self._job = _winjob.create_job()
             if self._job is None:
@@ -274,8 +293,6 @@ class BashHandle:
         stdout = self._proc.stdout
         assert stdout is not None
         if not _IS_POSIX:
-            # Windows: no FIONREAD fence; the drain keeps its quiescence
-            # heuristic (best-effort parity).
             try:
                 while chunk := stdout.read1(_READ_CHUNK):
                     self._buffer.write(chunk)
@@ -284,9 +301,6 @@ class BashHandle:
             stdout.close()
             self._eof.set()
             return
-        # POSIX: select-gate the read and flag the read->commit window, so the
-        # drain fence never sees "pipe empty + buffer quiescent" while a chunk
-        # is in flight between the pipe read and the buffer commit.
         fd = stdout.fileno()
         try:
             with selectors.DefaultSelector() as sel:
@@ -298,16 +312,53 @@ class BashHandle:
                         chunk = os.read(fd, _READ_CHUNK)
                         if not chunk:
                             break
-                        self._buffer.write(chunk)
+                        self._consume_output(chunk)
                     finally:
                         self._pump_transfer = False
         except (OSError, ValueError):
             pass
+        self._abandon_completion()
         try:
             stdout.close()
         except OSError:
             pass
         self._eof.set()
+
+    def _consume_output(self, chunk: bytes) -> None:
+        marker = self._completion_marker
+        assert marker is not None
+        with self._completion_lock:
+            if self._completion_terminal.is_set():
+                self._buffer.write(chunk)
+                return
+            data = self._completion_pending + chunk
+            marker_at = data.find(marker)
+            if marker_at >= 0:
+                self._buffer.write(data[:marker_at])
+                self._completion_pending = b""
+                self._completion_output = self._buffer.text()
+                self._completion_terminal.set()
+                self._buffer.write(data[marker_at + len(marker) :])
+                return
+            retained = 0
+            for size in range(min(len(data), len(marker) - 1), 0, -1):
+                if data.endswith(marker[:size]):
+                    retained = size
+                    break
+            self._buffer.write(data[:-retained] if retained else data)
+            self._completion_pending = data[-retained:] if retained else b""
+
+    def _abandon_completion(self) -> None:
+        with self._completion_lock:
+            if self._completion_terminal.is_set():
+                return
+            self._buffer.write(self._completion_pending)
+            self._completion_pending = b""
+            self._completion_terminal.set()
+
+    def _wait_for_completion(self) -> str | None:
+        self._completion_terminal.wait()
+        return self._completion_output
 
     def _report(self) -> None:
         # Finalize at foreground completion (status channel), not EOF, so
@@ -325,8 +376,10 @@ class BashHandle:
             # (parsed status, EOF, garbage, exception) must set it.
             self._status_known.set()
         if status is not None:
-            self._drain_grace()
-            self._finalize(status)
+            output = self._wait_for_completion()
+            if output is None:
+                self._drain_grace()
+            self._finalize(status, output)
 
     def _watch(self) -> None:
         # Observe shell death independently of the status socket: an early
@@ -347,6 +400,7 @@ class BashHandle:
         with self._callback_lock:
             delivered = self._status
         if delivered is None and not self._done.is_set():
+            self._abandon_completion()
             self._drain_grace()
             self._finalize(exit_code)
         with self._kill_lock:
@@ -409,10 +463,7 @@ class BashHandle:
             os.close(self._wake_read)
 
     def _drain_grace(self) -> None:
-        # Bounded wait so the result includes foreground output still in the pipe:
-        # EOF arrives immediately without background jobs, otherwise stop once the
-        # buffer is quiescent for one tick AND the pipe holds no unread bytes (a
-        # slow pump must not lose output the shell wrote before its status).
+        # Best-effort fallback when process exit/EOF arrives without a sentinel.
         deadline = time.monotonic() + 0.5
         size = self._buffer.size()
         while time.monotonic() < deadline:
@@ -442,13 +493,13 @@ class BashHandle:
             return False
         return pending > 0
 
-    def _finalize(self, exit_code: int) -> None:
+    def _finalize(self, exit_code: int, output: str | None = None) -> None:
         with self._callback_lock:
             if self._done.is_set():
                 return
             self._result = BashResult(
                 exit_code=exit_code,
-                output=self._buffer.text(),
+                output=self._buffer.text() if output is None else output,
                 duration=time.monotonic() - self._started,
             )
             self._done.set()
@@ -642,24 +693,20 @@ def _with_prefix(command: str) -> str:
     return f"{prefix}\n{command}" if prefix else command
 
 
-def _status_script(command: str) -> str:
-    # The status socket arrives as stdin (fd 0); the prologue dups it to the
-    # single-digit _STATUS_FD (dash rejects multi-digit fds in redirections at
-    # parse time) and points stdin at /dev/null, so no other copy remains. The
-    # gate read blocks until the parent has journaled the pid; EOF (parent died
-    # first) exits without running the command. The brace group runs the command
-    # with the status fd closed so `&` children do not inherit it; the trailing
-    # `wait` keeps the shell alive as group leader until its own jobs exit
-    # (double-forked daemons stay out of scope).
+def _status_script(command: str, completion_a: str, completion_b: str) -> str:
+    # Closed control fds preserve background behavior; supported shells atomically write the frame.
     return (
-        f"exec {_STATUS_FD}>&0 0</dev/null\n"
+        f"exec {_STATUS_FD}>&0 {_OUTPUT_FD}>&1 0</dev/null\n"
         f"read -r _prime_agent_gate <&{_STATUS_FD} || exit 127\n"
         "{\n"
         f"{command}\n"
-        f"}} {_STATUS_FD}>&-\n"
+        f"}} {_OUTPUT_FD}>&- {_STATUS_FD}>&-\n"
         "__prime_status=$?\n"
-        f"printf '%s\\n' \"$__prime_status\" >&{_STATUS_FD}\n"
-        f"exec {_STATUS_FD}>&-\n"
+        "\\set +x\n"
+        f"\\command -p printf '\\036prime-agent-complete:%s%s\\037' "
+        f"'{completion_a}' '{completion_b}' >&{_OUTPUT_FD} || exit \"$__prime_status\"\n"
+        f"\\command -p printf '%s\\n' \"$__prime_status\" >&{_STATUS_FD}\n"
+        f"exec {_OUTPUT_FD}>&- {_STATUS_FD}>&-\n"
         "wait\n"
         'exit "$__prime_status"\n'
     )

--- a/prime-agent-runtime/src/rlm/bash.py
+++ b/prime-agent-runtime/src/rlm/bash.py
@@ -660,6 +660,9 @@ def bash(command: str) -> BashHandle:
     POSIX; a kill-on-close job object on Windows entered while the child is
     still suspended, so no descendant can escape it and kill()/crash cleanup
     are unconditional -- bash() raises if containment cannot be established.
+    Output written after the completion fence (e.g. by an EXIT trap or a
+    background job) is not in BashResult.output but stays visible via
+    handle.output()/tail().
     """
     if not isinstance(command, str) or not command:
         raise TypeError("command must be a non-empty str")

--- a/prime-agent-runtime/src/rlm/bash.py
+++ b/prime-agent-runtime/src/rlm/bash.py
@@ -696,8 +696,21 @@ def _with_prefix(command: str) -> str:
     return f"{prefix}\n{command}" if prefix else command
 
 
+def _fence_printf() -> str:
+    # `\command -p printf` defeats alias expansion but not a user-defined shell
+    # function named `command`, which would swallow both fence frames and leave
+    # the await hanging until the shell dies (wedged behind background jobs). A
+    # slash-qualified command name bypasses function and alias lookup in every
+    # POSIX shell, so resolve printf on the system default utility PATH.
+    path = shutil.which("printf", path=os.confstr("CS_PATH") or os.defpath)
+    if path and "'" not in path:
+        return f"'{path}'"
+    return "\\command -p printf"
+
+
 def _status_script(command: str, completion_a: str, completion_b: str) -> str:
     # Closed control fds preserve background behavior; supported shells atomically write the frame.
+    emit = _fence_printf()
     return (
         f"exec {_STATUS_FD}>&0 {_OUTPUT_FD}>&1 0</dev/null\n"
         f"read -r _prime_agent_gate <&{_STATUS_FD} || exit 127\n"
@@ -706,9 +719,9 @@ def _status_script(command: str, completion_a: str, completion_b: str) -> str:
         f"}} {_OUTPUT_FD}>&- {_STATUS_FD}>&-\n"
         "__prime_status=$?\n"
         "\\set +x\n"
-        f"\\command -p printf '\\036prime-agent-complete:%s%s\\037' "
+        f"{emit} '\\036prime-agent-complete:%s%s\\037' "
         f"'{completion_a}' '{completion_b}' >&{_OUTPUT_FD} || exit \"$__prime_status\"\n"
-        f"\\command -p printf '%s\\n' \"$__prime_status\" >&{_STATUS_FD}\n"
+        f"{emit} '%s\\n' \"$__prime_status\" >&{_STATUS_FD}\n"
         f"exec {_OUTPUT_FD}>&- {_STATUS_FD}>&-\n"
         "wait\n"
         'exit "$__prime_status"\n'

--- a/prime-agent-runtime/src/rlm/bash.py
+++ b/prime-agent-runtime/src/rlm/bash.py
@@ -700,8 +700,8 @@ def _fence_printf() -> str:
     # `\command -p printf` defeats alias expansion but not a user-defined shell
     # function named `command`, which would swallow both fence frames and leave
     # the await hanging until the shell dies (wedged behind background jobs). A
-    # slash-qualified command name bypasses function and alias lookup in every
-    # POSIX shell, so resolve printf on the system default utility PATH.
+    # slash-qualified command name bypasses function and alias lookup for
+    # ordinary command names, so resolve printf on the system default utility PATH.
     path = shutil.which("printf", path=os.confstr("CS_PATH") or os.defpath)
     if path and "'" not in path:
         return f"'{path}'"

--- a/prime-agent-runtime/test/test_bash.py
+++ b/prime-agent-runtime/test/test_bash.py
@@ -176,20 +176,20 @@ class BashTest(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(records[-1]["active"])
             await _poll_group_dead(handle.pid)
 
-    async def test_delivered_status_wins_when_shell_dies_during_drain(self):
+    async def test_delivered_status_wins_when_shell_dies_during_completion(self):
         entered = threading.Event()
         release = threading.Event()
-        original = bash_module.BashHandle._drain_grace
+        original = bash_module.BashHandle._wait_for_completion
 
-        def held_drain(handle_self):
-            # Hold only the first caller (the reporter, which drains right after
-            # reading status 0); any later caller must proceed normally.
-            if not entered.is_set():
-                entered.set()
-                release.wait(10)
-            original(handle_self)
+        def held_completion(handle_self):
+            output = original(handle_self)
+            entered.set()
+            release.wait(10)
+            return output
 
-        with mock.patch.object(bash_module.BashHandle, "_drain_grace", held_drain):
+        with mock.patch.object(
+            bash_module.BashHandle, "_wait_for_completion", held_completion
+        ):
             # Background job keeps the shell alive in `wait` after status 0 is delivered.
             handle = bash("sleep 30 & true")
             try:
@@ -337,7 +337,7 @@ class BashTest(unittest.IsolatedAsyncioTestCase):
             self.skipTest("POSIX-only gate")
         with tempfile.TemporaryDirectory() as tmp:
             marker = os.path.join(tmp, "ran")
-            script = bash_module._status_script(f"touch {marker}")
+            script = bash_module._status_script(f"touch {marker}", "a" * 32, "b" * 32)
             parent, child = socket.socketpair()
             proc = subprocess.Popen(
                 [bash_module._shell(), "-c", script],
@@ -539,26 +539,29 @@ class BashTest(unittest.IsolatedAsyncioTestCase):
                     bash_module._shell()
                 which.assert_not_called()
 
-    async def test_pump_paused_between_read_and_commit_does_not_lose_output(self):
-        # Reviewer repro: the chunk is out of the pipe (FIONREAD 0) but not yet
-        # in the buffer; the drain fence must wait for the commit.
+    async def test_pump_delayed_past_old_quiescence_bound_captures_all_output(self):
+        # The ordered sentinel must wait through a pump delay beyond the old 500 ms bound.
         original_write = bash_module._BoundedBuffer.write
         delayed_once = threading.Event()
 
         def delayed_write(buffer_self, chunk):
             if not delayed_once.is_set():
                 delayed_once.set()
-                time.sleep(0.3)
+                time.sleep(0.7)
             original_write(buffer_self, chunk)
 
         with mock.patch.object(bash_module._BoundedBuffer, "write", delayed_write):
-            result = await asyncio.wait_for(bash("printf between-read-and-write"), timeout=5)
+            result = await asyncio.wait_for(bash("printf delayed-output-complete"), timeout=5)
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("between-read-and-write", result.output)
+        self.assertEqual(result.output, "delayed-output-complete")
+
+    async def test_completion_marker_split_across_reads_is_removed(self):
+        with mock.patch.object(bash_module, "_READ_CHUNK", 7):
+            result = await asyncio.wait_for(bash("printf exact-pre-fence-output"), timeout=5)
+        self.assertEqual(result.output, "exact-pre-fence-output")
 
     async def test_slow_pump_does_not_lose_foreground_output(self):
-        # A descheduled pump must not let _drain_grace conclude quiescence
-        # while the shell's output still sits unread in the pipe.
+        # Finalization waits for the pump to parse the ordered sentinel.
         original_pump = bash_module.BashHandle._pump
 
         def slow_pump(handle_self):
@@ -569,6 +572,45 @@ class BashTest(unittest.IsolatedAsyncioTestCase):
             result = await asyncio.wait_for(bash("printf slow-pump-x"), timeout=5)
         self.assertEqual(result.exit_code, 0)
         self.assertIn("slow-pump-x", result.output)
+
+    async def test_sentinel_like_output_and_echoed_wrapper_do_not_truncate(self):
+        token = "0123456789abcdef" * 4
+        raw_lookalike = "\x1eprime-agent-complete:not-this-invocation\x1f"
+        command = (
+            "set -x\n"
+            "printf '\\036prime-agent-complete:not-this-invocation\\037'\n"
+            "if [ -r /proc/$$/cmdline ]; then cat /proc/$$/cmdline; fi\n"
+            "printf '\\nafter-sentinel-lookalike\\n'"
+        )
+        with mock.patch.object(bash_module.secrets, "token_hex", return_value=token):
+            result = await asyncio.wait_for(bash(command), timeout=5)
+        actual_marker = (
+            bash_module._COMPLETION_PREFIX + token.encode() + bash_module._COMPLETION_SUFFIX
+        )
+        self.assertIn(raw_lookalike, result.output)
+        self.assertIn("after-sentinel-lookalike", result.output)
+        self.assertNotIn(actual_marker.decode(), result.output)
+
+    async def test_user_alias_cannot_replace_completion_emitter(self):
+        if os.path.basename(bash_module._shell()) != "bash":
+            self.skipTest("bash alias expansion semantics")
+        handle = bash(
+            "shopt -s expand_aliases; alias command='printf alias-expanded'; sleep 30 &"
+        )
+        try:
+            result = await asyncio.wait_for(handle, timeout=5)
+            self.assertEqual(result.exit_code, 0)
+            self.assertNotIn("alias-expanded", result.output)
+        finally:
+            handle.kill(signal.SIGKILL)
+            await _poll_group_dead(handle.pid)
+
+    async def test_shell_killed_before_sentinel_finalizes_from_exit(self):
+        result = await asyncio.wait_for(
+            bash("printf output-before-shell-kill; kill -KILL $$"), timeout=5
+        )
+        self.assertEqual(result.exit_code, -signal.SIGKILL)
+        self.assertIn("output-before-shell-kill", result.output)
 
     async def test_relative_bash_shell_override_rejected(self):
         with mock.patch.dict(os.environ, {"PRIME_AGENT_BASH_SHELL": "bash"}):

--- a/prime-agent-runtime/test/test_bash.py
+++ b/prime-agent-runtime/test/test_bash.py
@@ -605,6 +605,19 @@ class BashTest(unittest.IsolatedAsyncioTestCase):
             handle.kill(signal.SIGKILL)
             await _poll_group_dead(handle.pid)
 
+    async def test_user_function_cannot_replace_completion_emitter(self):
+        # The backslash in `\command` defeats alias expansion only: a shell
+        # function named `command` would otherwise swallow both fence frames
+        # and wedge the await behind the background job until shell death.
+        handle = bash("command() { printf function-expanded; }; sleep 30 &")
+        try:
+            result = await asyncio.wait_for(handle, timeout=5)
+            self.assertEqual(result.exit_code, 0)
+            self.assertNotIn("function-expanded", result.output)
+        finally:
+            handle.kill(signal.SIGKILL)
+            await _poll_group_dead(handle.pid)
+
     async def test_shell_killed_before_sentinel_finalizes_from_exit(self):
         result = await asyncio.wait_for(
             bash("printf output-before-shell-kill; kill -KILL $$"), timeout=5


### PR DESCRIPTION
POSIX `bash()` results now finalize on an ordered completion fence instead of a 50/500 ms output-quiescence heuristic that could freeze results before delayed pump bytes arrived.

- Per-invocation 256-bit token; the complete marker never exists in any passively inspectable location (halves as separate shell literals, xtrace disabled, `\command -p printf`). A deliberate argv-reconstruction forgery only freezes that invocation's own result; post-fence bytes stay visible as live output.
- Combined pipe saved on fd 8; fds 8/9 closed inside the user brace group, so background jobs cannot inherit the control fds. Order: marker -> status -> wait; the pipe itself guarantees ordering. No timers in the success path.
- The pump parses the frame across chunk boundaries (regression forces the frame across ~13 reads); output snapshots exactly at the fence; later background output remains captured as live output.
- Liveness: killed shell, closed stdout, exec-replaced shell, swallowed status all finalize via the existing exit/EOF fallback; `cmd &` early-result behavior preserved. Windows keeps documented best-effort exit-drain semantics.

+138/-48.

Linear: [ENG-5691](https://linear.app/primeintellect/issue/ENG-5691/ordered-bash-output-completion-sentinel-audit-f7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core shell I/O finalization for every POSIX `bash()` await; incorrect sentinel handling could truncate output or hang, though fallbacks and extensive tests mitigate this.
> 
> **Overview**
> POSIX **`bash()`** no longer finalizes **`BashResult.output`** using a ~500ms pipe-quiescence heuristic. After the user command finishes, the wrapper emits a **per-invocation completion marker** on a dedicated fd before reporting exit status; the parent pump strips that frame (including when it spans reads), snapshots output at the fence, and **`_report`** waits on that sentinel before finalizing.
> 
> **Behavior:** awaited results include all **foreground** stdout up to the marker. Bytes after the fence (e.g. **`EXIT`** traps, background jobs) stay in the live buffer and show up via **`handle.output()`** / **`tail()`**, not in **`BashResult.output`**. Marker emission uses a path-qualified **`printf`** and split token literals so user aliases/functions cannot hijack completion; lookalike output must not truncate early. If the sentinel never arrives, **`_abandon_completion`** and the existing drain/exit paths still unblock finalization. **Windows** is unchanged (best-effort drain).
> 
> Adds a coding-agent changelog note and expands **`test_bash.py`** for delayed pumps, split markers, forgery, and emitter hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ccabfa8d08b122cd32c053b6b3f912b7c3a14b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ordered bash output completion sentinel in `BashHandle`
> - Prevents loss of foreground output by waiting for a unique per-command completion marker before finalizing results.
> - `BashHandle` generates a token passed to `_status_script`, which duplicates stdout to `_OUTPUT_FD=8` and emits the marker via a path/alias-immune `_fence_printf` before reporting status.
> - The pump loop calls `_consume_output` to detect the marker across read boundaries, snapshots the exact pre-marker output for `BashResult.output`, and continues buffering subsequent data for live viewing.
> - `_abandon_completion` handles early shell exits to prevent waiters from hanging on a missing marker.
> - Risk: changes stdout duplication in `_status_script` and output selection in `BashHandle._finalize`; output from background jobs arriving after the marker is excluded from `result.output` but remains accessible via `handle.output()`/`tail()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5ccabf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->