### PR TITLE
fix(coding-agent): kernel test fixtures speak protocol 3

### DIFF
--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -73,7 +73,7 @@ function writeFakeReplRuntime(markerPath: string): string {
 const fs = require("node:fs");
 const readline = require("node:readline");
 const emit = (event) => process.stdout.write(JSON.stringify(event) + "\\n");
-emit({ event: "ready", protocol: 2, python: process.version });
+emit({ event: "ready", protocol: 3, python: process.version });
 const input = readline.createInterface({ input: process.stdin });
 input.on("line", (line) => {
 	const request = JSON.parse(line);

--- a/packages/coding-agent/test/repl-kernel-protocol-corruption.test.ts
+++ b/packages/coding-agent/test/repl-kernel-protocol-corruption.test.ts
@@ -32,10 +32,10 @@ if (fs.existsSync(process.env.FAKE_REPL_CORRUPT_BOOT)) {
   process.stdout.write("BROKEN-BOOT\\n");
 } else if (fs.existsSync(process.env.FAKE_REPL_READY_WITH_GARBAGE)) {
   process.stdout.write(
-    JSON.stringify({ event: "ready", protocol: 2, python: process.version }) + "\\nBROKEN-WITH-READY\\n",
+    JSON.stringify({ event: "ready", protocol: 3, python: process.version }) + "\\nBROKEN-WITH-READY\\n",
   );
 } else if (!(count > 1 && fs.existsSync(process.env.FAKE_REPL_DELAY_READY))) {
-  emit({ event: "ready", protocol: 2, python: process.version });
+  emit({ event: "ready", protocol: 3, python: process.version });
 }
 const input = readline.createInterface({ input: process.stdin });
 input.on("line", (line) => {


### PR DESCRIPTION
## Summary

- the fake-runtime fixtures in `repl-kernel-protocol-corruption.test.ts` (lines 35/38) and `ipython-provisioner.test.ts` (line 76) hardcode `protocol: 2`, while `repl-manager.ts` requires `REPL_PROTOCOL_VERSION = 3`
- as a result, current main deterministically fails 23 tests across these two files in any clean environment ('Kernel runtime speaks protocol 2, expected 3')
- update the three fixture occurrences to protocol 3; repo-wide grep confirms no other stale fixtures
- `REPL_PROTOCOL_VERSION` is module-private, so the fixtures use the literal rather than importing it

## Validation

- both suites: 39/39 pass (previously 23 failed / 16 passed in the identical environment)
- `npm run check`: biome, tsgo, installer render, and browser smoke all pass
- test-only change; no changelog fragment required (fragment check triggers on `src/` changes only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates embedded test fixture strings; no runtime or security impact.
> 
> **Overview**
> **Test-only fix:** fake Node-based REPL runtimes in `ipython-provisioner.test.ts` and `repl-kernel-protocol-corruption.test.ts` now advertise `protocol: 3` on their `ready` events instead of `protocol: 2`.
> 
> That matches what `ReplKernelManager` enforces (`REPL_PROTOCOL_VERSION = 3`), so kernel tests stop failing immediately with “Kernel runtime speaks protocol 2, expected 3” before exercising provisioner or protocol-corruption behavior. No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a97f6995d39f2cccbd33123ab246f9786fc8ac13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump kernel test fixtures to protocol 3
> Updates the `protocol` field from 2 to 3 in the ready event emitted by embedded child-process scripts across two test fixtures. Affects both the normal boot path and the `READY_WITH_GARBAGE` path in the fake REPL script.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a97f699.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->