### PR TITLE
feat(daemon): fence RLM child cancellation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added capability-gated compare-and-cancel semantics for RLM child runs, allowing recovery tools to reject cancellation atomically when their authoritative child roster is stale.
 - Fixed background (unattributed) kernel output missing from the expanded IPython cell view: it is now surfaced in the tool details and rendered under a "background output (unattributed)" label after stdout/stderr/result.
 - Fixed a protocol interrupt during a REPL state restore leaving a mixed old/new namespace: names are now staged first and applied atomically with SIGINT parked across the apply, and an interrupt landing anywhere between a committed snapshot or restore and its request finishing is recovered instead of misreporting the completed operation as failed.
 - Fixed the REPL snapshot writer leaving a new payload beside a truncated manifest on mid-write failures: payload and manifest now commit via unique same-directory temp files and atomic renames with guaranteed cleanup, and an interrupt during cleanup can no longer misreport a completed destructive snapshot as failed.

--- a/packages/coding-agent/src/modes/daemon/daemon-errors.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-errors.ts
@@ -3,6 +3,18 @@ import { SessionImportFileNotFoundError } from "../../core/session-import-errors
 import { SessionAlreadyActiveError } from "../../core/session-lease.js";
 import type { DaemonErrorInfo, DaemonResponse } from "./daemon-protocol.js";
 
+export class RlmChildRosterChangedError extends Error {
+	constructor(
+		readonly expectedEventSequence: number,
+		readonly actualEventSequence: number,
+	) {
+		super(
+			`RLM child roster changed before cancellation (expected event sequence ${expectedEventSequence}, current ${actualEventSequence})`,
+		);
+		this.name = "RlmChildRosterChangedError";
+	}
+}
+
 export function serializeDaemonError(error: unknown): DaemonErrorInfo | undefined {
 	if (error instanceof MissingSessionCwdError) {
 		return { code: "missing_session_cwd", issue: error.issue };
@@ -15,6 +27,13 @@ export function serializeDaemonError(error: unknown): DaemonErrorInfo | undefine
 			code: "session_already_active",
 			sessionPath: error.sessionPath,
 			activeSessionId: error.activeSessionId,
+		};
+	}
+	if (error instanceof RlmChildRosterChangedError) {
+		return {
+			code: "rlm_child_roster_changed",
+			expectedEventSequence: error.expectedEventSequence,
+			actualEventSequence: error.actualEventSequence,
 		};
 	}
 	return undefined;
