### PR TITLE
refactor(coding-agent): remove the NODE_ENV=test telemetry branch

### DIFF
--- a/packages/coding-agent/.changes/remove-test-telemetry-branch.md
+++ b/packages/coding-agent/.changes/remove-test-telemetry-branch.md
@@ -1,0 +1,1 @@
+- Stopped treating `NODE_ENV=test` as an implicit telemetry opt-out.

--- a/packages/coding-agent/src/core/telemetry.ts
+++ b/packages/coding-agent/src/core/telemetry.ts
@@ -212,9 +212,6 @@ export function isTelemetryEnabled(settingsManager: SettingsManager): boolean {
 	if (override !== undefined) {
 		return override;
 	}
-	if (process.env.NODE_ENV === "test") {
-		return false;
-	}
 	return settingsManager.getTelemetryEnabled();
 }
 

--- a/packages/coding-agent/test/agent-session-services.test.ts
+++ b/packages/coding-agent/test/agent-session-services.test.ts
@@ -29,6 +29,7 @@ describe("createAgentSessionFromServices", () => {
 	});
 
 	it("shows the telemetry disclosure independently of the Herdr reporter", async () => {
+		vi.stubEnv("DO_NOT_TRACK", "0");
 		vi.stubEnv("PRIME_AGENT_TELEMETRY", "1");
 		const tempDir = join(tmpdir(), `pi-session-telemetry-notice-${Date.now()}`);
 		mkdirSync(tempDir, { recursive: true });
@@ -50,6 +51,7 @@ describe("createAgentSessionFromServices", () => {
 	});
 
 	it("honors an explicit daemon-carried telemetry opt-out", async () => {
+		vi.stubEnv("DO_NOT_TRACK", "0");
 		vi.stubEnv("PRIME_AGENT_TELEMETRY", "1");
 		const tempDir = join(tmpdir(), `pi-session-daemon-telemetry-opt-out-${Date.now()}`);
 		mkdirSync(tempDir, { recursive: true });
@@ -81,6 +83,7 @@ describe("createAgentSessionFromServices", () => {
 	});
 
 	it("does not install top-level telemetry for a resumed child session", async () => {
+		vi.stubEnv("DO_NOT_TRACK", "0");
 		vi.stubEnv("PRIME_AGENT_TELEMETRY", "1");
 		const tempDir = join(tmpdir(), `pi-session-child-telemetry-${Date.now()}`);
 		mkdirSync(tempDir, { recursive: true });

--- a/packages/coding-agent/test/telemetry.test.ts
+++ b/packages/coding-agent/test/telemetry.test.ts
@@ -2,7 +2,7 @@ import { lstatSync, mkdtempSync, readFileSync, statSync, symlinkSync, writeFileS
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentSession, AgentSessionEvent } from "../src/core/agent-session.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 import {
@@ -236,7 +236,7 @@ describe("telemetry controls", () => {
 	it("honors settings and environment opt-outs", () => {
 		const settings = SettingsManager.inMemory({ telemetry: { enabled: true } });
 
-		vi.stubEnv("NODE_ENV", "production");
+		vi.stubEnv("DO_NOT_TRACK", "0");
 		expect(isTelemetryEnabled(settings)).toBe(true);
 
 		vi.stubEnv("DO_NOT_TRACK", "1");
@@ -249,14 +249,6 @@ describe("telemetry controls", () => {
 		vi.stubEnv("PRIME_AGENT_TELEMETRY", "1");
 		vi.stubEnv("PI_OFFLINE", "true");
 		expect(isTelemetryEnabled(settings)).toBe(false);
-	});
-
-	it("is disabled by default in tests unless explicitly enabled", () => {
-		const settings = SettingsManager.inMemory({ telemetry: { enabled: true } });
-		vi.stubEnv("NODE_ENV", "test");
-		expect(isTelemetryEnabled(settings)).toBe(false);
-		vi.stubEnv("PRIME_AGENT_TELEMETRY", "1");
-		expect(isTelemetryEnabled(settings)).toBe(true);
 	});
 
 	it("normalizes malformed telemetry settings before updating them", async () => {
@@ -276,6 +268,10 @@ describe("telemetry controls", () => {
 });
 
 describe("agent telemetry aggregation", () => {
+	beforeEach(() => {
+		vi.stubEnv("DO_NOT_TRACK", "0");
+	});
+
 	it("captures only allowlisted built-in command names", async () => {
 		vi.stubEnv("PRIME_AGENT_TELEMETRY", "1");
 		const sink = new FakeTelemetrySink();

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		testTimeout: 30000,
+		env: { DO_NOT_TRACK: "1" },
 		tags: [
 			{
 				name: "process-stress",


### PR DESCRIPTION
## What was wrong

Shipped telemetry code behaved differently under `NODE_ENV=test`: a production branch existed purely so tests wouldn't send events. Tests should opt out through the same controls users have, not through a special production code path (audit: test-only production code, test-only.md finding 1).

## The fix

- The `NODE_ENV=test` branch in `telemetry.ts` is deleted — the only `NODE_ENV` reference in the monorepo. Telemetry enablement now depends only on `PI_OFFLINE`, `DO_NOT_TRACK`, `PRIME_AGENT_TELEMETRY`, and settings.
- The test suite opts out via `DO_NOT_TRACK=1` in vitest's env config (pure test config, needed because telemetry defaults to enabled).
- Tests that verify *enabled* telemetry explicitly set `DO_NOT_TRACK=0` with their existing fake sinks, so they can't pass vacuously under the suite opt-out.
- The test asserting the removed branch is deleted; its override half was already covered elsewhere.

+11/−13.

## How it's verified

Reviewer confirmed: no `NODE_ENV=test` path remains anywhere in src; child-process env inheritance is equivalent (spawns spread `process.env`, no spawning test expects production telemetry defaults); the deleted test was incidental. Focused suites 109/109; full CI-style suite failure set identical to stack base. Two-model implement/review loop, approved first pass.

Stacked on #1734 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry gating change is limited to tests and opt-in env flags; default Vitest opt-out avoids accidental network sends. Any test file outside this config that enables telemetry without DO_NOT_TRACK could behave differently than before.
> 
> **Overview**
> Removes the production-only **`NODE_ENV=test`** shortcut in **`isTelemetryEnabled`**, so telemetry follows the same **`PI_OFFLINE`**, **`DO_NOT_TRACK`**, **`PRIME_AGENT_TELEMETRY`**, and settings path as real runs.
> 
> The Vitest config now sets **`DO_NOT_TRACK=1`** by default so the suite stays opted out without that branch. Tests that assert enabled telemetry or disclosure behavior explicitly stub **`DO_NOT_TRACK=0`** (with existing fake sinks / env overrides) so they still exercise real enablement logic. The dedicated test for the removed branch is deleted; override behavior remains covered elsewhere.
> 
> A short changelog note records the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f442a5514f501847c52afcbb0d42243e36cff89e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `NODE_ENV=test` branch from `isTelemetryEnabled` function
> - Removes the early-return in `isTelemetryEnabled` that disabled telemetry when `NODE_ENV === "test"`, so the function now checks only `PI_OFFLINE`, `DO_NOT_TRACK`, `PRIME_AGENT_TELEMETRY`, and `SettingsManager`.
> - Sets `DO_NOT_TRACK=1` by default in [vitest.config.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1848/files#diff-bde9d899eecf81df61ac3e23b7661d244fa4c650c879157d49d0577ad9063862) so tests still opt out of telemetry unless they explicitly override it.
> - Updates affected tests in [telemetry.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1848/files#diff-c66ea84d0d1cb3278023b8a31ff450dbe9085c13ab1de7616ddd468f7b938d5f) and [agent-session-services.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1848/files#diff-08e24b8bac1b86435d41ff43cee17b122479e6cd927ea7b4a36ac2a56b6d99d7) to stub `DO_NOT_TRACK` explicitly instead of relying on `NODE_ENV`.
> - Behavioral Change: any process running with `NODE_ENV=test` but without `DO_NOT_TRACK` set will now report telemetry according to settings and env vars instead of being implicitly opted out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f442a55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Linear: [ENG-5655](https://linear.app/primeintellect/issue/ENG-5655/refactorcoding-agent-remove-the-node-envtest-telemetry-branch)