### PR TITLE
refactor(ai): delete the unused getOverflowPatterns export

### DIFF
--- a/packages/ai/.changes/remove-overflow-pattern.md
+++ b/packages/ai/.changes/remove-overflow-pattern.md
@@ -1,0 +1,1 @@
+- Removed the unused overflow pattern helper from `utils/overflow.ts`.

--- a/packages/ai/.changes/remove-overflow-pattern.md
+++ b/packages/ai/.changes/remove-overflow-pattern.md
@@ -1,1 +1,1 @@
-- Removed the unused overflow pattern helper from `utils/overflow.ts`.
+- Removed the `getOverflowPatterns()` test helper export from `utils/overflow.ts`; use `isContextOverflow()` directly.

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -142,10 +142,3 @@ export function isContextOverflow(message: AssistantMessage, contextWindow?: num
 
 	return false;
 }
-
-/**
- * Get the overflow patterns for testing purposes.
- */
-export function getOverflowPatterns(): RegExp[] {
-	return [...OVERFLOW_PATTERNS];
-}

--- a/packages/coding-agent/.changes/remove-overflow-patterns-export.md
+++ b/packages/coding-agent/.changes/remove-overflow-patterns-export.md
@@ -1,0 +1,1 @@
+- Removed the unused `getOverflowPatterns` public API.

--- a/packages/coding-agent/.changes/remove-overflow-patterns-export.md
+++ b/packages/coding-agent/.changes/remove-overflow-patterns-export.md
@@ -1,1 +1,0 @@
-- Removed the unused `getOverflowPatterns` public API.


### PR DESCRIPTION
## What was wrong

`getOverflowPatterns()` in packages/ai was added "for testing purposes" but ended up with zero callers — no production use, no test use — while being published API via the package's wildcard export (audit: test-only production code, test-only.md finding 4).

## The fix

Pure deletion: the function and its doc comment are gone (+1/−7 including the changelog fragment). `OVERFLOW_PATTERNS` stays internal to `isContextOverflow`, untouched.

## How it's verified

Repo-wide search confirms zero references; tsgo clean; overflow suite 9/9; full coding-agent suite failure set identical to stack base. Two-model implement/review loop, approved first pass.

Stacked on #1736 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; overflow detection logic is untouched, though any external importer of `getOverflowPatterns` would need to stop using it.
> 
> **Overview**
> Removes the public **`getOverflowPatterns()`** helper from `utils/overflow.ts`, which duplicated internal overflow regexes for tests but had no callers. **Context overflow behavior is unchanged** — `OVERFLOW_PATTERNS` stays private and **`isContextOverflow()`** remains the supported API.
> 
> A **`packages/ai`** changeset documents the removal for consumers who might have imported the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e14ecfd6a48bf71ba6c5decdc40bec24770a8c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `getOverflowPatterns` export from `overflow.ts`
> Deletes the exported helper `getOverflowPatterns()` that returned a copy of the internal `OVERFLOW_PATTERNS` array, and adds a changeset entry advising callers to use `isContextOverflow()` directly.
> - Risk: `packages/ai/src/utils/overflow.ts` no longer exports `getOverflowPatterns`; any import of this symbol will fail at build/runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e14ecf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Linear ticket: [ENG-5657](https://linear.app/primeintellect/issue/ENG-5657/refactorai-delete-the-unused-getoverflowpatterns-export)
(ticket linked above)