### PR TITLE
fix(coding-agent): keep saved draft and archived sessions out of the agents view

### DIFF
--- a/packages/coding-agent/.changes/agents-view-hidden-draft-rows.md
+++ b/packages/coding-agent/.changes/agents-view-hidden-draft-rows.md
@@ -1,0 +1,1 @@
+- Fixed message-less draft and archived session files surfacing as agents-view rows that Ctrl+X could never delete.

--- a/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
+++ b/packages/coding-agent/src/modes/agents-view/agents-view-state.ts
@@ -1,7 +1,11 @@
 import { basename, resolve } from "node:path";
 import { canonicalizePath } from "../../utils/paths.js";
 import type { AgentConnectionHeartbeat, AgentConnectionSavedSessionInfo } from "../agent-connection/index.js";
-import { classifySessionRosterStatus, type SessionSummary } from "../daemon/daemon-session-list.js";
+import {
+	classifySessionRosterStatus,
+	inactiveLifecycleForSession,
+	type SessionSummary,
+} from "../daemon/daemon-session-list.js";
 
 export type AgentsViewSection = "running" | "idle" | "inactive";
 
@@ -111,6 +115,16 @@ export function shouldShowAgentsViewSession(summary: SessionSummary, manuallyIna
 	return summary.lifecycle === "live" && (summary.workerState === undefined || summary.workerState === "ready");
 }
 
