### PR TITLE
fix(coding-agent): single-dump kernel snapshots

### DIFF
--- a/packages/coding-agent/.changes/kernel-snapshot-single-dump.md
+++ b/packages/coding-agent/.changes/kernel-snapshot-single-dump.md
@@ -1,0 +1,1 @@
+- Reduced kernel memory spikes during namespace snapshots: the payload now pickles straight into the staged file instead of building serialized copies in memory (peak snapshot overhead ~3.9x payload -> ~1x; ENG-5819).

--- a/prime-agent-runtime/src/rlm/repl.py
+++ b/prime-agent-runtime/src/rlm/repl.py
@@ -589,20 +589,21 @@ class _SnapshotSizeLimitExceeded(Exception):
     pass
 
 
-class _SnapshotBuffer:
-    def __init__(self, limit: int) -> None:
-        import io
+class _CappedWriter:
+    """Pass-through writer that fails once total written bytes would exceed the cap."""
 
-        self._buf = io.BytesIO()
+    def __init__(self, sink: Any, limit: int) -> None:
+        self._sink = sink
         self._limit = limit
+        self.written = 0
 
-    def write(self, chunk: bytes) -> int:
-        if self._buf.tell() + len(chunk) > self._limit:
+    def write(self, chunk: Any) -> int:
+        size = len(chunk)
+        if self.written + size > self._limit:
             raise _SnapshotSizeLimitExceeded()
