### PR TITLE
refactor(coding-agent): remove the test-only daemon-lookup seam from main.ts

### DIFF
--- a/packages/coding-agent/.changes/remove-daemon-lookup-fake.md
+++ b/packages/coding-agent/.changes/remove-daemon-lookup-fake.md
@@ -1,0 +1,1 @@
+- Removed the test-only daemon active-session lookup override.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -302,20 +302,17 @@ export function shouldEnsureDaemonBeforeActiveSessionLookup(options: DaemonActiv
 	);
 }
 
-type ActiveDaemonSessionSummaryLookup = (socketPath: string, selector: string) => Promise<SessionSummary | undefined>;
-
 interface ActiveDaemonSessionSummaryLookupOptions {
 	fallbackOnError?: boolean;
-	lookup?: ActiveDaemonSessionSummaryLookup;
 }
 
-export async function findActiveDaemonSessionSummaryForInteractiveStartup(
+async function findActiveDaemonSessionSummaryForInteractiveStartup(
 	socketPath: string,
 	selector: string,
 	options: ActiveDaemonSessionSummaryLookupOptions = {},
 ): Promise<SessionSummary | undefined> {
 	try {
-		return await (options.lookup ?? findActiveDaemonSessionSummary)(socketPath, selector);
+		return await findActiveDaemonSessionSummary(socketPath, selector);
 	} catch (error) {
 		if (options.fallbackOnError === false) {
 			throw error;

--- a/packages/coding-agent/test/main-interactive-routing.test.ts
+++ b/packages/coding-agent/test/main-interactive-routing.test.ts
@@ -8,7 +8,6 @@ import {
 	type AppMode,
 	type DaemonInteractiveSessionManagerDecision,
 	daemonServerDefaultSessionConfig,
-	findActiveDaemonSessionSummaryForInteractiveStartup,
 	findActiveDaemonSessionSummaryForSessionFile,
 	type InteractiveDaemonStartupDecision,
 	isClientOwnedDaemonSession,
@@ -230,48 +229,6 @@ describe("daemon-backed interactive session manager routing", () => {
 				resumeSelector: "active-1",
 			}),
 		).toBe(false);
-	});
-
-	test("falls back to local session lookup when daemon active-session probing fails", async () => {
-		await expect(
-			findActiveDaemonSessionSummaryForInteractiveStartup("/tmp/prime.sock", "saved-session-id", {
-				lookup: async () => {
-					throw new Error("Daemon returned an invalid active session summary");
-				},
-			}),
-		).resolves.toBeUndefined();
-	});
-
-	test("propagates active-session lookup failures for explicit attach", async () => {
-		await expect(
-			findActiveDaemonSessionSummaryForInteractiveStartup("/tmp/prime.sock", "active-1", {
-				fallbackOnError: false,
-				lookup: async () => {
-					throw new Error("protocol mismatch");
-				},
-			}),
-		).rejects.toThrow("protocol mismatch");
-	});
-
-	test("uses daemon active-session summary when probing succeeds", async () => {
-		await expect(
-			findActiveDaemonSessionSummaryForInteractiveStartup("/tmp/prime.sock", "active-1", {
-				lookup: async () => ({
-					id: "active-1",
-					activeSessionId: "active-1",
-					lifecycle: "draft",
-					activity: "idle",
-					isSessionActive: false,
-					sessionId: "session-1",
-					cwd: "/tmp/project",
-					isStreaming: false,
-					isCompacting: false,
-					attachedClients: 0,
-					messageCount: 0,
-					sessionActions: { queuedCount: 0, steering: [], followUps: [] },
-				}),
-			}),
-		).resolves.toMatchObject({ activeSessionId: "active-1" });
 	});
 
 	test("uses an ephemeral local session manager for fresh daemon-owned sessions", () => {


### PR DESCRIPTION
## What was wrong

`main.ts`'s interactive-startup wrapper accepted an optional injected daemon-lookup function that only three unit tests ever passed — a test-only seam in production code. Those tests asserted the wrapper's own try/catch branches through the fake, i.e. they restated the implementation (audit: test-only production code, test-only.md finding 5).

## The fix

+2/−48: the lookup type and option are deleted, `findActiveDaemonSessionSummary` is called directly, the three fake-lookup tests and their import are gone, and the function's now-unimported `export` keyword is dropped. The real `fallbackOnError` policy and its production caller are byte-identical.

## How it's verified

Reviewer confirmed no other caller passed the option, the deleted tests covered no user-relevant obligation, and the remaining 52 routing tests pass. tsgo/biome clean; full CI-style suite failure set identical to stack base (two unrelated full-load flakes pass focused on both branches). Two-model implement/review loop, approved first pass.

Stacked on #1737 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production lookup and error-handling paths are unchanged aside from removing test-only injection; no new runtime behavior.
> 
> **Overview**
> Removes a **test-only injection point** for interactive startup’s daemon active-session lookup. The optional `lookup` override and its type are deleted; the wrapper now always calls `findActiveDaemonSessionSummary` directly while keeping the same `fallbackOnError` behavior for production callers.
> 
> `findActiveDaemonSessionSummaryForInteractiveStartup` is no longer exported, and three unit tests that drove the wrapper through a fake lookup (success, silent fallback, and explicit attach error propagation) are removed. Routing tests that cover real startup decisions remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6aa67f7e8d4a74b63ce87ccf2f9b20a780919eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove test-only daemon-lookup override seam from `main.ts`
> Removes the `ActiveDaemonSessionSummaryLookup` type alias and the optional `lookup` property from `ActiveDaemonSessionSummaryLookupOptions` in [main.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1851/files#diff-4baeaa77e0a68df3cb411f5b9f216f6a26a7a23495a61b955b1d46482f76d586). The function `findActiveDaemonSessionSummaryForInteractiveStartup` is no longer exported and always calls `findActiveDaemonSessionSummary` directly. Deletes three tests in [main-interactive-routing.test.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1851/files#diff-89dfe485dd3ffd7ea9be1643b043fb348a4ce584df7326f371af8901633f8e84) that depended on injecting a custom lookup.
> - Risk: `findActiveDaemonSessionSummaryForInteractiveStartup` is now internal; any out-of-tree importers will break. The `lookup` option is silently ignored if still passed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6aa67f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Linear ticket: [ENG-5658](https://linear.app/primeintellect/issue/ENG-5658/refactorcoding-agent-remove-the-test-only-daemon-lookup-seam-from)
(ticket linked above)