### PR TITLE
refactor(coding-agent): query agent peers on demand instead of broadcasting mirrors

### DIFF
--- a/packages/coding-agent/.changes/on-demand-agent-peers.md
+++ b/packages/coding-agent/.changes/on-demand-agent-peers.md
@@ -1,0 +1,1 @@
+- Made cross-worker agent lists current without broadcasting duplicate peer rosters.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3726,6 +3726,12 @@ export class AgentDaemon {
 					this.writeWorkerSuccess(client, command);
 					return;
 				}
+				default: {
+					// Legacy commands from older supervisors (e.g. worker_sync_agent_peers) must fail fast, not time out.
+					const unknown = command as { id?: string; type: string };
+					this.write(client, failure(unknown.id, unknown.type, `Unknown worker command: ${unknown.type}`));
+					return;
+				}
 			}
 		} catch (error) {
 			this.write(client, failure(command.id, command.type, error, serializeDaemonError(error)));

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -526,7 +526,6 @@ export class AgentDaemon {
 	private readonly agentDir: string;
 	private readonly cronScheduler: AgentCronScheduler;
 	private readonly agentMessageRateLimiter = new AgentSessionMessageRateLimiter();
-	private readonly remoteAgentPeers = new Map<string, AgentSessionMessageAgentSummary>();
 	private readonly agentMessagePendingReservations = new Map<string, number>();
 	private readonly agentMessageTargetLocks = new Map<string, Promise<void>>();
 	private readonly agentMessageAcceptingTargets = new Set<string>();
@@ -3658,13 +3657,6 @@ export class AgentDaemon {
 					this.write(client, success(command.id, "detach"));
 					return;
 				}
-				case "worker_sync_agent_peers":
-					this.remoteAgentPeers.clear();
-					for (const peer of command.peers) {
-						this.remoteAgentPeers.set(peer.activeSessionId, peer);
-					}
-					this.writeWorkerSuccess(client, command);
-					return;
 				case "worker_archive_and_shutdown": {
 					for (const state of [...this.sessions.values()]) {
 						await this.closeSession(state, "killed");
@@ -5367,7 +5359,32 @@ export class AgentDaemon {
 		};
 	}
 
-	private async createAgentMessageListResult(current: ActiveSessionState): Promise<AgentSessionMessageListResult> {
+	private async listSupervisorAgentPeers(): Promise<AgentSessionMessageAgentSummary[]> {
+		const supervisorSocketPath = this.supervisorSocketPathFromEnv();
+		if (!this.options.worker || !supervisorSocketPath) return [];
+		const client = new DaemonClient(supervisorSocketPath);
+		try {
+			await client.connect(1000);
+			await client.waitForHello(1000);
+			const response = await client.request(
+				{ type: "list_agent_peers", workerToken: this.options.worker.authenticationToken },
+				5000,
+			);
+			if (!response.success) throw deserializeDaemonError(response);
+			// SAFETY: The authenticated supervisor constructs the peer response.
+			return (response.data as { peers: AgentSessionMessageAgentSummary[] }).peers;
+		} catch {
+			return [];
+		} finally {
+			client.close();
+		}
+	}
+
+	private async createAgentMessageListResult(
+		current: ActiveSessionState,
+		peers?: AgentSessionMessageAgentSummary[],
+	): Promise<AgentSessionMessageListResult> {
+		peers ??= await this.listSupervisorAgentPeers();
 		const localAgents = this.listTargetableSessionStates(current).map((state) =>
 			this.createAgentMessageAgentSummary(state),
 		);
@@ -5400,28 +5417,24 @@ export class AgentDaemon {
 			});
 		}
 		const localIds = new Set(localAgents.map((agent) => agent.activeSessionId));
+		const remoteAgents = peers.filter(
+			(peer) => !localIds.has(peer.activeSessionId) && !this.closingSessions.has(peer.activeSessionId),
+		);
 		return {
 			current: this.createAgentSessionMessageEndpoint(current),
-			agents: [
-				...localAgents,
-				...[...this.remoteAgentPeers.values()].filter(
-					(peer) =>
-						peer.status !== "inactive" &&
-						!localIds.has(peer.activeSessionId) &&
-						!this.closingSessions.has(peer.activeSessionId),
-				),
-			],
+			agents: [...localAgents, ...remoteAgents],
 		};
 	}
 
 	private async createAgentFamilyCatalog(currentState?: ActiveSessionState): Promise<AgentFamilyCatalogEntry[]> {
 		const current =
 			currentState ?? [...this.sessions.values()].find((state) => !this.bindingSessions.has(state.activeSessionId));
-		const listed = current ? await this.createAgentMessageListResult(current) : { agents: [] };
-		const remotePeers = new Set(this.remoteAgentPeers.values());
+		const remotePeers = current ? await this.listSupervisorAgentPeers() : [];
+		const listed = current ? await this.createAgentMessageListResult(current, remotePeers) : { agents: [] };
+		const remotePeerSet = new Set(remotePeers);
 		const localAgents = current
-			? [this.createAgentMessageAgentSummary(current), ...listed.agents.filter((agent) => !remotePeers.has(agent))]
-			: listed.agents.filter((agent) => !remotePeers.has(agent));
+			? [this.createAgentMessageAgentSummary(current), ...listed.agents.filter((agent) => !remotePeerSet.has(agent))]
+			: listed.agents;
 		const activePaths = new Set(
 			localAgents.flatMap((agent) => (agent.sessionPath ? [canonicalSessionPath(agent.sessionPath)] : [])),
 		);
@@ -5462,7 +5475,7 @@ export class AgentDaemon {
 				...(agent.sessionPath ? { sessionPath: canonicalSessionPath(agent.sessionPath) } : {}),
 			});
 		};
-		for (const peer of this.remoteAgentPeers.values()) addAgent(peer);
+		for (const peer of remotePeers) addAgent(peer);
 		for (const agent of localAgents) addAgent(agent);
 		for (const state of this.sessions.values()) {
 			const entry = byId.get(state.runtime.session.sessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -66,9 +66,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 19 adds daemon-held session input pauses.
 // Revision 20 lets cancellation target a prompt the session owns but has not started.
 // Revision 21 adds capability-gated, session-scoped ACP MCP server replacement.
-// Revision 22 scopes ACP MCP replacement and cleanup to a connection owner.
-export const DAEMON_SCHEMA_REVISION = 22;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-22-4d515169dc6b";
+// Revision 23 lets workers query the supervisor agent roster on demand.
+export const DAEMON_SCHEMA_REVISION = 23;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-23-649fe649d15e";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -377,6 +377,7 @@ export type DaemonCommand =
 			includeClientOwned?: boolean;
 	  }
 	| DaemonSavedSessionListCommand
+	| { id?: string; type: "list_agent_peers"; workerToken: string }
 	| ({
 			id?: string;
 			type: "create";
@@ -712,11 +713,13 @@ const SESSION_INPUT_PAUSE_COMMAND = {
 	minSchemaRevision: 19,
 	capability: "session_input_pause",
 } as const;
+const AGENT_PEER_LIST_COMMAND = { minProtocol: 7, minSchemaRevision: 23 } as const;
 
 export const DAEMON_COMMAND_COMPATIBILITY = {
 	ack_result: LEGACY_DAEMON_COMMAND,
 	list: LEGACY_DAEMON_COMMAND,
 	list_saved_sessions: LEGACY_DAEMON_COMMAND,
+	list_agent_peers: AGENT_PEER_LIST_COMMAND,
 	create: LEGACY_DAEMON_COMMAND,
 	attach: LEGACY_DAEMON_COMMAND,
 	reattach: LEGACY_DAEMON_COMMAND,
@@ -1106,6 +1109,7 @@ const READ_ONLY_DAEMON_COMMANDS: ReadonlySet<DaemonCommand["type"]> = new Set([
 	"ack_result",
 	"list",
 	"list_saved_sessions",
+	"list_agent_peers",
 	"attach",
 	"reattach",
 	"agent_messages_status",

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -167,6 +167,7 @@ const WORKER_STARTUP_GATE_FD = 3;
 const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"ack_result",
 	"list",
+	"list_agent_peers",
 	"list_saved_sessions",
 	"create",
 	"attach",
@@ -641,7 +642,6 @@ export class DaemonSupervisor {
 	private commandJournal!: CommandRecoveryJournal;
 	private readonly streamReconstructor = new CompactAssistantStreamReconstructor();
 	private readonly compactCatchupInProgress = new Set<string>();
-	private agentPeerSyncQueue: Promise<void> = Promise.resolve();
 	private readonly pendingSessionNames = new Set<string>();
 	private readonly catalog: DaemonCatalogClient;
 	private readonly settingsManager: SettingsManager;
@@ -740,7 +740,6 @@ export class DaemonSupervisor {
 			if (adoptionFailed) {
 				throw adoptionFailure;
 			}
-			await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 			for (const worker of this.workers.values()) {
 				this.scheduleOwnedWorkerCleanup(worker);
 			}
@@ -1537,6 +1536,25 @@ export class DaemonSupervisor {
 				return undefined;
 			case "list":
 				return this.handleList(client, command);
+			case "list_agent_peers": {
+				const requester = [...this.workers.values()].find(
+					(worker) => worker.descriptor.authenticationToken === command.workerToken,
+				);
+				if (!requester) throw new Error("Worker authentication failed");
+				const peers = [...this.workers.values()]
+					.filter(
+						(worker) =>
+							worker !== requester &&
+							this.isLiveWorker(worker) &&
+							worker.descriptor.lifecycle === "ready" &&
+							worker.client !== undefined,
+					)
+					.flatMap((worker) => {
+						const root = worker.summaries.get(worker.descriptor.rootActiveSessionId);
+						return root ? [this.agentPeerSummary(root)] : [];
+					});
+				return success(command.id, command.type, { peers });
+			}
 			case "list_saved_sessions":
 				return this.handleSavedSessionList(client, command);
 			case "create": {
@@ -1552,7 +1570,6 @@ export class DaemonSupervisor {
 					const response = await this.forwardToWorker(worker, withoutSupervisorCreateFields(command));
 					if (response.success && isSessionSummary(response.data)) {
 						await this.refreshWorkerSummaries(worker);
-						await this.syncAgentPeers().catch(() => undefined);
 						return { ...response, id: command.id, data: this.publicSummary(worker, response.data) };
 					}
 					return responseWithId(response, command.id);
@@ -2166,7 +2183,6 @@ export class DaemonSupervisor {
 				.filter((worker) => !this.isWorkerStopping(worker))
 				.map((worker) => this.refreshWorkerSummaries(worker).catch(() => undefined)),
 		);
-		await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 		const clientOwnedWorkers = [...this.workers.values()].filter((worker) => !this.isVisibleWorker(worker));
 		// Stopping workers stay listed (with an honest workerState) because this
 		// list also feeds busy-daemon safety checks in daemon-launch.
@@ -2343,7 +2359,6 @@ export class DaemonSupervisor {
 			this.invalidateWorkerSessionInputPauses(worker, "Session worker stopped while input was paused");
 			this.workers.delete(worker.descriptor.workerId);
 			this.deleteWorkerDescriptor(worker);
-			await this.syncAgentPeers().catch(() => undefined);
 			return true;
 		}
 		// Fail fast before waiting on anything: only a confirmed-dead process is
@@ -2395,7 +2410,6 @@ export class DaemonSupervisor {
 		}
 		worker.launchEnv = undefined;
 		worker.transientCreateCommand = undefined;
-		await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 	}
 
 	private async launchWorker(
@@ -2577,7 +2591,6 @@ export class DaemonSupervisor {
 				worker.launchEnv = undefined;
 				worker.transientCreateCommand = undefined;
 			}
-			await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 			this.broadcastHeartbeatsChanged();
 			return worker;
 		} catch (error) {
@@ -2804,7 +2817,6 @@ export class DaemonSupervisor {
 		worker.descriptor.lifecycle = "recovering";
 		worker.descriptor.lastError = error.message;
 		this.persistWorker(worker);
-		void this.syncAgentPeers().catch(() => undefined);
 		void this.recoverWorker(worker);
 	}
 
@@ -2857,7 +2869,6 @@ export class DaemonSupervisor {
 			worker.descriptor.lifecycle = "recovering";
 			worker.descriptor.lastError = disconnectError.message;
 			this.persistWorker(worker);
-			void this.syncAgentPeers().catch(() => undefined);
 			void this.recoverWorker(worker);
 			return;
 		}
@@ -3085,9 +3096,6 @@ export class DaemonSupervisor {
 							worker.descriptor.lifecycle = "ready";
 							worker.descriptor.consecutiveFailures = 0;
 							this.persistWorker(worker);
-							await this.syncAgentPeers().catch((error) =>
-								this.log(`Could not synchronize agent peers after worker recovery: ${String(error)}`),
-							);
 							this.broadcastHeartbeatsChanged();
 							return;
 						} catch (error) {
@@ -3116,7 +3124,6 @@ export class DaemonSupervisor {
 						worker.descriptor.lifecycle = "failed";
 						worker.descriptor.lastError = "Waiting for a client with fresh runtime context";
 						this.persistWorker(worker);
-						await this.syncAgentPeers().catch(() => undefined);
 						return;
 					}
 					const safeToKillWorkerProcess =
@@ -3151,7 +3158,6 @@ export class DaemonSupervisor {
 			}
 			worker.descriptor.lifecycle = "failed";
 			this.persistWorker(worker);
-			await this.syncAgentPeers().catch(() => undefined);
 			this.log(`Worker ${worker.descriptor.workerId} failed after three recovery attempts`);
 		})().finally(() => {
 			worker.recovery = undefined;
@@ -3415,35 +3421,6 @@ export class DaemonSupervisor {
 				ignoreSessionId: target.id,
 			},
 		);
-	}
-
-	private syncAgentPeers(): Promise<void> {
-		const sync = this.agentPeerSyncQueue
-			.catch(() => undefined)
-			.then(async () => {
-				const readyWorkers = [...this.workers.values()].filter(
-					(worker): worker is ResidentWorker & { client: DaemonWorkerClient } =>
-						this.isLiveWorker(worker) && worker.descriptor.lifecycle === "ready" && worker.client !== undefined,
-				);
-				await Promise.all(
-					readyWorkers.map(async (worker) => {
-						const peers = [
-							...readyWorkers
-								.filter((candidate) => candidate !== worker)
-								.flatMap((candidate) => {
-									const root = candidate.summaries.get(candidate.descriptor.rootActiveSessionId);
-									return root ? [this.agentPeerSummary(root)] : [];
-								}),
-						];
-						const response = await worker.client.requestWorker({ type: "worker_sync_agent_peers", peers }, 5000);
-						if (!response.success) {
-							throw new Error(response.error);
-						}
-					}),
-				);
-			});
-		this.agentPeerSyncQueue = sync;
-		return sync;
 	}
 
 	private isVisibleWorker(worker: ResidentWorker): boolean {
@@ -4549,17 +4526,13 @@ export class DaemonSupervisor {
 			this.writeSerialized(client, publicPayload);
 		}
 		if (outboundType === "session_replaced" || outboundType === "session_closed") {
-			void this.refreshWorkerSummaries(worker)
-				.then(() => this.syncAgentPeers())
-				.catch(() => undefined);
+			void this.refreshWorkerSummaries(worker).catch(() => undefined);
 		} else if (
 			sessionEventType === "turn_start" ||
 			sessionEventType === "turn_end" ||
 			sessionEventType === "rlm_child_update"
 		) {
-			void this.refreshWorkerSummaries(worker)
-				.then(() => this.syncAgentPeers())
-				.catch(() => undefined);
+			void this.refreshWorkerSummaries(worker).catch(() => undefined);
 		}
 		if (
 			decodedOutbound?.type === "session_closed" &&
@@ -4575,7 +4548,6 @@ export class DaemonSupervisor {
 				this.invalidateWorkerSessionInputPauses(worker, "Session worker stopped while input was paused");
 				this.workers.delete(worker.descriptor.workerId);
 				this.deleteWorkerDescriptor(worker);
-				void this.syncAgentPeers().catch(() => undefined);
 			}
 		}
 	}
@@ -5140,7 +5112,6 @@ export class DaemonSupervisor {
 			this.deleteWorkerDescriptor(worker);
 		}
 		if (!this.shuttingDown) {
-			void this.syncAgentPeers().catch(() => undefined);
 			this.broadcastHeartbeatsChanged();
 		}
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
@@ -1,9 +1,5 @@
 import { closeSync, readFileSync } from "node:fs";
-import type {
-	AgentSessionMessageAgentSummary,
-	AgentSessionMessageDeliveryMode,
-	AgentSessionMessageSender,
-} from "../../core/agent-messages.js";
+import type { AgentSessionMessageDeliveryMode, AgentSessionMessageSender } from "../../core/agent-messages.js";
 import type { IdleEvictionMinutes } from "../../core/session-action-store.js";
 
 export { SESSION_LEASE_OWNER_ID_ENV, SESSION_LEASES_ENABLED_ENV } from "../../core/session-lease.js";
@@ -70,7 +66,6 @@ export type DaemonWorkerCommand =
 			supportsExtensionUi?: boolean;
 	  }
 	| { id?: string; type: "worker_unsubscribe"; activeSessionId: string }
-	| { id?: string; type: "worker_sync_agent_peers"; peers: AgentSessionMessageAgentSummary[] }
 	| { id?: string; type: "worker_archive_and_shutdown" }
 	| {
 			id?: string;

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -279,6 +279,26 @@ describe("daemon mode helpers", () => {
 		expect(releaseAcpMcpServers).toHaveBeenLastCalledWith("other-token", ["other"]);
 	});
 
+	it("fails fast on unknown worker commands instead of dropping them", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-unknown-worker-command.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const internals = daemon as unknown as {
+			handleWorkerCommand(client: DaemonSocketClient, command: unknown): Promise<void>;
+			write: ReturnType<typeof vi.fn>;
+		};
+		internals.write = vi.fn();
+		const client = makeClient("legacy-supervisor", "active");
+
+		await internals.handleWorkerCommand(client, { id: "legacy-1", type: "worker_sync_agent_peers", peers: [] });
+
+		expect(internals.write).toHaveBeenCalledWith(
+			client,
+			expect.objectContaining({ id: "legacy-1", command: "worker_sync_agent_peers", success: false }),
+		);
+	});
+
 	it("cancels pending extension UI requests directly", () => {
 		const resolve = vi.fn();
 		const state = {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -549,120 +549,26 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("keeps fresh local rows over stale synced peers in the family catalog", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-local-precedence.sock", {
-			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
-			createRuntime: vi.fn(),
-		});
-		const state = makeState("local-active");
-		state.runtime = {
-			...state.runtime,
-			cwd: "/tmp",
-			metadata: { kind: "top-level", createdAt: 1 },
-			session: {
-				sessionId: "shared-session",
-				sessionName: "fresh-local",
-				isSessionActive: false,
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				hasRunningRlmChildren: () => false,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			remoteAgentPeers: Map<string, Record<string, unknown>>;
-			createAgentFamilyCatalog(): Promise<Array<{ id: string; name?: string }>>;
-		};
-		internals.sessions.set(state.activeSessionId, state);
-		internals.remoteAgentPeers.set("stale-active", {
-			activeSessionId: "stale-active",
-			sessionId: "shared-session",
-			sessionName: "stale-peer",
-			runtimeKind: "top-level",
-			cwd: "/tmp",
-			isStreaming: false,
-			unfinishedActionCount: 0,
-		});
-		const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
-		try {
-			expect(await internals.createAgentFamilyCatalog()).toContainEqual(
-				expect.objectContaining({ id: "shared-session", name: "fresh-local" }),
-			);
-		} finally {
-			listAll.mockRestore();
-		}
-	});
-
-	it("canonicalizes symlinked paths in the family catalog and name reservations", async () => {
+	it("canonicalizes symlinked parent paths in name reservations", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-family-catalog-paths-"));
 		try {
 			const realDir = join(tempDir, "real");
 			const aliasDir = join(tempDir, "alias");
 			mkdirSync(realDir);
 			symlinkSync(realDir, aliasDir, "dir");
-			const parentPath = join(realDir, "parent.jsonl");
-			writeFileSync(parentPath, "");
-			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
-				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: tempDir },
-				createRuntime: vi.fn(),
-			});
-			const parent = makeState("parent");
-			parent.runtime = {
-				...parent.runtime,
-				cwd: tempDir,
-				metadata: { kind: "top-level", createdAt: 1 },
-				session: {
-					sessionId: "session-parent",
-					sessionName: "parent",
-					sessionFile: parentPath,
-					sessionManager: { getSessionArtifactDir: () => undefined },
-					rlmDepth: 0,
-					isStreaming: false,
-					isSessionActive: false,
-					unfinishedActionCount: 0,
-					hasRunningRlmChildren: () => false,
-				},
-			} as never;
-			const child = {
-				activeSessionId: "child-active",
-				sessionId: "session-child",
-				sessionName: "child",
-				runtimeKind: "subagent",
-				cwd: tempDir,
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				parentSessionPath: join(aliasDir, "parent.jsonl"),
-				rlmDepth: 1,
-				status: "idle",
-			};
-			const internals = daemon as unknown as {
-				sessions: Map<string, ActiveSessionState>;
-				remoteAgentPeers: Map<string, typeof child>;
-				createAgentFamilyRoster(state: ActiveSessionState): Promise<{ entries: Array<{ id: string }> }>;
-			};
-			internals.sessions.set(parent.activeSessionId, parent);
-			internals.remoteAgentPeers.set(child.activeSessionId, child);
-			const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
-			try {
-				expect(await internals.createAgentFamilyRoster(parent)).toMatchObject({
-					entries: [expect.objectContaining({ id: "session-child" })],
-				});
-				expect(
-					sessionNameReservationKey({
-						name: "worker",
-						depth: 1,
-						parentSessionPath: parentPath,
-					}),
-				).toBe(
-					sessionNameReservationKey({
-						name: "worker",
-						depth: 1,
-						parentSessionPath: join(aliasDir, "parent.jsonl"),
-					}),
-				);
-			} finally {
-				listAll.mockRestore();
-			}
+			expect(
+				sessionNameReservationKey({
+					name: "worker",
+					depth: 1,
+					parentSessionPath: join(realDir, "parent.jsonl"),
+				}),
+			).toBe(
+				sessionNameReservationKey({
+					name: "worker",
+					depth: 1,
+					parentSessionPath: join(aliasDir, "parent.jsonl"),
+				}),
+			);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -1439,6 +1345,28 @@ describe("daemon mode helpers", () => {
 		expect(internals.closingSessions.has(state.activeSessionId)).toBe(false);
 	});
 
+	it("returns no peers when the supervisor query fails", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-peer-query-failure-"));
+		const previousSupervisorSocket = process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
+		try {
+			process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = join(tempDir, "missing.sock");
+			const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
+				createRuntime: vi.fn(),
+				worker: { authenticationToken: "worker-token" },
+			});
+			const listSupervisorAgentPeers = (
+				daemon as unknown as { listSupervisorAgentPeers(): Promise<unknown[]> }
+			).listSupervisorAgentPeers.bind(daemon);
+
+			await expect(listSupervisorAgentPeers()).resolves.toEqual([]);
+		} finally {
+			if (previousSupervisorSocket === undefined) delete process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
+			else process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSupervisorSocket;
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("lists and role-addresses root siblings hosted by another worker", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -1471,7 +1399,7 @@ describe("daemon mode helpers", () => {
 		const sendRemoteAgentSessionMessage = vi.fn().mockResolvedValue(receipt);
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
-			remoteAgentPeers: Map<string, Record<string, unknown>>;
+			listSupervisorAgentPeers: ReturnType<typeof vi.fn>;
 			createAgentMessageListResult(
 				current: ActiveSessionState,
 			): Promise<{ agents: Array<{ activeSessionId: string }> }>;
@@ -1479,15 +1407,17 @@ describe("daemon mode helpers", () => {
 			sendRemoteAgentSessionMessage: typeof sendRemoteAgentSessionMessage;
 		};
 		internals.sessions.set(source.activeSessionId, source);
-		internals.remoteAgentPeers.set(remoteSelector, {
-			activeSessionId: remoteSelector,
-			sessionId: "session-remote",
-			sessionName: "Remote",
-			runtimeKind: "top-level",
-			cwd: "/tmp/remote",
-			isStreaming: false,
-			sessionActions: { queuedCount: 0, steering: [], followUps: [] },
-		});
+		internals.listSupervisorAgentPeers = vi.fn(async () => [
+			{
+				activeSessionId: remoteSelector,
+				sessionId: "session-remote",
+				sessionName: "Remote",
+				runtimeKind: "top-level",
+				cwd: "/tmp/remote",
+				isStreaming: false,
+				unfinishedActionCount: 0,
+			},
+		]);
 		internals.sendRemoteAgentSessionMessage = sendRemoteAgentSessionMessage;
 
 		expect((await internals.createAgentMessageListResult(source)).agents).toContainEqual(

--- a/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
@@ -4,19 +4,21 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	type AgentFamilyCatalogEntry,
-	type AgentSessionMessageAgentSummary,
 	assertAgentFamilyReach,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
 import { readSessionInfo, SessionManager } from "../src/core/session-manager.js";
+import { DaemonCatalogClient } from "../src/modes/daemon/daemon-catalog-process.js";
+import { DaemonClient } from "../src/modes/daemon/daemon-client.js";
 import { success } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 
 interface SupervisorInternals {
 	workers: Map<string, WorkerFixture>;
+	start(): Promise<void>;
+	cleanupSupervisorResources(): Promise<void>;
 	refreshWorkerSummaries(worker: WorkerFixture): Promise<void>;
-	syncAgentPeers(): Promise<void>;
 	findSummaryInWorker(worker: WorkerFixture, selector: string): SessionSummary | undefined;
 	createOrReuseWorker(
 		clientId: string,
@@ -84,7 +86,7 @@ function worker(workerId: string, summaries: SessionSummary[] = []): WorkerFixtu
 		},
 		client: {
 			request: vi.fn(),
-			requestWorker: vi.fn(async () => ({ type: "response", command: "worker_sync_agent_peers", success: true })),
+			requestWorker: vi.fn(),
 		},
 		summaries: new Map(summaries.map((entry) => [entry.activeSessionId ?? entry.id, entry])),
 	};
@@ -645,13 +647,16 @@ describe("daemon supervisor passive subagent topology", () => {
 		await expect(first).resolves.toBe(launched);
 	});
 
-	it("retains passive worker summaries but syncs only roots to cross-worker peer maps", async () => {
+	it("dispatches authenticated peer queries and excludes disconnected workers", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-passive-peers-"));
 		tempDirs.push(directory);
-		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+		const socketPath = join(directory, "daemon.sock");
+		const supervisor = new DaemonSupervisor(socketPath, {
 			defaultSessionConfig: { agentDir: directory, cwd: directory },
 			descriptorDir: join(directory, "workers"),
 		}) as unknown as SupervisorInternals;
+		const client = new DaemonClient(socketPath);
+		vi.spyOn(DaemonCatalogClient.prototype, "start").mockResolvedValue();
 
 		const passive = summary({
 			id: "passive-session",
@@ -667,36 +672,54 @@ describe("daemon supervisor passive subagent topology", () => {
 			sessionId: "first-root-session",
 			runtimeKind: "top-level",
 		});
-		const first = worker("first");
-		first.client.request.mockResolvedValue(success(undefined, "list", { sessions: [passive] }));
 		const secondRoot = summary({
 			id: "second-root-active",
 			activeSessionId: "second-root-active",
 			sessionId: "second-root-session",
 		});
-		const second = worker("second", [secondRoot]);
-		supervisor.workers.set("first", first);
-		supervisor.workers.set("second", second);
-
-		await supervisor.refreshWorkerSummaries(first);
-		expect(first.client.request).toHaveBeenCalledWith({ type: "list" }, 5000);
-		expect(first.summaries.get("passive-session")).toMatchObject({
-			sessionFile: passive.sessionFile,
-			runtimeKind: "subagent",
-			rlmChildId: "passive-child",
+		const disconnectedRoot = summary({
+			id: "disconnected-root-active",
+			activeSessionId: "disconnected-root-active",
+			sessionId: "disconnected-root-session",
 		});
-		first.summaries.set(first.descriptor.rootActiveSessionId, firstRoot);
+		const first = worker("first", [firstRoot, passive]);
+		const second = worker("second", [secondRoot]);
+		const disconnected = worker("disconnected", [disconnectedRoot]);
+		Object.assign(disconnected, { client: undefined });
 
-		await supervisor.syncAgentPeers();
-		const secondPeerCommand = second.client.requestWorker.mock.calls[0]?.[0] as
-			| { peers: AgentSessionMessageAgentSummary[] }
-			| undefined;
-		expect(secondPeerCommand?.peers).toEqual([
-			expect.objectContaining({
-				activeSessionId: "first-root-active",
-				sessionId: "first-root-session",
-				runtimeKind: "top-level",
-			}),
-		]);
+		try {
+			await supervisor.start();
+			supervisor.workers.set("first", first);
+			supervisor.workers.set("second", second);
+			supervisor.workers.set("disconnected", disconnected);
+			await client.connect();
+
+			await expect(
+				client.request({ type: "list_agent_peers", workerToken: "invalid-token" }),
+			).resolves.toMatchObject({
+				success: false,
+				error: "Worker authentication failed",
+			});
+			const response = await client.request({
+				type: "list_agent_peers",
+				workerToken: second.descriptor.authenticationToken,
+			});
+			expect(response).toMatchObject({
+				success: true,
+				data: {
+					peers: [
+						expect.objectContaining({
+							activeSessionId: "first-root-active",
+							sessionId: "first-root-session",
+							runtimeKind: "top-level",
+						}),
+					],
+				},
+			});
+		} finally {
+			client.close();
+			supervisor.workers.clear();
+			await supervisor.cleanupSupervisorResources();
+		}
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -155,7 +155,6 @@ interface DeferredRecoveryHarness {
 	shuttingDown: boolean;
 	assertRecoveryAllowed: ReturnType<typeof vi.fn>;
 	persistWorker: ReturnType<typeof vi.fn>;
-	syncAgentPeers: ReturnType<typeof vi.fn>;
 	recoverWorker: ReturnType<typeof vi.fn>;
 	handleWorkerClose(worker: DeferredRecoveryWorker, client: object, error: Error): Promise<void>;
 	deferWorkerRecovery(worker: DeferredRecoveryWorker, error: Error): void;
@@ -610,7 +609,6 @@ describe("daemon worker supervisor monitoring", () => {
 				}
 			}),
 			connectWorker,
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			launchWorker(command: { type: "create"; config: { cwd: string; agentDir: string } }): Promise<unknown>;
@@ -673,7 +671,6 @@ describe("daemon worker supervisor monitoring", () => {
 			connectWorker,
 			subscribeWorker: vi.fn(async () => undefined),
 			refreshWorkerSummaries: vi.fn(async () => undefined),
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			launchWorker(command: {
@@ -736,7 +733,6 @@ describe("daemon worker supervisor monitoring", () => {
 				}
 				Reflect.apply(persistWorker, this, [worker]);
 			}),
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			launchWorker(command: { type: "create"; config: { cwd: string; agentDir: string } }): Promise<unknown>;
@@ -797,7 +793,6 @@ describe("daemon worker supervisor monitoring", () => {
 				Reflect.apply(persistWorker, this, [worker]);
 			}),
 			deferWorkerRecovery,
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			launchWorker(
@@ -883,7 +878,6 @@ describe("daemon worker supervisor monitoring", () => {
 			connectWorker,
 			stopWorker: controlledStopWorker,
 			deferWorkerRecovery,
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			shuttingDown: boolean;
@@ -1124,7 +1118,6 @@ describe("daemon worker supervisor monitoring", () => {
 			shuttingDown: false,
 			assertRecoveryAllowed,
 			persistWorker,
-			syncAgentPeers: vi.fn(async () => undefined),
 			recoverWorker,
 		}) as DeferredRecoveryHarness;
 
@@ -1183,7 +1176,6 @@ describe("daemon worker supervisor monitoring", () => {
 			shuttingDown: false,
 			assertRecoveryAllowed,
 			persistWorker,
-			syncAgentPeers: vi.fn(async () => undefined),
 			recoverWorker,
 		}) as DeferredRecoveryHarness;
 
@@ -1254,7 +1246,6 @@ describe("daemon worker supervisor monitoring", () => {
 			shuttingDown: false,
 			assertRecoveryAllowed,
 			persistWorker,
-			syncAgentPeers: vi.fn(async () => undefined),
 			recoverWorker,
 		}) as DeferredRecoveryHarness;
 
@@ -1299,7 +1290,6 @@ describe("daemon worker supervisor monitoring", () => {
 				resolveAssertion = resolve;
 			});
 			const persistWorker = vi.fn();
-			const syncAgentPeers = vi.fn(async () => undefined);
 			const recoverWorker = vi.fn(async () => undefined);
 			const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 				...createSupervisorSnapshotState(),
@@ -1307,7 +1297,6 @@ describe("daemon worker supervisor monitoring", () => {
 				shuttingDown: false,
 				assertRecoveryAllowed: vi.fn(() => assertion),
 				persistWorker,
-				syncAgentPeers,
 				recoverWorker,
 			}) as DeferredRecoveryHarness;
 
@@ -1319,7 +1308,6 @@ describe("daemon worker supervisor monitoring", () => {
 			expect(worker.descriptor.lifecycle).toBe("ready");
 			expect(worker.descriptor.lastError).toBeUndefined();
 			expect(persistWorker).not.toHaveBeenCalled();
-			expect(syncAgentPeers).not.toHaveBeenCalled();
 			expect(recoverWorker).not.toHaveBeenCalled();
 		},
 	);
@@ -1494,7 +1482,6 @@ describe("daemon worker supervisor monitoring", () => {
 			streamReconstructor: { observe: vi.fn() },
 			invalidateWorkerSnapshot: vi.fn(),
 			refreshWorkerSummaries: vi.fn(async () => undefined),
-			syncAgentPeers: vi.fn(async () => undefined),
 			persistWorkerStopTombstone: vi.fn(),
 			deleteWorkerDescriptor,
 			broadcastHeartbeatsChanged: vi.fn(),
@@ -1591,7 +1578,6 @@ describe("daemon worker supervisor monitoring", () => {
 			recoverUncertainWorkerOperations: ReturnType<typeof vi.fn>;
 			launchWorker: ReturnType<typeof vi.fn>;
 			persistWorker: ReturnType<typeof vi.fn>;
-			syncAgentPeers: ReturnType<typeof vi.fn>;
 			assertRecoveryAllowed: ReturnType<typeof vi.fn>;
 			recoverWorker(worker: RecoveryWorker): Promise<void>;
 		};
@@ -1613,7 +1599,6 @@ describe("daemon worker supervisor monitoring", () => {
 			recoverUncertainWorkerOperations: vi.fn(async () => {}),
 			launchWorker: vi.fn(async () => worker),
 			persistWorker: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			assertRecoveryAllowed: vi.fn(async () => {}),
 		}) as RecoveryHarness;
 
@@ -1686,7 +1671,6 @@ describe("daemon worker supervisor monitoring", () => {
 			processIdentity: vi.fn(() => "gone"),
 			recoverUncertainWorkerOperations,
 			deleteWorkerDescriptor,
-			syncAgentPeers: vi.fn(async () => {}),
 		}) as {
 			reclaimStaleWorkerRegistration(target: typeof worker): Promise<boolean>;
 		};
@@ -1747,7 +1731,6 @@ describe("daemon worker supervisor monitoring", () => {
 			recoverUncertainWorkerOperations: ReturnType<typeof vi.fn>;
 			launchWorker: ReturnType<typeof vi.fn>;
 			persistWorker: ReturnType<typeof vi.fn>;
-			syncAgentPeers: ReturnType<typeof vi.fn>;
 			broadcastHeartbeatsChanged: ReturnType<typeof vi.fn>;
 			log: ReturnType<typeof vi.fn>;
 			assertRecoveryAllowed: ReturnType<typeof vi.fn>;
@@ -1773,7 +1756,6 @@ describe("daemon worker supervisor monitoring", () => {
 			recoverUncertainWorkerOperations: vi.fn(async () => {}),
 			launchWorker: vi.fn(async () => worker),
 			persistWorker: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			log: vi.fn(),
 			assertRecoveryAllowed: vi.fn(async () => {}),
 		}) as RecoveryHarness;
@@ -1786,75 +1768,6 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(supervisor.recoverUncertainWorkerOperations).not.toHaveBeenCalled();
 		expect(supervisor.launchWorker).not.toHaveBeenCalled();
 		expect(worker.descriptor.lifecycle).toBe("failed");
-	});
-
-	it("keeps a recovered worker ready when peer synchronization fails", async () => {
-		vi.useFakeTimers();
-		type RecoveryWorker = {
-			descriptor: {
-				workerId: string;
-				pid: number;
-				processStartId?: string;
-				rootActiveSessionId: string;
-				createCommand: { type: "create" };
-				lifecycle?: string;
-				consecutiveFailures: number;
-			};
-			intentionalStop: boolean;
-			stopRevision: number;
-			recovery?: Promise<void>;
-		};
-		type RecoveryHarness = {
-			workers: Map<string, RecoveryWorker>;
-			shuttingDown: boolean;
-			connectWorker: ReturnType<typeof vi.fn>;
-			subscribeWorker: ReturnType<typeof vi.fn>;
-			refreshWorkerSummaries: ReturnType<typeof vi.fn>;
-			recoverUncertainWorkerOperations: ReturnType<typeof vi.fn>;
-			launchWorker: ReturnType<typeof vi.fn>;
-			persistWorker: ReturnType<typeof vi.fn>;
-			syncAgentPeers: ReturnType<typeof vi.fn>;
-			log: ReturnType<typeof vi.fn>;
-			assertRecoveryAllowed: ReturnType<typeof vi.fn>;
-			recoverWorker(worker: RecoveryWorker): Promise<void>;
-		};
-		const worker: RecoveryWorker = {
-			descriptor: {
-				workerId: "worker-peer-sync-failure",
-				pid: process.pid,
-				rootActiveSessionId: "active-1",
-				createCommand: { type: "create" },
-				consecutiveFailures: 1,
-			},
-			intentionalStop: false,
-			stopRevision: 0,
-		};
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			workers: new Map([[worker.descriptor.workerId, worker]]),
-			shuttingDown: false,
-			connectWorker: vi.fn(async () => ({})),
-			subscribeWorker: vi.fn(async () => {}),
-			refreshWorkerSummaries: vi.fn(async () => {}),
-			recoverUncertainWorkerOperations: vi.fn(async () => {}),
-			launchWorker: vi.fn(async () => worker),
-			persistWorker: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {
-				throw new Error("peer unavailable");
-			}),
-			broadcastHeartbeatsChanged: vi.fn(),
-			log: vi.fn(),
-			assertRecoveryAllowed: vi.fn(async () => {}),
-		}) as RecoveryHarness;
-
-		const recovery = supervisor.recoverWorker(worker);
-		await vi.advanceTimersByTimeAsync(250);
-		await recovery;
-
-		expect(supervisor.connectWorker).toHaveBeenCalledOnce();
-		expect(supervisor.recoverUncertainWorkerOperations).not.toHaveBeenCalled();
-		expect(supervisor.launchWorker).not.toHaveBeenCalled();
-		expect(worker.descriptor.lifecycle).toBe("ready");
-		expect(worker.descriptor.consecutiveFailures).toBe(0);
 	});
 
 	it("reports a stop-tombstoned worker as stopping, not ready", () => {
@@ -1933,7 +1846,6 @@ describe("daemon worker supervisor monitoring", () => {
 			]),
 			clients: new Set(),
 			refreshWorkerSummaries: vi.fn(async () => {}),
-			syncAgentPeers: vi.fn(async () => {}),
 			log: vi.fn(),
 		}) as {
 			handleList(
@@ -2284,7 +2196,6 @@ describe("daemon worker supervisor monitoring", () => {
 				worker.descriptor.stopRequestedAt = undefined;
 			}),
 			deleteWorkerDescriptor: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			broadcastHeartbeatsChanged: vi.fn(),
 			log: vi.fn(),
 			reportCleanupFailure: vi.fn(),
@@ -2343,7 +2254,6 @@ describe("daemon worker supervisor monitoring", () => {
 				worker.descriptor.stopRequestedAt = undefined;
 			}),
 			deleteWorkerDescriptor: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			broadcastHeartbeatsChanged: vi.fn(),
 			log: vi.fn(),
 			reportCleanupFailure: vi.fn(),
@@ -2395,7 +2305,6 @@ describe("daemon worker supervisor monitoring", () => {
 			persistWorker: vi.fn(),
 			persistWorkerStopTombstone: vi.fn(),
 			scheduleWorkerStopFinalization: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			broadcastHeartbeatsChanged: vi.fn(),
 		}) as unknown as {
 			stopWorker(target: object, removeDescriptor: boolean, force?: boolean): Promise<void>;

--- a/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
@@ -581,19 +581,16 @@ describe("ENG-4602 snapshot transfer containment", () => {
 		});
 		const recoverWorker = vi.fn(async () => {});
 		const persistWorker = vi.fn();
-		const syncAgentPeers = vi.fn(async () => {});
 		const assertRecoveryAllowed = vi.fn(async () => {});
 		const internals = supervisor as unknown as {
 			workers: Map<string, WorkerHarness>;
 			recoverWorker: typeof recoverWorker;
 			persistWorker: typeof persistWorker;
-			syncAgentPeers: typeof syncAgentPeers;
 			assertRecoveryAllowed: typeof assertRecoveryAllowed;
 			handleWorkerFrame(worker: WorkerHarness, frame: PrivateFrame<DaemonWorkerFrameHeader>): void;
 		};
 		internals.recoverWorker = recoverWorker;
 		internals.persistWorker = persistWorker;
-		internals.syncAgentPeers = syncAgentPeers;
 		internals.assertRecoveryAllowed = assertRecoveryAllowed;
 		const frames = snapshotFrames([{ role: "user", content: "stable", timestamp: 1 }]);
 

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -149,22 +149,16 @@ async function runRpc(
 }
 
 describe("ENG-4685 daemon-backed client modes", () => {
-	it("commits owned-worker promotion before best-effort peer synchronization", async () => {
+	it("commits owned-worker promotion once", async () => {
 		const client = { id: "client-1" } as DaemonSocketClient;
 		const worker = {
 			descriptor: { ownerClientId: "protocol-client" },
 			launchEnv: { TEST: "value" },
 		};
 		const persistWorker = vi.fn();
-		const syncAgentPeers = vi.fn(async () => {
-			throw new Error("peer unavailable");
-		});
-		const log = vi.fn();
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			protocolClientId: () => "protocol-client",
 			persistWorker,
-			syncAgentPeers,
-			log,
 		}) as {
 			promoteOwnedWorker(client: DaemonSocketClient, resident: typeof worker): Promise<void>;
 		};
@@ -175,8 +169,6 @@ describe("ENG-4685 daemon-backed client modes", () => {
 		expect(worker.descriptor.ownerClientId).toBeUndefined();
 		expect(worker.launchEnv).toBeUndefined();
 		expect(persistWorker).toHaveBeenCalledOnce();
-		expect(syncAgentPeers).toHaveBeenCalledOnce();
-		expect(log).toHaveBeenCalledWith(expect.stringContaining("peer unavailable"));
 	});
 
 	it("rolls back owned-worker promotion when persistence fails", async () => {


### PR DESCRIPTION
## What was wrong

The supervisor owns the roster of agents across workers, but it also pushed a mutable copy (`remoteAgentPeers`) into every worker via a per-worker sync queue and a `worker_sync_agent_peers` message — O(n²) replication with 13 broadcast triggers whose failures were swallowed. Workers made list/reachability decisions from arbitrarily stale mirrors (root cause of the rename bug fixed in #1702) (audit: overlap.md finding 1 ≡ dup-truth.md finding 2).

## The fix

The mirror, sync queue, message type, and all 13 broadcast triggers are deleted (+101/−312). Workers now issue an authenticated, read-only `list_agent_peers` query to the supervisor only when a list/family catalog is actually requested — request-scoped, never cached, so strictly fresher than the old mirror. Local rows keep precedence. Daemon schema revision bumped to 23; mixed-version windows degrade cleanly in both directions during update-restart.

Latency pre-check (plan gate): p50 0.071ms / p95 0.111ms over a real Unix-socket connect+hello harness — three orders of magnitude inside the interactive list budget.

## How it's verified

Reviewer enumerated all 6 former mirror readers and all 13 triggers on the base and accounted for each; confirmed no response caching, complete schema-rev machinery, honest mixed-version degradation, preserved local precedence, and untouched #1702/passive-hydration paths. Focused suites green with the 5 remaining failures reproducing identically at the exact base commit. Two-model implement/review loop, approved first pass.

Stacked on #1746 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon protocol and cross-worker agent targeting/listing behavior; mixed-version deployments depend on schema-rev gating and graceful empty-peer fallback when queries fail.
> 
> **Overview**
> **Cross-worker agent rosters are no longer pushed into workers.** The supervisor drops `syncAgentPeers`, the `worker_sync_agent_peers` worker command, and the worker-side `remoteAgentPeers` cache, along with every lifecycle hook that used to broadcast peer mirrors.
> 
> When a worker builds an agent message list or family catalog, it calls **`listSupervisorAgentPeers`**, which issues an authenticated read-only **`list_agent_peers`** request to the supervisor (schema revision **23**). The supervisor returns root summaries for other live, ready workers with connected clients; workers merge those peers with local agents (locals still win on ID collisions). Failed or unreachable supervisor queries yield an empty remote list instead of stale mirrors.
> 
> **Unknown worker commands** (including legacy `worker_sync_agent_peers` from older supervisors) now get an explicit failure response instead of hanging until timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d66b12e4e1d7c22d39aeded881204050dfbfa25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Linear ticket: [ENG-5664](https://linear.app/primeintellect/issue/ENG-5664/refactorcoding-agent-query-agent-peers-on-demand-instead-of)
(ticket linked above)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace broadcast peer sync with on-demand `list_agent_peers` query in `AgentDaemon`
> - Removes the `remoteAgentPeers` cache on workers and the `syncAgentPeers` broadcast on supervisors; workers now fetch current peers from the supervisor only when needed via the new `listSupervisorAgentPeers` helper.
> - Adds the `list_agent_peers` daemon command (gated at schema revision 23) with token-based authentication; the supervisor returns peer summaries for other live, ready workers.
> - Unknown worker commands now return an immediate failure response instead of timing out.
> - Behavioral Change: `DAEMON_SCHEMA_REVISION` bumps from 22 to 23 and the legacy `worker_sync_agent_peers` command is removed; older workers or clients that still send `worker_sync_agent_peers` will receive an unknown-command failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d66b12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->