### PR TITLE
fix(coding-agent): show the expand hint on sent agent-message summary lines

### DIFF
--- a/packages/coding-agent/.changes/sent-agent-message-expand-hint.md
+++ b/packages/coding-agent/.changes/sent-agent-message-expand-hint.md
@@ -1,0 +1,1 @@
+- Fixed sent agent messages under Python cells not showing the expand/collapse keybinding hint that received agent messages show.

--- a/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
+++ b/packages/coding-agent/src/modes/interactive/components/ipython-cell.ts
@@ -653,11 +653,12 @@ export class IPythonCellComponent implements Component {
 		for (const message of messages) {
 			const label = message.deliveryStatus === "delivered" ? "Agent message sent" : "Agent message queued";
 			const recipient = formatAgentMessageParticipant("sent", message.receiverRole, message.target);
+			const hint = expandCollapseHint("app.messages.expand", this.state.agentMessagesExpanded === true);
 			if (this.state.agentMessagesExpanded) {
 				this.addBlank(lines, width);
 				this.addPlain(
 					lines,
-					truncateToWidth(agentMessageSummaryLine(label, recipient), Math.max(1, width - 1), "…"),
+					truncateToWidth(`${agentMessageSummaryLine(label, recipient)} ${hint}`, Math.max(1, width - 1), "…"),
 				);
 				for (const bodyLine of agentMessageBodyLines(message.message, width)) {
 					lines.push(bodyLine);
@@ -668,7 +669,11 @@ export class IPythonCellComponent implements Component {
 			const preview = agentMessagePreview(prefixWidth, message.message);
 			this.addPlain(
 				lines,
-				truncateToWidth(agentMessageSummaryLine(label, recipient, preview), Math.max(1, width - 1), "…"),
+				truncateToWidth(
+					`${agentMessageSummaryLine(label, recipient, preview)} ${hint}`,
+					Math.max(1, width - 1),
+					"…",
+				),
 			);
 		}
 	}

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -493,51 +493,6 @@ describe("ENG-4531 agent message UI", () => {
 		expect(expanded).not.toContain("Message id:");
 	});
 
-	it("renders sent messages beneath collapsed Python cells", () => {
-		const component = new IPythonCellComponent({
-			code: 'await agent_message.send("worker-active", "Review shard seven.")',
-			executionStarted: true,
-			details: {
-				status: "ok",
-				sentAgentMessages: [
-					{
-						id: "agentmsg_4531",
-						message: "Review shard seven.",
-						deliveryStatus: "queued",
-						receiverRole: "child",
-						target: {
-							activeSessionId: "worker-active",
-							sessionId: "worker-session",
-							sessionName: "Worker",
-						},
-					},
-					{
-						id: "agentmsg_4531_delivered",
-						message: "Continue with shard eight.",
-						deliveryStatus: "delivered",
-						receiverRole: "parent",
-						target: {
-							activeSessionId: "worker-active",
-							sessionId: "worker-session",
-							sessionName: "Worker",
-						},
-					},
-				],
-			},
-		});
-
-		const rendered = stripAnsi(component.render(120).join("\n"));
-		const lines = rendered.split("\n");
-		expect(lines).toEqual([
-			expect.stringContaining("python"),
-			expect.stringMatching(/^ ◆ Agent message queued · to child Worker · Review shard seven\. \(.*to expand\)$/),
-			expect.stringMatching(
-				/^ ◆ Agent message sent · to parent Worker · Continue with shard eight\. \(.*to expand\)$/,
-			),
-		]);
-		expect(rendered).not.toContain("Agent message received");
-	});
-
 	it("expands sent messages to the message text without the receipt metadata", () => {
 		const receipt =
 			"{'id': 'agentmsg_4531_delivered',\n" +

--- a/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4531-agent-message-ui.test.ts
@@ -530,8 +530,10 @@ describe("ENG-4531 agent message UI", () => {
 		const lines = rendered.split("\n");
 		expect(lines).toEqual([
 			expect.stringContaining("python"),
-			" ◆ Agent message queued · to child Worker · Review shard seven.",
-			" ◆ Agent message sent · to parent Worker · Continue with shard eight.",
+			expect.stringMatching(/^ ◆ Agent message queued · to child Worker · Review shard seven\. \(.*to expand\)$/),
+			expect.stringMatching(
+				/^ ◆ Agent message sent · to parent Worker · Continue with shard eight\. \(.*to expand\)$/,
+			),
 		]);
 		expect(rendered).not.toContain("Agent message received");
 	});
@@ -574,7 +576,7 @@ describe("ENG-4531 agent message UI", () => {
 		expect(lines).toEqual([
 			expect.stringContaining("python"),
 			expect.stringContaining("await agent_message.send"),
-			" ◆ Agent message sent · to parent Worker",
+			expect.stringMatching(/^ ◆ Agent message sent · to parent Worker \(.*to collapse\)$/),
 			" ╰─ Continue with shard eight.",
 			"    Then report back.",
 		]);


### PR DESCRIPTION
Received agent messages render with the expand/collapse keybinding hint (e.g. `(Ctrl+P to expand)`) on their summary line, but agent messages *sent* from a Python cell did not — their summary lines under the collapsed cell showed only the label, recipient, and preview. The expansion toggle itself worked; nothing advertised it.

The sent-message renderer in `ipython-cell.ts` builds its summary lines without the hint that the received-message component appends. The fix appends the same `expandCollapseHint("app.messages.expand", …)` in both the collapsed and expanded states, matching the received-message UI exactly.

Validation: the expanded-state pin asserts the hint; the low-value exact-line rendering test for collapsed sent messages is removed (net −37 lines). `npm run check` green.

Linear: [ENG-5833](https://linear.app/primeintellect/issue/ENG-5833/sent-agent-messages-dont-show-the-expand-keybinding-hint)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only copy change in the interactive Python cell renderer; no auth, data, or delivery logic touched.
> 
> **Overview**
> **Sent agent messages under Python cells** now show the same expand/collapse keybinding hint as received agent messages (e.g. `(Ctrl+P to expand)` / `to collapse`).
> 
> `renderSentAgentMessages` in `ipython-cell.ts` calls `expandCollapseHint("app.messages.expand", …)` and appends it to the summary line in both collapsed (label + preview) and expanded states. Behavior was already wired; only the summary text was missing the hint.
> 
> Regression tests in `4531-agent-message-ui.test.ts` expect the hint on expanded sent-message rows; a redundant collapsed-only assertion was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef427c1b889ec49a99977a0fb30e27212b957051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show expand/collapse hint on sent agent-message summary lines in `IPythonCellComponent`
> Sent agent messages under Python cells now display the same expand/collapse keybinding hint that received agent messages already show. The hint is appended to the summary line in both expanded and collapsed rendering paths via `renderSentAgentMessages` in [ipython-cell.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1948/files#diff-0c68a1ddc7ca42ea120720a8a68c087bc0da2b18a8ee0fbdca8136759057bcdf). The existing regression test for sent messages is updated to expect the hint, and an obsolete test asserting sent messages render without metadata beneath collapsed cells is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef427c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