+/**
+ * Same live-only rule for catalog rows that have no daemon summary to classify.
+ * A message-less file is a draft: the daemon hides its resident row but keeps
+ * the session, and delete_saved_session refuses to remove a file that is still
+ * resident, so a saved-only draft row is undeletable from the view.
+ */
+export function shouldShowAgentsViewSavedSession(saved: AgentConnectionSavedSessionInfo): boolean {
+	return inactiveLifecycleForSession(saved) === "live";
+}
+
 export function sectionTitle(section: AgentsViewSection): string {
 	switch (section) {
 		case "running":
@@ -213,6 +227,9 @@ export function reconcileUnifiedSessions(
 			record.identityAliases = [...new Set([...record.identityAliases, ...aliases])];
 			record.searchableText = createUnifiedSearchableText(record.daemon, saved);
 			for (const alias of aliases) recordByAlias.set(alias, record);
+			continue;
+		}
+		if (!shouldShowAgentsViewSavedSession(saved)) {
 			continue;
 		}
 		const inactive: UnifiedSessionRecord = {

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -407,7 +407,7 @@ export function activeActivityForSession(activeSession: ActiveSessionState): Ses
  * session_state is treated as not-archived, so older sessions that never wrote a
  * lifecycle entry still surface. Message-based to match activeLifecycleForSession.
  */
-export function inactiveLifecycleForSession(session: SessionInfo): SessionLifecycle {
+export function inactiveLifecycleForSession(session: Pick<SessionInfo, "state" | "messageCount">): SessionLifecycle {
 	const status = session.state?.status;
 	if (status === "archived" || status === "crash") {
 		return "archived";

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -56,6 +56,7 @@ export {
 	scopeToSessionSubtree,
 	sectionTitle,
 	shouldApplyScopeResolution,
+	shouldShowAgentsViewSavedSession,
 	shouldShowAgentsViewSession,
 	transitionAgentsViewScope,
 	type UnifiedSessionHeartbeat,

--- a/packages/coding-agent/test/agents-view-state.test.ts
+++ b/packages/coding-agent/test/agents-view-state.test.ts
@@ -42,6 +42,7 @@ import {
 	scopeToSessionSubtree,
 	sectionTitle,
 	shouldApplyScopeResolution,
+	shouldShowAgentsViewSavedSession,
 	shouldShowAgentsViewSession,
 	transitionAgentsViewScope,
 } from "../src/modes/index.js";
@@ -962,6 +963,43 @@ describe("agents view state", () => {
 			title: "Live name",
 			record,
 		});
+	});
+
+	test("keeps saved drafts and archived files out of the catalog rows", () => {
+		// A message-less file is a draft. The daemon hides its resident row and refuses to
+		// delete a file it still holds, so a saved-only draft row could never be removed.
+		const draft = makeSessionInfo({ path: "/tmp/draft.jsonl", id: "draft", messageCount: 0, firstMessage: "" });
+		const archived = makeSessionInfo({ path: "/tmp/archived.jsonl", id: "archived", state: { status: "archived" } });
+		const crashed = makeSessionInfo({ path: "/tmp/crashed.jsonl", id: "crashed", state: { status: "crash" } });
+		const live = makeSessionInfo({ path: "/tmp/live.jsonl", id: "live" });
+
+		expect(shouldShowAgentsViewSavedSession(draft)).toBe(false);
+		expect(shouldShowAgentsViewSavedSession(archived)).toBe(false);
+		expect(shouldShowAgentsViewSavedSession(crashed)).toBe(false);
+		expect(shouldShowAgentsViewSavedSession(live)).toBe(true);
+		expect(reconcileUnifiedSessions([], [draft, archived, crashed, live]).map((record) => record.saved?.id)).toEqual([
+			"live",
+		]);
+	});
+
+	test("still merges a hidden saved draft into its resident session", () => {
+		const draft = makeSessionInfo({
+			path: "/tmp/draft.jsonl",
+			id: "draft-session",
+			messageCount: 0,
+			firstMessage: "",
+			name: "Durable name",
+		});
+		const daemon = makeSummary({
+			id: "runtime",
+			activeSessionId: "runtime",
+			sessionId: "draft-session",
+			sessionFile: "/tmp/draft.jsonl",
+		});
+
+		const records = reconcileUnifiedSessions([daemon], [draft]);
+		expect(records).toHaveLength(1);
+		expect(records[0]).toMatchObject({ daemon, saved: draft });
 	});
 
 	test("retains the ancestor chain when search matches only a nested subagent", () => {


### PR DESCRIPTION
Follow-up to discussion #1531, re-diagnosed on current main (c718bf3). Details and the live daemon evidence are in https://github.com/PrimeIntellect-ai/prime-agent/discussions/1531#discussioncomment-18219447.

## Problem

A message-less session file is a draft. `activeLifecycleForSession` marks the resident session `draft` and `shouldShowAgentsViewSession` drops it, but `reconcileCatalogs` passes the saved-session catalog through unfiltered, so the same file returns as an `inactive` row titled `(no messages)`.

That row cannot be removed:

- Ctrl+X twice hits `resolveAgentsViewActiveSummaryForPath` against the unfiltered daemon list, finds the hidden draft, and reports `Session became active; stop it before deleting`.
- `delete_saved_session` would refuse anyway with `Cannot delete the currently active session`.
- The session cannot be stopped from the UI, because its only row is the hidden one.

Every abandoned new session leaves one such row: the startup `model_change`, `thinking_level_change`, and `service_tier_change` entries make `hasUserContent()` true, so the empty-draft discard guard never fires and the file stays on disk.

## Change

Apply the live-only rule to catalog rows that have no daemon summary, reusing `inactiveLifecycleForSession` so on-disk and resident classification stay in sync. Daemon records are still enriched by their saved twin; only the saved-only row is dropped.

Archived and crashed files are covered by the same rule, which `deactivatePendingAgent` already assumes when it writes the archived marker so a row does not resurface on the next scan.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/agents-view-state.test.ts` - 67 passed, including two new tests. The row test fails without the guard (`expected [ Array(4) ] to deeply equal [ 'live' ]`).
- Also green: `test/agents-view-mode.test.ts`, `test/agents-view-inactive-reply.test.ts`, `test/agents-view-missing-cwd.test.ts`, `test/session-view-search.test.ts`, `test/daemon-session-list.test.ts`, `test/session-manager/session-state.test.ts`, `test/suite/regressions/502-unified-session-view.test.ts`.
- `npm run check` clean.

## Out of scope

The draft files still accumulate on disk, now invisibly. A sweep for message-less drafts with no resident session, and the `hasUserContent()` treatment of the startup config snapshot, are tracked separately in the discussion.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter out draft and archived sessions from agents view in `agents-view-state`
> - Adds `shouldShowAgentsViewSavedSession` which delegates to `inactiveLifecycleForSession` and returns true only for sessions with a "live" lifecycle (message count > 0 and not archived/crashed)
> - Updates `reconcileUnifiedSessions` to skip creating inactive `UnifiedSessionRecord` entries for saved sessions that are drafts (no messages) or archived/crashed; those sessions still merge into a matching daemon-backed record if identities align
> - Narrows `inactiveLifecycleForSession` parameter type from `SessionInfo` to `Pick<SessionInfo, "state" | "messageCount">` to allow calls with partial shapes
> - Behavioral Change: saved-only draft and archived sessions no longer appear as standalone rows in the agents view, fixing rows that could not be deleted via Ctrl+X
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57a8f8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->