### PR TITLE
fix(ai): omit service tier for incompatible Responses providers

### DIFF
--- a/packages/ai/.changes/omit-copilot-service-tier.md
+++ b/packages/ai/.changes/omit-copilot-service-tier.md
@@ -1,0 +1,1 @@
+- Fixed OpenAI Responses requests for providers that do not support the `service_tier` parameter, including GitHub Copilot.

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -45,6 +45,7 @@ function resolveCacheRetention(cacheRetention?: CacheRetention): CacheRetention 
 function getCompat(model: Model<"openai-responses">): Required<OpenAIResponsesCompat> {
 	return {
 		sendSessionIdHeader: model.compat?.sendSessionIdHeader ?? true,
+		supportsServiceTier: model.compat?.supportsServiceTier ?? model.provider !== "github-copilot",
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
 	};
 }
@@ -237,7 +238,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		params.temperature = options?.temperature;
 	}
 
-	if (options?.serviceTier !== undefined) {
+	if (options?.serviceTier !== undefined && compat.supportsServiceTier) {
 		params.service_tier = options.serviceTier;
 	}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -331,6 +331,8 @@ export interface OpenAICompletionsCompat {
 export interface OpenAIResponsesCompat {
 	/** Whether to send the OpenAI `session_id` cache-affinity header from `options.sessionId` when caching is enabled. Default: true. */
 	sendSessionIdHeader?: boolean;
+	/** Whether the provider supports the `service_tier` request parameter. Default: true except for providers known not to support it. */
+	supportsServiceTier?: boolean;
 	/** Whether the provider supports `prompt_cache_retention: "24h"`. Default: true. */
 	supportsLongCacheRetention?: boolean;
 }

--- a/packages/ai/test/openai-responses-copilot-provider.test.ts
+++ b/packages/ai/test/openai-responses-copilot-provider.test.ts
@@ -91,6 +91,69 @@ describe("openai-responses provider defaults", () => {
 		});
 	});
 
+	it("omits service tier for GitHub Copilot Responses requests", async () => {
+		const model = getModel("github-copilot", "gpt-5-mini");
+		let capturedPayload: unknown;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\\n\\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-key",
+				serviceTier: "default",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		await stream.result();
+
+		expect(capturedPayload).toBeDefined();
+		expect(capturedPayload).not.toHaveProperty("service_tier");
+	});
+
+	it("preserves service tier for OpenAI Responses requests", async () => {
+		const model = getModel("openai", "gpt-5.4");
+		let capturedPayload: unknown;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\\n\\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-key",
+				serviceTier: "default",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		await stream.result();
+
+		expect(capturedPayload).toMatchObject({ service_tier: "default" });
+	});
+
 	it.each(["gpt-5.1", "gpt-5.2", "gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.5"] as const)(
 		"sends none reasoning effort for OpenAI %s when no reasoning is requested",
 		async (modelId) => {


### PR DESCRIPTION
## Summary

- Add a generic `supportsServiceTier` compatibility capability for OpenAI Responses providers.
- Omit `service_tier` for GitHub Copilot Responses requests, which rejects the parameter.
- Preserve `service_tier` for OpenAI Responses requests and other compatible providers.

## Testing

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-responses-copilot-provider.test.ts`
- `npm run check`

The focused regression covers both Copilot omission and OpenAI preservation.

Related: #645


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit `service_tier` for incompatible OpenAI Responses providers
> Adds a `supportsServiceTier` flag to the `OpenAIResponsesCompat` interface and extends `getCompat()` to default it to `false` for `github-copilot` and `true` otherwise. The `buildParams` builder now only sets `params.service_tier` when both `options.serviceTier` is provided and `compat.supportsServiceTier` is true. Risk: providers that relied on receiving `service_tier` but are not explicitly recognized by `getCompat()` will lose the parameter if their model compat does not set `supportsServiceTier`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6363805.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->