### PR TITLE
feat(ai): add xAI Grok OAuth login via device code flow

### DIFF
--- a/packages/ai/.changes/xai-oauth.md
+++ b/packages/ai/.changes/xai-oauth.md
@@ -1,0 +1,1 @@
+- Added xAI (Grok) OAuth login via the device code flow for SuperGrok / Premium+ accounts. `/login` can now authenticate against `auth.x.ai`; access tokens refresh automatically, refresh tokens rotate, and HTTP 403 is reported as a subscription-tier gate with `XAI_API_KEY` as the fallback.

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -5,6 +5,7 @@
  * for OAuth-based providers:
  * - Anthropic (Claude Pro/Max)
  * - GitHub Copilot
+ * - xAI (Grok SuperGrok / Premium+)
  */
 
 export { anthropicOAuthProvider, loginAnthropic, refreshAnthropicToken } from "./anthropic.js";
@@ -16,18 +17,20 @@ export {
 	refreshGitHubCopilotToken,
 } from "./github-copilot.js";
 export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.js";
-
 export * from "./types.js";
+export { loginXai, refreshXaiToken, xaiOAuthProvider } from "./xai.js";
 
 import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
+import { xaiOAuthProvider } from "./xai.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	anthropicOAuthProvider,
 	githubCopilotOAuthProvider,
 	openaiCodexOAuthProvider,
