### PR TITLE
fix(coding-agent): honest status and prompt eviction for empty sessions

### DIFF
--- a/packages/coding-agent/.changes/empty-session-idle-status.md
+++ b/packages/coding-agent/.changes/empty-session-idle-status.md
@@ -1,0 +1,1 @@
+- Fixed `prime-agent list` pinning an abandoned empty session at "working" forever; an empty session with nothing in flight now reports "idle".

--- a/packages/coding-agent/.changes/evict-empty-session-on-detach.md
+++ b/packages/coding-agent/.changes/evict-empty-session-on-detach.md
@@ -1,0 +1,1 @@
+- Evict an empty, unnamed session's worker as soon as its last client disconnects, instead of parking it for the idle sweep; the on-disk draft session is preserved.

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -395,6 +395,12 @@ export function activeActivityForSession(activeSession: ActiveSessionState): Ses
 	if (activeSession.runtime.metadata?.kind === "subagent") {
 		return "idle";
 	}
+	// An empty session never gets a summarizer verdict either (there is nothing
+	// to classify), so don't hold it at "working" forever. A first turn that has
+	// not persisted a message yet is busy and already returned "working" above.
+	if (activeSession.runtime.session.messages.length === 0) {
+		return "idle";
+	}
 	// Hold at "working" until the idle verdict is current, so the view never
 	// buckets an unlabeled idle session.
 	return isSummaryCurrent(activeSession) ? "idle" : "working";

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -110,6 +110,23 @@ export function isSessionSummaryBusy(summary: SessionSummary): boolean {
 	return summary.isSessionActive || summary.hasRunningRlmChildren === true;
 }
 
