### PR TITLE
fix(coding-agent): evict empty drafts when the last direct viewer detaches (ENG-5831)

### DIFF
--- a/packages/coding-agent/.changes/eng-5831-direct-detach-eviction.md
+++ b/packages/coding-agent/.changes/eng-5831-direct-detach-eviction.md
@@ -1,0 +1,1 @@
+- Fixed empty draft sessions lingering as zombie rows after the last viewer quit: a direct-transport client's detach or socket drop now triggers the same last-detach eviction as supervisor-routed clients.

--- a/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-supervisor.ts
@@ -1048,10 +1048,9 @@ export class DaemonSupervisor {
 		const summaries = this.workerRosterEntries(worker)
 			.filter((entry) => !entry.queuedChild)
 			.map(sessionSummaryFromRosterEntry);
-		const hasAttachedClient = summaries.some((summary) => {
-			const summaryActiveSessionId = summary.activeSessionId ?? summary.id;
-			return [...this.clients].some((client) => client.attachedActiveSessionIds.has(summaryActiveSessionId));
-		});
+		const hasAttachedClient = summaries.some(
+			(summary) => this.attachedClientCount(summary, summary.activeSessionId ?? summary.id) > 0,
+		);
 		return summaries.length > 0 && !hasAttachedClient && summaries.every(isEvictableEmptySessionSummary);
 	}
 
