### PR TITLE
fix(coding-agent): reconcile completed worker status

### DIFF
--- a/packages/coding-agent/.changes/fix-stale-worker-status.md
+++ b/packages/coding-agent/.changes/fix-stale-worker-status.md
@@ -1,0 +1,1 @@
+- Fixed completed resident subagents appearing active when their in-memory execution state was stale.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -200,6 +200,7 @@ import {
 	RlmSpawnLedger,
 } from "./rlm-ledger.js";
 import {
+	type RlmSubagentDisplayEntry,
 	readRlmSubagentDisplayEntry,
 	rlmSubagentDisplayPath,
 	writeRlmSubagentDisplayEntry,
@@ -3160,13 +3161,15 @@ export class AgentDaemon {
 	}
 
 	private async createAgentObserveListResult(currentState: ActiveSessionState): Promise<AgentObserveListResult> {
-		const agents = this.listTargetableSessionStates(currentState)
-			.filter(
-				(state) =>
-					state.activeSessionId === currentState.activeSessionId ||
-					this.isAgentFamilyReachable(currentState, state),
-			)
-			.map((state) => this.createAgentObserveSummary(state, currentState));
+		const targetableStates = this.listTargetableSessionStates(currentState).filter(
+			(state) =>
+				state.activeSessionId === currentState.activeSessionId || this.isAgentFamilyReachable(currentState, state),
+		);
+		const agents = await Promise.all(
+			targetableStates.map(async (state) =>
+				this.createAgentObserveSummary(state, currentState, await this.readResidentRlmLifecycleStatus(state)),
+			),
+		);
 		const residentIds = new Set(agents.map((agent) => agent.activeSessionId));
 		for (const passive of await this.listPassiveRlmSubagents()) {
 			if (residentIds.has(passive.info.id)) continue;
@@ -3201,7 +3204,9 @@ export class AgentDaemon {
 			residentIds.add(passive.info.id);
 		}
 		return {
-			current: this.createAgentObserveSummary(currentState, currentState),
+			current:
+				agents.find((agent) => agent.activeSessionId === currentState.activeSessionId) ??
+				this.createAgentObserveSummary(currentState, currentState),
 			agents,
 		};
 	}
@@ -3213,7 +3218,11 @@ export class AgentDaemon {
 		const targetState = await this.getOrHydrateAuthorizedAgentFamilyTarget(currentState, target);
 		this.assertAgentFamilyReachable(currentState, targetState);
 		return {
-			agent: this.createAgentObserveSummary(targetState, currentState),
+			agent: this.createAgentObserveSummary(
+				targetState,
+				currentState,
+				await this.readResidentRlmLifecycleStatus(targetState),
+			),
 		};
 	}
 
@@ -3228,7 +3237,11 @@ export class AgentDaemon {
 		const messages = targetState.runtime.session.messages;
 		const startIndex = Math.max(0, messages.length - limit);
 		return {
-			agent: this.createAgentObserveSummary(targetState, currentState),
+			agent: this.createAgentObserveSummary(
+				targetState,
+				currentState,
+				await this.readResidentRlmLifecycleStatus(targetState),
+			),
 			messages: messages
 				.slice(startIndex)
 				.map((message, offset) => createAgentObserveMessagePreview(message, startIndex + offset, maxChars)),
@@ -3241,22 +3254,26 @@ export class AgentDaemon {
 	private createAgentObserveSummary(
 		state: ActiveSessionState,
 		currentState: ActiveSessionState,
+		rlmLifecycleStatus?: RlmSubagentDisplayEntry["status"],
 	): AgentObserveAgentSummary {
 		const summary = summaryForActiveSession(state);
 		const session = state.runtime.session;
 		const messages = session.messages;
 		const latest = messages.at(-1);
-		const status = session.isStreaming
-			? session.state.pendingToolCalls.size > 0
-				? "tool"
-				: "model"
-			: session.isCompacting
-				? "compacting"
-				: session.isSessionActive || session.hasRunningRlmChildren()
-					? "busy"
-					: state.clients.size > 0
-						? "user"
-						: "idle";
+		const isTerminalRlmChild = rlmLifecycleStatus === "completed" || rlmLifecycleStatus === "deleted";
+		const status = isTerminalRlmChild
+			? "idle"
+			: session.isStreaming
+				? session.state.pendingToolCalls.size > 0
+					? "tool"
+					: "model"
+				: session.isCompacting
+					? "compacting"
+					: session.isSessionActive || session.hasRunningRlmChildren()
+						? "busy"
+						: state.clients.size > 0
+							? "user"
+							: "idle";
 		return {
 			activeSessionId: state.activeSessionId,
 			sessionId: summary.sessionId,
@@ -3265,12 +3282,12 @@ export class AgentDaemon {
 			cwd: summary.cwd,
 			status,
 			isCurrent: state.activeSessionId === currentState.activeSessionId,
-			isStreaming: summary.isStreaming,
-			isCompacting: summary.isCompacting,
+			isStreaming: isTerminalRlmChild ? false : summary.isStreaming,
+			isCompacting: isTerminalRlmChild ? false : summary.isCompacting,
 			attachedClients: summary.attachedClients,
 			messageCount: summary.messageCount,
-			queuedCount: summary.sessionActions.queuedCount,
-			isSessionActive: summary.isSessionActive,
+			queuedCount: isTerminalRlmChild ? 0 : summary.sessionActions.queuedCount,
+			isSessionActive: isTerminalRlmChild ? false : summary.isSessionActive,
 			...(summary.parentActiveSessionId ? { parentActiveSessionId: summary.parentActiveSessionId } : {}),
 			...(summary.parentSessionId ? { parentSessionId: summary.parentSessionId } : {}),
 			...(summary.rlmChildId ? { rlmChildId: summary.rlmChildId } : {}),
@@ -5338,38 +5355,56 @@ export class AgentDaemon {
 		};
 	}
 
-	private createAgentMessageAgentSummary(state: ActiveSessionState): AgentSessionMessageAgentSummary {
+	private async readResidentRlmLifecycleStatus(
+		state: ActiveSessionState,
+	): Promise<RlmSubagentDisplayEntry["status"] | undefined> {
+		const metadata = state.runtime.metadata;
+		if (metadata.kind !== "subagent" || !metadata.rlmChildId || !metadata.sessionDir) return undefined;
+		const display = await readRlmSubagentDisplayEntry(metadata.sessionDir);
+		return display?.childId === metadata.rlmChildId ? display.status : undefined;
+	}
+
+	private createAgentMessageAgentSummary(
+		state: ActiveSessionState,
+		rlmLifecycleStatus?: RlmSubagentDisplayEntry["status"],
+	): AgentSessionMessageAgentSummary {
 		const metadata = state.runtime.metadata;
 		const session = state.runtime.session;
+		const isTerminalRlmChild = rlmLifecycleStatus === "completed" || rlmLifecycleStatus === "deleted";
 		return {
 			...this.createAgentSessionMessageEndpoint(state),
 			cwd: state.runtime.cwd,
-			isStreaming: session.isStreaming,
-			unfinishedActionCount: session.unfinishedActionCount,
+			isStreaming: isTerminalRlmChild ? false : session.isStreaming,
+			unfinishedActionCount: isTerminalRlmChild ? 0 : session.unfinishedActionCount,
 			...(metadata.parentActiveSessionId ? { parentActiveSessionId: metadata.parentActiveSessionId } : {}),
 			...(metadata.parentSessionId ? { parentSessionId: metadata.parentSessionId } : {}),
 			...(metadata.parentSessionFile ? { parentSessionPath: metadata.parentSessionFile } : {}),
 			rlmDepth: session.rlmDepth,
-			status: classifySessionRosterStatus({
-				activeSessionId: state.activeSessionId,
-				runtimeKind: metadata.kind,
-				activity: session.isSessionActive ? "working" : "idle",
-				isSessionActive: session.isSessionActive,
-				hasRunningRlmChildren: session.hasRunningRlmChildren?.() ?? false,
-				hasActiveHeartbeat:
-					this.cronStore.getHeartbeat(state.activeSessionId)?.status === "active" ||
-					this.cronStore.listRlmHeartbeats(state.activeSessionId).some((job) => job.status === "active"),
-				isStreaming: session.isStreaming,
-			} as SessionSummary),
+			status: isTerminalRlmChild
+				? "inactive"
+				: classifySessionRosterStatus({
+						activeSessionId: state.activeSessionId,
+						runtimeKind: metadata.kind,
+						activity: session.isSessionActive ? "working" : "idle",
+						isSessionActive: session.isSessionActive,
+						hasRunningRlmChildren: session.hasRunningRlmChildren?.() ?? false,
+						hasActiveHeartbeat:
+							this.cronStore.getHeartbeat(state.activeSessionId)?.status === "active" ||
+							this.cronStore.listRlmHeartbeats(state.activeSessionId).some((job) => job.status === "active"),
+						isStreaming: session.isStreaming,
+					} as SessionSummary),
 			...(metadata.rlmChildId ? { rlmChildId: metadata.rlmChildId } : {}),
+			...(rlmLifecycleStatus ? { rlmChildRegistryStatus: rlmLifecycleStatus } : {}),
 			...(metadata.sessionDir ? { sessionDir: metadata.sessionDir } : {}),
 			...(session.sessionFile ? { sessionPath: session.sessionFile } : {}),
 		};
 	}
 
 	private async createAgentMessageListResult(current: ActiveSessionState): Promise<AgentSessionMessageListResult> {
-		const localAgents = this.listTargetableSessionStates(current).map((state) =>
-			this.createAgentMessageAgentSummary(state),
+		const localAgents = await Promise.all(
+			this.listTargetableSessionStates(current).map(async (state) =>
+				this.createAgentMessageAgentSummary(state, await this.readResidentRlmLifecycleStatus(state)),
+			),
 		);
 		for (const passive of await this.listPassiveRlmSubagents()) {
 			const { entry, info } = passive;

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -711,22 +711,37 @@ describe("daemon mode helpers", () => {
 			metadata: {
 				...subagentState.runtime.metadata,
 				rlmChildId: "child-1",
+				sessionDir: "/tmp/child-1",
 			},
 			session: {
+				...subagentState.runtime.session,
 				sessionId: "session-child",
 				sessionName: defaultSubagentName,
-				isStreaming: false,
+				isStreaming: true,
+				isSessionActive: true,
+				isCompacting: false,
+				isBashRunning: false,
+				hasRunningRlmChildren: () => false,
+				messages: [],
+				sessionManager: { getHeader: () => ({}), getCwd: () => "/tmp" },
+				state: { pendingToolCalls: new Map() },
+				unfinishedActionCount: 1,
 				sessionActions: { queuedCount: 0, steering: [], followUps: [] },
 				acceptAgentMessagePrompt,
 			},
 		} as never;
 		const internals = daemon as unknown as {
 			sessions: Map<string, ActiveSessionState>;
+			readResidentRlmLifecycleStatus(state: ActiveSessionState): Promise<"completed" | undefined>;
 			createAgentMessageController(
 				getCurrentState: () => ActiveSessionState | undefined,
 			): AgentSessionMessageController;
 		};
 		internals.sessions.set(parentState.activeSessionId, parentState);
+		vi.spyOn(internals, "readResidentRlmLifecycleStatus").mockImplementation(async (state) => {
+			if (state === subagentState) return "completed";
+			return undefined as never;
+		});
 		// A successfully completed RLM child remains idle in this daemon registry.
 		internals.sessions.set(subagentState.activeSessionId, subagentState);
 
@@ -739,10 +754,20 @@ describe("daemon mode helpers", () => {
 			runtimeKind: "subagent",
 			parentActiveSessionId: parentState.activeSessionId,
 			rlmChildId: "child-1",
+			rlmChildRegistryStatus: "completed",
+			status: "inactive",
+			isStreaming: false,
+			unfinishedActionCount: 0,
 		});
 		if (!subagentSummary?.sessionName) {
 			throw new Error("Missing default subagent session name");
 		}
+
+		Object.assign(subagentState.runtime.session, {
+			isStreaming: false,
+			isSessionActive: false,
+			unfinishedActionCount: 0,
+		});
 
 		await expect(
 			controller.sendAgentMessage({


### PR DESCRIPTION
## Problem

A completed resident RLM child can retain stale in-memory streaming or pending-tool state. `rlm.list_subagents()` then reports `completed`, while `agent_message.list_agents()` reports `running` and `agent_observe` reports an active tool stream.

## Fix

Read the persisted per-child lifecycle record before creating resident agent summaries. A terminal lifecycle now overrides stale execution fields:

- `agent_message` reports the child as inactive and not streaming.
- `agent_observe` reports the child as idle, inactive, and not streaming.
- The resident session remains available for transcript inspection and later messages.
- Late messages cannot reactivate the reported lifecycle state.

Passive child behavior is unchanged.

## Validation

- `npm run check`
- `packages/coding-agent/test/daemon-mode.test.ts`: 199 passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix completed resident subagents appearing active in `AgentDaemon` observe and message APIs
> - Completed or deleted RLM subagents were still shown as streaming/active because in-memory session flags were stale after the on-disk lifecycle already reached a terminal state.
> - Adds `AgentDaemon.readResidentRlmLifecycleStatus` to read the persisted subagent display entry and confirm the `rlmChildId` matches before trusting the status.
> - `createAgentObserveSummary`, `createAgentObserveAgentSnapshot`, `createAgentObserveRecentMessages`, `createAgentMessageAgentSummary`, and their callers now pass the persisted lifecycle status through; when it is `completed` or `deleted`, they force `idle`/`inactive`, clear `isStreaming`, `isCompacting`, `unfinishedActionCount`, and `queuedCount`.
> - Risk: summaries rely on the on-disk display entry being current; if `readResidentRlmLifecycleStatus` cannot find or match the entry it falls back to the prior in-memory classification, so a missing or stale file could still show a completed worker as active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad1364e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->