+	xaiOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(
@@ -118,8 +121,11 @@ export async function getOAuthApiKey(
 	if (Date.now() >= creds.expires) {
 		try {
 			creds = await provider.refreshToken(creds);
-		} catch (_error) {
-			throw new Error(`Failed to refresh OAuth token for ${providerId}`);
+		} catch (error) {
+			// Keep the provider's detailed refresh error (tier gates, re-login
+			// hints, server response) attached so callers can surface it.
+			const reason = error instanceof Error ? error.message : String(error);
+			throw new Error(`Failed to refresh OAuth token for ${providerId}: ${reason}`, { cause: error });
 		}
 	}
 

--- a/packages/ai/src/utils/oauth/xai.ts
+++ b/packages/ai/src/utils/oauth/xai.ts
@@ -1,0 +1,352 @@
+/**
+ * xAI (Grok) OAuth device flow — SuperGrok / Premium+ subscriptions.
+ *
+ * Uses xAI's OAuth 2.0 device authorization grant (RFC 8628) against
+ * auth.x.ai: request a device code, have the user approve at
+ * verification_uri_complete, then poll the token endpoint. The returned
+ * access token is used as the API key against https://api.x.ai/v1.
+ *
+ * Notes:
+ * - The client id is the public grok-cli client (same one other community
+ *   clients use); xAI does not offer per-app OAuth registration for CLI tools.
+ * - Access tokens are short-lived (about 6h in SuperGrok flows; device logins
+ *   can return ~15-minute JWTs). Stored expiry is skewed so the runtime
+ *   refresh happens well before the real expiry; the skew scales down for
+ *   short-lived tokens so they do not refresh on every call.
+ * - xAI rotates the refresh token on every refresh; the response may carry a
+ *   new refresh_token which replaces the stored one.
+ * - A 403 from the token endpoint is a subscription-tier gate (the OAuth
+ *   grant exists but the account is not entitled to API access). Re-login
+ *   does not fix it; the XAI_API_KEY provider is the fallback.
+ */
+
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+
+const ISSUER = "https://auth.x.ai";
+const DEVICE_CODE_URL = `${ISSUER}/oauth2/device/code`;
+const TOKEN_URL = `${ISSUER}/oauth2/token`;
+const CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const SCOPE = "openid profile email offline_access grok-cli:access api:access";
+
+/** How far before real expiry a long-lived token should be refreshed. */
+const REFRESH_SKEW_MS = 60 * 60 * 1000;
+
+interface DeviceCodeResponse {
+	device_code: string;
+	user_code: string;
+	verification_uri: string;
+	verification_uri_complete?: string;
+	interval: number;
+	expires_in: number;
+}
+
+interface TokenPayload {
+	access_token: string;
+	refresh_token?: string;
+	id_token?: string;
+	expires_in: number;
+	token_type?: string;
+}
+
+interface DeviceTokenErrorResponse {
+	error: string;
+	error_description?: string;
+	interval?: number;
+}
+
+/**
+ * Compute the stored expiry (ms epoch) for a token issued at `nowMs`.
+ *
+ * Long-lived tokens are refreshed REFRESH_SKEW_MS early (matches daemon-style
+ * workloads that may touch the provider only every 30+ minutes). Short-lived
+ * tokens scale the skew down to a quarter of their lifetime so a 15-minute
+ * JWT is not refreshed on every call.
+ */
+export function computeStoredExpiry(nowMs: number, expiresInSeconds: number): number {
+	const lifeMs = expiresInSeconds * 1000;
+	const skewMs = Math.min(REFRESH_SKEW_MS, Math.floor(lifeMs / 4));
+	return nowMs + lifeMs - skewMs;
+}
+
+async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
+	const response = await fetch(url, init);
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`${response.status} ${response.statusText}: ${text}`);
+	}
+	return response.json();
+}
+
+function formBody(params: Record<string, string>): URLSearchParams {
+	return new URLSearchParams(params);
+}
+
+function jsonHeaders(): Record<string, string> {
+	return {
+		Accept: "application/json",
+		"Content-Type": "application/x-www-form-urlencoded",
+	};
+}
+
+async function requestDeviceCode(signal?: AbortSignal): Promise<DeviceCodeResponse> {
+	const data = await fetchJson(DEVICE_CODE_URL, {
+		method: "POST",
+		headers: jsonHeaders(),
+		body: formBody({
+			client_id: CLIENT_ID,
+			scope: SCOPE,
+		}),
+		signal,
+	});
+
+	if (!data || typeof data !== "object") {
+		throw new Error("Invalid xAI device code response");
+	}
+
+	const device = data as Record<string, unknown>;
+	const deviceCode = device.device_code;
+	const userCode = device.user_code;
+	const verificationUri = device.verification_uri;
+	const interval = device.interval;
+	const expiresIn = device.expires_in;
+
+	if (
+		typeof deviceCode !== "string" ||
+		typeof userCode !== "string" ||
+		typeof verificationUri !== "string" ||
+		typeof interval !== "number" ||
+		typeof expiresIn !== "number"
+	) {
+		throw new Error("Invalid xAI device code response fields");
+	}
+
+	return {
+		device_code: deviceCode,
+		user_code: userCode,
+		verification_uri: verificationUri,
+		verification_uri_complete:
+			typeof device.verification_uri_complete === "string" ? device.verification_uri_complete : undefined,
+		interval,
+		expires_in: expiresIn,
+	};
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Login cancelled"));
+			return;
+		}
+
+		const timeout = setTimeout(resolve, ms);
+
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timeout);
+				reject(new Error("Login cancelled"));
+			},
+			{ once: true },
+		);
+	});
+}
+
+async function pollForToken(
+	deviceCode: string,
+	intervalSeconds: number,
+	expiresIn: number,
+	signal?: AbortSignal,
+): Promise<TokenPayload> {
+	const deadline = Date.now() + expiresIn * 1000;
+	let intervalMs = Math.max(1000, Math.floor(intervalSeconds * 1000));
+
+	while (Date.now() < deadline) {
+		if (signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+
+		// Never sleep past the deadline (mirrors the copilot poll loop).
+		await abortableSleep(Math.min(intervalMs, deadline - Date.now()), signal);
+
+		let response: Response;
+		try {
+			response = await fetch(TOKEN_URL, {
+				method: "POST",
+				headers: jsonHeaders(),
+				body: formBody({
+					client_id: CLIENT_ID,
+					device_code: deviceCode,
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+				}),
+				signal,
+			});
+		} catch {
+			// Network-level failures are transient; poll again until the deadline.
+			if (signal?.aborted) {
+				throw new Error("Login cancelled");
+			}
+			continue;
+		}
+
+		let data: unknown = null;
+		try {
+			data = await response.json();
+		} catch {
+			// Non-JSON body (e.g. an HTML error page from a proxy): transient.
+			if (!response.ok) {
+				continue;
+			}
+		}
+
+		if (data && typeof data === "object" && typeof (data as TokenPayload).access_token === "string") {
+			const payload = data as TokenPayload;
+			if (!payload.access_token) {
+				throw new Error("xAI device flow returned an empty access token");
+			}
+			return payload;
+		}
+
+		if (data && typeof data === "object" && typeof (data as DeviceTokenErrorResponse).error === "string") {
+			const { error, error_description: description, interval } = data as DeviceTokenErrorResponse;
+			if (error === "authorization_pending") {
+				continue;
+			}
+			if (error === "slow_down") {
+				// RFC 8628: increase the interval by at least 5 seconds; a server
+				// hint can widen it further but must never shrink it.
+				const serverIntervalMs = typeof interval === "number" && interval > 0 ? interval * 1000 : 0;
+				intervalMs = Math.max(intervalMs + 5000, serverIntervalMs);
+				continue;
+			}
+			const descriptionSuffix = description ? `: ${description}` : "";
+			throw new Error(`xAI device flow failed: ${error}${descriptionSuffix}`);
+		}
+	}
+
+	throw new Error("xAI device flow timed out");
+}
+
+function tokenPayloadToCredentials(payload: TokenPayload, nowMs: number): OAuthCredentials {
+	return {
+		access: payload.access_token,
+		refresh: payload.refresh_token ?? "",
+		expires: computeStoredExpiry(nowMs, payload.expires_in),
+		...(payload.id_token ? { id_token: payload.id_token } : {}),
+	};
+}
+
+/**
+ * Login with xAI (Grok) OAuth via the device code flow.
+ */
+export async function loginXai(options: {
+	onAuth: (url: string, instructions?: string) => void;
+	onProgress?: (message: string) => void;
+	signal?: AbortSignal;
+}): Promise<OAuthCredentials> {
+	const device = await requestDeviceCode(options.signal);
+
+	const verificationUrl = device.verification_uri_complete || device.verification_uri;
+	// The verification URL is opened in the user's browser; only accept xAI's
+	// own origin (RFC 8628 recommends clients verify the verification URI).
+	try {
+		if (new URL(verificationUrl).origin !== ISSUER) {
+			throw new Error("unexpected origin");
+		}
+	} catch {
+		throw new Error(`xAI returned an unexpected verification URL: ${verificationUrl}`);
+	}
+	options.onAuth(verificationUrl, `Enter code: ${device.user_code}`);
+
+	let payload: TokenPayload;
+	try {
+		payload = await pollForToken(device.device_code, device.interval, device.expires_in, options.signal);
+	} catch (error) {
+		// Cancellation must surface as a clean "Login cancelled", not a raw AbortError.
+		if (options.signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+		throw error;
+	}
+	if (!payload.refresh_token) {
+		throw new Error("xAI login response did not include a refresh token");
+	}
+
+	return tokenPayloadToCredentials(payload, Date.now());
+}
+
+/**
+ * Refresh an xAI access token. xAI rotates refresh tokens; when the response
+ * carries a new refresh_token it replaces the previous one, otherwise the
+ * previous token is kept.
+ */
+export async function refreshXaiToken(refreshToken: string): Promise<OAuthCredentials> {
+	if (!refreshToken.trim()) {
+		throw new Error("xAI OAuth is missing a refresh token. Log in again with /login.");
+	}
+
+	const response = await fetch(TOKEN_URL, {
+		method: "POST",
+		headers: jsonHeaders(),
+		body: formBody({
+			grant_type: "refresh_token",
+			client_id: CLIENT_ID,
+			refresh_token: refreshToken,
+		}),
+	});
+
+	if (response.status === 403) {
+		const detail = (await response.text()).trim();
+		throw new Error(
+			"xAI token refresh was denied (HTTP 403)." +
+				(detail ? ` Response: ${detail}.` : "") +
+				" This account is not entitled to xAI API access — xAI may restrict API/OAuth use to specific" +
+				" SuperGrok tiers even when the subscription is active. Logging in again will not fix this." +
+				" Run /logout to remove the xAI credentials, set XAI_API_KEY to use the API-key provider instead," +
+				" or review your subscription at https://x.ai/grok.",
+		);
+	}
+
+	if (!response.ok) {
+		const detail = (await response.text()).trim();
+		const reloginHint = response.status === 400 || response.status === 401 ? " Log in again with /login." : "";
+		throw new Error(
+			`xAI token refresh failed (${response.status} ${response.statusText}).${detail ? ` Response: ${detail}.` : ""}${reloginHint}`,
+		);
+	}
+
+	const payload = (await response.json()) as TokenPayload;
+	if (typeof payload.access_token !== "string" || !payload.access_token) {
+		throw new Error("xAI token refresh response did not include an access token. Log in again with /login.");
+	}
+	if (typeof payload.expires_in !== "number" || !Number.isFinite(payload.expires_in) || payload.expires_in <= 0) {
+		throw new Error("xAI token refresh response did not include a valid expires_in. Log in again with /login.");
+	}
+
+	const credentials = tokenPayloadToCredentials(payload, Date.now());
+	// Rotation: keep the previous refresh token when the response omits one.
+	if (!payload.refresh_token) {
+		credentials.refresh = refreshToken;
+	}
+	return credentials;
+}
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+	id: "xai",
+	name: "xAI (Grok SuperGrok / Premium+)",
+
+	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+		return loginXai({
+			onAuth: (url, instructions) => callbacks.onAuth({ url, instructions }),
+			onProgress: callbacks.onProgress,
+			signal: callbacks.signal,
+		});
+	},
+
+	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+		return refreshXaiToken(credentials.refresh);
+	},
+
+	getApiKey(credentials: OAuthCredentials): string {
+		return credentials.access;
+	},
+};

