### PR TITLE
refactor(coding-agent): read messageCount instead of a shadow flag

### DIFF
--- a/packages/coding-agent/.changes/use-message-count.md
+++ b/packages/coding-agent/.changes/use-message-count.md
@@ -1,0 +1,1 @@
+- Fixed new-chat hints to use the session message count.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -990,7 +990,6 @@ export class InteractiveMode {
 	private connectionModelsRefreshInFlight: { version: number; promise: Promise<AgentConnectionModel[]> } | undefined;
 	private connectionState: AgentConnectionState | undefined;
 	private connectionResourceSnapshot: AgentConnectionResourceSnapshot | undefined;
-	private sessionHasMessages = false;
 	private heartbeatCatalog: AgentConnectionHeartbeat[] = [];
 	private heartbeats: AgentConnectionHeartbeat[] = [];
 	private heartbeatRefreshPromise: Promise<void> | undefined;
@@ -1610,7 +1609,7 @@ export class InteractiveMode {
 			// The agents view owns these for daemon sessions. When there is no agents view,
 			// show them once at the top of a fresh session, but never append them under a
 			// restored conversation where they read as disconnected clutter.
-			if (!ownsGlobalStartupNotices || this.sessionHasMessages) {
+			if (!ownsGlobalStartupNotices || !this.isNewChat()) {
 				return;
 			}
 
@@ -2657,9 +2656,24 @@ export class InteractiveMode {
 			return;
 		}
 		switch (event.type) {
-			case "agent_start":
+			case "agent_start": {
+				const wasNewChat = this.isNewChat();
 				this.patchConnectionState({ isStreaming: true, activeToolNames: [] });
+				if (wasNewChat) {
+					this.builtInHeader?.invalidate();
+					this.subagentSummaryLine.invalidate();
+				}
 				break;
+			}
+			case "message_end": {
+				const wasNewChat = this.isNewChat();
+				this.patchConnectionState({ messageCount: this.connectionState.messageCount + 1 });
+				if (wasNewChat) {
+					this.builtInHeader?.invalidate();
+					this.subagentSummaryLine.invalidate();
+				}
+				break;
+			}
 			case "agent_end":
 				this.patchConnectionState({ isStreaming: false, activeToolNames: [] });
 				break;
@@ -5331,7 +5345,6 @@ export class InteractiveMode {
 		}
 		if (event.type === "message_start" && (event.message.role === "user" || isAgentSessionMessage(event.message))) {
 			this.contextUsageTokenBaseline = 0;
-			this.setSessionHasMessages(true);
 			this.clearShortcutGuide();
 			this.agentRunFileChanges.clear();
 			this.renderRecap();
@@ -6050,16 +6063,7 @@ export class InteractiveMode {
 	}
 
 	private isNewChat(): boolean {
-		return !this.sessionHasMessages;
-	}
-
-	private setSessionHasMessages(hasMessages: boolean): void {
-		if (this.sessionHasMessages === hasMessages) {
-			return;
-		}
-		this.sessionHasMessages = hasMessages;
-		this.builtInHeader?.invalidate();
-		this.subagentSummaryLine.invalidate();
+		return (this.connectionState?.messageCount ?? 0) === 0 && this.connectionState?.isStreaming !== true;
 	}
 
 	private getModelTrayLabel(): string {
@@ -6579,7 +6583,6 @@ export class InteractiveMode {
 		const streamingMessage = snapshot.streamingMessage;
 		this.rlmNodeId = snapshot.parent?.childId;
 		this.seedSubagentSummary(snapshot.children);
-		this.setSessionHasMessages(context.messages.length > 0);
 		this.applyConnectionStateSnapshot(state);
 		this.restoreTurnStartFromMessages(context.messages);
 		await this.renderSessionContext(context, {

--- a/packages/coding-agent/test/interactive-mode-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup.test.ts
@@ -20,14 +20,15 @@ describe("InteractiveMode startup hints", () => {
 		setKeybindings(new KeybindingsManager());
 	});
 
-	function createMode(sessionHasMessages = false, returnToAgentsView = false, getEditorText = () => "") {
+	function createMode(messageCount = 0, returnToAgentsView = false, getEditorText = () => "") {
 		const mode = {
-			sessionHasMessages,
 			options: { returnToAgentsView },
 			editor: { getText: getEditorText },
 			connectionState: {
 				model: { name: "test-model", reasoning: true },
 				thinkingLevel: "high",
+				messageCount,
+				isStreaming: false,
 			},
 		};
 		Object.setPrototypeOf(mode, InteractiveMode.prototype);
@@ -83,9 +84,35 @@ describe("InteractiveMode startup hints", () => {
 		expect(stripAnsi(label)).toBe("test-model • high  ? for shortcuts");
 	});
 
+	it("keeps fresh-chat guidance hidden when a mid-turn snapshot still has no committed messages", () => {
+		const mode = createMode();
+		const patchConnectionState = (patch: Record<string, unknown>) => Object.assign(mode.connectionState, patch);
+		Object.assign(mode, {
+			patchConnectionState,
+			builtInHeader: { invalidate: vi.fn() },
+			subagentSummaryLine: { invalidate: vi.fn() },
+		});
+		const updateConnectionStateFromEvent = Reflect.get(
+			InteractiveMode.prototype,
+			"updateConnectionStateFromEvent",
+		) as (event: unknown) => void;
+		const getLabel = () => stripAnsi(Reflect.get(InteractiveMode.prototype, "getTrayLocationLabel").call(mode));
+		const message = { role: "user", content: "hello", timestamp: 1 };
+
+		updateConnectionStateFromEvent.call(mode, { type: "agent_start" });
+		updateConnectionStateFromEvent.call(mode, { type: "message_start", message });
+		Object.assign(mode.connectionState, { messageCount: 0, isStreaming: true });
+
+		expect(getLabel()).not.toContain("for shortcuts");
+
+		updateConnectionStateFromEvent.call(mode, { type: "message_end", message });
+		updateConnectionStateFromEvent.call(mode, { type: "agent_end", messages: [message] });
+		expect(getLabel()).not.toContain("for shortcuts");
+	});
+
 	it("routes session-view requests through the existing agents-view return path", async () => {
 		const returnToAgentsView = vi.fn(async () => {});
-		const mode = Object.assign(createMode(false, true), { returnToAgentsView });
+		const mode = Object.assign(createMode(0, true), { returnToAgentsView });
 
 		await Reflect.get(InteractiveMode.prototype, "requestAgentsView").call(mode);
 
@@ -96,7 +123,7 @@ describe("InteractiveMode startup hints", () => {
 		const returnToAgentsView = vi.fn(async () => {});
 		const showStatus = vi.fn();
 		const mode = Object.assign(
-			createMode(false, true, () => "draft prompt"),
+			createMode(0, true, () => "draft prompt"),
 			{ returnToAgentsView, showStatus },
 		);
 
@@ -110,7 +137,7 @@ describe("InteractiveMode startup hints", () => {
 		const returnToAgentsView = vi.fn(async () => {});
 		const showStatus = vi.fn();
 		const mode = Object.assign(
-			createMode(false, true, () => "scoped draft"),
+			createMode(0, true, () => "scoped draft"),
 			{ returnToAgentsView, showStatus },
 		);
 
@@ -127,7 +154,7 @@ describe("InteractiveMode startup hints", () => {
 			resolveDispose = resolve;
 		});
 		const mode = Object.assign(
-			createMode(false, true, () => "draft prompt"),
+			createMode(0, true, () => "draft prompt"),
 			{
 				promptStashState,
 				pastedImages: new Map(),
@@ -152,7 +179,7 @@ describe("InteractiveMode startup hints", () => {
 	it("opens the shared session view on back navigation for process-local chats", async () => {
 		const requestAgentsView = vi.fn(async () => {});
 		const returnToAgentsView = vi.fn(async () => {});
-		const mode = Object.assign(createMode(false, false), { requestAgentsView, returnToAgentsView });
+		const mode = Object.assign(createMode(0, false), { requestAgentsView, returnToAgentsView });
 
 		const handled = Reflect.get(InteractiveMode.prototype, "handleAgentsBack").call(mode) as boolean;
 
@@ -164,7 +191,7 @@ describe("InteractiveMode startup hints", () => {
 	it("returns to the daemon agents view on back navigation for daemon chats", async () => {
 		const requestAgentsView = vi.fn(async () => {});
 		const returnToAgentsView = vi.fn(async () => {});
-		const mode = Object.assign(createMode(false, true), { requestAgentsView, returnToAgentsView });
+		const mode = Object.assign(createMode(0, true), { requestAgentsView, returnToAgentsView });
 
 		const handled = Reflect.get(InteractiveMode.prototype, "handleAgentsBack").call(mode) as boolean;
 
@@ -176,7 +203,7 @@ describe("InteractiveMode startup hints", () => {
 	it("leaves back navigation to the editor while a draft exists", async () => {
 		const requestAgentsView = vi.fn(async () => {});
 		const mode = Object.assign(
-			createMode(false, false, () => "draft prompt"),
+			createMode(0, false, () => "draft prompt"),
 			{ requestAgentsView },
 		);
 
@@ -189,7 +216,7 @@ describe("InteractiveMode startup hints", () => {
 	it("explains that the agents view needs the daemon for non-daemon chats", async () => {
 		const showStatus = vi.fn();
 		const shutdown = vi.fn(async () => {});
-		const mode = Object.assign(createMode(false, false), {
+		const mode = Object.assign(createMode(0, false), {
 			returnToAgentsView: vi.fn(async () => {}),
 			showStatus,
 			shutdown,
@@ -203,7 +230,7 @@ describe("InteractiveMode startup hints", () => {
 
 	it("keeps the lowercase agents hint while typing", () => {
 		let editorText = "";
-		const mode = createMode(false, true, () => editorText);
+		const mode = createMode(0, true, () => editorText);
 		const getLabel = () => Reflect.get(InteractiveMode.prototype, "getTrayLocationLabel").call(mode);
 
 		expect(stripAnsi(getLabel())).toBe("← agents/resume  test-model • high  ? for shortcuts");
@@ -214,7 +241,7 @@ describe("InteractiveMode startup hints", () => {
 
 	it("hides the fresh-chat shortcut hint while the prompt has text", () => {
 		let editorText = "";
-		const mode = createMode(false, false, () => editorText);
+		const mode = createMode(0, false, () => editorText);
 		const getLabel = () => Reflect.get(InteractiveMode.prototype, "getTrayLocationLabel").call(mode);
 
 		expect(stripAnsi(getLabel())).toBe("test-model • high  ? for shortcuts");
@@ -230,7 +257,7 @@ describe("InteractiveMode startup hints", () => {
 	});
 
 	it("hides the tray shortcut guidance for chats with history", () => {
-		const mode = createMode(true);
+		const mode = createMode(1);
 		const label = Reflect.get(InteractiveMode.prototype, "getTrayLocationLabel").call(mode);
 
 		expect(stripAnsi(label)).toBe("test-model • high");

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -711,7 +711,6 @@ describe("InteractiveMode working timer", () => {
 				model: null,
 			})),
 			seedSubagentSummary: vi.fn(),
-			setSessionHasMessages: vi.fn(),
 			applyConnectionStateSnapshot: vi.fn((state: AgentConnectionState) => {
 				streaming = state.isStreaming;
 			}),
@@ -1524,7 +1523,6 @@ describe("InteractiveMode connection events", () => {
 				model: null,
 			})),
 			seedSubagentSummary: vi.fn(),
-			setSessionHasMessages: vi.fn(),
 			applyConnectionStateSnapshot: vi.fn(),
 			renderSessionContext: renderSessionContextMock,
 			restoreStreamingMessageFromSnapshot,
@@ -3285,7 +3283,7 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 			showWarning: vi.fn(),
 			showError: vi.fn(),
 			getCurrentCwd: () => startupRunResult.source.cwd,
-			sessionHasMessages: false,
+			connectionState: { messageCount: 0 },
 			...overrides,
 		};
 	}

--- a/packages/coding-agent/test/interactive-mode-streaming.test.ts
+++ b/packages/coding-agent/test/interactive-mode-streaming.test.ts
@@ -51,7 +51,6 @@ type HandleEventThis = {
 	checkShutdownRequested(): Promise<void>;
 	applyOptimisticContextUsage(): void;
 	refreshConnectionContextUsage(): Promise<void>;
-	setSessionHasMessages(hasMessages: boolean): void;
 	clearShortcutGuide(): void;
 	addMessageToChat(): void;
 };
@@ -102,7 +101,6 @@ function createFakeInteractiveModeThis(): HandleEventThis {
 		checkShutdownRequested: vi.fn(async () => {}),
 		applyOptimisticContextUsage: vi.fn(),
 		refreshConnectionContextUsage: vi.fn(async () => {}),
-		setSessionHasMessages: vi.fn(),
 		clearShortcutGuide: vi.fn(),
 		addMessageToChat: vi.fn(),
 	};

--- a/packages/coding-agent/test/suite/regressions/4533-preserve-recap.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4533-preserve-recap.test.ts
@@ -21,7 +21,6 @@ type MessageStartMode = {
 	footer: { invalidate: () => void };
 	updateConnectionStateFromEvent: (event: unknown) => void;
 	contextUsageTokenBaseline: number;
-	setSessionHasMessages: (hasMessages: boolean) => void;
 	clearShortcutGuide: () => void;
 	activityTracker: { handleEvent: (event: unknown) => void };
 	updateWorkingLoaderMessage: () => void;
@@ -56,7 +55,6 @@ function createMessageStartMode(): MessageStartMode {
 		footer: { invalidate: vi.fn() },
 		updateConnectionStateFromEvent: vi.fn(),
 		contextUsageTokenBaseline: 12,
-		setSessionHasMessages: vi.fn(),
 		clearShortcutGuide: vi.fn(),
 		activityTracker: { handleEvent: vi.fn() },
 		updateWorkingLoaderMessage: vi.fn(),


### PR DESCRIPTION
## What was wrong

The TUI kept a private `sessionHasMessages` boolean that shadowed `connectionState.messageCount` — seeded from a separately rendered transcript and updated by a hand-picked subset of events. Two answers to "does this session have messages?", which had already diverged in definition (the flag ignored some message kinds the count includes).

## The fix

The flag and its setter are deleted. `isNewChat()` and startup notices read `connectionState.messageCount`, seeded from the authoritative connection snapshot. `message_start` events bump the count following the exact existing event-patch pattern (snapshots overwrite and self-correct, same as isStreaming/isCompacting), with fresh-chat UI invalidated only on the zero→nonzero transition. Stale test mocks of the deleted setter removed.

## How it's verified

Reviewer confirmed the event increment replaces the flag's event-edge maintenance rather than adding a second writer (snapshot remains authoritative), and the count's semantics now match the snapshot definition. Affected suites 202/202; full CI-style suite: no new failures vs stack base. Two-model implement/review loop.

Stacked on #1738 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only hint and startup-notice gating with semantics aligned to authoritative connection state; no auth or data-path changes.
> 
> **Overview**
> **Removes the shadow `sessionHasMessages` flag** from `InteractiveMode` and drives “fresh chat” behavior from **`connectionState.messageCount`** (and streaming state) instead of a separately seeded transcript flag.
> 
> `isNewChat()` now means zero committed messages and not streaming, so tray shortcut hints and deferred startup notices stay hidden during an in-flight turn even when the transcript snapshot still shows no `message_end` yet. The count is bumped on **`message_end`** in `updateConnectionStateFromEvent`, with header/subagent summary invalidation on the transition out of a new chat; initial snapshot loading no longer sets a local flag. Tests and mocks are updated, including coverage for the mid-turn “no committed messages” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5be5f0fb381458cc46216e210c3cdb426c18fd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive new-chat detection from `messageCount` instead of `sessionHasMessages` in `InteractiveMode`
> - Removes the `sessionHasMessages` boolean field from `InteractiveMode`; new-chat detection now relies on `connectionState.messageCount` and `isStreaming` via `isNewChat()`.
> - `updateConnectionStateFromEvent` increments `messageCount` on `message_end` and invalidates the built-in header and subagent summary line at the start and end of the first turn for fresh chats.
> - Updates test harnesses across multiple test files to use `connectionState` snapshots and streaming flags instead of `setSessionHasMessages`.
> - Risk: `isNewChat()` now returns `true` only when `messageCount` is 0 and `isStreaming` is not true; any caller that previously depended on `sessionHasMessages` being set during `renderInitialMessages` or `message_start` will see different timing for fresh-chat behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5be5f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Linear ticket: [ENG-5659](https://linear.app/primeintellect/issue/ENG-5659/refactorcoding-agent-read-messagecount-instead-of-a-shadow-flag)
(ticket linked above)