### PR TITLE
fix(coding-agent): preserve terminal events under daemon backpressure

### DIFF
--- a/packages/coding-agent/.changes/lossless-daemon-terminal-events.md
+++ b/packages/coding-agent/.changes/lossless-daemon-terminal-events.md
@@ -1,0 +1,1 @@
+- Fixed daemon backpressure catch-up dropping terminal tool events after large tool results.

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -6370,7 +6370,9 @@ export class AgentDaemon {
 				this.write(client, sequencedMessage);
 				continue;
 			}
-			if (client.snapshotActiveSessionIds?.has(state.activeSessionId)) {
+			const losslessCheckpoint =
+				sequencedMessage.type === "session_event" && RECOVERY_CHECKPOINT_EVENTS.has(sequencedMessage.event.type);
+			if (client.snapshotActiveSessionIds?.has(state.activeSessionId) && !losslessCheckpoint) {
 				this.queueClientCatchup(
 					client,
 					state.activeSessionId,
@@ -6378,7 +6380,7 @@ export class AgentDaemon {
 				);
 				continue;
 			}
-			if (client.backpressured === true) {
+			if (client.backpressured === true && !losslessCheckpoint) {
 				this.queueClientCatchup(
 					client,
 					state.activeSessionId,

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -4577,11 +4577,12 @@ export class DaemonSupervisor {
 			if (outboundType === "extension_ui_request" && !client.supportsExtensionUi) {
 				continue;
 			}
-			if (client.snapshotActiveSessionIds?.has(activeSessionId)) {
+			const losslessTerminalToolEvent = sessionEventType === "tool_execution_end";
+			if (client.snapshotActiveSessionIds?.has(activeSessionId) && !losslessTerminalToolEvent) {
 				this.queueCatchup(client, activeSessionId, outboundType === "session_replaced" ? "replacement" : "resync");
 				continue;
 			}
-			if (client.backpressured === true) {
+			if (client.backpressured === true && !losslessTerminalToolEvent) {
 				this.queueCatchup(client, activeSessionId, outboundType === "session_replaced" ? "replacement" : "resync");
 				continue;
 			}

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -3209,7 +3209,7 @@ describe("daemon mode helpers", () => {
 		expect(client.catchupActiveSessionIds).not.toContain(state.activeSessionId);
 	});
 
-	it("catches up on drain only after events are skipped behind a backpressured write", async () => {
+	it("preserves recovery checkpoints while catching up skipped backpressured events", async () => {
 		const daemon = new AgentDaemon("/tmp/prime-agent-test.sock", {
 			defaultSessionConfig: { agentDir: "/tmp/prime-agent-test-agent", cwd: "/tmp" },
 			createRuntime: async () => {
@@ -3229,16 +3229,7 @@ describe("daemon mode helpers", () => {
 			sessions: Map<string, ActiveSessionState>;
 			handleConnection(socket: Socket): void;
 			createAttachResult(client: DaemonSocketClient, state: ActiveSessionState): DaemonAttachResult;
-			broadcastToSession(
-				state: ActiveSessionState,
-				message: {
-					type: "extension_error";
-					activeSessionId: string;
-					extensionPath: string;
-					event: string;
-					error: string;
-				},
-			): void;
+			broadcastToSession(state: ActiveSessionState, message: DaemonOutbound): void;
 		};
 		internals.handleConnection(socket);
 		const client = [...internals.clients][0]!;
@@ -3265,6 +3256,24 @@ describe("daemon mode helpers", () => {
 		expect(writes).toHaveLength(2);
 		expect(writes[1]).toContain('"error":"first"');
 
+		client.snapshotActiveSessionIds?.add(state.activeSessionId);
+		internals.broadcastToSession(state, {
+			type: "session_event",
+			activeSessionId: state.activeSessionId,
+			event: {
+				type: "tool_execution_end",
+				toolCallId: "tool-1",
+				toolName: "ipython",
+				result: {},
+				isError: false,
+			},
+		});
+
+		expect(writes).toHaveLength(3);
+		expect(writes[2]).toContain('"type":"tool_execution_end"');
+		expect(client.catchupActiveSessionIds).toEqual(new Set());
+
+		client.snapshotActiveSessionIds?.delete(state.activeSessionId);
 		internals.broadcastToSession(state, {
 			type: "extension_error",
 			activeSessionId: state.activeSessionId,
@@ -3273,7 +3282,7 @@ describe("daemon mode helpers", () => {
 			error: "skipped",
 		});
 
-		expect(writes).toHaveLength(2);
+		expect(writes).toHaveLength(3);
 		expect(client.catchupActiveSessionIds).toEqual(new Set([state.activeSessionId]));
 
 		write.mockImplementation((data: unknown) => {
@@ -3281,13 +3290,13 @@ describe("daemon mode helpers", () => {
 			return true;
 		});
 		socket.emit("drain");
-		await vi.waitFor(() => expect(writes).toHaveLength(3));
+		await vi.waitFor(() => expect(writes).toHaveLength(4));
 
-		expect(JSON.parse(writes[2] ?? "{}")).toMatchObject({
+		expect(JSON.parse(writes[3] ?? "{}")).toMatchObject({
 			type: "session_resynced",
 			activeSessionId: state.activeSessionId,
-			meta: { sequence: 2, cursor: { generation: "generation-1", sequence: 2 } },
-			snapshot: { lastEventSequence: 2 },
+			meta: { sequence: 3, cursor: { generation: "generation-1", sequence: 3 } },
+			snapshot: { lastEventSequence: 3 },
 		});
 		expect(client.catchupActiveSessionIds).toEqual(new Set());
 	});

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -3511,7 +3511,7 @@ describe("daemon worker supervisor monitoring", () => {
 		).rejects.toThrow(`Unknown active session: ${activeSessionId}`);
 	});
 
-	it("catches up only after worker events are skipped behind a backpressured write", async () => {
+	it("preserves terminal tool events while catching up skipped worker events", async () => {
 		const activeSessionId = "active-backpressure";
 		const writes: string[] = [];
 		const write = vi.fn((data: unknown) => {
@@ -3549,6 +3549,27 @@ describe("daemon worker supervisor monitoring", () => {
 				`${JSON.stringify({ type: "extension_error", activeSessionId, extensionPath, event: "load", error })}\n`,
 			),
 		});
+		const terminalFrame: PrivateFrame<DaemonWorkerFrameHeader> = {
+			header: {
+				kind: "outbound",
+				outboundType: "session_event",
+				activeSessionId,
+				sessionEventType: "tool_execution_end",
+			},
+			payload: Buffer.from(
+				`${JSON.stringify({
+					type: "session_event",
+					activeSessionId,
+					event: {
+						type: "tool_execution_end",
+						toolCallId: "tool-1",
+						toolName: "ipython",
+						result: {},
+						isError: false,
+					},
+				})}\n`,
+			),
+		};
 
 		supervisor.handleWorkerFrame(worker, frame("first", "x".repeat(1024 * 1024)));
 
@@ -3557,9 +3578,17 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(writes).toHaveLength(1);
 		expect(writes[0]).toContain('"error":"first"');
 
+		client.snapshotActiveSessionIds = new Set([activeSessionId]);
+		supervisor.handleWorkerFrame(worker, terminalFrame);
+
+		expect(writes).toHaveLength(2);
+		expect(writes[1]).toContain('"type":"tool_execution_end"');
+		expect(client.catchupActiveSessionIds).toEqual(new Set());
+
+		client.snapshotActiveSessionIds.delete(activeSessionId);
 		supervisor.handleWorkerFrame(worker, frame("skipped", "/tmp/extension.ts"));
 
-		expect(writes).toHaveLength(1);
+		expect(writes).toHaveLength(2);
 		expect(client.catchupActiveSessionIds).toEqual(new Set([activeSessionId]));
 		expect(catchUpClient).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## Summary

- keep sequenced recovery checkpoints deliverable when the worker daemon is snapshotting or backpressured
- keep `tool_execution_end` deliverable through the daemon supervisor under the same conditions
- retain snapshot catch-up for ordinary high-volume events

## Problem

Prime Agent 0.8.1 can lose the terminal event after a large tool result. The large frame is already accepted by `socket.write()`, but `false` marks the client as backpressured. The next event is then skipped by both `AgentDaemon.broadcastToSession()` and `DaemonSupervisor.handleWorkerFrame()` in favor of snapshot catch-up.

A snapshot restores session state, but it does not replay the missing `tool_execution_end` boundary. RPC clients that wait for the end event can therefore wait until their deadline even though the successful tool result is durable in the session JSONL.

The same filtering happens while a snapshot for the active session is in progress.

Observed on:

- package/tag: `v0.8.1` (`514633727bf26d74f39f3119c2b0e31a5ceb2a9d`)
- still present on PR base: `5b6c0e94e11a97fcfdd7a9fc9dc4f7acbda9c853`
- typical triggering result: approximately 219 KiB

## Reproduction

```bash
npm ci
cd packages/coding-agent
npx tsx ../../node_modules/vitest/dist/cli.js --run \
  test/daemon-mode.test.ts \
  test/daemon-supervisor-monitor.test.ts \
  -t 'preserves (recovery checkpoints|terminal tool events)'
```

The focused cases make a large write return `false`, mark the same session as snapshot-active, and then deliver `tool_execution_end`. Without the source changes, the terminal frame is replaced by catch-up and both cases fail. With this patch, both pass while an ordinary following event is still coalesced into catch-up.

## Fix

Node accepts and orders the bytes passed to `socket.write()` even when it returns `false`; the return value is a signal to pause bulk production, not a rejection of that frame. Recovery checkpoints are sparse compared with tool-result deltas, so the worker daemon writes those sequenced boundaries through. The supervisor applies the narrow end-to-end exception required by the reported failure: `tool_execution_end`.

Ordinary events still use the existing bounded snapshot catch-up path. This does not change the daemon wire schema, capabilities, or protocol version.

## Checks

- `268` tests passed across the two affected test files
- `npm run check` passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve terminal tool events during daemon backpressure
> - Fixes `AgentDaemon.broadcastToSession` and `DaemonSupervisor.broadcastOutboundToClients` so recovery checkpoint and `tool_execution_end` events are written directly to clients instead of being queued as catch-up.
> - Non-terminal events continue to use the existing snapshot/backpressure catch-up path.
> - Risk: bypassing backpressure for checkpoint events means these writes are not deferred; if a client socket is genuinely saturated, the direct write could still fail or block the broadcaster. Check `RECOVERY_CHECKPOINT_EVENTS` handling in [daemon-mode.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1901/files#diff-f657fb72071b9bcb67235932ddc24164a0376dc918944a8f58b857c2ac43e450) and the `losslessTerminalToolEvent` flag in [daemon-supervisor.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1901/files#diff-18f2d5ec391785bebc6ddf3c1bd3b795e4ed6e02d0aa3852f5bf247d61d012f8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78cdf24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->