### PR TITLE
fix(coding-agent): surface the real spawn error when the daemon cannot launch a worker

### DIFF
--- a/packages/coding-agent/.changes/emfile-worker-spawn.md
+++ b/packages/coding-agent/.changes/emfile-worker-spawn.md
@@ -1,0 +1,1 @@
+- Fixed daemon session create when the worker process cannot be spawned (e.g. EMFILE from fd exhaustion): the create now fails with the real spawn error plus a resident-worker/ulimit hint, and the CLI prints a one-line error instead of crashing with a TypeError stack dump.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -74,7 +74,7 @@ import { isTelemetryEnabled } from "./core/telemetry.js";
 import { printTimings, resetTimings, time } from "./core/timings.js";
 import { runMigrations, showDeprecationWarnings } from "./migrations.js";
 import { isDaemonCatalogProcess, runDaemonCatalogProcess } from "./modes/daemon/daemon-catalog-process.js";
-import { deserializeDaemonError } from "./modes/daemon/daemon-errors.js";
+import { DaemonSessionCreateError, deserializeDaemonCreateError } from "./modes/daemon/daemon-errors.js";
 import { collectDaemonClientEnv, collectDaemonLaunchEnv } from "./modes/daemon/daemon-protocol.js";
 import {
 	DAEMON_WORKER_ACTIVE_SESSION_ID_ENV,
@@ -1006,7 +1006,7 @@ async function createDaemonClientConnection(options: {
 			launchEnv: collectDaemonLaunchEnv(),
 		});
 		if (!response.success) {
-			throw deserializeDaemonError(response);
+			throw deserializeDaemonCreateError(response);
 		}
 		if (!isDaemonSessionSummary(response.data)) {
 			throw new Error("Daemon returned an invalid create response");
@@ -1452,17 +1452,27 @@ export async function main(args: string[], options?: MainOptions) {
 		// no DeferredAgentConnection is needed to avoid creating it up front.
 		const isFreshDefaultSession =
 			!activeDaemonSessionSummary && !getInteractiveDaemonSessionPath(parsed, sessionManager);
-		const { connection, summary } = await createDaemonClientConnection({
-			socketPath: daemonSocketPath,
-			config: defaultSessionConfig,
-			activeSessionId: activeDaemonSessionSummary
-				? getDaemonSummaryActiveSessionId(activeDaemonSessionSummary)
-				: undefined,
-			sessionPath: getInteractiveDaemonSessionPath(parsed, sessionManager),
-			clientOwned: parsed.noSession,
-			noSession: parsed.noSession,
-			supportsExtensionUi: true,
-		});
+		let connection: DaemonAgentConnection;
+		let summary: SessionSummary;
+		try {
+			({ connection, summary } = await createDaemonClientConnection({
+				socketPath: daemonSocketPath,
+				config: defaultSessionConfig,
+				activeSessionId: activeDaemonSessionSummary
+					? getDaemonSummaryActiveSessionId(activeDaemonSessionSummary)
+					: undefined,
+				sessionPath: getInteractiveDaemonSessionPath(parsed, sessionManager),
+				clientOwned: parsed.noSession,
+				noSession: parsed.noSession,
+				supportsExtensionUi: true,
+			}));
+		} catch (error) {
+			if (error instanceof DaemonSessionCreateError) {
+				console.error(chalk.red(`Error: ${error.message}`));
+				process.exit(1);
+			}
+			throw error;
+		}
 		const agentConnection: AgentConnection = connection;
 		const attachModelFallbackMessage = isFreshDefaultSession
 			? startupModel.modelFallbackMessage
@@ -1544,7 +1554,7 @@ export async function main(args: string[], options?: MainOptions) {
 				supportsExtensionUi: appMode === "rpc",
 			}));
 		} catch (error) {
-			if (error instanceof SessionAlreadyActiveError) {
+			if (error instanceof SessionAlreadyActiveError || error instanceof DaemonSessionCreateError) {
 				console.error(chalk.red(`Error: ${error.message}`));
 				process.exit(1);
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-errors.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-errors.ts
@@ -27,10 +27,7 @@ export class DaemonSessionCreateError extends Error {
 	}
 }
 
-/**
- * Create failures without a dedicated typed error are wrapped so the CLI can
- * surface them as a clean one-line error instead of an unhandled throw.
- */
+/** Wraps untyped create failures so the CLI prints one line instead of rethrowing. */
 export function deserializeDaemonCreateError(response: Extract<DaemonResponse, { success: false }>): Error {
 	const error = deserializeDaemonError(response);
 	if (response.errorInfo) return error;

--- a/packages/coding-agent/src/modes/daemon/daemon-errors.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-errors.ts
@@ -20,6 +20,23 @@ export function serializeDaemonError(error: unknown): DaemonErrorInfo | undefine
 	return undefined;
 }
 
+export class DaemonSessionCreateError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "DaemonSessionCreateError";
+	}
+}
+
+/**
+ * Create failures without a dedicated typed error are wrapped so the CLI can
+ * surface them as a clean one-line error instead of an unhandled throw.
+ */
+export function deserializeDaemonCreateError(response: Extract<DaemonResponse, { success: false }>): Error {
+	const error = deserializeDaemonError(response);
+	if (response.errorInfo) return error;
+	return new DaemonSessionCreateError(error.message);
+}
+
 export function deserializeDaemonError(response: Extract<DaemonResponse, { success: false }>): Error {
 	const { errorInfo } = response;
 	if (errorInfo?.code === "missing_session_cwd") {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2470,6 +2470,15 @@ export class DaemonSupervisor {
 		worker.transientCreateCommand = undefined;
 	}
 
+	private describeWorkerSpawnFailure(error: Error): Error {
+		const errno = (error as NodeJS.ErrnoException).code;
+		const hint =
+			errno === "EMFILE" || errno === "ENFILE"
+				? ` (${this.workers.size} resident session workers are holding file descriptors; stop unused sessions or raise the open-file limit (ulimit -n))`
+				: "";
+		return new Error(`Failed to spawn session worker: ${error.message}${hint}`);
+	}
+
 	private async launchWorker(
 		command: DaemonCreateCommand,
 		existing?: ResidentWorker,
@@ -2525,12 +2534,21 @@ export class DaemonSupervisor {
 			: () => {};
 		child.once("close", detachWorkerStderr);
 		const childClosed = new Promise<void>((resolveClose) => child.once("close", () => resolveClose()));
+		let spawnFailure: Error | undefined;
+		const spawnSettled = new Promise<void>((resolveSpawn) => {
+			child.once("spawn", () => resolveSpawn());
+			child.once("error", (error) => {
+				spawnFailure = error instanceof Error ? error : new Error(String(error));
+				resolveSpawn();
+			});
+		});
 		child.on("error", (error) => {
 			this.log(
 				`Session worker ${workerId} process error: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		});
-		const startupGate = child.stdio[WORKER_STARTUP_GATE_FD];
+		// A failed spawn (e.g. EMFILE) leaves child.stdio undefined.
+		const startupGate = child.stdio?.[WORKER_STARTUP_GATE_FD];
 		const previousDescriptor = existing?.descriptor;
 		const previousIntentionalStop = existing?.intentionalStop;
 		let descriptorAssigned = false;
@@ -2538,6 +2556,12 @@ export class DaemonSupervisor {
 		let childProcessStartId: string | undefined;
 		let worker: ResidentWorker;
 		try {
+			// A spawn failure must fail the create with the spawn error, never a
+			// TypeError from the missing stdio pipes.
+			await spawnSettled;
+			if (spawnFailure) {
+				throw this.describeWorkerSpawnFailure(spawnFailure);
+			}
 			if (!child.pid) {
 				throw new Error("Failed to obtain daemon session worker pid");
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -2556,8 +2556,6 @@ export class DaemonSupervisor {
 		let childProcessStartId: string | undefined;
 		let worker: ResidentWorker;
 		try {
-			// A spawn failure must fail the create with the spawn error, never a
-			// TypeError from the missing stdio pipes.
 			await spawnSettled;
 			if (spawnFailure) {
 				throw this.describeWorkerSpawnFailure(spawnFailure);

--- a/packages/coding-agent/test/daemon-errors.test.ts
+++ b/packages/coding-agent/test/daemon-errors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { SessionAlreadyActiveError } from "../src/core/session-lease.js";
+import { DaemonSessionCreateError, deserializeDaemonCreateError } from "../src/modes/daemon/daemon-errors.js";
+
+describe("deserializeDaemonCreateError", () => {
+	it("wraps generic create failures so the CLI boundary prints one line instead of rethrowing", () => {
+		const error = deserializeDaemonCreateError({
+			type: "response",
+			command: "create",
+			success: false,
+			error: "Failed to spawn session worker: spawn node EMFILE",
+		});
+		expect(error).toBeInstanceOf(DaemonSessionCreateError);
+		expect(error.message).toContain("EMFILE");
+	});
+
+	it("preserves typed daemon errors for their dedicated boundaries", () => {
+		const error = deserializeDaemonCreateError({
+			type: "response",
+			command: "create",
+			success: false,
+			error: "session already active",
+			errorInfo: { code: "session_already_active", sessionPath: "/tmp/session.jsonl" },
+		});
+		expect(error).toBeInstanceOf(SessionAlreadyActiveError);
+	});
+});

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -679,6 +679,14 @@ describe("daemon worker supervisor monitoring", () => {
 			/EMFILE.*resident session workers.*ulimit -n/s,
 		);
 		expect(workers.size).toBe(0);
+
+		workerLaunchTestState.spawnFailureCode = "ENOENT";
+		const enoentFailure = await supervisor
+			.launchWorker({ type: "create", config: { cwd: root, agentDir: root } })
+			.then(() => undefined)
+			.catch((error: Error) => error);
+		expect(enoentFailure?.message).toContain("ENOENT");
+		expect(enoentFailure?.message).not.toContain("ulimit");
 	});
 
 	it("commits the startup marker after durable worker publication", async () => {

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -51,8 +51,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 		spawn(command: string, args: readonly string[], options: SpawnOptions): ChildProcess {
 			const failureCode = workerLaunchTestState.spawnFailureCode;
 			if (failureCode) {
-				// Mirror Node's fd-exhaustion spawn failure: no pid, stdio undefined,
-				// "error" emitted before "close".
+				// Node's failed-spawn shape: no pid, stdio undefined, "error" then "close".
 				const failing = Object.assign(new EventEmitter(), {
 					pid: undefined,
 					stdio: undefined,

--- a/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-monitor.test.ts
@@ -38,6 +38,7 @@ const workerLaunchTestState = vi.hoisted(() => ({
 	gateMarkerPath: "",
 	tsxCliPath: "",
 	cliEntrypoint: "",
+	spawnFailureCode: undefined as string | undefined,
 	spawned: [] as Array<{ child: ChildProcess; args: readonly string[] }>,
 }));
 
@@ -48,6 +49,25 @@ vi.mock("node:child_process", async (importOriginal) => {
 	return {
 		...actual,
 		spawn(command: string, args: readonly string[], options: SpawnOptions): ChildProcess {
+			const failureCode = workerLaunchTestState.spawnFailureCode;
+			if (failureCode) {
+				// Mirror Node's fd-exhaustion spawn failure: no pid, stdio undefined,
+				// "error" emitted before "close".
+				const failing = Object.assign(new EventEmitter(), {
+					pid: undefined,
+					stdio: undefined,
+					stderr: undefined,
+					unref: () => {},
+				}) as unknown as ChildProcess;
+				process.nextTick(() => {
+					failing.emit(
+						"error",
+						Object.assign(new Error(`spawn ${command} ${failureCode}`), { code: failureCode }),
+					);
+					failing.emit("close", null, null);
+				});
+				return failing;
+			}
 			const child = actual.spawn(command, args, options);
 			if (workerLaunchTestState.capture) {
 				workerLaunchTestState.spawned.push({ child, args });
@@ -288,6 +308,7 @@ describe("daemon worker supervisor monitoring", () => {
 		workerLaunchTestState.gateMarkerPath = "";
 		workerLaunchTestState.tsxCliPath = "";
 		workerLaunchTestState.cliEntrypoint = "";
+		workerLaunchTestState.spawnFailureCode = undefined;
 		workerLaunchTestState.spawned.length = 0;
 		vi.useRealTimers();
 		for (const registryDir of supervisorRegistryDirs) {
@@ -633,6 +654,31 @@ describe("daemon worker supervisor monitoring", () => {
 		expect(readdirSync(descriptorDir).filter((name) => name.endsWith(".json"))).toEqual([]);
 		const child = workerLaunchTestState.spawned.at(-1)?.child;
 		expect(child?.exitCode !== null || child?.signalCode !== null).toBe(true);
+	});
+
+	it("fails the create with the spawn error when the worker process cannot be spawned", async () => {
+		workerLaunchTestState.spawnFailureCode = "EMFILE";
+		const root = mkdtempSync(join(tmpdir(), "prime-supervisor-spawn-failure-test-"));
+		const descriptorDir = join(root, "descriptors");
+		mkdirSync(descriptorDir, { recursive: true });
+		supervisorRegistryDirs.add(root);
+		const workers = new Map<string, unknown>();
+		const supervisor = Object.assign(Object.create(DaemonSupervisor.prototype), {
+			...createSupervisorSnapshotState(),
+			defaultSessionConfig: { cwd: root, agentDir: root },
+			descriptorDir,
+			socketPath: join(root, "supervisor.sock"),
+			workers,
+			assertRecoveryAllowed: vi.fn(async () => {}),
+			log: vi.fn(),
+		}) as {
+			launchWorker(command: { type: "create"; config: { cwd: string; agentDir: string } }): Promise<unknown>;
+		};
+
+		await expect(supervisor.launchWorker({ type: "create", config: { cwd: root, agentDir: root } })).rejects.toThrow(
+			/EMFILE.*resident session workers.*ulimit -n/s,
+		);
+		expect(workers.size).toBe(0);
 	});
 
 	it("commits the startup marker after durable worker publication", async () => {


### PR DESCRIPTION
On macOS the daemon inherits the first client's file-descriptor soft limit (default 256). Each detached session keeps a resident worker (+2 daemon fds), so heavy multi-session use eventually makes worker `spawn()` fail with `EMFILE`. On that failure Node returns a ChildProcess with `pid=undefined` and `stdio=undefined`, and `launchWorker` dereferenced `child.stdio[WORKER_STARTUP_GATE_FD]` synchronously:

```
Session worker <id> process error: spawn .../bin/node EMFILE
Supervisor command create failed: TypeError: Cannot read properties of undefined (reading '3')
```

The TypeError masked the real error, was sent to the client as the create failure, and crashed the client with a raw Node stack dump. Users saw "after a couple of sessions it can't create a new one" with no clue that killing resident workers (freeing fds) was the fix.

## The fix

- **Supervisor**: `launchWorker` awaits a `spawnSettled` race of the child's `spawn` vs `error` events before touching stdio. A failed spawn now rejects the create with the real spawn error, plus - for `EMFILE`/`ENFILE` - the resident worker count and a hint (`stop unused sessions or raise the open-file limit (ulimit -n)`). Other errnos (e.g. `ENOENT`) keep their message without the fd hint. On success `stdio` is populated synchronously before the await, so the healthy path is unchanged; failure cleanup rides the existing close/catch path (verified for both the EMFILE shape, `stdio=undefined`, and the ENOENT shape, live gate stream destroyed).
- **Client**: generic create failures deserialize as `DaemonSessionCreateError` and are handled at the two existing call-site boundaries - one red line, exit 1 - instead of escaping `runCli` as an unhandled stack dump. Responses with typed `errorInfo` (e.g. `session_already_active`) pass through unwrapped, keeping their dedicated handling.

Both failure shapes were probed against real Node on macOS (`ulimit -n 64`) rather than assumed; the supervisor test's fake child mirrors that verified shape, and the pre-fix test run reproduced the exact production TypeError.

Linear: [ENG-5808](https://linear.app/primeintellect/issue/ENG-5808/emfile-at-worker-spawn-crashes-the-client-with-a-typeerror-instead-of)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon worker launch and CLI error boundaries; behavior change is intentional (fail fast with clear messages) but alters how create failures surface to callers.
> 
> **Overview**
> Fixes daemon session **create** when worker `spawn()` fails (e.g. **EMFILE** from too many resident workers): users previously saw a masked **TypeError** on undefined `child.stdio` and an unhandled CLI stack dump instead of the real spawn error.
> 
> **Supervisor** (`launchWorker`) now waits for the child **`spawn` or `error`** event before touching stdio, rejects create with the actual spawn message, and for **EMFILE/ENFILE** appends resident worker count plus a hint to stop sessions or raise **`ulimit -n`**.
> 
> **Client** deserializes untyped create failures as **`DaemonSessionCreateError`** (typed **`errorInfo`** responses still map to existing errors like **`SessionAlreadyActiveError`**). **`main.ts`** catches that at interactive and RPC create paths, prints one red error line, and exits **1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01d964326979119465c4023d685a26bc410e8eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CLI crash when daemon cannot spawn a worker, surfacing the real error
> - `DaemonSupervisor.launchWorker` now awaits a `spawnSettled` promise before accessing `child.stdio`, so failed spawns (e.g. EMFILE) throw a clear error instead of crashing later on undefined stdio
> - Adds `describeWorkerSpawnFailure` which appends a resident-worker count and `ulimit -n` hint for EMFILE/ENFILE errors
> - Introduces `DaemonSessionCreateError` and `deserializeDaemonCreateError` so generic daemon create failures are deserialized into a distinct error type that the CLI can handle
> - [main.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1918/files#diff-4baeaa77e0a68df3cb411f5b9f216f6a26a7a23495a61b955b1d46482f76d586) catches `DaemonSessionCreateError` at session creation and prints a single-line error with exit code 1 instead of rethrowing a stack trace
> - Behavioral Change: callers of `createDaemonClientConnection` now receive `DaemonSessionCreateError` for untyped create failures instead of a generic `Error`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01d9643.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->