### PR TITLE
revert(coding-agent): restore subagent cleanup guidance

### DIFF
--- a/packages/coding-agent/.changes/prompt-subagent-deletion-user-only.md
+++ b/packages/coding-agent/.changes/prompt-subagent-deletion-user-only.md
@@ -1,1 +1,0 @@
-- The system prompt no longer tells the model to delete finished subagents by default; deletion is now described as user-requested only, so idle children stay available for follow-ups.

--- a/packages/coding-agent/src/core/prompts/rlm.ts
+++ b/packages/coding-agent/src/core/prompts/rlm.ts
@@ -169,7 +169,7 @@ export function buildRlmPrompt(options: RlmPromptOptions): string {
 			parts.push("Inspect files a child wrote when you need to collect its work without an observation capability.");
 		}
 		parts.push(
-			"Spawn independent children in separate calls and end your turn instead of awaiting completion. Multiple replies may arrive over multiple turns. You can delete a direct child explicitly with `await rlm.delete_subagent(child)`. Only do this if and when a user asks for it.",
+			"Spawn independent children in separate calls and end your turn instead of awaiting completion. Multiple replies may arrive over multiple turns. Delete a direct child explicitly with `await rlm.delete_subagent(child)` when it is no longer needed.",
 		);
 	}
 

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -154,6 +154,8 @@ describe("buildRlmPrompt", () => {
 		for (const prompt of [withoutObserve, withObserve]) {
 			expect(prompt).toContain("await rlm.list_subagents()");
 			expect(prompt).toContain("await rlm.delete_subagent(child)");
+			expect(prompt).toContain("when it is no longer needed");
+			expect(prompt).not.toContain("Only do this if and when a user asks for it");
 			expect(prompt).toContain("recover direct child handles");
 			expect(prompt).not.toContain("Write a small disk registry");
 		}

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -154,8 +154,6 @@ describe("buildRlmPrompt", () => {
 		for (const prompt of [withoutObserve, withObserve]) {
 			expect(prompt).toContain("await rlm.list_subagents()");
 			expect(prompt).toContain("await rlm.delete_subagent(child)");
-			expect(prompt).toContain("when it is no longer needed");
-			expect(prompt).not.toContain("Only do this if and when a user asks for it");
 			expect(prompt).toContain("recover direct child handles");
 			expect(prompt).not.toContain("Write a small disk registry");
 		}


### PR DESCRIPTION
## Summary

- Reverts #1952 and restores the instruction to delete direct subagents when they are no longer needed.
- Removes #1952's unreleased changelog fragment.

## Why

Requiring an explicit user request for every deletion causes completed subagent sessions to accumulate and retain memory. Cleanup should remain the default once a direct subagent is no longer needed.

## Validation

- `test/system-prompt.test.ts`: 25 passed
- `git diff --check`: passed
- `npm run check`: Biome passed; the local typecheck could not resolve pre-existing workspace dependencies (`@smithy/types`, `@smithy/node-http-handler`, `@anthropic-ai/sdk`, and `grok-mermaid`). CI will run in the complete repository environment.

Linear: [ENG-5836](https://linear.app/primeintellect/issue/ENG-5836/system-prompt-tells-models-to-delete-subagents-when-done)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change that nudges model behavior around subagent lifecycle; no runtime API or security surface changes.
> 
> **Overview**
> Reverts **#1952** and restores default subagent cleanup in the RLM harness system prompt.
> 
> In `buildRlmPrompt` (`rlm.ts`), the guidance for `rlm.delete_subagent` again tells parent agents to **delete direct children when they are no longer needed**, instead of limiting deletion to explicit user requests. The unreleased changelog note that documented the user-only policy is removed.
> 
> This is intended to stop finished subagent sessions from accumulating and holding memory when parents never get a delete instruction from the user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f91731ba20ec71f60dbfc11d986faa6c11659d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore subagent deletion guidance in `buildRlmPrompt`
> Reverts the child-agent doctrine in [rlm.ts](https://github.com/PrimeIntellect-ai/prime-agent/pull/1955/files#diff-64c77a41480409e73a6d87d381a618f83c44304c3677d755b3ef66d7a5ddce29) so the prompt says to delete a direct child with `await rlm.delete_subagent(child)` when it is no longer needed, instead of only on explicit user request. Removes the now-obsolete changeset file `prompt-subagent-deletion-user-only.md`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f91731.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->