--- a/packages/ai/test/xai-oauth.test.ts
+++ b/packages/ai/test/xai-oauth.test.ts
@@ -1,0 +1,444 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { computeStoredExpiry, loginXai, refreshXaiToken } from "../src/utils/oauth/xai.js";
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+}
+
+function getUrl(input: unknown): string {
+	if (typeof input === "string") {
+		return input;
+	}
+	if (input instanceof URL) {
+		return input.toString();
+	}
+	if (input instanceof Request) {
+		return input.url;
+	}
+	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+describe("computeStoredExpiry", () => {
+	it("refreshes long-lived tokens a full hour early", () => {
+		const now = 1_000_000_000;
+		// 6h token: expiry skewed by the full 1h REFRESH_SKEW_MS.
+		expect(computeStoredExpiry(now, 6 * 60 * 60)).toBe(now + 5 * 60 * 60 * 1000);
+	});
+
+	it("scales the skew down for short-lived tokens", () => {
+		const now = 1_000_000_000;
+		// 15-minute JWT: skew is a quarter of the lifetime (~3.75 min).
+		const life = 15 * 60 * 1000;
+		expect(computeStoredExpiry(now, 15 * 60)).toBe(now + life - Math.floor(life / 4));
+	});
+});
+
+describe("xAI OAuth device flow", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it("completes the device flow and returns skewed credentials", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-03-09T00:00:00Z"));
+		const now = Date.now();
+
+		const tokenResponses = [
+			jsonResponse({ error: "authorization_pending" }),
+			jsonResponse({ error: "authorization_pending" }),
+			jsonResponse({
+				access_token: "xai-access",
+				refresh_token: "xai-refresh",
+				id_token: "xai-id",
+				expires_in: 6 * 60 * 60,
+				token_type: "Bearer",
+			}),
+		];
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+
+			if (url.endsWith("/oauth2/device/code")) {
+				expect(init?.method).toBe("POST");
+				expect(init?.headers).toMatchObject({
+					Accept: "application/json",
+					"Content-Type": "application/x-www-form-urlencoded",
+				});
+				expect(String(init?.body)).toContain("client_id=");
+				expect(String(init?.body)).toContain("grok-cli%3Aaccess");
+				return jsonResponse({
+					device_code: "device-code",
+					user_code: "ABCD-EFGH",
+					verification_uri: "https://auth.x.ai/device",
+					verification_uri_complete: "https://auth.x.ai/device?code=ABCD-EFGH",
+					interval: 1,
+					expires_in: 900,
+				});
+			}
+
+			if (url.endsWith("/oauth2/token")) {
+				expect(String(init?.body)).toContain("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code");
+				const response = tokenResponses.shift();
+				if (!response) {
+					throw new Error("Unexpected extra token poll");
+				}
+				return response;
+			}
+
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const onAuth = vi.fn();
+		const credentialsPromise = loginXai({ onAuth });
+		// Let the polling sleeps advance.
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		const credentials = await credentialsPromise;
+		expect(onAuth).toHaveBeenCalledWith("https://auth.x.ai/device?code=ABCD-EFGH", "Enter code: ABCD-EFGH");
+		expect(credentials.access).toBe("xai-access");
+		expect(credentials.refresh).toBe("xai-refresh");
+		// 6h token -> stored expiry is 5h out (1h refresh skew) from the
+		// token response time (three 1s polls: issued at now + 3s).
+		expect(credentials.expires).toBe(now + 3000 + 5 * 60 * 60 * 1000);
+	});
+
+	it("honors slow_down responses by widening the poll interval", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-03-09T00:00:00Z"));
+
+		const pollTimes: number[] = [];
+		let lastPoll = Date.now();
+		const tokenResponses = [
+			jsonResponse({ error: "slow_down", interval: 3 }),
+			jsonResponse({ access_token: "xai-access", refresh_token: "xai-refresh", expires_in: 3600 }),
+		];
+		const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.endsWith("/oauth2/device/code")) {
+				return jsonResponse({
+					device_code: "device-code",
+					user_code: "ABCD-EFGH",
+					verification_uri: "https://auth.x.ai/device",
+					interval: 1,
+					expires_in: 900,
+				});
+			}
+			if (url.endsWith("/oauth2/token")) {
+				const now = Date.now();
+				pollTimes.push(now - lastPoll);
+				lastPoll = now;
+				const response = tokenResponses.shift();
+				if (!response) {
+					throw new Error("Unexpected extra token poll");
+				}
+				return response;
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const promise = loginXai({ onAuth: vi.fn() });
+		await vi.advanceTimersByTimeAsync(15_000);
+		const credentials = await promise;
+
+		expect(credentials.access).toBe("xai-access");
+		// First poll after ~1s; slow_down bumps the interval to 3s.
+		expect(pollTimes[0]).toBeGreaterThanOrEqual(1000);
+		expect(pollTimes[1]).toBeGreaterThanOrEqual(3000);
+	});
+
+	it("surfaces a missing refresh token as an error", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.endsWith("/oauth2/device/code")) {
+				return jsonResponse({
+					device_code: "device-code",
+					user_code: "ABCD-EFGH",
+					verification_uri: "https://auth.x.ai/device",
+					interval: 1,
+					expires_in: 900,
+				});
+			}
+			return jsonResponse({ access_token: "xai-access", expires_in: 3600 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const captured = loginXai({ onAuth: vi.fn() }).then(
+			() => new Error("expected rejection"),
+			(error: Error) => error,
+		);
+		await vi.advanceTimersByTimeAsync(10_000);
+		const error = await captured;
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain("did not include a refresh token");
+	});
+});
+
+describe("xAI token refresh", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("uses the rotated refresh token from the response", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-03-09T00:00:00Z"));
+		const now = Date.now();
+
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			expect(getUrl(input)).toBe("https://auth.x.ai/oauth2/token");
+			expect(init?.method).toBe("POST");
+			const body = String(init?.body);
+			expect(body).toContain("grant_type=refresh_token");
+			expect(body).toContain("refresh_token=old-refresh");
+			expect(body).toContain("client_id=");
+			return jsonResponse({
+				access_token: "new-access",
+				refresh_token: "rotated-refresh",
+				expires_in: 6 * 60 * 60,
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await refreshXaiToken("old-refresh");
+		expect(credentials.access).toBe("new-access");
+		expect(credentials.refresh).toBe("rotated-refresh");
+		expect(credentials.expires).toBe(now + 5 * 60 * 60 * 1000);
+	});
+
+	it("keeps the previous refresh token when the response omits one", async () => {
+		const fetchMock = vi.fn(
+			async (): Promise<Response> => jsonResponse({ access_token: "new-access", expires_in: 6 * 60 * 60 }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await refreshXaiToken("kept-refresh");
+		expect(credentials.refresh).toBe("kept-refresh");
+	});
+
+	it("explains the tier gate on 403 without suggesting re-login", async () => {
+		const fetchMock = vi.fn(async (): Promise<Response> => jsonResponse({ error: "access_denied" }, 403));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const error = await refreshXaiToken("some-refresh").catch((e: Error) => e);
+		expect(error).toBeInstanceOf(Error);
+		expect(error.message).toContain("403");
+		expect(error.message).toContain("XAI_API_KEY");
+		expect(error.message).toContain("not entitled");
+	});
+
+	it("suggests re-login on 400/401", async () => {
+		const fetchMock = vi.fn(async (): Promise<Response> => jsonResponse({ error: "invalid_grant" }, 400));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(refreshXaiToken("bad-refresh")).rejects.toThrow("/login");
+	});
+
+	it("rejects empty refresh tokens before any network call", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		await expect(refreshXaiToken("  ")).rejects.toThrow("missing a refresh token");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("xAI device flow error handling", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	function deviceResponse() {
+		return jsonResponse({
+			device_code: "device-code",
+			user_code: "ABCD-EFGH",
+			verification_uri: "https://auth.x.ai/device",
+			interval: 1,
+			expires_in: 900,
+		});
+	}
+
+	it("throws immediately for a terminal OAuth error delivered as 200+JSON", async () => {
+		vi.useFakeTimers();
+		const polls: number[] = [];
+		const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.endsWith("/oauth2/device/code")) return deviceResponse();
+			if (url.endsWith("/oauth2/token")) {
+				polls.push(Date.now());
+				return jsonResponse({ error: "access_denied", error_description: "user denied" });
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const captured = loginXai({ onAuth: vi.fn() }).then(
+			() => new Error("expected rejection"),
+			(error: Error) => error,
+		);
+		await vi.advanceTimersByTimeAsync(10_000);
+		const error = await captured;
+		expect((error as Error).message).toContain("access_denied");
+		expect((error as Error).message).toContain("user denied");
+		expect(polls).toHaveLength(1);
+	});
+
+	it("throws immediately for a terminal OAuth error delivered as HTTP 400+JSON", async () => {
+		vi.useFakeTimers();
+		const polls: number[] = [];
+		const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.endsWith("/oauth2/device/code")) return deviceResponse();
+			if (url.endsWith("/oauth2/token")) {
+				polls.push(Date.now());
+				return jsonResponse({ error: "expired_token" }, 400);
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const captured = loginXai({ onAuth: vi.fn() }).then(
+			() => new Error("expected rejection"),
+			(error: Error) => error,
+		);
+		await vi.advanceTimersByTimeAsync(10_000);
+		const error = await captured;
+		expect((error as Error).message).toContain("expired_token");
+		expect(polls).toHaveLength(1);
+	});
+
+	it("treats non-JSON HTTP 500 responses as transient and keeps polling", async () => {
+		vi.useFakeTimers();
+		const polls: number[] = [];
+		const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.endsWith("/oauth2/device/code")) return deviceResponse();
+			if (url.endsWith("/oauth2/token")) {
+				polls.push(Date.now());
+				if (polls.length === 1) {
+					return new Response("<html>proxy error</html>", { status: 500 });
+				}
+				return jsonResponse({ access_token: "xai-access", refresh_token: "xai-refresh", expires_in: 3600 });
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const promise = loginXai({ onAuth: vi.fn() });
+		await vi.advanceTimersByTimeAsync(10_000);
+		const credentials = await promise;
+		expect(credentials.access).toBe("xai-access");
+		expect(polls.length).toBe(2);
+	});
+
+	it("reports a timeout when polling never succeeds before the deadline", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.endsWith("/oauth2/device/code")) return deviceResponse();
+			return jsonResponse({ error: "authorization_pending" });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const captured = loginXai({ onAuth: vi.fn() }).then(
+			() => new Error("expected rejection"),
+			(error: Error) => error,
+		);
+		await vi.advanceTimersByTimeAsync(900_000);
+		const error = await captured;
+		expect((error as Error).message).toContain("timed out");
+	});
+
+	it("surfaces cancellation as 'Login cancelled' when aborted mid-fetch", async () => {
+		vi.useFakeTimers();
+		const controller = new AbortController();
+		const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.endsWith("/oauth2/device/code")) return deviceResponse();
+			if (url.endsWith("/oauth2/token")) {
+				// Abort while the fetch is in flight.
+				controller.abort();
+				throw new DOMException("This operation was aborted", "AbortError");
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const captured = loginXai({ onAuth: vi.fn(), signal: controller.signal }).then(
+			() => new Error("expected rejection"),
+			(error: Error) => error,
+		);
+		await vi.advanceTimersByTimeAsync(10_000);
+		const error = await captured;
+		expect((error as Error).message).toBe("Login cancelled");
+	});
+
+	it("widens the interval after slow_down even when the server echo is smaller", async () => {
+		vi.useFakeTimers();
+		const pollTimes: number[] = [];
+		let lastPoll = Date.now();
+		const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.endsWith("/oauth2/device/code")) return deviceResponse();
+			if (url.endsWith("/oauth2/token")) {
+				const now = Date.now();
+				pollTimes.push(now - lastPoll);
+				lastPoll = now;
+				if (pollTimes.length === 1) {
+					// Malformed hint: interval smaller than the original.
+					return jsonResponse({ error: "slow_down", interval: 1 });
+				}
+				return jsonResponse({ access_token: "xai-access", refresh_token: "xai-refresh", expires_in: 3600 });
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const promise = loginXai({ onAuth: vi.fn() });
+		await vi.advanceTimersByTimeAsync(30_000);
+		await promise;
+		// interval starts at 1s; slow_down must add at least 5s -> >=6s gap.
+		expect(pollTimes[0]).toBeGreaterThanOrEqual(1000);
+		expect(pollTimes[1]).toBeGreaterThanOrEqual(6000);
+	});
+
+	it("rejects a verification URI from a foreign origin", async () => {
+		const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url.endsWith("/oauth2/device/code")) {
+				return jsonResponse({
+					device_code: "device-code",
+					user_code: "ABCD-EFGH",
+					verification_uri: "https://evil.example.com/device",
+					interval: 1,
+					expires_in: 900,
+				});
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(loginXai({ onAuth: vi.fn() })).rejects.toThrow("unexpected verification URL");
+	});
+});
+
+describe("xAI token refresh validation", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("rejects a refresh response without a valid expires_in", async () => {
+		const fetchMock = vi.fn(
+			async (): Promise<Response> => jsonResponse({ access_token: "new-access", refresh_token: "new-refresh" }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(refreshXaiToken("old-refresh")).rejects.toThrow("expires_in");
+	});
+});

--- a/packages/coding-agent/.changes/xai-oauth.md
+++ b/packages/coding-agent/.changes/xai-oauth.md
@@ -1,0 +1,1 @@
+- Added xAI (Grok SuperGrok / Premium+) subscription login to `/login` via the OAuth device code flow, including the waiting-for-browser state used by other device-flow providers.

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -18,6 +18,7 @@ Use `/login` in interactive mode, then select a provider:
 - ChatGPT Plus/Pro (Codex)
 - Claude Pro/Max
 - GitHub Copilot
+- xAI (Grok SuperGrok / Premium+)
 
 Use `/logout` to clear credentials. Tokens are stored in `~/.prime/agent/auth.json` and auto-refresh when expired.
 
@@ -29,6 +30,10 @@ Use `/logout` to clear credentials. Tokens are stored in `~/.prime/agent/auth.js
 ### Claude Pro/Max
 
 Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party harness usage draws from [extra usage](https://claude.ai/settings/usage) and is billed per token, not against Claude plan limits.
+
+### xAI (Grok SuperGrok / Premium+)
+
+xAI subscription auth uses the OAuth device code flow: `/login` -> xAI opens a verification URL, approve it in the browser, and the returned token is used against `https://api.x.ai/v1`. xAI requires a subscription tier entitled to API access; if refresh returns HTTP 403, the account is tier-gated — run `/logout` to remove the xAI credentials and use `XAI_API_KEY` instead (stored OAuth credentials take priority over the environment variable).
 
 ### GitHub Copilot
 

--- a/packages/coding-agent/src/modes/interactive/auth-flows.ts
+++ b/packages/coding-agent/src/modes/interactive/auth-flows.ts
@@ -842,7 +842,7 @@ export class ProviderAuthFlows {
 									manualCodeReject = undefined;
 								}
 							});
-					} else if (providerId === "github-copilot") {
+					} else if (providerId === "github-copilot" || providerId === "xai") {
 						dialog.showWaiting("Waiting for browser authentication...");
 					}
 				},


