### PR TITLE
fix(coding-agent): scope the roster seed to live families and unify seeded-row hydration

### DIFF
--- a/packages/coding-agent/.changes/roster-seed-scope.md
+++ b/packages/coding-agent/.changes/roster-seed-scope.md
@@ -1,0 +1,1 @@
+- Scoped the roster's restart seed to registered workers' families: the saved-session corpus stays owned by the disk catalog (list --all, search), so a supervisor restart no longer publishes thousands of inactive rows (and one header read per row) to every roster subscriber.

--- a/packages/coding-agent/src/modes/daemon/agent-roster.ts
+++ b/packages/coding-agent/src/modes/daemon/agent-roster.ts
@@ -118,8 +118,7 @@ export function passivatedWorkerRosterEntry(
 
 export function sessionSummaryFromRosterEntry(entry: WorkerRosterEntry | AgentRosterEntry): SessionSummary {
 	const ledger = "status" in entry ? entry : undefined;
-	// statusLabel/lastHeardFromAt ride only when the roster flags an exceptional state
-	// (queued/recovering/failed, watchdog staleness); viewers key label display on their presence.
+	// statusLabel/lastHeardFromAt are set only for exceptional states; viewers key label display on their presence.
 	return {
 		...entry.summary,
 		sessionActions: { queuedCount: 0, steering: [], followUps: [] },

--- a/packages/coding-agent/src/modes/daemon/agent-roster.ts
+++ b/packages/coding-agent/src/modes/daemon/agent-roster.ts
@@ -118,6 +118,8 @@ export function passivatedWorkerRosterEntry(
 
 export function sessionSummaryFromRosterEntry(entry: WorkerRosterEntry | AgentRosterEntry): SessionSummary {
 	const ledger = "status" in entry ? entry : undefined;
+	// statusLabel/lastHeardFromAt ride only when the roster flags an exceptional state
+	// (queued/recovering/failed, watchdog staleness); viewers key label display on their presence.
 	return {
 		...entry.summary,
 		sessionActions: { queuedCount: 0, steering: [], followUps: [] },

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -434,7 +434,6 @@ function isSupervisorRecoveryCancelled(error: unknown): boolean {
 	return isSupervisorShutdownAdmissionCancelled(error) || isSupervisorGenerationStale(error);
 }
 
-/** Resolves paths to their family root through the edge set; a cycle terminates at first revisit. */
 function rosterFamilyRoot(edges: readonly RlmLedgerEdge[]): (path: string) => string {
 	const parentByChild = new Map(
 		edges.map((edge) => [canonicalSessionPath(edge.child), canonicalSessionPath(edge.parent)]),
@@ -2467,7 +2466,6 @@ export class DaemonSupervisor {
 		return success(command.id, "list", { ...data, sessions: merged });
 	}
 
-	/** The one hydration owner: a seeded row's display cwd comes from one transcript-header read. */
 	private async hydratedSeedEntry<T extends WorkerRosterEntry>(entry: T): Promise<T> {
 		const info = entry.summary.sessionFile
 			? await readSessionInfo(entry.summary.sessionFile).catch(() => undefined)
@@ -3964,12 +3962,6 @@ export class DaemonSupervisor {
 		return this.roster().entriesForWorker(worker.descriptor.workerId);
 	}
 
-	/**
-	 * The roster seeds only registered workers' families: stat-reconciled ledger children whose
-	 * family root is a registered worker's session. The saved-session corpus stays owned by the
-	 * disk catalog (list --all, search) — seeding it published the whole corpus (~thousands of
-	 * inactive rows and sequential header reads) to every subscriber after a restart.
-	 */
 	private async seedRosterLedger(): Promise<void> {
 		try {
 			const roots = new Set<string>();
@@ -4097,7 +4089,6 @@ export class DaemonSupervisor {
 		delta: Extract<DaemonWorkerRosterOutbound, { type: "roster_delta" }>,
 		source?: DaemonWorkerClient,
 	): Promise<void> {
-		// Live edges are read before any deletion, so a reseeded child never surfaces as a transient removal.
 		let edgesFailed = false;
 		const edges = await this.rlmSpawnLedger()
 			.liveEdges()
@@ -4117,19 +4108,14 @@ export class DaemonSupervisor {
 				unclaimed.set(entry.agentId, entry);
 			}
 		}
-		// A reseed keeps the previous claim and hydrated summary; a synthetic seed would drop
-		// lastActivityAt (pinning canEvictWorker on NaN) and flap the claim off on every snapshot.
-		// Only THIS worker's family reseeds: other families' rows are owned by their own workers or
-		// the startup seed, and a client-owned worker's dropped rows must not resurrect as public rows.
+		// Only this worker's family reseeds: anything wider can resurrect a client-owned worker's dropped children.
 		const workerRoot = worker.descriptor.sessionFile ?? worker.descriptor.createCommand.sessionPath;
 		const rootPath = workerRoot !== undefined ? canonicalSessionPath(workerRoot) : undefined;
 		const familyRoot = rosterFamilyRoot(edges);
 		const familyEdges = edges.filter(
 			(edge) => rootPath !== undefined && familyRoot(canonicalSessionPath(edge.child)) === rootPath,
 		);
-		// A ledger child needs no reseed when something else keeps a row for it: the sweep's
-		// unclaimed set restores it, the snapshot (re)sends it, or a surviving row already owns
-		// its id or its file.
+		// "Unclaimed" rows survive: the sweep deletes them but the restore branch rewrites them.
 		const rowSurvivesWithoutReseed = (entry: WorkerRosterEntry, childPath: string): boolean => {
 			if (unclaimed.has(entry.agentId)) return true;
 			if (sent.has(entry.agentId) && !removed.has(entry.agentId)) return true;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -434,20 +434,25 @@ function isSupervisorRecoveryCancelled(error: unknown): boolean {
 	return isSupervisorShutdownAdmissionCancelled(error) || isSupervisorGenerationStale(error);
 }
 
-function rosterFamilyRoot(edges: readonly RlmLedgerEdge[]): (path: string) => string {
+// Workers can be registered mid-tree (a resumed subagent transcript), so descent is membership at
+// any step of the parent walk, never a comparison against the ultimate root alone.
+function rosterFamilyDescendsFrom(
+	edges: readonly RlmLedgerEdge[],
+): (path: string, roots: ReadonlySet<string>) => boolean {
 	const parentByChild = new Map(
 		edges.map((edge) => [canonicalSessionPath(edge.child), canonicalSessionPath(edge.parent)]),
 	);
-	return (path) => {
+	return (path, roots) => {
 		const visited = new Set<string>();
 		let current = path;
 		while (!visited.has(current)) {
+			if (roots.has(current)) return true;
 			visited.add(current);
 			const parent = parentByChild.get(current);
-			if (parent === undefined) return current;
+			if (parent === undefined) return false;
 			current = parent;
 		}
-		return current;
+		return false;
 	};
 }
 
@@ -3971,9 +3976,9 @@ export class DaemonSupervisor {
 			}
 			if (roots.size === 0) return;
 			const edges = await this.rlmSpawnLedger().liveEdges();
-			const familyRoot = rosterFamilyRoot(edges);
+			const descendsFrom = rosterFamilyDescendsFrom(edges);
 			for (const edge of edges) {
-				if (!roots.has(familyRoot(canonicalSessionPath(edge.child)))) continue;
+				if (!descendsFrom(canonicalSessionPath(edge.parent), roots)) continue;
 				const entry = this.rosterEntryForSpawnLedgerEdge(edge);
 				if (this.roster().has(entry.agentId)) continue;
 				if (this.roster().hasSessionFile(canonicalSessionPath(edge.child))) continue;
@@ -4110,11 +4115,9 @@ export class DaemonSupervisor {
 		}
 		// Only this worker's family reseeds: anything wider can resurrect a client-owned worker's dropped children.
 		const workerRoot = worker.descriptor.sessionFile ?? worker.descriptor.createCommand.sessionPath;
-		const rootPath = workerRoot !== undefined ? canonicalSessionPath(workerRoot) : undefined;
-		const familyRoot = rosterFamilyRoot(edges);
-		const familyEdges = edges.filter(
-			(edge) => rootPath !== undefined && familyRoot(canonicalSessionPath(edge.child)) === rootPath,
-		);
+		const rootPaths = new Set(workerRoot !== undefined ? [canonicalSessionPath(workerRoot)] : []);
+		const descendsFrom = rosterFamilyDescendsFrom(edges);
+		const familyEdges = edges.filter((edge) => descendsFrom(canonicalSessionPath(edge.parent), rootPaths));
 		// "Unclaimed" rows survive: the sweep deletes them but the restore branch rewrites them.
 		const rowSurvivesWithoutReseed = (entry: WorkerRosterEntry, childPath: string): boolean => {
 			if (unclaimed.has(entry.agentId)) return true;

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -434,6 +434,24 @@ function isSupervisorRecoveryCancelled(error: unknown): boolean {
 	return isSupervisorShutdownAdmissionCancelled(error) || isSupervisorGenerationStale(error);
 }
 
+/** Resolves paths to their family root through the edge set; a cycle terminates at first revisit. */
+function rosterFamilyRoot(edges: readonly RlmLedgerEdge[]): (path: string) => string {
+	const parentByChild = new Map(
+		edges.map((edge) => [canonicalSessionPath(edge.child), canonicalSessionPath(edge.parent)]),
+	);
+	return (path) => {
+		const visited = new Set<string>();
+		let current = path;
+		while (!visited.has(current)) {
+			visited.add(current);
+			const parent = parentByChild.get(current);
+			if (parent === undefined) return current;
+			current = parent;
+		}
+		return current;
+	};
+}
+
 function isDaemonWorkerProbeTimeout(error: unknown): boolean {
 	return error instanceof DaemonWorkerProbeTimeoutError;
 }
@@ -2449,18 +2467,23 @@ export class DaemonSupervisor {
 		return success(command.id, "list", { ...data, sessions: merged });
 	}
 
+	/** The one hydration owner: a seeded row's display cwd comes from one transcript-header read. */
+	private async hydratedSeedEntry<T extends WorkerRosterEntry>(entry: T): Promise<T> {
+		const info = entry.summary.sessionFile
+			? await readSessionInfo(entry.summary.sessionFile).catch(() => undefined)
+			: undefined;
+		if (!info) return { ...entry, seededCwd: true as const };
+		const { seededCwd, ...rest } = entry;
+		return { ...rest, summary: { ...entry.summary, cwd: info.cwd } } as T;
+	}
+
 	private async hydrateSeededEntry(entry: AgentRosterEntry): Promise<AgentRosterEntry> {
 		if (entry.seededCwd !== true || !entry.summary.sessionFile) return entry;
-		const info = await readSessionInfo(entry.summary.sessionFile).catch(() => undefined);
-		if (!info) return entry;
+		const hydrated = await this.hydratedSeedEntry(entry);
+		if (hydrated.seededCwd === true) return entry;
 		const current = this.roster().get(entry.agentId);
 		if (current !== entry) return current ?? entry;
-		const { seededCwd, ...rest } = entry;
-		return this.roster().write(
-			{ ...rest, summary: { ...entry.summary, cwd: info.cwd } },
-			entry.workerId,
-			entry.statusLabel,
-		);
+		return this.roster().write(hydrated, entry.workerId, entry.statusLabel);
 	}
 
 	private matchesListSessionDir(summary: SessionSummary, sessionDir: string | undefined): boolean {
@@ -3941,25 +3964,28 @@ export class DaemonSupervisor {
 		return this.roster().entriesForWorker(worker.descriptor.workerId);
 	}
 
+	/**
+	 * The roster seeds only registered workers' families: stat-reconciled ledger children whose
+	 * family root is a registered worker's session. The saved-session corpus stays owned by the
+	 * disk catalog (list --all, search) — seeding it published the whole corpus (~thousands of
+	 * inactive rows and sequential header reads) to every subscriber after a restart.
+	 */
 	private async seedRosterLedger(): Promise<void> {
 		try {
-			for (const info of await this.catalog.list(undefined, this.defaultSessionConfig.sessionDir)) {
-				const entry = workerRosterEntryFromSummary(summaryForInactiveSession(info));
-				if (!this.roster().has(entry.agentId)) this.writeRosterEntry(entry);
+			const roots = new Set<string>();
+			for (const worker of this.workers.values()) {
+				const root = worker.descriptor.sessionFile ?? worker.descriptor.createCommand.sessionPath;
+				if (root !== undefined) roots.add(canonicalSessionPath(root));
 			}
-		} catch (error) {
-			this.log(`Could not seed the agent roster from the session catalog: ${String(error)}`);
-		}
-		try {
-			// Stat-reconciled: rows the disk cannot back (out-of-band transcript removal) never seed.
-			for (const edge of await this.rlmSpawnLedger().liveEdges()) {
+			if (roots.size === 0) return;
+			const edges = await this.rlmSpawnLedger().liveEdges();
+			const familyRoot = rosterFamilyRoot(edges);
+			for (const edge of edges) {
+				if (!roots.has(familyRoot(canonicalSessionPath(edge.child)))) continue;
 				const entry = this.rosterEntryForSpawnLedgerEdge(edge);
 				if (this.roster().has(entry.agentId)) continue;
 				if (this.roster().hasSessionFile(canonicalSessionPath(edge.child))) continue;
-				const info = await readSessionInfo(edge.child).catch(() => undefined);
-				this.roster().write(
-					info ? { ...entry, summary: { ...entry.summary, cwd: info.cwd } } : { ...entry, seededCwd: true },
-				);
+				this.roster().write(await this.hydratedSeedEntry(entry));
 			}
 		} catch (error) {
 			this.log(`Could not seed the agent roster from the spawn ledger: ${String(error)}`);
@@ -4097,42 +4123,25 @@ export class DaemonSupervisor {
 		// the startup seed, and a client-owned worker's dropped rows must not resurrect as public rows.
 		const workerRoot = worker.descriptor.sessionFile ?? worker.descriptor.createCommand.sessionPath;
 		const rootPath = workerRoot !== undefined ? canonicalSessionPath(workerRoot) : undefined;
-		const parentByChild = new Map(
-			edges.map((edge) => [canonicalSessionPath(edge.child), canonicalSessionPath(edge.parent)]),
-		);
-		const familyRoot = (path: string): string => {
-			const visited = new Set<string>();
-			let current = path;
-			while (!visited.has(current)) {
-				visited.add(current);
-				const parent = parentByChild.get(current);
-				if (parent === undefined) return current;
-				current = parent;
-			}
-			return current;
-		};
+		const familyRoot = rosterFamilyRoot(edges);
 		const familyEdges = edges.filter(
 			(edge) => rootPath !== undefined && familyRoot(canonicalSessionPath(edge.child)) === rootPath,
 		);
-		const seedInfo = new Map<string, SessionInfo | null | undefined>();
+		// A ledger child needs no reseed when something else keeps a row for it: the sweep's
+		// unclaimed set restores it, the snapshot (re)sends it, or a surviving row already owns
+		// its id or its file.
+		const rowSurvivesWithoutReseed = (entry: WorkerRosterEntry, childPath: string): boolean => {
+			if (unclaimed.has(entry.agentId)) return true;
+			if (sent.has(entry.agentId) && !removed.has(entry.agentId)) return true;
+			const survives = (row: AgentRosterEntry | undefined): boolean =>
+				row !== undefined && !unclaimed.has(row.agentId) && !removed.has(row.agentId);
+			return survives(this.roster().get(entry.agentId)) || survives(this.roster().bySessionFile(childPath));
+		};
+		const seededEntries = new Map<string, WorkerRosterEntry>();
 		for (const edge of familyEdges) {
 			const entry = this.rosterEntryForSpawnLedgerEdge(edge);
-			const childPath = canonicalSessionPath(edge.child);
-			const currentById = this.roster().get(entry.agentId);
-			const currentByFile = this.roster().bySessionFile(childPath);
-			const currentIdSurvives =
-				currentById !== undefined && !unclaimed.has(currentById.agentId) && !removed.has(currentById.agentId);
-			const currentFileSurvives =
-				currentByFile !== undefined && !unclaimed.has(currentByFile.agentId) && !removed.has(currentByFile.agentId);
-			if (
-				unclaimed.has(entry.agentId) ||
-				(sent.has(entry.agentId) && !removed.has(entry.agentId)) ||
-				currentIdSurvives ||
-				currentFileSurvives
-			) {
-				continue;
-			}
-			seedInfo.set(entry.agentId, await readSessionInfo(edge.child).catch(() => undefined));
+			if (rowSurvivesWithoutReseed(entry, canonicalSessionPath(edge.child))) continue;
+			seededEntries.set(entry.agentId, await this.hydratedSeedEntry(entry));
 			if (!this.isWorkerRosterApplyCurrent(worker, applySource)) return;
 		}
 
@@ -4157,10 +4166,7 @@ export class DaemonSupervisor {
 				this.writeRosterEntry(rest, worker);
 				continue;
 			}
-			const info = seedInfo.get(entry.agentId);
-			this.roster().write(
-				info ? { ...entry, summary: { ...entry.summary, cwd: info.cwd } } : { ...entry, seededCwd: true },
-			);
+			this.roster().write(seededEntries.get(entry.agentId) ?? { ...entry, seededCwd: true });
 		}
 	}
 

--- a/packages/coding-agent/test/daemon-agent-roster.test.ts
+++ b/packages/coding-agent/test/daemon-agent-roster.test.ts
@@ -827,17 +827,20 @@ describe("supervisor roster ledger", () => {
 		}
 	});
 
-	it("seeds catalog and ledger rows list-all-only, serves resident worker rows, and keeps evicted rows inactive", async () => {
+	it("seeds only registered workers' families; the saved corpus stays catalog-owned", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "prime-roster-seed-"));
 		tempDirs.push(directory);
 		const sessionsDir = join(directory, "sessions");
 		const ledger = new RlmSpawnLedger(directory, sessionsDir);
 		const liveChildPath = join(directory, "artifacts", "live-child.jsonl");
 		const deletedChildPath = join(directory, "artifacts", "deleted-child.jsonl");
+		const foreignChildPath = join(directory, "artifacts", "foreign-child.jsonl");
 		mkdirSync(sessionsDir, { recursive: true });
 		writeFileSync(join(sessionsDir, "root.jsonl"), "");
+		writeFileSync(join(sessionsDir, "foreign-root.jsonl"), "");
 		mkdirSync(dirname(liveChildPath), { recursive: true });
 		writeFileSync(liveChildPath, "");
+		writeFileSync(foreignChildPath, "");
 		await ledger.appendSpawn({
 			childId: "live-child",
 			parent: join(sessionsDir, "root.jsonl"),
@@ -861,8 +864,18 @@ describe("supervisor roster ledger", () => {
 			depth: 1,
 			name: "ghost-child",
 		});
+		// A dead family: its root has no registered worker, so its children never seed.
+		await ledger.appendSpawn({
+			childId: "foreign-child",
+			parent: join(sessionsDir, "foreign-root.jsonl"),
+			child: foreignChildPath,
+			depth: 1,
+			name: "foreign-child",
+		});
 
-		const supervisor = makeSupervisor([], {
+		const worker = makeWorker("worker-1");
+		Object.assign(worker.descriptor, { sessionFile: join(sessionsDir, "root.jsonl") });
+		const supervisor = makeSupervisor([worker], {
 			rlmSpawnLedger: () => ledger,
 			catalog: {
 				list: vi.fn(async () => [
@@ -876,22 +889,33 @@ describe("supervisor roster ledger", () => {
 						firstMessage: "hello",
 						allMessagesText: "",
 					},
+					{
+						id: "foreign-root",
+						path: join(sessionsDir, "foreign-root.jsonl"),
+						cwd: "/tmp/project",
+						created: new Date(0),
+						modified: new Date(0),
+						messageCount: 1,
+						firstMessage: "",
+						allMessagesText: "",
+					},
 				]),
 			},
 		});
 		await supervisor.seedRosterLedger();
 
-		// A push-only view needs saved top-level rows in the ledger itself, not only in list-all rescans.
-		expect(supervisor.roster().has("saved-root")).toBe(true);
+		// Only the registered worker's family seeds; the saved corpus is served by the catalog scan alone.
+		expect(supervisor.roster().has("saved-root")).toBe(false);
+		expect([...supervisor.roster().values()].some((entry) => entry.summary.rlmChildId === "foreign-child")).toBe(
+			false,
+		);
 		const listed = await supervisor.handleList({}, { type: "list", all: true });
 		const ids = listed.data?.sessions.map((session) => session.sessionId).sort();
-		expect(ids).toEqual(["live-child", "saved-root"]);
+		expect(ids).toEqual(["foreign-root", "live-child", "saved-root"]);
 		expect(listed.data?.sessions.every((session) => session.activeSessionId === undefined)).toBe(true);
 		expect((await supervisor.handleList({}, { type: "list" })).data?.sessions).toEqual([]);
 
 		// A live worker's rows: the active root and its passivated child are resident; seeded rows stay list-all-only.
-		const worker = makeWorker("worker-1");
-		supervisor.workers.set("worker-1", worker);
 		supervisor.writeRosterEntry(
 			workerRosterEntryFromSummary(
 				summary({
@@ -927,6 +951,7 @@ describe("supervisor roster ledger", () => {
 		expect(liveAll.data?.sessions.map((session) => session.sessionId).sort()).toEqual([
 			"child-session",
 			"evicted",
+			"foreign-root",
 			"live-child",
 			"saved-root",
 		]);

--- a/packages/coding-agent/test/daemon-agent-roster.test.ts
+++ b/packages/coding-agent/test/daemon-agent-roster.test.ts
@@ -872,10 +872,31 @@ describe("supervisor roster ledger", () => {
 			depth: 1,
 			name: "foreign-child",
 		});
+		// A worker registered mid-tree (resumed subagent) seeds its descendants, not its siblings.
+		const foreignGrandPath = join(directory, "artifacts", "foreign-grand.jsonl");
+		const foreignSiblingPath = join(directory, "artifacts", "foreign-sibling.jsonl");
+		writeFileSync(foreignGrandPath, "");
+		writeFileSync(foreignSiblingPath, "");
+		await ledger.appendSpawn({
+			childId: "foreign-grand",
+			parent: foreignChildPath,
+			child: foreignGrandPath,
+			depth: 2,
+			name: "foreign-grand",
+		});
+		await ledger.appendSpawn({
+			childId: "foreign-sibling",
+			parent: join(sessionsDir, "foreign-root.jsonl"),
+			child: foreignSiblingPath,
+			depth: 1,
+			name: "foreign-sibling",
+		});
 
 		const worker = makeWorker("worker-1");
 		Object.assign(worker.descriptor, { sessionFile: join(sessionsDir, "root.jsonl") });
-		const supervisor = makeSupervisor([worker], {
+		const midWorker = makeWorker("worker-mid");
+		Object.assign(midWorker.descriptor, { sessionFile: foreignChildPath });
+		const supervisor = makeSupervisor([worker, midWorker], {
 			rlmSpawnLedger: () => ledger,
 			catalog: {
 				list: vi.fn(async () => [
@@ -904,14 +925,16 @@ describe("supervisor roster ledger", () => {
 		});
 		await supervisor.seedRosterLedger();
 
-		// Only the registered worker's family seeds; the saved corpus is served by the catalog scan alone.
+		// Only registered workers' descendants seed; the saved corpus is served by the catalog scan alone.
 		expect(supervisor.roster().has("saved-root")).toBe(false);
-		expect([...supervisor.roster().values()].some((entry) => entry.summary.rlmChildId === "foreign-child")).toBe(
-			false,
-		);
+		const seededChildIds = new Set([...supervisor.roster().values()].map((entry) => entry.summary.rlmChildId));
+		// The mid-tree worker seeds its descendant, never its own transcript's siblings or ancestors.
+		expect(seededChildIds.has("foreign-grand")).toBe(true);
+		expect(seededChildIds.has("foreign-child")).toBe(false);
+		expect(seededChildIds.has("foreign-sibling")).toBe(false);
 		const listed = await supervisor.handleList({}, { type: "list", all: true });
 		const ids = listed.data?.sessions.map((session) => session.sessionId).sort();
-		expect(ids).toEqual(["foreign-root", "live-child", "saved-root"]);
+		expect(ids).toEqual(["foreign-grand", "foreign-root", "live-child", "saved-root"]);
 		expect(listed.data?.sessions.every((session) => session.activeSessionId === undefined)).toBe(true);
 		expect((await supervisor.handleList({}, { type: "list" })).data?.sessions).toEqual([]);
 
@@ -951,6 +974,7 @@ describe("supervisor roster ledger", () => {
 		expect(liveAll.data?.sessions.map((session) => session.sessionId).sort()).toEqual([
 			"child-session",
 			"evicted",
+			"foreign-grand",
 			"foreign-root",
 			"live-child",
 			"saved-root",

--- a/packages/coding-agent/test/rlm-ledger.test.ts
+++ b/packages/coding-agent/test/rlm-ledger.test.ts
@@ -1089,6 +1089,10 @@ describe("rlm spawn ledger supervisor wiring", () => {
 				depth: 1,
 				name: "worker",
 			});
+			// The seed scopes to registered workers' families.
+			supervisor.workers.set("worker-1", {
+				descriptor: { workerId: "worker-1", sessionFile: parentFile, createCommand: { type: "create" } },
+			} as never);
 
 			await supervisor.seedRosterLedger();
 			const response = await supervisor.handleCommand({}, { type: "roster_subscribe" });
@@ -1134,6 +1138,10 @@ describe("rlm spawn ledger supervisor wiring", () => {
 				name: "existing",
 			});
 			Object.assign(supervisor.catalog, { list: vi.fn(async () => []) });
+			// The seed scopes to registered workers' families.
+			supervisor.workers.set("worker-1", {
+				descriptor: { workerId: "worker-1", sessionFile: parentFile, createCommand: { type: "create" } },
+			} as never);
 			await supervisor.seedRosterLedger();
 			const seeded = await supervisor.handleCommand({}, { type: "roster_subscribe" });
 			if (!seeded?.success) throw new Error("Roster subscription failed");


### PR DESCRIPTION
After a daemon restart, the supervisor published a roster row for every subagent transcript ever recorded — about 3000 rows at rest in a real sessions directory — and re-read thousands of session files at startup to fill them in. Every roster subscriber received that full corpus in the initial payload, and the agents view showed ~3000 inactive sessions at rest that a long-running daemon would never show.

The fix scopes what the roster seeds at startup: only the families of currently registered workers, i.e. spawn-ledger children (already filtered to ones whose transcript still exists on disk) whose parent chain reaches a registered worker's session. Saved top-level sessions are not seeded at all — `list --all` already reads them from disk on every call, so the catalog remains their single source. Children passivated while the daemon runs still enter the roster through worker updates, unchanged. Startup work drops from one file read per transcript ever recorded to a handful for the live families.

Measured on an identical 3001-file / 3.3 GB sessions corpus (cold supervisor, same sandbox, main vs this branch):

| | main | this branch |
|---|---|---|
| daemon hello | 4659 ms | 1510 ms |
| roster rows at rest | 3001 | 0 (with 2 live sessions: exactly 2) |
| `roster_subscribe` p50 | 83 ms (3001-row payload) | 0.32 ms |
| `list --all` p50 | 857 ms, 3001 rows | 860 ms, 3001 rows |

Main spent ~3 s scanning the corpus before hello because the deleted catalog-seed loop sat on the boot path. `list --all` is unchanged at steady state; its first post-boot sample on this branch is slower (3209 ms — main had pre-warmed the catalog cache during its boot-time seed), identical afterwards.

Behavior change a reviewer should know: subagent transcripts whose family has no registered worker no longer appear in `list --all` (they previously appeared via their seeded rows). They remain reachable through the spawn-ledger family/sibling lookups used for waking and name resolution. Workers can be rooted at a subagent transcript (resuming a persisted child); seeding covers their descendants and only their descendants.

The remaining items are small cleanups in the same area:
- The three copies of "read a seeded row's cwd from its transcript header" (list path, startup seed, snapshot reseed) are now one function.
- With the seed scoped, the per-row header reads at startup are few enough that reading them sequentially is fine; left as is.
- The agents view gates its status label on the presence of `statusLabel`/`lastHeardFromAt`; those fields are only ever set for exceptional states (queued/recovering/failed/stale), so the gate is correct as written — that contract is now stated where the fields are produced.
- The snapshot-reseed survival condition is extracted into a named predicate; no behavior change.

Linear: [ENG-5820](https://linear.app/primeintellect/issue/ENG-5820/agents-view-rest-state-inactive-rows-depend-on-supervisor-lifetime), [ENG-5829](https://linear.app/primeintellect/issue/ENG-5829/roster-follow-up-hydration-owner-seed-read-amplification-status-label)

Validation: roster, ledger, agents-view, supervisor monitor/eviction, and session-list suites all green; `npm run check` green.