### PR TITLE
refactor(coding-agent): derive available connection models on read

### DIFF
--- a/packages/coding-agent/.changes/derive-connection-models.md
+++ b/packages/coding-agent/.changes/derive-connection-models.md
@@ -1,0 +1,1 @@
+- Kept available model lists in sync with the current catalog and configured providers.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -982,7 +982,6 @@ export class InteractiveMode {
 
 	private skillCommands = new Map<string, string>();
 	private connectionCommands: AgentConnectionSlashCommand[] = [];
-	private connectionModels: AgentConnectionModel[] = [];
 	private connectionModelCatalog: AgentConnectionModel[] = [];
 	private connectionConfiguredProviders = new Set<string>();
 	private connectionModelsFetchedAt = 0;
@@ -7772,7 +7771,10 @@ export class InteractiveMode {
 	private applyConnectionModelCatalog(catalog: AgentConnectionModelCatalog): void {
 		this.connectionModelCatalog = [...catalog.models];
 		this.connectionConfiguredProviders = new Set(catalog.configuredProviders);
-		this.connectionModels = catalog.models.filter((model) => this.connectionConfiguredProviders.has(model.provider));
+	}
+
+	private getAvailableConnectionModels(): AgentConnectionModel[] {
+		return this.connectionModelCatalog.filter((model) => this.connectionConfiguredProviders.has(model.provider));
 	}
 
 	private async getConnectionAvailableModels(): Promise<AgentConnectionModel[]> {
@@ -7784,11 +7786,11 @@ export class InteractiveMode {
 		const version = this.connectionModelsRefreshVersion;
 		const promise = this.agentConnection.getModelCatalog().then((catalog) => {
 			if (version !== this.connectionModelsRefreshVersion) {
-				return [...this.connectionModels];
+				return this.getAvailableConnectionModels();
 			}
 			this.applyConnectionModelCatalog(catalog);
 			this.connectionModelsFetchedAt = Date.now();
-			return [...this.connectionModels];
+			return this.getAvailableConnectionModels();
 		});
 		this.connectionModelsRefreshInFlight = { version, promise };
 
@@ -7839,7 +7841,6 @@ export class InteractiveMode {
 	}
 
 	private invalidateConnectionModels(): void {
-		this.connectionModels = [];
 		this.connectionConfiguredProviders = new Set();
 		this.connectionModelsFetchedAt = 0;
 		this.invalidateConnectionModelRefresh();

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -2172,7 +2172,6 @@ describe("InteractiveMode startup onboarding warnings", () => {
 describe("InteractiveMode model candidates", () => {
 	type ModelCandidatesHarness = {
 		agentConnection: { getModelCatalog: () => Promise<AgentConnectionModelCatalog> };
-		connectionModels: AgentConnectionModel[];
 		connectionModelCatalog: AgentConnectionModel[];
 		connectionConfiguredProviders: Set<string>;
 		connectionModelsFetchedAt: number;
@@ -2180,6 +2179,7 @@ describe("InteractiveMode model candidates", () => {
 		connectionModelsRefreshInFlight: { version: number; promise: Promise<AgentConnectionModel[]> } | undefined;
 		getScopedModelState(): AgentConnectionState["scopedModels"];
 		applyConnectionModelCatalog(catalog: AgentConnectionModelCatalog): void;
+		getAvailableConnectionModels(): AgentConnectionModel[];
 		getConnectionAvailableModels(): Promise<AgentConnectionModel[]>;
 		getModelCandidates(): Promise<AgentConnectionModel[]>;
 		getScopedModelsFromModelIds(
@@ -2201,7 +2201,6 @@ describe("InteractiveMode model candidates", () => {
 		const getModelCatalog = vi.fn(async () => ({ models: [model], configuredProviders: [model.provider] }));
 		const fakeThis: ModelCandidatesHarness = {
 			agentConnection: { getModelCatalog },
-			connectionModels: [],
 			connectionModelCatalog: [],
 			connectionConfiguredProviders: new Set(),
 			connectionModelsFetchedAt: 0,
@@ -2209,6 +2208,7 @@ describe("InteractiveMode model candidates", () => {
 			connectionModelsRefreshInFlight: undefined,
 			getScopedModelState: () => [],
 			applyConnectionModelCatalog: prototype.applyConnectionModelCatalog,
+			getAvailableConnectionModels: prototype.getAvailableConnectionModels,
 			getConnectionAvailableModels: prototype.getConnectionAvailableModels,
 			getModelCandidates: prototype.getModelCandidates,
 			getScopedModelsFromModelIds: prototype.getScopedModelsFromModelIds,
@@ -2218,7 +2218,7 @@ describe("InteractiveMode model candidates", () => {
 
 		expect(result).toEqual([model]);
 		expect(getModelCatalog).toHaveBeenCalledTimes(1);
-		expect(fakeThis.connectionModels).toEqual([model]);
+		expect(fakeThis.getAvailableConnectionModels()).toEqual([model]);
 	});
 
 	test("uses connection state for scoped model candidates", async () => {
@@ -2229,7 +2229,6 @@ describe("InteractiveMode model candidates", () => {
 		});
 		const fakeThis: ModelCandidatesHarness = {
 			agentConnection: { getModelCatalog },
-			connectionModels: [],
 			connectionModelCatalog: [],
 			connectionConfiguredProviders: new Set(),
 			connectionModelsFetchedAt: 0,
@@ -2237,6 +2236,7 @@ describe("InteractiveMode model candidates", () => {
 			connectionModelsRefreshInFlight: undefined,
 			getScopedModelState: () => [{ model, thinkingLevel: "medium" }],
 			applyConnectionModelCatalog: prototype.applyConnectionModelCatalog,
+			getAvailableConnectionModels: prototype.getAvailableConnectionModels,
 			getConnectionAvailableModels: prototype.getConnectionAvailableModels,
 			getModelCandidates: prototype.getModelCandidates,
 			getScopedModelsFromModelIds: prototype.getScopedModelsFromModelIds,
@@ -2299,7 +2299,6 @@ describe("InteractiveMode model selection persistence", () => {
 			getModelCatalog(): Promise<AgentConnectionModelCatalog>;
 			setModel(provider: string, modelId: string): Promise<void>;
 		};
-		connectionModels: AgentConnectionModel[];
 		connectionModelCatalog: AgentConnectionModel[];
 		connectionConfiguredProviders: Set<string>;
 		connectionModelsFetchedAt: number;
@@ -2321,6 +2320,7 @@ describe("InteractiveMode model selection persistence", () => {
 		getScopedModelState(): AgentConnectionState["scopedModels"];
 		getCurrentModel(): AgentConnectionModel | undefined;
 		applyConnectionModelCatalog(catalog: AgentConnectionModelCatalog): void;
+		getAvailableConnectionModels(): AgentConnectionModel[];
 		findExactModelMatch(searchTerm: string): Promise<AgentConnectionModel | undefined>;
 		getConnectionAvailableModels(): Promise<AgentConnectionModel[]>;
 		getCachedModelCandidates(): AgentConnectionModel[];
@@ -2409,7 +2409,6 @@ describe("InteractiveMode model selection persistence", () => {
 				}),
 			setModel: vi.fn(async () => {}),
 		};
-		fakeThis.connectionModels = [...options.connectionModels];
 		fakeThis.connectionModelCatalog = catalogModels;
 		fakeThis.connectionConfiguredProviders = configuredProviders;
 		fakeThis.connectionModelsFetchedAt = options.connectionModelsFetchedAt ?? 0;
@@ -2947,7 +2946,6 @@ describe("InteractiveMode model selection persistence", () => {
 			getResourceSnapshot: vi.fn(async () => ({})),
 			setModel: vi.fn(async () => {}),
 		} as never;
-		fakeThis.connectionModels = [];
 		fakeThis.connectionModelCatalog = [];
 		fakeThis.connectionConfiguredProviders = new Set();
 		fakeThis.connectionModelsFetchedAt = 0;
@@ -2973,7 +2971,7 @@ describe("InteractiveMode model selection persistence", () => {
 
 		await expect(staleRefresh).resolves.toEqual([freshModel]);
 
-		expect(fakeThis.connectionModels).toEqual([freshModel]);
+		expect(fakeThis.getAvailableConnectionModels()).toEqual([freshModel]);
 	});
 
 	test("keeps the cached model catalog when a catalog refresh fails", async () => {
@@ -2997,7 +2995,6 @@ describe("InteractiveMode model selection persistence", () => {
 			getResourceSnapshot: vi.fn(async () => ({})),
 			setModel: vi.fn(async () => {}),
 		} as never;
-		fakeThis.connectionModels = [cachedModel];
 		fakeThis.connectionModelCatalog = [cachedModel];
 		fakeThis.connectionConfiguredProviders = new Set([cachedModel.provider]);
 		fakeThis.connectionModelsFetchedAt = Date.now();
@@ -3015,7 +3012,7 @@ describe("InteractiveMode model selection persistence", () => {
 		await expect(fakeThis.refreshConnectionCatalog()).resolves.toBeUndefined();
 
 		expect(fakeThis.connectionCommands).toEqual([]);
-		expect(fakeThis.connectionModels).toEqual([expect.objectContaining({ id: "fresh" })]);
+		expect(fakeThis.getAvailableConnectionModels()).toEqual([expect.objectContaining({ id: "fresh" })]);
 		expect(fakeThis.connectionModelsFetchedAt).toBeGreaterThan(0);
 	});
 
@@ -3223,7 +3220,6 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 	};
 	type OnboardingFake = OnboardingHarness & {
 		connectionState: AgentConnectionState;
-		connectionModels: AgentConnectionModel[];
 		agentConnection: {
 			getAvailableModels?: () => Promise<AgentConnectionModel[]>;
 			setModel?: (provider: string, modelId: string) => Promise<void>;
@@ -3898,7 +3894,6 @@ describe("InteractiveMode Prime CLI onboarding", () => {
 	function createPrimeCliHarness(shown: boolean): OnboardingFake {
 		const fakeThis = Object.create(InteractiveMode.prototype) as OnboardingFake;
 		fakeThis.connectionState = createConnectionState({ model: primeModel });
-		fakeThis.connectionModels = [primeModel];
 		fakeThis.agentConnection = {
 			getAvailableModels: vi.fn(async () => [primeModel]),
 		};

--- a/packages/coding-agent/test/suite/regressions/4575-model-auth-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4575-model-auth-selection.test.ts
@@ -11,7 +11,6 @@ import { createHarness, type Harness } from "../harness.js";
 
 interface ConnectionAuthRefreshHarness {
 	agentConnection: { getModelCatalog(): Promise<AgentConnectionModelCatalog> };
-	connectionModels: AgentConnectionModel[];
 	connectionModelCatalog: AgentConnectionModel[];
 	connectionConfiguredProviders: Set<string>;
 	connectionModelsFetchedAt: number;
@@ -19,6 +18,7 @@ interface ConnectionAuthRefreshHarness {
 	connectionModelsRefreshInFlight: { version: number; promise: Promise<AgentConnectionModel[]> } | undefined;
 	invalidateConnectionModels(): void;
 	applyConnectionModelCatalog(catalog: AgentConnectionModelCatalog): void;
+	getAvailableConnectionModels(): AgentConnectionModel[];
 	getConnectionAvailableModels(): Promise<AgentConnectionModel[]>;
 	getConnectionModelCatalog(): Promise<AgentConnectionModel[]>;
 	refreshConnectionModelsAfterAuthChange(): Promise<void>;
@@ -124,7 +124,6 @@ describe("ENG-4575 model authentication", () => {
 		const getModelCatalog = vi.fn(async () => ({ models: [model], configuredProviders: [] }));
 		const fakeThis = Object.create(InteractiveMode.prototype) as ConnectionAuthRefreshHarness;
 		fakeThis.agentConnection = { getModelCatalog };
-		fakeThis.connectionModels = [model];
 		fakeThis.connectionModelCatalog = [model];
 		fakeThis.connectionConfiguredProviders = new Set([model.provider]);
 		fakeThis.connectionModelsFetchedAt = Date.now();
@@ -135,7 +134,7 @@ describe("ENG-4575 model authentication", () => {
 
 		expect(getModelCatalog).toHaveBeenCalledOnce();
 		expect(fakeThis.connectionConfiguredProviders).toEqual(new Set());
-		expect(fakeThis.connectionModels).toEqual([]);
+		expect(fakeThis.getAvailableConnectionModels()).toEqual([]);
 		expect(fakeThis.connectionModelCatalog).toEqual([model]);
 	});
 
@@ -147,7 +146,6 @@ describe("ENG-4575 model authentication", () => {
 		fakeThis.agentConnection = {
 			getModelCatalog: vi.fn(async () => ({ models: [model], configuredProviders: [] })),
 		};
-		fakeThis.connectionModels = [];
 		fakeThis.connectionModelCatalog = [];
 		fakeThis.connectionConfiguredProviders = new Set();
 		fakeThis.connectionModelsFetchedAt = 0;
@@ -155,7 +153,7 @@ describe("ENG-4575 model authentication", () => {
 		fakeThis.connectionModelsRefreshInFlight = undefined;
 
 		await expect(fakeThis.getConnectionModelCatalog()).resolves.toEqual([model]);
-		expect(fakeThis.connectionModels).toEqual([]);
+		expect(fakeThis.getAvailableConnectionModels()).toEqual([]);
 	});
 
 	test("uses the full public catalog for scoped-session model autocomplete", async () => {


### PR DESCRIPTION
## What was wrong

The TUI stored `connectionModels` — a filtered copy of the model catalog x configured providers — with its own assignment, clearing, and versioned return paths. A pure function of two other fields, stored, and therefore synchronizable and driftable (audit: duplicate sources of truth, dup-truth.md finding 4).

## The fix

The stored copy and its sync paths are deleted; the available-model list derives on read with the identical predicate (`catalog.filter(m => providers.has(m.provider))`). The catalog, provider set, and async-refresh generation guard remain — they are source data and stale-request protection, not copy-sync. +17/−22.

## How it's verified

Reviewer confirmed all 4 former field sites converted (zero references remain), predicate character-identical including the invalidate and stale-generation cases, derivation off any render hot path, and the retained machinery guards source data only. 174/174 focused; full CI-style suite identical failing set to stack base. Two-model implement/review loop, approved first pass.

Stacked on #1739 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal deduplication of model-list state with the same filter predicate; behavior should match prior sync paths aside from eliminating drift between copies.
> 
> **Overview**
> **InteractiveMode** no longer keeps a separate `connectionModels` array that mirrored “catalog ∩ configured providers.” That filtered list is now computed on demand via **`getAvailableConnectionModels()`**, using the same provider filter as before.
> 
> **`applyConnectionModelCatalog`** only updates `connectionModelCatalog` and `connectionConfiguredProviders`; **`getConnectionAvailableModels`**, stale-refresh handling, and **`invalidateConnectionModels`** read from the derived list instead of maintaining a second copy. Test harnesses assert availability through **`getAvailableConnectionModels()`** rather than a `connectionModels` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1063d080b18a9f382d5906daab0d517f9b09368c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive `connectionModels` on read instead of caching in `InteractiveMode`
> - Removes the cached `connectionModels` field from `InteractiveMode` and replaces it with a derived accessor, `getAvailableConnectionModels`, which filters `connectionModelCatalog` against `connectionConfiguredProviders` on each call.
> - `applyConnectionModelCatalog` now only sets the catalog and configured providers; `invalidateConnectionModels` no longer clears the deleted cache.
> - All call sites in [interactive-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1853/files#diff-b96137f89d422953665b334785273ae6cdbcb53ff37d8828db43f85038658316) and related tests are updated to use the new accessor.
> - Risk: `getAvailableConnectionModels` recomputes the filtered list on every read rather than returning a stored array; callers that read it in a hot loop should verify the per-call cost is acceptable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1063d08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Linear ticket: [ENG-5660](https://linear.app/primeintellect/issue/ENG-5660/refactorcoding-agent-derive-available-connection-models-on-read)
(ticket linked above)