### PR TITLE
refactor(coding-agent): await in-flight bash completion during daemon close

### DIFF
--- a/packages/coding-agent/.changes/await-daemon-bash-end.md
+++ b/packages/coding-agent/.changes/await-daemon-bash-end.md
@@ -1,0 +1,1 @@
+- Made daemon shutdown wait for Bash completion without polling.

--- a/packages/coding-agent/src/modes/daemon/active-session-state.ts
+++ b/packages/coding-agent/src/modes/daemon/active-session-state.ts
@@ -40,6 +40,7 @@ export interface ActiveSessionState {
 	extensionUiRequests: Map<string, ActiveSessionExtensionUiRequest>;
 	eventGeneration: string;
 	lastEventSequence: DaemonEventSequence;
+	inFlightBash?: Promise<void>;
 	unsubscribe?: () => void;
 	/** Latest background status summary, surfaced in the agents view. */
 	summaryState?: AgentStatus;

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -4357,28 +4357,23 @@ export class AgentDaemon {
 				}
 				// Respond before completion (bash can outlive the client request
 				// timeout); output and completion stream via bash_* session events.
-				void state.runtime.session
-					.runUserBash(command.command, {
-						excludeFromContext: command.excludeFromContext,
-						transient: command.transient,
-						runId: command.runId,
-					})
-					.catch((error) => {
-						this.broadcastToSession(
-							state,
-							failure(undefined, "execute_bash", error, serializeDaemonError(error)),
-						);
-					});
+				const bash = state.runtime.session.runUserBash(command.command, {
+					excludeFromContext: command.excludeFromContext,
+					transient: command.transient,
+					runId: command.runId,
+				});
+				state.inFlightBash = Promise.allSettled([state.inFlightBash, bash]).then(() => undefined);
+				void bash.catch((error) => {
+					this.broadcastToSession(state, failure(undefined, "execute_bash", error, serializeDaemonError(error)));
+				});
 				return success(command.id, "execute_bash");
 			}
 
 			case "execute_bash_and_wait": {
 				const state = this.getSessionState(command.activeSessionId);
-				return success(
-					command.id,
-					"execute_bash_and_wait",
-					await state.runtime.session.executeBash(command.command),
-				);
+				const bash = state.runtime.session.executeBash(command.command);
+				state.inFlightBash = Promise.allSettled([state.inFlightBash, bash]).then(() => undefined);
+				return success(command.id, "execute_bash_and_wait", await bash);
 			}
 
 			case "abort_bash": {
@@ -6471,14 +6466,12 @@ export class AgentDaemon {
 	}
 
 	private async abortBashForClose(state: ActiveSessionState): Promise<void> {
-		if (!state.runtime.session.isBashRunning) {
+		const session = state.runtime.session;
+		if (!session.isBashRunning) {
 			return;
 		}
-		state.runtime.session.abortBash();
-		const deadline = Date.now() + UPDATE_RESTART_ABORT_BASH_TIMEOUT_MS;
-		while (state.runtime.session.isBashRunning && Date.now() < deadline) {
-			await delay(50);
-		}
+		session.abortBash();
+		await Promise.race([state.inFlightBash ?? Promise.resolve(), delay(UPDATE_RESTART_ABORT_BASH_TIMEOUT_MS)]);
 	}
 
 	private async closeSessionOnce(

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -70,6 +70,103 @@ describe("daemon mode helpers", () => {
 		expect(client.id).toBe("public-client");
 	});
 
+	it("waits for overlapping Bash commands with a bounded close deadline", async () => {
+		vi.useFakeTimers();
+		try {
+			const daemon = new AgentDaemon("/tmp/unused-daemon.sock", {
+				defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
+				createRuntime: vi.fn(),
+			});
+			const internals = daemon as unknown as {
+				sessions: Map<string, ActiveSessionState>;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<DaemonOutbound | undefined>;
+				abortBashForClose(state: ActiveSessionState): Promise<void>;
+			};
+
+			let resolveFirstBash!: () => void;
+			let resolveSecondBash!: () => void;
+			const firstBash = new Promise<void>((resolve) => {
+				resolveFirstBash = resolve;
+			});
+			const secondBash = new Promise<void>((resolve) => {
+				resolveSecondBash = resolve;
+			});
+			let isBashRunning = false;
+			const abortBash = vi.fn();
+			const state = makeState("active");
+			state.runtime = {
+				...state.runtime,
+				session: {
+					get isBashRunning() {
+						return isBashRunning;
+					},
+					runUserBash: vi.fn(() => {
+						isBashRunning = true;
+						return firstBash;
+					}),
+					executeBash: vi.fn(() => secondBash),
+					abortBash,
+				},
+			} as never;
+			internals.sessions.set(state.activeSessionId, state);
+			const client = makeClient("client", state.activeSessionId);
+
+			await internals.handleCommand(client, {
+				id: "first",
+				type: "execute_bash",
+				activeSessionId: state.activeSessionId,
+				command: "first",
+			});
+			const secondResponse = internals.handleCommand(client, {
+				id: "second",
+				type: "execute_bash_and_wait",
+				activeSessionId: state.activeSessionId,
+				command: "second",
+			});
+			resolveSecondBash();
+			await secondResponse;
+
+			const closing = internals.abortBashForClose(state);
+			expect(await Promise.race([closing.then(() => "done"), Promise.resolve("pending")])).toBe("pending");
+			resolveFirstBash();
+			await expect(closing).resolves.toBeUndefined();
+			expect(abortBash).toHaveBeenCalledOnce();
+
+			let isStalledBashRunning = false;
+			const abortStalledBash = vi.fn();
+			const stalledState = makeState("stalled");
+			stalledState.runtime = {
+				...stalledState.runtime,
+				session: {
+					get isBashRunning() {
+						return isStalledBashRunning;
+					},
+					runUserBash: vi.fn(() => {
+						isStalledBashRunning = true;
+						return new Promise<void>(() => {});
+					}),
+					abortBash: abortStalledBash,
+				},
+			} as never;
+			internals.sessions.set(stalledState.activeSessionId, stalledState);
+			await internals.handleCommand(makeClient("stalled-client", stalledState.activeSessionId), {
+				id: "stalled",
+				type: "execute_bash",
+				activeSessionId: stalledState.activeSessionId,
+				command: "stalled",
+			});
+
+			const stalledClose = internals.abortBashForClose(stalledState);
+			await vi.advanceTimersByTimeAsync(4999);
+			expect(await Promise.race([stalledClose.then(() => "done"), Promise.resolve("pending")])).toBe("pending");
+			await vi.advanceTimersByTimeAsync(1);
+			await expect(stalledClose).resolves.toBeUndefined();
+			expect(abortStalledBash).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("normalizes daemon session names before validation and persistence", async () => {
 		const daemon = new AgentDaemon("/tmp/unused-daemon.sock", {
 			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },


### PR DESCRIPTION
## What was wrong

When the daemon closed a session with a Bash command running, it polled `isBashRunning` every 50ms — a timer standing in for the completion signal the system already produces (audit: timeouts.md finding 5).

## The fix

The poll is deleted. The two daemon Bash handlers (the only producers of `isBashRunning` in daemon mode) retain their in-flight completion promise on session state; close aborts and races that promise against the single pre-existing 5-second forced-shutdown deadline. All completion paths — success, rejection, either handler — settle close immediately; a truly stuck process stays bounded by the existing deadline.

An earlier event-subscription approach was rejected in review: `bash_end` is only emitted by one of the two paths, so an RPC-driven `execute_bash_and_wait` run would have stalled close for the full deadline.

## How it's verified

Reviewer traced both handler chains end-to-end (including RPC-over-daemon reachability), confirmed no stale-promise window across sequential runs, unchanged external behavior (error broadcast, request rejection), and bounded fallback semantics. Focused tests cover both behaviors (in-flight completion releases close; stalled completion bounded); daemon-mode 201/201. Two-model implement/review loop, approved on second pass.

Stacked on #1749 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon shutdown/session-close timing for Bash-heavy sessions; behavior is bounded by the existing 5s deadline but close may wait longer than the old poll loop when Bash completes cleanly.
> 
> **Overview**
> Daemon session close no longer **polls** `isBashRunning` every 50ms after aborting Bash. Each session now keeps an **`inFlightBash`** promise that chains completions from **`execute_bash`** and **`execute_bash_and_wait`**; on close, **`abortBashForClose`** still calls **`abortBash`**, then **`await`s** that promise raced against the existing **5s** shutdown deadline.
> 
> Overlapping or sequential Bash runs settle the tracked promise when each handler’s work finishes, so close can proceed as soon as in-flight work completes without waiting on a poll loop. Stuck processes remain bounded by the same timeout.
> 
> Tests cover overlapping Bash (close waits for the slower run) and a never-finishing run (close releases after the deadline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db998a594789c98e28bdcc4a6356b84094df324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Linear ticket: [ENG-5666](https://linear.app/primeintellect/issue/ENG-5666/refactorcoding-agent-await-in-flight-bash-completion-during-daemon)
(ticket linked above)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Await in-flight bash completion in `AgentDaemon.abortBashForClose` instead of polling
> - Adds optional `inFlightBash` promise to `ActiveSessionState` to track Bash work in flight per session.
> - `AgentDaemon.handleCommand` captures and chains Bash promises for `execute_bash` and `execute_bash_and_wait` into `state.inFlightBash` via `Promise.allSettled`.
> - `AgentDaemon.abortBashForClose` now awaits `Promise.race` between the tracked `inFlightBash` chain and `UPDATE_RESTART_ABORT_BASH_TIMEOUT_MS` instead of polling `isBashRunning`.
> - Behavioral Change: daemon close/update no longer polls for Bash completion; it awaits the session's `inFlightBash` chain, bounded by the existing timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3db998a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->