### PR DESCRIPTION
<!--
Pull requests are accepted from maintainers and vouched contributors only.
If a maintainer has not invited this work, start with a GitHub Discussion:
https://github.com/PrimeIntellect-ai/prime-agent/discussions
-->

## Context

The built-in `xai` provider already serves Grok models at `https://api.x.ai/v1`, but `/login` only accepts an API key (`XAI_API_KEY`). SuperGrok / Premium+ subscribers cannot authenticate with their subscription the way Claude Pro/Max and ChatGPT Plus/Pro users already can.

This PR adds subscription OAuth for that existing provider. The scope is auth only: no model-catalog changes, no reasoning-effort changes, and no unrelated extensions.

## Changes

- Register a built-in `xai` OAuth provider that implements RFC 8628 device authorization against `auth.x.ai`.
- `/login` → **xAI (Grok SuperGrok / Premium+)** opens the verification URL, waits for browser approval, and stores the tokens in `auth.json`. There is no local callback server, so the flow works over SSH and other headless setups.
- Use the access token as the Bearer token for the existing `openai-completions` client at `https://api.x.ai/v1`.
- Refresh follows xAI's refresh-token rotation. Stored expiry is skewed so long-lived tokens refresh up to an hour early, while short-lived JWTs (~15 minutes) do not refresh on every call.
- HTTP 403 on refresh is reported as a subscription-tier gate. The message tells the user to `/logout` first (stored OAuth credentials take priority over `XAI_API_KEY`) and then fall back to an API key if the account is not entitled to API access. 400/401 ask the user to log in again.
- The public grok-cli client id is used because xAI does not offer per-app OAuth registration for CLI tools. This is the same client other community CLIs use.
- The login dialog's "Waiting for browser authentication..." state now applies to `xai` as well as GitHub Copilot.
- Changelog fragments are included for `packages/ai` and `packages/coding-agent`. Docs list xAI under Subscriptions.