-        return self._buf.write(chunk)
-
-    def getvalue(self) -> bytes:
-        return self._buf.getvalue()
+        self._sink.write(chunk)
+        self.written += size
+        return size
 
 
 def _snapshot_state(
@@ -637,9 +638,9 @@ def _snapshot_state(
             continue
         remaining = max_bytes - total
         limit = max_variable_bytes if prune_oversized else min(max_variable_bytes, remaining)
-        buffer = _SnapshotBuffer(limit)
+        buffer = io.BytesIO()
         try:
-            dill.dump(value, buffer)
+            dill.dump(value, _CappedWriter(buffer, limit))
             blob = buffer.getvalue()
         except _SnapshotSizeLimitExceeded:
             if not prune_oversized and remaining < max_variable_bytes:
@@ -688,39 +689,45 @@ def _snapshot_state(
     previous = None
     try:
         try:
-            def serialize(candidate: dict[str, bytes]) -> bytes | None:
-                buffer = _SnapshotBuffer(max_bytes)
-                try:
-                    dill.dump(candidate, buffer)
-                except _SnapshotSizeLimitExceeded:
-                    return None
-                return buffer.getvalue()
-
-            serialized_payload = serialize(payload)
-            if serialized_payload is None:
-                items = list(payload.items())
-                serialized_payload = serialize({})
-                if serialized_payload is None:
-                    return {"error": "write failed: snapshot exceeds aggregate snapshot size cap"}
-                # Keep the largest insertion-order prefix whose complete pickle fits.
-                # Prefix pickle size is monotonic because each prefix only adds a string key and bytes value.
-                low, high = 0, len(items) - 1
-                while low < high:
-                    mid = (low + high + 1) // 2
-                    candidate = serialize(dict(items[:mid]))
-                    if candidate is None:
-                        high = mid - 1
-                    else:
-                        low = mid
-                        serialized_payload = candidate
-                for name, _ in items[low:]:
-                    skipped.append({"name": name, "reason": "exceeds aggregate snapshot size cap"})
-                payload = dict(items[:low])
-
+            # The payload pickles straight into the staged temp; an in-memory
+            # aggregate copy would transiently double the snapshot's footprint.
             fh, tmp = stage_temp(path, "wb")
             with fh:
-                fh.write(serialized_payload)
-            bytes_written = len(serialized_payload)
+                def dump_to_temp(candidate: dict[str, bytes]) -> int | None:
+                    writer = _CappedWriter(fh, max_bytes)
+                    try:
+                        dill.dump(candidate, writer)
+                    except _SnapshotSizeLimitExceeded:
+                        return None
+                    return writer.written
+
+                def redump_to_temp(candidate: dict[str, bytes]) -> int | None:
+                    fh.seek(0)
+                    fh.truncate()
+                    return dump_to_temp(candidate)
+
+                bytes_written = dump_to_temp(payload)
+                if bytes_written is None:
+                    # The blob total fit, so only the dict pickle's key/framing overhead is over.
+                    # Keep the largest insertion-order prefix whose complete pickle fits.
+                    # Prefix pickle size is monotonic because each prefix only adds a string key and bytes value.
+                    items = list(payload.items())
+                    if redump_to_temp({}) is None:
+                        return {"error": "write failed: snapshot exceeds aggregate snapshot size cap"}
+                    low, high = 0, len(items) - 1
+                    while low < high:
+                        mid = (low + high + 1) // 2
+                        if redump_to_temp(dict(items[:mid])) is None:
+                            high = mid - 1
+                        else:
+                            low = mid
+                    for name, _ in items[low:]:
+                        skipped.append({"name": name, "reason": "exceeds aggregate snapshot size cap"})
+                    payload = dict(items[:low])
+                    # The search's last attempt may have overflowed the temp; rewrite the chosen prefix.
+                    bytes_written = redump_to_temp(payload)
+                    if bytes_written is None:
+                        return {"error": "write failed: snapshot exceeds aggregate snapshot size cap"}
             saved = sorted(payload.keys())
             pruned = sorted(name for name in oversized if name in ns) if prune_oversized else []
             manifest = {

--- a/prime-agent-runtime/src/rlm/repl.py
+++ b/prime-agent-runtime/src/rlm/repl.py
@@ -590,8 +590,6 @@ class _SnapshotSizeLimitExceeded(Exception):
 
 
 class _CappedWriter:
-    """Pass-through writer that fails once total written bytes would exceed the cap."""
-
     def __init__(self, sink: Any, limit: int) -> None:
         self._sink = sink
         self._limit = limit
@@ -689,8 +687,6 @@ def _snapshot_state(
     previous = None
     try:
         try:
-            # The payload pickles straight into the staged temp; an in-memory
-            # aggregate copy would transiently double the snapshot's footprint.
             fh, tmp = stage_temp(path, "wb")
             with fh:
                 def dump_to_temp(candidate: dict[str, bytes]) -> int | None:
@@ -708,8 +704,6 @@ def _snapshot_state(
 
                 bytes_written = dump_to_temp(payload)
                 if bytes_written is None:
-                    # The blob total fit, so only the dict pickle's key/framing overhead is over.
-                    # Keep the largest insertion-order prefix whose complete pickle fits.
                     # Prefix pickle size is monotonic because each prefix only adds a string key and bytes value.
                     items = list(payload.items())
                     if redump_to_temp({}) is None:


### PR DESCRIPTION
Saving kernel state — the namespace snapshot that lets a resumed session keep its variables — buffered the whole pickled namespace in memory up to three times over before writing it to disk: each variable was pickled into a dict of blobs, that dict was pickled again into a second in-memory buffer, and that buffer was copied once more for the file write. A snapshot runs shortly after every successful cell, so long sessions with sizeable variables repeatedly spike to roughly 4x the payload in transient RSS. This is the kernel-side memory spike tracked in ENG-5819 (kernel processes ballooning to 1.3-1.9GB and getting OOM-killed).

The fix deletes the in-memory aggregate stage: the dict of blobs now pickles directly into the staged temp file through a small size-capped writer (the same class replaces the old per-variable buffer). The on-disk format, the manifest, the `max_bytes` cap semantics, and the overflow fallback that keeps the largest prefix that fits are all unchanged; overflow retries rewind and rewrite the temp file instead of allocating fresh buffers. No host or protocol changes.

Measured on a 250MB namespace (25 x 10MB variables, fresh process per side, 3 snapshots, `ru_maxrss`):

| | peak RSS | snapshot transient overhead | latency |
|---|---|---|---|
| before (74c8d39ee) | 1242 MB | 963 MB (~3.9x payload) | 0.11-0.20 s |
| after | 529 MB | 253 MB (~1.0x payload) | 0.03-0.14 s |

The remaining ~1x overhead is the per-variable blob dict, which pickling the aggregate genuinely needs. The snapshot still runs synchronously on the kernel loop; moving it off-loop is out of scope here because that ordering is what keeps the namespace stable while it pickles.

Validation: `prime-agent-runtime` `python -m unittest test.test_repl` 95/95 with no test changes (the cap and overflow-fallback behaviors are already pinned there); coding-agent kernel suites (`repl-kernel-state-roundtrip` against the real runtime, execute/abort/shutdown/startup/protocol-corruption, `npm run test:kernel`) green; root `npm run check` green.

Linear: ENG-5819

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the kernel snapshot write path used after every successful cell; behavior is intended to be equivalent but mistakes could truncate or mis-record state under size caps.
> 
> **Overview**
> **Fixes ENG-5819** by changing how `_snapshot_state` writes the aggregate namespace payload so the kernel no longer holds multiple full-size serialized copies in RAM on every debounced snapshot.
> 
> The in-memory `_SnapshotBuffer` path is replaced with **`_CappedWriter`**, which enforces per-dump byte limits while streaming `dill` output into a sink (still `BytesIO` for per-variable blobs, **the staged temp file** for the full payload dict). Aggregate overflow handling keeps the same largest-prefix binary search and skip reasons, but retries **`seek`/`truncate`/`redump`** on that temp file instead of re-pickling into fresh buffers.
> 
> Snapshot caps, manifest fields, on-disk format, and host protocol are unchanged; this is a memory/latency optimization inside the REPL kernel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bffb62d06a408ce2504d6927d04dc23a34ba4f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream kernel snapshot payload directly to temp file instead of memory
> - Replaces the in-memory `_SnapshotBuffer` (BytesIO wrapper) in `prime-agent-runtime/src/rlm/repl.py` with `_CappedWriter`, a capped writer that streams writes to an arbitrary sink while enforcing a byte limit.
> - `_snapshot_state` now serializes the payload directly into the staged temp file using `_CappedWriter` instead of calling `serialize()` to build a full in-memory copy first. This reduces kernel memory spikes during namespace snapshots.
> - The prefix-truncation binary search rewrites candidate prefixes to the temp file via `seek(0)`/`truncate()`; `bytes_written` is sourced from the writer's running count rather than `len(serialized)`.
> - Behavioral Change: `_SnapshotBuffer` is removed; any code importing it directly will break. Per-variable serialization now uses `io.BytesIO` + `_CappedWriter` instead of `_SnapshotBuffer`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bffb62d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->