### PR TITLE
fix(coding-agent): make conditional goals crash-safe

### DIFF
--- a/PRIME_AGENT_DAEMON_GOAL_FENCE_DIFFERENTIAL_REVIEW_2026-09-01.md
+++ b/PRIME_AGENT_DAEMON_GOAL_FENCE_DIFFERENTIAL_REVIEW_2026-09-01.md
@@ -1,0 +1,82 @@
+# Prime Agent conditional-goal differential review
+
+## Executive summary
+
+| Severity | Count |
+| --- | ---: |
+| Critical | 0 |
+| High | 0 |
+| Medium | 0 |
+| Low | 0 |
+
+**Overall risk:** high-impact control-plane change, mitigated by exact fences and
+failure-injection coverage. **Recommendation:** APPROVE after rebasing the one
+new `origin/main` commit and repeating the full gate.
+
+Thirteen changed files were reviewed (7 production/docs, 6 test), with 1,579
+additions and 107 deletions against `9f5edc192`. The change affects persisted
+goal state, daemon admission, cron recovery, session restore, and the public
+daemon protocol. No validation removal or prior security-fix regression was
+found.
+
+## What changed
+
+- A conditional `/goal` admission persists a bounded receipt and phase before
+  provider execution (`agent-session.ts:5374`, `agent-session.ts:6138`).
+- Recovery commits its counter before queueing; the fifth failure terminalizes
+  both goal and cron receipt (`daemon-mode.ts:1538`, `cron-jobs.ts:716`).
+- Restores rebind conditional jobs only for the exact stable session file, while
+  rotating the daemon-local active ID (`cron-jobs.ts:292`).
+- Sanitized session summaries expose only receipt/phase metadata needed by CTO;
+  protocol schema/capability negotiation rejects mixed-version guarded calls.
+
+## Adversarial analysis
+
+Attacker model: a stale or racing local coordinator able to issue daemon cron
+requests, but unable to alter the private session file. The relevant attacks
+are duplicate `/goal` delivery, cross-root delivery after `switch_session`, and
+crash-after-receipt loss.
+
+All three paths fail closed: admission compares the exact idle-root fence;
+conditional rebind requires the same resolved session file; recovery recognizes
+only the exact receipt and refuses unfinished actions; the provider boundary
+requires active status, matching receipt, and `receipt` phase. Retry exhaustion
+produces a terminal durable marker instead of unbounded replay.
+
+## Test coverage and blast radius
+
+The five new/modified critical methods occur in 2–4 source/test files each,
+giving a low direct caller count but high operational impact. Coverage includes
+receipt persistence failure, provider-boundary invalidation, daemon death,
+counter-write failure, fifth-attempt exhaustion, queued fifth-attempt guard,
+same-file restore, and cross-file switch-session refusal.
+
+Validation observed before compatibility rebase:
+
+- `npm run check`: pass.
+- Six focused Vitest files: 386/386 pass.
+- Biome formatting/lint and TypeScript checks: pass.
+
+## Historical context
+
+`rebindSessionJobs` originated in `ce095e9fc` (session/heartbeat support). The
+review preserves its generic live-session migration behavior while narrowing
+only conditional jobs to stable-file identity. Removed persistence code was
+replaced by persist-before-memory/side-effect logic; no security-motivated
+guard was removed without replacement.
+
+## Recommendations
+
+- Rebase `origin/main`, inspect the combined diff, and repeat all gates.
+- Install Prime before the dependent CTO skill so schema 24 and
+  `conditional_cron_delivery` negotiate atomically.
+- Keep the 72-hour soak and injected daemon/session failures as the production
+  acceptance gate.
+
+## Methodology
+
+FOCUSED differential review: all changed files, one-hop callers, removed-check
+scan, history search, state-flow tracing, adversarial race/crash scenarios, and
+independent Sol/xhigh review. Confidence is high for the changed control-plane
+scope; external provider behavior and the pending 72-hour soak remain outside
+this pre-merge proof.

--- a/packages/coding-agent/.changes/daemon-sanitized-goal-fence.md
+++ b/packages/coding-agent/.changes/daemon-sanitized-goal-fence.md
@@ -1,0 +1,1 @@
+- Added sanitized goal-generation and conditional-delivery receipt fences to resident daemon summaries, with crash-safe pre-provider recovery and explicit exhaustion.

--- a/packages/coding-agent/docs/long-running-agents.md
+++ b/packages/coding-agent/docs/long-running-agents.md
@@ -167,7 +167,7 @@ prime-agent schedule list --all
 prime-agent schedule cancel <job-id>
 ```
 
-Scheduled jobs are persisted per session and continue while the UI is detached. Due ticks are claimed before delivery so a crash does not replay an uncertain prompt, and missed ticks are coalesced rather than accumulated into an unbounded backlog.
+Scheduled jobs are persisted per session and continue while the UI is detached. Due ticks are claimed before delivery so a crash does not replay an uncertain prompt, and missed ticks are coalesced rather than accumulated into an unbounded backlog. A conditionally fenced `/goal` additionally persists its job receipt before queueing and its provider-commit phase before provider code can observe the prompt. Daemon recovery rebuilds only a receipt-phase turn, counts each recovery before queue admission, and terminalizes an exhausted pre-provider receipt so an external coordinator can safely rearm it.
 
 ## Persistent Goals
 
@@ -195,6 +195,8 @@ await goal.complete()
 ```
 
 Goal state records token usage, elapsed time, continuation count, and an optional explicit token budget. The harness keeps prompting an active goal after ordinary assistant turns; only `goal.complete()` marks successful completion. Creating a persistent goal is an explicit user or host action, not something the agent should infer from every task.
+
+Resident daemon `get_state` summaries expose a non-sensitive goal fence (`active`, `status`, `goalId`, `updatedAt`, and optional `dispatchReceiptId`/`dispatchPhase`, or `null` when absent) so supervisors can make deterministic scheduling and crash-recovery decisions without receiving the goal objective.
 
 ## Autonomous Mode
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -151,6 +151,7 @@ import {
 	GOAL_CONTEXT_PREVIEW_LABEL,
 	GOAL_SKILL_NAME,
 	GOAL_STATE_CUSTOM_TYPE,
+	type GoalContextDetails,
 	type GoalHostResponse,
 	type GoalState,
 	type GoalStatus,
@@ -159,6 +160,7 @@ import {
 	isPersistedGoalState,
 	normalizeGoalState,
 	validateGoalBudget,
+	validateGoalDispatchReceiptId,
 	validateGoalObjective,
 } from "./goals.js";
 import type { HostRequestHandlers, KernelSentAgentMessage } from "./kernel/index.js";
@@ -700,6 +702,24 @@ function cloneQueuedAgentMessage(message: QueuedAgentMessage): QueuedAgentMessag
 	};
 }
 