### Files

- `packages/ai/src/utils/oauth/xai.ts` — login, refresh, provider object
- `packages/ai/src/utils/oauth/index.ts` — registry + exports; refresh errors keep the provider detail via `{ cause }`
- `packages/ai/test/xai-oauth.test.ts` — 18 tests
- `packages/coding-agent/src/modes/interactive/auth-flows.ts` — device-flow waiting UI
- `packages/coding-agent/docs/providers.md`
- `packages/ai/.changes/xai-oauth.md`
- `packages/coding-agent/.changes/xai-oauth.md`

## Validation

- `npm test --workspace @earendil-works/pi-ai -- test/xai-oauth.test.ts` — 18/18 passed (fake timers + stubbed `fetch`)
- Existing OAuth tests still pass: GitHub Copilot (2), Anthropic (2), OpenAI Codex (1)
- Pre-commit: `biome check --error-on-warnings`, `tsgo --noEmit`, installer render, browser smoke

Covered cases include `authorization_pending`, `slow_down` (interval never shrinks; +5s floor per RFC 8628), terminal errors in both 200+JSON and 4xx+JSON form, non-JSON 5xx treated as transient, deadline timeout, mid-fetch abort → "Login cancelled", verification-URI origin check against `auth.x.ai`, expiry skew math, refresh-token rotation, missing `expires_in`, and 403 / 400 / 401 refresh errors.

