### PR TITLE
fix(coding-agent): close the Amazon Bedrock bundle runtime entry

### DIFF
--- a/packages/coding-agent/.changes/eng-bundle-amazon-bedrock-chunk-closure.md
+++ b/packages/coding-agent/.changes/eng-bundle-amazon-bedrock-chunk-closure.md
@@ -1,0 +1,1 @@
+- Fixed the Amazon Bedrock provider failing with "Cannot find module" on first use because the release bundle never emitted its chunk.

--- a/packages/coding-agent/scripts/bundle.mjs
+++ b/packages/coding-agent/scripts/bundle.mjs
@@ -44,7 +44,8 @@ rmSync(outdir, { recursive: true, force: true });
 // bundle it (and its `@aws-sdk` closure) into the exact filename the runtime
 // specifier expects, without changing the lazy, on-first-use loading behavior
 // for ordinary startup.
-const bedrockEntry = fileURLToPath(import.meta.resolve("@earendil-works/pi-ai/bedrock-provider"));
+const bedrockProviderShimEntry = fileURLToPath(import.meta.resolve("@earendil-works/pi-ai/bedrock-provider"));
+const bedrockEntry = join(dirname(bedrockProviderShimEntry), "providers", "amazon-bedrock.js");
 
 await build({
 	entryPoints: [

--- a/packages/coding-agent/scripts/bundle.mjs
+++ b/packages/coding-agent/scripts/bundle.mjs
@@ -11,7 +11,7 @@
  * compiled Bun binary), keyed off the __PI_BUNDLED__ define below, so extension
  * imports of pi packages share the bundle's module instances.
  */
-import { chmodSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -31,8 +31,26 @@ try {
 
 rmSync(outdir, { recursive: true, force: true });
 
+// The Bedrock provider is reached through a deliberately non-literal dynamic
+// import (`register-builtins.ts` builds the specifier at runtime) so esbuild's
+// static reachability analysis never sees it and cannot split it off the way
+// every other provider's plain `import("./provider.js")` gets split and
+// rewritten automatically. Left alone, esbuild never bundles the module or its
+// `@aws-sdk` dependency at all: the compiled output still calls
+// `import("./amazon-bedrock.js")`, but no such file is ever emitted, and
+// Bedrock fails at first use with "Cannot find module" (see #751 — the
+// released v0.7.0 tarball shipped exactly this way). Declaring the module as
+// its own literal, unhashed entry point here forces esbuild to compile and
+// bundle it (and its `@aws-sdk` closure) into the exact filename the runtime
+// specifier expects, without changing the lazy, on-first-use loading behavior
+// for ordinary startup.
+const bedrockEntry = fileURLToPath(import.meta.resolve("@earendil-works/pi-ai/bedrock-provider"));
+
 await build({
-	entryPoints: [join(packageDir, "dist", "cli.js")],
+	entryPoints: [
+		{ in: join(packageDir, "dist", "cli.js"), out: "cli" },
+		{ in: bedrockEntry, out: "amazon-bedrock" },
+	],
 	outdir,
 	bundle: true,
 	splitting: true,
@@ -49,4 +67,20 @@ await build({
 });
 
 chmodSync(join(outdir, "cli.js"), 0o755);
+
+// Verify bundle closure for every provider chunk reachable only through a
+// non-literal dynamic import, which esbuild cannot police on its own: an
+// unresolved specifier fails silently at first use instead of at build time
+// (see #751 and the "provider bundle closure" acceptance criterion tracked in
+// #1379). Extend this list if another provider adopts the same pattern.
+const requiredRuntimeChunks = ["amazon-bedrock.js"];
+const missingRuntimeChunks = requiredRuntimeChunks.filter((name) => !existsSync(join(outdir, name)));
+if (missingRuntimeChunks.length > 0) {
+	throw new Error(
+		`bundle.mjs: expected dist/bundle/{${missingRuntimeChunks.join(", ")}} to exist for a runtime dynamic ` +
+			"import esbuild cannot statically resolve, but esbuild did not emit them. " +
+			"This provider will fail with \"Cannot find module\" at first use.",
+	);
+}
+
 console.log("bundled dist/cli.js -> dist/bundle/");


### PR DESCRIPTION
Fixes #751.

## Summary

The release bundle emitted a runtime `import("./amazon-bedrock.js")` path for the Bedrock provider, but the bundle did not provide a module with the exports that `register-builtins.ts` expects.

This PR keeps the lazy Bedrock loading path and makes the bundle emit `dist/bundle/amazon-bedrock.js` from the real provider module, so the runtime import exposes `streamBedrock` and `streamSimpleBedrock`.

## Validation

```
npm --prefix packages/coding-agent run bundle
# exit 0

node --input-type=module -e 'const m = await import("./packages/coding-agent/dist/bundle/amazon-bedrock.js"); console.log(JSON.stringify({ streamBedrock: typeof m.streamBedrock, streamSimpleBedrock: typeof m.streamSimpleBedrock }));'
# {"streamBedrock":"function","streamSimpleBedrock":"function"}

npm run check
# exit 0
```

Follow-up to the automatically closed #1784 and Discussion #1410. The previous PR was closed by the non-vouched contribution gate, not by technical review.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing `amazon-bedrock` runtime chunk in coding-agent bundle
> The Amazon Bedrock provider failed on first use because its bundled chunk was missing. [bundle.mjs](https://github.com/PrimeIntellect-ai/prime-agent/pull/1874/files#diff-8606e8936a1a9a467bc717dab8da4d6bafd17f129a8e044e3054e4567b18803d) now uses explicit esbuild `entryPoints` with a named `amazon-bedrock` output and adds a post-build check that throws if `dist/bundle/amazon-bedrock.js` is not produced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7acfae7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->