### PR TITLE
feat(coding-agent): session-scoped host handler dispatch for shared kernels

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -10398,6 +10398,51 @@ export class AgentSession {
 		return { model };
 	}
 
+	/**
+	 * The kernel whose session-handlers registry this session's rlm children
+	 * must be registered on. Extensions that adopt a shared kernel (the
+	 * kernel-fulfill path) adopt the TOP session's provisioner and route EVERY
+	 * descendant's cells onto it, so registrations must land there no matter
+	 * how deep the spawn chain goes. Set by the parent at registration time,
+	 * propagating the root provisioner down the chain; unset on a top-level
+	 * session, which uses its own provisioner.
+	 */
+	private _rlmKernelHostRegistrar?: IpythonKernelProvisioner;
+
+	/**
+	 * Route host requests raised by this child's executions on the shared
+	 * kernel back to the child's own handlers. On the kernel-fulfill path
+	 * (extensions adopting the shared kernel), a child's cells execute on the
+	 * top session's kernel; without per-session dispatch, identity-bearing host
+	 * requests (agent_message.send, rlm.run) ran through the kernel owner's
+	 * handlers and acted as the owner. Executions tagged with the child's
+	 * session id (ExecuteOptions.ownerSessionId) now dispatch to the child's
+	 * handlers.
+	 *
+	 * Registration lands on the ROOT provisioner (inherited via
+	 * _rlmKernelHostRegistrar), not the spawning session's own: a grandchild's
+	 * cells run on the top session's kernel too, so registering it on the
+	 * middle child's provisioner would leave its requests falling back to the
+	 * top session's identity. The root is propagated onto the child so ITS
+	 * children register in the same place.
+	 *
+	 * The provider is liveness-checked through a WeakRef: once the child is
+	 * disposed or collected, dispatch falls back to the owner's handlers, so no
+	 * explicit unregistration is required on the many child-teardown paths.
+	 * Children retained for follow-up messaging stay resolvable.
+	 */
+	private _registerRlmChildKernelHostHandlers(child: AgentSession): void {
+		const provisioner = this._rlmKernelHostRegistrar ?? this._ipythonKernelProvisioner;
+		if (!provisioner) return;
+		child._rlmKernelHostRegistrar = provisioner;
+		const ref = new WeakRef(child);
+		provisioner.registerSessionHostHandlers(child.sessionId, () => {
+			const session = ref.deref();
+			if (!session || session._disposed || session._disposing) return undefined;
+			return session._createKernelHostHandlers();
+		});
+	}
+
 	private async _startRlmChildRun(
 		prompt: string,
 		kwargs: Record<string, unknown> = {},
@@ -10546,6 +10591,7 @@ export class AgentSession {
 				if (run.status === "cancelled") throw new Error(run.error ?? "RLM child cancelled");
 				if (child.sessionName !== sessionName) child.setSessionName(sessionName);
 				publishChildSession(child);
+				this._registerRlmChildKernelHostHandlers(child);
 				throwIfCancelled();
 				run.status = "running";
 				emitChildUpdate();

--- a/packages/coding-agent/src/core/kernel/repl-manager.ts
+++ b/packages/coding-agent/src/core/kernel/repl-manager.ts
@@ -136,7 +136,15 @@ function asReasonArray(value: unknown): { name: string; reason: string }[] {
 export class ReplKernelManager {
 	private readonly options: Pick<
 		KernelManagerOptions,
-		"python" | "cwd" | "env" | "sessionId" | "hostHandlers" | "pythonSkills" | "snapshot" | "bootstrapCode"
+		| "python"
+		| "cwd"
+		| "env"
+		| "sessionId"
+		| "hostHandlers"
+		| "sessionHostHandlers"
+		| "pythonSkills"
+		| "snapshot"
+		| "bootstrapCode"
 	>;
 	private readonly handledHostRequestIds = new Set<string>();
 	private child?: ChildProcess;
@@ -153,6 +161,10 @@ export class ReplKernelManager {
 	// rlm.run spawns from detached asyncio tasks (cell already idle) can still
 	// attribute their spawning program.
 	private lastCellCode?: string;
+	// Owner of the most recently started cell, retained for the same detached
+	// case: a host request that fires after the scheduling cell went idle still
+	// dispatches to the session that scheduled it.
+	private lastCellOwnerSessionId?: string;
 	/** Unattributed stream text that arrived between cells; surfaced on the next execution. */
 	private pendingBackgroundOutput = "";
 	private pendingBackgroundOutputTruncated = false;
@@ -190,6 +202,7 @@ export class ReplKernelManager {
 			env: options.env,
 			sessionId: options.sessionId,
 			hostHandlers: options.hostHandlers,
+			sessionHostHandlers: options.sessionHostHandlers,
 			pythonSkills: options.pythonSkills,
 			snapshot: options.snapshot,
 			bootstrapCode: options.bootstrapCode,
@@ -877,6 +890,7 @@ export class ReplKernelManager {
 			}
 			if (!opts.internal) {
 				this.lastCellCode = code;
+				this.lastCellOwnerSessionId = opts.ownerSessionId;
 			}
 			try {
 				const sendPromise = this.writeLine({ ...requestFields, id: requestId });
@@ -1125,13 +1139,27 @@ export class ReplKernelManager {
 			throw new Error("host request payload must have a string type");
 		}
 
-		const handler = this.options.hostHandlers?.[data.type];
+		// Attribute the request to the session whose cell raised it. A blocking
+		// call is still the in-flight execution; detached spawns
+		// (asyncio.create_task) fire after the scheduling cell goes idle, so fall
+		// back to the last cell's owner — mirroring the cellSourceCode fallback.
+		const attributedSessionId = this.activeExecution
+			? this.activeExecution.opts.ownerSessionId
+			: this.lastCellOwnerSessionId;
+		let handler = this.options.hostHandlers?.[data.type];
+		// Session-scoped dispatch (shared kernels): a cell tagged with another
+		// registered session's id uses THAT session's handlers, so identity-bearing
+		// requests (agent_message.send, rlm.run) act as the issuing session. A type
+		// the delegated set lacks falls back to the owner's handler — availability
+		// over attribution, and exactly the pre-registry behavior.
+		if (attributedSessionId && attributedSessionId !== this.options.sessionId) {
+			const delegated = this.options.sessionHostHandlers?.get(attributedSessionId)?.();
+			const delegatedHandler = delegated?.[data.type];
+			if (delegatedHandler) handler = delegatedHandler;
+		}
 		if (!handler) {
 			throw new Error(`host request type "${data.type}" is not available in this session`);
 		}
-		// Tag the request with the cell that triggered it. A blocking call is still
-		// the in-flight execution; detached spawns (asyncio.create_task) fire after
-		// the scheduling cell goes idle, so fall back to that last cell's source.
 		const cellSourceCode = this.activeExecution?.code ?? this.lastCellCode;
 		return handler({ ...data, cellSourceCode });
 	}

--- a/packages/coding-agent/src/core/kernel/shared.ts
+++ b/packages/coding-agent/src/core/kernel/shared.ts
@@ -30,6 +30,14 @@ export type HostRequestHandler = (payload: Record<string, unknown>) => Promise<R
 /** Host request handlers keyed by request type (e.g. "rlm.run", "goal.complete"). */
 export type HostRequestHandlers = Record<string, HostRequestHandler>;
 
+/**
+ * Lazily resolves the host handlers of a session other than the kernel's
+ * provisioning owner. Returns undefined once that session is gone (disposed /
+ * garbage-collected), in which case dispatch falls back to the owner's
+ * handlers — the pre-registration behavior.
+ */
+export type SessionHostHandlersProvider = () => HostRequestHandlers | undefined;
+
 /** Where and how to persist the kernel's user namespace so it survives resume. */
 export interface KernelSnapshotConfig {
 	/** Absolute path for the dill payload. */
@@ -51,6 +59,16 @@ export interface KernelManagerOptions {
 	env?: Record<string, string>;
 	sessionId?: string;
 	hostHandlers?: HostRequestHandlers;
+	/**
+	 * Live registry of OTHER sessions allowed to execute on this kernel (shared
+	 * kernels: rlm children on the kernel-fulfill path). When an execution is
+	 * tagged with an {@link ExecuteOptions.ownerSessionId} found here, host
+	 * requests raised by that execution dispatch to that session's handlers
+	 * instead of the provisioning session's — so e.g. agent_message.send goes
+	 * out under the child's identity, not the kernel owner's. The map is shared
+	 * by reference; registrations made after kernel start are visible.
+	 */
+	sessionHostHandlers?: ReadonlyMap<string, SessionHostHandlersProvider>;
 	pythonSkills?: readonly KernelPythonSkill[];
 	/** Persist/revive the user namespace across kernel restarts and session resume. */
 	snapshot?: KernelSnapshotConfig;
@@ -74,6 +92,13 @@ export interface ExecuteOptions {
 	internal?: boolean;
 	/** The protocol repair's own restore; exempt from waiting on the repair it belongs to. */
 	protocolRepair?: boolean;
+	/**
+	 * Session that issued this cell, when it is not the kernel's provisioning
+	 * owner (shared kernels). Host requests raised by the cell dispatch to that
+	 * session's handlers via {@link KernelManagerOptions.sessionHostHandlers}.
+	 * Omitted/unknown means the owner's handlers, today's behavior.
+	 */
+	ownerSessionId?: string;
 }
 
 /** MIME tag the `edit` skill emits diff payloads under. */

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -16,6 +16,7 @@ import {
 	type KernelDiffDisplay,
 	type KernelSentAgentMessage,
 	ReplKernelManager,
+	type SessionHostHandlersProvider,
 } from "../kernel/index.js";
 import { manifestPathIn, type RestoreResult, snapshotPathIn } from "../kernel/state-snapshot.js";
 import type { PythonSkillRuntimeInfo } from "../skills.js";
@@ -311,6 +312,9 @@ export class IpythonKernelProvisioner {
 	private lastStartupMessage?: string;
 	private _lastRestore?: RestoreResult;
 	private readonly disposeController = new AbortController();
+	// Shared by reference with every kernel this provisioner starts (including
+	// restarts), so sessions registered after kernel start are still seen.
+	private readonly sessionHostHandlers = new Map<string, SessionHostHandlersProvider>();
 
 	constructor(
 		private readonly cwd: string,
@@ -325,6 +329,22 @@ export class IpythonKernelProvisioner {
 	/** Result of reviving a prior session's namespace on the last kernel start, if any. */
 	get lastRestore(): RestoreResult | undefined {
 		return this._lastRestore;
+	}
+
+	/**
+	 * Allow another session (an rlm child executing on this shared kernel) to
+	 * receive host requests raised by executions tagged with its session id, so
+	 * identity-bearing requests (agent_message.send) act as that session rather
+	 * than this kernel's owner. The provider is resolved per host request and
+	 * should return undefined once its session is gone; dispatch then falls
+	 * back to the owner's handlers.
+	 */
+	registerSessionHostHandlers(sessionId: string, provider: SessionHostHandlersProvider): void {
+		this.sessionHostHandlers.set(sessionId, provider);
+	}
+
+	unregisterSessionHostHandlers(sessionId: string): void {
+		this.sessionHostHandlers.delete(sessionId);
 	}
 
 	/** Start the kernel in the background. Failures are swallowed here and surface on the next ensure(). */
@@ -466,6 +486,7 @@ export class IpythonKernelProvisioner {
 				},
 				sessionId: this.options?.sessionId,
 				hostHandlers: this.options?.hostHandlers,
+				sessionHostHandlers: this.sessionHostHandlers,
 				pythonSkills: this.options?.pythonSkills,
 				// Only persistent sessions (which have an artifact dir) get a revivable snapshot.
 				snapshot: snapshotDir

--- a/packages/coding-agent/test/kernel-session-scoped-host-handlers.test.ts
+++ b/packages/coding-agent/test/kernel-session-scoped-host-handlers.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { IpythonKernelProvisioner } from "../src/core/tools/ipython.js";
+
+/**
+ * Session-scoped host handler dispatch on a shared kernel.
+ *
+ * On the kernel-fulfill path an rlm child executes cells on its PARENT's
+ * kernel. Host requests raised by such a cell must dispatch to the CHILD's
+ * handlers (its own agent_message identity, its own rlm.run), not the kernel
+ * owner's. Executions tagged with ExecuteOptions.ownerSessionId look up the
+ * owning session in the provisioner's registry; everything else — untagged
+ * cells, the owner's own id, unknown ids, dead registrations, and request
+ * types the delegated set lacks — falls back to the owner's handlers.
+ */
+describe("session-scoped host handler dispatch", () => {
+	let tempDir: string;
+	let provisioner: IpythonKernelProvisioner | undefined;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-session-host-dispatch-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await provisioner?.dispose();
+		provisioner = undefined;
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("dispatches tagged executions to the registered session's handlers", async () => {
+		provisioner = new IpythonKernelProvisioner(tempDir, {
+			sessionId: "owner-session",
+			hostHandlers: {
+				"probe.whoami": async () => ({ who: "owner" }),
+				"probe.owner_only": async () => ({ who: "owner-only" }),
+			},
+		});
+		provisioner.registerSessionHostHandlers("child-session", () => ({
+			"probe.whoami": async () => ({ who: "child" }),
+		}));
+		provisioner.registerSessionHostHandlers("dead-session", () => undefined);
+
+		const manager = await provisioner.ensure();
+		const probe = async (type: string, ownerSessionId?: string) => {
+			const result = await manager.execute(
+				`from rlm import host_request\nprint((await host_request("${type}"))["who"])`,
+				ownerSessionId ? { ownerSessionId } : {},
+			);
+			expect(result.status).toBe("ok");
+			return result.stdout.trim();
+		};
+
+		// Untagged and owner-tagged cells use the owner's handlers.
+		expect(await probe("probe.whoami")).toBe("owner");
+		expect(await probe("probe.whoami", "owner-session")).toBe("owner");
+		// A cell tagged with a registered session dispatches to that session.
+		expect(await probe("probe.whoami", "child-session")).toBe("child");
+		// Unknown / dead sessions fall back to the owner.
+		expect(await probe("probe.whoami", "unknown-session")).toBe("owner");
+		expect(await probe("probe.whoami", "dead-session")).toBe("owner");
+		// A type the delegated set lacks falls back to the owner's handler.
+		expect(await probe("probe.owner_only", "child-session")).toBe("owner-only");
+
+		// Unregistration restores owner dispatch.
+		provisioner.unregisterSessionHostHandlers("child-session");
+		expect(await probe("probe.whoami", "child-session")).toBe("owner");
+	});
+});


### PR DESCRIPTION
## Problem

Kernel host requests always dispatch to the handlers of the session that provisioned the kernel — they are frozen into `KernelManagerOptions.hostHandlers` at construction, and `handleHostRequest` has no notion of which session issued the running cell.

That is correct while exactly one session executes on a kernel. But when an embedder routes another session's cells onto a shared kernel (e.g. an extension executing an rlm child's `ipython` traffic on the parent's kernel), every identity-bearing host request from those cells — `agent_message.send`, `rlm.run`, `rlm.list_subagents` — runs through the kernel owner's handlers and acts as the owner. A child calling `agent_message.send(receiver_role="parent")` either fails (the owner has no parent) or sends under the wrong identity.

## Design

- `ExecuteOptions.ownerSessionId` tags an execution with the session that issued it. `ReplKernelManager` keeps a `lastCellOwnerSessionId` alongside the existing `lastCellCode`, so detached tasks (`asyncio.create_task`) that fire after their scheduling cell went idle attribute to the last cell's owner — same semantics as the `cellSourceCode` fallback.
- `IpythonKernelProvisioner` owns a session-handlers registry (`registerSessionHostHandlers` / `unregisterSessionHostHandlers`), shared by reference with every kernel it starts, so registrations made after kernel start (and across restarts) are visible.
- `handleHostRequest` resolves the tagged session's handlers first and falls back to the owner's handlers for: untagged cells, the owner's own id, unknown or dead sessions, and request types the delegated set lacks. Every fallback path is byte-for-byte today's behavior, so untagged callers are unaffected.
- `AgentSession` registers each rlm child on the root kernel's registry at spawn (`_registerRlmChildKernelHostHandlers`), propagating the root provisioner down the spawn chain (`_rlmKernelHostRegistrar`) so a depth-2 grandchild registers on the kernel its cells actually execute on, not on the middle child's. Providers are liveness-checked through a `WeakRef` — a disposed child silently reverts to owner dispatch, so no explicit unregistration is needed across the many child-teardown paths, while children retained for follow-up messaging stay resolvable.

On the default path (each rlm child provisions its own kernel) the registration is dormant: those kernels dispatch through their own handlers as before. It becomes load-bearing exactly when kernels are shared across sessions.

## Testing

- New regression test `kernel-session-scoped-host-handlers.test.ts` boots a real kernel and covers all dispatch cases: untagged, owner-tagged, registered-session-tagged, unknown session, dead registration, missing request type in the delegated set, and unregistration.
- `kernel-agent-message-skill.test.ts` and `regressions/617-subagent-terminal-agent-message.test.ts` pass unchanged.
- Verified end to end downstream: a subagent whose cells execute on its parent's kernel sends `agent_message.send(receiver_role="parent")` and the receipt carries the child's `from.sessionId` and the parent's `target.sessionId`; a depth-2 grandchild's send resolves to its actual parent (the middle child) rather than the kernel-owning top session.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add session-scoped host handler dispatch for shared kernels in `coding-agent`
> - RLM child sessions on a shared kernel now get their host requests routed to their own handlers via provisioner-level registration, with automatic fallback to the owner's handlers when the child is gone
> - `ReplKernelManager.handleHostRequest` attributes each request to the session whose cell raised it using `ExecuteOptions.ownerSessionId` or `lastCellOwnerSessionId`, then looks up a delegated handler in `sessionHostHandlers` before falling back to the owner
> - `IpythonKernelProvisioner` gains a shared `sessionHostHandlers` map and `registerSessionHostHandlers`/`unregisterSessionHostHandlers` methods; the map is passed to every kernel the provisioner starts
> - `AgentSession._registerRlmChildKernelHostHandlers` registers newly spawned RLM child sessions using a `WeakRef`-based provider that returns `undefined` when the child is disposed
> - Risk: dispatch attribution relies on `ReplKernelManager.lastCellOwnerSessionId` and `opts.ownerSessionId` being set correctly for every non-internal execution; misattribution would route host requests to the wrong session's handlers
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e268b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->