## Notes

I am not currently listed in `.github/VOUCHED.td`. If the contribution gate closes this PR, I can continue from a Discussion. Several earlier community PRs targeted the same gap and were closed by that gate; this branch is rebased onto current `main` and follows the existing Copilot device-flow conventions rather than adding a loopback callback server.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add xAI Grok OAuth login via device code flow
> - Implements `loginXai` and `refreshXaiToken` in [xai.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1932/files#diff-a09114a3bec83ce83a7c3dfcaaf770c8e5e78ece71fae3b8e6de5109a64df65b) to handle RFC 8628 device code polling, backoff, and refresh token rotation
> - Treats HTTP 403 during token refresh as a subscription-tier gate, guiding users to use `XAI_API_KEY` or review their subscription
> - Registers `xaiOAuthProvider` in [index.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1932/files#diff-efc6db38cbfdae5194e1841f9348557af7a7e225651cdb079a65dda09ac46eb7) so the provider is auto-discovered by the OAuth registry
> - Updates the interactive login flow in [auth-flows.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1932/files#diff-f2484207f87351603fae4d33f2407db0f62fa1c1d2b19166e2e32547e1a62915) to show a waiting dialog for the `xai` provider
> - Behavioral Change: `getOAuthApiKey` now throws errors during token refresh that include the provider's detailed reason and preserve the original error as the `cause`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd472a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->