+/**
+ * An abandoned draft: no messages, no user-assigned name, nothing in flight or
+ * queued (isSessionActive covers unfinished actions), and no schedule pin.
+ * Safe to passivate as soon as its last client detaches instead of parking the
+ * worker for the idle sweep. Naming a session signals intent to return, so
+ * named sessions are exempt even when empty.
+ */
+export function isEvictableEmptySessionSummary(summary: SessionSummary): boolean {
+	return (
+		summary.messageCount === 0 &&
+		!summary.sessionName &&
+		!isSessionSummaryBusy(summary) &&
+		summary.hasRegisteredHeartbeat !== true &&
+		summary.hasRegisteredCronJob !== true
+	);
+}
+
 export function buildSessionList(
 	activeSessions: readonly ActiveSessionState[],
 	savedSessions: readonly SessionInfo[],

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -110,7 +110,7 @@ export function isSessionSummaryBusy(summary: SessionSummary): boolean {
 	return summary.isSessionActive || summary.hasRunningRlmChildren === true;
 }
 
-/** An abandoned draft, safe to passivate on last detach. Naming signals intent to return, so named sessions are exempt. */
+/** Naming signals intent to return, so named sessions are exempt even when empty. */
 export function isEvictableEmptySessionSummary(summary: SessionSummary): boolean {
 	return (
 		summary.messageCount === 0 &&

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -110,13 +110,7 @@ export function isSessionSummaryBusy(summary: SessionSummary): boolean {
 	return summary.isSessionActive || summary.hasRunningRlmChildren === true;
 }
 
-/**
- * An abandoned draft: no messages, no user-assigned name, nothing in flight or
- * queued (isSessionActive covers unfinished actions), and no schedule pin.
- * Safe to passivate as soon as its last client detaches instead of parking the
- * worker for the idle sweep. Naming a session signals intent to return, so
- * named sessions are exempt even when empty.
- */
+/** An abandoned draft, safe to passivate on last detach. Naming signals intent to return, so named sessions are exempt. */
 export function isEvictableEmptySessionSummary(summary: SessionSummary): boolean {
 	return (
 		summary.messageCount === 0 &&
@@ -412,9 +406,7 @@ export function activeActivityForSession(activeSession: ActiveSessionState): Ses
 	if (activeSession.runtime.metadata?.kind === "subagent") {
 		return "idle";
 	}
-	// An empty session never gets a summarizer verdict either (there is nothing
-	// to classify), so don't hold it at "working" forever. A first turn that has
-	// not persisted a message yet is busy and already returned "working" above.
+	// An empty session never gets a summarizer verdict; don't hold it at "working" forever.
 	if (activeSession.runtime.session.messages.length === 0) {
 		return "idle";
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -89,6 +89,7 @@ import { getDaemonRuntimeIdentity } from "./daemon-runtime-identity.js";
 import { matchesSessionIdSuffix } from "./daemon-session-id.js";
 import {
 	classifySessionRosterStatus,
+	isEvictableEmptySessionSummary,
 	isSessionSummaryBusy,
 	type SessionSummary,
 	summaryForInactiveSession,
@@ -914,6 +915,59 @@ export class DaemonSupervisor {
 		}
 	}
 
+	/**
+	 * Passivate an abandoned empty draft as soon as its last client lets go
+	 * instead of parking the worker for the idle sweep. Same passivation as idle
+	 * eviction: the on-disk session (if any) survives and is classified draft by
+	 * inactiveLifecycleForSession. Action-driven only; never rejects.
+	 */
+	private async evictEmptySessionOnLastDetach(activeSessionId: string): Promise<void> {
+		if (this.shuttingDown || this.updateRestartPhase !== undefined) return;
+		const worker = this.matchWorkers(activeSessionId)[0]?.worker;
+		if (
+			!worker ||
+			worker.descriptor.lifecycle !== "ready" ||
+			!worker.client ||
+			// Client-owned workers have their own disconnect cleanup with a grace period.
+			worker.descriptor.ownerClientId !== undefined ||
+			this.isWorkerStopping(worker)
+		) {
+			return;
+		}
+		try {
+			// Refresh so the busy check sees an admitted first turn that has not
+			// persisted a message yet.
+			await this.refreshWorkerSummaries(worker);
+		} catch {
+			return; // A stopping or disconnected worker is never a candidate.
+		}
+		if (
+			this.shuttingDown ||
+			this.updateRestartPhase !== undefined ||
+			this.workers.get(worker.descriptor.workerId) !== worker ||
+			this.isWorkerStopping(worker)
+		) {
+			return;
+		}
+		const summaries = [...worker.summaries.values()];
+		const hasAttachedClient = summaries.some((summary) => {
+			const summaryActiveSessionId = summary.activeSessionId ?? summary.id;
+			return [...this.clients].some((client) => client.attachedActiveSessionIds.has(summaryActiveSessionId));
+		});
+		if (summaries.length === 0 || hasAttachedClient || !summaries.every(isEvictableEmptySessionSummary)) {
+			return;
+		}
+		try {
+			await this.stopWorker(worker, true);
+		} catch (error) {
+			this.log(`Empty-session eviction failed for worker ${worker.descriptor.workerId}: ${String(error)}`);
+			return;
+		}
+		this.log(
+			`Evicted empty session worker ${worker.descriptor.workerId} root=${worker.descriptor.rootSessionId ?? worker.descriptor.rootActiveSessionId} on last client detach`,
+		);
+	}
+
 	private async assertCurrentOwnership(): Promise<void> {
 		const ownership = this.ownership;
 		if (!ownership) {
@@ -1106,6 +1160,7 @@ export class DaemonSupervisor {
 			for (const activeSessionId of [...client.attachedActiveSessionIds]) {
 				client.attachedActiveSessionIds.delete(activeSessionId);
 				void this.syncWorkerExtensionUi(activeSessionId);
+				void this.evictEmptySessionOnLastDetach(activeSessionId);
 			}
 			this.scheduleOwnedWorkerCleanupForClient(this.protocolClientId(client));
 		};
@@ -4174,6 +4229,7 @@ export class DaemonSupervisor {
 			client.catchupPurposes?.delete(resolvedId);
 			this.write(client, { type: "session_detached", activeSessionId: resolvedId });
 			void this.syncWorkerExtensionUi(resolvedId);
+			void this.evictEmptySessionOnLastDetach(resolvedId);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -870,13 +870,7 @@ export class DaemonSupervisor {
 		);
 		if (this.shuttingDown || this.updateRestartPhase !== undefined) return;
 
-		const releaseFence = await this.acquireIdleEvictionFence();
-		try {
-			await this.mutationDrain.waitForDrain(
-				0,
-				AbortSignal.timeout(IDLE_EVICTION_DRAIN_TIMEOUT_MS),
-				"Timed out draining daemon mutations for idle eviction",
-			);
+		await this.withEvictionFence("Timed out draining daemon mutations for idle eviction", async () => {
 			if (this.shuttingDown || this.updateRestartPhase !== undefined) return;
 			await Promise.all(
 				candidates.map((worker) => this.refreshWorkerSummaries(worker).catch(() => refreshed.delete(worker))),
@@ -905,9 +899,7 @@ export class DaemonSupervisor {
 					);
 				}),
 			);
-		} finally {
-			releaseFence();
-		}
+		});
 	}
 
 	/** Waits for any held eviction fence, then takes the slot; release clears it only if still ours. */
@@ -922,6 +914,29 @@ export class DaemonSupervisor {
 			if (this.idleEvictionFence === fence) this.idleEvictionFence = undefined;
 			releaseFence();
 		};
+	}
+
+	/** Runs a passivation decision under the eviction fence after draining admitted mutations. */
+	private async withEvictionFence(drainMessage: string, action: () => Promise<void>): Promise<void> {
+		const releaseFence = await this.acquireIdleEvictionFence();
+		try {
+			await this.mutationDrain.waitForDrain(0, AbortSignal.timeout(IDLE_EVICTION_DRAIN_TIMEOUT_MS), drainMessage);
+			await action();
+		} finally {
+			releaseFence();
+		}
+	}
+
+	/** Re-validates one worker on fresh summaries under the caller's fence, then passivates it. */
+	private async passivateWorkerIfStillEligible(
+		worker: ResidentWorker,
+		isStillEligible: () => boolean,
+		describeEvicted: () => string,
+	): Promise<void> {
+		await this.refreshWorkerSummaries(worker);
+		if (!isStillEligible()) return;
+		await this.stopWorker(worker, true);
+		this.log(describeEvicted());
 	}
 
 	private async evictEmptySessionOnLastDetach(activeSessionId: string): Promise<void> {
@@ -942,24 +957,18 @@ export class DaemonSupervisor {
 			return;
 		}
 		if (!this.isEmptyDetachEvictionCandidate(worker)) return;
-		// Idle-sweep coordination: fence new mutations, drain admitted ones, re-read before deciding.
-		const releaseFence = await this.acquireIdleEvictionFence();
 		try {
-			await this.mutationDrain.waitForDrain(
-				0,
-				AbortSignal.timeout(IDLE_EVICTION_DRAIN_TIMEOUT_MS),
-				"Timed out draining daemon mutations for empty-session eviction",
-			);
-			await this.refreshWorkerSummaries(worker);
-			if (!this.isEmptyDetachEvictionCandidate(worker)) return;
-			await this.stopWorker(worker, true);
-			this.log(
-				`Evicted empty session worker ${worker.descriptor.workerId} root=${worker.descriptor.rootSessionId ?? worker.descriptor.rootActiveSessionId} on last client detach`,
+			// Idle-sweep coordination: fence new mutations, drain admitted ones, re-read before deciding.
+			await this.withEvictionFence("Timed out draining daemon mutations for empty-session eviction", () =>
+				this.passivateWorkerIfStillEligible(
+					worker,
+					() => this.isEmptyDetachEvictionCandidate(worker),
+					() =>
+						`Evicted empty session worker ${worker.descriptor.workerId} root=${worker.descriptor.rootSessionId ?? worker.descriptor.rootActiveSessionId} on last client detach`,
+				),
 			);
 		} catch (error) {
 			this.log(`Empty-session eviction failed for worker ${worker.descriptor.workerId}: ${String(error)}`);
-		} finally {
-			releaseFence();
 		}
 	}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -870,11 +870,7 @@ export class DaemonSupervisor {
 		);
 		if (this.shuttingDown || this.updateRestartPhase !== undefined) return;
 
-		let releaseFence: () => void = () => {};
-		const fence = new Promise<void>((resolveFence) => {
-			releaseFence = resolveFence;
-		});
-		this.idleEvictionFence = fence;
+		const releaseFence = await this.acquireIdleEvictionFence();
 		try {
 			await this.mutationDrain.waitForDrain(
 				0,
@@ -910,13 +906,26 @@ export class DaemonSupervisor {
 				}),
 			);
 		} finally {
-			if (this.idleEvictionFence === fence) this.idleEvictionFence = undefined;
 			releaseFence();
 		}
 	}
 
+	/** Waits for any held eviction fence, then takes the slot; release clears it only if still ours. */
+	private async acquireIdleEvictionFence(): Promise<() => void> {
+		while (this.idleEvictionFence) await this.idleEvictionFence;
+		let releaseFence: () => void = () => {};
+		const fence = new Promise<void>((resolveFence) => {
+			releaseFence = resolveFence;
+		});
+		this.idleEvictionFence = fence;
+		return () => {
+			if (this.idleEvictionFence === fence) this.idleEvictionFence = undefined;
+			releaseFence();
+		};
+	}
+
 	private async evictEmptySessionOnLastDetach(activeSessionId: string): Promise<void> {
-		if (this.shuttingDown || this.updateRestartPhase !== undefined || this.idleEvictionFence) return;
+		if (this.shuttingDown || this.updateRestartPhase !== undefined) return;
 		const worker = this.matchWorkers(activeSessionId)[0]?.worker;
 		if (
 			!worker ||
@@ -932,13 +941,9 @@ export class DaemonSupervisor {
 		} catch {
 			return;
 		}
-		if (!this.isEmptyDetachEvictionCandidate(worker) || this.idleEvictionFence) return;
+		if (!this.isEmptyDetachEvictionCandidate(worker)) return;
 		// Idle-sweep coordination: fence new mutations, drain admitted ones, re-read before deciding.
-		let releaseFence: () => void = () => {};
-		const fence = new Promise<void>((resolveFence) => {
-			releaseFence = resolveFence;
-		});
-		this.idleEvictionFence = fence;
+		const releaseFence = await this.acquireIdleEvictionFence();
 		try {
 			await this.mutationDrain.waitForDrain(
 				0,
@@ -954,7 +959,6 @@ export class DaemonSupervisor {
 		} catch (error) {
 			this.log(`Empty-session eviction failed for worker ${worker.descriptor.workerId}: ${String(error)}`);
 		} finally {
-			if (this.idleEvictionFence === fence) this.idleEvictionFence = undefined;
 			releaseFence();
 		}
 	}

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -917,7 +917,7 @@ export class DaemonSupervisor {
 
 	/** Passivates an abandoned empty draft on last detach - same passivation as the idle sweep; never rejects. */
 	private async evictEmptySessionOnLastDetach(activeSessionId: string): Promise<void> {
-		if (this.shuttingDown || this.updateRestartPhase !== undefined) return;
+		if (this.shuttingDown || this.updateRestartPhase !== undefined || this.idleEvictionFence) return;
 		const worker = this.matchWorkers(activeSessionId)[0]?.worker;
 		if (
 			!worker ||
@@ -934,31 +934,49 @@ export class DaemonSupervisor {
 		} catch {
 			return;
 		}
+		if (!this.isEmptyDetachEvictionCandidate(worker) || this.idleEvictionFence) return;
+		// Same coordination as the idle sweep: fence new mutations, drain admitted
+		// ones, then re-read so the final decision reflects them.
+		let releaseFence: () => void = () => {};
+		const fence = new Promise<void>((resolveFence) => {
+			releaseFence = resolveFence;
+		});
+		this.idleEvictionFence = fence;
+		try {
+			await this.mutationDrain.waitForDrain(
+				0,
+				AbortSignal.timeout(IDLE_EVICTION_DRAIN_TIMEOUT_MS),
+				"Timed out draining daemon mutations for empty-session eviction",
+			);
+			await this.refreshWorkerSummaries(worker);
+			if (!this.isEmptyDetachEvictionCandidate(worker)) return;
+			await this.stopWorker(worker, true);
+			this.log(
+				`Evicted empty session worker ${worker.descriptor.workerId} root=${worker.descriptor.rootSessionId ?? worker.descriptor.rootActiveSessionId} on last client detach`,
+			);
+		} catch (error) {
+			this.log(`Empty-session eviction failed for worker ${worker.descriptor.workerId}: ${String(error)}`);
+		} finally {
+			if (this.idleEvictionFence === fence) this.idleEvictionFence = undefined;
+			releaseFence();
+		}
+	}
+
+	private isEmptyDetachEvictionCandidate(worker: ResidentWorker): boolean {
 		if (
 			this.shuttingDown ||
 			this.updateRestartPhase !== undefined ||
 			this.workers.get(worker.descriptor.workerId) !== worker ||
 			this.isWorkerStopping(worker)
 		) {
-			return;
+			return false;
 		}
 		const summaries = [...worker.summaries.values()];
 		const hasAttachedClient = summaries.some((summary) => {
 			const summaryActiveSessionId = summary.activeSessionId ?? summary.id;
 			return [...this.clients].some((client) => client.attachedActiveSessionIds.has(summaryActiveSessionId));
 		});
-		if (summaries.length === 0 || hasAttachedClient || !summaries.every(isEvictableEmptySessionSummary)) {
-			return;
-		}
-		try {
-			await this.stopWorker(worker, true);
-		} catch (error) {
-			this.log(`Empty-session eviction failed for worker ${worker.descriptor.workerId}: ${String(error)}`);
-			return;
-		}
-		this.log(
-			`Evicted empty session worker ${worker.descriptor.workerId} root=${worker.descriptor.rootSessionId ?? worker.descriptor.rootActiveSessionId} on last client detach`,
-		);
+		return summaries.length > 0 && !hasAttachedClient && summaries.every(isEvictableEmptySessionSummary);
 	}
 
 	private async assertCurrentOwnership(): Promise<void> {

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -915,7 +915,6 @@ export class DaemonSupervisor {
 		}
 	}
 
-	/** Passivates an abandoned empty draft on last detach - same passivation as the idle sweep; never rejects. */
 	private async evictEmptySessionOnLastDetach(activeSessionId: string): Promise<void> {
 		if (this.shuttingDown || this.updateRestartPhase !== undefined || this.idleEvictionFence) return;
 		const worker = this.matchWorkers(activeSessionId)[0]?.worker;
@@ -929,14 +928,12 @@ export class DaemonSupervisor {
 			return;
 		}
 		try {
-			// Fresh summaries, so an admitted-but-unpersisted first turn reads busy.
 			await this.refreshWorkerSummaries(worker);
 		} catch {
 			return;
 		}
 		if (!this.isEmptyDetachEvictionCandidate(worker) || this.idleEvictionFence) return;
-		// Same coordination as the idle sweep: fence new mutations, drain admitted
-		// ones, then re-read so the final decision reflects them.
+		// Idle-sweep coordination: fence new mutations, drain admitted ones, re-read before deciding.
 		let releaseFence: () => void = () => {};
 		const fence = new Promise<void>((resolveFence) => {
 			releaseFence = resolveFence;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -915,12 +915,7 @@ export class DaemonSupervisor {
 		}
 	}
 
-	/**
-	 * Passivate an abandoned empty draft as soon as its last client lets go
-	 * instead of parking the worker for the idle sweep. Same passivation as idle
-	 * eviction: the on-disk session (if any) survives and is classified draft by
-	 * inactiveLifecycleForSession. Action-driven only; never rejects.
-	 */
+	/** Passivates an abandoned empty draft on last detach - same passivation as the idle sweep; never rejects. */
 	private async evictEmptySessionOnLastDetach(activeSessionId: string): Promise<void> {
 		if (this.shuttingDown || this.updateRestartPhase !== undefined) return;
 		const worker = this.matchWorkers(activeSessionId)[0]?.worker;
@@ -928,18 +923,16 @@ export class DaemonSupervisor {
 			!worker ||
 			worker.descriptor.lifecycle !== "ready" ||
 			!worker.client ||
-			// Client-owned workers have their own disconnect cleanup with a grace period.
-			worker.descriptor.ownerClientId !== undefined ||
+			worker.descriptor.ownerClientId !== undefined || // owned workers have their own cleanup path
 			this.isWorkerStopping(worker)
 		) {
 			return;
 		}
 		try {
-			// Refresh so the busy check sees an admitted first turn that has not
-			// persisted a message yet.
+			// Fresh summaries, so an admitted-but-unpersisted first turn reads busy.
 			await this.refreshWorkerSummaries(worker);
 		} catch {
-			return; // A stopping or disconnected worker is never a candidate.
+			return;
 		}
 		if (
 			this.shuttingDown ||

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -230,6 +230,15 @@ describe("buildSessionList", () => {
 
 		expect(summary.sessionActions).toMatchObject({ queuedCount: 0, active: { kind: "turn" } });
 		expect(summary.unfinishedActionCount).toBe(3);
+		// An empty session whose first turn is in flight is busy, not idle.
+		expect(summary.activity).toBe("working");
+	});
+
+	it("marks an empty resident session idle instead of holding it at working", () => {
+		// No messages and nothing in flight: the summarizer never issues a verdict
+		// for an empty session, so it must not be pinned at "working" forever.
+		const summary = summaryForActiveSession(makeState({ activeSessionId: "empty" }));
+		expect(summary.activity).toBe("idle");
 	});
 
 	it("marks a finished subagent idle instead of holding it at working", () => {

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -230,13 +230,10 @@ describe("buildSessionList", () => {
 
 		expect(summary.sessionActions).toMatchObject({ queuedCount: 0, active: { kind: "turn" } });
 		expect(summary.unfinishedActionCount).toBe(3);
-		// An empty session whose first turn is in flight is busy, not idle.
 		expect(summary.activity).toBe("working");
 	});
 
 	it("marks an empty resident session idle instead of holding it at working", () => {
-		// No messages and nothing in flight: the summarizer never issues a verdict
-		// for an empty session, so it must not be pinned at "working" forever.
 		const summary = summaryForActiveSession(makeState({ activeSessionId: "empty" }));
 		expect(summary.activity).toBe("idle");
 	});

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -491,4 +491,54 @@ describe("daemon supervisor empty-session eviction on detach", () => {
 		expect(supervisor.stopWorker).not.toHaveBeenCalled();
 		expect([...supervisor.workers.keys()].sort()).toEqual(["busy", "named", "one-message"]);
 	});
+
+	it("keeps schedule-pinned and client-owned empty sessions resident when their last client detaches", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const heartbeat = makeWorker("heartbeat", [
+			makeSummary("heartbeat-root", now, { messageCount: 0, hasRegisteredHeartbeat: true }),
+		]);
+		const cron = makeWorker("cron", [makeSummary("cron-root", now, { messageCount: 0, hasRegisteredCronJob: true })]);
+		// Client-owned workers keep their own disconnect cleanup path.
+		const owned = makeWorker("owned", [makeSummary("owned-root", now, { messageCount: 0 })]);
+		owned.descriptor.ownerClientId = "owner";
+		for (const worker of [heartbeat, cron, owned]) {
+			supervisor.workers.set(worker.descriptor.workerId, worker);
+		}
+		const client = makeDetachClient("viewer", ["heartbeat-root", "cron-root", "owned-root"]);
+		supervisor.clients.add(client);
+
+		await supervisor.handleCommand(client, { id: "detach-all", type: "detach" });
+		await settle();
+
+		expect(supervisor.stopWorker).not.toHaveBeenCalled();
+		expect([...supervisor.workers.keys()].sort()).toEqual(["cron", "heartbeat", "owned"]);
+	});
+
+	it("does not stop a worker that was replaced while its summary refresh was in flight", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const worker = makeWorker("swap", [makeSummary("swap-root", now, { messageCount: 0 })]);
+		let releaseList!: () => void;
+		worker.client!.request.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					releaseList = () => resolve(success(undefined, "list", { sessions: [...worker.summaries.values()] }));
+				}),
+		);
+		supervisor.workers.set("swap", worker);
+		const client = makeDetachClient("viewer", ["swap-root"]);
+		supervisor.clients.add(client);
+
+		await supervisor.handleCommand(client, { id: "detach", type: "detach", activeSessionId: "swap-root" });
+		await vi.waitFor(() => expect(worker.client!.request).toHaveBeenCalled());
+		// The worker is stopped and relaunched under a successor registration mid-refresh.
+		const successor = makeWorker("swap", [makeSummary("swap-root", now, { messageCount: 0 })]);
+		supervisor.workers.set("swap", successor);
+		releaseList();
+		await settle();
+
+		expect(supervisor.stopWorker).not.toHaveBeenCalled();
+		expect(supervisor.workers.get("swap")).toBe(successor);
+	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -564,4 +564,63 @@ describe("daemon supervisor empty-session eviction on detach", () => {
 		expect(supervisor.stopWorker).not.toHaveBeenCalled();
 		expect(supervisor.workers.get("gap")).toBe(worker);
 	});
+
+	it("evicts every empty draft when one client detaches from several at once", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const draftA = makeWorker("draft-a", [makeSummary("draft-a-root", now, { messageCount: 0 })]);
+		const draftB = makeWorker("draft-b", [makeSummary("draft-b-root", now, { messageCount: 0 })]);
+		supervisor.workers.set("draft-a", draftA);
+		supervisor.workers.set("draft-b", draftB);
+		const client = makeDetachClient("viewer", ["draft-a-root", "draft-b-root"]);
+		supervisor.clients.add(client);
+
+		await supervisor.handleCommand(client, { id: "detach-all", type: "detach" });
+
+		await vi.waitFor(() => expect(supervisor.stopWorker).toHaveBeenCalledTimes(2));
+		expect(supervisor.workers.size).toBe(0);
+	});
+
+	it("makes a starting sweep wait for the detach fence instead of overwriting it", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		// Recent activity keeps the worker out of the sweep's own idle candidates.
+		const emptySessions = () => [
+			makeSummary("gap-root", now, { messageCount: 0, lastActivityAt: new Date(now).toISOString() }),
+		];
+		const worker = makeWorker("gap", emptySessions());
+		let releaseSweepList!: () => void;
+		let releaseHookList!: () => void;
+		worker
+			.client!.request.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						releaseSweepList = () => resolve(success(undefined, "list", { sessions: emptySessions() }));
+					}),
+			)
+			.mockImplementationOnce(async () => success(undefined, "list", { sessions: emptySessions() }))
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						releaseHookList = () => resolve(success(undefined, "list", { sessions: emptySessions() }));
+					}),
+			);
+		supervisor.workers.set("gap", worker);
+		const client = makeDetachClient("viewer", ["gap-root"]);
+		supervisor.clients.add(client);
+
+		const sweep = supervisor.runIdleEvictionSweep(now);
+		await vi.waitFor(() => expect(worker.client!.request).toHaveBeenCalledTimes(1));
+		await supervisor.handleCommand(client, { id: "detach", type: "detach", activeSessionId: "gap-root" });
+		await vi.waitFor(() => expect(worker.client!.request).toHaveBeenCalledTimes(3));
+		releaseSweepList();
+		await settle();
+
+		// The hook is still mid-decision, so its fence must still be in the slot.
+		expect(supervisor.idleEvictionFence).toBeDefined();
+		releaseHookList();
+		await sweep;
+		expect(supervisor.stopWorker).toHaveBeenCalledTimes(1);
+		expect(supervisor.stopWorker).toHaveBeenCalledWith(worker, true);
+	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -484,7 +484,6 @@ describe("daemon supervisor empty-session eviction on detach", () => {
 		supervisor.clients.add(first);
 		supervisor.clients.add(viewer);
 
-		// Not the last client of empty-root: nothing evicted.
 		await supervisor.handleCommand(first, { id: "detach-1", type: "detach", activeSessionId: "empty-root" });
 		await settle();
 		expect(supervisor.stopWorker).not.toHaveBeenCalled();

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -442,3 +442,53 @@ describe("daemon supervisor whole-tree eviction", () => {
 		expect(supervisor.createOrReuseWorker).not.toHaveBeenCalled();
 	});
 });
+
+describe("daemon supervisor empty-session eviction on detach", () => {
+	function makeDetachClient(id: string, attached: string[]) {
+		return { id, attachedActiveSessionIds: new Set(attached), socket: { destroyed: true } };
+	}
+
+	async function settle(): Promise<void> {
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+
+	it("evicts an empty unnamed session only when its last client detaches", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const empty = makeWorker("empty", [makeSummary("empty-root", now, { messageCount: 0 })]);
+		supervisor.workers.set("empty", empty);
+		const first = makeDetachClient("first", ["empty-root"]);
+		const second = makeDetachClient("second", ["empty-root"]);
+		supervisor.clients.add(first);
+		supervisor.clients.add(second);
+
+		await supervisor.handleCommand(first, { id: "detach-1", type: "detach", activeSessionId: "empty-root" });
+		await settle();
+		expect(supervisor.stopWorker).not.toHaveBeenCalled();
+
+		await supervisor.handleCommand(second, { id: "detach-2", type: "detach", activeSessionId: "empty-root" });
+		await vi.waitFor(() => expect(supervisor.stopWorker).toHaveBeenCalledWith(empty, true));
+		expect(supervisor.workers.has("empty")).toBe(false);
+		expect(supervisor.log).toHaveBeenCalledWith(expect.stringContaining("Evicted empty session worker empty"));
+	});
+
+	it("keeps named, busy, and non-empty sessions resident when their last client detaches", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const named = makeWorker("named", [makeSummary("named-root", now, { messageCount: 0, sessionName: "keep me" })]);
+		// An empty session whose first turn is in flight reports busy before any message persists.
+		const busy = makeWorker("busy", [makeSummary("busy-root", now, { messageCount: 0, isSessionActive: true })]);
+		const oneMessage = makeWorker("one-message", [makeSummary("one-message-root", now)]);
+		for (const worker of [named, busy, oneMessage]) {
+			supervisor.workers.set(worker.descriptor.workerId, worker);
+		}
+		const client = makeDetachClient("viewer", ["named-root", "busy-root", "one-message-root"]);
+		supervisor.clients.add(client);
+
+		await supervisor.handleCommand(client, { id: "detach-all", type: "detach" });
+		await settle();
+
+		expect(supervisor.stopWorker).not.toHaveBeenCalled();
+		expect([...supervisor.workers.keys()].sort()).toEqual(["busy", "named", "one-message"]);
+	});
+});

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -31,6 +31,7 @@ interface SupervisorInternals {
 	workers: Map<string, WorkerFixture>;
 	clients: Set<{ id: string; attachedActiveSessionIds: Set<string> }>;
 	idleEvictionFence?: Promise<void>;
+	mutationDrain: { begin(): void; end(): void };
 	catalog: { resolve: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> };
 	createOrReuseWorker: ReturnType<typeof vi.fn>;
 	stopWorker: ReturnType<typeof vi.fn>;
@@ -527,5 +528,41 @@ describe("daemon supervisor empty-session eviction on detach", () => {
 
 		expect(supervisor.stopWorker).not.toHaveBeenCalled();
 		expect(supervisor.workers.get("swap")).toBe(successor);
+	});
+
+	it("does not evict when a mutation admitted during the refresh registers a schedule", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const worker = makeWorker("gap", [makeSummary("gap-root", now, { messageCount: 0 })]);
+		let releaseList!: () => void;
+		worker.client!.request.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					releaseList = () =>
+						resolve(
+							success(undefined, "list", { sessions: [makeSummary("gap-root", now, { messageCount: 0 })] }),
+						);
+				}),
+		);
+		supervisor.workers.set("gap", worker);
+		const client = makeDetachClient("viewer", ["gap-root"]);
+		supervisor.clients.add(client);
+
+		await supervisor.handleCommand(client, { id: "detach", type: "detach", activeSessionId: "gap-root" });
+		await vi.waitFor(() => expect(worker.client!.request).toHaveBeenCalled());
+		// A heartbeat_set admitted mid-refresh registers a schedule before the eviction decision.
+		supervisor.mutationDrain.begin();
+		worker.client!.request.mockImplementation(async () =>
+			success(undefined, "list", {
+				sessions: [makeSummary("gap-root", now, { messageCount: 0, hasRegisteredHeartbeat: true })],
+			}),
+		);
+		releaseList();
+		await settle();
+		supervisor.mutationDrain.end();
+		await settle();
+
+		expect(supervisor.stopWorker).not.toHaveBeenCalled();
+		expect(supervisor.workers.get("gap")).toBe(worker);
 	});
 });

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -452,67 +452,55 @@ describe("daemon supervisor empty-session eviction on detach", () => {
 		await new Promise((resolve) => setTimeout(resolve, 25));
 	}
 
-	it("evicts an empty unnamed session only when its last client detaches", async () => {
+	it("evicts only abandoned empty unnamed sessions, and only on the last detach", async () => {
 		const now = Date.parse("2026-08-01T12:00:00.000Z");
 		const supervisor = makeSupervisor();
 		const empty = makeWorker("empty", [makeSummary("empty-root", now, { messageCount: 0 })]);
-		supervisor.workers.set("empty", empty);
+		const exempt = [
+			makeWorker("named", [makeSummary("named-root", now, { messageCount: 0, sessionName: "keep me" })]),
+			makeWorker("busy", [makeSummary("busy-root", now, { messageCount: 0, isSessionActive: true })]),
+			makeWorker("one-message", [makeSummary("one-message-root", now)]),
+			makeWorker("heartbeat", [
+				makeSummary("heartbeat-root", now, { messageCount: 0, hasRegisteredHeartbeat: true }),
+			]),
+			makeWorker("cron", [makeSummary("cron-root", now, { messageCount: 0, hasRegisteredCronJob: true })]),
+			makeWorker("owned", [makeSummary("owned-root", now, { messageCount: 0 })]),
+		];
+		exempt[5]!.descriptor.ownerClientId = "owner";
+		for (const worker of [empty, ...exempt]) {
+			supervisor.workers.set(worker.descriptor.workerId, worker);
+		}
 		const first = makeDetachClient("first", ["empty-root"]);
-		const second = makeDetachClient("second", ["empty-root"]);
+		const viewer = makeDetachClient("viewer", [
+			"empty-root",
+			"named-root",
+			"busy-root",
+			"one-message-root",
+			"heartbeat-root",
+			"cron-root",
+			"owned-root",
+		]);
 		supervisor.clients.add(first);
-		supervisor.clients.add(second);
+		supervisor.clients.add(viewer);
 
+		// Not the last client of empty-root: nothing evicted.
 		await supervisor.handleCommand(first, { id: "detach-1", type: "detach", activeSessionId: "empty-root" });
 		await settle();
 		expect(supervisor.stopWorker).not.toHaveBeenCalled();
 
-		await supervisor.handleCommand(second, { id: "detach-2", type: "detach", activeSessionId: "empty-root" });
+		await supervisor.handleCommand(viewer, { id: "detach-all", type: "detach" });
 		await vi.waitFor(() => expect(supervisor.stopWorker).toHaveBeenCalledWith(empty, true));
-		expect(supervisor.workers.has("empty")).toBe(false);
-		expect(supervisor.log).toHaveBeenCalledWith(expect.stringContaining("Evicted empty session worker empty"));
-	});
-
-	it("keeps named, busy, and non-empty sessions resident when their last client detaches", async () => {
-		const now = Date.parse("2026-08-01T12:00:00.000Z");
-		const supervisor = makeSupervisor();
-		const named = makeWorker("named", [makeSummary("named-root", now, { messageCount: 0, sessionName: "keep me" })]);
-		// An empty session whose first turn is in flight reports busy before any message persists.
-		const busy = makeWorker("busy", [makeSummary("busy-root", now, { messageCount: 0, isSessionActive: true })]);
-		const oneMessage = makeWorker("one-message", [makeSummary("one-message-root", now)]);
-		for (const worker of [named, busy, oneMessage]) {
-			supervisor.workers.set(worker.descriptor.workerId, worker);
-		}
-		const client = makeDetachClient("viewer", ["named-root", "busy-root", "one-message-root"]);
-		supervisor.clients.add(client);
-
-		await supervisor.handleCommand(client, { id: "detach-all", type: "detach" });
 		await settle();
-
-		expect(supervisor.stopWorker).not.toHaveBeenCalled();
-		expect([...supervisor.workers.keys()].sort()).toEqual(["busy", "named", "one-message"]);
-	});
-
-	it("keeps schedule-pinned and client-owned empty sessions resident when their last client detaches", async () => {
-		const now = Date.parse("2026-08-01T12:00:00.000Z");
-		const supervisor = makeSupervisor();
-		const heartbeat = makeWorker("heartbeat", [
-			makeSummary("heartbeat-root", now, { messageCount: 0, hasRegisteredHeartbeat: true }),
+		expect(supervisor.stopWorker).toHaveBeenCalledTimes(1);
+		expect([...supervisor.workers.keys()].sort()).toEqual([
+			"busy",
+			"cron",
+			"heartbeat",
+			"named",
+			"one-message",
+			"owned",
 		]);
-		const cron = makeWorker("cron", [makeSummary("cron-root", now, { messageCount: 0, hasRegisteredCronJob: true })]);
-		// Client-owned workers keep their own disconnect cleanup path.
-		const owned = makeWorker("owned", [makeSummary("owned-root", now, { messageCount: 0 })]);
-		owned.descriptor.ownerClientId = "owner";
-		for (const worker of [heartbeat, cron, owned]) {
-			supervisor.workers.set(worker.descriptor.workerId, worker);
-		}
-		const client = makeDetachClient("viewer", ["heartbeat-root", "cron-root", "owned-root"]);
-		supervisor.clients.add(client);
-
-		await supervisor.handleCommand(client, { id: "detach-all", type: "detach" });
-		await settle();
-
-		expect(supervisor.stopWorker).not.toHaveBeenCalled();
-		expect([...supervisor.workers.keys()].sort()).toEqual(["cron", "heartbeat", "owned"]);
+		expect(supervisor.log).toHaveBeenCalledWith(expect.stringContaining("Evicted empty session worker empty"));
 	});
 
 	it("does not stop a worker that was replaced while its summary refresh was in flight", async () => {
@@ -532,7 +520,6 @@ describe("daemon supervisor empty-session eviction on detach", () => {
 
 		await supervisor.handleCommand(client, { id: "detach", type: "detach", activeSessionId: "swap-root" });
 		await vi.waitFor(() => expect(worker.client!.request).toHaveBeenCalled());
-		// The worker is stopped and relaunched under a successor registration mid-refresh.
 		const successor = makeWorker("swap", [makeSummary("swap-root", now, { messageCount: 0 })]);
 		supervisor.workers.set("swap", successor);
 		releaseList();


### PR DESCRIPTION
Two empty-session lifecycle fixes, found while investigating the macOS "ctrl+c never ends the session / after a couple of sessions it can't create a new one" report (companion to #1918).

## Status honesty

A 0-message detached session was pinned at "working" forever - rendered as a red running entry in the agents view and `prime-agent list` - because `activeActivityForSession` holds sessions at "working" until a summarizer verdict exists, and an empty session never produces one. Users reasonably concluded that exiting "never ends the session". The fix is the same carve-out finished subagents already have: a session with 0 messages and nothing in flight is idle. An accepted in-flight first prompt still shows "working" (the busy guard runs first, pinned by test).

## Evict empty unnamed sessions on last-client disconnect

An abandoned empty session parked a resident worker (~80 MB) plus an IPython kernel for the 90-minute idle-eviction window, holding 2 daemon file descriptors - the accumulation ingredient behind the EMFILE failure fixed in #1918. Now, when the last client disconnects from a worker whose sessions are all empty (0 messages), unnamed, not busy, and hold no heartbeat/cron registration, the supervisor passivates it immediately through the existing eviction path. Action-driven only - no new timers. Naming a session exempts it (that is the "I want to come back" signal); client-owned workers keep their existing cleanup path; eviction remains passivation, so the on-disk session survives as a draft.

Races verified against the ownership machinery from #1756/#1864: a create/attach arriving mid-stop fails cleanly with "worker is stopping" and relaunches from the draft; the eviction re-checks worker identity after its summary refresh and cannot stop a relaunched successor (stopWorker additionally pins the entry pid). Cold reopen of an evicted draft measures ~0.55s on macOS, indistinguishable from a warm attach.

Deliberately not gated on `idleEvictionMinutes: "off"`: everything a user wants kept warm (messages, a name, a schedule, an attached client) already blocks this eviction, and gating would reinstate the leak for exactly the users most exposed to it.

## Tests

Six behavior tests plus one extended assertion across `daemon-session-list` and a new `daemon-supervisor-eviction` case set: empty-idle status (proven red), the in-flight-first-prompt guard, last-client-only eviction (proven red), named/busy/non-empty exemptions, schedule-pinned and client-owned exemptions, and a replaced-worker race guard.

Linear: [ENG-5809](https://linear.app/primeintellect/issue/ENG-5809/empty-sessions-show-as-running-forever-and-hold-a-resident-worker-for)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `evictEmptySessionOnLastDetach` stops workers on detach; reconnecting spins up a new worker, and fence/drain logic must stay correct alongside idle sweeps and mid-flight mutations.
> 
> **Overview**
> Fixes two empty-session lifecycle issues in the coding-agent daemon: **misleading "working" status** and **workers staying resident after abandon**.
> 
> **Status:** `activeActivityForSession` now treats zero-message resident sessions as **idle** (like finished subagents), so `prime-agent list` and the agents view no longer show abandoned empty drafts as permanently running. Sessions with real in-flight work still report **working** first.
> 
> **Eviction:** When the **last client** detaches or disconnects, the supervisor may **passivate** the worker immediately if every session on it matches `isEvictableEmptySessionSummary` (no messages, no name, not busy, no heartbeat/cron). Named sessions, busy sessions, client-owned workers, and multi-attach cases are exempt; eviction reuses the idle-sweep **mutation drain + fence** (`withEvictionFence`) so detach eviction and periodic idle sweeps do not race. On-disk draft sessions are preserved.
> 
> Tests cover empty-idle classification, detach-only eviction, exemptions, worker-replacement races, and fence coordination with idle sweeps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21143265a277746623739be1929f6e566bcf1514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `coding-agent` daemon to report idle status and evict empty sessions on detach
> - Empty resident sessions with zero messages and nothing in flight now report activity as `"idle"` instead of staying pinned at `"working"` in [daemon-session-list.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1920/files#diff-c440a99335cbc4d3fa06c11e80a709024e83ebd799f499397c5e8d21ba601e21).
> - When the last client detaches from an empty, unnamed, idle session, the worker is immediately stopped and its on-disk draft persists, via `daemon-supervisor.evictEmptySessionOnLastDetach`.
> - Eviction runs under a reusable eviction fence (`withEvictionFence`) that drains pending mutations before the decision, preventing races with in-flight worker refreshes or schedules registered during the drain.
> - Behavioral Change: `daemon-supervisor` client disconnect and `detach` command handlers now trigger eviction for qualifying empty sessions; sessions that were previously kept alive will be passivated immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2114326.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->