### PR TITLE
fix(coding-agent): don't block RLM subagent deletion on trace upload or a doomed kernel snapshot

### DIFF
--- a/packages/coding-agent/.changes/eng-5837-detach-trace-flush-on-delete.md
+++ b/packages/coding-agent/.changes/eng-5837-detach-trace-flush-on-delete.md
@@ -1,0 +1,1 @@
+- Deleting or killing a resident RLM subagent no longer blocks on the final trace upload (it now finishes detached) and no longer writes a kernel snapshot that the deletion sweep removes right away; daemon shutdown and update restarts still await the upload.

--- a/packages/coding-agent/.changes/eng-5837-detach-trace-flush-on-delete.md
+++ b/packages/coding-agent/.changes/eng-5837-detach-trace-flush-on-delete.md
@@ -1,1 +1,1 @@
-- Deleting or killing a resident RLM subagent no longer blocks on the final trace upload (it now finishes detached) and no longer writes a kernel snapshot that the deletion sweep removes right away; daemon shutdown and update restarts still await the upload.
+- Session disposal no longer blocks on the final trace upload (uploads finish detached; daemon exit, update restarts, and worker archive-and-shutdown drain them through a single barrier), and deleting an RLM subagent no longer writes a kernel snapshot that the deletion sweep removes right away.

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -62,13 +62,7 @@ function extractUserMessageText(content: string | Array<{ type: string; text?: s
 }
 
 export interface AgentSessionRuntimeDisposeOptions {
-	/**
-	 * "detach" fires the final trace upload without awaiting it. Only safe when
-	 * the process and the session file outlive the disposal so the upload can
-	 * still finish; exit paths must keep the default "await".
-	 */
-	traceFlush?: "await" | "detach";
-	/** Set false when the session's artifact dir is deleted right after disposal. Defaults to true. */
+	/** Set false when the session's artifact dir is deleted right after disposal (default true). */
 	kernelSnapshot?: boolean;
 }
 
@@ -210,8 +204,6 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			reason,
 			targetSessionFile,
 		});
-		// Replacement keeps this process and the outgoing session file alive, so
-		// the final trace upload can finish detached instead of stalling the swap.
 		this.detachTraceFlush();
 		this.beforeSessionInvalidate?.();
 		// Await the kernel's final snapshot flush before invalidating the session.
@@ -711,15 +703,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		} catch (error) {
 			disposeError ??= error;
 		}
