### PR TITLE
extensions: expose shared IPython kernel and tool-execution recording to extensions

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -119,6 +119,7 @@ import {
 	type ExtensionCommandContextActions,
 	type ExtensionErrorListener,
 	ExtensionRunner,
+	type ExtensionToolExecutionRecord,
 	type ExtensionUIContext,
 	type InputSource,
 	type MessageEndEvent,
@@ -1490,6 +1491,37 @@ export class AgentSession {
 				// receiving lifecycle and persistence events.
 			}
 		}
+	}
+
+	/**
+	 * Replay an extension-reported tool execution as the same
+	 * tool_execution_start/tool_execution_end records the agent loop emits for
+	 * native tool calls (packages/agent agent-loop.ts), so JSON-stream and
+	 * daemon consumers observe extension-driven executions identically. The
+	 * pair is also persisted to the session file; native executions are not
+	 * (they persist as toolResult message entries instead), but recorded ones
+	 * have no message to hang on, so the raw records are the durable trace.
+	 */
+	private _recordExtensionToolExecution(execution: ExtensionToolExecutionRecord): void {
+		const toolCallId =
+			execution.toolCallId ?? `recorded-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+		const args = execution.input;
+		this._emit({ type: "tool_execution_start", toolCallId, toolName: execution.toolName, args });
+		const content: TextContent[] = [{ type: "text", text: execution.output ?? "" }];
+		const details: Record<string, unknown> = {};
+		if (execution.title !== undefined) details.title = execution.title;
+		if (execution.exitCode !== undefined) details.exitCode = execution.exitCode;
+		if (execution.durationMs !== undefined) details.durationMs = execution.durationMs;
+		const isError = execution.isError ?? (execution.exitCode !== undefined ? execution.exitCode !== 0 : false);
+		this._emit({
+			type: "tool_execution_end",
+			toolCallId,
+			toolName: execution.toolName,
+			result: { content, details },
+			isError,
+		});
+		this.sessionManager.appendToolExecutionStart(toolCallId, execution.toolName, args, execution.startedAt);
+		this.sessionManager.appendToolExecutionEnd(toolCallId, execution.toolName, { content, details }, isError);
 	}
 
 	private _emitQueueUpdate(): void {
@@ -8788,6 +8820,9 @@ export class AgentSession {
 				setActiveTools: (toolNames) => this.setActiveToolsByName(toolNames),
 				refreshTools: () => this._refreshToolRegistry(),
 				getIpythonKernel: () => this._ipythonKernelProvisioner,
+				recordToolExecution: (execution) => {
+					this._recordExtensionToolExecution(execution);
+				},
 				getCommands,
 				setModel: async (model) => {
 					if (!this.modelRegistry.hasConfiguredAuth(model)) return false;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -8787,6 +8787,7 @@ export class AgentSession {
 				getAllTools: () => this.getAllTools(),
 				setActiveTools: (toolNames) => this.setActiveToolsByName(toolNames),
 				refreshTools: () => this._refreshToolRegistry(),
+				getIpythonKernel: () => this._ipythonKernelProvisioner,
 				getCommands,
 				setModel: async (model) => {
 					if (!this.modelRegistry.hasConfiguredAuth(model)) return false;

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -65,6 +65,7 @@ export type {
 	ExtensionHandler,
 	ExtensionRuntime,
 	ExtensionShortcut,
+	ExtensionToolExecutionRecord,
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
 	ExtensionWidgetOptions,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -139,6 +139,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
 		getThinkingLevel: notInitialized,
 		setThinkingLevel: notInitialized,
+		getIpythonKernel: notInitialized,
 		flagValues: new Map(),
 		pendingProviderRegistrations: [],
 		assertActive,
@@ -302,6 +303,11 @@ function createExtensionAPI(
 		setThinkingLevel(level) {
 			runtime.assertActive();
 			runtime.setThinkingLevel(level);
+		},
+
+		getIpythonKernel() {
+			runtime.assertActive();
+			return runtime.getIpythonKernel?.();
 		},
 
 		registerProvider(name: string, config: ProviderConfig) {

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -140,6 +140,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		getThinkingLevel: notInitialized,
 		setThinkingLevel: notInitialized,
 		getIpythonKernel: notInitialized,
+		recordToolExecution: notInitialized,
 		flagValues: new Map(),
 		pendingProviderRegistrations: [],
 		assertActive,
@@ -308,6 +309,11 @@ function createExtensionAPI(
 		getIpythonKernel() {
 			runtime.assertActive();
 			return runtime.getIpythonKernel?.();
+		},
+
+		recordToolExecution(execution) {
+			runtime.assertActive();
+			runtime.recordToolExecution?.(execution);
 		},
 
 		registerProvider(name: string, config: ProviderConfig) {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -31,6 +31,7 @@ import type {
 	ExtensionFlag,
 	ExtensionRuntime,
 	ExtensionShortcut,
+	ExtensionToolExecutionRecord,
 	ExtensionUIContext,
 	InputEvent,
 	InputEventResult,
@@ -251,6 +252,7 @@ export class ExtensionRunner {
 	private compactFn: (options?: CompactOptions) => void = () => {};
 	private getSystemPromptFn: () => string = () => "";
 	private getIpythonKernelFn: () => IpythonKernelProvisioner | undefined = () => undefined;
+	private recordToolExecutionFn: (execution: ExtensionToolExecutionRecord) => void = () => {};
 	private newSessionHandler: NewSessionHandler = async () => ({ cancelled: false });
 	private forkHandler: ForkHandler = async () => ({ cancelled: false });
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
@@ -313,6 +315,10 @@ export class ExtensionRunner {
 		// action) so either surface can reach the agent's own kernel.
 		this.getIpythonKernelFn = actions.getIpythonKernel ?? (() => undefined);
 		this.runtime.getIpythonKernel = this.getIpythonKernelFn;
+		// Extension-driven tool executions replay as native tool_execution_*
+		// events; hosts that do not bind the action drop them silently.
+		this.recordToolExecutionFn = actions.recordToolExecution ?? (() => {});
+		this.runtime.recordToolExecution = this.recordToolExecutionFn;
 
 		for (const { name, config, extensionPath } of this.runtime.pendingProviderRegistrations) {
 			try {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -11,6 +11,7 @@ import type { KeybindingsConfig } from "../keybindings.js";
 import type { ModelRegistry } from "../model-registry.js";
 import type { SessionManager } from "../session-manager.js";
 import type { BuildSystemPromptOptions } from "../system-prompt.js";
+import type { IpythonKernelProvisioner } from "../tools/index.js";
 import type {
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
@@ -249,6 +250,7 @@ export class ExtensionRunner {
 	private getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	private compactFn: (options?: CompactOptions) => void = () => {};
 	private getSystemPromptFn: () => string = () => "";
+	private getIpythonKernelFn: () => IpythonKernelProvisioner | undefined = () => undefined;
 	private newSessionHandler: NewSessionHandler = async () => ({ cancelled: false });
 	private forkHandler: ForkHandler = async () => ({ cancelled: false });
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
@@ -306,6 +308,11 @@ export class ExtensionRunner {
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
+		// The shared IPython kernel provisioner is host session state; it is
+		// exposed on both ctx (via getIpythonKernelFn) and pi (via the runtime
+		// action) so either surface can reach the agent's own kernel.
+		this.getIpythonKernelFn = actions.getIpythonKernel ?? (() => undefined);
+		this.runtime.getIpythonKernel = this.getIpythonKernelFn;
 
 		for (const { name, config, extensionPath } of this.runtime.pendingProviderRegistrations) {
 			try {
@@ -634,6 +641,10 @@ export class ExtensionRunner {
 			getSystemPrompt: () => {
 				runner.assertActive();
 				return runner.getSystemPromptFn();
+			},
+			getIpythonKernel: () => {
+				runner.assertActive();
+				return runner.getIpythonKernelFn();
 			},
 		};
 	}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -726,6 +726,34 @@ export interface ToolExecutionEndEvent {
 	result: any;
 	isError: boolean;
 }
+
+/**
+ * A completed tool execution reported by an extension via
+ * pi.recordToolExecution(). The host replays it as the same
+ * tool_execution_start + tool_execution_end records the agent loop emits for
+ * native tool calls, so stream consumers (JSON event log, daemon broadcast)
+ * observe extension-driven executions identically.
+ */
+export interface ExtensionToolExecutionRecord {
+	/** Tool name to attribute the execution to (e.g. "ipython"). */
+	toolName: string;
+	/** Call id correlating the start/end records; generated when omitted. */
+	toolCallId?: string;
+	/** Human-readable label for the execution. */
+	title?: string;
+	/** Tool input (e.g. { code }) — surfaced as the start record's args. */
+	input?: unknown;
+	/** Text output — surfaced as the end record's result content. */
+	output?: string;
+	/** Marks the end record as an error (defaults to exitCode !== 0). */
+	isError?: boolean;
+	/** Exit code, surfaced in result details and used to derive isError. */
+	exitCode?: number;
+	/** Epoch ms when the execution started. */
+	startedAt?: number;
+	/** Wall duration in ms, surfaced in result details. */
+	durationMs?: number;
+}
 export type ModelSelectSource = "set" | "cycle" | "restore";
 
 /** Fired when a new model is selected */
@@ -1126,6 +1154,15 @@ export interface ExtensionAPI {
 	 */
 	getIpythonKernel?(): IpythonKernelProvisioner | undefined;
 
+	/**
+	 * Record an extension-driven tool execution into the session event stream
+	 * as the same tool_execution_start + tool_execution_end events the agent
+	 * loop emits for native tool calls, and persist the pair to the session
+	 * file. Optional: hosts that do not support it expose no member, so
+	 * callers should optional-chain (pi.recordToolExecution?.(...)).
+	 */
+	recordToolExecution?(execution: ExtensionToolExecutionRecord): void;
+
 	/** Get available slash commands in the current session. */
 	getCommands(): SlashCommandInfo[];
 	/** Set the current model. Returns false if no API key available. */
@@ -1387,6 +1424,12 @@ export interface ExtensionActions {
 	 * an IPython kernel can still bind the core actions.
 	 */
 	getIpythonKernel?: () => IpythonKernelProvisioner | undefined;
+	/**
+	 * Record an extension-driven tool execution as native
+	 * tool_execution_start/end events. Optional so hosts without an event
+	 * stream can still bind the core actions (such hosts drop the records).
+	 */
+	recordToolExecution?: (execution: ExtensionToolExecutionRecord) => void;
 }
 
 /**

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -66,6 +66,7 @@ import type {
 	BashToolDetails,
 	BashToolInput,
 	EditToolInput,
+	IpythonKernelProvisioner,
 	IpythonToolDetails,
 	IpythonToolInput,
 } from "../tools/index.js";
@@ -308,6 +309,12 @@ export interface ExtensionContext {
 	compact(options?: CompactOptions): void;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
+	/**
+	 * Access the agent's shared IPython kernel provisioner (the same kernel
+	 * the `ipython` tool executes on). Returns undefined when no session
+	 * runtime with an IPython kernel is active.
+	 */
+	getIpythonKernel?(): IpythonKernelProvisioner | undefined;
 }
 
 /**
@@ -1101,6 +1108,24 @@ export interface ExtensionAPI {
 	/** Set the active tools by name. */
 	setActiveTools(toolNames: string[]): void;
 
+	/**
+	 * Access the agent's shared IPython kernel provisioner (the same kernel
+	 * the `ipython` tool executes on), so extensions can run code without
+	 * provisioning their own kernel.
+	 *
+	 * Returns undefined when no session runtime with an IPython kernel is
+	 * active (e.g. hosts that never built one). Throws when called during
+	 * extension loading, before the session runtime is bound.
+	 *
+	 * @example
+	 * const provisioner = pi.getIpythonKernel?.();
+	 * if (provisioner) {
+	 *   const manager = await provisioner.ensure();
+	 *   const result = await manager.execute("print('hello from extension')");
+	 * }
+	 */
+	getIpythonKernel?(): IpythonKernelProvisioner | undefined;
+
 	/** Get available slash commands in the current session. */
 	getCommands(): SlashCommandInfo[];
 	/** Set the current model. Returns false if no API key available. */
@@ -1356,6 +1381,12 @@ export interface ExtensionActions {
 	setModel: SetModelHandler;
 	getThinkingLevel: GetThinkingLevelHandler;
 	setThinkingLevel: SetThinkingLevelHandler;
+	/**
+	 * Get the host session's shared IPython kernel provisioner, or undefined
+	 * when the host has no active kernel runtime. Optional so hosts without
+	 * an IPython kernel can still bind the core actions.
+	 */
+	getIpythonKernel?: () => IpythonKernelProvisioner | undefined;
 }
 
 /**

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -198,6 +198,30 @@ export interface GitStateEntry extends SessionEntryBase {
 	git: GitContext;
 }
 
+/**
+ * A tool execution reported by the host (e.g. via the extension
+ * recordToolExecution API) instead of driven by the agent loop. Mirrors the
+ * tool_execution_start agent event so stream consumers and the session file
+ * treat recorded and native executions alike.
+ */
+export interface ToolExecutionStartEntry extends SessionEntryBase {
+	type: "tool_execution_start";
+	toolCallId: string;
+	toolName: string;
+	args?: unknown;
+	/** Epoch ms when the execution started, when the reporter knows it. */
+	startedAt?: number;
+}
+
+export interface ToolExecutionEndEntry extends SessionEntryBase {
+	type: "tool_execution_end";
+	toolCallId: string;
+	toolName: string;
+	/** ToolResult-shaped payload: content blocks plus optional details. */
+	result?: { content: (TextContent | ImageContent)[]; details?: Record<string, unknown> };
+	isError?: boolean;
+}
+
 export interface CustomMessageEntry<T = unknown> extends SessionEntryBase {
 	type: "custom_message";
 	customType: string;
@@ -220,7 +244,9 @@ export type SessionEntry =
 	| SessionInfoEntry
 	| SessionStateEntry
 	| AgentStatusEntry
-	| GitStateEntry;
+	| GitStateEntry
+	| ToolExecutionStartEntry
+	| ToolExecutionEndEntry;
 
 export type FileEntry = SessionHeader | SessionEntry;
 
@@ -1526,6 +1552,41 @@ export class SessionManager {
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 			state: { status: state.status },
+		};
+		this._appendEntry(entry);
+		return entry.id;
+	}
+
+	appendToolExecutionStart(toolCallId: string, toolName: string, args?: unknown, startedAt?: number): string {
+		const entry: ToolExecutionStartEntry = {
+			type: "tool_execution_start",
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			toolCallId,
+			toolName,
+			...(args !== undefined ? { args } : {}),
+			...(startedAt !== undefined ? { startedAt } : {}),
+		};
+		this._appendEntry(entry);
+		return entry.id;
+	}
+
+	appendToolExecutionEnd(
+		toolCallId: string,
+		toolName: string,
+		result: { content: (TextContent | ImageContent)[]; details?: Record<string, unknown> },
+		isError: boolean,
+	): string {
+		const entry: ToolExecutionEndEntry = {
+			type: "tool_execution_end",
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			toolCallId,
+			toolName,
+			result,
+			isError,
 		};
 		this._appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -239,6 +239,22 @@ export interface AgentConnectionGitStateEntry extends AgentConnectionSessionEntr
 	};
 }
 
+export interface AgentConnectionToolExecutionStartEntry extends AgentConnectionSessionEntryBase {
+	type: "tool_execution_start";
+	toolCallId: string;
+	toolName: string;
+	args?: unknown;
+	startedAt?: number;
+}
+
+export interface AgentConnectionToolExecutionEndEntry extends AgentConnectionSessionEntryBase {
+	type: "tool_execution_end";
+	toolCallId: string;
+	toolName: string;
+	result?: { content: (TextContent | ImageContent)[]; details?: Record<string, unknown> };
+	isError?: boolean;
+}
+
 export type AgentConnectionSessionEntry =
 	| AgentConnectionSessionMessageEntry
 	| AgentConnectionThinkingLevelChangeEntry
@@ -253,7 +269,9 @@ export type AgentConnectionSessionEntry =
 	| AgentConnectionSessionInfoEntry
 	| AgentConnectionSessionStateEntry
 	| AgentConnectionAgentStatusEntry
-	| AgentConnectionGitStateEntry;
+	| AgentConnectionGitStateEntry
+	| AgentConnectionToolExecutionStartEntry
+	| AgentConnectionToolExecutionEndEntry;
 
 export interface AgentConnectionSessionTreeFlatNode {
 	entry: AgentConnectionSessionEntry;


### PR DESCRIPTION
## Motivation

Extensions currently cannot participate in two core capabilities of the agent session:

1. **The agent's IPython kernel is private.** An extension that wants to run code (e.g. a custom provider whose sub-agent emits shell/python work) must provision its own kernel, doubling kernel processes and losing shared state with the agent's `ipython` tool.
2. **Extension-driven executions are invisible to traces.** Work performed by extensions never appears as `tool_execution_*` events, so `--mode json` streams, session JSONL, and downstream report tooling cannot see it.

We use both together to give a Cursor ACP-hosted model (composer-2.5) native, kernel-backed execution inside Prime Agent: its shell/python commands are fulfilled on the agent's shared kernel, and every execution surfaces as a native `ipython` tool execution in the trace.

## Changes

Two optional, purely additive `ExtensionAPI`/`ExtensionContext` members, wired through the existing runtime-action/Fn-injection pattern:

- **`getIpythonKernel?(): IpythonKernelProvisioner | undefined`** — returns the agent session's provisioner (same object the `ipython` tool uses; lazy field read so it is correct across `/reload` rebuilds). Undefined when no runtime is active.
- **`recordToolExecution?(event)`** — emits the same `tool_execution_start`/`tool_execution_end` records the agent loop emits (shape-identical, any `toolName`), and persists the pair to the session JSONL via new `appendToolExecutionStart/End` session-manager methods (extension executions have no toolResult message to hang them on). `isError` defaults to `exitCode !== 0`; `title`/`exitCode`/`durationMs` ride in `result.details`.

Both are optional everywhere: hosts without them keep working, tests/mocks are unchanged, native behavior is untouched.

## Evidence

- Full checks pass: biome, tsgo, vitest (extensions-runner 28/28, agent-connection suites), installer, browser-smoke.
- Live probe (composer-2.5 via ACP): `ctx.getIpythonKernel()` and `pi.getIpythonKernel()` both present; a real `print()` executed on the agent kernel through `provisioner.ensure() + manager.execute()`.
- Trace probe: `recordToolExecution` produces `{"type":"tool_execution_start","toolCallId":"...","toolName":"ipython","args":{...}}` + matching `end` in both the `--mode json` stream and the session JSONL; downstream log analysis reports `ipython_calls=1, ok=1` where it previously saw 0. Sessions reload cleanly with the new entry types (`loadEntriesFromFile`).
- End-to-end benchmark (3-task SWE trio, composer-2.5): all executions flowed through the shared kernel and appeared in native trace events; resolve rate unchanged vs. baseline, wall time −42%.

## Design notes for reviewers

- Events are shape-identical to agent-loop events. If you prefer distinguishing recorded executions, an `origin/source` field ("agent-loop" | "extension") can be added without changing consumers.
- `SessionEntry` and the `AgentConnectionSessionEntry` mirror union must stay in sync when adding entry types (the build catches drift).
- The daemon recovery-checkpoint list already includes `tool_execution_start/end`, so recorded events integrate with recovery fences for free.
- `--no-session` sessions are in-memory by design and write no JSONL; one-shot harnesses wanting durable records use session-ful runs or the `--mode json` stream.

## Testing

`npm run build`, `node dist/cli.js --version`, vitest suites, plus the probe evidence above. No changes to existing tests.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `getIpythonKernel` and `recordToolExecution` to extensions and persist tool execution entries
> - `AgentSession` binds `getIpythonKernel` (returns the IPython kernel provisioner) and `recordToolExecution` to the extension runtime, so extensions can access the shared kernel and report tool executions.
> - When an extension calls `recordToolExecution`, `AgentSession` emits `tool_execution_start`/`tool_execution_end` events and appends matching entries to the session log via new `SessionManager` methods `appendToolExecutionStart` and `appendToolExecutionEnd`.
> - Extension API surface in [loader.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1869/files#diff-311c408e76f099de0c37a26f8e4593f9560453788fa6f74b297f1faf04bf9097) and [runner.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1869/files#diff-f670444e55f19c700a16b9ea0e34ecd83f80894b8a4633f4a05a1a1f46726321) uses guarded stubs that throw before binding and delegate after binding.
> - Adds `ToolExecutionStartEntry` and `ToolExecutionEndEntry` to the session entry unions in both `SessionManager` and agent-connection types.
> - Risk: `getIpythonKernel()` and `recordToolExecution()` on the extension API throw if called before runtime binding; extensions relying on them must handle that case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72952e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->