### PR TITLE
refactor(coding-agent): wake RLM quiescence on activity changes instead of polling

### DIFF
--- a/packages/coding-agent/.changes/post-compaction-idle.md
+++ b/packages/coding-agent/.changes/post-compaction-idle.md
@@ -1,0 +1,1 @@
+- Removed the delay before continuing sessions after compaction.

--- a/packages/coding-agent/.changes/rlm-activity-change-waiter.md
+++ b/packages/coding-agent/.changes/rlm-activity-change-waiter.md
@@ -1,0 +1,1 @@
+- Wait for RLM session activity changes without zero-delay polling.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7668,7 +7668,7 @@ export class AgentSession {
 					return;
 				}
 
-				if (this._queuedWorkPauses.size > 0 || this._compactionOperation) {
+				if (this._queuedWorkPauses.size > 0 || this._compactionOperation || this._refineInFlight) {
 					continue;
 				}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7707,7 +7707,9 @@ export class AgentSession {
 
 			try {
 				await continuation;
-				this._forgetConsumedPostCompactionContinuations(continuationMessages);
+				if (this._postCompactionContinuationSettlement === settlement) {
+					this._forgetConsumedPostCompactionContinuations(continuationMessages);
+				}
 				return;
 			} catch (error) {
 				const code = error instanceof AgentContinueError ? error.code : undefined;
@@ -8541,6 +8543,11 @@ export class AgentSession {
 
 		this._emit({ type: "compaction_start", reason, customInstructions });
 		this._autoCompactionAbortController = new AbortController();
+		let resolveCompactionOperation: () => void = () => {};
+		const compactionOperation = new Promise<void>((resolve) => {
+			resolveCompactionOperation = resolve;
+		});
+		this._compactionOperation = compactionOperation;
 
 		try {
 			const authResult = this.model ? await this._modelRegistry.getApiKeyAndHeaders(this.model) : undefined;
@@ -8643,6 +8650,10 @@ export class AgentSession {
 			return false;
 		} finally {
 			this._autoCompactionAbortController = undefined;
+			if (this._compactionOperation === compactionOperation) {
+				this._compactionOperation = undefined;
+			}
+			resolveCompactionOperation();
 			this._scheduleSessionInputPump();
 		}
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -830,11 +830,12 @@ function createAgentMessageDeferred(): AgentMessageDeferred {
 
 /** One-shot settlement for a scheduled post-compaction continuation; a settled failure is never re-exposed to later waiters. */
 interface PostCompactionContinuationSettlement extends AgentMessageDeferred {
+	continueAfterSessionInput: boolean;
 	settled: boolean;
 }
 
 function createPostCompactionContinuationSettlement(): PostCompactionContinuationSettlement {
-	return { ...createAgentMessageDeferred(), settled: false };
+	return { ...createAgentMessageDeferred(), continueAfterSessionInput: false, settled: false };
 }
 
 export interface ModelCycleResult {
@@ -1198,7 +1199,6 @@ export class AgentSession {
 	private _compactAutoRefinePending = false;
 	private _turnIntervalAutoRefinePending = false;
 	private _postCompactionContinuationScheduled = false;
-	private _postCompactionContinuationTimer: ReturnType<typeof setTimeout> | undefined;
 	private _postCompactionContinuationSettlement: PostCompactionContinuationSettlement | undefined;
 	private _postCompactionContinuationMessages: AgentMessage[] = [];
 	private _scheduledPostCompactionContinuationMessages: AgentMessage[] = [];
@@ -7311,6 +7311,7 @@ export class AgentSession {
 			throw new Error("Cannot compact without aborting while the agent is running.");
 		}
 		const hadPostCompactionContinue = this._postCompactionContinuationScheduled;
+		const continueAfterSessionInput = this._postCompactionContinuationSettlement?.continueAfterSessionInput ?? false;
 		this._disconnectFromAgent();
 		if (!options.skipAbort) await this.abort();
 		let didCompact = false;
@@ -7379,7 +7380,7 @@ export class AgentSession {
 			if (didCompact) {
 				this._discardPendingAutoRefine({ cancelPostCompactionContinue: true });
 				if (hadPostCompactionContinue) {
-					this._schedulePostCompactionContinue();
+					this._schedulePostCompactionContinue(continueAfterSessionInput);
 				}
 				// Queued agent or session-owned inputs resume the loop; defer refine
 				// behind them instead of interleaving it before their turns.
@@ -7498,7 +7499,7 @@ export class AgentSession {
 	}
 
 	private _settlePostCompactionContinue(error?: Error): void {
-		if (!error && (this._postCompactionContinuationScheduled || this._postCompactionContinuationTimer)) return;
+		if (!error && this._postCompactionContinuationScheduled) return;
 		const settlement = this._postCompactionContinuationSettlement;
 		if (!settlement || settlement.settled) return;
 		settlement.settled = true;
@@ -7508,10 +7509,6 @@ export class AgentSession {
 	}
 
 	private _cancelPostCompactionContinue(): void {
-		if (this._postCompactionContinuationTimer) {
-			clearTimeout(this._postCompactionContinuationTimer);
-			this._postCompactionContinuationTimer = undefined;
-		}
 		this._postCompactionContinuationScheduled = false;
 		this._scheduledPostCompactionContinuationMessages = [];
 		this._settlePostCompactionContinue();
@@ -7607,75 +7604,124 @@ export class AgentSession {
 		this._scheduleAutoRefine("compact");
 	}
 
-	private _schedulePostCompactionContinue(): void {
-		if (this._postCompactionContinuationScheduled) {
-			return;
-		}
+	private _schedulePostCompactionContinue(continueAfterSessionInput = false): void {
 		if (!this._postCompactionContinuationSettlement || this._postCompactionContinuationSettlement.settled) {
 			this._postCompactionContinuationSettlement = createPostCompactionContinuationSettlement();
 		}
+		const settlement = this._postCompactionContinuationSettlement;
+		settlement.continueAfterSessionInput ||= continueAfterSessionInput;
+		if (this._postCompactionContinuationScheduled) {
+			return;
+		}
 		this._postCompactionContinuationScheduled = true;
 		this._scheduledPostCompactionContinuationMessages = [...this._postCompactionContinuationMessages];
-		this._postCompactionContinuationTimer = setTimeout(() => {
-			this._postCompactionContinuationTimer = undefined;
-			void this._runScheduledPostCompactionContinue()
-				.catch(() => undefined)
-				.finally(() => this._settlePostCompactionContinue());
-		}, 100);
+		void this._runScheduledPostCompactionContinue(settlement)
+			.catch(() => undefined)
+			.finally(() => {
+				if (this._postCompactionContinuationSettlement === settlement) {
+					this._settlePostCompactionContinue();
+				}
+			});
 	}
 
 	private _sessionOwnsScheduledContinuations(continuationMessages: AgentMessage[]): boolean {
 		return continuationMessages.some((message) => this._postCompactionContinuationMessages.includes(message));
 	}
 
-	private async _runScheduledPostCompactionContinue(): Promise<void> {
-		await this._waitForRefineIdle();
-		if (!this._postCompactionContinuationScheduled) {
-			return;
-		}
-		if (this.isStreaming || this.isCompacting || this.isRetrying || this._queuedWorkPauses.size > 0) {
-			this._postCompactionContinuationScheduled = false;
-			this._schedulePostCompactionContinue();
-			return;
-		}
-
-		const continuationMessages = [...this._scheduledPostCompactionContinuationMessages];
-		if (continuationMessages.length > 0 && !this._sessionOwnsScheduledContinuations(continuationMessages)) {
-			this._cancelPostCompactionContinue();
-			this._scheduleAutoRefineAfterAgentEnd();
-			return;
-		}
-		// An empty queue is not idle while the scheduler still owns active work.
-		if (this.unfinishedActionCount > 0 || this._sessionInputPumpRequested) {
-			this._scheduleSessionInputPump();
-			await this._sessionInputPump;
-			if (this._postCompactionContinuationScheduled) {
-				this._postCompactionContinuationScheduled = false;
-				const shouldReschedule =
-					continuationMessages.length === 0
-						? this.unfinishedActionCount > 0
-						: this._sessionOwnsScheduledContinuations(continuationMessages);
-				if (shouldReschedule) {
-					this._schedulePostCompactionContinue();
-				} else {
-					this._scheduledPostCompactionContinuationMessages = [];
-					this._scheduleAutoRefineAfterAgentEnd();
-				}
+	private async _waitForQueuedWorkResume(settlement: PostCompactionContinuationSettlement): Promise<void> {
+		while (this._queuedWorkPauses.size > 0 && this._postCompactionContinuationSettlement === settlement) {
+			let resume = () => {};
+			const resumed = new Promise<void>((resolve) => {
+				resume = resolve;
+				this._sessionInputCheckpointWaiters.add(resolve);
+			});
+			try {
+				await Promise.race([resumed, settlement.promise]);
+			} finally {
+				this._sessionInputCheckpointWaiters.delete(resume);
 			}
-			return;
 		}
+	}
 
-		this._postCompactionContinuationScheduled = false;
-		try {
-			await this.agent.continue();
-			this._forgetConsumedPostCompactionContinuations(continuationMessages);
-		} catch (error) {
-			const code = error instanceof AgentContinueError ? error.code : undefined;
-			if (code === "busy") {
-				this._schedulePostCompactionContinue();
-			} else if (code !== "nothing-to-continue") {
-				// "nothing-to-continue" means the turn already completed; anything else must reject headless idle waiters.
-				this._settlePostCompactionContinue(this._asError(error));
+	private async _runScheduledPostCompactionContinue(settlement: PostCompactionContinuationSettlement): Promise<void> {
+		while (this._postCompactionContinuationScheduled && this._postCompactionContinuationSettlement === settlement) {
+			await this.agent.waitForIdle();
+			await this.waitForRetry();
+			await this._waitForRefineIdle();
+			await this._waitForQueuedWorkResume(settlement);
+			const compactionOperation = this._compactionOperation;
+			if (compactionOperation) {
+				await Promise.race([compactionOperation, settlement.promise]);
+				continue;
+			}
+
+			const commitFence = await this._acquireSessionActionCommitFence();
+			let continuation: Promise<void> | undefined;
+			let continuationMessages: AgentMessage[] = [];
+			let waitForSessionInput = false;
+			try {
+				await this.agent.waitForIdle();
+				if (
+					!this._postCompactionContinuationScheduled ||
+					this._postCompactionContinuationSettlement !== settlement
+				) {
+					return;
+				}
+
+				if (this._queuedWorkPauses.size > 0 || this._compactionOperation) {
+					continue;
+				}
+
+				continuationMessages = [...this._scheduledPostCompactionContinuationMessages];
+				if (continuationMessages.length > 0 && !this._sessionOwnsScheduledContinuations(continuationMessages)) {
+					this._cancelPostCompactionContinue();
+					this._scheduleAutoRefineAfterAgentEnd();
+					return;
+				}
+				if (this.unfinishedActionCount > 0 || this._sessionInputPumpRequested) {
+					this._scheduleSessionInputPump();
+					waitForSessionInput = true;
+				} else {
+					this._postCompactionContinuationScheduled = false;
+					continuation = this.agent.continue();
+				}
+			} finally {
+				commitFence.release();
+			}
+
+			if (waitForSessionInput) {
+				await this.waitForIdle();
+				if (this._postCompactionContinuationSettlement !== settlement) return;
+				const shouldContinue =
+					(settlement.continueAfterSessionInput && continuationMessages.length === 0) ||
+					this._sessionOwnsScheduledContinuations(continuationMessages);
+				if (shouldContinue) {
+					this._scheduledPostCompactionContinuationMessages = [...this._postCompactionContinuationMessages];
+					continue;
+				}
+				this._postCompactionContinuationScheduled = false;
+				this._scheduledPostCompactionContinuationMessages = [];
+				this._scheduleAutoRefineAfterAgentEnd();
+				return;
+			}
+
+			try {
+				await continuation;
+				this._forgetConsumedPostCompactionContinuations(continuationMessages);
+				return;
+			} catch (error) {
+				const code = error instanceof AgentContinueError ? error.code : undefined;
+				if (code === "busy") {
+					if (this._postCompactionContinuationSettlement === settlement) {
+						this._postCompactionContinuationScheduled = true;
+						this._scheduledPostCompactionContinuationMessages = [...this._postCompactionContinuationMessages];
+					}
+					continue;
+				}
+				if (code !== "nothing-to-continue" && this._postCompactionContinuationSettlement === settlement) {
+					this._settlePostCompactionContinue(this._asError(error));
+				}
+				return;
 			}
 		}
 	}
@@ -8489,7 +8535,7 @@ export class AgentSession {
 				(reason === "requested" || reason === "threshold") &&
 				(shouldContinueAfterCompaction || this.agent.hasQueuedMessages() || this.hasPendingSessionWork)
 			) {
-				this._schedulePostCompactionContinue();
+				this._schedulePostCompactionContinue(shouldContinueAfterCompaction);
 			}
 		};
 
@@ -8541,13 +8587,13 @@ export class AgentSession {
 					this.agent.state.messages = messages.slice(0, -1);
 				}
 
-				this._schedulePostCompactionContinue();
+				this._schedulePostCompactionContinue(true);
 				this._scheduleAutoRefineAfterCompaction(willContinueAfterCompaction);
 				return true;
 			} else if (shouldContinueAfterCompaction || hasQueuedMessages) {
 				// Compaction can intentionally stop a tool loop between turns.
 				// Queued follow-up/steering/custom messages can also be waiting.
-				this._schedulePostCompactionContinue();
+				this._schedulePostCompactionContinue(shouldContinueAfterCompaction);
 				this._scheduleAutoRefineAfterCompaction(willContinueAfterCompaction);
 			} else {
 				this._scheduleAutoRefineAfterCompaction(willContinueAfterCompaction);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6810,10 +6810,29 @@ export class AgentSession {
 	}
 
 	async waitForIdle(): Promise<void> {
-		while (true) {
+		await this._waitForIdleOrSettlement();
+	}
+
+	/**
+	 * {@link waitForIdle} loop; with a settlement, returns once that settlement is
+	 * superseded so a cancelled post-compaction runner cannot keep a checkpoint
+	 * waiter registered (a leaked waiter holds hasPendingAdmissionWaiters true and
+	 * blocks daemon passivation).
+	 */
+	private async _waitForIdleOrSettlement(settlement?: PostCompactionContinuationSettlement): Promise<void> {
+		while (settlement === undefined || this._postCompactionContinuationSettlement === settlement) {
 			if (this._actionStore.queuedActions().length > 0) {
 				if (this._sessionInputPumpSuspended || this._queuedWorkPauses.size > 0) {
-					await new Promise<void>((resolve) => this._sessionInputCheckpointWaiters.add(resolve));
+					let wake = () => {};
+					const changed = new Promise<void>((resolve) => {
+						wake = resolve;
+						this._sessionInputCheckpointWaiters.add(resolve);
+					});
+					try {
+						await (settlement ? Promise.race([changed, settlement.promise]) : changed);
+					} finally {
+						this._sessionInputCheckpointWaiters.delete(wake);
+					}
 					continue;
 				}
 				this._scheduleSessionInputPump();
@@ -7708,7 +7727,7 @@ export class AgentSession {
 			}
 
 			if (waitForSessionInput) {
-				await this.waitForIdle();
+				await this._waitForIdleOrSettlement(settlement);
 				if (this._postCompactionContinuationSettlement !== settlement) return;
 				const shouldContinue =
 					(settlement.continueAfterSessionInput && continuationMessages.length === 0) ||

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1065,7 +1065,7 @@ export class AgentSession {
 	private _pendingSessionActionFenceWaiters = 0;
 	private readonly _sessionActionCommitContext = new AsyncLocalStorage<symbol>();
 	private readonly _sessionActionCommitDisposeAbortController = new AbortController();
-	// Checkpoint and handoff waiters share lifecycle-edge notifications to avoid polling.
+	// Checkpoint, handoff, and activity waiters share lifecycle-edge notifications to avoid polling.
 	private readonly _sessionInputCheckpointWaiters = new Set<() => void>();
 	private _pendingNextTurnMessages: CustomMessage[] = [];
 
@@ -2506,6 +2506,7 @@ export class AgentSession {
 			if (this._refineInFlight === applySettled) {
 				this._refineInFlight = undefined;
 			}
+			this._notifySessionInputCheckpointChange();
 			this._scheduleSessionInputPump();
 		}
 	}
@@ -2714,6 +2715,7 @@ export class AgentSession {
 			if (this._refineInFlight === applySettled) {
 				this._refineInFlight = undefined;
 			}
+			this._notifySessionInputCheckpointChange();
 			this._scheduleSessionInputPump();
 		}
 	}
@@ -3704,6 +3706,7 @@ export class AgentSession {
 			this._retryResolve();
 			this._retryResolve = undefined;
 			this._retryPromise = undefined;
+			this._notifySessionInputCheckpointChange();
 			this._scheduleSessionInputPump();
 		}
 	}
@@ -6583,6 +6586,19 @@ export class AgentSession {
 		for (const resolve of waiters) resolve();
 	}
 
+	private _waitForSessionActivityChange(signal: AbortSignal): Promise<void> {
+		return new Promise<void>((resolve) => {
+			const finish = () => {
+				this._sessionInputCheckpointWaiters.delete(finish);
+				signal.removeEventListener("abort", finish);
+				resolve();
+			};
+			this._sessionInputCheckpointWaiters.add(finish);
+			signal.addEventListener("abort", finish, { once: true });
+			if (signal.aborted) finish();
+		});
+	}
+
 	private _observeSessionActionDeferral(action: QueuedSessionAction): {
 		deferred: Promise<void>;
 		stop(): void;
@@ -7375,6 +7391,7 @@ export class AgentSession {
 				this._compactionOperation = undefined;
 			}
 			resolveCompactionOperation();
+			this._notifySessionInputCheckpointChange();
 			this._scheduleSessionInputPump();
 			if (didCompact) {
 				this._discardPendingAutoRefine({ cancelPostCompactionContinue: true });
@@ -7505,6 +7522,7 @@ export class AgentSession {
 		this._postCompactionContinuationSettlement = undefined;
 		if (error) settlement.reject(error);
 		else settlement.resolve();
+		this._notifySessionInputCheckpointChange();
 	}
 
 	private _cancelPostCompactionContinue(): void {
@@ -8019,6 +8037,7 @@ export class AgentSession {
 			if (this._refineInFlight === applySettled) {
 				this._refineInFlight = undefined;
 			}
+			this._notifySessionInputCheckpointChange();
 			this._scheduleSessionInputPump();
 		}
 	}
@@ -8597,6 +8616,7 @@ export class AgentSession {
 			return false;
 		} finally {
 			this._autoCompactionAbortController = undefined;
+			this._notifySessionInputCheckpointChange();
 			this._scheduleSessionInputPump();
 		}
 	}
@@ -10036,12 +10056,9 @@ export class AgentSession {
 		try {
 			while (true) {
 				await wait(this.waitForHeadlessIdle());
-				// Strong RLM quiescence also owns session-level work (bash, refine,
-				// branch mutation, and manual compaction) that interactive waitForIdle
-				// intentionally ignores. Yield a macrotask while such work is active so
-				// recursive parent/child barriers cannot form a microtask busy-loop.
+				// Strong RLM quiescence also owns work that interactive waitForIdle ignores.
 				if (this.isSessionActive || this._hasDeferredRlmTerminalNotices()) {
-					await wait(new Promise<void>((resolve) => setTimeout(resolve, 0)));
+					await wait(this._waitForSessionActivityChange(cancellation.signal));
 					continue;
 				}
 				const unsettledRuns = [...this._unsettledRlmChildRuns].filter((run) => !run.settled);
@@ -10941,6 +10958,7 @@ export class AgentSession {
 			return result;
 		} finally {
 			this._bashAbortController = undefined;
+			this._notifySessionInputCheckpointChange();
 		}
 	}
 
@@ -10985,6 +11003,7 @@ export class AgentSession {
 			);
 		} finally {
 			this._userBashRunning = false;
+			this._notifySessionInputCheckpointChange();
 		}
 		// Emitted after the slot is released so clients never observe a bash_end
 		// while the session still rejects new commands as already running.
@@ -11444,6 +11463,7 @@ export class AgentSession {
 				this._branchSummaryOperation = undefined;
 			}
 			resolveBranchSummaryOperation();
+			this._notifySessionInputCheckpointChange();
 		}
 	}
 

--- a/packages/coding-agent/test/agent-session-recursion.test.ts
+++ b/packages/coding-agent/test/agent-session-recursion.test.ts
@@ -1426,7 +1426,7 @@ describe("AgentSession rlm recursion", () => {
 		});
 	});
 
-	it("strong quiescence yields to a real gated child bash while interactive idle remains resolved", async () => {
+	it("strong quiescence waits for a gated child bash activity change", async () => {
 		const child = createSession({ rlmSessionDir: join(tempDir, "bash-active-child") });
 		const bashStarted = deferred<void>();
 		const bashCompletion = deferred<void>();
@@ -1446,7 +1446,7 @@ describe("AgentSession rlm recursion", () => {
 		const originalHeadlessIdle = child.waitForHeadlessIdle.bind(child);
 		let headlessIdleCalls = 0;
 		vi.spyOn(child, "waitForHeadlessIdle").mockImplementation(async () => {
-			if (++headlessIdleCalls > 100) throw new Error("RLM quiescence spun without yielding a macrotask");
+			headlessIdleCalls++;
 			await originalHeadlessIdle();
 		});
 
@@ -1459,11 +1459,12 @@ describe("AgentSession rlm recursion", () => {
 			sleep(20).then(() => "timer" as const),
 		]);
 		expect(firstBoundary).toBe("timer");
+		expect(headlessIdleCalls).toBe(1);
 
 		bashCompletion.resolve();
 		await bash;
 		await expect(quiescence).resolves.toBeUndefined();
-		expect(headlessIdleCalls).toBeLessThan(100);
+		expect(headlessIdleCalls).toBe(2);
 	});
 
 	it("rechecks parent self-activity after a child quiescence boundary", async () => {

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -4,6 +4,7 @@ import { type AssistantMessage, fauxAssistantMessage, type Model, type ToolResul
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../../src/core/session-manager.js";
 import { createHarness, getMessageText, type Harness } from "./harness.js";
+import { createDeferred } from "./scheduling.js";
 
 type SessionWithCompactionInternals = {
 	_checkCompaction: (
@@ -265,6 +266,51 @@ describe("AgentSession compaction characterization", () => {
 		} finally {
 			internals._cancelPostCompactionContinue();
 		}
+	});
+
+	it("waits for active manual compaction before continuing", async () => {
+		const compactionStarted = createDeferred();
+		const compactionRelease = createDeferred();
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						compactionStarted.resolve();
+						await compactionRelease.promise;
+						return {
+							compaction: {
+								summary: "summary from extension",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: { source: "extension" },
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const internals = harness.session as unknown as {
+			_schedulePostCompactionContinue(): void;
+		};
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("first");
+		await harness.session.prompt("second");
+		const pause = harness.session.acquireQueuedWorkPause();
+		const continueAgent = vi.spyOn(harness.session.agent, "continue").mockResolvedValue();
+		internals._schedulePostCompactionContinue();
+
+		const compaction = harness.session.compact(undefined, { skipAbort: true });
+		await compactionStarted.promise;
+		pause.release();
+		await new Promise<void>(setImmediate);
+		expect(continueAgent).not.toHaveBeenCalled();
+
+		compactionRelease.resolve();
+		await compaction;
+		await harness.session.waitForHeadlessIdle();
+		expect(continueAgent).toHaveBeenCalledTimes(1);
 	});
 
 	it("treats session-owned queued inputs as queued work after compaction", async () => {
@@ -875,12 +921,19 @@ describe("AgentSession compaction characterization", () => {
 			response: "continuation handled",
 			tracked: true,
 		},
-	])("does not continue again after the session pump handles $name", async ({ text, response, tracked }) => {
+		{
+			name: "an empty resume request",
+			text: "concurrent input",
+			response: "concurrent input handled",
+			tracked: false,
+			continueAfterSessionInput: true,
+		},
+	])("settles $name after the session pump runs", async ({ text, response, tracked, continueAfterSessionInput }) => {
 		vi.useFakeTimers();
 		const harness = await createHarness();
 		harnesses.push(harness);
 		const sessionInternals = harness.session as unknown as {
-			_schedulePostCompactionContinue(): void;
+			_schedulePostCompactionContinue(continueAfterSessionInput?: boolean): void;
 			_postCompactionContinuationMessages: AgentMessage[];
 			_postCompactionContinuationScheduled: boolean;
 			_createPreparedTurnAction(
@@ -906,10 +959,10 @@ describe("AgentSession compaction characterization", () => {
 		);
 		const continueSpy = vi.spyOn(harness.session.agent, "continue");
 
-		sessionInternals._schedulePostCompactionContinue();
+		sessionInternals._schedulePostCompactionContinue(continueAfterSessionInput);
 		await vi.advanceTimersByTimeAsync(200);
 
-		expect(continueSpy).not.toHaveBeenCalled();
+		expect(continueSpy).toHaveBeenCalledTimes(continueAfterSessionInput ? 1 : 0);
 		expect(sessionInternals._postCompactionContinuationScheduled).toBe(false);
 		expect(sessionInternals._postCompactionContinuationMessages).toEqual([]);
 		expect(harness.session.messages.at(-1)).toMatchObject({
@@ -919,7 +972,6 @@ describe("AgentSession compaction characterization", () => {
 	});
 
 	it("keeps autonomous threshold continuations when post-compaction continue must retry", async () => {
-		vi.useFakeTimers();
 		const harness = await createHarness({
 			autonomous: {
 				enabled: true,
@@ -933,6 +985,7 @@ describe("AgentSession compaction characterization", () => {
 		harnesses.push(harness);
 		const sessionInternals = harness.session as unknown as {
 			_schedulePostCompactionContinue(): void;
+			_cancelPostCompactionContinue(): void;
 			_postCompactionContinuationMessages: AgentMessage[];
 			_postCompactionContinuationScheduled: boolean;
 		};
@@ -945,16 +998,21 @@ describe("AgentSession compaction characterization", () => {
 		harness.session.agent.state.messages = [
 			{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: Date.now() - 1000 },
 		];
+		const activeRunSettled = createDeferred();
 		const continueSpy = vi
 			.spyOn(harness.session.agent, "continue")
 			.mockRejectedValueOnce(new AgentContinueError("busy", "already processing"));
+		vi.spyOn(harness.session.agent, "waitForIdle").mockImplementation(() =>
+			continueSpy.mock.calls.length === 0 ? Promise.resolve() : activeRunSettled.promise,
+		);
 
 		sessionInternals._schedulePostCompactionContinue();
-		await vi.advanceTimersByTimeAsync(100);
+		await vi.waitFor(() => expect(continueSpy).toHaveBeenCalledTimes(1));
 
-		expect(continueSpy).toHaveBeenCalledTimes(1);
 		expect(sessionInternals._postCompactionContinuationMessages).toEqual([queuedMessage]);
 		expect(sessionInternals._postCompactionContinuationScheduled).toBe(true);
+		sessionInternals._cancelPostCompactionContinue();
+		activeRunSettled.resolve();
 	});
 
 	it("clears queued autonomous threshold continuations when autonomous mode is disabled", async () => {

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -313,6 +313,51 @@ describe("AgentSession compaction characterization", () => {
 		expect(continueAgent).toHaveBeenCalledTimes(1);
 	});
 
+	it("waits for active auto-compaction before continuing", async () => {
+		const compactionStarted = createDeferred();
+		const compactionRelease = createDeferred();
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						compactionStarted.resolve();
+						await compactionRelease.promise;
+						return {
+							compaction: {
+								summary: "summary from extension",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: { source: "extension" },
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const internals = harness.session as unknown as SessionWithCompactionInternals & {
+			_schedulePostCompactionContinue(): void;
+		};
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("first");
+		await harness.session.prompt("second");
+		const pause = harness.session.acquireQueuedWorkPause();
+		const continueAgent = vi.spyOn(harness.session.agent, "continue").mockResolvedValue();
+		internals._schedulePostCompactionContinue();
+
+		const compaction = internals._runAutoCompaction("threshold", false);
+		await compactionStarted.promise;
+		pause.release();
+		await new Promise<void>(setImmediate);
+		expect(continueAgent).not.toHaveBeenCalled();
+
+		compactionRelease.resolve();
+		await compaction;
+		await harness.session.waitForHeadlessIdle();
+		expect(continueAgent).toHaveBeenCalledTimes(1);
+	});
+
 	it("treats session-owned queued inputs as queued work after compaction", async () => {
 		const harness = await createHarness({
 			settings: { compaction: { keepRecentTokens: 1 } },
@@ -1013,6 +1058,42 @@ describe("AgentSession compaction characterization", () => {
 		expect(sessionInternals._postCompactionContinuationScheduled).toBe(true);
 		sessionInternals._cancelPostCompactionContinue();
 		activeRunSettled.resolve();
+	});
+
+	it("keeps replacement continuation messages when a cancelled continue settles late", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as {
+			_schedulePostCompactionContinue(): void;
+			_cancelPostCompactionContinue(): void;
+			_postCompactionContinuationMessages: AgentMessage[];
+		};
+		const queuedMessage = {
+			role: "user",
+			content: [{ type: "text", text: "autonomous follow-up" }],
+			timestamp: Date.now(),
+		} satisfies AgentMessage;
+		sessionInternals._postCompactionContinuationMessages = [queuedMessage];
+		const staleRun = createDeferred();
+		const replacementRun = createDeferred();
+		const continueSpy = vi
+			.spyOn(harness.session.agent, "continue")
+			.mockReturnValueOnce(staleRun.promise)
+			.mockReturnValueOnce(replacementRun.promise);
+
+		sessionInternals._schedulePostCompactionContinue();
+		await vi.waitFor(() => expect(continueSpy).toHaveBeenCalledTimes(1));
+		sessionInternals._cancelPostCompactionContinue();
+		sessionInternals._schedulePostCompactionContinue();
+		await vi.waitFor(() => expect(continueSpy).toHaveBeenCalledTimes(2));
+
+		staleRun.resolve();
+		await new Promise<void>(setImmediate);
+		expect(sessionInternals._postCompactionContinuationMessages).toEqual([queuedMessage]);
+
+		replacementRun.resolve();
+		await harness.session.waitForHeadlessIdle();
+		expect(sessionInternals._postCompactionContinuationMessages).toEqual([]);
 	});
 
 	it("clears queued autonomous threshold continuations when autonomous mode is disabled", async () => {

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1096,6 +1096,31 @@ describe("AgentSession compaction characterization", () => {
 		expect(sessionInternals._postCompactionContinuationMessages).toEqual([]);
 	});
 
+	it("waits for an in-flight refine application before continuing", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as {
+			_schedulePostCompactionContinue(): void;
+			_refineInFlight: Promise<void> | undefined;
+		};
+		const continueSpy = vi.spyOn(harness.session.agent, "continue").mockResolvedValue();
+		const pause = harness.session.acquireQueuedWorkPause();
+		sessionInternals._schedulePostCompactionContinue();
+		await new Promise<void>(setImmediate);
+
+		// Refine enters its apply phase while the runner waits out the pause.
+		const refineApply = createDeferred();
+		sessionInternals._refineInFlight = refineApply.promise;
+		pause.release();
+		await new Promise<void>(setImmediate);
+		expect(continueSpy).not.toHaveBeenCalled();
+
+		sessionInternals._refineInFlight = undefined;
+		refineApply.resolve();
+		await harness.session.waitForHeadlessIdle();
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("clears queued autonomous threshold continuations when autonomous mode is disabled", async () => {
 		vi.useFakeTimers();
 		const harness = await createHarness({

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -401,6 +401,49 @@ describe("AgentSession compaction characterization", () => {
 		}
 	});
 
+	it("releases the runner's suspended idle wait when the continuation is cancelled", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const session = harness.session;
+		const internals = session as unknown as {
+			_schedulePostCompactionContinue(): void;
+			_cancelPostCompactionContinue(): void;
+			_sessionInputCheckpointWaiters: Set<() => void>;
+			_sessionInputPumpSuspended: boolean;
+		};
+		// A queued follow-up held back by a pause, then a pump suspension (the
+		// requestAbort teardown state): the queue stays populated but undispatchable.
+		const pause = session.acquireQueuedWorkPause();
+		await session.followUp("queued across abort");
+		expect(session.queuedActionCount).toBe(1);
+		session.requestAbort();
+		pause.release();
+		expect(internals._sessionInputPumpSuspended).toBe(true);
+		expect(session.queuedActionCount).toBe(1);
+
+		// The runner passes its pre-dispatch guards (no pauses, agent idle) and
+		// parks in the session idle wait on a checkpoint waiter.
+		internals._schedulePostCompactionContinue();
+		await vi.waitFor(() => {
+			expect(internals._sessionInputCheckpointWaiters.size).toBeGreaterThan(0);
+		});
+		expect(session.hasPendingAdmissionWaiters).toBe(true);
+
+		// Cancelling the continuation must release that waiter: a stuck waiter
+		// keeps hasPendingAdmissionWaiters true and blocks daemon passivation.
+		// The settle's own notify empties the set for a moment; a leaked runner
+		// re-parks within a microtask, so settle real time before asserting.
+		internals._cancelPostCompactionContinue();
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		try {
+			expect(internals._sessionInputCheckpointWaiters.size).toBe(0);
+			expect(session.hasPendingAdmissionWaiters).toBe(false);
+		} finally {
+			session.clearQueue();
+			session.resumeQueuedWork();
+		}
+	});
+
 	it("defers post-compaction refine behind a preparing session action", async () => {
 		const preparationReached = vi.fn();
 		let releasePreparation = () => {};

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -39,7 +39,7 @@ type AutoRefineInternals = {
 	_scheduleAutoRefine(reason: AutoRefineReason): void;
 	_scheduleAutoRefineAfterCompaction(willContinueAfterCompaction: boolean): void;
 	_scheduleAutoRefineAfterAgentEnd(): void;
-	_schedulePostCompactionContinue(): void;
+	_schedulePostCompactionContinue(continueAfterSessionInput?: boolean): void;
 	_invalidatePendingAutoRefineForBranchChange(): Promise<void>;
 	_cancelPostCompactionContinue(): void;
 	_assistantTurnsSinceAutoRefine: number;
@@ -327,34 +327,71 @@ describe("AgentSession queue characterization", () => {
 		}
 	});
 
-	it("retries a scheduled post-compaction continuation when another run starts first", async () => {
-		vi.useFakeTimers();
+	it("waits for the active run to settle before retrying a post-compaction continuation", async () => {
 		const harness = await createAutoRefineHarness({
 			settings: { autoRefine: { enabled: true, turnInterval: 25, cooldownMs: 0 } },
 		});
 		harnesses.push(harness);
 		const internals = harness.session as unknown as AutoRefineInternals;
+		const activeRunSettled = createDeferred();
 		const continueAgent = vi
 			.spyOn(harness.session.agent, "continue")
 			.mockRejectedValueOnce(
 				new AgentContinueError("busy", "Agent is already processing. Wait for completion before continuing."),
 			)
 			.mockResolvedValueOnce();
+		vi.spyOn(harness.session.agent, "waitForIdle").mockImplementation(() =>
+			continueAgent.mock.calls.length === 0 ? Promise.resolve() : activeRunSettled.promise,
+		);
 
-		try {
-			internals._schedulePostCompactionContinue();
-			await vi.advanceTimersByTimeAsync(100);
+		internals._schedulePostCompactionContinue();
+		await vi.waitFor(() => expect(continueAgent).toHaveBeenCalledTimes(1));
+		expect(internals._postCompactionContinuationScheduled).toBe(true);
 
-			expect(continueAgent).toHaveBeenCalledTimes(1);
-			expect(internals._postCompactionContinuationScheduled).toBe(true);
+		activeRunSettled.resolve();
+		await vi.waitFor(() => expect(continueAgent).toHaveBeenCalledTimes(2));
+		expect(internals._postCompactionContinuationScheduled).toBe(false);
+	});
 
-			await vi.advanceTimersByTimeAsync(100);
+	it("does not let a failed cancelled continuation reject its replacement", async () => {
+		const harness = await createAutoRefineHarness();
+		harnesses.push(harness);
+		const internals = harness.session as unknown as AutoRefineInternals;
+		const cancelledRun = createDeferred();
+		const replacementRun = createDeferred();
+		const continueAgent = vi
+			.spyOn(harness.session.agent, "continue")
+			.mockReturnValueOnce(cancelledRun.promise)
+			.mockReturnValueOnce(replacementRun.promise);
 
-			expect(continueAgent).toHaveBeenCalledTimes(2);
-			expect(internals._postCompactionContinuationScheduled).toBe(false);
-		} finally {
-			vi.useRealTimers();
-		}
+		internals._schedulePostCompactionContinue();
+		await vi.waitFor(() => expect(continueAgent).toHaveBeenCalledTimes(1));
+		internals._cancelPostCompactionContinue();
+		internals._schedulePostCompactionContinue();
+		await vi.waitFor(() => expect(continueAgent).toHaveBeenCalledTimes(2));
+		const idle = harness.session.waitForHeadlessIdle();
+
+		cancelledRun.reject(new Error("cancelled continuation failed"));
+		await new Promise<void>(setImmediate);
+		replacementRun.resolve();
+
+		await expect(idle).resolves.toBeUndefined();
+	});
+
+	it("waits for a queued-work pause to release before post-compaction continuation", async () => {
+		const harness = await createAutoRefineHarness();
+		harnesses.push(harness);
+		const internals = harness.session as unknown as AutoRefineInternals;
+		const pause = harness.session.acquireQueuedWorkPause();
+		const continueAgent = vi.spyOn(harness.session.agent, "continue").mockResolvedValue();
+
+		internals._schedulePostCompactionContinue();
+		await new Promise<void>(setImmediate);
+		expect(continueAgent).not.toHaveBeenCalled();
+
+		pause.release();
+		await harness.session.waitForHeadlessIdle();
+		expect(continueAgent).toHaveBeenCalledTimes(1);
 	});
 
 	it("cancels scheduled post-compaction continuation on branch changes", async () => {
@@ -407,24 +444,22 @@ describe("AgentSession queue characterization", () => {
 	});
 
 	it("keeps scheduled post-compaction continuation when session-input pump compaction skips without aborting", async () => {
-		vi.useFakeTimers();
 		const harness = await createAutoRefineHarness({
 			settings: { autoRefine: { enabled: true, turnInterval: 25, cooldownMs: 0 } },
 		});
 		harnesses.push(harness);
 		const internals = harness.session as unknown as AutoRefineInternals;
-		try {
-			internals._schedulePostCompactionContinue();
+		const idle = createDeferred();
+		vi.spyOn(harness.session.agent, "waitForIdle").mockReturnValue(idle.promise);
+		internals._schedulePostCompactionContinue();
 
-			await expect(harness.session.compact(undefined, { skipAbort: true })).rejects.toThrow(
-				"Session is too short to compact",
-			);
+		await expect(harness.session.compact(undefined, { skipAbort: true })).rejects.toThrow(
+			"Session is too short to compact",
+		);
 
-			expect(internals._postCompactionContinuationScheduled).toBe(true);
-		} finally {
-			internals._cancelPostCompactionContinue();
-			vi.useRealTimers();
-		}
+		expect(internals._postCompactionContinuationScheduled).toBe(true);
+		internals._cancelPostCompactionContinue();
+		idle.resolve();
 	});
 
 	it("auto-refine pending review uses the in-progress guard and catches refine failures", async () => {


### PR DESCRIPTION
> **Note:** this PR also contains the full change from #1844 (serialized post-compaction continuation: one settlement owner, commit-fence re-checks, and paused-continuation preservation replacing the racy fixed delay) - that PR is closed and merges here as one unit.

## What was wrong

`waitForRlmQuiescence` — the strong idle barrier gating goal continuations and daemon idle for sessions with subagent work — detected settlement by re-checking on a zero-delay `setTimeout(0)` loop: busy-spinning the event loop instead of being told when activity changes (audit: timeouts.md finding 7).

## The fix

The poll is replaced by an abort-aware activity-change waiter that reuses the existing session-input checkpoint waiter set (no second notification registry). Every component of the quiescence predicate now notifies on its clear path — bash, refine, retry, compaction, branch summaries, terminal actions, and (added in review) the post-compaction continuation settlement, which was the one clear path without a notify and could have hung the barrier permanently in a narrow registration window. Spurious wakes are safe in both directions: all consumers of the shared set re-check their predicates in loops. +31/−9.

## How it's verified

Reviewer performed an exhaustive missed-wake audit of every `isSessionActive` component with per-clear-site accounting, verified bidirectional spurious-wake safety across the shared waiter set, confirmed no hot-path notifies (all fire once per operation, never per-token), and validated the goal-continuation-quiescence suite (#1610) is untouched and green (7/7). Recursion suite 116/116; full CI-style failing set matches stack base. Two-model implement/review loop, approved on second pass.

Stacked on #1751 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session scheduling, compaction continuation, and RLM idle barriers; regressions could stall continuations, leak admission waiters, or mis-order resume vs queued input, though behavior is heavily covered by updated compaction, queue, and recursion tests.
> 
> **Overview**
> Replaces busy-wait patterns in **RLM quiescence** and **post-compaction continuation** with waits on shared session activity notifications.
> 
> `waitForRlmQuiescence` no longer spins on `setTimeout(0)` when session-level work is active; it blocks on a new **`_waitForSessionActivityChange`** hook that shares the existing checkpoint waiter set. **`_notifySessionInputCheckpointChange`** is invoked when that work finishes (bash, refine apply, retry, compaction, branch summary, post-compaction settlement, and related paths) so waiters wake instead of polling.
> 
> Post-compaction resume **drops the fixed 100ms timer**. **`_runScheduledPostCompactionContinue`** runs immediately and loops until it can safely call `agent.continue()`, explicitly waiting for agent idle, retries, refine, an in-flight **`_compactionOperation`**, queued-work pauses, and session-input pump idle. A **`continueAfterSessionInput`** flag on the continuation settlement controls whether an empty “resume after compaction” should still call `continue()` once queued session input has drained.
> 
> **`waitForIdle`** / checkpoint waiting now register and clean up waiters correctly and can **`Promise.race`** against a superseded post-compaction settlement so cancelled continuations do not leak waiters and block daemon passivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bcedd43b06a79a93bb81b0073270090f6d927e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Linear ticket: [ENG-5667](https://linear.app/primeintellect/issue/ENG-5667/refactorcoding-agent-wake-rlm-quiescence-on-activity-changes-instead)
(ticket linked above)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace polling with event-driven waiters for RLM quiescence and post-compaction continuations
> - Introduces `AgentSession._waitForSessionActivityChange` as a one-shot waiter that resolves on session activity or abort, replacing `setTimeout(0)` busy-loop yielding in `waitForRlmQuiescence`
> - Removes fixed-delay timer scheduling from post-compaction continuations; `_schedulePostCompactionContinue` now launches `_runScheduledPostCompactionContinue` directly, which loops waiting for idle, retry, refine, queued-work, and compaction completion
> - Adds `continueAfterSessionInput` flag to `PostCompactionContinuationSettlement` so continuations can optionally wait for pending session input before calling `agent.continue()`
> - Notifies session-input checkpoint waiters from `runUserBash`, refine-application paths, branch summary, retry resolution, and compaction completion so quiescence waiters wake promptly
> - Risk: `waitForRlmQuiescence` no longer polls on a macrotask interval; any missed `_notifySessionInputCheckpointChange` call site will cause quiescence to hang until the next activity notification. Reviewers should verify all session-input-producing paths in `AgentSession` notify checkpoint waiters in their `finally` blocks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bcedd4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Note: trivial textual overlap with #1844 (both add cleanup lines to the same `finally` block in `_runAutoCompaction`; both lines should survive). Whichever PR merges second will be refreshed against main.