@@ -44,6 +63,9 @@ export function deserializeDaemonError(response: Extract<DaemonResponse, { succe
 	}
 	if (errorInfo?.code === "session_already_active") {
 		return new SessionAlreadyActiveError(errorInfo.sessionPath, errorInfo.activeSessionId);
+	}
+	if (errorInfo?.code === "rlm_child_roster_changed") {
+		return new RlmChildRosterChangedError(errorInfo.expectedEventSequence, errorInfo.actualEventSequence);
 	}
 	return new Error(response.error);
 }

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -127,7 +127,7 @@ import {
 import { createCompactAssistantDelta } from "./compact-session-stream.js";
 import { DaemonClient } from "./daemon-client.js";
 import { filterClientEnv, withClientEnv } from "./daemon-client-env.js";
-import { deserializeDaemonError, serializeDaemonError } from "./daemon-errors.js";
+import { deserializeDaemonError, RlmChildRosterChangedError, serializeDaemonError } from "./daemon-errors.js";
 import { bindActiveSessionState } from "./daemon-extension-binding.js";
 import {
 	createDaemonEventMeta,
@@ -4205,6 +4205,14 @@ export class AgentDaemon {
 
 			case "cancel_rlm_child": {
 				const state = this.getSessionState(command.activeSessionId);
+				if (command.expectedEventSequence !== undefined) {
+					if (!Number.isSafeInteger(command.expectedEventSequence) || command.expectedEventSequence < 0) {
+						throw new Error("expectedEventSequence must be a non-negative safe integer");
+					}
+					if (state.lastEventSequence !== command.expectedEventSequence) {
+						throw new RlmChildRosterChangedError(command.expectedEventSequence, state.lastEventSequence);
+					}
+				}
 				const cancelled = state.runtime.session.cancelRlmChildRun(command.childId);
 				return success(command.id, "cancel_rlm_child", { cancelled });
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-protocol.ts
@@ -67,8 +67,9 @@ export const DAEMON_COMMAND_ENVELOPE_MIN_PROTOCOL_VERSION = 7;
 // Revision 20 lets cancellation target a prompt the session owns but has not started.
 // Revision 21 adds capability-gated, session-scoped ACP MCP server replacement.
 // Revision 23 lets workers query the supervisor agent roster on demand.
-export const DAEMON_SCHEMA_REVISION = 23;
-export const DAEMON_SCHEMA_ID = "protocol-7-schema-23-649fe649d15e";
+// Revision 24 adds compare-and-cancel semantics for RLM child runs.
+export const DAEMON_SCHEMA_REVISION = 24;
+export const DAEMON_SCHEMA_ID = "protocol-7-schema-24-2bcb370507d5";
 
 export type DaemonProtocolName = typeof DAEMON_PROTOCOL_NAME;
 export type DaemonProtocolVersion = number;
@@ -109,6 +110,7 @@ export type DaemonServerCapability =
 	| "prompt_admission_cancellation"
 	| "queue_message_mutation"
 	| "authoritative_child_roster"
+	| "conditional_rlm_child_cancel"
 	| "owned_session_recovery_context"
 	| "rlm_quiescence_barrier"
 	| "session_input_pause"
@@ -154,6 +156,7 @@ export const DAEMON_DEFAULT_SERVER_CAPABILITIES: readonly DaemonServerCapability
 	"owned_prompt_cancellation",
 	"queue_message_mutation",
 	"authoritative_child_roster",
+	"conditional_rlm_child_cancel",
 	"owned_session_recovery_context",
 	"rlm_quiescence_barrier",
 	"session_input_pause",
@@ -522,7 +525,13 @@ export type DaemonCommand =
 			runId?: string;
 	  }
 	| { id?: string; type: "abort_bash"; activeSessionId: string }
-	| { id?: string; type: "cancel_rlm_child"; activeSessionId: string; childId: string }
+	| {
+			id?: string;
+			type: "cancel_rlm_child";
+			activeSessionId: string;
+			childId: string;
+			expectedEventSequence?: DaemonEventSequence;
+	  }
 	| { id?: string; type: "delete_rlm_subagent"; activeSessionId: string; childId: string }
 	| { id?: string; type: "wait_for_idle"; activeSessionId: string }
 	| {
@@ -698,6 +707,11 @@ const AUTHORITATIVE_CHILD_ROSTER_COMMAND = {
 	minSchemaRevision: 17,
 	capability: "authoritative_child_roster",
 } as const;
+const CONDITIONAL_RLM_CHILD_CANCEL_COMMAND = {
+	minProtocol: 7,
+	minSchemaRevision: 24,
+	capability: "conditional_rlm_child_cancel",
+} as const;
 const OWNED_SESSION_RECOVERY_CONTEXT = {
 	minProtocol: 7,
 	minSchemaRevision: 17,
@@ -836,6 +850,9 @@ export function getDaemonCommandCompatibilities(command: DaemonCommand): readonl
 	if (command.type === "wait_for_headless_completion" && command.waitForRlmQuiescence === true) {
 		requirements.push(RLM_QUIESCENCE_BARRIER_COMMAND);
 	}
+	if (command.type === "cancel_rlm_child" && command.expectedEventSequence !== undefined) {
+		requirements.push(CONDITIONAL_RLM_CHILD_CANCEL_COMMAND);
+	}
 	if (command.type === "cancel_prompt_admission" && command.cancelOwned === true) {
 		requirements.push(OWNED_PROMPT_CANCELLATION_COMMAND);
 	}
@@ -857,6 +874,11 @@ export type DaemonErrorInfo =
 	| { code: "missing_session_cwd"; issue: SessionCwdIssue }
 	| { code: "session_import_file_not_found"; filePath: string }
 	| { code: "session_already_active"; sessionPath: string; activeSessionId?: string }
+	| {
+			code: "rlm_child_roster_changed";
+			expectedEventSequence: DaemonEventSequence;
+			actualEventSequence: DaemonEventSequence;
+	  }
 	| { code: "command_result_uncertain"; clientId: DaemonClientId; commandId: DaemonCommandId };
 
 export type DaemonSessionClosedReason = "killed" | "shutdown" | "completed" | "replaced" | "update";

--- a/packages/coding-agent/test/daemon-client.test.ts
+++ b/packages/coding-agent/test/daemon-client.test.ts
@@ -230,6 +230,26 @@ describe("DaemonClient", () => {
 		client.close();
 	});
 
+	it("does not send conditional RLM child cancellation to an older daemon", async () => {
+		const client = new DaemonClient("/tmp/prime-agent.sock");
+		const connect = client.connect();
+		const socket = netMock.sockets[0]!;
+		socket.emit("connect");
+		await connect;
+		emitHello(socket, DAEMON_PROTOCOL_VERSION, ["authoritative_child_roster"], DAEMON_SCHEMA_REVISION - 1);
+
+		await expect(
+			client.request({
+				type: "cancel_rlm_child",
+				activeSessionId: "active-1",
+				childId: "child-1",
+				expectedEventSequence: 17,
+			}),
+		).rejects.toThrow("does not support conditional_rlm_child_cancel");
+		expect(socket.writes).toEqual([]);
+		client.close();
+	});
+
 	it("sends subagent deletion to a capable daemon without requiring a schema bump", async () => {
 		const client = new DaemonClient("/tmp/prime-agent.sock");
 		const connect = client.connect();

--- a/packages/coding-agent/test/daemon-errors.test.ts
+++ b/packages/coding-agent/test/daemon-errors.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { SessionAlreadyActiveError } from "../src/core/session-lease.js";
-import { DaemonSessionCreateError, deserializeDaemonCreateError } from "../src/modes/daemon/daemon-errors.js";
+import {
+	DaemonSessionCreateError,
+	deserializeDaemonCreateError,
+	deserializeDaemonError,
+	RlmChildRosterChangedError,
+	serializeDaemonError,
+} from "../src/modes/daemon/daemon-errors.js";
 
 describe("deserializeDaemonCreateError", () => {
 	it("wraps generic create failures so the CLI boundary prints one line instead of rethrowing", () => {
@@ -23,5 +29,27 @@ describe("deserializeDaemonCreateError", () => {
 			errorInfo: { code: "session_already_active", sessionPath: "/tmp/session.jsonl" },
 		});
 		expect(error).toBeInstanceOf(SessionAlreadyActiveError);
+	});
+});
+
+describe("RLM child roster errors", () => {
+	it("round-trips the authoritative sequence mismatch", () => {
+		const source = new RlmChildRosterChangedError(17, 18);
+		const errorInfo = serializeDaemonError(source);
+		expect(errorInfo).toEqual({
+			code: "rlm_child_roster_changed",
+			expectedEventSequence: 17,
+			actualEventSequence: 18,
+		});
+
+		const restored = deserializeDaemonError({
+			type: "response",
+			command: "cancel_rlm_child",
+			success: false,
+			error: source.message,
+			errorInfo,
+		});
+		expect(restored).toBeInstanceOf(RlmChildRosterChangedError);
+		expect(restored).toMatchObject({ expectedEventSequence: 17, actualEventSequence: 18 });
 	});
 });

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -6296,6 +6296,50 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("atomically fences RLM child cancellation on the authoritative event sequence", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-conditional-rlm-cancel-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				handleCommand(client: DaemonSocketClient, command: DaemonCommand): Promise<unknown>;
+			};
+			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const parentSession = parentState.runtime.session as unknown as {
+				cancelRlmChildRun: ReturnType<typeof vi.fn>;
+			};
+			parentSession.cancelRlmChildRun = vi.fn(() => true);
+			parentState.lastEventSequence = 23;
+			const client = makeClient("client-1", parentState.activeSessionId);
+
+			await expect(
+				internals.handleCommand(client, {
+					type: "cancel_rlm_child",
+					activeSessionId: parentState.activeSessionId,
+					childId: fixture.childId,
+					expectedEventSequence: 22,
+				}),
+			).rejects.toMatchObject({
+				name: "RlmChildRosterChangedError",
+				expectedEventSequence: 22,
+				actualEventSequence: 23,
+			});
+			expect(parentSession.cancelRlmChildRun).not.toHaveBeenCalled();
+
+			const result = (await internals.handleCommand(client, {
+				type: "cancel_rlm_child",
+				activeSessionId: parentState.activeSessionId,
+				childId: fixture.childId,
+				expectedEventSequence: 23,
+			})) as { data: { cancelled: boolean } };
+			expect(result.data.cancelled).toBe(true);
+			expect(parentSession.cancelRlmChildRun).toHaveBeenCalledOnce();
+			expect(parentSession.cancelRlmChildRun).toHaveBeenCalledWith(fixture.childId);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("refuses to delete a busy hydrated child and deletes it after it becomes idle", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-hydrated-rlm-delete-"));
 		try {

--- a/packages/coding-agent/test/daemon-protocol.test.ts
+++ b/packages/coding-agent/test/daemon-protocol.test.ts
@@ -127,6 +127,16 @@ describe("daemon protocol helpers", () => {
 		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("delete_rlm_subagent");
 	});
 
+	it("capability- and schema-gates conditional RLM child cancellation", () => {
+		const legacy = { type: "cancel_rlm_child", activeSessionId: "active-1", childId: "child-1" } as const;
+		expect(getDaemonCommandCompatibilities(legacy)).toEqual([DAEMON_COMMAND_COMPATIBILITY.cancel_rlm_child]);
+		expect(getDaemonCommandCompatibilities({ ...legacy, expectedEventSequence: 17 })).toEqual([
+			{ minProtocol: 7, minSchemaRevision: 24, capability: "conditional_rlm_child_cancel" },
+			DAEMON_COMMAND_COMPATIBILITY.cancel_rlm_child,
+		]);
+		expect(DAEMON_DEFAULT_SERVER_CAPABILITIES).toContain("conditional_rlm_child_cancel");
+	});
+
 	it("capability- and schema-gates ACP MCP server replacement", () => {
 		expect(DAEMON_COMMAND_COMPATIBILITY.replace_acp_mcp_servers).toEqual({
 			minProtocol: 7,


### PR DESCRIPTION
## Summary

- advertise a capability-gated conditional RLM child cancellation contract
- compare the supplied authoritative event sequence immediately before cancellation
- return a typed stale-roster error and preserve legacy unconditional callers

## Verification

- `npm run check`
- `daemon-protocol.test.ts` (23 passed)
- `daemon-mode.test.ts` (181 passed)
- `daemon-client.test.ts` (30 passed)
- `daemon-errors.test.ts` (3 passed)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add compare-and-cancel fencing for `cancel_rlm_child` daemon command
> - Extends `cancel_rlm_child` with an optional `expectedEventSequence` field; when provided, the daemon compares it against `state.lastEventSequence` and throws `RlmChildRosterChangedError` on mismatch instead of canceling.
> - Introduces a new `conditional_rlm_child_cancel` server capability, gates the feature behind schema revision 24 (bumped from 23) and protocol 7, and adds it to `DAEMON_DEFAULT_SERVER_CAPABILITIES`.
> - Adds `RlmChildRosterChangedError` with `expectedEventSequence` and `actualEventSequence` fields, plus round-trip serialize/deserialize support under code `rlm_child_roster_changed` in `DaemonErrorInfo`.
> - Risk: `DAEMON_SCHEMA_REVISION` bump to 24 in `daemon-protocol.ts` may cause clients on older schema revisions to reject the daemon; `getDaemonCommandCompatibilities` now requires `conditional_rlm_child_cancel` capability and schema 24 when `expectedEventSequence` is sent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b755896.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->