### PR TITLE
feat(coding-agent): shared agent-status classifier, honest worker visibility, subagents bar rename

### DIFF
--- a/packages/coding-agent/.changes/eng-5794-agent-status-classifier.md
+++ b/packages/coding-agent/.changes/eng-5794-agent-status-classifier.md
@@ -1,0 +1,3 @@
+- Fixed the agents view hiding running subagents whose worker is starting or recovering; the worker state now shows as the row's status label.
+- Made spawned subagent sessions visible from creation, before their first message lands.
+- Renamed the subagent summary bar label from "agents" to "subagents" and unified the status formula behind both surfaces.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -103,7 +103,6 @@ export function classifyUnifiedSession(record: Pick<UnifiedSessionRecord, "daemo
 	return classifyAgentsViewSession(record.daemon);
 }
 
-// Live sessions only; drafts and archived stay out (a non-ready worker renders as a label, never hides).
 export function shouldShowAgentsViewSession(summary: SessionSummary, manuallyInactive = false): boolean {
 	if (manuallyInactive) {
 		return false;

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -103,12 +103,12 @@ export function classifyUnifiedSession(record: Pick<UnifiedSessionRecord, "daemo
 	return classifyAgentsViewSession(record.daemon);
 }
 
-// Live sessions only; drafts and archived stay out.
+// Live sessions only; drafts and archived stay out (a non-ready worker renders as a label, never hides).
 export function shouldShowAgentsViewSession(summary: SessionSummary, manuallyInactive = false): boolean {
 	if (manuallyInactive) {
 		return false;
 	}
-	return summary.lifecycle === "live" && (summary.workerState === undefined || summary.workerState === "ready");
+	return summary.lifecycle === "live";
 }
 
 export function sectionTitle(section: AgentsViewSection): string {
@@ -960,6 +960,10 @@ function getSessionSubtitle(summary: SessionSummary): string {
 }
 
 function getSessionStatusLabel(summary: SessionSummary, hasActiveHeartbeat = summary.hasActiveHeartbeat): string {
+	// A non-ready worker cannot report fresh runtime flags; its state is the row's story.
+	if (summary.workerState !== undefined && summary.workerState !== "ready") {
+		return summary.workerState;
+	}
 	if (summary.isCompacting) {
 		return "compacting";
 	}

--- a/packages/coding-agent/src/modes/daemon/agent-roster.ts
+++ b/packages/coding-agent/src/modes/daemon/agent-roster.ts
@@ -1,0 +1,18 @@
+// One status formula shared by every agent surface; surfaces adapt their inputs and never reimplement it.
+export type AgentRosterStatus = "running" | "idle" | "inactive";
+
+export interface AgentStatusInput {
+	/** A live runtime exists for the agent. */
+	resident: boolean;
+	/** Admitted child run whose session has not materialized yet. */
+	queuedChild: boolean;
+	/** Actively working: streaming, running tools/bash, or running children. */
+	busy: boolean;
+	hasActiveHeartbeat: boolean;
+}
+
+export function classifyAgentStatus(input: AgentStatusInput): AgentRosterStatus {
+	if (input.queuedChild) return "running";
+	if (!input.resident) return "inactive";
+	return input.busy || input.hasActiveHeartbeat ? "running" : "idle";
+}

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -19,7 +19,6 @@ export type SessionLifecycle = "draft" | "live" | "archived";
 // Heuristic activity of a live session. Classification-in-flight counts as
 // "working" so the view never sees an unlabeled idle session.
 export type SessionActivity = "working" | "idle";
-export type SessionRosterStatus = AgentRosterStatus;
 
 // Upper bound on the spawn-code source carried in a session summary. Generous
 // enough for real spawn cells while keeping the daemon wire payload bounded.
@@ -101,7 +100,7 @@ export function resolveAttachModelFallbackMessage(
 	return summary.model ? undefined : startupModelFallbackMessage;
 }
 
-export function classifySessionRosterStatus(summary: SessionSummary): SessionRosterStatus {
+export function classifySessionRosterStatus(summary: SessionSummary): AgentRosterStatus {
 	return classifyAgentStatus({
 		resident: !!summary.activeSessionId,
 		queuedChild: false,

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -9,6 +9,7 @@ import type { SessionActionSnapshot } from "../../core/session-action-store.js";
 import type { AgentTaskState, SessionInfo } from "../../core/session-manager.js";
 import type { AgentConnectionRlmChildAgentSnapshot } from "../agent-connection/types.js";
 import type { ActiveSessionState } from "./active-session-state.js";
+import { type AgentRosterStatus, classifyAgentStatus } from "./agent-roster.js";
 
 // Durable lifecycle; decides agents-view visibility. Only "live" is shown.
 // "draft" = no message sent yet (discarded on close); "archived" = ctrl+x'd,
@@ -18,7 +19,7 @@ export type SessionLifecycle = "draft" | "live" | "archived";
 // Heuristic activity of a live session. Classification-in-flight counts as
 // "working" so the view never sees an unlabeled idle session.
 export type SessionActivity = "working" | "idle";
-export type SessionRosterStatus = "running" | "idle" | "inactive";
+export type SessionRosterStatus = AgentRosterStatus;
 
 // Upper bound on the spawn-code source carried in a session summary. Generous
 // enough for real spawn cells while keeping the daemon wire payload bounded.
@@ -101,9 +102,12 @@ export function resolveAttachModelFallbackMessage(
 }
 
 export function classifySessionRosterStatus(summary: SessionSummary): SessionRosterStatus {
-	if (!summary.activeSessionId) return "inactive";
-	if (summary.hasActiveHeartbeat || summary.activity === "working" || isSessionSummaryBusy(summary)) return "running";
-	return "idle";
+	return classifyAgentStatus({
+		resident: !!summary.activeSessionId,
+		queuedChild: false,
+		busy: summary.activity === "working" || isSessionSummaryBusy(summary),
+		hasActiveHeartbeat: summary.hasActiveHeartbeat === true,
+	});
 }
 
 export function isSessionSummaryBusy(summary: SessionSummary): boolean {
@@ -431,6 +435,8 @@ export function inactiveLifecycleForSession(session: SessionInfo): SessionLifecy
 }
 
 export function activeLifecycleForSession(activeSession: ActiveSessionState): SessionLifecycle {
+	// A resident subagent is a spawned worker, not a user draft; it is visible before its first message lands.
+	if (activeSession.runtime.metadata?.kind === "subagent") return "live";
 	// Lifecycle drives agents-view visibility and is message-based: a session
 	// becomes live once a message is sent. A message-less session is a draft (hidden
 	// from the view) even if the user changed its model/name first — that config is

--- a/packages/coding-agent/src/modes/interactive/components/subagent-summary-line.ts
+++ b/packages/coding-agent/src/modes/interactive/components/subagent-summary-line.ts
@@ -93,7 +93,7 @@ export class SubagentSummaryLine implements Component, Focusable {
 		const inner = safeWidth - 2;
 		const label = theme.fg("accent", "[1msubagents[22m");
 		const top = truncateToWidth(
-			`${theme.fg("border", "╭─ ")}${label}${theme.fg("border", ` ${"─".repeat(Math.max(0, inner - 12))}╮`)}`,
+			`${theme.fg("border", "╭─ ")}${label}${theme.fg("border", ` ${"─".repeat(Math.max(0, inner - 3 - visibleWidth(label)))}╮`)}`,
 			safeWidth,
 			"…",
 		);

--- a/packages/coding-agent/src/modes/interactive/components/subagent-summary-line.ts
+++ b/packages/coding-agent/src/modes/interactive/components/subagent-summary-line.ts
@@ -1,5 +1,6 @@
 import { type Component, type Focusable, getKeybindings, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { AgentConnectionRlmChildAgentSnapshot } from "../../agent-connection/index.js";
+import { type AgentRosterStatus, classifyAgentStatus } from "../../daemon/agent-roster.js";
 import { theme } from "../theme/theme.js";
 import { keyText } from "./keybinding-hints.js";
 
@@ -10,29 +11,33 @@ export interface SubagentSummaryCounts {
 	inactive: number;
 }
 
+export function classifySubagentSnapshotStatus(
+	child: AgentConnectionRlmChildAgentSnapshot,
+	activeHeartbeatSessionIds: ReadonlySet<string>,
+): AgentRosterStatus {
+	// Activity implies a live session; the in-process connection never stamps activeSessionId.
+	const resident = child.activeSessionId !== undefined || child.activity !== undefined;
+	const busy = child.status === "running" || child.status === "queued" || child.activity !== undefined;
+	return classifyAgentStatus({
+		resident,
+		queuedChild: !resident && busy,
+		busy,
+		hasActiveHeartbeat: child.activeSessionId !== undefined && activeHeartbeatSessionIds.has(child.activeSessionId),
+	});
+}
+
 export function countDirectSubagentStatuses(
 	children: Iterable<AgentConnectionRlmChildAgentSnapshot>,
 	parentId: string | undefined,
 	activeHeartbeatSessionIds: ReadonlySet<string>,
 ): SubagentSummaryCounts {
-	let total = 0;
-	let running = 0;
-	let idle = 0;
+	const counts: SubagentSummaryCounts = { total: 0, running: 0, idle: 0, inactive: 0 };
 	for (const child of children) {
 		if (child.parentId !== parentId || child.status === "cancelled") continue;
-		total += 1;
-		const isRunning =
-			child.status === "running" ||
-			child.status === "queued" ||
-			child.activity !== undefined ||
-			(child.activeSessionId !== undefined && activeHeartbeatSessionIds.has(child.activeSessionId));
-		if (isRunning) {
-			running += 1;
-		} else if ((child.status === "done" || child.status === "error") && child.activeSessionId !== undefined) {
-			idle += 1;
-		}
+		counts.total += 1;
+		counts[classifySubagentSnapshotStatus(child, activeHeartbeatSessionIds)] += 1;
 	}
-	return { total, running, idle, inactive: total - running - idle };
+	return counts;
 }
 
 /** One-line entry into the current session's scoped agents view. */
@@ -86,9 +91,9 @@ export class SubagentSummaryLine implements Component, Focusable {
 		if (width < 2) return lines;
 		const safeWidth = width;
 		const inner = safeWidth - 2;
-		const label = theme.fg("accent", "[1magents[22m");
+		const label = theme.fg("accent", "[1msubagents[22m");
 		const top = truncateToWidth(
-			`${theme.fg("border", "╭─ ")}${label}${theme.fg("border", ` ${"─".repeat(Math.max(0, inner - 9))}╮`)}`,
+			`${theme.fg("border", "╭─ ")}${label}${theme.fg("border", ` ${"─".repeat(Math.max(0, inner - 12))}╮`)}`,
 			safeWidth,
 			"…",
 		);

--- a/packages/coding-agent/test/agent-roster.test.ts
+++ b/packages/coding-agent/test/agent-roster.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { AgentConnectionRlmChildAgentSnapshot } from "../src/modes/agent-connection/types.js";
+import {
+	type AgentRosterStatus,
+	type AgentStatusInput,
+	classifyAgentStatus,
+} from "../src/modes/daemon/agent-roster.js";
+import { classifySessionRosterStatus, type SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
+import { classifySubagentSnapshotStatus } from "../src/modes/interactive/components/subagent-summary-line.js";
+
+function summaryFor(resident: boolean, busy: boolean, heartbeat: boolean): SessionSummary {
+	return {
+		id: "s-1",
+		...(resident ? { activeSessionId: "as-1" } : {}),
+		lifecycle: "live",
+		activity: "idle",
+		isSessionActive: busy,
+		...(heartbeat ? { hasActiveHeartbeat: true } : {}),
+		sessionId: "session-1",
+		cwd: "/tmp/project",
+		isStreaming: busy,
+		isCompacting: false,
+		attachedClients: 0,
+		messageCount: 1,
+		sessionActions: { queuedCount: 0, steering: [], followUps: [] },
+	};
+}
+
+function childFor(resident: boolean, busy: boolean): AgentConnectionRlmChildAgentSnapshot {
+	return {
+		id: "child-1",
+		label: "child-1",
+		status: busy ? "running" : "done",
+		sessionDir: "/tmp/child-1",
+		...(resident ? { activeSessionId: "as-1" } : {}),
+	};
+}
+
+describe("classifyAgentStatus", () => {
+	it("classifies from the four input bits", () => {
+		const cases: Array<[AgentStatusInput, AgentRosterStatus]> = [
+			// An admitted-but-sessionless child run is already working.
+			[{ resident: false, queuedChild: true, busy: false, hasActiveHeartbeat: false }, "running"],
+			// Nothing resurrects a non-resident agent except a queued child run.
+			[{ resident: false, queuedChild: false, busy: true, hasActiveHeartbeat: true }, "inactive"],
+			[{ resident: true, queuedChild: false, busy: true, hasActiveHeartbeat: false }, "running"],
+			[{ resident: true, queuedChild: false, busy: false, hasActiveHeartbeat: true }, "running"],
+			[{ resident: true, queuedChild: false, busy: false, hasActiveHeartbeat: false }, "idle"],
+		];
+		for (const [input, expected] of cases) {
+			expect(classifyAgentStatus(input), JSON.stringify(input)).toBe(expected);
+		}
+	});
+
+	it("keeps the agents-view and subagents-bar adapters equal to the shared formula", () => {
+		for (const busy of [false, true]) {
+			for (const heartbeat of [false, true]) {
+				const expected = classifyAgentStatus({
+					resident: true,
+					queuedChild: false,
+					busy,
+					hasActiveHeartbeat: heartbeat,
+				});
+				const heartbeatIds = new Set(heartbeat ? ["as-1"] : []);
+				expect(classifySessionRosterStatus(summaryFor(true, busy, heartbeat)), `busy=${busy} hb=${heartbeat}`).toBe(
+					expected,
+				);
+				expect(
+					classifySubagentSnapshotStatus(childFor(true, busy), heartbeatIds),
+					`busy=${busy} hb=${heartbeat}`,
+				).toBe(expected);
+			}
+		}
+		// A passivated agent is inactive on both surfaces.
+		expect(classifySessionRosterStatus(summaryFor(false, false, false))).toBe("inactive");
+		expect(classifySubagentSnapshotStatus(childFor(false, false), new Set())).toBe("inactive");
+	});
+
+	it("treats a child run without a session yet as a running queued child", () => {
+		expect(classifySubagentSnapshotStatus(childFor(false, true), new Set())).toBe("running");
+		expect(classifySubagentSnapshotStatus({ ...childFor(false, false), status: "queued" }, new Set())).toBe(
+			"running",
+		);
+	});
+});

--- a/packages/coding-agent/test/agent-roster.test.ts
+++ b/packages/coding-agent/test/agent-roster.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentConnectionRlmChildAgentSnapshot } from "../src/modes/agent-connection/types.js";
-import {
-	type AgentRosterStatus,
-	type AgentStatusInput,
-	classifyAgentStatus,
-} from "../src/modes/daemon/agent-roster.js";
+import { classifyAgentStatus } from "../src/modes/daemon/agent-roster.js";
 import { classifySessionRosterStatus, type SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { classifySubagentSnapshotStatus } from "../src/modes/interactive/components/subagent-summary-line.js";
 
@@ -37,22 +33,18 @@ function childFor(resident: boolean, busy: boolean): AgentConnectionRlmChildAgen
 }
 
 describe("classifyAgentStatus", () => {
-	it("classifies from the four input bits", () => {
-		const cases: Array<[AgentStatusInput, AgentRosterStatus]> = [
-			// An admitted-but-sessionless child run is already working.
-			[{ resident: false, queuedChild: true, busy: false, hasActiveHeartbeat: false }, "running"],
-			// Nothing resurrects a non-resident agent except a queued child run.
-			[{ resident: false, queuedChild: false, busy: true, hasActiveHeartbeat: true }, "inactive"],
-			[{ resident: true, queuedChild: false, busy: true, hasActiveHeartbeat: false }, "running"],
-			[{ resident: true, queuedChild: false, busy: false, hasActiveHeartbeat: true }, "running"],
-			[{ resident: true, queuedChild: false, busy: false, hasActiveHeartbeat: false }, "idle"],
-		];
-		for (const [input, expected] of cases) {
-			expect(classifyAgentStatus(input), JSON.stringify(input)).toBe(expected);
-		}
-	});
-
-	it("keeps the agents-view and subagents-bar adapters equal to the shared formula", () => {
+	it("classifies once and both surface adapters agree with it", () => {
+		// The formula's three defining rows: a queued child runs before any session
+		// exists, nothing else resurrects a non-resident agent, residents split on work.
+		expect(classifyAgentStatus({ resident: false, queuedChild: true, busy: false, hasActiveHeartbeat: false })).toBe(
+			"running",
+		);
+		expect(classifyAgentStatus({ resident: false, queuedChild: false, busy: true, hasActiveHeartbeat: true })).toBe(
+			"inactive",
+		);
+		expect(classifySubagentSnapshotStatus({ ...childFor(false, false), status: "queued" }, new Set())).toBe(
+			"running",
+		);
 		for (const busy of [false, true]) {
 			for (const heartbeat of [false, true]) {
 				const expected = classifyAgentStatus({
@@ -61,6 +53,7 @@ describe("classifyAgentStatus", () => {
 					busy,
 					hasActiveHeartbeat: heartbeat,
 				});
+				expect(expected).toBe(busy || heartbeat ? "running" : "idle");
 				const heartbeatIds = new Set(heartbeat ? ["as-1"] : []);
 				expect(classifySessionRosterStatus(summaryFor(true, busy, heartbeat)), `busy=${busy} hb=${heartbeat}`).toBe(
 					expected,
@@ -71,15 +64,7 @@ describe("classifyAgentStatus", () => {
 				).toBe(expected);
 			}
 		}
-		// A passivated agent is inactive on both surfaces.
 		expect(classifySessionRosterStatus(summaryFor(false, false, false))).toBe("inactive");
 		expect(classifySubagentSnapshotStatus(childFor(false, false), new Set())).toBe("inactive");
-	});
-
-	it("treats a child run without a session yet as a running queued child", () => {
-		expect(classifySubagentSnapshotStatus(childFor(false, true), new Set())).toBe("running");
-		expect(classifySubagentSnapshotStatus({ ...childFor(false, false), status: "queued" }, new Set())).toBe(
-			"running",
-		);
 	});
 });

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -816,6 +816,15 @@ describe("agents view state", () => {
 		expect(shouldShowAgentsViewSession(makeSummary({ lifecycle: "live", activity: "idle" }), true)).toBe(false);
 	});
 
+	test("keeps sessions of non-ready workers visible and labels them with the worker state", () => {
+		for (const workerState of ["starting", "recovering", "stopping", "failed"] as const) {
+			const summary = makeSummary({ lifecycle: "live", workerState });
+			expect(shouldShowAgentsViewSession(summary), workerState).toBe(true);
+			expect(buildAgentsViewRows([summary])[0]?.statusLabel, workerState).toBe(workerState);
+		}
+		expect(buildAgentsViewRows([makeSummary({ workerState: "ready" })])[0]?.statusLabel).toBe("needs input");
+	});
+
 	test("does not override saved session cwd when reopening inactive agents", () => {
 		const config: AgentSessionRuntimeConfig = {
 			cwd: "/tmp/dashboard",

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -328,6 +328,24 @@ describe("buildSessionList", () => {
 		expect(entries[0]!.sessionName).toBe("session active-1");
 	});
 
+	it("keeps a resident message-less subagent live while a top-level one stays a draft", () => {
+		const entries = buildSessionList(
+			[
+				makeState({
+					activeSessionId: "child",
+					metadata: { kind: "subagent", createdAt: 1, rlmChildId: "child-1" },
+				}),
+				makeState({ activeSessionId: "top" }),
+			],
+			[],
+		);
+
+		expect(entries.map((entry) => [entry.id, entry.lifecycle])).toEqual([
+			["child", "live"],
+			["top", "draft"],
+		]);
+	});
+
 	it("treats a message-less on-disk active session as a hidden draft", () => {
 		const emptyPath = resolve("/tmp/project/empty.jsonl");
 		const usedPath = resolve("/tmp/project/used.jsonl");

--- a/packages/coding-agent/test/subagent-summary-line.test.ts
+++ b/packages/coding-agent/test/subagent-summary-line.test.ts
@@ -31,7 +31,7 @@ describe("SubagentSummaryLine", () => {
 		line.setSubagentCounts({ total: 1, running: 1, idle: 0, inactive: 0 });
 		let rendered = line.render(120).map(stripAnsi);
 		expect(rendered).toHaveLength(3);
-		expect(rendered[0]).toContain("╭─ agents ─");
+		expect(rendered[0]).toContain("╭─ subagents ─");
 		expect(rendered[1]).toContain("● 1 running   ◐ 0 idle   ○ 0 inactive");
 
 		line.setSubagentCounts({ total: 2, running: 1, idle: 1, inactive: 0 });
@@ -206,7 +206,7 @@ describe("SubagentSummaryLine", () => {
 		Reflect.set(mode, "rlmNodeId", "me");
 		seed.call(mode, [worker]);
 
-		expect(stripAnsi(line.render(100).join("\n"))).toContain("╭─ agents ─");
+		expect(stripAnsi(line.render(100).join("\n"))).toContain("╭─ subagents ─");
 	});
 
 	it("clears a resident session id when a terminal update reports an evicted child", () => {


### PR DESCRIPTION
Part 1 of 3 for ENG-5794 (https://linear.app/primeintellect/issue/ENG-5794). Stack: this PR -> roster ledger (daemon-internal) -> subscription push + TUI consumption.

## Summary

- add `classifyAgentStatus`, one pure status formula (`running`/`idle`/`inactive`) shared by every agent surface; the agents-view classifier (`classifySessionRosterStatus`) and the subagents-bar formula (`countDirectSubagentStatuses`) become thin adapters over it, so the two surfaces can no longer disagree on what a status means
- stop hiding sessions of non-ready workers: heavy RLM load flips a worker to `recovering`, which previously made the entire running family vanish from the agents view; the worker state now renders as the row's status label instead
- resident 0-message subagent sessions are `live` instead of draft-hidden: a spawned worker is visible from creation, before its first message lands (top-level drafts stay message-based; on-disk drafts of dead subagents are unaffected)
- rename the bar label `agents` -> `subagents`

## Validation

- adversarial review enumerated the full old-vs-new input space for both adapters: zero status deltas; the in-process-residency nuance (`activity` implies a live session; in-process connections never stamp `activeSessionId`) verified against all snapshot builders
- new tests: classifier truth table, formula-equality property across both adapters, non-ready-worker visibility+label pin, resident 0-message subagent pin; mutants (classifier precedence inversion, queued-as-idle, restored hiding clause) each killed by a named test
- sandbox: scoped suites 108/108; blast radius (agents-view-mode, daemon-mode, daemon-list-format, interactive-mode-status, +2) 399 passed; root `npm run check` green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agents-view visibility and lifecycle rules for subagents and non-ready workers; any code assuming those rows stay hidden will behave differently, though roster classification for existing inputs is intended to be unchanged.
> 
> **Overview**
> Unifies **running / idle / inactive** behind a single `classifyAgentStatus` helper so the agents view and subagent summary bar use the same rules (including **queued children** counting as running before a session exists).
> 
> **Agents view behavior changes:** live sessions stay visible when the worker is **starting, recovering, stopping, or failed** (no longer filtered to `workerState === "ready"`); those rows show the **worker state** as the status label. **Spawned subagents** are **live** as soon as they are resident, even with zero messages—top-level empty sessions remain drafts.
> 
> The chat **subagent summary** bar label is renamed from **agents** to **subagents**, with border layout adjusted for the longer label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee28dc715bc25f867faf4d1430eafbd685eb7e2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared `classifyAgentStatus` classifier and show subagents from creation in agents view
> - Introduces `classifyAgentStatus` in [agent-roster.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1895/files#diff-2b127d08f21e480f09a879f35db00adc006f514df49fdb999f987fe36eae6c40) as the single status formula across daemon session lists and subagent summary lines, replacing bespoke per-field logic.
> - Removes the `workerState` gate from `shouldShowAgentsViewSession` in [agents-view-state.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1895/files#diff-2e58b45b4d539a55b0a23f04ab90b169c6783299ca57cf9ce39557d901dcd3a1), so live sessions with non-ready worker states (`starting`, `recovering`, `stopping`, `failed`) are now visible instead of hidden; those states surface directly as the status label.
> - Treats resident subagent sessions as `live` immediately upon creation in `activeLifecycleForSession` in [daemon-session-list.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1895/files#diff-c440a99335cbc4d3fa06c11e80a709024e83ebd799f499397c5e8d21ba601e21), before any message is sent.
> - Renames the summary bar label from 'agents' to 'subagents' in [subagent-summary-line.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1895/files#diff-b8fd94fae8d7032bc4ed0f3d11fb3fff8c17dc31ad4eda340ad199b71388fb43) and adjusts border width calculation accordingly.
> - Behavioral Change: sessions previously hidden during worker startup/recovery are now visible with their raw worker state as the status label; subagent sessions appear as `live` from creation rather than `draft`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee28dc7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->