### PR TITLE
refactor(coding-agent): centralize agent-message admission in AgentSession

### DIFF
--- a/packages/coding-agent/.changes/daemon-agent-message-admission.md
+++ b/packages/coding-agent/.changes/daemon-agent-message-admission.md
@@ -1,0 +1,1 @@
+Agent messages now use core session admission to choose immediate or queued delivery.

--- a/packages/coding-agent/.changes/on-demand-agent-peers.md
+++ b/packages/coding-agent/.changes/on-demand-agent-peers.md
@@ -1,0 +1,1 @@
+- Made cross-worker agent lists current without broadcasting duplicate peer rosters.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -48,11 +48,14 @@ import {
 	type AgentSessionMessageController,
 	type AgentSessionMessageListResult,
 	type AgentSessionMessageReceipt,
+	assertAgentMessageQueueCapacity,
 	assertAgentSessionNameAvailable,
 	assertDirectAgentMessageTarget,
 	createAgentMessageHostHandlers,
+	DEFAULT_AGENT_MESSAGE_MAX_PENDING_PER_SESSION,
 	formatAgentSessionNameUnavailable,
 	isAgentSessionMessage,
+	isAgentSessionMessagePrompt,
 	normalizeAgentSessionMessage,
 	parseAgentSessionMessagePromptId,
 	startsAgentRun,
@@ -1095,6 +1098,7 @@ export class AgentSession {
 	private _retryPromise: Promise<void> | undefined = undefined;
 	private _retryResolve: (() => void) | undefined = undefined;
 	private _retryAuthFailureSources: AuthSourceToken[] = [];
+	private _agentMessageClearEpoch = 0;
 	private _agentMessageOutcomes = new Map<string, AgentMessageOutcome>();
 	private _lateIpythonSentAgentMessages = new Map<string, KernelSentAgentMessage[]>();
 	/** Outcome disclosures whose session-file append failed; retained for context rebuilds. */
@@ -4559,6 +4563,24 @@ export class AgentSession {
 	async acceptAgentMessagePrompt(text: string, options?: PromptOptions): Promise<void> {
 		const customMessage =
 			options?.customMessage && isAgentSessionMessage(options.customMessage) ? options.customMessage : undefined;
+		const clearEpoch = this._agentMessageClearEpoch;
+		const admissionCommitted = () => {
+			options?.admissionCommitted?.();
+			if (clearEpoch !== this._agentMessageClearEpoch) {
+				throw new Error("Agent message was cleared before admission");
+			}
+		};
+		if (
+			this._sessionInputPumpSuspended &&
+			this._isBusyForSessionInput("preflight") &&
+			options?.queueIfBusy === true &&
+			options.streamingBehavior
+		) {
+			admissionCommitted();
+			const queued = await this.queueAgentMessagePrompt(text, options.streamingBehavior, customMessage);
+			options.preflightResult?.(queued, queued);
+			return;
+		}
 		await this._prompt(text, {
 			...options,
 			resumeIfIdle: false,
@@ -4568,6 +4590,7 @@ export class AgentSession {
 			returnAfterAccepted: true,
 			agentMessageId: options?.agentMessageId ?? customMessage?.details.id ?? parseAgentSessionMessagePromptId(text),
 			customMessage,
+			admissionCommitted,
 		});
 		if (customMessage?.details.fromRelationship === "parent") this._repliedToParentSinceTask = false;
 	}
@@ -5539,6 +5562,16 @@ export class AgentSession {
 		if (this._sessionInputAdmissionPauses.size > 0) {
 			throw new Error("Cannot admit a session action while session input admission is paused.");
 		}
+		if (
+			options.restore !== true &&
+			action.payload.kind === "turn" &&
+			isAgentSessionMessage(primaryDeliveryRecord(action).message)
+		) {
+			assertAgentMessageQueueCapacity(
+				this._actionStore.unfinishedActions().length,
+				DEFAULT_AGENT_MESSAGE_MAX_PENDING_PER_SESSION,
+			);
+		}
 		const coalescedOwner = options.restore ? undefined : this._coalescedFollowUpOwner(action);
 		if (coalescedOwner) {
 			if (action.agentMessageId !== coalescedOwner.agentMessageId) {
@@ -6296,6 +6329,11 @@ export class AgentSession {
 		for (const action of this._actionStore.clearableActions()) {
 			if (action.payload.kind === "turn") action.payload.prepared = undefined;
 		}
+	}
+
+	clearQueuedAgentMessages(): { steering: string[]; followUp: string[] } {
+		this._agentMessageClearEpoch++;
+		return this.clearQueuedUserMessagesMatching(isAgentSessionMessagePrompt);
 	}
 
 	clearQueuedUserMessagesMatching(predicate: (text: string) => boolean): { steering: string[]; followUp: string[] } {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4863,6 +4863,10 @@ export class AgentSession {
 					expandPromptTemplates,
 				});
 				const normalized = normalizationResult instanceof Promise ? await normalizationResult : normalizationResult;
+				// Async input handlers ran between the admission check above and
+				// admission itself; re-check so content invalidated during that
+				// await (e.g. a cron job cancelled or updated) is not admitted.
+				if (normalizationResult instanceof Promise) options?.admissionCommitted?.();
 				if (normalized.kind === "extensionCommand") {
 					commitFence?.release();
 					reportPreflight(true);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -3726,6 +3726,12 @@ export class AgentDaemon {
 					this.writeWorkerSuccess(client, command);
 					return;
 				}
+				default: {
+					// Legacy commands from older supervisors (e.g. worker_sync_agent_peers) must fail fast, not time out.
+					const unknown = command as { id?: string; type: string };
+					this.write(client, failure(unknown.id, unknown.type, `Unknown worker command: ${unknown.type}`));
+					return;
+				}
 			}
 		} catch (error) {
 			this.write(client, failure(command.id, command.type, error, serializeDaemonError(error)));

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -526,7 +526,6 @@ export class AgentDaemon {
 	private readonly agentDir: string;
 	private readonly cronScheduler: AgentCronScheduler;
 	private readonly agentMessageRateLimiter = new AgentSessionMessageRateLimiter();
-	private readonly remoteAgentPeers = new Map<string, AgentSessionMessageAgentSummary>();
 	private readonly agentMessagePendingReservations = new Map<string, number>();
 	private readonly agentMessageTargetLocks = new Map<string, Promise<void>>();
 	private readonly agentMessageAcceptingTargets = new Set<string>();
@@ -3658,13 +3657,6 @@ export class AgentDaemon {
 					this.write(client, success(command.id, "detach"));
 					return;
 				}
-				case "worker_sync_agent_peers":
-					this.remoteAgentPeers.clear();
-					for (const peer of command.peers) {
-						this.remoteAgentPeers.set(peer.activeSessionId, peer);
-					}
-					this.writeWorkerSuccess(client, command);
-					return;
 				case "worker_archive_and_shutdown": {
 					for (const state of [...this.sessions.values()]) {
 						await this.closeSession(state, "killed");
@@ -5367,7 +5359,32 @@ export class AgentDaemon {
 		};
 	}
 
-	private async createAgentMessageListResult(current: ActiveSessionState): Promise<AgentSessionMessageListResult> {
+	private async listSupervisorAgentPeers(): Promise<AgentSessionMessageAgentSummary[]> {
+		const supervisorSocketPath = this.supervisorSocketPathFromEnv();
+		if (!this.options.worker || !supervisorSocketPath) return [];
+		const client = new DaemonClient(supervisorSocketPath);
+		try {
+			await client.connect(1000);
+			await client.waitForHello(1000);
+			const response = await client.request(
+				{ type: "list_agent_peers", workerToken: this.options.worker.authenticationToken },
+				5000,
+			);
+			if (!response.success) throw deserializeDaemonError(response);
+			// SAFETY: The authenticated supervisor constructs the peer response.
+			return (response.data as { peers: AgentSessionMessageAgentSummary[] }).peers;
+		} catch {
+			return [];
+		} finally {
+			client.close();
+		}
+	}
+
+	private async createAgentMessageListResult(
+		current: ActiveSessionState,
+		peers?: AgentSessionMessageAgentSummary[],
+	): Promise<AgentSessionMessageListResult> {
+		peers ??= await this.listSupervisorAgentPeers();
 		const localAgents = this.listTargetableSessionStates(current).map((state) =>
 			this.createAgentMessageAgentSummary(state),
 		);
@@ -5400,28 +5417,24 @@ export class AgentDaemon {
 			});
 		}
 		const localIds = new Set(localAgents.map((agent) => agent.activeSessionId));
+		const remoteAgents = peers.filter(
+			(peer) => !localIds.has(peer.activeSessionId) && !this.closingSessions.has(peer.activeSessionId),
+		);
 		return {
 			current: this.createAgentSessionMessageEndpoint(current),
-			agents: [
-				...localAgents,
-				...[...this.remoteAgentPeers.values()].filter(
-					(peer) =>
-						peer.status !== "inactive" &&
-						!localIds.has(peer.activeSessionId) &&
-						!this.closingSessions.has(peer.activeSessionId),
-				),
-			],
+			agents: [...localAgents, ...remoteAgents],
 		};
 	}
 
 	private async createAgentFamilyCatalog(currentState?: ActiveSessionState): Promise<AgentFamilyCatalogEntry[]> {
 		const current =
 			currentState ?? [...this.sessions.values()].find((state) => !this.bindingSessions.has(state.activeSessionId));
-		const listed = current ? await this.createAgentMessageListResult(current) : { agents: [] };
-		const remotePeers = new Set(this.remoteAgentPeers.values());
+		const remotePeers = current ? await this.listSupervisorAgentPeers() : [];
+		const listed = current ? await this.createAgentMessageListResult(current, remotePeers) : { agents: [] };
+		const remotePeerSet = new Set(remotePeers);
 		const localAgents = current
-			? [this.createAgentMessageAgentSummary(current), ...listed.agents.filter((agent) => !remotePeers.has(agent))]
-			: listed.agents.filter((agent) => !remotePeers.has(agent));
+			? [this.createAgentMessageAgentSummary(current), ...listed.agents.filter((agent) => !remotePeerSet.has(agent))]
+			: listed.agents;
 		const activePaths = new Set(
 			localAgents.flatMap((agent) => (agent.sessionPath ? [canonicalSessionPath(agent.sessionPath)] : [])),
 		);
@@ -5462,7 +5475,7 @@ export class AgentDaemon {
 				...(agent.sessionPath ? { sessionPath: canonicalSessionPath(agent.sessionPath) } : {}),
 			});
 		};
-		for (const peer of this.remoteAgentPeers.values()) addAgent(peer);
+		for (const peer of remotePeers) addAgent(peer);
 		for (const agent of localAgents) addAgent(agent);
 		for (const state of this.sessions.values()) {
 			const entry = byId.get(state.runtime.session.sessionId);

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1803,18 +1803,32 @@ export class AgentDaemon {
 		if (!current) {
 			return "skipped";
 		}
-		if (isHeartbeatCronJob(current)) {
-			await session.promptHeartbeat(current, {
-				streamingBehavior: resolveHeartbeatStreamingBehavior(current.deliveryMode),
-				followUpQueueKey: `heartbeat:${current.id}`,
+		// Re-check after the session admission fence wait: the job may have been cancelled or completed meanwhile.
+		const unrunnableAtAdmission = new Error("Cron job became unrunnable before admission");
+		const admissionCommitted = () => {
+			if (!getRunnableJob()) throw unrunnableAtAdmission;
+		};
+		try {
+			if (isHeartbeatCronJob(current)) {
+				await session.promptHeartbeat(current, {
+					streamingBehavior: resolveHeartbeatStreamingBehavior(current.deliveryMode),
+					followUpQueueKey: `heartbeat:${current.id}`,
+					source: "rpc",
+					admissionCommitted,
+				});
+				return;
+			}
+			await session.promptUntilAccepted(current.prompt, {
+				streamingBehavior: "followUp",
 				source: "rpc",
+				admissionCommitted,
 			});
-			return;
+		} catch (error) {
+			if (error === unrunnableAtAdmission) {
+				return "skipped";
+			}
+			throw error;
 		}
-		await session.promptUntilAccepted(current.prompt, {
-			streamingBehavior: "followUp",
-			source: "rpc",
-		});
 	}
 
 	private getRunnableCronJob(jobId: string): AgentCronJob | undefined {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -39,7 +39,6 @@ import {
 	type AgentSessionMessageSender,
 	agentFamilyRelationship,
 	assertAgentFamilyReach,
-	assertAgentMessageQueueCapacity,
 	assertAgentSessionNameAvailable,
 	assertDirectAgentMessageTarget,
 	buildAgentFamilyRoster,
@@ -51,7 +50,6 @@ import {
 	DEFAULT_AGENT_MESSAGE_RATE_LIMIT_CAPACITY,
 	DEFAULT_AGENT_MESSAGE_RATE_LIMIT_REFILL_MS,
 	formatAgentSessionNameUnavailable,
-	isAgentSessionMessagePrompt,
 	normalizeAgentSessionMessage,
 	sessionNameReservationKey,
 } from "../../core/agent-messages.js";
@@ -66,7 +64,7 @@ import {
 	normalizeObserveLimit,
 	normalizeObserveMaxChars,
 } from "../../core/agent-observe.js";
-import { type AgentSession, type PromptOptions, rlmChildLabel } from "../../core/agent-session.js";
+import { type PromptOptions, rlmChildLabel } from "../../core/agent-session.js";
 import { type AgentSessionRuntimeConfig, mergeAgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import {
 	type AgentSessionRuntime,
@@ -526,12 +524,6 @@ export class AgentDaemon {
 	private readonly agentDir: string;
 	private readonly cronScheduler: AgentCronScheduler;
 	private readonly agentMessageRateLimiter = new AgentSessionMessageRateLimiter();
-	private readonly agentMessagePendingReservations = new Map<string, number>();
-	private readonly agentMessageTargetLocks = new Map<string, Promise<void>>();
-	private readonly agentMessageAcceptingTargets = new Set<string>();
-	// Refcount of prompts in preflight (accepted but not yet streaming); >0 makes
-	// concurrent agent messages queue instead of racing agent.prompt.
-	private readonly agentMessagePreparingTargets = new Map<string, number>();
 	// Sessions inserted into `sessions` but still awaiting extension binding;
 	// visible to host controllers during bind, excluded from targeting.
 	private readonly bindingSessions = new Set<string>();
@@ -1785,17 +1777,10 @@ export class AgentDaemon {
 			return "skipped";
 		}
 		const session = state.runtime.session;
-		const isAgentMessagePromptInProgress =
-			this.agentMessageAcceptingTargets.has(state.activeSessionId) ||
-			this.agentMessagePreparingTargets.has(state.activeSessionId);
-		if (isHeartbeatCronJob(runnableJob) && isAgentMessagePromptInProgress) {
-			return "skipped";
-		}
 		if (shouldDeferHeartbeatCronJob(runnableJob, session)) {
 			return "skipped";
 		}
 		const shouldQueueCronPrompt =
-			isAgentMessagePromptInProgress ||
 			session.isStreaming ||
 			session.isCompacting ||
 			session.isRetrying ||
@@ -1814,149 +1799,26 @@ export class AgentDaemon {
 			const current = requirePersistedJob ? this.getRunnableCronJob(job.id) : runnableJob;
 			return current && this.isCronJobRunnableForState(current, state, requirePersistedJob) ? current : undefined;
 		};
-		if (isHeartbeatCronJob(runnableJob)) {
-			const streamingBehavior = resolveHeartbeatStreamingBehavior(runnableJob.deliveryMode);
-			const didPrompt = await this.promptHeartbeatWithAgentMessagePreparingGuard(
-				state,
-				runnableJob,
-				{
-					streamingBehavior,
-					followUpQueueKey: `heartbeat:${runnableJob.id}`,
-					source: "rpc",
-				},
-				getRunnableJob,
-			);
-			return didPrompt ? undefined : "skipped";
+		const current = getRunnableJob();
+		if (!current) {
+			return "skipped";
 		}
-		const canPrompt = () => getRunnableJob() !== undefined;
-		const didPrompt = await this.promptWithAgentMessagePreparingGuard(
-			state,
-			runnableJob.prompt,
-			{
-				streamingBehavior: "followUp",
+		if (isHeartbeatCronJob(current)) {
+			await session.promptHeartbeat(current, {
+				streamingBehavior: resolveHeartbeatStreamingBehavior(current.deliveryMode),
+				followUpQueueKey: `heartbeat:${current.id}`,
 				source: "rpc",
-			},
-			canPrompt,
-			false,
-		);
-		return didPrompt ? undefined : "skipped";
+			});
+			return;
+		}
+		await session.promptUntilAccepted(current.prompt, {
+			streamingBehavior: "followUp",
+			source: "rpc",
+		});
 	}
 
 	private getRunnableCronJob(jobId: string): AgentCronJob | undefined {
 		return this.cronStore.getClaimedJob(jobId) ?? this.cronStore.getDueJob(jobId);
-	}
-
-	// Wraps session.prompt so the target counts as "preparing" until the turn
-	// starts streaming (or the prompt settles); concurrent agent messages queue
-	// instead of racing agent.prompt during the preflight awaits. Refcounted so
-	// overlapping prompts each hold their own registration.
-	private async promptWithAgentMessagePreparingGuard(
-		state: ActiveSessionState,
-		message: string,
-		options?: PromptOptions,
-		canPrompt?: () => boolean,
-		waitForCompletion = true,
-	): Promise<boolean> {
-		return this.withAgentMessagePreparingGuard(
-			state,
-			(session, clearPreparing) => {
-				const prompt =
-					options?.agentMessageId !== undefined && options.expandPromptTemplates === false
-						? session.acceptAgentMessagePrompt.bind(session)
-						: waitForCompletion
-							? (session.promptAndWait ?? session.prompt).bind(session)
-							: (session.promptUntilAccepted ?? session.prompt).bind(session);
-				return prompt(message, {
-					...options,
-					preflightResult: (didSucceed, queued) => {
-						if (didSucceed && session.isStreaming) {
-							clearPreparing();
-						}
-						options?.preflightResult?.(didSucceed, queued);
-					},
-				});
-			},
-			canPrompt,
-			options?.signal,
-		);
-	}
-
-	private async promptHeartbeatWithAgentMessagePreparingGuard(
-		state: ActiveSessionState,
-		job: AgentCronJob,
-		options?: PromptOptions,
-		getPromptJob?: () => AgentCronJob | undefined,
-	): Promise<boolean> {
-		let promptJob = job;
-		return this.withAgentMessagePreparingGuard(
-			state,
-			(session, clearPreparing) =>
-				session.promptHeartbeat(promptJob, {
-					...options,
-					preflightResult: (didSucceed) => {
-						if (didSucceed && session.isStreaming) {
-							clearPreparing();
-						}
-						options?.preflightResult?.(didSucceed);
-					},
-				}),
-			() => {
-				if (!getPromptJob) {
-					return true;
-				}
-				const current = getPromptJob();
-				if (!current) {
-					return false;
-				}
-				promptJob = current;
-				return true;
-			},
-		);
-	}
-
-	private async withAgentMessagePreparingGuard(
-		state: ActiveSessionState,
-		run: (session: AgentSession, clearPreparing: () => void) => Promise<void>,
-		canRun?: () => boolean,
-		signal?: AbortSignal,
-	): Promise<boolean> {
-		const activeSessionId = state.activeSessionId;
-		this.agentMessagePreparingTargets.set(
-			activeSessionId,
-			(this.agentMessagePreparingTargets.get(activeSessionId) ?? 0) + 1,
-		);
-		let cleared = false;
-		const clearPreparing = () => {
-			if (cleared) {
-				return;
-			}
-			cleared = true;
-			const next = (this.agentMessagePreparingTargets.get(activeSessionId) ?? 1) - 1;
-			if (next <= 0) {
-				this.agentMessagePreparingTargets.delete(activeSessionId);
-			} else {
-				this.agentMessagePreparingTargets.set(activeSessionId, next);
-			}
-		};
-		try {
-			const targetLock = this.agentMessageTargetLocks.get(activeSessionId);
-			if (targetLock)
-				await waitForPromptAdmission(
-					targetLock.catch(() => undefined),
-					signal,
-				);
-			if (this.sessions.get(activeSessionId) !== state || this.closingSessions.has(activeSessionId)) {
-				throw new Error("Target session is closing before prompt delivery");
-			}
-			if (canRun && !canRun()) {
-				return false;
-			}
-			const session = state.runtime.session;
-			await run(session, clearPreparing);
-			return true;
-		} finally {
-			clearPreparing();
-		}
 	}
 
 	private createCronJobForState(state: ActiveSessionState, schedule: string, prompt: string): AgentCronJob {
@@ -2729,13 +2591,9 @@ export class AgentDaemon {
 					job.status !== "completed",
 			);
 		const hasPendingAdmission =
-			this.agentMessageAcceptingTargets.has(state.activeSessionId) ||
-			this.agentMessagePreparingTargets.has(state.activeSessionId) ||
-			this.agentMessageTargetLocks.has(state.activeSessionId) ||
 			[...this.promptAdmissions.values()].some(
 				(admission) => admission.activeSessionId === state.activeSessionId && admission.status !== "cancelled",
-			) ||
-			state.runtime.session.hasPendingAdmissionWaiters;
+			) || state.runtime.session.hasPendingAdmissionWaiters;
 		return {
 			isSessionActive: summary.isSessionActive || summary.hasRunningRlmChildren === true || hasPendingAdmission,
 			attachedClients: state.clients.size + state.pendingAttaches,
@@ -4115,7 +3973,7 @@ export class AgentDaemon {
 				};
 				if (command.type === "prompt_and_wait") {
 					try {
-						await this.promptWithAgentMessagePreparingGuard(state, command.message, {
+						await state.runtime.session.promptAndWait(command.message, {
 							...options,
 							preflightResult: (didSucceed) => {
 								if (didSucceed) this.recordWorkerRecoveryState(state, "prompt_accepted", true);
@@ -4134,25 +3992,23 @@ export class AgentDaemon {
 					responseSent = true;
 					this.write(client, success(command.id, "prompt"));
 				};
-				void this.promptWithAgentMessagePreparingGuard(
-					state,
-					command.message,
-					{
-						...options,
-						agentMessageId: command.agentMessageId,
-						customMessage: command.customMessage,
-						preflightResult: (didSucceed) => {
-							if (didSucceed) {
-								this.recordWorkerRecoveryState(state, "prompt_accepted", true);
-								sendSuccessResponse();
-							} else {
-								preflightRejected = true;
-							}
-						},
+				const prompt =
+					command.agentMessageId !== undefined && command.expandPromptTemplates === false
+						? state.runtime.session.acceptAgentMessagePrompt.bind(state.runtime.session)
+						: state.runtime.session.promptUntilAccepted.bind(state.runtime.session);
+				void prompt(command.message, {
+					...options,
+					agentMessageId: command.agentMessageId,
+					customMessage: command.customMessage,
+					preflightResult: (didSucceed) => {
+						if (didSucceed) {
+							this.recordWorkerRecoveryState(state, "prompt_accepted", true);
+							sendSuccessResponse();
+						} else {
+							preflightRejected = true;
+						}
 					},
-					undefined,
-					false,
-				)
+				})
 					.then(() => {
 						if (preflightRejected) {
 							const error = new Error("Prompt was not accepted by the session.");
@@ -4281,10 +4137,8 @@ export class AgentDaemon {
 
 			case "agent_messages_clear": {
 				const state = this.getSessionState(command.activeSessionId);
-				const cleared = await this.withAgentMessageTargetLock(state.activeSessionId, async () => {
-					this.agentMessageRateLimiter.clearMatching((key) => key.endsWith(`->${state.activeSessionId}`));
-					return state.runtime.session.clearQueuedUserMessagesMatching(isAgentSessionMessagePrompt);
-				});
+				this.agentMessageRateLimiter.clearMatching((key) => key.endsWith(`->${state.activeSessionId}`));
+				const cleared = state.runtime.session.clearQueuedAgentMessages();
 				return success(command.id, "agent_messages_clear", cleared);
 			}
 
@@ -5638,57 +5492,13 @@ export class AgentDaemon {
 	}
 
 	private async clearQueuedAgentSessionMessagesForState(state: ActiveSessionState) {
-		return this.withAgentMessageTargetLock(state.activeSessionId, async () =>
-			state.runtime.session.clearQueuedUserMessagesMatching(isAgentSessionMessagePrompt),
-		);
+		return state.runtime.session.clearQueuedAgentMessages();
 	}
 
 	private async clearQueuedAgentSessionMessagesForAllStates(): Promise<void> {
 		await Promise.all(
 			[...this.sessions.values()].map((state) => this.clearQueuedAgentSessionMessagesForState(state)),
 		);
-	}
-
-	private reserveAgentMessageQueueSlot(targetState: ActiveSessionState): () => void {
-		const activeSessionId = targetState.activeSessionId;
-		const reserved = this.agentMessagePendingReservations.get(activeSessionId) ?? 0;
-		assertAgentMessageQueueCapacity(
-			targetState.runtime.session.unfinishedActionCount + reserved,
-			DEFAULT_AGENT_MESSAGE_MAX_PENDING_PER_SESSION,
-		);
-		this.agentMessagePendingReservations.set(activeSessionId, reserved + 1);
-		let released = false;
-		return () => {
-			if (released) {
-				return;
-			}
-			released = true;
-			const next = (this.agentMessagePendingReservations.get(activeSessionId) ?? 1) - 1;
-			if (next <= 0) {
-				this.agentMessagePendingReservations.delete(activeSessionId);
-			} else {
-				this.agentMessagePendingReservations.set(activeSessionId, next);
-			}
-		};
-	}
-
-	private async withAgentMessageTargetLock<T>(activeSessionId: string, run: () => Promise<T>): Promise<T> {
-		const previous = this.agentMessageTargetLocks.get(activeSessionId) ?? Promise.resolve();
-		let releaseCurrent: () => void = () => {};
-		const current = new Promise<void>((resolve) => {
-			releaseCurrent = resolve;
-		});
-		const next = previous.catch(() => undefined).then(() => current);
-		this.agentMessageTargetLocks.set(activeSessionId, next);
-		await previous.catch(() => undefined);
-		try {
-			return await run();
-		} finally {
-			releaseCurrent();
-			if (this.agentMessageTargetLocks.get(activeSessionId) === next) {
-				this.agentMessageTargetLocks.delete(activeSessionId);
-			}
-		}
 	}
 
 	private agentFamilyEntry(state: ActiveSessionState): AgentFamilyCatalogEntry {
@@ -5863,13 +5673,11 @@ export class AgentDaemon {
 		if (options.origin === "agent" && options.fromState) {
 			this.assertAgentFamilyReachable(options.fromState, targetState);
 		}
-		const releaseQueueSlot = this.reserveAgentMessageQueueSlot(targetState);
 		const senderKey =
 			options.senderKey ?? options.fromState?.activeSessionId ?? `client:${options.clientId ?? "unknown"}`;
 		const rateLimitKey = `${senderKey}->${targetState.activeSessionId}`;
 		const rateLimit = this.agentMessageRateLimiter.tryConsume(rateLimitKey);
 		if (!rateLimit.ok) {
-			releaseQueueSlot();
 			throw new Error(`Agent messaging rate limit exceeded; retry after ${rateLimit.retryAfterMs}ms`);
 		}
 		const payload: AgentSessionMessagePayload = {
@@ -5883,28 +5691,11 @@ export class AgentDaemon {
 			target: this.createAgentSessionMessageEndpoint(targetState),
 		};
 		try {
-			const { status } = await this.withAgentMessageTargetLock(targetState.activeSessionId, async () => {
-				if (this.agentMessagesPaused) {
-					throw new Error("Agent messaging is paused");
-				}
-				if (
-					!this.sessions.has(targetState.activeSessionId) ||
-					this.closingSessions.has(targetState.activeSessionId)
-				) {
-					throw new Error("Target session is closing before agent message delivery");
-				}
-				if (targetState.runtime.session.sessionId !== payload.target.sessionId) {
-					throw new Error("Target session changed before agent message delivery");
-				}
-				return this.acceptAgentSessionMessage(targetState, payload, releaseQueueSlot);
-			});
+			const { status } = await this.acceptAgentSessionMessage(targetState, payload);
 			return createAgentSessionMessageReceipt(payload, status);
 		} catch (error) {
 			this.agentMessageRateLimiter.refund(rateLimitKey);
 			throw error;
-		} finally {
-			// Error-path backstop; success paths release inside acceptAgentSessionMessage.
-			releaseQueueSlot();
 		}
 	}
 
@@ -5959,69 +5750,38 @@ export class AgentDaemon {
 	private async acceptAgentSessionMessage(
 		targetState: ActiveSessionState,
 		payload: AgentSessionMessagePayload,
-		releaseReservation: () => void,
 	): Promise<{ status: AgentSessionMessageDeliveryStatus }> {
-		const session = targetState.runtime.session;
-		const reserved = this.agentMessagePendingReservations.get(targetState.activeSessionId) ?? 0;
-		const otherReservations = Math.max(0, reserved - 1);
-		assertAgentMessageQueueCapacity(
-			session.unfinishedActionCount + otherReservations,
-			DEFAULT_AGENT_MESSAGE_MAX_PENDING_PER_SESSION,
-		);
-		const shouldQueue =
-			this.agentMessageAcceptingTargets.has(targetState.activeSessionId) ||
-			this.agentMessagePreparingTargets.has(targetState.activeSessionId) ||
-			session.isStreaming ||
-			session.isCompacting ||
-			session.isRetrying ||
-			session.isBashRunning ||
-			session.unfinishedActionCount > 0;
-		const streamingBehavior = "steer";
 		const message = createAgentSessionMessage(payload);
-		const prompt = message.content;
-
-		if (shouldQueue) {
-			const didQueue = await session.queueAgentMessagePrompt(prompt, streamingBehavior, message);
-			if (!didQueue) {
-				throw new Error("Agent message was not queued");
-			}
-			// The queued message now counts in unfinishedActionCount.
-			releaseReservation();
-			// Do not await delivery: a queued message delivers only when the target's
-			// turn progresses, and the sender is blocked inside its own turn — awaiting
-			// here deadlocks mutual sends between busy sessions.
-			return { status: "queued" };
-		}
-
-		this.agentMessageAcceptingTargets.add(targetState.activeSessionId);
 		let preflightFailed = false;
 		let preflightQueued = false;
-		try {
-			const promptOptions: PromptOptions = {
-				expandPromptTemplates: false,
-				streamingBehavior,
-				queueIfBusy: true,
-				preflightResult: (didSucceed, didQueue) => {
-					preflightFailed = !didSucceed;
-					preflightQueued = didSucceed && didQueue === true;
-				},
-			};
-			if (typeof session.acceptAgentMessagePrompt === "function") {
-				await session.acceptAgentMessagePrompt(prompt, {
-					...promptOptions,
-					customMessage: message,
-				});
-			} else {
-				await session.prompt(prompt, promptOptions);
-			}
-			if (preflightFailed) {
-				throw new Error("Agent message was not accepted");
-			}
-			releaseReservation();
-			return { status: preflightQueued ? "queued" : "delivered" };
-		} finally {
-			this.agentMessageAcceptingTargets.delete(targetState.activeSessionId);
+		await targetState.runtime.session.acceptAgentMessagePrompt(message.content, {
+			expandPromptTemplates: false,
+			streamingBehavior: "steer",
+			queueIfBusy: true,
+			customMessage: message,
+			admissionCommitted: () => {
+				if (this.agentMessagesPaused) {
+					throw new Error("Agent messaging is paused");
+				}
+				if (
+					!this.sessions.has(targetState.activeSessionId) ||
+					this.closingSessions.has(targetState.activeSessionId)
+				) {
+					throw new Error("Target session is closing before agent message delivery");
+				}
+				if (targetState.runtime.session.sessionId !== payload.target.sessionId) {
+					throw new Error("Target session changed before agent message delivery");
+				}
+			},
+			preflightResult: (didSucceed, didQueue) => {
+				preflightFailed = !didSucceed;
+				preflightQueued = didSucceed && didQueue === true;
+			},
+		});
+		if (preflightFailed) {
+			throw new Error("Agent message was not accepted");
 		}
+		return { status: preflightQueued ? "queued" : "delivered" };
 	}
 
 	private detachClientFromSession(client: DaemonSocketClient, state: ActiveSessionState): void {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -1803,10 +1803,13 @@ export class AgentDaemon {
 		if (!current) {
 			return "skipped";
 		}
-		// Re-check after the session admission fence wait: the job may have been cancelled or completed meanwhile.
+		// Re-check after the session admission fence wait: the job may have been cancelled, completed, or updated meanwhile.
 		const unrunnableAtAdmission = new Error("Cron job became unrunnable before admission");
 		const admissionCommitted = () => {
-			if (!getRunnableJob()) throw unrunnableAtAdmission;
+			const refreshed = getRunnableJob();
+			if (!refreshed || refreshed.prompt !== current.prompt || refreshed.deliveryMode !== current.deliveryMode) {
+				throw unrunnableAtAdmission;
+			}
 		};
 		try {
 			if (isHeartbeatCronJob(current)) {

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -66,9 +66,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 19 adds daemon-held session input pauses.
 // Revision 20 lets cancellation target a prompt the session owns but has not started.
 // Revision 21 adds capability-gated, session-scoped ACP MCP server replacement.
-// Revision 22 scopes ACP MCP replacement and cleanup to a connection owner.
-export const DAEMON_SCHEMA_REVISION = 22;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-22-4d515169dc6b";
+// Revision 23 lets workers query the supervisor agent roster on demand.
+export const DAEMON_SCHEMA_REVISION = 23;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-23-649fe649d15e";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -377,6 +377,7 @@ export type DaemonCommand =
 			includeClientOwned?: boolean;
 	  }
 	| DaemonSavedSessionListCommand
+	| { id?: string; type: "list_agent_peers"; workerToken: string }
 	| ({
 			id?: string;
 			type: "create";
@@ -712,11 +713,13 @@ const SESSION_INPUT_PAUSE_COMMAND = {
 	minSchemaRevision: 19,
 	capability: "session_input_pause",
 } as const;
+const AGENT_PEER_LIST_COMMAND = { minProtocol: 7, minSchemaRevision: 23 } as const;
 
 export const DAEMON_COMMAND_COMPATIBILITY = {
 	ack_result: LEGACY_DAEMON_COMMAND,
 	list: LEGACY_DAEMON_COMMAND,
 	list_saved_sessions: LEGACY_DAEMON_COMMAND,
+	list_agent_peers: AGENT_PEER_LIST_COMMAND,
 	create: LEGACY_DAEMON_COMMAND,
 	attach: LEGACY_DAEMON_COMMAND,
 	reattach: LEGACY_DAEMON_COMMAND,
@@ -1106,6 +1109,7 @@ const READ_ONLY_DAEMON_COMMANDS: ReadonlySet<DaemonCommand["type"]> = new Set([
 	"ack_result",
 	"list",
 	"list_saved_sessions",
+	"list_agent_peers",
 	"attach",
 	"reattach",
 	"agent_messages_status",

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -167,6 +167,7 @@ const WORKER_STARTUP_GATE_FD = 3;
 const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"ack_result",
 	"list",
+	"list_agent_peers",
 	"list_saved_sessions",
 	"create",
 	"attach",
@@ -641,7 +642,6 @@ export class DaemonSupervisor {
 	private commandJournal!: CommandRecoveryJournal;
 	private readonly streamReconstructor = new CompactAssistantStreamReconstructor();
 	private readonly compactCatchupInProgress = new Set<string>();
-	private agentPeerSyncQueue: Promise<void> = Promise.resolve();
 	private readonly pendingSessionNames = new Set<string>();
 	private readonly catalog: DaemonCatalogClient;
 	private readonly settingsManager: SettingsManager;
@@ -740,7 +740,6 @@ export class DaemonSupervisor {
 			if (adoptionFailed) {
 				throw adoptionFailure;
 			}
-			await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 			for (const worker of this.workers.values()) {
 				this.scheduleOwnedWorkerCleanup(worker);
 			}
@@ -1537,6 +1536,25 @@ export class DaemonSupervisor {
 				return undefined;
 			case "list":
 				return this.handleList(client, command);
+			case "list_agent_peers": {
+				const requester = [...this.workers.values()].find(
+					(worker) => worker.descriptor.authenticationToken === command.workerToken,
+				);
+				if (!requester) throw new Error("Worker authentication failed");
+				const peers = [...this.workers.values()]
+					.filter(
+						(worker) =>
+							worker !== requester &&
+							this.isLiveWorker(worker) &&
+							worker.descriptor.lifecycle === "ready" &&
+							worker.client !== undefined,
+					)
+					.flatMap((worker) => {
+						const root = worker.summaries.get(worker.descriptor.rootActiveSessionId);
+						return root ? [this.agentPeerSummary(root)] : [];
+					});
+				return success(command.id, command.type, { peers });
+			}
 			case "list_saved_sessions":
 				return this.handleSavedSessionList(client, command);
 			case "create": {
@@ -1552,7 +1570,6 @@ export class DaemonSupervisor {
 					const response = await this.forwardToWorker(worker, withoutSupervisorCreateFields(command));
 					if (response.success && isSessionSummary(response.data)) {
 						await this.refreshWorkerSummaries(worker);
-						await this.syncAgentPeers().catch(() => undefined);
 						return { ...response, id: command.id, data: this.publicSummary(worker, response.data) };
 					}
 					return responseWithId(response, command.id);
@@ -2166,7 +2183,6 @@ export class DaemonSupervisor {
 				.filter((worker) => !this.isWorkerStopping(worker))
 				.map((worker) => this.refreshWorkerSummaries(worker).catch(() => undefined)),
 		);
-		await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 		const clientOwnedWorkers = [...this.workers.values()].filter((worker) => !this.isVisibleWorker(worker));
 		// Stopping workers stay listed (with an honest workerState) because this
 		// list also feeds busy-daemon safety checks in daemon-launch.
@@ -2343,7 +2359,6 @@ export class DaemonSupervisor {
 			this.invalidateWorkerSessionInputPauses(worker, "Session worker stopped while input was paused");
 			this.workers.delete(worker.descriptor.workerId);
 			this.deleteWorkerDescriptor(worker);
-			await this.syncAgentPeers().catch(() => undefined);
 			return true;
 		}
 		// Fail fast before waiting on anything: only a confirmed-dead process is
@@ -2395,7 +2410,6 @@ export class DaemonSupervisor {
 		}
 		worker.launchEnv = undefined;
 		worker.transientCreateCommand = undefined;
-		await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 	}
 
 	private async launchWorker(
@@ -2577,7 +2591,6 @@ export class DaemonSupervisor {
 				worker.launchEnv = undefined;
 				worker.transientCreateCommand = undefined;
 			}
-			await this.syncAgentPeers().catch((error) => this.log(`Could not synchronize agent peers: ${String(error)}`));
 			this.broadcastHeartbeatsChanged();
 			return worker;
 		} catch (error) {
@@ -2804,7 +2817,6 @@ export class DaemonSupervisor {
 		worker.descriptor.lifecycle = "recovering";
 		worker.descriptor.lastError = error.message;
 		this.persistWorker(worker);
-		void this.syncAgentPeers().catch(() => undefined);
 		void this.recoverWorker(worker);
 	}
 
@@ -2857,7 +2869,6 @@ export class DaemonSupervisor {
 			worker.descriptor.lifecycle = "recovering";
 			worker.descriptor.lastError = disconnectError.message;
 			this.persistWorker(worker);
-			void this.syncAgentPeers().catch(() => undefined);
 			void this.recoverWorker(worker);
 			return;
 		}
@@ -3085,9 +3096,6 @@ export class DaemonSupervisor {
 							worker.descriptor.lifecycle = "ready";
 							worker.descriptor.consecutiveFailures = 0;
 							this.persistWorker(worker);
-							await this.syncAgentPeers().catch((error) =>
-								this.log(`Could not synchronize agent peers after worker recovery: ${String(error)}`),
-							);
 							this.broadcastHeartbeatsChanged();
 							return;
 						} catch (error) {
@@ -3116,7 +3124,6 @@ export class DaemonSupervisor {
 						worker.descriptor.lifecycle = "failed";
 						worker.descriptor.lastError = "Waiting for a client with fresh runtime context";
 						this.persistWorker(worker);
-						await this.syncAgentPeers().catch(() => undefined);
 						return;
 					}
 					const safeToKillWorkerProcess =
@@ -3151,7 +3158,6 @@ export class DaemonSupervisor {
 			}
 			worker.descriptor.lifecycle = "failed";
 			this.persistWorker(worker);
-			await this.syncAgentPeers().catch(() => undefined);
 			this.log(`Worker ${worker.descriptor.workerId} failed after three recovery attempts`);
 		})().finally(() => {
 			worker.recovery = undefined;
@@ -3415,35 +3421,6 @@ export class DaemonSupervisor {
 				ignoreSessionId: target.id,
 			},
 		);
-	}
-
-	private syncAgentPeers(): Promise<void> {
-		const sync = this.agentPeerSyncQueue
-			.catch(() => undefined)
-			.then(async () => {
-				const readyWorkers = [...this.workers.values()].filter(
-					(worker): worker is ResidentWorker & { client: DaemonWorkerClient } =>
-						this.isLiveWorker(worker) && worker.descriptor.lifecycle === "ready" && worker.client !== undefined,
-				);
-				await Promise.all(
-					readyWorkers.map(async (worker) => {
-						const peers = [
-							...readyWorkers
-								.filter((candidate) => candidate !== worker)
-								.flatMap((candidate) => {
-									const root = candidate.summaries.get(candidate.descriptor.rootActiveSessionId);
-									return root ? [this.agentPeerSummary(root)] : [];
-								}),
-						];
-						const response = await worker.client.requestWorker({ type: "worker_sync_agent_peers", peers }, 5000);
-						if (!response.success) {
-							throw new Error(response.error);
-						}
-					}),
-				);
-			});
-		this.agentPeerSyncQueue = sync;
-		return sync;
 	}
 
 	private isVisibleWorker(worker: ResidentWorker): boolean {
@@ -4549,17 +4526,13 @@ export class DaemonSupervisor {
 			this.writeSerialized(client, publicPayload);
 		}
 		if (outboundType === "session_replaced" || outboundType === "session_closed") {
-			void this.refreshWorkerSummaries(worker)
-				.then(() => this.syncAgentPeers())
-				.catch(() => undefined);
+			void this.refreshWorkerSummaries(worker).catch(() => undefined);
 		} else if (
 			sessionEventType === "turn_start" ||
 			sessionEventType === "turn_end" ||
 			sessionEventType === "rlm_child_update"
 		) {
-			void this.refreshWorkerSummaries(worker)
-				.then(() => this.syncAgentPeers())
-				.catch(() => undefined);
+			void this.refreshWorkerSummaries(worker).catch(() => undefined);
 		}
 		if (
 			decodedOutbound?.type === "session_closed" &&
@@ -4575,7 +4548,6 @@ export class DaemonSupervisor {
 				this.invalidateWorkerSessionInputPauses(worker, "Session worker stopped while input was paused");
 				this.workers.delete(worker.descriptor.workerId);
 				this.deleteWorkerDescriptor(worker);
-				void this.syncAgentPeers().catch(() => undefined);
 			}
 		}
 	}
@@ -5140,7 +5112,6 @@ export class DaemonSupervisor {
 			this.deleteWorkerDescriptor(worker);
 		}
 		if (!this.shuttingDown) {
-			void this.syncAgentPeers().catch(() => undefined);
 			this.broadcastHeartbeatsChanged();
 		}
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-worker-protocol.ts
@@ -1,9 +1,5 @@
 import { closeSync, readFileSync } from "node:fs";
-import type {
-	AgentSessionMessageAgentSummary,
-	AgentSessionMessageDeliveryMode,
-	AgentSessionMessageSender,
-} from "../../core/agent-messages.js";
+import type { AgentSessionMessageDeliveryMode, AgentSessionMessageSender } from "../../core/agent-messages.js";
 import type { IdleEvictionMinutes } from "../../core/session-action-store.js";
 
 export { SESSION_LEASE_OWNER_ID_ENV, SESSION_LEASES_ENABLED_ENV } from "../../core/session-lease.js";
@@ -70,7 +66,6 @@ export type DaemonWorkerCommand =
 			supportsExtensionUi?: boolean;
 	  }
 	| { id?: string; type: "worker_unsubscribe"; activeSessionId: string }
-	| { id?: string; type: "worker_sync_agent_peers"; peers: AgentSessionMessageAgentSummary[] }
 	| { id?: string; type: "worker_archive_and_shutdown" }
 	| {
 			id?: string;

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -12,8 +12,11 @@ import {
 } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAgentSessionMessage } from "../src/core/agent-messages.js";
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
+import type { CompactionResult } from "../src/core/compaction/index.js";
+import type { AgentCronJob } from "../src/core/cron-jobs.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
@@ -403,6 +406,237 @@ describe("AgentSession concurrent prompt guard", () => {
 
 		expect(inputCalls).toBe(0);
 		expect(receivedUserText).toBe("agent-to-agent payload");
+	});
+
+	it("queues an agent message behind an active turn", async () => {
+		createSession();
+		const activeTurn = session.prompt("active turn");
+		await vi.waitFor(() => expect(session.isStreaming).toBe(true));
+		let queued: boolean | undefined;
+
+		await session.acceptAgentMessagePrompt("message during turn", {
+			queueIfBusy: true,
+			streamingBehavior: "steer",
+			preflightResult: (accepted, didQueue) => {
+				expect(accepted).toBe(true);
+				queued = didQueue;
+			},
+		});
+
+		expect(queued).toBe(true);
+		expect(session.getSessionActionSnapshot().steering).toContain("message during turn");
+		await session.abort();
+		await activeTurn.catch(() => undefined);
+	});
+
+	it("serializes an agent message behind cron admission", async () => {
+		createSession();
+		const now = new Date().toISOString();
+		const job: AgentCronJob = {
+			id: "cron-overlap",
+			status: "active",
+			source: "cron",
+			activeSessionId: "active-1",
+			sessionId: session.sessionId,
+			sessionFile: "/tmp/session.jsonl",
+			cwd: tempDir,
+			prompt: "cron prompt",
+			schedule: { kind: "interval", expression: "every 5m", intervalMs: 300_000 },
+			createdAt: now,
+			updatedAt: now,
+			runCount: 0,
+		};
+		const cronTurn = session.promptHeartbeat(job, { streamingBehavior: "followUp", source: "rpc" });
+		let queued: boolean | undefined;
+
+		await session.acceptAgentMessagePrompt("message during cron admission", {
+			queueIfBusy: true,
+			streamingBehavior: "steer",
+			preflightResult: (accepted, didQueue) => {
+				expect(accepted).toBe(true);
+				queued = didQueue;
+			},
+		});
+
+		expect(queued).toBe(true);
+		expect(session.getSessionActionSnapshot().steering).toContain("message during cron admission");
+		await session.abort();
+		await cronTurn.catch(() => undefined);
+	});
+
+	it("serializes concurrent agent messages", async () => {
+		createSession();
+		const dispositions = new Map<string, boolean | undefined>();
+		const accept = (message: string) =>
+			session.acceptAgentMessagePrompt(message, {
+				queueIfBusy: true,
+				streamingBehavior: "steer",
+				preflightResult: (accepted, queued) => {
+					expect(accepted).toBe(true);
+					dispositions.set(message, queued);
+				},
+			});
+
+		await Promise.all([accept("first concurrent message"), accept("second concurrent message")]);
+
+		expect(dispositions.get("first concurrent message")).toBe(false);
+		expect(dispositions.get("second concurrent message")).toBe(true);
+		expect(session.getSessionActionSnapshot().steering).toContain("second concurrent message");
+		await session.abort();
+	});
+
+	it("enforces the agent message queue cap inside core admission", async () => {
+		createSession();
+		const accept = (index: number) => {
+			const message = createAgentSessionMessage({
+				id: `agentmsg-${index}`,
+				source: "agent_message",
+				message: `message ${index}`,
+				from: { clientId: "test" },
+				target: {
+					activeSessionId: "target",
+					sessionId: session.sessionId,
+					runtimeKind: "subagent",
+				},
+			});
+			return session.queueAgentMessagePrompt(message.content, "steer", message);
+		};
+
+		for (let index = 0; index < 20; index++) {
+			await accept(index);
+		}
+		await expect(accept(20)).rejects.toThrow("Target session has too many pending messages");
+		expect(session.unfinishedActionCount).toBe(20);
+		const snapshot = session.getSessionActionRecoverySnapshot();
+		session.dispose();
+
+		createSession();
+		await expect(session.restoreSessionActions(snapshot)).resolves.toBe(20);
+		expect(session.unfinishedActionCount).toBe(20);
+	});
+
+	it("rejects an agent message when clear wins core admission", async () => {
+		createSession();
+		const internals = session as unknown as {
+			_acquireSessionActionCommitFence(): Promise<{ release(): void }>;
+		};
+		const fence = await internals._acquireSessionActionCommitFence();
+		const message = createAgentSessionMessage({
+			id: "agentmsg-clear-race",
+			source: "agent_message",
+			message: "clear race",
+			from: { clientId: "test" },
+			target: {
+				activeSessionId: "target",
+				sessionId: session.sessionId,
+				runtimeKind: "subagent",
+			},
+		});
+		const accepted = session.acceptAgentMessagePrompt(message.content, {
+			customMessage: message,
+			queueIfBusy: true,
+			streamingBehavior: "steer",
+		});
+		await Promise.resolve();
+
+		session.clearQueuedAgentMessages();
+		fence.release();
+
+		await expect(accepted).rejects.toThrow("Agent message was cleared before admission");
+		expect(session.unfinishedActionCount).toBe(0);
+	});
+
+	it("accepts agent messages during and after direct compaction", async () => {
+		createSession();
+		let releaseCompaction: (result: CompactionResult) => void = () => {};
+		const compactionGate = new Promise<CompactionResult>((resolve) => {
+			releaseCompaction = resolve;
+		});
+		const internals = session as unknown as {
+			_performCompaction: () => Promise<CompactionResult>;
+		};
+		vi.spyOn(internals, "_performCompaction").mockImplementation(() => compactionGate);
+		const compaction = session.compact();
+		await vi.waitFor(() => expect(session.isCompacting).toBe(true));
+		let queued: boolean | undefined;
+
+		await session.acceptAgentMessagePrompt("message during direct compaction", {
+			queueIfBusy: true,
+			streamingBehavior: "steer",
+			preflightResult: (accepted, didQueue) => {
+				expect(accepted).toBe(true);
+				queued = didQueue;
+			},
+		});
+
+		expect(queued).toBe(true);
+		expect(session.getSessionActionSnapshot().steering).toContain("message during direct compaction");
+		releaseCompaction({ summary: "compacted", firstKeptEntryId: "entry-1", tokensBefore: 1 });
+		await compaction;
+		let postCompactionQueued: boolean | undefined;
+		await session.acceptAgentMessagePrompt("message after direct compaction", {
+			queueIfBusy: true,
+			streamingBehavior: "steer",
+			preflightResult: (accepted, didQueue) => {
+				expect(accepted).toBe(true);
+				postCompactionQueued = didQueue;
+			},
+		});
+		expect(postCompactionQueued).toBe(true);
+		const deliveryCount = (text: string) =>
+			session.messages.filter(
+				(message) =>
+					message.role === "user" &&
+					typeof message.content !== "string" &&
+					message.content.some((part) => part.type === "text" && part.text === text),
+			).length;
+		expect(deliveryCount("message during direct compaction")).toBe(0);
+		expect(deliveryCount("message after direct compaction")).toBe(0);
+
+		session.resumeQueuedWork();
+		await vi.waitFor(() => expect(deliveryCount("message during direct compaction")).toBe(1));
+		expect(session.getSessionActionSnapshot().steering).toContain("message after direct compaction");
+	});
+
+	it("delivers an accepted agent message once after scheduler-owned compaction", async () => {
+		createSession();
+		let releaseCompaction: (result: CompactionResult) => void = () => {};
+		const compactionGate = new Promise<CompactionResult>((resolve) => {
+			releaseCompaction = resolve;
+		});
+		const internals = session as unknown as {
+			_performCompaction: () => Promise<CompactionResult>;
+		};
+		vi.spyOn(internals, "_performCompaction").mockImplementation(() => compactionGate);
+		const compaction = session.compact(undefined, { skipAbort: true });
+		await vi.waitFor(() => expect(session.isCompacting).toBe(true));
+		let queued: boolean | undefined;
+
+		await session.acceptAgentMessagePrompt("message during scheduled compaction", {
+			queueIfBusy: true,
+			streamingBehavior: "steer",
+			preflightResult: (accepted, didQueue) => {
+				expect(accepted).toBe(true);
+				queued = didQueue;
+			},
+		});
+
+		expect(queued).toBe(true);
+		expect(session.getSessionActionSnapshot().steering).toContain("message during scheduled compaction");
+		releaseCompaction({ summary: "compacted", firstKeptEntryId: "entry-1", tokensBefore: 1 });
+		await compaction;
+		const deliveryCount = () =>
+			session.messages.filter(
+				(message) =>
+					message.role === "user" &&
+					typeof message.content !== "string" &&
+					message.content.some(
+						(part) => part.type === "text" && part.text === "message during scheduled compaction",
+					),
+			).length;
+
+		await vi.waitFor(() => expect(deliveryCount()).toBe(1));
+		expect(deliveryCount()).toBe(1);
 	});
 
 	it("delivers internal prompts without extension input interception", async () => {

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -464,6 +464,77 @@ describe("AgentSession concurrent prompt guard", () => {
 		await cronTurn.catch(() => undefined);
 	});
 
+	it("does not admit a cron prompt invalidated while async input handlers ran", async () => {
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		let deliveredUserText: string | undefined;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: "Test",
+				tools: [],
+			},
+			streamFn: (_model, context) => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const user = context.messages.filter((message) => message.role === "user").at(-1);
+					if (user && typeof user.content !== "string") {
+						deliveredUserText = user.content
+							.filter(
+								(part): part is TextContent =>
+									typeof part === "object" && part !== null && part.type === "text",
+							)
+							.map((part) => part.text)
+							.join("\n");
+					}
+					stream.push({ type: "start", partial: createAssistantMessage("") });
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("Delivered") });
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = ModelRegistry.create(authStorage, tempDir);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		let jobInvalidated = false;
+		const extensionsResult = await createTestExtensionsResult([
+			(pi) => {
+				pi.on("input", async () => {
+					jobInvalidated = true;
+					return undefined;
+				});
+			},
+		]);
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader({ extensionsResult }),
+		});
+
+		// Mirrors the daemon cron path: admissionCommitted re-checks the job and
+		// throws when it was cancelled or updated before the prompt is admitted.
+		await expect(
+			session.promptUntilAccepted("stale cron prompt", {
+				streamingBehavior: "followUp",
+				source: "rpc",
+				admissionCommitted: () => {
+					if (jobInvalidated) throw new Error("Cron job became unrunnable before admission");
+				},
+			}),
+		).rejects.toThrow("Cron job became unrunnable before admission");
+
+		await session.agent.waitForIdle();
+		expect(deliveredUserText).toBeUndefined();
+		expect(session.isStreaming).toBe(false);
+	});
+
 	it("serializes concurrent agent messages", async () => {
 		createSession();
 		const dispositions = new Map<string, boolean | undefined>();

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -279,6 +279,26 @@ describe("daemon mode helpers", () => {
 		expect(releaseAcpMcpServers).toHaveBeenLastCalledWith("other-token", ["other"]);
 	});
 
+	it("fails fast on unknown worker commands instead of dropping them", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-unknown-worker-command.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: vi.fn(),
+		});
+		const internals = daemon as unknown as {
+			handleWorkerCommand(client: DaemonSocketClient, command: unknown): Promise<void>;
+			write: ReturnType<typeof vi.fn>;
+		};
+		internals.write = vi.fn();
+		const client = makeClient("legacy-supervisor", "active");
+
+		await internals.handleWorkerCommand(client, { id: "legacy-1", type: "worker_sync_agent_peers", peers: [] });
+
+		expect(internals.write).toHaveBeenCalledWith(
+			client,
+			expect.objectContaining({ id: "legacy-1", command: "worker_sync_agent_peers", success: false }),
+		);
+	});
+
 	it("cancels pending extension UI requests directly", () => {
 		const resolve = vi.fn();
 		const state = {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -549,120 +549,26 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("keeps fresh local rows over stale synced peers in the family catalog", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-local-precedence.sock", {
-			defaultSessionConfig: { agentDir: "/tmp", cwd: "/tmp" },
-			createRuntime: vi.fn(),
-		});
-		const state = makeState("local-active");
-		state.runtime = {
-			...state.runtime,
-			cwd: "/tmp",
-			metadata: { kind: "top-level", createdAt: 1 },
-			session: {
-				sessionId: "shared-session",
-				sessionName: "fresh-local",
-				isSessionActive: false,
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				hasRunningRlmChildren: () => false,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			remoteAgentPeers: Map<string, Record<string, unknown>>;
-			createAgentFamilyCatalog(): Promise<Array<{ id: string; name?: string }>>;
-		};
-		internals.sessions.set(state.activeSessionId, state);
-		internals.remoteAgentPeers.set("stale-active", {
-			activeSessionId: "stale-active",
-			sessionId: "shared-session",
-			sessionName: "stale-peer",
-			runtimeKind: "top-level",
-			cwd: "/tmp",
-			isStreaming: false,
-			unfinishedActionCount: 0,
-		});
-		const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
-		try {
-			expect(await internals.createAgentFamilyCatalog()).toContainEqual(
-				expect.objectContaining({ id: "shared-session", name: "fresh-local" }),
-			);
-		} finally {
-			listAll.mockRestore();
-		}
-	});
-
-	it("canonicalizes symlinked paths in the family catalog and name reservations", async () => {
+	it("canonicalizes symlinked parent paths in name reservations", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-family-catalog-paths-"));
 		try {
 			const realDir = join(tempDir, "real");
 			const aliasDir = join(tempDir, "alias");
 			mkdirSync(realDir);
 			symlinkSync(realDir, aliasDir, "dir");
-			const parentPath = join(realDir, "parent.jsonl");
-			writeFileSync(parentPath, "");
-			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
-				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir: tempDir },
-				createRuntime: vi.fn(),
-			});
-			const parent = makeState("parent");
-			parent.runtime = {
-				...parent.runtime,
-				cwd: tempDir,
-				metadata: { kind: "top-level", createdAt: 1 },
-				session: {
-					sessionId: "session-parent",
-					sessionName: "parent",
-					sessionFile: parentPath,
-					sessionManager: { getSessionArtifactDir: () => undefined },
-					rlmDepth: 0,
-					isStreaming: false,
-					isSessionActive: false,
-					unfinishedActionCount: 0,
-					hasRunningRlmChildren: () => false,
-				},
-			} as never;
-			const child = {
-				activeSessionId: "child-active",
-				sessionId: "session-child",
-				sessionName: "child",
-				runtimeKind: "subagent",
-				cwd: tempDir,
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				parentSessionPath: join(aliasDir, "parent.jsonl"),
-				rlmDepth: 1,
-				status: "idle",
-			};
-			const internals = daemon as unknown as {
-				sessions: Map<string, ActiveSessionState>;
-				remoteAgentPeers: Map<string, typeof child>;
-				createAgentFamilyRoster(state: ActiveSessionState): Promise<{ entries: Array<{ id: string }> }>;
-			};
-			internals.sessions.set(parent.activeSessionId, parent);
-			internals.remoteAgentPeers.set(child.activeSessionId, child);
-			const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
-			try {
-				expect(await internals.createAgentFamilyRoster(parent)).toMatchObject({
-					entries: [expect.objectContaining({ id: "session-child" })],
-				});
-				expect(
-					sessionNameReservationKey({
-						name: "worker",
-						depth: 1,
-						parentSessionPath: parentPath,
-					}),
-				).toBe(
-					sessionNameReservationKey({
-						name: "worker",
-						depth: 1,
-						parentSessionPath: join(aliasDir, "parent.jsonl"),
-					}),
-				);
-			} finally {
-				listAll.mockRestore();
-			}
+			expect(
+				sessionNameReservationKey({
+					name: "worker",
+					depth: 1,
+					parentSessionPath: join(realDir, "parent.jsonl"),
+				}),
+			).toBe(
+				sessionNameReservationKey({
+					name: "worker",
+					depth: 1,
+					parentSessionPath: join(aliasDir, "parent.jsonl"),
+				}),
+			);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -1439,6 +1345,28 @@ describe("daemon mode helpers", () => {
 		expect(internals.closingSessions.has(state.activeSessionId)).toBe(false);
 	});
 
+	it("returns no peers when the supervisor query fails", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-peer-query-failure-"));
+		const previousSupervisorSocket = process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
+		try {
+			process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = join(tempDir, "missing.sock");
+			const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir },
+				createRuntime: vi.fn(),
+				worker: { authenticationToken: "worker-token" },
+			});
+			const listSupervisorAgentPeers = (
+				daemon as unknown as { listSupervisorAgentPeers(): Promise<unknown[]> }
+			).listSupervisorAgentPeers.bind(daemon);
+
+			await expect(listSupervisorAgentPeers()).resolves.toEqual([]);
+		} finally {
+			if (previousSupervisorSocket === undefined) delete process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV];
+			else process.env[DAEMON_WORKER_SUPERVISOR_SOCKET_ENV] = previousSupervisorSocket;
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("lists and role-addresses root siblings hosted by another worker", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -1471,7 +1399,7 @@ describe("daemon mode helpers", () => {
 		const sendRemoteAgentSessionMessage = vi.fn().mockResolvedValue(receipt);
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
-			remoteAgentPeers: Map<string, Record<string, unknown>>;
+			listSupervisorAgentPeers: ReturnType<typeof vi.fn>;
 			createAgentMessageListResult(
 				current: ActiveSessionState,
 			): Promise<{ agents: Array<{ activeSessionId: string }> }>;
@@ -1479,15 +1407,17 @@ describe("daemon mode helpers", () => {
 			sendRemoteAgentSessionMessage: typeof sendRemoteAgentSessionMessage;
 		};
 		internals.sessions.set(source.activeSessionId, source);
-		internals.remoteAgentPeers.set(remoteSelector, {
-			activeSessionId: remoteSelector,
-			sessionId: "session-remote",
-			sessionName: "Remote",
-			runtimeKind: "top-level",
-			cwd: "/tmp/remote",
-			isStreaming: false,
-			sessionActions: { queuedCount: 0, steering: [], followUps: [] },
-		});
+		internals.listSupervisorAgentPeers = vi.fn(async () => [
+			{
+				activeSessionId: remoteSelector,
+				sessionId: "session-remote",
+				sessionName: "Remote",
+				runtimeKind: "top-level",
+				cwd: "/tmp/remote",
+				isStreaming: false,
+				unfinishedActionCount: 0,
+			},
+		]);
 		internals.sendRemoteAgentSessionMessage = sendRemoteAgentSessionMessage;
 
 		expect((await internals.createAgentMessageListResult(source)).agents).toContainEqual(

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1144,6 +1144,88 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("skips a heartbeat whose instruction changed while its prompt waits for admission", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-heartbeat-admission-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) {
+				throw new Error("Missing session file");
+			}
+			let updateHeartbeatDuringAdmission: (() => void) | undefined;
+			const promptHeartbeat = vi.fn(async (_job: AgentCronJob, options?: { admissionCommitted?: () => void }) => {
+				updateHeartbeatDuringAdmission?.();
+				updateHeartbeatDuringAdmission = undefined;
+				options?.admissionCommitted?.();
+			});
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				Object.assign(session, {
+					isStreaming: false,
+					isCompacting: false,
+					isRetrying: false,
+					isBashRunning: false,
+					unfinishedActionCount: 0,
+					hasAcceptedPromptInFlight: false,
+					sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+					promptHeartbeat,
+				});
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				cronStore: AgentCronJobStore;
+				cronScheduler: { runDue(now: Date): Promise<number> };
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+			};
+			const state = await internals.createRuntime({ type: "create", sessionPath: sessionFile });
+			const heartbeat = internals.cronStore.createRlmHeartbeat({
+				activeSessionId: state.activeSessionId,
+				sessionId: state.runtime.session.sessionId,
+				sessionFile,
+				cwd: tempDir,
+				runtimeKind: "top-level",
+				scheduleText: "every 5m",
+				prompt: "old instruction",
+			});
+			updateHeartbeatDuringAdmission = () => {
+				internals.cronStore.updateRlmHeartbeat(state.activeSessionId, heartbeat.id, { prompt: "new instruction" });
+			};
+
+			expect(await internals.cronScheduler.runDue(new Date(Date.now() + 10 * 60 * 1000))).toBe(0);
+			expect(promptHeartbeat).toHaveBeenCalledOnce();
+			expect(promptHeartbeat.mock.calls[0]?.[0]).toMatchObject({ prompt: "old instruction" });
+			expect(internals.cronStore.list().find((candidate) => candidate.id === heartbeat.id)).toMatchObject({
+				status: "active",
+				runCount: 0,
+			});
+
+			expect(await internals.cronScheduler.runDue(new Date(Date.now() + 20 * 60 * 1000))).toBe(1);
+			expect(promptHeartbeat).toHaveBeenCalledTimes(2);
+			expect(promptHeartbeat.mock.calls[1]?.[0]).toMatchObject({ prompt: "new instruction" });
+			expect(internals.cronStore.list().find((candidate) => candidate.id === heartbeat.id)).toMatchObject({
+				status: "active",
+				runCount: 1,
+			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("closes the exact parent-scoped daemon runtime when a retained subagent is deleted", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1056,6 +1056,74 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("skips a cron job cancelled while its prompt waits for admission", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-cron-admission-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) {
+				throw new Error("Missing session file");
+			}
+			let cancelJobDuringAdmission: (() => void) | undefined;
+			const promptUntilAccepted = vi.fn(async (_prompt: string, options?: { admissionCommitted?: () => void }) => {
+				cancelJobDuringAdmission?.();
+				options?.admissionCommitted?.();
+			});
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				Object.assign(session, {
+					isStreaming: false,
+					isCompacting: false,
+					isRetrying: false,
+					isBashRunning: false,
+					unfinishedActionCount: 0,
+					hasAcceptedPromptInFlight: false,
+					sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+					promptUntilAccepted,
+				});
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				cronStore: AgentCronJobStore;
+				cronScheduler: { runDue(now: Date): Promise<number> };
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+			};
+			const state = await internals.createRuntime({ type: "create", sessionPath: sessionFile });
+			const job = internals.cronStore.create({
+				activeSessionId: state.activeSessionId,
+				sessionId: state.runtime.session.sessionId,
+				sessionFile,
+				cwd: tempDir,
+				scheduleText: "every 5m",
+				prompt: "scheduled work",
+			});
+			cancelJobDuringAdmission = () => {
+				internals.cronStore.cancel(job.id);
+			};
+
+			expect(await internals.cronScheduler.runDue(new Date(Date.now() + 10 * 60 * 1000))).toBe(0);
+			expect(promptUntilAccepted).toHaveBeenCalledOnce();
+			expect(internals.cronStore.list().find((candidate) => candidate.id === job.id)?.status).toBe("cancelled");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("closes the exact parent-scoped daemon runtime when a retained subagent is deleted", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -1258,8 +1258,6 @@ describe("daemon mode helpers", () => {
 			): AgentSessionMessageController;
 			getBoundSessionState(id: string): ActiveSessionState;
 			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
-			agentMessageTargetLocks: Map<string, Promise<void>>;
-			promptWithAgentMessagePreparingGuard(state: ActiveSessionState, message: string): Promise<boolean>;
 		};
 		internals.sessions.set(parentState.activeSessionId, parentState);
 		internals.sessions.set(childState.activeSessionId, childState);
@@ -1282,19 +1280,6 @@ describe("daemon mode helpers", () => {
 		] as const) {
 			await expect(internals.handleCommand(client, command)).rejects.toThrow("is closing");
 		}
-
-		internals.closingSessions.delete(childState.activeSessionId);
-		let releaseTargetLock: () => void = () => {};
-		const targetLock = new Promise<void>((resolve) => {
-			releaseTargetLock = resolve;
-		});
-		internals.agentMessageTargetLocks.set(childState.activeSessionId, targetLock);
-		const guardedPrompt = internals.promptWithAgentMessagePreparingGuard(childState, "continue");
-		await Promise.resolve();
-		internals.closingSessions.set(childState.activeSessionId, { promise: Promise.resolve(), reason: "shutdown" });
-		releaseTargetLock();
-		await expect(guardedPrompt).rejects.toThrow("closing before prompt delivery");
-		expect(sessionPrompt).not.toHaveBeenCalled();
 	});
 
 	it("removes a closing daemon session even when runtime disposal fails", async () => {
@@ -1806,6 +1791,71 @@ describe("daemon mode helpers", () => {
 		expect(acceptAgentMessagePrompt.mock.calls[0]?.[1]).toMatchObject({ streamingBehavior: "steer" });
 	});
 
+	it("rejects an agent message when pause wins core admission", async () => {
+		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
+			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
+			createRuntime: async () => {
+				throw new Error("unexpected runtime creation");
+			},
+		});
+		const targetState = makeState("target");
+		let releaseAdmission: () => void = () => {};
+		const admissionGate = new Promise<void>((resolve) => {
+			releaseAdmission = resolve;
+		});
+		let markAdmissionStarted: () => void = () => {};
+		const admissionStarted = new Promise<void>((resolve) => {
+			markAdmissionStarted = resolve;
+		});
+		const acceptAgentMessagePrompt = vi.fn(
+			async (
+				_message: string,
+				options?: {
+					admissionCommitted?: () => void;
+					preflightResult?: (accepted: boolean) => void;
+				},
+			) => {
+				markAdmissionStarted();
+				await admissionGate;
+				options?.admissionCommitted?.();
+				options?.preflightResult?.(true);
+			},
+		);
+		targetState.runtime = {
+			...targetState.runtime,
+			cwd: "/tmp",
+			session: {
+				sessionId: "session-target",
+				sessionName: "Target",
+				acceptAgentMessagePrompt,
+				clearQueuedAgentMessages: vi.fn(() => ({ steering: [], followUp: [] })),
+			},
+		} as never;
+		const internals = daemon as unknown as {
+			sessions: Map<string, ActiveSessionState>;
+			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			sendAgentSessionMessage(options: {
+				targetSelector: string;
+				message: string;
+				origin: "agent" | "cli";
+			}): Promise<unknown>;
+		};
+		internals.sessions.set(targetState.activeSessionId, targetState);
+
+		const send = internals.sendAgentSessionMessage({
+			targetSelector: targetState.activeSessionId,
+			message: "pause race",
+			origin: "agent",
+		});
+		await admissionStarted;
+		await internals.handleCommand(makeClient("client-1", targetState.activeSessionId), {
+			type: "agent_messages_pause",
+		});
+		releaseAdmission();
+
+		await expect(send).rejects.toThrow("Agent messaging is paused");
+	});
+
 	it("ignores a legacy follow-up mode and always steers agent messages", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -1814,7 +1864,12 @@ describe("daemon mode helpers", () => {
 			},
 		});
 		const targetState = makeState("target");
-		const queueAgentMessagePrompt = vi.fn(async () => true);
+		const acceptAgentMessagePrompt = vi.fn(
+			(_message: string, options?: { preflightResult?: (accepted: boolean, queued?: boolean) => void }) => {
+				options?.preflightResult?.(true, true);
+				return Promise.resolve();
+			},
+		);
 		targetState.runtime = {
 			...targetState.runtime,
 			cwd: "/tmp",
@@ -1826,7 +1881,7 @@ describe("daemon mode helpers", () => {
 				isRetrying: false,
 				isBashRunning: false,
 				unfinishedActionCount: 0,
-				queueAgentMessagePrompt,
+				acceptAgentMessagePrompt,
 			},
 		} as never;
 		const internals = daemon as unknown as {
@@ -1843,10 +1898,12 @@ describe("daemon mode helpers", () => {
 		});
 
 		expect(response).toMatchObject({ data: { deliveryStatus: "queued", deliveryMode: "steer" } });
-		expect(queueAgentMessagePrompt).toHaveBeenCalledWith(
+		expect(acceptAgentMessagePrompt).toHaveBeenCalledWith(
 			expect.stringContaining("do not defer"),
-			"steer",
-			expect.objectContaining({ customType: "agent_message" }),
+			expect.objectContaining({
+				streamingBehavior: "steer",
+				customMessage: expect.objectContaining({ customType: "agent_message" }),
+			}),
 		);
 	});
 
@@ -1873,10 +1930,15 @@ describe("daemon mode helpers", () => {
 					sessionName: targetState.activeSessionId,
 					isStreaming: false,
 					sessionActions: { queuedCount: 0, steering: [], followUps: [] },
-					prompt: vi.fn(async () => {}),
+					acceptAgentMessagePrompt: vi.fn(
+						(_message: string, options?: { preflightResult?: (accepted: boolean) => void }) => {
+							options?.preflightResult?.(true);
+							return Promise.resolve();
+						},
+					),
 					followUp: vi.fn(async () => true),
 					clearQueue: vi.fn(() => ({ cleared: 0 })),
-					clearQueuedUserMessagesMatching: vi.fn(() => ({ steering: [], followUp: [] })),
+					clearQueuedAgentMessages: vi.fn(() => ({ steering: [], followUp: [] })),
 				},
 			} as never;
 		}
@@ -1943,12 +2005,7 @@ describe("daemon mode helpers", () => {
 			},
 		});
 		const targetState = makeState("target");
-		const agentMessageText =
-			"Agent-to-agent message received.\nSource: agent_message\nTo: Target, active target, session session-target\nMessage id: agentmsg_test\n\nhello";
-		const clearQueuedUserMessagesMatching = vi.fn((predicate: (text: string) => boolean) => ({
-			steering: [agentMessageText].filter(predicate),
-			followUp: [],
-		}));
+		const clearQueuedAgentMessages = vi.fn(() => ({ steering: ["agent message"], followUp: [] }));
 		const clearQueue = vi.fn(() => ({ steering: ["user prompt"], followUp: ["heartbeat"] }));
 		targetState.runtime = {
 			...targetState.runtime,
@@ -1958,7 +2015,7 @@ describe("daemon mode helpers", () => {
 				sessionName: "Target",
 				isStreaming: false,
 				unfinishedActionCount: 2,
-				clearQueuedUserMessagesMatching,
+				clearQueuedAgentMessages,
 				clearQueue,
 			},
 		} as never;
@@ -1974,10 +2031,7 @@ describe("daemon mode helpers", () => {
 			activeSessionId: targetState.activeSessionId,
 		});
 
-		expect(clearQueuedUserMessagesMatching).toHaveBeenCalledOnce();
-		const predicate = clearQueuedUserMessagesMatching.mock.calls[0]?.[0];
-		expect(predicate?.(agentMessageText)).toBe(true);
-		expect(predicate?.("ordinary queued follow-up")).toBe(false);
+		expect(clearQueuedAgentMessages).toHaveBeenCalledOnce();
 		expect(clearQueue).not.toHaveBeenCalled();
 	});
 
@@ -1992,7 +2046,7 @@ describe("daemon mode helpers", () => {
 		const secondState = makeState("target-2");
 		const firstClear = vi.fn(() => ({ steering: [], followUp: ["agent message"] }));
 		const secondClear = vi.fn(() => ({ steering: ["agent message"], followUp: [] }));
-		for (const [state, clearQueuedUserMessagesMatching] of [
+		for (const [state, clearQueuedAgentMessages] of [
 			[firstState, firstClear],
 			[secondState, secondClear],
 		] as const) {
@@ -2004,7 +2058,7 @@ describe("daemon mode helpers", () => {
 					sessionName: state.activeSessionId,
 					isStreaming: false,
 					unfinishedActionCount: 1,
-					clearQueuedUserMessagesMatching,
+					clearQueuedAgentMessages,
 				},
 			} as never;
 		}
@@ -2044,7 +2098,7 @@ describe("daemon mode helpers", () => {
 				}),
 		);
 		const readyClear = vi.fn(() => ({ steering: [], followUp: ["agent message"] }));
-		for (const [state, clearQueuedUserMessagesMatching] of [
+		for (const [state, clearQueuedAgentMessages] of [
 			[blockedState, blockedClear],
 			[readyState, readyClear],
 		] as const) {
@@ -2056,7 +2110,7 @@ describe("daemon mode helpers", () => {
 					sessionName: state.activeSessionId,
 					isStreaming: false,
 					unfinishedActionCount: 1,
-					clearQueuedUserMessagesMatching,
+					clearQueuedAgentMessages,
 				},
 			} as never;
 		}
@@ -2101,7 +2155,7 @@ describe("daemon mode helpers", () => {
 				sessionName: "Target",
 				isStreaming: false,
 				unfinishedActionCount: 0,
-				prompt: vi.fn(async () => {
+				acceptAgentMessagePrompt: vi.fn(async () => {
 					throw new Error("missing model");
 				}),
 			},
@@ -2136,315 +2190,6 @@ describe("daemon mode helpers", () => {
 				origin: "agent",
 			}),
 		).rejects.toThrow("missing model");
-	});
-
-	it("counts concurrent agent message queue reservations against the target queue cap", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		let rejectQueuedMessage: (error: Error) => void = () => {};
-		const queueAgentMessagePrompt = vi.fn(
-			(_message: string, _streamingBehavior: "steer" | "followUp") =>
-				new Promise<boolean>((_resolve, reject) => {
-					rejectQueuedMessage = reject;
-				}),
-		);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: true,
-				unfinishedActionCount: 19,
-				clearQueue: vi.fn(() => ({ cleared: 0 })),
-				clearQueuedUserMessagesMatching: vi.fn(() => ({ steering: [], followUp: [] })),
-				queueAgentMessagePrompt,
-				prompt: vi.fn(async () => {}),
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const first = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "first",
-			fromState,
-			origin: "agent",
-		});
-		await Promise.resolve();
-
-		const clear = internals.handleCommand(makeClient("client-1", targetState.activeSessionId), {
-			id: "command-1",
-			type: "agent_messages_clear",
-			activeSessionId: targetState.activeSessionId,
-		});
-		await Promise.resolve();
-
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "second",
-				fromState,
-				origin: "agent",
-			}),
-		).rejects.toThrow("Target session has too many pending messages");
-
-		rejectQueuedMessage(new Error("release reservation"));
-		await expect(first).rejects.toThrow("release reservation");
-		await clear;
-	});
-
-	it("releases queue reservations once messages are queued so concurrent senders do not halve capacity", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const targetState = makeState("target");
-		let pending = 0;
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => {
-			pending += 1;
-			return true;
-		});
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: true,
-				get unfinishedActionCount() {
-					return pending;
-				},
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(targetState.activeSessionId, targetState);
-		// Distinct senders so the per-sender rate limit stays out of the way.
-		const senders = Array.from({ length: 12 }, (_, i) => {
-			const fromState = makeState(`source-${i}`);
-			fromState.runtime = {
-				...fromState.runtime,
-				session: { sessionId: `session-source-${i}`, sessionName: `Source ${i}` },
-			} as never;
-			internals.sessions.set(fromState.activeSessionId, fromState);
-			return fromState;
-		});
-
-		const errors: unknown[] = [];
-		for (const [i, fromState] of senders.entries()) {
-			void internals
-				.sendAgentSessionMessage({
-					targetSelector: targetState.activeSessionId,
-					message: `message ${i}`,
-					fromState,
-					origin: "agent",
-				})
-				.catch((error) => {
-					errors.push(error);
-				});
-		}
-		for (let attempt = 0; attempt < 200 && queueAgentMessagePrompt.mock.calls.length < 12; attempt++) {
-			await Promise.resolve();
-		}
-
-		// With reservations held past queue time, 12 concurrent senders would
-		// count as 24 against the 20-slot cap and the tail would reject.
-		expect(errors).toEqual([]);
-		expect(queueAgentMessagePrompt).toHaveBeenCalledTimes(12);
-	});
-
-	it("resolves queued sends immediately with a queued receipt while the target is streaming", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
-		// A real streaming session only resolves this once its turn progresses;
-		// the send must not depend on it.
-		const waitForAgentMessagePromptDelivery = vi.fn(() => new Promise<void>(() => {}));
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: true,
-				unfinishedActionCount: 0,
-				queueAgentMessagePrompt,
-				waitForAgentMessagePromptDelivery,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "queued while streaming",
-				fromState,
-				origin: "agent",
-			}),
-		).resolves.toMatchObject({
-			deliveryStatus: "queued",
-			target: { activeSessionId: targetState.activeSessionId },
-		});
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(waitForAgentMessagePromptDelivery).not.toHaveBeenCalled();
-	});
-
-	it("resolves mutual sends between two busy sessions without deadlocking", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const makeBusyState = (name: string) => {
-			const state = makeState(name);
-			state.runtime = {
-				...state.runtime,
-				cwd: "/tmp",
-				session: {
-					sessionId: `session-${name}`,
-					sessionName: name,
-					isStreaming: true,
-					unfinishedActionCount: 0,
-					queueAgentMessagePrompt: vi.fn(async () => true),
-					// Neither turn ends while both sessions block inside their own send.
-					waitForAgentMessagePromptDelivery: vi.fn(() => new Promise<void>(() => {})),
-				},
-			} as never;
-			return state;
-		};
-		const stateA = makeBusyState("alpha");
-		const stateB = makeBusyState("beta");
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(stateA.activeSessionId, stateA);
-		internals.sessions.set(stateB.activeSessionId, stateB);
-
-		const [aToB, bToA] = await Promise.all([
-			internals.sendAgentSessionMessage({
-				targetSelector: stateB.activeSessionId,
-				message: "alpha to beta",
-				fromState: stateA,
-				origin: "agent",
-			}),
-			internals.sendAgentSessionMessage({
-				targetSelector: stateA.activeSessionId,
-				message: "beta to alpha",
-				fromState: stateB,
-				origin: "agent",
-			}),
-		]);
-
-		expect(aToB).toMatchObject({ deliveryStatus: "queued", target: { activeSessionId: stateB.activeSessionId } });
-		expect(bToA).toMatchObject({ deliveryStatus: "queued", target: { activeSessionId: stateA.activeSessionId } });
-	});
-
-	it("counts accepted in-flight agent messages against the target queue cap", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		const acceptAgentMessagePrompt = vi.fn(async () => {});
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 20,
-				hasAcceptedPromptInFlight: true,
-				acceptAgentMessagePrompt,
-				queueAgentMessagePrompt: vi.fn(async () => true),
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "over cap",
-				fromState,
-				origin: "agent",
-			}),
-		).rejects.toThrow("Target session has too many pending messages");
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
 	});
 
 	it("reports accepted in-flight agent messages in agent-message lists", async () => {
@@ -2874,483 +2619,6 @@ describe("daemon mode helpers", () => {
 		expect(sibling.acceptAgentMessagePrompt).not.toHaveBeenCalled();
 	});
 
-	it("serializes concurrent agent messages to an idle target", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		const promptResolves: Array<() => void> = [];
-		const prompt = vi.fn(
-			(_message: string, _options?: { streamingBehavior?: "steer" | "followUp" }) =>
-				new Promise<void>((resolve) => {
-					promptResolves.push(resolve);
-				}),
-		);
-		const followUp = vi.fn(async () => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				prompt,
-				followUp,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const first = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "first",
-			fromState,
-			origin: "agent",
-		});
-		const second = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "second",
-			fromState,
-			origin: "agent",
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(prompt).toHaveBeenCalledTimes(1);
-
-		promptResolves[0]?.();
-		await expect(first).resolves.toMatchObject({ message: "first" });
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(prompt).toHaveBeenCalledTimes(2);
-		expect(followUp).not.toHaveBeenCalled();
-		promptResolves[1]?.();
-		await expect(second).resolves.toMatchObject({ message: "second" });
-	});
-
-	it("queues agent messages behind an idle target with a pending retry", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		const prompt = vi.fn(async (_message: string, _options?: { streamingBehavior?: "steer" | "followUp" }) => {});
-		const followUp = vi.fn(async () => true);
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				isRetrying: true,
-				unfinishedActionCount: 0,
-				prompt,
-				followUp,
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "queued behind retry",
-				fromState,
-				origin: "agent",
-			}),
-		).resolves.toMatchObject({ target: { activeSessionId: targetState.activeSessionId } });
-
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
-		expect(followUp).not.toHaveBeenCalled();
-		expect(prompt).not.toHaveBeenCalled();
-	});
-
-	it("queues agent messages behind existing pending work on an idle target", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		const prompt = vi.fn(async (_message: string, _options?: { streamingBehavior?: "steer" | "followUp" }) => {});
-		const followUp = vi.fn(async () => true);
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 1,
-				prompt,
-				followUp,
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "queued behind existing work",
-				fromState,
-				origin: "agent",
-			}),
-		).resolves.toMatchObject({ target: { activeSessionId: targetState.activeSessionId } });
-
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
-		expect(followUp).not.toHaveBeenCalled();
-		expect(prompt).not.toHaveBeenCalled();
-	});
-
-	it("queues agent messages while the target is compacting", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		const prompt = vi.fn(async (_message: string, _options?: { streamingBehavior?: "steer" | "followUp" }) => {});
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				isCompacting: true,
-				unfinishedActionCount: 0,
-				prompt,
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "queued behind compaction",
-				fromState,
-				origin: "agent",
-			}),
-		).resolves.toMatchObject({ target: { activeSessionId: targetState.activeSessionId } });
-
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
-		expect(prompt).not.toHaveBeenCalled();
-	});
-
-	it("queues agent messages while target bash is running", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		const acceptAgentMessagePrompt = vi.fn(async () => {});
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				isBashRunning: true,
-				unfinishedActionCount: 0,
-				acceptAgentMessagePrompt,
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "queued behind bash",
-				fromState,
-				origin: "agent",
-			}),
-		).resolves.toMatchObject({ target: { activeSessionId: targetState.activeSessionId } });
-
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
-	});
-
-	it("acknowledges queued agent messages after queue insertion", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		let resolveQueuedDelivery: () => void = () => {};
-		const waitForAgentMessagePromptDelivery = vi.fn(
-			() =>
-				new Promise<void>((resolve) => {
-					resolveQueuedDelivery = resolve;
-				}),
-		);
-		const queueAgentMessagePrompt = vi.fn(async () => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: true,
-				unfinishedActionCount: 0,
-				queueAgentMessagePrompt,
-				waitForAgentMessagePromptDelivery,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "queued",
-				fromState,
-				origin: "agent",
-			}),
-		).resolves.toMatchObject({ target: { activeSessionId: targetState.activeSessionId } });
-
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(waitForAgentMessagePromptDelivery).not.toHaveBeenCalled();
-		resolveQueuedDelivery();
-	});
-
-	it("recomputes agent message streaming behavior after waiting for the target lock", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		const promptResolves: Array<() => void> = [];
-		const prompt = vi.fn(
-			(_message: string, _options?: { streamingBehavior?: "steer" | "followUp" }) =>
-				new Promise<void>((resolve) => {
-					promptResolves.push(resolve);
-				}),
-		);
-		const followUp = vi.fn(async () => true);
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				prompt,
-				followUp,
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const first = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "first",
-			fromState,
-			origin: "agent",
-		});
-		const second = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "second",
-			fromState,
-			origin: "agent",
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(prompt).toHaveBeenCalledTimes(1);
-		(targetState.runtime.session as { isStreaming: boolean }).isStreaming = true;
-		promptResolves[0]?.();
-		await expect(first).resolves.toMatchObject({ message: "first" });
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(prompt).toHaveBeenCalledTimes(1);
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
-		expect(followUp).not.toHaveBeenCalled();
-		await expect(second).resolves.toMatchObject({ message: "second" });
-	});
-
-	it("rejects agent messages when queued delivery is coalesced", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		const queueAgentMessagePrompt = vi.fn(async () => false);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: true,
-				unfinishedActionCount: 1,
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		await expect(
-			internals.sendAgentSessionMessage({
-				targetSelector: targetState.activeSessionId,
-				message: "coalesced",
-				fromState,
-				origin: "agent",
-			}),
-		).rejects.toThrow("Agent message was not queued");
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-	});
-
 	it("rejects agent messages when direct delivery preflight fails", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -3403,353 +2671,6 @@ describe("daemon mode helpers", () => {
 		).rejects.toThrow("Agent message was not accepted");
 	});
 
-	it("queues agent messages while daemon prompts prepare to stream", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const targetState = makeState("target");
-		let resolvePrompt: () => void = () => {};
-		let reportPreflight: ((didSucceed: boolean) => void) | undefined;
-		const prompt = vi.fn((_message: string, options?: { preflightResult?: (didSucceed: boolean) => void }) => {
-			reportPreflight = options?.preflightResult;
-			return new Promise<void>((resolve) => {
-				resolvePrompt = resolve;
-			});
-		});
-		const acceptAgentMessagePrompt = vi.fn(async () => {});
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				prompt,
-				acceptAgentMessagePrompt,
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(targetState.activeSessionId, targetState);
-		const promptClient = makeClient("client-1", targetState.activeSessionId);
-		(promptClient.socket as unknown as { write: ReturnType<typeof vi.fn> }).write = vi.fn();
-
-		internals.handleCommand(promptClient, {
-			id: "command-1",
-			type: "prompt",
-			activeSessionId: targetState.activeSessionId,
-			message: "normal prompt",
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-		reportPreflight?.(true);
-
-		const send = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "agent message",
-			origin: "agent",
-		});
-		await Promise.resolve();
-		await send;
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt.mock.calls[0]?.[1]).toBe("steer");
-		resolvePrompt();
-	});
-
-	it("waits for an in-flight agent-message accept before starting daemon prompts", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const targetState = makeState("target");
-		let resolveAccept: () => void = () => {};
-		const acceptAgentMessagePrompt = vi.fn(
-			(_message: string, options?: { preflightResult?: (didSucceed: boolean) => void }) => {
-				options?.preflightResult?.(true);
-				return new Promise<void>((resolve) => {
-					resolveAccept = resolve;
-				});
-			},
-		);
-		const prompt = vi.fn(async (_message: string, options?: { preflightResult?: (didSucceed: boolean) => void }) => {
-			options?.preflightResult?.(true);
-		});
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				prompt,
-				acceptAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const send = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "agent message",
-			origin: "agent",
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
-
-		const promptClient = makeClient("client-1", targetState.activeSessionId);
-		(promptClient.socket as unknown as { write: ReturnType<typeof vi.fn> }).write = vi.fn();
-		internals.handleCommand(promptClient, {
-			id: "command-1",
-			type: "prompt",
-			activeSessionId: targetState.activeSessionId,
-			message: "normal prompt",
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-		expect(prompt).not.toHaveBeenCalled();
-
-		resolveAccept();
-		await send;
-		for (let attempt = 0; attempt < 10 && prompt.mock.calls.length === 0; attempt++) {
-			await Promise.resolve();
-		}
-
-		expect(prompt).toHaveBeenCalledOnce();
-	});
-
-	it("releases cron preparing state after prompt admission", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const targetState = makeState("target");
-		let resolvePrompt: () => void = () => {};
-		const prompt = vi.fn(
-			(_message: string, _options?: unknown) =>
-				new Promise<void>((resolve) => {
-					resolvePrompt = resolve;
-				}),
-		);
-		const promptUntilAccepted = vi.fn(async () => {});
-		const acceptAgentMessagePrompt = vi.fn(async () => {});
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				isBashRunning: false,
-				unfinishedActionCount: 0,
-				prompt,
-				promptUntilAccepted,
-				acceptAgentMessagePrompt,
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const cronRun = internals.runCronJob(
-			makeCronJob({ id: "cron-1", source: "cron", activeSessionId: targetState.activeSessionId }),
-		);
-		await Promise.resolve();
-		await Promise.resolve();
-		expect(promptUntilAccepted).toHaveBeenCalledOnce();
-		expect(prompt).not.toHaveBeenCalled();
-
-		await internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "agent message",
-			origin: "agent",
-		});
-
-		expect(acceptAgentMessagePrompt).toHaveBeenCalledOnce();
-		expect(queueAgentMessagePrompt).not.toHaveBeenCalled();
-		resolvePrompt();
-		await cronRun;
-	});
-
-	it("keeps the preparing state until every concurrent prompt settles", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const targetState = makeState("target");
-		const promptResolves: Array<() => void> = [];
-		const prompt = vi.fn(
-			(_message: string, _options?: unknown) =>
-				new Promise<void>((resolve) => {
-					promptResolves.push(resolve);
-				}),
-		);
-		const acceptAgentMessagePrompt = vi.fn(async () => {});
-		const queueAgentMessagePrompt = vi.fn(async (_message: string, _streamingBehavior: "steer" | "followUp") => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				prompt,
-				acceptAgentMessagePrompt,
-				queueAgentMessagePrompt,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(targetState.activeSessionId, targetState);
-		const promptClient = makeClient("client-1", targetState.activeSessionId);
-		(promptClient.socket as unknown as { write: ReturnType<typeof vi.fn> }).write = vi.fn();
-
-		internals.handleCommand(promptClient, {
-			id: "command-1",
-			type: "prompt",
-			activeSessionId: targetState.activeSessionId,
-			message: "first prompt",
-		});
-		internals.handleCommand(promptClient, {
-			id: "command-2",
-			type: "prompt",
-			activeSessionId: targetState.activeSessionId,
-			message: "second prompt",
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-		expect(prompt).toHaveBeenCalledTimes(2);
-
-		// The first prompt settles; the second is still in preflight, so agent
-		// messages must keep queueing (a plain Set would have lost the flag here).
-		promptResolves[0]?.();
-		await Promise.resolve();
-		await Promise.resolve();
-
-		await internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "agent message",
-			origin: "agent",
-		});
-
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
-		expect(queueAgentMessagePrompt).toHaveBeenCalledOnce();
-		promptResolves[1]?.();
-	});
-
-	it("re-checks agent message queue capacity after waiting for the target lock", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const fromState = makeState("source");
-		const targetState = makeState("target");
-		fromState.runtime = {
-			...fromState.runtime,
-			session: { sessionId: "session-source", sessionName: "Source" },
-		} as never;
-		let resolveFirstPrompt: () => void = () => {};
-		const acceptAgentMessagePrompt = vi.fn(
-			() =>
-				new Promise<void>((resolve) => {
-					resolveFirstPrompt = resolve;
-				}),
-		);
-		const followUp = vi.fn(async () => true);
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				acceptAgentMessagePrompt,
-				followUp,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				fromState?: ActiveSessionState;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(fromState.activeSessionId, fromState);
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const first = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "first",
-			fromState,
-			origin: "agent",
-		});
-		const second = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "second",
-			fromState,
-			origin: "agent",
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-		(targetState.runtime.session as { unfinishedActionCount: number }).unfinishedActionCount = 20;
-
-		resolveFirstPrompt();
-		await expect(first).resolves.toMatchObject({ message: "first" });
-		await expect(second).rejects.toThrow("Target session has too many pending messages");
-		expect(followUp).not.toHaveBeenCalled();
-	});
-
 	it("rate limits CLI agent messages by stable daemon identity", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -3766,7 +2687,12 @@ describe("daemon mode helpers", () => {
 				sessionName: "Target",
 				isStreaming: false,
 				unfinishedActionCount: 0,
-				prompt: vi.fn(async () => {}),
+				acceptAgentMessagePrompt: vi.fn(
+					(_message: string, options?: { preflightResult?: (accepted: boolean) => void }) => {
+						options?.preflightResult?.(true);
+						return Promise.resolve();
+					},
+				),
 			},
 		} as never;
 		const internals = daemon as unknown as {
@@ -3793,266 +2719,6 @@ describe("daemon mode helpers", () => {
 				message: "over limit",
 			}),
 		).rejects.toThrow("Agent messaging rate limit exceeded");
-	});
-
-	it("holds the target lock while clearing queued agent messages", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const targetState = makeState("target");
-		let resolvePrompt: () => void = () => {};
-		const acceptAgentMessagePrompt = vi.fn(
-			(_message: string, options?: { preflightResult?: (didSucceed: boolean) => void }) => {
-				options?.preflightResult?.(true);
-				return new Promise<void>((resolve) => {
-					resolvePrompt = resolve;
-				});
-			},
-		);
-		const clearQueuedUserMessagesMatching = vi.fn(() => ({ steering: [], followUp: [] }));
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				acceptAgentMessagePrompt,
-				clearQueuedUserMessagesMatching,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const send = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "first",
-			origin: "agent",
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-
-		const clear = internals.handleCommand(makeClient("client-1", targetState.activeSessionId), {
-			id: "command-1",
-			type: "agent_messages_clear",
-			activeSessionId: targetState.activeSessionId,
-		});
-		await Promise.resolve();
-		expect(clearQueuedUserMessagesMatching).not.toHaveBeenCalled();
-
-		resolvePrompt();
-		await send;
-		await clear;
-		expect(clearQueuedUserMessagesMatching).toHaveBeenCalledOnce();
-	});
-
-	it("rejects agent messages when pause wins the target lock", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const targetState = makeState("target");
-		let resolveBlockedClear: () => void = () => {};
-		const clearQueuedUserMessagesMatching = vi.fn(
-			() =>
-				new Promise<{ steering: string[]; followUp: string[] }>((resolve) => {
-					resolveBlockedClear = () => resolve({ steering: [], followUp: [] });
-				}),
-		);
-		const acceptAgentMessagePrompt = vi.fn(async () => {});
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				acceptAgentMessagePrompt,
-				clearQueuedUserMessagesMatching,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const pause = internals.handleCommand(makeClient("client-1", targetState.activeSessionId), {
-			id: "command-1",
-			type: "agent_messages_pause",
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-
-		const send = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "after pause requested",
-			origin: "agent",
-		});
-		await Promise.resolve();
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
-
-		resolveBlockedClear();
-		await pause;
-		await expect(send).rejects.toThrow("Agent messaging is paused");
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
-	});
-
-	it("rejects agent messages when the target session changes before delivery", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const targetState = makeState("target");
-		let resolveBlockedClear: () => void = () => {};
-		const clearQueuedUserMessagesMatching = vi.fn(
-			() =>
-				new Promise<{ steering: string[]; followUp: string[] }>((resolve) => {
-					resolveBlockedClear = () => resolve({ steering: [], followUp: [] });
-				}),
-		);
-		const acceptAgentMessagePrompt = vi.fn(async () => {});
-		targetState.runtime = {
-			...targetState.runtime,
-			cwd: "/tmp",
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				acceptAgentMessagePrompt,
-				clearQueuedUserMessagesMatching,
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const clear = internals.handleCommand(makeClient("client-1", targetState.activeSessionId), {
-			id: "command-1",
-			type: "agent_messages_clear",
-			activeSessionId: targetState.activeSessionId,
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-
-		const send = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "after session switch",
-			origin: "agent",
-		});
-		await Promise.resolve();
-		(targetState.runtime.session as { sessionId: string }).sessionId = "session-replacement";
-		resolveBlockedClear();
-		await clear;
-
-		await expect(send).rejects.toThrow("Target session changed before agent message delivery");
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
-	});
-
-	it("rejects agent messages when the target session closes before delivery", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const targetState = makeState("target");
-		targetState.extensionUiRequests = new Map();
-		let resolveBlockedClear: () => void = () => {};
-		const clearQueuedUserMessagesMatching = vi.fn(
-			() =>
-				new Promise<{ steering: string[]; followUp: string[] }>((resolve) => {
-					resolveBlockedClear = () => resolve({ steering: [], followUp: [] });
-				}),
-		);
-		const acceptAgentMessagePrompt = vi.fn(async () => {});
-		const dispose = vi.fn(async () => {});
-		targetState.runtime = {
-			...targetState.runtime,
-			dispose,
-			cwd: "/tmp",
-			metadata: { kind: "subagent", createdAt: 1 },
-			session: {
-				sessionId: "session-target",
-				sessionName: "Target",
-				isStreaming: false,
-				unfinishedActionCount: 0,
-				messages: [],
-				acceptAgentMessagePrompt,
-				clearQueuedUserMessagesMatching,
-				abort: vi.fn(async () => {}),
-				dispose: vi.fn(),
-				sessionManager: { appendSessionState: vi.fn(), hasUserContent: () => true },
-			},
-		} as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
-			sendAgentSessionMessage(options: {
-				targetSelector: string;
-				message: string;
-				origin: "agent" | "cli";
-			}): Promise<unknown>;
-		};
-		internals.sessions.set(targetState.activeSessionId, targetState);
-
-		const clear = internals.handleCommand(makeClient("client-1", targetState.activeSessionId), {
-			id: "command-1",
-			type: "agent_messages_clear",
-			activeSessionId: targetState.activeSessionId,
-		});
-		await Promise.resolve();
-		await Promise.resolve();
-
-		const send = internals.sendAgentSessionMessage({
-			targetSelector: targetState.activeSessionId,
-			message: "after close requested",
-			origin: "agent",
-		});
-		await Promise.resolve();
-
-		const close = internals.handleCommand(makeClient("client-2", targetState.activeSessionId), {
-			id: "command-2",
-			type: "kill",
-			activeSessionId: targetState.activeSessionId,
-		});
-		await close;
-		expect(dispose).toHaveBeenCalledOnce();
-
-		resolveBlockedClear();
-		await clear;
-		await expect(send).rejects.toThrow("Target session is closing before agent message delivery");
-		expect(acceptAgentMessagePrompt).not.toHaveBeenCalled();
 	});
 
 	it("rejects agent messages to the sending session", async () => {
@@ -7834,7 +6500,12 @@ describe("daemon mode helpers", () => {
 			});
 			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
 				const session = makeRuntimeSession(options.sessionManager);
-				session.prompt = vi.fn(async () => {});
+				session.acceptAgentMessagePrompt = vi.fn(
+					(_message: string, promptOptions?: { preflightResult?: (accepted: boolean) => void }) => {
+						promptOptions?.preflightResult?.(true);
+						return Promise.resolve();
+					},
+				);
 				session.bindExtensions = vi.fn(async () => {
 					await bindBarrier;
 				});
@@ -8834,126 +7505,6 @@ describe("daemon mode helpers", () => {
 		expect(fixture.followUp).not.toHaveBeenCalled();
 	});
 
-	it("delivers steer heartbeats after an RPC prompt finishes preflight while its turn is still streaming", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		let releasePrompt = () => {};
-		const promptFinished = new Promise<void>((resolve) => {
-			releasePrompt = resolve;
-		});
-		let reportPromptStarted = () => {};
-		const promptStarted = new Promise<void>((resolve) => {
-			reportPromptStarted = resolve;
-		});
-		const sessionState = {
-			isStreaming: false,
-			isBashRunning: false,
-			hasPendingSessionWork: false,
-			unfinishedActionCount: 1,
-			sessionActions: { queuedCount: 0, steering: [], followUps: [] },
-		};
-		const prompt = vi.fn(async (_message: string, options?: { preflightResult?: (didSucceed: boolean) => void }) => {
-			sessionState.isStreaming = true;
-			options?.preflightResult?.(true);
-			reportPromptStarted();
-			await promptFinished;
-		});
-		const promptHeartbeat = vi.fn(
-			async (
-				_job: AgentCronJob,
-				options?: { streamingBehavior?: "steer" | "followUp"; preflightResult?: (didSucceed: boolean) => void },
-			) => {
-				options?.preflightResult?.(true);
-			},
-		);
-		const state = makeState("active-1") as ActiveSessionState & {
-			runtime: ActiveSessionState["runtime"] & {
-				session: typeof sessionState & {
-					prompt: typeof prompt;
-					promptHeartbeat: typeof promptHeartbeat;
-				};
-			};
-		};
-		state.runtime.session = Object.assign(sessionState, { prompt, promptHeartbeat }) as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			agentMessagePreparingTargets: Map<string, number>;
-			promptWithAgentMessagePreparingGuard(state: ActiveSessionState, message: string): Promise<void>;
-			runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
-		};
-		internals.sessions.set(state.activeSessionId, state);
-
-		const promptPromise = internals.promptWithAgentMessagePreparingGuard(state, "long-running prompt");
-		await promptStarted;
-		const preparingReleased = !internals.agentMessagePreparingTargets.has(state.activeSessionId);
-		const result = await internals.runCronJob(
-			makeCronJob({ id: "heartbeat-1", source: "heartbeat", activeSessionId: state.activeSessionId }),
-		);
-		releasePrompt();
-		await promptPromise;
-
-		expect(preparingReleased).toBe(true);
-		expect(result).toBeUndefined();
-		expect(promptHeartbeat).toHaveBeenCalledWith(
-			expect.objectContaining({ id: "heartbeat-1" }),
-			expect.objectContaining({ streamingBehavior: "steer" }),
-		);
-	});
-
-	it.each(["steer", "follow_up"] as const)(
-		"idle daemon %s inserts into its scheduler lane exactly once",
-		async (type) => {
-			const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-				defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-				createRuntime: async () => {
-					throw new Error("unexpected runtime creation");
-				},
-			});
-			const steer = vi.fn(async () => {});
-			const followUp = vi.fn(async () => true);
-			const state = makeState("active-1") as ActiveSessionState & {
-				runtime: ActiveSessionState["runtime"] & {
-					session: { isStreaming: boolean; steer: typeof steer; followUp: typeof followUp };
-				};
-			};
-			state.runtime = { ...state.runtime, session: { isStreaming: false, steer, followUp } } as never;
-			const internals = daemon as unknown as {
-				sessions: Map<string, ActiveSessionState>;
-				recordWorkerRecoveryState: ReturnType<typeof vi.fn>;
-				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
-			};
-			internals.sessions.set(state.activeSessionId, state);
-			internals.recordWorkerRecoveryState = vi.fn();
-
-			await expect(
-				internals.handleCommand(makeClient("client-1", state.activeSessionId), {
-					id: "command-1",
-					type,
-					activeSessionId: state.activeSessionId,
-					message: "idle queued turn",
-				}),
-			).resolves.toMatchObject({
-				success: true,
-				command: type,
-				...(type === "follow_up" ? { data: { queued: true } } : {}),
-			});
-			const queue = type === "steer" ? steer : followUp;
-			expect(queue).toHaveBeenCalledOnce();
-			expect(queue).toHaveBeenCalledWith("idle queued turn", undefined, {
-				queueKey: undefined,
-				agentMessageId: undefined,
-				resumeIfIdle: true,
-			});
-			if (type === "follow_up") {
-				expect(internals.recordWorkerRecoveryState).toHaveBeenCalledWith(state, "follow_up_queued", true);
-			}
-		},
-	);
-
 	it("clears prompt admission registered before unauthenticated worker rejection", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-worker-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
@@ -9189,53 +7740,6 @@ describe("daemon mode helpers", () => {
 		).resolves.toMatchObject({ success: true, data: { status: "owned" } });
 		expect(promptOptions?.signal?.aborted).toBe(true);
 		rejectPrompt?.(new Error("test cleanup"));
-	});
-
-	it("settles cancellation while prompt routing waits on the target lock", async () => {
-		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
-			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
-			createRuntime: async () => {
-				throw new Error("unexpected runtime creation");
-			},
-		});
-		const promptUntilAccepted = vi.fn(async () => {});
-		const state = makeState("active-lock") as ActiveSessionState;
-		state.runtime = { ...state.runtime, session: { promptUntilAccepted } } as never;
-		const internals = daemon as unknown as {
-			sessions: Map<string, ActiveSessionState>;
-			agentMessageTargetLocks: Map<string, Promise<void>>;
-			promptAdmissions: Map<string, unknown>;
-			parseCommandAndRegisterPromptAdmission(client: DaemonSocketClient, line: string): unknown;
-			handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown> | undefined;
-		};
-		internals.sessions.set(state.activeSessionId, state);
-		internals.agentMessageTargetLocks.set(state.activeSessionId, new Promise(() => {}));
-		const client = makeClient("client-lock", state.activeSessionId);
-		client.socket = { destroyed: false, write: vi.fn(() => true) } as unknown as Socket;
-		internals.parseCommandAndRegisterPromptAdmission(
-			client,
-			JSON.stringify({
-				type: "prompt",
-				activeSessionId: state.activeSessionId,
-				message: "blocked",
-				admissionId: "lock-admission",
-			}),
-		);
-		internals.handleCommand(client, {
-			type: "prompt",
-			activeSessionId: state.activeSessionId,
-			message: "blocked",
-			admissionId: "lock-admission",
-		});
-		await expect(
-			internals.handleCommand(client, {
-				type: "cancel_prompt_admission",
-				activeSessionId: state.activeSessionId,
-				admissionId: "lock-admission",
-			}),
-		).resolves.toMatchObject({ data: { status: "cancelled" } });
-		await vi.waitFor(() => expect(internals.promptAdmissions.size).toBe(0));
-		expect(promptUntilAccepted).not.toHaveBeenCalled();
 	});
 
 	it("aborts waiting prompt admissions when their session closes", () => {
@@ -9967,10 +8471,11 @@ function makeCronAdmissionFixture(
 			isCompacting: false,
 			isRetrying: false,
 			isBashRunning: false,
-			hasPendingSessionWork: false,
-			unfinishedActionCount: 0,
+			hasPendingSessionWork: options.acceptingAgentMessage === true,
+			unfinishedActionCount: options.acceptingAgentMessage === true ? 1 : 0,
 			...activity,
 			prompt,
+			promptUntilAccepted: prompt,
 			promptHeartbeat,
 			followUp,
 			removeQueuedFollowUp,
@@ -9978,13 +8483,9 @@ function makeCronAdmissionFixture(
 	} as never;
 	const internals = daemon as unknown as {
 		sessions: Map<string, ActiveSessionState>;
-		agentMessageAcceptingTargets: Set<string>;
 		runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
 	};
 	internals.sessions.set(activeSessionId, state);
-	if (options.acceptingAgentMessage) {
-		internals.agentMessageAcceptingTargets.add(activeSessionId);
-	}
 
 	return {
 		activeSessionId,
@@ -10108,13 +8609,19 @@ function makePersistedRlmDaemonFixture(
 `,
 	);
 
+	let admissionPending = false;
 	const acceptAgentMessagePrompt = vi.fn(
 		async (_message: string, promptOptions?: { preflightResult?: (didSucceed: boolean) => void }) => {
-			if (options.childAdmissionGate) {
-				options.childAdmissionStarted?.();
-				await options.childAdmissionGate;
+			admissionPending = true;
+			try {
+				if (options.childAdmissionGate) {
+					options.childAdmissionStarted?.();
+					await options.childAdmissionGate;
+				}
+				promptOptions?.preflightResult?.(true);
+			} finally {
+				admissionPending = false;
 			}
-			promptOptions?.preflightResult?.(true);
 		},
 	);
 	const runtimeSessions: Array<ReturnType<typeof makeRuntimeSession>> = [];
@@ -10144,6 +8651,9 @@ function makePersistedRlmDaemonFixture(
 				await options.childDisposeGate;
 			});
 		}
+		Object.defineProperty(runtimeSession, "hasPendingAdmissionWaiters", {
+			get: () => admissionPending,
+		});
 		Object.assign(runtimeSession, {
 			isStreaming: false,
 			isCompacting: false,

--- a/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-lazy-subagents.test.ts
@@ -4,19 +4,21 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	type AgentFamilyCatalogEntry,
-	type AgentSessionMessageAgentSummary,
 	assertAgentFamilyReach,
 	sessionNameReservationKey,
 } from "../src/core/agent-messages.js";
 import { readSessionInfo, SessionManager } from "../src/core/session-manager.js";
+import { DaemonCatalogClient } from "../src/modes/daemon/daemon-catalog-process.js";
+import { DaemonClient } from "../src/modes/daemon/daemon-client.js";
 import { success } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DaemonSupervisor } from "../src/modes/daemon/daemon-supervisor.js";
 
 interface SupervisorInternals {
 	workers: Map<string, WorkerFixture>;
+	start(): Promise<void>;
+	cleanupSupervisorResources(): Promise<void>;
 	refreshWorkerSummaries(worker: WorkerFixture): Promise<void>;
-	syncAgentPeers(): Promise<void>;
 	findSummaryInWorker(worker: WorkerFixture, selector: string): SessionSummary | undefined;
 	createOrReuseWorker(
 		clientId: string,
@@ -84,7 +86,7 @@ function worker(workerId: string, summaries: SessionSummary[] = []): WorkerFixtu
 		},
 		client: {
 			request: vi.fn(),
-			requestWorker: vi.fn(async () => ({ type: "response", command: "worker_sync_agent_peers", success: true })),
+			requestWorker: vi.fn(),
 		},
 		summaries: new Map(summaries.map((entry) => [entry.activeSessionId ?? entry.id, entry])),
 	};
@@ -645,13 +647,16 @@ describe("daemon supervisor passive subagent topology", () => {
 		await expect(first).resolves.toBe(launched);
 	});
 
-	it("retains passive worker summaries but syncs only roots to cross-worker peer maps", async () => {
+	it("dispatches authenticated peer queries and excludes disconnected workers", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "prime-supervisor-passive-peers-"));
 		tempDirs.push(directory);
-		const supervisor = new DaemonSupervisor(join(directory, "daemon.sock"), {
+		const socketPath = join(directory, "daemon.sock");
+		const supervisor = new DaemonSupervisor(socketPath, {
 			defaultSessionConfig: { agentDir: directory, cwd: directory },
 			descriptorDir: join(directory, "workers"),
 		}) as unknown as SupervisorInternals;
+		const client = new DaemonClient(socketPath);
+		vi.spyOn(DaemonCatalogClient.prototype, "start").mockResolvedValue();
 
 		const passive = summary({
 			id: "passive-session",
@@ -667,36 +672,54 @@ describe("daemon supervisor passive subagent topology", () => {
 			sessionId: "first-root-session",
 			runtimeKind: "top-level",
 		});
-		const first = worker("first");
-		first.client.request.mockResolvedValue(success(undefined, "list", { sessions: [passive] }));
 		const secondRoot = summary({
 			id: "second-root-active",
 			activeSessionId: "second-root-active",
 			sessionId: "second-root-session",
 		});
-		const second = worker("second", [secondRoot]);
-		supervisor.workers.set("first", first);
-		supervisor.workers.set("second", second);
-
-		await supervisor.refreshWorkerSummaries(first);
-		expect(first.client.request).toHaveBeenCalledWith({ type: "list" }, 5000);
-		expect(first.summaries.get("passive-session")).toMatchObject({
-			sessionFile: passive.sessionFile,
-			runtimeKind: "subagent",
-			rlmChildId: "passive-child",
+		const disconnectedRoot = summary({
+			id: "disconnected-root-active",
+			activeSessionId: "disconnected-root-active",
+			sessionId: "disconnected-root-session",
 		});
-		first.summaries.set(first.descriptor.rootActiveSessionId, firstRoot);
+		const first = worker("first", [firstRoot, passive]);
+		const second = worker("second", [secondRoot]);
+		const disconnected = worker("disconnected", [disconnectedRoot]);
+		Object.assign(disconnected, { client: undefined });
 
-		await supervisor.syncAgentPeers();
-		const secondPeerCommand = second.client.requestWorker.mock.calls[0]?.[0] as
-			| { peers: AgentSessionMessageAgentSummary[] }
-			| undefined;
-		expect(secondPeerCommand?.peers).toEqual([
-			expect.objectContaining({
-				activeSessionId: "first-root-active",
-				sessionId: "first-root-session",
-				runtimeKind: "top-level",
-			}),
-		]);
+		try {
+			await supervisor.start();
+			supervisor.workers.set("first", first);
+			supervisor.workers.set("second", second);
+			supervisor.workers.set("disconnected", disconnected);
+			await client.connect();
+
+			await expect(
+				client.request({ type: "list_agent_peers", workerToken: "invalid-token" }),
+			).resolves.toMatchObject({
+				success: false,
+				error: "Worker authentication failed",
+			});
+			const response = await client.request({
+				type: "list_agent_peers",
+				workerToken: second.descriptor.authenticationToken,
+			});
+			expect(response).toMatchObject({
+				success: true,
+				data: {
+					peers: [
+						expect.objectContaining({
+							activeSessionId: "first-root-active",
+							sessionId: "first-root-session",
+							runtimeKind: "top-level",
+						}),
+					],
+				},
+			});
+		} finally {
+			client.close();
+			supervisor.workers.clear();
+			await supervisor.cleanupSupervisorResources();
+		}
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -155,7 +155,6 @@ interface DeferredRecoveryHarness {
 	shuttingDown: boolean;
 	assertRecoveryAllowed: ReturnType<typeof vi.fn>;
 	persistWorker: ReturnType<typeof vi.fn>;
-	syncAgentPeers: ReturnType<typeof vi.fn>;
 	recoverWorker: ReturnType<typeof vi.fn>;
 	handleWorkerClose(worker: DeferredRecoveryWorker, client: object, error: Error): Promise<void>;
 	deferWorkerRecovery(worker: DeferredRecoveryWorker, error: Error): void;
@@ -610,7 +609,6 @@ describe("daemon worker supervisor monitoring", () => {
 				}
 			}),
 			connectWorker,
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			launchWorker(command: { type: "create"; config: { cwd: string; agentDir: string } }): Promise<unknown>;
@@ -673,7 +671,6 @@ describe("daemon worker supervisor monitoring", () => {
 			connectWorker,
 			subscribeWorker: vi.fn(async () => undefined),
 			refreshWorkerSummaries: vi.fn(async () => undefined),
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			launchWorker(command: {
@@ -736,7 +733,6 @@ describe("daemon worker supervisor monitoring", () => {
 				}
 				Reflect.apply(persistWorker, this, [worker]);
 			}),
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			launchWorker(command: { type: "create"; config: { cwd: string; agentDir: string } }): Promise<unknown>;
@@ -797,7 +793,6 @@ describe("daemon worker supervisor monitoring", () => {
 				Reflect.apply(persistWorker, this, [worker]);
 			}),
 			deferWorkerRecovery,
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			launchWorker(
@@ -883,7 +878,6 @@ describe("daemon worker supervisor monitoring", () => {
 			connectWorker,
 			stopWorker: controlledStopWorker,
 			deferWorkerRecovery,
-			syncAgentPeers: vi.fn(async () => undefined),
 			log: vi.fn(),
 		}) as {
 			shuttingDown: boolean;
@@ -1124,7 +1118,6 @@ describe("daemon worker supervisor monitoring", () => {
 			shuttingDown: false,
 			assertRecoveryAllowed,
 			persistWorker,
-			syncAgentPeers: vi.fn(async () => undefined),
 			recoverWorker,
 		}) as DeferredRecoveryHarness;
 
@@ -1183,7 +1176,6 @@ describe("daemon worker supervisor monitoring", () => {
 			shuttingDown: false,
 			assertRecoveryAllowed,
 			persistWorker,
-			syncAgentPeers: vi.fn(async () => undefined),
 			recoverWorker,
 		}) as DeferredRecoveryHarness;
 
@@ -1254,7 +1246,6 @@ describe("daemon worker supervisor monitoring", () => {
 			shuttingDown: false,
 			assertRecoveryAllowed,
 			persistWorker,
-			syncAgentPeers: vi.fn(async () => undefined),
 			recoverWorker,
 		}) as DeferredRecoveryHarness;
 
@@ -1299,7 +1290,6 @@ describe("daemon worker supervisor monitoring", () => {
 				resolveAssertion = resolve;
 			});
 			const persistWorker = vi.fn();
-			const syncAgentPeers = vi.fn(async () => undefined);
 			const recoverWorker = vi.fn(async () => undefined);
 			const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 				...createSupervisorSnapshotState(),
@@ -1307,7 +1297,6 @@ describe("daemon worker supervisor monitoring", () => {
 				shuttingDown: false,
 				assertRecoveryAllowed: vi.fn(() => assertion),
 				persistWorker,
-				syncAgentPeers,
 				recoverWorker,
 			}) as DeferredRecoveryHarness;
 
@@ -1319,7 +1308,6 @@ describe("daemon worker supervisor monitoring", () => {
 			expect(worker.descriptor.lifecycle).toBe("ready");
 			expect(worker.descriptor.lastError).toBeUndefined();
 			expect(persistWorker).not.toHaveBeenCalled();
-			expect(syncAgentPeers).not.toHaveBeenCalled();
 			expect(recoverWorker).not.toHaveBeenCalled();
 		},
 	);
@@ -1494,7 +1482,6 @@ describe("daemon worker supervisor monitoring", () => {
 			streamReconstructor: { observe: vi.fn() },
 			invalidateWorkerSnapshot: vi.fn(),
 			refreshWorkerSummaries: vi.fn(async () => undefined),
-			syncAgentPeers: vi.fn(async () => undefined),
 			persistWorkerStopTombstone: vi.fn(),
 			deleteWorkerDescriptor,
 			broadcastHeartbeatsChanged: vi.fn(),
@@ -1591,7 +1578,6 @@ describe("daemon worker supervisor monitoring", () => {
 			recoverUncertainWorkerOperations: ReturnType<typeof vi.fn>;
 			launchWorker: ReturnType<typeof vi.fn>;
 			persistWorker: ReturnType<typeof vi.fn>;
-			syncAgentPeers: ReturnType<typeof vi.fn>;
 			assertRecoveryAllowed: ReturnType<typeof vi.fn>;
 			recoverWorker(worker: RecoveryWorker): Promise<void>;
 		};
@@ -1613,7 +1599,6 @@ describe("daemon worker supervisor monitoring", () => {
 			recoverUncertainWorkerOperations: vi.fn(async () => {}),
 			launchWorker: vi.fn(async () => worker),
 			persistWorker: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			assertRecoveryAllowed: vi.fn(async () => {}),
 		}) as RecoveryHarness;
 
@@ -1686,7 +1671,6 @@ describe("daemon worker supervisor monitoring", () => {
 			processIdentity: vi.fn(() => "gone"),
 			recoverUncertainWorkerOperations,
 			deleteWorkerDescriptor,
-			syncAgentPeers: vi.fn(async () => {}),
 		}) as {
 			reclaimStaleWorkerRegistration(target: typeof worker): Promise<boolean>;
 		};
@@ -1747,7 +1731,6 @@ describe("daemon worker supervisor monitoring", () => {
 			recoverUncertainWorkerOperations: ReturnType<typeof vi.fn>;
 			launchWorker: ReturnType<typeof vi.fn>;
 			persistWorker: ReturnType<typeof vi.fn>;
-			syncAgentPeers: ReturnType<typeof vi.fn>;
 			broadcastHeartbeatsChanged: ReturnType<typeof vi.fn>;
 			log: ReturnType<typeof vi.fn>;
 			assertRecoveryAllowed: ReturnType<typeof vi.fn>;
@@ -1773,7 +1756,6 @@ describe("daemon worker supervisor monitoring", () => {
 			recoverUncertainWorkerOperations: vi.fn(async () => {}),
 			launchWorker: vi.fn(async () => worker),
 			persistWorker: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			log: vi.fn(),
 			assertRecoveryAllowed: vi.fn(async () => {}),
 		}) as RecoveryHarness;
@@ -1786,75 +1768,6 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(supervisor.recoverUncertainWorkerOperations).not.toHaveBeenCalled();
 		expect(supervisor.launchWorker).not.toHaveBeenCalled();
 		expect(worker.descriptor.lifecycle).toBe("failed");
-	});
-
-	it("keeps a recovered worker ready when peer synchronization fails", async () => {
-		vi.useFakeTimers();
-		type RecoveryWorker = {
-			descriptor: {
-				workerId: string;
-				pid: number;
-				processStartId?: string;
-				rootActiveSessionId: string;
-				createCommand: { type: "create" };
-				lifecycle?: string;
-				consecutiveFailures: number;
-			};
-			intentionalStop: boolean;
-			stopRevision: number;
-			recovery?: Promise<void>;
-		};
-		type RecoveryHarness = {
-			workers: Map<string, RecoveryWorker>;
-			shuttingDown: boolean;
-			connectWorker: ReturnType<typeof vi.fn>;
-			subscribeWorker: ReturnType<typeof vi.fn>;
-			refreshWorkerSummaries: ReturnType<typeof vi.fn>;
-			recoverUncertainWorkerOperations: ReturnType<typeof vi.fn>;
-			launchWorker: ReturnType<typeof vi.fn>;
-			persistWorker: ReturnType<typeof vi.fn>;
-			syncAgentPeers: ReturnType<typeof vi.fn>;
-			log: ReturnType<typeof vi.fn>;
-			assertRecoveryAllowed: ReturnType<typeof vi.fn>;
-			recoverWorker(worker: RecoveryWorker): Promise<void>;
-		};
-		const worker: RecoveryWorker = {
-			descriptor: {
-				workerId: "worker-peer-sync-failure",
-				pid: process.pid,
-				rootActiveSessionId: "active-1",
-				createCommand: { type: "create" },
-				consecutiveFailures: 1,
-			},
-			intentionalStop: false,
-			stopRevision: 0,
-		};
-		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
-			workers: new Map([[worker.descriptor.workerId, worker]]),
-			shuttingDown: false,
-			connectWorker: vi.fn(async () => ({})),
-			subscribeWorker: vi.fn(async () => {}),
-			refreshWorkerSummaries: vi.fn(async () => {}),
-			recoverUncertainWorkerOperations: vi.fn(async () => {}),
-			launchWorker: vi.fn(async () => worker),
-			persistWorker: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {
-				throw new Error("peer unavailable");
-			}),
-			broadcastHeartbeatsChanged: vi.fn(),
-			log: vi.fn(),
-			assertRecoveryAllowed: vi.fn(async () => {}),
-		}) as RecoveryHarness;
-
-		const recovery = supervisor.recoverWorker(worker);
-		await vi.advanceTimersByTimeAsync(250);
-		await recovery;
-
-		expect(supervisor.connectWorker).toHaveBeenCalledOnce();
-		expect(supervisor.recoverUncertainWorkerOperations).not.toHaveBeenCalled();
-		expect(supervisor.launchWorker).not.toHaveBeenCalled();
-		expect(worker.descriptor.lifecycle).toBe("ready");
-		expect(worker.descriptor.consecutiveFailures).toBe(0);
 	});
 
 	it("reports a stop-tombstoned worker as stopping, not ready", () => {
@@ -1933,7 +1846,6 @@ describe("daemon worker supervisor monitoring", () => {
 			]),
 			clients: new Set(),
 			refreshWorkerSummaries: vi.fn(async () => {}),
-			syncAgentPeers: vi.fn(async () => {}),
 			log: vi.fn(),
 		}) as {
 			handleList(
@@ -2284,7 +2196,6 @@ describe("daemon worker supervisor monitoring", () => {
 				worker.descriptor.stopRequestedAt = undefined;
 			}),
 			deleteWorkerDescriptor: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			broadcastHeartbeatsChanged: vi.fn(),
 			log: vi.fn(),
 			reportCleanupFailure: vi.fn(),
@@ -2343,7 +2254,6 @@ describe("daemon worker supervisor monitoring", () => {
 				worker.descriptor.stopRequestedAt = undefined;
 			}),
 			deleteWorkerDescriptor: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			broadcastHeartbeatsChanged: vi.fn(),
 			log: vi.fn(),
 			reportCleanupFailure: vi.fn(),
@@ -2395,7 +2305,6 @@ describe("daemon worker supervisor monitoring", () => {
 			persistWorker: vi.fn(),
 			persistWorkerStopTombstone: vi.fn(),
 			scheduleWorkerStopFinalization: vi.fn(),
-			syncAgentPeers: vi.fn(async () => {}),
 			broadcastHeartbeatsChanged: vi.fn(),
 		}) as unknown as {
 			stopWorker(target: object, removeDescriptor: boolean, force?: boolean): Promise<void>;

--- a/packages/coding-agent/test/suite/regressions/4519-heartbeat-rebirth.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4519-heartbeat-rebirth.test.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AgentSession } from "../../../src/core/agent-session.js";
 import type { CreateAgentSessionRuntimeFactory } from "../../../src/core/agent-session-runtime.js";
 import type { AgentCronJob, AgentCronJobStore, AgentCronScheduler } from "../../../src/core/cron-jobs.js";
 import type { ActiveSessionState } from "../../../src/modes/daemon/active-session-state.js";
@@ -9,18 +8,11 @@ import { AgentDaemon } from "../../../src/modes/daemon/daemon-mode.js";
 import { createHarness, type Harness } from "../harness.js";
 
 type AgentDaemonCronInternals = {
-	agentMessagePreparingTargets: Map<string, number>;
-	agentMessageTargetLocks: Map<string, Promise<void>>;
 	cronStore: AgentCronJobStore;
 	cronScheduler: AgentCronScheduler;
 	createRuntime(command: { type: "create"; sessionPath: string }): Promise<ActiveSessionState>;
 	sessions: Map<string, ActiveSessionState>;
 	runCronJob(job: AgentCronJob): Promise<"skipped" | undefined>;
-	withAgentMessagePreparingGuard(
-		state: ActiveSessionState,
-		run: (session: AgentSession) => Promise<void>,
-		canRun?: () => boolean,
-	): Promise<boolean>;
 };
 
 function createDaemon(harness: Harness, createRuntime: CreateAgentSessionRuntimeFactory): AgentDaemon {
@@ -166,124 +158,6 @@ describe("ENG-4519 heartbeat rebirth", () => {
 
 		await expect(run).resolves.toBe("skipped");
 		expect(internals.sessions.size).toBe(0);
-	});
-
-	it("records a heartbeat cancelled while waiting to prompt as skipped", async () => {
-		const harness = await createHarness({ persistSession: true });
-		harnesses.push(harness);
-		harness.sessionManager.appendSessionState({ status: "active" });
-		const promptHeartbeat = vi.spyOn(harness.session, "promptHeartbeat").mockResolvedValue();
-		const createRuntime = vi.fn<CreateAgentSessionRuntimeFactory>(async ({ cwd, agentDir }) =>
-			runtimeResult(harness, cwd, agentDir),
-		);
-		const daemon = createDaemon(harness, createRuntime);
-		const internals = daemon as unknown as AgentDaemonCronInternals;
-		const state = await internals.createRuntime({
-			type: "create",
-			sessionPath: harness.session.sessionFile!,
-		});
-		const heartbeat = createDueHeartbeat(internals.cronStore, {
-			activeSessionId: state.activeSessionId,
-			sessionId: harness.session.sessionId,
-			sessionFile: harness.session.sessionFile!,
-			cwd: harness.tempDir,
-		});
-		let releaseLock: () => void = () => {};
-		const lock = new Promise<void>((resolve) => {
-			releaseLock = resolve;
-		});
-		internals.agentMessageTargetLocks.set(state.activeSessionId, lock);
-
-		const run = internals.cronScheduler.runDue(new Date());
-		await waitForCondition(() => internals.agentMessagePreparingTargets.has(state.activeSessionId));
-		internals.cronStore.cancel(heartbeat.id);
-		releaseLock();
-
-		await expect(run).resolves.toBe(0);
-		expect(promptHeartbeat).not.toHaveBeenCalled();
-		const storedHeartbeat = internals.cronStore.list().find((job) => job.id === heartbeat.id);
-		expect(storedHeartbeat).toMatchObject({
-			status: "cancelled",
-			runCount: 0,
-		});
-		expect(storedHeartbeat?.lastRunAt).toBeUndefined();
-	});
-
-	it("uses an updated RLM heartbeat instruction after waiting to prompt", async () => {
-		const harness = await createHarness({ persistSession: true });
-		harnesses.push(harness);
-		harness.sessionManager.appendSessionState({ status: "active" });
-		const promptHeartbeat = vi.spyOn(harness.session, "promptHeartbeat").mockResolvedValue();
-		const createRuntime = vi.fn<CreateAgentSessionRuntimeFactory>(async ({ cwd, agentDir }) =>
-			runtimeResult(harness, cwd, agentDir),
-		);
-		const daemon = createDaemon(harness, createRuntime);
-		const internals = daemon as unknown as AgentDaemonCronInternals;
-		const state = await internals.createRuntime({
-			type: "create",
-			sessionPath: harness.session.sessionFile!,
-		});
-		const heartbeat = internals.cronStore.createRlmHeartbeat({
-			activeSessionId: state.activeSessionId,
-			sessionId: harness.session.sessionId,
-			sessionFile: harness.session.sessionFile!,
-			cwd: harness.tempDir,
-			scheduleText: "every 10s",
-			prompt: "old instruction",
-			now: new Date(Date.now() - 20_000),
-		});
-		let releaseLock: () => void = () => {};
-		const lock = new Promise<void>((resolve) => {
-			releaseLock = resolve;
-		});
-		internals.agentMessageTargetLocks.set(state.activeSessionId, lock);
-
-		const run = internals.cronScheduler.runDue(new Date());
-		await waitForCondition(() => internals.agentMessagePreparingTargets.has(state.activeSessionId));
-		internals.cronStore.updateRlmHeartbeat(state.activeSessionId, heartbeat.id, {
-			prompt: "updated instruction",
-		});
-		releaseLock();
-
-		await expect(run).resolves.toBe(1);
-		expect(promptHeartbeat).toHaveBeenCalledWith(
-			expect.objectContaining({ id: heartbeat.id, prompt: "updated instruction" }),
-			expect.anything(),
-		);
-	});
-
-	it("uses the current runtime session after waiting for a prompt lock", async () => {
-		const original = await createHarness();
-		const replacement = await createHarness();
-		harnesses.push(original, replacement);
-		const daemon = createDaemon(original, async () => {
-			throw new Error("runtime creation is not expected");
-		});
-		const internals = daemon as unknown as AgentDaemonCronInternals;
-		const activeSessionId = "active-session";
-		const runtime = { session: original.session };
-		const state = { activeSessionId, runtime } as unknown as ActiveSessionState;
-		internals.sessions.set(activeSessionId, state);
-		let releaseLock: () => void = () => {};
-		const lock = new Promise<void>((resolve) => {
-			releaseLock = resolve;
-		});
-		internals.agentMessageTargetLocks.set(activeSessionId, lock);
-		let promptedSession: AgentSession | undefined;
-
-		const guardedRun = internals.withAgentMessagePreparingGuard(
-			state,
-			async (session) => {
-				promptedSession = session;
-			},
-			() => runtime.session === replacement.session,
-		);
-		await waitForCondition(() => internals.agentMessagePreparingTargets.has(activeSessionId));
-		runtime.session = replacement.session;
-		releaseLock();
-
-		await expect(guardedRun).resolves.toBe(true);
-		expect(promptedSession).toBe(replacement.session);
 	});
 
 	it("still restores and prompts a session explicitly persisted as active", async () => {

--- a/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4602-snapshot-transfer-idempotency.test.ts
@@ -581,19 +581,16 @@ describe("ENG-4602 snapshot transfer containment", () => {
 		});
 		const recoverWorker = vi.fn(async () => {});
 		const persistWorker = vi.fn();
-		const syncAgentPeers = vi.fn(async () => {});
 		const assertRecoveryAllowed = vi.fn(async () => {});
 		const internals = supervisor as unknown as {
 			workers: Map<string, WorkerHarness>;
 			recoverWorker: typeof recoverWorker;
 			persistWorker: typeof persistWorker;
-			syncAgentPeers: typeof syncAgentPeers;
 			assertRecoveryAllowed: typeof assertRecoveryAllowed;
 			handleWorkerFrame(worker: WorkerHarness, frame: PrivateFrame<DaemonWorkerFrameHeader>): void;
 		};
 		internals.recoverWorker = recoverWorker;
 		internals.persistWorker = persistWorker;
-		internals.syncAgentPeers = syncAgentPeers;
 		internals.assertRecoveryAllowed = assertRecoveryAllowed;
 		const frames = snapshotFrames([{ role: "user", content: "stable", timestamp: 1 }]);
 

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -149,22 +149,16 @@ async function runRpc(
 }
 
 describe("ENG-4685 daemon-backed client modes", () => {
-	it("commits owned-worker promotion before best-effort peer synchronization", async () => {
+	it("commits owned-worker promotion once", async () => {
 		const client = { id: "client-1" } as DaemonSocketClient;
 		const worker = {
 			descriptor: { ownerClientId: "protocol-client" },
 			launchEnv: { TEST: "value" },
 		};
 		const persistWorker = vi.fn();
-		const syncAgentPeers = vi.fn(async () => {
-			throw new Error("peer unavailable");
-		});
-		const log = vi.fn();
 		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
 			protocolClientId: () => "protocol-client",
 			persistWorker,
-			syncAgentPeers,
-			log,
 		}) as {
 			promoteOwnedWorker(client: DaemonSocketClient, resident: typeof worker): Promise<void>;
 		};
@@ -175,8 +169,6 @@ describe("ENG-4685 daemon-backed client modes", () => {
 		expect(worker.descriptor.ownerClientId).toBeUndefined();
 		expect(worker.launchEnv).toBeUndefined();
 		expect(persistWorker).toHaveBeenCalledOnce();
-		expect(syncAgentPeers).toHaveBeenCalledOnce();
-		expect(log).toHaveBeenCalledWith(expect.stringContaining("peer unavailable"));
 	});
 
 	it("rolls back owned-worker promotion when persistence fails", async () => {


### PR DESCRIPTION
> **Note:** this PR also contains the full change from #1856 (worker-initiated on-demand agent-peer listing replacing the supervisor roster push, with fast-fail for unknown legacy worker commands) - that PR is closed and merges here as one unit.

## What was wrong

The daemon re-implemented admission decisions that AgentSession already owns: it predicted busy/queue state, maintained target locks, reservations, refcounts, and accepting/preparing sets around the session's own admission fences and action scheduling — a parallel state machine that had to mirror core's semantics to stay correct (audit: overlap.md finding 3, the largest responsibility overlap found).

## The fix

+401/−2,108. The daemon always calls `acceptAgentMessagePrompt`; AgentSession owns the single accept-or-queue choice. All four daemon structures and their helper wrappers are deleted:
- The 20-message cap moved to the synchronous admission choke point — the reservation refcounts that compensated for the daemon's async check-then-enqueue gap dissolve rather than move (core has no such gap).
- Target-lock serialization is replaced by the core FIFO admission fence every prompt path already traverses.
- Cron enters through the same fence; passivation reads core's admission-waiter state, accurate precisely because everything now goes through the fence.
- One 10-line core branch covers the direct-compaction window (pump abort-suspended) at exact parity with the old daemon queueing — retention until resume, delivery exactly once, no new timeouts.

Developed tests-first: four concurrency interleavings (message vs turn, vs cron, concurrent, during compaction) were written against the old code before any deletion; the compaction gap they exposed drove the design.

## How it's verified

Reviewer performed a full deletion audit (every structure's responsibility traced to its absorber), verified the +18 core lines reuse existing primitives, traced receipt parity across all dispositions (including the mutual-busy-senders no-deadlock property), validated compaction retention/exactly-once tests, and confirmed cron fence/pause semantics at parity with base. 17 concurrency tests + 177 adjacent tests green; full CI-style failing file sets exactly identical to stack base (verified on a detached base worktree). Two-model implement/review loop.

Stacked on #1754 (test the whole stack at the leaf; merge base-first). Final PR of the audit stack.

Note: intentionally no Linear ticket for this cleanup stack, so that check stays red.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session admission and daemon messaging concurrency; mis-timed `admissionCommitted` or queue semantics could affect cron delivery and cross-worker targeting, though extensive tests cover the main interleavings.
> 
> **Overview**
> **Agent-to-agent delivery now routes through `AgentSession` admission** instead of daemon-side locks, reservations, and busy heuristics. The daemon calls `acceptAgentMessagePrompt` with `queueIfBusy: true`; core decides immediate vs queued delivery, enforces the pending-message cap at admission, and exposes `clearQueuedAgentMessages` with a clear epoch so in-flight admissions fail if the queue was cleared.
> 
> **`admissionCommitted` hooks** let callers re-validate state after async preflight work: cron/heartbeat jobs skip when cancelled or mutated before commit; daemon checks pause, closing sessions, and target identity at commit time.
> 
> **Cross-worker agent rosters are on-demand**: schema revision 23 adds authenticated `list_agent_peers` on the supervisor; workers query it when building message lists. The broadcast `worker_sync_agent_peers` path and `remoteAgentPeers` cache are removed, with unknown worker commands failing fast instead of hanging.
> 
> Daemon prompts and cron no longer use `promptWithAgentMessagePreparingGuard` or per-target serialization—the same session input fence serializes everything.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985234c141886ff05d1f25dfc2c508d8dc7f84d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Linear ticket: [ENG-5669](https://linear.app/primeintellect/issue/ENG-5669/refactorcoding-agent-centralize-agent-message-admission-in)
(ticket linked above)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize agent-message admission in `AgentSession` and replace push-based peer sync with on-demand `list_agent_peers`
> - Moves agent-message admission, queuing, and capacity checks into `AgentSession` via `acceptAgentMessagePrompt`, `clearQueuedAgentMessages`, and `assertAgentMessageQueueCapacity`; removes daemon-level target locks, queue reservations, and preparing/accepting state maps from `AgentDaemon`
> - Replaces periodic `syncAgentPeers` push synchronization with an authenticated `list_agent_peers` supervisor query (schema rev 23); workers fetch peer rosters on demand and receive an empty list on error
> - Cron and heartbeat prompts now validate staleness at admission time through an `admissionCommitted` callback that throws a sentinel error to skip cancelled or updated jobs; `_prompt` re-checks admission after async input handlers
> - Unknown worker commands now fail fast with an error response instead of timing out
> - Risk: removes `DaemonWorkerCommand` variant `worker_sync_agent_peers` and the `AgentDaemon` fields `remoteAgentPeers`, `agentMessageTargetLocks`, `agentMessageAcceptingTargets`, `agentMessagePreparingTargets`, and `agentMessagePendingReservations`; out-of-tree code referencing these will break. Session active detection in `getSessionSummaryForState` no longer consults the removed maps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 985234c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->