### PR TITLE
refactor(coding-agent): remove test-only parser and feature-hint seams

### DIFF
--- a/packages/coding-agent/.changes/test-only-parser-hints.md
+++ b/packages/coding-agent/.changes/test-only-parser-hints.md
@@ -1,0 +1,1 @@
+- Simplified model resolution and feature hint shuffling internals.

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -147,7 +147,7 @@ function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Mod
 	}
 }
 
-export interface ParsedModelResult {
+interface ParsedModelResult {
 	model: Model<Api> | undefined;
 	/** Thinking level if explicitly specified in pattern, undefined otherwise */
 	thinkingLevel?: ThinkingLevel;
@@ -199,10 +199,8 @@ function findPreferredDefaultModel(availableModels: Model<Api>[]): Model<Api> | 
  * 3. If not found and has colons, split on last colon:
  *    - If suffix is valid thinking level, use it and recurse on prefix
  *    - If suffix is invalid, warn and recurse on prefix with "off"
- *
- * @internal Exported for testing
  */
-export function parseModelPattern(
+function parseModelPattern(
 	pattern: string,
 	availableModels: Model<Api>[],
 	options?: { allowInvalidThinkingLevelFallback?: boolean },

--- a/packages/coding-agent/src/modes/interactive/feature-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/feature-hints.ts
@@ -109,8 +109,6 @@ export class FeatureHintDeck {
 	private remaining: FeatureHint[] = [];
 	private previousId: string | undefined;
 
-	constructor(private readonly random: () => number = Math.random) {}
-
 	next(context: FeatureHintContext): FeatureHint | undefined {
 		if (this.remaining.length === 0) {
 			this.refill(context);
@@ -128,8 +126,7 @@ export class FeatureHintDeck {
 			return text ? [{ id: hint.id, text }] : [];
 		});
 		for (let index = hints.length - 1; index > 0; index--) {
-			const random = Math.min(0.999999999, Math.max(0, this.random()));
-			const target = Math.floor(random * (index + 1));
+			const target = Math.floor(Math.random() * (index + 1));
 			[hints[index], hints[target]] = [hints[target]!, hints[index]!];
 		}
 		if (hints.length > 1 && hints[hints.length - 1]?.id === this.previousId) {

--- a/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
+++ b/packages/coding-agent/test/interactive-mode-feature-hints.test.ts
@@ -54,7 +54,7 @@ function createMode() {
 
 describe("feature hint deck", () => {
 	it("shows every available hint before repeating and avoids a boundary repeat", () => {
-		const deck = new FeatureHintDeck(() => 0);
+		const deck = new FeatureHintDeck();
 		const context = { getKeybinding: (action: string) => `Custom ${action}`, isResidentSession: true };
 		const firstCycle = FEATURE_HINTS.map(() => deck.next(context));
 
@@ -64,7 +64,6 @@ describe("feature hint deck", () => {
 	});
 
 	it("uses configured shortcuts in keybinding-based hints", () => {
-		const deck = new FeatureHintDeck(() => 0);
 		const context = {
 			getKeybinding: (action: string) => {
 				if (action === "app.prompt.stash") return "Meta+S";
@@ -73,39 +72,11 @@ describe("feature hint deck", () => {
 			},
 			isResidentSession: true,
 		};
-		const hints = FEATURE_HINTS.map(() => deck.next(context));
+		const textById = new Map(FEATURE_HINTS.map((hint) => [hint.id, hint.getText(context)]));
 
-		expect(hints.find((hint) => hint?.id === "prompt-stash")?.text).toContain("Meta+S");
-		expect(hints.find((hint) => hint?.id === "follow-up")?.text).toContain("Meta+Enter");
-		expect(hints.find((hint) => hint?.id === "agents-view")?.text).toContain("Meta+Left");
-	});
-
-	it("covers Prime Agent workflows with capability-focused copy", () => {
-		const deck = new FeatureHintDeck(() => 0);
-		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Meta+A", isResidentSession: true }));
-		const textById = new Map(hints.map((hint) => [hint?.id, hint?.text]));
-
-		expect(textById.get("subagents")).toBe("Prime Agent can delegate tasks to subagents and run them in parallel.");
-		expect(textById.get("agents-view")).toContain("Session View");
-		expect(textById.get("session-rewind")).toContain("/tree");
-		expect(textById.get("steering")).toContain("steer");
-		expect(textById.get("agent-messaging")).toContain("message each other");
-		expect(textById.get("goal")).toContain("/goal");
-		expect(textById.get("refine")).toContain("/refine");
-		expect(textById.get("persistent-ipython")).toContain("kernel variables");
-		expect(textById.get("context-usage")).toContain("/context");
-		expect(textById.get("session-fork")).toContain("/fork");
-		expect(textById.get("compaction")).toContain("/compact");
-		expect(textById.get("auto-compaction")).toContain("automatically compacts");
-		expect(textById.get("auto-refine")).toContain("self-improves");
-		expect(textById.get("background-running")).toContain("close the terminal");
-	});
-
-	it("keeps every hint concise", () => {
-		const deck = new FeatureHintDeck(() => 0);
-		const hints = FEATURE_HINTS.map(() => deck.next({ getKeybinding: () => "Ctrl+Key", isResidentSession: true }));
-
-		expect(hints.every((hint) => hint !== undefined && hint.text.length <= 80)).toBe(true);
+		expect(textById.get("prompt-stash")).toContain("Meta+S");
+		expect(textById.get("follow-up")).toContain("Meta+Enter");
+		expect(textById.get("agents-view")).toContain("Meta+Left");
 	});
 
 	it("hides resident-only hints in ephemeral sessions", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from "vitest";
 import {
 	defaultModelPerProvider,
 	findInitialModel,
-	parseModelPattern,
 	resolveCliModel,
 	resolveModelScopeFromModels,
 } from "../src/core/model-resolver.js";
@@ -90,163 +89,17 @@ describe("resolveModelScopeFromModels", () => {
 		expect(result[1]?.model.provider).toBe("openai");
 		expect(result[1]?.model.id).toBe("gpt-4o");
 	});
-});
 
-describe("parseModelPattern", () => {
-	describe("simple patterns without colons", () => {
-		test("exact match returns model with undefined thinking level", () => {
-			const result = parseModelPattern("claude-sonnet-4-5", allModels);
-			expect(result.model?.id).toBe("claude-sonnet-4-5");
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toBeUndefined();
-		});
+	test("resolves a thinking level after a colon-bearing model id", () => {
+		const result = resolveModelScopeFromModels(["openrouter/qwen/qwen3-coder:exacto:high"], allModels);
 
-		test("partial match returns best model with undefined thinking level", () => {
-			const result = parseModelPattern("sonnet", allModels);
-			expect(result.model?.id).toBe("claude-sonnet-4-5");
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toBeUndefined();
-		});
-
-		test("preserves provider-qualified selections when model names overlap", () => {
-			const primeInferenceModel: Model<"anthropic-messages"> = {
-				...mockModels[0],
-				id: "z-ai/glm-5.2",
-				name: "GLM 5.2",
-				provider: "prime-inference",
-				baseUrl: "https://api.pinference.ai/api/v1",
-			};
-			const huggingFaceModel: Model<"anthropic-messages"> = {
-				...primeInferenceModel,
-				id: "zai-org/GLM-5.2",
-				provider: "huggingface",
-				baseUrl: "https://router.huggingface.co/v1",
-			};
-
-			const result = parseModelPattern("huggingface/zai-org/GLM-5.2", [primeInferenceModel, huggingFaceModel]);
-
-			expect(result.model).toBe(huggingFaceModel);
-		});
-
-		test("no match returns undefined model and thinking level", () => {
-			const result = parseModelPattern("nonexistent", allModels);
-			expect(result.model).toBeUndefined();
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toBeUndefined();
-		});
+		expect(result).toEqual([{ model: mockOpenRouterModels[0], thinkingLevel: "high" }]);
 	});
 
-	describe("patterns with valid thinking levels", () => {
-		test("sonnet:high returns sonnet with high thinking level", () => {
-			const result = parseModelPattern("sonnet:high", allModels);
-			expect(result.model?.id).toBe("claude-sonnet-4-5");
-			expect(result.thinkingLevel).toBe("high");
-			expect(result.warning).toBeUndefined();
-		});
+	test("keeps the model and drops an invalid thinking suffix", () => {
+		const result = resolveModelScopeFromModels(["sonnet:random"], allModels);
 
-		test("gpt-4o:medium returns gpt-4o with medium thinking level", () => {
-			const result = parseModelPattern("gpt-4o:medium", allModels);
-			expect(result.model?.id).toBe("gpt-4o");
-			expect(result.thinkingLevel).toBe("medium");
-			expect(result.warning).toBeUndefined();
-		});
-
-		test("all valid thinking levels work", () => {
-			for (const level of ["off", "minimal", "low", "medium", "high", "xhigh"]) {
-				const result = parseModelPattern(`sonnet:${level}`, allModels);
-				expect(result.model?.id).toBe("claude-sonnet-4-5");
-				expect(result.thinkingLevel).toBe(level);
-				expect(result.warning).toBeUndefined();
-			}
-		});
-	});
-
-	describe("patterns with invalid thinking levels", () => {
-		test("sonnet:random returns sonnet with undefined thinking level and warning", () => {
-			const result = parseModelPattern("sonnet:random", allModels);
-			expect(result.model?.id).toBe("claude-sonnet-4-5");
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toContain("Invalid thinking level");
-			expect(result.warning).toContain("random");
-		});
-
-		test("gpt-4o:invalid returns gpt-4o with undefined thinking level and warning", () => {
-			const result = parseModelPattern("gpt-4o:invalid", allModels);
-			expect(result.model?.id).toBe("gpt-4o");
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toContain("Invalid thinking level");
-		});
-	});
-
-	describe("OpenRouter models with colons in IDs", () => {
-		test("qwen3-coder:exacto matches the model with undefined thinking level", () => {
-			const result = parseModelPattern("qwen/qwen3-coder:exacto", allModels);
-			expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toBeUndefined();
-		});
-
-		test("openrouter/qwen/qwen3-coder:exacto matches with provider prefix", () => {
-			const result = parseModelPattern("openrouter/qwen/qwen3-coder:exacto", allModels);
-			expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
-			expect(result.model?.provider).toBe("openrouter");
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toBeUndefined();
-		});
-
-		test("qwen3-coder:exacto:high matches model with high thinking level", () => {
-			const result = parseModelPattern("qwen/qwen3-coder:exacto:high", allModels);
-			expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
-			expect(result.thinkingLevel).toBe("high");
-			expect(result.warning).toBeUndefined();
-		});
-
-		test("openrouter/qwen/qwen3-coder:exacto:high matches with provider and thinking level", () => {
-			const result = parseModelPattern("openrouter/qwen/qwen3-coder:exacto:high", allModels);
-			expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
-			expect(result.model?.provider).toBe("openrouter");
-			expect(result.thinkingLevel).toBe("high");
-			expect(result.warning).toBeUndefined();
-		});
-
-		test("gpt-4o:extended matches the extended model with undefined thinking level", () => {
-			const result = parseModelPattern("openai/gpt-4o:extended", allModels);
-			expect(result.model?.id).toBe("openai/gpt-4o:extended");
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toBeUndefined();
-		});
-	});
-
-	describe("invalid thinking levels with OpenRouter models", () => {
-		test("qwen3-coder:exacto:random returns model with undefined thinking level and warning", () => {
-			const result = parseModelPattern("qwen/qwen3-coder:exacto:random", allModels);
-			expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toContain("Invalid thinking level");
-			expect(result.warning).toContain("random");
-		});
-
-		test("qwen3-coder:exacto:high:random returns model with undefined thinking level and warning", () => {
-			const result = parseModelPattern("qwen/qwen3-coder:exacto:high:random", allModels);
-			expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
-			expect(result.thinkingLevel).toBeUndefined();
-			expect(result.warning).toContain("Invalid thinking level");
-			expect(result.warning).toContain("random");
-		});
-	});
-
-	describe("edge cases", () => {
-		test("empty pattern matches via partial matching", () => {
-			const result = parseModelPattern("", allModels);
-			expect(result.model).not.toBeNull();
-			expect(result.thinkingLevel).toBeUndefined();
-		});
-
-		test("pattern ending with colon treats empty suffix as invalid", () => {
-			const result = parseModelPattern("sonnet:", allModels);
-			expect(result.model?.id).toBe("claude-sonnet-4-5");
-			expect(result.warning).toContain("Invalid thinking level");
-		});
+		expect(result).toEqual([{ model: mockModels[0], thinkingLevel: undefined }]);
 	});
 });
 

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1,5 +1,5 @@
 import type { Model } from "@earendil-works/pi-ai";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
 	defaultModelPerProvider,
 	findInitialModel,
@@ -96,10 +96,39 @@ describe("resolveModelScopeFromModels", () => {
 		expect(result).toEqual([{ model: mockOpenRouterModels[0], thinkingLevel: "high" }]);
 	});
 
-	test("keeps the model and drops an invalid thinking suffix", () => {
-		const result = resolveModelScopeFromModels(["sonnet:random"], allModels);
+	test("keeps the model, warns, and drops an invalid thinking suffix", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const result = resolveModelScopeFromModels(["sonnet:random"], allModels);
 
-		expect(result).toEqual([{ model: mockModels[0], thinkingLevel: undefined }]);
+			expect(result).toEqual([{ model: mockModels[0], thinkingLevel: undefined }]);
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining('Invalid thinking level "random"'));
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	test("preserves provider-qualified selections when model names overlap", () => {
+		const primeInferenceModel: Model<"anthropic-messages"> = {
+			...mockModels[0]!,
+			id: "z-ai/glm-5.2",
+			name: "GLM 5.2",
+			provider: "prime-inference",
+			baseUrl: "https://api.pinference.ai/api/v1",
+		};
+		const huggingFaceModel: Model<"anthropic-messages"> = {
+			...primeInferenceModel,
+			id: "zai-org/GLM-5.2",
+			provider: "huggingface",
+			baseUrl: "https://router.huggingface.co/v1",
+		};
+
+		const result = resolveModelScopeFromModels(
+			["huggingface/zai-org/GLM-5.2"],
+			[primeInferenceModel, huggingFaceModel],
+		);
+
+		expect(result).toEqual([{ model: huggingFaceModel, thinkingLevel: undefined }]);
 	});
 });
 


### PR DESCRIPTION
## What was wrong

Two production seams existed only for tests (audit: test-only production code, findings 6-7 adjuncts):
- `parseModelPattern` (and its result type) were exported from the model resolver solely so tests could call the internal parser directly — 18 tests restating parser internals.
- `FeatureHintDeck` accepted an injected RNG solely so presentation tests could be deterministic, plus a defensive clamp that only mattered for injected RNGs.

## The fix

+13/−198 (with the review addition): the parser and its type are private; parser behavior is tested through the public resolvers (one added scope case for colon-bearing IDs, one for the lenient invalid-suffix fallback — the strict CLI cases already existed). The RNG parameter and its clamp are gone; the deck's no-repeat invariant is asserted order-independently (verified deterministic without seeding — the refill swap guard guarantees the boundary). Exact marketing-copy and max-length assertions deleted as incidental.

## How it's verified

Reviewer confirmed the unexport is complete, the RNG-free invariant test is mathematically deterministic (5 standalone runs), the test-count delta reconciles exactly, and required the one genuine coverage gap be filled (lenient fallback — now covered through the public API). Focused suites green; full CI-style runs fully green on both branch and base in a cleaned env. Two-model implement/review loop.

Stacked on #1753 (test the whole stack at the leaf; merge base-first).

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and test reshaping only; runtime behavior is unchanged aside from removing non-production test hooks.
> 
> **Overview**
> Removes **test-only production seams** in model resolution and interactive feature hints, with tests retargeted at public APIs.
> 
> **Model resolver:** `parseModelPattern` and `ParsedModelResult` are no longer exported; parsing stays internal. The large direct `parseModelPattern` suite is replaced by a few `resolveModelScopeFromModels` cases (colon-bearing OpenRouter IDs, invalid thinking suffix with console warn, provider-qualified overlap).
> 
> **Feature hints:** `FeatureHintDeck` drops the injectable RNG and the defensive random clamp; shuffling uses `Math.random()` only. Tests no longer seed the deck or assert full marketing copy / 80-char limits; keybindings are checked via `FEATURE_HINTS.getText`, and the deck cycle test uses the default constructor.
> 
> Adds a short changelog note for the cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe33567f541dd9ff609f9469ff0c828cbecf5c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Linear ticket: [ENG-5668](https://linear.app/primeintellect/issue/ENG-5668/refactorcoding-agent-remove-test-only-parser-and-feature-hint-seams)
(ticket linked above)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove test-only seams from `model-resolver` and `FeatureHintDeck`
> - Unexports `parseModelPattern` and `ParsedModelResult` from [model-resolver.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1860/files#diff-22e2eb9b044dcbda43aec220ab0d91127a4f6ed0cc7e2757843bd6bc6aeaa144); removes the now-unused `parseModelPattern` test suite and replaces it with `resolveModelScopeFromModels` tests.
> - `FeatureHintDeck` in [feature-hints.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1860/files#diff-031f07d5a709bbcd6852e0ca041ca0b03ea9d8ddaf2009f5e8556550419250f0) drops its injectable RNG constructor and shuffles via `Math.random()` directly; tests now read hint text from `FEATURE_HINTS` instead of relying on a controllable shuffle.
> - Behavioral Change: `FeatureHintDeck` no longer accepts a custom RNG, so hint order is not controllable via dependency injection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe33567.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->