### PR TITLE
feat(extensions): built-in Datadog token metrics extension

### DIFF
--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -9,6 +9,7 @@ import { installAgentTraceUpload } from "./agent-traces.js";
 import { AuthStorage } from "./auth-storage.js";
 import type { AgentAutonomousConfig } from "./autonomous.js";
 import type { AgentRlmHeartbeatController } from "./cron-jobs.js";
+import { createDatadogTokensExtension } from "./extensions/builtin/datadog-tokens.js";
 import { createHerdrAgentStateExtension } from "./extensions/builtin/herdr-agent-state.js";
 import type { SessionStartEvent, ToolDefinition } from "./extensions/index.js";
 import { McpManager } from "./mcp/mcp-manager.js";
@@ -164,9 +165,16 @@ export async function createAgentSessionServices(
 	// noExtensions is a full opt-out: it disables the built-in reporter too,
 	// not just discovered extension files.
 	const skipHerdrReporter = options.noBuiltinHerdrReporter || options.resourceLoaderOptions?.noExtensions;
-	const builtinExtensionFactories = skipHerdrReporter
+	// Datadog token metrics are env-opt-in (PRIME_AGENT_DATADOG_METRICS=1) and
+	// self-disable, so they load unconditionally unless extensions are fully off.
+	const builtinExtensionFactories = options.resourceLoaderOptions?.noExtensions
 		? []
-		: [createHerdrAgentStateExtension(() => resourceLoader.getLoadedExtensionPaths())];
+		: [
+				...(skipHerdrReporter
+					? []
+					: [createHerdrAgentStateExtension(() => resourceLoader.getLoadedExtensionPaths())]),
+				createDatadogTokensExtension(),
+			];
 	const resourceLoader: DefaultResourceLoader = new DefaultResourceLoader({
 		...(options.resourceLoaderOptions ?? {}),
 		extensionFactories: [...builtinExtensionFactories, ...userExtensionFactories],

--- a/packages/coding-agent/src/core/extensions/builtin/datadog-tokens.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/datadog-tokens.ts
@@ -1,0 +1,167 @@
+/**
+ * Built-in Datadog token-metrics extension.
+ *
+ * Emits per-API-call token counts as DogStatsD metrics labeled by model,
+ * provider, and API type — the Prime Agent equivalent of Hermes'
+ * `plugins/observability/datadog_tokens` plugin. Uses non-blocking UDP to
+ * a local DogStatsD agent (default 127.0.0.1:8125).
+ *
+ * Metrics emitted (all counters, Datadog auto-rollups by time window):
+ *
+ *   prime.tokens.input        — prompt/input tokens per API call
+ *   prime.tokens.output       — completion/output tokens per API call
+ *   prime.tokens.cache_read   — cache-read tokens (cached prefix replay)
+ *   prime.tokens.cache_write  — cache-write tokens (newly cached prefix)
+ *   prime.tokens.total        — total tokens per API call
+ *   prime.api.calls           — 1 per assistant message (request counter)
+ *   prime.api.duration_ms     — request-to-message-end duration (HISTOGRAM)
+ *
+ * All metrics tagged with:
+ *   model     — the model that served the request (responseModel preferred)
+ *   provider  — the provider string (openai, anthropic, custom:midagent, ...)
+ *   api       — the API protocol (openai-completions, anthropic-messages, ...)
+ *
+ * Disabled by default. Enable with PRIME_AGENT_DATADOG_METRICS=1.
+ * Optional env vars:
+ *   PRIME_AGENT_DATADOG_AGENT_HOST  — DogStatsD host (default: 127.0.0.1)
+ *   PRIME_AGENT_DATADOG_AGENT_PORT  — DogStatsD port (default: 8125)
+ *
+ * Fail-open: UDP sends never block the agent loop and never throw into it.
+ */
+
+import { createSocket } from "node:dgram";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ExtensionFactory } from "../types.js";
+
+/** Characters that break the DogStatsD wire format (pipe, comma, colon, whitespace). */
+const TAG_SANITIZE_RE = /[|:,\s\r\n]/g;
+
+interface DogStatsDClient {
+	send(metric: string, value: number, type: "c" | "h", tags: string[]): void;
+	close(): void;
+}
+
+/** Parse a positive-int env value, falling back when absent or malformed. */
+function parsePortEnv(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (!raw) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Create a lazily-initialized DogStatsD client over a UDP socket.
+ * Returns null when metrics are disabled via env. The socket is unref'd so
+ * it never keeps the process alive, and send failures are swallowed —
+ * observability must never break the agent.
+ */
+export function createDogStatsDClient(enabled: boolean, host: string, port: number): DogStatsDClient | null {
+	if (!enabled) return null;
+
+	let socket: import("node:dgram").Socket | undefined;
+	let closed = false;
+
+	function ensureSocket(): import("node:dgram").Socket {
+		if (!socket) {
+			socket = createSocket("udp4");
+			socket.unref();
+		}
+		return socket;
+	}
+
+	return {
+		send(metric, value, type, tags) {
+			if (closed) return;
+			try {
+				const tagSuffix = tags.length > 0 ? `|#${tags.join(",")}` : "";
+				const packet = `${metric}:${value}|${type}${tagSuffix}`;
+				const buf = Buffer.from(packet, "utf8");
+				ensureSocket().send(buf, port, host, () => {
+					// Fire-and-forget: ignore DNS/send errors, UDP is best-effort.
+				});
+			} catch {
+				// Fail-open: metrics are best-effort.
+			}
+		},
+		close() {
+			closed = true;
+			try {
+				socket?.close();
+			} catch {
+				// already closed
+			}
+			socket = undefined;
+		},
+	};
+}
+
+/** Build a sorted tag list, sanitizing values for the DogStatsD wire format. */
+function safeTags(values: Record<string, string>): string[] {
+	const tags: string[] = [];
+	for (const key of Object.keys(values).sort()) {
+		const raw = values[key] || "unknown";
+		tags.push(`${key}:${String(raw).replace(TAG_SANITIZE_RE, "_")}`);
+	}
+	return tags;
+}
+
+export interface DatadogTokensResult {
+	metrics: string[];
+}
+
+function datadogTokensExtensionImpl(pi: ExtensionAPI, client: DogStatsDClient): void {
+	pi.on("message_end", (event) => {
+		try {
+			const message = event.message;
+			if (message.role !== "assistant") return;
+			const msg = message as AssistantMessage;
+
+			const tags = safeTags({
+				model: msg.responseModel || msg.model,
+				provider: msg.provider,
+				api: msg.api,
+			});
+
+			// Counter metrics — skip zero values to avoid empty timeseries.
+			const counts: Array<[string, number]> = [
+				["prime.tokens.input", msg.usage?.input ?? 0],
+				["prime.tokens.output", msg.usage?.output ?? 0],
+				["prime.tokens.cache_read", msg.usage?.cacheRead ?? 0],
+				["prime.tokens.cache_write", msg.usage?.cacheWrite ?? 0],
+				["prime.tokens.total", msg.usage?.totalTokens ?? 0],
+			];
+			for (const [metric, value] of counts) {
+				if (value > 0) {
+					client.send(metric, value, "c", tags);
+				}
+			}
+
+			// Request counter: 1 per assistant message (i.e. per API call).
+			client.send("prime.api.calls", 1, "c", tags);
+
+			// Duration histogram (ms), from request start to message end.
+			const durationMs = Date.now() - msg.timestamp;
+			if (Number.isFinite(durationMs) && durationMs > 0) {
+				client.send("prime.api.duration_ms", durationMs, "h", tags);
+			}
+		} catch {
+			// Fail-open: never block or crash the agent loop from a metrics hook.
+		}
+	});
+}
+
+/**
+ * Extension factory for Datadog token metrics. Self-disables when
+ * PRIME_AGENT_DATADOG_METRICS is not "1", so it is safe to always load.
+ */
+export function createDatadogTokensExtension(): ExtensionFactory {
+	return (pi: ExtensionAPI) => {
+		const enabled = process.env.PRIME_AGENT_DATADOG_METRICS === "1";
+		if (!enabled) return;
+		const host = process.env.PRIME_AGENT_DATADOG_AGENT_HOST || "127.0.0.1";
+		const port = parsePortEnv("PRIME_AGENT_DATADOG_AGENT_PORT", 8125);
+		const client = createDogStatsDClient(enabled, host, port);
+		if (!client) return;
+		datadogTokensExtensionImpl(pi, client);
+	};
+}

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -4,6 +4,7 @@
 
 export type { SlashCommandInfo, SlashCommandSource } from "../slash-commands.js";
 export type { SourceInfo } from "../source-info.js";
+export { createDatadogTokensExtension, createDogStatsDClient } from "./builtin/datadog-tokens.js";
 export {
 	createHerdrAgentStateExtension,
 	hasFileBasedHerdrIntegration,

--- a/packages/coding-agent/test/datadog-tokens.test.ts
+++ b/packages/coding-agent/test/datadog-tokens.test.ts
@@ -1,0 +1,232 @@
+import { createSocket, type RemoteInfo } from "node:dgram";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDatadogTokensExtension, createDogStatsDClient } from "../src/core/extensions/builtin/datadog-tokens.js";
+import type { ExtensionAPI } from "../src/core/extensions/types.js";
+
+interface CapturedPacket {
+	metric: string;
+	value: number;
+	type: string;
+	tags: string[];
+	raw: string;
+}
+
+function parsePacket(raw: string): CapturedPacket {
+	const [head, ...rest] = raw.split("|");
+	const [name, value] = head.split(":");
+	const tags = rest.find((part) => part.startsWith("#"));
+	return {
+		metric: name,
+		value: Number(value),
+		type: rest.find((part) => part.startsWith("c") || part.startsWith("h"))?.[0] ?? "",
+		tags: tags ? tags.slice(1).split(",") : [],
+		raw,
+	};
+}
+
+function createMockPi() {
+	const handlers = new Map<string, Array<(...args: unknown[]) => unknown>>();
+	const pi = {
+		on(event: string, handler: (...args: unknown[]) => unknown) {
+			const list = handlers.get(event) ?? [];
+			list.push(handler);
+			handlers.set(event, list);
+		},
+	} as unknown as ExtensionAPI;
+	return { pi, handlers };
+}
+
+function assistantMessage(overrides: Record<string, unknown> = {}) {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "hi" }],
+		api: "anthropic-messages",
+		provider: "custom:midagent",
+		model: "glm-53-fp8-mi325",
+		usage: { input: 100, output: 42, cacheRead: 7, cacheWrite: 3, totalTokens: 152 },
+		stopReason: "stop",
+		timestamp: Date.now() - 500,
+		...overrides,
+	};
+}
+
+async function startUdpCollector(): Promise<{
+	port: number;
+	packets: CapturedPacket[];
+	waitForPackets: (count: number, timeoutMs?: number) => Promise<void>;
+	stop: () => Promise<void>;
+}> {
+	const packets: CapturedPacket[] = [];
+	const socket = createSocket("udp4");
+	const waiters: Array<{ count: number; resolve: () => void }> = [];
+	let stopped = false;
+
+	socket.on("message", (msg: Buffer, _rinfo: RemoteInfo) => {
+		for (const line of msg.toString("utf8").split("\n")) {
+			if (!line.trim()) continue;
+			packets.push(parsePacket(line));
+		}
+		for (const waiter of [...waiters]) {
+			if (packets.length >= waiter.count) {
+				waiters.splice(waiters.indexOf(waiter), 1);
+				waiter.resolve();
+			}
+		}
+	});
+
+	const port = await new Promise<number>((resolve) => {
+		socket.bind(0, "127.0.0.1", () => resolve(socket.address().port));
+	});
+
+	return {
+		port,
+		packets,
+		waitForPackets(count: number, timeoutMs = 3000) {
+			if (packets.length >= count) return Promise.resolve();
+			return new Promise((resolve, reject) => {
+				const timer = setTimeout(() => reject(new Error(`timeout: got ${packets.length}/${count}`)), timeoutMs);
+				waiters.push({
+					count,
+					resolve: () => {
+						clearTimeout(timer);
+						resolve();
+					},
+				});
+			});
+		},
+		stop: () =>
+			new Promise((resolve) => {
+				if (stopped) {
+					resolve();
+					return;
+				}
+				stopped = true;
+				socket.close(() => resolve());
+			}),
+	};
+}
+
+describe("createDogStatsDClient", () => {
+	it("returns null when disabled", () => {
+		expect(createDogStatsDClient(false, "127.0.0.1", 8125)).toBeNull();
+	});
+});
+
+describe("datadog-tokens extension", () => {
+	let collector: Awaited<ReturnType<typeof startUdpCollector>>;
+	const prevEnv = { ...process.env };
+
+	afterEach(async () => {
+		process.env = { ...prevEnv };
+		if (collector) await collector.stop();
+	});
+
+	it("emits token counters and api.call when enabled", async () => {
+		collector = await startUdpCollector();
+		process.env.PRIME_AGENT_DATADOG_METRICS = "1";
+		process.env.PRIME_AGENT_DATADOG_AGENT_HOST = "127.0.0.1";
+		process.env.PRIME_AGENT_DATADOG_AGENT_PORT = String(collector.port);
+
+		const { pi, handlers } = createMockPi();
+		createDatadogTokensExtension()(pi);
+
+		const messageEndHandlers = handlers.get("message_end") ?? [];
+		expect(messageEndHandlers.length).toBe(1);
+
+		for (const handler of messageEndHandlers) {
+			await handler({ type: "message_end", message: assistantMessage() }, {} as never);
+			// allow the UDP send callback to flush
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+
+		await collector.waitForPackets(7);
+		const byMetric = new Map(collector.packets.map((p) => [p.metric, p]));
+
+		expect(byMetric.get("prime.tokens.input")?.value).toBe(100);
+		expect(byMetric.get("prime.tokens.output")?.value).toBe(42);
+		expect(byMetric.get("prime.tokens.cache_read")?.value).toBe(7);
+		expect(byMetric.get("prime.tokens.cache_write")?.value).toBe(3);
+		expect(byMetric.get("prime.tokens.total")?.value).toBe(152);
+		expect(byMetric.get("prime.api.calls")?.value).toBe(1);
+		expect(byMetric.get("prime.api.duration_ms")?.type).toBe("h");
+
+		for (const packet of collector.packets) {
+			expect(packet.tags).toContain("model:glm-53-fp8-mi325");
+			// ":" is sanitized per the DogStatsD wire format.
+			expect(packet.tags).toContain("provider:custom_midagent");
+			expect(packet.tags).toContain("api:anthropic-messages");
+			const expectedType = packet.metric === "prime.api.duration_ms" ? "h" : "c";
+			expect(packet.type).toBe(expectedType);
+		}
+	});
+
+	it("prefers responseModel over requested model", async () => {
+		collector = await startUdpCollector();
+		process.env.PRIME_AGENT_DATADOG_METRICS = "1";
+		process.env.PRIME_AGENT_DATADOG_AGENT_PORT = String(collector.port);
+
+		const { pi, handlers } = createMockPi();
+		createDatadogTokensExtension()(pi);
+		const handler = handlers.get("message_end")?.[0];
+
+		await handler?.(
+			{
+				type: "message_end",
+				message: assistantMessage({ responseModel: "anthropic/claude-x" }),
+			},
+			{} as never,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		await collector.waitForPackets(6);
+
+		const input = collector.packets.find((p) => p.metric === "prime.tokens.input");
+		expect(input?.tags).toContain("model:anthropic/claude-x");
+	});
+
+	it("does not register handlers when disabled", () => {
+		delete process.env.PRIME_AGENT_DATADOG_METRICS;
+		const { pi, handlers } = createMockPi();
+		createDatadogTokensExtension()(pi);
+		expect(handlers.size).toBe(0);
+	});
+
+	it("skips zero-value counters but still emits api.calls", async () => {
+		collector = await startUdpCollector();
+		process.env.PRIME_AGENT_DATADOG_METRICS = "1";
+		process.env.PRIME_AGENT_DATADOG_AGENT_PORT = String(collector.port);
+
+		const { pi, handlers } = createMockPi();
+		createDatadogTokensExtension()(pi);
+		const handler = handlers.get("message_end")?.[0];
+
+		await handler?.(
+			{
+				type: "message_end",
+				message: assistantMessage({
+					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+				}),
+			},
+			{} as never,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		await collector.waitForPackets(2);
+
+		// Zero token counters are skipped; api.calls and the (positive) duration
+		// histogram still go out.
+		expect(collector.packets.map((p) => p.metric).sort()).toEqual(["prime.api.calls", "prime.api.duration_ms"]);
+	});
+
+	it("never throws from the message_end handler", async () => {
+		process.env.PRIME_AGENT_DATADOG_METRICS = "1";
+		const { pi, handlers } = createMockPi();
+		createDatadogTokensExtension()(pi);
+		const handler = handlers.get("message_end")?.[0];
+
+		// Malformed messages must not break the agent loop (fail-open catch inside).
+		expect(() => handler?.({ type: "message_end", message: { role: "assistant" } }, {} as never)).not.toThrow();
+		expect(() => handler?.({ type: "message_end", message: null }, {} as never)).not.toThrow();
+		expect(() =>
+			handler?.({ type: "message_end", message: { role: "assistant", usage: null } }, {} as never),
+		).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

Adds an opt-in built-in extension that emits per-API-call token usage as DogStatsD metrics — the Prime Agent equivalent of the Hermes `plugins/observability/datadog_tokens` plugin.

### Metrics

| Metric | Type | Description |
|---|---|---|
| `prime.tokens.input` | counter | prompt/input tokens per API call |
| `prime.tokens.output` | counter | completion/output tokens per API call |
| `prime.tokens.cache_read` | counter | cache-read tokens |
| `prime.tokens.cache_write` | counter | cache-write tokens |
| `prime.tokens.total` | counter | total tokens per API call |
| `prime.api.calls` | counter | 1 per assistant message |
| `prime.api.duration_ms` | histogram | request start -> message end |

All tagged with `model` (prefers `responseModel` when the provider echoes a concrete one), `provider`, and `api`. Zero-value token counters are skipped to avoid empty timeseries.

### Usage

```bash
PRIME_AGENT_DATADOG_METRICS=1 prime-agent   # enable (off by default)
# optional: PRIME_AGENT_DATADOG_AGENT_HOST / PRIME_AGENT_DATADOG_AGENT_PORT
```

### Design notes

- Hooks the `message_end` extension event; every assistant message carries `usage` + `model` + `provider` + `api`, so one hook covers every API call.
- Raw DogStatsD client over `node:dgram` (unref'd UDP socket, fire-and-forget) — no new dependencies, no `datadog` SDK needed.
- Fail-open: metric emission can never throw into or block the agent loop.
- Self-disables when `PRIME_AGENT_DATADOG_METRICS != "1"`, so the factory loads unconditionally unless extensions are fully off (`noExtensions`).
- Tag values are sanitized per the DogStatsD wire format (pipe, comma, colon, whitespace -> `_`).

### Verification

- 6 new unit tests (`test/datadog-tokens.test.ts`) using a real UDP collector: counters, tags, responseModel preference, disabled-by-default, zero-value skipping, fail-open on malformed messages.
- E2E verified against a local DogStatsD listener with a real session: token counters, request counter, and duration histogram arrive with correct `model`/`provider`/`api` tags; failed API calls emit `prime.api.calls` + duration but no zero token counters.
- Repo pre-commit checks passed (biome, tsgo --noEmit, installer render, browser smoke).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add built-in Datadog token metrics extension to `createAgentSessionServices`
> - Introduces `createDatadogTokensExtension`, which emits `prime.tokens.*` counters, a `prime.api.calls` counter, and a `prime.api.duration_ms` histogram via a UDP DogStatsD client on each assistant `message_end` event.
> - The extension self-disables unless `PRIME_AGENT_DATADOG_METRICS==='1'`; host/port are configurable via env vars. Tags are sanitized and sorted, and all sends are best-effort with errors swallowed.
> - `createAgentSessionServices` now always registers the Datadog extension unless `resourceLoaderOptions.noExtensions` is true; the Herdr reporter extension remains gated on `skipHerdrReporter`.
> - Risk: `createAgentSessionServices` no longer returns an empty builtin list when `skipHerdrReporter` is true — callers that relied on no extensions being present in that mode now get the Datadog extension (inactive unless env-enabled).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bfb672.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->