-		if (options.traceFlush === "detach") {
-			this.detachTraceFlush();
-		} else {
-			try {
-				await flushAgentTraceUpload(this.session.sessionManager);
-			} catch (error) {
-				disposeError ??= error;
-			}
-		}
+		this.detachTraceFlush();
 		try {
 			this.beforeSessionInvalidate?.();
 		} catch (error) {
@@ -747,7 +731,6 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 
 	async dispose(options?: AgentSessionRuntimeDisposeOptions): Promise<void> {
 		if (!this.disposePromise) {
-			// Concurrent disposers join the first caller's teardown (and its options).
 			this.disposePromise = this.disposeOnce(options ?? {});
 		}
 		await this.disposePromise;

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -7,7 +7,7 @@ import type {
 	AgentSessionRuntimeDiagnostic,
 	AgentSessionServices,
 } from "./agent-session-services.js";
-import { flushAgentTraceUpload } from "./agent-traces.js";
+import { flushAgentTraceUpload, logDetachedAgentTraceFlushFailure } from "./agent-traces.js";
 import { isNoModelsAvailableMessage } from "./auth-guidance.js";
 import type { ReplacedSessionContext, SessionShutdownEvent, SessionStartEvent } from "./extensions/index.js";
 import { emitSessionShutdownEvent } from "./extensions/runner.js";
@@ -59,6 +59,17 @@ function extractUserMessageText(content: string | Array<{ type: string; text?: s
 		.filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
 		.map((part) => part.text)
 		.join("");
+}
+
+export interface AgentSessionRuntimeDisposeOptions {
+	/**
+	 * "detach" fires the final trace upload without awaiting it. Only safe when
+	 * the process and the session file outlive the disposal so the upload can
+	 * still finish; exit paths must keep the default "await".
+	 */
+	traceFlush?: "await" | "detach";
+	/** Set false when the session's artifact dir is deleted right after disposal. Defaults to true. */
+	kernelSnapshot?: boolean;
 }
 
 export class AgentSessionRuntime implements SubagentRuntimeHost {
@@ -199,7 +210,9 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 			reason,
 			targetSessionFile,
 		});
-		await flushAgentTraceUpload(this.session.sessionManager).catch(() => undefined);
+		// Replacement keeps this process and the outgoing session file alive, so
+		// the final trace upload can finish detached instead of stalling the swap.
+		this.detachTraceFlush();
 		this.beforeSessionInvalidate?.();
 		// Await the kernel's final snapshot flush before invalidating the session.
 		await this.session.disposeAsync();
@@ -681,7 +694,14 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		return { cancelled: false };
 	}
 
-	private async disposeOnce(): Promise<void> {
+	private detachTraceFlush(): void {
+		const sessionManager = this.session.sessionManager;
+		void flushAgentTraceUpload(sessionManager).catch((error) =>
+			logDetachedAgentTraceFlushFailure(sessionManager.getSessionFile(), error),
+		);
+	}
+
+	private async disposeOnce(options: AgentSessionRuntimeDisposeOptions): Promise<void> {
 		let disposeError: unknown;
 		try {
 			await emitSessionShutdownEvent(this.session.extensionRunner, {
@@ -691,10 +711,14 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		} catch (error) {
 			disposeError ??= error;
 		}
-		try {
-			await flushAgentTraceUpload(this.session.sessionManager);
-		} catch (error) {
-			disposeError ??= error;
+		if (options.traceFlush === "detach") {
+			this.detachTraceFlush();
+		} else {
+			try {
+				await flushAgentTraceUpload(this.session.sessionManager);
+			} catch (error) {
+				disposeError ??= error;
+			}
 		}
 		try {
 			this.beforeSessionInvalidate?.();
@@ -703,7 +727,7 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		}
 		try {
 			// Await the kernel's final snapshot flush before tearing the session down.
-			await this.session.disposeAsync();
+			await this.session.disposeAsync({ kernelSnapshot: options.kernelSnapshot ?? true });
 		} catch (error) {
 			disposeError ??= error;
 		}
@@ -721,9 +745,10 @@ export class AgentSessionRuntime implements SubagentRuntimeHost {
 		}
 	}
 
-	async dispose(): Promise<void> {
+	async dispose(options?: AgentSessionRuntimeDisposeOptions): Promise<void> {
 		if (!this.disposePromise) {
-			this.disposePromise = this.disposeOnce();
+			// Concurrent disposers join the first caller's teardown (and its options).
+			this.disposePromise = this.disposeOnce(options ?? {});
 		}
 		await this.disposePromise;
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3880,9 +3880,8 @@ export class AgentSession {
 		if (this._disposed) {
 			return this._disposeCallbacksPromise;
 		}
-		// Concurrent callers await the same in-flight teardown (started with the
-		// first caller's options) so none resolves before the kernel snapshot
-		// flush finishes.
+		// Concurrent callers await the same in-flight teardown so none resolves before
+		// the kernel snapshot flush finishes.
 		if (this._disposeAsyncPromise) {
 			return this._disposeAsyncPromise;
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3876,15 +3876,17 @@ export class AgentSession {
 	 * (which flushes a final namespace snapshot) before the synchronous dispose, so
 	 * the latest state reaches disk instead of racing process exit.
 	 */
-	async disposeAsync(): Promise<void> {
+	async disposeAsync(options?: { kernelSnapshot?: boolean }): Promise<void> {
 		if (this._disposed) {
 			return this._disposeCallbacksPromise;
 		}
-		// Concurrent callers await the same in-flight teardown so none resolves before
-		// the kernel snapshot flush finishes.
+		// Concurrent callers await the same in-flight teardown (started with the
+		// first caller's options) so none resolves before the kernel snapshot
+		// flush finishes.
 		if (this._disposeAsyncPromise) {
 			return this._disposeAsyncPromise;
 		}
+		const kernelSnapshot = options?.kernelSnapshot ?? true;
 		this._disposeAsyncPromise = (async () => {
 			// Drain before marking _disposing so a refine triggered at the final
 			// agent_end completes instead of being aborted by dispose().
@@ -3894,7 +3896,7 @@ export class AgentSession {
 			}
 			this._disposing = true;
 			this._sessionActionCommitDisposeAbortController.abort();
-			await this._disposeAsyncOnce();
+			await this._disposeAsyncOnce(kernelSnapshot);
 		})();
 		return this._disposeAsyncPromise;
 	}
@@ -4031,7 +4033,7 @@ export class AgentSession {
 		}
 	}
 
-	private async _disposeAsyncOnce(): Promise<void> {
+	private async _disposeAsyncOnce(kernelSnapshot: boolean): Promise<void> {
 		// Flush kernels/traces for both still-running and retained children; the sync
 		// dispose() below only tears them down synchronously.
 		for (const run of [...this._activeRlmChildRuns.values()]) {
@@ -4063,7 +4065,7 @@ export class AgentSession {
 		this._rlmChildCleanupFailures.clear();
 		this._deletedRlmChildIds.clear();
 		try {
-			await this._ipythonKernelProvisioner?.dispose();
+			await this._ipythonKernelProvisioner?.dispose({ snapshot: kernelSnapshot });
 		} catch {
 			// a failed kernel startup already cleaned up after itself
 		}

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -966,3 +966,12 @@ export async function flushAgentTraceUpload(
 ): Promise<AgentTraceUploadResult | undefined> {
 	return traceUploadControllers.get(sessionManager)?.flush();
 }
+
+/** Log a detached (fire-and-forget) flush rejection; upload outcomes themselves are already logged per attempt. */
+export function logDetachedAgentTraceFlushFailure(sessionFile: string | undefined, error: unknown): void {
+	const suffix = sessionFile ? ` [${sessionFile}]` : "";
+	appendRotatingLog(
+		getAgentTracesLogPath(),
+		`[${new Date().toISOString()}] detached flush failed: ${describeError(error)}${suffix}`,
+	);
+}

--- a/packages/coding-agent/src/core/agent-traces.ts
+++ b/packages/coding-agent/src/core/agent-traces.ts
@@ -866,6 +866,7 @@ class AgentTraceUploadController {
 
 	schedule = (): void => {
 		this.pending = true;
+		pendingUploadControllers.add(this);
 		if (this.timeout) {
 			clearTimeout(this.timeout);
 		}
@@ -908,6 +909,9 @@ class AgentTraceUploadController {
 			return await this.flushPromise;
 		} finally {
 			this.flushPromise = undefined;
+			if (!this.pending) {
+				pendingUploadControllers.delete(this);
+			}
 		}
 	}
 
@@ -948,6 +952,8 @@ class AgentTraceUploadController {
 }
 
 const traceUploadControllers = new WeakMap<SessionManager, AgentTraceUploadController>();
+// Disposal never awaits uploads; exit paths drain this set instead.
+const pendingUploadControllers = new Set<AgentTraceUploadController>();
 
 export function installAgentTraceUpload(sessionManager: SessionManager, options: AgentTraceUploadInstallOptions): void {
 	let controller = traceUploadControllers.get(sessionManager);
@@ -965,6 +971,11 @@ export async function flushAgentTraceUpload(
 	sessionManager: SessionManager,
 ): Promise<AgentTraceUploadResult | undefined> {
 	return traceUploadControllers.get(sessionManager)?.flush();
+}
+
+/** Exit barrier: drains every scheduled or in-flight trace upload. */
+export async function flushAllPendingAgentTraceUploads(): Promise<void> {
+	await Promise.allSettled([...pendingUploadControllers].map((controller) => controller.flush()));
 }
 
 /** Log a detached (fire-and-forget) flush rejection; upload outcomes themselves are already logged per attempt. */

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -311,6 +311,8 @@ export class IpythonKernelProvisioner {
 	private lastStartupMessage?: string;
 	private _lastRestore?: RestoreResult;
 	private readonly disposeController = new AbortController();
+	/** Snapshot policy of the dispose that aborted a startup, honored by startKernel's failure teardown. */
+	private disposeSnapshot = true;
 
 	constructor(
 		private readonly cwd: string,
@@ -350,12 +352,9 @@ export class IpythonKernelProvisioner {
 		return (await m?.listNamespaceNames(signal)) ?? null;
 	}
 
-	/**
-	 * Dispose the kernel owned by this provisioner, including one still starting up.
-	 * Pass snapshot:false when the artifact dir is deleted right after (kill/delete),
-	 * so no doomed final snapshot is written.
-	 */
+	/** Dispose the kernel owned by this provisioner, including one still starting up. */
 	async dispose(options?: { snapshot?: boolean }): Promise<void> {
+		this.disposeSnapshot = options?.snapshot ?? true;
 		// Drops a still-queued boot out of the semaphore and short-circuits an
 		// in-flight startKernel before it spawns, so a disposed session's boot
 		// doesn't waste a slot during a fan-out.
@@ -366,7 +365,7 @@ export class IpythonKernelProvisioner {
 		if (!pending) return;
 		try {
 			const m = await pending;
-			await m.shutdown({ snapshot: options?.snapshot ?? true, drainHostRequests: true });
+			await m.shutdown({ snapshot: this.disposeSnapshot, drainHostRequests: true });
 		} catch {
 			// a failed startup already cleaned up after itself
 		}
@@ -518,7 +517,7 @@ export class IpythonKernelProvisioner {
 				// surface the failure before the teardown (final snapshot flush included)
 				// finished, or a replacement provisioner gated on this dispose could
 				// race the still-flushing kernel over the same snapshot files.
-				await m.shutdown({ snapshot: true, drainHostRequests: true }).catch(() => undefined);
+				await m.shutdown({ snapshot: this.disposeSnapshot, drainHostRequests: true }).catch(() => undefined);
 				throw error;
 			}
 			// Only tell the model what was revived once the kernel is actually usable —

--- a/packages/coding-agent/src/core/tools/ipython.ts
+++ b/packages/coding-agent/src/core/tools/ipython.ts
@@ -350,8 +350,12 @@ export class IpythonKernelProvisioner {
 		return (await m?.listNamespaceNames(signal)) ?? null;
 	}
 
-	/** Dispose the kernel owned by this provisioner, including one still starting up. */
-	async dispose(): Promise<void> {
+	/**
+	 * Dispose the kernel owned by this provisioner, including one still starting up.
+	 * Pass snapshot:false when the artifact dir is deleted right after (kill/delete),
+	 * so no doomed final snapshot is written.
+	 */
+	async dispose(options?: { snapshot?: boolean }): Promise<void> {
 		// Drops a still-queued boot out of the semaphore and short-circuits an
 		// in-flight startKernel before it spawns, so a disposed session's boot
 		// doesn't waste a slot during a fan-out.
@@ -362,7 +366,7 @@ export class IpythonKernelProvisioner {
 		if (!pending) return;
 		try {
 			const m = await pending;
-			await m.shutdown({ snapshot: true, drainHostRequests: true });
+			await m.shutdown({ snapshot: options?.snapshot ?? true, drainHostRequests: true });
 		} catch {
 			// a failed startup already cleaned up after itself
 		}

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -3,6 +3,7 @@ import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core"
 import type { ImageContent, ServiceTier, Transport } from "@earendil-works/pi-ai";
 import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
+import { flushAllPendingAgentTraceUploads } from "../../core/agent-traces.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
@@ -634,6 +635,7 @@ export class InProcessAgentConnection implements AgentConnection {
 		}
 		this.runtimeHost.setRebindSession(undefined);
 		await this.runtimeHost.dispose();
+		await flushAllPendingAgentTraceUploads();
 	}
 
 	private get session() {

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -634,8 +634,11 @@ export class InProcessAgentConnection implements AgentConnection {
 			this.runtimeHost.setBeforeSessionInvalidate(undefined);
 		}
 		this.runtimeHost.setRebindSession(undefined);
-		await this.runtimeHost.dispose();
-		await flushAllPendingAgentTraceUploads();
+		try {
+			await this.runtimeHost.dispose();
+		} finally {
+			await flushAllPendingAgentTraceUploads();
+		}
 	}
 
 	private get session() {

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -68,6 +68,7 @@ import { type PromptOptions, rlmChildLabel } from "../../core/agent-session.js";
 import { type AgentSessionRuntimeConfig, mergeAgentSessionRuntimeConfig } from "../../core/agent-session-config.js";
 import {
 	type AgentSessionRuntime,
+	type AgentSessionRuntimeDisposeOptions,
 	type AgentSessionRuntimeMetadata,
 	type CreateAgentSessionRuntimeFactory,
 	createAgentSessionRuntime,
@@ -2371,11 +2372,21 @@ export class AgentDaemon {
 						candidate.runtime.metadata.rlmChildId === options.id &&
 						candidate.runtime.session === runtime.session,
 				);
+				// A cancelled release is a deletion: the artifact sweep below removes
+				// the kernel snapshot right away, so skip writing it.
+				const disposal = status === "cancelled" ? { kernelSnapshot: false } : undefined;
 				try {
 					if (state) {
-						await this.closeSession(state, status === "cancelled" ? "killed" : "completed");
+						await this.closeSession(
+							state,
+							status === "cancelled" ? "killed" : "completed",
+							true,
+							true,
+							undefined,
+							disposal,
+						);
 					} else {
-						await runtime.session.disposeAsync();
+						await runtime.session.disposeAsync(disposal);
 					}
 				} finally {
 					// Sweep even when teardown throws (see deleteRlmSubagentRuntime);
@@ -2432,12 +2443,14 @@ export class AgentDaemon {
 				try {
 					try {
 						if (state) {
-							await this.closeSession(state, "killed", false);
+							// The artifact sweep below deletes the kernel snapshot
+							// milliseconds after it would be written: skip it.
+							await this.closeSession(state, "killed", false, true, undefined, { kernelSnapshot: false });
 						} else {
-							await session?.disposeAsync();
+							await session?.disposeAsync({ kernelSnapshot: false });
 						}
 					} finally {
-						await staleSession?.disposeAsync();
+						await staleSession?.disposeAsync({ kernelSnapshot: false });
 					}
 				} finally {
 					// Runs even when teardown throws: the jobs-cancel rewrite and the
@@ -3659,8 +3672,9 @@ export class AgentDaemon {
 				}
 				case "worker_archive_and_shutdown": {
 					// Close sessions first so direct peers read session_closed "killed", not a daemon shutdown.
+					// The daemon exits right after, so the trace flush must complete now.
 					for (const state of [...this.sessions.values()]) {
-						await this.closeSession(state, "killed");
+						await this.closeSession(state, "killed", true, true, undefined, { traceFlush: "await" });
 					}
 					this.fencePeerTransports();
 					this.writeWorkerSuccess(client, command);
@@ -6239,12 +6253,23 @@ export class AgentDaemon {
 		const closeStates = [...this.sessions.values()].sort(
 			(left, right) => this.getUpdateRestartSessionDepth(right) - this.getUpdateRestartSessionDepth(left),
 		);
+		// The daemon restarts right after: even the discarded ("killed") sessions
+		// must finish their trace flush before this process goes away.
 		for (const state of closeStates) {
 			if (this.sessions.has(state.activeSessionId)) {
-				await this.closeSession(state, restartByActiveSessionId.has(state.activeSessionId) ? "update" : "killed");
+				await this.closeSession(
+					state,
+					restartByActiveSessionId.has(state.activeSessionId) ? "update" : "killed",
+					true,
+					true,
+					undefined,
+					{ traceFlush: "await" },
+				);
 			}
 		}
-		for (const state of [...this.sessions.values()]) await this.closeSession(state, "killed");
+		for (const state of [...this.sessions.values()]) {
+			await this.closeSession(state, "killed", true, true, undefined, { traceFlush: "await" });
+		}
 		return manifest;
 	}
 
@@ -6337,6 +6362,7 @@ export class AgentDaemon {
 		waitForAbort = true,
 		cascadeChildren = true,
 		descendantCollector?: Set<ActiveSessionState>,
+		disposal?: AgentSessionRuntimeDisposeOptions,
 	): Promise<void> {
 		this.abortWaitingPromptAdmissionsForSession(state.activeSessionId);
 		for (const client of state.clients) {
@@ -6375,7 +6401,7 @@ export class AgentDaemon {
 		}
 		const descendants = new Set<ActiveSessionState>();
 		const closePromise = Promise.resolve().then(() =>
-			this.closeSessionOnce(state, reason, waitForAbort, cascadeChildren, descendants),
+			this.closeSessionOnce(state, reason, waitForAbort, cascadeChildren, descendants, disposal),
 		);
 		const close = { promise: closePromise, reason, descendants };
 		this.closingSessions.set(state.activeSessionId, close);
@@ -6448,6 +6474,7 @@ export class AgentDaemon {
 		waitForAbort: boolean,
 		cascadeChildren: boolean,
 		descendants: Set<ActiveSessionState>,
+		disposal?: AgentSessionRuntimeDisposeOptions,
 	): Promise<void> {
 		if (!this.sessions.has(state.activeSessionId)) {
 			return;
@@ -6461,7 +6488,7 @@ export class AgentDaemon {
 		// agent_status to a session being torn down.
 		this.summarizer.forget(state.activeSessionId);
 		const cascadeError = cascadeChildren
-			? await this.closeChildSessions(state, reason, waitForAbort, descendants)
+			? await this.closeChildSessions(state, reason, waitForAbort, descendants, disposal)
 			: undefined;
 		// Empty draft (no messages, config, or jobs): discard rather than persist an
 		// empty session file. Mirrors the detach-time discard so a config-bearing
@@ -6496,7 +6523,14 @@ export class AgentDaemon {
 		state.unsubscribe?.();
 		let disposeError: unknown;
 		try {
-			await state.runtime.dispose();
+			// "shutdown"/"update" closes precede a process exit that a detached
+			// upload would not survive; every other close leaves the daemon and
+			// the session file alive, so the final trace flush finishes on its
+			// own (exit-adjacent callers with other reasons override explicitly).
+			await state.runtime.dispose({
+				traceFlush: disposal?.traceFlush ?? (reason === "shutdown" || reason === "update" ? "await" : "detach"),
+				kernelSnapshot: disposal?.kernelSnapshot,
+			});
 		} catch (error) {
 			disposeError = error;
 		}
@@ -6538,12 +6572,13 @@ export class AgentDaemon {
 		reason: DaemonSessionClosedReason,
 		waitForAbort = true,
 		descendants = new Set<ActiveSessionState>(),
+		disposal?: AgentSessionRuntimeDisposeOptions,
 	): Promise<unknown> {
 		let cascadeError: unknown;
 		for (const childState of getChildActiveSessionStates(this.sessions, parentState)) {
 			descendants.add(childState);
 			try {
-				await this.closeSession(childState, reason, waitForAbort, true, descendants);
+				await this.closeSession(childState, reason, waitForAbort, true, descendants, disposal);
 			} catch (error) {
 				cascadeError ??= error;
 			}

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -73,6 +73,7 @@ import {
 	type CreateAgentSessionRuntimeFactory,
 	createAgentSessionRuntime,
 } from "../../core/agent-session-runtime.js";
+import { flushAllPendingAgentTraceUploads } from "../../core/agent-traces.js";
 import {
 	type AgentCronJob,
 	AgentCronJobStore,
@@ -2372,8 +2373,6 @@ export class AgentDaemon {
 						candidate.runtime.metadata.rlmChildId === options.id &&
 						candidate.runtime.session === runtime.session,
 				);
-				// A cancelled release is a deletion: the artifact sweep below removes
-				// the kernel snapshot right away, so skip writing it.
 				const disposal = status === "cancelled" ? { kernelSnapshot: false } : undefined;
 				try {
 					if (state) {
@@ -2443,8 +2442,6 @@ export class AgentDaemon {
 				try {
 					try {
 						if (state) {
-							// The artifact sweep below deletes the kernel snapshot
-							// milliseconds after it would be written: skip it.
 							await this.closeSession(state, "killed", false, true, undefined, { kernelSnapshot: false });
 						} else {
 							await session?.disposeAsync({ kernelSnapshot: false });
@@ -3672,10 +3669,10 @@ export class AgentDaemon {
 				}
 				case "worker_archive_and_shutdown": {
 					// Close sessions first so direct peers read session_closed "killed", not a daemon shutdown.
-					// The daemon exits right after, so the trace flush must complete now.
 					for (const state of [...this.sessions.values()]) {
-						await this.closeSession(state, "killed", true, true, undefined, { traceFlush: "await" });
+						await this.closeSession(state, "killed");
 					}
+					await flushAllPendingAgentTraceUploads();
 					this.fencePeerTransports();
 					this.writeWorkerSuccess(client, command);
 					setImmediate(() => void this.shutdown(0));
@@ -6253,23 +6250,13 @@ export class AgentDaemon {
 		const closeStates = [...this.sessions.values()].sort(
 			(left, right) => this.getUpdateRestartSessionDepth(right) - this.getUpdateRestartSessionDepth(left),
 		);
-		// The daemon restarts right after: even the discarded ("killed") sessions
-		// must finish their trace flush before this process goes away.
 		for (const state of closeStates) {
 			if (this.sessions.has(state.activeSessionId)) {
-				await this.closeSession(
-					state,
-					restartByActiveSessionId.has(state.activeSessionId) ? "update" : "killed",
-					true,
-					true,
-					undefined,
-					{ traceFlush: "await" },
-				);
+				await this.closeSession(state, restartByActiveSessionId.has(state.activeSessionId) ? "update" : "killed");
 			}
 		}
-		for (const state of [...this.sessions.values()]) {
-			await this.closeSession(state, "killed", true, true, undefined, { traceFlush: "await" });
-		}
+		for (const state of [...this.sessions.values()]) await this.closeSession(state, "killed");
+		await flushAllPendingAgentTraceUploads();
 		return manifest;
 	}
 
@@ -6523,14 +6510,7 @@ export class AgentDaemon {
 		state.unsubscribe?.();
 		let disposeError: unknown;
 		try {
-			// "shutdown"/"update" closes precede a process exit that a detached
-			// upload would not survive; every other close leaves the daemon and
-			// the session file alive, so the final trace flush finishes on its
-			// own (exit-adjacent callers with other reasons override explicitly).
-			await state.runtime.dispose({
-				traceFlush: disposal?.traceFlush ?? (reason === "shutdown" || reason === "update" ? "await" : "detach"),
-				kernelSnapshot: disposal?.kernelSnapshot,
-			});
+			await state.runtime.dispose(disposal);
 		} catch (error) {
 			disposeError = error;
 		}
@@ -7327,6 +7307,7 @@ export class AgentDaemon {
 		for (const state of [...this.sessions.values()]) {
 			await this.closeSession(state, closingReason);
 		}
+		await flushAllPendingAgentTraceUploads();
 		for (const client of this.clients) {
 			client.detachInput();
 			client.socket.end();

--- a/packages/coding-agent/src/modes/daemon/daemon-mode.ts
+++ b/packages/coding-agent/src/modes/daemon/daemon-mode.ts
@@ -7304,10 +7304,13 @@ export class AgentDaemon {
 			cleanup();
 		}
 		this.cronScheduler.stop();
-		for (const state of [...this.sessions.values()]) {
-			await this.closeSession(state, closingReason);
+		try {
+			for (const state of [...this.sessions.values()]) {
+				await this.closeSession(state, closingReason);
+			}
+		} finally {
+			await flushAllPendingAgentTraceUploads();
 		}
-		await flushAllPendingAgentTraceUploads();
 		for (const client of this.clients) {
 			client.detachInput();
 			client.socket.end();

--- a/packages/coding-agent/test/agent-connection-in-process.test.ts
+++ b/packages/coding-agent/test/agent-connection-in-process.test.ts
@@ -1,9 +1,17 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { getModel } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentSessionEvent, AgentSessionEventListener, PromptOptions } from "../src/core/agent-session.js";
 import type { AgentSessionRuntime } from "../src/core/agent-session-runtime.js";
+import { installAgentTraceUpload } from "../src/core/agent-traces.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
 import { emptyGoalState } from "../src/core/goals.js";
+import { PRIME_AGENT_TRACES_PROVIDER_ID } from "../src/core/prime-inference-auth.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
 import { InProcessAgentConnection } from "../src/modes/agent-connection/in-process-agent-connection.js";
 import type { AgentConnectionEvent, AgentConnectionState } from "../src/modes/agent-connection/types.js";
 
@@ -143,6 +151,56 @@ function createFakeSession(id: string, messages: AgentMessage[]): FakeSessionCon
 }
 
 describe("InProcessAgentConnection", () => {
+	it("drains pending trace uploads even when runtime disposal throws", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-in-process-dispose-"));
+		try {
+			const sessionManager = SessionManager.create(tempDir, join(tempDir, "sessions"));
+			sessionManager.newSession();
+			const calls: string[] = [];
+			let releaseFetch: () => void = () => {};
+			const gate = new Promise<void>((resolve) => {
+				releaseFetch = resolve;
+			});
+			installAgentTraceUpload(sessionManager, {
+				authStorage: AuthStorage.inMemory({
+					[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
+				}),
+				settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+				baseUrl: "https://api.example.test",
+				fetchFn: (async (input: unknown) => {
+					calls.push(String(input));
+					await gate;
+					return new Response(JSON.stringify({ bytes_stored: 1 }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					});
+				}) as typeof fetch,
+			});
+			sessionManager.appendMessage({ role: "user", content: "pending trace data", timestamp: 1 });
+			sessionManager.flushNow();
+
+			const control = createFakeSession("dispose-throws", []);
+			const runtime = new FakeRuntime(control.session);
+			runtime.dispose = async () => {
+				throw new Error("teardown failed");
+			};
+			const connection = new InProcessAgentConnection(asRuntime(runtime));
+
+			let settledError: Error | undefined;
+			const disposal = connection.dispose().catch((error: Error) => {
+				settledError = error;
+				return error;
+			});
+			await vi.waitFor(() => expect(calls).toHaveLength(1));
+			expect(settledError).toBeUndefined();
+			releaseFetch();
+			await expect(disposal).resolves.toMatchObject({ message: "teardown failed" });
+			expect(calls).toHaveLength(1);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it.each([
 		{ accepted: true, promptResult: "pending", expectedError: undefined },
 		{ accepted: false, promptResult: "resolve", expectedError: "Prompt was not accepted by the session." },

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -188,6 +188,15 @@ describe("AgentSession concurrent prompt guard", () => {
 		expect(disposed).toBe(true);
 	});
 
+	it("forwards kernelSnapshot: false to the kernel provisioner during disposal", async () => {
+		createSession();
+		const dispose = vi.fn(async () => {});
+		Reflect.set(session, "_ipythonKernelProvisioner", { dispose });
+
+		await session.disposeAsync({ kernelSnapshot: false });
+		expect(dispose).toHaveBeenCalledWith({ snapshot: false });
+	});
+
 	it("should throw when prompt() called while streaming", async () => {
 		createSession();
 

--- a/packages/coding-agent/test/agent-traces.test.ts
+++ b/packages/coding-agent/test/agent-traces.test.ts
@@ -8,6 +8,7 @@ import { ENV_AGENT_DIR, getAgentTracesLogPath } from "../src/config.js";
 import {
 	findAgentTraceFiles,
 	flushAgentTraceUpload,
+	flushAllPendingAgentTraceUploads,
 	installAgentTraceUpload,
 	previewAgentTraceFile,
 	uploadAgentTraceFile,
@@ -385,6 +386,55 @@ describe("agent trace upload", () => {
 
 		expect(results.map((result) => result?.status)).toEqual(["uploaded", "uploaded"]);
 		expect(calls).toHaveLength(1);
+	});
+
+	it("drains scheduled and in-flight uploads through the exit barrier", async () => {
+		const cwd = join(tempDir, "project");
+		const sessionDir = join(tempDir, "sessions");
+		mkdirSync(cwd, { recursive: true });
+		let releaseFetch: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseFetch = resolve;
+		});
+		const calls: string[] = [];
+		const fetchFn: typeof fetch = async (input) => {
+			calls.push(String(input));
+			await gate;
+			return new Response(JSON.stringify({ bytes_stored: 1 }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
+		const install = (sessionManager: SessionManager) => {
+			installAgentTraceUpload(sessionManager, {
+				authStorage: AuthStorage.inMemory({
+					[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
+				}),
+				settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+				baseUrl: "https://api.example.test",
+				fetchFn,
+			});
+			sessionManager.appendMessage(createUserMessage("hello"));
+			sessionManager.appendMessage(createAssistantMessage("hi"));
+		};
+		const scheduled = SessionManager.create(cwd, sessionDir);
+		scheduled.newSession({ id: "barrier-scheduled" });
+		install(scheduled);
+		const inFlight = SessionManager.create(cwd, sessionDir);
+		inFlight.newSession({ id: "barrier-in-flight" });
+		install(inFlight);
+		const detached = flushAgentTraceUpload(inFlight);
+
+		let drained = false;
+		const barrier = flushAllPendingAgentTraceUploads().then(() => {
+			drained = true;
+		});
+		await vi.waitFor(() => expect(calls).toHaveLength(2));
+		expect(drained).toBe(false);
+		releaseFetch();
+		await barrier;
+		await detached;
+		expect(calls).toHaveLength(2);
 	});
 
 	it("schedules automatic uploads at most once per minute and only after new entries persist", async () => {

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -24,7 +24,10 @@ import {
 } from "../src/core/agent-messages.js";
 import type { AgentObserveController } from "../src/core/agent-observe.js";
 import type { CreateAgentSessionRuntimeFactory } from "../src/core/agent-session-runtime.js";
+import { flushAgentTraceUpload, installAgentTraceUpload } from "../src/core/agent-traces.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
 import type { AgentCronJob, AgentCronJobStore } from "../src/core/cron-jobs.js";
+import { PRIME_AGENT_TRACES_PROVIDER_ID } from "../src/core/prime-inference-auth.js";
 import {
 	type CreateRlmSubagentRuntimeOptions,
 	createDefaultRlmSubagentSessionName,
@@ -32,6 +35,7 @@ import {
 } from "../src/core/rlm-runtime.js";
 import { canonicalSessionPath } from "../src/core/session-lease.js";
 import { readSessionInfo, type SessionInfo, SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
 import type { ActiveSessionState, DaemonSocketClient } from "../src/modes/daemon/active-session-state.js";
 import {
 	AgentDaemon,
@@ -852,7 +856,7 @@ describe("daemon mode helpers", () => {
 			);
 
 		expect(recordDeletion).not.toHaveBeenCalled();
-		expect(closeSession).toHaveBeenCalledWith(childState, "completed");
+		expect(closeSession).toHaveBeenCalledWith(childState, "completed", true, true, undefined, undefined);
 		internals.sessions.set(childState.activeSessionId, childState);
 		await internals
 			.createSubagentRuntimeHost(parentState)
@@ -863,7 +867,9 @@ describe("daemon mode helpers", () => {
 			);
 		expect(recordDeletion).toHaveBeenCalledWith(parentState, "child-1", "revoked");
 		expect(recordDeletion.mock.invocationCallOrder[0]).toBeLessThan(closeSession.mock.invocationCallOrder[1]!);
-		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
+		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed", true, true, undefined, {
+			kernelSnapshot: false,
+		});
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 
 		// A registry failure must not strand the cancelled child as a stale resident session.
@@ -880,7 +886,9 @@ describe("daemon mode helpers", () => {
 					"cancelled",
 				),
 		).rejects.toThrow("registry write failed");
-		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed");
+		expect(closeSession).toHaveBeenLastCalledWith(childState, "killed", true, true, undefined, {
+			kernelSnapshot: false,
+		});
 		expect(internals.sessions.has(childState.activeSessionId)).toBe(false);
 	});
 
@@ -1409,7 +1417,9 @@ describe("daemon mode helpers", () => {
 		await host.deleteRlmSubagentRuntime("child-1", staleParentReference);
 
 		expect(closeSession).toHaveBeenCalledOnce();
-		expect(closeSession).toHaveBeenCalledWith(childState, "killed", false);
+		expect(closeSession).toHaveBeenCalledWith(childState, "killed", false, true, undefined, {
+			kernelSnapshot: false,
+		});
 		expect(closeSession).not.toHaveBeenCalledWith(foreignChildState, expect.anything());
 		expect(childSession.disposeAsync).not.toHaveBeenCalled();
 		expect(staleParentReference.disposeAsync).toHaveBeenCalledOnce();
@@ -6505,6 +6515,71 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
+	it("deletes a resident child without awaiting its pending trace upload and skips the doomed kernel snapshot", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-trace-flush-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+			};
+			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const childState = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const childManager = childState.runtime.session.sessionManager as SessionManager;
+			const { calls, releaseFetch } = installGatedTraceUpload(childManager);
+			childManager.appendMessage({ role: "user", content: "pending trace data", timestamp: 3 });
+			childManager.flushNow();
+
+			// Resolving while the stubbed fetch is still gated is the pin: the
+			// delete must not await the upload.
+			await internals
+				.createSubagentRuntimeHost(parentState)
+				.deleteRlmSubagentRuntime(fixture.childId, childState.runtime.session);
+
+			// The detached upload still fired exactly once.
+			await vi.waitFor(() => expect(calls).toHaveLength(1));
+			// The artifact sweep deletes the snapshot right away, so none is written.
+			expect(childState.runtime.session.disposeAsync).toHaveBeenCalledWith({ kernelSnapshot: false });
+			releaseFetch();
+			await flushAgentTraceUpload(childManager);
+			expect(calls).toHaveLength(1);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("awaits the pending trace upload and keeps the kernel snapshot on a shutdown close", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-shutdown-trace-flush-"));
+		try {
+			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const internals = fixture.daemon as unknown as {
+				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
+				closeSession(state: ActiveSessionState, reason: string): Promise<void>;
+			};
+			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const childState = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			const childManager = childState.runtime.session.sessionManager as SessionManager;
+			const { calls, releaseFetch } = installGatedTraceUpload(childManager);
+			childManager.appendMessage({ role: "user", content: "pending trace data", timestamp: 3 });
+			childManager.flushNow();
+
+			// Passivation and daemon exit both close with "shutdown": the flush
+			// stays blocking there and the kernel snapshot is still written.
+			let closeSettled = false;
+			const closing = internals.closeSession(childState, "shutdown").then(() => {
+				closeSettled = true;
+			});
+			await vi.waitFor(() => expect(calls).toHaveLength(1));
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
+			expect(closeSettled).toBe(false);
+			releaseFetch();
+			await closing;
+			expect(childState.runtime.session.disposeAsync).toHaveBeenCalledWith({ kernelSnapshot: true });
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	// chmod-based read-only dirs don't block root, so skip when running as uid 0.
 	it.skipIf(process.getuid?.() === 0)("does not fail a deletion when the artifact dir cannot be removed", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-artifact-rm-failure-"));
@@ -8923,6 +8998,37 @@ function makeCronJob(input: {
 		nextRunAt: "2026-01-01T12:05:00.000Z",
 		runCount: 0,
 	};
+}
+
+/**
+ * Arm a child session's trace-upload controller with a gated fetch stub so a
+ * test can observe whether a close awaits the final upload.
+ */
+function installGatedTraceUpload(sessionManager: SessionManager): {
+	calls: string[];
+	releaseFetch: () => void;
+} {
+	const calls: string[] = [];
+	let releaseFetch: () => void = () => {};
+	const gate = new Promise<void>((resolveGate) => {
+		releaseFetch = resolveGate;
+	});
+	installAgentTraceUpload(sessionManager, {
+		authStorage: AuthStorage.inMemory({
+			[PRIME_AGENT_TRACES_PROVIDER_ID]: { type: "api_key", key: "trace-key" },
+		}),
+		settingsManager: SettingsManager.inMemory({ agentTraces: { enabled: true } }),
+		baseUrl: "https://api.example.test",
+		fetchFn: (async (input: unknown) => {
+			calls.push(String(input));
+			await gate;
+			return new Response(JSON.stringify({ bytes_stored: 1 }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch,
+	});
+	return { calls, releaseFetch };
 }
 
 function makePersistedRlmDaemonFixture(

--- a/packages/coding-agent/test/daemon-mode.test.ts
+++ b/packages/coding-agent/test/daemon-mode.test.ts
@@ -6530,15 +6530,12 @@ describe("daemon mode helpers", () => {
 			childManager.appendMessage({ role: "user", content: "pending trace data", timestamp: 3 });
 			childManager.flushNow();
 
-			// Resolving while the stubbed fetch is still gated is the pin: the
-			// delete must not await the upload.
+			// The fetch gate is still held: the delete must not await the upload.
 			await internals
 				.createSubagentRuntimeHost(parentState)
 				.deleteRlmSubagentRuntime(fixture.childId, childState.runtime.session);
 
-			// The detached upload still fired exactly once.
 			await vi.waitFor(() => expect(calls).toHaveLength(1));
-			// The artifact sweep deletes the snapshot right away, so none is written.
 			expect(childState.runtime.session.disposeAsync).toHaveBeenCalledWith({ kernelSnapshot: false });
 			releaseFetch();
 			await flushAgentTraceUpload(childManager);
@@ -6548,34 +6545,50 @@ describe("daemon mode helpers", () => {
 		}
 	});
 
-	it("awaits the pending trace upload and keeps the kernel snapshot on a shutdown close", async () => {
-		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-shutdown-trace-flush-"));
+	it("resolves a delete that joins an in-flight passivation close without awaiting the trace upload", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "prime-agent-daemon-delete-passivation-flush-"));
+		let releaseDispose!: () => void;
+		const disposeGate = new Promise<void>((resolve) => {
+			releaseDispose = resolve;
+		});
+		let markDisposeStarted!: () => void;
+		const disposeStarted = new Promise<void>((resolve) => {
+			markDisposeStarted = resolve;
+		});
 		try {
-			const fixture = makePersistedRlmDaemonFixture(tempDir);
+			const fixture = makePersistedRlmDaemonFixture(tempDir, {
+				childDisposeStarted: markDisposeStarted,
+				childDisposeGate: disposeGate,
+			});
 			const internals = fixture.daemon as unknown as {
 				createRuntime(command: Extract<DaemonCommand, { type: "create" }>): Promise<ActiveSessionState>;
-				closeSession(state: ActiveSessionState, reason: string): Promise<void>;
+				createSubagentRuntimeHost(parent: ActiveSessionState): SubagentRuntimeHost;
+				passivateIdleChildren(threshold: number, now: number, limit: number): Promise<number>;
 			};
-			await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
+			const parentState = await internals.createRuntime({ type: "create", sessionPath: fixture.parentSessionFile });
 			const childState = await internals.createRuntime({ type: "create", sessionPath: fixture.childSessionFile });
+			(
+				parentState.runtime.session as unknown as { releaseRlmChildSession: ReturnType<typeof vi.fn> }
+			).releaseRlmChildSession = vi.fn(() => vi.fn());
 			const childManager = childState.runtime.session.sessionManager as SessionManager;
 			const { calls, releaseFetch } = installGatedTraceUpload(childManager);
 			childManager.appendMessage({ role: "user", content: "pending trace data", timestamp: 3 });
 			childManager.flushNow();
 
-			// Passivation and daemon exit both close with "shutdown": the flush
-			// stays blocking there and the kernel snapshot is still written.
-			let closeSettled = false;
-			const closing = internals.closeSession(childState, "shutdown").then(() => {
-				closeSettled = true;
-			});
-			await vi.waitFor(() => expect(calls).toHaveLength(1));
-			await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
-			expect(closeSettled).toBe(false);
-			releaseFetch();
-			await closing;
+			const passivation = internals.passivateIdleChildren(90, Date.parse("2036-08-01T12:00:00Z"), 1);
+			await disposeStarted;
+			const deletion = internals
+				.createSubagentRuntimeHost(parentState)
+				.deleteRlmSubagentRuntime(fixture.childId, childState.runtime.session);
+			releaseDispose();
+			// Both resolve while the fetch gate is still held.
+			await Promise.all([passivation, deletion]);
+			expect(calls).toHaveLength(1);
 			expect(childState.runtime.session.disposeAsync).toHaveBeenCalledWith({ kernelSnapshot: true });
+			releaseFetch();
+			await flushAgentTraceUpload(childManager);
 		} finally {
+			releaseDispose();
 			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
@@ -9000,10 +9013,7 @@ function makeCronJob(input: {
 	};
 }
 
-/**
- * Arm a child session's trace-upload controller with a gated fetch stub so a
- * test can observe whether a close awaits the final upload.
- */
+/** Gated fetch stub on a session's trace-upload controller: observes whether a close awaits the upload. */
 function installGatedTraceUpload(sessionManager: SessionManager): {
 	calls: string[];
 	releaseFetch: () => void;

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -186,6 +186,16 @@ describe("IpythonKernelProvisioner", () => {
 		expect(provisioner.manager).toBeUndefined();
 	});
 
+	it("dispose({ snapshot: false }) skips the kernel's final snapshot flush", async () => {
+		const { python } = writeFakePython();
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python });
+		const shutdown = vi.fn(async () => {});
+		Reflect.set(provisioner, "managerPromise", Promise.resolve({ shutdown }));
+
+		await provisioner.dispose({ snapshot: false });
+		expect(shutdown).toHaveBeenCalledWith({ snapshot: false, drainHostRequests: true });
+	});
+
 	it("dispose() before the boot slot prevents the kernel from spawning", async () => {
 		const { python, countRuns } = writeFakePython();
 		let release: () => void = () => {};

--- a/packages/coding-agent/test/ipython-provisioner.test.ts
+++ b/packages/coding-agent/test/ipython-provisioner.test.ts
@@ -65,8 +65,21 @@ function createBusyKernelContext(
 	return { ctx, setWorkingMessage };
 }
 
-function writeFakeReplRuntime(markerPath: string): string {
+function writeFakeReplRuntime(
+	markerPath: string,
+	options: { gatedExecute?: { startedPath: string; gatePath: string } } = {},
+): string {
 	const python = join(tempDir, "python-repl");
+	const refuse = `emit({ event: "error", id: request.id, ename: "RuntimeError", evalue: "bootstrap refused", traceback: [] });
+		emit({ event: "done", id: request.id, status: "error" });`;
+	const executeBranch = options.gatedExecute
+		? `fs.writeFileSync(${JSON.stringify(options.gatedExecute.startedPath)}, "1");
+		const gate = setInterval(() => {
+			if (!fs.existsSync(${JSON.stringify(options.gatedExecute.gatePath)})) return;
+			clearInterval(gate);
+			${refuse}
+		}, 10);`
+		: refuse;
 	writeFileSync(
 		python,
 		`#!/usr/bin/env node
@@ -89,8 +102,7 @@ input.on("line", (line) => {
 		return;
 	}
 	if (request.type === "execute") {
-		emit({ event: "error", id: request.id, ename: "RuntimeError", evalue: "bootstrap refused", traceback: [] });
-		emit({ event: "done", id: request.id, status: "error" });
+		${executeBranch}
 		return;
 	}
 	if (request.type === "shutdown") {
@@ -184,6 +196,25 @@ describe("IpythonKernelProvisioner", () => {
 		provisioner.prewarm();
 		await provisioner.dispose();
 		expect(provisioner.manager).toBeUndefined();
+	});
+
+	it("skips the snapshot when dispose({ snapshot: false }) aborts a startup in flight", async () => {
+		const marker = join(tempDir, "snapshot-flushed");
+		const executeStarted = join(tempDir, "execute-started");
+		const executeGate = join(tempDir, "execute-gate");
+		const snapshotDir = join(tempDir, "snapshots");
+		mkdirSync(snapshotDir, { recursive: true });
+		const python = writeFakeReplRuntime(marker, {
+			gatedExecute: { startedPath: executeStarted, gatePath: executeGate },
+		});
+		const provisioner = new IpythonKernelProvisioner(tempDir, { python, snapshotDir });
+
+		const started = provisioner.ensure().catch(() => undefined);
+		await vi.waitFor(() => expect(existsSync(executeStarted)).toBe(true));
+		const disposed = provisioner.dispose({ snapshot: false });
+		writeFileSync(executeGate, "1");
+		await Promise.all([disposed, started]);
+		expect(existsSync(marker)).toBe(false);
 	});
 
 	it("dispose({ snapshot: false }) skips the kernel's final snapshot flush", async () => {


### PR DESCRIPTION
## Problem

`rlm.delete_subagent` on a resident (hydrated) child could take seconds to over a minute. Two causes, both in the disposal path:

1. `AgentSessionRuntime.disposeOnce` awaited `flushAgentTraceUpload` — a PUT of the full raw session JSONL with a 15s timeout, 3 retries, and a flat 60s sleep on HTTP 429 when the server sends no retry-after. The delete blocked on all of that, even though the child's transcript deliberately survives deletion as the durable record, so the upload does not need to finish before the delete resolves.
2. The killed/delete close path still wrote a final kernel snapshot (the provisioner hardcoded `snapshot: true`; up to ~5s and 256MB) that `deleteRlmSubagentRuntime`'s artifact sweep removed milliseconds later.

## Fix

- Session disposal never awaits the trace upload anymore. The final flush is always fired detached (a rejection is logged to agent-traces.log; upload outcomes were already logged per attempt). This covers deletes, kills, completed/replaced closes, passivation, session replacement (`/new`, resume, fork), and hosted-child disposal — there is no per-close policy to inherit or to leak across concurrent closes.
- Durability is owned by one exit barrier, `flushAllPendingAgentTraceUploads()`, which drains every scheduled and in-flight upload. The four places where the process (or its data) actually goes away await it after their close loops: daemon shutdown, update restart, worker archive-and-shutdown, and in-process connection dispose (interactive/print/rpc/acp exits). A barrier flush on a controller with an upload already in flight joins it through the controller's existing `flushPromise` joining, so nothing uploads twice.
- The RLM delete paths (`deleteRlmSubagentRuntime`, cancelled `releaseRlmSubagentRuntime`) dispose the kernel with `snapshot: false`, threaded down to the kernel shutdown call — including a dispose that aborts a kernel startup still in flight. Passivation, normal shutdown, and plain session kills keep `snapshot: true` (those sessions stay resumable with kernel revival).

## Numbers

Measured deleting a resident child with a pending trace flush (daemon fixture, stubbed fetch, scratch dirs):

| scenario | before | after |
|---|---|---|
| upload pending, 3s network | 3024ms | 11ms |
| upload pending, HTTP 429 without retry-after | 60120ms | 9ms |

## Risk

If the process dies within ~60s after a close without reaching an exit barrier (crash, SIGKILL), the last increment of that session's trace upload can be lost (telemetry-acceptable; the transcript itself is untouched). Graceful exits drain everything through the barrier. SDK consumers that dispose a runtime and exit immediately no longer get an implicit flush; they exit through the in-process connection, which awaits the barrier.

## Tests

- delete of a resident child with a pending flush resolves without awaiting the upload; the detached upload fires exactly once; the session disposes with `kernelSnapshot: false`.
- delete that joins an in-flight passivation close resolves while the upload is still gated; the passivation dispose keeps `kernelSnapshot: true`.
- the exit barrier does not resolve until scheduled and in-flight uploads finish, and uploads exactly once per session.
- `dispose({ snapshot: false })` reaches the kernel shutdown with `snapshot: false`, both for a running kernel and for a startup it aborts mid-boot; `AgentSession.disposeAsync` forwards the flag to the provisioner.

All behavior pins fail on the unfixed code (the delete pins time out waiting on the gated fetch; the startup-abort pin sees the doomed snapshot get written).

Linear: [ENG-5837](https://linear.app/primeintellect/issue/ENG-5837/rlmdelete-subagent-blocks-on-trace-upload-and-doomed-kernel-snapshot)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disposal no longer guarantees trace upload completion before return; only graceful exit paths drain uploads, so abrupt process death can drop the last telemetry increment.
> 
> **Overview**
> **Session disposal no longer waits on the final agent-trace upload.** Teardown fires `flushAgentTraceUpload` in the background and logs detached failures instead of blocking on retries and rate limits. A process-level **`flushAllPendingAgentTraceUploads`** barrier drains scheduled and in-flight uploads when the agent actually exits (daemon shutdown, update restart, worker archive-and-shutdown, in-process connection dispose).
> 
> **RLM subagent delete and cancelled release** close with **`kernelSnapshot: false`**, threaded through `AgentSessionRuntime.dispose`, `AgentSession.disposeAsync`, daemon `closeSession`, and `IpythonKernelProvisioner.dispose` / kernel shutdown—including aborting a kernel still starting—so deletion does not spend time on a snapshot that the artifact sweep removes immediately. Normal passivation and other closes keep the default snapshot behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80dd3ec941ad05128d3f8537955eb4f447e026ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Don't block RLM subagent deletion on trace upload or doomed kernel snapshot
> - Session disposal now fires-and-forgets trace upload via `detachTraceFlush` instead of awaiting it, logging failures asynchronously rather than propagating them
> - RLM subagent deletion and cancellation pass `kernelSnapshot: false` through the disposal chain (`AgentSession.disposeAsync`, `IpythonKernelProvisioner.dispose`, `AgentDaemon.closeSession`), skipping a snapshot that would be immediately discarded
> - Adds `flushAllPendingAgentTraceUploads` as a global barrier and calls it at daemon shutdown, update restart, and worker archive-and-shutdown to ensure traces are drained before process exit
> - `InProcessAgentConnection.dispose` wraps runtime disposal in try/finally to guarantee trace draining even on error
> - Behavioral Change: `AgentSessionRuntime.dispose` no longer awaits trace upload completion; detached flush failures are logged via `logDetachedAgentTraceFlushFailure` and are not visible to callers. `IpythonKernelProvisioner.dispose` now accepts `{ snapshot?: boolean }` and a concurrent dispose can override the snapshot policy mid-startup via `disposeSnapshot`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80dd3ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->