### PR TITLE
docs(coding-agent): document the daemon clientId trust model

### DIFF
--- a/packages/coding-agent/.changes/daemon-clientid-trust-model.md
+++ b/packages/coding-agent/.changes/daemon-clientid-trust-model.md
@@ -1,0 +1,1 @@
+- Documented the daemon protocol clientId trust model: it is a same-user reconnection cookie, not authentication; unix socket permissions remain the security boundary.

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -625,6 +625,8 @@ export class DaemonSupervisor {
 	private readonly connectionIds = new WeakMap<DaemonSocketClient, string>();
 	private readonly sessionInputPauseEpochs = new WeakMap<DaemonSocketClient, number>();
 	private readonly detachingInputPauseSessions = new WeakMap<DaemonSocketClient, Set<string>>();
+	// Self-asserted same-user reconnection cookie, not auth: socket perms (0o700 dir/0o600 socket) are the boundary.
+	// ownerClientId checks derived from it are collision hygiene between cooperating clients, not access control.
 	private readonly protocolClientIds = new WeakMap<DaemonSocketClient, string>();
 	private readonly workers = new Map<string, ResidentWorker>();
 	private workerStopCounts?: Map<ResidentWorker, number>;
@@ -1378,6 +1380,7 @@ export class DaemonSupervisor {
 		}
 		const envelopeClientId = preParsed.envelopeClientId;
 		if (envelopeClientId) {
+			// Trust the asserted cookie: reconnects legitimately replay it on a new socket before the old one closes.
 			this.protocolClientIds.set(client, envelopeClientId);
 			client.id = envelopeClientId;
 		}


### PR DESCRIPTION
Documents the daemon protocol identity trust model at the point where it is established.

- `clientId` is a self-asserted, per-client-instance reconnection cookie (`daemon-client:<uuid>`), replayed unchanged across socket reconnects so request recovery and owned-worker grace cleanup can recognize a returning client.
- It is NOT authentication: the unix socket permissions (0o700 directory, 0o600 socket) are the security boundary; any same-user process can assert any cookie.
- `ownerClientId` checks derived from it are collision hygiene between cooperating clients, not access control.

Documentation-only (+3 comment lines). The optional hardening from the ticket (binding a cookie to the first live socket) was investigated and deliberately rejected: reconnecting clients legitimately re-assert their cookie on a new socket before the supervisor observes the old fd's close event (the owned-worker cleanup path explicitly scans all live clients for a matching cookie), so takeover rejection would nondeterministically break request replay - and it adds no security at a same-user boundary.

Linear: [ENG-5695](https://linear.app/primeintellect/issue/ENG-5695/daemon-documentharden-self-asserted-protocol-clientid-reconnection)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and changelog only; no runtime, auth, or protocol logic changes.
> 
> **Overview**
> **Documentation-only** clarification of how daemon protocol **`clientId`** is treated in the supervisor—no behavior changes.
> 
> The **`protocolClientIds`** map and envelope handling are annotated to state that **`clientId`** is a **self-asserted same-user reconnection cookie** (replayed on a new socket before the old connection closes), **not authentication**. Unix socket permissions (**0o700** dir, **0o600** socket) remain the security boundary; **`ownerClientId`** checks are **collision hygiene** between cooperating clients, not access control.
> 
> A **changelog** entry in `.changes/daemon-clientid-trust-model.md` records the same model for release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b484add79f0796b243240ff9d5af55dc2302c946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document daemon `clientId` trust model in `DaemonSupervisor` comments
> Adds comments to [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1863/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8) clarifying that the protocol `clientId` is a self-asserted same-user reconnection cookie, not an authentication mechanism. States that Unix socket permissions (`0o700` directory, `0o600` socket) are the real security boundary and that `ownerClientId` checks exist for collision hygiene among cooperating clients. Adds a matching changelog entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b484add.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->