### PR TITLE
refactor(coding-agent): delete unreachable empty-selector auto-cancel timers

### DIFF
--- a/packages/coding-agent/.changes/remove-empty-selector-timers.md
+++ b/packages/coding-agent/.changes/remove-empty-selector-timers.md
@@ -1,0 +1,1 @@
+- Removed delayed cancellation callbacks from empty interactive selectors.

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -1198,10 +1198,6 @@ export class TreeSelectorComponent extends Container implements Focusable {
 		this.addChild(this.labelInputContainer);
 		this.addChild(new Spacer(1));
 		this.addChild(new DynamicBorder());
-
-		if (tree.length === 0) {
-			setTimeout(() => onCancel(), 100);
-		}
 	}
 
 	private showLabelInput(entryId: string, currentLabel: string | undefined): void {

--- a/packages/coding-agent/src/modes/interactive/components/user-message-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/user-message-selector.ts
@@ -117,10 +117,6 @@ export class UserMessageSelectorComponent extends Container {
 
 		this.addChild(new Spacer(1));
 		this.addChild(new DynamicBorder());
-
-		if (messages.length === 0) {
-			setTimeout(() => onCancel(), 100);
-		}
 	}
 
 	getMessageList(): UserMessageList {


### PR DESCRIPTION
## What was wrong

Both TUI selectors (fork-message and session-tree) carried a 100ms auto-cancel timer for the empty-collection case — but their only construction sites already return early with a user-facing notice when the collection is empty. Unreachable defensive timers, plus the stale-callback hazard they imply (audit: timeouts.md finding 8).

## The fix

Pure deletion of both blocks (+1/−8). No replacement assertions — the callers own the precondition.

## How it's verified

Reviewer independently enumerated all construction sites (production + tests) confirming the empty case cannot reach the components, and that the deleted blocks held no listener registrations — nothing leaks. tsgo/biome clean, tree-selector 18/18, full CI-style suite failing set matches stack base. Two-model implement/review loop, approved first pass.

Stacked on #1744 (test the whole stack at the leaf; merge base-first). This completes the deletion-only wave of the audit stack.

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal in interactive TUI selectors; no change to production paths that already guard empty collections before opening the UI.
> 
> **Overview**
> Removes **100ms delayed `onCancel` timers** from `TreeSelectorComponent` and `UserMessageSelectorComponent` that fired when the tree or message list was empty.
> 
> Those branches were unreachable in practice: `interactive-mode` already returns early with a status message (`No entries in session` / `No messages to fork from`) before constructing either selector. The components still render empty-state UI when filters yield no rows; that behavior is unchanged—only the automatic cancel is gone.
> 
> This is deletion-only cleanup aligned with the timeouts audit (stale callback hazard from defensive timers with no matching teardown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37225b216a5d86b3572f5fc3cd6d44ba6fda25de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Linear ticket: [ENG-5663](https://linear.app/primeintellect/issue/ENG-5663/refactorcoding-agent-delete-unreachable-empty-selector-auto-cancel)
(ticket linked above)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unreachable empty-selector auto-cancel timers in `TreeSelectorComponent` and `UserMessageSelectorComponent`
> - Removes the `setTimeout`-based auto-cancellation from the constructors of [tree-selector.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1855/files#diff-eb3a2b5ed9743a3bf5f855316bb3f508141b0d28028ed4cc246be17d04a77fa6) and [user-message-selector.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1855/files#diff-765e46fbefdcec9ce9507b650603d3ec700d3ee3bad49a7bd4e971e09b9b1cd0)
> - Both selectors previously auto-invoked `onCancel` after 100ms when given an empty tree or messages array; this logic was unreachable and is now deleted
> - Behavioral Change: empty selectors no longer auto-cancel; they remain active until explicitly canceled by the user or caller
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37225b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->