### PR TITLE
refactor(coding-agent): remove test-only config cache reset APIs

### DIFF
--- a/packages/coding-agent/.changes/remove-config-cache-reset.md
+++ b/packages/coding-agent/.changes/remove-config-cache-reset.md
@@ -1,0 +1,1 @@
+- Removed internal test-only configuration cache reset hooks.

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -37,7 +37,6 @@ import {
 } from "./prime-inference-models.js";
 import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "./provider-display-names.js";
 import {
-	clearConfigValueCache,
 	resolveConfigValueOrThrow,
 	resolveConfigValueUncached,
 	resolveHeadersOrThrow,
@@ -348,9 +347,6 @@ function applyModelOverride(model: Model<Api>, override: ModelOverride): Model<A
 
 	return result;
 }
-
-/** Clear the config value command cache. Exported for testing. */
-export const clearApiKeyCache = clearConfigValueCache;
 
 function readOpenAICodexAccountId(token: string): string | undefined {
 	try {

--- a/packages/coding-agent/src/core/resolve-config-value.ts
+++ b/packages/coding-agent/src/core/resolve-config-value.ts
@@ -141,8 +141,3 @@ export function resolveHeadersOrThrow(
 	}
 	return Object.keys(resolved).length > 0 ? resolved : undefined;
 }
-
-/** Clear the config value command cache. Exported for testing. */
-export function clearConfigValueCache(): void {
-	commandResultCache.clear();
-}

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -5,7 +5,6 @@ import { registerOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import lockfile from "proper-lockfile";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
-import { clearConfigValueCache } from "../src/core/resolve-config-value.js";
 
 describe("AuthStorage", () => {
 	let tempDir: string;
@@ -22,7 +21,6 @@ describe("AuthStorage", () => {
 		if (tempDir && existsSync(tempDir)) {
 			rmSync(tempDir, { recursive: true });
 		}
-		clearConfigValueCache();
 		vi.restoreAllMocks();
 	});
 
@@ -833,26 +831,6 @@ describe("AuthStorage", () => {
 
 				const count = parseInt(readFileSync(counterFile, "utf-8").trim(), 10);
 				expect(count).toBe(1);
-			});
-
-			test("clearConfigValueCache allows command to run again", async () => {
-				const counterFile = join(tempDir, "counter");
-				writeFileSync(counterFile, "0");
-
-				const counterPath = toShPath(counterFile);
-				const command = `!sh -c 'count=$(cat "${counterPath}"); echo $((count + 1)) > "${counterPath}"; echo "key-value"'`;
-				writeAuthJson({
-					anthropic: { type: "api_key", key: command },
-				});
-
-				authStorage = AuthStorage.create(authJsonPath);
-				await authStorage.getApiKey("anthropic");
-
-				clearConfigValueCache();
-				await authStorage.getApiKey("anthropic");
-
-				const count = parseInt(readFileSync(counterFile, "utf-8").trim(), 10);
-				expect(count).toBe(2);
 			});
 
 			test("different commands are cached separately", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -6,7 +6,7 @@ import { getApiProvider } from "@earendil-works/pi-ai";
 import { getOAuthProvider, registerOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
-import { clearApiKeyCache, ModelRegistry, type ProviderConfigInput } from "../src/core/model-registry.js";
+import { ModelRegistry, type ProviderConfigInput } from "../src/core/model-registry.js";
 
 describe("ModelRegistry", () => {
 	let tempDir: string;
@@ -24,7 +24,6 @@ describe("ModelRegistry", () => {
 		if (tempDir && existsSync(tempDir)) {
 			rmSync(tempDir, { recursive: true });
 		}
-		clearApiKeyCache();
 	});
 
 	function providerConfig(


### PR DESCRIPTION
## What was wrong

Two production APIs existed only so tests could reset module-level caches between cases: `clearConfigValueCache` (resolve-config-value.ts, exported "for tests") and a duplicate `clearApiKeyCache` alias (model-registry.ts). One test existed solely to test the reset API itself (audit: test-only production code, test-only.md finding 3).

## The fix

Pure deletion (+2/−33): both APIs, both `afterEach` reset hooks, and the reset-only test are gone. No replacement machinery — the remaining tests don't need resets: cache keys embed per-test temp paths (unique per test), the literal-command tests are deterministic (cached result ≡ fresh result), stale-marker tests route through the uncached resolver by design, and vitest's default per-file isolation gives fresh module state anyway.

## How it's verified

Reviewer verified the no-reset argument test-by-test across both files (execution-count assertions, persistence assertions, failure-caching assertions) and confirmed cross-file leakage is impossible under the current vitest config. 124/124 focused, full CI-style suite failure set identical to stack base. Two-model implement/review loop, approved first pass.

Stacked on #1735 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of exported test utilities with no runtime behavior change; only risk is out-of-tree code importing the removed symbols.
> 
> **Overview**
> Removes **test-only hooks** that cleared the module-level shell-command result cache in `resolve-config-value.ts`: `clearConfigValueCache` and the `clearApiKeyCache` alias on `model-registry`.
> 
> Production behavior is unchanged—the `!command` cache still exists for normal resolution. Tests no longer call reset helpers in `afterEach` or assert that clearing the cache re-runs commands; remaining coverage still validates caching, cross-instance persistence, and failure caching without manual clears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3403b25cebe407530be381a8535fc83d17772b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove test-only config cache reset APIs `clearConfigValueCache` and `clearApiKeyCache`
> - Deletes `clearConfigValueCache` from [resolve-config-value.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1849/files#diff-9c9e4beada8f63cdfcc059c43b10a7c5f0e86908cd7261e8c567b1c8cc9b2097) and its alias `clearApiKeyCache` from [model-registry.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1849/files#diff-2fd8c4a2672b4ce27e73d494479df612c8b30ebac3dda5a160e2d861c612f453)
> - Removes the `afterEach` cache-reset calls and the deleted cache-clearing test case from [auth-storage.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1849/files#diff-3c6aa63c02f897b2adca3a38c73c6df1ad8ca39fde071c4ec66ed643ed9a06c5) and [model-registry.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1849/files#diff-8d8833bcc0c6e8be4f7c99f8d1fa90a2b3f85b8258ebedddf4003bdcc0b28e99)
> - Risk: external callers importing `clearApiKeyCache` or `clearConfigValueCache` will break; only in-tree test references were updated
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3403b25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Linear: [ENG-5656](https://linear.app/primeintellect/issue/ENG-5656/refactorcoding-agent-remove-test-only-config-cache-reset-apis)