### PR TITLE
fix(ai): advance Anthropic cache marker across tool results

### DIFF
--- a/packages/ai/.changes/fix-anthropic-tool-cache.md
+++ b/packages/ai/.changes/fix-anthropic-tool-cache.md
@@ -1,0 +1,1 @@
+- Fixed Anthropic-compatible prompt caching so the rolling cache marker advances to the latest tool result.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -724,7 +724,7 @@ function addCacheControlToLastConversationMessage(
 ): void {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const message = messages[i];
-		if (message.role === "user" || message.role === "assistant") {
+		if (message.role === "user" || message.role === "assistant" || message.role === "tool") {
 			if (addCacheControlToMessage(message, cacheControl)) {
 				return;
 			}
@@ -755,7 +755,7 @@ function addCacheControlToMessage(
 	message: ChatCompletionMessageParam,
 	cacheControl: OpenAICompatCacheControl,
 ): boolean {
-	if (message.role === "user" || message.role === "assistant") {
+	if (message.role === "user" || message.role === "assistant" || message.role === "tool") {
 		return addCacheControlToTextContent(message, cacheControl);
 	}
 	return false;
@@ -765,6 +765,7 @@ function addCacheControlToTextContent(
 	message:
 		| ChatCompletionInstructionMessageParam
 		| ChatCompletionAssistantMessageParam
+		| ChatCompletionToolMessageParam
 		| Extract<ChatCompletionMessageParam, { role: "user" }>,
 	cacheControl: OpenAICompatCacheControl,
 ): boolean {

--- a/packages/ai/test/openai-completions-cache-control-format.test.ts
+++ b/packages/ai/test/openai-completions-cache-control-format.test.ts
@@ -179,59 +179,36 @@ describe("openai-completions cacheControlFormat", () => {
 		expect(result.usage.cost.cacheWrite).toBeCloseTo((80 * model.cost.cacheWrite) / 1_000_000);
 	});
 
-	it("advances the Anthropic cache marker to the latest tool result", async () => {
+	it("advances the Anthropic cache marker to a tool result", async () => {
 		const model = getModel("prime-inference", "anthropic/claude-fable-5");
 		const now = Date.now();
-		const firstAssistant: AssistantMessage = {
-			role: "assistant",
-			content: [
-				{ type: "text", text: "Starting the first read." },
-				{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "first.txt" } },
-			],
-			api: model.api,
-			provider: model.provider,
-			model: model.id,
-			usage: emptyUsage,
-			stopReason: "toolUse",
-			timestamp: now + 1,
-		};
-		const secondAssistant: AssistantMessage = {
-			...firstAssistant,
-			content: [{ type: "toolCall", id: "tool-2", name: "read", arguments: { path: "second.txt" } }],
-			timestamp: now + 3,
-		};
 		const messages: Context["messages"] = [
-			{ role: "user", content: "Read both files", timestamp: now },
-			firstAssistant,
+			{ role: "user", content: "Read the file", timestamp: now },
+			{
+				role: "assistant",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "file.txt" } }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: emptyUsage,
+				stopReason: "toolUse",
+				timestamp: now + 1,
+			},
 			{
 				role: "toolResult",
 				toolCallId: "tool-1",
 				toolName: "read",
-				content: [{ type: "text", text: "first result" }],
+				content: [{ type: "text", text: "file contents" }],
 				isError: false,
 				timestamp: now + 2,
-			},
-			secondAssistant,
-			{
-				role: "toolResult",
-				toolCallId: "tool-2",
-				toolName: "read",
-				content: [{ type: "text", text: "second result" }],
-				isError: false,
-				timestamp: now + 4,
 			},
 		];
 
 		const { params } = await runCompletion(model, undefined, messages);
-		const lastMessage = params.messages[params.messages.length - 1];
-		expect(lastMessage.role).toBe("tool");
-		expect(Array.isArray(lastMessage.content)).toBe(true);
-		expect((lastMessage.content as TextPart[])[0]?.cache_control).toEqual({ type: "ephemeral" });
-
-		const firstAssistantPayload = params.messages.find(
-			(message) => message.role === "assistant" && message.content !== null,
-		);
-		expect(typeof firstAssistantPayload?.content).toBe("string");
+		expect(params.messages.at(-1)).toMatchObject({
+			role: "tool",
+			content: [{ type: "text", text: "file contents", cache_control: { type: "ephemeral" } }],
+		});
 	});
 
 	it("preserves Anthropic-style cache markers for OpenRouter Anthropic models", async () => {

--- a/packages/ai/test/openai-completions-cache-control-format.test.ts
+++ b/packages/ai/test/openai-completions-cache-control-format.test.ts
@@ -180,7 +180,7 @@ describe("openai-completions cacheControlFormat", () => {
 	});
 
 	it("advances the Anthropic cache marker to a tool result", async () => {
-		const model = getModel("prime-inference", "anthropic/claude-fable-5");
+		const model = getModel("prime-inference", "anthropic/claude-haiku-4.5");
 		const now = Date.now();
 		const messages: Context["messages"] = [
 			{ role: "user", content: "Read the file", timestamp: now },

--- a/packages/ai/test/openai-completions-cache-control-format.test.ts
+++ b/packages/ai/test/openai-completions-cache-control-format.test.ts
@@ -2,7 +2,7 @@ import { Type } from "typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getModel } from "../src/models.js";
 import { streamOpenAICompletions } from "../src/providers/openai-completions.js";
-import type { AssistantMessage, Model } from "../src/types.js";
+import type { AssistantMessage, Context, Model, Usage } from "../src/types.js";
 
 interface CacheControl {
 	type: "ephemeral";
@@ -31,6 +31,15 @@ interface CapturedParams {
 const mockState = vi.hoisted(() => ({
 	lastParams: undefined as CapturedParams | undefined,
 }));
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
 
 vi.mock("openai", () => {
 	class FakeOpenAI {
@@ -78,6 +87,7 @@ vi.mock("openai", () => {
 async function runCompletion(
 	model: Model<"openai-completions">,
 	options?: { cacheRetention?: "none" | "short" | "long" },
+	messages?: Context["messages"],
 ): Promise<{ params: CapturedParams; result: AssistantMessage }> {
 	const timestamp = Date.now();
 
@@ -85,7 +95,7 @@ async function runCompletion(
 		model,
 		{
 			systemPrompt: "System prompt",
-			messages: [{ role: "user", content: "Hello", timestamp }],
+			messages: messages ?? [{ role: "user", content: "Hello", timestamp }],
 			tools: [
 				{
 					name: "read",
@@ -167,6 +177,61 @@ describe("openai-completions cacheControlFormat", () => {
 		const { params, result } = await runCompletion(model);
 		expectAnthropicCacheMarkers(params);
 		expect(result.usage.cost.cacheWrite).toBeCloseTo((80 * model.cost.cacheWrite) / 1_000_000);
+	});
+
+	it("advances the Anthropic cache marker to the latest tool result", async () => {
+		const model = getModel("prime-inference", "anthropic/claude-fable-5");
+		const now = Date.now();
+		const firstAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Starting the first read." },
+				{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "first.txt" } },
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: now + 1,
+		};
+		const secondAssistant: AssistantMessage = {
+			...firstAssistant,
+			content: [{ type: "toolCall", id: "tool-2", name: "read", arguments: { path: "second.txt" } }],
+			timestamp: now + 3,
+		};
+		const messages: Context["messages"] = [
+			{ role: "user", content: "Read both files", timestamp: now },
+			firstAssistant,
+			{
+				role: "toolResult",
+				toolCallId: "tool-1",
+				toolName: "read",
+				content: [{ type: "text", text: "first result" }],
+				isError: false,
+				timestamp: now + 2,
+			},
+			secondAssistant,
+			{
+				role: "toolResult",
+				toolCallId: "tool-2",
+				toolName: "read",
+				content: [{ type: "text", text: "second result" }],
+				isError: false,
+				timestamp: now + 4,
+			},
+		];
+
+		const { params } = await runCompletion(model, undefined, messages);
+		const lastMessage = params.messages[params.messages.length - 1];
+		expect(lastMessage.role).toBe("tool");
+		expect(Array.isArray(lastMessage.content)).toBe(true);
+		expect((lastMessage.content as TextPart[])[0]?.cache_control).toEqual({ type: "ephemeral" });
+
+		const firstAssistantPayload = params.messages.find(
+			(message) => message.role === "assistant" && message.content !== null,
+		);
+		expect(typeof firstAssistantPayload?.content).toBe("string");
 	});
 
 	it("preserves Anthropic-style cache markers for OpenRouter Anthropic models", async () => {


### PR DESCRIPTION
## Summary

- include tool-result messages when placing Anthropic-style rolling cache markers
- allow tool message text content to carry `cache_control`
- add a regression test for sessions with tool-call-only assistant turns

Linear: ENG-5823

## Why

Prime Agent's Python kernel loop often emits assistant messages with `content: null` after the first turn, while each kernel result is sent as a `tool` message. The cache-marker scan skipped tool messages, so it walked back to an earlier assistant text block and left the rolling breakpoint frozen there. Every later tool call and result was then resent as uncached input.

## Test plan

- `npm test -w packages/ai`
- `npx biome check packages/ai/src/providers/openai-completions.ts packages/ai/test/openai-completions-cache-control-format.test.ts`
- `npx tsgo --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to where cache markers are attached on Anthropic-format completions; improves caching behavior without touching auth or data handling.
> 
> **Overview**
> Fixes Anthropic-compatible **rolling prompt cache** placement so the ephemeral `cache_control` marker can land on the latest **`tool`** message, not only user or assistant turns.
> 
> In `openai-completions.ts`, the backward scan in `addCacheControlToLastConversationMessage` and the helpers `addCacheControlToMessage` / `addCacheControlToTextContent` now treat `role: "tool"` like other conversational messages. That matters when assistant turns are tool-call-only (e.g. empty text) and each kernel step ends with a tool result—the marker previously stuck on an earlier assistant block, so later tool traffic was treated as uncached input.
> 
> Adds a regression test that asserts the last outbound message is a `tool` payload with `cache_control` on its text part, plus a short changelog note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb645563cd8c8d386239861e3bdbfe82e5045fa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Anthropic cache marker to advance across `tool` result messages
> Previously the rolling `cache_control` marker could only land on user or assistant messages, so it never advanced past a tool result. Expands `addCacheControlToLastConversationMessage`, `addCacheControlToMessage`, and `addCacheControlToTextContent` in [openai-completions.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1927/files#diff-d3f9c03940767ab76191513078367a64d9e38e58fbdff99f5ad7bf65786b4246) to also consider `role: 'tool'` messages when placing the ephemeral cache marker. Adds a test confirming the marker lands on the final tool message in a conversation ending with a tool result.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1927 opened
>
> - Updated model identifier in test case [eb64556]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be91ea9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