@@ -3928,7 +3927,14 @@ export class DaemonSupervisor {
 		worker?: ResidentWorker,
 		statusLabel?: AgentRosterEntry["statusLabel"],
 	): AgentRosterEntry {
-		return this.roster().write(entry, worker?.descriptor.workerId, statusLabel);
+		const previousDirect = this.roster().get(entry.agentId)?.summary.directAttachedClients ?? 0;
+		const stored = this.roster().write(entry, worker?.descriptor.workerId, statusLabel);
+		// Direct peers attach and detach on the worker socket, so their last detach arrives
+		// here as roster truth instead of through a supervisor-socket close.
+		if (worker !== undefined && previousDirect > 0 && (entry.summary.directAttachedClients ?? 0) === 0) {
+			void this.evictEmptySessionOnLastDetach(entry.summary.activeSessionId ?? entry.summary.id);
+		}
+		return stored;
 	}
 
 	private workerOwnedRosterSummaryForPath(canonicalPath: string): SessionSummary | undefined {

--- a/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
+++ b/packages/coding-agent/test/daemon-supervisor-eviction.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { workerRosterEntryFromSummary } from "../src/modes/daemon/agent-roster.js";
 import { success } from "../src/modes/daemon/daemon-protocol.js";
 import type { SessionSummary } from "../src/modes/daemon/daemon-session-list.js";
 import { DaemonSupervisor, idleEvictionSweepIntervalMs } from "../src/modes/daemon/daemon-supervisor.js";
@@ -41,6 +42,7 @@ interface SupervisorInternals {
 	runIdleEvictionSweep(now?: number): Promise<void>;
 	shutdown(exitCode: number, stopWorkers: boolean): Promise<never>;
 	handleCommand(client: object, command: object): Promise<unknown>;
+	writeRosterEntry(entry: object, worker?: object): unknown;
 }
 
 const tempDirs: string[] = [];
@@ -515,6 +517,46 @@ describe("daemon supervisor empty-session eviction on detach", () => {
 			"owned",
 		]);
 		expect(supervisor.log).toHaveBeenCalledWith(expect.stringContaining("Evicted empty session worker empty"));
+	});
+
+	it("evicts an empty draft when the worker reports its last direct viewer gone", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const liveSummaries = [makeSummary("draft-root", now, { messageCount: 0, directAttachedClients: 1 })];
+		const worker = makeWorker("draft", liveSummaries);
+		supervisor.workers.set("draft", worker);
+		seedSupervisorRoster(supervisor, worker);
+
+		// Clean detach and socket drop both surface as the same worker roster truth.
+		const detached = makeSummary("draft-root", now, { messageCount: 0 });
+		liveSummaries[0] = detached;
+		worker.summaries.set("draft-root", detached);
+		supervisor.writeRosterEntry(workerRosterEntryFromSummary(detached), worker);
+
+		await vi.waitFor(() => expect(supervisor.stopWorker).toHaveBeenCalledWith(worker, true));
+		expect(supervisor.log).toHaveBeenCalledWith(expect.stringContaining("Evicted empty session worker draft"));
+	});
+
+	it("evicts a mixed-client empty draft only when the last of both client kinds is gone", async () => {
+		const now = Date.parse("2026-08-01T12:00:00.000Z");
+		const supervisor = makeSupervisor();
+		const liveSummaries = [makeSummary("mixed-root", now, { messageCount: 0, directAttachedClients: 1 })];
+		const worker = makeWorker("mixed", liveSummaries);
+		supervisor.workers.set("mixed", worker);
+		seedSupervisorRoster(supervisor, worker);
+		const routed = makeDetachClient("routed", ["mixed-root"]);
+		supervisor.clients.add(routed);
+
+		await supervisor.handleCommand(routed, { id: "detach-1", type: "detach", activeSessionId: "mixed-root" });
+		await settle();
+		expect(supervisor.stopWorker).not.toHaveBeenCalled();
+
+		const detached = makeSummary("mixed-root", now, { messageCount: 0 });
+		liveSummaries[0] = detached;
+		worker.summaries.set("mixed-root", detached);
+		supervisor.writeRosterEntry(workerRosterEntryFromSummary(detached), worker);
+
+		await vi.waitFor(() => expect(supervisor.stopWorker).toHaveBeenCalledWith(worker, true));
 	});
 
 	it("does not stop a worker that was replaced while its summary refresh was in flight", async () => {


### PR DESCRIPTION
## Problem

Starting the TUI and quitting right away leaves the empty draft session behind as a zombie row in the agents view until an idle sweep catches it, if one ever runs (ENG-5831).

The empty-draft eviction from #1920 runs when the supervisor sees a client's last detach: on a supervisor socket close it walks that socket's attached sessions and evicts abandoned empty drafts. #1926 moved attach and detach onto the direct worker transport, so the session's viewer now attaches and detaches on the worker's own socket. The supervisor socket never records the attachment, its close-time walk finds nothing, and a clean quit does not touch the supervisor at all.

## Fix

The worker already reports the exact signal: since #1926 it flushes a roster update when a direct viewer attaches or detaches, and that summary carries `directAttachedClients`. Both exit paths produce it — a clean `detach` command and an unclean socket drop share the worker's detach path.

The supervisor's roster write funnel now triggers the existing last-detach eviction when a worker-reported summary's `directAttachedClients` drops to zero. The eviction candidate check also counts direct viewers through the shared attachment sum, so with one routed and one direct client the session is evicted only when the last of both is gone, in either order.

No new wire frames, timers, or sweep changes: the fix reuses the roster signal and the eviction path that already exist.

## Validation

- New pins in `daemon-supervisor-eviction.test.ts`: a worker-reported drop to zero direct viewers evicts an empty draft; a mixed routed+direct session evicts only after the last of both detaches.
- Existing #1920 eviction pins, `daemon-peer-transport`, `agent-connection-daemon`, `daemon-supervisor-monitor`, and `daemon-routed-client` suites all green with sanitized env.
- Root `npm run check` green.

Linear: ENG-5831

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Evict empty drafts when last direct-attached viewer detaches in `DaemonSupervisor`
> - Updates the `evictable-empty-worker` check to use `attachedClientCount` so it accounts for both supervisor-routed and direct-attached clients when deciding if a worker is evictable
> - In `writeRosterEntry`, detects when a worker's `directAttachedClients` transitions from >0 to 0 and triggers `evictEmptySessionOnLastDetach`, aligning direct-transport detach behavior with supervisor-routed clients
> - Adds tests covering eviction on last direct detach and the mixed client-kind case where eviction only fires after both routed and direct clients are gone
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f879e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon session eviction and roster-driven lifecycle, but reuses existing eviction helpers and is covered by new unit tests rather than new wire protocol.
> 
> **Overview**
> Fixes **empty draft sessions** sticking around in the agents list after a user opens the TUI and quits immediately, because viewers on the **direct worker transport** no longer detach through the supervisor socket.
> 
> When a worker roster update shows **`directAttachedClients`** dropping from above zero to zero, **`writeRosterEntry`** now runs the same **`evictEmptySessionOnLastDetach`** path used for supervisor-routed clients (clean detach or socket drop both show up this way). The **empty-worker eviction check** uses **`attachedClientCount`** so routed and direct attachments are counted together—mixed sessions are only evicted after **both** kinds of viewer are gone.
> 
> Adds eviction tests for last direct detach and routed+direct ordering; changelog note for ENG-5831.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f879e6b953ade269d342bfef4318d377fe44731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->