### PR TITLE
feat(coding-agent): preview bash-skill commands as bash in collapsed cells

### DIFF
--- a/packages/coding-agent/.changes/bash-skill-preview.md
+++ b/packages/coding-agent/.changes/bash-skill-preview.md
@@ -1,0 +1,1 @@
+- Collapsed ipython cells that call the bash skill with a literal command now preview as `bash · <command>` instead of the python wrapper.

--- a/packages/coding-agent/src/core/tools/code-preview.ts
+++ b/packages/coding-agent/src/core/tools/code-preview.ts
@@ -58,6 +58,7 @@ function redactNoise(text: string): string {
 			/\b((?=\w*(?:token|key|secret|password))[A-Za-z_]\w*)\s*=\s*(?!<redacted>)(?!["'])\S+/gi,
 			"$1=<redacted>",
 		)
+		.replace(/\b(authorization:\s*(?:bearer\s+)?)[^\s"']+/gi, "$1<redacted>")
 		.replace(/(["'])sk-[^"']+\1/g, "$1<redacted>$1")
 		.replace(/(["']).{160,}\1/g, "$1…$1");
 }
@@ -424,14 +425,12 @@ interface PythonStringScan {
 	value: string;
 	end: number;
 	closed: boolean;
-	/** A cooked escape (\x, \u, octal, \a…) whose value the preview does not compute. */
+	/** Saw a cooked escape (\x, \u, octal, \a…) whose value is not computed here. */
 	unsupportedEscape: boolean;
 }
 
-// Walks a python string-literal body starting just after the opening delimiter.
-// In both raw and cooked strings a backslash consumes the next char (python's
-// raw-string rule: backslash-quote never closes the literal); only cooked
-// strings unescape, and unknown escapes keep the backslash, matching python.
+// Walks a python string-literal body from just after the opening delimiter,
+// following python's escape rules (in raw strings backslash-quote never closes).
 function scanPythonStringLiteral(code: string, start: number, quote: string, raw: boolean): PythonStringScan {
 	let value = "";
 	let i = start;
@@ -441,8 +440,6 @@ function scanPythonStringLiteral(code: string, start: number, quote: string, raw
 		if (char === "\\" && i + 1 < code.length) {
 			const next = code[i + 1] ?? "";
 			if (!raw && /[xuUN0-7abfv]/.test(next)) {
-				// \x41, \u…, octal, \a\b\f\v change the value; showing the source
-				// form would preview a command that differs from what ran.
 				unsupportedEscape = true;
 			}
 			value += raw ? char + next : (PYTHON_ESCAPES[next] ?? char + next);
@@ -461,8 +458,7 @@ function scanPythonStringLiteral(code: string, start: number, quote: string, raw
 	return { value, end: i, closed: false, unsupportedEscape };
 }
 
-// True when the lines end inside an unterminated triple-quoted string, meaning
-// the following line is string text rather than code.
+// True when the lines end inside an unterminated triple-quoted string.
 function endsInsideMultilineString(lines: readonly string[]): boolean {
 	const text = lines.join("\n");
 	let i = 0;
@@ -518,8 +514,7 @@ export function previewPythonCode(code: string): CodePreview {
 
 	if (bestIndex !== undefined && bestScore >= 0) {
 		const previewIndex = pythonPreviewIndex(lines, bestIndex);
-		// The literal may span lines below the chosen one, so extract from the full tail.
-		// A line inside a multiline string is text, not a bash-skill call: no bash ran.
+		// Extract from the full tail (literals may span lines), unless the chosen line is string text.
 		const bashCommand = endsInsideMultilineString(lines.slice(0, previewIndex))
 			? undefined
 			: extractBashSkillCommand(lines.slice(previewIndex).join("\n"));

--- a/packages/coding-agent/src/core/tools/code-preview.ts
+++ b/packages/coding-agent/src/core/tools/code-preview.ts
@@ -424,6 +424,8 @@ interface PythonStringScan {
 	value: string;
 	end: number;
 	closed: boolean;
+	/** A cooked escape (\x, \u, octal, \a…) whose value the preview does not compute. */
+	unsupportedEscape: boolean;
 }
 
 // Walks a python string-literal body starting just after the opening delimiter.
@@ -433,16 +435,22 @@ interface PythonStringScan {
 function scanPythonStringLiteral(code: string, start: number, quote: string, raw: boolean): PythonStringScan {
 	let value = "";
 	let i = start;
+	let unsupportedEscape = false;
 	while (i < code.length) {
 		const char = code[i] ?? "";
 		if (char === "\\" && i + 1 < code.length) {
 			const next = code[i + 1] ?? "";
+			if (!raw && /[xuUN0-7abfv]/.test(next)) {
+				// \x41, \u…, octal, \a\b\f\v change the value; showing the source
+				// form would preview a command that differs from what ran.
+				unsupportedEscape = true;
+			}
 			value += raw ? char + next : (PYTHON_ESCAPES[next] ?? char + next);
 			i += 2;
 			continue;
 		}
 		if (code.startsWith(quote, i)) {
-			return { value, end: i + quote.length, closed: true };
+			return { value, end: i + quote.length, closed: true, unsupportedEscape };
 		}
 		if (quote.length === 1 && char === "\n") {
 			break; // single-quoted literals cannot span lines
@@ -450,7 +458,7 @@ function scanPythonStringLiteral(code: string, start: number, quote: string, raw
 		value += char;
 		i += 1;
 	}
-	return { value, end: i, closed: false };
+	return { value, end: i, closed: false, unsupportedEscape };
 }
 
 // True when the lines end inside an unterminated triple-quoted string, meaning
@@ -487,7 +495,7 @@ function extractBashSkillCommand(code: string): string | undefined {
 	const start = match[0].length;
 	const prefixChar = match[0][start - quote.length - 1];
 	const scan = scanPythonStringLiteral(code, start, quote, prefixChar === "r" || prefixChar === "R");
-	if (!scan.closed) return undefined;
+	if (!scan.closed || scan.unsupportedEscape) return undefined;
 	const rest = code.slice(scan.end).trimStart();
 	// Require a plain literal first argument; concatenation or other expressions fall back.
 	if (!rest.startsWith(",") && !rest.startsWith(")")) return undefined;

--- a/packages/coding-agent/src/core/tools/code-preview.ts
+++ b/packages/coding-agent/src/core/tools/code-preview.ts
@@ -417,6 +417,9 @@ function extractBashSkillCommand(code: string): string | undefined {
 	const start = match?.[0].length ?? 0;
 	const end = code.indexOf(quote, start);
 	if (end < 0) return undefined;
+	// A backslash before the close quote means an escaped quote inside the literal;
+	// extracting the mis-cut prefix would preview a wrong command, so fall back.
+	if (quote.length === 1 && code[end - 1] === "\\") return undefined;
 	const rest = code.slice(end + quote.length).trimStart();
 	// Require a plain literal first argument; concatenation or other expressions fall back.
 	if (!rest.startsWith(",") && !rest.startsWith(")")) return undefined;

--- a/packages/coding-agent/src/core/tools/code-preview.ts
+++ b/packages/coding-agent/src/core/tools/code-preview.ts
@@ -410,20 +410,88 @@ function pythonPreviewIndex(lines: readonly string[], index: number): number {
 	return childIndex === undefined ? index : pythonPreviewIndex(lines, childIndex);
 }
 
+const PYTHON_ESCAPES: Record<string, string> = {
+	"\n": "", // backslash-newline is a line continuation
+	'"': '"',
+	"'": "'",
+	"\\": "\\",
+	n: "\n",
+	r: "\r",
+	t: "\t",
+};
+
+interface PythonStringScan {
+	value: string;
+	end: number;
+	closed: boolean;
+}
+
+// Walks a python string-literal body starting just after the opening delimiter.
+// In both raw and cooked strings a backslash consumes the next char (python's
+// raw-string rule: backslash-quote never closes the literal); only cooked
+// strings unescape, and unknown escapes keep the backslash, matching python.
+function scanPythonStringLiteral(code: string, start: number, quote: string, raw: boolean): PythonStringScan {
+	let value = "";
+	let i = start;
+	while (i < code.length) {
+		const char = code[i] ?? "";
+		if (char === "\\" && i + 1 < code.length) {
+			const next = code[i + 1] ?? "";
+			value += raw ? char + next : (PYTHON_ESCAPES[next] ?? char + next);
+			i += 2;
+			continue;
+		}
+		if (code.startsWith(quote, i)) {
+			return { value, end: i + quote.length, closed: true };
+		}
+		if (quote.length === 1 && char === "\n") {
+			break; // single-quoted literals cannot span lines
+		}
+		value += char;
+		i += 1;
+	}
+	return { value, end: i, closed: false };
+}
+
+// True when the lines end inside an unterminated triple-quoted string, meaning
+// the following line is string text rather than code.
+function endsInsideMultilineString(lines: readonly string[]): boolean {
+	const text = lines.join("\n");
+	let i = 0;
+	while (i < text.length) {
+		const char = text[i] ?? "";
+		if (char === "#") {
+			const newline = text.indexOf("\n", i);
+			if (newline < 0) return false;
+			i = newline + 1;
+			continue;
+		}
+		if (char === '"' || char === "'") {
+			const quote = text.startsWith(char.repeat(3), i) ? char.repeat(3) : char;
+			const scan = scanPythonStringLiteral(text, i + quote.length, quote, true);
+			if (!scan.closed && scan.end >= text.length) {
+				return quote.length === 3;
+			}
+			i = scan.end;
+			continue;
+		}
+		i += 1;
+	}
+	return false;
+}
+
 function extractBashSkillCommand(code: string): string | undefined {
 	const match = code.match(BASH_SKILL_CALL_PATTERN);
 	const quote = match?.[1];
-	if (!quote) return undefined;
-	const start = match?.[0].length ?? 0;
-	const end = code.indexOf(quote, start);
-	if (end < 0) return undefined;
-	// A backslash before the close quote means an escaped quote inside the literal;
-	// extracting the mis-cut prefix would preview a wrong command, so fall back.
-	if (quote.length === 1 && code[end - 1] === "\\") return undefined;
-	const rest = code.slice(end + quote.length).trimStart();
+	if (!match || !quote) return undefined;
+	const start = match[0].length;
+	const prefixChar = match[0][start - quote.length - 1];
+	const scan = scanPythonStringLiteral(code, start, quote, prefixChar === "r" || prefixChar === "R");
+	if (!scan.closed) return undefined;
+	const rest = code.slice(scan.end).trimStart();
 	// Require a plain literal first argument; concatenation or other expressions fall back.
 	if (!rest.startsWith(",") && !rest.startsWith(")")) return undefined;
-	return code.slice(start, end);
+	return scan.value;
 }
 
 export function previewPythonCode(code: string): CodePreview {
@@ -443,7 +511,10 @@ export function previewPythonCode(code: string): CodePreview {
 	if (bestIndex !== undefined && bestScore >= 0) {
 		const previewIndex = pythonPreviewIndex(lines, bestIndex);
 		// The literal may span lines below the chosen one, so extract from the full tail.
-		const bashCommand = extractBashSkillCommand(lines.slice(previewIndex).join("\n"));
+		// A line inside a multiline string is text, not a bash-skill call: no bash ran.
+		const bashCommand = endsInsideMultilineString(lines.slice(0, previewIndex))
+			? undefined
+			: extractBashSkillCommand(lines.slice(previewIndex).join("\n"));
 		if (bashCommand) {
 			return previewBashCommand(bashCommand);
 		}

--- a/packages/coding-agent/src/core/tools/code-preview.ts
+++ b/packages/coding-agent/src/core/tools/code-preview.ts
@@ -13,6 +13,7 @@ const PYTHON_DEFINITION_PATTERN = /^\s*(?:async\s+def|def|class)\s+/;
 const PYTHON_MAIN_PATTERN = /^\s*if\s+__name__\s*==\s*['"]__main__['"]\s*:/;
 const PYTHON_CONTROL_PATTERN = /^\s*(?:if|elif|else|for|while|with|try|except|finally)\b.*:\s*$/;
 const PYTHON_CALL_PATTERN = /^\s*(?:await\s+)?[A-Za-z_][A-Za-z0-9_.]*\s*\(/;
+const BASH_SKILL_CALL_PATTERN = /^\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*=\s*)?(?:await\s+)?bash\s*\(\s*[rR]?("""|'''|"|')/;
 const PYTHON_LOW_SIGNAL_CALL_PATTERN = /^\s*(?:await\s+)?(?:print|len|str|repr|int|float|list|dict|set|tuple)\s*\(/;
 const PYTHON_ASSIGNMENT_CALL_PATTERN =
 	/^\s*[A-Za-z_][A-Za-z0-9_]*(?:\s*:\s*[^=]+)?\s*=\s*(?:await\s+)?[A-Za-z_][A-Za-z0-9_.]*\s*\(/;
@@ -409,6 +410,19 @@ function pythonPreviewIndex(lines: readonly string[], index: number): number {
 	return childIndex === undefined ? index : pythonPreviewIndex(lines, childIndex);
 }
 
+function extractBashSkillCommand(code: string): string | undefined {
+	const match = code.match(BASH_SKILL_CALL_PATTERN);
+	const quote = match?.[1];
+	if (!quote) return undefined;
+	const start = match?.[0].length ?? 0;
+	const end = code.indexOf(quote, start);
+	if (end < 0) return undefined;
+	const rest = code.slice(end + quote.length).trimStart();
+	// Require a plain literal first argument; concatenation or other expressions fall back.
+	if (!rest.startsWith(",") && !rest.startsWith(")")) return undefined;
+	return code.slice(start, end);
+}
+
 export function previewPythonCode(code: string): CodePreview {
 	const lines = code.split("\n");
 	const paths = pythonPathVars(lines);
@@ -425,6 +439,11 @@ export function previewPythonCode(code: string): CodePreview {
 
 	if (bestIndex !== undefined && bestScore >= 0) {
 		const previewIndex = pythonPreviewIndex(lines, bestIndex);
+		// The literal may span lines below the chosen one, so extract from the full tail.
+		const bashCommand = extractBashSkillCommand(lines.slice(previewIndex).join("\n"));
+		if (bashCommand) {
+			return previewBashCommand(bashCommand);
+		}
 		return {
 			language: "python",
 			text: descriptor(pythonPreviewLine(lines, previewIndex, paths)),

--- a/packages/coding-agent/test/code-preview.test.ts
+++ b/packages/coding-agent/test/code-preview.test.ts
@@ -161,6 +161,19 @@ git add packages/foo.ts
 		});
 	});
 
+	it("keeps backslashes in raw bash-skill literals", () => {
+		// python: r'grep \'x\' f' stays open at the escaped quote and the backslash stays in the value.
+		expect(previewIpythonCode("r = await bash(r'grep \\'x\\' f')")).toEqual({
+			language: "bash",
+			text: "grep \\'x\\' f",
+		});
+	});
+
+	it("keeps the python preview when the literal never closes", () => {
+		// python: a raw newline inside a single-quoted literal is a syntax error, so no bash ran.
+		expect(previewIpythonCode("r = await bash('echo hi\n)").language).toBe("python");
+	});
+
 	it("evaluates escapes in bash-skill literals instead of previewing source text", () => {
 		// \n in the source is a real newline in the executed command; salience follows the evaluated text.
 		expect(previewIpythonCode("r = await bash('printf \"a\\nb\"\\ngit add -A')")).toEqual({
@@ -181,6 +194,11 @@ git add packages/foo.ts
 		expect(previewIpythonCode('doc = """\nbash("git status")\n"""')).toEqual({
 			language: "python",
 			text: 'bash("git status")',
+		});
+		// A triple-quoted string that closed above is code again: extraction must still work.
+		expect(previewIpythonCode('doc = """usage"""\nr = await bash(\'git status\')')).toEqual({
+			language: "bash",
+			text: "git status",
 		});
 	});
 

--- a/packages/coding-agent/test/code-preview.test.ts
+++ b/packages/coding-agent/test/code-preview.test.ts
@@ -152,6 +152,17 @@ git add packages/foo.ts
 		});
 	});
 
+	it("keeps the python preview when the literal is not the whole first argument", () => {
+		expect(previewIpythonCode("r = await bash('echo ' + name)")).toEqual({
+			language: "python",
+			text: "r = await bash('echo ' + name)",
+		});
+		expect(previewIpythonCode("r = await bash('echo can\\'t stop')")).toEqual({
+			language: "python",
+			text: "r = await bash('echo can\\'t stop')",
+		});
+	});
+
 	it("previews the bash-skill call when the scorer picks it among other lines", () => {
 		const code = `import json
 r = await bash('git diff --stat')

--- a/packages/coding-agent/test/code-preview.test.ts
+++ b/packages/coding-agent/test/code-preview.test.ts
@@ -174,6 +174,12 @@ git add packages/foo.ts
 		expect(previewIpythonCode("r = await bash('echo hi\n)").language).toBe("python");
 	});
 
+	it("keeps the python preview for value-changing escapes it does not compute", () => {
+		// '\x41' executes as 'A'; previewing the source form would show a command that never ran.
+		expect(previewIpythonCode("r = await bash('echo \\x41')").language).toBe("python");
+		expect(previewIpythonCode("r = await bash('grep \\bword\\b f')").language).toBe("python");
+	});
+
 	it("evaluates escapes in bash-skill literals instead of previewing source text", () => {
 		// \n in the source is a real newline in the executed command; salience follows the evaluated text.
 		expect(previewIpythonCode("r = await bash('printf \"a\\nb\"\\ngit add -A')")).toEqual({

--- a/packages/coding-agent/test/code-preview.test.ts
+++ b/packages/coding-agent/test/code-preview.test.ts
@@ -161,6 +161,8 @@ git add packages/foo.ts
 			language: "python",
 			text: "r = await bash('echo can\\'t stop')",
 		});
+		// Escaped quote directly before the close quote: a mis-cut here would preview a wrong command.
+		expect(previewIpythonCode('r = await bash("grep -n \\")\\" src.c")').language).toBe("python");
 	});
 
 	it("previews the bash-skill call when the scorer picks it among other lines", () => {

--- a/packages/coding-agent/test/code-preview.test.ts
+++ b/packages/coding-agent/test/code-preview.test.ts
@@ -125,6 +125,40 @@ EOF`;
 		expect(previewBashCommand(command)).toEqual({ language: "bash", text: "hello world" });
 	});
 
+	it("routes bash-skill calls with literal commands to the bash preview", () => {
+		expect(previewIpythonCode("r = await bash('git status --porcelain')")).toEqual({
+			language: "bash",
+			text: "git status --porcelain",
+		});
+		const longCommand = `git log --oneline -- ${Array.from({ length: 8 }, (_, i) => `packages/coding-agent/src/dir-${i}`).join(" ")}`;
+		const longPreview = previewIpythonCode(`result = await bash("${longCommand}", timeout=120)`);
+		expect(longPreview.language).toBe("bash");
+		expect(longPreview.text.startsWith("git log --oneline")).toBe(true);
+	});
+
+	it("passes triple-quoted bash-skill bodies through like %%bash cells", () => {
+		const code = `r = await bash('''
+set -e
+git add packages/foo.ts
+''')`;
+		expect(previewIpythonCode(code)).toEqual({ language: "bash", text: "git add packages/foo.ts" });
+	});
+
+	it("keeps the python preview for non-literal bash-skill arguments", () => {
+		expect(previewIpythonCode("r = await bash(cmd)")).toEqual({ language: "python", text: "r = await bash(cmd)" });
+		expect(previewIpythonCode('r = await bash(f"git checkout {branch}")')).toEqual({
+			language: "python",
+			text: 'r = await bash(f"git checkout {branch}")',
+		});
+	});
+
+	it("previews the bash-skill call when the scorer picks it among other lines", () => {
+		const code = `import json
+r = await bash('git diff --stat')
+print(r)`;
+		expect(previewIpythonCode(code)).toEqual({ language: "bash", text: "git diff --stat" });
+	});
+
 	it("prefers a later meaningful heredoc over an earlier generic one", () => {
 		const command = `cat <<'CFG'
 key=value

--- a/packages/coding-agent/test/code-preview.test.ts
+++ b/packages/coding-agent/test/code-preview.test.ts
@@ -134,54 +134,22 @@ EOF`;
 		const longPreview = previewIpythonCode(`result = await bash("${longCommand}", timeout=120)`);
 		expect(longPreview.language).toBe("bash");
 		expect(longPreview.text.startsWith("git log --oneline")).toBe(true);
+		const scorer = `import json
+r = await bash('git diff --stat')
+print(r)`;
+		expect(previewIpythonCode(scorer)).toEqual({ language: "bash", text: "git diff --stat" });
+		expect(
+			previewIpythonCode(`r = await bash('curl -H "Authorization: Bearer sec-abc123" https://api.example.com')`)
+				.text,
+		).not.toContain("sec-abc123");
 	});
 
-	it("passes triple-quoted bash-skill bodies through like %%bash cells", () => {
-		const code = `r = await bash('''
+	it("evaluates bash-skill literals the way python does", () => {
+		const tripleBody = `r = await bash('''
 set -e
 git add packages/foo.ts
 ''')`;
-		expect(previewIpythonCode(code)).toEqual({ language: "bash", text: "git add packages/foo.ts" });
-		// Escaped quote adjacent to the closing delimiter: the full evaluated command, never a mis-cut prefix.
-		expect(previewIpythonCode("r = await bash('''echo it\\'''')")).toEqual({ language: "bash", text: "echo it'" });
-	});
-
-	it("keeps the python preview for non-literal bash-skill arguments", () => {
-		expect(previewIpythonCode("r = await bash(cmd)")).toEqual({ language: "python", text: "r = await bash(cmd)" });
-		expect(previewIpythonCode('r = await bash(f"git checkout {branch}")')).toEqual({
-			language: "python",
-			text: 'r = await bash(f"git checkout {branch}")',
-		});
-	});
-
-	it("keeps the python preview when the literal is not the whole first argument", () => {
-		expect(previewIpythonCode("r = await bash('echo ' + name)")).toEqual({
-			language: "python",
-			text: "r = await bash('echo ' + name)",
-		});
-	});
-
-	it("keeps backslashes in raw bash-skill literals", () => {
-		// python: r'grep \'x\' f' stays open at the escaped quote and the backslash stays in the value.
-		expect(previewIpythonCode("r = await bash(r'grep \\'x\\' f')")).toEqual({
-			language: "bash",
-			text: "grep \\'x\\' f",
-		});
-	});
-
-	it("keeps the python preview when the literal never closes", () => {
-		// python: a raw newline inside a single-quoted literal is a syntax error, so no bash ran.
-		expect(previewIpythonCode("r = await bash('echo hi\n)").language).toBe("python");
-	});
-
-	it("keeps the python preview for value-changing escapes it does not compute", () => {
-		// '\x41' executes as 'A'; previewing the source form would show a command that never ran.
-		expect(previewIpythonCode("r = await bash('echo \\x41')").language).toBe("python");
-		expect(previewIpythonCode("r = await bash('grep \\bword\\b f')").language).toBe("python");
-	});
-
-	it("evaluates escapes in bash-skill literals instead of previewing source text", () => {
-		// \n in the source is a real newline in the executed command; salience follows the evaluated text.
+		expect(previewIpythonCode(tripleBody)).toEqual({ language: "bash", text: "git add packages/foo.ts" });
 		expect(previewIpythonCode("r = await bash('printf \"a\\nb\"\\ngit add -A')")).toEqual({
 			language: "bash",
 			text: "git add -A",
@@ -194,6 +162,24 @@ git add packages/foo.ts
 			language: "bash",
 			text: 'grep -n ")" src.c',
 		});
+		expect(previewIpythonCode("r = await bash('''echo it\\'''')")).toEqual({ language: "bash", text: "echo it'" });
+		expect(previewIpythonCode("r = await bash(r'grep \\'x\\' f')")).toEqual({
+			language: "bash",
+			text: "grep \\'x\\' f",
+		});
+	});
+
+	it("keeps the python preview when the exact command cannot be known", () => {
+		for (const code of [
+			"r = await bash(cmd)",
+			'r = await bash(f"git checkout {branch}")',
+			"r = await bash('echo ' + name)",
+			"r = await bash('echo hi\n)", // unterminated literal: python syntax error
+			"r = await bash('echo \\x41')", // value-changing escape not computed here
+			"r = await bash('grep \\bword\\b f')",
+		]) {
+			expect(previewIpythonCode(code).language).toBe("python");
+		}
 	});
 
 	it("keeps the python preview for bash-looking text inside a multiline string", () => {
@@ -201,18 +187,10 @@ git add packages/foo.ts
 			language: "python",
 			text: 'bash("git status")',
 		});
-		// A triple-quoted string that closed above is code again: extraction must still work.
-		expect(previewIpythonCode('doc = """usage"""\nr = await bash(\'git status\')')).toEqual({
+		expect(previewIpythonCode(`doc = """usage"""\nr = await bash('git status')`)).toEqual({
 			language: "bash",
 			text: "git status",
 		});
-	});
-
-	it("previews the bash-skill call when the scorer picks it among other lines", () => {
-		const code = `import json
-r = await bash('git diff --stat')
-print(r)`;
-		expect(previewIpythonCode(code)).toEqual({ language: "bash", text: "git diff --stat" });
 	});
 
 	it("prefers a later meaningful heredoc over an earlier generic one", () => {

--- a/packages/coding-agent/test/code-preview.test.ts
+++ b/packages/coding-agent/test/code-preview.test.ts
@@ -142,6 +142,8 @@ set -e
 git add packages/foo.ts
 ''')`;
 		expect(previewIpythonCode(code)).toEqual({ language: "bash", text: "git add packages/foo.ts" });
+		// Escaped quote adjacent to the closing delimiter: the full evaluated command, never a mis-cut prefix.
+		expect(previewIpythonCode("r = await bash('''echo it\\'''')")).toEqual({ language: "bash", text: "echo it'" });
 	});
 
 	it("keeps the python preview for non-literal bash-skill arguments", () => {
@@ -157,12 +159,29 @@ git add packages/foo.ts
 			language: "python",
 			text: "r = await bash('echo ' + name)",
 		});
-		expect(previewIpythonCode("r = await bash('echo can\\'t stop')")).toEqual({
-			language: "python",
-			text: "r = await bash('echo can\\'t stop')",
+	});
+
+	it("evaluates escapes in bash-skill literals instead of previewing source text", () => {
+		// \n in the source is a real newline in the executed command; salience follows the evaluated text.
+		expect(previewIpythonCode("r = await bash('printf \"a\\nb\"\\ngit add -A')")).toEqual({
+			language: "bash",
+			text: "git add -A",
 		});
-		// Escaped quote directly before the close quote: a mis-cut here would preview a wrong command.
-		expect(previewIpythonCode('r = await bash("grep -n \\")\\" src.c")').language).toBe("python");
+		expect(previewIpythonCode("r = await bash('echo can\\'t stop')")).toEqual({
+			language: "bash",
+			text: "echo can't stop",
+		});
+		expect(previewIpythonCode('r = await bash("grep -n \\")\\" src.c")')).toEqual({
+			language: "bash",
+			text: 'grep -n ")" src.c',
+		});
+	});
+
+	it("keeps the python preview for bash-looking text inside a multiline string", () => {
+		expect(previewIpythonCode('doc = """\nbash("git status")\n"""')).toEqual({
+			language: "python",
+			text: 'bash("git status")',
+		});
 	});
 
 	it("previews the bash-skill call when the scorer picks it among other lines", () => {


### PR DESCRIPTION
In the interactive TUI, a python cell that runs a shell command through the bash skill collapses to a line like `python · r = await bash('…')` - the command string is erased by the long-string redaction in the preview descriptor, and even short commands show the python wrapper instead of the command. Repeated bash-skill calls are indistinguishable (screenshot case: three consecutive `python · r = await bash('…')` lines).

## The fix

`%%bash` cells already have the right treatment: routed through `previewBashCommand`, labeled `bash`, bash-highlighted, salient-command descriptor. This PR extends that to bash-skill calls: after the python scorer picks the preview line, if that line is a `bash(...)` / `await bash(...)` / `x = await bash(...)` call whose first argument is a plain string literal (single-, double-, or triple-quoted; raw strings included), the literal is extracted and previewed via the existing `previewBashCommand`:

```
✓ bash · git status --porcelain · ↑ 2 lines · 21ms
```

- One extraction function + one regex in `code-preview.ts`; no component changes (`ipython-cell.ts` already labels from `preview.language`).
- The extracted command flows through the same descriptor/redaction path as `%%bash` cells (secrets stay redacted; verified with export/token/password cases).
- Non-literal arguments (variables, f-strings, concatenation) and escaped-quote literals that cannot be cut safely fall back to the current python preview - extraction never shows a command that differs from what ran.
- Match is anchored to the scorer-chosen line; trailing arguments (`bash(cmd, timeout=...)`) are tolerated.

## Tests

Five focused cases in `code-preview.test.ts`: literal routing (short + >=160-char command with kwarg, proving the redaction-erasure is gone), triple-quoted multi-line body, non-literal fallback (variable + f-string), non-literal-first-argument/escaped-quote fallback (including the `grep -n \")\"` mis-cut guard), and scorer coexistence with other code. The routing assertions were proven red against the pre-fix preview.

Linear: [ENG-5802](https://linear.app/primeintellect/issue/ENG-5802/collapsed-ipython-cell-preview-hides-bash-skill-commands)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only preview heuristics in `code-preview.ts` with conservative fallbacks; extracted commands reuse existing bash redaction paths.
> 
> **Overview**
> Collapsed ipython cells that invoke the **bash** skill with a **plain string literal** now show **`bash · <command>`** (via `previewBashCommand`) instead of a generic **`python · await bash('…')`** line where long commands were truncated or redacted.
> 
> `previewPythonCode` detects `bash(...)` / `await bash(...)` on the scorer’s preview line, parses the first argument with a small Python string-literal scanner (single/double/triple quotes, raw strings, common escapes), and **falls back** to the existing Python preview when the argument isn’t a safe literal (variables, f-strings, concatenation, unclosed strings, or escapes like `\x`/`\b` that aren’t evaluated). **`redactNoise`** also redacts **`Authorization:`** headers in preview text so curl-style bash-skill calls stay safe.
> 
> Tests cover routing, literal evaluation, fallbacks, and docstring false positives; no TUI component changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2402762c012ef7a6ccb836854227a31f0182e1de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preview `bash(...)` skill calls as bash in collapsed ipython cells
> - When an ipython cell invokes `bash("...")` with a standalone quoted string literal, `previewPythonCode` now returns a bash-language preview (`bash · <command>`) instead of the Python wrapper. The new `extractBashSkillCommand` helper uses `BASH_SKILL_CALL_PATTERN` to locate the call and `scanPythonStringLiteral` to decode the literal, rejecting unterminated strings, unsupported escapes, or non-literal first arguments.
> - Adds `endsInsideMultilineString` so bash-like text inside an open triple-quoted Python string is not misinterpreted as a bash call.
> - `redactNoise` now redacts `Authorization:` header values (including optional `Bearer ` prefix) from preview text.
> - Behavioral Change: `previewPythonCode` in [code-preview.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1911/files#diff-28436f1cd6f16a4eca47794b9011c3f4e08d31dbcf611794e657a37ea0979a09) gains new code paths; cells that previously previewed as Python may now preview as bash when they match the pattern. `redactNoise` additionally strips Authorization tokens that were previously visible in previews.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2402762.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->