+function conditionalGoalReceiptForMessage(message: CustomMessage | undefined): string | undefined {
+	if (message?.customType !== GOAL_CONTEXT_CUSTOM_TYPE || !message.details || typeof message.details !== "object") {
+		return undefined;
+	}
+	const receiptId = (message.details as Partial<GoalContextDetails>).dispatchReceiptId;
+	return typeof receiptId === "string" && receiptId.length > 0 ? receiptId : undefined;
+}
+
+function conditionalGoalReceiptForRecoveryPayload(payload: SessionActionRecoveryPayload): string | undefined {
+	return payload.kind === "turn" ? conditionalGoalReceiptForMessage(payload.customMessage) : undefined;
+}
+
+function conditionalGoalReceiptForPreparedPayload(
+	payload: PreparedTurnPayload | PreparedCommandPayload,
+): string | undefined {
+	return payload.kind === "turn" ? conditionalGoalReceiptForMessage(payload.customMessage) : undefined;
+}
+
 function primaryDeliveryRecord(action: QueuedSessionAction): DeliveryRecord {
 	if (action.payload.kind !== "turn") throw new Error(`Session action ${action.id} is not a turn`);
 	const record = action.payload.records.find((candidate) => candidate.role === "primary");
@@ -1085,6 +1105,7 @@ export class AgentSession {
 	private _goalState: GoalState = emptyGoalState();
 	private _goalAccountingStartedAt: number | undefined = undefined;
 	private _goalContinuationAwaitsRlmWork = false;
+	private readonly _recoveredConditionalGoalReceipts = new Set<string>();
 	private _goalAccountedAssistantMessages = new WeakSet<AssistantMessage>();
 	private _goalAbortInProgress = false;
 	private _autonomousState: AutonomousRuntimeState;
@@ -1663,11 +1684,9 @@ export class AgentSession {
 	}
 
 	private _persistGoalState(goal: GoalState): void {
-		this.sessionManager.appendCustomEntry(GOAL_STATE_CUSTOM_TYPE, goal);
-		// Force flush so the goal state is durable on disk immediately,
-		// even before the first assistant response. This ensures idempotent
-		// restart/rehydration can detect the persisted goal.
-		this.sessionManager.flushNow();
+		// Append and flush as one rollback-capable branch mutation so a failed
+		// conditional start cannot leave an unsaved live goal behind.
+		this.sessionManager.appendCustomEntryWithRollback(GOAL_STATE_CUSTOM_TYPE, goal);
 	}
 
 	private _setGoalState(next: GoalState, options: { persist?: boolean } = {}): void {
@@ -1675,15 +1694,23 @@ export class AgentSession {
 			...next,
 			updatedAt: Date.now(),
 		});
+		if (options.persist !== false) {
+			this._persistGoalState(normalized);
+		}
 		this._goalState = normalized;
 		if (normalized.status === "active") {
 			this._goalAccountingStartedAt ??= Date.now();
 		} else {
 			this._goalAccountingStartedAt = undefined;
 		}
-		if (options.persist !== false) {
-			this._persistGoalState(normalized);
-		}
+		this._emitGoalUpdate();
+	}
+
+	private _restoreGoalStateGeneration(goal: GoalState): void {
+		const restored = normalizeGoalState(goal);
+		this._persistGoalState(restored);
+		this._goalState = restored;
+		this._goalAccountingStartedAt = restored.status === "active" ? Date.now() : undefined;
 		this._emitGoalUpdate();
 	}
 
@@ -1789,14 +1816,17 @@ export class AgentSession {
 		this._emitQueueUpdate();
 	}
 
-	private _startGoal(objectiveText: string, tokenBudget: number | undefined): GoalState {
+	private _startGoal(objectiveText: string, tokenBudget: number | undefined, dispatchReceiptId?: string): GoalState {
 		const objective = validateGoalObjective(objectiveText);
 		const budget = validateGoalBudget(tokenBudget);
+		const receiptId = validateGoalDispatchReceiptId(dispatchReceiptId);
 		const now = Date.now();
 		const goal: GoalState = {
 			active: true,
 			status: "active",
 			goalId: randomUUID(),
+			...(receiptId ? { dispatchReceiptId: receiptId } : {}),
+			...(receiptId ? { dispatchPhase: "receipt" as const } : {}),
 			objective,
 			tokenBudget: budget,
 			tokensUsed: 0,
@@ -2102,8 +2132,12 @@ export class AgentSession {
 		}
 	}
 
-	private _runOrQueueGoalContext(kind: "continuation" | "objective_updated", images?: ImageContent[]): void {
-		if (!this._goalState.objective) return;
+	private _runOrQueueGoalContext(
+		kind: "continuation" | "objective_updated",
+		images?: ImageContent[],
+		options: { wake?: boolean } = {},
+	): ActionTicket {
+		if (!this._goalState.objective) throw new Error("Cannot queue goal context without an objective");
 		this._ensureGoalRuntimeActive();
 		const message = createGoalContextMessage(this._goalState, kind, images);
 		const normalized = normalizeMessageContent(message.content);
@@ -2111,7 +2145,11 @@ export class AgentSession {
 			message,
 			resumeIfIdle: true,
 		});
-		this._admitSessionInput(action, { front: true, wake: false });
+		const admission = this._admitSessionInput(action, { front: true, wake: options.wake ?? false });
+		if (!admission.accepted || !admission.ticket) {
+			throw new Error("Goal context was not accepted by the session action queue");
+		}
+		return admission.ticket;
 	}
 
 	private async _handleGoalSlashCommand(text: string, images: ImageContent[] | undefined): Promise<boolean> {
@@ -2140,15 +2178,34 @@ export class AgentSession {
 			return true;
 		}
 
+		await this._startGoalSlashCommand(command, images);
+		return true;
+	}
+
+	private async _startGoalSlashCommand(
+		command: Extract<GoalSlashCommand, { kind: "start" }>,
+		images: ImageContent[] | undefined,
+		beforeStart?: () => void,
+		dispatchReceiptId?: string,
+		wake = false,
+	): Promise<ActionTicket> {
 		const previousWasActive = this._goalState.status === "active";
+		const previousGoal = this._goalState;
 		if (!this.isStreaming) {
 			await this._validateCanStartAgentRun();
 		}
-		this._ensureGoalRuntimeActive();
-		this._clearQueuedGoalContexts();
-		this._startGoal(command.objective, command.tokenBudget);
-		await this._runOrQueueGoalContext(previousWasActive ? "objective_updated" : "continuation", images);
-		return true;
+		let goalStarted = false;
+		try {
+			beforeStart?.();
+			this._ensureGoalRuntimeActive();
+			this._clearQueuedGoalContexts();
+			this._startGoal(command.objective, command.tokenBudget, dispatchReceiptId);
+			goalStarted = true;
+			return this._runOrQueueGoalContext(previousWasActive ? "objective_updated" : "continuation", images, { wake });
+		} catch (error) {
+			if (beforeStart && goalStarted) this._restoreGoalStateGeneration(previousGoal);
+			throw error;
+		}
 	}
 
 	private _accountGoalUsageForAssistantMessage(message: AssistantMessage): boolean {
@@ -4534,6 +4591,48 @@ export class AgentSession {
 		return this._prompt(text, { ...options, returnAfterAccepted: true });
 	}
 
+	/**
+	 * Atomically validate and persist a scheduled /goal start. The caller's
+	 * admission fence is checked both after ownership and immediately before
+	 * the goal state changes, so async model validation cannot open a stale
+	 * delivery window.
+	 */
+	async startGoalFromConditionalPrompt(
+		text: string,
+		options: { admissionCommitted: () => void; receiptId: string; signal?: AbortSignal },
+	): Promise<void> {
+		const receiptId = validateGoalDispatchReceiptId(options.receiptId);
+		if (!receiptId) throw new Error("Conditional goal delivery requires a dispatch receipt");
+		if (this.isStreaming) {
+			throw new Error("Conditional goal delivery requires an idle session");
+		}
+		this._resumeSessionInputAdmission();
+		this._assertSessionActionAdmissionAvailable();
+		const admissionEpoch = this._sessionInputPumpEpoch;
+		const commitFence = await this._acquireDirectTurnAdmissionFence(options.signal).catch((error: unknown) => {
+			throwIfPromptAdmissionCancelled(options.signal);
+			throw error;
+		});
+		const run = async (): Promise<ActionTicket> => {
+			try {
+				throwIfPromptAdmissionCancelled(options.signal);
+				if (admissionEpoch !== this._sessionInputPumpEpoch) {
+					throw new Error("Session input was invalidated before conditional goal admission");
+				}
+				options.admissionCommitted();
+				const command = this._parseGoalSlashCommand(text);
+				if (command?.kind !== "start") {
+					throw new Error("Conditional goal delivery requires a /goal start command");
+				}
+				return await this._startGoalSlashCommand(command, undefined, options.admissionCommitted, receiptId, true);
+			} finally {
+				commitFence.release();
+			}
+		};
+		const ticket = await this._sessionActionCommitContext.run(commitFence.owner, run);
+		await ticket.delivered;
+	}
+
 	async promptAndWait(text: string, options?: PromptOptions): Promise<void> {
 		const agentMessageId = options?.agentMessageId ?? `prompt-wait:${randomUUID()}`;
 		if (this._agentMessageOutcomes.get(agentMessageId)?.completion) {
@@ -5167,82 +5266,97 @@ export class AgentSession {
 			throw new Error(`Unsupported session action recovery format version: ${snapshot.formatVersion}`);
 		}
 		const actionIds = new Set(this._actionStore.ownedActions().map((action) => action.id));
-		const actions = snapshot.actions.map((recovered): QueuedSessionAction => {
-			if (actionIds.has(recovered.id)) throw new Error(`Duplicate session action id: ${recovered.id}`);
-			actionIds.add(recovered.id);
-			if (
-				recovered.payload.kind === "turn" &&
-				recovered.payload.records.some((record) => record.ownerActionId !== recovered.id)
-			) {
-				throw new Error(`Session action ${recovered.id} has invalid delivery correlation`);
-			}
-			const payload: PreparedTurnPayload | PreparedCommandPayload =
-				recovered.payload.kind === "turn"
-					? {
-							kind: "turn",
-							text: recovered.payload.text,
-							...(recovered.payload.preview ? { preview: recovered.payload.preview } : {}),
-							records: recovered.payload.records.map((record) => ({
-								id: record.id,
-								role: record.role,
-								message: cloneQueuedAgentMessage(record.message),
-								started: false,
-								durable: false,
-								ownerActionId: record.ownerActionId,
-							})),
-							...(recovered.payload.images
-								? {
-										images: recovered.payload.images.map((image) => ({
-											...image,
-										})),
-									}
-								: {}),
-							...(recovered.payload.content
-								? {
-										content: recovered.payload.content.map((block) => ({
-											...block,
-										})),
-									}
-								: {}),
-							...(recovered.payload.customMessage
-								? {
-										customMessage: cloneCustomMessage(recovered.payload.customMessage),
-									}
-								: {}),
-							executionPolicy: {
-								...recovered.payload.executionPolicy,
-								preparation: {
-									...recovered.payload.executionPolicy.preparation,
+		const actions = snapshot.actions
+			.filter((recovered) => {
+				const receiptId = conditionalGoalReceiptForRecoveryPayload(recovered.payload);
+				if (!receiptId) return true;
+				if (this._recoveredConditionalGoalReceipts.has(receiptId)) return false;
+				if (
+					this._goalState.dispatchReceiptId === receiptId &&
+					this._goalState.dispatchPhase === "provider_committed"
+				) {
+					return false;
+				}
+				return !this.agent.state.messages.some(
+					(message) => message.role === "custom" && conditionalGoalReceiptForMessage(message) === receiptId,
+				);
+			})
+			.map((recovered): QueuedSessionAction => {
+				if (actionIds.has(recovered.id)) throw new Error(`Duplicate session action id: ${recovered.id}`);
+				actionIds.add(recovered.id);
+				if (
+					recovered.payload.kind === "turn" &&
+					recovered.payload.records.some((record) => record.ownerActionId !== recovered.id)
+				) {
+					throw new Error(`Session action ${recovered.id} has invalid delivery correlation`);
+				}
+				const payload: PreparedTurnPayload | PreparedCommandPayload =
+					recovered.payload.kind === "turn"
+						? {
+								kind: "turn",
+								text: recovered.payload.text,
+								...(recovered.payload.preview ? { preview: recovered.payload.preview } : {}),
+								records: recovered.payload.records.map((record) => ({
+									id: record.id,
+									role: record.role,
+									message: cloneQueuedAgentMessage(record.message),
+									started: false,
+									durable: false,
+									ownerActionId: record.ownerActionId,
+								})),
+								...(recovered.payload.images
+									? {
+											images: recovered.payload.images.map((image) => ({
+												...image,
+											})),
+										}
+									: {}),
+								...(recovered.payload.content
+									? {
+											content: recovered.payload.content.map((block) => ({
+												...block,
+											})),
+										}
+									: {}),
+								...(recovered.payload.customMessage
+									? {
+											customMessage: cloneCustomMessage(recovered.payload.customMessage),
+										}
+									: {}),
+								executionPolicy: {
+									...recovered.payload.executionPolicy,
+									preparation: {
+										...recovered.payload.executionPolicy.preparation,
+									},
 								},
-							},
-							queueVisible: recovered.payload.queueVisible,
-							acceptedAgentMessage: recovered.payload.acceptedAgentMessage,
-							acceptedBeforeCompletion: recovered.payload.acceptedBeforeCompletion,
-						}
-					: {
-							kind: "session_command",
-							text: recovered.payload.text,
-							command: { ...recovered.payload.command },
-							...(recovered.payload.images
-								? {
-										images: recovered.payload.images.map((image) => ({
-											...image,
-										})),
-									}
-								: {}),
-						};
-			return {
-				id: recovered.id,
-				source: recovered.source,
-				delivery: recovered.delivery,
-				wake: recovered.wake,
-				payload,
-				lifecycle: { state: "queued" },
-				...(recovered.queueKey ? { queueKey: recovered.queueKey } : {}),
-				...(recovered.agentMessageId ? { agentMessageId: recovered.agentMessageId } : {}),
-				...(recovered.suppressAutonomousContinuation ? { suppressAutonomousContinuation: true } : {}),
-			};
-		});
+								queueVisible: recovered.payload.queueVisible,
+								acceptedAgentMessage: recovered.payload.acceptedAgentMessage,
+								acceptedBeforeCompletion: recovered.payload.acceptedBeforeCompletion,
+							}
+						: {
+								kind: "session_command",
+								text: recovered.payload.text,
+								command: { ...recovered.payload.command },
+								...(recovered.payload.images
+									? {
+											images: recovered.payload.images.map((image) => ({
+												...image,
+											})),
+										}
+									: {}),
+							};
+				return {
+					id: recovered.id,
+					source: recovered.source,
+					delivery: recovered.delivery,
+					wake: recovered.wake,
+					payload,
+					lifecycle: { state: "queued" },
+					...(recovered.queueKey ? { queueKey: recovered.queueKey } : {}),
+					...(recovered.agentMessageId ? { agentMessageId: recovered.agentMessageId } : {}),
+					...(recovered.suppressAutonomousContinuation ? { suppressAutonomousContinuation: true } : {}),
+				};
+			});
 		for (const action of actions) {
 			const durableTerminalNotice = this._isRlmTerminalNoticeAction(action);
 			if (durableTerminalNotice) this._durableRlmTerminalNoticeActionIds.add(action.id);
@@ -5254,6 +5368,69 @@ export class AgentSession {
 			}
 		}
 		return actions.length;
+	}
+
+	/** Rebuild the goal turn lost with an interrupted conditional cron dispatch. */
+	recoverConditionalGoalDelivery(receiptValue: string, options: { recoveryCommitted?: () => void } = {}): boolean {
+		const receiptId = validateGoalDispatchReceiptId(receiptValue);
+		if (
+			!receiptId ||
+			this._goalState.status !== "active" ||
+			this._goalState.dispatchReceiptId !== receiptId ||
+			this._goalState.dispatchPhase !== "receipt"
+		) {
+			return false;
+		}
+		this._recoveredConditionalGoalReceipts.add(receiptId);
+		if (
+			this.agent.state.messages.some(
+				(message) => message.role === "custom" && conditionalGoalReceiptForMessage(message) === receiptId,
+			)
+		) {
+			return false;
+		}
+		const alreadyQueued = this._actionStore
+			.unfinishedActions()
+			.some((action) => conditionalGoalReceiptForPreparedPayload(action.payload) === receiptId);
+		if (alreadyQueued) return false;
+		try {
+			options.recoveryCommitted?.();
+			this._runOrQueueGoalContext("continuation", undefined, { wake: true });
+			return true;
+		} catch (error) {
+			this._recoveredConditionalGoalReceipts.delete(receiptId);
+			throw error;
+		}
+	}
+
+	/** Fail a pre-provider conditional receipt after its bounded recovery budget. */
+	failConditionalGoalDelivery(receiptValue: string): boolean {
+		const receiptId = validateGoalDispatchReceiptId(receiptValue);
+		if (
+			!receiptId ||
+			this._goalState.status !== "active" ||
+			this._goalState.dispatchReceiptId !== receiptId ||
+			this._goalState.dispatchPhase !== "receipt"
+		) {
+			return false;
+		}
+		if (
+			this._actionStore
+				.unfinishedActions()
+				.some((action) => conditionalGoalReceiptForPreparedPayload(action.payload) === receiptId)
+		) {
+			return false;
+		}
+		const now = Date.now();
+		this._setGoalState({
+			...this._goalState,
+			active: false,
+			status: "error",
+			updatedAt: now,
+			lastError: "Conditional goal delivery recovery exhausted",
+		});
+		this._recoveredConditionalGoalReceipts.delete(receiptId);
+		return true;
 	}
 
 	private _restoreSessionCommand(
@@ -5958,6 +6135,26 @@ export class AgentSession {
 		}
 	}
 
+	private _commitConditionalGoalProviderBoundary(messages: readonly AgentMessage[]): void {
+		const receiptId = messages.find(
+			(message): message is CustomMessage =>
+				message.role === "custom" && conditionalGoalReceiptForMessage(message) !== undefined,
+		);
+		const deliveredReceiptId = conditionalGoalReceiptForMessage(receiptId);
+		if (!deliveredReceiptId) return;
+		if (
+			this._goalState.active !== true ||
+			this._goalState.status !== "active" ||
+			this._goalState.dispatchReceiptId !== deliveredReceiptId ||
+			this._goalState.dispatchPhase !== "receipt"
+		) {
+			throw new Error("Conditional goal delivery state invalidated before provider commit");
+		}
+		// Persist the fail-closed boundary before provider code can observe the
+		// goal context. A restart may reconstruct only the earlier receipt phase.
+		this._setGoalState({ ...this._goalState, dispatchPhase: "provider_committed" });
+	}
+
 	private async _startPreparedTurnActions(actions: QueuedSessionAction[], epoch: number): Promise<void> {
 		let nextTurnMessages: CustomMessage[] = [];
 		const activeTurns = () =>
@@ -6057,6 +6254,7 @@ export class AgentSession {
 					for (const action of turns) transitionSessionAction(action, { state: "committing" });
 					this._notifySessionInputCheckpointChange();
 					this._emitQueueUpdate();
+					this._commitConditionalGoalProviderBoundary(preparedMessages);
 					return turns.some((action) => action.suppressAutonomousContinuation)
 						? this._runWithAutonomousContinuationSuppressed(() => this.agent.prompt(preparedMessages))
 						: this.agent.prompt(preparedMessages);

--- a/packages/coding-agent/src/core/cron-jobs.ts
+++ b/packages/coding-agent/src/core/cron-jobs.ts
@@ -11,11 +11,12 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { lockSync } from "proper-lockfile";
+import type { GoalState } from "./goals.js";
 import { getSessionArtifactPathForFile } from "./session-manager.js";
 
 export type AgentCronJobStatus = "active" | "paused" | "completed" | "cancelled";
 export type AgentCronScheduleKind = "once" | "cron" | "interval";
-export type AgentCronJobSource = "cron" | "heartbeat" | "rlm_heartbeat";
+export type AgentCronJobSource = "cron" | "conditional_cron" | "heartbeat" | "rlm_heartbeat";
 export type AgentCronJobRuntimeKind = "top-level" | "subagent";
 export type AgentHeartbeatUpdateAction = "pause" | "resume" | "clear";
 export type AgentHeartbeatManagementAction = "pause" | "resume" | "stop";
@@ -32,6 +33,29 @@ export interface AgentCronSchedule {
 	intervalMs?: number;
 }
 
+export type AgentCronGoalFence = Pick<
+	GoalState,
+	"active" | "status" | "goalId" | "updatedAt" | "dispatchReceiptId" | "dispatchPhase"
+>;
+
+export interface AgentCronModelFence {
+	provider: string;
+	id: string;
+}
+
+export interface AgentCronDeliveryFence {
+	version: 1;
+	activeSessionId: string;
+	sessionName: string;
+	cwd: string;
+	model: AgentCronModelFence;
+	thinkingLevel: string;
+	messageCount: number;
+	lastActivityAt: string;
+	taskState: "needs_input" | "completed";
+	goal: AgentCronGoalFence | null;
+}
+
 export interface AgentCronJob {
 	id: string;
 	status: AgentCronJobStatus;
@@ -39,6 +63,11 @@ export interface AgentCronJob {
 	runtimeKind?: AgentCronJobRuntimeKind;
 	/** Delivery mode for heartbeat/rlm_heartbeat jobs when the session is busy. Defaults to "steer". */
 	deliveryMode?: AgentHeartbeatDeliveryMode;
+	deliveryFence?: AgentCronDeliveryFence;
+	/** Durable bounded attempts to rebuild a pre-provider conditional goal turn. */
+	deliveryRecoveryCount?: number;
+	/** Durable terminal marker after the pre-provider recovery budget is exhausted. */
+	deliveryRecoveryExhaustedAt?: string;
 	activeSessionId: string;
 	sessionId: string;
 	sessionFile: string;
@@ -66,6 +95,7 @@ export interface CreateAgentCronJobInput {
 	source?: AgentCronJobSource;
 	runtimeKind?: AgentCronJobRuntimeKind;
 	deliveryMode?: AgentHeartbeatDeliveryMode;
+	deliveryFence?: AgentCronDeliveryFence;
 	now?: Date;
 }
 
@@ -81,6 +111,7 @@ export interface AgentCronSchedulerHooks {
 	beginDispatch?: (dispatch: AgentCronDispatch) => (() => void) | undefined;
 	now?: () => Date;
 	onError?: (job: AgentCronJob, error: unknown) => void;
+	onRecovered?: (jobs: readonly AgentCronJob[]) => void;
 }
 
 export interface HeartbeatCronSessionActivity {
@@ -227,11 +258,12 @@ export class AgentCronJobStore {
 			throw new Error("Cron job prompt cannot be empty");
 		}
 		const parsed = parseAgentCronSchedule(input.scheduleText, now);
+		const deliveryFence = normalizeAgentCronDeliveryFence(input.deliveryFence);
 		const nowIso = now.toISOString();
 		const job: AgentCronJob = {
 			id: randomUUID(),
 			status: "active",
-			source: input.source ?? "cron",
+			source: deliveryFence ? "conditional_cron" : (input.source ?? "cron"),
 			runtimeKind: input.runtimeKind,
 			activeSessionId: input.activeSessionId,
 			sessionId: input.sessionId,
@@ -239,6 +271,7 @@ export class AgentCronJobStore {
 			cwd: input.cwd,
 			label: normalizeOptionalLabel(input.label),
 			prompt,
+			deliveryFence,
 			schedule: parsed.schedule,
 			createdAt: nowIso,
 			updatedAt: nowIso,
@@ -265,20 +298,34 @@ export class AgentCronJobStore {
 		const targetSessionFile = resolve(input.sessionFile);
 		const reboundJobs: AgentCronJob[] = [];
 		const jobs = this.readJobs().map((job) => {
-			if (job.activeSessionId !== input.activeSessionId && resolve(job.sessionFile) !== targetSessionFile) {
+			const sameSessionFile = resolve(job.sessionFile) === targetSessionFile;
+			if (
+				job.source === "conditional_cron"
+					? !sameSessionFile
+					: job.activeSessionId !== input.activeSessionId && !sameSessionFile
+			) {
 				return job;
 			}
 			if (
 				job.activeSessionId === input.activeSessionId &&
 				job.sessionId === input.sessionId &&
 				resolve(job.sessionFile) === targetSessionFile &&
-				job.cwd === input.cwd
+				job.cwd === input.cwd &&
+				(!job.deliveryFence || job.deliveryFence.activeSessionId === input.activeSessionId)
 			) {
 				return job;
 			}
 			const rebound = {
 				...job,
 				activeSessionId: input.activeSessionId,
+				...(job.deliveryFence
+					? {
+							deliveryFence: {
+								...job.deliveryFence,
+								activeSessionId: input.activeSessionId,
+							},
+						}
+					: {}),
 				sessionId: input.sessionId,
 				sessionFile: input.sessionFile,
 				cwd: input.cwd,
@@ -634,6 +681,54 @@ export class AgentCronJobStore {
 		return cancelled;
 	}
 
+	rejectDelivery(id: string, reason: string, now = new Date()): AgentCronJob | undefined {
+		let rejected: AgentCronJob | undefined;
+		const jobs = this.readJobs().map((job) => {
+			if (job.id !== id || job.status !== "active") return job;
+			rejected = withoutNextRunAt({
+				...job,
+				status: "cancelled",
+				lastSkippedAt: now.toISOString(),
+				lastError: reason,
+				updatedAt: now.toISOString(),
+			});
+			return rejected;
+		});
+		if (rejected) this.writeJobs(jobs);
+		return rejected;
+	}
+
+	recordDeliveryRecoveryAttempt(id: string, now = new Date()): AgentCronJob | undefined {
+		let updated: AgentCronJob | undefined;
+		const jobs = this.readJobs().map((job) => {
+			if (job.id !== id || job.source !== "conditional_cron" || job.status !== "cancelled") return job;
+			updated = {
+				...job,
+				deliveryRecoveryCount: (job.deliveryRecoveryCount ?? 0) + 1,
+				updatedAt: now.toISOString(),
+			};
+			return updated;
+		});
+		if (updated) this.writeJobs(jobs);
+		return updated;
+	}
+
+	recordDeliveryRecoveryExhausted(id: string, now = new Date()): AgentCronJob | undefined {
+		let updated: AgentCronJob | undefined;
+		const jobs = this.readJobs().map((job) => {
+			if (job.id !== id || job.source !== "conditional_cron" || job.status !== "cancelled") return job;
+			updated = {
+				...job,
+				deliveryRecoveryExhaustedAt: now.toISOString(),
+				lastError: "Conditional goal delivery recovery exhausted",
+				updatedAt: now.toISOString(),
+			};
+			return updated;
+		});
+		if (updated) this.writeJobs(jobs);
+		return updated;
+	}
+
 	recordRunResult(id: string, result: { now?: Date; error?: unknown }): AgentCronJob | undefined {
 		const now = result.now ?? new Date();
 		let updated: AgentCronJob | undefined;
@@ -945,7 +1040,8 @@ export class AgentCronScheduler {
 		this.stopped = false;
 		if (!this.hasStarted) {
 			this.hasStarted = true;
-			this.store.recoverInterruptedDispatches(this.now());
+			const recovered = this.store.recoverInterruptedDispatches(this.now());
+			if (recovered.length > 0) this.hooks.onRecovered?.(recovered);
 		}
 		this.scheduleNext();
 	}
@@ -1618,7 +1714,13 @@ function recoverInterruptedInState(
 		}
 		const next = {
 			...job,
-			status: job.schedule.kind === "once" ? ("completed" as const) : job.status,
+			status:
+				job.source === "conditional_cron"
+					? ("cancelled" as const)
+					: job.schedule.kind === "once"
+						? ("completed" as const)
+						: job.status,
+			...(job.source === "conditional_cron" ? { lastSkippedAt: now.toISOString() } : {}),
 			lastError: "Interrupted before scheduled operation completion",
 			updatedAt: now.toISOString(),
 		};
@@ -1675,6 +1777,81 @@ function normalizeOptionalLabel(label: string | undefined): string | undefined {
 	return trimmed ? trimmed : undefined;
 }
 
+export function normalizeAgentCronDeliveryFence(value: unknown): AgentCronDeliveryFence | undefined {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("Cron delivery fence must be an object");
+	}
+	const candidate = value as Partial<AgentCronDeliveryFence>;
+	const keys = Object.keys(candidate).sort();
+	if (
+		keys.join(",") !==
+			"activeSessionId,cwd,goal,lastActivityAt,messageCount,model,sessionName,taskState,thinkingLevel,version" ||
+		candidate.version !== 1 ||
+		typeof candidate.activeSessionId !== "string" ||
+		candidate.activeSessionId.length === 0 ||
+		typeof candidate.sessionName !== "string" ||
+		candidate.sessionName.length === 0 ||
+		typeof candidate.cwd !== "string" ||
+		candidate.cwd.length === 0 ||
+		!candidate.model ||
+		typeof candidate.model !== "object" ||
+		Array.isArray(candidate.model) ||
+		Object.keys(candidate.model).sort().join(",") !== "id,provider" ||
+		typeof candidate.model.provider !== "string" ||
+		candidate.model.provider.length === 0 ||
+		typeof candidate.model.id !== "string" ||
+		candidate.model.id.length === 0 ||
+		typeof candidate.thinkingLevel !== "string" ||
+		candidate.thinkingLevel.length === 0 ||
+		!Number.isSafeInteger(candidate.messageCount) ||
+		(candidate.messageCount ?? -1) < 0 ||
+		typeof candidate.lastActivityAt !== "string" ||
+		!Number.isFinite(Date.parse(candidate.lastActivityAt)) ||
+		(candidate.taskState !== "needs_input" && candidate.taskState !== "completed")
+	) {
+		throw new Error("Cron delivery fence is invalid");
+	}
+	let goal: AgentCronGoalFence | null = null;
+	if (candidate.goal !== null) {
+		if (!candidate.goal || typeof candidate.goal !== "object" || Array.isArray(candidate.goal)) {
+			throw new Error("Cron delivery fence goal is invalid");
+		}
+		const goalKeys = Object.keys(candidate.goal).sort();
+		if (
+			goalKeys.some(
+				(key) => !["active", "dispatchPhase", "dispatchReceiptId", "goalId", "status", "updatedAt"].includes(key),
+			) ||
+			candidate.goal.active !== false ||
+			(candidate.goal.status !== "complete" && candidate.goal.status !== "error") ||
+			(candidate.goal.goalId !== undefined && typeof candidate.goal.goalId !== "string") ||
+			(candidate.goal.dispatchReceiptId !== undefined &&
+				(typeof candidate.goal.dispatchReceiptId !== "string" || candidate.goal.dispatchReceiptId.length === 0)) ||
+			(candidate.goal.dispatchPhase !== undefined &&
+				candidate.goal.dispatchPhase !== "receipt" &&
+				candidate.goal.dispatchPhase !== "provider_committed") ||
+			(candidate.goal.dispatchPhase !== undefined && candidate.goal.dispatchReceiptId === undefined) ||
+			(candidate.goal.updatedAt !== undefined &&
+				(typeof candidate.goal.updatedAt !== "number" || !Number.isFinite(candidate.goal.updatedAt)))
+		) {
+			throw new Error("Cron delivery fence goal is invalid");
+		}
+		goal = { ...candidate.goal } as AgentCronGoalFence;
+	}
+	return {
+		version: 1,
+		activeSessionId: candidate.activeSessionId,
+		sessionName: candidate.sessionName,
+		cwd: candidate.cwd,
+		model: { provider: candidate.model.provider, id: candidate.model.id },
+		thinkingLevel: candidate.thinkingLevel,
+		messageCount: candidate.messageCount!,
+		lastActivityAt: candidate.lastActivityAt,
+		taskState: candidate.taskState,
+		goal,
+	};
+}
+
 function withoutNextRunAt(job: AgentCronJob): AgentCronJob {
 	const { nextRunAt: _nextRunAt, ...rest } = job;
 	return rest;
@@ -1693,6 +1870,7 @@ function isAgentCronJob(value: unknown): value is AgentCronJob {
 			candidate.status === "cancelled") &&
 		(candidate.source === undefined ||
 			candidate.source === "cron" ||
+			candidate.source === "conditional_cron" ||
 			candidate.source === "heartbeat" ||
 			candidate.source === "rlm_heartbeat") &&
 		(candidate.runtimeKind === undefined ||
@@ -1701,6 +1879,13 @@ function isAgentCronJob(value: unknown): value is AgentCronJob {
 		(candidate.deliveryMode === undefined ||
 			candidate.deliveryMode === "steer" ||
 			candidate.deliveryMode === "follow_up") &&
+		(candidate.deliveryRecoveryCount === undefined ||
+			(Number.isSafeInteger(candidate.deliveryRecoveryCount) && candidate.deliveryRecoveryCount >= 0)) &&
+		(candidate.deliveryRecoveryExhaustedAt === undefined ||
+			(typeof candidate.deliveryRecoveryExhaustedAt === "string" &&
+				Number.isFinite(new Date(candidate.deliveryRecoveryExhaustedAt).getTime()))) &&
+		((candidate.source === "conditional_cron" && isAgentCronDeliveryFence(candidate.deliveryFence)) ||
+			(candidate.source !== "conditional_cron" && candidate.deliveryFence === undefined)) &&
 		typeof candidate.activeSessionId === "string" &&
 		typeof candidate.sessionId === "string" &&
 		typeof candidate.sessionFile === "string" &&
@@ -1719,6 +1904,14 @@ function isAgentCronJob(value: unknown): value is AgentCronJob {
 		typeof candidate.updatedAt === "string" &&
 		typeof candidate.runCount === "number"
 	);
+}
+
+function isAgentCronDeliveryFence(value: unknown): value is AgentCronDeliveryFence {
+	try {
+		return normalizeAgentCronDeliveryFence(value) !== undefined;
+	} catch {
+		return false;
+	}
 }
 
 function isAgentCronDispatchRecord(value: unknown): value is AgentCronDispatchRecord {

--- a/packages/coding-agent/src/core/goals.ts
+++ b/packages/coding-agent/src/core/goals.ts
@@ -6,6 +6,7 @@ export const GOAL_CONTEXT_CUSTOM_TYPE = "goal_context";
 export const GOAL_CONTEXT_PREVIEW_LABEL = "Goal context";
 export const GOAL_SKILL_NAME = "goal";
 export const MAX_THREAD_GOAL_OBJECTIVE_CHARS = 4000;
+export const MAX_GOAL_DISPATCH_RECEIPT_CHARS = 256;
 
 export type GoalStatus = "idle" | "active" | "paused" | "budget_limited" | "complete" | "error";
 export type GoalContextKind = "continuation" | "budget_limit" | "objective_updated";
@@ -14,6 +15,10 @@ export interface GoalState {
 	active: boolean;
 	status: GoalStatus;
 	goalId?: string;
+	/** Durable correlation for a conditionally delivered scheduled /goal. */
+	dispatchReceiptId?: string;
+	/** Durable provider boundary for crash-safe conditional delivery recovery. */
+	dispatchPhase?: "receipt" | "provider_committed";
 	objective?: string;
 	tokenBudget?: number;
 	tokensUsed: number;
@@ -47,6 +52,7 @@ export type GoalHostResponse = {
 export interface GoalContextDetails {
 	kind: GoalContextKind;
 	goalId?: string;
+	dispatchReceiptId?: string;
 	objective: string;
 	status: GoalStatus;
 	continuationsUsed: number;
@@ -93,6 +99,15 @@ export function validateGoalBudget(value: number | undefined): number | undefine
 	return value;
 }
 
+export function validateGoalDispatchReceiptId(value: string | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	const receiptId = value.trim();
+	if (!receiptId || receiptId.length > MAX_GOAL_DISPATCH_RECEIPT_CHARS) {
+		throw new Error(`Goal dispatch receipt must be between 1 and ${MAX_GOAL_DISPATCH_RECEIPT_CHARS} characters.`);
+	}
+	return receiptId;
+}
+
 export function goalTokenDeltaForUsage(usage: { input: number; output: number }): number {
 	return Math.max(0, usage.input) + Math.max(0, usage.output);
 }
@@ -113,6 +128,24 @@ export function isPersistedGoalState(value: unknown): value is GoalState {
 		record.status !== "complete" &&
 		record.status !== "error"
 	) {
+		return false;
+	}
+	if (
+		record.dispatchReceiptId !== undefined &&
+		(typeof record.dispatchReceiptId !== "string" ||
+			record.dispatchReceiptId.length === 0 ||
+			record.dispatchReceiptId.length > MAX_GOAL_DISPATCH_RECEIPT_CHARS)
+	) {
+		return false;
+	}
+	if (
+		record.dispatchPhase !== undefined &&
+		record.dispatchPhase !== "receipt" &&
+		record.dispatchPhase !== "provider_committed"
+	) {
+		return false;
+	}
+	if (record.dispatchPhase !== undefined && typeof record.dispatchReceiptId !== "string") {
 		return false;
 	}
 	return (
@@ -171,6 +204,7 @@ export function createGoalContextMessage(
 		details: {
 			kind,
 			goalId: goal.goalId,
+			dispatchReceiptId: goal.dispatchReceiptId,
 			objective: goal.objective,
 			status: goal.status,
 			continuationsUsed: goal.continuationsUsed,

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -73,6 +73,7 @@ import {
 	createAgentSessionRuntime,
 } from "../../core/agent-session-runtime.js";
 import {
+	type AgentCronDeliveryFence,
 	type AgentCronJob,
 	AgentCronJobStore,
 	AgentCronScheduler,
@@ -238,6 +239,45 @@ const structuredLog = getLogger("coding-agent.daemon");
 const WORKER_SNAPSHOT_TERMINAL_DRAIN_TIMEOUT_MS = 1_000;
 const UPDATE_RESTART_PREPARE_TIMEOUT_MS = 90_000;
 const MAX_SESSION_SNAPSHOT_STABILIZATION_RETRIES = 3;
+const MAX_CONDITIONAL_GOAL_RECOVERY_ATTEMPTS = 5;
+
+function matchesCronDeliveryFence(fence: AgentCronDeliveryFence, state: ActiveSessionState): boolean {
+	const summary = summaryForActiveSession(state);
+	const actualGoal = summary.goal ?? null;
+	const goalMatches =
+		fence.goal === null
+			? actualGoal === null
+			: actualGoal !== null &&
+				actualGoal.active === fence.goal.active &&
+				actualGoal.status === fence.goal.status &&
+				actualGoal.goalId === fence.goal.goalId &&
+				actualGoal.dispatchReceiptId === fence.goal.dispatchReceiptId &&
+				actualGoal.dispatchPhase === fence.goal.dispatchPhase &&
+				actualGoal.updatedAt === fence.goal.updatedAt;
+	return (
+		summary.activeSessionId === fence.activeSessionId &&
+		summary.runtimeKind === "top-level" &&
+		summary.rlmDepth === 0 &&
+		summary.sessionName === fence.sessionName &&
+		summary.cwd === fence.cwd &&
+		summary.model?.provider === fence.model.provider &&
+		summary.model.id === fence.model.id &&
+		summary.thinkingLevel === fence.thinkingLevel &&
+		summary.messageCount === fence.messageCount &&
+		summary.lastActivityAt === fence.lastActivityAt &&
+		summary.taskState === fence.taskState &&
+		goalMatches &&
+		!isActiveSessionBusy(state) &&
+		!state.runtime.session.isRetrying &&
+		summary.isStreaming === false &&
+		summary.isCompacting === false &&
+		summary.isBashRunning === false &&
+		summary.hasRunningRlmChildren === false &&
+		summary.isRunningTools === false &&
+		summary.unfinishedActionCount === 0 &&
+		summary.sessionActions.queuedCount === 0
+	);
+}
 
 const DAEMON_COMMAND_TYPES: ReadonlySet<string> = new Set([
 	"ack_result",
@@ -544,6 +584,7 @@ export class AgentDaemon {
 	private rlmSpawnLedgerInstance?: RlmSpawnLedger;
 	/** In-flight admission spawn appends, awaited (and consumed) by createRlmSubagentRuntime. */
 	private readonly pendingRlmSpawnAppends = new Map<string, Promise<void>>();
+	private readonly recoveredConditionalCronJobs = new Map<string, AgentCronJob>();
 
 	constructor(
 		private readonly socketPath: string,
@@ -570,6 +611,7 @@ export class AgentDaemon {
 			onError: (job, error) => {
 				this.log(`Cron job ${job.id} failed: ${error instanceof Error ? error.message : String(error)}`);
 			},
+			onRecovered: (jobs) => this.rememberRecoveredConditionalCronJobs(jobs),
 		});
 		this.cronStore.onHeartbeatChange(() => this.broadcastGlobal({ type: "heartbeats_changed" }));
 	}
@@ -1421,6 +1463,7 @@ export class AgentDaemon {
 		}
 		this.registerCronStoreForState(state);
 		this.rebindCronJobsToState(state);
+		this.recoverConditionalCronDeliveryForState(state);
 		if (runtime.metadata.kind !== "subagent") {
 			// Mark the session as daemon-resident so a restarted daemon can
 			// restore it. Closes for kill/completed/replaced flip this back to
@@ -1452,6 +1495,69 @@ export class AgentDaemon {
 		}
 		this.registerCronStoreForState(state);
 		this.rebindCronJobsToState(state);
+		this.recoverConditionalCronDeliveryForState(state);
+	}
+
+	private rememberRecoveredConditionalCronJobs(jobs: readonly AgentCronJob[]): void {
+		for (const job of jobs) {
+			if (
+				job.source === "conditional_cron" &&
+				job.status === "cancelled" &&
+				job.lastError === "Interrupted before scheduled operation completion"
+			) {
+				this.recoveredConditionalCronJobs.set(job.id, job);
+			}
+		}
+		for (const state of this.sessions.values()) this.recoverConditionalCronDeliveryForState(state);
+	}
+
+	private recoverConditionalCronDeliveryForState(state: ActiveSessionState): void {
+		const goalState = state.runtime.session.goalState;
+		const receiptId = goalState?.dispatchReceiptId;
+		if (!receiptId) return;
+		const job =
+			this.recoveredConditionalCronJobs.get(receiptId) ??
+			this.cronStore
+				.list()
+				.find(
+					(candidate) =>
+						candidate.id === receiptId &&
+						candidate.source === "conditional_cron" &&
+						candidate.status === "cancelled" &&
+						candidate.lastError !== "Delivery fence changed before prompt admission",
+				);
+		if (!job || job.sessionId !== state.runtime.session.sessionId) return;
+		if (goalState.dispatchPhase !== "receipt") {
+			this.recoveredConditionalCronJobs.delete(receiptId);
+			return;
+		}
+		if ((job.deliveryRecoveryCount ?? 0) >= MAX_CONDITIONAL_GOAL_RECOVERY_ATTEMPTS) {
+			const alreadyFailed =
+				goalState.status === "error" && goalState.lastError === "Conditional goal delivery recovery exhausted";
+			try {
+				if (alreadyFailed || state.runtime.session.failConditionalGoalDelivery(receiptId)) {
+					this.cronStore.recordDeliveryRecoveryExhausted(receiptId);
+					this.recoveredConditionalCronJobs.delete(receiptId);
+				}
+			} catch (error) {
+				this.log(`Conditional cron recovery exhaustion ${receiptId} failed: ${String(error)}`);
+			}
+			return;
+		}
+		const recover = state.runtime.session.recoverConditionalGoalDelivery;
+		if (typeof recover !== "function") return;
+		try {
+			recover.call(state.runtime.session, receiptId, {
+				recoveryCommitted: () => {
+					if (!this.cronStore.recordDeliveryRecoveryAttempt(receiptId)) {
+						throw new Error(`Conditional cron recovery receipt ${receiptId} disappeared`);
+					}
+				},
+			});
+			this.recoveredConditionalCronJobs.delete(receiptId);
+		} catch (error) {
+			this.log(`Conditional cron recovery ${receiptId} failed: ${String(error)}`);
+		}
 	}
 
 	private registerCronStoreForState(state: ActiveSessionState): void {
@@ -1464,7 +1570,7 @@ export class AgentDaemon {
 			return;
 		}
 		if (this.cronStore.registerSessionArtifact(session.sessionId, artifactDir)) {
-			this.cronStore.recoverSessionArtifact(session.sessionId);
+			this.rememberRecoveredConditionalCronJobs(this.cronStore.recoverSessionArtifact(session.sessionId));
 			this.cronScheduler.wake();
 		}
 	}
@@ -1731,6 +1837,10 @@ export class AgentDaemon {
 		if (!state || !runnableJob || !this.isCronJobRunnableForState(runnableJob, state, requirePersistedJob)) {
 			return "skipped";
 		}
+		if (runnableJob.deliveryFence && !matchesCronDeliveryFence(runnableJob.deliveryFence, state)) {
+			this.cronStore.rejectDelivery(runnableJob.id, "Delivery fence changed before prompt admission");
+			return "skipped";
+		}
 		const session = state.runtime.session;
 		if (shouldDeferHeartbeatCronJob(runnableJob, session)) {
 			return "skipped";
@@ -1741,6 +1851,10 @@ export class AgentDaemon {
 			session.isRetrying ||
 			session.isBashRunning ||
 			session.unfinishedActionCount > 0;
+		if (runnableJob.deliveryFence && shouldQueueCronPrompt) {
+			this.cronStore.rejectDelivery(runnableJob.id, "Delivery fence changed before prompt admission");
+			return "skipped";
+		}
 		if (!isHeartbeatCronJob(runnableJob) && shouldQueueCronPrompt) {
 			if (!this.isCronJobRunnableForState(runnableJob, state, requirePersistedJob)) {
 				return "skipped";
@@ -1760,10 +1874,15 @@ export class AgentDaemon {
 		}
 		// Re-check after the session admission fence wait: the job may have been cancelled, completed, or updated meanwhile.
 		const unrunnableAtAdmission = new Error("Cron job became unrunnable before admission");
+		const deliveryFenceChangedAtAdmission = new Error("Cron delivery fence changed before admission");
 		const admissionCommitted = () => {
 			const refreshed = getRunnableJob();
 			if (!refreshed || refreshed.prompt !== current.prompt || refreshed.deliveryMode !== current.deliveryMode) {
 				throw unrunnableAtAdmission;
+			}
+			if (refreshed.deliveryFence && !matchesCronDeliveryFence(refreshed.deliveryFence, state)) {
+				this.cronStore.rejectDelivery(refreshed.id, "Delivery fence changed before prompt admission");
+				throw deliveryFenceChangedAtAdmission;
 			}
 		};
 		try {
@@ -1776,6 +1895,13 @@ export class AgentDaemon {
 				});
 				return;
 			}
+			if (current.deliveryFence) {
+				await session.startGoalFromConditionalPrompt(current.prompt, {
+					admissionCommitted,
+					receiptId: current.id,
+				});
+				return;
+			}
 			await session.promptUntilAccepted(current.prompt, {
 				streamingBehavior: "followUp",
 				source: "rpc",
@@ -1783,6 +1909,26 @@ export class AgentDaemon {
 			});
 		} catch (error) {
 			if (error === unrunnableAtAdmission) {
+				if (current.deliveryFence) {
+					this.cronStore.rejectDelivery(current.id, "Conditional goal admission invalidated");
+				}
+				return "skipped";
+			}
+			if (error === deliveryFenceChangedAtAdmission) {
+				return "skipped";
+			}
+			if (current.deliveryFence) {
+				const reason = error instanceof Error ? error.message : String(error);
+				const receiptPersisted = session.goalState.dispatchReceiptId === current.id;
+				this.cronStore.rejectDelivery(
+					current.id,
+					`${
+						receiptPersisted
+							? "Conditional goal receipt persisted before delivery error"
+							: "Conditional goal delivery retryable"
+					}: ${reason.slice(0, 500)}`,
+				);
+				if (receiptPersisted) this.recoverConditionalCronDeliveryForState(state);
 				return "skipped";
 			}
 			throw error;
@@ -1793,7 +1939,12 @@ export class AgentDaemon {
 		return this.cronStore.getClaimedJob(jobId) ?? this.cronStore.getDueJob(jobId);
 	}
 
-	private createCronJobForState(state: ActiveSessionState, schedule: string, prompt: string): AgentCronJob {
+	private createCronJobForState(
+		state: ActiveSessionState,
+		schedule: string,
+		prompt: string,
+		deliveryFence?: AgentCronDeliveryFence,
+	): AgentCronJob {
 		const session = state.runtime.session;
 		const sessionFile = session.sessionFile;
 		if (!sessionFile) {
@@ -1807,6 +1958,7 @@ export class AgentDaemon {
 			runtimeKind: state.runtime.metadata.kind,
 			scheduleText: schedule,
 			prompt,
+			deliveryFence,
 		});
 		this.cronScheduler.wake();
 		return job;
@@ -4464,6 +4616,10 @@ export class AgentDaemon {
 			}
 
 			case "cron_list": {
+				if (command.activeSessionId) {
+					const state = this.sessions.get(command.activeSessionId);
+					if (state) this.recoverConditionalCronDeliveryForState(state);
+				}
 				const jobs = this.cronStore.list().filter((job) => {
 					if (!command.includeInactive && job.status !== "active" && job.status !== "paused") {
 						return false;
@@ -4491,7 +4647,7 @@ export class AgentDaemon {
 
 			case "cron_add": {
 				const state = this.getSessionState(command.activeSessionId);
-				const job = this.createCronJobForState(state, command.schedule, command.prompt);
+				const job = this.createCronJobForState(state, command.schedule, command.prompt, command.deliveryFence);
 				return success(command.id, "cron_add", { job });
 			}
 

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -11,6 +11,7 @@ import type { AgentSessionRuntimeMetadata } from "../../core/agent-session-runti
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type {
+	AgentCronDeliveryFence,
 	AgentCronJob,
 	AgentHeartbeatDeliveryMode,
 	AgentHeartbeatManagementAction,
@@ -67,8 +68,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 20 lets cancellation target a prompt the session owns but has not started.
 // Revision 21 adds capability-gated, session-scoped ACP MCP server replacement.
 // Revision 23 lets workers query the supervisor agent roster on demand.
-export const DAEMON_SCHEMA_REVISION = 23;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-23-649fe649d15e";
+// Revision 24 adds capability-gated, delivery-time fenced cron prompts.
+export const DAEMON_SCHEMA_REVISION = 24;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-24-9bb630bf7f1d";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -113,7 +115,8 @@ export type DaemonServerCapability =
 	| "rlm_quiescence_barrier"
 	| "session_input_pause"
 	| "owned_prompt_cancellation"
-	| "acp_mcp_servers";
+	| "acp_mcp_servers"
+	| "conditional_cron_delivery";
 
 export type DaemonReplayStatus = "complete" | "partial" | "unavailable";
 
@@ -158,6 +161,7 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"rlm_quiescence_barrier",
 	"session_input_pause",
 	"acp_mcp_servers",
+	"conditional_cron_delivery",
 ];
 
 export interface DaemonRuntimeIdentity {
@@ -578,6 +582,7 @@ export type DaemonCommand =
 			activeSessionId: string;
 			schedule: string;
 			prompt: string;
+			deliveryFence?: AgentCronDeliveryFence;
 			promoteOwnedSession?: boolean;
 	  }
 	| { id?: string; type: "cron_cancel"; activeSessionId?: string; jobId: string }
@@ -714,6 +719,11 @@ const SESSION_INPUT_PAUSE_COMMAND = {
 	capability: "session_input_pause",
 } as const;
 const AGENT_PEER_LIST_COMMAND = { minProtocol: 7, minSchemaRevision: 23 } as const;
+const CONDITIONAL_CRON_DELIVERY_COMMAND = {
+	minProtocol: 7,
+	minSchemaRevision: 24,
+	capability: "conditional_cron_delivery",
+} as const;
 
 export const DAEMON_COMMAND_COMPATIBILITY = {
 	ack_result: LEGACY_DAEMON_COMMAND,
@@ -838,6 +848,9 @@ export function getDaemonCommandCompatibilities(command: DaemonCommand): readonl
 	}
 	if (command.type === "cancel_prompt_admission" && command.cancelOwned === true) {
 		requirements.push(OWNED_PROMPT_CANCELLATION_COMMAND);
+	}
+	if (command.type === "cron_add" && command.deliveryFence !== undefined) {
+		requirements.push(CONDITIONAL_CRON_DELIVERY_COMMAND);
 	}
 	return [...requirements, DAEMON_COMMAND_COMPATIBILITY[command.type]];
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-session-list.ts
@@ -5,6 +5,7 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import { compactRlmText } from "../../core/agent-session.js";
 import type { AgentSessionRuntimeDiagnostic } from "../../core/agent-session-services.js";
 import { type AgentCronJob, isHeartbeatCronJob } from "../../core/cron-jobs.js";
+import type { GoalState } from "../../core/goals.js";
 import type { SessionActionSnapshot } from "../../core/session-action-store.js";
 import type { AgentTaskState, SessionInfo } from "../../core/session-manager.js";
 import type { AgentConnectionRlmChildAgentSnapshot } from "../agent-connection/types.js";
@@ -19,6 +20,10 @@ export type SessionLifecycle = "draft" | "live" | "archived";
 // "working" so the view never sees an unlabeled idle session.
 export type SessionActivity = "working" | "idle";
 export type SessionRosterStatus = "running" | "idle" | "inactive";
+export type SessionGoalFence = Pick<
+	GoalState,
+	"active" | "status" | "goalId" | "updatedAt" | "dispatchReceiptId" | "dispatchPhase"
+>;
 
 // Upper bound on the spawn-code source carried in a session summary. Generous
 // enough for real spawn cells while keeping the daemon wire payload bounded.
@@ -76,6 +81,8 @@ export interface SessionSummary {
 	summary?: string;
 	/** Completion verdict for an idle session; absent while working or unjudged. */
 	taskState?: AgentTaskState;
+	/** Non-sensitive exact goal generation for deterministic resident-session fencing. */
+	goal?: SessionGoalFence | null;
 	/** Resident session-host process state, populated by the global supervisor. */
 	workerState?: "starting" | "ready" | "recovering" | "stopping" | "failed";
 	/** Diagnostic process identity; clients must not use this as a stable session identifier. */
@@ -219,6 +226,7 @@ export function summaryForActiveSession(
 		}
 	}
 
+	const goalState = session.goalState;
 	return {
 		id: activeSession.activeSessionId,
 		lifecycle: activeLifecycleForSession(activeSession),
@@ -245,6 +253,17 @@ export function summaryForActiveSession(
 		isRunningTools: session.isStreaming && session.state.pendingToolCalls.size > 0,
 		attachedClients: activeSession.clients.size,
 		messageCount: session.messages.length,
+		goal:
+			!goalState || goalState.status === "idle"
+				? null
+				: {
+						active: goalState.active,
+						status: goalState.status,
+						...(goalState.goalId ? { goalId: goalState.goalId } : {}),
+						...(goalState.dispatchReceiptId ? { dispatchReceiptId: goalState.dispatchReceiptId } : {}),
+						...(goalState.dispatchPhase ? { dispatchPhase: goalState.dispatchPhase } : {}),
+						...(goalState.updatedAt !== undefined ? { updatedAt: goalState.updatedAt } : {}),
+					},
 		unfinishedActionCount: session.unfinishedActionCount,
 		sessionActions: session.getSessionActionSnapshot(),
 		streamingMessage: session.state.streamingMessage,

--- a/packages/coding-agent/test/cron-jobs.test.ts
+++ b/packages/coding-agent/test/cron-jobs.test.ts
@@ -193,6 +193,113 @@ describe("AgentCronJobStore", () => {
 		expect(store.list()[0]).not.toHaveProperty("nextRunAt");
 	});
 
+	it("persists guarded jobs with a downgrade-safe source discriminator and exact fence", () => {
+		const storePath = makeStorePath(tempDirs);
+		const store = new AgentCronJobStore(storePath);
+		const deliveryFence = {
+			version: 1 as const,
+			activeSessionId: "active-1",
+			sessionName: "project-root",
+			cwd: "/tmp/project",
+			model: { provider: "test", id: "planner" },
+			thinkingLevel: "xhigh",
+			messageCount: 4,
+			lastActivityAt: "2026-01-01T12:30:00.000Z",
+			taskState: "needs_input" as const,
+			goal: null,
+		};
+		const job = store.create({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "in 1h",
+			prompt: "/goal guarded work",
+			deliveryFence,
+			now: start,
+		});
+
+		expect(job).toMatchObject({ source: "conditional_cron", deliveryFence });
+		expect(new AgentCronJobStore(storePath).list()).toMatchObject([
+			{ id: job.id, source: "conditional_cron", deliveryFence },
+		]);
+		expect(JSON.parse(readFileSync(storePath, "utf8"))).toMatchObject({
+			jobs: [{ id: job.id, source: "conditional_cron", deliveryFence }],
+		});
+	});
+
+	it("persists an explicit terminal receipt after conditional recovery exhaustion", () => {
+		const storePath = makeStorePath(tempDirs);
+		const store = new AgentCronJobStore(storePath);
+		const job = store.create({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "in 1h",
+			prompt: "/goal guarded work",
+			deliveryFence: {
+				version: 1,
+				activeSessionId: "active-1",
+				sessionName: "project-root",
+				cwd: "/tmp/project",
+				model: { provider: "test", id: "planner" },
+				thinkingLevel: "xhigh",
+				messageCount: 4,
+				lastActivityAt: "2026-01-01T12:30:00.000Z",
+				taskState: "needs_input",
+				goal: null,
+			},
+			now: start,
+		});
+		store.rejectDelivery(
+			job.id,
+			"Conditional goal receipt persisted before delivery error: disk full",
+			new Date("2026-01-01T12:35:00.000Z"),
+		);
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			store.recordDeliveryRecoveryAttempt(job.id, new Date(`2026-01-01T12:4${attempt}:00.000Z`));
+		}
+
+		const exhausted = store.recordDeliveryRecoveryExhausted(job.id, new Date("2026-01-01T12:50:00.000Z"));
+
+		expect(exhausted).toMatchObject({
+			id: job.id,
+			status: "cancelled",
+			deliveryRecoveryCount: 5,
+			deliveryRecoveryExhaustedAt: "2026-01-01T12:50:00.000Z",
+			lastError: "Conditional goal delivery recovery exhausted",
+		});
+		expect(new AgentCronJobStore(storePath).list()[0]).toMatchObject(exhausted!);
+	});
+
+	it("rejects guarded jobs whose profile fence is incomplete", () => {
+		const store = new AgentCronJobStore(makeStorePath(tempDirs));
+		expect(() =>
+			store.create({
+				activeSessionId: "active-1",
+				sessionId: "session-1",
+				sessionFile: "/tmp/session.jsonl",
+				cwd: "/tmp/project",
+				scheduleText: "in 1h",
+				prompt: "/goal guarded work",
+				deliveryFence: {
+					version: 1,
+					activeSessionId: "active-1",
+					sessionName: "project-root",
+					cwd: "/tmp/project",
+					model: { provider: "test", id: "" },
+					thinkingLevel: "xhigh",
+					messageCount: 4,
+					lastActivityAt: "2026-01-01T12:30:00.000Z",
+					taskState: "needs_input",
+					goal: null,
+				},
+				now: start,
+			}),
+		).toThrow("Cron delivery fence is invalid");
+	});
+
 	it("isolates worker-owned jobs in registered session artifact stores", () => {
 		const root = makeTempDir(tempDirs);
 		const firstArtifactDir = join(root, "session-artifacts", "session-1");
@@ -570,6 +677,27 @@ describe("AgentCronJobStore", () => {
 			prompt: "review the latest output",
 			now: start,
 		});
+		const conditional = store.create({
+			activeSessionId: "old-active",
+			sessionId: "old-session",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "in 5m",
+			prompt: "/goal guarded work",
+			deliveryFence: {
+				version: 1,
+				activeSessionId: "old-active",
+				sessionName: "project-root",
+				cwd: "/tmp/project-restored",
+				model: { provider: "test", id: "planner" },
+				thinkingLevel: "xhigh",
+				messageCount: 4,
+				lastActivityAt: "2026-01-01T12:30:00.000Z",
+				taskState: "needs_input",
+				goal: null,
+			},
+			now: start,
+		});
 		store.createHeartbeat({
 			activeSessionId: "other-active",
 			sessionId: "other-session",
@@ -587,7 +715,9 @@ describe("AgentCronJobStore", () => {
 			cwd: "/tmp/project-restored",
 		});
 
-		expect(rebound.map((job) => job.id)).toEqual(expect.arrayContaining([userHeartbeat.id, rlmHeartbeat.id]));
+		expect(rebound.map((job) => job.id)).toEqual(
+			expect.arrayContaining([userHeartbeat.id, rlmHeartbeat.id, conditional.id]),
+		);
 		expect(store.getHeartbeat("old-active")).toBeUndefined();
 		expect(store.getHeartbeat("new-active")).toMatchObject({
 			id: userHeartbeat.id,
@@ -598,6 +728,10 @@ describe("AgentCronJobStore", () => {
 			id: rlmHeartbeat.id,
 			sessionId: "new-session",
 			cwd: "/tmp/project-restored",
+		});
+		expect(store.list().find((job) => job.id === conditional.id)).toMatchObject({
+			activeSessionId: "new-active",
+			deliveryFence: { activeSessionId: "new-active" },
 		});
 		expect(store.getHeartbeat("other-active")).toMatchObject({ prompt: "check on a different session" });
 	});
@@ -632,6 +766,27 @@ describe("AgentCronJobStore", () => {
 			prompt: "review the latest output",
 			now: start,
 		});
+		const conditional = store.create({
+			activeSessionId: "active-1",
+			sessionId: "old-session",
+			sessionFile: "/tmp/old-session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "in 5m",
+			prompt: "/goal stay with the stable root",
+			deliveryFence: {
+				version: 1,
+				activeSessionId: "active-1",
+				sessionName: "old-root",
+				cwd: "/tmp/project",
+				model: { provider: "test", id: "planner" },
+				thinkingLevel: "xhigh",
+				messageCount: 4,
+				lastActivityAt: "2026-01-01T12:30:00.000Z",
+				taskState: "needs_input",
+				goal: null,
+			},
+			now: start,
+		});
 
 		const rebound = store.rebindSessionJobs({
 			activeSessionId: "active-1",
@@ -662,6 +817,12 @@ describe("AgentCronJobStore", () => {
 				}),
 			]),
 		);
+		expect(rebound.map((job) => job.id)).not.toContain(conditional.id);
+		expect(store.list().find((job) => job.id === conditional.id)).toMatchObject({
+			sessionId: "old-session",
+			sessionFile: "/tmp/old-session.jsonl",
+			deliveryFence: { activeSessionId: "active-1" },
+		});
 	});
 
 	it("keeps multiple RLM heartbeats separate from the single user heartbeat", () => {
@@ -1325,6 +1486,45 @@ describe("AgentCronScheduler", () => {
 		]);
 		expect(recovered.getClaimedJob(heartbeat.id)).toBeUndefined();
 		expect(recovered.getDueJob(heartbeat.id, new Date("2026-01-01T12:34:11.000Z"))).toBeUndefined();
+	});
+
+	it("cancels an interrupted guarded one-shot without claiming it ran", () => {
+		const storePath = makeStorePath(tempDirs);
+		const store = new AgentCronJobStore(storePath);
+		const guarded = store.create({
+			activeSessionId: "active-1",
+			sessionId: "session-1",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp/project",
+			scheduleText: "in 1m",
+			prompt: "/goal guarded work",
+			deliveryFence: {
+				version: 1,
+				activeSessionId: "active-1",
+				sessionName: "project-root",
+				cwd: "/tmp/project",
+				model: { provider: "test", id: "planner" },
+				thinkingLevel: "xhigh",
+				messageCount: 0,
+				lastActivityAt: "2026-01-01T12:34:00.000Z",
+				taskState: "needs_input",
+				goal: null,
+			},
+			now: start,
+		});
+		store.claimDue(new Date("2026-01-01T12:35:00.000Z"));
+
+		const recovered = new AgentCronJobStore(storePath);
+		expect(recovered.recoverInterruptedDispatches(new Date("2026-01-01T12:35:01.000Z"))).toEqual([
+			expect.objectContaining({
+				id: guarded.id,
+				status: "cancelled",
+				runCount: 0,
+				lastSkippedAt: "2026-01-01T12:35:01.000Z",
+				lastError: "Interrupted before scheduled operation completion",
+			}),
+		]);
+		expect(recovered.getClaimedJob(guarded.id)).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -248,6 +248,57 @@ describe("DaemonClient", () => {
 		await expect(request).rejects.toThrow("closed before the operation completed");
 	});
 
+	it("does not send a guarded cron job to a daemon without conditional delivery", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, DAEMON_PROTOCOL_VERSION, [], DAEMON_SCHEMA_REVISION - 1);
+
+		await expect(
+			client.request({
+				type: "cron_add",
+				activeSessionId: "active-1",
+				schedule: "in 1m",
+				prompt: "/goal guarded work",
+				deliveryFence: {
+					version: 1,
+					activeSessionId: "active-1",
+					sessionName: "project-root",
+					cwd: "/tmp/project",
+					model: { provider: "test", id: "planner" },
+					thinkingLevel: "xhigh",
+					messageCount: 4,
+					lastActivityAt: "2026-08-31T12:00:00.000Z",
+					taskState: "needs_input",
+					goal: null,
+				},
+			}),
+		).rejects.toThrow("does not support conditional_cron_delivery");
+		expect(socket.writes).toEqual([]);
+		client.close();
+	});
+
+	it("keeps legacy cron requests compatible with a new daemon", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, DAEMON_PROTOCOL_VERSION, ["conditional_cron_delivery"], DAEMON_SCHEMA_REVISION);
+
+		const request = client.request({
+			type: "cron_add",
+			activeSessionId: "active-1",
+			schedule: "in 1m",
+			prompt: "legacy work",
+		});
+		await vi.waitFor(() => expect(socket.writes).toHaveLength(1));
+		client.close();
+		await expect(request).rejects.toThrow("closed before the operation completed");
+	});
+
 	it("rejects an old daemon before requesting session state", async () => {
 		const client = new DaemonClient("/tmp/prime-agent.sock");
 		const connect = client.connect();

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -53,7 +53,7 @@ import {
 	type DaemonOutbound,
 	failure,
 } from "../src/modes/daemon/daemon-protocol.js";
-import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
+import { type SessionSummary, summaryForActiveSession } from "../src/modes/daemon/daemon-session-list.js";
 import { DAEMON_WORKER_SUPERVISOR_SOCKET_ENV } from "../src/modes/daemon/daemon-worker-protocol.js";
 import { RlmSpawnLedger } from "../src/modes/daemon/rlm-ledger.js";
 
@@ -1271,6 +1271,314 @@ describe("daemon mode helpers", () => {
 			expect(await internals.cronScheduler.runDue(new Date(Date.now() + 10 * 60 * 1000))).toBe(0);
 			expect(promptUntilAccepted).toHaveBeenCalledOnce();
 			expect(internals.cronStore.list().find((candidate) => candidate.id === job.id)?.status).toBe("cancelled");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a guarded cron job when its session fence drifts during admission", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-guarded-cron-admission-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) throw new Error("Missing session file");
+
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				options.sessionManager.appendSessionInfo("guarded-root");
+				const promptUntilAccepted = vi.fn(
+					async (_prompt: string, promptOptions?: { admissionCommitted?: () => void }) => {
+						Object.assign(session, { thinkingLevel: "high" });
+						promptOptions?.admissionCommitted?.();
+					},
+				);
+				Object.assign(session, {
+					model: { provider: "test", id: "planner" } as Model<Api>,
+					thinkingLevel: "xhigh",
+					isStreaming: false,
+					isCompacting: false,
+					isRetrying: false,
+					isBashRunning: false,
+					isSessionActive: false,
+					unfinishedActionCount: 0,
+					rlmDepth: 0,
+					goalState: { active: false, status: "idle", tokensUsed: 0, timeUsedSeconds: 0, continuationsUsed: 0 },
+					state: { pendingToolCalls: new Set(), streamingMessage: undefined },
+					hasRunningRlmChildren: () => false,
+					getSessionActionSnapshot: () => ({ queuedCount: 0, steering: [], followUps: [] }),
+					promptUntilAccepted,
+					startGoalFromConditionalPrompt: promptUntilAccepted,
+				});
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				cronStore: AgentCronJobStore;
+				cronScheduler: { runDue(now: Date): Promise<number> };
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+			};
+			const state = await internals.createRuntime({ type: "create", sessionPath: sessionFile });
+			state.summaryState = { taskState: "needs_input", basedOnMessageCount: 0 } as never;
+			const baseline = summaryForActiveSession(state);
+			const job = internals.cronStore.create({
+				activeSessionId: state.activeSessionId,
+				sessionId: state.runtime.session.sessionId,
+				sessionFile,
+				cwd: tempDir,
+				scheduleText: "in 1m",
+				prompt: "/goal guarded objective",
+				deliveryFence: {
+					version: 1,
+					activeSessionId: state.activeSessionId,
+					sessionName: baseline.sessionName!,
+					cwd: baseline.cwd,
+					model: { provider: baseline.model!.provider, id: baseline.model!.id },
+					thinkingLevel: baseline.thinkingLevel!,
+					messageCount: baseline.messageCount,
+					lastActivityAt: baseline.lastActivityAt!,
+					taskState: "needs_input",
+					goal: null,
+				},
+			});
+
+			expect(await internals.cronScheduler.runDue(new Date(Date.now() + 2 * 60 * 1000))).toBe(0);
+			expect(internals.cronStore.list().find((candidate) => candidate.id === job.id)).toMatchObject({
+				status: "cancelled",
+				lastError: "Delivery fence changed before prompt admission",
+				runCount: 0,
+			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a guarded cron job before the busy queue path when its idle profile drifts", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-guarded-cron-busy-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			manager.appendSessionInfo("guarded-root");
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) throw new Error("Missing session file");
+
+			const followUp = vi.fn(async () => {});
+			const promptUntilAccepted = vi.fn(async () => {});
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				Object.assign(session, {
+					model: { provider: "test", id: "planner" } as Model<Api>,
+					thinkingLevel: "xhigh",
+					isStreaming: false,
+					isCompacting: false,
+					isRetrying: false,
+					isBashRunning: false,
+					isSessionActive: false,
+					unfinishedActionCount: 0,
+					rlmDepth: 0,
+					goalState: { active: false, status: "idle", tokensUsed: 0, timeUsedSeconds: 0, continuationsUsed: 0 },
+					state: { pendingToolCalls: new Set(), streamingMessage: undefined },
+					hasRunningRlmChildren: () => false,
+					getSessionActionSnapshot: () => ({ queuedCount: 0, steering: [], followUps: [] }),
+					followUp,
+					promptUntilAccepted,
+					startGoalFromConditionalPrompt: promptUntilAccepted,
+				});
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				cronStore: AgentCronJobStore;
+				cronScheduler: { runDue(now: Date): Promise<number> };
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+			};
+			const state = await internals.createRuntime({ type: "create", sessionPath: sessionFile });
+			state.summaryState = { taskState: "needs_input", basedOnMessageCount: 0 } as never;
+			const baseline = summaryForActiveSession(state);
+			const job = internals.cronStore.create({
+				activeSessionId: state.activeSessionId,
+				sessionId: state.runtime.session.sessionId,
+				sessionFile,
+				cwd: tempDir,
+				scheduleText: "in 1m",
+				prompt: "/goal guarded objective",
+				deliveryFence: {
+					version: 1,
+					activeSessionId: state.activeSessionId,
+					sessionName: baseline.sessionName!,
+					cwd: baseline.cwd,
+					model: { provider: baseline.model!.provider, id: baseline.model!.id },
+					thinkingLevel: baseline.thinkingLevel!,
+					messageCount: baseline.messageCount,
+					lastActivityAt: baseline.lastActivityAt!,
+					taskState: "needs_input",
+					goal: null,
+				},
+			});
+
+			Object.assign(state.runtime.session, {
+				isStreaming: true,
+				model: { provider: "test", id: "changed-model" } as Model<Api>,
+			});
+			expect(await internals.cronScheduler.runDue(new Date(Date.now() + 2 * 60 * 1000))).toBe(0);
+			expect(followUp).not.toHaveBeenCalled();
+			expect(promptUntilAccepted).not.toHaveBeenCalled();
+			expect(internals.cronStore.list().find((candidate) => candidate.id === job.id)).toMatchObject({
+				status: "cancelled",
+				lastError: "Delivery fence changed before prompt admission",
+				runCount: 0,
+			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("terminalizes a pre-provider goal receipt when conditional recovery is exhausted", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-guarded-cron-exhausted-"));
+		try {
+			const sessionDir = join(tempDir, "sessions");
+			const manager = SessionManager.create(tempDir, sessionDir);
+			manager.newSession();
+			manager.appendSessionInfo("guarded-root");
+			const sessionFile = manager.getSessionFile();
+			if (!sessionFile) throw new Error("Missing session file");
+			let expectedReceiptId = "pending";
+			const failConditionalGoalDelivery = vi.fn((receiptId: string) => {
+				if (receiptId !== expectedReceiptId) return false;
+				Object.assign(goalState, {
+					active: false,
+					status: "error",
+					lastError: "Conditional goal delivery recovery exhausted",
+				});
+				return true;
+			});
+			const goalState = {
+				active: true,
+				status: "active",
+				goalId: "guarded-goal",
+				dispatchReceiptId: expectedReceiptId,
+				dispatchPhase: "receipt",
+				objective: "guarded objective",
+				tokensUsed: 0,
+				timeUsedSeconds: 0,
+				continuationsUsed: 0,
+			};
+			let recoveryQueued = false;
+			const recoverConditionalGoalDelivery = vi.fn(
+				(_receiptId: string, options?: { recoveryCommitted?: () => void }) => {
+					options?.recoveryCommitted?.();
+					recoveryQueued = true;
+					return true;
+				},
+			);
+			const createRuntime = vi.fn(async (options: Parameters<CreateAgentSessionRuntimeFactory>[0]) => {
+				const session = makeRuntimeSession(options.sessionManager);
+				Object.assign(session, {
+					model: { provider: "test", id: "planner" } as Model<Api>,
+					thinkingLevel: "xhigh",
+					goalState,
+					failConditionalGoalDelivery,
+					recoverConditionalGoalDelivery,
+				});
+				return {
+					session,
+					extensionsResult: { extensions: [], errors: [], runtime: {} } as unknown as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["extensionsResult"],
+					services: { cwd: options.cwd, agentDir: options.agentDir } as Awaited<
+						ReturnType<CreateAgentSessionRuntimeFactory>
+					>["services"],
+					diagnostics: [],
+				};
+			});
+			const daemon = new AgentDaemon(join(tempDir, "daemon.sock"), {
+				defaultSessionConfig: { agentDir: tempDir, cwd: tempDir, sessionDir },
+				createRuntime,
+			});
+			const internals = daemon as unknown as {
+				cronStore: AgentCronJobStore;
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				recoverConditionalCronDeliveryForState(state: ActiveSessionState): void;
+			};
+			const state = await internals.createRuntime({ type: "create", sessionPath: sessionFile });
+			const job = internals.cronStore.create({
+				activeSessionId: state.activeSessionId,
+				sessionId: state.runtime.session.sessionId,
+				sessionFile,
+				cwd: tempDir,
+				scheduleText: "in 1m",
+				prompt: "/goal guarded objective",
+				deliveryFence: {
+					version: 1,
+					activeSessionId: state.activeSessionId,
+					sessionName: "guarded-root",
+					cwd: tempDir,
+					model: { provider: "test", id: "planner" },
+					thinkingLevel: "xhigh",
+					messageCount: 0,
+					lastActivityAt: "2026-01-01T00:00:00.000Z",
+					taskState: "needs_input",
+					goal: null,
+				},
+			});
+			expectedReceiptId = job.id;
+			goalState.dispatchReceiptId = job.id;
+			internals.cronStore.rejectDelivery(
+				job.id,
+				"Conditional goal receipt persisted before delivery error: disk full",
+			);
+			const recoveryWrite = vi
+				.spyOn(internals.cronStore, "recordDeliveryRecoveryAttempt")
+				.mockImplementationOnce(() => {
+					throw new Error("recovery counter write failed");
+				});
+
+			internals.recoverConditionalCronDeliveryForState(state);
+
+			expect(recoveryQueued).toBe(false);
+			expect(internals.cronStore.list().find((candidate) => candidate.id === job.id)).not.toHaveProperty(
+				"deliveryRecoveryCount",
+			);
+			recoveryWrite.mockRestore();
+			for (let attempt = 0; attempt < 5; attempt += 1) {
+				internals.cronStore.recordDeliveryRecoveryAttempt(job.id);
+			}
+
+			internals.recoverConditionalCronDeliveryForState(state);
+
+			expect(failConditionalGoalDelivery).toHaveBeenCalledOnce();
+			expect(goalState).toMatchObject({ active: false, status: "error" });
+			expect(internals.cronStore.list().find((candidate) => candidate.id === job.id)).toMatchObject({
+				deliveryRecoveryCount: 5,
+				deliveryRecoveryExhaustedAt: expect.any(String),
+				lastError: "Conditional goal delivery recovery exhausted",
+			});
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -136,6 +136,33 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("acp_mcp_servers");
 	});
 
+	it("capability-gates guarded cron delivery without breaking legacy cron clients", () => {
+		const legacyCron = {
+			type: "cron_add",
+			activeSessionId: "active-1",
+			schedule: "in 1m",
+			prompt: "legacy prompt",
+		} as const satisfies DaemonCommand;
+		const guardedCron = {
+			...legacyCron,
+			deliveryFence: {
+				version: 1,
+				activeSessionId: "active-1",
+				messageCount: 4,
+				lastActivityAt: "2026-08-31T12:00:00.000Z",
+				taskState: "needs_input",
+				goal: null,
+			},
+		} as DaemonCommand;
+
+		expect(getDaemonCommandCompatibilities(legacyCron)).toEqual([{ minProtocol: 7 }]);
+		expect(getDaemonCommandCompatibilities(guardedCron)).toEqual([
+			{ minProtocol: 7, minSchemaRevision: 24, capability: "conditional_cron_delivery" },
+			{ minProtocol: 7 },
+		]);
+		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("conditional_cron_delivery");
+	});
+
 	it("capability-gates the optional model catalog surface", () => {
 		expect(DAEMON_COMMAND_COMPATIBILITY.get_model_catalog).toEqual({
 			minProtocol: 7,

--- a/packages/coding-agent/test/daemon-session-list.test.ts
+++ b/packages/coding-agent/test/daemon-session-list.test.ts
@@ -500,6 +500,33 @@ describe("summaryForActiveSession recap currency", () => {
 		expect(summary.summary).toBeUndefined();
 		expect(summary.taskState).toBeUndefined();
 	});
+
+	it("exposes a sanitized exact goal fence without the objective", () => {
+		const summary = summaryForActiveSession(
+			makeState({
+				activeSessionId: "s1",
+				goalState: {
+					active: false,
+					status: "complete",
+					goalId: "goal-1",
+					objective: "secret owner objective",
+					tokensUsed: 123,
+					timeUsedSeconds: 45,
+					continuationsUsed: 2,
+					createdAt: 100,
+					updatedAt: 200,
+				},
+			}),
+		);
+
+		expect(summary).toHaveProperty("goal", {
+			active: false,
+			status: "complete",
+			goalId: "goal-1",
+			updatedAt: 200,
+		});
+		expect(JSON.stringify(summary)).not.toContain("secret owner objective");
+	});
 });
 
 describe("buildRlmChildSnapshots", () => {
@@ -590,6 +617,7 @@ interface StateOptions {
 	messages?: AgentMessage[];
 	hasUserContent?: boolean;
 	summaryState?: ActiveSessionState["summaryState"];
+	goalState?: ActiveSessionState["runtime"]["session"]["goalState"];
 	hasRunningRlmChildren?: boolean;
 	hasAcceptedPromptInFlight?: boolean;
 	unfinishedActionCount?: number;
@@ -625,6 +653,13 @@ function makeState(options: StateOptions): ActiveSessionState {
 			metadata: options.metadata ?? { kind: "top-level", createdAt: 1 },
 			diagnostics: [],
 			session: {
+				goalState: options.goalState ?? {
+					active: false,
+					status: "idle",
+					tokensUsed: 0,
+					timeUsedSeconds: 0,
+					continuationsUsed: 0,
+				},
 				model: options.model,
 				thinkingLevel: "off",
 				isStreaming: options.isStreaming ?? false,

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -6,6 +6,7 @@ import { fauxAssistantMessage, fauxToolCall, type Model } from "@earendil-works/
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BashResult } from "../../src/core/bash-executor.js";
+import { createGoalContextMessage } from "../../src/core/goals.js";
 import type { PromptTemplate } from "../../src/core/prompt-templates.js";
 import { createSyntheticSourceInfo } from "../../src/core/source-info.js";
 import { createTestResourceLoader } from "../utilities.js";
@@ -64,6 +65,241 @@ describe("AgentSession prompt characterization", () => {
 		harness.setResponses([fauxAssistantMessage("recovered")]);
 		await harness.session.prompt("second");
 		expect(getUserTexts(harness)).toEqual(["second"]);
+	});
+
+	it("rechecks a conditional goal fence after validation and before persisting the goal", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		let validationReached = () => {};
+		const reached = new Promise<void>((resolve) => {
+			validationReached = resolve;
+		});
+		let releaseValidation = () => {};
+		const validationGate = new Promise<void>((resolve) => {
+			releaseValidation = resolve;
+		});
+		const internals = harness.session as unknown as {
+			_validateCanStartAgentRun(): Promise<void>;
+			startGoalFromConditionalPrompt(
+				text: string,
+				options: { admissionCommitted(): void; receiptId: string },
+			): Promise<void>;
+		};
+		internals._validateCanStartAgentRun = vi.fn(async () => {
+			validationReached();
+			await validationGate;
+		});
+		const expectedName = harness.session.sessionName;
+		const fenceChanged = new Error("conditional goal fence changed");
+		const start = internals.startGoalFromConditionalPrompt("/goal guarded objective", {
+			receiptId: "cron-delivery-1",
+			admissionCommitted: () => {
+				if (harness.session.sessionName !== expectedName) throw fenceChanged;
+			},
+		});
+
+		await reached;
+		harness.session.setSessionName("changed-during-validation");
+		releaseValidation();
+		await expect(start).rejects.toBe(fenceChanged);
+		expect(harness.session.goalState.status).toBe("idle");
+	});
+
+	it("persists a conditional delivery receipt before starting its goal turn", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("working")]);
+
+		await harness.session.startGoalFromConditionalPrompt("/goal guarded objective", {
+			receiptId: "cron-delivery-committed",
+			admissionCommitted: () => {},
+		});
+		await vi.waitFor(() => expect(getAssistantTexts(harness)).toContain("working"));
+
+		expect(harness.session.goalState).toMatchObject({
+			dispatchReceiptId: "cron-delivery-committed",
+			dispatchPhase: "provider_committed",
+		});
+	});
+
+	it("reconstructs only a pre-provider conditional receipt and wakes its turn", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const now = Date.now();
+		const internals = harness.session as unknown as {
+			_setGoalState(goal: typeof harness.session.goalState): void;
+			recoverConditionalGoalDelivery(receiptId: string): boolean;
+		};
+		internals._setGoalState({
+			active: true,
+			status: "active",
+			goalId: "recovered-goal",
+			dispatchReceiptId: "cron-delivery-recovered",
+			dispatchPhase: "receipt",
+			objective: "recover guarded objective",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			continuationsUsed: 0,
+			createdAt: now,
+			updatedAt: now,
+		});
+		harness.setResponses([fauxAssistantMessage("recovered")]);
+
+		expect(internals.recoverConditionalGoalDelivery("cron-delivery-recovered")).toBe(true);
+		await vi.waitFor(() => expect(getAssistantTexts(harness)).toContain("recovered"));
+		expect(harness.session.goalState.dispatchPhase).toBe("provider_committed");
+		expect(internals.recoverConditionalGoalDelivery("cron-delivery-recovered")).toBe(false);
+	});
+
+	it("persists a recovery attempt before rebuilding the conditional goal turn", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const now = Date.now();
+		const recoveryWriteError = new Error("recovery counter write failed");
+		const internals = harness.session as unknown as {
+			_setGoalState(goal: typeof harness.session.goalState): void;
+			recoverConditionalGoalDelivery(receiptId: string, options: { recoveryCommitted(): void }): boolean;
+		};
+		internals._setGoalState({
+			active: true,
+			status: "active",
+			goalId: "recovered-goal",
+			dispatchReceiptId: "cron-delivery-counter-failed",
+			dispatchPhase: "receipt",
+			objective: "recover guarded objective",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			continuationsUsed: 0,
+			createdAt: now,
+			updatedAt: now,
+		});
+		harness.setResponses([fauxAssistantMessage("must not run")]);
+
+		expect(() =>
+			internals.recoverConditionalGoalDelivery("cron-delivery-counter-failed", {
+				recoveryCommitted: () => {
+					throw recoveryWriteError;
+				},
+			}),
+		).toThrow(recoveryWriteError);
+		expect(harness.session.goalState.dispatchPhase).toBe("receipt");
+		expect(getAssistantTexts(harness)).toEqual([]);
+	});
+
+	it("terminalizes an exhausted pre-provider conditional receipt without calling the provider", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const now = Date.now();
+		const internals = harness.session as unknown as {
+			_setGoalState(goal: typeof harness.session.goalState): void;
+			failConditionalGoalDelivery(receiptId: string): boolean;
+		};
+		internals._setGoalState({
+			active: true,
+			status: "active",
+			goalId: "exhausted-goal",
+			dispatchReceiptId: "cron-delivery-exhausted",
+			dispatchPhase: "receipt",
+			objective: "recover guarded objective",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			continuationsUsed: 0,
+			createdAt: now,
+			updatedAt: now,
+		});
+
+		expect(internals.failConditionalGoalDelivery("cron-delivery-exhausted")).toBe(true);
+		expect(harness.session.goalState).toMatchObject({
+			active: false,
+			status: "error",
+			dispatchReceiptId: "cron-delivery-exhausted",
+			dispatchPhase: "receipt",
+			lastError: "Conditional goal delivery recovery exhausted",
+		});
+		expect(internals.failConditionalGoalDelivery("cron-delivery-exhausted")).toBe(false);
+		expect(getAssistantTexts(harness)).toEqual([]);
+	});
+
+	it("does not exhaust a conditional receipt while its final recovery action is queued", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const now = Date.now();
+		const internals = harness.session as unknown as {
+			_setGoalState(goal: typeof harness.session.goalState): void;
+			recoverConditionalGoalDelivery(receiptId: string): boolean;
+			failConditionalGoalDelivery(receiptId: string): boolean;
+		};
+		internals._setGoalState({
+			active: true,
+			status: "active",
+			goalId: "queued-recovery-goal",
+			dispatchReceiptId: "cron-delivery-final-attempt",
+			dispatchPhase: "receipt",
+			objective: "recover guarded objective",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			continuationsUsed: 0,
+			createdAt: now,
+			updatedAt: now,
+		});
+		vi.spyOn(harness.session, "isCompacting", "get").mockReturnValue(true);
+
+		expect(internals.recoverConditionalGoalDelivery("cron-delivery-final-attempt")).toBe(true);
+		expect(internals.failConditionalGoalDelivery("cron-delivery-final-attempt")).toBe(false);
+		expect(harness.session.goalState).toMatchObject({ active: true, status: "active", dispatchPhase: "receipt" });
+	});
+
+	it("rejects an invalidated conditional receipt at the provider boundary", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const now = Date.now();
+		const receiptGoal = {
+			active: true,
+			status: "active" as const,
+			goalId: "invalidated-recovery-goal",
+			dispatchReceiptId: "cron-delivery-invalidated",
+			dispatchPhase: "receipt" as const,
+			objective: "recover guarded objective",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			continuationsUsed: 0,
+			createdAt: now,
+			updatedAt: now,
+		};
+		const internals = harness.session as unknown as {
+			_setGoalState(goal: typeof harness.session.goalState): void;
+			_commitConditionalGoalProviderBoundary(messages: ReturnType<typeof createGoalContextMessage>[]): void;
+		};
+		internals._setGoalState({
+			...receiptGoal,
+			active: false,
+			status: "error",
+			lastError: "Conditional goal delivery recovery exhausted",
+		});
+
+		expect(() =>
+			internals._commitConditionalGoalProviderBoundary([createGoalContextMessage(receiptGoal, "continuation")]),
+		).toThrow("Conditional goal delivery state invalidated before provider commit");
+		expect(harness.session.goalState.dispatchPhase).toBe("receipt");
+		expect(getAssistantTexts(harness)).toEqual([]);
+	});
+
+	it("leaves no live goal when its conditional receipt cannot be persisted", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const persistenceError = new Error("disk full");
+		vi.spyOn(harness.session.sessionManager, "appendCustomEntryWithRollback").mockImplementation(() => {
+			throw persistenceError;
+		});
+
+		await expect(
+			harness.session.startGoalFromConditionalPrompt("/goal guarded objective", {
+				receiptId: "cron-delivery-failed",
+				admissionCommitted: () => {},
+			}),
+		).rejects.toBe(persistenceError);
+		expect(harness.session.goalState).toMatchObject({ status: "idle", active: false });
+		expect(harness.session.goalState).not.toHaveProperty("dispatchReceiptId");
 	});
 
 	it("keeps a prompt session-owned when cancellation arrives after admission", async () => {


### PR DESCRIPTION
## Summary

- persist conditional goal receipt and provider-commit phase before side effects
- recover exact receipts after daemon death with bounded, durable retry exhaustion
- fence cron delivery and restore by stable session file; expose only sanitized receipt metadata
- negotiate conditional_cron_delivery through protocol schema 24

## Failure modes covered

- crash after receipt but before provider call
- crash while persisting a recovery attempt
- fifth-attempt exhaustion and queued fifth attempt
- daemon-local active ID rotation for the same stable session
- switch_session to a different stable root
- admission drift after the first conditional compare-and-set

## Validation

- npm run check
- 386 tests across the six modified coding-agent suites
- independent Sol/xhigh differential review: merge-ready, no high/medium findings

The CTO-side consumer is a separate dependent PR and defers safely against older schemas.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make conditional goal deliveries crash-safe with delivery fences and bounded recovery
> - Adds `startGoalFromConditionalPrompt` to `AgentSession` to atomically validate, fence, and persist a conditional `/goal` start with a dispatch receipt, using rollback-capable persistence via `appendCustomEntryWithRollback`
> - Introduces a `provider_committed` dispatch phase in `GoalState`, persisted right before the agent is prompted, so restarts after a crash fail-closed rather than re-delivering
> - Adds `AgentCronDeliveryFence` to cron jobs (new `conditional_cron` source) so the daemon rejects delivery when session identity, model, thinking level, or goal state have drifted since scheduling
> - Implements bounded crash recovery in `AgentDaemon`: interrupted conditional cron deliveries are rebuilt and re-enqueued up to a retry limit, then terminally failed via `failConditionalGoalDelivery` with exhaustion metadata recorded in the cron store
> - Bumps daemon schema revision from 23 to 24 and gates the new `cron_add` delivery fence behind the `conditional_cron_delivery` capability; legacy `cron_add` remains compatible
> - **Behavioral Change:** `DAEMON_SCHEMA_REVISION` is now 24 and `DAEMON_SCHEMA_ID` changed; peers must negotiate schema 24 and advertise `conditional_cron_delivery` to use fenced cron delivery. `recoverInterruptedInState` now cancels (not completes) interrupted `conditional_cron` one-shot jobs, setting `lastSkippedAt` without incrementing `runCount`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd89d92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->