### PR TITLE
refactor(coding-agent): centralize the session-path predicate

### DIFF
--- a/packages/coding-agent/.changes/session-path-predicate.md
+++ b/packages/coding-agent/.changes/session-path-predicate.md
@@ -1,0 +1,1 @@
+- Made session path detection consistent across direct and daemon commands.

--- a/packages/coding-agent/src/cli/daemon-command.ts
+++ b/packages/coding-agent/src/cli/daemon-command.ts
@@ -8,6 +8,7 @@ import { expandTildePath } from "../config.js";
 import type { AgentSessionEvent } from "../core/agent-session.js";
 import type { AgentSessionRuntimeConfig } from "../core/agent-session-config.js";
 import { type AgentCronJob, formatAgentCronJob } from "../core/cron-jobs.js";
+import { looksLikeSessionPath } from "../core/session-resolver.js";
 import { DaemonClient, type DaemonClientMessageListener } from "../modes/daemon/daemon-client.js";
 import type { DaemonOutbound, DaemonResponse } from "../modes/daemon/daemon-protocol.js";
 import { matchesSessionIdSuffix } from "../modes/daemon/daemon-session-id.js";
@@ -619,10 +620,6 @@ function parseExtensionFlagOption(
 	const name = arg.slice(2);
 	config.extensionFlagValues[name] = true;
 	return { consumed: 0, daemonArg: arg };
-}
-
-function looksLikeSessionPath(value: string): boolean {
-	return value.includes("/") || value.includes("\\") || value.endsWith(".jsonl");
 }
 
 function requireOptionValue(args: string[], index: number, option: string): string {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2,7 +2,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { chmodSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { Writable } from "node:stream";
 import { getLogger } from "@earendil-works/pi-ai";
 import { createCliSubprocessEnv, createCliSubprocessLaunchSpec } from "../../cli/subprocess-launch.js";
@@ -49,6 +49,7 @@ import {
 } from "../../core/session-action-store.js";
 import { canonicalSessionPath, getProcessStartId, SessionAlreadyActiveError } from "../../core/session-lease.js";
 import { getSessionArtifactPathForFile, readSessionInfo, type SessionInfo } from "../../core/session-manager.js";
+import { looksLikeSessionPath } from "../../core/session-resolver.js";
 import { SettingsManager } from "../../core/settings-manager.js";
 import { isProcessAlive, processIdExists, signalProcessGroupOrProcess } from "../../utils/child-process.js";
 import type { AgentConnectionHeartbeat } from "../agent-connection/types.js";
@@ -544,10 +545,6 @@ function workerSocketPath(supervisorSocketPath: string, workerId: string): strin
 		return `\\\\.\\pipe\\prime-agent-worker-${key}-${workerId.slice(0, 12)}`;
 	}
 	return join(defaultDaemonSocketDir(), `worker-${key}-${workerId.slice(0, 12)}.sock`);
-}
-
-function looksLikeSessionPath(selector: string): boolean {
-	return isAbsolute(selector) || selector.endsWith(".jsonl") || selector.includes("/") || selector.includes("\\");
 }
 
 function isFinalizedTranscriptEvent(eventType: string | undefined): boolean {


### PR DESCRIPTION
## What was wrong

"Does this selector look like a session file path?" was answered by three independent copies of the same predicate — in core, the CLI, and the daemon supervisor — and the supervisor's copy had already drifted (an extra `isAbsolute` term). One domain decision, three owners.

## The fix

The CLI and supervisor now import the core definition (`core/session-resolver.ts`); their private copies are deleted. The supervisor's extra `isAbsolute` term was verified strictly redundant before dropping: every absolute path form (posix and win32, including drive and UNC forms) necessarily contains a separator, and forms like `C:foo` were non-paths under both old and new predicates — so no caller's behavior changes on any platform.

+4/−9. No new tests: behavior-preserving deletion, existing caller suites exercise the predicate.

## How it's verified

Reviewer independently enumerated candidate inputs against node's posix/win32 `isAbsolute` to prove redundancy at all call sites. daemon-command 19/19, supervisor admission 10/10, tsgo/biome clean, full CI-style suite failures identical to stack base. Two-model implement/review loop, approved first pass.

Stacked on #1731 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor that removes duplicate predicates; supervisor’s dropped `isAbsolute` term was redundant with separator checks at all call sites.
> 
> **Overview**
> **Session path detection** now uses a single shared helper instead of three separate copies.
> 
> `daemon-command.ts` and `daemon-supervisor.ts` import `looksLikeSessionPath` from `session-resolver.ts` and delete their local predicates. The supervisor’s extra `isAbsolute` check is removed so daemon and CLI resume/session selectors follow the same rule as core: path-like when the selector contains `/` or `\`, or ends with `.jsonl`.
> 
> A short changelog note records that direct and daemon commands now agree on this behavior. No new logic beyond consolidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f25ff7a4b9818b81d3996537605d0a9caf62f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize `looksLikeSessionPath` in `session-resolver`
> Replaces the local `looksLikeSessionPath` helpers in [daemon-command.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1846/files#diff-8b3c6f9e7b81c79ba3c91a7bb6319511d80c770e6730f3367c36ec31caf1580b) and [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1846/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) with a shared import from [session-resolver.js](https://github.com/PrimeIntellect-ai/prime-agent/pull/1846/files#diff-d2ee6b8ad7a779988a1acf7c69bffd9135de2c43cb8a0b8688f4d6fa0406bbe2). Also removes the now-unused `isAbsolute` import in the supervisor. Makes session path detection consistent across direct and daemon commands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79f25ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Linear: [ENG-5653](https://linear.app/primeintellect/issue/ENG-5653/refactorcoding-agent-centralize-the-session-path-predicate)