### PR TITLE
fix(coding-agent): make subagent deletion user-requested in the system prompt

### DIFF
--- a/packages/coding-agent/.changes/prompt-subagent-deletion-user-only.md
+++ b/packages/coding-agent/.changes/prompt-subagent-deletion-user-only.md
@@ -1,0 +1,1 @@
+- The system prompt no longer tells the model to delete finished subagents by default; deletion is now described as user-requested only, so idle children stay available for follow-ups.

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -169,7 +169,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			parts.push("Inspect files a child wrote when you need to collect its work without an observation capability.");
 		}
 		parts.push(
-			"Spawn independent children in separate calls and end your turn instead of awaiting completion. Multiple replies may arrive over multiple turns. Delete a direct child explicitly with `await rlm.delete_subagent(child)` when it is no longer needed.",
+			"Spawn independent children in separate calls and end your turn instead of awaiting completion. Multiple replies may arrive over multiple turns. You can delete a direct child explicitly with `await rlm.delete_subagent(child)`. Only do this if and when a user asks for it.",
 		);
 	}
 


### PR DESCRIPTION
The delegation section of the system prompt instructs the model to "Delete a direct child explicitly with `await rlm.delete_subagent(child)` when it is no longer needed." Models follow it: finished subagents get deleted routinely, destroying their sessions and any warm context that would make them cheap to reuse for follow-up work. Idle children cost little to keep.

The sentence now reads: "You can delete a direct child explicitly with `await rlm.delete_subagent(child)`. Only do this if and when a user asks for it." The capability stays documented; the default behavior flips from delete-when-done to keep-unless-asked.

Prompt-content tests still pass unchanged (they pin the call form, not the old sentence).

Linear: [ENG-5836](https://linear.app/primeintellect/issue/ENG-5836/system-prompt-tells-models-to-delete-subagents-when-done)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict subagent deletion to user-requested only in `buildRlmPrompt`
> Updates the delegation guidance in the RLM system prompt so that explicit deletion of a direct child subagent occurs only when the user asks for it. Previously the prompt directed deletion when the child was no longer needed. Idle children now remain available for follow-ups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5523618.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->